### PR TITLE
fix(split): stop main terminal from flashing on split open/close

### DIFF
--- a/.claude/skills/code-police/SKILL.md
+++ b/.claude/skills/code-police/SKILL.md
@@ -13,6 +13,21 @@ Review the current changes (scoped to the current branch/PR) against the rules b
 
 Two similar instances are fine — don't abstract prematurely. Three is the threshold for extraction. But identical content that must stay in sync (same HTML, same version string) should be deduplicated immediately regardless of count. Versions, ports, paths — define once, reference everywhere.
 
+### prefer-focused-library
+
+Before hand-rolling a utility (string tokenizer, quoted-string parser, date helper, semver comparator, URL builder, CLI arg parser, tree walker, regex-based matcher, path normalizer, etc.), check whether a focused library solves the same problem. If one exists with a matching scope and a reasonable bundle cost, **prefer it — even if it's a new dependency**. Hand-rolling is only justified when the library would add capabilities you actively don't want (tagging, env expansion, i18n layers, etc. you'd have to ignore), or when the hand-roll is genuinely a handful of lines with no branching.
+
+_Rationale_: "Zero deps" is an easiness judgment dressed as a simplicity judgment. Code you don't own is genuinely simpler than code you do own — it doesn't accumulate private test fixtures, it doesn't bitrot when requirements shift, and its edge cases are someone else's problem to fix. Hand-rolled utilities routinely grow past the library they displaced as new edge cases surface. A small focused library with a single exported function is the _same_ complexity to your reader as a one-line utility import, and _less_ complexity than a 40-line loop with state variables.
+
+_How to apply_: When you're about to write a loop with nested state-machine variables, a tokenizer, a parser, a semver comparator, a date math helper, a quoted-string handler, or a path normalizer — **stop and search for the focused library first**. Only fall back to hand-roll after seeing a concrete library and judging that its scope genuinely exceeds what you need.
+
+_Anti-patterns in this rule's application_:
+
+- "It's already in the tree" is not a _requirement_ for preferring the library. Adding a small focused dep is fine. The "already transitive" check is a convenience shortcut, not a gate.
+- "Only ~40 lines, well-scoped" is not a license to hand-roll. 40 lines of state-machine code is usually worse than one line of library call plus a dep.
+- "I don't want a dep" is dependency-aversion, not simplicity. State it as such in the eval and evaluate it honestly as a preference, not as a neutral principle.
+- The gating criteria are **scope fit** and **bundle cost** — not ideology in either direction. Left-pad exists; don't flip to "always use a library." Judge each case on whether the library's surface matches what you need.
+
 ### invalid-states-unrepresentable
 
 Use discriminated unions, not booleans or stringly-typed fields. If two fields can't both be `undefined` at the same time, model that in the type.

--- a/.claude/skills/hickey/SKILL.md
+++ b/.claude/skills/hickey/SKILL.md
@@ -76,6 +76,7 @@ Scan for known structural patterns **and any additional patterns from project in
 | ORM | Object identity + relational model + query | Plain data + declarative queries |
 | Conditionals scattered across code | One decision braided across many sites | Rules, declarative policies, lookup tables |
 | Callbacks/closures over mutable state | Control flow + state + time | Streams, queues, immutable values |
+| Hand-rolled utility (tokenizer, parser, walker, normalizer, state machine, date/semver/URL helper, CLI arg parser) when a focused library solves the exact problem | *Scope decision* (how much to implement) with *implementation choice* (write it yourself) | Use the library. Hand-roll only when the library adds surface area you actively don't want, not when it would save you writing code you'd otherwise own. "Zero deps" is an easiness judgment dressed as a simplicity judgment — code you don't own is genuinely simpler than code you do own: it doesn't accumulate private test fixtures, it doesn't bitrot when requirements shift, and its edge cases are someone else's problem to fix. |
 
 **Fragmentation patterns (things-that-belong-together split apart)**
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-11T14:19:24.039407+00:00'
+generated_at: '2026-04-12T13:24:18.911633+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -47,7 +47,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 888548f2483149ac304882942c60732916b34a01
+  resolved_commit: bf326121e72c49d4b3c849d61d8798ca42caf71c
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-12T13:24:18.911633+00:00'
+generated_at: '2026-04-12T13:32:34.725553+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -58,4 +58,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:38a20197bcb411a82c2893ef852ca47ab30db9c14852d279e8753bd9c21ae386
+  content_hash: sha256:1087074544f2086da8694112467e7b4cf84a7f565a1185f328bb3cab62a889b1

--- a/client/src/TerminalPane.tsx
+++ b/client/src/TerminalPane.tsx
@@ -45,65 +45,40 @@ const TerminalPane: Component<{
   }
 
   return (
-    <div class="w-full h-full relative" classList={{ hidden: !props.visible }}>
+    <div
+      class="w-full h-full relative flex flex-col"
+      classList={{ hidden: !props.visible }}
+    >
       {/*
-        No subs: plain terminal. With subs: Resizable split.
-        Sub-terminals mount once via Show+For and stay alive across collapse.
+        Main terminal lives inside Resizable unconditionally so it is never
+        unmounted when splits are created/removed. Sub-panel content is gated
+        by Show/For without affecting the main terminal's lifecycle.
       */}
-      <Show
-        when={hasSubs()}
-        fallback={
-          <div class="flex flex-col h-full">
-            <div class="flex-1 min-h-0">
-              <Terminal
-                terminalId={props.terminalId}
-                visible={props.visible}
-                theme={props.theme}
-                searchOpen={props.searchOpen}
-                onSearchOpenChange={props.onSearchOpenChange}
-                scrollLockEnabled={props.scrollLockEnabled}
-              />
-            </div>
-            <SplitStrip
-              variant="prompt"
-              onClick={() =>
-                props.onCreateSubTerminal(
-                  props.terminalId,
-                  props.activeMeta?.cwd,
-                )
-              }
-            />
-          </div>
+      <Resizable
+        orientation="vertical"
+        sizes={
+          isExpanded()
+            ? [1 - panelState().panelSize, panelState().panelSize]
+            : [1, 0]
         }
+        onSizesChange={handleSizesChange}
+        class="flex-1 min-h-0"
       >
-        <Resizable
-          orientation="vertical"
-          sizes={
-            isExpanded()
-              ? [1 - panelState().panelSize, panelState().panelSize]
-              : [1, 0]
-          }
-          onSizesChange={handleSizesChange}
-          class="h-full"
-        >
-          <Resizable.Panel
-            as="div"
-            class="min-h-0 overflow-hidden"
-            minSize={0.2}
-          >
-            <Terminal
-              terminalId={props.terminalId}
-              visible={props.visible}
-              focused={shouldFocusMain()}
-              theme={props.theme}
-              searchOpen={props.searchOpen}
-              onSearchOpenChange={props.onSearchOpenChange}
-              onFocus={() => subPanel.setFocusTarget(props.terminalId, "main")}
-              scrollLockEnabled={props.scrollLockEnabled}
-            />
-          </Resizable.Panel>
+        <Resizable.Panel as="div" class="min-h-0 overflow-hidden" minSize={0.2}>
+          <Terminal
+            terminalId={props.terminalId}
+            visible={props.visible}
+            focused={shouldFocusMain()}
+            theme={props.theme}
+            searchOpen={props.searchOpen}
+            onSearchOpenChange={props.onSearchOpenChange}
+            onFocus={() => subPanel.setFocusTarget(props.terminalId, "main")}
+            scrollLockEnabled={props.scrollLockEnabled}
+          />
+        </Resizable.Panel>
 
-          {/* Resize handle — only visible when expanded */}
+        {/* Resize handle — only visible when expanded */}
+        <Show when={hasSubs()}>
           <Resizable.Handle
             data-testid="resize-handle"
             class="shrink-0 transition-all"
@@ -113,66 +88,74 @@ const TerminalPane: Component<{
             }}
             aria-label="Resize terminal split"
           />
+        </Show>
 
-          {/* Collapsed strip — plain button, no Corvu resize interference */}
-          <Show when={!isExpanded()}>
-            <SplitStrip
-              variant="collapsed"
-              count={props.subTerminalIds.length}
-              onClick={() => subPanel.expandPanel(props.terminalId)}
+        {/* Collapsed strip — plain button, no Corvu resize interference */}
+        <Show when={hasSubs() && !isExpanded()}>
+          <SplitStrip
+            variant="collapsed"
+            count={props.subTerminalIds.length}
+            onClick={() => subPanel.expandPanel(props.terminalId)}
+          />
+        </Show>
+
+        <Resizable.Panel
+          as="div"
+          class="min-h-0 overflow-hidden flex flex-col"
+          minSize={0}
+          collapsible
+          collapsedSize={0}
+          onCollapse={() => subPanel.collapsePanel(props.terminalId)}
+          onExpand={() => subPanel.expandPanel(props.terminalId)}
+        >
+          <Show when={isExpanded()}>
+            <SubPanelTabBar
+              subIds={props.subTerminalIds}
+              activeSubTab={activeSubTab()}
+              getMetadata={props.getMetadata}
+              onSelect={(id) => subPanel.setActiveSubTab(props.terminalId, id)}
+              onClose={props.onCloseTerminal}
+              onCollapse={() => subPanel.collapsePanel(props.terminalId)}
+              onCreate={() =>
+                props.onCreateSubTerminal(
+                  props.terminalId,
+                  props.activeMeta?.cwd,
+                )
+              }
             />
           </Show>
+          <div class="flex-1 min-h-0">
+            <For each={props.subTerminalIds}>
+              {(subId) => (
+                <Terminal
+                  terminalId={subId}
+                  visible={
+                    props.visible && isExpanded() && activeSubTab() === subId
+                  }
+                  focused={shouldFocusSub(subId)}
+                  theme={props.theme}
+                  searchOpen={false}
+                  onSearchOpenChange={() => {}}
+                  onFocus={() =>
+                    subPanel.setFocusTarget(props.terminalId, "sub")
+                  }
+                  scrollLockEnabled={props.scrollLockEnabled}
+                  isSub
+                />
+              )}
+            </For>
+          </div>
+        </Resizable.Panel>
+      </Resizable>
 
-          <Resizable.Panel
-            as="div"
-            class="min-h-0 overflow-hidden flex flex-col"
-            minSize={0}
-            collapsible
-            collapsedSize={0}
-            onCollapse={() => subPanel.collapsePanel(props.terminalId)}
-            onExpand={() => subPanel.expandPanel(props.terminalId)}
-          >
-            <Show when={isExpanded()}>
-              <SubPanelTabBar
-                subIds={props.subTerminalIds}
-                activeSubTab={activeSubTab()}
-                getMetadata={props.getMetadata}
-                onSelect={(id) =>
-                  subPanel.setActiveSubTab(props.terminalId, id)
-                }
-                onClose={props.onCloseTerminal}
-                onCollapse={() => subPanel.collapsePanel(props.terminalId)}
-                onCreate={() =>
-                  props.onCreateSubTerminal(
-                    props.terminalId,
-                    props.activeMeta?.cwd,
-                  )
-                }
-              />
-            </Show>
-            <div class="flex-1 min-h-0">
-              <For each={props.subTerminalIds}>
-                {(subId) => (
-                  <Terminal
-                    terminalId={subId}
-                    visible={
-                      props.visible && isExpanded() && activeSubTab() === subId
-                    }
-                    focused={shouldFocusSub(subId)}
-                    theme={props.theme}
-                    searchOpen={false}
-                    onSearchOpenChange={() => {}}
-                    onFocus={() =>
-                      subPanel.setFocusTarget(props.terminalId, "sub")
-                    }
-                    scrollLockEnabled={props.scrollLockEnabled}
-                    isSub
-                  />
-                )}
-              </For>
-            </div>
-          </Resizable.Panel>
-        </Resizable>
+      {/* Prompt strip — only when no splits exist */}
+      <Show when={!hasSubs()}>
+        <SplitStrip
+          variant="prompt"
+          onClick={() =>
+            props.onCreateSubTerminal(props.terminalId, props.activeMeta?.cwd)
+          }
+        />
       </Show>
     </div>
   );


### PR DESCRIPTION
**Opening or closing a split terminal caused the main terminal to flash dark for ~200-500ms.** The root cause: `TerminalPane` used a `<Show>` to switch between two entirely different render trees — a plain `<Terminal>` (no splits) vs a `<Terminal>` inside `<Resizable>` (with splits). When `hasSubs()` flipped, SolidJS unmounted one branch and mounted the other, *destroying the xterm instance and recreating it from scratch* — font loading, WebGL context, stream attachment, the works.

The fix **renders one `<Resizable>` unconditionally** with the main terminal always mounted inside it. When there are no splits, it simply gets `sizes={[1, 0]}` — the same pattern already used for collapsed state. `<Show>` now only gates sub-panel content (tab bar, sub-terminals, resize handle), never the main terminal's lifecycle.