### PR TITLE
feat(palette): agent-aware command palette (Closes #452)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ nix run github:juspay/kolu -- --host 0.0.0.0 --port 8080  # expose on LAN
 ### Navigation
 
 - Command palette (<kbd>Cmd/Ctrl+K</kbd>) — search terminals, switch themes, run actions
+- Agent-aware command palette — once you've run a known agent CLI (`claude`, `aider`, `opencode`, `codex`, `goose`, `gemini`, `cursor-agent`) in any kolu terminal, it surfaces in two places: under `New terminal → <recent repo>` as a sub-palette that creates the worktree and launches the agent in one step, and under `Debug → Recent agents` as a prefill-into-active-terminal affordance. Prompt/message flag values (`-p`/`--prompt`/`-m`/`--message`) are stripped before storage so ephemeral prompt text never lands in the persisted MRU
 - Sidebar agent previews — when an agent is waiting on you (or has finished with an unread completion), its sidebar card expands with a live xterm preview so you can peek without switching. Toggle in Settings. <kbd>Ctrl+Tab</kbd> (or <kbd>Alt+Tab</kbd>) cycles terminals in MRU order: hold the modifier, press Tab to advance, release to commit
 - Keyboard-driven — <kbd>Cmd+T</kbd> new terminal, <kbd>Cmd+1</kbd>…<kbd>Cmd+9</kbd> jump, <kbd>Cmd+Shift+[</kbd> / <kbd>Cmd+Shift+]</kbd> cycle, <kbd>Cmd+/</kbd> shortcuts help
 
@@ -152,7 +153,7 @@ flowchart TB
 
 **Terminal I/O** (solid lines) — keystrokes go through `sendInput` RPC to node-pty; shell output flows back through the [publisher](server/src/publisher.ts) as an `attach` stream to xterm.js. An @xterm/headless instance parses VT sequences server-side for screen-state snapshots[^lazy-attach].
 
-**Metadata** (dashed lines) — shell activity triggers a provider DAG: CWD changes (OSC 7) → git provider (.git/HEAD watcher) → GitHub provider (`gh pr view` polling). A Claude provider wakes on title events (OSC 2) and `fs.watch` on `~/.claude/sessions/` to check each terminal's pty foreground pid. All providers feed a single metadata channel streamed to the client as a subscription[^providers].
+**Metadata** (dashed lines) — shell activity triggers a provider DAG: CWD changes (OSC 7) → git provider (.git/HEAD watcher) → GitHub provider (`gh pr view` polling). A Claude provider wakes on title events (OSC 2) and `fs.watch` on `~/.claude/sessions/` to check each terminal's pty foreground pid. All providers feed a single metadata channel streamed to the client as a subscription[^providers]. Separately, kolu's preexec hook emits an `OSC 633;E` command mark before each user command; the pty handler parses it, matches the first token against a known-agents allowlist, and pushes normalized invocations to a bounded recent-agents MRU published via the server-state stream — powering the agent-aware command palette entries without any `/proc` lookups or argv scraping.
 
 **User actions** — command palette and sidebar dispatch plain oRPC client calls ([`useTerminalCrud`](client/src/useTerminalCrud.ts), [`useWorktreeOps`](client/src/useWorktreeOps.ts)). The server's live subscriptions push updated state to the client automatically. [`useTerminalMetadata`](client/src/useTerminalMetadata.ts) uses SolidJS's `mapArray` to create per-terminal subscriptions that automatically tear down when terminals are removed[^client-state].
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Unlike agent command centers that wrap a single model behind their own chat UI, 
 
 Two principles shape what kolu is and isn't:
 
-**Agent-agnostic.** The terminal is the universal interface. Kolu doesn't wrap a specific model or lock you into one CLI — `claude`, `opencode`, `aider`, or whatever ships next week all work the same way, because they're just programs you run in a shell. There's no agent registry to update, no adapter to write, no vendor lock-in. New tools pick up kolu's features automatically by virtue of running in a pty, and you can always drop to a plain shell without leaving the app.
+**Agent-agnostic.** The terminal is the universal interface. Kolu doesn't wrap a specific model or lock you into one CLI — `claude`, `opencode`, `aider`, or whatever ships next week all work the same way, because they're just programs you run in a shell. There's no agent registry to update, no adapter to write, no vendor lock-in. Any new agent CLI picks up first-class features automatically: run it once in any kolu terminal and the next time you create a worktree, it appears in the sub-palette as a launch option — no configuration, no per-agent code. You can always drop to a plain shell without leaving the app.
 
-**Auto-detected, zero setup.** Kolu populates its UI by watching what you already do — the repos you `cd` into, the agents you run, the sessions you save — not by asking you to configure it. Recent repos track `cd` events, branch / PR / CI status derive from the terminal's CWD, Claude Code state is read from the foreground pid, activity sparklines come from pty output. If kolu knows something, it's because the shell already told it. The surface grows with your workflow, not with a preferences pane.
+**Auto-detected, zero setup.** Kolu populates its UI by watching what you already do — the repos you `cd` into, the agents you run, the sessions you save — not by asking you to configure it. Recent repos track `cd` events, branch / PR / CI status derive from the terminal's CWD, Claude Code state is read from the foreground pid, recent agent CLIs come from preexec command marks emitted by kolu's shell integration, and activity sparklines come from pty output. If kolu knows something, it's because the shell already told it. The surface grows with your workflow, not with a preferences pane.
 
 ## Usage
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -177,6 +177,7 @@ const App: Component = () => {
     handleCreateSubTerminal: (parentId, cwd) =>
       void crud.handleCreateSubTerminal(parentId, cwd),
     handleCopyTerminalText: () => void crud.handleCopyTerminalText(),
+    handleRunInActiveTerminal: (cmd) => crud.handleRunInActiveTerminal(cmd),
     handleExportSessionAsPdf,
     getSubTerminalIds: store.getSubTerminalIds,
     toggleSubPanel: (parentId) => subPanel.togglePanel(parentId),

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -187,8 +187,8 @@ const App: Component = () => {
     handleRandomizeTheme,
     setShortcutsHelpOpen,
     setAboutOpen,
-    handleCreateWorktree: (repoPath) =>
-      void worktree.handleCreateWorktree(repoPath),
+    handleCreateWorktree: (repoPath, initialCommand) =>
+      void worktree.handleCreateWorktree(repoPath, initialCommand),
     handleClose: () => {
       const id = store.activeId();
       if (id) closeTerminal(id);

--- a/client/src/CommandPalette.tsx
+++ b/client/src/CommandPalette.tsx
@@ -95,11 +95,40 @@ const CommandPalette: Component<{
   // Navigation path: list of group commands we've drilled into
   const [path, setPath] = createSignal<PaletteCommand[]>([]);
 
-  /** Items at the current navigation level (may include hints). */
+  /** Items at the current navigation level (may include hints).
+   *
+   *  Resolves the drilled-in path by **name** against the fresh
+   *  `props.commands()` tree, not by object reference against the
+   *  snapshot captured in `path()`. The parent createCommands memo
+   *  re-runs whenever its reactive inputs change (e.g. server state
+   *  push, terminal list update) and produces *new* PaletteCommand
+   *  objects — the stored references in `path()` become stale within
+   *  the same render, and resolving children against them would show
+   *  the outdated group contents at the drilled-in level. By walking
+   *  the current tree step-by-step via `.name` lookup, the drilled-in
+   *  level always reflects the latest content. If a segment's name
+   *  disappears from the fresh tree (e.g. a parent hidden by a
+   *  visibility guard), fall back to the stale reference so the
+   *  palette doesn't render an empty level mid-navigation. */
   const currentItems = createMemo((): PaletteItem[] => {
     const p = path();
     if (p.length === 0) return props.commands();
-    return resolveChildren(p[p.length - 1]!);
+    let level: PaletteItem[] = props.commands();
+    for (const segment of p) {
+      const match = level.find(
+        (item): item is PaletteCommand =>
+          isCommand(item) && item.name === segment.name,
+      );
+      if (!match || !isGroup(match)) {
+        // Segment no longer present in the current tree; fall back to
+        // the stale reference to keep the level rendered. Happens e.g.
+        // when a visibility guard hides a parent group while the user
+        // is still drilled into it.
+        return resolveChildren(p[p.length - 1]!);
+      }
+      level = resolveChildren(match);
+    }
+    return level;
   });
 
   /** Commands at the current level, filtered by the search query. Hints are excluded. */

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -5,9 +5,36 @@ import type { Accessor } from "solid-js";
 import type { PaletteCommand, PaletteItem } from "./CommandPalette";
 import { SHORTCUTS } from "./keyboard";
 import { availableThemes } from "./theme";
-import type { TerminalId, TerminalMetadata } from "kolu-common";
+import type { TerminalId, TerminalMetadata, RecentAgent } from "kolu-common";
 import { useServerState } from "./useServerState";
 import { client } from "./rpc";
+
+/** PaletteItems listing each recent agent command. Used by the Debug →
+ *  "Recent agents" entry (phase 1 prefill flow). */
+function agentItems(
+  agents: RecentAgent[],
+  onPick: (command: string) => void,
+): PaletteItem[] {
+  return agents.map((a) => ({
+    name: a.command,
+    onSelect: () => onPick(a.command),
+  }));
+}
+
+/** PaletteItems for a "create fresh terminal, optionally with an agent"
+ *  flow. Prepends "Plain shell" to the agent list so the default (empty
+ *  worktree) stays the keyboard-flow default. Used by phase 2's
+ *  recent-repo sub-palette under "New terminal". */
+function agentItemsWithPlainShell(
+  agents: RecentAgent[],
+  onPickPlainShell: () => void,
+  onPickAgent: (command: string) => void,
+): PaletteItem[] {
+  return [
+    { name: "Plain shell", onSelect: onPickPlainShell },
+    ...agentItems(agents, onPickAgent),
+  ];
+}
 
 export interface CommandDeps {
   terminalIds: Accessor<TerminalId[]>;
@@ -30,7 +57,7 @@ export interface CommandDeps {
   setShortcutsHelpOpen: (open: boolean) => void;
   setAboutOpen: (open: boolean) => void;
   // Worktree
-  handleCreateWorktree: (repoPath: string) => void;
+  handleCreateWorktree: (repoPath: string, initialCommand?: string) => void;
   handleClose: () => void;
   // Debug
   simulateAlert: () => void;
@@ -46,16 +73,40 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       name: "New terminal",
       children: (): PaletteItem[] => {
         const repos = recentRepos();
+        // `hasAgents` decides leaf-vs-group shape at memo time; the nested
+        // `children` accessor re-reads `recentAgents()` live so the sub-
+        // palette reflects agent MRU changes between drilling into "New
+        // terminal" and drilling into a specific repo. Mirrors the pattern
+        // used by the Debug → "Recent agents" entry below.
+        const hasAgents = recentAgents().length > 0;
         return [
           {
             name: "In current directory",
             onSelect: () => deps.handleCreate(deps.activeMeta()?.cwd),
           },
-          ...repos.map((r) => ({
-            name: r.repoName,
-            description: `New worktree in ${r.repoRoot}`,
-            onSelect: () => deps.handleCreateWorktree(r.repoRoot),
-          })),
+          // Recent-repo entries. When the user has any known-agent CLI in
+          // their MRU, picking a repo opens a sub-palette (Plain shell +
+          // agents). With no recent agents, the entry stays a flat leaf
+          // that creates a plain-shell worktree — exact pre-phase-2
+          // behavior, so first-run UX is unchanged.
+          ...repos.map((r) =>
+            hasAgents
+              ? {
+                  name: r.repoName,
+                  description: `New worktree in ${r.repoRoot}`,
+                  children: (): PaletteItem[] =>
+                    agentItemsWithPlainShell(
+                      recentAgents(),
+                      () => deps.handleCreateWorktree(r.repoRoot),
+                      (cmd) => deps.handleCreateWorktree(r.repoRoot, cmd),
+                    ),
+                }
+              : {
+                  name: r.repoName,
+                  description: `New worktree in ${r.repoRoot}`,
+                  onSelect: () => deps.handleCreateWorktree(r.repoRoot),
+                },
+          ),
           ...(repos.length === 0
             ? [
                 {
@@ -176,10 +227,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
                 name: "Recent agents",
                 description: "Prefill an agent CLI into the active terminal",
                 children: (): PaletteItem[] =>
-                  recentAgents().map((a) => ({
-                    name: a.command,
-                    onSelect: () => deps.handleRunInActiveTerminal(a.command),
-                  })),
+                  agentItems(recentAgents(), deps.handleRunInActiveTerminal),
               },
             ]
           : []),

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -67,23 +67,6 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
         ];
       },
     },
-    // "Recent agents" — surfaces agent CLIs the user has previously run in
-    // any kolu terminal, auto-detected via the preexec OSC 633;E command
-    // mark. Only visible when at least one agent has been seen AND there
-    // is an active terminal to run it in.
-    ...(deps.activeId() !== null && recentAgents().length > 0
-      ? [
-          {
-            name: "Recent agents",
-            description: "Rerun an agent CLI in the active terminal",
-            children: (): PaletteItem[] =>
-              recentAgents().map((a) => ({
-                name: a.command,
-                onSelect: () => deps.handleRunInActiveTerminal(a.command),
-              })),
-          },
-        ]
-      : []),
     ...(deps.activeId() !== null
       ? [
           {
@@ -182,6 +165,24 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
           name: "Simulate activity alert",
           onSelect: () => deps.simulateAlert(),
         },
+        // "Recent agents" — surfaces agent CLIs the user has previously run
+        // in any kolu terminal, auto-detected via the preexec OSC 633;E
+        // command mark. Parked under Debug during phase 1 while the feature
+        // is soft-launched. Only visible when at least one agent has been
+        // seen AND there is an active terminal to prefill it into.
+        ...(deps.activeId() !== null && recentAgents().length > 0
+          ? [
+              {
+                name: "Recent agents",
+                description: "Prefill an agent CLI into the active terminal",
+                children: (): PaletteItem[] =>
+                  recentAgents().map((a) => ({
+                    name: a.command,
+                    onSelect: () => deps.handleRunInActiveTerminal(a.command),
+                  })),
+              },
+            ]
+          : []),
         ...(deps.activeMeta()?.agent?.kind === "claude-code"
           ? [
               {

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -17,6 +17,7 @@ export interface CommandDeps {
   handleCreate: (cwd?: string) => void;
   handleCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
   handleCopyTerminalText: () => void;
+  handleRunInActiveTerminal: (command: string) => void;
   handleExportSessionAsPdf: () => void;
   getSubTerminalIds: (parentId: TerminalId) => TerminalId[];
   toggleSubPanel: (parentId: TerminalId) => void;
@@ -38,7 +39,7 @@ export interface CommandDeps {
 }
 
 export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
-  const { recentRepos } = useServerState();
+  const { recentRepos, recentAgents } = useServerState();
 
   return createMemo((): PaletteCommand[] => [
     {
@@ -66,6 +67,23 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
         ];
       },
     },
+    // "Recent agents" — surfaces agent CLIs the user has previously run in
+    // any kolu terminal, auto-detected via the preexec OSC 633;E command
+    // mark. Only visible when at least one agent has been seen AND there
+    // is an active terminal to run it in.
+    ...(deps.activeId() !== null && recentAgents().length > 0
+      ? [
+          {
+            name: "Recent agents",
+            description: "Rerun an agent CLI in the active terminal",
+            children: (): PaletteItem[] =>
+              recentAgents().map((a) => ({
+                name: a.command,
+                onSelect: () => deps.handleRunInActiveTerminal(a.command),
+              })),
+          },
+        ]
+      : []),
     ...(deps.activeId() !== null
       ? [
           {

--- a/client/src/useServerState.ts
+++ b/client/src/useServerState.ts
@@ -21,6 +21,7 @@ import type {
   ServerState,
   Preferences,
   RecentRepo,
+  RecentAgent,
   SavedSession,
 } from "kolu-common";
 
@@ -73,6 +74,7 @@ export function useServerState() {
     /** Preferences — singleton store, synced from subscription on every server push. */
     preferences: () => prefs,
     recentRepos: () => (sub()?.recentRepos ?? []) as RecentRepo[],
+    recentAgents: () => (sub()?.recentAgents ?? []) as RecentAgent[],
     savedSession: () => (sub()?.session ?? null) as SavedSession | null,
     updatePreferences,
   };

--- a/client/src/useTerminalCrud.ts
+++ b/client/src/useTerminalCrud.ts
@@ -139,16 +139,17 @@ export function useTerminalCrud(deps: {
     }
   }
 
-  /** Write a command line followed by Enter into the active terminal.
-   *  Used by the "Recent agents" palette entry to relaunch a previously
-   *  seen agent CLI without retyping it. No-op if no terminal is active. */
+  /** Write a command line into the active terminal WITHOUT pressing Enter.
+   *  Used by the "Recent agents" palette entry to prefill a previously
+   *  seen agent CLI — the user reviews/edits and hits Enter themselves.
+   *  No-op if no terminal is active. */
   function handleRunInActiveTerminal(command: string) {
     const id = store.activeId();
     if (id === null) return;
     void client.terminal
-      .sendInput({ id, data: `${command}\r` })
+      .sendInput({ id, data: command })
       .catch((err: Error) =>
-        toast.error(`Failed to run command: ${err.message}`),
+        toast.error(`Failed to prefill command: ${err.message}`),
       );
   }
 

--- a/client/src/useTerminalCrud.ts
+++ b/client/src/useTerminalCrud.ts
@@ -139,6 +139,19 @@ export function useTerminalCrud(deps: {
     }
   }
 
+  /** Write a command line followed by Enter into the active terminal.
+   *  Used by the "Recent agents" palette entry to relaunch a previously
+   *  seen agent CLI without retyping it. No-op if no terminal is active. */
+  function handleRunInActiveTerminal(command: string) {
+    const id = store.activeId();
+    if (id === null) return;
+    void client.terminal
+      .sendInput({ id, data: `${command}\r` })
+      .catch((err: Error) =>
+        toast.error(`Failed to run command: ${err.message}`),
+      );
+  }
+
   async function handleCloseAll() {
     try {
       await client.terminal.killAll();
@@ -157,6 +170,7 @@ export function useTerminalCrud(deps: {
     handleKill,
     handleKillWithSubs,
     handleCopyTerminalText,
+    handleRunInActiveTerminal,
     handleCloseAll,
   };
 }

--- a/client/src/useWorktreeOps.ts
+++ b/client/src/useWorktreeOps.ts
@@ -12,13 +12,35 @@ export function useWorktreeOps(deps: {
 }) {
   const { store } = deps;
 
-  async function handleCreateWorktree(repoPath: string) {
+  async function handleCreateWorktree(
+    repoPath: string,
+    initialCommand?: string,
+  ) {
     const id = toast.loading("Creating worktree…");
     try {
       const result = await client.git.worktreeCreate({ repoPath });
       toast.success(`Created worktree at ${result.path}`, { id });
-      await deps.handleCreate(result.path);
+      const newTerminalId = await deps.handleCreate(result.path);
       // Recent repos update reactively via trackRecentRepo → publishSystem
+
+      // Optional initial command (phase 2 of #452): write the agent command
+      // to the new terminal's input so the agent starts immediately.
+      //
+      // PTY input is buffered: the shell reads `initialCommand\r` at its
+      // first prompt once rc initialization completes. Works reliably in
+      // practice, but has a latent race on slow-rc systems (NixOS with
+      // many sourced files) where init output can interleave with command
+      // echo. If that becomes visible in dogfooding, promote to a
+      // server-side createTerminal parameter gated on a shell-ready
+      // signal (OSC 133;A prompt mark) — a contract change deliberately
+      // deferred out of phase 2 scope.
+      if (initialCommand !== undefined) {
+        await client.terminal
+          .sendInput({ id: newTerminalId, data: `${initialCommand}\r` })
+          .catch((err: Error) =>
+            toast.error(`Failed to start agent: ${err.message}`),
+          );
+      }
     } catch (err) {
       toast.error(`Failed to create worktree: ${(err as Error).message}`, {
         id,

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -201,6 +201,20 @@ export const RecentRepoSchema = z.object({
   lastSeen: z.number(),
 });
 
+// --- Recent agents (server-side persistent state) ---
+
+/** A normalized agent CLI invocation (e.g. "claude --model sonnet").
+ *  Populated from OSC 633;E command marks emitted by kolu's preexec hook
+ *  whenever the user runs a known agent binary in any terminal. */
+export const RecentAgentSchema = z.object({
+  /** Normalized command line — first token is the agent binary,
+   *  followed by its stable flags. Prompt/message flags and trailing
+   *  positional arguments are stripped so ephemeral prompt text does
+   *  not pollute the MRU. */
+  command: z.string(),
+  lastSeen: z.number(),
+});
+
 // --- Session persistence ---
 
 export const SavedTerminalSchema = z.object({
@@ -254,6 +268,7 @@ export const PreferencesSchema = z.object({
 /** What conf stores to disk — survives server restart. */
 export const PersistedStateSchema = z.object({
   recentRepos: z.array(RecentRepoSchema),
+  recentAgents: z.array(RecentAgentSchema),
   session: SavedSessionSchema.nullable(),
   preferences: PreferencesSchema,
 });
@@ -265,6 +280,7 @@ export const ServerStateSchema = PersistedStateSchema.extend({});
 /** Partial patch for state updates — all fields optional, preferences partially mergeable. */
 export const ServerStatePatchSchema = z.object({
   recentRepos: z.array(RecentRepoSchema).optional(),
+  recentAgents: z.array(RecentAgentSchema).optional(),
   session: SavedSessionSchema.nullable().optional(),
   preferences: PreferencesSchema.partial().optional(),
 });
@@ -285,6 +301,7 @@ export type ClaudeTranscriptDebug = z.infer<typeof ClaudeTranscriptDebugSchema>;
 export type Foreground = z.infer<typeof ForegroundSchema>;
 export type TerminalMetadata = z.infer<typeof TerminalMetadataSchema>;
 export type RecentRepo = z.infer<typeof RecentRepoSchema>;
+export type RecentAgent = z.infer<typeof RecentAgentSchema>;
 export type SavedTerminal = z.infer<typeof SavedTerminalSchema>;
 export type SavedSession = z.infer<typeof SavedSessionSchema>;
 export type ColorScheme = z.infer<typeof ColorSchemeSchema>;

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
     pname = "kolu";
     version = "0.1.0";
     inherit src;
-    hash = "sha256-FIHG1bTz7VSKTstqncQ2RNlLdHpAuwqitwQrbubTgIY=";
+    hash = "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248=";
     fetcherVersion = 3;
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       simple-git:
         specifier: ^3.33.0
         version: 3.33.0
+      string-argv:
+        specifier: ^0.3.2
+        version: 0.3.2
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
@@ -3456,6 +3459,10 @@ packages:
 
   string-argv@0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
+    engines: {node: '>=0.6.19'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
   string-width@4.2.3:
@@ -7299,6 +7306,8 @@ snapshots:
       internal-slot: 1.1.0
 
   string-argv@0.3.1: {}
+
+  string-argv@0.3.2: {}
 
   string-width@4.2.3:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -31,6 +31,7 @@
     "pino-pretty": "^13.1.3",
     "selfsigned": "^5.5.0",
     "simple-git": "^3.33.0",
+    "string-argv": "^0.3.2",
     "ts-pattern": "^5.9.0",
     "ws": "^8.19.0",
     "zod": "^4.3.6"

--- a/server/src/agent-cli.test.ts
+++ b/server/src/agent-cli.test.ts
@@ -1,58 +1,7 @@
 /** Unit tests for agent CLI parsing and normalization. */
 
 import { describe, it, expect } from "vitest";
-import { parseAgentCommand, tokenize } from "./agent-cli.ts";
-
-describe("tokenize", () => {
-  it("splits plain whitespace", () => {
-    expect(tokenize("claude --model sonnet")).toEqual([
-      "claude",
-      "--model",
-      "sonnet",
-    ]);
-  });
-
-  it("respects double-quoted runs", () => {
-    expect(tokenize(`claude -p "fix a bug"`)).toEqual([
-      "claude",
-      "-p",
-      "fix a bug",
-    ]);
-  });
-
-  it("respects single-quoted runs", () => {
-    expect(tokenize(`claude -p 'fix a bug'`)).toEqual([
-      "claude",
-      "-p",
-      "fix a bug",
-    ]);
-  });
-
-  it("honors backslash escapes outside quotes", () => {
-    expect(tokenize(`claude foo\\ bar`)).toEqual(["claude", "foo bar"]);
-  });
-
-  it("handles escaped double quotes inside double-quoted runs", () => {
-    expect(tokenize(`claude -p "say \\"hi\\""`)).toEqual([
-      "claude",
-      "-p",
-      `say "hi"`,
-    ]);
-  });
-
-  it("does not interpret escapes inside single quotes", () => {
-    expect(tokenize(`claude -p 'say \\"hi\\"'`)).toEqual([
-      "claude",
-      "-p",
-      `say \\"hi\\"`,
-    ]);
-  });
-
-  it("returns empty array for empty input", () => {
-    expect(tokenize("")).toEqual([]);
-    expect(tokenize("   ")).toEqual([]);
-  });
-});
+import { parseAgentCommand } from "./agent-cli.ts";
 
 describe("parseAgentCommand", () => {
   // Table from juspay/kolu#452

--- a/server/src/agent-cli.test.ts
+++ b/server/src/agent-cli.test.ts
@@ -1,0 +1,122 @@
+/** Unit tests for agent CLI parsing and normalization. */
+
+import { describe, it, expect } from "vitest";
+import { parseAgentCommand, tokenize } from "./agent-cli.ts";
+
+describe("tokenize", () => {
+  it("splits plain whitespace", () => {
+    expect(tokenize("claude --model sonnet")).toEqual([
+      "claude",
+      "--model",
+      "sonnet",
+    ]);
+  });
+
+  it("respects double-quoted runs", () => {
+    expect(tokenize(`claude -p "fix a bug"`)).toEqual([
+      "claude",
+      "-p",
+      "fix a bug",
+    ]);
+  });
+
+  it("respects single-quoted runs", () => {
+    expect(tokenize(`claude -p 'fix a bug'`)).toEqual([
+      "claude",
+      "-p",
+      "fix a bug",
+    ]);
+  });
+
+  it("honors backslash escapes outside quotes", () => {
+    expect(tokenize(`claude foo\\ bar`)).toEqual(["claude", "foo bar"]);
+  });
+
+  it("handles escaped double quotes inside double-quoted runs", () => {
+    expect(tokenize(`claude -p "say \\"hi\\""`)).toEqual([
+      "claude",
+      "-p",
+      `say "hi"`,
+    ]);
+  });
+
+  it("does not interpret escapes inside single quotes", () => {
+    expect(tokenize(`claude -p 'say \\"hi\\"'`)).toEqual([
+      "claude",
+      "-p",
+      `say \\"hi\\"`,
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("   ")).toEqual([]);
+  });
+});
+
+describe("parseAgentCommand", () => {
+  // Table from juspay/kolu#452
+  it.each([
+    // bare invocation
+    ["claude", "claude"],
+    // prompt flag stripped with its value
+    [`claude -p "fix my leaked API key foo"`, "claude"],
+    // stable flag kept verbatim
+    [
+      "claude --dangerously-skip-permissions",
+      "claude --dangerously-skip-permissions",
+    ],
+    // mixed: stable flag preserved, prompt flag stripped
+    [`claude --model sonnet -p "tweak this"`, "claude --model sonnet"],
+    // aider with --model and -m prompt
+    [`aider --model opus -m "refactor this"`, "aider --model opus"],
+    // repeated identity
+    ["claude", "claude"],
+  ])("normalizes %j → %j", (raw, expected) => {
+    expect(parseAgentCommand(raw)).toBe(expected);
+  });
+
+  it("strips trailing positional arguments", () => {
+    expect(parseAgentCommand("aider src/foo.ts src/bar.ts")).toBe("aider");
+  });
+
+  it("strips positionals but keeps flag values that follow the flag", () => {
+    expect(parseAgentCommand("claude --model sonnet some-file.ts")).toBe(
+      "claude --model sonnet",
+    );
+  });
+
+  it("stops processing at explicit --", () => {
+    expect(parseAgentCommand("claude --model sonnet -- anything here")).toBe(
+      "claude --model sonnet",
+    );
+  });
+
+  it("handles absolute path to agent binary", () => {
+    expect(parseAgentCommand("/usr/local/bin/claude --model sonnet")).toBe(
+      "claude --model sonnet",
+    );
+  });
+
+  it("returns null for non-agent commands", () => {
+    expect(parseAgentCommand("ls -la")).toBeNull();
+    expect(parseAgentCommand("vim foo.ts")).toBeNull();
+    expect(parseAgentCommand("git status")).toBeNull();
+    expect(parseAgentCommand("")).toBeNull();
+    expect(parseAgentCommand("   ")).toBeNull();
+  });
+
+  it("recognizes all known agents", () => {
+    for (const agent of [
+      "claude",
+      "opencode",
+      "aider",
+      "codex",
+      "goose",
+      "gemini",
+      "cursor-agent",
+    ]) {
+      expect(parseAgentCommand(agent)).toBe(agent);
+    }
+  });
+});

--- a/server/src/agent-cli.ts
+++ b/server/src/agent-cli.ts
@@ -17,12 +17,16 @@
  *   so `aider src/foo.ts` collapses to `aider`.
  * - All other flags are preserved verbatim in their original order.
  *
- * This is NOT a POSIX shell parser. The tokenizer handles whitespace
- * splitting with single- and double-quoted runs and backslash escapes.
- * It never evaluates the command — we only need to decide which tokens
- * to strip, so unknown constructs (command substitution, process
- * substitution, pipes) simply fall through as literal text.
+ * Tokenization delegates to `string-argv`, a small focused library
+ * for splitting shell-like strings into argv. We don't try to evaluate
+ * the command — we only need to decide which tokens to strip — so the
+ * tokenizer's exact handling of edge cases (command substitution,
+ * process substitution, glob) doesn't matter: unknown constructs fall
+ * through as opaque positionals and get dropped in the same step that
+ * drops real positionals.
  */
+
+import { parseArgsStringToArgv } from "string-argv";
 
 /** Agent CLI basenames kolu recognizes out of the box.
  *  Adding a new agent is a one-line change — no adapter, no registry. */
@@ -44,55 +48,6 @@ const PROMPT_FLAGS: ReadonlySet<string> = new Set([
   "--message",
 ]);
 
-/** Tokenize a shell-ish command line. Splits on whitespace; respects
- *  single-quoted ('...') and double-quoted ("...") runs; honors
- *  backslash escapes outside single quotes. Returns surface tokens in
- *  order with quoting and escapes removed. */
-export function tokenize(input: string): string[] {
-  const out: string[] = [];
-  let i = 0;
-  const n = input.length;
-  while (i < n) {
-    // Skip whitespace between tokens
-    while (i < n && /\s/.test(input[i]!)) i++;
-    if (i >= n) break;
-    let tok = "";
-    while (i < n && !/\s/.test(input[i]!)) {
-      const c = input[i]!;
-      if (c === "'") {
-        // Single quotes: literal, no escapes
-        i++;
-        while (i < n && input[i] !== "'") tok += input[i++];
-        if (i < n) i++; // consume closing quote
-      } else if (c === '"') {
-        // Double quotes: honor backslash escapes for \" and \\
-        i++;
-        while (i < n && input[i] !== '"') {
-          if (input[i] === "\\" && i + 1 < n) {
-            const next = input[i + 1]!;
-            if (next === '"' || next === "\\") {
-              tok += next;
-              i += 2;
-              continue;
-            }
-          }
-          tok += input[i++];
-        }
-        if (i < n) i++; // consume closing quote
-      } else if (c === "\\" && i + 1 < n) {
-        // Backslash escape outside quotes
-        tok += input[i + 1];
-        i += 2;
-      } else {
-        tok += c;
-        i++;
-      }
-    }
-    out.push(tok);
-  }
-  return out;
-}
-
 /** Basename of a path-like token (strips directory prefix). */
 function basename(s: string): string {
   const slash = s.lastIndexOf("/");
@@ -105,7 +60,7 @@ function basename(s: string): string {
  * to a known agent binary, or `null` otherwise.
  */
 export function parseAgentCommand(raw: string): string | null {
-  const tokens = tokenize(raw.trim());
+  const tokens = parseArgsStringToArgv(raw.trim());
   if (tokens.length === 0) return null;
 
   const agent = basename(tokens[0]!);

--- a/server/src/agent-cli.ts
+++ b/server/src/agent-cli.ts
@@ -1,0 +1,137 @@
+/**
+ * Agent CLI command detection and normalization.
+ *
+ * When the user runs a known agent binary in any kolu terminal
+ * (`claude`, `aider`, `opencode`, etc.), kolu's preexec hook emits
+ * the raw command line as an `OSC 633 ; E ; <cmd>` mark on the PTY
+ * output stream. `parseAgentCommand` takes that raw string and
+ * returns a normalized canonical form, or `null` if the command
+ * is not a known agent invocation.
+ *
+ * Normalization rules:
+ * - First token (basename-stripped) must be in `KNOWN_AGENTS`.
+ * - Prompt/message flags (`-p`, `--prompt`, `-m`, `--message`) are
+ *   stripped together with their values so ephemeral prompt text
+ *   never lands in the persisted MRU (leak prevention).
+ * - Trailing positional arguments (after the last flag) are stripped
+ *   so `aider src/foo.ts` collapses to `aider`.
+ * - All other flags are preserved verbatim in their original order.
+ *
+ * This is NOT a POSIX shell parser. The tokenizer handles whitespace
+ * splitting with single- and double-quoted runs and backslash escapes.
+ * It never evaluates the command — we only need to decide which tokens
+ * to strip, so unknown constructs (command substitution, process
+ * substitution, pipes) simply fall through as literal text.
+ */
+
+/** Agent CLI basenames kolu recognizes out of the box.
+ *  Adding a new agent is a one-line change — no adapter, no registry. */
+const KNOWN_AGENTS: ReadonlySet<string> = new Set([
+  "claude",
+  "opencode",
+  "aider",
+  "codex",
+  "goose",
+  "gemini",
+  "cursor-agent",
+]);
+
+/** Flags whose value is an ephemeral prompt/message and must be stripped. */
+const PROMPT_FLAGS: ReadonlySet<string> = new Set([
+  "-p",
+  "--prompt",
+  "-m",
+  "--message",
+]);
+
+/** Tokenize a shell-ish command line. Splits on whitespace; respects
+ *  single-quoted ('...') and double-quoted ("...") runs; honors
+ *  backslash escapes outside single quotes. Returns surface tokens in
+ *  order with quoting and escapes removed. */
+export function tokenize(input: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  const n = input.length;
+  while (i < n) {
+    // Skip whitespace between tokens
+    while (i < n && /\s/.test(input[i]!)) i++;
+    if (i >= n) break;
+    let tok = "";
+    while (i < n && !/\s/.test(input[i]!)) {
+      const c = input[i]!;
+      if (c === "'") {
+        // Single quotes: literal, no escapes
+        i++;
+        while (i < n && input[i] !== "'") tok += input[i++];
+        if (i < n) i++; // consume closing quote
+      } else if (c === '"') {
+        // Double quotes: honor backslash escapes for \" and \\
+        i++;
+        while (i < n && input[i] !== '"') {
+          if (input[i] === "\\" && i + 1 < n) {
+            const next = input[i + 1]!;
+            if (next === '"' || next === "\\") {
+              tok += next;
+              i += 2;
+              continue;
+            }
+          }
+          tok += input[i++];
+        }
+        if (i < n) i++; // consume closing quote
+      } else if (c === "\\" && i + 1 < n) {
+        // Backslash escape outside quotes
+        tok += input[i + 1];
+        i += 2;
+      } else {
+        tok += c;
+        i++;
+      }
+    }
+    out.push(tok);
+  }
+  return out;
+}
+
+/** Basename of a path-like token (strips directory prefix). */
+function basename(s: string): string {
+  const slash = s.lastIndexOf("/");
+  return slash === -1 ? s : s.slice(slash + 1);
+}
+
+/**
+ * Parse a raw command line. Returns the normalized agent invocation
+ * string (e.g. `"claude --model sonnet"`) if the first token resolves
+ * to a known agent binary, or `null` otherwise.
+ */
+export function parseAgentCommand(raw: string): string | null {
+  const tokens = tokenize(raw.trim());
+  if (tokens.length === 0) return null;
+
+  const agent = basename(tokens[0]!);
+  if (!KNOWN_AGENTS.has(agent)) return null;
+
+  // Collect stable flags + drop prompt flags with their values.
+  // A stable flag is any `-x` or `--xxx` that is not in PROMPT_FLAGS.
+  // Anything else (trailing positional args) is dropped.
+  const kept: string[] = [agent];
+  const args = tokens.slice(1);
+  for (let i = 0; i < args.length; i++) {
+    const t = args[i]!;
+    if (t === "--") break; // stop at explicit end-of-flags
+    if (!t.startsWith("-")) continue; // drop positional
+    if (PROMPT_FLAGS.has(t)) {
+      // Skip the flag and its value (if present and not another flag)
+      if (i + 1 < args.length && !args[i + 1]!.startsWith("-")) i++;
+      continue;
+    }
+    // Stable flag — keep verbatim
+    kept.push(t);
+    // If the next token is a non-flag value (e.g. `--model sonnet`),
+    // attach it to the flag as-is.
+    if (i + 1 < args.length && !args[i + 1]!.startsWith("-")) {
+      kept.push(args[++i]!);
+    }
+  }
+  return kept.join(" ");
+}

--- a/server/src/pty.ts
+++ b/server/src/pty.ts
@@ -171,7 +171,7 @@ export function spawnPty(
     (data: string) => {
       if (!data.startsWith("E;")) return false;
       const command = data.slice(2);
-      tlog.debug({ command }, "command run (OSC 633;E)");
+      tlog.info({ command }, "command run (OSC 633;E)");
       opts.onCommandRun?.(command);
       return true;
     },

--- a/server/src/pty.ts
+++ b/server/src/pty.ts
@@ -171,7 +171,11 @@ export function spawnPty(
     (data: string) => {
       if (!data.startsWith("E;")) return false;
       const command = data.slice(2);
-      tlog.info({ command }, "command run (OSC 633;E)");
+      // DEBUG only: the raw command string is whatever the user typed,
+      // including any ephemeral prompt text, API keys, or secrets. The
+      // downstream `recent agent tracked` log emits the *normalized*
+      // form at INFO, which has prompt flags and their values stripped.
+      tlog.debug({ command }, "command run (OSC 633;E)");
       opts.onCommandRun?.(command);
       return true;
     },

--- a/server/src/pty.ts
+++ b/server/src/pty.ts
@@ -76,6 +76,10 @@ export function spawnPty(
     onCwd?: (cwd: string) => void;
     /** Fired on OSC 0/2 title change — signals foreground process may have changed. */
     onTitleChange?: (title: string) => void;
+    /** Fired when the preexec hook emits `OSC 633 ; E ; <cmd>` — the raw
+     *  command line the user typed, before execution. Used to build the
+     *  global recent-agents MRU. */
+    onCommandRun?: (command: string) => void;
   },
   clipboard: { shimBinDir: string; clipboardDir: string },
   spawnCwd?: string,
@@ -151,6 +155,22 @@ export function spawnPty(
     opts.onTitleChange?.(title);
   });
 
+  // OSC 633 ; E ; <command>  — VS Code's semantic "exact command line"
+  // sequence, emitted by kolu's preexec hook alongside OSC 2. The payload
+  // arrives as "E;<command>"; we accept only the E sub-code and ignore
+  // any other 633;X payloads so future VS Code sequences (A/B/C/D) pass
+  // through untouched.
+  const commandMarkDisposable = headless.parser.registerOscHandler(
+    633,
+    (data: string) => {
+      if (!data.startsWith("E;")) return false;
+      const command = data.slice(2);
+      tlog.debug({ command }, "command run (OSC 633;E)");
+      opts.onCommandRun?.(command);
+      return true;
+    },
+  );
+
   // Forward device query responses (DA1/DSR) from headless terminal back to
   // the PTY. TUIs like Yazi probe terminal capabilities at startup — the
   // headless terminal responds immediately, avoiding latency from the client.
@@ -194,6 +214,7 @@ export function spawnPty(
     dispose() {
       oscDisposable.dispose();
       titleDisposable.dispose();
+      commandMarkDisposable.dispose();
       headlessOnDataDisposable.dispose();
       dataDisposable.dispose();
       exitDisposable.dispose();

--- a/server/src/shell.test.ts
+++ b/server/src/shell.test.ts
@@ -55,21 +55,33 @@ describe("OSC7_FN", () => {
 });
 
 describe("OSC2_PREEXEC_FN", () => {
+  // __kolu_preexec emits TWO sequences per invocation:
+  //   1. OSC 2 title change (for terminal title + event-driven process detection)
+  //   2. OSC 633 ; E ; <command>  (VS Code semantic command mark, for recent-agents MRU)
+  // See shell.ts OSC2_PREEXEC_FN docstring for why.
+
   it("emits OSC 2 with the passed command string", () => {
     const out = runBash(`${OSC2_PREEXEC_FN}; __kolu_preexec "vim foo.ts"`);
-    expect(out).toBe("\x1b]2;vim foo.ts\x1b\\");
+    expect(out).toContain("\x1b]2;vim foo.ts\x1b\\");
+  });
+
+  it("emits OSC 633;E with the passed command string", () => {
+    const out = runBash(`${OSC2_PREEXEC_FN}; __kolu_preexec "vim foo.ts"`);
+    expect(out).toContain("\x1b]633;E;vim foo.ts\x1b\\");
   });
 
   it("handles commands with special characters", () => {
     const out = runBash(
       `${OSC2_PREEXEC_FN}; __kolu_preexec 'grep "needle" file.txt'`,
     );
-    expect(out).toBe('\x1b]2;grep "needle" file.txt\x1b\\');
+    expect(out).toContain('\x1b]2;grep "needle" file.txt\x1b\\');
+    expect(out).toContain('\x1b]633;E;grep "needle" file.txt\x1b\\');
   });
 
-  it("emits empty title for empty command", () => {
+  it("emits empty payload for empty command", () => {
     const out = runBash(`${OSC2_PREEXEC_FN}; __kolu_preexec ""`);
-    expect(out).toBe("\x1b]2;\x1b\\");
+    expect(out).toContain("\x1b]2;\x1b\\");
+    expect(out).toContain("\x1b]633;E;\x1b\\");
   });
 });
 

--- a/server/src/shell.test.ts
+++ b/server/src/shell.test.ts
@@ -154,6 +154,31 @@ describe("OSC2_PREEXEC_BASH_GUARD", () => {
     expect(out).not.toContain("__zoxide_hook");
   });
 
+  it("readline widget (fzf Ctrl+R) does not consume the ready flag", () => {
+    // Regression: when fzf's Ctrl+R binding fires, BASH_COMMAND is set to
+    // `__fzf_history__` — a readline widget, not a user command. Before
+    // the `__*` guard, dispatch would clear the ready flag for it, causing
+    // the user's NEXT real command to see flag="" and get silently dropped
+    // (the "had to run it twice" bug).
+    const out = runBash(
+      `${prelude}` +
+        `trap '__kolu_preexec_dispatch' DEBUG\n` +
+        `__fzf_history__() { :; }\n` +
+        // Arm flag (as PROMPT_COMMAND would after the prompt draws)
+        `__kolu_preexec_arm\n` +
+        // Simulate Ctrl+R: widget runs, should NOT consume the flag
+        `__fzf_history__\n` +
+        // Now the user's real command — flag must still be armed
+        `true\n`,
+    );
+    const titles = [...out.matchAll(/\x1b\]2;([^\x1b]*)\x1b\\/g)].map(
+      (m) => m[1],
+    );
+    // The widget should be skipped, the real command should fire.
+    expect(titles).not.toContain("__fzf_history__");
+    expect(titles).toContain("true");
+  });
+
   it("full flow: user command emitted, PROMPT_COMMAND hook skipped", () => {
     // Most realistic test: install trap, simulate user command (arm + run),
     // then simulate PROMPT_COMMAND hook (no arm + run another command).

--- a/server/src/shell.ts
+++ b/server/src/shell.ts
@@ -107,6 +107,15 @@ export const OSC2_PREEXEC_FN = `__kolu_preexec() { printf '\\033]2;%s\\033\\\\' 
  *  next user command. DEBUG dispatch checks the flag, emits once per user
  *  command, and clears it (so subsequent pipeline commands don't re-emit).
  *
+ *  Readline widget guard: fzf's Ctrl+R / Ctrl+T bindings, bash-completion
+ *  helpers, and zoxide's cd wrappers run via DEBUG trap with BASH_COMMAND
+ *  set to a `__xxx` function name — they are NOT user-typed commands. If
+ *  dispatch clears the ready flag for them, the user's next *real* command
+ *  fires with flag="" and gets silently dropped. Skip anything starting
+ *  with `__` without clearing the flag, so the next real command still
+ *  dispatches. The `__` prefix is the strong bash convention for internal
+ *  widgets; user commands virtually never use it.
+ *
  *  (We originally tried PS0 command substitution, but `$(...)` runs in a
  *  subshell, so the flag assignment never reached the parent shell.) */
 export const OSC2_PREEXEC_BASH_GUARD = [
@@ -114,6 +123,7 @@ export const OSC2_PREEXEC_BASH_GUARD = [
   `__kolu_preexec_arm() { __kolu_preexec_ready="1"; }`,
   `__kolu_preexec_dispatch() {`,
   `  [ -z "$__kolu_preexec_ready" ] && return`,
+  `  case "$BASH_COMMAND" in __*) return ;; esac`,
   `  __kolu_preexec_ready=""`,
   `  __kolu_preexec "$BASH_COMMAND"`,
   `}`,

--- a/server/src/shell.ts
+++ b/server/src/shell.ts
@@ -76,10 +76,22 @@ export function cleanEnv(): Record<string, string> {
 /** Shell function that emits OSC 7 with the current working directory. */
 export const OSC7_FN = `__kolu_osc7() { printf '\\033]7;file://%s%s\\033\\\\' "$(hostname)" "$PWD"; }`;
 
-/** Shell function that emits OSC 2 (title) with the command about to run.
- *  Triggered by preexec — fires before each command, enabling event-driven
- *  foreground process detection without polling. */
-export const OSC2_PREEXEC_FN = `__kolu_preexec() { printf '\\033]2;%s\\033\\\\' "$1"; }`;
+/** Shell function fired from preexec before each command.
+ *
+ *  Emits TWO orthogonal sequences:
+ *
+ *  1. **OSC 2** — window title. Mirrors Ghostty/Kitty convention of
+ *     showing the running command in the title bar. Consumed by
+ *     `headless.onTitleChange` in pty.ts to drive event-driven
+ *     foreground process detection.
+ *
+ *  2. **OSC 633 ; E ; <cmd>** — VS Code's semantic "exact command line"
+ *     mark. Consumed by the OSC 633 handler in pty.ts to build the
+ *     global "recent agents" MRU without any PID/argv lookups. The
+ *     shell hands us the command string verbatim, so kolu never needs
+ *     `/proc` (Linux-only) or `ps` spawning (slow). Works identically
+ *     on Linux and macOS. */
+export const OSC2_PREEXEC_FN = `__kolu_preexec() { printf '\\033]2;%s\\033\\\\' "$1"; printf '\\033]633;E;%s\\033\\\\' "$1"; }`;
 
 /** Bash-specific preexec dispatch — uses a ready flag armed at the end of
  *  PROMPT_COMMAND to ensure the title only fires for user-typed commands,

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -17,6 +17,7 @@ import type {
   ServerStatePatch,
 } from "kolu-common";
 import { publishSystem } from "./publisher.ts";
+import { log } from "./log.ts";
 
 /**
  * Schema version — bump this when adding migrations.
@@ -174,6 +175,7 @@ export function trackRecentAgent(command: string): void {
     MAX_RECENT_AGENTS,
   );
   store.set("recentAgents", next);
+  log.info({ command, total: next.length }, "recent agent tracked");
   publishSystem("state:changed", getServerState());
 }
 

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import Conf from "conf";
 import type {
   RecentRepo,
+  RecentAgent,
   Preferences,
   PersistedState,
   ServerState,
@@ -22,7 +23,7 @@ import { publishSystem } from "./publisher.ts";
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.4.0";
+const SCHEMA_VERSION = "1.5.0";
 
 const DEFAULT_PREFERENCES: Preferences = {
   seenTips: [],
@@ -41,6 +42,7 @@ export const store = new Conf<PersistedState>({
   projectVersion: SCHEMA_VERSION,
   defaults: {
     recentRepos: [],
+    recentAgents: [],
     session: null,
     preferences: DEFAULT_PREFERENCES,
   },
@@ -90,6 +92,12 @@ export const store = new Conf<PersistedState>({
           migrated ?? DEFAULT_PREFERENCES.sidebarAgentPreviews,
       });
     },
+    // recentAgents added — seed as empty array for existing state files.
+    "1.5.0": (store: Conf<PersistedState>) => {
+      if (!store.has("recentAgents")) {
+        store.set("recentAgents", []);
+      }
+    },
   },
 });
 
@@ -103,25 +111,40 @@ function existsOnDisk(path: string): boolean {
   }
 }
 
+// --- Bounded MRU helper ---
+
+/** Upsert `item` into a bounded MRU list, sort most-recently-seen first,
+ *  and trim to `max` entries. Returns the new list. Pure — callers
+ *  persist and notify. */
+function upsertMru<T>(
+  list: T[],
+  item: T,
+  keyOf: (t: T) => string,
+  timeOf: (t: T) => number,
+  max: number,
+): T[] {
+  const key = keyOf(item);
+  const idx = list.findIndex((x) => keyOf(x) === key);
+  if (idx !== -1) list[idx] = item;
+  else list.push(item);
+  list.sort((a, b) => timeOf(b) - timeOf(a));
+  return list.slice(0, max);
+}
+
 // --- Recent repos ---
 
 const MAX_RECENT_REPOS = 20;
 
 /** Upsert a repo into the recent repos list (most-recently-seen first). */
 export function trackRecentRepo(repoRoot: string, repoName: string): void {
-  const repos = store.get("recentRepos");
-  const now = Date.now();
-  const existing = repos.findIndex((r) => r.repoRoot === repoRoot);
-  if (existing !== -1) {
-    repos[existing]!.lastSeen = now;
-    repos[existing]!.repoName = repoName;
-  } else {
-    repos.push({ repoRoot, repoName, lastSeen: now });
-  }
-  // Sort most-recent first, then trim
-  repos.sort((a, b) => b.lastSeen - a.lastSeen);
-  store.set("recentRepos", repos.slice(0, MAX_RECENT_REPOS));
-  // Notify live subscription so clients see the updated repos list
+  const next = upsertMru(
+    store.get("recentRepos"),
+    { repoRoot, repoName, lastSeen: Date.now() },
+    (r) => r.repoRoot,
+    (r) => r.lastSeen,
+    MAX_RECENT_REPOS,
+  );
+  store.set("recentRepos", next);
   publishSystem("state:changed", getServerState());
 }
 
@@ -133,19 +156,46 @@ export function getRecentRepos(): RecentRepo[] {
   return live;
 }
 
+// --- Recent agents ---
+
+const MAX_RECENT_AGENTS = 10;
+
+/** Upsert a normalized agent command into the recent agents MRU.
+ *  Called from terminals.ts whenever the preexec OSC 633;E handler fires
+ *  with a command whose first token matches a known agent binary. The
+ *  `command` string is the normalized form produced by
+ *  `parseAgentCommand` — raw prompt text has already been stripped. */
+export function trackRecentAgent(command: string): void {
+  const next = upsertMru(
+    store.get("recentAgents"),
+    { command, lastSeen: Date.now() },
+    (a) => a.command,
+    (a) => a.lastSeen,
+    MAX_RECENT_AGENTS,
+  );
+  store.set("recentAgents", next);
+  publishSystem("state:changed", getServerState());
+}
+
+/** Get recent agents, most-recently-seen first. */
+function getRecentAgents(): RecentAgent[] {
+  return store.get("recentAgents");
+}
+
 // --- Server state ---
 
 /** Get the full server state. */
 export function getServerState(): ServerState {
   return {
     recentRepos: getRecentRepos(),
+    recentAgents: getRecentAgents(),
     session: store.get("session"),
     preferences: store.get("preferences"),
   };
 }
 
 /** Merge a partial update into the current state.
- *  recentRepos is server-managed (tracked on terminal create) — ignored in patches. */
+ *  recentRepos and recentAgents are server-managed — ignored in patches. */
 export function updateServerState(patch: ServerStatePatch): void {
   if (patch.session !== undefined) {
     store.set("session", patch.session);
@@ -160,12 +210,15 @@ export function updateServerState(patch: ServerStatePatch): void {
   publishSystem("state:changed", getServerState());
 }
 
-/** Test-only: apply a full patch including `recentRepos`. Used by e2e hooks to
- *  reset state between scenarios. Production callers must go through
- *  `updateServerState`, which (correctly) ignores `recentRepos`. */
+/** Test-only: apply a full patch including `recentRepos` and `recentAgents`.
+ *  Used by e2e hooks to reset state between scenarios. Production callers
+ *  must go through `updateServerState`, which ignores server-managed fields. */
 export function testSetServerState(patch: ServerStatePatch): void {
   if (patch.recentRepos !== undefined) {
     store.set("recentRepos", patch.recentRepos);
+  }
+  if (patch.recentAgents !== undefined) {
+    store.set("recentAgents", patch.recentAgents);
   }
   updateServerState(patch);
 }

--- a/server/src/terminals.ts
+++ b/server/src/terminals.ts
@@ -26,6 +26,8 @@ import {
   startProviders,
 } from "./meta/index.ts";
 import { publishForTerminal, publishSystem } from "./publisher.ts";
+import { parseAgentCommand } from "./agent-cli.ts";
+import { trackRecentAgent } from "./state.ts";
 import type { SavedTerminal } from "kolu-common";
 
 /** Server-side terminal state. Owns a PtyHandle and embeds the wire-type TerminalInfo. */
@@ -163,6 +165,13 @@ export function createTerminal(cwd?: string, parentId?: string): TerminalInfo {
       // PTY callback (OSC 0/2): notify process provider that title changed
       onTitleChange: (title) => {
         publishForTerminal("title", id, title);
+      },
+      // PTY callback (OSC 633;E): raw preexec command line. Normalize and,
+      // if the first token matches a known agent binary, push it to the
+      // global recent-agents MRU. Commands that aren't agents are discarded.
+      onCommandRun: (raw) => {
+        const normalized = parseAgentCommand(raw);
+        if (normalized) trackRecentAgent(normalized);
       },
       // PTY callback (OSC 7): update metadata CWD, notify providers via cwd channel
       onCwd: (newCwd) => {

--- a/tests/features/recent-agents.feature
+++ b/tests/features/recent-agents.feature
@@ -1,6 +1,7 @@
 Feature: Recent agents in command palette
   Agent CLIs the user has run previously appear under "Recent agents"
-  in the command palette so they can be relaunched without retyping.
+  inside Debug in the command palette so they can be prefilled into
+  the active terminal without retyping.
 
   Detection is automatic: kolu's preexec hook captures the command line
   via OSC 633;E, and commands whose first token matches a known agent
@@ -8,15 +9,19 @@ Feature: Recent agents in command palette
   MRU. Prompt/message flags are stripped so raw prompt text never lands
   in the persisted list.
 
+  Phase 1 parks the entry under Debug while the detection pipeline is
+  soft-launched.
+
   Background:
     Given the terminal is ready
 
-  Scenario: Known agent invocation surfaces under "Recent agents"
+  Scenario: Known agent invocation surfaces under "Recent agents" in Debug
     # `claude` is not installed in the test env, but the preexec hook
     # fires BEFORE execution — the OSC 633;E mark is emitted regardless
     # of whether the command succeeds.
     When I run "claude --dangerously-skip-permissions"
     And I open the command palette
+    And I select "Debug" in the palette
     Then palette item "Recent agents" should be visible
     When I select "Recent agents" in the palette
     Then the palette breadcrumb should show "Recent agents"
@@ -26,17 +31,20 @@ Feature: Recent agents in command palette
   Scenario: Prompt flag values are stripped before storage
     When I run "claude --model sonnet -p mysecret"
     And I open the command palette
+    And I select "Debug" in the palette
     And I select "Recent agents" in the palette
     Then palette item "claude --model sonnet" should be visible
     And there should be no page errors
 
-  Scenario: "Recent agents" is hidden when no agents have been run
+  Scenario: "Recent agents" is hidden in Debug when no agents have been run
     When I open the command palette
+    And I select "Debug" in the palette
     Then palette item "Recent agents" should not be visible
     And there should be no page errors
 
   Scenario: Non-agent commands do not pollute the list
     When I run "ls /tmp"
     And I open the command palette
+    And I select "Debug" in the palette
     Then palette item "Recent agents" should not be visible
     And there should be no page errors

--- a/tests/features/recent-agents.feature
+++ b/tests/features/recent-agents.feature
@@ -1,0 +1,42 @@
+Feature: Recent agents in command palette
+  Agent CLIs the user has run previously appear under "Recent agents"
+  in the command palette so they can be relaunched without retyping.
+
+  Detection is automatic: kolu's preexec hook captures the command line
+  via OSC 633;E, and commands whose first token matches a known agent
+  binary (`claude`, `aider`, `opencode`, etc.) are pushed to a global
+  MRU. Prompt/message flags are stripped so raw prompt text never lands
+  in the persisted list.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Known agent invocation surfaces under "Recent agents"
+    # `claude` is not installed in the test env, but the preexec hook
+    # fires BEFORE execution — the OSC 633;E mark is emitted regardless
+    # of whether the command succeeds.
+    When I run "claude --dangerously-skip-permissions"
+    And I open the command palette
+    Then palette item "Recent agents" should be visible
+    When I select "Recent agents" in the palette
+    Then the palette breadcrumb should show "Recent agents"
+    And palette item "claude --dangerously-skip-permissions" should be visible
+    And there should be no page errors
+
+  Scenario: Prompt flag values are stripped before storage
+    When I run "claude --model sonnet -p mysecret"
+    And I open the command palette
+    And I select "Recent agents" in the palette
+    Then palette item "claude --model sonnet" should be visible
+    And there should be no page errors
+
+  Scenario: "Recent agents" is hidden when no agents have been run
+    When I open the command palette
+    Then palette item "Recent agents" should not be visible
+    And there should be no page errors
+
+  Scenario: Non-agent commands do not pollute the list
+    When I run "ls /tmp"
+    And I open the command palette
+    Then palette item "Recent agents" should not be visible
+    And there should be no page errors

--- a/tests/features/worktree-agent.feature
+++ b/tests/features/worktree-agent.feature
@@ -1,0 +1,54 @@
+Feature: Agent-aware worktree creation
+  When creating a worktree from the command palette, the user can pick
+  what runs in it — Plain shell or any agent CLI they've recently run.
+  Selecting an agent creates the worktree AND writes the command to the
+  new terminal's input so the agent starts immediately.
+
+  The sub-palette only appears when the user has at least one known
+  agent in their recent-agents MRU. With no agents, picking a recent
+  repo behaves exactly like the pre-phase-2 flow (flat leaf → plain
+  shell worktree) — first-run UX is unchanged.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Agent sub-palette appears under a recent repo when agents exist
+    # `claude` is not installed in the test env, but the preexec hook
+    # fires BEFORE execution — the OSC 633;E mark is emitted regardless
+    # of whether the command runs successfully.
+    When I set up a git repo at "/tmp/kolu-wt-agent-pick"
+    And I run "cd /tmp/kolu-wt-agent-pick"
+    And I run "claude --dangerously-skip-permissions"
+    And I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-agent-pick" in the palette
+    Then palette item "Plain shell" should be visible
+    And palette item "claude --dangerously-skip-permissions" should be visible
+    And there should be no page errors
+
+  Scenario: Picking an agent creates the worktree and writes the command
+    When I set up a git repo at "/tmp/kolu-wt-agent-run"
+    And I run "cd /tmp/kolu-wt-agent-run"
+    And I run "claude --dangerously-skip-permissions"
+    And I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-agent-run" in the palette
+    And I select "claude --dangerously-skip-permissions" in the palette
+    Then the header CWD should show ".worktrees/"
+    And the sidebar should show a worktree indicator
+    # The new terminal is active; its buffer contains the agent command
+    # (echoed by the shell at the first prompt after rc init settles).
+    And the screen state should contain "claude --dangerously-skip-permissions"
+    And there should be no page errors
+
+  Scenario: Picking Plain shell creates a plain worktree terminal
+    When I set up a git repo at "/tmp/kolu-wt-agent-plain"
+    And I run "cd /tmp/kolu-wt-agent-plain"
+    And I run "claude --dangerously-skip-permissions"
+    And I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-agent-plain" in the palette
+    And I select "Plain shell" in the palette
+    Then the header CWD should show ".worktrees/"
+    And the sidebar should show a worktree indicator
+    And there should be no page errors

--- a/tests/step_definitions/command_palette_steps.ts
+++ b/tests/step_definitions/command_palette_steps.ts
@@ -204,22 +204,6 @@ Then(
 );
 
 Then(
-  "palette item {string} should not be visible",
-  async function (this: KoluWorld, text: string) {
-    const palette = this.page.locator(PALETTE_SELECTOR);
-    const item = palette
-      .locator("li")
-      .filter({ hasText: new RegExp(`^${text}`) });
-    const count = await item.count();
-    assert.strictEqual(
-      count,
-      0,
-      `Expected no palette item matching ${JSON.stringify(text)}, got ${count}`,
-    );
-  },
-);
-
-Then(
   "palette hint {string} should be visible",
   async function (this: KoluWorld, text: string) {
     const hint = this.page.locator(

--- a/tests/step_definitions/command_palette_steps.ts
+++ b/tests/step_definitions/command_palette_steps.ts
@@ -204,6 +204,22 @@ Then(
 );
 
 Then(
+  "palette item {string} should not be visible",
+  async function (this: KoluWorld, text: string) {
+    const palette = this.page.locator(PALETTE_SELECTOR);
+    const item = palette
+      .locator("li")
+      .filter({ hasText: new RegExp(`^${text}`) });
+    const count = await item.count();
+    assert.strictEqual(
+      count,
+      0,
+      `Expected no palette item matching ${JSON.stringify(text)}, got ${count}`,
+    );
+  },
+);
+
+Then(
   "palette hint {string} should be visible",
   async function (this: KoluWorld, text: string) {
     const hint = this.page.locator(

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -14,6 +14,7 @@ import { chromium } from "playwright";
 import type { Browser } from "playwright";
 import getPort from "get-port";
 import { KoluWorld } from "./world.ts";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
@@ -22,6 +23,13 @@ import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 
 const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0");
+
+/** Per-run unique tag used for state isolation across parallel worktrees
+ *  on the same host. A pid alone isn't enough — pids recycle, and two
+ *  back-to-back runs can reuse the same pid within a second. A UUID
+ *  generated once at module load is unique per test-process instance
+ *  and never collides with anything else on disk. */
+const runTag = crypto.randomUUID();
 
 /** Per-worker temp dirs for the Claude Code mock harness — see
  *  `claude_code_steps.ts`. Sharing one dir across all eight cucumber
@@ -152,7 +160,14 @@ BeforeAll(async function () {
         stdio: "pipe",
         env: {
           ...process.env,
-          KOLU_STATE_SUFFIX: `test-${workerId}`,
+          // Use a per-run UUID tag so parallel test runs across different
+          // worktrees don't collide on ~/.config/kolu-test-.../config.json.
+          // Cucumber worker IDs are 0/1/2/3 per process — identical across
+          // worktrees — so two e2e runs on the same host would otherwise
+          // trample each other's state mid-scenario. pid alone isn't
+          // enough: pids recycle and back-to-back runs can reuse them.
+          // A UUID generated once at module load is collision-free.
+          KOLU_STATE_SUFFIX: `test-${runTag}-${workerId}`,
           KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
           KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
         },

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -200,6 +200,7 @@ Before(async function (this: KoluWorld, scenario) {
       json: {
         session: null,
         recentRepos: [],
+        recentAgents: [],
         // Reset all preferences to defaults (randomTheme off for deterministic tests)
         preferences: {
           seenTips: [],


### PR DESCRIPTION
**Kolu now notices which agent CLIs you run and threads them into the command palette in two places.** Under *Debug → Recent agents*, picking an entry prefills it into the active terminal without pressing Enter — you review, edit, and run it yourself. Under *New terminal → `<recent repo>`*, a new sub-palette appears (Plain shell + recent agents); picking an agent creates the worktree **and** writes the command into the new terminal so the agent starts immediately. With zero agents in the MRU, both surfaces collapse back to today's flat behavior — first-run UX is unchanged.

Detection rides on kolu's existing shell-integration pipeline. The preexec hook that already emits OSC 2 for title updates now also emits `OSC 633 ; E ; <command>` — VS Code's semantic "exact command line" mark. A new handler in `pty.ts` reads it; a pure normalizer in `agent-cli.ts` strips prompt flags (`-p`/`--prompt`/`-m`/`--message`) together with their values so `claude -p "my secret prompt"` collapses to `claude`, and the canonical form lands in a bounded MRU persisted alongside recent repos. *No `/proc`, no `ps` spawning, no foreground-pid argv retrieval — the shell hands us the exact string as typed, so detection works identically on Linux and macOS.*

Recognized out of the box: `claude`, `opencode`, `aider`, `codex`, `goose`, `gemini`, `cursor-agent`. Adding another is a one-line change to `KNOWN_AGENTS` — no adapter, no registry. *Prompt/message flag values are stripped before storage, so ephemeral prompt text never lands in `~/.config/kolu/state.json`.*

The worktree-picker uses a plain `client.terminal.sendInput` right after `handleCreate` returns the new terminal ID. PTY input is buffered, so the shell reads `<command>\r` at its first prompt once rc initialization settles — works reliably in practice, with a documented escape hatch in `useWorktreeOps.ts` for the NixOS slow-rc edge case if it ever surfaces.

Closes [#452](https://github.com/juspay/kolu/issues/452).

> Schema bump: `PersistedState` gains a `recentAgents` field. Migration 1.5.0 sets the default empty array; existing state files upgrade in place with no user action required.