### PR TITLE
Sharpen README: ADE description + Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # kolu
 
-Web-based [Agenting Development Environment](https://x.com/jdegoes/status/2036931874057314390) (ADE) built on terminals.
+Web-based [Agentic Development Environment](https://x.com/jdegoes/status/2036931874057314390) (ADE) built on terminals.
 
 Named after [கோலு](<https://en.wikipedia.org/wiki/Golu_(festival)>), the tradition of arranging figures on tiered steps.
 


### PR DESCRIPTION
**Updated the project description** from a generic terminal-multiplexer blurb to position kolu as a web-based Agenting Development Environment (ADE) built on terminals — reflecting what it actually is now.

Moved the production run instructions near the top as a **Usage** section with `nix run github:juspay/kolu`, so newcomers see how to try it immediately. *The old Production section was buried below Architecture and Development, which isn't where you want your "try it now" command.*

### Try it locally
`nix run github:juspay/kolu/docs/readme-update`