### PR TITLE
Distinguish alerting from active terminals with orange

### DIFF
--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -62,7 +62,7 @@ const SidebarEntry: Component<{
         }}
         style={{
           "border-left-color": props.alerting
-            ? "var(--color-accent)"
+            ? "var(--color-alert)"
             : (props.displayInfo?.repoColor ??
               (props.isActive ? "var(--accent)" : "transparent")),
           ...(props.alerting

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,6 +21,7 @@
   --color-fg-3: #838390;
 
   --color-accent: #5a9ea0;
+  --color-alert: #fb923c;
 
   --color-ok: #4ade80;
   --color-warning: #facc15;
@@ -44,6 +45,7 @@
   --color-fg-3: #8a8a96;
 
   --color-accent: #3d8486;
+  --color-alert: #ea580c;
 
   --color-ok: #16a34a;
   --color-warning: #ca8a04;
@@ -63,13 +65,13 @@
   }
 }
 
-/* Pulsing accent glow on sidebar entry when a background terminal's Claude finishes */
+/* Pulsing warm glow on sidebar entry when a background terminal's Claude finishes */
 @keyframes alerting-glow {
   0%,
   100% {
-    background-color: oklch(from var(--color-accent) l c h / 0.08);
+    background-color: oklch(from var(--color-alert) l c h / 0.08);
   }
   50% {
-    background-color: oklch(from var(--color-accent) l c h / 0.25);
+    background-color: oklch(from var(--color-alert) l c h / 0.25);
   }
 }


### PR DESCRIPTION
**Alerting sidebar entries now pulse orange instead of teal**, making them immediately distinguishable from the active (selected) terminal — even without animation. Previously both states shared `--color-accent` (teal), and the only difference was a subtle background pulse that was easy to miss, *especially for users with low vision*.

A new `--color-alert` CSS variable (orange-400 dark / orange-600 light) replaces accent in the alerting glow animation and left-border color. Active terminals keep their teal accent unchanged.

Closes #266