### PR TITLE
Extract SessionWatcher into integration library

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -191,7 +191,7 @@ If no documentation files are documented, skip this step with a note.
 
 ### police
 
-Use `git diff <default-branch>...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
+Use `git diff origin/HEAD...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
 
 Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.
 
@@ -226,7 +226,7 @@ Create a NEW commit (never amend) with a conventional commit message. Push to th
 
 Read the project's instructions to find the test command and strategy. Run only the tests relevant to the code paths changed in this PR.
 
-Use `git diff <default-branch>...HEAD --name-only` to identify changed files and determine which tests are relevant.
+Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and determine which tests are relevant.
 
 If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, skip with a note.
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-10T01:47:57.310147+00:00'
+generated_at: '2026-04-10T22:34:41.019031+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -47,7 +47,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 7865404ef96de256504c86270c7be4ac579d2d3a
+  resolved_commit: c4e635227f10cd8c032b08e1e469f16900fec236
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-10T22:34:41.019031+00:00'
+generated_at: '2026-04-10T22:40:06.077919+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -20,7 +20,7 @@ dependencies:
   local_path: ./agents
 - repo_url: anthropics/skills
   host: github.com
-  resolved_commit: ca1e7dc13c0ab5e2dfaa6de71991cd951b8f1cf2
+  resolved_commit: 12ab35c2eb5668c95810e6a6066f40f4218adc39
   virtual_path: skills/frontend-design
   is_virtual: true
   package_type: claude_skill
@@ -58,4 +58,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:e703883f10500518539f45051b25c8545e0fe9d2d326bcec12e0634110f1b339
+  content_hash: sha256:4ba6ce28e089b597023a3d065997d06d0c9271d36b9776c2ff7a01c66321c51b

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -4,10 +4,20 @@
 // this module re-exports them and composes the AgentInfo union.
 
 import { z } from "zod";
-import { ClaudeCodeInfoSchema, TaskProgressSchema } from "kolu-claude-code";
+import {
+  ClaudeCodeInfoSchema,
+  TaskProgressSchema,
+  ClaudeStateChangeSchema,
+  ClaudeTranscriptDebugSchema,
+} from "kolu-claude-code";
 
 // Re-export integration schemas so consumers import from kolu-common only.
-export { ClaudeCodeInfoSchema, TaskProgressSchema };
+export {
+  ClaudeCodeInfoSchema,
+  TaskProgressSchema,
+  ClaudeStateChangeSchema,
+  ClaudeTranscriptDebugSchema,
+};
 
 // --- Zod schemas ---
 
@@ -69,24 +79,6 @@ export const AgentInfoSchema = z.discriminatedUnion("kind", [
   ClaudeCodeInfoSchema,
   OpenCodeInfoSchema,
 ]);
-
-/** A single state transition the server observed. `info: null` = session ended. */
-export const ClaudeStateChangeSchema = z.object({
-  ts: z.number(),
-  info: ClaudeCodeInfoSchema.nullable(),
-});
-
-/** Diagnostic snapshot comparing what the server saw against the on-disk JSONL.
- *  Used by the Debug → "Show Claude transcript" command. */
-export const ClaudeTranscriptDebugSchema = z.object({
-  transcriptPath: z.string(),
-  /** epoch ms when kolu attached its transcript watcher (= start of monitoring). */
-  startedAt: z.number(),
-  /** What the server believes happened — every transition that passed `infoEqual`. */
-  stateChanges: z.array(ClaudeStateChangeSchema),
-  /** Raw JSONL lines from disk, from `startedAt` offset to EOF. One element per line. */
-  rawEvents: z.array(z.unknown()),
-});
 
 // --- Foreground process context ---
 

--- a/integrations/claude-code/src/index.ts
+++ b/integrations/claude-code/src/index.ts
@@ -429,3 +429,34 @@ export async function fetchSessionSummary(
   const info = await getSessionInfo(sessionId, { dir: cwd });
   return info?.summary ?? null;
 }
