### PR TITLE
Decouple alerts from streams via reactive store watching

### DIFF
--- a/client/src/useTerminalAlerts.ts
+++ b/client/src/useTerminalAlerts.ts
@@ -1,22 +1,41 @@
-/** Terminal alerts — detect Claude state transitions and fire notifications. */
+/** Terminal alerts — reactively detect Claude state transitions and fire notifications.
+ *  Watches the terminal store for Claude state changes instead of being called via callback. */
 
-import type { Accessor } from "solid-js";
+import { type Accessor, createEffect } from "solid-js";
 import type { TerminalId } from "kolu-common";
 import {
   fireActivityAlert,
   requestNotificationPermission,
 } from "./useActivityAlerts";
-import type { SetTerminalMeta } from "./useTerminalStore";
+import type { TerminalMetaStore, SetTerminalMeta } from "./useTerminalStore";
 
 export function useTerminalAlerts(deps: {
   activityAlerts: Accessor<boolean>;
   activeId: Accessor<TerminalId | null>;
+  meta: TerminalMetaStore;
   setMeta: SetTerminalMeta;
   terminalIds: Accessor<TerminalId[]>;
   terminalLabel: (id: TerminalId) => string;
 }) {
   // Request browser notification permission eagerly when alerts are enabled
   if (deps.activityAlerts()) requestNotificationPermission();
+
+  // Track previous Claude state per terminal for transition detection.
+  const prevStates = new Map<TerminalId, string | undefined>();
+
+  // Reactively watch Claude state for all terminals.
+  // Re-runs when terminalIds change or any terminal's Claude state changes.
+  createEffect(() => {
+    for (const id of deps.terminalIds()) {
+      const state = deps.meta[id]?.meta?.claude?.state;
+      const prev = prevStates.get(id);
+      // Skip initial observation (prev not yet tracked) — only fire on transitions
+      if (prev !== undefined) {
+        checkClaudeFinished(id, prev, state);
+      }
+      prevStates.set(id, state);
+    }
+  });
 
   /** Alert when Claude transitions to "waiting" on a terminal. */
   function checkClaudeFinished(
@@ -43,5 +62,5 @@ export function useTerminalAlerts(deps: {
     fireActivityAlert(deps.terminalLabel(id));
   }
 
-  return { checkClaudeFinished, simulateAlert };
+  return { simulateAlert };
 }

--- a/client/src/useTerminalStreams.ts
+++ b/client/src/useTerminalStreams.ts
@@ -1,8 +1,9 @@
-/** Terminal streams — server event subscriptions for metadata, activity, and exit. */
+/** Terminal streams — server event subscriptions for metadata, activity, and exit.
+ *  Streams write to the store. Alert detection is handled reactively elsewhere. */
 
 import type { TerminalId } from "kolu-common";
 import { client } from "./rpc";
-import type { TerminalMetaStore, SetTerminalMeta } from "./useTerminalStore";
+import type { SetTerminalMeta } from "./useTerminalStore";
 
 /** Fire-and-forget stream subscription with AbortController cleanup. */
 function subscribeStream<T>(
@@ -22,25 +23,15 @@ function subscribeStream<T>(
 }
 
 export function useTerminalStreams(deps: {
-  meta: TerminalMetaStore;
   setMeta: SetTerminalMeta;
   pushActivity: (id: TerminalId, active: boolean) => void;
   onExit: (id: TerminalId, code: number) => void;
-  onClaudeStateChange: (
-    id: TerminalId,
-    prev: string | undefined,
-    next: string | undefined,
-  ) => void;
 }) {
   /** Subscribe to metadata changes for a terminal. */
   function subscribeMetadata(id: TerminalId) {
     return subscribeStream(
       (signal) => client.terminal.onMetadataChange({ id }, { signal }),
-      (metadata) => {
-        const prevState = deps.meta[id]?.meta?.claude?.state;
-        deps.setMeta(id, "meta", metadata);
-        deps.onClaudeStateChange(id, prevState, metadata.claude?.state);
-      },
+      (metadata) => deps.setMeta(id, "meta", metadata),
     );
   }
 

--- a/client/src/useTerminals.ts
+++ b/client/src/useTerminals.ts
@@ -3,9 +3,9 @@
  *  ARCHITECTURE: This file wires together four focused modules via deps objects.
  *  Do NOT add behavior here — each concern has its own module:
  *    - useTerminalStore.ts  — store, signals, accessors (pure state)
- *    - useTerminalStreams.ts — server event subscriptions
+ *    - useTerminalStreams.ts — server event subscriptions (write to store)
  *    - useTerminalLifecycle.ts — CRUD, restore-on-load, worktree ops
- *    - useTerminalAlerts.ts — Claude state detection + notifications
+ *    - useTerminalAlerts.ts — Claude state detection (watches store reactively)
  *  New features should go in the appropriate module (or a new one),
  *  not back into this composition root. See #221. */
 
@@ -28,16 +28,17 @@ export function useTerminals(deps: {
 
   const store = useTerminalStore({ getActivityHistory });
 
+  // Alerts watch the store reactively — no callback wiring needed
   const alerts = useTerminalAlerts({
     activityAlerts: deps.activityAlerts,
     activeId: store.activeId,
+    meta: store.meta,
     setMeta: store.setMeta,
     terminalIds: store.terminalIds,
     terminalLabel: store.terminalLabel,
   });
 
   const streams = useTerminalStreams({
-    meta: store.meta,
     setMeta: store.setMeta,
     pushActivity,
     onExit: (id, code) => {
@@ -47,7 +48,6 @@ export function useTerminals(deps: {
       );
       lifecycle.removeAndAutoSwitch(id);
     },
-    onClaudeStateChange: alerts.checkClaudeFinished,
   });
 
   const lifecycle = useTerminalLifecycle({


### PR DESCRIPTION
**Alerts now watch the store reactively instead of being called via callbacks threaded through streams.** Previously, `useTerminalStreams` took an `onClaudeStateChange` callback from `useTerminalAlerts`, creating a bidirectional dependency between the two modules that had to be wired in `useTerminals.ts`.

Now the metadata stream just writes to the store (`setMeta(id, "meta", metadata)`), and `useTerminalAlerts` runs a `createEffect` that watches each terminal's `meta[id].meta.claude.state` for transitions. *When Claude moves to "waiting", the alert fires — same behavior, but the stream doesn't know or care about alerts.*

This removes one dep from `useTerminalStreams` (no more `onClaudeStateChange` or `meta` read access) and simplifies the wiring in `useTerminals.ts`. Builds on #237.