### PR TITLE
fix(ci): poll user@1000.service to end home-manager vm-test flake

### DIFF
--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -62,8 +62,13 @@
 
         testScript = ''
           machine.wait_for_unit("multi-user.target")
-          # Wait for alice's user session to come up
-          machine.wait_for_unit("user@1000.service")
+          # Poll for alice's user session. wait_for_unit fails fast if the
+          # unit is still inactive with no pending job — a race with
+          # auto-login queueing user@1000. wait_until_succeeds retries.
+          machine.wait_until_succeeds(
+              "systemctl is-active user@1000.service",
+              timeout=60,
+          )
 
           # Use machinectl shell to get a proper user session with
           # DBUS_SESSION_BUS_ADDRESS and XDG_RUNTIME_DIR set.


### PR DESCRIPTION
**The `ci/home-manager@x86_64-linux` vm-test flakes because `wait_for_unit("user@1000.service")` fails fast** when the unit is still inactive with no pending job — a race with auto-login session activation. `wait_for_unit` treats "no pending jobs" as terminal, so a ~sub-second window where systemd hasn't yet queued the user session is enough to abort the test. Most recent hit: PR #445, commit 25d737d.

Fix swaps that one call for `wait_until_succeeds("systemctl is-active user@1000.service", timeout=60)`, making the readiness probe symmetric with the existing curl poll at line 77. _No server, client, or module changes — test-script only, ~1 line._

Closes the home-manager half of #440. See #320 for the flake history.