+
+// --- Debug schemas ---
+
+/** A single state transition the server observed. `info: null` = session ended. */
+export const ClaudeStateChangeSchema = z.object({
+  ts: z.number(),
+  info: ClaudeCodeInfoSchema.nullable(),
+});
+
+/** Diagnostic snapshot comparing what the server saw against the on-disk JSONL.
+ *  Used by the Debug → "Show Claude transcript" command. */
+export const ClaudeTranscriptDebugSchema = z.object({
+  transcriptPath: z.string(),
+  /** epoch ms when kolu attached its transcript watcher (= start of monitoring). */
+  startedAt: z.number(),
+  /** What the server believes happened — every transition that passed `infoEqual`. */
+  stateChanges: z.array(ClaudeStateChangeSchema),
+  /** Raw JSONL lines from disk, from `startedAt` offset to EOF. One element per line. */
+  rawEvents: z.array(z.unknown()),
+});
+
+// --- Session watcher ---
+
+export {
+  createSessionWatcher,
+  infoEqual,
+  type SessionWatcher,
+  type ClaudeStateChange,
+  type ClaudeTranscriptDebug,
+  type WatcherLog,
+} from "./session-watcher.ts";

--- a/integrations/claude-code/src/session-watcher.ts
+++ b/integrations/claude-code/src/session-watcher.ts
@@ -1,0 +1,314 @@
+/**
+ * SessionWatcher — encapsulates all per-session lifecycle state.
+ *
+ * Creating a SessionWatcher starts transcript watching, task scanning,
+ * and summary fetching. Destroying it tears everything down. No "remember
+ * to reset N variables" invariant — the lifetime IS the object.
+ *
+ * The server's claude provider creates one of these per matched session
+ * and replaces it on session change.
+ */
+
+import fs from "node:fs";
+import { match } from "ts-pattern";
+import {
+  type SessionFile,
+  type ClaudeCodeInfo,
+  type TaskProgress,
+  PROJECTS_DIR,
+  TAIL_BYTES,
+  encodeProjectPath,
+  findTranscriptPath,
+  tailJsonlLines,
+  readJsonlFromOffset,
+  deriveState,
+  extractTasks,
+  deriveTaskProgress,
+  watchOrWaitForDir,
+  fetchSessionSummary,
+} from "./index.ts";
+
+// --- Debug types ---
+// Structurally identical to the Zod-inferred types from the schemas
+// in index.ts. Defined as interfaces here to avoid a circular import
+// (index.ts re-exports from this module).
+
+export interface ClaudeStateChange {
+  ts: number;
+  info: ClaudeCodeInfo | null;
+}
+
+export interface ClaudeTranscriptDebug {
+  transcriptPath: string;
+  startedAt: number;
+  stateChanges: ClaudeStateChange[];
+  rawEvents: unknown[];
+}
+
+// --- Equality helpers ---
+
+/** Compare two TaskProgress values for equality. */
+function taskProgressEqual(
+  a: TaskProgress | null,
+  b: TaskProgress | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.total === b.total && a.completed === b.completed;
+}
+
+/** Compare two ClaudeCodeInfo values for equality. */
+export function infoEqual(
+  a: ClaudeCodeInfo | null,
+  b: ClaudeCodeInfo | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.state === b.state &&
+    a.sessionId === b.sessionId &&
+    a.model === b.model &&
+    a.summary === b.summary &&
+    taskProgressEqual(a.taskProgress, b.taskProgress)
+  );
+}
+
+// --- Transcript watching lifecycle ---
+
+/**
+ * Transcript-watching state machine — mutually exclusive states.
+ * Diagnostic state (stateChanges, startOffset) lives alongside the
+ * watcher, not embedded in the union — it shares the SessionWatcher
+ * lifetime, not the transcript-attach lifecycle.
+ */
+type TranscriptWatching =
+  | { kind: "none" }
+  | { kind: "waiting"; dirWatcher: () => void }
+  | { kind: "watching"; path: string; fileWatcher: fs.FSWatcher };
+
+// --- Logger interface ---
+
+export interface WatcherLog {
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  debug: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+}
+
+// --- SessionWatcher ---
+
+export interface SessionWatcher {
+  readonly session: SessionFile;
+  readonly destroy: () => void;
+  readonly getDebug: () => ClaudeTranscriptDebug | null;
+}
+
+/**
+ * Create a SessionWatcher for a matched Claude Code session.
+ *
+ * Starts transcript watching, incremental task scanning, and summary
+ * fetching. Calls `onUpdate` whenever the derived ClaudeCodeInfo changes
+ * (change-gated via `infoEqual`).
+ *
+ * Call `destroy()` to tear everything down.
+ */
+export function createSessionWatcher(
+  session: SessionFile,
+  onUpdate: (info: ClaudeCodeInfo) => void,
+  plog: WatcherLog,
+): SessionWatcher {
+  let transcriptWatching: TranscriptWatching = { kind: "none" };
+  let lastInfo: ClaudeCodeInfo | null = null;
+  let lastSummary: string | null = null;
+  let taskMap = new Map<string, "pending" | "in_progress" | "completed">();
+  let taskScanOffset = 0;
+
+  // Diagnostic state — shares the SessionWatcher lifetime.
+  let debugStartOffset = 0;
+  let debugStartedAt = 0;
+  const stateChanges: ClaudeStateChange[] = [];
+
+  let destroyed = false;
+
+  function teardownTranscriptWatching() {
+    match(transcriptWatching)
+      .with({ kind: "none" }, () => {})
+      .with({ kind: "waiting" }, ({ dirWatcher }) => dirWatcher())
+      .with({ kind: "watching" }, ({ fileWatcher }) => fileWatcher.close())
+      .exhaustive();
+    transcriptWatching = { kind: "none" };
+  }
+
+  function attachTranscriptWatcher(tp: string) {
+    try {
+      const fileWatcher = fs.watch(tp, () => onTranscriptMaybeChanged());
+      transcriptWatching = { kind: "watching", path: tp, fileWatcher };
+      debugStartOffset = fs.statSync(tp).size;
+      debugStartedAt = Date.now();
+    } catch (err) {
+      plog.warn({ err, path: tp }, "failed to watch transcript");
+      transcriptWatching = { kind: "none" };
+    }
+  }
+
+  function setupTranscriptWatching() {
+    const tp = findTranscriptPath(session);
+    if (tp) {
+      plog.info({ path: tp }, "transcript found");
+      attachTranscriptWatcher(tp);
+      onTranscriptMaybeChanged();
+      return;
+    }
+    plog.debug(
+      { session: session.sessionId, cwd: session.cwd },
+      "transcript not found yet (JSONL created after first message)",
+    );
+    const projectDir = PROJECTS_DIR + "/" + encodeProjectPath(session.cwd);
+    const dirWatcher = watchOrWaitForDir(projectDir, () =>
+      onProjectDirChanged(),
+    );
+    transcriptWatching = { kind: "waiting", dirWatcher };
+  }
+
+  function onProjectDirChanged() {
+    if (destroyed) return;
+    if (transcriptWatching.kind !== "waiting") return;
+    const tp = findTranscriptPath(session);
+    if (!tp) return;
+    plog.info({ path: tp }, "transcript appeared");
+    transcriptWatching.dirWatcher();
+    attachTranscriptWatcher(tp);
+    onTranscriptMaybeChanged();
+  }
+
+  function onTranscriptMaybeChanged() {
+    if (destroyed) return;
+    if (transcriptWatching.kind !== "watching") return;
+
+    const lines = tailJsonlLines(transcriptWatching.path, TAIL_BYTES);
+    const derived = deriveState(lines);
+    if (!derived) {
+      plog.debug(
+        { path: transcriptWatching.path },
+        "no user/assistant message in transcript tail",
+      );
+      return;
+    }
+
+    scanTasksIncremental(transcriptWatching.path);
+
+    const info: ClaudeCodeInfo = {
+      kind: "claude-code",
+      state: derived.state,
+      sessionId: session.sessionId,
+      model: derived.model,
+      summary: lastSummary,
+      taskProgress: deriveTaskProgress(taskMap),
+    };
+
+    if (!infoEqual(info, lastInfo)) {
+      plog.info(
+        { state: info.state, model: info.model, session: info.sessionId },
+        "claude code state updated",
+      );
+      lastInfo = info;
+      stateChanges.push({ ts: Date.now(), info });
+      onUpdate(info);
+    }
+
+    refreshSummary();
+  }
+
+  function scanTasksIncremental(filePath: string) {
+    try {
+      const size = fs.statSync(filePath).size;
+      if (taskScanOffset >= size) return;
+      const length = size - taskScanOffset;
+      const fd = fs.openSync(filePath, "r");
+      let buf: Buffer;
+      try {
+        buf = Buffer.alloc(length);
+        fs.readSync(fd, buf, 0, length, taskScanOffset);
+      } finally {
+        fs.closeSync(fd);
+      }
+      const newLines = buf
+        .toString("utf8")
+        .split("\n")
+        .filter((l) => l.length > 0);
+      // First line may be partial when reading from a mid-file offset — safe to drop.
+      if (taskScanOffset > 0 && newLines.length > 0) {
+        try {
+          JSON.parse(newLines[0]!);
+        } catch {
+          newLines.shift();
+        }
+      }
+      const prevOffset = taskScanOffset;
+      taskScanOffset = size;
+      const changed = extractTasks(newLines, taskMap, plog);
+      if (changed) {
+        const progress = deriveTaskProgress(taskMap);
+        plog.info(
+          {
+            tasks: taskMap.size,
+            progress,
+            bytesScanned: length,
+            from: prevOffset,
+          },
+          "task progress updated",
+        );
+      }
+    } catch (err) {
+      plog.warn({ err, filePath, taskScanOffset }, "task scan failed");
+    }
+  }
+
+  function refreshSummary() {
+    if (destroyed) return;
+    fetchSessionSummary(session.sessionId, session.cwd)
+      .then((summary) => {
+        if (destroyed) return;
+        if (summary === lastSummary) return;
+        lastSummary = summary;
+        if (!lastInfo) return;
+        plog.info(
+          { summary, session: session.sessionId },
+          "claude summary updated",
+        );
+        const updated: ClaudeCodeInfo = { ...lastInfo, summary };
+        lastInfo = updated;
+        onUpdate(updated);
+      })
+      .catch((err) => {
+        plog.debug(
+          { err, session: session.sessionId },
+          "getSessionInfo failed",
+        );
+      });
+  }
+
+  // --- Start watching ---
+  setupTranscriptWatching();
+
+  return {
+    session,
+
+    destroy() {
+      destroyed = true;
+      teardownTranscriptWatching();
+    },
+
+    getDebug(): ClaudeTranscriptDebug | null {
+      if (transcriptWatching.kind !== "watching") return null;
+      return {
+        transcriptPath: transcriptWatching.path,
+        startedAt: debugStartedAt,
+        stateChanges: [...stateChanges],
+        rawEvents: readJsonlFromOffset(
+          transcriptWatching.path,
+          debugStartOffset,
+        ),
+      };
+    },
+  };
+}

