### PR TITLE
Tab through command palette results

### DIFF
--- a/client/src/CommandPalette.tsx
+++ b/client/src/CommandPalette.tsx
@@ -79,6 +79,14 @@ const CommandPalette: Component<{
         if (items.length === 0) return;
         setSelectedIndex((i) => Math.max(i - 1, 0));
         break;
+      case "Tab":
+        if (items.length === 0) return;
+        setSelectedIndex((i) =>
+          e.shiftKey
+            ? (i - 1 + items.length) % items.length
+            : (i + 1) % items.length,
+        );
+        break;
       case "Enter": {
         const selected = items[selectedIndex()];
         if (selected) execute(selected);

--- a/tests/features/command-palette.feature
+++ b/tests/features/command-palette.feature
@@ -83,6 +83,29 @@ Feature: Command Palette
     And the terminal canvas should be visible
     And there should be no page errors
 
+  Scenario: Tab cycles through results
+    When I open the app
+    And I create a terminal
+    And I create a terminal
+    And I open the command palette
+    Then palette item 1 should be selected
+    When I press Tab
+    Then palette item 2 should be selected
+    When I press Tab
+    Then palette item 3 should be selected
+    And there should be no page errors
+
+  Scenario: Shift+Tab cycles backwards and wraps
+    When I open the app
+    And I create a terminal
+    And I create a terminal
+    And I open the command palette
+    Then palette item 1 should be selected
+    # Wrap to last
+    When I press Shift+Tab
+    Then the last palette item should be selected
+    And there should be no page errors
+
   Scenario: Cmd/Ctrl+K does not leak to terminal
     Given I intercept oRPC sendInput calls
     When I open the command palette

--- a/tests/step_definitions/command_palette_steps.ts
+++ b/tests/step_definitions/command_palette_steps.ts
@@ -73,6 +73,20 @@ Then(
 );
 
 Then(
+  "the last palette item should be selected",
+  async function (this: KoluWorld) {
+    const items = this.page.locator(`${PALETTE_SELECTOR} li`);
+    const count = await items.count();
+    const last = items.nth(count - 1);
+    const classes = await last.getAttribute("class");
+    assert.ok(
+      classes?.includes("bg-slate-600"),
+      `Last palette item is not selected (classes: ${classes})`,
+    );
+  },
+);
+
+Then(
   "no sendInput call should contain {string}",
   async function (this: KoluWorld, key: string) {
     const messages: string[] = await this.page.evaluate(


### PR DESCRIPTION
**Tab and Shift+Tab now cycle through command palette results**, wrapping around at both ends. Arrow keys still stop at the first/last item — Tab wraps, matching the convention from VS Code and Spotlight.

*Browser's default tab-focus behavior is suppressed while the palette is open, so Tab won't jump focus out of the modal.* Two new e2e scenarios cover forward cycling and backward wrap-around.