### PR TITLE
fix: sidebar scrolls when terminals overflow viewport

### DIFF
--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -239,7 +239,7 @@ const Sidebar: Component<{
             </button>
           </div>
         </Tip>
-        <nav class="flex-1 overflow-y-auto py-0.5 sidebar-scroll">
+        <nav class="flex-1 min-h-0 overflow-y-auto py-0.5 sidebar-scroll">
           <DragDropProvider
             collisionDetector={closestCenter}
             onDragStart={({ draggable }) => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -67,11 +67,19 @@
   }
 }
 
-/* Hide sidebar scrollbar — still scrollable via wheel/touch */
+/* Slim sidebar scrollbar — only visible when content actually overflows */
 .sidebar-scroll {
-  scrollbar-width: none; /* Firefox */
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: var(--color-edge) transparent;
   &::-webkit-scrollbar {
-    display: none; /* Chrome/Safari */
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--color-edge);
+    border-radius: 3px;
   }
 }
 


### PR DESCRIPTION
**Open enough terminals and the sidebar used to silently push its bottom entries off-screen** with no way to reach them. Two compounding bugs: the scrollable `nav` was missing `min-h-0`, so flexbox's default `min-height: auto` let it grow past its container instead of clipping; and `.sidebar-scroll` was actively hiding the scrollbar on every browser, so even if scrolling worked, there'd be no affordance.

Fix is two lines. *Add `min-h-0` to the nav so flex shrinking actually engages, and replace the display:none scrollbar rule with a slim, themed scrollbar that only appears when overflow is real.*

### Try it locally
\`nix run github:juspay/kolu/fix/sidebar-scroll\`