### PR TITLE
fix(terminal): stop flashing on switch back to visible terminal

### DIFF
--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -136,7 +136,6 @@ const Terminal: Component<{
         scrollLock.reset();
         terminal.scrollToBottom();
         debouncedFit();
-        clearTextureAtlas();
         if (props.focused !== false) terminal.focus();
       },
       { defer: true },


### PR DESCRIPTION
**Switching between terminals in the same tab caused a visible flash/repaint on every switch**, most noticeable on whichever terminal had more scrollback. The visibility-true effect in `Terminal.tsx` unconditionally cleared the WebGL texture atlas, which forces a full viewport redraw via xterm's `_clearModel(true)` + `_requestRedrawViewport()` — that's the flash.

The atlas-clear was added in #248 as a prophylactic fix for #239 (font rendering corruption) and shotgunned across four call sites: visibility change, theme change, font-size change, and tab-focus restore. _Three of those are legitimate triggers — they actually invalidate glyphs._ The visibility-within-tab path is not: switching between terminals keeps the GPU context, font, and theme identical, so there's no reason for glyphs to have corrupted since the last paint.

The other three calls in the same effect (`scrollLock.reset`, `scrollToBottom`, `debouncedFit`) stay — they're no-ops when nothing changed while the terminal was hidden (verified against xterm.js 6.0.0 source: `FitAddon.ts:45` guards on dim change, `BufferService.scrollLines` early-returns at `:146` when `ydisp` is unchanged).

> If #239 recurs and turns out to be triggered specifically by visibility transitions, the right fix is to identify the actual trigger — not re-add the blanket clear.

### Try it locally

```sh
nix run github:juspay/kolu/fix/terminal-switch-flash
```