### PR TITLE
Suppress tips on mobile, kill autocorrect on terminal input

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -52,13 +52,25 @@ After each step's verification, write/update `.do-results.json`:
 - Use the Write tool to update the file after each step.
 - Capture timestamps via Bash: `date -u +%Y-%m-%dT%H:%M:%SZ`. Do not guess or hallucinate timestamps.
 
+## Progress tracking
+
+Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with all 14 step names in order:
+
+```
+sync, research, hickey, branch, implement, check, docs, police, fmt, commit, test, ci, update-pr, done
+```
+
+At each step boundary, update task state **alongside** the `.do-results.json` write — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
+
+Rules:
+
+- **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
+- **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
+- **`--from <step>` entry points**: still seed all 14 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 14-item view regardless of entry point.
+- **Skipped steps** (e.g. `branch`/`commit`/`update-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason lives in `.do-results.json`; the task list just shows the step as done.
+- **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and set the JSON `status: "failed"`.
+
 ## Steps
-
-Print a progress line before each step:
-
-```
-[do] ✓sync ✓research ▸hickey · branch · implement · check · docs · police · fmt · commit · test · ci · update-pr · done
-```
 
 ### sync
 

--- a/.claude/commands/talk.md
+++ b/.claude/commands/talk.md
@@ -15,10 +15,38 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 - You MAY use `AskUserQuestion` freely — this is a conversation, not an autonomous workflow.
 - **Talk mode ends when the user invokes an action command** (e.g., `/do`). Until then, stay in talk mode.
 
+## Research before answering — MANDATORY
+
+Talk mode is a research-first workflow, not an off-the-cuff conversation. Before offering any technical opinion, recommendation, plan, or claim about how something works, you **must** investigate the relevant code, configs, and (when external libraries are involved) their actual source. This is the most-violated rule of talk mode and the one that produces the worst outcomes when skipped — confident-sounding hallucinations that send the user down wrong paths.
+
+**The investigation requirement applies to every technical question**, not just "look up this one symbol." It applies even when you think you already know the answer.
+
+### When to use the Explore subagent
+
+Use `Agent(subagent_type=Explore)` for any of:
+
+- Questions about a third-party library's behavior (read the library source in `node_modules/`, `vendor/`, etc. — do not rely on memory of how the library worked in some other version).
+- Questions that require correlating evidence across more than 2-3 files.
+- Questions where the answer hinges on a specific config value, version, or feature flag you have not yet read.
+- "Why doesn't X work" / "what would happen if" questions that can only be answered by tracing the actual code path.
+
+For narrow, single-file lookups, `Grep`/`Read` directly is fine. The line is: if you would be guessing without reading, you must read first.
+
+### Citation requirement
+
+Every non-trivial claim in your response must be backed by a `file:line` reference you actually read in this session. If you cannot cite a file:line for a claim, either go read the source and come back, or explicitly mark the claim as a guess (e.g. "I'm guessing — haven't verified") so the user can weigh it accordingly.
+
+### Anti-patterns
+
+- ❌ "I think xterm.js handles touch via..." (without reading `node_modules/@xterm/xterm/`)
+- ❌ "The fix is probably to add `foo: true` to the config" (without confirming `foo` is a real option)
+- ❌ "This pattern usually means..." (pattern-matching from training data instead of reading the actual codebase)
+- ❌ Recommending a library API that may not exist in the installed version
+- ✅ "I read `Viewport.ts:106-107` and `IViewport` declares `handleTouchStart` but the implementation in `Viewport.ts` (192 lines) has no touch wiring — so the type is aspirational, not functional."
+
 ## Behavior
 
 - Be direct, opinionated, and concise.
-- If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead.
-- **Research before answering.** Read the code, check configs, use Explore/Grep/WebSearch — don't hallucinate or guess. Fact-check your claims against the actual codebase.
+- If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
 
 ARGUMENTS: $ARGUMENTS

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-09T21:26:35.963411+00:00'
+generated_at: '2026-04-10T01:47:57.310147+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -47,7 +47,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: e361365a49dffdd009f42fbb5b49dc6da9a45b5f
+  resolved_commit: bfe880d60f00fb512107e4e43dd5a9b061190b09
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -47,7 +47,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: bfe880d60f00fb512107e4e43dd5a9b061190b09
+  resolved_commit: c53d0b4f849497017e1ce82f7753422dc4cd3ced
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -58,4 +58,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:9b0fea8e9199d162a607989e035def4c2cc8d11f7280432eb0ffb1ee5a21ef7d
+  content_hash: sha256:55ad9eaf0fd8de789cea49aa92af30b0d8d10c453c3eaaea04f9623e7f1f71a4

--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -239,6 +239,15 @@ const Terminal: Component<{
     term.loadAddon(serializeAddon);
 
     term.open(containerRef);
+    // Mobile virtual keyboards autocorrect/autocapitalize xterm's hidden
+    // textarea by default, mangling shell input. Disable all correction
+    // features — terminal input is never prose.
+    if (term.textarea) {
+      term.textarea.setAttribute("autocorrect", "off");
+      term.textarea.setAttribute("autocapitalize", "off");
+      term.textarea.setAttribute("autocomplete", "off");
+      term.textarea.setAttribute("spellcheck", "false");
+    }
     // Expose for e2e tests: read buffer content at viewport position.
     (containerRef as HTMLDivElement & { __xterm?: XTerm }).__xterm = term;
     // Production path for handlers that need live xterm/addon refs

--- a/client/src/useTips.ts
+++ b/client/src/useTips.ts
@@ -9,6 +9,12 @@ import { AMBIENT_TIPS, CONTEXTUAL_TIPS, type Tip, type TipId } from "./tips";
 import type { TerminalId } from "kolu-common";
 import { useServerState } from "./useServerState";
 
+// Tips are suppressed on mobile: they reference keybinds the user can't press
+// and add toast clutter on a small viewport. Snapshot at module load — mirrors
+// the `isPWA` pattern in tips.ts. Crossing the breakpoint mid-session isn't a
+// real flow; a reload re-evaluates.
+const isMobile = window.matchMedia("(max-width: 639px)").matches;
+
 // Module-level references, set on first useTips() call.
 let _prefs: ReturnType<typeof useServerState>;
 let _initialized = false;
@@ -34,6 +40,7 @@ const TIP_PREFIX = "\u{1F4A1} ";
 
 /** Show a contextual tip toast if the user hasn't seen it yet. */
 function showTipOnce(tip: Tip) {
+  if (isMobile) return;
   if (seen().has(tip.id)) return;
   markSeen(tip.id);
   toast(TIP_PREFIX + tip.text, { duration: 5000 });
@@ -41,6 +48,7 @@ function showTipOnce(tip: Tip) {
 
 /** Pick a random ambient tip (prefers unseen, falls back to any). */
 function randomAmbientTip(): string {
+  if (isMobile) return "";
   const unseen = AMBIENT_TIPS.filter((t) => !seen().has(t.id));
   const pool = unseen.length > 0 ? unseen : AMBIENT_TIPS;
   const pick = pool[Math.floor(Math.random() * pool.length)]!;
@@ -50,6 +58,7 @@ function randomAmbientTip(): string {
 
 /** Show a random tip as a toast (for startup). Respects the startup-tips setting. */
 function showStartupTip() {
+  if (isMobile) return;
   if (!_prefs.preferences().startupTips) return;
   const text = randomAmbientTip();
   toast(TIP_PREFIX + text, {

--- a/tests/features/command-palette.feature
+++ b/tests/features/command-palette.feature
@@ -162,6 +162,18 @@ Feature: Command Palette
     Then the shortcuts help should be visible
     And there should be no page errors
 
+  Scenario: Ambient tip shown in palette footer on desktop
+    When I open the command palette
+    Then the palette tip should be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tips suppressed on mobile
+    When I open the command palette
+    Then the command palette should be visible
+    And no palette tip should be visible
+    And there should be no page errors
+
   Scenario: Cmd/Ctrl+K does not leak to terminal
     Given I intercept oRPC sendInput calls
     When I open the command palette

--- a/tests/step_definitions/command_palette_steps.ts
+++ b/tests/step_definitions/command_palette_steps.ts
@@ -214,6 +214,20 @@ Then(
   },
 );
 
+Then("the palette tip should be visible", async function (this: KoluWorld) {
+  const tip = this.page.locator(
+    `${PALETTE_SELECTOR} [data-testid="palette-tip"]`,
+  );
+  await tip.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+});
+
+Then("no palette tip should be visible", async function (this: KoluWorld) {
+  const count = await this.page
+    .locator(`${PALETTE_SELECTOR} [data-testid="palette-tip"]`)
+    .count();
+  assert.strictEqual(count, 0, `Expected no palette tip, got ${count}`);
+});
+
 Then("no palette hint should be visible", async function (this: KoluWorld) {
   const count = await this.page
     .locator(`${PALETTE_SELECTOR} [data-testid="palette-hint"]`)


### PR DESCRIPTION
**Two mobile-input papercuts in one PR.** Tips toasts referenced keybinds the user can't press on a phone and cluttered the small viewport. Mobile virtual keyboards autocorrect/autocapitalize xterm's hidden textarea by default, mangling shell input.

For tips: gated at a single entry point in `useTips.ts` via a module-level `isMobile` snapshot (`matchMedia("(max-width: 639px)")`, mirroring the existing `isPWA` snapshot in `tips.ts`). `showTipOnce` and `showStartupTip` early-return; `randomAmbientTip` returns `""` so `CommandPalette`'s existing `<Show when={ambientTip()}>` suppresses the footer row.

For autocorrect: after `term.open()` in `Terminal.tsx`, set `autocorrect`/`autocapitalize`/`autocomplete`/`spellcheck` to `off` on `term.textarea`. Unconditional — terminal input is never prose, so this is correct on every platform; mobile keyboards just happen to be the ones that respect the hint.

_No reactive media query for the tips gate — crossing the 640px boundary mid-session isn't a real flow, and a reload re-evaluates._

Adds a `@mobile` e2e scenario verifying the command palette ambient tip is suppressed on phone viewports, plus a desktop regression scenario. Also bumps `srid/agency` to `c53d0b4f` (lockfile + regenerated `.claude/commands/{do,talk}.md`) since CI's apm-sync caught the upstream drift.