### PR TITLE
Show git repo remote and branch in header

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ const App: Component = () => {
     activeThemeName,
     activeTheme,
     activeCwd,
+    activeGitInfo,
     existingTerminals,
     handleCreate,
     getTerminalThemeName,
@@ -72,6 +73,7 @@ const App: Component = () => {
         onThemeClick={() => openPaletteWith("Theme: ")}
         themeName={activeThemeName()}
         cwd={activeCwd()}
+        gitInfo={activeGitInfo()}
         onToggleSidebar={toggleSidebar}
       />
       {/* relative: anchor for sidebar's absolute overlay on mobile */}

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -2,6 +2,7 @@ import { type Component, Show, mergeProps } from "solid-js";
 import { isMac } from "./platform";
 import { shortenCwd } from "./path";
 import type { WsStatus } from "./rpc";
+import type { GitInfo } from "kolu-common";
 
 /** WS connection status indicator colors. */
 const statusColors: Record<WsStatus, string> = {
@@ -16,6 +17,7 @@ const Header: Component<{
   onThemeClick?: () => void;
   themeName?: string;
   cwd?: string | null;
+  gitInfo?: GitInfo | null;
   onToggleSidebar?: () => void;
 }> = (rawProps) => {
   const props = mergeProps({ status: "connecting" as const }, rawProps);
@@ -52,6 +54,21 @@ const Header: Component<{
             data-testid="header-cwd"
           >
             {shortenCwd(cwd())}
+          </span>
+        )}
+      </Show>
+      <Show when={props.gitInfo}>
+        {(info) => (
+          <span class="text-xs text-slate-500" data-testid="header-git-repo">
+            · {info().remoteUrl}
+            <Show when={info().branch}>
+              {(branch) => (
+                <span class="text-slate-600" data-testid="header-git-branch">
+                  {" "}
+                  @ {branch()}
+                </span>
+              )}
+            </Show>
           </span>
         )}
       </Show>

--- a/client/src/useTerminals.ts
+++ b/client/src/useTerminals.ts
@@ -5,7 +5,7 @@ import { createStore, reconcile } from "solid-js/store";
 import { makePersisted } from "@solid-primitives/storage";
 import { DEFAULT_THEME_NAME, availableThemes, getThemeByName } from "./theme";
 import { client } from "./rpc";
-import type { TerminalInfo } from "kolu-common";
+import type { TerminalInfo, GitInfo } from "kolu-common";
 
 const ACTIVE_TERMINAL_KEY = "kolu-active-terminal";
 
@@ -27,6 +27,11 @@ export function useTerminals() {
   const [terminalCwds, setTerminalCwds] = createStore<Record<string, string>>(
     {},
   );
+
+  // Per-terminal git info (terminal ID → GitInfo | null).
+  const [terminalGit, setTerminalGit] = createStore<
+    Record<string, GitInfo | null>
+  >({});
 
   // Per-terminal activity state (terminal ID → isActive).
   const [terminalActivity, setTerminalActivity] = createStore<
@@ -63,6 +68,12 @@ export function useTerminals() {
     return id ? (terminalCwds[id] ?? null) : null;
   });
 
+  /** The active terminal's git info (for header display). */
+  const activeGitInfo = createMemo(() => {
+    const id = activeId();
+    return id ? (terminalGit[id] ?? null) : null;
+  });
+
   /** Fire-and-forget stream subscription with AbortController cleanup. */
   function subscribeStream<T>(
     startStream: (signal: AbortSignal) => Promise<AsyncIterable<T>>,
@@ -84,7 +95,10 @@ export function useTerminals() {
   function subscribeCwd(id: string) {
     return subscribeStream(
       (signal) => client.terminal.onCwdChange({ id }, { signal }),
-      (cwd) => setTerminalCwds(id, cwd),
+      ({ cwd, git }) => {
+        setTerminalCwds(id, cwd);
+        setTerminalGit(id, git);
+      },
     );
   }
 
@@ -185,6 +199,7 @@ export function useTerminals() {
     activeThemeName,
     activeTheme,
     activeCwd,
+    activeGitInfo,
     existingTerminals,
     handleCreate,
     getTerminalThemeName,

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -47,7 +47,16 @@ export const TerminalSetThemeInputSchema = z.object({
 export const TerminalAttachInputSchema = z.object({ id: TerminalIdSchema });
 export const TerminalAttachOutputSchema = z.string();
 export const TerminalOnExitOutputSchema = z.number();
-export const TerminalCwdOutputSchema = z.string();
+export const GitInfoSchema = z.object({
+  remoteUrl: z.string(), // formatted "org/repo"
+  branch: z.string().nullable(), // current branch name, null if detached HEAD
+  toplevel: z.string(), // repo root path
+});
+
+export const TerminalCwdOutputSchema = z.object({
+  cwd: z.string(),
+  git: GitInfoSchema.nullable(),
+});
 export const TerminalActivityOutputSchema = z.boolean();
 
 // --- Derived types ---
@@ -55,6 +64,9 @@ export const TerminalActivityOutputSchema = z.boolean();
 export type TerminalInfo = z.infer<typeof TerminalInfoSchema>;
 export type TerminalId = TerminalInfo["id"];
 export type TerminalStatus = TerminalInfo["status"];
+export type GitInfo = z.infer<typeof GitInfoSchema>;
+/** CWD + associated git info, streamed from server on directory changes. */
+export type CwdOutput = z.infer<typeof TerminalCwdOutputSchema>;
 
 /** Extract the status discriminant from TerminalInfo for reuse (e.g. server-side TerminalEntry). */
 export type TerminalRunning = Extract<TerminalInfo, { status: "running" }>;

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -1,0 +1,68 @@
+/**
+ * Git info resolution: extracts repo remote URL and toplevel for a given CWD.
+ * Caches by toplevel path (remote doesn't change within a session).
+ */
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import type { GitInfo } from "kolu-common";
+
+const execFile = promisify(execFileCb);
+const TIMEOUT_MS = 2000;
+
+/** Cache: repo toplevel → formatted remote URL. */
+const remoteCache = new Map<string, string>();
+
+/** Run a git command in the given directory. Returns trimmed stdout or null on error. */
+async function git(cwd: string, ...args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFile("git", ["-C", cwd, ...args], {
+      timeout: TIMEOUT_MS,
+    });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a git remote URL to "org/repo" form.
+ * Handles SSH (`git@host:org/repo.git`) and HTTPS (`https://host/org/repo.git`).
+ */
+function formatRemoteUrl(url: string): string {
+  // SSH: git@github.com:org/repo.git
+  const sshMatch = url.match(/@[^:]+:(.+?)(?:\.git)?$/);
+  if (sshMatch) return sshMatch[1];
+  // HTTPS: https://github.com/org/repo.git
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname.replace(/^\//, "").replace(/\.git$/, "");
+  } catch {
+    return url;
+  }
+}
+
+/** Resolve git info for a CWD. Returns null if not in a git repo. */
+export async function getGitInfo(cwd: string): Promise<GitInfo | null> {
+  const toplevel = await git(cwd, "rev-parse", "--show-toplevel");
+  if (!toplevel) return null;
+
+  // Branch can change on every cd (e.g. worktree switch), always resolve
+  const branch = await git(cwd, "rev-parse", "--abbrev-ref", "HEAD");
+
+  // Check cache by toplevel for remote (doesn't change within a session)
+  const cached = remoteCache.get(toplevel);
+  if (cached !== undefined) {
+    return {
+      remoteUrl: cached,
+      branch: branch === "HEAD" ? null : branch,
+      toplevel,
+    };
+  }
+
+  const rawUrl = await git(cwd, "remote", "get-url", "origin");
+  if (!rawUrl) return null;
+
+  const remoteUrl = formatRemoteUrl(rawUrl);
+  remoteCache.set(toplevel, remoteUrl);
+  return { remoteUrl, branch: branch === "HEAD" ? null : branch, toplevel };
+}

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -17,6 +17,7 @@ import {
   type TerminalEntry,
 } from "./terminals.ts";
 import { subscribeAndYield } from "./streaming.ts";
+import { getGitInfo } from "./git.ts";
 
 const t = implement(contract);
 
@@ -79,8 +80,9 @@ export const appRouter = t.router({
     }) {
       const entry = requireTerminal(input.id);
 
-      // Yield current CWD immediately
-      yield entry.handle.cwd;
+      // Yield current CWD + git info immediately
+      const cwd = entry.handle.cwd;
+      yield { cwd, git: await getGitInfo(cwd) };
 
       // Then stream changes
       yield* subscribeAndYield(entry.emitter, "cwd", signal);

--- a/server/src/terminals.ts
+++ b/server/src/terminals.ts
@@ -8,16 +8,18 @@ import type {
   TerminalInfo,
   TerminalRunning,
   TerminalExited,
+  CwdOutput,
 } from "kolu-common";
 import { ACTIVITY_IDLE_THRESHOLD_S } from "kolu-common/config";
 import { EventEmitter } from "node:events";
 import { log } from "./log.ts";
+import { getGitInfo } from "./git.ts";
 
 /** Typed event map — eliminates stringly-typed emit/on/off calls. */
 export interface TerminalEvents {
   data: [data: string];
   exit: [exitCode: number];
-  cwd: [cwd: string];
+  cwd: [data: CwdOutput];
   activity: [isActive: boolean];
 }
 
@@ -83,7 +85,12 @@ export function createTerminal(): TerminalInfo {
       }
       emitter.emit("exit", exitCode);
     },
-    onCwd: (cwd) => emitter.emit("cwd", cwd),
+    onCwd: (cwd) => {
+      getGitInfo(cwd).then(
+        (git) => emitter.emit("cwd", { cwd, git }),
+        () => emitter.emit("cwd", { cwd, git: null }),
+      );
+    },
   });
 
   const entry: TerminalEntry = {


### PR DESCRIPTION
**Header now displays the git remote and branch** (e.g. `juspay/kolu @ main`) next to the CWD when the terminal is inside a git repository. `cd` out of a repo and it disappears; `cd` into a worktree and it shows the same remote as the main repo with the worktree's branch.

The CWD stream was extended from plain strings to `{ cwd, git }` objects — server resolves the repo toplevel, origin URL, and current branch on each directory change, *caching remote by repo root so only the first `cd` into a repo pays for the remote lookup*. Branch is always resolved fresh since it can differ across worktrees.

Detached HEAD shows the remote without a branch name.

Closes #48