### PR TITLE
Whitelist env vars for PTY shells in nix dev mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ test-quick *args: install
     trap 'rm -f "$wrapper"' EXIT
     cat > "$wrapper" <<SCRIPT
     #!/bin/sh
-    KOLU_CLIENT_DIST="$PWD/client/dist" exec tsx "$PWD/server/src/index.ts" --allow-nix-shell-with-env-whitelist "\$@"
+    KOLU_CLIENT_DIST="$PWD/client/dist" exec tsx "$PWD/server/src/index.ts" --allow-nix-shell-with-env-whitelist default "\$@"
     SCRIPT
     chmod +x "$wrapper"
     cd tests

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {
-    "dev": "node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist",
+    "dev": "node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,10 +50,9 @@ const argv = cli({
       default: false,
     },
     allowNixShellWithEnvWhitelist: {
-      type: Boolean,
+      type: String,
       description:
-        "Allow running inside a nix shell, forwarding only essential env vars to PTY shells (dev/test only)",
-      default: false,
+        "Allow running inside a nix shell, forwarding only these comma-separated env vars to PTY shells (dev/test only). Uses built-in default list if set to 'default'.",
     },
   },
   strictFlags: true,

--- a/server/src/shell.ts
+++ b/server/src/shell.ts
@@ -13,34 +13,27 @@ import { writeFileSync, rmSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 
 /**
- * Env vars safe to forward from a nix devshell to PTY shells.
+ * Default env vars safe to forward from a nix devshell to PTY shells.
  * Everything else (NIX_*, DIRENV_*, derivation vars) is excluded.
+ * Exported so callers can pass it as the default whitelist value.
  */
-const NIX_ENV_WHITELIST = new Set([
-  "HOME",
-  "USER",
-  "PATH",
-  "TERM",
-  "LANG",
-  "LC_ALL",
-  "LOGNAME",
-  "DISPLAY",
-  "COLORTERM",
-  "TERM_PROGRAM",
-]);
+export const NIX_ENV_WHITELIST =
+  "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM,TERM_PROGRAM";
 
-/** Whether to use the whitelist; set once at startup by configureNixShellEnv. */
-let useEnvWhitelist = false;
+/** Whitelist set once at startup; undefined means passthrough mode (production). */
+let envWhitelist: Set<string> | undefined;
 
 /**
  * Configure nix shell env handling at startup.
  *
- * When enabled: cleanEnv() will only forward NIX_ENV_WHITELIST vars.
- * When disabled: crash if IN_NIX_SHELL is set (production safety net).
+ * - "default"       → use NIX_ENV_WHITELIST
+ * - "FOO,BAR,..."   → use custom whitelist
+ * - undefined       → crash if IN_NIX_SHELL is set (production safety net)
  */
-export function configureNixShellEnv(enabled: boolean): void {
-  if (enabled) {
-    useEnvWhitelist = true;
+export function configureNixShellEnv(whitelist: string | undefined): void {
+  if (whitelist != null) {
+    const list = whitelist === "default" ? NIX_ENV_WHITELIST : whitelist;
+    envWhitelist = new Set(list.split(",").filter(Boolean));
     return;
   }
   if (!process.env.IN_NIX_SHELL) return;
@@ -61,9 +54,9 @@ export function configureNixShellEnv(enabled: boolean): void {
  */
 export function cleanEnv(): Record<string, string> {
   let env: Record<string, string>;
-  if (useEnvWhitelist) {
+  if (envWhitelist) {
     env = {};
-    for (const key of NIX_ENV_WHITELIST) {
+    for (const key of envWhitelist) {
       if (process.env[key] != null) env[key] = process.env[key]!;
     }
     // Nix sets SHELL to /nix/store/.../bash which lacks features like progcomp

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -72,7 +72,12 @@ BeforeAll(async function () {
     console.log(`[worker:${workerId}] Starting server on port ${port}...`);
     serverProcess = spawn(
       koluServer,
-      ["--allow-nix-shell-with-env-whitelist", "--port", String(port)],
+      [
+        "--allow-nix-shell-with-env-whitelist",
+        "default",
+        "--port",
+        String(port),
+      ],
       {
         stdio: "pipe",
       },


### PR DESCRIPTION
**Replaces `--allow-nix-shell-env` with `--allow-nix-shell-with-env-whitelist`**, which takes a comma-separated list of env var names to forward to PTY shells. PR #164 fixed nix env pollution for production by rejecting startup inside nix shells entirely, but `just dev` still passed everything through — causing `progcomp` errors from nix's bash and direnv state leaking into user terminals.

Now when running inside `nix develop`, only the explicitly listed vars (HOME, USER, TERM, etc.) reach spawned shells, and SHELL is always overridden with the user's login shell from `/etc/passwd`. *Production deployments are unchanged — they still hard-fail if accidentally run inside a nix shell without the flag.*

### Try it locally
`nix run github:juspay/kolu/feat/nix-shell-env-whitelist`