### PR TITLE
Stop e2e CI from rebuilding nix package

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ client:
 test: install
     #!/usr/bin/env bash
     set -euo pipefail
-    KOLU_SERVER="$(nix build path:{{ justfile_directory() }} --print-out-paths)/bin/kolu"
+    KOLU_SERVER="${KOLU_SERVER:-$(nix build --print-out-paths)/bin/kolu}"
     cd tests
     {{ nix_shell }} pnpm install
     # Temp dirs for Claude Code status detection mock tests


### PR DESCRIPTION
**The e2e CI step was doing a full nix rebuild** even though the `nix` step had already built the package. Root cause: the `test` recipe used `nix build path:.` (path-based source) while devour-flake uses `.` (git-based source) — same files, *different store hashes*, triggering a redundant rebuild of kolu every CI run.

Switching to `nix build` (git flake ref) makes the derivation hash match what's already in the store, turning the second build into an instant no-op. The `KOLU_SERVER` env var is now also overridable for callers that already have the binary path.

Closes #246