### PR TITLE
Show Claude Code task progress in sidebar

### DIFF
--- a/client/src/TerminalMeta.tsx
+++ b/client/src/TerminalMeta.tsx
@@ -128,7 +128,7 @@ const TerminalMeta: Component<{
                     {(tp) => (
                       <span
                         data-testid="claude-task-progress"
-                        class="text-xs text-fg-3 tabular-nums"
+                        class="text-xs text-fg-2 tabular-nums"
                         title={`${tp().completed}/${tp().total} tasks completed`}
                       >
                         {tp().completed}/{tp().total}

--- a/client/src/TerminalMeta.tsx
+++ b/client/src/TerminalMeta.tsx
@@ -122,7 +122,20 @@ const TerminalMeta: Component<{
           <Show when={info().meta.claude}>
             {(claude) => (
               <div class="mt-1">
-                <ClaudeIndicator state={claude().state} />
+                <div class="flex items-center gap-1.5">
+                  <ClaudeIndicator state={claude().state} />
+                  <Show when={claude().taskProgress}>
+                    {(tp) => (
+                      <span
+                        data-testid="claude-task-progress"
+                        class="text-xs text-fg-3 tabular-nums"
+                        title={`${tp().completed}/${tp().total} tasks completed`}
+                      >
+                        {tp().completed}/{tp().total}
+                      </span>
+                    )}
+                  </Show>
+                </div>
                 <Show when={claude().summary}>
                   {(summary) => (
                     <div

--- a/client/src/TerminalMeta.tsx
+++ b/client/src/TerminalMeta.tsx
@@ -126,13 +126,23 @@ const TerminalMeta: Component<{
                   <ClaudeIndicator state={claude().state} />
                   <Show when={claude().taskProgress}>
                     {(tp) => (
-                      <span
+                      <div
                         data-testid="claude-task-progress"
-                        class="text-xs text-fg-2 tabular-nums"
+                        class="flex items-center gap-1.5 flex-1 min-w-0"
                         title={`${tp().completed}/${tp().total} tasks completed`}
                       >
-                        {tp().completed}/{tp().total}
-                      </span>
+                        <div class="flex-1 h-1 rounded-full bg-fg/10 min-w-8 overflow-hidden">
+                          <div
+                            class="h-full rounded-full bg-busy transition-all duration-300"
+                            style={{
+                              width: `${tp().total > 0 ? (tp().completed / tp().total) * 100 : 0}%`,
+                            }}
+                          />
+                        </div>
+                        <span class="text-xs text-fg-2 tabular-nums shrink-0">
+                          {tp().completed}/{tp().total}
+                        </span>
+                      </div>
                     )}
                   </Show>
                 </div>

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -57,6 +57,13 @@ export const ClaudeCodeStateSchema = z.enum([
   "waiting",
 ]);
 
+export const TaskProgressSchema = z.object({
+  /** Total number of tasks created (excluding deleted). */
+  total: z.number(),
+  /** Number of tasks with status "completed". */
+  completed: z.number(),
+});
+
 export const ClaudeCodeInfoSchema = z.object({
   /** Current state derived from session JSONL. */
   state: ClaudeCodeStateSchema,
@@ -67,6 +74,9 @@ export const ClaudeCodeInfoSchema = z.object({
   /** Display title from the Claude Agent SDK — custom title › auto-summary › first prompt.
    *  Refreshed best-effort on each transcript change; null until the first lookup resolves. */
   summary: z.string().nullable(),
+  /** Task checklist progress derived from TaskCreate/TaskUpdate tool calls in the transcript.
+   *  null when no tasks have been created in the session. */
+  taskProgress: TaskProgressSchema.nullable(),
 });
 
 /** A single state transition the server observed. `info: null` = session ended. */
@@ -282,6 +292,7 @@ export type TerminalId = TerminalInfo["id"];
 
 export type GitInfo = z.infer<typeof GitInfoSchema>;
 export type GitHubPrInfo = z.infer<typeof GitHubPrInfoSchema>;
+export type TaskProgress = z.infer<typeof TaskProgressSchema>;
 export type ClaudeCodeInfo = z.infer<typeof ClaudeCodeInfoSchema>;
 export type ClaudeStateChange = z.infer<typeof ClaudeStateChangeSchema>;
 export type ClaudeTranscriptDebug = z.infer<typeof ClaudeTranscriptDebugSchema>;

--- a/server/src/meta/claude.test.ts
+++ b/server/src/meta/claude.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import os from "node:os";
 import {
   deriveState,
+  deriveTaskProgress,
   encodeProjectPath,
+  extractTasks,
   infoEqual,
   readJsonlFromOffset,
   tailJsonlLines,
@@ -111,6 +113,7 @@ describe("infoEqual", () => {
     sessionId: "abc-123",
     model: "claude-opus-4-6",
     summary: "Refactor sidebar layout",
+    taskProgress: null,
   };
 
   it("returns true for identical references", () => {
@@ -136,6 +139,7 @@ describe("infoEqual", () => {
     { field: "model", value: "claude-sonnet-4-6" },
     { field: "summary", value: "Different topic" },
     { field: "summary", value: null },
+    { field: "taskProgress", value: { total: 3, completed: 1 } },
   ] as const)("detects different $field", ({ field, value }) => {
     expect(infoEqual(info, { ...info, [field]: value })).toBe(false);
   });
@@ -296,5 +300,123 @@ describe("findTranscriptPath", () => {
       cwd: "/nonexistent/path",
     });
     expect(result).toBeNull();
+  });
+});
+
+describe("extractTasks", () => {
+  const mockLog = { warn: vi.fn() };
+
+  function taskCreateResult(id: string, subject: string): string {
+    return JSON.stringify({
+      type: "user",
+      uuid: `u-${id}`,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: [] },
+      toolUseResult: { task: { id, subject } },
+    });
+  }
+
+  function taskUpdate(taskId: string, status: string): string {
+    return JSON.stringify({
+      type: "assistant",
+      uuid: `a-${taskId}-${status}`,
+      timestamp: new Date().toISOString(),
+      message: {
+        model: "claude-opus-4-6",
+        role: "assistant",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use",
+            id: `tool-${taskId}`,
+            name: "TaskUpdate",
+            input: { taskId, status },
+          },
+        ],
+      },
+    });
+  }
+
+  it("extracts tasks from TaskCreate results", () => {
+    const tasks = new Map<string, "pending" | "in_progress" | "completed">();
+    const lines = [
+      taskCreateResult("1", "Task one"),
+      taskCreateResult("2", "Task two"),
+    ];
+    const changed = extractTasks(lines, tasks, mockLog);
+    expect(changed).toBe(true);
+    expect(tasks.size).toBe(2);
+    expect(tasks.get("1")).toBe("pending");
+    expect(tasks.get("2")).toBe("pending");
+  });
+
+  it("updates task status from TaskUpdate calls", () => {
+    const tasks = new Map<string, "pending" | "in_progress" | "completed">();
+    tasks.set("1", "pending");
+    const lines = [taskUpdate("1", "in_progress")];
+    const changed = extractTasks(lines, tasks, mockLog);
+    expect(changed).toBe(true);
+    expect(tasks.get("1")).toBe("in_progress");
+  });
+
+  it("handles TaskUpdate with deleted status", () => {
+    const tasks = new Map<string, "pending" | "in_progress" | "completed">();
+    tasks.set("1", "pending");
+    const lines = [taskUpdate("1", "deleted")];
+    const changed = extractTasks(lines, tasks, mockLog);
+    expect(changed).toBe(true);
+    expect(tasks.has("1")).toBe(false);
+  });
+
+  it("returns false when nothing changed", () => {
+    const tasks = new Map<string, "pending" | "in_progress" | "completed">();
+    tasks.set("1", "completed");
+    const lines = [taskUpdate("1", "completed")];
+    const changed = extractTasks(lines, tasks, mockLog);
+    expect(changed).toBe(false);
+  });
+
+  it("warns on unexpected TaskUpdate input shape", () => {
+    mockLog.warn.mockClear();
+    const tasks = new Map<string, "pending" | "in_progress" | "completed">();
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", name: "TaskUpdate", input: { bad: true } },
+        ],
+      },
+    });
+    extractTasks([line], tasks, mockLog);
+    expect(mockLog.warn).toHaveBeenCalled();
+  });
+
+  it("ignores non-task tool calls", () => {
+    const tasks = new Map<string, "pending" | "in_progress" | "completed">();
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", name: "Read", input: { path: "/foo" } }],
+      },
+    });
+    const changed = extractTasks([line], tasks, mockLog);
+    expect(changed).toBe(false);
+    expect(tasks.size).toBe(0);
+  });
+});
+
+describe("deriveTaskProgress", () => {
+  it("returns null for empty map", () => {
+    expect(deriveTaskProgress(new Map())).toBeNull();
+  });
+
+  it("returns correct counts", () => {
+    const tasks = new Map<string, "pending" | "in_progress" | "completed">([
+      ["1", "completed"],
+      ["2", "in_progress"],
+      ["3", "completed"],
+      ["4", "pending"],
+    ]);
+    expect(deriveTaskProgress(tasks)).toEqual({ total: 4, completed: 2 });
   });
 });

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -620,7 +620,12 @@ export function startClaudeCodeProvider(
       if (changed) {
         const progress = deriveTaskProgress(taskMap);
         plog.info(
-          { tasks: taskMap.size, progress, bytesScanned: length, from: prevOffset },
+          {
+            tasks: taskMap.size,
+            progress,
+            bytesScanned: length,
+            from: prevOffset,
+          },
           "task progress updated",
         );
       }

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -614,10 +614,18 @@ export function startClaudeCodeProvider(
           newLines.shift();
         }
       }
+      const prevOffset = taskScanOffset;
       taskScanOffset = size;
-      extractTasks(newLines, taskMap, plog);
+      const changed = extractTasks(newLines, taskMap, plog);
+      if (changed) {
+        const progress = deriveTaskProgress(taskMap);
+        plog.info(
+          { tasks: taskMap.size, progress, bytesScanned: length, from: prevOffset },
+          "task progress updated",
+        );
+      }
     } catch (err) {
-      plog.debug({ err, filePath }, "task scan failed");
+      plog.warn({ err, filePath, taskScanOffset }, "task scan failed");
     }
   }
 

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -40,6 +40,7 @@ import type {
   ClaudeCodeInfo,
   ClaudeStateChange,
   ClaudeTranscriptDebug,
+  TaskProgress,
 } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
 import { updateMetadata } from "./index.ts";
