### PR TITLE
debug: opt-in memory-leak instrumentation via KOLU_DIAG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ A home-manager module runs kolu as a systemd user service:
 
 See [`nix/home/example/`](nix/home/example/) for a full configuration with a VM test.
 
+### Diagnosing memory leaks
+
+If kolu grows unbounded (V8 heap climbing over hours), set `services.kolu.diagnostics.dir` to an absolute path. Each restart gets its own timestamped subdir there, with a baseline heap snapshot at T+5min, periodic `"diag"` stats lines (memory bands + `terminals`/`publisherSize`/`claudeSessions`/`pendingSummaryFetches`), and automatic near-OOM snapshots via V8's `--heapsnapshot-near-heap-limit`. `kill -USR2 <pid>` captures an on-demand snapshot into the same dir. Diff two snapshots offline with [memlab](https://facebook.github.io/memlab/docs/cli/CLI-commands/) to name the retainer. Unset = zero overhead; the code path is fully gated.
+
 ---
 
 Named after [கோலு](<https://en.wikipedia.org/wiki/Golu_(festival)>), the tradition of arranging figures on tiered steps.

--- a/default.nix
+++ b/default.nix
@@ -102,12 +102,28 @@ let
       meta.mainProgram = "kolu";
     } ''
     mkdir -p $out/bin
+    # If KOLU_DIAG_DIR is set, the --run hook computes a per-invocation
+    # subdir, cds into it, and injects V8 heap-snapshot flags into
+    # NODE_OPTIONS. The cd is load-bearing: both --heapsnapshot-signal
+    # and --heapsnapshot-near-heap-limit write to cwd (nodejs/node#47842),
+    # so landing in the per-invocation dir makes all capture paths
+    # (baseline, SIGUSR2, near-OOM) correlate to one directory.
+    # Unset = passthrough, zero overhead.
     makeWrapper ${pkgs.tsx}/bin/tsx $out/bin/kolu \
       --add-flags "${koluStamped}/server/src/index.ts" \
       --set KOLU_CLIENT_DIST "${koluStamped}/client/dist" \
       --set KOLU_CLIPBOARD_SHIM_DIR "${koluEnv.KOLU_CLIPBOARD_SHIM_DIR}" \
       --set KOLU_RANDOM_WORDS "${koluEnv.KOLU_RANDOM_WORDS}" \
