### PR TITLE
Fix mobile sidebar scrolling and pull-to-refresh hijack

### DIFF
--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   createEffect,
   createSignal,
 } from "solid-js";
+import { createMediaQuery } from "@solid-primitives/media";
 import {
   DragDropProvider,
   DragDropSensors,
@@ -115,6 +116,12 @@ const SidebarEntry: Component<{
   };
   const sortable = createSortable(props.id);
   const tier = () => cardTier(props.displayInfo?.meta.claude?.state);
+  /** On touch devices, drag-anywhere conflicts with vertical scrolling
+   *  (every swipe becomes a drag candidate via `touch-action: none`).
+   *  When coarse, drag activation moves to a small grip handle inside
+   *  the card and the button switches to `touch-action: pan-y` so the
+   *  list scrolls. Desktop keeps the drag-anywhere behavior unchanged. */
+  const isCoarse = createMediaQuery("(pointer: coarse)");
 
   /** When this entry becomes active, scroll itself into view. Handles both
    *  switching to an existing terminal AND creating a new one: in either
@@ -183,7 +190,10 @@ const SidebarEntry: Component<{
             sortable.ref(el);
             buttonRef = el;
           }}
-          {...sortable.dragActivators}
+          // Drag activators only on the button when NOT coarse — desktop
+          // keeps drag-anywhere; on coarse, the grip span below owns
+          // activation so the button surface stays scroll-friendly.
+          {...(isCoarse() ? {} : sortable.dragActivators)}
           data-terminal-id={props.id}
           data-active={props.isActive ? "" : undefined}
           data-activity={
@@ -192,8 +202,13 @@ const SidebarEntry: Component<{
               : "sleeping"
           }
           data-unread={props.unread ? "" : undefined}
-          class="group relative w-full text-sm text-left touch-none transition-all duration-200"
+          class="group relative w-full text-sm text-left transition-all duration-200"
           classList={{
+            // touch-pan-y on coarse lets vertical scroll pass through;
+            // touch-none on non-coarse preserves the existing desktop
+            // drag-anywhere activation surface.
+            "touch-pan-y": isCoarse(),
+            "touch-none": !isCoarse(),
             "rounded-[14px]": !props.isActive,
             "rounded-l-[14px] rounded-r-none": props.isActive,
             "text-fg": props.isActive || tier() !== "idle",
@@ -259,6 +274,37 @@ const SidebarEntry: Component<{
           >
             ×
           </span>
+          {/* Drag handle — only on coarse-pointer devices. Owns drag
+           *  activation so the rest of the card surface can stay
+           *  scrollable (touch-pan-y). touch-none on the handle itself
+           *  ensures the browser hands the gesture to dnd-kit. */}
+          <Show when={isCoarse()}>
+            <span
+              {...sortable.dragActivators}
+              data-testid="sidebar-drag-handle"
+              // stopPropagation: a tap on the grip is a drag affordance,
+              // not a terminal selector — don't bubble to the button's
+              // onClick (which would switch terminals on every grab).
+              onClick={(e) => e.stopPropagation()}
+              class="absolute bottom-1 right-1 flex items-center justify-center w-7 h-7 text-fg-3 touch-none cursor-grab"
+              aria-label="Drag to reorder"
+              title="Drag to reorder"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <circle cx="5" cy="4" r="1.2" />
+                <circle cx="5" cy="8" r="1.2" />
+                <circle cx="5" cy="12" r="1.2" />
+                <circle cx="11" cy="4" r="1.2" />
+                <circle cx="11" cy="8" r="1.2" />
+                <circle cx="11" cy="12" r="1.2" />
+              </svg>
+            </span>
+          </Show>
         </button>
       </div>
     </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,16 @@
 @import "kolu-fonts";
 @import "tailwindcss";
 
