### PR TITLE
perf(claude): debounce, chunked scan, bounded buffers, shared watcher

### DIFF
--- a/integrations/claude-code/src/index.ts
+++ b/integrations/claude-code/src/index.ts
@@ -418,6 +418,76 @@ export function watchOrWaitForDir(
   };
 }
 
+// --- Shared SESSIONS_DIR watcher ---
+//
+// Every consumer of this package that wants to react to session
+// file appearance/disappearance needs a watch on SESSIONS_DIR. Rather
+// than have each caller install its own fs.watch (so N consumers = N
+// duplicate watchers + N duplicate dispatches per event), this module
+// refcounts a single watcher: first subscriber lazily installs it,
+// last unsubscribe tears it down.
+//
+// `sharedSessionsDir` is a single nullable structure (not a
+// {watcher, listeners} pair) so the "active iff non-empty" invariant
+// is mechanical — there's no way for the two halves to disagree.
+//
+// Per-listener `onError` is required (not optional) so fault isolation
+// is a type-system obligation, not a convention. If one listener's
+// callback throws, its own onError runs, and iteration continues to
+// the next listener unaffected.
+
+interface SessionsDirListener {
+  cb: () => void;
+  onError: (err: unknown) => void;
+}
+
+let sharedSessionsDir: {
+  cleanup: () => void;
+  listeners: Set<SessionsDirListener>;
+} | null = null;
+
+/**
+ * Subscribe to changes in `SESSIONS_DIR`. Returns an unsubscribe
+ * function. The underlying `fs.watch` is shared across all
+ * subscribers — refcounted, installed on first subscribe, torn down
+ * on last unsubscribe.
+ *
+ * `onError` receives any exception thrown by `onChange` and runs
+ * in place of breaking the iteration over peer listeners. Callers
+ * must provide one (silent swallowing would hide bugs) — pass a
+ * logger call like `(err) => log.warn({ err }, "...")`.
+ */
+export function subscribeSessionsDir(
+  onChange: () => void,
+  onError: (err: unknown) => void,
+): () => void {
+  if (!sharedSessionsDir) {
+    const listeners = new Set<SessionsDirListener>();
+    const cleanup = watchOrWaitForDir(SESSIONS_DIR, () => {
+      // Snapshot before iteration so a listener that subscribes or
+      // unsubscribes synchronously can't skip a peer for this event.
+      for (const l of [...listeners]) {
+        try {
+          l.cb();
+        } catch (err) {
+          l.onError(err);
+        }
+      }
+    });
+    sharedSessionsDir = { cleanup, listeners };
+  }
+  const listener: SessionsDirListener = { cb: onChange, onError };
+  sharedSessionsDir.listeners.add(listener);
+  return () => {
+    if (!sharedSessionsDir) return;
+    sharedSessionsDir.listeners.delete(listener);
+    if (sharedSessionsDir.listeners.size === 0) {
+      sharedSessionsDir.cleanup();
+      sharedSessionsDir = null;
+    }
+  };
+}
+
 // --- Summary fetching ---
 
 /** Fetch the display summary from the Claude Agent SDK. Returns null on failure. */

--- a/integrations/claude-code/src/session-watcher.ts
+++ b/integrations/claude-code/src/session-watcher.ts
@@ -73,6 +73,29 @@ export function infoEqual(
   );
 }
 