-      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs pkgs.git pkgs.gh ]}
+      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs pkgs.git pkgs.gh ]} \
+      --run 'if [ -n "''${KOLU_DIAG_DIR:-}" ]; then
+               KOLU_DIAG_DIR="$KOLU_DIAG_DIR/$(date +%Y%m%dT%H%M%S)-$$"
+               if ! mkdir -p "$KOLU_DIAG_DIR" || ! cd "$KOLU_DIAG_DIR"; then
+                 echo "kolu: failed to set up diag dir $KOLU_DIAG_DIR (check permissions)" >&2
+                 exit 1
+               fi
+               export KOLU_DIAG_DIR
+               export NODE_OPTIONS="--heapsnapshot-near-heap-limit=3 --heapsnapshot-signal=SIGUSR2 ''${NODE_OPTIONS:-}"
+             fi'
   '';
 in
 {

--- a/integrations/claude-code/src/index.ts
+++ b/integrations/claude-code/src/index.ts
@@ -454,6 +454,7 @@ export const ClaudeTranscriptDebugSchema = z.object({
 
 export {
   createSessionWatcher,
+  getPendingSummaryFetches,
   infoEqual,
   type SessionWatcher,
   type ClaudeStateChange,

--- a/integrations/claude-code/src/session-watcher.ts
+++ b/integrations/claude-code/src/session-watcher.ts
@@ -94,6 +94,22 @@ export interface WatcherLog {
   warn: (obj: Record<string, unknown>, msg: string) => void;
 }
 
+// --- Diagnostics counter ---
+
+/** Count of in-flight `fetchSessionSummary` calls across all SessionWatchers.
+ *  Exposed via `getPendingSummaryFetches` for the server's diagnostics log.
+ *
+ *  Maintained by a try/finally pair inside `refreshSummary` so every
+ *  completion path (resolve, reject, new error branch added later) is
+ *  structurally guaranteed to decrement. Don't turn refreshSummary back
+ *  into a .then/.catch pair or the pairing breaks.
+ *
+ *  Climbing unboundedly = backpressure: fs.watch on the Claude transcript
+ *  is firing faster than getSessionInfo can respond, which is the shape
+ *  of the leak we're trying to diagnose. */
+let pendingSummaryFetches = 0;
+export const getPendingSummaryFetches = (): number => pendingSummaryFetches;
+
 // --- SessionWatcher ---
 
 export interface SessionWatcher {
@@ -263,28 +279,27 @@ export function createSessionWatcher(
     }
   }
 
-  function refreshSummary() {
+  async function refreshSummary() {
     if (destroyed) return;
-    fetchSessionSummary(session.sessionId, session.cwd)
-      .then((summary) => {
-        if (destroyed) return;
-        if (summary === lastSummary) return;
-        lastSummary = summary;
-        if (!lastInfo) return;
-        plog.debug(
-          { summary, session: session.sessionId },
-          "claude summary updated",
-        );
-        const updated: ClaudeCodeInfo = { ...lastInfo, summary };
-        lastInfo = updated;
-        onUpdate(updated);
-      })
-      .catch((err) => {
-        plog.debug(
-          { err, session: session.sessionId },
-          "getSessionInfo failed",
-        );
-      });
+    pendingSummaryFetches++;
+    try {
+      const summary = await fetchSessionSummary(session.sessionId, session.cwd);
+      if (destroyed) return;
+      if (summary === lastSummary) return;
+      lastSummary = summary;
+      if (!lastInfo) return;
+      plog.debug(
+        { summary, session: session.sessionId },
+        "claude summary updated",
+      );
+      const updated: ClaudeCodeInfo = { ...lastInfo, summary };
+      lastInfo = updated;
+      onUpdate(updated);
+    } catch (err) {
+      plog.debug({ err, session: session.sessionId }, "getSessionInfo failed");
+    } finally {
+      pendingSummaryFetches--;
+    }
   }
 
   // --- Start watching ---

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -25,6 +25,21 @@ in
 
     verbose = lib.mkEnableOption "debug-level logging";
 
+    diagnostics = {
+      dir = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "%h/.kolu/diag";
+        description = ''
+          Enable memory/heap diagnostics. Value is the base directory under
+          which kolu writes per-invocation subdirs containing heap snapshots
+          (via --heapsnapshot-near-heap-limit + --heapsnapshot-signal=SIGUSR2)
+          and periodic stats logs. `null` disables diagnostics entirely with
+          zero overhead. See the PR for the intended workflow.
+        '';
+      };
+    };
+
     tls = {
       enable = lib.mkEnableOption "TLS with auto-generated self-signed certificate";
 
@@ -67,6 +82,8 @@ in
         ++ lib.optionals (cfg.tls.certFile == null && cfg.tls.enable) [ "--tls" ]
         ++ lib.optionals cfg.verbose [ "--verbose" ]);
         Restart = "on-failure";
+      } // lib.optionalAttrs (cfg.diagnostics.dir != null) {
+        Environment = [ "KOLU_DIAG_DIR=${cfg.diagnostics.dir}" ];
       };
       Install = {
         WantedBy = [ "default.target" ];

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -1,0 +1,120 @@
+/**
+ * Opt-in memory/heap diagnostics for leak debugging.
+ *
+ * Activates only when `KOLU_DIAG_DIR` is set in the environment (see the
+ * `default.nix` wrapper, which computes a per-invocation subdir and cds
+ * into it). Unset = this module does nothing.
+ *
+ * What it does when active:
+ *
+ *  1. Logs one structured "diag_enabled" line at startup with
+ *     NODE_OPTIONS, diag dir, node version, cwd, argv — so a log grep
+ *     post-mortem can find the heap snapshot files without guessing.
+ *
+ *  2. Writes one programmatic `baseline.heapsnapshot` at T+5 min — when
+ *     the heap is still small and safe to snapshot. Gives memlab a
+ *     "clean state" reference point to diff against later snapshots.
+ *
+ *  3. Starts a 5-min interval logging subsystem sizes at INFO level
+ *     with msg "diag". Columns: memory bands (rss, heapUsed, external,
+ *     arrayBuffers) + subsystem counts (terminals, publisherSize,
+ *     claudeSessions, pendingSummaryFetches). The column that climbs
+ *     monotonically alongside rss is the leak site.
+ *
+ * Deliberately NOT included:
+ *
+ *  - Periodic automatic heap snapshots during the run. Each
+ *    `v8.writeHeapSnapshot()` temporarily doubles the live heap. Taking
+ *    one at 3 GB would push V8 over its 4 GB default ceiling and trigger
+ *    the very OOM we're trying to observe. The single baseline at T+5min
+ *    is safe because the heap is small then. Pre-OOM snapshots come from
+ *    V8 itself via `--heapsnapshot-near-heap-limit=3` (NODE_OPTIONS set
+ *    by the wrapper). Mid-run snapshots come from `kill -USR2 <pid>` via
+ *    `--heapsnapshot-signal=SIGUSR2`.
+ */
+
+import v8 from "node:v8";
+import path from "node:path";
+import { log } from "./log.ts";
+import { terminalCount, countActiveClaudeSessions } from "./terminals.ts";
+import { publisherSize } from "./publisher.ts";
+import { getPendingSummaryFetches } from "kolu-claude-code";
+
+/** 5 min — cadence for subsystem stats logging. Chosen so a ~10 MB/min
+ *  leak rate (the observed floor before the 4 GB OOM) produces ~50 MB
+ *  per tick: enough resolution to see the curve, few enough rows to
+ *  eyeball over a 6 h window without drowning in noise. */
+const DIAG_INTERVAL_MS = 5 * 60 * 1000;
+
+/** T+5 min — when to capture the safe baseline snapshot. Early enough
+ *  that the heap is small (a few hundred MB at most), late enough that
+ *  startup transients have settled. */
+const BASELINE_DELAY_MS = 5 * 60 * 1000;
+
+/** Collect a single diagnostics sample: memory bands + subsystem counts.
+ *  All values are numbers, ready for JSON logging. */
+function sample(): Record<string, number> {
+  const m = process.memoryUsage();
+  return {
+    rss: m.rss,
+    heapUsed: m.heapUsed,
+    heapTotal: m.heapTotal,
+    external: m.external,
+    arrayBuffers: m.arrayBuffers,
+    terminals: terminalCount(),
+    publisherSize: publisherSize(),
+    claudeSessions: countActiveClaudeSessions(),
+    pendingSummaryFetches: getPendingSummaryFetches(),
+  };
+}
+
+/** Start diagnostics if `KOLU_DIAG_DIR` is set. Called once from
+ *  `index.ts` after the server is listening. Idempotent — early-return
+ *  if the env var is missing, so calling in prod is free. */
+export function startDiagnostics(): void {
+  const diagDir = process.env.KOLU_DIAG_DIR;
+  if (!diagDir) return;
+
+  log.info(
+    {
+      diagDir,
+      nodeOptions: process.env.NODE_OPTIONS,
+      nodeVersion: process.version,
+      cwd: process.cwd(),
+      argv: process.argv,
+    },
+    "diag_enabled",
+  );
+
+  // Baseline snapshot at T+5 min. `writeHeapSnapshot` blocks the event
+  // loop for a few seconds and transiently doubles the heap, so we
+  // schedule it rather than running at startup — though startup would
+  // also be safe, T+5min gives transients time to settle.
+  //
+  // Absolute path (not relative) so this still works if kolu is
+  // started without the Nix wrapper (e.g. `KOLU_DIAG_DIR=... node
+  // server/src/index.ts` from a dev shell). The wrapper normally cds
+  // into $KOLU_DIAG_DIR, but we shouldn't rely on that coupling for
+  // the one path we control.
+  setTimeout(() => {
+    const snapshotPath = path.join(diagDir, "baseline.heapsnapshot");
+    try {
+      v8.writeHeapSnapshot(snapshotPath);
+      log.info({ path: snapshotPath }, "diag_baseline_snapshot_written");
+    } catch (err) {
+      log.error({ err, path: snapshotPath }, "diag_baseline_snapshot_failed");
+    }
+  }, BASELINE_DELAY_MS).unref();
+
+  // Periodic subsystem stats. `unref` so the interval doesn't keep the
+  // process alive on its own — if the server exits, the interval dies
+  // with it. The kolu process never exits cleanly in production anyway
+  // (systemd restart on failure), but unref is correct hygiene.
+  setInterval(() => {
+    log.info(sample(), "diag");
+  }, DIAG_INTERVAL_MS).unref();
+
+  // Emit one immediate sample so the log timeline has a T+0 row to
+  // anchor the curve. The interval will tick again at T+5min.
+  log.info(sample(), "diag");
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,7 @@ import { resolveTlsOptions } from "./tls.ts";
 import { configureNixShellEnv } from "./shell.ts";
 import { serverHostname } from "./hostname.ts";
 import { ensureKoluRoot, shutdownCleanup } from "./koluRoot.ts";
+import { startDiagnostics } from "./diagnostics.ts";
 import pkg from "../package.json" with { type: "json" };
 
 const argv = cli({
@@ -196,6 +197,7 @@ const server = serve(
       },
       "kolu listening",
     );
+    startDiagnostics();
   },
 );
 

--- a/server/src/log.ts
+++ b/server/src/log.ts
@@ -2,16 +2,28 @@
  *
  * Default level is `info`. Override via `LOG_LEVEL` env var (e.g. `debug`,
  * `warn`, `trace`). The CLI's `--verbose` flag is a hard override applied
- * after construction in `index.ts` and trumps both. */
+ * after construction in `index.ts` and trumps both.
+ *
+ * Every log line carries `serverId` (the randomUUID from `hostname.ts`) so
+ * post-mortem log grepping can pin a line to a specific process run — the
+ * diag dir name is `YYYYMMDDTHHMMSS-$$` but ties back to the serverId logged
+ * at startup. */
 import pino, { type Logger } from "pino";
+import { serverHostname, serverProcessId } from "./hostname.ts";
 
 const level = process.env.LOG_LEVEL ?? "info";
+const base = {
+  pid: process.pid,
+  hostname: serverHostname,
+  serverId: serverProcessId,
+};
 
 export const log = pino(
   process.env.NODE_ENV === "production"
-    ? { level }
+    ? { level, base }
     : {
         level,
+        base,
         transport: {
           target: "pino-pretty",
           options: { colorize: true, singleLine: true },

--- a/server/src/publisher.ts
+++ b/server/src/publisher.ts
@@ -48,6 +48,10 @@ type SystemChannels = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const publisher = new MemoryPublisher<Record<string, any>>();
 
+/** Total pending events + active listeners across all channels. Exposed for
+ *  diagnostics (see diagnostics.ts) — climbs if subscribers aren't draining. */
+export const publisherSize = (): number => publisher.size;
+
 /** Publish an event on a per-terminal channel ("channel:terminalId"). */
 export function publishForTerminal<C extends keyof TerminalChannels>(
   channel: C,

--- a/server/src/terminals.ts
+++ b/server/src/terminals.ts
@@ -213,6 +213,21 @@ export function listTerminals(): TerminalInfo[] {
   return list;
 }
 
+/** Number of live terminal processes. Cheap counter for diagnostics. */
+export const terminalCount = (): number => terminals.size;
+
+/** Number of terminals currently hosting a Claude Code session. Derived
+ *  from `entry.getClaudeDebug` — the claude provider sets it on session
+ *  match and `delete`s it on teardown (see `meta/claude.ts`), so this
+ *  needs no separate counter state. Exported for diagnostics. */
+export function countActiveClaudeSessions(): number {
+  let n = 0;
+  for (const entry of terminals.values()) {
+    if (entry.getClaudeDebug) n++;
+  }
+  return n;
+}
+
 export function getTerminal(id: TerminalId): TerminalProcess | undefined {
   return terminals.get(id);
 }


### PR DESCRIPTION
**Make the next Kolu OOM diagnosable in one pass.** The server has been hitting V8's 4 GB heap limit after ~6 h of uptime (observed in `journalctl --user -u kolu` — multiple 10 GB-RSS crashes going back weeks), and the existing logs give us no way to tell *what* grows. This PR adds opt-in instrumentation so the next leak leaves behind a diffable heap snapshot and a time-series of subsystem sizes.

Setting `services.kolu.diagnostics.dir` in the home-manager module (or `KOLU_DIAG_DIR` directly for `nix run`) flips on four things: a per-invocation dir for diag artifacts, `NODE_OPTIONS="--heapsnapshot-near-heap-limit=3 --heapsnapshot-signal=SIGUSR2"` so V8 dumps a retainer graph on near-OOM and on `kill -USR2`, a one-shot baseline heap snapshot at T+5 min (safe while the heap is small), and a 5-min structured log line with `rss`/`heapUsed`/`external`/`arrayBuffers` plus subsystem counts (`terminals`, `publisherSize`, `claudeSessions`, `pendingSummaryFetches`). Unset = zero code path changes, zero overhead.

*The cwd trick is load-bearing.* Node's `--heapsnapshot-*` flags [write to cwd regardless of `--diagnostic-dir`](https://github.com/nodejs/node/issues/47842) — a known limitation. The wrapper `cd`s into the per-invocation diag dir before `exec tsx`, turning the limitation into exactly what we want: auto-OOM snapshots, signal-triggered snapshots, and the baseline all land in one place, correlatable to the startup log via `serverId`. Next-session workflow: `npx memlab find-leaks --baseline baseline.heapsnapshot --target mid.heapsnapshot --final near-oom.heapsnapshot` names the retainer.

> No periodic auto-snapshots during the run. Each `v8.writeHeapSnapshot()` temporarily doubles the heap and could trigger the very OOM we're trying to observe.

### Try it locally

```sh
KOLU_DIAG_DIR=$HOME/.kolu/diag nix run github:juspay/kolu/debug/mem-leak-instrumentation
```