### PR TITLE
feat: make theme name in header clickable

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,17 +31,31 @@ const App: Component = () => {
 
   // Shared open state: CommandPalette owns it, Header can trigger it
   const [paletteOpen, setPaletteOpen] = createSignal(false);
+  const [paletteInitialQuery, setPaletteInitialQuery] = createSignal("");
+
+  function openPaletteWith(query: string) {
+    setPaletteInitialQuery(query);
+    setPaletteOpen(true);
+  }
+
+  // Reset initial query on close so Cmd/Ctrl+K opens with a clean slate
+  function handlePaletteOpenChange(open: boolean) {
+    setPaletteOpen(open);
+    if (!open) setPaletteInitialQuery("");
+  }
 
   return (
     <div class="flex flex-col h-dvh bg-slate-900 text-white">
       <CommandPalette
         commands={commands}
         open={paletteOpen()}
-        onOpenChange={setPaletteOpen}
+        onOpenChange={handlePaletteOpenChange}
+        initialQuery={paletteInitialQuery()}
       />
       <Header
         status={wsStatus()}
-        onOpenPalette={() => setPaletteOpen(true)}
+        onOpenPalette={() => openPaletteWith("")}
+        onThemeClick={() => openPaletteWith("Theme: ")}
         themeName={activeThemeName()}
       />
       <div class="flex flex-1 min-h-0">

--- a/client/src/CommandPalette.tsx
+++ b/client/src/CommandPalette.tsx
@@ -29,6 +29,7 @@ const CommandPalette: Component<{
   commands: Accessor<Command[]>;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  initialQuery?: string;
 }> = (props) => {
   let inputRef!: HTMLInputElement;
   let panelRef!: HTMLDivElement;
@@ -104,7 +105,7 @@ const CommandPalette: Component<{
       () => props.open,
       (isOpen) => {
         if (isOpen) {
-          setQuery("");
+          setQuery(props.initialQuery ?? "");
           setSelectedIndex(0);
           requestAnimationFrame(() => inputRef?.focus());
         }

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -12,6 +12,7 @@ const statusColors: Record<WsStatus, string> = {
 const Header: Component<{
   status?: WsStatus;
   onOpenPalette?: () => void;
+  onThemeClick?: () => void;
   themeName?: string;
 }> = (rawProps) => {
   const props = mergeProps({ status: "connecting" as const }, rawProps);
@@ -23,9 +24,14 @@ const Header: Component<{
       {/* Push remaining items to the right */}
       <div class="ml-auto flex items-center gap-2">
         {props.themeName && (
-          <span class="px-2 py-0.5 text-xs text-slate-400 bg-slate-700/50 rounded">
+          <button
+            data-testid="theme-name"
+            class="px-2 py-0.5 text-xs text-slate-400 hover:text-white bg-slate-700/50 hover:bg-slate-600/50 rounded transition-colors cursor-pointer"
+            onClick={() => props.onThemeClick?.()}
+            title="Change theme"
+          >
             {props.themeName}
-          </span>
+          </button>
         )}
         <button
           data-testid="palette-trigger"

--- a/tests/features/theme.feature
+++ b/tests/features/theme.feature
@@ -23,6 +23,12 @@ Feature: Theme switching
     And I refresh the page
     Then the header should show theme "Nord"
 
+  Scenario: Click theme name opens palette with prefix
+    When I click the theme name in the header
+    Then the command palette should be visible
+    And the palette input should contain "Theme: "
+    And there should be no page errors
+
   Scenario: Each terminal has independent theme
     When I open the command palette
     And I type "Theme: Dracula" in the palette

--- a/tests/step_definitions/theme_steps.ts
+++ b/tests/step_definitions/theme_steps.ts
@@ -62,6 +62,29 @@ Then(
   },
 );
 
+const PALETTE_SELECTOR = '[data-testid="command-palette"]';
+
+When("I click the theme name in the header", async function (this: KoluWorld) {
+  const themeButton = this.page.locator('[data-testid="theme-name"]');
+  await themeButton.waitFor({ state: "visible", timeout: 3000 });
+  await themeButton.click();
+  await this.page.waitForTimeout(200);
+});
+
+Then(
+  "the palette input should contain {string}",
+  async function (this: KoluWorld, expected: string) {
+    const input = this.page.locator(`${PALETTE_SELECTOR} input`);
+    await input.waitFor({ state: "visible", timeout: 3000 });
+    const value = await input.inputValue();
+    assert.strictEqual(
+      value,
+      expected,
+      `Expected palette input to contain "${expected}" but got "${value}"`,
+    );
+  },
+);
+
 Then(
   "the header should show theme {string}",
   async function (this: KoluWorld, expectedTheme: string) {


### PR DESCRIPTION
## Summary
- Clicking the theme name in the header opens the command palette pre-filled with "Theme: " prefix
- Theme name changed from `<span>` to `<button>` with hover styling
- Added `initialQuery` prop to CommandPalette for pre-filling search
- Stale query is cleared on palette close so Cmd/Ctrl+K always opens clean

Closes #49

## Test plan
- [x] Added e2e test: "Click theme name opens palette with prefix"
- [ ] Existing theme and palette tests still pass
- [ ] CI passes