### PR TITLE
Fan out home-manager and e2e on the linux CI lane

### DIFF
--- a/ci/lib.just
+++ b/ci/lib.just
@@ -118,22 +118,29 @@ _contexts:
     #!/usr/bin/env bash
     set -euo pipefail
     just --dump --dump-format json | jq -r '
-      .modules.ci.recipes
-      | to_entries[]
+      .modules.ci.recipes as $r
+      # Expand a recipe name to its externally-visible step names.
+      # Underscore-prefixed recipes (e.g. _linux-fanout) are internal helpers,
+      # not CI contexts — replace them with their dependencies, recursively.
+      | def expand:
+          if startswith("_") then
+            [ $r[.].dependencies[]?.recipe | expand ] | add // []
+          else [.] end;
+      $r | to_entries[]
       | select(.key | startswith("_"))
       | .value.body[0][0] // "" as $first
       # Multi-system: CI_SYSTEM=<sys> just ci::<step> ...
       | if ($first | test("^CI_SYSTEM=")) then
-          .value.body[0][0]
+          $first
           | capture("CI_SYSTEM=(?<system>[^ ]+) just (?<steps>.+?)( \\|\\| true)?$")
           | .system as $sys
-          | .steps | split(" ") | map(ltrimstr("ci::")) | .[]
+          | ([ .steps | split(" ")[] | ltrimstr("ci::") | expand ] | add // [])[]
           | . + "@" + $sys
         # Local-only: just ci::<step> ... (exclude internal _helpers)
         elif ($first | test("^just ci::[a-z]")) then
           $first
           | capture("just (?<steps>.+?)( \\|\\| true)?$")
-          | .steps | split(" ") | map(ltrimstr("ci::")) | .[]
+          | ([ .steps | split(" ")[] | ltrimstr("ci::") | expand ] | add // [])[]
         else empty end'
 
 # Print summary table of all CI statuses for the current sha

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -22,7 +22,13 @@ _local:
     just ci::fmt ci::typecheck ci::unit ci::apm-sync || true
 
 _linux:
-    CI_SYSTEM=x86_64-linux just ci::nix ci::home-manager ci::e2e || true
+    CI_SYSTEM=x86_64-linux just ci::nix ci::_linux-fanout || true
+
+# Runs home-manager and e2e in parallel after nix has completed.
+# Within the same just process, their `: nix` deps are already satisfied,
+# so nix is not rebuilt.
+[parallel]
+_linux-fanout: home-manager e2e
 
 _darwin:
     CI_SYSTEM=aarch64-darwin just ci::nix ci::e2e || true


### PR DESCRIPTION
**`just ci` on linux now runs `home-manager` and `e2e` in parallel** once the shared `nix` build finishes, instead of chaining all three serially. On a trivial config PR the linux lane was routinely the critical path — home-manager sat idle behind e2e for minutes when it had no reason to.

A new `[parallel]` helper recipe `_linux-fanout` depends on `home-manager` and `e2e`, and `_linux` invokes it as `just ci::nix ci::_linux-fanout`. *Within a single `just` process, dep-dedup collapses the implicit `: nix` deps to a no-op*, so `nix` still runs exactly once and the fanout kicks in only after it completes.

Safe with respect to the per-step `_guard` clean-worktree check: both steps execute remotely via SSH, and the only local write is `tee` into `.logs/`, which is gitignored. *No new worktree-mutation hazard beyond what `_run-all` already tolerates across lanes.*