--- a/integrations/claude-code/tsconfig.json
+++ b/integrations/claude-code/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "allowImportingTsExtensions": true,
-    "noEmit": true
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -2,28 +2,13 @@
  * Claude Code metadata provider — thin adapter that wires the
  * `kolu-claude-code` integration library into the server's metadata system.
  *
- * All Claude-specific logic (session reading, transcript tailing, state
- * derivation, task extraction) lives in `integrations/claude-code`.
- * This file owns the provider lifecycle: subscribing to events, managing
- * watcher state, and calling `updateMetadata`.
- *
- * Event-driven — no polling. Trigger sources:
- *   - title event (subscribeForTerminal("title", ...)) — fires on shell
- *     preexec/precmd OSC 2, which is when foregroundPid is likely to change
- *   - fs.watch(SESSIONS_DIR) — fires when session files appear/disappear
- *   - fs.watch(projectDir) — fires when the JSONL transcript is created
- *   - fs.watch(transcriptPath) — fires on each message, drives state updates
+ * All per-session lifecycle (transcript watching, state derivation, task
+ * scanning, summary fetching) lives in `SessionWatcher` from the
+ * integration library. This file owns only session matching (correlating
+ * foreground PID to a Claude session file) and event wiring.
  */
 
-import fs from "node:fs";
-import { match } from "ts-pattern";
-import type {
-  AgentInfo,
-  ClaudeCodeInfo,
-  ClaudeStateChange,
-  ClaudeTranscriptDebug,
-  TaskProgress,
-} from "kolu-common";
+import type { AgentInfo } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
 import { updateMetadata } from "./index.ts";
 import { subscribeForTerminal } from "../publisher.ts";
