### PR TITLE
Use semantic toast variants and enable richColors

### DIFF
--- a/.claude/rules/toast-conventions.md
+++ b/.claude/rules/toast-conventions.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "client/src/**"
+---
+
+## Toast Conventions
+
+- **Semantic variants**: Use `toast.success()` for success outcomes, `toast.error()` for failures, `toast.warning()` for degraded states (e.g. non-zero exit codes), `toast.info()` for informational notices with actions. Never use bare `toast()` for outcomes — reserve it for neutral notifications (tips, exit-code-0).
+- **Colocated, not centralized**: Keep toast calls next to the logic that triggers them (mutation `onError` callbacks, post-`await` success lines). Do not extract into a separate toast helper module.
+- **`richColors` is enabled**: The `<Toaster>` has `richColors` set, so semantic variants automatically get colored backgrounds. Choosing the right variant matters for UX.
+- **No `toast.promise()`**: Our mutations do post-success work (cache updates, state transitions) after `await mutateAsync()`. Wrapping in `toast.promise()` would braid mutation invocation with toast lifecycle. Use explicit `onError` + post-await `toast.success()` instead.
+- **Action toasts**: For persistent notifications requiring user action, use `duration: Infinity` with an `action` prop (see server-update toast in `rpc.ts`).

--- a/PERL/.apm/instructions/toast-conventions.instructions.md
+++ b/PERL/.apm/instructions/toast-conventions.instructions.md
@@ -1,0 +1,12 @@
+---
+description: Toast notification conventions using solid-sonner
+applyTo: "client/src/**"
+---
+
+## Toast Conventions
+
+- **Semantic variants**: Use `toast.success()` for success outcomes, `toast.error()` for failures, `toast.warning()` for degraded states (e.g. non-zero exit codes), `toast.info()` for informational notices with actions. Never use bare `toast()` for outcomes — reserve it for neutral notifications (tips, exit-code-0).
+- **Colocated, not centralized**: Keep toast calls next to the logic that triggers them (mutation `onError` callbacks, post-`await` success lines). Do not extract into a separate toast helper module.
+- **`richColors` is enabled**: The `<Toaster>` has `richColors` set, so semantic variants automatically get colored backgrounds. Choosing the right variant matters for UX.
+- **No `toast.promise()`**: Our mutations do post-success work (cache updates, state transitions) after `await mutateAsync()`. Wrapping in `toast.promise()` would braid mutation invocation with toast lifecycle. Use explicit `onError` + post-await `toast.success()` instead.
+- **Action toasts**: For persistent notifications requiring user action, use `duration: Infinity` with an `action` prop (see server-update toast in `rpc.ts`).

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -234,9 +234,9 @@ const App: Component = () => {
       <Toaster
         position="bottom-right"
         theme="dark"
+        richColors
         toastOptions={{
           style: {
-            background: "var(--color-surface-1)",
             color: "var(--color-fg)",
             border: "1px solid var(--color-edge-bright)",
           },

--- a/client/src/useTerminalCrud.ts
+++ b/client/src/useTerminalCrud.ts
@@ -173,7 +173,7 @@ export function useTerminalCrud(deps: {
     try {
       const text = await client.terminal.screenText({ id });
       await navigator.clipboard.writeText(text);
-      toast("Copied terminal text to clipboard");
+      toast.success("Copied terminal text to clipboard");
     } catch (err) {
       console.error("Failed to copy terminal text:", err);
       toast.error("Failed to copy terminal text");

--- a/client/src/useTerminals.ts
+++ b/client/src/useTerminals.ts
@@ -41,11 +41,11 @@ export function useTerminals(deps: {
         const stream = await client.terminal.onExit({ id });
         for await (const code of stream) {
           const label = store.terminalLabel(id);
-          toast(
-            code === 0
-              ? `${label} exited`
-              : `${label} exited with code ${code}`,
-          );
+          if (code === 0) {
+            toast(`${label} exited`);
+          } else {
+            toast.warning(`${label} exited with code ${code}`);
+          }
           crud.removeAndAutoSwitch(id);
         }
       } catch {

--- a/client/src/useWorktreeOps.ts
+++ b/client/src/useWorktreeOps.ts
@@ -30,7 +30,7 @@ export function useWorktreeOps(deps: {
 
   async function handleCreateWorktree(repoPath: string) {
     const result = await worktreeCreateMut.mutateAsync({ repoPath });
-    toast(`Created worktree at ${result.path}`);
+    toast.success(`Created worktree at ${result.path}`);
     await deps.handleCreate(result.path);
     invalidateRepos();
   }
@@ -47,7 +47,7 @@ export function useWorktreeOps(deps: {
     await deps.handleKill(id);
     if (worktreePath) {
       await worktreeRemoveMut.mutateAsync({ worktreePath });
-      toast(`Removed worktree at ${worktreePath}`);
+      toast.success(`Removed worktree at ${worktreePath}`);
       invalidateRepos();
     }
   }


### PR DESCRIPTION
**Toasts now use semantic variants** (`success`, `error`, `warning`) with `richColors` enabled, so each notification type gets a distinct colored background instead of all looking identical.

Previously, success outcomes like "Created worktree" and "Copied terminal text" used bare `toast()` — visually indistinguishable from errors or warnings. Terminal exits with non-zero codes got the same neutral treatment as clean exits. Now each toast carries the right visual weight: *green for success, red for errors, amber for non-zero exits*.

Also adds a PERL rule (`toast-conventions`) so agents follow these patterns going forward — use semantic variants, never bare `toast()` for outcomes, keep calls colocated with the triggering logic.