### PR TITLE
Fix sidebar close button overlapping subterminal count

### DIFF
--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -53,7 +53,7 @@ const SidebarEntry: Component<{
           props.displayInfo?.activityHistory.at(-1)?.[1] ? "active" : "sleeping"
         }
         data-alerting={props.alerting ? "" : undefined}
-        class="group w-full py-2 px-2 text-sm text-left transition-colors duration-150 touch-none border-b border-edge"
+        class="group w-full py-2 pl-2 pr-6 text-sm text-left transition-colors duration-150 touch-none border-b border-edge"
         classList={{
           "border-l-4 bg-accent/10 text-fg": props.isActive,
           "border-l-4 border-l-transparent hover:bg-surface-2": !props.isActive,


### PR DESCRIPTION
**The close button and subterminal count badge no longer overlap** in sidebar entries. The `×` button is absolutely positioned in the top-right corner and appears on hover, but the content area had no padding to account for it — so the `+N` sub-count badge (pushed right via `ml-auto`) sat directly underneath.

*One-class fix*: adds right padding to the sidebar entry button so content stays clear of the overlay zone.

Closes #298