### PR TITLE
Add hover close button to sub-terminal tabs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -397,6 +397,7 @@ const App: Component = () => {
                     onCreateSubTerminal={(parentId, cwd) =>
                       void crud.handleCreateSubTerminal(parentId, cwd)
                     }
+                    onCloseTerminal={closeTerminal}
                     activeMeta={store.activeMeta()}
                     scrollLockEnabled={scrollLock()}
                   />

--- a/client/src/SubPanelTabBar.tsx
+++ b/client/src/SubPanelTabBar.tsx
@@ -9,6 +9,7 @@ const SubPanelTabBar: Component<{
   activeSubTab: TerminalId | null;
   getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
   onSelect: (id: TerminalId) => void;
+  onClose: (id: TerminalId) => void;
   onCreate: () => void;
   onCollapse: () => void;
 }> = (props) => {
@@ -28,16 +29,29 @@ const SubPanelTabBar: Component<{
           };
           const isActive = () => props.activeSubTab === id;
           return (
-            <button
-              class="px-3 py-1 rounded text-fg-3 hover:text-fg transition-colors cursor-pointer truncate max-w-[120px]"
-              classList={{
-                "bg-surface-2 text-fg font-medium": isActive(),
-              }}
-              data-active={isActive() || undefined}
-              onClick={() => props.onSelect(id)}
-            >
-              {label()}
-            </button>
+            <div class="group relative">
+              <button
+                class="px-3 pr-6 py-1 rounded text-fg-3 hover:text-fg transition-colors cursor-pointer truncate max-w-[120px]"
+                classList={{
+                  "bg-surface-2 text-fg font-medium": isActive(),
+                }}
+                data-active={isActive() || undefined}
+                onClick={() => props.onSelect(id)}
+              >
+                {label()}
+              </button>
+              <span
+                data-testid="sub-tab-close"
+                class="absolute top-0.5 right-0.5 hidden group-hover:flex items-center justify-center w-4 h-4 rounded text-fg-3 hover:text-fg hover:bg-surface-3 transition-colors cursor-pointer text-xs"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  props.onClose(id);
+                }}
+                title="Close sub-terminal"
+              >
+                ×
+              </span>
+            </div>
           );
         }}
       </For>

--- a/client/src/TerminalPane.tsx
+++ b/client/src/TerminalPane.tsx
@@ -18,6 +18,7 @@ const TerminalPane: Component<{
   subTerminalIds: TerminalId[];
   getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
   onCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
+  onCloseTerminal: (id: TerminalId) => void;
   activeMeta: TerminalMetadata | null;
   scrollLockEnabled?: boolean;
 }> = (props) => {
@@ -139,6 +140,7 @@ const TerminalPane: Component<{
                 onSelect={(id) =>
                   subPanel.setActiveSubTab(props.terminalId, id)
                 }
+                onClose={props.onCloseTerminal}
                 onCollapse={() => subPanel.collapsePanel(props.terminalId)}
                 onCreate={() =>
                   props.onCreateSubTerminal(

--- a/tests/features/sub-terminal.feature
+++ b/tests/features/sub-terminal.feature
@@ -97,6 +97,23 @@ Feature: Sub-terminals
     Then the sub-terminal should have keyboard focus
     And there should be no page errors
 
+  Scenario: Close sub-terminal via tab close button
+    When I create a sub-terminal via command palette
+    And I create another sub-terminal via command palette
+    Then the sub-panel tab bar should have 2 tabs
+    When I close sub-terminal tab 1
+    Then the sub-panel tab bar should have 1 tab
+    And the sub-terminal should have keyboard focus
+    And the sidebar entry should show sub-terminal count 1
+    And there should be no page errors
+
+  Scenario: Close last sub-terminal collapses panel
+    When I create a sub-terminal via command palette
+    When I close sub-terminal tab 1
+    Then the sub-panel should eventually collapse
+    And the sidebar entry should not show a sub-terminal count
+    And there should be no page errors
+
   Scenario: Resize handle visible when expanded
     When I create a sub-terminal via command palette
     Then the resize handle should be visible

--- a/tests/step_definitions/sub_terminal_steps.ts
+++ b/tests/step_definitions/sub_terminal_steps.ts
@@ -234,6 +234,21 @@ Then(
   },
 );
 
+When(
+  "I close sub-terminal tab {int}",
+  async function (this: KoluWorld, index: number) {
+    const tab = this.page
+      .locator(
+        '[data-testid="sub-panel-tab-bar"] [data-testid="sub-tab-close"]',
+      )
+      .nth(index - 1);
+    // Hover the parent to reveal the close button
+    await tab.locator("..").hover();
+    await tab.click();
+    await this.waitForFrame();
+  },
+);
+
 Then(
   "the sub-panel should eventually collapse",
   { timeout: 60_000 },


### PR DESCRIPTION
Sub-terminal tabs in the split panel have no way to close individual tabs — you can only collapse the whole panel or wait for the shell to exit. Meanwhile, sidebar entries have had a hover-to-reveal **×** button since day one.

This adds the same `group-hover` close affordance to each sub-terminal tab, threading the existing `closeTerminal` callback through `TerminalPane` into `SubPanelTabBar`. The pattern is identical to sidebar entries: invisible by default, appears on hover, `stopPropagation` so it doesn't trigger tab selection.