### PR TITLE
feat: add mouse support for TUI apps

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "@orpc/contract": "^1.13.9",
     "@solid-primitives/event-listener": "^2.4.5",
     "@solid-primitives/resize-observer": "^2.1.5",
-    "ghostty-web": "^0.4.0",
+    "ghostty-web": "0.4.0-next.14.g6a1a50d",
     "partysocket": "^1.1.16",
     "solid-js": "^1.9.0"
   },

--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -201,6 +201,10 @@ const Terminal: Component<{
     );
     // Capture phase: intercept before ghostty's own keydown handler in bubble phase
     makeEventListener(window, "keydown", handleZoomKeys, { capture: true });
+    // Prevent browser context menu so right-click reaches the terminal (mouse tracking)
+    makeEventListener(containerRef, "contextmenu", (e: Event) =>
+      e.preventDefault(),
+    );
 
     onCleanup(() => {
       streamAbort?.abort();

--- a/nix/modules/typescript.nix
+++ b/nix/modules/typescript.nix
@@ -22,7 +22,7 @@
         pname = "kolu";
         version = "0.1.0";
         inherit src;
-        hash = "sha256-Y7xWmZW1VMvCB7HRvASPkvQvkuLELClkeETm747B5Kk=";
+        hash = "sha256-khoNz+JaTLMQYzw0DW8Ys9TDC1q0T+UiqofgWqEKSoA=";
         fetcherVersion = 3;
       };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^2.1.5
         version: 2.1.5(solid-js@1.9.11)
       ghostty-web:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: 0.4.0-next.14.g6a1a50d
+        version: 0.4.0-next.14.g6a1a50d
       partysocket:
         specifier: ^1.1.16
         version: 1.1.16
@@ -1172,8 +1172,8 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
-  ghostty-web@0.4.0:
-    resolution: {integrity: sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg==}
+  ghostty-web@0.4.0-next.14.g6a1a50d:
+    resolution: {integrity: sha512-01H59pAKq43Y8ZZiIhH98cu0ahZaoGoPQPtW4KnZPT0JFdQYen2djsXrOnt27JnMv64D4eLeAq8D6h72mo52xQ==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -2738,7 +2738,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  ghostty-web@0.4.0: {}
+  ghostty-web@0.4.0-next.14.g6a1a50d: {}
 
   glob@10.5.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Upgrade ghostty-web from 0.4.0 to 0.4.0-next.14 which includes InputHandler mouse tracking (SGR escape sequence generation for clicks/motion)
- Prevent browser context menu on terminal container so right-clicks reach TUI apps like lazygit

Closes #29

## Test plan
- [ ] Run `just dev`, open lazygit in a terminal, verify mouse clicks select items
- [ ] Verify right-click in terminal does NOT show browser context menu
- [ ] Verify keyboard zoom (Ctrl/Cmd +/-) still works
- [ ] Verify terminal resize still works