### PR TITLE
Revert resizable sidebar

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,7 +13,6 @@ import {
 } from "solid-js";
 import { Title } from "@solidjs/meta";
 import { Toaster } from "solid-sonner";
-import Resizable from "@corvu/resizable";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
 import TerminalPane from "./TerminalPane";
@@ -27,9 +26,6 @@ import { useTerminals } from "./useTerminals";
 import { useSidebar } from "./useSidebar";
 import { useShortcuts } from "./useShortcuts";
 import { useSubPanel } from "./useSubPanel";
-
-/** Minimum sidebar panel fraction (below this it collapses to closed). */
-const SIDEBAR_MIN = 0.05;
 
 const App: Component = () => {
   const {
@@ -54,14 +50,7 @@ const App: Component = () => {
     setRandomTheme,
   } = useTerminals();
 
-  const {
-    sidebarOpen,
-    toggleSidebar,
-    closeSidebar,
-    sidebarSize,
-    setSidebarSize,
-    isDesktop,
-  } = useSidebar();
+  const { sidebarOpen, toggleSidebar, closeSidebar } = useSidebar();
   const subPanel = useSubPanel();
 
   // Fetch hostname from server; used in document title and header
@@ -169,102 +158,69 @@ const App: Component = () => {
       />
       {/* relative: anchor for sidebar's absolute overlay on mobile */}
       <div class="relative flex flex-1 min-h-0">
-        <Resizable
-          orientation="horizontal"
-          sizes={
-            sidebarOpen() && isDesktop()
-              ? [sidebarSize(), 1 - sidebarSize()]
-              : [0, 1]
-          }
-          onSizesChange={(sizes) => {
-            const s = sizes[0];
-            // Only persist when panel is meaningfully open (not mid-collapse)
-            if (sidebarOpen() && s !== undefined && s >= SIDEBAR_MIN)
-              setSidebarSize(s);
-          }}
-          class="flex flex-1 min-h-0"
-        >
-          <Resizable.Panel
-            as="div"
-            class="min-w-0 overflow-hidden"
-            minSize={SIDEBAR_MIN}
-            collapsible
-            collapsedSize={0}
-            onCollapse={closeSidebar}
+        <Sidebar
+          terminalIds={terminalIds()}
+          activeId={activeId()}
+          getMeta={getMeta}
+          getActivityHistory={getActivityHistory}
+          getSubTerminalIds={getSubTerminalIds}
+          onSelect={setActiveId}
+          onCreate={() => handleCreate()}
+          onReorder={reorderTerminals}
+          open={sidebarOpen()}
+          onClose={closeSidebar}
+        />
+        {/* min-w-0: override flex min-width:auto so terminal area shrinks below canvas intrinsic size */}
+        <div class="flex-1 min-h-0 min-w-0 p-1">
+          <div
+            class="h-full rounded border border-edge overflow-hidden p-1"
+            style={{ "background-color": activeTheme().background }}
           >
-            <Sidebar
-              terminalIds={terminalIds()}
-              activeId={activeId()}
-              getMeta={getMeta}
-              getActivityHistory={getActivityHistory}
-              getSubTerminalIds={getSubTerminalIds}
-              onSelect={setActiveId}
-              onCreate={() => handleCreate()}
-              onReorder={reorderTerminals}
-              open={sidebarOpen()}
-              onClose={closeSidebar}
-            />
-          </Resizable.Panel>
-
-          <Resizable.Handle
-            class="w-1 bg-edge hover:bg-accent-bright cursor-col-resize shrink-0 transition-colors hidden sm:block"
-            aria-label="Resize sidebar"
-          />
-
-          {/* min-w-0: override flex min-width:auto so terminal area shrinks below canvas intrinsic size */}
-          <Resizable.Panel as="div" class="min-w-0 min-h-0" minSize={0.3}>
-            <div class="h-full p-1">
-              <div
-                class="h-full rounded border border-edge overflow-hidden p-1"
-                style={{ "background-color": activeTheme().background }}
+            <ErrorBoundary
+              fallback={(err) => (
+                <div class="text-danger p-4">
+                  Failed to connect: {String(err)}
+                </div>
+              )}
+            >
+              <Suspense
+                fallback={
+                  <div class="flex items-center justify-center h-full text-fg-3 text-sm">
+                    Connecting...
+                  </div>
+                }
               >
-                <ErrorBoundary
-                  fallback={(err) => (
-                    <div class="text-danger p-4">
-                      Failed to connect: {String(err)}
-                    </div>
-                  )}
-                >
-                  <Suspense
-                    fallback={
-                      <div class="flex items-center justify-center h-full text-fg-3 text-sm">
-                        Connecting...
-                      </div>
-                    }
+                {/* Read the resource to trigger Suspense while it loads */}
+                {void existingTerminals()}
+                <Show when={terminalIds().length === 0}>
+                  <div
+                    data-testid="empty-state"
+                    class="flex items-center justify-center h-full text-fg-3 text-sm"
                   >
-                    {/* Read the resource to trigger Suspense while it loads */}
-                    {void existingTerminals()}
-                    <Show when={terminalIds().length === 0}>
-                      <div
-                        data-testid="empty-state"
-                        class="flex items-center justify-center h-full text-fg-3 text-sm"
-                      >
-                        Click + to create a terminal
-                      </div>
-                    </Show>
-                    <For each={terminalIds()}>
-                      {(id) => (
-                        <TerminalPane
-                          terminalId={id}
-                          visible={activeId() === id}
-                          theme={getTerminalTheme(id)}
-                          searchOpen={searchOpen()}
-                          onSearchOpenChange={setSearchOpen}
-                          subTerminalIds={getSubTerminalIds(id)}
-                          getMeta={getMeta}
-                          onCreateSubTerminal={(parentId, cwd) =>
-                            void handleCreateSubTerminal(parentId, cwd)
-                          }
-                          activeCwd={activeCwd()}
-                        />
-                      )}
-                    </For>
-                  </Suspense>
-                </ErrorBoundary>
-              </div>
-            </div>
-          </Resizable.Panel>
-        </Resizable>
+                    Click + to create a terminal
+                  </div>
+                </Show>
+                <For each={terminalIds()}>
+                  {(id) => (
+                    <TerminalPane
+                      terminalId={id}
+                      visible={activeId() === id}
+                      theme={getTerminalTheme(id)}
+                      searchOpen={searchOpen()}
+                      onSearchOpenChange={setSearchOpen}
+                      subTerminalIds={getSubTerminalIds(id)}
+                      getMeta={getMeta}
+                      onCreateSubTerminal={(parentId, cwd) =>
+                        void handleCreateSubTerminal(parentId, cwd)
+                      }
+                      activeCwd={activeCwd()}
+                    />
+                  )}
+                </For>
+              </Suspense>
+            </ErrorBoundary>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -188,10 +188,10 @@ const Sidebar: Component<{
       {/* Sidebar panel — absolute within content area on mobile, in-flow on desktop */}
       <aside
         data-testid="sidebar"
-        class="flex flex-col w-44 sm:size-full bg-surface-1 border-r border-edge transition-transform duration-200 ease-out z-40"
+        class="flex flex-col w-44 bg-surface-1 border-r border-edge transition-transform duration-200 ease-out z-40"
         classList={{
           "absolute inset-y-0 left-0 sm:relative sm:inset-auto": true,
-          "-translate-x-full": !props.open,
+          "-translate-x-full sm:hidden": !props.open,
           "translate-x-0": props.open,
         }}
       >

--- a/client/src/useSidebar.ts
+++ b/client/src/useSidebar.ts
@@ -1,33 +1,20 @@
-/** Sidebar open/close + width state — singleton module. Syncs with sm breakpoint. */
+/** Sidebar open/close state — singleton module. Syncs with sm breakpoint. */
 
 import { createSignal } from "solid-js";
-import { makePersisted } from "@solid-primitives/storage";
 import { makeEventListener } from "@solid-primitives/event-listener";
 
 const SM_QUERY = window.matchMedia("(min-width: 640px)");
 const [sidebarOpen, setSidebarOpen] = createSignal(SM_QUERY.matches);
-const [isDesktop, setIsDesktop] = createSignal(SM_QUERY.matches);
-
-/** Sidebar panel size as a fraction (0–1). Default ~11rem / typical viewport. */
-const DEFAULT_SIZE = 0.15;
-const [sidebarSize, setSidebarSize] = makePersisted(
-  createSignal(DEFAULT_SIZE),
-  { name: "kolu-sidebar-size" },
-);
 
 // Auto-close on mobile, auto-open on desktop when viewport crosses sm breakpoint
-makeEventListener(SM_QUERY, "change", (e: MediaQueryListEvent) => {
-  setSidebarOpen(e.matches);
-  setIsDesktop(e.matches);
-});
+makeEventListener(SM_QUERY, "change", (e: MediaQueryListEvent) =>
+  setSidebarOpen(e.matches),
+);
 
 export function useSidebar() {
   return {
     sidebarOpen,
     toggleSidebar: () => setSidebarOpen((prev) => !prev),
     closeSidebar: () => setSidebarOpen(false),
-    sidebarSize,
-    setSidebarSize,
-    isDesktop,
   } as const;
 }

--- a/tests/features/responsive.feature
+++ b/tests/features/responsive.feature
@@ -39,14 +39,6 @@ Feature: Responsive sidebar layout
     When I select terminal 1 in the sidebar
     Then the sidebar should not be visible
 
-  Scenario: Sidebar resize handle is visible on desktop
-    Then the sidebar resize handle should be visible
-
-  Scenario: Dragging resize handle changes sidebar width
-    Given I note the sidebar width
-    When I drag the sidebar resize handle 100 pixels to the right
-    Then the sidebar should be wider than before
-
   Scenario: Sidebar does not overlap header on mobile
     When I resize the viewport to 375x667
     And I click the sidebar toggle

--- a/tests/step_definitions/responsive_steps.ts
+++ b/tests/step_definitions/responsive_steps.ts
@@ -1,55 +1,6 @@
-import { Given, When, Then } from "@cucumber/cucumber";
+import { When, Then } from "@cucumber/cucumber";
 import { KoluWorld } from "../support/world.ts";
 import * as assert from "node:assert";
-
-Then(
-  "the sidebar resize handle should be visible",
-  async function (this: KoluWorld) {
-    const handle = this.page.locator('[aria-label="Resize sidebar"]');
-    const visible = await handle.isVisible();
-    assert.ok(visible, "Expected sidebar resize handle to be visible");
-  },
-);
-
-Given("I note the sidebar width", async function (this: KoluWorld) {
-  const sidebar = this.page.locator('[data-testid="sidebar"]');
-  const box = await sidebar.boundingBox();
-  assert.ok(box, "Sidebar has no bounding box");
-  this.savedSidebarWidth = box.width;
-});
-
-When(
-  "I drag the sidebar resize handle {int} pixels to the right",
-  async function (this: KoluWorld, pixels: number) {
-    const handle = this.page.locator('[aria-label="Resize sidebar"]');
-    const box = await handle.boundingBox();
-    assert.ok(box, "Resize handle has no bounding box");
-    const x = box.x + box.width / 2;
-    const y = box.y + box.height / 2;
-    await this.page.mouse.move(x, y);
-    await this.page.mouse.down();
-    await this.page.mouse.move(x + pixels, y, { steps: 10 });
-    await this.page.mouse.up();
-    await this.page.waitForTimeout(300);
-  },
-);
-
-Then(
-  "the sidebar should be wider than before",
-  async function (this: KoluWorld) {
-    const sidebar = this.page.locator('[data-testid="sidebar"]');
-    const box = await sidebar.boundingBox();
-    assert.ok(box, "Sidebar has no bounding box");
-    assert.ok(
-      this.savedSidebarWidth !== undefined,
-      "No saved sidebar width — did you forget 'I note the sidebar width'?",
-    );
-    assert.ok(
-      box.width > this.savedSidebarWidth!,
-      `Expected sidebar to be wider (was ${this.savedSidebarWidth}, now ${box.width})`,
-    );
-  },
-);
 
 When("I click the sidebar toggle", async function (this: KoluWorld) {
   await this.page.locator('[data-testid="sidebar-toggle"]').click();

--- a/tests/support/world.ts
+++ b/tests/support/world.ts
@@ -36,7 +36,6 @@ export class KoluWorld extends World {
   lastResponseOk?: boolean;
   terminalCountBeforeRefresh?: number;
   savedSidebarCount?: number;
-  savedSidebarWidth?: number;
   createdTerminalIds: string[] = [];
 
   get canvas(): Locator {


### PR DESCRIPTION
**Reverts the resizable sidebar feature** (#145) and its follow-up lock fix (#150) — the resize behavior was broken.

*Clean revert of both commits; sidebar goes back to its pre-drag-handle state.*