### PR TITLE
Replace screenState RPC with client-side xterm buffer reads

### DIFF
--- a/tests/step_definitions/scroll_lock_steps.ts
+++ b/tests/step_definitions/scroll_lock_steps.ts
@@ -20,7 +20,7 @@ When(
     await this.terminalRun(
       `for i in $(seq 1 ${count}); do echo scroll-test-$i; done`,
     );
-    await pollUntilBufferContains(this, `scroll-test-${count}`);
+    await pollUntilBufferContains(this.page, `scroll-test-${count}`);
   },
 );
 
@@ -30,7 +30,7 @@ When(
     await this.terminalRun(
       `for i in $(seq 1 ${count}); do echo extra-line-$i; done`,
     );
-    await pollUntilBufferContains(this, `extra-line-${count}`);
+    await pollUntilBufferContains(this.page, `extra-line-${count}`);
   },
 );
 
@@ -65,7 +65,7 @@ When("I fire the output trigger", async function (this: KoluWorld) {
   // entirely, so scrollOnUserInput doesn't interfere with scroll lock state.
   const lines = Array.from({ length: 10 }, (_, i) => `triggered-${i + 1}`);
   await writeFile(scrollFifo(this), lines.join("\n") + "\n");
-  await pollUntilBufferContains(this, "triggered-10");
+  await pollUntilBufferContains(this.page, "triggered-10");
 });
 
 When(
@@ -73,34 +73,20 @@ When(
   async function (this: KoluWorld, count: number) {
     const lines = Array.from({ length: count }, (_, i) => `triggered-${i + 1}`);
     await writeFile(scrollFifo(this), lines.join("\n") + "\n");
-    await pollUntilBufferContains(this, `triggered-${count}`);
+    await pollUntilBufferContains(this.page, `triggered-${count}`);
   },
 );
 
-/**
- * Read text of the first visible row from the xterm buffer.
- * Uses the __xterm ref exposed on the container element.
- */
+/** Read the first visible row from the xterm buffer at the current viewport position. */
 function readFirstVisibleLine(world: KoluWorld) {
   return world.page.evaluate(() => {
     const container = document.querySelector(
       "[data-visible][data-terminal-id]",
-    ) as HTMLElement & {
-      __xterm?: {
-        buffer: {
-          active: {
-            viewportY: number;
-            getLine(
-              y: number,
-            ): { translateToString(trimRight?: boolean): string } | undefined;
-          };
-        };
-      };
-    };
-    const term = container?.__xterm;
+    );
+    const term = (container as any)?.__xterm;
     if (!term) return "";
-    const vY = term.buffer.active.viewportY;
-    return term.buffer.active.getLine(vY)?.translateToString(true) ?? "";
+    const buf = term.buffer.active;
+    return buf.getLine(buf.viewportY)?.translateToString(true) ?? "";
   });
 }
 

--- a/tests/step_definitions/sidebar_steps.ts
+++ b/tests/step_definitions/sidebar_steps.ts
@@ -77,6 +77,6 @@ Then(
 Then(
   "the active terminal should show {string}",
   async function (this: KoluWorld, expected: string) {
-    await pollUntilBufferContains(this, expected);
+    await pollUntilBufferContains(this.page, expected);
   },
 );

--- a/tests/step_definitions/sub_terminal_steps.ts
+++ b/tests/step_definitions/sub_terminal_steps.ts
@@ -103,7 +103,7 @@ Then(
     await this.page.keyboard.type(`echo ${marker}`);
     await this.page.keyboard.press("Enter");
     // Poll the first visible terminal's buffer for the marker
-    await pollUntilBufferContains(this, marker, {
+    await pollUntilBufferContains(this.page, marker, {
       selector: "[data-terminal-id][data-visible]",
       attempts: 20,
       intervalMs: 300,
@@ -212,7 +212,7 @@ Then(
   "the sub-terminal screen should contain {string}",
   async function (this: KoluWorld, expected: string) {
     // Sub-terminal is the second visible terminal container (index 1)
-    await pollUntilBufferContains(this, expected, {
+    await pollUntilBufferContains(this.page, expected, {
       selector: "[data-terminal-id][data-visible]",
       index: 1,
       attempts: 20,

--- a/tests/step_definitions/terminal_steps.ts
+++ b/tests/step_definitions/terminal_steps.ts
@@ -86,7 +86,7 @@ Given("I note the font size", async function (this: KoluWorld) {
 Then(
   "the screen state should contain {string}",
   async function (this: KoluWorld, expected: string) {
-    await pollUntilBufferContains(this, expected);
+    await pollUntilBufferContains(this.page, expected);
   },
 );
 

--- a/tests/support/buffer.ts
+++ b/tests/support/buffer.ts
@@ -5,13 +5,12 @@
  */
 
 import type { Page } from "playwright";
-import type { KoluWorld } from "./world.ts";
 
 /** Default selector for the active (visible) terminal container. */
 const ACTIVE_TERMINAL = "[data-visible][data-terminal-id]";
 
 /**
- * Read all non-empty lines from a terminal's xterm buffer.
+ * Read all lines from a terminal's xterm buffer (joined by newline).
  * @param index — when multiple terminals match the selector, pick the Nth (0-based). Default: 0.
  */
 export function readBufferText(
@@ -42,7 +41,7 @@ export function readBufferText(
  * Returns the full buffer content on match, or throws on timeout.
  */
 export async function pollUntilBufferContains(
-  world: KoluWorld,
+  page: Page,
   expected: string,
   {
     selector = ACTIVE_TERMINAL,
@@ -53,9 +52,9 @@ export async function pollUntilBufferContains(
 ): Promise<string> {
   let content = "";
   for (let i = 0; i < attempts; i++) {
-    content = await readBufferText(world.page, selector, index);
+    content = await readBufferText(page, selector, index);
     if (content.includes(expected)) return content;
-    await world.page.waitForTimeout(intervalMs);
+    await page.waitForTimeout(intervalMs);
   }
   throw new Error(
     `Buffer does not contain "${expected}" after ${attempts} attempts.\nBuffer (partial): ${content.slice(0, 500)}`,


### PR DESCRIPTION
**E2e tests now read terminal content directly from the xterm.js buffer** instead of making HTTP round-trips to `/rpc/terminal/screenState`. A new `pollUntilBufferContains` helper in `tests/support/buffer.ts` uses the `__xterm` ref (exposed on container elements since #162) to poll the client-side buffer for expected text — instant reads, no serialization overhead, no server dependency.

All five `screenState` polling sites across `terminal_steps`, `sidebar_steps`, and `sub_terminal_steps` are replaced, along with four fixed-delay `waitForTimeout` sleeps in `scroll_lock_steps` that now poll for specific output text instead of guessing how long to wait. *Scroll position checks still use `scrollTop` since scroll lock operates at the DOM level, not the xterm buffer level.*

The net result is ~40 fewer lines of test code, elimination of the `fetchActiveScreenState` helper and its retry machinery, and deterministic waits that finish as soon as content appears rather than burning a fixed 1-2s per step.

Closes #163