### PR TITLE
feat: improve mobile UX with virtual keyboard support

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+    />
     <title>kolu</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -73,7 +73,7 @@ const App: Component = () => {
   );
 
   return (
-    <div class="flex flex-col h-screen bg-slate-900 text-white">
+    <div class="flex flex-col h-dvh bg-slate-900 text-white">
       <Show when={paletteOpen()}>
         <CommandPalette
           commands={commands()}

--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -233,12 +233,14 @@ const Terminal: Component<{
   return (
     <div
       ref={containerRef}
-      class="w-full h-full overflow-hidden"
+      // touch-manipulation: eliminate 300ms tap delay and prevent double-tap-to-zoom on mobile
+      class="w-full h-full overflow-hidden touch-manipulation"
       // Hide via display:none (not unmount) to preserve ghostty canvas state and scrollback
       style={{ display: props.visible ? undefined : "none" }}
       data-terminal-id={props.terminalId}
       data-visible={props.visible ? "" : undefined}
       data-font-size={fontSize()}
+      onClick={() => focusInput()}
     />
   );
 };

--- a/tests/features/terminal.feature
+++ b/tests/features/terminal.feature
@@ -47,6 +47,11 @@ Feature: Terminal
     Then the file "/tmp/kolu-test-cols" should contain a number greater than 80
     And there should be no page errors
 
+  Scenario: Clicking terminal focuses input
+    When I click the terminal canvas
+    Then the terminal input should be focused
+    And there should be no page errors
+
   Scenario: Zoom changes font size
     Given I note the font size
     When I zoom in 1 time

--- a/tests/step_definitions/terminal_steps.ts
+++ b/tests/step_definitions/terminal_steps.ts
@@ -137,6 +137,21 @@ Then(
   },
 );
 
+// ── Click-to-focus (mobile tap-to-focus) ──
+
+When("I click the terminal canvas", async function (this: KoluWorld) {
+  // Click the body first to blur any focused element, then click the terminal
+  await this.page.locator("body").click({ position: { x: 0, y: 0 } });
+  await this.canvas.click();
+});
+
+Then("the terminal input should be focused", async function (this: KoluWorld) {
+  const focused = await this.page.evaluate(
+    () => !!document.activeElement?.closest("[data-visible]"),
+  );
+  assert.ok(focused, "Terminal input is not focused after clicking canvas");
+});
+
 // ── Zoom keystroke leak detection (intercept oRPC sendInput via WebSocket.send) ──
 
 Given("I intercept oRPC sendInput calls", async function (this: KoluWorld) {


### PR DESCRIPTION
## Summary
- Add `interactive-widget=resizes-content` to viewport meta so layout viewport shrinks when virtual keyboard appears (Chrome 108+, Firefox 132+)
- Switch root from `h-screen` (100vh) to `h-dvh` (100dvh) — dynamic viewport height that accounts for keyboards/address bars
- Add tap-to-focus on terminal container + `touch-manipulation` to eliminate 300ms tap delay

Closes #39

## Follow-up
- #41 tracks responsive sidebar/header redesign for mobile (deferred)

## Test plan
- [x] e2e: new "Clicking terminal focuses input" scenario passes
- [x] e2e: all 24 existing scenarios pass
- [x] pre-commit hooks pass
- [ ] Manual: open on phone, tap terminal, verify keyboard doesn't cover typing area