### PR TITLE
Make workflow summary.md recording mandatory

### DIFF
--- a/.claude/commands/workflow.md
+++ b/.claude/commands/workflow.md
@@ -66,7 +66,13 @@ For the current node:
    - `skill`: Invoke via the Skill tool — `skill: "<target>"`, `args: "<args>"`.
    - `run`: Execute via Bash tool. Use `run_in_background: true` if description contains "background".
    - `prompt`: Execute the instruction directly — read files, write code, run commands, whatever the prompt says.
-5. **Record in summary.md** — Append the node's result: what happened, which edge will be taken and why.
+5. **Record in summary.md** — BEFORE proceeding to the next node, append this node's result to `.workflow-runs/<branch-name>/summary.md`. This is NOT optional — skip this and the workflow is broken. If `summary.md` doesn't exist yet, create it with a `# Summary` header and the task description. Each append must use this format:
+   ```
+   ### <node-id> (visit N/max)
+   What happened (1-2 sentences).
+   → edge: <condition matched> or <default> — <why>
+   ```
+   Write this to the file using the Write/Edit tool. Do not batch — append after *every* node, including trivial ones like `sync` and `fmt`.
 6. **Pick the next edge.** Look at the node's `on:` map. For each non-`default` key, evaluate the condition against what just happened (conversation context, command output, skill results). If a condition matches, follow that edge. If none match, follow `default`. If there is no `on:` map, the workflow is **done**.
 7. **Continue** with the next node.
 


### PR DESCRIPTION
**Step 5 of the workflow execution loop was too soft** — "Append the node's result" reads as advisory, so the LLM skips it when focused on the main task. This rewrites it as a blocking step with an explicit markdown template (`### node-id (visit N/max)` + what happened + edge taken).

The key insight: *LLMs skip steps that feel like side-effects.* Making the format concrete and mechanical — with a template to fill in rather than prose to compose — turns it into a rote action instead of a judgment call.

https://github.com/juspay/kolu/issues/280