### PR TITLE
Fix palette keyboard nav resetting on background data updates

### DIFF
--- a/client/src/CommandPalette.tsx
+++ b/client/src/CommandPalette.tsx
@@ -204,8 +204,11 @@ const CommandPalette: Component<{
     ),
   );
 
-  // Reset selection when filter results change (defer: skip initial run)
-  createEffect(on(filtered, () => setSelectedIndex(0), { defer: true }));
+  // Reset selection when the user types (defer: skip initial run).
+  // Intentionally tracks `query`, not `filtered` — filtered returns a new array
+  // reference on every recomputation, so tracking it would reset the index whenever
+  // upstream data (commands memo) recomputes in the background.
+  createEffect(on(query, () => setSelectedIndex(0), { defer: true }));
 
   // Notify highlighted item when selection changes.
   // Uses on() for stable dependency tracking — bare createEffect would drop


### PR DESCRIPTION
Closes #348.

The command palette's `selectedIndex` was resetting to 0 mid-navigation because the reset effect tracked `filtered()` — a memo that returns a **new array reference** on every recomputation, even when the contents haven't changed. Any background reactive update (live query pushing new terminal state, `activeId` shifting) would recompute the `commands` memo → `currentItems` → `filtered` → reset effect fires → selection jumps back to item 1.

The fix narrows the reset trigger from `filtered` to `query`. Typing in the search box is the *only* case that needs an automatic reset — drill-in, drill-out, breadcrumb navigation, and palette open all already call `setSelectedIndex(0)` explicitly.