### PR TITLE
Stop hook prevents /execute from quitting mid-workflow

### DIFF
--- a/.claude/hooks/execute-stop-guard.sh
+++ b/.claude/hooks/execute-stop-guard.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Prevents Claude from stopping while /execute workflow is still running.
+# Reads .execute-results.json and blocks the stop if status == "running".
+# Safe default: if the file exists but can't be parsed, block (not approve).
+results="$CLAUDE_PROJECT_DIR/.execute-results.json"
+if [ ! -f "$results" ]; then
+  echo '{"decision":"approve"}'
+  exit 0
+fi
+status=$(jq -r '.status // empty' "$results" 2>/dev/null) || status="parse_error"
+case "$status" in
+  running)
+    echo '{"decision":"block","reason":"Execute workflow still running — continue from where you left off. Check .execute-results.json for current progress."}'
+    ;;
+  parse_error)
+    echo '{"decision":"block","reason":"Could not parse .execute-results.json — file may be corrupted. Check and fix it before stopping."}'
+    ;;
+  *)
+    echo '{"decision":"approve"}'
+    ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/execute-stop-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**The `/execute` workflow now can't silently stop before finishing.** A deterministic `Stop` hook checks `.execute-results.json` — if `status` is still `"running"`, Claude is blocked from ending its turn and forced to continue.

The key design choice: *this is a `jq` check, not an LLM prompt.* The original bug was Claude not following instructions to keep going — asking Claude to decide whether to keep going is the same class of unreliability. A binary file check removes the LLM from the decision loop entirely.

The hook has a **safe default**: if the file exists but `jq` can't parse it (partial write, corruption), it blocks rather than approves — so a transient I/O glitch can't silently drop the workflow.

Two new files: `.claude/settings.json` wires the hook, `.claude/hooks/execute-stop-guard.sh` does the check.

Closes #309