### PR TITLE
Upgrade srid/agency (hickey PR comments, smarter police)

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -105,7 +105,9 @@ Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
 
 **MANDATORY**: Load the `github-pr` skill (via Skill tool) BEFORE writing the PR title/body.
 
-**Verify**: On a feature branch (not master/main), draft PR exists (`gh pr view` succeeds).
+5. **Post hickey results**: If the hickey step produced findings with suggestions, post the full hickey analysis as a PR comment using `gh pr comment`. Use a `## Hickey Analysis` header. Skip this if hickey found no issues.
+
+**Verify**: On a feature branch (not master/main), draft PR exists (`gh pr view` succeeds). If hickey had findings, a PR comment exists.
 
 ---
 
@@ -132,7 +134,9 @@ If no documentation files are documented, skip this step with a note.
 
 ### police
 
-Invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.
+Use `git diff <default-branch>...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
+
+Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.
 
 When `/code-police` asks about scope: **changes in the current branch/PR only**.
 
@@ -234,6 +238,10 @@ gh pr comment --body "$(cat <<'COMMENT'
 | research | ✓ | 45s | ... |
 ...
 | **Total** | | **4m 32s** | |
+
+### Optimization suggestions
+
+- <2–4 concrete suggestions based on timing data>
 
 Workflow completed at <timestamp>.
 COMMENT

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-04T01:23:58.927890+00:00'
+generated_at: '2026-04-05T15:51:27.780955+00:00'
 apm_version: 0.8.10
 dependencies:
 - repo_url: _local/agents
@@ -45,7 +45,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 5266a6a8e1a31f4a055325502528c4fec66b11da
+  resolved_commit: e3f4cf3af68f2834478973b455738dd1a5a297b5
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -56,4 +56,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/github-pr
   - .claude/skills/hickey
-  content_hash: sha256:78151824ef8c7304e7aa5098f85bcc3335ef22053845a4b738ba036f276b6a8d
+  content_hash: sha256:f48fa97a1aceca8287b7d2e0d75881ec1f5128c99b23b2d682f472a39d8c155d


### PR DESCRIPTION
**Bumps srid/agency** to `e3f4cf3a`, picking up three `/do` workflow improvements:

The hickey analysis step now **posts its findings as a PR comment** instead of just running locally — reviewers see the structural simplicity report directly on the PR. The police step **skips docs-only PRs** rather than running a full code-police pass on markdown changes. The final workflow summary includes **optimization suggestions** based on timing data.

_Settings.json duplicate hook issue from upstream was excluded from this PR — the existing hook entry already covers it._