### PR TITLE
fix: Three-zone header layout prevents control clipping

### DIFF
--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -54,24 +54,28 @@ const Header: Component<{
   const [settingsOpen, setSettingsOpen] = createSignal(false);
 
   return (
-    <header class="flex items-center gap-2 px-2 sm:px-4 h-10 shrink-0 overflow-hidden bg-surface-1 border-b border-edge">
-      <Tip label="Toggle sidebar">
-        <button
-          data-testid="sidebar-toggle"
-          class="p-1 text-fg-2 hover:text-fg hover:bg-surface-2 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-          onClick={() => props.onToggleSidebar?.()}
-        >
-          <MenuIcon />
-        </button>
-      </Tip>
-      <img src="/favicon.svg" alt="kolu" class="w-5 h-5" />
-      <span class="font-semibold text-sm hidden sm:inline">
-        {props.appTitle ?? "kolu"}
-      </span>
-      <Show when={props.meta}>
+    <header class="flex items-center h-10 shrink-0 bg-surface-1 border-b border-edge">
+      {/* Zone A: Identity — rigid, never compresses */}
+      <div class="flex items-center gap-2 px-2 sm:px-4 shrink-0">
+        <Tip label="Toggle sidebar">
+          <button
+            data-testid="sidebar-toggle"
+            class="p-1 text-fg-2 hover:text-fg hover:bg-surface-2 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+            onClick={() => props.onToggleSidebar?.()}
+          >
+            <MenuIcon />
+          </button>
+        </Tip>
+        <img src="/favicon.svg" alt="kolu" class="w-5 h-5" />
+        <span class="font-semibold text-sm hidden sm:inline">
+          {props.appTitle ?? "kolu"}
+        </span>
+      </div>
+      {/* Zone B: Context — elastic shock absorber, truncates under pressure */}
+      <Show when={props.meta} fallback={<div class="flex-1" />}>
         {(meta) => (
-          <span
-            class="flex items-center gap-1 text-xs min-w-0"
+          <div
+            class="flex-1 min-w-0 flex items-center gap-1 text-xs overflow-hidden"
             data-testid="header-cwd"
           >
             <span class="text-fg-2 truncate" title={meta().cwd}>
@@ -79,7 +83,11 @@ const Header: Component<{
             </span>
             <Show when={meta().git}>
               {(git) => (
-                <span class="text-fg-3 shrink-0" data-testid="header-branch">
+                <span
+                  class="text-fg-3 min-w-0 truncate"
+                  data-testid="header-branch"
+                  title={git().branch}
+                >
                   &middot; {git().branch}
                   <Show when={git().isWorktree}>
                     <WorktreeIcon class="inline w-3 h-3 ml-0.5" />
@@ -113,11 +121,11 @@ const Header: Component<{
                 </span>
               )}
             </Show>
-          </span>
+          </div>
         )}
       </Show>
-      {/* Push remaining items to the right */}
-      <div class="ml-auto flex items-center gap-2">
+      {/* Zone C: Controls — rigid, never clips */}
+      <div class="flex items-center gap-2 px-2 sm:px-4 shrink-0">
         <Tip label="Mission Control">
           <button
             data-testid="mission-control-trigger"
@@ -128,10 +136,10 @@ const Header: Component<{
           </button>
         </Tip>
         {props.themeName && (
-          <Tip label="Change theme">
+          <Tip label={`Theme: ${props.themeName}`}>
             <button
               data-testid="theme-name"
-              class="h-7 px-2 text-xs text-fg-2 hover:text-fg bg-surface-2/50 hover:bg-surface-3/50 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              class="h-7 px-2 text-xs text-fg-2 hover:text-fg bg-surface-2/50 hover:bg-surface-3/50 rounded transition-colors cursor-pointer max-w-[14ch] truncate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
               onClick={() => {
                 props.onThemeClick?.();
                 setTimeout(


### PR DESCRIPTION
Fixes #330

The header was a flat flex row where 14+ elements competed for space with no budget — the outer `overflow-hidden` silently clipped whatever lost the fight, including the theme name.

Restructures the header into **three explicit zones** with defined flex behavior: an *Identity* zone (sidebar toggle, logo, app title) and a *Controls* zone (icons, theme, palette, status) are both `shrink-0` so they **never compress**, while the *Context* zone (cwd, branch, PR info, Claude indicator) sits between them as `flex-1 min-w-0` — the elastic shock absorber that truncates gracefully under pressure.

The branch name changes from `shrink-0` to `min-w-0 truncate` so it can compress instead of pushing everything off-screen, and the theme name button gets a `max-w-[14ch] truncate` safety valve with the existing tooltip providing full-name access on hover.

## Test plan
- [ ] Verify theme name displays fully at normal widths, truncates with tooltip at narrow widths
- [ ] Verify branch name truncates gracefully with long branch names
- [ ] Verify controls (settings, search, palette, status dot) never clip at any viewport width
- [ ] Verify no visual regression at wide viewports — layout should look identical