### PR TITLE
Stop dialogs from closing on terminal output

### DIFF
--- a/client/src/ModalDialog.tsx
+++ b/client/src/ModalDialog.tsx
@@ -36,6 +36,7 @@ const ModalDialog: Component<{
   <Dialog
     open={props.open}
     onOpenChange={props.onOpenChange}
+    closeOnOutsideFocus={false}
     restoreFocus={false}
     onFinalFocus={(e) => e.preventDefault()}
     initialFocusEl={props.initialFocusEl}

--- a/tests/features/command-palette.feature
+++ b/tests/features/command-palette.feature
@@ -163,6 +163,17 @@ Feature: Command Palette
     Then the shortcuts help should be visible
     And there should be no page errors
 
+  Scenario: Dialog stays open during terminal output
+    When I run "sleep 0.5 && echo dialog-survives &"
+    And I open the command palette
+    Then the command palette should be visible
+    # Wait for background output to arrive
+    When I wait 1500ms
+    Then the command palette should be visible
+    When I press Escape
+    Then the active terminal should show "dialog-survives"
+    And there should be no page errors
+
   Scenario: Cmd/Ctrl+K does not leak to terminal
     Given I intercept oRPC sendInput calls
     When I open the command palette

--- a/tests/step_definitions/terminal_steps.ts
+++ b/tests/step_definitions/terminal_steps.ts
@@ -25,6 +25,10 @@ When("I run {string}", async function (this: KoluWorld, command: string) {
   await this.waitForFrame();
 });
 
+When("I wait {int}ms", async function (this: KoluWorld, ms: number) {
+  await this.page.waitForTimeout(ms);
+});
+
 When("I refresh the page", async function (this: KoluWorld) {
   // Snapshot terminal count before refresh so post-refresh assertions can verify reconnect
   this.terminalCountBeforeRefresh = await countTerminals(this);


### PR DESCRIPTION
**Dialogs dismiss themselves the moment the terminal behind them receives output** — xterm's data writes fire `focusin` events that Corvu's `solid-dismissible` interprets as "user focused outside the dialog." The worktree-remove confirmation is the most visible victim, but every `ModalDialog` has this problem.

The root cause is Corvu Dialog defaulting `closeOnOutsideFocus` to `true` when focus trapping is enabled. *That default makes sense for typical web apps, but not when there's an always-mounted terminal emitter firing focus events in the background.* One prop override on the shared `ModalDialog` wrapper fixes every dialog at once.

Closes #303

- [ ] Implementation
- [ ] E2E test
- [ ] CI green