### PR TITLE
Fix toast readability in light mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -230,7 +230,7 @@ const App: Component = () => {
       </Show>
       <Toaster
         position="bottom-right"
-        theme="dark"
+        theme={colorScheme()}
         richColors
         toastOptions={{
           style: {


### PR DESCRIPTION
**Notification toasts are now readable in light mode.** The `<Toaster>` had its theme hardcoded to `"dark"`, so when switching to light mode the sonner background stayed dark while CSS variables flipped the text color to dark too — dark-on-dark, unreadable.

The fix passes the existing `colorScheme()` signal directly to solid-sonner's `theme` prop, which natively supports `"system"` mode. *One-line change — no new imports, no derivation functions.*

Closes #335