### PR TITLE
Fix settings popover invisible behind header clip

### DIFF
--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -48,6 +48,7 @@ const Header: Component<{
 }> = (rawProps) => {
   const props = mergeProps({ status: "connecting" as const }, rawProps);
   const { showTipOnce } = useTips();
+  let settingsTriggerRef!: HTMLButtonElement;
   const [settingsOpen, setSettingsOpen] = createSignal(false);
 
   return (
@@ -151,9 +152,10 @@ const Header: Component<{
             <SearchIcon />
           </button>
         </Tip>
-        <div class="relative">
+        <div>
           <Tip label="Settings">
             <button
+              ref={settingsTriggerRef}
               data-testid="settings-trigger"
               class="h-7 w-7 flex items-center justify-center text-fg-2 hover:text-fg hover:bg-surface-2 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
               onClick={() => setSettingsOpen(!settingsOpen())}
@@ -164,6 +166,7 @@ const Header: Component<{
           <SettingsPopover
             open={settingsOpen()}
             onOpenChange={setSettingsOpen}
+            triggerRef={settingsTriggerRef}
             randomTheme={props.randomTheme ?? true}
             onRandomThemeChange={(on) => props.onRandomThemeChange?.(on)}
             scrollLock={props.scrollLock ?? true}

--- a/client/src/SettingsPopover.tsx
+++ b/client/src/SettingsPopover.tsx
@@ -1,6 +1,7 @@
 /** Settings popover — toggleable settings anchored to a trigger button. */
 
-import { type Component, Show, For } from "solid-js";
+import { type Component, Show, For, createSignal } from "solid-js";
+import { Portal } from "solid-js/web";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import Toggle from "./Toggle";
 import type { ColorScheme } from "./useColorScheme";
@@ -14,6 +15,7 @@ const SCHEME_OPTIONS: { value: ColorScheme; label: string }[] = [
 const SettingsPopover: Component<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  triggerRef?: HTMLElement;
   randomTheme: boolean;
   onRandomThemeChange: (on: boolean) => void;
   scrollLock: boolean;
@@ -24,10 +26,23 @@ const SettingsPopover: Component<{
   onStartupTipsChange: (on: boolean) => void;
 }> = (props) => {
   let panelRef: HTMLDivElement | undefined;
+  const [pos, setPos] = createSignal({ top: 0, right: 0 });
 
-  // Close on click outside
+  // Recompute position each time popover opens
+  const updatePos = () => {
+    if (!props.triggerRef) return;
+    const rect = props.triggerRef.getBoundingClientRect();
+    setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+  };
+
+  // Close on click outside (ignore clicks on the trigger itself)
   makeEventListener(document, "mousedown", (e) => {
-    if (props.open && panelRef && !panelRef.contains(e.target as Node)) {
+    if (
+      props.open &&
+      panelRef &&
+      !panelRef.contains(e.target as Node) &&
+      !props.triggerRef?.contains(e.target as Node)
+    ) {
       props.onOpenChange(false);
     }
   });
@@ -41,64 +56,71 @@ const SettingsPopover: Component<{
 
   return (
     <Show when={props.open}>
-      <div
-        ref={panelRef}
-        data-testid="settings-popover"
-        class="absolute right-0 top-full mt-1 z-50 bg-surface-1 border border-edge-bright rounded-lg shadow-lg p-3 min-w-[200px] space-y-3"
-      >
-        {/* Color scheme */}
-        <div class="flex items-center justify-between gap-3 text-sm">
-          <span class="text-fg-2">Theme</span>
-          <div
-            data-testid="color-scheme-toggle"
-            class="flex rounded-md overflow-hidden border border-edge"
-          >
-            <For each={SCHEME_OPTIONS}>
-              {(opt) => (
-                <button
-                  data-testid={`color-scheme-${opt.value}`}
-                  class="px-2 py-0.5 text-xs transition-colors cursor-pointer"
-                  classList={{
-                    "bg-accent text-surface-0": props.colorScheme === opt.value,
-                    "bg-surface-2 text-fg-2 hover:text-fg":
-                      props.colorScheme !== opt.value,
-                  }}
-                  onClick={() => props.onColorSchemeChange(opt.value)}
-                >
-                  {opt.label}
-                </button>
-              )}
-            </For>
+      <Portal>
+        <div
+          ref={(el) => {
+            panelRef = el;
+            updatePos();
+          }}
+          data-testid="settings-popover"
+          class="fixed z-50 bg-surface-1 border border-edge-bright rounded-lg shadow-lg p-3 min-w-[200px] space-y-3"
+          style={{ top: `${pos().top}px`, right: `${pos().right}px` }}
+        >
+          {/* Color scheme */}
+          <div class="flex items-center justify-between gap-3 text-sm">
+            <span class="text-fg-2">Theme</span>
+            <div
+              data-testid="color-scheme-toggle"
+              class="flex rounded-md overflow-hidden border border-edge"
+            >
+              <For each={SCHEME_OPTIONS}>
+                {(opt) => (
+                  <button
+                    data-testid={`color-scheme-${opt.value}`}
+                    class="px-2 py-0.5 text-xs transition-colors cursor-pointer"
+                    classList={{
+                      "bg-accent text-surface-0":
+                        props.colorScheme === opt.value,
+                      "bg-surface-2 text-fg-2 hover:text-fg":
+                        props.colorScheme !== opt.value,
+                    }}
+                    onClick={() => props.onColorSchemeChange(opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                )}
+              </For>
+            </div>
           </div>
+          {/* Random terminal theme */}
+          <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
+            <span class="text-fg-2">Random theme</span>
+            <Toggle
+              testId="random-theme-toggle"
+              enabled={props.randomTheme}
+              onChange={props.onRandomThemeChange}
+            />
+          </label>
+          {/* Scroll lock */}
+          <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
+            <span class="text-fg-2">Scroll lock</span>
+            <Toggle
+              testId="scroll-lock-toggle"
+              enabled={props.scrollLock}
+              onChange={props.onScrollLockChange}
+            />
+          </label>
+          {/* Startup tips */}
+          <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
+            <span class="text-fg-2">Startup tips</span>
+            <Toggle
+              testId="startup-tips-toggle"
+              enabled={props.startupTips}
+              onChange={props.onStartupTipsChange}
+            />
+          </label>
         </div>
-        {/* Random terminal theme */}
-        <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
-          <span class="text-fg-2">Random theme</span>
-          <Toggle
-            testId="random-theme-toggle"
-            enabled={props.randomTheme}
-            onChange={props.onRandomThemeChange}
-          />
-        </label>
-        {/* Scroll lock */}
-        <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
-          <span class="text-fg-2">Scroll lock</span>
-          <Toggle
-            testId="scroll-lock-toggle"
-            enabled={props.scrollLock}
-            onChange={props.onScrollLockChange}
-          />
-        </label>
-        {/* Startup tips */}
-        <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
-          <span class="text-fg-2">Startup tips</span>
-          <Toggle
-            testId="startup-tips-toggle"
-            enabled={props.startupTips}
-            onChange={props.onStartupTipsChange}
-          />
-        </label>
-      </div>
+      </Portal>
     </Show>
   );
 };


### PR DESCRIPTION
**Settings gear icon did nothing when clicked** — the popover rendered inside the `<header>` which has `overflow-hidden`, so it was clipped the moment it appeared below the header bar.

Portals the popover out of the header DOM via `<Portal>` and positions it with `fixed` coordinates anchored to the trigger button. *Also fixes the click-outside handler to exclude the trigger itself*, which would have caused a close-then-reopen race when toggling off.