@@ -255,6 +256,107 @@ export function deriveState(
   return null;
 }
 
+/**
+ * Scan JSONL lines for TaskCreate/TaskUpdate tool calls and accumulate into
+ * the provided task map. Returns true if the map changed.
+ *
+ * The transcript format is an internal Claude Code implementation detail.
+ * Warnings are logged when tool call inputs have unexpected shapes so that
+ * format drift is visible rather than silently ignored.
+ */
+export function extractTasks(
+  lines: string[],
+  tasks: Map<string, "pending" | "in_progress" | "completed">,
+  plog: { warn: (obj: Record<string, unknown>, msg: string) => void },
+): boolean {
+  let changed = false;
+  for (const line of lines) {
+    let entry: {
+      type?: string;
+      message?: {
+        content?: Array<{
+          type?: string;
+          name?: string;
+          input?: Record<string, unknown>;
+        }>;
+      };
+      toolUseResult?: { task?: { id?: string } };
+    };
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    // TaskCreate results come on "user" type messages with toolUseResult.task
+    if (entry.type === "user" && entry.toolUseResult?.task?.id) {
+      const id = entry.toolUseResult.task.id;
+      if (typeof id === "string" && !tasks.has(id)) {
+        tasks.set(id, "pending");
+        changed = true;
+      }
+      continue;
+    }
+
+    // TaskUpdate calls come on "assistant" type messages as tool_use content blocks
+    if (entry.type !== "assistant" || !Array.isArray(entry.message?.content))
+      continue;
+
+    for (const block of entry.message!.content!) {
+      if (block.type !== "tool_use" || block.name !== "TaskUpdate") continue;
+      const input = block.input;
+      if (!input || typeof input !== "object") {
+        plog.warn({ block }, "TaskUpdate tool call has unexpected input shape");
+        continue;
+      }
+      const taskId = input.taskId;
+      const status = input.status;
+      if (typeof taskId !== "string" || typeof status !== "string") {
+        plog.warn({ input }, "TaskUpdate tool call missing taskId or status");
+        continue;
+      }
+      if (status === "deleted") {
+        if (tasks.has(taskId)) {
+          tasks.delete(taskId);
+          changed = true;
+        }
+      } else if (
+        status === "pending" ||
+        status === "in_progress" ||
+        status === "completed"
+      ) {
+        if (tasks.get(taskId) !== status) {
+          tasks.set(taskId, status);
+          changed = true;
+        }
+      }
+    }
+  }
+  return changed;
+}
+
+/** Derive TaskProgress summary from a task map. Returns null if empty. */
+export function deriveTaskProgress(
+  tasks: Map<string, "pending" | "in_progress" | "completed">,
+): TaskProgress | null {
+  if (tasks.size === 0) return null;
+  let completed = 0;
+  for (const status of tasks.values()) {
+    if (status === "completed") completed++;
+  }
+  return { total: tasks.size, completed };
+}
+
+/** Compare two TaskProgress values for equality. */
+function taskProgressEqual(
+  a: TaskProgress | null,
+  b: TaskProgress | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.total === b.total && a.completed === b.completed;
+}
+
 /** Compare two ClaudeCodeInfo values for equality. */
 export function infoEqual(
   a: ClaudeCodeInfo | null,
@@ -266,7 +368,8 @@ export function infoEqual(
     a.state === b.state &&
     a.sessionId === b.sessionId &&
     a.model === b.model &&
-    a.summary === b.summary
+    a.summary === b.summary &&
+    taskProgressEqual(a.taskProgress, b.taskProgress)
   );
 }
 
