### PR TITLE
Fix e2e TIME_WAIT socket leak on darwin CI

### DIFF
--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -15,6 +15,7 @@ import type { Browser } from "playwright";
 import getPort from "get-port";
 import { KoluWorld } from "./world.ts";
 import * as fs from "node:fs";
+import * as http from "node:http";
 import * as path from "node:path";
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
@@ -24,6 +25,59 @@ const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0");
 let baseUrl: string;
 let browser: Browser;
 let serverProcess: ChildProcess | undefined;
+
+// Reuse TCP connections across scenarios to avoid TIME_WAIT socket
+// accumulation on macOS (see #334).
+const keepAliveAgent = new http.Agent({ keepAlive: true });
+
+/** POST JSON to a local URL, reusing TCP connections via keepAlive. */
+function postJSON(url: string, body: object): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = http.request(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname,
+        method: "POST",
+        agent: keepAliveAgent,
+        headers: { "Content-Type": "application/json" },
+      },
+      (res) => {
+        res.resume();
+        res.on("end", resolve);
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.end(JSON.stringify(body));
+  });
+}
+
+/** GET a URL, reusing TCP connections via keepAlive. */
+function httpGet(url: string): Promise<{ ok: boolean }> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const req = http.request(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname,
+        method: "GET",
+        agent: keepAliveAgent,
+      },
+      (res) => {
+        res.resume();
+        res.on("end", () =>
+          resolve({ ok: res.statusCode! >= 200 && res.statusCode! < 300 }),
+        );
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 /** Kill the server child on any exit path (crash, SIGINT, SIGTERM). */
 function killServer() {
@@ -46,7 +100,7 @@ async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
-      const resp = await fetch(url);
+      const resp = await httpGet(url);
       if (resp.ok) return;
     } catch {
       // server not up yet
@@ -99,34 +153,27 @@ BeforeAll(async function () {
 
 AfterAll(async function () {
   if (browser) await browser.close();
+  keepAliveAgent.destroy();
   killServer();
 });
 
 Before(async function (this: KoluWorld) {
   // Kill leftover terminals and reset state so each scenario starts clean
   await Promise.all([
-    fetch(`${baseUrl}/rpc/terminal/killAll`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    }),
-    fetch(`${baseUrl}/rpc/state/test__set`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        json: {
-          session: null,
-          // Reset all preferences to defaults (randomTheme off for deterministic tests)
-          preferences: {
-            seenTips: [],
-            startupTips: true,
-            randomTheme: false,
-            scrollLock: true,
-            activityAlerts: true,
-            colorScheme: "dark",
-          },
+    postJSON(`${baseUrl}/rpc/terminal/killAll`, {}),
+    postJSON(`${baseUrl}/rpc/state/test__set`, {
+      json: {
+        session: null,
+        // Reset all preferences to defaults (randomTheme off for deterministic tests)
+        preferences: {
+          seenTips: [],
+          startupTips: true,
+          randomTheme: false,
+          scrollLock: true,
+          activityAlerts: true,
+          colorScheme: "dark",
         },
-      }),
+      },
     }),
   ]);
 


### PR DESCRIPTION
**Reuse TCP connections in test hooks** to stop accumulating TIME_WAIT sockets that eventually exhaust the ephemeral port range on macOS CI builders.

The Before hook's `fetch()` calls create two fresh TCP connections per scenario — with 8 workers × ~50 scenarios, that's ~800 sockets entering TIME_WAIT per run. On macOS, a kernel bug prevents these from draining after extended uptime, leading to port exhaustion and Nix daemon crashes.

The fix replaces bare `fetch()` with `http.request()` backed by a shared `http.Agent({ keepAlive: true })`, so each worker reuses a single TCP connection across all scenarios. *The `waitForHealth` polling loop also uses the same agent for consistency.*

Closes #334