### PR TITLE
Touch-swipe scrolls the terminal scrollback on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nix run github:juspay/kolu -- --host 0.0.0.0 --port 8080  # expose on LAN
 - Font zoom (<kbd>Cmd/Ctrl</kbd> <kbd>+</kbd>/<kbd>-</kbd>), persisted per terminal across sessions
 - WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Lazy attach — late-joining clients receive serialized screen state (~4KB) instead of replaying raw buffer
-- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap
+- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap. Touch-swipe inside the terminal scrolls the scrollback buffer
 
 ### Navigation
 

--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -371,6 +371,56 @@ const Terminal: Component<{
       e.preventDefault(),
     );
 
+    // Touch-scroll the scrollback. xterm.js 6.0.0 declares
+    // IViewport.handleTouchStart/Move types but Viewport.ts has zero
+    // touch wiring, and the WebGL canvas eats touch events on the way
+    // to the parent .xterm-viewport — so swipes inside the terminal
+    // do nothing on mobile until we bridge them ourselves.
+    //
+    // Single-variable state machine: touchAnchorY is the Y baseline
+    // that line conversion is measured from. null when idle, a number
+    // while a swipe is in progress. On every emitted line the anchor
+    // advances by exactly the consumed pixels, so the sub-line residue
+    // lives implicitly in (currentY - touchAnchorY) on the next move
+    // — no separate accumulator to keep in sync.
+    //
+    // scrollLock picks up the resulting term.onScroll for free, so
+    // freezing live output while the user reads scrollback works
+    // without any extra wiring.
+    let touchAnchorY: number | null = null;
+    makeEventListener(containerRef, "touchstart", (e: TouchEvent) => {
+      // Multi-touch (pinch-zoom) passes through to the browser
+      if (e.touches.length !== 1) return;
+      touchAnchorY = e.touches[0]!.clientY;
+    });
+    makeEventListener(containerRef, "touchmove", (e: TouchEvent) => {
+      // Multi-touch interrupts a swipe — drop the anchor so the next
+      // single-finger move starts a fresh gesture instead of resuming
+      // from a stale (possibly far-away) reference point.
+      if (e.touches.length !== 1) {
+        touchAnchorY = null;
+        return;
+      }
+      if (touchAnchorY === null || !terminal) return;
+      const screen = terminal.element?.querySelector(
+        ".xterm-screen",
+      ) as HTMLElement | null;
+      if (!screen) return;
+      const cellHeight = screen.clientHeight / terminal.rows;
+      // Number.isFinite catches NaN (0/0 if rows is transiently 0) which
+      // a bare `<= 0` check would miss — NaN poisons the anchor.
+      if (!Number.isFinite(cellHeight) || cellHeight <= 0) return;
+      const currentY = e.touches[0]!.clientY;
+      const lines = Math.trunc((currentY - touchAnchorY) / cellHeight);
+      if (lines === 0) return;
+      // Down-swipe (positive delta) shows earlier scrollback → scrollLines(-N)
+      terminal.scrollLines(-lines);
+      touchAnchorY += lines * cellHeight;
+    });
+    makeEventListener(containerRef, "touchend", () => {
+      touchAnchorY = null;
+    });
+
     // Bridge browser clipboard images → PTY for Claude Code's Ctrl+V image paste.
     // Capture phase fires before xterm's own paste handler on the textarea,
     // letting us intercept images while text paste falls through to xterm.

--- a/tests/features/mobile-terminal-scroll.feature
+++ b/tests/features/mobile-terminal-scroll.feature
@@ -1,0 +1,18 @@
+@mobile
+Feature: Mobile terminal touch-scroll
+  On coarse-pointer devices, swiping vertically inside the terminal
+  viewport should scroll the xterm scrollback buffer. xterm.js 6.0.0
+  ships type declarations for IViewport touch handling without an
+  implementation, and the WebGL canvas eats touch events on the way
+  to the parent scrollable div — so a hand-rolled touchstart/touchmove
+  bridge calls terminal.scrollLines() based on the cell-height
+  conversion of the swipe delta.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Touch-swiping down inside the terminal scrolls the scrollback up
+    When I run "seq 1 200"
+    And I note the terminal viewport scroll position
+    And I swipe down inside the terminal viewport
+    Then the terminal viewport scroll position should have decreased

