### PR TITLE
Ctrl+Tab terminal switching

### DIFF
--- a/client/src/ShortcutsHelp.tsx
+++ b/client/src/ShortcutsHelp.tsx
@@ -9,8 +9,8 @@ import { SHORTCUTS, formatKeybind } from "./keyboard";
 const DISPLAY_SHORTCUTS = [
   SHORTCUTS.commandPalette,
   SHORTCUTS.createTerminal,
-  SHORTCUTS.nextTerminal,
-  SHORTCUTS.prevTerminal,
+  SHORTCUTS.nextTerminalTab,
+  SHORTCUTS.prevTerminalTab,
   { ...SHORTCUTS.switchTo1, label: "Switch to terminal 1–9" },
   SHORTCUTS.findInTerminal,
   SHORTCUTS.zoomIn,

--- a/client/src/keyboard.ts
+++ b/client/src/keyboard.ts
@@ -94,6 +94,14 @@ export const SHORTCUTS = {
     keybind: { key: "[", code: "BracketLeft", mod: true, shift: true },
     label: "Previous terminal",
   },
+  nextTerminalTab: {
+    keybind: { key: "Tab", code: "Tab", ctrl: true },
+    label: "Next terminal",
+  },
+  prevTerminalTab: {
+    keybind: { key: "Tab", code: "Tab", ctrl: true, shift: true },
+    label: "Previous terminal",
+  },
   commandPalette: {
     keybind: { key: "k", mod: true },
     label: "Command palette",

--- a/client/src/useShortcuts.ts
+++ b/client/src/useShortcuts.ts
@@ -56,12 +56,18 @@ function dispatch(e: KeyboardEvent, deps: ShortcutDeps): boolean {
     return true;
   }
 
-  if (matchesKeybind(e, SHORTCUTS.nextTerminal.keybind)) {
+  if (
+    matchesKeybind(e, SHORTCUTS.nextTerminal.keybind) ||
+    matchesKeybind(e, SHORTCUTS.nextTerminalTab.keybind)
+  ) {
     cycleTerminal(deps, 1);
     return true;
   }
 
-  if (matchesKeybind(e, SHORTCUTS.prevTerminal.keybind)) {
+  if (
+    matchesKeybind(e, SHORTCUTS.prevTerminal.keybind) ||
+    matchesKeybind(e, SHORTCUTS.prevTerminalTab.keybind)
+  ) {
     cycleTerminal(deps, -1);
     return true;
   }

--- a/tests/features/keyboard-shortcuts.feature
+++ b/tests/features/keyboard-shortcuts.feature
@@ -50,6 +50,20 @@ Feature: Keyboard Shortcuts
     Then the active terminal should show "cycle-third"
     And there should be no page errors
 
+  Scenario: Cycle terminals with Ctrl+Tab shortcuts
+    When I open the app
+    And I create a terminal
+    And I run "echo tab-second"
+    And I create a terminal
+    And I run "echo tab-third"
+    # We're on terminal 3 (last created). Prev should go to terminal 2.
+    When I press the prev terminal tab shortcut
+    Then the active terminal should show "tab-second"
+    # Next should go back to terminal 3.
+    When I press the next terminal tab shortcut
+    Then the active terminal should show "tab-third"
+    And there should be no page errors
+
   Scenario: Create terminal with shortcut
     Given I note the sidebar entry count
     When I press the create terminal shortcut

--- a/tests/step_definitions/keyboard_shortcut_steps.ts
+++ b/tests/step_definitions/keyboard_shortcut_steps.ts
@@ -27,6 +27,22 @@ When("I press the prev terminal shortcut", async function (this: KoluWorld) {
   await this.page.waitForTimeout(200);
 });
 
+When(
+  "I press the next terminal tab shortcut",
+  async function (this: KoluWorld) {
+    await this.page.keyboard.press("Control+Tab");
+    await this.page.waitForTimeout(200);
+  },
+);
+
+When(
+  "I press the prev terminal tab shortcut",
+  async function (this: KoluWorld) {
+    await this.page.keyboard.press("Control+Shift+Tab");
+    await this.page.waitForTimeout(200);
+  },
+);
+
 When("I press the create terminal shortcut", async function (this: KoluWorld) {
   await this.page.keyboard.press(`${MOD_KEY}+t`);
   await this.page.waitForTimeout(500);


### PR DESCRIPTION
**Ctrl+Tab and Ctrl+Shift+Tab now cycle through terminals**, matching the muscle memory from Chrome's tab switching. These work alongside the existing Ctrl+Shift+] / Ctrl+Shift+[ bindings, which remain functional.

The shortcuts help overlay now shows the *Tab variants* as the primary display since they're more discoverable — most users expect Ctrl+Tab to switch tabs.

Closes #135