### PR TITLE
docs: instruct agents to log flaky tests under #320

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -39,6 +39,8 @@ gh api "repos/<owner>/<repo>/statuses/<sha>" --jq '[.[] | select(.context | star
 
 **Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`).
 
+**Log flaky tests**: If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
+
 ## Local CI
 
 Run `just ci` to build and test across all systems. It:

--- a/agents/.apm/instructions/workflow.instructions.md
+++ b/agents/.apm/instructions/workflow.instructions.md
@@ -39,6 +39,8 @@ gh api "repos/<owner>/<repo>/statuses/<sha>" --jq '[.[] | select(.context | star
 
 **Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`).
 
+**Log flaky tests**: If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
+
 ## Local CI
 
 Run `just ci` to build and test across all systems. It:


### PR DESCRIPTION
**Agents now have an explicit instruction to log flaky tests**: when CI detects a test that failed once but passed on retry, the agent should post a comment on #320 capturing the failure, so the running flaky-test log stays current without humans curating it.

The instruction lives next to the existing flaky-vs-real guidance in the CI section of `workflow.instructions.md`, which is the canonical place `/do` reads its CI conventions from. _No code changes — purely a docs nudge so agents stop silently swallowing flakes on retry._

Closes #400.