--- a/tests/step_definitions/mobile_terminal_scroll_steps.ts
+++ b/tests/step_definitions/mobile_terminal_scroll_steps.ts
@@ -1,0 +1,141 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import { pollUntilBufferContains } from "../support/buffer.ts";
+import * as assert from "node:assert";
+
+/** Read xterm's current viewportY (top row of the visible window). When the
+ *  user is scrolled to the bottom, viewportY === baseY. Scrolling up
+ *  decreases it; we use that signed change as the "did scroll" assertion. */
+async function readViewportY(world: KoluWorld): Promise<number> {
+  return world.page.evaluate(() => {
+    const container = document.querySelector(
+      "[data-visible][data-terminal-id]",
+    ) as
+      | (HTMLElement & {
+          __xterm?: { buffer: { active: { viewportY: number } } };
+        })
+      | null;
+    const y = container?.__xterm?.buffer.active.viewportY;
+    if (y === undefined) throw new Error("xterm not found on active terminal");
+    return y;
+  });
+}
+
+When(
+  "I note the terminal viewport scroll position",
+  async function (this: KoluWorld) {
+    // Wait for `seq` output to fill scrollback past the viewport so there's
+    // somewhere to scroll TO. Polling on a high line number guarantees the
+    // buffer is deeper than the visible window.
+    await pollUntilBufferContains(this.page, "200");
+    this.savedScrollTop = await readViewportY(this);
+  },
+);
+
+When(
+  "I swipe down inside the terminal viewport",
+  async function (this: KoluWorld) {
+    // Dispatch a synthetic touchstart/touchmove/touchend on the terminal
+    // container. Playwright's touchscreen.tap() only does single taps, and
+    // hasTouch context doesn't translate mouse drags to touch — synthetic
+    // TouchEvent dispatch is the most reliable path for swipe gestures.
+    //
+    // Down-swipe (deltaY positive) is what users do to reveal earlier
+    // scrollback. Anchor near the bottom of the viewport, drag to near the
+    // top — a ~400px stroke covers many cells regardless of font size.
+    const container = this.page.locator("[data-visible][data-terminal-id]");
+    const box = await container.boundingBox();
+    assert.ok(box, "Terminal container has no bounding box");
+    const x = box.x + box.width / 2;
+    // Finger swipes DOWN — start near the top, end near the bottom.
+    // (Y increases downward in screen coordinates.) The handler converts
+    // a positive Y-delta into scrollLines(-N), which moves the viewport
+    // up the scrollback.
+    const startY = box.y + 20;
+    const endY = box.y + box.height - 20;
+
+    // NOTE: no nested function declarations inside page.evaluate.
+    // swc wraps named functions with a `__name` debug helper that
+    // doesn't exist in the browser context (other step files in this
+    // repo follow the same single-level arrow pattern). The Y values
+    // for each event are pre-computed in this Node-side scope and
+    // passed across as a plain array.
+    const steps = 8;
+    const ys: number[] = [];
+    for (let i = 1; i <= steps; i++) {
+      ys.push(startY + ((endY - startY) * i) / steps);
+    }
+    await this.page.evaluate(
+      ({ sel, x, startY, endY, ys }) => {
+        const target = document.querySelector(sel) as HTMLElement | null;
+        if (!target) throw new Error("No element matches " + sel);
+        const startTouch = new Touch({
+          identifier: 0,
+          target,
+          clientX: x,
+          clientY: startY,
+        });
+        target.dispatchEvent(
+          new TouchEvent("touchstart", {
+            touches: [startTouch],
+            targetTouches: [startTouch],
+            changedTouches: [startTouch],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        for (const y of ys) {
+          const t = new Touch({
+            identifier: 0,
+            target,
+            clientX: x,
+            clientY: y,
+          });
+          target.dispatchEvent(
+            new TouchEvent("touchmove", {
+              touches: [t],
+              targetTouches: [t],
+              changedTouches: [t],
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        }
+        const endTouch = new Touch({
+          identifier: 0,
+          target,
+          clientX: x,
+          clientY: endY,
+        });
+        target.dispatchEvent(
+          new TouchEvent("touchend", {
+            touches: [],
+            targetTouches: [],
+            changedTouches: [endTouch],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      },
+      { sel: "[data-visible][data-terminal-id]", x, startY, endY, ys },
+    );
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the terminal viewport scroll position should have decreased",
+  async function (this: KoluWorld) {
+    const before = this.savedScrollTop;
+    assert.ok(before !== undefined, "No scroll position was noted earlier");
+    let after = before;
+    for (let i = 0; i < 20; i++) {
+      after = await readViewportY(this);
+      if (after < before) return;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.fail(
+      `Expected viewportY to decrease from ${before}, but it stayed at ${after} after ${POLL_TIMEOUT}ms`,
+    );
+  },
+);


### PR DESCRIPTION
**Swiping vertically inside the terminal viewport on mobile now scrolls the xterm scrollback** instead of doing nothing. The mobile work in #412/#418/#419 fixed the keyboard, the sidebar, and pull-to-refresh — but the terminal itself was still a dead zone for touch, because xterm.js 6.0.0 ships type declarations for `IViewport.handleTouchStart`/`handleTouchMove` without an actual implementation in `Viewport.ts`, and the WebGL canvas eats touch events on the way to the parent scrollable div.

A small hand-rolled handler in `Terminal.tsx` bridges the gap: `touchstart` captures an anchor Y, `touchmove` converts the pixel delta into whole lines using the live cell height (`screen.clientHeight / term.rows`), and calls `terminal.scrollLines()`. *The anchor advances by exactly the consumed pixels on each emission, so the sub-line residue lives in `(currentY − anchorY)` instead of a separate accumulator — one variable, two states (idle and anchored), no rule to remember.* Multi-touch is ignored so pinch-zoom still passes through to the browser.

The existing `scrollLock` state machine picks up the touch-driven scroll for free via `term.onScroll`, so freezing live output while the user reads scrollback Just Works without any new wiring.

A `@mobile` cucumber scenario fills 200 lines of scrollback, dispatches a synthetic `touchstart`/`touchmove`/`touchend` sequence on the viewport, and asserts the visible buffer text changed. Reuses the `hasTouch + isMobile` Playwright context that landed in #419.

### Try it locally

```sh
nix run github:juspay/kolu/feat/mobile-terminal-touch-scroll
```