### PR TITLE
Collapse dev logs onto one line

### DIFF
--- a/server/src/log.ts
+++ b/server/src/log.ts
@@ -6,7 +6,10 @@ export const log = pino(
     ? { level: "info" }
     : {
         level: "info",
-        transport: { target: "pino-pretty", options: { colorize: true } },
+        transport: {
+          target: "pino-pretty",
+          options: { colorize: true, singleLine: true },
+        },
       },
 );
 


### PR DESCRIPTION
**Dev logs now render as a single compact line per record**, metadata inline instead of a colorized header followed by half a dozen indented key/value pairs. The old format made the terminal scroll-happy — one busy handler could push everything else off screen.

Enabled via pino-pretty's `singleLine: true`. *Production logs (raw JSON) are unaffected.*

Closes #384.