### PR TITLE
Adopt agency's `check` step and rename `just watch` → `just check`

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -48,7 +48,7 @@ After each step's verification, write/update `.do-results.json`:
 Print a progress line before each step:
 
 ```
-[do] ✓sync ✓research ▸hickey · branch · implement · docs · police · fmt · commit · test · ci · update-pr · done
+[do] ✓sync ✓research ▸hickey · branch · implement · check · docs · police · fmt · commit · test · ci · update-pr · done
 ```
 
 ### sync
@@ -120,6 +120,17 @@ Otherwise: implement the planned changes. Prefer simplicity. Do the boring obvio
 **E2E coverage**: When the change introduces multiple user-facing paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**. Enumerate the user-visible paths, then check that every one has a corresponding test.
 
 **Verify**: Code changes match the planned approach. All distinct user-facing paths have test coverage.
+
+---
+
+### check
+
+Read the project's instructions to find the check command — a fast static-correctness gate (e.g. `tsc --noEmit`, `cargo check`, `cabal build`, `mypy`, `dune build @check`). Run it.
+
+This is the cheapest gate in the pipeline, so it runs first — fail fast on broken code before any downstream step does work over it. If no check command is documented, skip this step with a note.
+
+**Verify**: Check ran without errors, or no command configured.
+**If failed** (max 3 attempts): Fix the errors and re-run check. Do not fall back to **implement** — the agent is already in fix mode and the failure is local to just-written code.
 
 ---
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -5,7 +5,7 @@ paths:
 
 ## Workflow
 
-- Use `/do` to execute tasks end-to-end: sync → research → hickey → branch+PR → implement → docs → police → fmt → commit → test → CI → update-pr → done. Each step has a verification check.
+- Use `/do` to execute tasks end-to-end: sync → research → hickey → branch+PR → implement → check → docs → police → fmt → commit → test → CI → update-pr → done. Each step has a verification check.
 - For standalone quality checks, run `/code-police` (includes rules checklist + fact-check + elegance passes).
 - Run `just fmt` (formatting) before declaring done.
 - **Quick e2e tests**: Run `just test-quick` (or `just test-quick features/foo.feature:42` for a single scenario) to verify UI changes. Fast — no nix build, no separate dev server.
@@ -13,7 +13,11 @@ paths:
 
 ## Execute Pipeline Commands
 
-These commands are used by the `/do` workflow's fmt, test, and ci steps.
+These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
+
+### Check command
+
+`just check` — fast static-correctness gate (`pnpm typecheck` under the hood). Runs across the workspace. CI's `ci::typecheck` step uses the same recipe.
 
 ### Format command
 

--- a/agents/.apm/instructions/workflow.instructions.md
+++ b/agents/.apm/instructions/workflow.instructions.md
@@ -5,7 +5,7 @@ applyTo: "**"
 
 ## Workflow
 
-- Use `/do` to execute tasks end-to-end: sync → research → hickey → branch+PR → implement → docs → police → fmt → commit → test → CI → update-pr → done. Each step has a verification check.
+- Use `/do` to execute tasks end-to-end: sync → research → hickey → branch+PR → implement → check → docs → police → fmt → commit → test → CI → update-pr → done. Each step has a verification check.
 - For standalone quality checks, run `/code-police` (includes rules checklist + fact-check + elegance passes).
 - Run `just fmt` (formatting) before declaring done.
 - **Quick e2e tests**: Run `just test-quick` (or `just test-quick features/foo.feature:42` for a single scenario) to verify UI changes. Fast — no nix build, no separate dev server.
@@ -13,7 +13,11 @@ applyTo: "**"
 
 ## Execute Pipeline Commands
 
-These commands are used by the `/do` workflow's fmt, test, and ci steps.
+These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
+
+### Check command
+
+`just check` — fast static-correctness gate (`pnpm typecheck` under the hood). Runs across the workspace. CI's `ci::typecheck` step uses the same recipe.
 
 ### Format command
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-07T20:51:34.652861+00:00'
+generated_at: '2026-04-08T15:15:58.602902+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -46,7 +46,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 965b58d7a88f90e063a3378e4fd22c431866b80f
+  resolved_commit: 8bcef5ca67d7c55a31e012a2b1ee7c907c18af99
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -57,4 +57,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/github-pr
   - .claude/skills/hickey
-  content_hash: sha256:72cb34f3d2d6179297c6b282b7ae531c2639607cc4ba69f26f4c716461b50139
+  content_hash: sha256:5db4048d5766ea64b168da87195ef7f2f13bb2df2ddce0e1ed763670cfd95481

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -40,7 +40,7 @@ home-manager: nix
     just ci::_devour-flake home-manager --override-input flake ./nix/home/example --override-input flake/kolu .
 
 typecheck:
-    just ci::_run typecheck just watch
+    just ci::_run typecheck just check
 
 e2e: nix
     just ci::_run e2e just test

--- a/justfile
+++ b/justfile
@@ -29,8 +29,8 @@ _dev: install _dev-parallel
 [parallel]
 _dev-parallel: server client
 
-# Run TypeScript type checking across all packages
-watch: install
+# Run TypeScript type checking across all packages — fast static-correctness gate
+check: install
     {{ nix_shell }} pnpm typecheck
 
 # Run server with auto-reload


### PR DESCRIPTION
**Agency just gained a `check` step** in `/do` (srid/agency#27) that runs the project's static-correctness command before commit, so type errors don't have to wait for CI. Adopting it here means declaring kolu's check command (`just check`) in workflow instructions and bumping the agency lockfile to pull the new step.

While we're here, the existing `just watch` recipe gets renamed to `just check`. _The name was actively misleading_ — it doesn't watch anything, it runs `pnpm typecheck` once. The rename also lines it up with the new agency step name so workflow.instructions.md reads naturally.

> Migration: anyone with `just watch` in muscle memory needs to switch to `just check`. Repo-wide grep turned up only `justfile` itself and `ci/mod.just`; no other call sites.