### PR TITLE
Fix font for sidebar foreground title

### DIFF
--- a/client/src/TerminalMeta.tsx
+++ b/client/src/TerminalMeta.tsx
@@ -137,7 +137,7 @@ const TerminalMeta: Component<{
               <Show when={info().meta.foreground}>
                 {(fg) => (
                   <span
-                    class="text-xs text-fg-3 font-mono truncate min-w-0 flex-1"
+                    class="text-xs text-fg-3 truncate min-w-0 flex-1"
                     data-testid="process-name"
                     title={fg().title ?? fg().name}
                   >


### PR DESCRIPTION
**The sidebar foreground-title line now uses the default sans font** instead of monospace. Monospace rendered visibly larger than surrounding text, which pushed the line out of its allotted width and caused it to get trimmed.

One-class removal on `TerminalMeta.tsx` — the process/title row no longer carries `font-mono`.

Closes #375