### PR TITLE
Source login profile files in terminal shells for full PATH

### DIFF
--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -67,9 +67,6 @@ in
         ++ lib.optionals (cfg.tls.certFile == null && cfg.tls.enable) [ "--tls" ]
         ++ lib.optionals cfg.verbose [ "--verbose" ]);
         Restart = "on-failure";
-        Environment = [
-          "SHELL=${lib.getExe pkgs.bashInteractive}"
-        ];
       };
       Install = {
         WantedBy = [ "default.target" ];

--- a/server/src/shell.ts
+++ b/server/src/shell.ts
@@ -65,6 +65,9 @@ export function cleanEnv(): Record<string, string> {
   } else {
     env = { ...process.env } as Record<string, string>;
   }
+  // Ensure SHELL is set — systemd user services may not have it.
+  // Fall back to the login shell from /etc/passwd.
+  env.SHELL ??= userInfo().shell || "/bin/sh";
   // Enable VTE integration in bash/zsh (some tools like direnv check this).
   env.VTE_VERSION ??= "7603";
   return env;
@@ -109,11 +112,15 @@ export const OSC2_PRECMD_BASH = `__kolu_title_precmd() { printf '\\033]2;%s\\033
 export const OSC2_PRECMD_ZSH = `__kolu_title_precmd() { print -Pn '\\e]2;%(4~|…/%3~|%~)\\a'; }`;
 
 /**
- * Prepare shell init that injects an OSC 7 hook *after* the user's rc files.
+ * Prepare shell init that injects hooks *after* the user's login + rc files.
+ *
+ * The wrapper rc sources the login init chain (/etc/profile, ~/.bash_profile
+ * or ~/.zprofile) followed by the interactive rc (~/.bashrc / ~/.zshrc), then
+ * appends kolu's OSC hooks. This gives terminals the full PATH even when
+ * the server runs as a systemd user service with a minimal environment.
  *
  * We can't just set PROMPT_COMMAND in env — tools like starship overwrite it.
- * Instead we create a wrapper rc file that sources the user's config first,
- * then appends our hook to whatever PROMPT_COMMAND/precmd ended up being.
+ * The wrapper approach lets us append after all user init completes.
  *
  * Returns extra spawn args, env overrides, and a cleanup function to remove
  * any temp files created.
@@ -137,7 +144,15 @@ export function osc7Init(
     writeFileSync(
       rcFile,
       [
-        `[ -f "${home}/.bashrc" ] && . "${home}/.bashrc"`,
+        // Source login init chain so the shell inherits the full PATH
+        // (e.g., from /etc/profile.d/hm-session-vars.sh on NixOS).
+        // Mirrors bash login behavior: /etc/profile, then the first of
+        // ~/.bash_profile / ~/.bash_login / ~/.profile.
+        // If no login file exists, fall back to ~/.bashrc directly.
+        `[ -f /etc/profile ] && . /etc/profile`,
+        `__kolu_login=0; for __f in "${home}/.bash_profile" "${home}/.bash_login" "${home}/.profile"; do [ -f "$__f" ] && { . "$__f"; __kolu_login=1; break; }; done`,
+        `[ "$__kolu_login" = 0 ] && [ -f "${home}/.bashrc" ] && . "${home}/.bashrc"`,
+        `unset __kolu_login __f`,
         pathLine,
         OSC7_FN,
         OSC2_PREEXEC_FN,
@@ -172,6 +187,8 @@ export function osc7Init(
     writeFileSync(
       join(zdotdir, ".zshrc"),
       [
+        `[ -f /etc/zprofile ] && source /etc/zprofile`,
+        `[ -f "${home}/.zprofile" ] && source "${home}/.zprofile"`,
         `[ -f "${home}/.zshrc" ] && ZDOTDIR="${home}" source "${home}/.zshrc"`,
         pathLine,
         OSC7_FN,


### PR DESCRIPTION
**Kolu terminals now inherit the user's full login PATH**, fixing
bare-bones PATH when running as a systemd user service (e.g., via
home-manager). Previously, shells were spawned as non-login
interactive shells that only sourced `~/.bashrc`/`~/.zshrc`, missing
PATH entries from `/etc/profile`, `~/.bash_profile`, and
`~/.zprofile`.

The wrapper rc files now source the login init chain first — mirroring
what a login shell would do — then source the interactive rc, then
inject kolu's hooks last. *For bash this means `/etc/profile` →
`~/.bash_profile` (or `~/.bash_login`/`~/.profile`) → hooks. If no
login file exists, `~/.bashrc` is sourced as fallback.* For zsh,
`~/.zprofile` is sourced before `~/.zshrc`.

Also removes the hardcoded `SHELL=bashInteractive` from the
home-manager module — it was overriding the user's preferred shell and
is no longer needed since `cleanEnv()` now falls back to the login
shell from `/etc/passwd` when `$SHELL` is unset.

### Try it locally

```sh
nix run github:juspay/kolu/fix/login-shell-path
```