+/* Suppress the browser's pull-to-refresh and scroll-chaining at the
+ * document level. Without this, swiping down at the top of the
+ * sidebar or terminal viewport hijacks the gesture into a page
+ * reload — destroying every open terminal session. `contain` keeps
+ * the local rubber-band feel intact while killing chain-up. */
+html,
+body {
+  overscroll-behavior: contain;
+}
+
 /*
  * @theme registers color names with Tailwind and generates :root CSS custom properties.
  * Values here double as the dark palette — :root:not(.dark) overrides them for light mode.

--- a/tests/features/mobile-sidebar.feature
+++ b/tests/features/mobile-sidebar.feature
@@ -1,0 +1,21 @@
+@mobile
+Feature: Mobile sidebar drag handle
+  On coarse-pointer devices, the sidebar card surface must stay scrollable,
+  so drag-to-reorder activation moves to a small grip handle inside the
+  card. Tapping the handle is a drag affordance only — it must not select
+  the terminal.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Drag handle is rendered on coarse-pointer devices
+    Then the sidebar drag handle should be visible
+
+  Scenario: Card body uses touch-action pan-y so vertical scroll passes through
+    Then the sidebar card should have touch-action "pan-y"
+
+  Scenario: Tapping the drag handle does not switch the active terminal
+    When I create a terminal
+    And I note the active terminal
+    And I tap the drag handle on a non-active sidebar entry
+    Then the active terminal should be unchanged

--- a/tests/step_definitions/mobile_sidebar_steps.ts
+++ b/tests/step_definitions/mobile_sidebar_steps.ts
@@ -1,0 +1,86 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import * as assert from "node:assert";
+
+/** Locator for the drag handle inside any sidebar entry. */
+const DRAG_HANDLE = '[data-testid="sidebar-drag-handle"]';
+
+Then(
+  "the sidebar drag handle should be visible",
+  async function (this: KoluWorld) {
+    const handle = this.page.locator(DRAG_HANDLE).first();
+    await handle.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the sidebar card should have touch-action {string}",
+  async function (this: KoluWorld, expected: string) {
+    // Read the computed touch-action from the actual button DOM node — the
+    // card surface that needs to stay scrollable on touch. Tailwind compiles
+    // touch-pan-y to `touch-action: pan-y`.
+    const card = this.page
+      .locator('[data-testid="sidebar"] [data-terminal-id]')
+      .first();
+    await card.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const actual = await card.evaluate(
+      (el) => getComputedStyle(el).touchAction,
+    );
+    assert.strictEqual(
+      actual,
+      expected,
+      `Expected sidebar card touch-action to be "${expected}", got "${actual}"`,
+    );
+  },
+);
+
+When("I note the active terminal", async function (this: KoluWorld) {
+  // Active sidebar entry carries the `data-active` attribute (set in
+  // SidebarEntry when props.isActive). Snapshot the id for the
+  // "should be unchanged" assertion below.
+  const id = await this.page
+    .locator('[data-testid="sidebar"] [data-active]')
+    .first()
+    .getAttribute("data-terminal-id");
+  assert.ok(id, "No active sidebar entry found to note");
+  this.savedActiveTerminalId = id;
+});
+
+When(
+  "I tap the drag handle on a non-active sidebar entry",
+  async function (this: KoluWorld) {
+    // Find any sidebar entry that is NOT the active one and tap its grip.
+    // Uses page.touchscreen.tap to dispatch a real touch event — a click
+    // would also work since stopPropagation is on click, but tap exercises
+    // the pointerdown path the dnd library actually subscribes to.
+    const inactive = this.page
+      .locator('[data-testid="sidebar"] [data-terminal-id]:not([data-active])')
+      .first();
+    await inactive.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const handle = inactive.locator(DRAG_HANDLE);
+    const box = await handle.boundingBox();
+    assert.ok(box, "Drag handle has no bounding box");
+    await this.page.touchscreen.tap(
+      box.x + box.width / 2,
+      box.y + box.height / 2,
+    );
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the active terminal should be unchanged",
+  async function (this: KoluWorld) {
+    const expected = this.savedActiveTerminalId;
+    assert.ok(expected, "No active terminal was noted earlier");
+    const current = await this.page
+      .locator('[data-testid="sidebar"] [data-active]')
+      .first()
+      .getAttribute("data-terminal-id");
+    assert.strictEqual(
+      current,
+      expected,
+      `Active terminal changed: expected ${expected}, got ${current}`,
+    );
+  },
+);

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -178,7 +178,7 @@ AfterAll(async function () {
   killServer();
 });
 
-Before(async function (this: KoluWorld) {
+Before(async function (this: KoluWorld, scenario) {
   // Kill leftover terminals and reset state so each scenario starts clean
   await Promise.all([
     postJSON(`${baseUrl}/rpc/terminal/killAll`, {}),
@@ -200,9 +200,17 @@ Before(async function (this: KoluWorld) {
     }),
   ]);
 
+  // @mobile tag → emulate a touch phone (flips `(pointer: coarse)` to true,
+  // mounts the mobile drag handle, switches the sidebar into overlay mode).
+  // Without the tag, scenarios run in the desktop context unchanged.
+  const isMobile = scenario.pickle.tags.some((t) => t.name === "@mobile");
+
   this.browser = browser;
   this.context = await browser.newContext({
-    viewport: { width: 1280, height: 720 },
+    viewport: isMobile
+      ? { width: 390, height: 844 }
+      : { width: 1280, height: 720 },
+    ...(isMobile && { hasTouch: true, isMobile: true }),
     baseURL: baseUrl,
     ignoreHTTPSErrors: true,
     // clipboard-write: lets tests place images in the clipboard for paste testing.

--- a/tests/support/world.ts
+++ b/tests/support/world.ts
@@ -37,6 +37,7 @@ export class KoluWorld extends World {
   lastResponseOk?: boolean;
   terminalCountBeforeRefresh?: number;
   savedSidebarCount?: number;
+  savedActiveTerminalId?: string;
   savedScrollTop?: number;
   savedVisibleText?: string;
   _scrollFifo?: string;
@@ -62,11 +63,30 @@ export class KoluWorld extends World {
     const settled = this.page.locator(SETTLED_SELECTOR);
     await settled.first().waitFor({ state: "visible", timeout });
 
+    // On mobile (@mobile tag) the sidebar starts collapsed (`-translate-x-full`)
+    // so the create button sits at a negative x. `isVisible()` doesn't catch
+    // this — translated-offscreen elements still have a non-empty bounding box.
+    // Check the actual x coordinate and click the hamburger if needed.
+    const createBtn = this.page.locator('[data-testid="create-terminal"]');
+    const box = await createBtn.boundingBox();
+    if (!box || box.x < 0) {
+      await this.page.locator('[data-testid="sidebar-toggle"]').click();
+      await this.page.waitForFunction(
+        () => {
+          const btn = document.querySelector('[data-testid="create-terminal"]');
+          if (!btn) return false;
+          const r = btn.getBoundingClientRect();
+          return r.x >= 0;
+        },
+        { timeout },
+      );
+    }
+
     // Note the last sidebar entry before creating, so we can identify the new one
     const entries = this.page.locator(SIDEBAR_ENTRY_SELECTOR);
     const countBefore = await entries.count();
 
-    await this.page.locator('[data-testid="create-terminal"]').click();
+    await createBtn.click();
 
     // Wait for the new entry to appear in the sidebar
     await entries.nth(countBefore).waitFor({ state: "visible", timeout });


### PR DESCRIPTION
**The mobile sidebar was unscrollable and the browser's pull-to-refresh kept eating downward swipes** intended for the terminal viewport. Two surgical fixes for the on-phone experience that landed alongside the mobile key bar in #412.

The sidebar bug came from `touch-action: none` on the entire card surface, which `@thisbeyond/solid-dnd` documents as the way to make drag work on touch — fine for desktop, lethal for thumbs. *Every vertical swipe became a drag candidate, so the list never scrolled.* On coarse-pointer devices, drag activation now lives on a small grip handle inside the card; the card body switches to `touch-action: pan-y` so vertical scroll passes through. Desktop keeps drag-anywhere unchanged — the grip is hidden via a `Show` gate and drag activators remain on the button.

Pull-to-refresh is suppressed with a one-liner `overscroll-behavior: contain` on `html, body`. *This is the cheapest possible fix for the gesture that's been silently breaking every other touch interaction at the top of the page.*

### Try it locally

```sh
nix run github:juspay/kolu/fix/mobile-sidebar-scroll-and-pull-refresh
```