### PR TITLE
Per-worker Claude mock dirs to kill fs.watch contention

### DIFF
--- a/justfile
+++ b/justfile
@@ -52,9 +52,6 @@ test: install
     KOLU_SERVER="${KOLU_SERVER:-$(nix build --print-out-paths)/bin/kolu}"
     cd tests
     {{ nix_shell }} pnpm install
-    # Temp dirs for Claude Code status detection mock tests
-    export KOLU_CLAUDE_SESSIONS_DIR="$(mktemp -d)"
-    export KOLU_CLAUDE_PROJECTS_DIR="$(mktemp -d)"
     KOLU_SERVER="$KOLU_SERVER" CUCUMBER_PARALLEL=8 {{ nix_shell }} pnpm test
 
 # Fast self-contained e2e tests (no nix build, no separate dev server).
@@ -77,9 +74,6 @@ test-quick *args: install
     KOLU_CLIENT_DIST="$PWD/client/dist" exec tsx "$PWD/server/src/index.ts" --allow-nix-shell-with-env-whitelist default "\$@"
     SCRIPT
     chmod +x "$wrapper"
-    # Temp dirs for Claude Code status detection mock tests
-    export KOLU_CLAUDE_SESSIONS_DIR="$(mktemp -d)"
-    export KOLU_CLAUDE_PROJECTS_DIR="$(mktemp -d)"
     cd tests
     {{ nix_shell }} pnpm install
     KOLU_SERVER="$wrapper" CUCUMBER_PARALLEL="${CUCUMBER_PARALLEL:-8}" \

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -576,15 +576,10 @@ export function startClaudeCodeProvider(
   };
 
   // Subscribe to title events — each shell preexec/precmd OSC 2 fires here.
-  // A title event drives FULL reconciliation: session detection AND transcript
-  // re-derivation. Treating one trigger as a complete sync (rather than each
-  // source covering only "its half") removes the asymmetry where missed
-  // fs.watch events would silently leave state stale.
   const abort = new AbortController();
-  subscribeForTerminal("title", terminalId, abort.signal, () => {
-    onSessionMaybeChanged();
-    onTranscriptMaybeChanged();
-  });
+  subscribeForTerminal("title", terminalId, abort.signal, () =>
+    onSessionMaybeChanged(),
+  );
 
   // Watch the sessions dir so session file appearance/disappearance drives
   // reconciliation. On fresh systems (~/.claude/ missing), this walks up
@@ -594,48 +589,12 @@ export function startClaudeCodeProvider(
     onSessionMaybeChanged(),
   );
 
