### PR TITLE
feat(palette): pick an agent when creating a worktree

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -187,8 +187,8 @@ const App: Component = () => {
     handleRandomizeTheme,
     setShortcutsHelpOpen,
     setAboutOpen,
-    handleCreateWorktree: (repoPath) =>
-      void worktree.handleCreateWorktree(repoPath),
+    handleCreateWorktree: (repoPath, initialCommand) =>
+      void worktree.handleCreateWorktree(repoPath, initialCommand),
     handleClose: () => {
       const id = store.activeId();
       if (id) closeTerminal(id);

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -5,9 +5,36 @@ import type { Accessor } from "solid-js";
 import type { PaletteCommand, PaletteItem } from "./CommandPalette";
 import { SHORTCUTS } from "./keyboard";
 import { availableThemes } from "./theme";
-import type { TerminalId, TerminalMetadata } from "kolu-common";
+import type { TerminalId, TerminalMetadata, RecentAgent } from "kolu-common";
 import { useServerState } from "./useServerState";
 import { client } from "./rpc";
+
+/** PaletteItems listing each recent agent command. Used by the Debug →
+ *  "Recent agents" entry (phase 1 prefill flow). */
+function agentItems(
+  agents: RecentAgent[],
+  onPick: (command: string) => void,
+): PaletteItem[] {
+  return agents.map((a) => ({
+    name: a.command,
+    onSelect: () => onPick(a.command),
+  }));
+}
+
+/** PaletteItems for a "create fresh terminal, optionally with an agent"
+ *  flow. Prepends "Plain shell" to the agent list so the default (empty
+ *  worktree) stays the keyboard-flow default. Used by phase 2's
+ *  recent-repo sub-palette under "New terminal". */
+function agentItemsWithPlainShell(
+  agents: RecentAgent[],
+  onPickPlainShell: () => void,
+  onPickAgent: (command: string) => void,
+): PaletteItem[] {
+  return [
+    { name: "Plain shell", onSelect: onPickPlainShell },
+    ...agentItems(agents, onPickAgent),
+  ];
+}
 
 export interface CommandDeps {
   terminalIds: Accessor<TerminalId[]>;
@@ -30,7 +57,7 @@ export interface CommandDeps {
   setShortcutsHelpOpen: (open: boolean) => void;
   setAboutOpen: (open: boolean) => void;
   // Worktree
-  handleCreateWorktree: (repoPath: string) => void;
+  handleCreateWorktree: (repoPath: string, initialCommand?: string) => void;
   handleClose: () => void;
   // Debug
   simulateAlert: () => void;
@@ -46,16 +73,40 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       name: "New terminal",
       children: (): PaletteItem[] => {
         const repos = recentRepos();
+        // `hasAgents` decides leaf-vs-group shape at memo time; the nested
+        // `children` accessor re-reads `recentAgents()` live so the sub-
+        // palette reflects agent MRU changes between drilling into "New
+        // terminal" and drilling into a specific repo. Mirrors the pattern
+        // used by the Debug → "Recent agents" entry below.
+        const hasAgents = recentAgents().length > 0;
         return [
           {
             name: "In current directory",
             onSelect: () => deps.handleCreate(deps.activeMeta()?.cwd),
           },
-          ...repos.map((r) => ({
-            name: r.repoName,
-            description: `New worktree in ${r.repoRoot}`,
-            onSelect: () => deps.handleCreateWorktree(r.repoRoot),
-          })),
+          // Recent-repo entries. When the user has any known-agent CLI in
+          // their MRU, picking a repo opens a sub-palette (Plain shell +
+          // agents). With no recent agents, the entry stays a flat leaf
+          // that creates a plain-shell worktree — exact pre-phase-2
+          // behavior, so first-run UX is unchanged.
+          ...repos.map((r) =>
+            hasAgents
+              ? {
+                  name: r.repoName,
+                  description: `New worktree in ${r.repoRoot}`,
+                  children: (): PaletteItem[] =>
+                    agentItemsWithPlainShell(
+                      recentAgents(),
+                      () => deps.handleCreateWorktree(r.repoRoot),
+                      (cmd) => deps.handleCreateWorktree(r.repoRoot, cmd),
+                    ),
+                }
+              : {
+                  name: r.repoName,
+                  description: `New worktree in ${r.repoRoot}`,
+                  onSelect: () => deps.handleCreateWorktree(r.repoRoot),
+                },
+          ),
           ...(repos.length === 0
             ? [
                 {
@@ -176,10 +227,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
                 name: "Recent agents",
                 description: "Prefill an agent CLI into the active terminal",
                 children: (): PaletteItem[] =>
-                  recentAgents().map((a) => ({
-                    name: a.command,
-                    onSelect: () => deps.handleRunInActiveTerminal(a.command),
-                  })),
+                  agentItems(recentAgents(), deps.handleRunInActiveTerminal),
               },
             ]
           : []),

--- a/client/src/useWorktreeOps.ts
+++ b/client/src/useWorktreeOps.ts
@@ -12,13 +12,35 @@ export function useWorktreeOps(deps: {
 }) {
   const { store } = deps;
 
-  async function handleCreateWorktree(repoPath: string) {
+  async function handleCreateWorktree(
+    repoPath: string,
+    initialCommand?: string,
+  ) {
     const id = toast.loading("Creating worktree…");
     try {
       const result = await client.git.worktreeCreate({ repoPath });
       toast.success(`Created worktree at ${result.path}`, { id });
-      await deps.handleCreate(result.path);
+      const newTerminalId = await deps.handleCreate(result.path);
       // Recent repos update reactively via trackRecentRepo → publishSystem
+
+      // Optional initial command (phase 2 of #452): write the agent command
+      // to the new terminal's input so the agent starts immediately.
+      //
+      // PTY input is buffered: the shell reads `initialCommand\r` at its
+      // first prompt once rc initialization completes. Works reliably in
+      // practice, but has a latent race on slow-rc systems (NixOS with
+      // many sourced files) where init output can interleave with command
+      // echo. If that becomes visible in dogfooding, promote to a
+      // server-side createTerminal parameter gated on a shell-ready
+      // signal (OSC 133;A prompt mark) — a contract change deliberately
+      // deferred out of phase 2 scope.
+      if (initialCommand !== undefined) {
+        await client.terminal
+          .sendInput({ id: newTerminalId, data: `${initialCommand}\r` })
+          .catch((err: Error) =>
+            toast.error(`Failed to start agent: ${err.message}`),
+          );
+      }
     } catch (err) {
       toast.error(`Failed to create worktree: ${(err as Error).message}`, {
         id,

--- a/tests/features/worktree-agent.feature
+++ b/tests/features/worktree-agent.feature
@@ -1,0 +1,54 @@
+Feature: Agent-aware worktree creation
+  When creating a worktree from the command palette, the user can pick
+  what runs in it — Plain shell or any agent CLI they've recently run.
+  Selecting an agent creates the worktree AND writes the command to the
+  new terminal's input so the agent starts immediately.
+
+  The sub-palette only appears when the user has at least one known
+  agent in their recent-agents MRU. With no agents, picking a recent
+  repo behaves exactly like the pre-phase-2 flow (flat leaf → plain
+  shell worktree) — first-run UX is unchanged.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Agent sub-palette appears under a recent repo when agents exist
+    # `claude` is not installed in the test env, but the preexec hook
+    # fires BEFORE execution — the OSC 633;E mark is emitted regardless
+    # of whether the command runs successfully.
+    When I set up a git repo at "/tmp/kolu-wt-agent-pick"
+    And I run "cd /tmp/kolu-wt-agent-pick"
+    And I run "claude --dangerously-skip-permissions"
+    And I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-agent-pick" in the palette
+    Then palette item "Plain shell" should be visible
+    And palette item "claude --dangerously-skip-permissions" should be visible
+    And there should be no page errors
+
+  Scenario: Picking an agent creates the worktree and writes the command
+    When I set up a git repo at "/tmp/kolu-wt-agent-run"
+    And I run "cd /tmp/kolu-wt-agent-run"
+    And I run "claude --dangerously-skip-permissions"
+    And I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-agent-run" in the palette
+    And I select "claude --dangerously-skip-permissions" in the palette
+    Then the header CWD should show ".worktrees/"
+    And the sidebar should show a worktree indicator
+    # The new terminal is active; its buffer contains the agent command
+    # (echoed by the shell at the first prompt after rc init settles).
+    And the screen state should contain "claude --dangerously-skip-permissions"
+    And there should be no page errors
+
+  Scenario: Picking Plain shell creates a plain worktree terminal
+    When I set up a git repo at "/tmp/kolu-wt-agent-plain"
+    And I run "cd /tmp/kolu-wt-agent-plain"
+    And I run "claude --dangerously-skip-permissions"
+    And I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-agent-plain" in the palette
+    And I select "Plain shell" in the palette
+    Then the header CWD should show ".worktrees/"
+    And the sidebar should show a worktree indicator
+    And there should be no page errors


### PR DESCRIPTION
**Creating a worktree from Cmd+K now lets you choose what runs in it.** Drill into a recent repo and you get a sub-palette: `Plain shell` on top, followed by every agent CLI you've recently run in any kolu terminal. Pick `Plain shell` → today's behavior (empty worktree terminal). Pick an agent → the worktree is created and the chosen command is written to the new terminal's input, so the agent starts immediately.

The sub-palette only appears when [#454](https://github.com/juspay/kolu/pull/454)'s MRU has at least one agent. Fresh installs — and anyone who has never run a known agent binary — keep the current flat flow: pick a repo, get a plain-shell worktree. _No configuration, no adapter registry, no schema changes. The recent-agents list that phase 1 built is simply reused at a second call site._

The delivery mechanism is deliberately boring: after `handleCreateWorktree` awaits the new terminal ID, it calls `client.terminal.sendInput` with `<command>\r`. PTY input is buffered, so the shell reads it at its first prompt once rc initialization completes. _This has a latent race on slow-rc systems (e.g. NixOS with many sourced files) where init output may interleave with the command echo — if that becomes visible in dogfooding, the escape hatch is a server-side `initialCommand` parameter gated on an OSC 133;A prompt mark, which is a contract change we've deliberately deferred._

Stacked on top of [#454](https://github.com/juspay/kolu/pull/454) — that PR must merge first. Phase 2 of [#452](https://github.com/juspay/kolu/issues/452).

> The phase 1 "Recent agents under Debug" entry stays where it is. Phase 1 prefills into the active terminal; phase 2 creates a fresh worktree and runs. Two different user actions, two different surfaces.