### PR TITLE
Drop 'waiting' from attention preview gate

### DIFF
--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -57,25 +57,22 @@ function cardTier(claudeState: ClaudeState | undefined): CardTier {
  *    handy for testing the preview plumbing itself.
  *  - `"agents"`: any terminal with a running code agent. This was the
  *    behavior before the enum was introduced (legacy `true`).
- *  - `"attention"` (**default**): only agents that actually want the
- *    user's eyes — when Claude is **waiting** for input or when
- *    there's an **unread** completion. Rationale: previews are
- *    expensive vertically (only ~3 cards fit — see #388), so we
- *    reserve them for the moments peeking without switching actually
- *    helps. Thinking/tool_use agents are busy but don't need
- *    attention; idle terminals have nothing to show. Edit this single
- *    branch if the "needs attention" heuristic needs to change. */
+ *  - `"attention"` (**default**): only agents with an **unread**
+ *    completion — Claude finished and the user hasn't seen it yet.
+ *    Previews are expensive vertically (only ~3 cards fit — see #388),
+ *    so we reserve them for the moment peeking without switching
+ *    actually helps. Once the user looks, the preview disappears and
+ *    frees the sidebar slot. */
 function shouldShowPreview(
   mode: SidebarAgentPreviews,
   hasAgent: boolean,
-  claudeState: ClaudeState | undefined,
   unread: boolean,
 ): boolean {
   return match(mode)
     .with("none", () => false)
     .with("all", () => true)
     .with("agents", () => hasAgent)
-    .with("attention", () => hasAgent && (claudeState === "waiting" || unread))
+    .with("attention", () => hasAgent && unread)
     .exhaustive();
 }
 
@@ -108,7 +105,6 @@ const SidebarEntry: Component<{
     return shouldShowPreview(
       props.previewMode,
       props.metadata?.claude != null,
-      props.displayInfo?.meta.claude?.state,
       props.unread,
     )
       ? vp

--- a/tests/features/claude-code.feature
+++ b/tests/features/claude-code.feature
@@ -44,8 +44,7 @@ Feature: Claude Code status detection
   Scenario: Sidebar shows a live preview for unread agent completions
     When a Claude Code session is mocked with state "waiting"
     And I create a terminal
-    And the Claude Code session state changes to "thinking"
-    And the Claude Code session state changes to "waiting"
+    And I simulate an activity alert
     Then a sidebar entry should be notified
     And the sidebar should show a terminal preview
     And there should be no page errors
@@ -63,8 +62,7 @@ Feature: Claude Code status detection
   Scenario: Setting agent previews to "none" hides the sidebar preview
     When a Claude Code session is mocked with state "waiting"
     And I create a terminal
-    And the Claude Code session state changes to "thinking"
-    And the Claude Code session state changes to "waiting"
+    And I simulate an activity alert
     Then a sidebar entry should be notified
     And the sidebar should show a terminal preview
     When I click the settings button

--- a/tests/features/claude-code.feature
+++ b/tests/features/claude-code.feature
@@ -37,11 +37,22 @@ Feature: Claude Code status detection
     Then the header should show a Claude indicator with state "thinking"
     And there should be no page errors
 
-  # Preview shows only when the agent is waiting on the user or has an unread completion.
-  # A "thinking" agent is busy but doesn't need attention — see shouldShowPreview() in Sidebar.tsx.
-  Scenario: Sidebar shows a live preview for agents waiting on the user
+  # Preview shows only for agents with an unread completion (#434).
+  # "waiting" alone (on the active terminal) doesn't trigger a preview —
+  # the user is already looking at it. A background agent that finishes
+  # gets marked unread, which triggers the preview.
+  Scenario: Sidebar shows a live preview for unread agent completions
     When a Claude Code session is mocked with state "waiting"
-    Then the sidebar should show a terminal preview
+    And I create a terminal
+    And the Claude Code session state changes to "thinking"
+    And the Claude Code session state changes to "waiting"
+    Then a sidebar entry should be notified
+    And the sidebar should show a terminal preview
+    And there should be no page errors
+
+  Scenario: Sidebar hides the preview for waiting agents the user has already seen
+    When a Claude Code session is mocked with state "waiting"
+    Then the sidebar should not show a terminal preview
     And there should be no page errors
 
   Scenario: Sidebar hides the preview for thinking agents
@@ -51,7 +62,11 @@ Feature: Claude Code status detection
 
   Scenario: Setting agent previews to "none" hides the sidebar preview
     When a Claude Code session is mocked with state "waiting"
-    Then the sidebar should show a terminal preview
+    And I create a terminal
+    And the Claude Code session state changes to "thinking"
+    And the Claude Code session state changes to "waiting"
+    Then a sidebar entry should be notified
+    And the sidebar should show a terminal preview
     When I click the settings button
     And I set the agent previews mode to "none"
     Then the sidebar should not show a terminal preview

--- a/tests/features/claude-code.feature
+++ b/tests/features/claude-code.feature
@@ -49,6 +49,17 @@ Feature: Claude Code status detection
     And the sidebar should show a terminal preview
     And there should be no page errors
 
+  Scenario: Visiting an unread agent clears its preview
+    When a Claude Code session is mocked with state "waiting"
+    And I create a terminal
+    And I simulate an activity alert
+    Then a sidebar entry should be notified
+    And the sidebar should show a terminal preview
+    When I click the notified sidebar entry
+    Then no sidebar entry should be notified
+    And the sidebar should not show a terminal preview
+    And there should be no page errors
+
   Scenario: Sidebar hides the preview for waiting agents the user has already seen
     When a Claude Code session is mocked with state "waiting"
     Then the sidebar should not show a terminal preview


### PR DESCRIPTION
**Agent previews in "attention" mode now trigger only on unread completions**, not on the `waiting` Claude state. The `waiting` check fired whenever Claude finished its turn — including "task complete, nothing to do" — which made previews pop up when there was nothing to act on. With `--dangerously-skip-permissions`, `tool_use` never means blocked either, so the signal was pure noise.

`unread` alone is the right heuristic: Claude finished and the user hasn't looked yet. Once they glance at it, the preview disappears and frees the sidebar slot. _The spinning border and orange "Waiting" badge on the card itself still distinguish idle-but-waiting agents from truly idle terminals — no visual information is lost._

Removes the now-dead `claudeState` parameter from `shouldShowPreview` and its call site.

Closes #434