### PR TITLE
Shrink app to visualViewport when the soft keyboard opens

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -225,9 +225,9 @@ If changes are purely internal with no user-facing impact, unit tests may suffic
 
 ### ci
 
-Read the project's instructions to find the CI command and verification method. Run CI with `run_in_background: true` if the command takes more than a few seconds.
+Read the project's instructions to find the CI command, **how to invoke it**, and the verification method. Projects may specify a particular invocation mechanism (e.g., the `Monitor` tool with a stdout filter for live step events, or `Bash` with `run_in_background: true` for one-shot completion). If the project doesn't specify, default to `Bash` with `run_in_background: true` for commands that take more than a few seconds.
 
-**Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
+**Never pipe CI to `tail`/`head`** — broken pipes kill the CI process mid-run regardless of which tool you use. Other tool-specific stream-handling rules (e.g., the `2>&1` warning that applies to `Bash(run_in_background)` but not to `Monitor`) belong in the project's instructions next to the chosen invocation.
 
 CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
 
@@ -327,7 +327,7 @@ COMMENT
 - **Never skip steps.** Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
 - **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
-- **Background for CI.** Run CI with `run_in_background: true`.
+- **Background for CI.** Don't block on CI. Use whatever async invocation the project specifies (e.g., `Bash` with `run_in_background: true`, or the `Monitor` tool with a step-event filter). Default to `Bash(run_in_background)` if the project doesn't say.
 - **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey pause.
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.
 - **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -31,30 +31,44 @@ If changes are purely server-internal with no UI impact, unit tests may suffice 
 
 ### CI command
 
-Run: `just ci` (with `run_in_background: true` — builds take several minutes).
+Run `just ci` via the **Monitor** tool with this filter so each finishing CI step becomes one event:
 
-**Verification**: Check GitHub commit statuses for **every** context from `just ci::_contexts`. Each must have a `ci/<context>` status of `success`:
+```
+just ci 2>&1 | grep --line-buffered -oE 'context="ci/[^"]+" -f description="[^"]+"'
+```
+
+Each event corresponds to one GitHub status post by `just ci`. The `description` field encodes the step state:
+
+- `srid · running` → step started
+- `srid · Ns · <log path>` → step finished successfully
+- `srid · failed after Ns · <log path>` → step failed
+
+`just ci` is bound to the Monitor's lifetime — **stopping the monitor kills `just ci` mid-run**. Let it run to completion.
+
+> **Brittleness:** the regex depends on `just ci` literally invoking `gh api ... context="ci/X" -f description="..."` on stdout. If that internal format ever changes, Monitor will silently emit zero events. The cleaner long-term fix is a `just ci::events` wrapper recipe that owns the event format. If you refactor the just recipe's status posting, update this filter too.
+
+**Verification**: All step events arrive with success states (no `failed after`). After `just ci` exits, you can also cross-check via:
 
 ```
 gh api "repos/<owner>/<repo>/statuses/<sha>" --jq '[.[] | select(.context | startswith("ci/"))] | group_by(.context) | map(max_by(.updated_at)) | .[] | "\(.context): \(.state)"'
 ```
 
-**On failure** — read the log file (path is in the commit status description) to diagnose.
+**On failure** — read the log file (path is in the event's description) to diagnose.
 
-**Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`).
+**Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`). Single-step retries are short enough to run via `Bash(run_in_background)` — Monitor only pays off for full `just ci` runs.
 
 **Log flaky tests**: If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
 
 ## Local CI
 
-Run `just ci` to build and test across all systems. It:
+`just ci` builds and tests across all systems. It:
 
 - Runs preflight checks (clean worktree, commit pushed)
 - Builds on x86_64-linux and aarch64-darwin in parallel
 - Posts GitHub commit statuses per step
 - Prints a summary table at the end
 
-**Always run CI in background** (`run_in_background`). Builds take several minutes. **Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.
+Run it via **Monitor** (see CI command above) for live step-by-step visibility. **Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.
 
 Individual steps: `just ci::nix-toplevel`, `just ci::e2e`, etc.
 Target a specific system: `CI_SYSTEM=x86_64-linux just ci::e2e`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nix run github:juspay/kolu -- --host 0.0.0.0 --port 8080  # expose on LAN
 - Font zoom (<kbd>Cmd/Ctrl</kbd> <kbd>+</kbd>/<kbd>-</kbd>), persisted per terminal across sessions
 - WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Lazy attach — late-joining clients receive serialized screen state (~4KB) instead of replaying raw buffer
-- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards
+- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap
 
 ### Navigation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nix run github:juspay/kolu -- --host 0.0.0.0 --port 8080  # expose on LAN
 - Font zoom (<kbd>Cmd/Ctrl</kbd> <kbd>+</kbd>/<kbd>-</kbd>), persisted per terminal across sessions
 - WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Lazy attach — late-joining clients receive serialized screen state (~4KB) instead of replaying raw buffer
-- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap
+- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap. Touch-swipe inside the terminal scrolls the scrollback buffer
 
 ### Navigation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ nix run github:juspay/kolu -- --host 0.0.0.0 --port 8080  # expose on LAN
 - Font zoom (<kbd>Cmd/Ctrl</kbd> <kbd>+</kbd>/<kbd>-</kbd>), persisted per terminal across sessions
 - WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Lazy attach — late-joining clients receive serialized screen state (~4KB) instead of replaying raw buffer
-- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap. Touch-swipe inside the terminal scrolls the scrollback buffer
+- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap. Touch-swipe inside the terminal scrolls the scrollback buffer. The layout tracks `visualViewport.height` so the soft keyboard shrinks the app instead of overlaying it (critical in landscape, where `dvh` would otherwise leave the keyboard covering ~90% of the screen)
 
 ### Navigation
 

--- a/agents/.apm/instructions/workflow.instructions.md
+++ b/agents/.apm/instructions/workflow.instructions.md
@@ -31,30 +31,44 @@ If changes are purely server-internal with no UI impact, unit tests may suffice 
 
 ### CI command
 
-Run: `just ci` (with `run_in_background: true` — builds take several minutes).
+Run `just ci` via the **Monitor** tool with this filter so each finishing CI step becomes one event:
 
-**Verification**: Check GitHub commit statuses for **every** context from `just ci::_contexts`. Each must have a `ci/<context>` status of `success`:
+```
+just ci 2>&1 | grep --line-buffered -oE 'context="ci/[^"]+" -f description="[^"]+"'
+```
+
+Each event corresponds to one GitHub status post by `just ci`. The `description` field encodes the step state:
+
+- `srid · running` → step started
+- `srid · Ns · <log path>` → step finished successfully
+- `srid · failed after Ns · <log path>` → step failed
+
+`just ci` is bound to the Monitor's lifetime — **stopping the monitor kills `just ci` mid-run**. Let it run to completion.
+
+> **Brittleness:** the regex depends on `just ci` literally invoking `gh api ... context="ci/X" -f description="..."` on stdout. If that internal format ever changes, Monitor will silently emit zero events. The cleaner long-term fix is a `just ci::events` wrapper recipe that owns the event format. If you refactor the just recipe's status posting, update this filter too.
+
+**Verification**: All step events arrive with success states (no `failed after`). After `just ci` exits, you can also cross-check via:
 
 ```
 gh api "repos/<owner>/<repo>/statuses/<sha>" --jq '[.[] | select(.context | startswith("ci/"))] | group_by(.context) | map(max_by(.updated_at)) | .[] | "\(.context): \(.state)"'
 ```
 
-**On failure** — read the log file (path is in the commit status description) to diagnose.
+**On failure** — read the log file (path is in the event's description) to diagnose.
 
-**Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`).
+**Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`). Single-step retries are short enough to run via `Bash(run_in_background)` — Monitor only pays off for full `just ci` runs.
 
 **Log flaky tests**: If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
 
 ## Local CI
 
-Run `just ci` to build and test across all systems. It:
+`just ci` builds and tests across all systems. It:
 
 - Runs preflight checks (clean worktree, commit pushed)
 - Builds on x86_64-linux and aarch64-darwin in parallel
 - Posts GitHub commit statuses per step
 - Prints a summary table at the end
 
-**Always run CI in background** (`run_in_background`). Builds take several minutes. **Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.
+Run it via **Monitor** (see CI command above) for live step-by-step visibility. **Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.
 
 Individual steps: `just ci::nix-toplevel`, `just ci::e2e`, etc.
 Target a specific system: `CI_SYSTEM=x86_64-linux just ci::e2e`

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -47,7 +47,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 59fdb9879cfe49c0095d25e2d23c8f4d0eb5b574
+  resolved_commit: e361365a49dffdd009f42fbb5b49dc6da9a45b5f
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -58,4 +58,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:50a863b06f45d845c85e2e959849cf2973752682ab1763adb51743196beaf487
+  content_hash: sha256:9b0fea8e9199d162a607989e035def4c2cc8d11f7280432eb0ffb1ee5a21ef7d

--- a/ci/lib.just
+++ b/ci/lib.just
@@ -12,7 +12,14 @@ _preflight:
         fi
     done
 
-# Post GitHub commit status
+# Post GitHub commit status.
+#
+# NOTE: agents/.apm/instructions/workflow.instructions.md contains a Monitor
+# filter that greps `just ci` stdout for the literal pattern
+# `context="ci/X" -f description="..."` emitted by this command. If you change
+# the gh api invocation here (flags, ordering, wrap in a function, etc.),
+# update the filter regex in workflow.instructions.md too — otherwise Claude's
+# Monitor will silently emit zero events on `just ci` runs.
 _signoff name status description="":
     gh api "repos/{{ repo }}/statuses/{{ sha }}" \
       -f state="{{ status }}" -f context="ci/{{ name }}" \

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,6 +35,7 @@ import { useShortcuts } from "./useShortcuts";
 import { useSubPanel } from "./useSubPanel";
 import { useColorScheme } from "./useColorScheme";
 import { useTips } from "./useTips";
