### PR TITLE
Stream recent repos live instead of one-shot RPC

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -139,15 +139,6 @@ const App: Component = () => {
     handleCopyTerminalText: () => void handleCopyTerminalText(),
   });
 
-  const { refetch: refetchRecentRepos } = useRecentRepos();
-
-  // Refetch recent repos whenever the palette opens, regardless of how (Ctrl+K, header click, etc.)
-  createEffect(
-    on(paletteOpen, (open) => {
-      if (open) refetchRecentRepos();
-    }),
-  );
-
   function openPalette() {
     setPaletteInitialGroup(undefined);
     setPaletteOpen(true);

--- a/client/src/useRecentRepos.ts
+++ b/client/src/useRecentRepos.ts
@@ -1,14 +1,25 @@
-/** Recent repos — fetched from server for worktree creation without needing an active git terminal. */
+/** Recent repos — live-streamed from server for worktree creation. */
 
-import { createResource } from "solid-js";
+import { createSignal } from "solid-js";
 import { client } from "./rpc";
 import type { RecentRepo } from "kolu-common";
 
-const [recentRepos, { refetch }] = createResource<RecentRepo[]>(
-  () => client.git.recentRepos(),
-  { initialValue: [] },
-);
+const [recentRepos, setRecentRepos] = createSignal<RecentRepo[]>([]);
+
+// Subscribe to the live stream — first value is the current list, then updates.
+const controller = new AbortController();
+(async () => {
+  try {
+    const stream = await client.git.onRecentReposChange(
+      {},
+      { signal: controller.signal },
+    );
+    for await (const repos of stream) setRecentRepos(repos);
+  } catch {
+    // Stream aborted — expected on cleanup
+  }
+})();
 
 export function useRecentRepos() {
-  return { recentRepos, refetch };
+  return { recentRepos };
 }

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -73,5 +73,7 @@ export const contract = oc.router({
       .output(WorktreeCreateOutputSchema),
     worktreeRemove: oc.input(WorktreeRemoveInputSchema).output(z.void()),
     recentRepos: oc.output(z.array(RecentRepoSchema)),
+    // Stream recent repos changes (yields current list immediately, then updates)
+    onRecentReposChange: oc.output(eventIterator(z.array(RecentRepoSchema))),
   },
 });

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -23,7 +23,8 @@ import { saveClipboardImage } from "./clipboard.ts";
 import { subscribeAndYield } from "./streaming.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import { worktreeCreate, worktreeRemove } from "./git.ts";
-import { getRecentRepos } from "./state.ts";
+import { getRecentRepos, stateEvents } from "./state.ts";
+import type { RecentRepo } from "kolu-common";
 
 const t = implement(contract);
 
@@ -164,5 +165,16 @@ export const appRouter = t.router({
       await worktreeRemove(input.worktreePath);
     }),
     recentRepos: t.git.recentRepos.handler(async () => getRecentRepos()),
+    onRecentReposChange: t.git.onRecentReposChange.handler(async function* ({
+      signal,
+    }) {
+      const live = subscribeAndYield<RecentRepo[]>(
+        stateEvents,
+        "recentRepos",
+        signal,
+      );
+      yield getRecentRepos();
+      yield* live;
+    }),
   },
 });

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -6,9 +6,13 @@
  * corrupt/missing files can safely reset to defaults.
  */
 
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import Conf from "conf";
 import type { RecentRepo } from "kolu-common";
+
+/** Emits state change events for streaming to clients. */
+export const stateEvents = new EventEmitter();
 
 interface StateSchema {
   recentRepos: RecentRepo[];
@@ -39,6 +43,7 @@ export function trackRecentRepo(repoRoot: string, repoName: string): void {
   // Sort most-recent first, then trim
   repos.sort((a, b) => b.lastSeen - a.lastSeen);
   store.set("recentRepos", repos.slice(0, MAX_RECENT_REPOS));
+  stateEvents.emit("recentRepos", getRecentRepos());
 }
 
 /** Get recent repos, most-recently-seen first. Filters out repos that no longer exist on disk. */


### PR DESCRIPTION
**Recent repos now stream from the server in real-time** instead of being fetched once and manually refetched when the palette opens. When a terminal \`cd\`s into a new git repo, the worktree dialog updates immediately — no refetch, no polling.

The server adds an EventEmitter to \`state.ts\` that fires on \`trackRecentRepo()\` mutations, and a new \`onRecentReposChange\` streaming endpoint using the existing \`subscribeAndYield\` pattern. The client replaces \`createResource\` + manual \`refetch\` with a \`subscribeStream\` call — *the same pattern already used for terminal metadata, activity, and exit streams*. Zero new dependencies, one paradigm.

> This is the minimal version of #229. The TanStack Query approach in #232 adds caching/mutation abstractions but doesn't earn its complexity for this use case — direct oRPC streaming is simpler and consistent with the rest of the codebase.

### Try it locally
\`nix run github:juspay/kolu/feat/reactive-recent-repos\`

Closes #229