### PR TITLE
Increase scrollback to 10,000 lines

### DIFF
--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -26,6 +26,7 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { ImageAddon } from "@xterm/addon-image";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import "@xterm/xterm/css/xterm.css";
+import { DEFAULT_SCROLLBACK } from "kolu-common/config";
 import { FONT_FAMILY } from "./theme";
 import { client } from "./rpc";
 import { matchesAnyShortcut } from "./keyboard";
@@ -181,6 +182,7 @@ const Terminal: Component<{
       fontFamily: FONT_FAMILY,
       theme: props.theme,
       fontSize: fontSize(),
+      scrollback: DEFAULT_SCROLLBACK,
       cursorBlink: true,
       // Required by SerializeAddon and ImageAddon for buffer access
       allowProposedApi: true,

--- a/common/src/config.ts
+++ b/common/src/config.ts
@@ -15,5 +15,8 @@ export const DEFAULT_PORT = 7681;
 /** Default font size for the terminal (px). */
 export const DEFAULT_FONT_SIZE = 14;
 
+/** Scrollback buffer size in lines. Matches Ghostty's ~10K default. */
+export const DEFAULT_SCROLLBACK = 10_000;
+
 /** Seconds of no PTY output before a terminal is considered idle/sleeping. */
 export const ACTIVITY_IDLE_THRESHOLD_S = 5;

--- a/server/src/pty.ts
+++ b/server/src/pty.ts
@@ -7,7 +7,11 @@
  */
 import * as pty from "node-pty";
 import { createRequire } from "node:module";
-import { DEFAULT_COLS, DEFAULT_ROWS } from "kolu-common/config";
+import {
+  DEFAULT_COLS,
+  DEFAULT_ROWS,
+  DEFAULT_SCROLLBACK,
+} from "kolu-common/config";
 import { cleanEnv, osc7Init } from "./shell.ts";
 import type { Logger } from "./log.ts";
 
@@ -71,6 +75,7 @@ export function spawnPty(
   const headless = new Terminal({
     cols: DEFAULT_COLS,
     rows: DEFAULT_ROWS,
+    scrollback: DEFAULT_SCROLLBACK,
     allowProposedApi: true,
   });
   const serializeAddon = new SerializeAddon();

--- a/tests/features/terminal.feature
+++ b/tests/features/terminal.feature
@@ -54,6 +54,12 @@ Feature: Terminal
     And the screen state should have at least 50 lines
     And there should be no page errors
 
+  Scenario: Scrollback retains more than 1000 lines
+    When I generate 2000 lines of output
+    Then the screen state should contain "scroll-test-1"
+    And the screen state should contain "scroll-test-2000"
+    And there should be no page errors
+
   Scenario: Clicking terminal focuses input
     When I click the terminal canvas
     Then the terminal input should be focused


### PR DESCRIPTION
**Bumps the scrollback buffer from xterm.js's default of 1,000 lines to 10,000**, matching Ghostty's default. Both the client-side `Terminal` and server-side headless xterm instance now use a shared `DEFAULT_SCROLLBACK` constant from `common/src/config.ts`.

The old 1,000-line default was too small for agentic workflows — a single `nix build` or CI run easily exceeds it, and the upcoming tmux shim (#185) will expose `capture-pane -S -` (all history) where a shallow buffer is a real limitation. *Memory impact is ~30-40 MB per terminal at 80 columns, reasonable for desktop use.*

> `TerminalPreview` intentionally keeps `scrollback: 0` — it's read-only with no scrolling, unchanged by this PR.

Closes #188