### PR TITLE
ci(apm-sync): verify .claude/ without wiping it

### DIFF
--- a/agents/ai.just
+++ b/agents/ai.just
@@ -5,11 +5,15 @@ apm_cmd := 'uvx --from git+https://github.com/microsoft/apm apm'
 
 # Deploy APM primitives to .claude/ (rules, commands, skills, hooks)
 apm:
-    # APM install is additive — it writes declared files but never prunes
-    # files whose upstream sources disappeared, so orphans accumulate
-    # silently (and `apm-sync` can't see them via git status). Wipe the
-    # APM-owned tree before reinstalling; keep-list preserves user-owned
-    # launch.json. https://github.com/microsoft/apm/issues/561
+    # APM install cleans up stale files from upgraded *local* packages
+    # (see install.py's _local_deployed path) but not from upgraded
+    # *remote* packages — upstream `apm prune` only removes orphan
+    # packages, not orphan files from still-declared packages whose
+    # contents shrank. Wipe the APM-owned tree before reinstalling so
+    # remote-package orphans don't linger; keep-list preserves the
+    # user-owned launch.json. Destructive by design — this is an
+    # explicit developer action. CI uses `apm-sync` below, which
+    # verifies without mutating. See #468.
     find .claude -mindepth 1 -maxdepth 1 ! -name launch.json -exec rm -rf {} +
     {{ apm_cmd }} install
 
@@ -24,12 +28,32 @@ apm-audit:
     {{ apm_cmd }} audit --ci
 
 # Verify vendored .claude/ matches .apm/ sources + security audit
-apm-sync: apm apm-audit
+#
+# Must NOT mutate the live .claude/ tree — concurrent Claude Code
+# sessions in the same worktree would see stop hooks / rules / skills
+# disappear mid-CI and crash. See #468. Instead we stage a fresh tree
+# in a scratch dir and diff. The `apm` recipe above is destructive and
+# stays a dev-only action.
+apm-sync: apm-audit
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ -n "$(git status --porcelain .claude/)" ]; then
-        echo "ERROR: .claude/ out of sync with .apm/ — run: just ai::apm"
-        git status .claude/
+    scratch=$(mktemp -d)
+    trap 'rm -rf "$scratch"' EXIT
+    # Local inputs: symlink what apm only reads, cp what it writes through.
+    # `apm install` rewrites apm.lock.yaml's `generated_at` on every run,
+    # so a symlink here would mutate the real lockfile.
+    ln -s "$PWD/apm.yml" "$PWD/agents" "$scratch/"
+    cp "$PWD/apm.lock.yaml" "$scratch/"
+    # apm's target auto-detection picks "claude" when `.claude/` exists
+    # (target_detection.py). The explicit `-t claude` flag does *not*
+    # produce an equivalent result — local-package integration silently
+    # no-ops — so folder-existence is the reliable signal.
+    mkdir "$scratch/.claude"
+    (cd "$scratch" && {{ apm_cmd }} install >/dev/null)
+    # launch.json is user-owned; apm never manages it, so exclude from
+    # the drift check.
+    if ! diff -r -x launch.json .claude "$scratch/.claude"; then
+        echo "ERROR: .claude/ out of sync with sources — run: just ai::apm" >&2
         exit 1
     fi
 

--- a/agents/ai.just
+++ b/agents/ai.just
@@ -33,7 +33,8 @@ apm-audit:
 # sessions in the same worktree would see stop hooks / rules / skills
 # disappear mid-CI and crash. See #468. Instead we stage a fresh tree
 # in a scratch dir and diff. The `apm` recipe above is destructive and
-# stays a dev-only action.
+# stays a dev-only action. This workaround can be removed if upstream
+# adds content verification to `apm audit --ci`: microsoft/apm#684.
 apm-sync: apm-audit
     #!/usr/bin/env bash
     set -euo pipefail

--- a/agents/ai.just
+++ b/agents/ai.just
@@ -50,9 +50,17 @@ apm-sync: apm-audit
     # no-ops — so folder-existence is the reliable signal.
     mkdir "$scratch/.claude"
     (cd "$scratch" && {{ apm_cmd }} install >/dev/null)
-    # launch.json is user-owned; apm never manages it, so exclude from
-    # the drift check.
-    if ! diff -r -x launch.json .claude "$scratch/.claude"; then
+    # Exclude files that apm doesn't manage: launch.json is user-owned,
+    # and `.claude/*` entries in .gitignore are runtime state written by
+    # Claude Code itself (worktree bookkeeping, local settings, session
+    # lockfiles). Keep this list in sync with .gitignore — if a new
+    # runtime file appears in .claude/, add it to .gitignore and here.
+    if ! diff -r \
+        -x launch.json \
+        -x worktrees \
+        -x settings.local.json \
+        -x scheduled_tasks.lock \
+        .claude "$scratch/.claude"; then
         echo "ERROR: .claude/ out of sync with sources — run: just ai::apm" >&2
         exit 1
     fi


### PR DESCRIPTION
**`ci::apm-sync` no longer mutates the live `.claude/` tree.** Previously it depended on `ai::apm`, which did `find .claude -mindepth 1 ... -exec rm -rf` and then ran `apm install` — opening a window where `.claude/hooks/`, `settings.json`, commands, rules, and skills did not exist on disk. Any concurrent Claude Code session in the same worktree whose stop hook fired during that window crashed with `No such file or directory`.

The fix performs the verification in a scratch directory: symlink `apm.yml` and `agents/`, `cp apm.lock.yaml`, `mkdir .claude/` (this is how apm's target auto-detection picks claude mode — see `target_detection.py:82,102`), run `apm install` inside scratch, then `diff -r` against the live tree. *The real `.claude/` is never touched during CI.*

The lockfile is copied rather than symlinked because `apm install` writes `generated_at` through on every run — a symlink would mutate the real lockfile. Runtime files that apm doesn't manage (`launch.json`, plus the three `.claude/*` entries already listed in `.gitignore`: `worktrees/`, `settings.local.json`, `scheduled_tasks.lock`) are excluded from the diff — the old `git status` approach filtered these implicitly via gitignore; the new diff approach has to do it explicitly. The dev `ai::apm` recipe keeps its destructive wipe — that's an explicit developer action, not a background CI step.

> Also refreshes the stale `apm#561` comment — upstream `apm prune` now exists, but it only handles orphan packages (not orphan files from upgraded packages), so the wipe in the dev recipe is still justified.

Closes #468.