### PR TITLE
refactor: adopt SolidJS idiomatic patterns (mergeProps, Suspense, solid-primitives)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@orpc/client": "^1.13.9",
     "@orpc/contract": "^1.13.9",
+    "@solid-primitives/event-listener": "^2.4.5",
+    "@solid-primitives/resize-observer": "^2.1.5",
     "ghostty-web": "^0.4.0",
     "partysocket": "^1.1.16",
     "solid-js": "^1.9.0"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,10 @@
 import {
   type Component,
   createSignal,
-  onMount,
+  createResource,
   Show,
   For,
+  Suspense,
   ErrorBoundary,
 } from "solid-js";
 import Header, { type WsStatus } from "./Header";
@@ -11,17 +12,16 @@ import Sidebar from "./Sidebar";
 import Terminal from "./Terminal";
 import { THEME } from "./theme";
 import { client } from "./rpc";
+import type { TerminalInfo } from "kolu-common";
 
 const App: Component = () => {
   const [wsStatus, setWsStatus] = createSignal<WsStatus>("connecting");
   const [terminalIds, setTerminalIds] = createSignal<string[]>([]);
   const [activeId, setActiveId] = createSignal<string | null>(null);
-  // Prevents empty-state flash while onMount restores terminals from server
-  const [loaded, setLoaded] = createSignal(false);
 
   // Restore existing terminals on page load (e.g. after browser refresh).
   // A successful list() call proves the WebSocket is connected.
-  onMount(async () => {
+  const [existingTerminals] = createResource<TerminalInfo[]>(async () => {
     const existing = await client.terminal.list();
     setWsStatus("open");
     if (existing.length > 0) {
@@ -31,7 +31,7 @@ const App: Component = () => {
       // Prefer a running terminal; fall back to first (which may be exited)
       setActiveId(running?.id ?? ids[0]);
     }
-    setLoaded(true);
+    return existing;
   });
 
   /** Create a new terminal on the server, add it to the list, and make it active. */
@@ -64,19 +64,29 @@ const App: Component = () => {
                 </div>
               )}
             >
-              <Show when={loaded() && terminalIds().length === 0}>
-                <div
-                  data-testid="empty-state"
-                  class="flex items-center justify-center h-full text-slate-500 text-sm"
-                >
-                  Click + to create a terminal
-                </div>
-              </Show>
-              <For each={terminalIds()}>
-                {(id) => (
-                  <Terminal terminalId={id} visible={activeId() === id} />
-                )}
-              </For>
+              <Suspense
+                fallback={
+                  <div class="flex items-center justify-center h-full text-slate-500 text-sm">
+                    Connecting...
+                  </div>
+                }
+              >
+                {/* Read the resource to trigger Suspense while it loads */}
+                {void existingTerminals()}
+                <Show when={terminalIds().length === 0}>
+                  <div
+                    data-testid="empty-state"
+                    class="flex items-center justify-center h-full text-slate-500 text-sm"
+                  >
+                    Click + to create a terminal
+                  </div>
+                </Show>
+                <For each={terminalIds()}>
+                  {(id) => (
+                    <Terminal terminalId={id} visible={activeId() === id} />
+                  )}
+                </For>
+              </Suspense>
             </ErrorBoundary>
           </div>
         </div>

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -1,4 +1,4 @@
-import type { Component } from "solid-js";
+import { type Component, mergeProps } from "solid-js";
 
 /** WS connection status indicator colors. */
 const statusColors = {
@@ -9,18 +9,18 @@ const statusColors = {
 
 export type WsStatus = keyof typeof statusColors;
 
-const Header: Component<{ status?: WsStatus }> = (props) => {
-  const status = () => props.status ?? "connecting";
+const Header: Component<{ status?: WsStatus }> = (rawProps) => {
+  const props = mergeProps({ status: "connecting" as const }, rawProps);
 
   return (
     <header class="flex items-center gap-2 px-4 py-2 bg-slate-800 border-b border-slate-700">
       <img src="/favicon.svg" alt="kolu" class="w-5 h-5" />
       <span class="font-semibold text-sm">kolu</span>
       <span
-        class={`ml-auto text-xs ${statusColors[status()]}`}
-        data-ws-status={status()}
+        class={`ml-auto text-xs ${statusColors[props.status]}`}
+        data-ws-status={props.status}
       >
-        ● {status()}
+        ● {props.status}
       </span>
     </header>
   );

--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -13,6 +13,8 @@ import {
   createEffect,
   on,
 } from "solid-js";
+import { createResizeObserver } from "@solid-primitives/resize-observer";
+import { makeEventListener } from "@solid-primitives/event-listener";
 import { initGhostty, type Terminal as GhosttyTerminal } from "./ghostty";
 import { TERMINAL_DEFAULTS } from "./theme";
 import { client } from "./rpc";
@@ -193,14 +195,14 @@ const Terminal: Component<{
       void client.terminal.sendInput({ id: props.terminalId, data });
     });
 
-    const observer = new ResizeObserver(() => void fit());
-    observer.observe(containerRef);
+    createResizeObserver(
+      () => containerRef,
+      () => void fit(),
+    );
     // Capture phase: intercept before ghostty's own keydown handler in bubble phase
-    window.addEventListener("keydown", handleZoomKeys, { capture: true });
+    makeEventListener(window, "keydown", handleZoomKeys, { capture: true });
 
     onCleanup(() => {
-      window.removeEventListener("keydown", handleZoomKeys, { capture: true });
-      observer.disconnect();
       streamAbort?.abort();
       terminal?.dispose();
     });

--- a/nix/modules/typescript.nix
+++ b/nix/modules/typescript.nix
@@ -22,7 +22,7 @@
         pname = "kolu";
         version = "0.1.0";
         inherit src;
-        hash = "sha256-HzeszNBqdbaWFbsV8ZBIm7OHartiRhAxNVNEMI1iv7s=";
+        hash = "sha256-Y7xWmZW1VMvCB7HRvASPkvQvkuLELClkeETm747B5Kk=";
         fetcherVersion = 3;
       };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,12 @@ importers:
       '@orpc/contract':
         specifier: ^1.13.9
         version: 1.13.9
+      '@solid-primitives/event-listener':
+        specifier: ^2.4.5
+        version: 2.4.5(solid-js@1.9.11)
+      '@solid-primitives/resize-observer':
+        specifier: ^2.1.5
+        version: 2.1.5(solid-js@1.9.11)
       ghostty-web:
         specifier: ^0.4.0
         version: 0.4.0
@@ -798,6 +804,31 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@solid-primitives/event-listener@2.4.5':
+    resolution: {integrity: sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/resize-observer@2.1.5':
+    resolution: {integrity: sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/rootless@1.5.3':
+    resolution: {integrity: sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/static-store@0.1.3':
+    resolution: {integrity: sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+
+  '@solid-primitives/utils@6.4.0':
+    resolution: {integrity: sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==}
+    peerDependencies:
+      solid-js: ^1.6.12
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2349,6 +2380,33 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.11)':
+    dependencies:
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
+      solid-js: 1.9.11
+
+  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.11)':
+    dependencies:
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.11)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.11)
+      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.11)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
+      solid-js: 1.9.11
+
+  '@solid-primitives/rootless@1.5.3(solid-js@1.9.11)':
+    dependencies:
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
+      solid-js: 1.9.11
+
+  '@solid-primitives/static-store@0.1.3(solid-js@1.9.11)':
+    dependencies:
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.11)
+      solid-js: 1.9.11
+
+  '@solid-primitives/utils@6.4.0(solid-js@1.9.11)':
+    dependencies:
+      solid-js: 1.9.11
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
## Summary

Closes #19

- **Header.tsx**: Replace manual `?? "connecting"` with `mergeProps` — canonical Solid pattern for default props
- **App.tsx**: Replace `onMount` + manual `loaded` signal with `createResource` + `<Suspense>` — native async loading state
- **Terminal.tsx**: Replace manual `ResizeObserver` with `createResizeObserver` from `@solid-primitives/resize-observer` — auto-cleanup
- **Terminal.tsx**: Replace manual `window.addEventListener` with `makeEventListener` from `@solid-primitives/event-listener` — auto-cleanup

## Test plan

- [ ] `nix build` passes
- [ ] `just ci` passes (e2e tests: smoke, sidebar, terminal)
- [ ] Manual: terminals create, resize, zoom, persist across refresh