### PR TITLE
feat: add agent parallelization skills for Nix workflows

### DIFF
--- a/.claude/skills/nix-pre-commit/SKILL.md
+++ b/.claude/skills/nix-pre-commit/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: nix-pre-commit
+description: Pre-commit hook conventions for Nix projects. Covers hook configuration and background execution.
+user-invocable: false
+---
+
+# Pre-commit hooks (Nix)
+
+## Configuration
+
+Hooks are defined in `nix/modules/pre-commit.nix` via `git-hooks.nix` flake module:
+
+- **nixpkgs-fmt** — Nix file formatting
+- **prettier** — JS/TS/JSON/CSS formatting (excludes `pnpm-lock.yaml`)
+
+## Running
+
+```sh
+just pc          # runs: nix develop -c pre-commit run -a
+```
+
+## Parallelization
+
+**Run `just pc` in background after finishing a batch of edits.** Don't wait for it to complete before moving on to the next task. If it fails with formatting issues, fix them and re-run.

--- a/.claude/skills/nix-typescript/SKILL.md
+++ b/.claude/skills/nix-typescript/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: nix-typescript
+description: pnpm + Nix build conventions. Covers fetchPnpmDeps hash management and dependency workflow.
+user-invocable: false
+---
+
+# TypeScript + Nix (pnpm)
+
+## Dependency hash management
+
+`nix/modules/typescript.nix` uses `fetchPnpmDeps` with a pinned hash. When `pnpm-lock.yaml` changes (via `pnpm add/remove/update`), this hash goes stale and `nix build` fails.
+
+### Fix recipe
+
+1. Run `nix build 2>&1` — it fails with a hash mismatch
+2. Extract the correct hash from the `got: sha256-...` line in the error
+3. Update the `hash = "sha256-..."` line in `nix/modules/typescript.nix`
+
+### Parallelization
+
+**Run the hash fix in background immediately after `pnpm-lock.yaml` changes.** Don't wait until end of session — kick it off as soon as the lock file is modified, then continue coding. The `nix build` takes minutes; doing it in background avoids blocking other work.
+
+## Build
+
+- `nix build` — full production build (client + server bundle)
+- `nix run` — build and run
+- Client is built with `pnpm --filter kolu-client build` (Vite)
+- Server runs via `tsx` (TypeScript execution without compile step)


### PR DESCRIPTION
## Summary

Closes #16.

- Adds `nix-typescript` skill: teaches agents to run `fetchPnpmDeps` hash fix in background immediately after `pnpm-lock.yaml` changes, instead of serially at end of session
- Adds `nix-pre-commit` skill: teaches agents to run `just pc` in background after edits

Both are non-user-invocable reference skills — agents pick them up automatically.

## Test plan

- [ ] Verify skills appear in Claude Code's skill list
- [ ] Modify `package.json` in a session and confirm agent attempts background hash fix
- [ ] Confirm `just pc` passes