### PR TITLE
Dialog for new worktree creation (agent command + rename)

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-10T22:40:06.077919+00:00'
+generated_at: '2026-04-11T14:20:31.447679+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -47,7 +47,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: c4e635227f10cd8c032b08e1e469f16900fec236
+  resolved_commit: 888548f2483149ac304882942c60732916b34a01
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import ModalDialog, { refocusTerminal } from "./ModalDialog";
 import Dialog from "@corvu/dialog";
 import EmptyState from "./EmptyState";
 import CloseConfirm, { type CloseConfirmTarget } from "./CloseConfirm";
+import NewWorktreeDialog, { type NewWorktreeTarget } from "./NewWorktreeDialog";
 import { createCommands } from "./commands";
 import { exportSessionAsPdf } from "./exportSessionAsPdf";
 
@@ -37,11 +38,12 @@ import { useColorScheme } from "./useColorScheme";
 import { useTips } from "./useTips";
 
 const App: Component = () => {
-  const { preferences, updatePreferences } = useServerState();
+  const { preferences, updatePreferences, recentRepos } = useServerState();
   const randomTheme = () => preferences().randomTheme;
   const scrollLock = () => preferences().scrollLock;
   const activityAlerts = () => preferences().activityAlerts;
   const sidebarAgentPreviews = () => preferences().sidebarAgentPreviews;
+  const worktreeAutoRun = () => preferences().worktreeAutoRun;
 
   const { store, crud, session, worktree, alerts } = useTerminals({
     randomTheme,
@@ -102,6 +104,10 @@ const App: Component = () => {
   // stale-target bugs if the user switches terminals while the dialog is open.
   const [closeConfirmTarget, setCloseConfirmTarget] =
     createSignal<CloseConfirmTarget | null>(null);
+
+  // New-worktree dialog state — target is the repo selected from the palette.
+  const [newWorktreeTarget, setNewWorktreeTarget] =
+    createSignal<NewWorktreeTarget | null>(null);
 
   // Terminal search bar state — close when switching terminals
   const [searchOpen, setSearchOpen] = createSignal(false);
@@ -186,8 +192,11 @@ const App: Component = () => {
     handleRandomizeTheme,
     setShortcutsHelpOpen,
     setAboutOpen,
-    handleCreateWorktree: (repoPath) =>
-      void worktree.handleCreateWorktree(repoPath),
+    handleCreateWorktree: (repoPath) => {
+      const repo = recentRepos().find((r) => r.repoRoot === repoPath);
+      if (!repo) return;
+      setNewWorktreeTarget({ repo });
+    },
     handleClose: () => {
       const id = store.activeId();
       if (id) closeTerminal(id);
@@ -299,6 +308,28 @@ const App: Component = () => {
           </div>
         </Dialog.Content>
       </ModalDialog>
+      <NewWorktreeDialog
+        target={newWorktreeTarget()}
+        initialAutoRun={worktreeAutoRun()}
+        onCancel={() => {
+          setNewWorktreeTarget(null);
+          requestAnimationFrame(refocusTerminal);
+        }}
+        onCreate={async ({ branchName, autoRun }) => {
+          const target = newWorktreeTarget();
+          if (!target) return;
+          // Persist the auto-run command as the new global default if it
+          // changed — next invocation's dialog pre-fills with this value.
+          if (autoRun !== worktreeAutoRun()) {
+            updatePreferences({ worktreeAutoRun: autoRun });
+          }
+          await worktree.handleCreateWorktree(target.repo.repoRoot, {
+            branchName,
+            autoRun,
+          });
+          setNewWorktreeTarget(null);
+        }}
+      />
       <CloseConfirm
         target={closeConfirmTarget()}
         onCancel={() => {

--- a/client/src/NewWorktreeDialog.tsx
+++ b/client/src/NewWorktreeDialog.tsx
@@ -1,0 +1,158 @@
+/** New worktree dialog — pre-fills a fetched branch name suggestion and
+ *  a persisted auto-run command, letting the user rename and/or edit the
+ *  command before creating the worktree. On successful create, the edited
+ *  auto-run becomes the new persisted default. */
+
+import { type Component, createSignal, createEffect, on, Show } from "solid-js";
+import Dialog from "@corvu/dialog";
+import ModalDialog from "./ModalDialog";
+import { client } from "./rpc";
+import type { RecentRepo } from "kolu-common";
+
+export interface NewWorktreeTarget {
+  repo: RecentRepo;
+}
+
+const NewWorktreeDialog: Component<{
+  target: NewWorktreeTarget | null;
+  /** Initial value for the auto-run field (persisted global default). */
+  initialAutoRun: string;
+  onCancel: () => void;
+  onCreate: (args: { branchName: string; autoRun: string }) => Promise<void>;
+}> = (props) => {
+  let branchRef!: HTMLInputElement;
+  const [branchName, setBranchName] = createSignal("");
+  const [autoRun, setAutoRun] = createSignal("");
+  const [error, setError] = createSignal<string | null>(null);
+  const [submitting, setSubmitting] = createSignal(false);
+
+  // On open: reset state, fetch a fresh suggestion, seed auto-run from pref.
+  createEffect(
+    on(
+      () => props.target,
+      (target) => {
+        if (!target) return;
+        setError(null);
+        setSubmitting(false);
+        setBranchName("");
+        setAutoRun(props.initialAutoRun);
+        void client.git
+          .worktreeSuggestName({ repoPath: target.repo.repoRoot })
+          .then((r) => setBranchName(r.branch))
+          .catch((err: Error) =>
+            setError(`Failed to suggest branch name: ${err.message}`),
+          );
+      },
+    ),
+  );
+
+  async function submit(e?: Event) {
+    e?.preventDefault();
+    const name = branchName().trim();
+    if (name.length === 0) {
+      setError("Branch name cannot be empty");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await props.onCreate({ branchName: name, autoRun: autoRun() });
+    } catch (err) {
+      setError((err as Error).message);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <ModalDialog
+      open={props.target !== null}
+      onOpenChange={(open) => {
+        if (!open && !submitting()) props.onCancel();
+      }}
+      initialFocusEl={branchRef}
+    >
+      <Dialog.Content
+        class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 w-[28rem] max-w-[90vw] text-sm space-y-4"
+        data-testid="new-worktree-dialog"
+      >
+        <Dialog.Label class="font-semibold text-fg">
+          New worktree in{" "}
+          <span class="text-accent">{props.target?.repo.repoName}</span>
+        </Dialog.Label>
+
+        <form onSubmit={submit} class="space-y-3">
+          <div class="space-y-1">
+            <label class="block text-xs text-fg-3" for="new-worktree-branch">
+              Branch name
+            </label>
+            <input
+              ref={branchRef}
+              id="new-worktree-branch"
+              type="text"
+              value={branchName()}
+              onInput={(e) => {
+                setBranchName(e.currentTarget.value);
+                if (error()) setError(null);
+              }}
+              class="w-full bg-surface-2 border border-edge rounded-lg px-2.5 py-1.5 text-fg font-mono text-xs focus:outline-none focus:border-accent"
+              data-testid="new-worktree-branch"
+              autocomplete="off"
+              spellcheck={false}
+            />
+          </div>
+
+          <div class="space-y-1">
+            <label class="block text-xs text-fg-3" for="new-worktree-autorun">
+              Auto-run command{" "}
+              <span class="text-fg-3">(leave empty for plain shell)</span>
+            </label>
+            <input
+              id="new-worktree-autorun"
+              type="text"
+              value={autoRun()}
+              onInput={(e) => setAutoRun(e.currentTarget.value)}
+              placeholder="e.g. claude --dangerously-skip-permissions"
+              class="w-full bg-surface-2 border border-edge rounded-lg px-2.5 py-1.5 text-fg font-mono text-xs focus:outline-none focus:border-accent"
+              data-testid="new-worktree-autorun"
+              autocomplete="off"
+              spellcheck={false}
+            />
+          </div>
+
+          <Show when={error()}>
+            {(msg) => (
+              <div
+                class="text-xs text-danger bg-danger/10 rounded-lg px-2.5 py-2"
+                data-testid="new-worktree-error"
+              >
+                {msg()}
+              </div>
+            )}
+          </Show>
+
+          <div class="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              class="px-3 py-1.5 text-xs rounded-lg text-fg-3 hover:text-fg-2 transition-colors cursor-pointer"
+              data-testid="new-worktree-cancel"
+              onClick={() => props.onCancel()}
+              disabled={submitting()}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              class="px-3 py-1.5 text-xs rounded-lg bg-accent text-surface-1 hover:brightness-110 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="new-worktree-create"
+              disabled={submitting() || branchName().trim().length === 0}
+            >
+              {submitting() ? "Creating…" : "Create"}
+            </button>
+          </div>
+        </form>
+      </Dialog.Content>
+    </ModalDialog>
+  );
+};
+
+export default NewWorktreeDialog;

--- a/client/src/useServerState.ts
+++ b/client/src/useServerState.ts
@@ -32,6 +32,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   activityAlerts: true,
   colorScheme: "dark",
   sidebarAgentPreviews: "attention",
+  worktreeAutoRun: "",
 };
 
 // Singleton store — all callers share one reactive source of truth for preferences.

--- a/client/src/useWorktreeOps.ts
+++ b/client/src/useWorktreeOps.ts
@@ -12,12 +12,26 @@ export function useWorktreeOps(deps: {
 }) {
   const { store } = deps;
 
-  async function handleCreateWorktree(repoPath: string) {
+  async function handleCreateWorktree(
+    repoPath: string,
+    opts?: { branchName?: string; autoRun?: string },
+  ) {
     const id = toast.loading("Creating worktree…");
     try {
-      const result = await client.git.worktreeCreate({ repoPath });
+      const result = await client.git.worktreeCreate({
+        repoPath,
+        branchName: opts?.branchName,
+      });
       toast.success(`Created worktree at ${result.path}`, { id });
-      await deps.handleCreate(result.path);
+      const termId = await deps.handleCreate(result.path);
+      // Autolaunch command — send after terminal is created. Trailing \r submits.
+      if (opts?.autoRun && opts.autoRun.trim().length > 0) {
+        await client.terminal
+          .sendInput({ id: termId, data: `${opts.autoRun}\r` })
+          .catch((err: Error) =>
+            toast.error(`Failed to send auto-run command: ${err.message}`),
+          );
+      }
       // Recent repos update reactively via trackRecentRepo → publishSystem
     } catch (err) {
       toast.error(`Failed to create worktree: ${(err as Error).message}`, {

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -23,6 +23,8 @@ import {
   ServerInfoSchema,
   WorktreeCreateInputSchema,
   WorktreeCreateOutputSchema,
+  WorktreeSuggestNameInputSchema,
+  WorktreeSuggestNameOutputSchema,
   WorktreeRemoveInputSchema,
   ServerStateSchema,
   ServerStatePatchSchema,
@@ -78,6 +80,12 @@ export const contract = oc.router({
     worktreeCreate: oc
       .input(WorktreeCreateInputSchema)
       .output(WorktreeCreateOutputSchema),
+    /** Suggest a fresh, non-colliding worktree branch name for the given repo.
+     *  Client uses this to pre-fill the New Worktree dialog so users can rename
+     *  before creation. Server still validates on create. */
+    worktreeSuggestName: oc
+      .input(WorktreeSuggestNameInputSchema)
+      .output(WorktreeSuggestNameOutputSchema),
     worktreeRemove: oc.input(WorktreeRemoveInputSchema).output(z.void()),
   },
   claude: {

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -38,10 +38,20 @@ export const GitInfoSchema = z.object({
 
 export const WorktreeCreateInputSchema = z.object({
   repoPath: z.string(),
+  /** Branch name to use. If omitted, server picks a random name. */
+  branchName: z.string().optional(),
 });
 
 export const WorktreeCreateOutputSchema = z.object({
   path: z.string(),
+  branch: z.string(),
+});
+
+export const WorktreeSuggestNameInputSchema = z.object({
+  repoPath: z.string(),
+});
+
+export const WorktreeSuggestNameOutputSchema = z.object({
   branch: z.string(),
 });
 
@@ -247,6 +257,9 @@ export const PreferencesSchema = z.object({
   activityAlerts: z.boolean(),
   colorScheme: ColorSchemeSchema,
   sidebarAgentPreviews: SidebarAgentPreviewsSchema,
+  /** Command run in new worktree terminals (e.g. "claude --dangerously-skip-permissions").
+   *  Empty string = no autolaunch. Pre-fills the New Worktree dialog's auto-run field. */
+  worktreeAutoRun: z.string(),
 });
 
 // --- Server state ---

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -6,6 +6,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import { simpleGit } from "simple-git";
+import { ORPCError } from "@orpc/server";
 import { log } from "./log.ts";
 import { randomName } from "./randomName.ts";
 
@@ -119,11 +120,13 @@ export async function worktreeCreate(
   const defaultBranch = await detectDefaultBranch(mainRoot);
 
   // User-provided name: validate once, fail with a clear error on collision.
+  // Throw ORPCError so the message survives oRPC's default error wrapping
+  // ("Internal server error") and reaches the dialog's inline error display.
   if (branchName !== undefined) {
     const invalid = validateBranchName(branchName);
-    if (invalid) throw new Error(invalid);
+    if (invalid) throw new ORPCError("BAD_REQUEST", { message: invalid });
     const reason = await branchCollisionReason(mainRoot, branchName);
-    if (reason) throw new Error(reason);
+    if (reason) throw new ORPCError("CONFLICT", { message: reason });
     return runWorktreeAdd(mainRoot, branchName, defaultBranch);
   }
 

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -34,12 +34,74 @@ async function detectDefaultBranch(repoPath: string): Promise<string> {
   }
 }
 
+/** Returns null if the name is free, or a human-readable collision reason. */
+function branchCollisionReason(
+  mainRoot: string,
+  branch: string,
+): Promise<string | null> {
+  const targetPath = path.join(mainRoot, ".worktrees", branch);
+  if (fs.existsSync(targetPath)) {
+    return Promise.resolve(`A worktree already exists at ${targetPath}`);
+  }
+  return simpleGit(mainRoot)
+    .raw(["rev-parse", "--verify", `refs/heads/${branch}`])
+    .then(() => `Branch "${branch}" already exists`)
+    .catch(() => null);
+}
+
+/** Run `git worktree add` for a freshly-chosen branch name. */
+async function runWorktreeAdd(
+  mainRoot: string,
+  branch: string,
+  defaultBranch: string,
+): Promise<{ path: string; branch: string }> {
+  const targetPath = path.join(mainRoot, ".worktrees", branch);
+  log.info(
+    { mainRoot, targetPath, branch, base: `origin/${defaultBranch}` },
+    "creating worktree",
+  );
+  await simpleGit(mainRoot).raw([
+    "worktree",
+    "add",
+    targetPath,
+    "-b",
+    branch,
+    `origin/${defaultBranch}`,
+  ]);
+  return { path: targetPath, branch };
+}
+
+/** Validate a user-supplied branch name.
+ *  Rejects path-traversal (`..`) and restricts the character set to a
+ *  safe subset of git's valid-ref grammar. The name must also not start
+ *  with `.`, `-`, or `/` — these confuse `git branch` or `path.join`. */
+function validateBranchName(name: string): string | null {
+  if (name.length === 0) return "Branch name cannot be empty";
+  if (name.includes("..")) return "Branch name cannot contain '..'";
+  if (!/^[A-Za-z0-9_][A-Za-z0-9._/-]*$/.test(name)) {
+    return "Branch name must start with a letter, digit, or underscore, and contain only letters, digits, dots, slashes, dashes, underscores";
+  }
+  return null;
+}
+
+/** Generate a random, non-colliding worktree branch name. */
+export async function worktreeSuggestName(repoPath: string): Promise<string> {
+  const mainRoot = await resolveMainRepoRoot(repoPath);
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const branch = randomName();
+    if ((await branchCollisionReason(mainRoot, branch)) === null) return branch;
+  }
+  throw new Error("Failed to generate unique worktree name after 5 attempts");
+}
+
 /**
- * Create a git worktree with a random name, branching from origin/<default>.
- * Retries with a new name on collision.
+ * Create a git worktree, branching from origin/<default>.
+ * If `branchName` is omitted, the server picks a random non-colliding name.
+ * If provided, the name is validated and throws on collision (no retry).
  */
 export async function worktreeCreate(
   repoPath: string,
+  branchName?: string,
 ): Promise<{ path: string; branch: string }> {
   const mainRoot = await resolveMainRepoRoot(repoPath);
   const git = simpleGit(mainRoot);
@@ -56,38 +118,23 @@ export async function worktreeCreate(
   }
   const defaultBranch = await detectDefaultBranch(mainRoot);
 
+  // User-provided name: validate once, fail with a clear error on collision.
+  if (branchName !== undefined) {
+    const invalid = validateBranchName(branchName);
+    if (invalid) throw new Error(invalid);
+    const reason = await branchCollisionReason(mainRoot, branchName);
+    if (reason) throw new Error(reason);
+    return runWorktreeAdd(mainRoot, branchName, defaultBranch);
+  }
+
+  // No name provided: retry with fresh random names on collision.
   for (let attempt = 0; attempt < 5; attempt++) {
     const branch = randomName();
-    const targetPath = path.join(mainRoot, ".worktrees", branch);
-
-    // Check for both directory and branch name collision — a previous worktree
-    // removal deletes the directory but leaves the branch behind.
-    if (fs.existsSync(targetPath)) {
-      wtLog.info({ branch }, "path collision, retrying");
+    if ((await branchCollisionReason(mainRoot, branch)) !== null) {
+      wtLog.info({ branch }, "name collision, retrying");
       continue;
     }
-    try {
-      await git.raw(["rev-parse", "--verify", `refs/heads/${branch}`]);
-      wtLog.info({ branch }, "branch collision, retrying");
-      continue;
-    } catch {
-      // Branch doesn't exist — good
-    }
-
-    wtLog.info(
-      { targetPath, branch, base: `origin/${defaultBranch}` },
-      "creating worktree",
-    );
-    await git.raw([
-      "worktree",
-      "add",
-      targetPath,
-      "-b",
-      branch,
-      `origin/${defaultBranch}`,
-    ]);
-
-    return { path: targetPath, branch };
+    return runWorktreeAdd(mainRoot, branch, defaultBranch);
   }
 
   throw new Error("Failed to generate unique worktree name after 5 attempts");

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -22,7 +22,7 @@ import {
 import { saveClipboardImage } from "./clipboard.ts";
 import { subscribeForTerminal_, subscribeSystem_ } from "./publisher.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
-import { worktreeCreate, worktreeRemove } from "./git.ts";
+import { worktreeCreate, worktreeRemove, worktreeSuggestName } from "./git.ts";
 import {
   getServerState,
   testSetServerState,
@@ -181,14 +181,23 @@ export const appRouter = t.router({
   },
   git: {
     worktreeCreate: t.git.worktreeCreate.handler(async ({ input }) => {
-      log.info({ repo: input.repoPath }, "worktree create");
-      const result = await worktreeCreate(input.repoPath);
+      log.info(
+        { repo: input.repoPath, branch: input.branchName ?? "(auto)" },
+        "worktree create",
+      );
+      const result = await worktreeCreate(input.repoPath, input.branchName);
       log.info(
         { repo: input.repoPath, path: result.path, branch: result.branch },
         "worktree created",
       );
       return result;
     }),
+    worktreeSuggestName: t.git.worktreeSuggestName.handler(
+      async ({ input }) => {
+        const branch = await worktreeSuggestName(input.repoPath);
+        return { branch };
+      },
+    ),
     worktreeRemove: t.git.worktreeRemove.handler(async ({ input }) => {
       log.info({ worktree: input.worktreePath }, "worktree remove");
       await worktreeRemove(input.worktreePath);

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -22,7 +22,7 @@ import { publishSystem } from "./publisher.ts";
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.4.0";
+const SCHEMA_VERSION = "1.5.0";
 
 const DEFAULT_PREFERENCES: Preferences = {
   seenTips: [],
@@ -32,6 +32,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   activityAlerts: true,
   colorScheme: "dark",
   sidebarAgentPreviews: "attention",
+  worktreeAutoRun: "",
 };
 
 export const store = new Conf<PersistedState>({
@@ -68,6 +69,18 @@ export const store = new Conf<PersistedState>({
     // sidebarAgentPreviews: boolean → enum. Previously `true` meant
     // "preview every agent terminal" (now "agents"), `false` meant off
     // (now "none"). New installs default to "attention".
+    // worktreeAutoRun added — old preference blobs lack this field.
+    // Defaults to empty string (no autolaunch).
+    "1.5.0": (store: Conf<PersistedState>) => {
+      const current = store.get("preferences") as
+        | Partial<Preferences>
+        | undefined;
+      store.set("preferences", {
+        ...DEFAULT_PREFERENCES,
+        ...current,
+        worktreeAutoRun: current?.worktreeAutoRun ?? "",
+      });
+    },
     "1.4.0": (store: Conf<PersistedState>) => {
       // Cast through `unknown` because the persisted shape predates
       // the enum — on disk the field may still be a boolean.

--- a/tests/features/worktree.feature
+++ b/tests/features/worktree.feature
@@ -32,6 +32,20 @@ Feature: Git worktree management
     Then the header CWD should show ".worktrees/fix-login-bug"
     And there should be no page errors
 
+  Scenario: New worktree dialog shows server error inline on branch collision
+    When I set up a git repo at "/tmp/kolu-wt-collide"
+    And I run "cd /tmp/kolu-wt-collide"
+    And the header should show a branch name
+    When I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-collide" in the palette
+    Then the new worktree dialog should be visible
+    When I set the new worktree branch name to "master"
+    And I click create in the new worktree dialog
+    Then the new worktree dialog should show error containing "master"
+    And the new worktree dialog should be visible
+    And there should be no page errors
+
   Scenario: New worktree dialog auto-runs a configured command
     When I set up a git repo at "/tmp/kolu-wt-autorun"
     And I run "cd /tmp/kolu-wt-autorun"

--- a/tests/features/worktree.feature
+++ b/tests/features/worktree.feature
@@ -13,8 +13,37 @@ Feature: Git worktree management
     When I open the command palette
     And I select "New terminal" in the palette
     And I select "kolu-wt-test" in the palette
+    Then the new worktree dialog should be visible
+    When I submit the new worktree dialog
     Then the header CWD should show ".worktrees/"
     And the sidebar should show a worktree indicator
+    And there should be no page errors
+
+  Scenario: New worktree dialog lets user rename the branch before creation
+    When I set up a git repo at "/tmp/kolu-wt-rename"
+    And I run "cd /tmp/kolu-wt-rename"
+    And the header should show a branch name
+    When I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-rename" in the palette
+    Then the new worktree dialog should be visible
+    When I set the new worktree branch name to "fix-login-bug"
+    And I submit the new worktree dialog
+    Then the header CWD should show ".worktrees/fix-login-bug"
+    And there should be no page errors
+
+  Scenario: New worktree dialog auto-runs a configured command
+    When I set up a git repo at "/tmp/kolu-wt-autorun"
+    And I run "cd /tmp/kolu-wt-autorun"
+    And the header should show a branch name
+    When I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-autorun" in the palette
+    Then the new worktree dialog should be visible
+    When I set the new worktree auto-run command to "echo worktree-autorun-marker"
+    And I submit the new worktree dialog
+    Then the header CWD should show ".worktrees/"
+    And the screen state should contain "worktree-autorun-marker"
     And there should be no page errors
 
   Scenario: Close terminal on worktree shows confirmation and removes worktree
@@ -24,6 +53,8 @@ Feature: Git worktree management
     When I open the command palette
     And I select "New terminal" in the palette
     And I select "kolu-wt-remove" in the palette
+    Then the new worktree dialog should be visible
+    When I submit the new worktree dialog
     Then the header CWD should show ".worktrees/"
     Given I note the sidebar entry count
     When I open the command palette
@@ -40,6 +71,8 @@ Feature: Git worktree management
     When I open the command palette
     And I select "New terminal" in the palette
     And I select "kolu-wt-cancel" in the palette
+    Then the new worktree dialog should be visible
+    When I submit the new worktree dialog
     Then the header CWD should show ".worktrees/"
     Given I note the sidebar entry count
     When I open the command palette
@@ -56,6 +89,8 @@ Feature: Git worktree management
     When I open the command palette
     And I select "New terminal" in the palette
     And I select "kolu-wt-close-only" in the palette
+    Then the new worktree dialog should be visible
+    When I submit the new worktree dialog
     Then the header CWD should show ".worktrees/"
     Given I note the sidebar entry count
     When I open the command palette
@@ -72,6 +107,8 @@ Feature: Git worktree management
     When I open the command palette
     And I select "New terminal" in the palette
     And I select "kolu-wt-splits" in the palette
+    Then the new worktree dialog should be visible
+    When I submit the new worktree dialog
     Then the header CWD should show ".worktrees/"
     When I create a sub-terminal via command palette
     Given I note the sidebar entry count

--- a/tests/step_definitions/worktree_steps.ts
+++ b/tests/step_definitions/worktree_steps.ts
@@ -84,6 +84,27 @@ When("I submit the new worktree dialog", async function (this: KoluWorld) {
     .waitFor({ state: "hidden", timeout: POLL_TIMEOUT });
 });
 
+When(
+  "I click create in the new worktree dialog",
+  async function (this: KoluWorld) {
+    await this.page.locator('[data-testid="new-worktree-create"]').click();
+  },
+);
+
+Then(
+  "the new worktree dialog should show error containing {string}",
+  async function (this: KoluWorld, needle: string) {
+    const err = this.page.locator('[data-testid="new-worktree-error"]');
+    await err.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const text = (await err.textContent()) ?? "";
+    if (!text.includes(needle)) {
+      throw new Error(
+        `Expected worktree dialog error to contain "${needle}", got: ${text}`,
+      );
+    }
+  },
+);
+
 Then(
   "the close confirmation should be visible",
   async function (this: KoluWorld) {

--- a/tests/step_definitions/worktree_steps.ts
+++ b/tests/step_definitions/worktree_steps.ts
@@ -41,6 +41,50 @@ When(
 );
 
 Then(
+  "the new worktree dialog should be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator('[data-testid="new-worktree-dialog"]')
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    // Wait until the branch name suggestion has arrived from the server
+    // so the dialog is fully seeded before interaction.
+    await this.page.waitForFunction(
+      () => {
+        const el = document.querySelector<HTMLInputElement>(
+          '[data-testid="new-worktree-branch"]',
+        );
+        return el !== null && el.value.length > 0;
+      },
+      undefined,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+When(
+  "I set the new worktree branch name to {string}",
+  async function (this: KoluWorld, name: string) {
+    const input = this.page.locator('[data-testid="new-worktree-branch"]');
+    await input.fill(name);
+  },
+);
+
+When(
+  "I set the new worktree auto-run command to {string}",
+  async function (this: KoluWorld, cmd: string) {
+    const input = this.page.locator('[data-testid="new-worktree-autorun"]');
+    await input.fill(cmd);
+  },
+);
+
+When("I submit the new worktree dialog", async function (this: KoluWorld) {
+  await this.page.locator('[data-testid="new-worktree-create"]').click();
+  await this.page
+    .locator('[data-testid="new-worktree-dialog"]')
+    .waitFor({ state: "hidden", timeout: POLL_TIMEOUT });
+});
+
+Then(
   "the close confirmation should be visible",
   async function (this: KoluWorld) {
     await this.page


### PR DESCRIPTION
**Selecting a repo under "New terminal" now opens a dialog** instead of silently creating a worktree. The dialog surfaces the server-generated branch name so you can rename it before the worktree exists, and remembers your preferred auto-run command (e.g. `claude --dangerously-skip-permissions`) as a global default that pre-fills on every subsequent invocation.

The branch field seeds from a new `git.worktreeSuggestName` endpoint — the server generates and collision-checks a name, the client shows it, and if you edit it the server revalidates on create (inline error on collision, no toast-then-close). *The auto-run command is just appended to the new terminal via `terminal.sendInput` after creation — no server-side agent coupling.*

Closes #269.