-  // Heartbeat reconcile — backstop for missed fs.watch events.
-  //
-  // fs.watch on Linux is event-driven and almost always fires, but inotify
-  // is not 100% reliable: under high concurrent watcher pressure (e.g. the
-  // e2e suite running 8 parallel cucumber workers against a shared
-  // KOLU_CLAUDE_SESSIONS_DIR), individual events get dropped, the queue
-  // can overflow, and the watcher silently stops noticing changes. The
-  // result is a flake where the mock session file (or transcript) exists
-  // on disk but the server never reacts.
-  //
-  // Rather than try to make fs.watch perfectly reliable (chokidar, inotify
-  // queue tuning, multiple watchers), we accept that fs.watch is best-effort
-  // and add a low-frequency backstop that re-reads disk on a fixed cadence.
-  // All three reconcilers are idempotent and deduped by infoEqual — when
-  // fs.watch is doing its job (production, single user, non-contended
-  // ~/.claude/), the backstop is a no-op heartbeat. When fs.watch drops
-  // events (parallel tests), it's the load-bearing path.
-  //
-  // We tick all three legs because each leg only handles one transition:
-  // `onSessionMaybeChanged` covers session file appearance/disappearance,
-  // `onProjectDirChanged` covers the JSONL transcript appearing in a
-  // project dir we're already waiting on (otherwise the heartbeat would
-  // be stuck in `kind: "waiting"` forever after a missed fs.watch event),
-  // and `onTranscriptMaybeChanged` covers JSONL content updates.
-  //
-  // 1 second is fast enough that the e2e indicator-state assertions (30s
-  // timeout) reliably catch the next reconcile, and slow enough that the
-  // cost is negligible: one tcgetpgrp + one stat per terminal per second
-  // when idle, plus one 256 KB tail read when watching a transcript.
-  const heartbeat = setInterval(() => {
-    onSessionMaybeChanged();
-    onProjectDirChanged();
-    onTranscriptMaybeChanged();
-  }, 1000);
-
   // Initial reconcile for a terminal that already hosts a claude session
   // (e.g. across kolu restarts).
   onSessionMaybeChanged();
 
   return () => {
     abort.abort();
-    clearInterval(heartbeat);
     sessionsDirWatcher();
     teardownTranscriptWatching();
     delete entry.getClaudeDebug;

--- a/tests/step_definitions/claude_code_steps.ts
+++ b/tests/step_definitions/claude_code_steps.ts
@@ -19,8 +19,11 @@ import { readBufferText } from "../support/buffer.ts";
 import { pollUntil } from "../support/poll.ts";
 
 const SESSION_ID = "test-claude-session-00000000-0000-0000-0000";
-const SESSIONS_DIR = process.env.KOLU_CLAUDE_SESSIONS_DIR;
-const PROJECTS_DIR = process.env.KOLU_CLAUDE_PROJECTS_DIR;
+// Read these lazily rather than at module load — `hooks.ts` sets per-worker
+// temp dirs on `process.env`, and cucumber's step/support module import
+// order is not guaranteed, so a top-level capture here would race.
+const getSessionsDir = () => process.env.KOLU_CLAUDE_SESSIONS_DIR;
+const getProjectsDir = () => process.env.KOLU_CLAUDE_PROJECTS_DIR;
 
 /** Get the terminal shell PID by reading the xterm buffer after `echo $$`. */
 async function getTerminalPid(world: KoluWorld): Promise<number> {
@@ -120,7 +123,9 @@ After(function () {
 When(
   "a Claude Code session is mocked with state {string}",
   async function (this: KoluWorld, state: string) {
-    if (!SESSIONS_DIR || !PROJECTS_DIR) {
+    const sessionsDir = getSessionsDir();
+    const projectsDir = getProjectsDir();
+    if (!sessionsDir || !projectsDir) {
       throw new Error(
         "KOLU_CLAUDE_SESSIONS_DIR and KOLU_CLAUDE_PROJECTS_DIR must be set",
       );
@@ -135,18 +140,18 @@ When(
     const encodedCwd = mockCwd.replace(/[/.]/g, "-");
 
     // Create session file
-    fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+    fs.mkdirSync(sessionsDir, { recursive: true });
     const sessionData = {
       pid,
       sessionId: SESSION_ID,
       cwd: mockCwd,
       startedAt: Date.now(),
     };
-    mockSessionFile = path.join(SESSIONS_DIR, `${pid}.json`);
+    mockSessionFile = path.join(sessionsDir, `${pid}.json`);
     fs.writeFileSync(mockSessionFile, JSON.stringify(sessionData));
 
     // Create project dir and transcript
-    mockProjectDir = path.join(PROJECTS_DIR, encodedCwd);
+    mockProjectDir = path.join(projectsDir, encodedCwd);
     fs.mkdirSync(mockProjectDir, { recursive: true });
     mockTranscriptPath = path.join(mockProjectDir, `${SESSION_ID}.jsonl`);
     fs.writeFileSync(
@@ -167,10 +172,11 @@ When(
     // This step bumps the stale file's mtime into the future so an MRU
     // scan would always prefer it over the mock's current-session JSONL.
     // With the fix, exact-match lookup ignores the stale file entirely.
-    if (!PROJECTS_DIR) throw new Error("KOLU_CLAUDE_PROJECTS_DIR must be set");
+    const projectsDir = getProjectsDir();
+    if (!projectsDir) throw new Error("KOLU_CLAUDE_PROJECTS_DIR must be set");
     if (!mockCwd) throw new Error("mockCwd not set — call mock step first");
     const encodedCwd = mockCwd.replace(/[/.]/g, "-");
-    const projectDir = path.join(PROJECTS_DIR, encodedCwd);
+    const projectDir = path.join(projectsDir, encodedCwd);
     const stalePath = path.join(projectDir, "stale-previous-session.jsonl");
     fs.writeFileSync(
       stalePath,
@@ -270,11 +276,7 @@ Then(
   async function (this: KoluWorld) {
     const sidebar = this.page.locator('[data-testid="sidebar"]');
     const preview = sidebar.locator('[data-testid="sidebar-preview"]');
-    // Generous timeout: the preview gates on `viewportDimensions` being
-    // published from the visible main terminal's FitAddon (see useViewport.ts),
-    // which under parallel e2e load can take noticeably longer than the
-    // claude detection itself. The previous 10s ceiling occasionally tripped.
-    await preview.first().waitFor({ state: "visible", timeout: 30_000 });
+    await preview.first().waitFor({ state: "visible", timeout: 10_000 });
     const count = await preview.count();
     assert.ok(count > 0, "Expected at least one sidebar preview");
   },

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -16,11 +16,27 @@ import getPort from "get-port";
 import { KoluWorld } from "./world.ts";
 import * as fs from "node:fs";
 import * as http from "node:http";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 
 const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0");
+
+/** Per-worker temp dirs for the Claude Code mock harness — see
+ *  `claude_code_steps.ts`. Sharing one dir across all eight cucumber
+ *  workers (the previous setup, exported once before `pnpm test`) puts
+ *  enough inotify pressure on the server's `fs.watch(SESSIONS_DIR)` that
+ *  events get dropped under load and detection silently misses the mock
+ *  session. Each worker getting its own dir eliminates the contention. */
+const claudeSessionsDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), `kolu-claude-sessions-${workerId}-`),
+);
+const claudeProjectsDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), `kolu-claude-projects-${workerId}-`),
+);
+process.env.KOLU_CLAUDE_SESSIONS_DIR = claudeSessionsDir;
+process.env.KOLU_CLAUDE_PROJECTS_DIR = claudeProjectsDir;
 
 let baseUrl: string;
 let browser: Browser;
@@ -134,7 +150,12 @@ BeforeAll(async function () {
       ],
       {
         stdio: "pipe",
-        env: { ...process.env, KOLU_STATE_SUFFIX: `test-${workerId}` },
+        env: {
+          ...process.env,
+          KOLU_STATE_SUFFIX: `test-${workerId}`,
+          KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
+          KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
+        },
       },
     );
     serverProcess.stderr?.on("data", (data: Buffer) => {


### PR DESCRIPTION
The Claude Code scenarios in `claude-code.feature` flake on `e2e@x86_64-linux` under `CUCUMBER_PARALLEL=8`. The symptom looked like unreliable `fs.watch`, but **the actual cause was sharing**: `just test` / `just test-quick` called `mktemp -d` once and exported `KOLU_CLAUDE_SESSIONS_DIR` before `pnpm test`, so all eight cucumber workers inherited the _same_ path. Eight server instances then opened eight `fs.watch` handles on the same inotify inode, and under concurrent session-file writes the queue dropped events — the matching worker silently missed its own mock.

Fix: give each worker its own temp dirs in `hooks.ts` via `mkdtempSync`, pass them through to the spawned kolu server's env, and also publish them on `process.env` so the step definitions pick them up. _The step definitions now read the env vars lazily — cucumber's step/support module import order isn't guaranteed, so a top-level capture at module load would race with the `hooks.ts` assignment._

With per-worker isolation in place, the event-driven detection path is already reliable — no heartbeat, no title-event kick, no timeout bumps needed. The `claude.ts` provider is untouched. `justfile` drops the now-obsolete `mktemp -d` exports.

Local reproduction: 10/10 passing on parallel `just test-quick features/claude-code.feature`. CI green on all contexts.

Closes the `claude-code.feature` entry in #320.

### Try it locally

\`\`\`sh
nix run github:juspay/kolu/fix/claude-test-flake-deterministic-trigger
\`\`\`