### PR TITLE
Fix git context on NixOS by adding git to runtime deps

### DIFF
--- a/nix/modules/typescript.nix
+++ b/nix/modules/typescript.nix
@@ -88,7 +88,7 @@
 
         default = pkgs.writeShellApplication {
           name = "kolu";
-          runtimeInputs = [ nodejs pkgs.tsx ];
+          runtimeInputs = [ nodejs pkgs.tsx pkgs.git ];
           text = ''
             export KOLU_CLIENT_DIST="${kolu}/client/dist"
             export KOLU_CLIPBOARD_SHIM_DIR="${config.packages.clipboard-shims}/bin"


### PR DESCRIPTION
**Git repo/branch display in the header was silently broken on NixOS** — `simple-git` shells out to `git`, which wasn't in the nix wrapper's PATH. On macOS this worked by accident because `/usr/bin/git` (Xcode CLT) is always available system-wide; NixOS has no such fallback.

One-line fix: add `pkgs.git` to `runtimeInputs` in the `writeShellApplication` wrapper.

### Try it locally
`nix run github:juspay/kolu/fix/git-runtime-dep`