@@ -368,6 +471,11 @@ export function startClaudeCodeProvider(
    *  and until the first lookup resolves. Survives across transcript
    *  events so deduped state updates can carry it forward. */
   let lastSummary: string | null = null;
+  /** Accumulated task state from TaskCreate/TaskUpdate tool calls.
+   *  Incrementally scanned from a tracked byte offset. Reset on session change. */
+  let taskMap = new Map<string, "pending" | "in_progress" | "completed">();
+  /** Byte offset up to which the transcript has been scanned for tasks. */
+  let taskScanOffset = 0;
 
   plog.info("started");
 
@@ -449,11 +557,15 @@ export function startClaudeCodeProvider(
       return;
     }
 
+    // Incrementally scan new transcript bytes for task tool calls.
+    scanTasksIncremental(transcriptWatching.path);
+
     const info: ClaudeCodeInfo = {
       state: derived.state,
       sessionId: matchedSession.sessionId,
       model: derived.model,
       summary: lastSummary,
+      taskProgress: deriveTaskProgress(taskMap),
     };
 
     if (!infoEqual(info, entry.info.meta.claude)) {
@@ -471,6 +583,42 @@ export function startClaudeCodeProvider(
     // latency here never blocks state updates — `infoEqual` dedupes the
     // follow-up emit if the summary turns out unchanged.
     refreshSummary(matchedSession);
+  }
+
+  /** Read new bytes from the transcript and extract TaskCreate/TaskUpdate calls. */
+  function scanTasksIncremental(filePath: string) {
+    try {
+      const size = fs.statSync(filePath).size;
+      if (taskScanOffset >= size) return;
+      const length = size - taskScanOffset;
+      const fd = fs.openSync(filePath, "r");
+      let buf: Buffer;
+      try {
+        buf = Buffer.alloc(length);
+        fs.readSync(fd, buf, 0, length, taskScanOffset);
+      } finally {
+        fs.closeSync(fd);
+      }
+      const newLines = buf
+        .toString("utf8")
+        .split("\n")
+        .filter((l) => l.length > 0);
+      // First line may be partial if taskScanOffset landed mid-line.
+      // This can only happen on the very first scan (offset 0 is always a
+      // line boundary; subsequent offsets are at EOF which is also a boundary).
+      // Drop a partial first line only when resuming mid-file.
+      if (taskScanOffset > 0 && newLines.length > 0) {
+        try {
+          JSON.parse(newLines[0]!);
+        } catch {
+          newLines.shift();
+        }
+      }
+      taskScanOffset = size;
+      extractTasks(newLines, taskMap, plog);
+    } catch (err) {
+      plog.debug({ err, filePath }, "task scan failed");
+    }
   }
 
   /**
@@ -537,6 +685,8 @@ export function startClaudeCodeProvider(
     teardownTranscriptWatching();
     matchedSession = newSession;
     lastSummary = null;
+    taskMap = new Map();
+    taskScanOffset = 0;
 
     if (!newSession) {
       plog.info("claude code session ended");

--- a/tests/features/claude-code.feature
+++ b/tests/features/claude-code.feature
@@ -82,6 +82,12 @@ Feature: Claude Code status detection
     Then palette item "Show Claude transcript" should not be visible
     And there should be no page errors
 
+  Scenario: Sidebar shows task progress when Claude has tasks
+    When a Claude Code session is mocked with state "tool_use"
+    And the Claude Code session has 5 tasks with 3 completed
+    Then the sidebar should show task progress "3/5"
+    And there should be no page errors
+
   Scenario: Claude Code indicator disappears when session ends
     When a Claude Code session is mocked with state "thinking"
     Then the header should show a Claude indicator with state "thinking"

--- a/tests/step_definitions/claude_code_steps.ts
+++ b/tests/step_definitions/claude_code_steps.ts
@@ -349,6 +349,99 @@ Then(
   },
 );
 
+/** Build JSONL lines for TaskCreate result + TaskUpdate calls. */
+function buildTaskLines(
+  tasks: Array<{ id: string; subject: string; status: string }>,
+): string {
+  const lines: string[] = [];
+  for (const task of tasks) {
+    // TaskCreate result (appears on "user" type messages)
+    lines.push(
+      JSON.stringify({
+        type: "user",
+        uuid: `task-create-${task.id}`,
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "user",
+          content: [
+            {
+              tool_use_id: `tool-${task.id}`,
+              type: "tool_result",
+              content: `Task #${task.id} created successfully: ${task.subject}`,
+            },
+          ],
+        },
+        toolUseResult: { task: { id: task.id, subject: task.subject } },
+      }),
+    );
+    // TaskUpdate to set status (appears on "assistant" type messages)
+    if (task.status !== "pending") {
+      lines.push(
+        JSON.stringify({
+          type: "assistant",
+          uuid: `task-update-${task.id}`,
+          timestamp: new Date().toISOString(),
+          message: {
+            model: "claude-opus-4-6",
+            role: "assistant",
+            stop_reason: "tool_use",
+            content: [
+              {
+                type: "tool_use",
+                id: `tool-update-${task.id}`,
+                name: "TaskUpdate",
+                input: { taskId: task.id, status: task.status },
+              },
+            ],
+          },
+        }),
+      );
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+When(
+  "the Claude Code session has {int} tasks with {int} completed",
+  async function (this: KoluWorld, total: number, completed: number) {
+    if (!mockTranscriptPath) throw new Error("No mock transcript to update");
+    const tasks: Array<{ id: string; subject: string; status: string }> = [];
+    for (let i = 1; i <= total; i++) {
+      tasks.push({
+        id: String(i),
+        subject: `Task ${i}`,
+        status: i <= completed ? "completed" : "in_progress",
+      });
+    }
+    // Append task lines to existing transcript
+    fs.appendFileSync(mockTranscriptPath, buildTaskLines(tasks));
+  },
+);
+
+Then(
+  "the sidebar should show task progress {string}",
+  async function (this: KoluWorld, expected: string) {
+    const el = this.page.locator('[data-testid="claude-task-progress"]');
+    const text = await pollUntil(
+      this.page,
+      async () => {
+        try {
+          return (await el.first().textContent({ timeout: 1000 })) ?? "";
+        } catch {
+          return "";
+        }
+      },
+      (t) => t.trim() === expected,
+      { attempts: 30, intervalMs: 200 },
+    );
+    assert.strictEqual(
+      text.trim(),
+      expected,
+      `Expected task progress "${expected}", got "${text.trim()}"`,
+    );
+  },
+);
+
 Then(
   "the header should not show a Claude indicator",
   async function (this: KoluWorld) {

--- a/tests/step_definitions/claude_code_steps.ts
+++ b/tests/step_definitions/claude_code_steps.ts
@@ -392,23 +392,15 @@ When(
 Then(
   "the sidebar should show task progress {string}",
   async function (this: KoluWorld, expected: string) {
-    const el = this.page.locator('[data-testid="claude-task-progress"]');
-    const text = await pollUntil(
-      this.page,
-      async () => {
-        try {
-          return (await el.first().textContent({ timeout: 1000 })) ?? "";
-        } catch {
-          return "";
-        }
+    await this.page.waitForFunction(
+      (expected) => {
+        const el = document.querySelector(
+          '[data-testid="claude-task-progress"]',
+        );
+        return el?.textContent?.trim() === expected;
       },
-      (t) => t.trim() === expected,
-      { attempts: 30, intervalMs: 200 },
-    );
-    assert.strictEqual(
-      text.trim(),
       expected,
-      `Expected task progress "${expected}", got "${text.trim()}"`,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );


### PR DESCRIPTION
**Surfaces Claude Code's task checklist as a compact progress bar in the sidebar**, so you can see at a glance how far along an agent is without switching to its terminal.

The server incrementally scans each Claude session's JSONL transcript for `TaskCreate`/`TaskUpdate` tool calls, accumulating a live task map per session. The sidebar displays a thin animated progress bar alongside a "completed/total" counter next to the existing Claude state badge. _Warnings are logged when the transcript contains task tool calls with unexpected shapes_, making the implicit dependency on Claude Code's internal format visible when it eventually drifts.

Closes #427