### PR TITLE
Fix command palette search focus on reopen

### DIFF
--- a/client/src/CommandPalette.tsx
+++ b/client/src/CommandPalette.tsx
@@ -186,6 +186,11 @@ const CommandPalette: Component<{
             : undefined;
           setPath(group ? [group] : []);
           didSelect = false;
+          // forceMount keeps the dialog in the DOM, so Corvu's initialFocusEl
+          // only fires on first mount. Re-focus explicitly on every open.
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => inputRef.focus()),
+          );
         } else {
           if (!didSelect) for (const g of path()) g.onCancel?.();
           didSelect = false;

--- a/tests/features/theme.feature
+++ b/tests/features/theme.feature
@@ -68,6 +68,17 @@ Feature: Theme switching
     Then the header theme should differ from "Tomorrow Night"
     And there should be no page errors
 
+  Scenario: Reopening theme palette refocuses search input
+    When I click the theme name in the header
+    Then the command palette should be visible
+    And the palette search input should be focused
+    When I press Escape
+    Then the command palette should not be visible
+    When I click the theme name in the header
+    Then the command palette should be visible
+    And the palette search input should be focused
+    And there should be no page errors
+
   Scenario: Each terminal has independent theme
     When I open the command palette
     And I select "Theme" in the palette


### PR DESCRIPTION
**Reopening the command palette now correctly focuses the search input.** The palette uses Corvu's `forceMount` to avoid mount lag, but this means `initialFocusEl` only fires on the first mount — subsequent opens left the searchbox unfocused.

The fix is a double-`requestAnimationFrame` focus call in the open effect, matching the timing Corvu uses internally. *Minimal change, no new abstractions.*

E2e test added: open theme palette via header click, close with Escape, reopen, verify search input has focus.