### PR TITLE
Group server temp files under a per-instance UUID dir

### DIFF
--- a/server/src/clipboard.ts
+++ b/server/src/clipboard.ts
@@ -33,13 +33,15 @@ export function createClipboardDir(terminalId: string): string {
   return dir;
 }
 
-/** Save base64-encoded image data to the terminal's clipboard directory. */
+/** Save base64-encoded image data to the terminal's clipboard directory.
+ *  Returns the on-disk path so callers can log / reference it. */
 export function saveClipboardImage(
   clipboardDir: string,
   base64Data: string,
-): void {
+): string {
   const imagePath = join(clipboardDir, "image.png");
   writeFileSync(imagePath, Buffer.from(base64Data, "base64"));
+  return imagePath;
 }
 
 /** Remove a terminal's clipboard directory. */

--- a/server/src/clipboard.ts
+++ b/server/src/clipboard.ts
@@ -13,7 +13,7 @@
 
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { koluClipboardDir } from "./koluRoot.ts";
 
 /** Clipboard shim bin directory — required, crashes on startup if missing. */
 export const CLIPBOARD_SHIM_DIR = (() => {
@@ -26,9 +26,9 @@ export const CLIPBOARD_SHIM_DIR = (() => {
   return dir;
 })();
 
-/** Create a per-terminal clipboard directory (namespaced by PID to avoid collisions between parallel workers). */
+/** Create a per-terminal clipboard directory under the server's per-instance root. */
 export function createClipboardDir(terminalId: string): string {
-  const dir = join(tmpdir(), `kolu-clipboard-${process.pid}-${terminalId}`);
+  const dir = join(koluClipboardDir, terminalId);
   mkdirSync(dir, { recursive: true });
   return dir;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -114,22 +114,26 @@ app.use("/rpc/*", async (c, next) => {
   return next();
 });
 
-// --- Graceful shutdown logging ---
+// --- Graceful shutdown ---
+// One cleanup registration covers every exit path (signals, fatal
+// handlers, natural exit). `process.on('exit', ...)` fires on any call
+// to process.exit() and runs synchronously — exactly what rmSync needs.
+// Only SIGKILL / power loss bypass it, and XDG logout-wipe is the
+// backstop for those.
+process.on("exit", shutdownCleanup);
+
 for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
   process.on(sig, () => {
     log.info({ signal: sig }, "shutting down");
-    shutdownCleanup();
     process.exit(0);
   });
 }
 process.on("uncaughtException", (err) => {
   log.fatal({ err }, "uncaught exception");
-  shutdownCleanup();
   process.exit(1);
 });
 process.on("unhandledRejection", (reason) => {
   log.fatal({ reason }, "unhandled rejection");
-  shutdownCleanup();
   process.exit(1);
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,6 +17,7 @@ import { snapshotSession } from "./terminals.ts";
 import { resolveTlsOptions } from "./tls.ts";
 import { configureNixShellEnv } from "./shell.ts";
 import { serverHostname } from "./hostname.ts";
+import { ensureKoluRoot, shutdownCleanup } from "./koluRoot.ts";
 import pkg from "../package.json" with { type: "json" };
 
 const argv = cli({
@@ -61,6 +62,7 @@ const argv = cli({
 });
 
 configureNixShellEnv(argv.flags.allowNixShellWithEnvWhitelist);
+ensureKoluRoot();
 initSessionAutoSave(snapshotSession);
 if (argv.flags.verbose) log.level = "debug";
 
@@ -116,15 +118,18 @@ app.use("/rpc/*", async (c, next) => {
 for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
   process.on(sig, () => {
     log.info({ signal: sig }, "shutting down");
+    shutdownCleanup();
     process.exit(0);
   });
 }
 process.on("uncaughtException", (err) => {
   log.fatal({ err }, "uncaught exception");
+  shutdownCleanup();
   process.exit(1);
 });
 process.on("unhandledRejection", (reason) => {
   log.fatal({ reason }, "unhandled rejection");
+  shutdownCleanup();
   process.exit(1);
 });
 

--- a/server/src/koluRoot.ts
+++ b/server/src/koluRoot.ts
@@ -1,0 +1,63 @@
+/**
+ * Per-server-instance temp root for server-generated files.
+ *
+ * Kolu injects shell rc files and clipboard image shim directories on a
+ * per-terminal basis. Those go under a single root keyed by the server's
+ * startup UUID, rooted at $XDG_RUNTIME_DIR when available.
+ *
+ * Privacy: $XDG_RUNTIME_DIR on Linux is /run/user/$UID — tmpfs, mode 0700,
+ * wiped at logout. Clipboard images can contain screenshots, drag-dropped
+ * files, and secrets; sharing /tmp with every other user on the host was
+ * the wrong default. macOS os.tmpdir() already returns a per-user dir.
+ * Non-systemd Linux falls back to /tmp with no regression.
+ */
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { serverProcessId } from "./hostname.ts";
+
+const runtimeRoot = process.env.XDG_RUNTIME_DIR ?? tmpdir();
+
+/** Per-server-instance root. Everything kolu's server writes to disk for
+ *  transient per-terminal use lives under here. */
+export const koluRoot = join(runtimeRoot, `kolu-${serverProcessId}`);
+
+/** Injected bash rc files and zsh ZDOTDIRs, one pair per spawned terminal.
+ *  Regenerated on every terminal spawn — removed on server shutdown. */
+export const koluShellDir = join(koluRoot, "shell");
+
+/** Per-terminal clipboard image-paste shim directories.
+ *  Preserved across server shutdown — the user may still want pasted
+ *  screenshots inspectable; aged out by XDG logout-wipe. */
+export const koluClipboardDir = join(koluRoot, "clipboard");
+
+/** `KOLU_TEST_MODE=1` flips shutdown cleanup from selective (production) to
+ *  full-root (e2e fixture wipe). Set once at module load; tests pass it via
+ *  the spawned server's env. */
+const isTestMode = process.env.KOLU_TEST_MODE === "1";
+
+/** Create the root + subdirs with owner-only mode. Called once at server
+ *  startup before any terminal spawns. Idempotent. */
+export function ensureKoluRoot(): void {
+  mkdirSync(koluShellDir, { recursive: true, mode: 0o700 });
+  mkdirSync(koluClipboardDir, { recursive: true, mode: 0o700 });
+}
+
+/** Cleanup run from the signal/fatal handlers at process exit.
+ *
+ *  - Test mode: remove the whole root (all fixture data, nothing valuable).
+ *  - Production: remove only `shell/`. Clipboard images may still matter to
+ *    the user and XDG logout-wipe will reclaim them later.
+ *
+ *  Errors are swallowed on purpose: this runs from uncaughtException /
+ *  unhandledRejection paths where a throw would cascade past `process.exit`
+ *  and leave the process wedged in Node's default crash path. A failed
+ *  cleanup is strictly better than a stuck server. */
+export function shutdownCleanup(): void {
+  const target = isTestMode ? koluRoot : koluShellDir;
+  try {
+    rmSync(target, { recursive: true, force: true });
+  } catch {
+    // Best-effort — see doc comment above.
+  }
+}

--- a/server/src/koluRoot.ts
+++ b/server/src/koluRoot.ts
@@ -35,17 +35,10 @@ export function ensureKoluRoot(): void {
   mkdirSync(koluClipboardDir, { recursive: true, mode: 0o700 });
 }
 
-/** Remove the whole per-instance root on shutdown. Run from signal/fatal
- *  handlers.
- *
- *  Errors are swallowed on purpose: this runs from uncaughtException /
- *  unhandledRejection paths where a throw would cascade past `process.exit`
- *  and leave the process wedged in Node's default crash path. A failed
- *  cleanup is strictly better than a stuck server. */
+/** Remove the whole per-instance root on shutdown. Registered on the
+ *  `process.on('exit', ...)` hook so it runs synchronously from every exit
+ *  path. If rmSync throws, Node's default exit-handler reporter prints the
+ *  stack — we do not swallow. */
 export function shutdownCleanup(): void {
-  try {
-    rmSync(koluRoot, { recursive: true, force: true });
-  } catch {
-    // Best-effort — see doc comment above.
-  }
+  rmSync(koluRoot, { recursive: true, force: true });
 }

--- a/server/src/koluRoot.ts
+++ b/server/src/koluRoot.ts
@@ -22,19 +22,11 @@ const runtimeRoot = process.env.XDG_RUNTIME_DIR ?? tmpdir();
  *  transient per-terminal use lives under here. */
 export const koluRoot = join(runtimeRoot, `kolu-${serverProcessId}`);
 
-/** Injected bash rc files and zsh ZDOTDIRs, one pair per spawned terminal.
- *  Regenerated on every terminal spawn — removed on server shutdown. */
+/** Injected bash rc files and zsh ZDOTDIRs, one pair per spawned terminal. */
 export const koluShellDir = join(koluRoot, "shell");
 
-/** Per-terminal clipboard image-paste shim directories.
- *  Preserved across server shutdown — the user may still want pasted
- *  screenshots inspectable; aged out by XDG logout-wipe. */
+/** Per-terminal clipboard image-paste shim directories. */
 export const koluClipboardDir = join(koluRoot, "clipboard");
-
-/** `KOLU_TEST_MODE=1` flips shutdown cleanup from selective (production) to
- *  full-root (e2e fixture wipe). Set once at module load; tests pass it via
- *  the spawned server's env. */
-const isTestMode = process.env.KOLU_TEST_MODE === "1";
 
 /** Create the root + subdirs with owner-only mode. Called once at server
  *  startup before any terminal spawns. Idempotent. */
@@ -43,20 +35,16 @@ export function ensureKoluRoot(): void {
   mkdirSync(koluClipboardDir, { recursive: true, mode: 0o700 });
 }
 
-/** Cleanup run from the signal/fatal handlers at process exit.
- *
- *  - Test mode: remove the whole root (all fixture data, nothing valuable).
- *  - Production: remove only `shell/`. Clipboard images may still matter to
- *    the user and XDG logout-wipe will reclaim them later.
+/** Remove the whole per-instance root on shutdown. Run from signal/fatal
+ *  handlers.
  *
  *  Errors are swallowed on purpose: this runs from uncaughtException /
  *  unhandledRejection paths where a throw would cascade past `process.exit`
  *  and leave the process wedged in Node's default crash path. A failed
  *  cleanup is strictly better than a stuck server. */
 export function shutdownCleanup(): void {
-  const target = isTestMode ? koluRoot : koluShellDir;
   try {
-    rmSync(target, { recursive: true, force: true });
+    rmSync(koluRoot, { recursive: true, force: true });
   } catch {
     // Best-effort — see doc comment above.
   }

--- a/server/src/pty.ts
+++ b/server/src/pty.ts
@@ -70,6 +70,7 @@ export interface PtyHandle {
 /** Spawn a shell in a PTY, calling back on data, exit, CWD, and title changes. */
 export function spawnPty(
   tlog: Logger,
+  terminalId: string,
   opts: {
     onData: (data: string) => void;
     onExit: (exitCode: number) => void;
@@ -86,7 +87,12 @@ export function spawnPty(
 
   // Inject clipboard shim dir into shell rc AFTER the user's rc —
   // NixOS rebuilds PATH during shell init, so env-level PATH gets lost.
-  const osc7 = osc7Init(shell, env.HOME, clipboard.shimBinDir);
+  const osc7 = osc7Init({
+    shell,
+    home: env.HOME,
+    terminalId,
+    extraPath: clipboard.shimBinDir,
+  });
   Object.assign(env, osc7.env);
   env.KOLU_CLIPBOARD_DIR = clipboard.clipboardDir;
 

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -111,8 +111,8 @@ export const appRouter = t.router({
           ? 1
           : 0;
       const bytes = Math.floor((input.data.length * 3) / 4) - padding;
-      log.info({ terminal: input.id, bytes }, "paste image");
-      saveClipboardImage(entry.clipboardDir, input.data);
+      const path = saveClipboardImage(entry.clipboardDir, input.data);
+      log.info({ terminal: input.id, bytes, path }, "paste image");
     }),
 
     kill: t.terminal.kill.handler(async ({ input }) => {

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -104,6 +104,14 @@ export const appRouter = t.router({
 
     pasteImage: t.terminal.pasteImage.handler(async ({ input }) => {
       const entry = requireTerminal(input.id);
+      // base64 → decoded byte count: (len * 3/4) minus padding
+      const padding = input.data.endsWith("==")
+        ? 2
+        : input.data.endsWith("=")
+          ? 1
+          : 0;
+      const bytes = Math.floor((input.data.length * 3) / 4) - padding;
+      log.info({ terminal: input.id, bytes }, "paste image");
       saveClipboardImage(entry.clipboardDir, input.data);
     }),
 

--- a/server/src/shell.ts
+++ b/server/src/shell.ts
@@ -8,9 +8,10 @@
  * `just test`).
  */
 
-import { userInfo, tmpdir } from "node:os";
-import { writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { userInfo } from "node:os";
+import { writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
+import { koluShellDir } from "./koluRoot.ts";
 
 /**
  * Default env vars safe to forward from a nix devshell to PTY shells.
@@ -125,11 +126,13 @@ export const OSC2_PRECMD_ZSH = `__kolu_title_precmd() { print -Pn '\\e]2;%(4~|â€
  * Returns extra spawn args, env overrides, and a cleanup function to remove
  * any temp files created.
  */
-export function osc7Init(
-  shell: string,
-  home: string | undefined,
-  extraPath?: string,
-): { args: string[]; env: Record<string, string>; cleanup: () => void } {
+export function osc7Init(opts: {
+  shell: string;
+  home: string | undefined;
+  terminalId: string;
+  extraPath?: string;
+}): { args: string[]; env: Record<string, string>; cleanup: () => void } {
+  const { shell, home, terminalId, extraPath } = opts;
   const noop = { args: [], env: {}, cleanup: () => {} };
   if (!home) return noop;
 
@@ -140,7 +143,7 @@ export function osc7Init(
   const pathLine = extraPath ? `export PATH="${extraPath}:$PATH"` : "";
 
   if (isBash) {
-    const rcFile = join(tmpdir(), `kolu-bashrc-${process.pid}-${Date.now()}`);
+    const rcFile = join(koluShellDir, `bashrc-${terminalId}`);
     writeFileSync(
       rcFile,
       [
@@ -183,7 +186,8 @@ export function osc7Init(
   }
 
   if (isZsh) {
-    const zdotdir = mkdtempSync(join(tmpdir(), "kolu-zsh-"));
+    const zdotdir = join(koluShellDir, `zdotdir-${terminalId}`);
+    mkdirSync(zdotdir, { recursive: true });
     writeFileSync(
       join(zdotdir, ".zshrc"),
       [

--- a/server/src/terminals.ts
+++ b/server/src/terminals.ts
@@ -136,6 +136,7 @@ export function createTerminal(cwd?: string, parentId?: string): TerminalInfo {
 
   const handle = spawnPty(
     tlog,
+    id,
     {
       onData: (data) => {
         const entry = terminals.get(id);

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -155,9 +155,6 @@ BeforeAll(async function () {
           KOLU_STATE_SUFFIX: `test-${workerId}`,
           KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
           KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
-          // Nuke the entire per-server temp root (shell rc + clipboard) on
-          // shutdown — it's fixture data, none of it should survive.
-          KOLU_TEST_MODE: "1",
         },
       },
     );

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -155,6 +155,9 @@ BeforeAll(async function () {
           KOLU_STATE_SUFFIX: `test-${workerId}`,
           KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
           KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
+          // Nuke the entire per-server temp root (shell rc + clipboard) on
+          // shutdown — it's fixture data, none of it should survive.
+          KOLU_TEST_MODE: "1",
         },
       },
     );


### PR DESCRIPTION
**Kolu's server now drops its injected shell rc files and clipboard image directories under a single per-instance root** at `$XDG_RUNTIME_DIR/kolu-{serverUuid}/`, instead of scattering them flat across `/tmp` with `pid`- and `epoch`-keyed names. On Linux with systemd this lands in `/run/user/$UID`, which is tmpfs-backed, mode 0700, and wiped on logout — exactly the privacy story `/tmp` doesn't give you.

The flat layout was both a privacy leak and a debugging footgun. `/tmp` is world-readable, and kolu's clipboard directories cache whatever the user pasted — *screenshots, drag-dropped files, possibly secrets* — into filenames siblings of every other user's kolu session on a shared host. Separately, during the [#454](https://github.com/juspay/kolu/pull/454) shell-integration work, `grep 633 /tmp/kolu-bashrc-*` kept returning hits from previous server processes and led to wrong conclusions about what the *current* server was injecting. Grouping under the startup UUID makes \"which server wrote this\" self-evident at the filesystem level.

Shutdown cleanup is a single `rmSync(koluRoot)` — *same path for tests and production*. No mode flag, no per-subdir retention policy. The tree is transient per-server scratch space; when the server exits, none of it matters. XDG logout-wipe is the backstop for abnormal exits.

Closes #457.