### PR TITLE
Quiet INFO logs; add LOG_LEVEL env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ result
 apm_modules/
 .claude/worktrees/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 test-results/
 tests/reports/
 client/public/fonts

--- a/integrations/claude-code/src/session-watcher.ts
+++ b/integrations/claude-code/src/session-watcher.ts
@@ -153,7 +153,7 @@ export function createSessionWatcher(
   function setupTranscriptWatching() {
     const tp = findTranscriptPath(session);
     if (tp) {
-      plog.info({ path: tp }, "transcript found");
+      plog.debug({ path: tp }, "transcript found");
       attachTranscriptWatcher(tp);
       onTranscriptMaybeChanged();
       return;
@@ -174,7 +174,7 @@ export function createSessionWatcher(
     if (transcriptWatching.kind !== "waiting") return;
     const tp = findTranscriptPath(session);
     if (!tp) return;
-    plog.info({ path: tp }, "transcript appeared");
+    plog.debug({ path: tp }, "transcript appeared");
     transcriptWatching.dirWatcher();
     attachTranscriptWatcher(tp);
     onTranscriptMaybeChanged();
@@ -206,7 +206,7 @@ export function createSessionWatcher(
     };
 
     if (!infoEqual(info, lastInfo)) {
-      plog.info(
+      plog.debug(
         { state: info.state, model: info.model, session: info.sessionId },
         "claude code state updated",
       );
@@ -248,7 +248,7 @@ export function createSessionWatcher(
       const changed = extractTasks(newLines, taskMap, plog);
       if (changed) {
         const progress = deriveTaskProgress(taskMap);
-        plog.info(
+        plog.debug(
           {
             tasks: taskMap.size,
             progress,
@@ -271,7 +271,7 @@ export function createSessionWatcher(
         if (summary === lastSummary) return;
         lastSummary = summary;
         if (!lastInfo) return;
-        plog.info(
+        plog.debug(
           { summary, session: session.sessionId },
           "claude summary updated",
         );

--- a/server/src/log.ts
+++ b/server/src/log.ts
@@ -1,11 +1,17 @@
-/** Pino logger — JSON in production, pretty-printed in development. */
+/** Pino logger — JSON in production, pretty-printed in development.
+ *
+ * Default level is `info`. Override via `LOG_LEVEL` env var (e.g. `debug`,
+ * `warn`, `trace`). The CLI's `--verbose` flag is a hard override applied
+ * after construction in `index.ts` and trumps both. */
 import pino, { type Logger } from "pino";
+
+const level = process.env.LOG_LEVEL ?? "info";
 
 export const log = pino(
   process.env.NODE_ENV === "production"
-    ? { level: "info" }
+    ? { level }
     : {
-        level: "info",
+        level,
         transport: {
           target: "pino-pretty",
           options: { colorize: true, singleLine: true },

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -47,7 +47,7 @@ export function startClaudeCodeProvider(
 
   let current: SessionWatcher | null = null;
 
-  plog.info("started");
+  plog.debug("started");
 
   function onSessionMaybeChanged() {
     const fgPid = entry.handle.foregroundPid;
@@ -66,7 +66,7 @@ export function startClaudeCodeProvider(
     delete entry.getClaudeDebug;
 
     if (!newSession) {
-      plog.info("claude code session ended");
+      plog.debug("claude code session ended");
       if (entry.info.meta.agent !== null) {
         updateMetadata(entry, terminalId, (m) => {
           m.agent = null;
@@ -75,7 +75,7 @@ export function startClaudeCodeProvider(
       return;
     }
 
-    plog.info(
+    plog.debug(
       { session: newSession.sessionId, pid: newSession.pid },
       "claude code session matched",
     );
@@ -112,6 +112,6 @@ export function startClaudeCodeProvider(
     sessionsDirWatcher();
     current?.destroy();
     delete entry.getClaudeDebug;
-    plog.info("stopped");
+    plog.debug("stopped");
   };
 }

--- a/server/src/meta/git.ts
+++ b/server/src/meta/git.ts
@@ -155,7 +155,7 @@ export function startGitProvider(
   let lastCwd = meta.cwd;
   let stopHeadWatch = watchGitHead(meta.cwd, handleHeadChange);
 
-  plog.info({ cwd: lastCwd }, "started");
+  plog.debug({ cwd: lastCwd }, "started");
 
   // Resolve immediately for initial CWD
   void resolve(meta.cwd);
@@ -168,7 +168,7 @@ export function startGitProvider(
       }
       return;
     }
-    plog.info({ from: lastCwd, to: newCwd }, "cwd changed, re-resolving");
+    plog.debug({ from: lastCwd, to: newCwd }, "cwd changed, re-resolving");
     lastCwd = newCwd;
     // Restart HEAD watcher for new directory
     stopHeadWatch();
@@ -177,7 +177,7 @@ export function startGitProvider(
   }
 
   function handleHeadChange() {
-    plog.info("HEAD changed, re-resolving");
+    plog.debug("HEAD changed, re-resolving");
     void resolve(lastCwd);
   }
 
@@ -197,7 +197,10 @@ export function startGitProvider(
       m.git = git;
       m.pr = null;
     });
-    plog.info({ repo: git?.repoName, branch: git?.branch }, "git info updated");
+    plog.debug(
+      { repo: git?.repoName, branch: git?.branch },
+      "git info updated",
+    );
     // Notify downstream providers (github) via dedicated channel
     publishForTerminal("git", terminalId, git);
   }
@@ -208,6 +211,6 @@ export function startGitProvider(
   return () => {
     abort.abort();
     stopHeadWatch();
-    plog.info("stopped");
+    plog.debug("stopped");
   };
 }

--- a/server/src/meta/github.ts
+++ b/server/src/meta/github.ts
@@ -168,7 +168,7 @@ export function startGitHubPrProvider(
   let lastBranch: string | undefined = meta.git?.branch;
   let lastRepoRoot: string | undefined = meta.git?.repoRoot;
 
-  plog.info({ branch: lastBranch }, "started");
+  plog.debug({ branch: lastBranch }, "started");
 
   // Resolve immediately if we have git context
   if (lastBranch && lastRepoRoot) {
@@ -179,7 +179,10 @@ export function startGitHubPrProvider(
     const branch = git?.branch;
     const repoRoot = git?.repoRoot;
     if (branch === lastBranch && repoRoot === lastRepoRoot) return;
-    plog.info({ from: lastBranch, to: branch }, "branch changed, re-resolving");
+    plog.debug(
+      { from: lastBranch, to: branch },
+      "branch changed, re-resolving",
+    );
     lastBranch = branch;
     lastRepoRoot = repoRoot;
     if (branch && repoRoot) {
@@ -197,7 +200,7 @@ export function startGitHubPrProvider(
   async function resolve(repoRoot: string) {
     const pr = await resolveGitHubPr(repoRoot);
     if (prInfoEqual(pr, entry.info.meta.pr)) return;
-    plog.info(
+    plog.debug(
       pr
         ? { pr: pr.number, title: pr.title, state: pr.state, checks: pr.checks }
         : { pr: null },
@@ -222,6 +225,6 @@ export function startGitHubPrProvider(
   return () => {
     abort.abort();
     clearInterval(pollTimer);
-    plog.info("stopped");
+    plog.debug("stopped");
   };
 }

--- a/server/src/meta/index.ts
+++ b/server/src/meta/index.ts
@@ -44,7 +44,7 @@ export function updateMetadata(
 ): void {
   mutate(entry.info.meta);
   const m = entry.info.meta;
-  log.info(
+  log.debug(
     {
       terminal: terminalId,
       cwd: m.cwd,

--- a/server/src/meta/process.ts
+++ b/server/src/meta/process.ts
@@ -28,14 +28,14 @@ export function startProcessProvider(
   let lastName: string | null = null;
   let lastTitle: string | null = null;
 
-  plog.info("started");
+  plog.debug("started");
 
   function update(title?: string) {
     const name = processBasename(entry.handle.process);
     const newTitle = title ?? lastTitle;
     if (name === lastName && newTitle === lastTitle) return;
 
-    plog.info(
+    plog.debug(
       { from: lastName, to: name, title: newTitle },
       "foreground process changed",
     );
@@ -57,6 +57,6 @@ export function startProcessProvider(
 
   return () => {
     abort.abort();
-    plog.info("stopped");
+    plog.debug("stopped");
   };
 }

--- a/server/src/pty.ts
+++ b/server/src/pty.ts
@@ -90,7 +90,7 @@ export function spawnPty(
   Object.assign(env, osc7.env);
   env.KOLU_CLIPBOARD_DIR = clipboard.clipboardDir;
 
-  tlog.info({ shell, cwd }, "spawning pty");
+  tlog.debug({ shell, cwd }, "spawning pty");
   const proc = pty.spawn(shell, osc7.args, {
     name: "xterm-256color",
     cols: DEFAULT_COLS,
@@ -98,7 +98,7 @@ export function spawnPty(
     cwd,
     env,
   });
-  tlog.info({ pid: proc.pid }, "pty spawned");
+  tlog.debug({ pid: proc.pid }, "pty spawned");
 
   // Sanity-check the node-pty fork's foregroundPid accessor — if upstream
   // changes drop it, fail loud here instead of silently breaking claude
@@ -147,7 +147,7 @@ export function spawnPty(
   // OSC 0/2 title changes signal that the foreground process may have changed.
   // The shell preexec hook (injected in shell.ts) emits OSC 2 before each command.
   const titleDisposable = headless.onTitleChange((title: string) => {
-    tlog.info({ title }, "title changed (OSC 0/2)");
+    tlog.debug({ title }, "title changed (OSC 0/2)");
     opts.onTitleChange?.(title);
   });
 

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -28,6 +28,7 @@ import {
   testSetServerState,
   updateServerState,
 } from "./state.ts";
+import { log } from "./log.ts";
 
 const t = implement(contract);
 
@@ -66,6 +67,7 @@ export const appRouter = t.router({
 
     setTheme: t.terminal.setTheme.handler(async ({ input }) => {
       requireTerminal(input.id);
+      log.info({ terminal: input.id, theme: input.themeName }, "set theme");
       setTerminalTheme(input.id, input.themeName);
     }),
 
@@ -112,11 +114,16 @@ export const appRouter = t.router({
     }),
 
     reorder: t.terminal.reorder.handler(async ({ input }) => {
+      log.info({ count: input.ids.length }, "reorder terminals");
       reorderTerminals(input.ids);
     }),
 
     setParent: t.terminal.setParent.handler(async ({ input }) => {
       requireTerminal(input.id);
+      log.info(
+        { terminal: input.id, parent: input.parentId },
+        "set terminal parent",
+      );
       setTerminalParent(input.id, input.parentId);
     }),
 
@@ -173,10 +180,17 @@ export const appRouter = t.router({
     }),
   },
   git: {
-    worktreeCreate: t.git.worktreeCreate.handler(async ({ input }) =>
-      worktreeCreate(input.repoPath),
-    ),
+    worktreeCreate: t.git.worktreeCreate.handler(async ({ input }) => {
+      log.info({ repo: input.repoPath }, "worktree create");
+      const result = await worktreeCreate(input.repoPath);
+      log.info(
+        { repo: input.repoPath, path: result.path, branch: result.branch },
+        "worktree created",
+      );
+      return result;
+    }),
     worktreeRemove: t.git.worktreeRemove.handler(async ({ input }) => {
+      log.info({ worktree: input.worktreePath }, "worktree remove");
       await worktreeRemove(input.worktreePath);
     }),
   },
@@ -188,6 +202,17 @@ export const appRouter = t.router({
       }
     }),
     update: t.state.update.handler(async ({ input }) => {
+      // Log only the keys being patched — values may carry session blobs,
+      // recent-repo paths, or other content not safe for the operator log.
+      log.info(
+        {
+          keys: Object.keys(input),
+          preferences: input.preferences
+            ? Object.keys(input.preferences)
+            : undefined,
+        },
+        "state update",
+      );
       updateServerState(input);
     }),
     test__set: t.state.test__set.handler(async ({ input }) => {


### PR DESCRIPTION
**Kolu's server log shouted into the void at INFO level** — ~60 lines in 2 seconds of normal use, drowning out anything an operator actually cares about. This PR cuts the chatter and reframes INFO to mean *user actions*, not background telemetry.

The 13 noisiest sites — pty lifecycle, metadata publishes, OSC title changes, per-provider lifecycle from `meta/*`, and Claude session-watcher state/summary/transcript/task-progress ticks — drop to `debug`. They're still available with `--verbose` or `LOG_LEVEL=debug`. *Background watchers report passive state changes that aren't operator-relevant unless you're actively debugging.*

In their place, six previously-silent oRPC mutations now log at INFO: theme changes, terminal reorder/parent edits, worktree create/remove, and the generic `state.update`. **You can now read the INFO log as a record of what the user actually did.** For `state.update` only the patch *keys* are logged — preference values may carry paths or session blobs.

Finally, `server/src/log.ts` reads `LOG_LEVEL` from the environment as the initial pino level (default `info`). The existing `--verbose` CLI flag still hard-overrides to `debug`.

> Drive-by: gitignored `.claude/scheduled_tasks.lock` (runtime artifact from the schedule skill) so `just ci::apm-sync` stays clean across local CI runs.

Closes #441

### Try it locally

```sh
nix run github:juspay/kolu/reduce-log-noise
```