### PR TITLE
Add PWA install top bar for browser users

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import {
 import { Title } from "@solidjs/meta";
 import { Toaster } from "solid-sonner";
 import Header from "./Header";
+import PwaInstallBar from "./PwaInstallBar";
 import Sidebar from "./Sidebar";
 import TerminalPane from "./TerminalPane";
 import MobileKeyBar from "./MobileKeyBar";
@@ -318,6 +319,7 @@ const App: Component = () => {
           if (target) void worktree.handleKillWorktree(target.id);
         }}
       />
+      <PwaInstallBar />
       <Header
         status={wsStatus()}
         onOpenPalette={() => openPalette()}

--- a/client/src/ClaudeTranscriptDialog.tsx
+++ b/client/src/ClaudeTranscriptDialog.tsx
@@ -31,6 +31,7 @@ const ClaudeTranscriptDialog: Component<{
       <Dialog.Content
         data-testid="claude-transcript"
         class="w-[min(95vw,1200px)] h-[80vh] bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 flex flex-col overflow-hidden"
+        style={{ "background-color": "var(--color-surface-1)" }}
       >
         <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">
           Claude transcript (server's view vs disk)

--- a/client/src/CloseConfirm.tsx
+++ b/client/src/CloseConfirm.tsx
@@ -37,6 +37,7 @@ const CloseConfirm: Component<{
       <Dialog.Content
         class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 max-w-sm text-sm space-y-4"
         data-testid="close-confirm"
+        style={{ "background-color": "var(--color-surface-1)" }}
       >
         <Dialog.Label class="font-semibold text-fg">
           <Show

--- a/client/src/CommandPalette.tsx
+++ b/client/src/CommandPalette.tsx
@@ -262,7 +262,13 @@ const CommandPalette: Component<{
         forceMount
         data-testid="command-palette"
         class="w-md bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
-        style={{ height: "24rem" }}
+        style={{
+          height: "24rem",
+          // Firefox workaround: bg-surface-1 utility intermittently fails
+          // to apply to Corvu-portalled dialog content, leaving it
+          // transparent. Inline style guarantees the background paints.
+          "background-color": "var(--color-surface-1)",
+        }}
       >
         {/* Breadcrumb — visible when drilled into a group */}
         <Show when={path().length > 0}>

--- a/client/src/EmptyState.tsx
+++ b/client/src/EmptyState.tsx
@@ -5,8 +5,6 @@ import type { SavedSession } from "kolu-common";
 import { SHORTCUTS, formatKeybind } from "./keyboard";
 import Kbd from "./Kbd";
 
-const isPWA = window.matchMedia("(display-mode: standalone)").matches;
-
 const features = [
   { label: "New terminal", shortcut: SHORTCUTS.createTerminalAlt.keybind },
   { label: "Command palette", shortcut: SHORTCUTS.commandPalette.keybind },
@@ -78,12 +76,6 @@ const EmptyState: Component<EmptyStateProps> = (props) => (
           )}
         </For>
       </div>
-      <Show when={!isPWA}>
-        <p class="mt-4 pt-3 border-t border-edge text-xs text-fg-3">
-          💡 Install as PWA for full shortcut support (<Kbd>⌘T</Kbd>,{" "}
-          <Kbd>⌃Tab</Kbd>, etc.)
-        </p>
-      </Show>
     </div>
   </div>
 );

--- a/client/src/PwaInstallBar.tsx
+++ b/client/src/PwaInstallBar.tsx
@@ -115,30 +115,40 @@ const PwaInstallBar: Component = () => {
 
   return (
     <Show when={!isPWA && !installed() && !dismissed()}>
-      {/* Styled as a browser-level notification, not Kolu chrome: uses the
-       *  accent color for the whole bar so it visually detaches from the
-       *  Header (bg-surface-1) sitting directly below. */}
+      {/* Overt browser-level notification: accent background, taller than
+       *  the Header, larger text, and a pulsing download glyph to pull the
+       *  eye. Deliberately loud — the goal is to catch attention, not blend. */}
       <div
         data-testid="pwa-install-bar"
-        class="flex items-center gap-2 h-9 shrink-0 px-3 sm:px-4 bg-accent text-surface-0 border-b border-black/20 text-xs font-medium shadow-sm"
+        class="flex items-center gap-3 min-h-12 shrink-0 px-4 sm:px-6 py-2 bg-accent text-surface-0 border-b-2 border-black/30 text-sm font-semibold shadow-lg"
       >
-        <span class="flex-1 min-w-0 truncate">
-          Install Kolu as an app
-          <Show when={!installEvent()}> — {INSTRUCTIONS[browser]}</Show>
+        <span class="shrink-0 text-lg animate-bounce" aria-hidden="true">
+          ⬇
+        </span>
+        <span class="flex-1 min-w-0">
+          <span class="uppercase tracking-wide text-xs font-bold opacity-80">
+            Install Kolu
+          </span>
+          <span class="block truncate">
+            <Show when={installEvent()} fallback={INSTRUCTIONS[browser]}>
+              Get the full experience with native keyboard shortcuts and offline
+              support.
+            </Show>
+          </span>
         </span>
         <Show when={installEvent()}>
           <button
             data-testid="pwa-install-button"
-            class="shrink-0 px-2.5 py-0.5 rounded-md bg-surface-0 text-accent font-semibold hover:brightness-110 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50"
+            class="shrink-0 px-4 py-1.5 rounded-md bg-surface-0 text-accent font-bold text-sm hover:brightness-110 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50 ring-1 ring-black/20"
             onClick={() => void handleInstall()}
           >
-            Install
+            Install app
           </button>
         </Show>
         <button
           data-testid="pwa-install-dismiss"
           aria-label="Dismiss install prompt"
-          class="shrink-0 p-1 text-surface-0/70 hover:text-surface-0 hover:bg-black/10 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50"
+          class="shrink-0 p-1.5 text-surface-0/70 hover:text-surface-0 hover:bg-black/15 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50"
           onClick={() => setDismissed(true)}
         >
           <CloseIcon />

--- a/client/src/PwaInstallBar.tsx
+++ b/client/src/PwaInstallBar.tsx
@@ -131,8 +131,8 @@ const PwaInstallBar: Component = () => {
           </span>
           <span class="block truncate">
             <Show when={installEvent()} fallback={INSTRUCTIONS[browser]}>
-              Get the full experience with native keyboard shortcuts and offline
-              support.
+              Unlock native keyboard shortcuts (⌘T, ⌃Tab, …) and a dedicated
+              app window.
             </Show>
           </span>
         </span>

--- a/client/src/PwaInstallBar.tsx
+++ b/client/src/PwaInstallBar.tsx
@@ -77,6 +77,13 @@ function detectBrowser(ua: string): BrowserHint {
 
 const isPWA = window.matchMedia("(display-mode: standalone)").matches;
 
+/** Fixed palette — deliberately not the app theme. See component comment. */
+const BG = "#0a0a0f";
+const FG = "#e5e5e7";
+const DIM = "#6b7280";
+const GREEN = "#32d583";
+const BORDER = "rgba(50, 213, 131, 0.3)";
+
 const PwaInstallBar: Component = () => {
   const [dismissed, setDismissed] = createSignal(false);
   const [installEvent, setInstallEvent] =
@@ -115,38 +122,51 @@ const PwaInstallBar: Component = () => {
   return (
     <Show when={!isPWA && !installed() && !dismissed()}>
       {/* TUI status-line aesthetic: monospace, fixed dark palette, terminal
-       *  green accent. Intentionally uses hard-coded hex colors (not the
-       *  app's CSS vars) because the bar is *not* part of the app — it's
-       *  meta-chrome above it. This also sidesteps any theme-resolution
-       *  oddities across browsers. */}
+       *  green accent. Colors go through inline `style` (not Tailwind
+       *  arbitrary values) so the bar is immune to HMR cache staleness,
+       *  Tailwind content-scanning gaps, and browser extensions that
+       *  rewrite dark backgrounds. The bar is *not* part of the app —
+       *  it's meta-chrome above it — so deliberately skips the app theme. */}
       <div
         data-testid="pwa-install-bar"
-        class="flex items-center gap-2 min-h-10 shrink-0 px-4 sm:px-6 py-1.5 bg-[#0a0a0f] text-[#e5e5e7] border-b border-[#32d583]/30 font-mono text-xs"
-        style={{ "box-shadow": "0 1px 0 0 rgba(50, 213, 131, 0.12)" }}
+        class="flex items-center gap-2 min-h-10 shrink-0 px-4 sm:px-6 py-1.5 font-mono text-xs"
+        style={{
+          "background-color": BG,
+          color: FG,
+          "border-bottom": `1px solid ${BORDER}`,
+          "box-shadow": "0 1px 0 0 rgba(50, 213, 131, 0.12)",
+        }}
       >
-        <span class="text-[#32d583] shrink-0 select-none" aria-hidden="true">
+        <span
+          class="shrink-0 select-none"
+          style={{ color: GREEN }}
+          aria-hidden="true"
+        >
           ▶
         </span>
         <span class="flex-1 min-w-0 truncate">
-          <span class="text-[#32d583] font-semibold">kolu</span>
-          <span class="text-[#6b7280]"> // </span>
+          <span class="font-semibold" style={{ color: GREEN }}>
+            kolu
+          </span>
+          <span style={{ color: DIM }}> // </span>
           <Show
             when={installEvent()}
             fallback={
-              <span class="text-[#e5e5e7]">{INSTRUCTIONS[browser]}</span>
+              <span style={{ color: FG }}>{INSTRUCTIONS[browser]}</span>
             }
           >
-            <span class="text-[#e5e5e7]">install as native app for </span>
-            <span class="text-[#32d583]">⌘T</span>
-            <span class="text-[#6b7280]">, </span>
-            <span class="text-[#32d583]">⌃Tab</span>
-            <span class="text-[#e5e5e7]"> and friends</span>
+            <span style={{ color: FG }}>install as native app for </span>
+            <span style={{ color: GREEN }}>⌘T</span>
+            <span style={{ color: DIM }}>, </span>
+            <span style={{ color: GREEN }}>⌃Tab</span>
+            <span style={{ color: FG }}> and friends</span>
           </Show>
         </span>
         <Show when={installEvent()}>
           <button
             data-testid="pwa-install-button"
-            class="shrink-0 px-2.5 py-0.5 bg-[#32d583] text-[#0a0a0f] font-bold uppercase tracking-wider text-[11px] hover:bg-[#5ce69f] transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#32d583]"
+            class="shrink-0 px-2.5 py-0.5 font-bold uppercase tracking-wider text-[11px] cursor-pointer focus-visible:outline-none"
+            style={{ "background-color": GREEN, color: BG }}
             onClick={() => void handleInstall()}
           >
             [install]
@@ -155,7 +175,8 @@ const PwaInstallBar: Component = () => {
         <button
           data-testid="pwa-install-dismiss"
           aria-label="Dismiss install prompt"
-          class="shrink-0 px-1 text-[#6b7280] hover:text-[#e5e5e7] transition-colors cursor-pointer focus-visible:outline-none focus-visible:text-[#e5e5e7]"
+          class="shrink-0 px-1 cursor-pointer focus-visible:outline-none"
+          style={{ color: DIM }}
           onClick={() => setDismissed(true)}
         >
           [×]

--- a/client/src/PwaInstallBar.tsx
+++ b/client/src/PwaInstallBar.tsx
@@ -22,7 +22,6 @@ import {
   onCleanup,
 } from "solid-js";
 import { toast } from "solid-sonner";
-import { CloseIcon } from "./Icons";
 
 /**
  * Subset of Chromium's non-standard BeforeInstallPromptEvent we actually use.
@@ -115,46 +114,51 @@ const PwaInstallBar: Component = () => {
 
   return (
     <Show when={!isPWA && !installed() && !dismissed()}>
-      {/* Overt browser-level notification: accent background, taller than
-       *  the Header, larger text. The animated arrow next to the Install
-       *  button leads the eye directly to the CTA. */}
+      {/* TUI status-line aesthetic: monospace, fixed dark palette, terminal
+       *  green accent. Intentionally uses hard-coded hex colors (not the
+       *  app's CSS vars) because the bar is *not* part of the app — it's
+       *  meta-chrome above it. This also sidesteps any theme-resolution
+       *  oddities across browsers. */}
       <div
         data-testid="pwa-install-bar"
-        class="flex items-center gap-3 min-h-12 shrink-0 px-4 sm:px-6 py-2 bg-accent text-surface-0 border-b-2 border-black/30 text-sm font-semibold shadow-lg"
+        class="flex items-center gap-2 min-h-10 shrink-0 px-4 sm:px-6 py-1.5 bg-[#0a0a0f] text-[#e5e5e7] border-b border-[#32d583]/30 font-mono text-xs"
+        style={{ "box-shadow": "0 1px 0 0 rgba(50, 213, 131, 0.12)" }}
       >
-        <span class="flex-1 min-w-0">
-          <span class="uppercase tracking-wide text-xs font-bold opacity-80">
-            Install Kolu
-          </span>
-          <span class="block truncate">
-            <Show when={installEvent()} fallback={INSTRUCTIONS[browser]}>
-              Unlock native keyboard shortcuts (⌘T, ⌃Tab, …) and a dedicated
-              app window.
-            </Show>
-          </span>
+        <span class="text-[#32d583] shrink-0 select-none" aria-hidden="true">
+          ▶
+        </span>
+        <span class="flex-1 min-w-0 truncate">
+          <span class="text-[#32d583] font-semibold">kolu</span>
+          <span class="text-[#6b7280]"> // </span>
+          <Show
+            when={installEvent()}
+            fallback={
+              <span class="text-[#e5e5e7]">{INSTRUCTIONS[browser]}</span>
+            }
+          >
+            <span class="text-[#e5e5e7]">install as native app for </span>
+            <span class="text-[#32d583]">⌘T</span>
+            <span class="text-[#6b7280]">, </span>
+            <span class="text-[#32d583]">⌃Tab</span>
+            <span class="text-[#e5e5e7]"> and friends</span>
+          </Show>
         </span>
         <Show when={installEvent()}>
-          <span
-            class="shrink-0 text-lg animate-pulse hidden sm:inline"
-            aria-hidden="true"
-          >
-            →
-          </span>
           <button
             data-testid="pwa-install-button"
-            class="shrink-0 px-4 py-1.5 rounded-md bg-surface-0 text-accent font-bold text-sm hover:brightness-110 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50 ring-1 ring-black/20"
+            class="shrink-0 px-2.5 py-0.5 bg-[#32d583] text-[#0a0a0f] font-bold uppercase tracking-wider text-[11px] hover:bg-[#5ce69f] transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#32d583]"
             onClick={() => void handleInstall()}
           >
-            Install app
+            [install]
           </button>
         </Show>
         <button
           data-testid="pwa-install-dismiss"
           aria-label="Dismiss install prompt"
-          class="shrink-0 p-1.5 text-surface-0/70 hover:text-surface-0 hover:bg-black/15 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50"
+          class="shrink-0 px-1 text-[#6b7280] hover:text-[#e5e5e7] transition-colors cursor-pointer focus-visible:outline-none focus-visible:text-[#e5e5e7]"
           onClick={() => setDismissed(true)}
         >
-          <CloseIcon />
+          [×]
         </button>
       </div>
     </Show>

--- a/client/src/PwaInstallBar.tsx
+++ b/client/src/PwaInstallBar.tsx
@@ -116,15 +116,12 @@ const PwaInstallBar: Component = () => {
   return (
     <Show when={!isPWA && !installed() && !dismissed()}>
       {/* Overt browser-level notification: accent background, taller than
-       *  the Header, larger text, and a pulsing download glyph to pull the
-       *  eye. Deliberately loud — the goal is to catch attention, not blend. */}
+       *  the Header, larger text. The animated arrow next to the Install
+       *  button leads the eye directly to the CTA. */}
       <div
         data-testid="pwa-install-bar"
         class="flex items-center gap-3 min-h-12 shrink-0 px-4 sm:px-6 py-2 bg-accent text-surface-0 border-b-2 border-black/30 text-sm font-semibold shadow-lg"
       >
-        <span class="shrink-0 text-lg animate-bounce" aria-hidden="true">
-          ⬇
-        </span>
         <span class="flex-1 min-w-0">
           <span class="uppercase tracking-wide text-xs font-bold opacity-80">
             Install Kolu
@@ -137,6 +134,12 @@ const PwaInstallBar: Component = () => {
           </span>
         </span>
         <Show when={installEvent()}>
+          <span
+            class="shrink-0 text-lg animate-pulse hidden sm:inline"
+            aria-hidden="true"
+          >
+            →
+          </span>
           <button
             data-testid="pwa-install-button"
             class="shrink-0 px-4 py-1.5 rounded-md bg-surface-0 text-accent font-bold text-sm hover:brightness-110 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50 ring-1 ring-black/20"

--- a/client/src/PwaInstallBar.tsx
+++ b/client/src/PwaInstallBar.tsx
@@ -115,19 +115,21 @@ const PwaInstallBar: Component = () => {
 
   return (
     <Show when={!isPWA && !installed() && !dismissed()}>
+      {/* Styled as a browser-level notification, not Kolu chrome: uses the
+       *  accent color for the whole bar so it visually detaches from the
+       *  Header (bg-surface-1) sitting directly below. */}
       <div
         data-testid="pwa-install-bar"
-        class="flex items-center gap-2 h-9 shrink-0 px-3 sm:px-4 bg-surface-2 border-b border-edge text-xs"
+        class="flex items-center gap-2 h-9 shrink-0 px-3 sm:px-4 bg-accent text-surface-0 border-b border-black/20 text-xs font-medium shadow-sm"
       >
-        <span class="text-fg-2 shrink-0">📱</span>
-        <span class="flex-1 min-w-0 truncate text-fg">
+        <span class="flex-1 min-w-0 truncate">
           Install Kolu as an app
           <Show when={!installEvent()}> — {INSTRUCTIONS[browser]}</Show>
         </span>
         <Show when={installEvent()}>
           <button
             data-testid="pwa-install-button"
-            class="shrink-0 px-2 py-1 rounded-md bg-accent text-surface-0 font-medium hover:brightness-110 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+            class="shrink-0 px-2.5 py-0.5 rounded-md bg-surface-0 text-accent font-semibold hover:brightness-110 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50"
             onClick={() => void handleInstall()}
           >
             Install
@@ -136,7 +138,7 @@ const PwaInstallBar: Component = () => {
         <button
           data-testid="pwa-install-dismiss"
           aria-label="Dismiss install prompt"
-          class="shrink-0 p-1 text-fg-2 hover:text-fg hover:bg-surface-3 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+          class="shrink-0 p-1 text-surface-0/70 hover:text-surface-0 hover:bg-black/10 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-surface-0/50"
           onClick={() => setDismissed(true)}
         >
           <CloseIcon />

--- a/client/src/PwaInstallBar.tsx
+++ b/client/src/PwaInstallBar.tsx
@@ -1,0 +1,149 @@
+/**
+ * Top bar nudging browser users to install Kolu as a PWA.
+ *
+ * Visible when:
+ *  - Not already running as an installed PWA (display-mode != standalone), AND
+ *  - User hasn't dismissed the bar this session.
+ *
+ * Dismissal is intentionally session-only — the bar reappears on each page
+ * load. If Chrome's `beforeinstallprompt` fires, we stash it and render a
+ * one-click Install button; otherwise we show browser-specific instructions.
+ *
+ * We deliberately do NOT call `event.preventDefault()` — on desktop it has no
+ * effect anyway, and on mobile letting the browser's own mini-infobar also
+ * show is acceptable (users can take either path).
+ */
+
+import {
+  type Component,
+  Show,
+  createSignal,
+  onMount,
+  onCleanup,
+} from "solid-js";
+import { toast } from "solid-sonner";
+import { CloseIcon } from "./Icons";
+
+/**
+ * Subset of Chromium's non-standard BeforeInstallPromptEvent we actually use.
+ * Not in lib.dom.d.ts yet.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+/**
+ * Module-scope capture of `beforeinstallprompt`. The event can fire before
+ * SolidJS hydrates and mounts this component, so we listen from module-load
+ * time and stash the event. The component reads it on mount.
+ */
+let earlyInstallEvent: BeforeInstallPromptEvent | null = null;
+const earlyListeners = new Set<(e: BeforeInstallPromptEvent) => void>();
+window.addEventListener("beforeinstallprompt", (e) => {
+  const evt = e as unknown as BeforeInstallPromptEvent;
+  earlyInstallEvent = evt;
+  for (const fn of earlyListeners) fn(evt);
+});
+
+type BrowserHint =
+  | "ios-safari"
+  | "macos-safari"
+  | "firefox-desktop"
+  | "firefox-android"
+  | "other";
+
+/** Per-browser manual install instructions. Pure lookup table — exhaustive via Record. */
+const INSTRUCTIONS: Record<BrowserHint, string> = {
+  "ios-safari": "Tap the Share button, then 'Add to Home Screen'.",
+  "macos-safari": "Choose File → Add to Dock from the menu bar.",
+  "firefox-desktop":
+    "Firefox doesn't support installing web apps. For the full experience, open Kolu in Chrome or Edge.",
+  "firefox-android": "Open the menu (⋮) and tap 'Install'.",
+  other: "Look for 'Install app' in your browser menu.",
+};
+
+/** UA-based browser identification. Feature detection can't answer "which menu", so sniff. */
+function detectBrowser(ua: string): BrowserHint {
+  // iOS Safari (and all iOS browsers — they use the same Share → Add to Home Screen flow).
+  if (/iPad|iPhone|iPod/.test(ua)) return "ios-safari";
+  // Android Firefox must be checked before desktop Firefox.
+  if (/Android.*Firefox/.test(ua)) return "firefox-android";
+  if (/Firefox/.test(ua)) return "firefox-desktop";
+  // macOS Safari: contains "Safari" but not "Chrome"/"Chromium".
+  if (/Macintosh/.test(ua) && /Safari/.test(ua) && !/Chrome|Chromium/.test(ua))
+    return "macos-safari";
+  return "other";
+}
+
+const isPWA = window.matchMedia("(display-mode: standalone)").matches;
+
+const PwaInstallBar: Component = () => {
+  const [dismissed, setDismissed] = createSignal(false);
+  const [installEvent, setInstallEvent] =
+    createSignal<BeforeInstallPromptEvent | null>(earlyInstallEvent);
+  const [installed, setInstalled] = createSignal(false);
+
+  // Subscribe to late-firing beforeinstallprompt events (the early listener
+  // runs at module load; this covers events that fire after mount).
+  const lateListener = (evt: BeforeInstallPromptEvent) => setInstallEvent(evt);
+  earlyListeners.add(lateListener);
+  onCleanup(() => earlyListeners.delete(lateListener));
+
+  // If the user installs mid-session (via our button or the browser's own UI),
+  // hide the bar immediately.
+  const onAppInstalled = () => setInstalled(true);
+  onMount(() => window.addEventListener("appinstalled", onAppInstalled));
+  onCleanup(() => window.removeEventListener("appinstalled", onAppInstalled));
+
+  const browser = detectBrowser(navigator.userAgent);
+
+  const handleInstall = async () => {
+    const evt = installEvent();
+    if (!evt) return;
+    try {
+      await evt.prompt();
+    } catch (err) {
+      toast.error(
+        `Install failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      // A prompt can only be used once; drop the reference regardless of outcome.
+      setInstallEvent(null);
+    }
+  };
+
+  return (
+    <Show when={!isPWA && !installed() && !dismissed()}>
+      <div
+        data-testid="pwa-install-bar"
+        class="flex items-center gap-2 h-9 shrink-0 px-3 sm:px-4 bg-surface-2 border-b border-edge text-xs"
+      >
+        <span class="text-fg-2 shrink-0">📱</span>
+        <span class="flex-1 min-w-0 truncate text-fg">
+          Install Kolu as an app
+          <Show when={!installEvent()}> — {INSTRUCTIONS[browser]}</Show>
+        </span>
+        <Show when={installEvent()}>
+          <button
+            data-testid="pwa-install-button"
+            class="shrink-0 px-2 py-1 rounded-md bg-accent text-surface-0 font-medium hover:brightness-110 transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+            onClick={() => void handleInstall()}
+          >
+            Install
+          </button>
+        </Show>
+        <button
+          data-testid="pwa-install-dismiss"
+          aria-label="Dismiss install prompt"
+          class="shrink-0 p-1 text-fg-2 hover:text-fg hover:bg-surface-3 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+          onClick={() => setDismissed(true)}
+        >
+          <CloseIcon />
+        </button>
+      </div>
+    </Show>
+  );
+};
+
+export default PwaInstallBar;

--- a/client/src/SettingsPopover.tsx
+++ b/client/src/SettingsPopover.tsx
@@ -80,7 +80,11 @@ const SettingsPopover: Component<{
           }}
           data-testid="settings-popover"
           class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[200px] space-y-3"
-          style={{ top: `${pos().top}px`, right: `${pos().right}px` }}
+          style={{
+            top: `${pos().top}px`,
+            right: `${pos().right}px`,
+            "background-color": "var(--color-surface-1)",
+          }}
         >
           {/* Color scheme */}
           <div class="flex items-center justify-between gap-3 text-sm">

--- a/client/src/ShortcutsHelp.tsx
+++ b/client/src/ShortcutsHelp.tsx
@@ -40,6 +40,7 @@ const ShortcutsHelp: Component<{
     <Dialog.Content
       data-testid="shortcuts-help"
       class="w-full max-w-sm bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden"
+      style={{ "background-color": "var(--color-surface-1)" }}
     >
       <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">
         Keyboard Shortcuts

--- a/client/src/tips.ts
+++ b/client/src/tips.ts
@@ -32,17 +32,7 @@ export const CONTEXTUAL_TIPS = {
   },
 } as const satisfies Record<string, Tip>;
 
-const isPWA = window.matchMedia("(display-mode: standalone)").matches;
-
 export const AMBIENT_TIPS: readonly Tip[] = [
-  ...(!isPWA
-    ? [
-        {
-          id: "amb-pwa",
-          text: "Install as PWA for full shortcut support (⌘T, ⌃Tab, etc.)",
-        },
-      ]
-    : []),
   {
     id: "amb-sub",
     text: `${formatKeybind(SHORTCUTS.toggleSubPanel.keybind)} splits your terminal into a bottom pane`,

--- a/tests/features/pwa_install_bar.feature
+++ b/tests/features/pwa_install_bar.feature
@@ -1,0 +1,24 @@
+Feature: PWA install bar
+  A dismissible top bar nudges browser users to install Kolu as a PWA.
+  The bar only appears when not already running as an installed PWA.
+  Dismissal is session-only — the bar reappears on each page load.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Install bar is visible in the browser
+    Then the PWA install bar should be visible
+    And there should be no page errors
+
+  Scenario: Dismissing the bar hides it for the session
+    Then the PWA install bar should be visible
+    When I dismiss the PWA install bar
+    Then the PWA install bar should not be visible
+    And there should be no page errors
+
+  Scenario: Install button appears when browser fires beforeinstallprompt
+    Given the browser fires beforeinstallprompt
+    Then the PWA install button should be visible
+    When I click the PWA install button
+    Then the browser install prompt should have been invoked
+    And there should be no page errors

--- a/tests/step_definitions/pwa_install_bar_steps.ts
+++ b/tests/step_definitions/pwa_install_bar_steps.ts
@@ -1,0 +1,80 @@
+import { Given, When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import * as assert from "node:assert";
+
+Then("the PWA install bar should be visible", async function (this: KoluWorld) {
+  const bar = this.page.locator('[data-testid="pwa-install-bar"]');
+  await bar.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+});
+
+Then(
+  "the PWA install bar should not be visible",
+  async function (this: KoluWorld) {
+    const bar = this.page.locator('[data-testid="pwa-install-bar"]');
+    await bar.waitFor({ state: "hidden", timeout: POLL_TIMEOUT });
+  },
+);
+
+When("I dismiss the PWA install bar", async function (this: KoluWorld) {
+  await this.page.locator('[data-testid="pwa-install-dismiss"]').click();
+});
+
+Given(
+  "the browser fires beforeinstallprompt",
+  async function (this: KoluWorld) {
+    // Chromium in Playwright doesn't fire beforeinstallprompt automatically,
+    // so we synthesize a minimal event that the component can stash and later
+    // call .prompt() on. A window-level flag records that .prompt() was called.
+    await this.page.evaluate(() => {
+      interface BipWindow extends Window {
+        __bipPromptCalled?: boolean;
+      }
+      const w = window as BipWindow;
+      w.__bipPromptCalled = false;
+      const evt = new Event("beforeinstallprompt") as Event & {
+        prompt?: () => Promise<void>;
+        userChoice?: Promise<{ outcome: "accepted" | "dismissed" }>;
+      };
+      evt.prompt = () => {
+        w.__bipPromptCalled = true;
+        return Promise.resolve();
+      };
+      evt.userChoice = Promise.resolve({ outcome: "accepted" as const });
+      window.dispatchEvent(evt);
+    });
+  },
+);
+
+Then(
+  "the PWA install button should be visible",
+  async function (this: KoluWorld) {
+    const button = this.page.locator('[data-testid="pwa-install-button"]');
+    await button.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+When("I click the PWA install button", async function (this: KoluWorld) {
+  await this.page.locator('[data-testid="pwa-install-button"]').click();
+});
+
+Then(
+  "the browser install prompt should have been invoked",
+  async function (this: KoluWorld) {
+    await this.page.waitForFunction(
+      () =>
+        (window as Window & { __bipPromptCalled?: boolean })
+          .__bipPromptCalled === true,
+      undefined,
+      { timeout: POLL_TIMEOUT },
+    );
+    const called = await this.page.evaluate(
+      () =>
+        (window as Window & { __bipPromptCalled?: boolean }).__bipPromptCalled,
+    );
+    assert.strictEqual(
+      called,
+      true,
+      "expected event.prompt() to have been called",
+    );
+  },
+);


### PR DESCRIPTION
**Kolu now nudges browser users toward installing it as a PWA** with a thin dismissible bar above the header. When Chrome's `beforeinstallprompt` event fires, the bar renders a one-click **Install** button that triggers the native install dialog; on browsers without programmatic install (Safari, Firefox), it falls back to browser-specific instructions.

Dismissal is session-only — the bar reappears on each page load, by design. *The existing ambient "Install as PWA" tip is removed to avoid nagging users in two places.*

Firefox desktop gets an honest message ("Firefox doesn't support installing web apps — open Kolu in Chrome or Edge") rather than silence. iOS Safari, macOS Safari, Firefox Android, and a generic fallback each get their own instruction text.

### Try it locally

```sh
nix run github:juspay/kolu/pretty-party
```