### PR TITLE
Add just ai::apm-update recipe and advance srid/agency

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -1,19 +1,22 @@
 ---
-argument-hint: <github-issue-url | prompt> [--review] [--from <step>]
+argument-hint: <issue-url | prompt> [--review] [--no-git] [--from <step>]
 description: Do a task end-to-end — implement, PR, CI loop, ship
 ---
 
 # Do Workflow
 
-Take a task and do it top-to-bottom: research, implement, open a draft PR, pass CI, refine, and ship.
+Take a task and do it top-to-bottom: research, implement, open a draft PR, pass CI, refine, and ship. (Under `--no-git`, extend the working tree in place — no branch, commit, or PR.)
 
 **Fully autonomous.** Do NOT use `AskUserQuestion` at any point (unless `--review` is active during the planning pause). Make sensible default choices and keep moving.
 
 ## Arguments
 
-Parse the arguments string: `[--review] [--from <step-id>] <task description or github-issue-url>`
+Parse the arguments string: `[--review] [--no-git] [--from <step-id>] <task description or issue-url>`
+
+The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** step (see Forge Detection). Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
 
 - `--review`: Pause after **hickey** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously
+- `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, and test all run; git-mutating steps (**branch**, **commit**, **update-pr**) are skipped. Use this when you have uncommitted local work and want the agent to build on it without taking over git state. Feedback from a Bitbucket user in [#26](https://github.com/srid/agency/issues/26).
 - `--from <step-id>`: Start from a specific step (see entry points below)
 
 ## Results Tracking
@@ -26,6 +29,8 @@ After each step's verification, write/update `.do-results.json`:
   "startedAt": "<ISO timestamp>",
   "active": true,
   "status": "running",
+  "forge": "github",
+  "noGit": false,
   "steps": [
     {
       "name": "sync",
@@ -37,6 +42,10 @@ After each step's verification, write/update `.do-results.json`:
   ]
 }
 ```
+
+- `forge` is set during **sync** (see Forge Detection below). One of `github`, `bitbucket`, `unknown`.
+- `noGit` is `true` if the user passed `--no-git`. When set, git-mutating steps (**branch**, **commit**, **update-pr**) record status `skipped` with reason `"--no-git"`.
+- Step `status` is one of `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` field explaining why (e.g., `"non-github forge: bitbucket"`, `"--no-git"`, `"no check command configured"`).
 
 - Set `active` to `true` when the workflow starts (**sync**), and `false` when it ends (**done**). The stop hook uses this field to block premature exits.
 - Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
@@ -55,9 +64,25 @@ Print a progress line before each step:
 
 Run: `git fetch origin && git remote set-head origin --auto`
 
-If current branch is behind origin, fast-forward with `git pull --ff-only`.
+**If `--no-git` is NOT set**: if current branch is behind origin, fast-forward with `git pull --ff-only`.
 
-**Verify**: git fetch ran without error.
+**If `--no-git` is set**: do **not** pull. Fetching the remote is harmless and useful context, but modifying the working tree could conflict with the user's uncommitted work. Leave the branch where it is.
+
+**Dirty-tree hint**: run `git status --porcelain`. If it is non-empty and `--no-git` was NOT passed, print a one-line hint to the terminal:
+
+> _Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with `--no-git`._
+
+Do **not** pause or ask — just print and continue. The user's default-mode invocation is respected.
+
+**Forge detection**: Inspect `git remote get-url origin` and classify:
+
+- URL contains `github.com` → `github`
+- URL contains `bitbucket.` (covers `bitbucket.org` and self-hosted Bitbucket Server, e.g. `bitbucket.juspay.net`) → `bitbucket`
+- Otherwise → `unknown`
+
+Record the result in `.do-results.json` as the top-level `forge` field. Subsequent steps branch on this value. **Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
+
+**Verify**: git fetch ran without error, `forge` is recorded, and `noGit` is recorded.
 
 ---
 
