### PR TITLE
Revise plan: CWD-based git discovery over repo registry

### DIFF
--- a/docs/plans/000-KOLU.md
+++ b/docs/plans/000-KOLU.md
@@ -124,7 +124,15 @@ directory" command in palette (uses active terminal's CWD). Existing
 
 ### Phase 4: Git context + worktree-aware sidebar
 
-Auto-discover git context from terminal CWDs — no repo registry needed.
+Kolu is a terminal multiplexer organized around repos and branches.
+A flat terminal list doesn't reflect how developers actually work —
+juggling multiple worktrees across repos, often with several terminals
+per worktree. Rather than a heavyweight repo registry (the original
+Phase 3), we auto-discover git context from terminal CWDs: the server
+enriches the existing CWD stream with `git rev-parse` data, and the
+client derives a Repo → Worktree → Terminal tree reactively. No config,
+no registration — just `cd` into a repo and kolu organizes itself.
+
 Uses [`simple-git`](https://github.com/steveukx/git-js) on the server.
 
 #### 4a: Git context in header ([#48](https://github.com/juspay/kolu/issues/48))


### PR DESCRIPTION
**Phases 3-5 replaced with a simpler approach** that auto-discovers git context from terminal CWDs instead of maintaining a repo registry. No new UI for managing repos or worktrees — kolu just observes where terminals are and groups accordingly.

The new phases: **Phase 3** adds `cwd` to `terminal.create` so new terminals inherit the active terminal's directory. **Phase 4a** enriches the existing CWD stream with git context (repo name, branch) and surfaces it in the header (closes #48). **Phase 4b** redesigns the sidebar into a Repo → Worktree → Terminal tree, with per-group "+" buttons. *All discovery is reactive — terminals re-group as users `cd` between repos.*

The key insight: CWD tracking already exists via OSC 7. We just enrich it server-side with `git rev-parse` (~2ms) and derive the sidebar grouping client-side with a `createMemo`.