@@ -31,80 +16,28 @@ import { log } from "../log.ts";
 
 import {
   SESSIONS_DIR,
-  PROJECTS_DIR,
-  TAIL_BYTES,
-  type SessionFile,
   readSessionFile,
-  encodeProjectPath,
-  findTranscriptPath,
-  readJsonlFromOffset,
-  tailJsonlLines,
-  deriveState,
-  extractTasks,
-  deriveTaskProgress,
-  tryWatchDir,
   watchOrWaitForDir,
-  fetchSessionSummary,
+  createSessionWatcher,
+  infoEqual as claudeInfoEqual,
+  type SessionWatcher,
 } from "kolu-claude-code";
-
-// --- Equality helpers ---
-
-/** Compare two TaskProgress values for equality. */
-function taskProgressEqual(
-  a: TaskProgress | null,
-  b: TaskProgress | null,
-): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  return a.total === b.total && a.completed === b.completed;
-}
 
 /** Compare two AgentInfo values for equality. */
 export function infoEqual(a: AgentInfo | null, b: AgentInfo | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
   if (a.kind !== b.kind) return false;
-  if (a.state !== b.state || a.sessionId !== b.sessionId) return false;
   if (a.kind === "claude-code" && b.kind === "claude-code") {
-    return (
-      a.model === b.model &&
-      a.summary === b.summary &&
-      taskProgressEqual(a.taskProgress, b.taskProgress)
-    );
+    return claudeInfoEqual(a, b);
   }
-  return true;
+  return a.state === b.state && a.sessionId === b.sessionId;
 }
