### PR TITLE
Badge the PWA dock icon when agents need attention

### DIFF
--- a/client/src/useTerminalAlerts.ts
+++ b/client/src/useTerminalAlerts.ts
@@ -12,12 +12,25 @@ export function useTerminalAlerts(deps: {
   activityAlerts: Accessor<boolean>;
   activeId: Accessor<TerminalId | null>;
   getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
+  isUnread: (id: TerminalId) => boolean;
   markUnread: (id: TerminalId) => void;
   terminalIds: Accessor<TerminalId[]>;
   terminalLabel: (id: TerminalId) => string;
 }) {
   // Request browser notification permission eagerly when alerts are enabled
   if (deps.activityAlerts()) requestNotificationPermission();
+
+  // Badge the PWA dock icon with the unread agent count (Badging API).
+  // Clears automatically when the user visits all unread terminals.
+  createEffect(() => {
+    if (!("setAppBadge" in navigator)) return;
+    const count = deps.terminalIds().filter((id) => deps.isUnread(id)).length;
+    if (count > 0) {
+      void navigator.setAppBadge(count);
+    } else {
+      void navigator.clearAppBadge();
+    }
+  });
 
   // Reactively watch Claude state for all terminals.
   // SolidJS's on() tracks previous values natively — no manual Map needed.

--- a/client/src/useTerminals.ts
+++ b/client/src/useTerminals.ts
@@ -30,6 +30,7 @@ export function useTerminals(deps: {
     activityAlerts: deps.activityAlerts,
     activeId: store.activeId,
     getMetadata: store.getMetadata,
+    isUnread: store.isUnread,
     markUnread: store.markUnread,
     terminalIds: store.terminalIds,
     terminalLabel: store.terminalLabel,

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 declare const __KOLU_COMMIT__: string;
+
+// Badging API (Chrome/Edge PWAs) — not yet in TypeScript's lib.dom.
+interface Navigator {
+  setAppBadge(count?: number): Promise<void>;
+  clearAppBadge(): Promise<void>;
+}

--- a/tests/features/activity-alerts.feature
+++ b/tests/features/activity-alerts.feature
@@ -18,6 +18,15 @@ Feature: Activity Alerts
     Then no sidebar entry should be notified
     And there should be no page errors
 
+  Scenario: Simulated alert badges the PWA dock icon
+    When I create a terminal
+    And I stub the Badging API
+    And I simulate an activity alert
+    Then the app badge should show 1
+    When I click the notified sidebar entry
+    Then the app badge should be cleared
+    And there should be no page errors
+
   Scenario: Alerts respect the settings toggle
     When I create a terminal
     And I click the settings button

--- a/tests/step_definitions/activity_alert_steps.ts
+++ b/tests/step_definitions/activity_alert_steps.ts
@@ -37,3 +37,42 @@ When("I click the notified sidebar entry", async function (this: KoluWorld) {
   await notified.first().click();
   await this.waitForFrame();
 });
+
+When("I stub the Badging API", async function (this: KoluWorld) {
+  await this.page.evaluate(() => {
+    (window as any).__badgeCalls = [] as Array<
+      { method: "set"; count?: number } | { method: "clear" }
+    >;
+    (navigator as any).setAppBadge = (count?: number) => {
+      (window as any).__badgeCalls.push({ method: "set", count });
+      return Promise.resolve();
+    };
+    (navigator as any).clearAppBadge = () => {
+      (window as any).__badgeCalls.push({ method: "clear" });
+      return Promise.resolve();
+    };
+  });
+});
+
+Then(
+  "the app badge should show {int}",
+  async function (this: KoluWorld, expected: number) {
+    await this.waitForFrame();
+    const lastSet = await this.page.evaluate(() => {
+      const calls: any[] = (window as any).__badgeCalls ?? [];
+      return calls.filter((c: any) => c.method === "set").pop();
+    });
+    assert.ok(lastSet, "Expected setAppBadge to have been called");
+    assert.strictEqual(lastSet.count, expected);
+  },
+);
+
+Then("the app badge should be cleared", async function (this: KoluWorld) {
+  await this.waitForFrame();
+  const lastCall = await this.page.evaluate(() => {
+    const calls: any[] = (window as any).__badgeCalls ?? [];
+    return calls[calls.length - 1];
+  });
+  assert.ok(lastCall, "Expected a badge API call");
+  assert.strictEqual(lastCall.method, "clear");
+});


### PR DESCRIPTION
**Unread agent completions now badge the PWA app icon** via the
Badging API (`navigator.setAppBadge`). When Claude transitions to
*waiting* in a background terminal, the dock/taskbar icon shows a
count of how many agents need your eyes — and clears when you visit
them.

This completes the attention funnel that already has sound and browser
Notifications: the badge is the persistent, glanceable layer that
survives after the notification dismisses. Particularly useful when
running multiple Kolu instances as installed PWAs, where there's no
browser tab bar to scan.

The implementation is a single `createEffect` inside
`useTerminalAlerts` — the module that already owns all "agent needs
you" signaling. It derives the count from the existing `unread` store
and `terminalIds`, so no new state or plumbing is introduced.

> The Badging API is Chrome/Edge-only today (Safari and Firefox ignore
> it). The calls are guarded behind capability checks, so non-supporting
> browsers see zero impact.