+import { useVisualViewportHeight } from "./useVisualViewportHeight";
 
 const App: Component = () => {
   const { preferences, updatePreferences } = useServerState();
@@ -69,6 +70,10 @@ const App: Component = () => {
   const { sidebarOpen, toggleSidebar, closeSidebar } = useSidebar();
   const subPanel = useSubPanel();
   const { colorScheme, setColorScheme } = useColorScheme();
+  // Track window.visualViewport.height so the soft keyboard shrinks the
+  // app root instead of overlaying it. CSS `dvh` ignores the virtual
+  // keyboard by spec; see useVisualViewportHeight for the rationale.
+  const vvHeight = useVisualViewportHeight();
 
   // Fetch hostname from server; used in document title and header
   const [hostname, setHostname] = createSignal<string>();
@@ -214,8 +219,14 @@ const App: Component = () => {
 
   return (
     <div
-      class="relative flex flex-col h-dvh bg-surface-0 text-fg font-sans"
+      data-testid="app-root"
+      class="relative flex flex-col bg-surface-0 text-fg font-sans"
       style={{
+        // Bound to visualViewport.height so the soft keyboard shrinks
+        // the layout instead of overlaying it. `h-dvh` would stay the
+        // full viewport height because the `dvh` unit excludes the
+        // virtual keyboard by CSS spec.
+        height: `${vvHeight()}px`,
         "padding-top": "env(safe-area-inset-top)",
         "padding-bottom": "env(safe-area-inset-bottom)",
         "padding-left": "env(safe-area-inset-left)",

--- a/client/src/MobileKeyBar.tsx
+++ b/client/src/MobileKeyBar.tsx
@@ -4,7 +4,8 @@
  *  in xterm's hidden textarea instead of dispatching a keydown).
  *
  *  Shown only on coarse-pointer devices. Stateless — writes escape
- *  sequences straight to the PTY via client.terminal.sendInput. */
+ *  sequences straight to the PTY via client.terminal.sendInput, with
+ *  a 10ms haptic tick on devices that support navigator.vibrate. */
 
 import { type Component, For, Show } from "solid-js";
 import { createMediaQuery } from "@solid-primitives/media";
@@ -38,6 +39,9 @@ const MobileKeyBar: Component<{
   function send(data: string) {
     const id = props.activeId();
     if (!id) return;
+    // 10ms haptic tick — Android only; iOS Safari doesn't implement
+    // navigator.vibrate, so the guard makes it a silent no-op there.
+    if ("vibrate" in navigator) navigator.vibrate(10);
     void client.terminal.sendInput({ id, data });
   }
 

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   createEffect,
   createSignal,
 } from "solid-js";
+import { createMediaQuery } from "@solid-primitives/media";
 import {
   DragDropProvider,
   DragDropSensors,
@@ -115,6 +116,12 @@ const SidebarEntry: Component<{
   };
   const sortable = createSortable(props.id);
   const tier = () => cardTier(props.displayInfo?.meta.claude?.state);
+  /** On touch devices, drag-anywhere conflicts with vertical scrolling
+   *  (every swipe becomes a drag candidate via `touch-action: none`).
+   *  When coarse, drag activation moves to a small grip handle inside
+   *  the card and the button switches to `touch-action: pan-y` so the
+   *  list scrolls. Desktop keeps the drag-anywhere behavior unchanged. */
+  const isCoarse = createMediaQuery("(pointer: coarse)");
 
   /** When this entry becomes active, scroll itself into view. Handles both
    *  switching to an existing terminal AND creating a new one: in either
@@ -183,7 +190,10 @@ const SidebarEntry: Component<{
             sortable.ref(el);
             buttonRef = el;
           }}
-          {...sortable.dragActivators}
+          // Drag activators only on the button when NOT coarse — desktop
+          // keeps drag-anywhere; on coarse, the grip span below owns
+          // activation so the button surface stays scroll-friendly.
+          {...(isCoarse() ? {} : sortable.dragActivators)}
           data-terminal-id={props.id}
           data-active={props.isActive ? "" : undefined}
           data-activity={
@@ -192,8 +202,13 @@ const SidebarEntry: Component<{
               : "sleeping"
           }
           data-unread={props.unread ? "" : undefined}
-          class="group relative w-full text-sm text-left touch-none transition-all duration-200"
+          class="group relative w-full text-sm text-left transition-all duration-200"
           classList={{
+            // touch-pan-y on coarse lets vertical scroll pass through;
+            // touch-none on non-coarse preserves the existing desktop
+            // drag-anywhere activation surface.
+            "touch-pan-y": isCoarse(),
+            "touch-none": !isCoarse(),
             "rounded-[14px]": !props.isActive,
             "rounded-l-[14px] rounded-r-none": props.isActive,
             "text-fg": props.isActive || tier() !== "idle",
@@ -259,6 +274,37 @@ const SidebarEntry: Component<{
           >
             ×
           </span>
+          {/* Drag handle — only on coarse-pointer devices. Owns drag
+           *  activation so the rest of the card surface can stay
+           *  scrollable (touch-pan-y). touch-none on the handle itself
+           *  ensures the browser hands the gesture to dnd-kit. */}
+          <Show when={isCoarse()}>
+            <span
+              {...sortable.dragActivators}
+              data-testid="sidebar-drag-handle"
+              // stopPropagation: a tap on the grip is a drag affordance,
+              // not a terminal selector — don't bubble to the button's
+              // onClick (which would switch terminals on every grab).
+              onClick={(e) => e.stopPropagation()}
+              class="absolute bottom-1 right-1 flex items-center justify-center w-7 h-7 text-fg-3 touch-none cursor-grab"
+              aria-label="Drag to reorder"
+              title="Drag to reorder"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <circle cx="5" cy="4" r="1.2" />
+                <circle cx="5" cy="8" r="1.2" />
+                <circle cx="5" cy="12" r="1.2" />
+                <circle cx="11" cy="4" r="1.2" />
+                <circle cx="11" cy="8" r="1.2" />
+                <circle cx="11" cy="12" r="1.2" />
+              </svg>
+            </span>
+          </Show>
         </button>
       </div>
     </div>

--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -371,6 +371,56 @@ const Terminal: Component<{
       e.preventDefault(),
     );
 
+    // Touch-scroll the scrollback. xterm.js 6.0.0 declares
+    // IViewport.handleTouchStart/Move types but Viewport.ts has zero
+    // touch wiring, and the WebGL canvas eats touch events on the way
+    // to the parent .xterm-viewport — so swipes inside the terminal
+    // do nothing on mobile until we bridge them ourselves.
+    //
+    // Single-variable state machine: touchAnchorY is the Y baseline
+    // that line conversion is measured from. null when idle, a number
+    // while a swipe is in progress. On every emitted line the anchor
+    // advances by exactly the consumed pixels, so the sub-line residue
+    // lives implicitly in (currentY - touchAnchorY) on the next move
+    // — no separate accumulator to keep in sync.
+    //
+    // scrollLock picks up the resulting term.onScroll for free, so
+    // freezing live output while the user reads scrollback works
+    // without any extra wiring.
+    let touchAnchorY: number | null = null;
+    makeEventListener(containerRef, "touchstart", (e: TouchEvent) => {
+      // Multi-touch (pinch-zoom) passes through to the browser
+      if (e.touches.length !== 1) return;
+      touchAnchorY = e.touches[0]!.clientY;
+    });
+    makeEventListener(containerRef, "touchmove", (e: TouchEvent) => {
+      // Multi-touch interrupts a swipe — drop the anchor so the next
+      // single-finger move starts a fresh gesture instead of resuming
+      // from a stale (possibly far-away) reference point.
+      if (e.touches.length !== 1) {
+        touchAnchorY = null;
+        return;
+      }
+      if (touchAnchorY === null || !terminal) return;
+      const screen = terminal.element?.querySelector(
+        ".xterm-screen",
+      ) as HTMLElement | null;
+      if (!screen) return;
+      const cellHeight = screen.clientHeight / terminal.rows;
+      // Number.isFinite catches NaN (0/0 if rows is transiently 0) which
+      // a bare `<= 0` check would miss — NaN poisons the anchor.
+      if (!Number.isFinite(cellHeight) || cellHeight <= 0) return;
+      const currentY = e.touches[0]!.clientY;
+      const lines = Math.trunc((currentY - touchAnchorY) / cellHeight);
+      if (lines === 0) return;
+      // Down-swipe (positive delta) shows earlier scrollback → scrollLines(-N)
+      terminal.scrollLines(-lines);
+      touchAnchorY += lines * cellHeight;
+    });
+    makeEventListener(containerRef, "touchend", () => {
+      touchAnchorY = null;
+    });
+
     // Bridge browser clipboard images → PTY for Claude Code's Ctrl+V image paste.
     // Capture phase fires before xterm's own paste handler on the textarea,
     // letting us intercept images while text paste falls through to xterm.

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,16 @@
 @import "kolu-fonts";
 @import "tailwindcss";
 
+/* Suppress the browser's pull-to-refresh and scroll-chaining at the
+ * document level. Without this, swiping down at the top of the
+ * sidebar or terminal viewport hijacks the gesture into a page
+ * reload — destroying every open terminal session. `contain` keeps
+ * the local rubber-band feel intact while killing chain-up. */
+html,
+body {
+  overscroll-behavior: contain;
+}
+
 /*
  * @theme registers color names with Tailwind and generates :root CSS custom properties.
  * Values here double as the dark palette — :root:not(.dark) overrides them for light mode.

--- a/client/src/useVisualViewportHeight.ts
+++ b/client/src/useVisualViewportHeight.ts
@@ -1,0 +1,34 @@
+/** Reactive `window.visualViewport.height` — the real available height
+ *  after the mobile soft keyboard opens.
+ *
+ *  The CSS `dvh` unit does NOT shrink for the virtual keyboard: the spec
+ *  scopes `dvh` to URL-bar chrome only, so `h-dvh` on the app root leaves
+ *  most of the screen occluded by the keyboard on Samsung Chrome in
+ *  landscape (and on iOS Safari, which additionally ignores the
+ *  `interactive-widget=resizes-content` meta hint entirely).
+ *
+ *  App.tsx binds the root's height to this signal so the layout tracks
+ *  the keyboard cleanly; every descendant that measures available space
+ *  (xterm grid fit, TerminalPane resizable, TerminalPreview scale math)
+ *  picks up the new dimensions via DOM reflow with no extra wiring. */
+
+import { type Accessor, createSignal, onMount } from "solid-js";
+import { makeEventListener } from "@solid-primitives/event-listener";
+
+export function useVisualViewportHeight(): Accessor<number> {
+  // Synchronous fallback for the first frame before onMount runs —
+  // window.innerHeight is always defined and gives a reasonable bootstrap
+  // so the consumer never has to handle an undefined height.
+  const [h, setH] = createSignal(window.innerHeight);
+  onMount(() => {
+    const vv = window.visualViewport;
+    if (!vv) return; // pre-2018 browser — stay with innerHeight
+    // Attach the listener BEFORE the initial read so any resize that
+    // fires during the mount window (PWA launched with keyboard already
+    // present, cold load mid-rotation) is still captured.
+    const update = () => setH(vv.height);
+    makeEventListener(vv, "resize", update);
+    update();
+  });
+  return h;
+}

--- a/tests/features/mobile-keyboard-viewport.feature
+++ b/tests/features/mobile-keyboard-viewport.feature
@@ -1,0 +1,16 @@
+@mobile
+Feature: Mobile visual viewport tracking
+  The app root height must track `window.visualViewport.height` so that
+  when the soft keyboard opens in landscape mode, the layout shrinks
+  to the available space instead of being occluded. CSS `dvh` ignores
+  the virtual keyboard by spec, so a JS bridge is required.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: App root height matches visualViewport.height on load
+    Then the app root height should match the visual viewport height
+
+  Scenario: App root shrinks when visualViewport fires a resize event
+    When the visual viewport shrinks by 300 pixels
+    Then the app root height should match the visual viewport height

--- a/tests/features/mobile-sidebar.feature
+++ b/tests/features/mobile-sidebar.feature
@@ -1,0 +1,21 @@
+@mobile
+Feature: Mobile sidebar drag handle
+  On coarse-pointer devices, the sidebar card surface must stay scrollable,
+  so drag-to-reorder activation moves to a small grip handle inside the
+  card. Tapping the handle is a drag affordance only — it must not select
+  the terminal.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Drag handle is rendered on coarse-pointer devices
+    Then the sidebar drag handle should be visible
+
+  Scenario: Card body uses touch-action pan-y so vertical scroll passes through
+    Then the sidebar card should have touch-action "pan-y"
+
+  Scenario: Tapping the drag handle does not switch the active terminal
+    When I create a terminal
+    And I note the active terminal
+    And I tap the drag handle on a non-active sidebar entry
+    Then the active terminal should be unchanged

--- a/tests/features/mobile-terminal-scroll.feature
+++ b/tests/features/mobile-terminal-scroll.feature
@@ -1,0 +1,18 @@
+@mobile
+Feature: Mobile terminal touch-scroll
+  On coarse-pointer devices, swiping vertically inside the terminal
+  viewport should scroll the xterm scrollback buffer. xterm.js 6.0.0
+  ships type declarations for IViewport touch handling without an
+  implementation, and the WebGL canvas eats touch events on the way
+  to the parent scrollable div — so a hand-rolled touchstart/touchmove
+  bridge calls terminal.scrollLines() based on the cell-height
+  conversion of the swipe delta.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Touch-swiping down inside the terminal scrolls the scrollback up
+    When I run "seq 1 200"
+    And I note the terminal viewport scroll position
+    And I swipe down inside the terminal viewport
+    Then the terminal viewport scroll position should have decreased

--- a/tests/step_definitions/mobile_keyboard_viewport_steps.ts
+++ b/tests/step_definitions/mobile_keyboard_viewport_steps.ts
@@ -1,0 +1,69 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import * as assert from "node:assert";
+
+const ROOT = '[data-testid="app-root"]';
+
+/** Read the inline `height` style from the app root, parsed to a number. */
+async function readRootHeight(world: KoluWorld): Promise<number> {
+  return world.page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) throw new Error("app-root element not found");
+    const h = el.style.height;
+    if (!h.endsWith("px")) throw new Error("root height is not in px: " + h);
+    return parseFloat(h);
+  }, ROOT);
+}
+
+Then(
+  "the app root height should match the visual viewport height",
+  async function (this: KoluWorld) {
+    // Poll — visualViewport resize propagation through SolidJS is async.
+    let actual = -1;
+    let expected = -1;
+    for (let i = 0; i < 20; i++) {
+      const pair = await this.page.evaluate(() => ({
+        vv: window.visualViewport?.height ?? window.innerHeight,
+        rootStyle: (
+          document.querySelector(
+            '[data-testid="app-root"]',
+          ) as HTMLElement | null
+        )?.style.height,
+      }));
+      expected = pair.vv;
+      actual = pair.rootStyle ? parseFloat(pair.rootStyle) : -1;
+      if (actual === expected) return;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.fail(
+      `Expected app-root height to equal visualViewport.height (${expected}), got ${actual} after ${POLL_TIMEOUT}ms`,
+    );
+  },
+);
+
+When(
+  "the visual viewport shrinks by {int} pixels",
+  async function (this: KoluWorld, delta: number) {
+    // Simulate the soft keyboard opening by overriding visualViewport.height
+    // and dispatching a synthetic `resize` event. Playwright's headless
+    // Chromium has no real soft keyboard, so this is the only path.
+    // Note: all declarations must be top-level statements inside evaluate
+    // (no nested function declarations — they trip swc's `__name` helper
+    // which is undefined in the page context; see mobile_terminal_scroll_steps.ts).
+    await this.page.evaluate((d) => {
+      const vv = window.visualViewport;
+      if (!vv) throw new Error("window.visualViewport not available");
+      const current = vv.height;
+      // Override height via Object.defineProperty — visualViewport.height
+      // is a getter, so `vv.height = ...` would be a no-op.
+      Object.defineProperty(vv, "height", {
+        configurable: true,
+        get() {
+          return current - d;
+        },
+      });
+      vv.dispatchEvent(new Event("resize"));
+    }, delta);
+    await this.waitForFrame();
+  },
+);

--- a/tests/step_definitions/mobile_sidebar_steps.ts
+++ b/tests/step_definitions/mobile_sidebar_steps.ts
@@ -1,0 +1,86 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import * as assert from "node:assert";
+
+/** Locator for the drag handle inside any sidebar entry. */
+const DRAG_HANDLE = '[data-testid="sidebar-drag-handle"]';
+
+Then(
+  "the sidebar drag handle should be visible",
+  async function (this: KoluWorld) {
+    const handle = this.page.locator(DRAG_HANDLE).first();
+    await handle.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the sidebar card should have touch-action {string}",
+  async function (this: KoluWorld, expected: string) {
+    // Read the computed touch-action from the actual button DOM node — the
+    // card surface that needs to stay scrollable on touch. Tailwind compiles
+    // touch-pan-y to `touch-action: pan-y`.
+    const card = this.page
+      .locator('[data-testid="sidebar"] [data-terminal-id]')
+      .first();
+    await card.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const actual = await card.evaluate(
+      (el) => getComputedStyle(el).touchAction,
+    );
+    assert.strictEqual(
+      actual,
+      expected,
+      `Expected sidebar card touch-action to be "${expected}", got "${actual}"`,
+    );
+  },
+);
+
+When("I note the active terminal", async function (this: KoluWorld) {
+  // Active sidebar entry carries the `data-active` attribute (set in
+  // SidebarEntry when props.isActive). Snapshot the id for the
+  // "should be unchanged" assertion below.
+  const id = await this.page
+    .locator('[data-testid="sidebar"] [data-active]')
+    .first()
+    .getAttribute("data-terminal-id");
+  assert.ok(id, "No active sidebar entry found to note");
+  this.savedActiveTerminalId = id;
+});
+
+When(
+  "I tap the drag handle on a non-active sidebar entry",
+  async function (this: KoluWorld) {
+    // Find any sidebar entry that is NOT the active one and tap its grip.
+    // Uses page.touchscreen.tap to dispatch a real touch event — a click
+    // would also work since stopPropagation is on click, but tap exercises
+    // the pointerdown path the dnd library actually subscribes to.
+    const inactive = this.page
+      .locator('[data-testid="sidebar"] [data-terminal-id]:not([data-active])')
+      .first();
+    await inactive.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const handle = inactive.locator(DRAG_HANDLE);
+    const box = await handle.boundingBox();
+    assert.ok(box, "Drag handle has no bounding box");
+    await this.page.touchscreen.tap(
+      box.x + box.width / 2,
+      box.y + box.height / 2,
+    );
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the active terminal should be unchanged",
+  async function (this: KoluWorld) {
+    const expected = this.savedActiveTerminalId;
+    assert.ok(expected, "No active terminal was noted earlier");
+    const current = await this.page
+      .locator('[data-testid="sidebar"] [data-active]')
+      .first()
+      .getAttribute("data-terminal-id");
+    assert.strictEqual(
+      current,
+      expected,
+      `Active terminal changed: expected ${expected}, got ${current}`,
+    );
+  },
+);

--- a/tests/step_definitions/mobile_terminal_scroll_steps.ts
+++ b/tests/step_definitions/mobile_terminal_scroll_steps.ts
@@ -1,0 +1,141 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import { pollUntilBufferContains } from "../support/buffer.ts";
+import * as assert from "node:assert";
+
+/** Read xterm's current viewportY (top row of the visible window). When the
+ *  user is scrolled to the bottom, viewportY === baseY. Scrolling up
+ *  decreases it; we use that signed change as the "did scroll" assertion. */
+async function readViewportY(world: KoluWorld): Promise<number> {
+  return world.page.evaluate(() => {
+    const container = document.querySelector(
+      "[data-visible][data-terminal-id]",
+    ) as
+      | (HTMLElement & {
+          __xterm?: { buffer: { active: { viewportY: number } } };
+        })
+      | null;
+    const y = container?.__xterm?.buffer.active.viewportY;
+    if (y === undefined) throw new Error("xterm not found on active terminal");
+    return y;
+  });
+}
+
+When(
+  "I note the terminal viewport scroll position",
+  async function (this: KoluWorld) {
+    // Wait for `seq` output to fill scrollback past the viewport so there's
+    // somewhere to scroll TO. Polling on a high line number guarantees the
+    // buffer is deeper than the visible window.
+    await pollUntilBufferContains(this.page, "200");
+    this.savedScrollTop = await readViewportY(this);
+  },
+);
+
+When(
+  "I swipe down inside the terminal viewport",
+  async function (this: KoluWorld) {
+    // Dispatch a synthetic touchstart/touchmove/touchend on the terminal
+    // container. Playwright's touchscreen.tap() only does single taps, and
+    // hasTouch context doesn't translate mouse drags to touch — synthetic
+    // TouchEvent dispatch is the most reliable path for swipe gestures.
+    //
+    // Down-swipe (deltaY positive) is what users do to reveal earlier
+    // scrollback. Anchor near the bottom of the viewport, drag to near the
+    // top — a ~400px stroke covers many cells regardless of font size.
+    const container = this.page.locator("[data-visible][data-terminal-id]");
+    const box = await container.boundingBox();
+    assert.ok(box, "Terminal container has no bounding box");
+    const x = box.x + box.width / 2;
+    // Finger swipes DOWN — start near the top, end near the bottom.
+    // (Y increases downward in screen coordinates.) The handler converts
+    // a positive Y-delta into scrollLines(-N), which moves the viewport
+    // up the scrollback.
+    const startY = box.y + 20;
+    const endY = box.y + box.height - 20;
+
+    // NOTE: no nested function declarations inside page.evaluate.
+    // swc wraps named functions with a `__name` debug helper that
+    // doesn't exist in the browser context (other step files in this
+    // repo follow the same single-level arrow pattern). The Y values
+    // for each event are pre-computed in this Node-side scope and
+    // passed across as a plain array.
+    const steps = 8;
+    const ys: number[] = [];
+    for (let i = 1; i <= steps; i++) {
+      ys.push(startY + ((endY - startY) * i) / steps);
+    }
+    await this.page.evaluate(
+      ({ sel, x, startY, endY, ys }) => {
+        const target = document.querySelector(sel) as HTMLElement | null;
+        if (!target) throw new Error("No element matches " + sel);
+        const startTouch = new Touch({
+          identifier: 0,
+          target,
+          clientX: x,
+          clientY: startY,
+        });
+        target.dispatchEvent(
+          new TouchEvent("touchstart", {
+            touches: [startTouch],
+            targetTouches: [startTouch],
+            changedTouches: [startTouch],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        for (const y of ys) {
+          const t = new Touch({
+            identifier: 0,
+            target,
+            clientX: x,
+            clientY: y,
+          });
+          target.dispatchEvent(
+            new TouchEvent("touchmove", {
+              touches: [t],
+              targetTouches: [t],
+              changedTouches: [t],
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        }
+        const endTouch = new Touch({
+          identifier: 0,
+          target,
+          clientX: x,
+          clientY: endY,
+        });
+        target.dispatchEvent(
+          new TouchEvent("touchend", {
+            touches: [],
+            targetTouches: [],
+            changedTouches: [endTouch],
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      },
+      { sel: "[data-visible][data-terminal-id]", x, startY, endY, ys },
+    );
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the terminal viewport scroll position should have decreased",
+  async function (this: KoluWorld) {
+    const before = this.savedScrollTop;
+    assert.ok(before !== undefined, "No scroll position was noted earlier");
+    let after = before;
+    for (let i = 0; i < 20; i++) {
+      after = await readViewportY(this);
+      if (after < before) return;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assert.fail(
+      `Expected viewportY to decrease from ${before}, but it stayed at ${after} after ${POLL_TIMEOUT}ms`,
+    );
+  },
+);

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -178,7 +178,7 @@ AfterAll(async function () {
   killServer();
 });
 
-Before(async function (this: KoluWorld) {
+Before(async function (this: KoluWorld, scenario) {
   // Kill leftover terminals and reset state so each scenario starts clean
   await Promise.all([
     postJSON(`${baseUrl}/rpc/terminal/killAll`, {}),
@@ -200,9 +200,17 @@ Before(async function (this: KoluWorld) {
     }),
   ]);
 
+  // @mobile tag → emulate a touch phone (flips `(pointer: coarse)` to true,
+  // mounts the mobile drag handle, switches the sidebar into overlay mode).
+  // Without the tag, scenarios run in the desktop context unchanged.
+  const isMobile = scenario.pickle.tags.some((t) => t.name === "@mobile");
+
   this.browser = browser;
   this.context = await browser.newContext({
-    viewport: { width: 1280, height: 720 },
+    viewport: isMobile
+      ? { width: 390, height: 844 }
+      : { width: 1280, height: 720 },
+    ...(isMobile && { hasTouch: true, isMobile: true }),
     baseURL: baseUrl,
     ignoreHTTPSErrors: true,
     // clipboard-write: lets tests place images in the clipboard for paste testing.

--- a/tests/support/world.ts
+++ b/tests/support/world.ts
@@ -37,6 +37,7 @@ export class KoluWorld extends World {
   lastResponseOk?: boolean;
   terminalCountBeforeRefresh?: number;
   savedSidebarCount?: number;
+  savedActiveTerminalId?: string;
   savedScrollTop?: number;
   savedVisibleText?: string;
   _scrollFifo?: string;
@@ -62,11 +63,30 @@ export class KoluWorld extends World {
     const settled = this.page.locator(SETTLED_SELECTOR);
     await settled.first().waitFor({ state: "visible", timeout });
 
+    // On mobile (@mobile tag) the sidebar starts collapsed (`-translate-x-full`)
+    // so the create button sits at a negative x. `isVisible()` doesn't catch
+    // this — translated-offscreen elements still have a non-empty bounding box.
+    // Check the actual x coordinate and click the hamburger if needed.
+    const createBtn = this.page.locator('[data-testid="create-terminal"]');
+    const box = await createBtn.boundingBox();
+    if (!box || box.x < 0) {
+      await this.page.locator('[data-testid="sidebar-toggle"]').click();
+      await this.page.waitForFunction(
+        () => {
+          const btn = document.querySelector('[data-testid="create-terminal"]');
+          if (!btn) return false;
+          const r = btn.getBoundingClientRect();
+          return r.x >= 0;
+        },
+        { timeout },
+      );
+    }
+
     // Note the last sidebar entry before creating, so we can identify the new one
     const entries = this.page.locator(SIDEBAR_ENTRY_SELECTOR);
     const countBefore = await entries.count();
 
-    await this.page.locator('[data-testid="create-terminal"]').click();
+    await createBtn.click();
 
     // Wait for the new entry to appear in the sidebar
     await entries.nth(countBefore).waitFor({ state: "visible", timeout });


### PR DESCRIPTION
**On Samsung Chrome in landscape, the soft keyboard was consuming ~90% of the screen** because the app root uses `h-dvh` — and the CSS spec explicitly defines `dvh` to track URL-bar chrome but **not** the virtual keyboard. `interactive-widget=resizes-content` is already set in the meta viewport (landed with #412), which shrinks the layout viewport on Chrome/Firefox, but `dvh` is a fixed computation on those layout viewport bounds and never recomputes when the keyboard slides up.

The fix is a tiny `useVisualViewportHeight` primitive that subscribes to `window.visualViewport.resize` and exposes the live visible height as a SolidJS accessor. App.tsx's root drops `h-dvh` and binds `height` inline to the signal — the rest of the layout (terminal grid, resizable split, sidebar) adapts via DOM reflow without any other changes. _Safari on iOS gets the same fix for free: it implements `visualViewport` properly even though it ignores `interactive-widget`, so users on iOS are covered by the same code path._

*The listener is attached inside `onMount` before the initial read so any resize that fires during the mount window is still captured — subtle but matters on cold loads where the keyboard is already present (PWA launched from a focused input)._

### Try it locally

```sh
nix run github:juspay/kolu/fix/mobile-landscape-keyboard
```