### PR TITLE
Collapse attention preview after user acknowledges waiting agent

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-10T01:47:57.310147+00:00'
+generated_at: '2026-04-10T13:02:56.083029+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -47,7 +47,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: c53d0b4f849497017e1ce82f7753422dc4cd3ced
+  resolved_commit: 367c5737316f2ce799c758a20b0b33d941fbcfc7
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -362,6 +362,7 @@ const App: Component = () => {
           activeId={store.activeId()}
           getMetadata={store.getMetadata}
           isUnread={store.isUnread}
+          isAcknowledged={store.isAcknowledged}
           getDisplayInfo={store.getDisplayInfo}
           getTerminalTheme={getTerminalTheme}
           previewMode={sidebarAgentPreviews()}

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -59,23 +59,27 @@ function cardTier(claudeState: ClaudeState | undefined): CardTier {
  *    behavior before the enum was introduced (legacy `true`).
  *  - `"attention"` (**default**): only agents that actually want the
  *    user's eyes — when Claude is **waiting** for input or when
- *    there's an **unread** completion. Rationale: previews are
- *    expensive vertically (only ~3 cards fit — see #388), so we
- *    reserve them for the moments peeking without switching actually
- *    helps. Thinking/tool_use agents are busy but don't need
- *    attention; idle terminals have nothing to show. Edit this single
- *    branch if the "needs attention" heuristic needs to change. */
+ *    there's an **unread** completion, *and* the user hasn't already
+ *    acknowledged this state by visiting the terminal. Once visited,
+ *    the preview collapses until the next Claude state transition
+ *    re-raises it. Rationale: previews are expensive vertically
+ *    (only ~3 cards fit — see #388), so we reserve them for moments
+ *    the user hasn't already seen. */
 function shouldShowPreview(
   mode: SidebarAgentPreviews,
   hasAgent: boolean,
   claudeState: ClaudeState | undefined,
   unread: boolean,
+  acknowledged: boolean,
 ): boolean {
   return match(mode)
     .with("none", () => false)
     .with("all", () => true)
     .with("agents", () => hasAgent)
-    .with("attention", () => hasAgent && (claudeState === "waiting" || unread))
+    .with(
+      "attention",
+      () => hasAgent && (claudeState === "waiting" || unread) && !acknowledged,
+    )
     .exhaustive();
 }
 
@@ -85,6 +89,7 @@ const SidebarEntry: Component<{
   isActive: boolean;
   metadata: TerminalMetadata | undefined;
   unread: boolean;
+  acknowledged: boolean;
   displayInfo: TerminalDisplayInfo | undefined;
   terminalTheme: ITheme;
   /** Preview mode — see {@link shouldShowPreview} for the semantics. */
@@ -110,6 +115,7 @@ const SidebarEntry: Component<{
       props.metadata?.claude != null,
       props.displayInfo?.meta.claude?.state,
       props.unread,
+      props.acknowledged,
     )
       ? vp
       : undefined;
@@ -317,6 +323,7 @@ const Sidebar: Component<{
   activeId: TerminalId | null;
   getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
   isUnread: (id: TerminalId) => boolean;
+  isAcknowledged: (id: TerminalId) => boolean;
   getDisplayInfo: (id: TerminalId) => TerminalDisplayInfo | undefined;
   getTerminalTheme: (id: TerminalId) => ITheme;
   previewMode: SidebarAgentPreviews;
@@ -436,6 +443,7 @@ const Sidebar: Component<{
                       isActive={props.activeId === id}
                       metadata={props.getMetadata(id)}
                       unread={props.isUnread(id)}
+                      acknowledged={props.isAcknowledged(id)}
                       displayInfo={props.getDisplayInfo(id)}
                       terminalTheme={props.getTerminalTheme(id)}
                       previewMode={props.previewMode}

--- a/client/src/useTerminalAlerts.ts
+++ b/client/src/useTerminalAlerts.ts
@@ -28,9 +28,15 @@ export function useTerminalAlerts(deps: {
       (states, prevStates) => {
         const ids = deps.terminalIds();
         for (let i = 0; i < ids.length; i++) {
-          if (prevStates && prevStates[i] !== undefined) {
+          if (prevStates) {
             if (prevStates[i] !== states[i]) deps.clearAcknowledged(ids[i]!);
-            checkClaudeFinished(ids[i]!, prevStates[i], states[i]);
+            if (prevStates[i] !== undefined)
+              checkClaudeFinished(ids[i]!, prevStates[i], states[i]);
+          } else if (states[i] !== undefined) {
+            // First effect run — agent already present when effect
+            // mounted (e.g. metadata arrived before the effect ran).
+            // Clear any stale acknowledged flag.
+            deps.clearAcknowledged(ids[i]!);
           }
         }
       },

--- a/client/src/useTerminalAlerts.ts
+++ b/client/src/useTerminalAlerts.ts
@@ -13,6 +13,7 @@ export function useTerminalAlerts(deps: {
   activeId: Accessor<TerminalId | null>;
   getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
   markUnread: (id: TerminalId) => void;
+  clearAcknowledged: (id: TerminalId) => void;
   terminalIds: Accessor<TerminalId[]>;
   terminalLabel: (id: TerminalId) => string;
 }) {
@@ -28,6 +29,7 @@ export function useTerminalAlerts(deps: {
         const ids = deps.terminalIds();
         for (let i = 0; i < ids.length; i++) {
           if (prevStates && prevStates[i] !== undefined) {
+            if (prevStates[i] !== states[i]) deps.clearAcknowledged(ids[i]!);
             checkClaudeFinished(ids[i]!, prevStates[i], states[i]);
           }
         }

--- a/client/src/useTerminals.ts
+++ b/client/src/useTerminals.ts
@@ -31,6 +31,7 @@ export function useTerminals(deps: {
     activeId: store.activeId,
     getMetadata: store.getMetadata,
     markUnread: store.markUnread,
+    clearAcknowledged: store.clearAcknowledged,
     terminalIds: store.terminalIds,
     terminalLabel: store.terminalLabel,
   });

--- a/client/src/useViewState.ts
+++ b/client/src/useViewState.ts
@@ -23,12 +23,20 @@ export function useViewState() {
   /** Terminals with unseen Claude completions (cleared when user visits). */
   const [unread, setUnread] = createStore<Record<TerminalId, true>>({});
 
+  /** Terminals whose waiting state the user has already seen (set on visit,
+   *  cleared when Claude's state transitions — so the preview reappears on
+   *  the *next* waiting transition). */
+  const [acknowledged, setAcknowledged] = createStore<Record<TerminalId, true>>(
+    {},
+  );
+
   const [mruOrder, setMruOrder] = createSignal<TerminalId[]>([]);
   createEffect(
     on(activeId, (id) => {
       if (id === null) return;
       setMruOrder((prev) => [id, ...prev.filter((x) => x !== id)]);
       if (unread[id]) setUnread(produce((s) => delete s[id]));
+      setAcknowledged(id, true);
     }),
   );
 
@@ -40,10 +48,19 @@ export function useViewState() {
     return !!unread[id];
   }
 
+  function clearAcknowledged(id: TerminalId) {
+    if (acknowledged[id]) setAcknowledged(produce((s) => delete s[id]));
+  }
+
+  function isAcknowledged(id: TerminalId): boolean {
+    return !!acknowledged[id];
+  }
+
   function reset() {
     setActiveId(null);
     setMruOrder([]);
     setUnread(reconcile({}));
+    setAcknowledged(reconcile({}));
   }
 
   return {
@@ -53,6 +70,8 @@ export function useViewState() {
     setMruOrder,
     markUnread,
     isUnread,
+    clearAcknowledged,
+    isAcknowledged,
     reset,
   };
 }

--- a/tests/features/claude-code.feature
+++ b/tests/features/claude-code.feature
@@ -65,6 +65,18 @@ Feature: Claude Code status detection
     Then the sidebar should show a terminal preview
     And there should be no page errors
 
+  Scenario: Visiting a waiting agent collapses its preview until the next state change
+    When a Claude Code session is mocked with state "waiting"
+    Then the sidebar should show a terminal preview
+    When I create a terminal
+    Then the sidebar should show a terminal preview
+    When I press the switch to terminal 1 shortcut
+    Then the sidebar should not show a terminal preview
+    When the Claude Code session state changes to "thinking"
+    And the Claude Code session state changes to "waiting"
+    Then the sidebar should show a terminal preview
+    And there should be no page errors
+
   Scenario: Debug command shows the Claude transcript when a session is active
     When a Claude Code session is mocked with state "waiting"
     Then the header should show a Claude indicator with state "waiting"

--- a/tests/features/claude-code.feature
+++ b/tests/features/claude-code.feature
@@ -73,7 +73,8 @@ Feature: Claude Code status detection
     When I press the switch to terminal 1 shortcut
     Then the sidebar should not show a terminal preview
     When the Claude Code session state changes to "thinking"
-    And the Claude Code session state changes to "waiting"
+    Then the header should show a Claude indicator with state "thinking"
+    When the Claude Code session state changes to "waiting"
     Then the sidebar should show a terminal preview
     And there should be no page errors
 


### PR DESCRIPTION
In **attention** mode, agent previews stay visible as long as Claude is waiting — even after you've already switched to that terminal and read the output. This wastes vertical sidebar space (only ~3 cards fit) on information you've already seen.

**Previews now collapse once you visit the terminal**, and reappear only when Claude's state changes again (e.g. finishes a new task). The existing unread dot and card-tier glow continue to distinguish waiting agents from idle ones, so you still know at a glance which agents need input — _without_ burning a preview slot on output you've already acknowledged.

The mechanism is a per-terminal `acknowledged` flag in view state — set on visit, cleared on any Claude state transition. `shouldShowPreview` folds it into the attention branch: `hasAgent && (waiting || unread) && !acknowledged`.