### PR TITLE
fix(deps): bump @anthropic-ai/sdk to 0.81.0 for CVE-2026-34451

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,7 +76,7 @@ let
     pname = "kolu";
     version = "0.1.0";
     inherit src;
-    hash = "sha256-AaL2hcUyzHvz9gxJzZFDIED3rSrHqrqyiP+GhRiBQ20=";
+    hash = "sha256-FIHG1bTz7VSKTstqncQ2RNlLdHpAuwqitwQrbubTgIY=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
       "serialize-javascript": "^7.0.3",
       "picomatch": "^4.0.4",
       "yaml": "^2.8.3",
-      "defu": "^6.1.5"
+      "defu": "^6.1.5",
+      "@anthropic-ai/sdk": "^0.81.0"
     },
     "patchedDependencies": {
       "node-pty@1.1.0": "patches/node-pty@1.1.0.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   picomatch: ^4.0.4
   yaml: ^2.8.3
   defu: ^6.1.5
+  '@anthropic-ai/sdk': ^0.81.0
 
 patchedDependencies:
   node-pty@1.1.0:
@@ -246,8 +247,8 @@ packages:
     peerDependencies:
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.80.0':
-    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -3918,7 +3919,7 @@ snapshots:
 
   '@anthropic-ai/claude-agent-sdk@0.2.96(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.80.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -3935,7 +3936,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
**Pins the transitive `@anthropic-ai/sdk` dependency to `^0.81.0`** via `pnpm.overrides` to resolve [Dependabot #23](https://github.com/juspay/kolu/security/dependabot/23) ([GHSA-5474-4w2j-mq4c](https://github.com/advisories/GHSA-5474-4w2j-mq4c) / CVE-2026-34451). The SDK's local filesystem memory tool had a path-prefix check that missed a trailing separator, letting a prompt-injected model read/write sibling directories sharing the memory root's name.

The dep is pulled in by `@anthropic-ai/claude-agent-sdk@0.2.96`, which declares `^0.80.0` — *in 0.x semver that resolves as `>=0.80.0 <0.81.0`, so a plain lockfile refresh won't pick up the patched version.* An override is the right lever. Following the existing pattern in `package.json`, this pins to `^0.81.0` (the minimum patched release), keeping the delta from upstream minimal.