### PR TITLE
Rewrite README tagline; fix broken split-terminals code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ nix run github:juspay/kolu -- --host 127.0.0.1 --port 8080  # custom bind
 ### Terminals
 
 - Create, switch, kill, and drag-to-reorder terminals from a collapsible sidebar
-- Split terminals — <kbd>Ctrl+`</kbd> splits a bottom pane per terminal; <kbd>Ctrl+Shift+`</kbd> adds tabs, <kbd>Ctrl+PageDown</kbd> / <kbd>Ctrl+PageUp</kbd> cycles
+- Split terminals — <kbd>Ctrl+&#96;</kbd> splits a bottom pane per terminal; <kbd>Ctrl+Shift+&#96;</kbd> adds tabs, <kbd>Ctrl+PageDown</kbd> / <kbd>Ctrl+PageUp</kbd> cycles
 - Font zoom (<kbd>Cmd/Ctrl</kbd> <kbd>+</kbd>/<kbd>-</kbd>), persisted per terminal across sessions
 - WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Lazy attach — late-joining clients receive serialized screen state (~4KB) instead of replaying raw buffer


### PR DESCRIPTION
**The first line of the README now leads with the job, not the substrate.** The old tagline — _Web-based Agentic Development Environment (ADE) built on terminals_ — invited two lazy misreads: "so, this is a tmux alternative?" and "so, another Claude Code wrapper?" Neither is what kolu is.

The new opener reframes kolu as **a browser cockpit for coding agents** where you **bring your own CLI** and **run them anywhere**. A supporting paragraph names the category kolu is explicitly _not_ in — the wrap-a-single-model-in-a-custom-chat-UI school of agent command centers — and makes the terminal-native stance a thesis rather than an implementation detail. The "run them anywhere" framing is forward-compatible with the upcoming incus/remote-VM work without promising it on day one.

_The கோலு etymology is demoted to a footnote_ so the opening lines carry positioning weight instead of trivia.

While in the neighbourhood, also fixes a long-broken inline code block on the split-terminals feature bullet where `` `Ctrl+` `` wasn't escaped properly and rendered as garbled markdown on GitHub.