### PR TITLE
Don't prompt to remove worktree when closing a split

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -161,10 +161,17 @@ const App: Component = () => {
     setPaletteOpen(true);
   }
 
-  /** Close a terminal — always shows the confirmation dialog. */
+  /** Close a terminal. Top-level terminals show a confirmation dialog;
+   *  splits (sub-terminals) are killed directly — they are ephemeral
+   *  sub-panes, like browser tabs, and should never pop the worktree
+   *  removal prompt (#462). */
   function closeTerminal(id: TerminalId) {
     const meta = store.getMetadata(id);
     if (!meta) return;
+    if (meta.parentId) {
+      void crud.handleKill(id);
+      return;
+    }
     const splitCount = store.getSubTerminalIds(id).length;
     setCloseConfirmTarget({ id, meta, splitCount });
   }

--- a/tests/features/worktree.feature
+++ b/tests/features/worktree.feature
@@ -65,6 +65,22 @@ Feature: Git worktree management
     Then the sidebar should have 1 fewer terminal entry
     And there should be no page errors
 
+  Scenario: Closing a split terminal in a worktree does not prompt for removal
+    When I set up a git repo at "/tmp/kolu-wt-split-close"
+    And I run "cd /tmp/kolu-wt-split-close"
+    And the header should show a branch name
+    When I open the command palette
+    And I select "New terminal" in the palette
+    And I select "kolu-wt-split-close" in the palette
+    Then the header CWD should show ".worktrees/"
+    When I create a sub-terminal via command palette
+    And I create another sub-terminal via command palette
+    Then the sub-panel tab bar should have 2 tabs
+    When I click close on sub-terminal tab 1
+    Then the close confirmation should not be visible
+    And the sub-panel tab bar should have 1 tab
+    And there should be no page errors
+
   Scenario: Worktree terminal with splits shows confirmation and removes all
     When I set up a git repo at "/tmp/kolu-wt-splits"
     And I run "cd /tmp/kolu-wt-splits"

--- a/tests/features/worktree.feature
+++ b/tests/features/worktree.feature
@@ -76,7 +76,7 @@ Feature: Git worktree management
     When I create a sub-terminal via command palette
     And I create another sub-terminal via command palette
     Then the sub-panel tab bar should have 2 tabs
-    When I click close on sub-terminal tab 1
+    When I close sub-terminal tab 1
     Then the close confirmation should not be visible
     And the sub-panel tab bar should have 1 tab
     And there should be no page errors

--- a/tests/step_definitions/sub_terminal_steps.ts
+++ b/tests/step_definitions/sub_terminal_steps.ts
@@ -220,25 +220,8 @@ When(
         '[data-testid="sub-panel-tab-bar"] [data-testid="sub-tab-close"]',
       )
       .nth(index - 1);
-    // Hover the parent to reveal the close button
-    await tab.locator("..").hover();
-    await tab.click();
-    // Confirm in the dialog — every close goes through CloseConfirm.
-    const confirm = this.page.locator('[data-testid="close-confirm"]');
-    await confirm.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await confirm.locator('[data-testid="close-confirm-close-all"]').click();
-    await this.waitForFrame();
-  },
-);
-
-When(
-  "I click close on sub-terminal tab {int}",
-  async function (this: KoluWorld, index: number) {
-    const tab = this.page
-      .locator(
-        '[data-testid="sub-panel-tab-bar"] [data-testid="sub-tab-close"]',
-      )
-      .nth(index - 1);
+    // Hover the parent to reveal the close button, then click.
+    // Splits close directly — no confirmation dialog.
     await tab.locator("..").hover();
     await tab.click();
     await this.waitForFrame();

--- a/tests/step_definitions/sub_terminal_steps.ts
+++ b/tests/step_definitions/sub_terminal_steps.ts
@@ -231,6 +231,20 @@ When(
   },
 );
 
+When(
+  "I click close on sub-terminal tab {int}",
+  async function (this: KoluWorld, index: number) {
+    const tab = this.page
+      .locator(
+        '[data-testid="sub-panel-tab-bar"] [data-testid="sub-tab-close"]',
+      )
+      .nth(index - 1);
+    await tab.locator("..").hover();
+    await tab.click();
+    await this.waitForFrame();
+  },
+);
+
 Then(
   "the sub-panel should eventually collapse",
   { timeout: 60_000 },

--- a/tests/step_definitions/worktree_steps.ts
+++ b/tests/step_definitions/worktree_steps.ts
@@ -49,6 +49,20 @@ Then(
   },
 );
 
+Then(
+  "the close confirmation should not be visible",
+  async function (this: KoluWorld) {
+    // Give the dialog a moment to appear if it's going to — then assert hidden.
+    await this.page.waitForTimeout(300);
+    const confirm = this.page.locator('[data-testid="close-confirm"]');
+    assert.strictEqual(
+      await confirm.isVisible(),
+      false,
+      "Expected close confirmation dialog to not be visible",
+    );
+  },
+);
+
 When(
   "I confirm close all in the close confirmation",
   async function (this: KoluWorld) {


### PR DESCRIPTION
**Closing the × on a split terminal tab no longer pops the "Remove worktree too?" dialog.** Splits are cheap, ephemeral sub-panes — killing one is like closing a browser tab, not a decision that deserves a confirmation, let alone a worktree-removal prompt.

The root cause was in `closeTerminal` (App.tsx): every close routed through `CloseConfirm`, and the dialog's label branched on `isWorktree`/`splitCount` but never on "am I a split?". So a split inside a worktree hit the worktree branch and offered to nuke the whole worktree. *The fix is a one-line early-return — if `meta.parentId` is set, call `crud.handleKill(id)` directly and skip the dialog.*

Landed in two commits per request: first a failing e2e scenario that reproduces the bug, then the fix plus the step-def update (the old sub-terminal close step expected the dialog, which is no longer correct).

Closes #462