-
-// --- Transcript watching lifecycle ---
-
-/**
- * Transcript-watching lifecycle as a sum type — mutually exclusive states,
- * checked exhaustively via ts-pattern on every transition.
- *
- * The `watching` variant carries the diagnostic state used by the Debug
- * transcript command: `startOffset` anchors "events since kolu attached"
- * for the on-demand disk read, and `stateChanges` is an in-memory log of
- * every transition the server believed happened. Both vanish naturally
- * when the watcher tears down — no separate cleanup path to forget.
- */
-type TranscriptWatching =
-  | { kind: "none" }
-  | { kind: "waiting"; dirWatcher: () => void }
-  | {
-      kind: "watching";
-      path: string;
-      fileWatcher: fs.FSWatcher;
-      /** File size at watcher-attach time. Always at a JSONL line boundary. */
-      startOffset: number;
-      /** epoch ms when the watcher attached — start of monitoring. */
-      startedAt: number;
-      /** Mutated in place; defensive-copied on read by the accessor. */
-      stateChanges: ClaudeStateChange[];
-    };
 
 /**
  * Start the Claude Code metadata provider for a terminal entry.
- * Wakes on title events + SESSIONS_DIR changes + transcript file changes.
+ * Wakes on title events + SESSIONS_DIR changes to detect sessions.
+ * Delegates all per-session lifecycle to SessionWatcher.
  */
 export function startClaudeCodeProvider(
   entry: TerminalProcess,
@@ -112,178 +45,9 @@ export function startClaudeCodeProvider(
 ): () => void {
   const plog = log.child({ provider: "claude-code", terminal: terminalId });
 
-  let matchedSession: SessionFile | null = null;
-  let transcriptWatching: TranscriptWatching = { kind: "none" };
-  let lastSummary: string | null = null;
-  let taskMap = new Map<string, "pending" | "in_progress" | "completed">();
-  let taskScanOffset = 0;
+  let current: SessionWatcher | null = null;
 
   plog.info("started");
-
-  function teardownTranscriptWatching() {
-    match(transcriptWatching)
-      .with({ kind: "none" }, () => {})
-      .with({ kind: "waiting" }, ({ dirWatcher }) => dirWatcher())
-      .with({ kind: "watching" }, ({ fileWatcher }) => fileWatcher.close())
-      .exhaustive();
-    transcriptWatching = { kind: "none" };
-  }
-
-  function attachTranscriptWatcher(tp: string) {
-    try {
-      const fileWatcher = fs.watch(tp, () => onTranscriptMaybeChanged());
-      const startOffset = fs.statSync(tp).size;
-      transcriptWatching = {
-        kind: "watching",
-        path: tp,
-        fileWatcher,
-        startOffset,
-        startedAt: Date.now(),
-        stateChanges: [],
-      };
-    } catch (err) {
-      plog.warn({ err, path: tp }, "failed to watch transcript");
-      transcriptWatching = { kind: "none" };
-    }
-  }
-
-  function setupTranscriptWatching(session: SessionFile) {
-    const tp = findTranscriptPath(session);
-    if (tp) {
-      plog.info({ path: tp }, "transcript found");
-      attachTranscriptWatcher(tp);
-      onTranscriptMaybeChanged();
-      return;
-    }
-    plog.debug(
-      { session: session.sessionId, cwd: session.cwd },
-      "transcript not found yet (JSONL created after first message)",
-    );
-    const projectDir = PROJECTS_DIR + "/" + encodeProjectPath(session.cwd);
-    const dirWatcher = watchOrWaitForDir(projectDir, () =>
-      onProjectDirChanged(),
-    );
-    transcriptWatching = { kind: "waiting", dirWatcher };
-  }
-
-  function onProjectDirChanged() {
-    if (!matchedSession) return;
-    if (transcriptWatching.kind !== "waiting") return;
-    const tp = findTranscriptPath(matchedSession);
-    if (!tp) return;
-    plog.info({ path: tp }, "transcript appeared");
-    transcriptWatching.dirWatcher();
-    attachTranscriptWatcher(tp);
-    onTranscriptMaybeChanged();
-  }
-
-  function onTranscriptMaybeChanged() {
-    if (transcriptWatching.kind !== "watching") return;
-    if (!matchedSession) return;
-
-    const lines = tailJsonlLines(transcriptWatching.path, TAIL_BYTES);
-    const derived = deriveState(lines);
-    if (!derived) {
-      plog.debug(
-        { path: transcriptWatching.path },
-        "no user/assistant message in transcript tail",
-      );
-      return;
-    }
-
-    // Incrementally scan new transcript bytes for task tool calls.
-    scanTasksIncremental(transcriptWatching.path);
-
-    const info: ClaudeCodeInfo = {
-      kind: "claude-code",
-      state: derived.state,
-      sessionId: matchedSession.sessionId,
-      model: derived.model,
-      summary: lastSummary,
-      taskProgress: deriveTaskProgress(taskMap),
-    };
-
-    if (!infoEqual(info, entry.info.meta.agent)) {
-      plog.info(
-        { state: info.state, model: info.model, session: info.sessionId },
-        "claude code state updated",
-      );
-      transcriptWatching.stateChanges.push({ ts: Date.now(), info });
-      updateMetadata(entry, terminalId, (m) => {
-        m.agent = info;
-      });
-    }
-
-    refreshSummary(matchedSession);
-  }
-
-  function scanTasksIncremental(filePath: string) {
-    try {
-      const size = fs.statSync(filePath).size;
-      if (taskScanOffset >= size) return;
-      const length = size - taskScanOffset;
-      const fd = fs.openSync(filePath, "r");
-      let buf: Buffer;
-      try {
-        buf = Buffer.alloc(length);
-        fs.readSync(fd, buf, 0, length, taskScanOffset);
-      } finally {
-        fs.closeSync(fd);
-      }
-      const newLines = buf
-        .toString("utf8")
-        .split("\n")
-        .filter((l) => l.length > 0);
-      if (taskScanOffset > 0 && newLines.length > 0) {
-        try {
-          JSON.parse(newLines[0]!);
-        } catch {
-          newLines.shift();
-        }
-      }
-      const prevOffset = taskScanOffset;
-      taskScanOffset = size;
-      const changed = extractTasks(newLines, taskMap, plog);
-      if (changed) {
-        const progress = deriveTaskProgress(taskMap);
-        plog.info(
-          {
-            tasks: taskMap.size,
-            progress,
-            bytesScanned: length,
-            from: prevOffset,
-          },
-          "task progress updated",
-        );
-      }
-    } catch (err) {
-      plog.warn({ err, filePath, taskScanOffset }, "task scan failed");
-    }
-  }
-
-  function refreshSummary(session: SessionFile) {
-    fetchSessionSummary(session.sessionId, session.cwd)
-      .then((summary) => {
-        if (matchedSession?.sessionId !== session.sessionId) return;
-        if (summary === lastSummary) return;
-        lastSummary = summary;
-        const current = entry.info.meta.agent;
-        if (!current || current.kind !== "claude-code") return;
-        plog.info(
-          { summary, session: session.sessionId },
-          "claude summary updated",
-        );
-        updateMetadata(entry, terminalId, (m) => {
-          m.agent = { ...current, summary };
-        });
-      })
-      .catch((err) => {
-        plog.debug(
-          { err, session: session.sessionId },
-          "getSessionInfo failed",
-        );
-      });
-  }
 
   function onSessionMaybeChanged() {
     const fgPid = entry.handle.foregroundPid;
@@ -291,16 +55,15 @@ export function startClaudeCodeProvider(
       fgPid !== undefined ? readSessionFile(fgPid, plog) : null;
 
     if (
-      (matchedSession?.sessionId ?? null) === (newSession?.sessionId ?? null)
+      (current?.session.sessionId ?? null) === (newSession?.sessionId ?? null)
     ) {
       return;
     }
 
-    teardownTranscriptWatching();
-    matchedSession = newSession;
-    lastSummary = null;
-    taskMap = new Map();
-    taskScanOffset = 0;
+    // Tear down previous session watcher.
+    current?.destroy();
+    current = null;
+    delete entry.getClaudeDebug;
 
     if (!newSession) {
       plog.info("claude code session ended");
@@ -316,25 +79,19 @@ export function startClaudeCodeProvider(
       { session: newSession.sessionId, pid: newSession.pid },
       "claude code session matched",
     );
-    setupTranscriptWatching(newSession);
-  }
 
-  // Debug accessor for the `claude.getTranscript` RPC.
-  entry.getClaudeDebug = (): ClaudeTranscriptDebug | null => {
-    if (transcriptWatching.kind !== "watching") return null;
-    const {
-      path: tp,
-      startOffset,
-      startedAt,
-      stateChanges,
-    } = transcriptWatching;
-    return {
-      transcriptPath: tp,
-      startedAt,
-      stateChanges: [...stateChanges],
-      rawEvents: readJsonlFromOffset(tp, startOffset),
-    };
-  };
+    current = createSessionWatcher(
+      newSession,
+      (info) => {
+        updateMetadata(entry, terminalId, (m) => {
+          m.agent = info;
+        });
+      },
+      plog,
+    );
+
+    entry.getClaudeDebug = () => current?.getDebug() ?? null;
+  }
 
   // Subscribe to title events — each shell preexec/precmd OSC 2 fires here.
   const abort = new AbortController();
@@ -353,7 +110,7 @@ export function startClaudeCodeProvider(
   return () => {
     abort.abort();
     sessionsDirWatcher();
-    teardownTranscriptWatching();
+    current?.destroy();
     delete entry.getClaudeDebug;
     plog.info("stopped");
   };

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "allowImportingTsExtensions": true,
-    "noEmit": true
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,8 @@
     "noUncheckedIndexedAccess": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
**Bundles all per-session state into a single `SessionWatcher`** whose creation = start watching and destruction = full teardown — eliminating the "remember to reset all 5 mutable variables together" invariant from the server's claude provider.

PR #436 extracted pure logic (state derivation, task extraction, JSONL reading) into `@integrations/claude-code/` but left behind a 250-line closure in `server/src/meta/claude.ts` braiding 8 concerns through 5 `let` bindings. This PR finishes the job: the new `createSessionWatcher` in the integration library owns the transcript-watching state machine, incremental task scanning, summary fetching, and debug accessor. The server adapter shrinks to ~130 lines of event wiring with one mutable variable (`current: SessionWatcher | null`).

*Debug schemas (`ClaudeStateChangeSchema`, `ClaudeTranscriptDebugSchema`) move from `common/` to the integration library alongside the code that produces them — `common/` re-exports them so the wire contract is unchanged.*

> `allowImportingTsExtensions` and `noEmit` are hoisted into `tsconfig.base.json` — the new cross-package `.ts` import in the integration library's barrel export required all downstream packages to allow `.ts` extensions, and every package already had these flags individually.