### PR TITLE
Decouple stop hook from workflow status

### DIFF
--- a/.claude/commands/execute.md
+++ b/.claude/commands/execute.md
@@ -24,6 +24,7 @@ After each step's verification, write/update `.execute-results.json`:
 {
   "workflow": "execute",
   "startedAt": "<ISO timestamp>",
+  "active": true,
   "status": "running",
   "steps": [
     {
@@ -36,7 +37,9 @@ After each step's verification, write/update `.execute-results.json`:
 }
 ```
 
-Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. Use the Write tool to update the file after each step.
+- Set `active` to `true` when the workflow starts (**sync**), and `false` when it ends (**done**). The stop hook uses this field to block premature exits.
+- Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
+- Use the Write tool to update the file after each step.
 
 ## Steps
 

--- a/.claude/hooks/PERL/scripts/execute-stop-guard.sh
+++ b/.claude/hooks/PERL/scripts/execute-stop-guard.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Prevents Claude from stopping while /execute workflow is still running.
-# Reads .execute-results.json and blocks the stop if status == "running".
+# Reads .execute-results.json and blocks the stop if active == true.
 # Safe default: if the file exists but can't be parsed, block (not approve).
 results="$CLAUDE_PROJECT_DIR/.execute-results.json"
 if [ ! -f "$results" ]; then
   echo '{"decision":"approve"}'
   exit 0
 fi
-status=$(jq -r '.status // empty' "$results" 2>/dev/null) || status="parse_error"
-case "$status" in
-  running)
+active=$(jq -r '.active // empty' "$results" 2>/dev/null) || active="parse_error"
+case "$active" in
+  true)
     echo '{"decision":"block","reason":"Execute workflow still running — continue from where you left off. Check .execute-results.json for current progress."}'
     ;;
   parse_error)

--- a/PERL/.apm/hooks/scripts/execute-stop-guard.sh
+++ b/PERL/.apm/hooks/scripts/execute-stop-guard.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Prevents Claude from stopping while /execute workflow is still running.
-# Reads .execute-results.json and blocks the stop if status == "running".
+# Reads .execute-results.json and blocks the stop if active == true.
 # Safe default: if the file exists but can't be parsed, block (not approve).
 results="$CLAUDE_PROJECT_DIR/.execute-results.json"
 if [ ! -f "$results" ]; then
   echo '{"decision":"approve"}'
   exit 0
 fi
-status=$(jq -r '.status // empty' "$results" 2>/dev/null) || status="parse_error"
-case "$status" in
-  running)
+active=$(jq -r '.active // empty' "$results" 2>/dev/null) || active="parse_error"
+case "$active" in
+  true)
     echo '{"decision":"block","reason":"Execute workflow still running — continue from where you left off. Check .execute-results.json for current progress."}'
     ;;
   parse_error)

--- a/PERL/.apm/prompts/execute.prompt.md
+++ b/PERL/.apm/prompts/execute.prompt.md
@@ -24,6 +24,7 @@ After each step's verification, write/update `.execute-results.json`:
 {
   "workflow": "execute",
   "startedAt": "<ISO timestamp>",
+  "active": true,
   "status": "running",
   "steps": [
     {
@@ -36,7 +37,9 @@ After each step's verification, write/update `.execute-results.json`:
 }
 ```
 
-Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. Use the Write tool to update the file after each step.
+- Set `active` to `true` when the workflow starts (**sync**), and `false` when it ends (**done**). The stop hook uses this field to block premature exits.
+- Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
+- Use the Write tool to update the file after each step.
 
 ## Steps
 


### PR DESCRIPTION
**Stop hook now checks a dedicated `active` flag** instead of the workflow `status` field, fixing the stop-loop that traps users when they ask for follow-up changes after `/execute` completes.

Previously `status` did double duty — tracking workflow history *and* controlling the stop hook. Once `/execute` finished and a user asked for more tweaks in the same conversation, Claude would re-enter the workflow, flip `status` back to `"running"`, and the hook would block every exit attempt. Now `active` is set to `true` only at the `sync` step and `false` at `done`, so ad-hoc follow-up work never triggers the guard.

Closes #325