+// --- Tuning constants ---
+
+/** Trailing-edge debounce for the transcript fs.watch callback. Claude
+ *  streams tokens, and Linux fs.watch fires multiple events per write —
+ *  without debouncing, `onTranscriptMaybeChanged` runs dozens to hundreds
+ *  of times per second, each iteration re-allocating a 256 KB tail buffer
+ *  and firing an async SDK summary fetch. 150 ms coalesces bursts into
+ *  one handler run while keeping the user-perceptible lag imperceptible. */
+const TRANSCRIPT_DEBOUNCE_MS = 150;
+
+/** Chunk size for `scanTasksIncremental`. The previous one-shot
+ *  `Buffer.alloc(size - offset)` could allocate hundreds of MB transiently
+ *  on first attach to a pre-existing transcript, pushing a climbing heap
+ *  over V8's 4 GB ceiling. 1 MB bounds peak transient memory regardless
+ *  of file size. */
+const TASK_SCAN_CHUNK_BYTES = 1024 * 1024;
+
+/** Cap on the per-SessionWatcher debug accumulator. Only read by the
+ *  "Show Claude transcript" debug view, which paginates — 500 entries is
+ *  more than the UI displays. Prevents unbounded growth in a debug-only
+ *  array over long sessions. */
+const MAX_STATE_CHANGES = 500;
+
 // --- Transcript watching lifecycle ---
 
 /**
@@ -137,6 +160,15 @@ export function createSessionWatcher(
   let lastSummary: string | null = null;
   let taskMap = new Map<string, "pending" | "in_progress" | "completed">();
   let taskScanOffset = 0;
+  // Partial final line from the previous chunked scan. Carried across
+  // calls so a line straddling a chunk or EOF boundary resolves to a
+  // single complete line once the newline arrives. Without this, the
+  // tail of one call would be split-processed at the head of the next
+  // call as if it were already a complete line — silent task corruption.
+  let taskScanRemainder = "";
+  // Trailing-edge debounce timer for transcript fs.watch events.
+  // Null when idle. Cleared on destroy.
+  let transcriptDebounceTimer: NodeJS.Timeout | null = null;
 
   // Diagnostic state — shares the SessionWatcher lifetime.
   let debugStartOffset = 0;
@@ -154,9 +186,23 @@ export function createSessionWatcher(
     transcriptWatching = { kind: "none" };
   }
 
+  /** Trailing-edge debounce: reset the timer on every event, fire
+   *  `onTranscriptMaybeChanged` once after `TRANSCRIPT_DEBOUNCE_MS` of
+   *  quiet. The handler's own `destroyed` guard makes late-firing
+   *  callbacks safe, but we clear the timer in `destroy()` anyway to
+   *  avoid holding closure refs unnecessarily. */
+  function scheduleTranscriptCheck() {
+    if (destroyed) return;
+    if (transcriptDebounceTimer) clearTimeout(transcriptDebounceTimer);
+    transcriptDebounceTimer = setTimeout(() => {
+      transcriptDebounceTimer = null;
+      onTranscriptMaybeChanged();
+    }, TRANSCRIPT_DEBOUNCE_MS);
+  }
+
   function attachTranscriptWatcher(tp: string) {
     try {
-      const fileWatcher = fs.watch(tp, () => onTranscriptMaybeChanged());
+      const fileWatcher = fs.watch(tp, () => scheduleTranscriptCheck());
       transcriptWatching = { kind: "watching", path: tp, fileWatcher };
       debugStartOffset = fs.statSync(tp).size;
       debugStartedAt = Date.now();
@@ -227,6 +273,8 @@ export function createSessionWatcher(
         "claude code state updated",
       );
       lastInfo = info;
+      // Ring-buffer the debug accumulator — see MAX_STATE_CHANGES.
+      if (stateChanges.length >= MAX_STATE_CHANGES) stateChanges.shift();
       stateChanges.push({ ts: Date.now(), info });
       onUpdate(info);
     }
@@ -234,41 +282,56 @@ export function createSessionWatcher(
     refreshSummary();
   }
 
+  /** Incrementally scan the transcript for TaskCreate/TaskUpdate entries.
+   *
+   *  Streams TASK_SCAN_CHUNK_BYTES at a time so peak transient memory is
+   *  O(chunk) rather than O(file). Partial lines at chunk boundaries are
+   *  accumulated into `taskScanRemainder` (persisted across calls) so
+   *  straddling lines resolve correctly once their newline arrives.
+   *
+   *  `taskScanOffset` always advances to the full file size — the
+   *  remainder lives separately, *not* in the unread region. On the next
+   *  call, the remainder is prepended to the newly-written bytes, then
+   *  split; the last (potentially partial) segment becomes the new
+   *  remainder. */
   function scanTasksIncremental(filePath: string) {
     try {
       const size = fs.statSync(filePath).size;
       if (taskScanOffset >= size) return;
-      const length = size - taskScanOffset;
       const fd = fs.openSync(filePath, "r");
-      let buf: Buffer;
+      const prevOffset = taskScanOffset;
+      let carried = taskScanRemainder;
+      let changed = false;
       try {
-        buf = Buffer.alloc(length);
-        fs.readSync(fd, buf, 0, length, taskScanOffset);
+        let offset = taskScanOffset;
+        while (offset < size) {
+          const toRead = Math.min(TASK_SCAN_CHUNK_BYTES, size - offset);
+          const buf = Buffer.alloc(toRead);
+          fs.readSync(fd, buf, 0, toRead, offset);
+          const text = carried + buf.toString("utf8");
+          const lines = text.split("\n");
+          // The last segment is either a complete line followed by a
+          // trailing newline (→ "") or a partial line (→ the fragment).
+          // Either way, carry it forward; never process it this round.
+          carried = lines.pop() ?? "";
+          const complete = lines.filter((l) => l.length > 0);
+          if (complete.length > 0) {
+            if (extractTasks(complete, taskMap, plog)) changed = true;
+          }
+          offset += toRead;
+        }
       } finally {
         fs.closeSync(fd);
       }
-      const newLines = buf
-        .toString("utf8")
-        .split("\n")
-        .filter((l) => l.length > 0);
-      // First line may be partial when reading from a mid-file offset — safe to drop.
-      if (taskScanOffset > 0 && newLines.length > 0) {
-        try {
-          JSON.parse(newLines[0]!);
-        } catch {
-          newLines.shift();
-        }
-      }
-      const prevOffset = taskScanOffset;
+      taskScanRemainder = carried;
       taskScanOffset = size;
-      const changed = extractTasks(newLines, taskMap, plog);
       if (changed) {
         const progress = deriveTaskProgress(taskMap);
         plog.debug(
           {
             tasks: taskMap.size,
             progress,
-            bytesScanned: length,
+            bytesScanned: size - prevOffset,
             from: prevOffset,
           },
           "task progress updated",
@@ -310,6 +373,10 @@ export function createSessionWatcher(
 
     destroy() {
       destroyed = true;
+      if (transcriptDebounceTimer) {
+        clearTimeout(transcriptDebounceTimer);
+        transcriptDebounceTimer = null;
+      }
       teardownTranscriptWatching();
     },
 

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -23,6 +23,57 @@ import {
   type SessionWatcher,
 } from "kolu-claude-code";
 
+// --- Shared SESSIONS_DIR watcher ---
+//
+// Every claude provider wants to know when `~/.claude/sessions/` changes.
+// The pre-sharing implementation installed one `fs.watch` per terminal,
+// so N terminals meant N independent inotify watches on the same
+// directory and N duplicate callback dispatches per file event. This
+// module-level singleton refcounts a single watcher: first subscriber
+// lazily installs it, last unsubscribe tears it down.
+//
+// `sharedSessionsDir` is a single nullable structure rather than a
+// {watcher, listeners} pair so the "active iff non-empty" invariant is
+// mechanical — there's no way for the two halves to disagree.
+//
+// Per-listener try/catch inside the iteration preserves the pre-sharing
+// fault isolation: one provider's callback throwing does not drop the
+// event for every subsequent provider.
+
+let sharedSessionsDir: {
+  cleanup: () => void;
+  listeners: Set<() => void>;
+} | null = null;
+
+function subscribeSessionsDir(cb: () => void): () => void {
+  if (!sharedSessionsDir) {
+    const listeners = new Set<() => void>();
+    const cleanup = watchOrWaitForDir(SESSIONS_DIR, () => {
+      // Snapshot before iteration so a listener that synchronously
+      // subscribes/unsubscribes can't skip a peer for this event. Today
+      // `onSessionMaybeChanged` does neither, but the guard is cheap
+      // and eliminates a future-footgun shape.
+      for (const fn of [...listeners]) {
+        try {
+          fn();
+        } catch (err) {
+          log.warn({ err }, "sessions-dir listener threw");
+        }
+      }
+    });
+    sharedSessionsDir = { cleanup, listeners };
+  }
+  sharedSessionsDir.listeners.add(cb);
+  return () => {
+    if (!sharedSessionsDir) return;
+    sharedSessionsDir.listeners.delete(cb);
+    if (sharedSessionsDir.listeners.size === 0) {
+      sharedSessionsDir.cleanup();
+      sharedSessionsDir = null;
+    }
+  };
+}
+
 /** Compare two AgentInfo values for equality. */
 export function infoEqual(a: AgentInfo | null, b: AgentInfo | null): boolean {
   if (a === b) return true;
@@ -99,8 +150,9 @@ export function startClaudeCodeProvider(
     onSessionMaybeChanged(),
   );
 
-  // Watch the sessions dir for session file appearance/disappearance.
-  const sessionsDirWatcher = watchOrWaitForDir(SESSIONS_DIR, () =>
+  // Subscribe to the shared sessions-dir watcher (one inotify watch
+  // process-wide, regardless of terminal count). See subscribeSessionsDir.
+  const unsubscribeSessionsDir = subscribeSessionsDir(() =>
     onSessionMaybeChanged(),
   );
 
@@ -109,7 +161,7 @@ export function startClaudeCodeProvider(
 
   return () => {
     abort.abort();
-    sessionsDirWatcher();
+    unsubscribeSessionsDir();
     current?.destroy();
     delete entry.getClaudeDebug;
     plog.debug("stopped");

--- a/server/src/meta/claude.ts
+++ b/server/src/meta/claude.ts
@@ -15,64 +15,12 @@ import { subscribeForTerminal } from "../publisher.ts";
 import { log } from "../log.ts";
 
 import {
-  SESSIONS_DIR,
   readSessionFile,
-  watchOrWaitForDir,
+  subscribeSessionsDir,
   createSessionWatcher,
   infoEqual as claudeInfoEqual,
   type SessionWatcher,
 } from "kolu-claude-code";
-
-// --- Shared SESSIONS_DIR watcher ---
-//
-// Every claude provider wants to know when `~/.claude/sessions/` changes.
-// The pre-sharing implementation installed one `fs.watch` per terminal,
-// so N terminals meant N independent inotify watches on the same
-// directory and N duplicate callback dispatches per file event. This
-// module-level singleton refcounts a single watcher: first subscriber
-// lazily installs it, last unsubscribe tears it down.
-//
-// `sharedSessionsDir` is a single nullable structure rather than a
-// {watcher, listeners} pair so the "active iff non-empty" invariant is
-// mechanical — there's no way for the two halves to disagree.
-//
-// Per-listener try/catch inside the iteration preserves the pre-sharing
-// fault isolation: one provider's callback throwing does not drop the
-// event for every subsequent provider.
-
-let sharedSessionsDir: {
-  cleanup: () => void;
-  listeners: Set<() => void>;
-} | null = null;
-
-function subscribeSessionsDir(cb: () => void): () => void {
-  if (!sharedSessionsDir) {
-    const listeners = new Set<() => void>();
-    const cleanup = watchOrWaitForDir(SESSIONS_DIR, () => {
-      // Snapshot before iteration so a listener that synchronously
-      // subscribes/unsubscribes can't skip a peer for this event. Today
-      // `onSessionMaybeChanged` does neither, but the guard is cheap
-      // and eliminates a future-footgun shape.
-      for (const fn of [...listeners]) {
-        try {
-          fn();
-        } catch (err) {
-          log.warn({ err }, "sessions-dir listener threw");
-        }
-      }
-    });
-    sharedSessionsDir = { cleanup, listeners };
-  }
-  sharedSessionsDir.listeners.add(cb);
-  return () => {
-    if (!sharedSessionsDir) return;
-    sharedSessionsDir.listeners.delete(cb);
-    if (sharedSessionsDir.listeners.size === 0) {
-      sharedSessionsDir.cleanup();
-      sharedSessionsDir = null;
-    }
-  };
-}
 
 /** Compare two AgentInfo values for equality. */
 export function infoEqual(a: AgentInfo | null, b: AgentInfo | null): boolean {
@@ -151,9 +99,12 @@ export function startClaudeCodeProvider(
   );
 
   // Subscribe to the shared sessions-dir watcher (one inotify watch
-  // process-wide, regardless of terminal count). See subscribeSessionsDir.
-  const unsubscribeSessionsDir = subscribeSessionsDir(() =>
-    onSessionMaybeChanged(),
+  // process-wide, regardless of terminal count). Implemented in the
+  // kolu-claude-code integration package so the server doesn't need
+  // to know SESSIONS_DIR exists.
+  const unsubscribeSessionsDir = subscribeSessionsDir(
+    () => onSessionMaybeChanged(),
+    (err) => plog.warn({ err }, "sessions-dir listener threw"),
   );
 
   // Initial reconcile for a terminal that already hosts a claude session.


### PR DESCRIPTION
**Four memory fixes in the Claude Code integration, all grounded in specific lines read during the post-mortem for PR #464.** The diagnostics we just landed will confirm which of these moves the needle, but every item is a defensible cleanup on its own terms — no speculative optimization.

The biggest lever is **debouncing the transcript `fs.watch` callback**. On Linux, fs.watch fires multiple events per write, and Claude streams tokens — the handler was running dozens to hundreds of times per second during active use, each call allocating a 256 KB tail-read buffer, parsing JSON, re-scanning tasks, and firing an async SDK summary fetch. A trailing-edge 150 ms debounce collapses bursts of writes into one handler run. *The derived state is already "what does the tail look like now" — there's no information loss from coalescing events within a debounce window.*

**`scanTasksIncremental` used to allocate the entire unread file in one `Buffer.alloc`** — a 200 MB transcript produced a ~200 MB buffer plus a ~200 MB UTF-8 string plus an array of N split lines, transiently. On a heap already climbing toward V8's 4 GB ceiling, that single spike could push us over. Rewritten to stream 1 MB chunks with a persistent `taskScanRemainder` carried across calls so partial lines at chunk/EOF boundaries resolve correctly (the naive version silently corrupts task scanning — hickey caught this one before any code was written).

The `stateChanges` array in each `SessionWatcher` was **unbounded and debug-only** — pushed on every state transition, only read by the "Show Claude transcript" debug view. Now capped at 500 entries via `shift`-before-push. The last lever is **deduping the `SESSIONS_DIR` inotify watcher**: every terminal's claude provider used to install its own `watchOrWaitForDir(SESSIONS_DIR, ...)`, so 10 terminals = 10 independent watchers on the same directory, 10 duplicate callbacks per file event. Now a refcounted module-level singleton fans out to a `Set` of listeners, with per-listener `try/catch` so one throwing provider can't break peers.

> Out of scope: inactive-terminal `@xterm/headless` scrollback eviction — tracked as a follow-up issue.

### Try it locally

```sh
nix run github:juspay/kolu/opt/claude-memory
```