@@ -65,7 +90,7 @@ If current branch is behind origin, fast-forward with `git pull --ff-only`.
 
 Research the task thoroughly before writing code.
 
-- If given a GitHub issue URL, fetch with `gh issue view`
+- If given a GitHub issue URL **and** `forge == github`, fetch with `gh issue view`. On non-GitHub forges, treat any issue-like URL as opaque context — use the prompt text as-is and do not attempt to fetch. (Bitbucket issue/Jira fetching is tracked in #10.)
 - Use Explore subagents, Grep, Glob, Read — whatever it takes to understand the problem
 - **Never assume** how something works. Read the code. Check the config.
 - If the prompt involves external tools/libraries, use WebSearch/WebFetch
@@ -96,18 +121,25 @@ Use `ExitPlanMode` to present the plan. Once approved, continue autonomously fro
 
 ### branch
 
+**If `--no-git`**: Skip this step entirely with status `skipped` and reason `"--no-git"`. Stay on the current branch — do not create, commit, or push anything. Move to **implement**.
+
 Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
 
 1. Create a descriptive feature branch from `origin/<default>`
 2. Create an empty commit: `git commit --allow-empty -m "chore: open PR"`
-3. Push the branch
+3. Push the branch with `git push -u origin <branch>`
+
+**If `forge != github`**: Stop here. Record this step as `passed` with verification noting that the branch was created and pushed but PR creation was skipped due to the non-GitHub forge. Do **not** attempt PR creation or hickey PR comments. Move to **implement**. (Bitbucket PR creation via `bkt pr create` is tracked in #10.)
+
+**If `forge == github`**:
+
 4. Open a draft PR: `gh pr create --draft`
 
-**MANDATORY**: Load the `github-pr` skill (via Skill tool) BEFORE writing the PR title/body.
+**MANDATORY**: Load the `forge-pr` skill (via Skill tool) BEFORE writing the PR title/body.
 
 5. **Post hickey results**: If the hickey step produced findings with suggestions, post the full hickey analysis as a PR comment using `gh pr comment`. Use a `## Hickey Analysis` header. Skip this if hickey found no issues.
 
-**Verify**: On a feature branch (not master/main), draft PR exists (`gh pr view` succeeds). If hickey had findings, a PR comment exists.
+**Verify**: On a feature branch (not master/main). If `forge == github`: draft PR exists (`gh pr view` succeeds), and if hickey had findings, a PR comment exists. If `forge != github`: branch was pushed to origin.
 
 ---
 
@@ -170,6 +202,8 @@ If no format command is documented, skip this step with a note.
 
 ### commit
 
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. Move to **test**. The working-tree changes stay uncommitted — that is the point.
+
 Create a NEW commit (never amend) with a conventional commit message. Push to the PR branch.
 
 **Verify**: `git log -1` shows a new commit on the feature branch, and it's pushed to remote.
@@ -195,21 +229,27 @@ Read the project's instructions to find the CI command and verification method. 
 
 **Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
 
-**Verify**: Use the verification method described in the project's instructions (e.g., checking commit statuses, reading CI output). If no CI command is documented, skip with a note.
+CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
+
+**Verify**: Use the verification method described in the project's instructions (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note.
 
 **On failure** — read logs or output to diagnose.
 
 **Flaky vs real**: A test is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge if the failure pattern is inherently flaky (race conditions, timing, async waits).
 
 **If flaky** (max 3 retries): Retry just the failing step.
-**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI.
+**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop (Fix → **fmt** → retry CI).
 **If retries exhausted**: Set workflow status to `"failed"`, skip to **done**.
 
 ---
 
 ### update-pr
 
-Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `github-pr` skill.
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to update. Proceed to **done**.
+
+**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket `bkt pr edit` wiring is tracked in #10.) Proceed to **done**.
+
+**If `forge == github`**: Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `forge-pr` skill.
 
 **Verify**: PR title/body matches the delivered scope.
 
@@ -219,7 +259,12 @@ Re-check the PR title/body against current scope. If scope changed, update via `
 
 Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
 
-`"completed"` requires **all steps passed**. No redefining "passed," no footnote caveats. Update `.do-results.json` accordingly.
+`"completed"` requires **all steps `passed`**, with two exceptions that count toward completion:
+
+1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
+2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
+
+A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update `.do-results.json` accordingly.
 
 #### Timing summary
 
@@ -239,7 +284,11 @@ Be specific to this run's data, not generic advice.
 
 #### PR comment & wrap-up
 
-Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment` with a markdown table including durations. Format:
+**If `--no-git`**: There is no branch or PR to report against. Print the timing table and optimization suggestions to the terminal only. List the files modified in the working tree (`git status --porcelain`) so the user can see what the agent touched. Remind the user that changes are uncommitted — the commit/push/PR steps are theirs to run.
+
+**If `forge != github`**: Report the branch name (and remote URL, if available via `git remote get-url origin`) instead of a PR URL. Print the timing table and optimization suggestions to the terminal only — do **not** attempt to post a PR comment. (Bitbucket `bkt pr comment` wiring is tracked in #10.)
+
+**If `forge == github`**: Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment` with a markdown table including durations. Format:
 
 ```
 gh pr comment --body "$(cat <<'COMMENT'
@@ -277,11 +326,11 @@ COMMENT
 
 - **Never skip steps.** Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
-- **Feature branches only.** Never commit to master/main.
+- **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
 - **Background for CI.** Run CI with `run_in_background: true`.
 - **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey pause.
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.
-- **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL is reported.
+- **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.
 - **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. Do not proceed to `update-pr` as if nothing happened.
 
 ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/forge-pr/SKILL.md
+++ b/.claude/skills/forge-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: github-pr
-description: Write engaging GitHub PR titles and descriptions. Use when creating or updating PRs. Avoids boring bullet lists; uses narrative paragraphs with bold/italic for emphasis.
+name: forge-pr
+description: Write engaging PR titles and descriptions for any forge (GitHub today; Bitbucket planned). Use when creating or updating PRs. Avoids boring bullet lists; uses narrative paragraphs with bold/italic for emphasis.
 ---
 
-# GitHub PR Writing
+# Forge PR Writing
 
-Write PR descriptions that fellow devs actually want to read.
+Write PR descriptions that fellow devs actually want to read. The writing guidance below is forge-agnostic — only the `gh` commands in the "Updating existing PRs" section are GitHub-specific today. Bitbucket support is tracked in [srid/agency#10](https://github.com/srid/agency/issues/10).
 
 ## Anti-patterns (what LLMs typically produce)
 
@@ -40,7 +40,7 @@ Write PR descriptions that fellow devs actually want to read.
 
 ## Try it locally
 
-If the repo is a Nix flake and the PR branch contains a buildable output (package, NixOS config, etc.), include a "Try it locally" section at the end of the body. Use the GitHub owner/repo and branch name to construct the command, and put it in a **fenced `sh` code block** (not inline backticks) so GitHub renders a copy button and the command doesn't line-wrap awkwardly:
+If the repo is a **GitHub** Nix flake and the PR branch contains a buildable output (package, NixOS config, etc.), include a "Try it locally" section at the end of the body. Use the GitHub owner/repo and branch name to construct the command, and put it in a **fenced `sh` code block** (not inline backticks) so GitHub renders a copy button and the command doesn't line-wrap awkwardly:
 
 ````
 ### Try it locally
@@ -50,14 +50,14 @@ nix run github:<owner>/<repo>/<branch>
 ```
 ````
 
-Adjust the command as needed — `nix build` for non-runnable outputs, add `#<output>` if the default package isn't the relevant one. Omit this section entirely if the change isn't meaningfully testable via `nix run/build` (e.g., CI-only changes, documentation, non-Nix repos).
+Adjust the command as needed — `nix build` for non-runnable outputs, add `#<output>` if the default package isn't the relevant one. Omit this section entirely if the change isn't meaningfully testable via `nix run/build` (e.g., CI-only changes, documentation, non-Nix repos, or non-GitHub forges where flake refs would be awkward).
 
 ## Updating existing PRs
 
 When the user pushes further changes to an already-PR'd branch:
 
 1. Check if the PR title/description still accurately reflects the full scope
-2. If new commits meaningfully change what the PR does, update the title and/or body via `gh pr edit`
+2. If new commits meaningfully change what the PR does, update the title and/or body via the forge's edit command (`gh pr edit` on GitHub)
 3. Don't rewrite from scratch — amend the existing description to cover new ground
 4. Add a brief note about what changed if the scope expanded significantly
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,12 +4,13 @@ Kolu-specific agent configuration, managed by [APM](https://microsoft.github.io/
 
 ## Recipes (`just ai::*`)
 
-| Recipe               | Purpose                                                 |
-| -------------------- | ------------------------------------------------------- |
-| `just ai`            | Install APM config + launch coding agent (default)      |
-| `just ai::apm`       | Deploy APM primitives to `.claude/`                     |
-| `just ai::apm-audit` | Security audit (Unicode, lockfile consistency)          |
-| `just ai::apm-sync`  | Verify vendored `.claude/` matches sources (used by CI) |
+| Recipe                | Purpose                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `just ai`             | Install APM config + launch coding agent (default)       |
+| `just ai::apm`        | Deploy APM primitives to `.claude/`                      |
+| `just ai::apm-update` | Advance locked deps to latest refs (all, or `<package>`) |
+| `just ai::apm-audit`  | Security audit (Unicode, lockfile consistency)           |
+| `just ai::apm-sync`   | Verify vendored `.claude/` matches sources (used by CI)  |
 
 Set `AI_AGENT` to override the default agent (`claude --dangerously-skip-permissions`).
 

--- a/agents/ai.just
+++ b/agents/ai.just
@@ -11,6 +11,12 @@ apm:
     rm -f .claude/settings.json
     {{ apm_cmd }} install
 
+# Advance locked APM dependencies to latest refs (all, or specific packages)
+apm-update *packages:
+    # Same hook-dup workaround as `apm` recipe — see apm#561.
+    rm -f .claude/settings.json
+    {{ apm_cmd }} deps update {{ packages }}
+
 # Audit APM packages for security issues (Unicode, lockfile consistency)
 apm-audit:
     {{ apm_cmd }} audit --ci

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -46,7 +46,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 8bcef5ca67d7c55a31e012a2b1ee7c907c18af99
+  resolved_commit: ff91c01b44b02b56d7946fbb727a7d6a1eb4aa74
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -55,6 +55,6 @@ dependencies:
   - .claude/hooks/agency/scripts/do-stop-guard.sh
   - .claude/rules/apm-sources.md
   - .claude/skills/code-police
-  - .claude/skills/github-pr
+  - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:5db4048d5766ea64b168da87195ef7f2f13bb2df2ddce0e1ed763670cfd95481
+  content_hash: sha256:905777db8cb0d177869ff767c5e6801ed4cbe587d728960fb2cc0222b3dc2748


### PR DESCRIPTION
**Adds `just ai::apm-update` for bumping locked APM dependencies** and uses it to advance `srid/agency` to latest `master`. Before this, there was no documented way to refresh the lockfile — `just ai::apm` honors the pin in `apm.lock.yaml`, so `srid/agency#master` was effectively frozen at whatever commit the lock recorded.

The new recipe wraps `apm deps update` and accepts optional package names (`just ai::apm-update srid/agency` to bump one, bare `just ai::apm-update` to bump all). It applies the same `rm -f .claude/settings.json` pre-clean as `just ai::apm`, since `deps update` re-runs the hook-install path affected by [apm#561](https://github.com/microsoft/apm/issues/561).