### PR TITLE
Fix flaky worktree e2e tests via reactive refetch

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -141,10 +141,16 @@ const App: Component = () => {
 
   const { refetch: refetchRecentRepos } = useRecentRepos();
 
+  // Refetch recent repos whenever the palette opens, regardless of how (Ctrl+K, header click, etc.)
+  createEffect(
+    on(paletteOpen, (open) => {
+      if (open) refetchRecentRepos();
+    }),
+  );
+
   function openPalette() {
     setPaletteInitialGroup(undefined);
     setPaletteOpen(true);
-    refetchRecentRepos();
   }
 
   /** Wrap a boolean setter so closing any dialog refocuses the terminal. */


### PR DESCRIPTION
**Worktree-related e2e tests flaked because the recent repos list was stale when the palette opened via Ctrl+K.** The keyboard shortcut called `setPaletteOpen` directly, bypassing `openPalette()` which was the only path that triggered `refetchRecentRepos()`. So the "New worktree…" picker showed repos from the initial page load — before the test had `cd`'d into the git repo.

The fix moves the refetch into a `createEffect` on `paletteOpen`, so it fires *regardless of how the palette is opened* — keyboard shortcut, header button, or any future trigger. This also simplifies `openPalette()` by removing the explicit refetch call.