### PR TITLE
docs: add Philosophy section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ A browser cockpit for coding agents. Bring your own CLI, run them anywhere.
 
 Unlike agent command centers that wrap a single model behind their own chat UI, kolu stays out of the agent's way: the terminal is the universal interface, so `claude`, `opencode`, `aider`, or whatever ships next week works out of the box — and you can drop to a plain shell whenever you want. It's an [Agentic Development Environment](https://x.com/jdegoes/status/2036931874057314390) (ADE) that treats terminals as the thesis, not the substrate.
 
+## Philosophy
+
+Two principles shape what kolu is and isn't:
+
+**Agent-agnostic.** The terminal is the universal interface. Kolu doesn't wrap a specific model or lock you into one CLI — `claude`, `opencode`, `aider`, or whatever ships next week all work the same way, because they're just programs you run in a shell. There's no agent registry to update, no adapter to write, no vendor lock-in. New tools pick up kolu's features automatically by virtue of running in a pty, and you can always drop to a plain shell without leaving the app.
+
+**Auto-detected, zero setup.** Kolu populates its UI by watching what you already do — the repos you `cd` into, the agents you run, the sessions you save — not by asking you to configure it. Recent repos track `cd` events, branch / PR / CI status derive from the terminal's CWD, Claude Code state is read from the foreground pid, activity sparklines come from pty output. If kolu knows something, it's because the shell already told it. The surface grows with your workflow, not with a preferences pane.
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
**Pull Kolu's two design principles — *agent-agnostic* and *auto-detected, zero setup* — out of the intro and feature descriptions and into an explicit Philosophy section.** The principles already shape every surface in the app, but they're currently scattered across the lead paragraph, Features, and Architecture footnotes, which makes them easy to miss when skimming.

Prompted by juspay/kolu#452, whose *Philosophy* preamble articulated the two tenets more crisply than the README ever had. Rather than let that framing live only in a feature ticket, this promotes it into the project's top-level identity — so future features can be evaluated against a stated stance, and readers know at a glance what Kolu is and isn't.

*Docs-only — no code changes.*