### PR TITLE
Replace pollUntil loops with Playwright-native waits

### DIFF
--- a/tests/step_definitions/activity_steps.ts
+++ b/tests/step_definitions/activity_steps.ts
@@ -1,40 +1,26 @@
 import { When, Then } from "@cucumber/cucumber";
-import { KoluWorld } from "../support/world.ts";
-import { pollUntil } from "../support/poll.ts";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 import * as assert from "node:assert";
 
-/** Check if the sidebar entry for a terminal (1-based index) shows active. */
-async function getIndicatorActive(
-  world: KoluWorld,
-  index: number,
-): Promise<boolean> {
-  const id = world.createdTerminalIds[index - 1];
-  assert.ok(id, `No terminal created at index ${index}`);
-  const entry = world.page.locator(
-    `[data-testid="sidebar"] [data-terminal-id="${id}"]`,
-  );
-  const activity = await entry.getAttribute("data-activity");
-  return activity === "active";
-}
-
-/** Poll until terminal reaches expected activity state, then assert. */
+/** Wait until terminal reaches expected activity state via waitForFunction. */
 async function assertActivity(
   world: KoluWorld,
   index: number,
   expectActive: boolean,
-  pollOpts?: { attempts: number; intervalMs: number },
+  timeout = POLL_TIMEOUT,
 ): Promise<void> {
-  const isActive = await pollUntil(
-    world.page,
-    () => getIndicatorActive(world, index),
-    (val) => val === expectActive,
-    pollOpts,
-  );
-  const label = expectActive ? "active" : "sleeping";
-  assert.strictEqual(
-    isActive,
-    expectActive,
-    `Expected terminal ${index} to be ${label}`,
+  const id = world.createdTerminalIds[index - 1];
+  assert.ok(id, `No terminal created at index ${index}`);
+  const expectedAttr = expectActive ? "active" : "sleeping";
+  await world.page.waitForFunction(
+    ({ id, expected }) => {
+      const entry = document.querySelector(
+        `[data-testid="sidebar"] [data-terminal-id="${id}"]`,
+      );
+      return entry?.getAttribute("data-activity") === expected;
+    },
+    { id, expected: expectedAttr },
+    { timeout },
   );
 }
 
@@ -64,16 +50,16 @@ Then("the activity graph should have data", async function (this: KoluWorld) {
   const index = this.createdTerminalIds.length;
   const id = this.createdTerminalIds[index - 1];
   assert.ok(id, `No terminal created at index ${index}`);
-  const graph = this.page.locator(
-    `[data-testid="sidebar"] [data-terminal-id="${id}"] [data-testid="activity-graph"]`,
+  await this.page.waitForFunction(
+    (id) => {
+      const graph = document.querySelector(
+        `[data-testid="sidebar"] [data-terminal-id="${id}"] [data-testid="activity-graph"]`,
+      );
+      return graph?.getAttribute("data-has-data") === "true";
+    },
+    id,
+    { timeout: POLL_TIMEOUT },
   );
-  const hasData = await pollUntil(
-    this.page,
-    async () => (await graph.getAttribute("data-has-data")) === "true",
-    (val) => val === true,
-    { attempts: 30, intervalMs: 200 },
-  );
-  assert.ok(hasData, "Expected activity graph to have data");
 });
 
 When(
@@ -81,10 +67,7 @@ When(
   async function (this: KoluWorld) {
     // The idle threshold is 5s, but shell init (starship, nix env, etc.) may
     // produce sporadic output that resets the timer. Under load from the full
-    // test suite, init can take 10-15s. Poll up to ~30s for safety.
-    await assertActivity(this, this.createdTerminalIds.length, false, {
-      attempts: 60,
-      intervalMs: 500,
-    });
+    // test suite, init can take 10-15s. Wait up to 30s for safety.
+    await assertActivity(this, this.createdTerminalIds.length, false, 30_000);
   },
 );

--- a/tests/step_definitions/claude_code_steps.ts
+++ b/tests/step_definitions/claude_code_steps.ts
@@ -14,9 +14,8 @@ import { When, Then, After } from "@cucumber/cucumber";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as assert from "node:assert";
-import { KoluWorld } from "../support/world.ts";
-import { readBufferText } from "../support/buffer.ts";
-import { pollUntil } from "../support/poll.ts";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import { readBufferText, ACTIVE_TERMINAL } from "../support/buffer.ts";
 
 const SESSION_ID = "test-claude-session-00000000-0000-0000-0000";
 // Read these lazily rather than at module load — `hooks.ts` sets per-worker
@@ -30,18 +29,18 @@ async function getTerminalPid(world: KoluWorld): Promise<number> {
   const marker = `PID_MARKER_${Date.now()}`;
   await world.page.keyboard.type(`echo $$; echo ${marker}`);
   await world.page.keyboard.press("Enter");
-  // Poll until we can actually parse the PID from the buffer. The marker
-  // appears in the echoed command line BEFORE the shell prints its output,
-  // so polling on the substring alone races the output. Instead poll until
-  // the structure we want — PID line + marker output line — is present.
-  const pid = await pollUntil(
-    world.page,
-    async () => {
-      const text = await readBufferText(world.page);
-      const lines = text.split("\n").map((l) => l.trim());
+  // Wait for the marker to appear in the buffer, then parse the PID from
+  // the surrounding lines — all inside waitForFunction so the buffer read
+  // and parse happen atomically in the browser context per rAF cycle.
+  // Uses the shared __readXtermBuffer helper (injected by hooks.ts).
+  const handle = await world.page.waitForFunction(
+    ({ marker, sel }) => {
+      const text = (window as any).__readXtermBuffer(sel, 0) as string;
+      if (!text) return null;
+      const lines = text.split("\n").map((l: string) => l.trim());
       // Find the marker on a line that's NOT the typed echo command.
       const markerIdx = lines.findIndex(
-        (l) => l.includes(marker) && !l.includes("echo"),
+        (l: string) => l.includes(marker) && !l.includes("echo"),
       );
       if (markerIdx <= 0) return null;
       // Walk backwards from marker to find the PID (first purely numeric line).
@@ -51,9 +50,10 @@ async function getTerminalPid(world: KoluWorld): Promise<number> {
       }
       return null;
     },
-    (val) => val !== null,
-    { attempts: 50, intervalMs: 100 },
+    { marker, sel: ACTIVE_TERMINAL },
+    { timeout: POLL_TIMEOUT },
   );
+  const pid = await handle.jsonValue();
   if (pid === null) {
     const text = await readBufferText(world.page);
     throw new Error(
@@ -214,53 +214,26 @@ When("the Claude Code session ends", async function (this: KoluWorld) {
 Then(
   "the header should show a Claude indicator with state {string}",
   async function (this: KoluWorld, expectedState: string) {
-    const el = this.page.locator('[data-testid="claude-indicator"]');
-    const state = await pollUntil(
-      this.page,
-      async () => {
-        try {
-          // There may be multiple (header + sidebar). Check the first one.
-          const first = el.first();
-          return (
-            (await first.getAttribute("data-claude-state", {
-              timeout: 1000,
-            })) ?? ""
-          );
-        } catch {
-          return "";
-        }
+    await this.page.waitForFunction(
+      (expected) => {
+        const el = document.querySelector('[data-testid="claude-indicator"]');
+        return el?.getAttribute("data-claude-state") === expected;
       },
-      (s) => s === expectedState,
-      { attempts: 30, intervalMs: 200 },
-    );
-    assert.strictEqual(
-      state,
       expectedState,
-      `Expected Claude indicator state "${expectedState}", got "${state}"`,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );
 
 /** Assert a claude-indicator exists within the given container testid. */
 async function expectClaudeIndicatorIn(world: KoluWorld, testId: string) {
-  const container = world.page.locator(`[data-testid="${testId}"]`);
-  const indicator = container.locator('[data-testid="claude-indicator"]');
-  await pollUntil(
-    world.page,
-    async () => {
-      try {
-        return await indicator.count();
-      } catch {
-        return 0;
-      }
-    },
-    (count) => count > 0,
-    { attempts: 30, intervalMs: 200 },
-  );
-  const count = await indicator.count();
-  assert.ok(
-    count > 0,
-    `Expected Claude indicator in [data-testid="${testId}"]`,
+  await world.page.waitForFunction(
+    (testId) =>
+      document.querySelector(
+        `[data-testid="${testId}"] [data-testid="claude-indicator"]`,
+      ) !== null,
+    testId,
+    { timeout: POLL_TIMEOUT },
   );
 }
 
@@ -316,19 +289,17 @@ Then(
     // `setupTranscriptWatching` runs the initial derive, an existing JSONL
     // tail produces ≥1 transition — that's the value we assert against.
     // (rawEvents stays empty by design when content predates the watcher.)
-    const count = await pollUntil(
-      this.page,
-      async () => {
-        const text = (await dialog.textContent()) ?? "";
+    await this.page.waitForFunction(
+      (min) => {
+        const dialog = document.querySelector(
+          '[data-testid="claude-transcript"]',
+        );
+        const text = dialog?.textContent ?? "";
         const m = text.match(/Server saw \((\d+) transitions?\)/);
-        return m ? parseInt(m[1]!, 10) : 0;
+        return m ? parseInt(m[1]!, 10) >= min : false;
       },
-      (n) => n >= min,
-      { attempts: 30, intervalMs: 200 },
-    );
-    assert.ok(
-      count >= min,
-      `Expected at least ${min} server transition(s) in Claude transcript dialog, got ${count}`,
+      min,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );
@@ -352,28 +323,9 @@ Then(
 Then(
   "the header should not show a Claude indicator",
   async function (this: KoluWorld) {
-    // Wait for it to disappear (may take a poll cycle)
-    await pollUntil(
-      this.page,
-      async () => {
-        try {
-          return await this.page
-            .locator('[data-testid="claude-indicator"]')
-            .count();
-        } catch {
-          return 0;
-        }
-      },
-      (count) => count === 0,
-      { attempts: 30, intervalMs: 200 },
-    );
-    const count = await this.page
-      .locator('[data-testid="claude-indicator"]')
-      .count();
-    assert.strictEqual(
-      count,
-      0,
-      `Expected no Claude indicator but found ${count}`,
+    await this.page.waitForFunction(
+      () => document.querySelector('[data-testid="claude-indicator"]') === null,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );

--- a/tests/step_definitions/cwd_steps.ts
+++ b/tests/step_definitions/cwd_steps.ts
@@ -1,27 +1,16 @@
 import { Then } from "@cucumber/cucumber";
-import { KoluWorld } from "../support/world.ts";
-import * as assert from "node:assert";
-import { pollUntil } from "../support/poll.ts";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
 Then(
   "the header CWD should show {string}",
   async function (this: KoluWorld, expected: string) {
-    const cwdEl = this.page.locator('[data-testid="header-cwd"]');
-    const text = await pollUntil(
-      this.page,
-      async () => {
-        try {
-          return (await cwdEl.textContent({ timeout: 1000 })) ?? "";
-        } catch {
-          return "";
-        }
+    await this.page.waitForFunction(
+      (exp) => {
+        const el = document.querySelector('[data-testid="header-cwd"]');
+        return (el?.textContent ?? "").includes(exp);
       },
-      (t) => t.includes(expected),
-      { attempts: 40, intervalMs: 200 },
-    );
-    assert.ok(
-      text.includes(expected),
-      `Expected header CWD to contain "${expected}" but got "${text}"`,
+      expected,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );

--- a/tests/step_definitions/foreground_process_steps.ts
+++ b/tests/step_definitions/foreground_process_steps.ts
@@ -6,36 +6,21 @@
  */
 
 import { Then, When } from "@cucumber/cucumber";
-import * as assert from "node:assert";
-import { KoluWorld } from "../support/world.ts";
-import { pollUntil } from "../support/poll.ts";
-
-/** Read the process name from the sidebar's data-testid="process-name" element. */
-async function getSidebarProcessName(world: KoluWorld): Promise<string | null> {
-  try {
-    const el = world.page
-      .locator('[data-testid="sidebar"]')
-      .locator('[data-testid="process-name"]')
-      .first();
-    const text = await el.textContent({ timeout: 1000 });
-    return text?.trim() ?? null;
-  } catch {
-    return null;
-  }
-}
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
 Then(
   "the sidebar process name should contain {string}",
   async function (this: KoluWorld, expected: string) {
-    const name = await pollUntil(
-      this.page,
-      () => getSidebarProcessName(this),
-      (n) => n !== null && n.includes(expected),
-      { attempts: 30, intervalMs: 200 },
-    );
-    assert.ok(
-      name && name.includes(expected),
-      `Expected sidebar process name to contain "${expected}", got "${name}"`,
+    await this.page.waitForFunction(
+      (exp) => {
+        const el = document.querySelector(
+          '[data-testid="sidebar"] [data-testid="process-name"]',
+        );
+        const text = el?.textContent?.trim() ?? "";
+        return text.includes(exp);
+      },
+      expected,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );
@@ -43,15 +28,14 @@ Then(
 Then(
   "the sidebar process name should be non-empty",
   async function (this: KoluWorld) {
-    const name = await pollUntil(
-      this.page,
-      () => getSidebarProcessName(this),
-      (n) => n !== null && n.length > 0,
-      { attempts: 30, intervalMs: 200 },
-    );
-    assert.ok(
-      name && name.length > 0,
-      `Expected sidebar process name to be non-empty, got "${name}"`,
+    await this.page.waitForFunction(
+      () => {
+        const el = document.querySelector(
+          '[data-testid="sidebar"] [data-testid="process-name"]',
+        );
+        return (el?.textContent?.trim() ?? "").length > 0;
+      },
+      { timeout: POLL_TIMEOUT },
     );
   },
 );

--- a/tests/step_definitions/git_context_steps.ts
+++ b/tests/step_definitions/git_context_steps.ts
@@ -68,13 +68,7 @@ Then(
 Then(
   "the sidebar label should show {string}",
   async function (this: KoluWorld, expected: string) {
-    const text = await pollTestId(this, "terminal-meta-name", (t) =>
-      t.includes(expected),
-    );
-    assert.ok(
-      text.includes(expected),
-      `Expected sidebar label to contain "${expected}", got "${text}"`,
-    );
+    await waitForTestIdText(this, "terminal-meta-name", expected);
   },
 );
 

--- a/tests/step_definitions/git_context_steps.ts
+++ b/tests/step_definitions/git_context_steps.ts
@@ -2,26 +2,21 @@ import { When, Then } from "@cucumber/cucumber";
 import { execFileSync } from "node:child_process";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 import * as assert from "node:assert";
-import { pollUntil } from "../support/poll.ts";
 
-/** Poll a data-testid element until its text satisfies a predicate. */
-async function pollTestId(
+/** Wait for a data-testid element's text to include the given substring. */
+async function waitForTestIdText(
   world: KoluWorld,
   testId: string,
-  predicate: (text: string) => boolean,
-): Promise<string> {
-  const el = world.page.locator(`[data-testid="${testId}"]`);
-  return pollUntil(
-    world.page,
-    async () => {
-      try {
-        return (await el.textContent({ timeout: 1000 })) ?? "";
-      } catch {
-        return "";
-      }
+  includes?: string,
+): Promise<void> {
+  await world.page.waitForFunction(
+    ({ testId, includes }) => {
+      const el = document.querySelector(`[data-testid="${testId}"]`);
+      const text = el?.textContent ?? "";
+      return includes ? text.includes(includes) : text.length > 0;
     },
-    predicate,
-    { attempts: 40, intervalMs: 200 },
+    { testId, includes },
+    { timeout: POLL_TIMEOUT },
   );
 }
 
@@ -35,43 +30,25 @@ When(
 );
 
 Then("the header should show a branch name", async function (this: KoluWorld) {
-  const text = await pollTestId(this, "header-branch", (t) => t.length > 0);
-  assert.ok(text.length > 0, `Expected header to show a branch name`);
+  await waitForTestIdText(this, "header-branch");
 });
 
 Then(
   "the header branch should contain {string}",
   async function (this: KoluWorld, expected: string) {
-    const text = await pollTestId(this, "header-branch", (t) =>
-      t.includes(expected),
-    );
-    assert.ok(
-      text.includes(expected),
-      `Expected header branch to contain "${expected}", got "${text}"`,
-    );
+    await waitForTestIdText(this, "header-branch", expected);
   },
 );
 
 Then(
   "the sidebar branch should contain {string}",
   async function (this: KoluWorld, expected: string) {
-    const text = await pollTestId(this, "terminal-meta-branch", (t) =>
-      t.includes(expected),
-    );
-    assert.ok(
-      text.includes(expected),
-      `Expected sidebar branch to contain "${expected}", got "${text}"`,
-    );
+    await waitForTestIdText(this, "terminal-meta-branch", expected);
   },
 );
 
 Then("the sidebar should show a branch name", async function (this: KoluWorld) {
-  const text = await pollTestId(
-    this,
-    "terminal-meta-branch",
-    (t) => t.length > 0,
-  );
-  assert.ok(text.length > 0, `Expected sidebar to show a branch name`);
+  await waitForTestIdText(this, "terminal-meta-branch");
 });
 
 Then(

--- a/tests/step_definitions/mobile_terminal_scroll_steps.ts
+++ b/tests/step_definitions/mobile_terminal_scroll_steps.ts
@@ -1,6 +1,6 @@
 import { When, Then } from "@cucumber/cucumber";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
-import { pollUntilBufferContains } from "../support/buffer.ts";
+import { waitForBufferContains } from "../support/buffer.ts";
 import * as assert from "node:assert";
 
 /** Read xterm's current viewportY (top row of the visible window). When the
@@ -27,7 +27,7 @@ When(
     // Wait for `seq` output to fill scrollback past the viewport so there's
     // somewhere to scroll TO. Polling on a high line number guarantees the
     // buffer is deeper than the visible window.
-    await pollUntilBufferContains(this.page, "200");
+    await waitForBufferContains(this.page, "200");
     this.savedScrollTop = await readViewportY(this);
   },
 );

--- a/tests/step_definitions/scroll_lock_steps.ts
+++ b/tests/step_definitions/scroll_lock_steps.ts
@@ -2,7 +2,7 @@ import { When, Then } from "@cucumber/cucumber";
 import assert from "node:assert";
 import { writeFile } from "node:fs/promises";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
-import { pollUntilBufferContains } from "../support/buffer.ts";
+import { waitForBufferContains } from "../support/buffer.ts";
 
 /** Per-scenario FIFO path (avoids collisions when CI runs parallel workers). */
 function scrollFifo(world: KoluWorld): string {
@@ -20,7 +20,7 @@ When(
     await this.terminalRun(
       `for i in $(seq 1 ${count}); do echo scroll-test-$i; done`,
     );
-    await pollUntilBufferContains(this.page, `scroll-test-${count}`);
+    await waitForBufferContains(this.page, `scroll-test-${count}`);
   },
 );
 
@@ -38,7 +38,7 @@ When(
         .locator('[data-testid="scroll-to-bottom"][data-active]')
         .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     } else {
-      await pollUntilBufferContains(this.page, `extra-line-${count}`);
+      await waitForBufferContains(this.page, `extra-line-${count}`);
     }
   },
 );

--- a/tests/step_definitions/sidebar_steps.ts
+++ b/tests/step_definitions/sidebar_steps.ts
@@ -4,7 +4,7 @@ import {
   SIDEBAR_ENTRY_SELECTOR,
   POLL_TIMEOUT,
 } from "../support/world.ts";
-import { pollUntilBufferContains } from "../support/buffer.ts";
+import { waitForBufferContains } from "../support/buffer.ts";
 import * as assert from "node:assert";
 
 When("I create a terminal", async function (this: KoluWorld) {
@@ -148,7 +148,7 @@ Then(
 Then(
   "the active terminal should show {string}",
   async function (this: KoluWorld, expected: string) {
-    await pollUntilBufferContains(this.page, expected);
+    await waitForBufferContains(this.page, expected);
   },
 );
 

--- a/tests/step_definitions/sub_terminal_steps.ts
+++ b/tests/step_definitions/sub_terminal_steps.ts
@@ -1,7 +1,6 @@
 import { When, Then } from "@cucumber/cucumber";
 import { KoluWorld, MOD_KEY, POLL_TIMEOUT } from "../support/world.ts";
-import { pollUntil } from "../support/poll.ts";
-import { pollUntilBufferContains } from "../support/buffer.ts";
+import { waitForBufferContains } from "../support/buffer.ts";
 import * as assert from "node:assert";
 
 const PALETTE = '[data-testid="command-palette"]';
@@ -115,28 +114,9 @@ Then(
   async function (this: KoluWorld) {
     // Wait for focus to land inside a [data-sub-terminal] container directly —
     // no indirect ID comparison with the sidebar's active entry.
-    const result = await pollUntil(
-      this.page,
-      () =>
-        this.page.evaluate(() => {
-          const active = document.activeElement;
-          if (!active) return { focused: false, reason: "no activeElement" };
-          const sub = active.closest("[data-sub-terminal]");
-          if (sub) return { focused: true, reason: "focus in sub-terminal" };
-          const container = active.closest("[data-terminal-id]");
-          return {
-            focused: false,
-            reason: container
-              ? `focus in main terminal (${container.getAttribute("data-terminal-id")})`
-              : "focus not in any terminal",
-          };
-        }),
-      (val) => val.focused,
-      { attempts: 50, intervalMs: 100 },
-    );
-    assert.ok(
-      result.focused,
-      `Expected keyboard focus in the sub-terminal (${result.reason})`,
+    await this.page.waitForFunction(
+      () => !!document.activeElement?.closest("[data-sub-terminal]"),
+      { timeout: POLL_TIMEOUT },
     );
   },
 );
@@ -161,10 +141,8 @@ Then(
     const marker = `focus-proof-${Date.now()}`;
     await this.page.keyboard.type(`echo ${marker}`);
     await this.page.keyboard.press("Enter");
-    await pollUntilBufferContains(this.page, marker, {
+    await waitForBufferContains(this.page, marker, {
       selector: "[data-terminal-id][data-visible]:not([data-sub-terminal])",
-      attempts: 50,
-      intervalMs: 100,
     });
   },
 );
@@ -298,10 +276,8 @@ Then(
     await this.page
       .locator('[data-testid="sub-panel-tab-bar"]')
       .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await pollUntilBufferContains(this.page, expected, {
+    await waitForBufferContains(this.page, expected, {
       selector: "[data-sub-terminal][data-visible]",
-      attempts: 50,
-      intervalMs: 100,
     });
   },
 );

--- a/tests/step_definitions/terminal_steps.ts
+++ b/tests/step_definitions/terminal_steps.ts
@@ -1,6 +1,6 @@
 import { Given, When, Then } from "@cucumber/cucumber";
 import { KoluWorld } from "../support/world.ts";
-import { readBufferText, pollUntilBufferContains } from "../support/buffer.ts";
+import { readBufferText, waitForBufferContains } from "../support/buffer.ts";
 import { pollUntil } from "../support/poll.ts";
 import * as assert from "node:assert";
 
@@ -99,7 +99,7 @@ Given("I note the font size", async function (this: KoluWorld) {
 Then(
   "the screen state should contain {string}",
   async function (this: KoluWorld, expected: string) {
-    await pollUntilBufferContains(this.page, expected);
+    await waitForBufferContains(this.page, expected);
   },
 );
 

--- a/tests/step_definitions/theme_steps.ts
+++ b/tests/step_definitions/theme_steps.ts
@@ -6,7 +6,6 @@ import {
   POLL_TIMEOUT,
 } from "../support/world.ts";
 import * as assert from "node:assert";
-import { pollUntil } from "../support/poll.ts";
 
 /** Convert "#rrggbb" to "rgb(r, g, b)" for comparison with getComputedStyle. */
 function hexToRgb(hex: string): string {
@@ -32,24 +31,19 @@ Then(
   "the terminal background should be {string}",
   async function (this: KoluWorld, expectedColor: string) {
     // The terminal viewport div has inline background-color set by the active theme.
-    // Poll since theme change involves async reset + screen state restore.
+    // waitForFunction since theme change involves async reset + screen state restore.
     const expectedRgb = hexToRgb(expectedColor);
-    const bgColor = await pollUntil(
-      this.page,
-      () =>
-        this.page.evaluate(() => {
-          const container = document.querySelector(
-            '[data-testid="terminal-viewport"]',
-          );
-          return container ? getComputedStyle(container).backgroundColor : "";
-        }),
-      (bg) => bg === expectedRgb,
-      { attempts: 50 },
-    );
-    assert.strictEqual(
-      bgColor,
+    await this.page.waitForFunction(
+      (expected) => {
+        const container = document.querySelector(
+          '[data-testid="terminal-viewport"]',
+        );
+        return container
+          ? getComputedStyle(container).backgroundColor === expected
+          : false;
+      },
       expectedRgb,
-      `Expected terminal background ${expectedColor}`,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );
@@ -64,15 +58,14 @@ Then(
   async function (this: KoluWorld, notExpected: string) {
     const themeName = this.page.locator('[data-testid="theme-name"]');
     await themeName.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    const text = await pollUntil(
-      this.page,
-      async () => (await themeName.textContent()) ?? "",
-      (t) => t !== notExpected,
-      { attempts: 30 },
-    );
-    assert.ok(
-      text !== notExpected,
-      `Expected theme to differ from "${notExpected}" but got "${text}"`,
+    await this.page.waitForFunction(
+      (not) => {
+        const el = document.querySelector('[data-testid="theme-name"]');
+        const text = el?.textContent ?? "";
+        return text.length > 0 && text !== not;
+      },
+      notExpected,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );
@@ -89,16 +82,13 @@ Then(
   async function (this: KoluWorld, expectedTheme: string) {
     const themeName = this.page.locator('[data-testid="theme-name"]');
     await themeName.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    const text = await pollUntil(
-      this.page,
-      async () => (await themeName.textContent()) ?? "",
-      (t) => t === expectedTheme,
-      { attempts: 30 },
-    );
-    assert.strictEqual(
-      text,
+    await this.page.waitForFunction(
+      (expected) => {
+        const el = document.querySelector('[data-testid="theme-name"]');
+        return el?.textContent === expected;
+      },
       expectedTheme,
-      `Expected theme "${expectedTheme}" but got "${text}"`,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );

--- a/tests/support/buffer.ts
+++ b/tests/support/buffer.ts
@@ -1,13 +1,17 @@
 /**
  * Helpers for reading the xterm.js buffer directly via the __xterm ref
- * exposed on terminal container elements. Replaces server-side screenState
- * RPC polling with instant client-side buffer reads.
+ * exposed on terminal container elements.
+ *
+ * The actual buffer-read loop lives in `hooks.ts` as `window.__readXtermBuffer`
+ * (injected via addInitScript) so it's defined once and shared across
+ * readBufferText, waitForBufferContains, and getTerminalPid.
  */
 
 import type { Page } from "playwright";
+import { POLL_TIMEOUT } from "./world.ts";
 
 /** Default selector for the active (visible) terminal container. */
-const ACTIVE_TERMINAL = "[data-visible][data-terminal-id]";
+export const ACTIVE_TERMINAL = "[data-visible][data-terminal-id]";
 
 /**
  * Read all lines from a terminal's xterm buffer (joined by newline).
@@ -19,44 +23,28 @@ export function readBufferText(
   index = 0,
 ): Promise<string> {
   return page.evaluate(
-    ({ sel, idx }) => {
-      const containers = document.querySelectorAll(sel);
-      const container = containers[idx] as HTMLElement | undefined;
-      if (!container) return "";
-      const term = (container as any).__xterm;
-      if (!term) return "";
-      const buf = term.buffer.active;
-      const lines: string[] = [];
-      for (let i = 0; i < buf.length; i++) {
-        lines.push(buf.getLine(i)?.translateToString(true) ?? "");
-      }
-      return lines.join("\n");
-    },
+    ({ sel, idx }) => (window as any).__readXtermBuffer(sel, idx),
     { sel: selector, idx: index },
   );
 }
 
 /**
- * Poll the xterm buffer until it contains the expected text.
+ * Wait for the xterm buffer to contain the expected text using Playwright's
+ * native waitForFunction (rAF-based polling inside the browser context).
  * Returns the full buffer content on match, or throws on timeout.
  */
-export async function pollUntilBufferContains(
+export async function waitForBufferContains(
   page: Page,
   expected: string,
-  {
-    selector = ACTIVE_TERMINAL,
-    index = 0,
-    attempts = 50,
-    intervalMs = 100,
-  } = {},
+  { selector = ACTIVE_TERMINAL, index = 0, timeout = POLL_TIMEOUT } = {},
 ): Promise<string> {
-  let content = "";
-  for (let i = 0; i < attempts; i++) {
-    content = await readBufferText(page, selector, index);
-    if (content.includes(expected)) return content;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  throw new Error(
-    `Buffer does not contain "${expected}" after ${attempts} attempts.\nBuffer (partial): ${content.slice(0, 500)}`,
+  const handle = await page.waitForFunction(
+    ({ sel, idx, exp }) => {
+      const content = (window as any).__readXtermBuffer(sel, idx);
+      return content.includes(exp) ? content : null;
+    },
+    { sel: selector, idx: index, exp: expected },
+    { timeout },
   );
+  return (await handle.jsonValue())!;
 }

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -229,6 +229,23 @@ Before(async function (this: KoluWorld, scenario) {
       style.textContent = "*, *::before, *::after { transition-duration: 0s !important; animation-duration: 0s !important; }";
       document.head.appendChild(style);
     });
+    // Shared xterm buffer reader for e2e tests — used by waitForBufferContains,
+    // readBufferText, and getTerminalPid via page.evaluate / page.waitForFunction.
+    // Single definition avoids the buffer-read loop being duplicated across files.
+    window.__readXtermBuffer = function(sel, idx) {
+      var containers = document.querySelectorAll(sel);
+      var container = containers[idx];
+      if (!container) return "";
+      var term = container.__xterm;
+      if (!term) return "";
+      var buf = term.buffer.active;
+      var lines = [];
+      for (var i = 0; i < buf.length; i++) {
+        var line = buf.getLine(i);
+        lines.push(line ? line.translateToString(true) : "");
+      }
+      return lines.join("\\n");
+    };
   `);
   this.errors = [];
   this.page.on("pageerror", (err) => this.errors.push(err.message));


### PR DESCRIPTION
**E2e test waits are now event-driven instead of time-based.** Every `pollUntil` and `pollUntilBufferContains` call that was polling DOM state or xterm buffer content on a fixed `sleep(N) → check → repeat` loop has been replaced with Playwright's native `page.waitForFunction`, which hooks into the browser's own rAF cycle.

The old approach guessed wall-clock budgets (e.g. 50 attempts × 100ms = 5s) that worked on fast machines but flaked under CI load — the budget is a bet on system speed, and bets lose. The new approach lets Playwright's adaptive polling handle scheduling: each check runs inside the browser context as a synchronous buffer/DOM read, re-evaluated every animation frame until the condition is met or the timeout expires. *No production code changes — this is purely test infrastructure.*

~15 DOM-attribute polls (activity state, CWD text, theme color, Claude indicator, process name, git context) and ~8 terminal buffer polls (`pollUntilBufferContains`) converted across 8 step definition files. The `pollUntil` helper survives only for one Node-side file-read poll that can't run in browser context.