### PR TITLE
refactor(agents): extract CI and test into skills

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -8,7 +8,6 @@ paths:
 - Use `/do` to execute tasks end-to-end: sync → research → hickey → branch+PR → implement → check → docs → police → fmt → commit → test → CI → update-pr → done. Each step has a verification check.
 - For standalone quality checks, run `/code-police` (includes rules checklist + fact-check + elegance passes).
 - Run `just fmt` (formatting) before declaring done.
-- **Quick e2e tests**: Run `just test-quick` (or `just test-quick features/foo.feature:42` for a single scenario) to verify UI changes. Fast — no nix build, no separate dev server.
 - **Prefer external libraries over hand-rolled code**: Use well-maintained SolidJS-native libraries (Corvu, solid-sonner, @solid-primitives, etc.) to reduce custom code surface area. Less code to maintain = fewer bugs.
 
 ## Execute Pipeline Commands
@@ -22,72 +21,6 @@ These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
 ### Format command
 
 `just fmt`
-
-### Test command
-
-Run `just test-quick` with only the `.feature` files relevant to the changed code paths (e.g., `just test-quick features/worktree.feature`). Use `git diff master...HEAD --name-only` to identify changed files and match them to feature files.
-
-If changes are purely server-internal with no UI impact, unit tests may suffice — skip e2e if no relevant scenarios exist.
-
-### CI command
-
-Run `just ci` via the **Monitor** tool with this filter so each finishing CI step becomes one event:
-
-```
-just ci 2>&1 | grep --line-buffered -oE 'context="ci/[^"]+" -f description="[^"]+"'
-```
-
-Each event corresponds to one GitHub status post by `just ci`. The `description` field encodes the step state:
-
-- `srid · running` → step started
-- `srid · Ns · <log path>` → step finished successfully
-- `srid · failed after Ns · <log path>` → step failed
-
-`just ci` is bound to the Monitor's lifetime — **stopping the monitor kills `just ci` mid-run**. Let it run to completion.
-
-> **Brittleness:** the regex depends on `just ci` literally invoking `gh api ... context="ci/X" -f description="..."` on stdout. If that internal format ever changes, Monitor will silently emit zero events. The cleaner long-term fix is a `just ci::events` wrapper recipe that owns the event format. If you refactor the just recipe's status posting, update this filter too.
-
-**Verification**: After `just ci` exits, confirm that **every expected context** reported success — not just that the ones which did report are green. Silence (a missing context) means the step never ran.
-
-1. Get the expected contexts: `just ci::_contexts` (one per line, e.g. `nix@x86_64-linux`).
-2. Query posted statuses and cross-check:
-
-```bash
-export EXPECTED=$(just ci::_contexts | sed 's/^/ci\//')
-export POSTED=$(gh api "repos/<owner>/<repo>/statuses/<sha>" \
-  --jq '[.[] | select(.context | startswith("ci/"))] | group_by(.context) | map(max_by(.updated_at)) | .[] | "\(.context) \(.state)"')
-
-# Check for missing contexts (expected but never posted)
-echo "$EXPECTED" | while read ctx; do
-  echo "$POSTED" | grep -q "^$ctx " || echo "MISSING: $ctx"
-done
-
-# Check for non-success contexts
-echo "$POSTED" | grep -v ' success$' || true
-```
-
-Both checks must pass: no `MISSING` lines and no non-success states. If any context is missing, the step was blocked before it could post — investigate why (see #471 for a prior example).
-
-**On failure** — read the log file (path is in the event's description) to diagnose.
-
-**Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`). Single-step retries are short enough to run via `Bash(run_in_background)` — Monitor only pays off for full `just ci` runs.
-
-**Log flaky tests**: If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
-
-## Local CI
-
-`just ci` builds and tests across all systems. It:
-
-- Runs preflight checks (clean worktree, commit pushed)
-- Builds on x86_64-linux and aarch64-darwin in parallel
-- Posts GitHub commit statuses per step
-- Prints a summary table at the end
-
-Run it via **Monitor** (see CI command above) for live step-by-step visibility. **Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.
-
-Individual steps: `just ci::nix-toplevel`, `just ci::e2e`, etc.
-Target a specific system: `CI_SYSTEM=x86_64-linux just ci::e2e`
-Logs are saved to `.logs/<short-sha>/<step>@<system>.log`.
 
 ## Feature Discoverability (Tips)
 

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: ci
+description: Run local CI (`just ci`) and verify all steps passed. Use when building, testing across systems, checking commit statuses, retrying failed CI steps, or diagnosing CI failures. Triggers on "run CI", "check CI", "CI failed", "retry CI", "build and test".
+---
+
+# CI
+
+Run `just ci` and verify every expected step reported success.
+
+## Running
+
+Run `just ci` via the **Monitor** tool with this filter so each finishing CI step becomes one event:
+
+```
+just ci 2>&1 | grep --line-buffered -oE 'context="ci/[^"]+" -f description="[^"]+"'
+```
+
+Each event corresponds to one GitHub status post by `just ci`. The `description` field encodes the step state:
+
+- `srid · running` → step started
+- `srid · Ns · <log path>` → step finished successfully
+- `srid · failed after Ns · <log path>` → step failed
+
+`just ci` is bound to the Monitor's lifetime — **stopping the monitor kills `just ci` mid-run**. Let it run to completion.
+
+> **Brittleness:** the regex depends on `just ci` literally invoking `gh api ... context="ci/X" -f description="..."` on stdout. If that internal format ever changes, Monitor will silently emit zero events. The cleaner long-term fix is a `just ci::events` wrapper recipe that owns the event format. If you refactor the just recipe's status posting, update this filter too.
+
+## Verification
+
+After `just ci` exits, confirm that **every expected context** reported success — not just that the ones which did report are green. Silence (a missing context) means the step never ran.
+
+1. Get the expected contexts: `just ci::_contexts` (one per line, e.g. `nix@x86_64-linux`).
+2. Query posted statuses and cross-check:
+
+```bash
+export EXPECTED=$(just ci::_contexts | sed 's/^/ci\//')
+export POSTED=$(gh api "repos/<owner>/<repo>/statuses/<sha>" \
+  --jq '[.[] | select(.context | startswith("ci/"))] | group_by(.context) | map(max_by(.updated_at)) | .[] | "\(.context) \(.state)"')
+
+# Check for missing contexts (expected but never posted)
+echo "$EXPECTED" | while read ctx; do
+  echo "$POSTED" | grep -q "^$ctx " || echo "MISSING: $ctx"
+done
+
+# Check for non-success contexts
+echo "$POSTED" | grep -v ' success$' || true
+```
+
+Both checks must pass: no `MISSING` lines and no non-success states. If any context is missing, the step was blocked before it could post — investigate why (see #471 for a prior example).
+
+## On failure
+
+Read the log file (path is in the event's description) to diagnose.
+
+## Retrying individual steps
+
+`just ci::<step>` (e.g., `just ci::e2e`). Single-step retries are short enough to run via `Bash(run_in_background)` — Monitor only pays off for full `just ci` runs.
+
+## Flaky tests
+
+If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
+
+## Reference
+
+`just ci` builds and tests across all systems. It:
+
+- Runs preflight checks (clean worktree, commit pushed)
+- Builds on x86_64-linux and aarch64-darwin in parallel
+- Posts GitHub commit statuses per step
+- Prints a summary table at the end
+
+Individual steps: `just ci::nix-toplevel`, `just ci::e2e`, etc.
+Target a specific system: `CI_SYSTEM=x86_64-linux just ci::e2e`
+Logs are saved to `.logs/<short-sha>/<step>@<system>.log`.
+
+**Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: test
+description: Run e2e tests relevant to the current changes. Selects `.feature` files based on `git diff`, runs `just test-quick`, and skips e2e when changes are server-only with no UI impact. Triggers on "run tests", "test this", "check if it works", "e2e", "test the changes".
+---
+
+# Test
+
+Run e2e tests scoped to the current branch's changes.
+
+## Steps
+
+1. **Identify changed files**: Run `git diff master...HEAD --name-only` to list files changed on this branch.
+2. **Select relevant feature files**: Match changed files to `.feature` files under `tests/features/`. Use file names, component names, and domain knowledge to find the right scenarios.
+3. **Decide whether to run e2e**:
+   - If changes touch `client/src/`, `tests/`, or `common/src/` — run the matching feature files.
+   - If changes are purely server-internal (`server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
+4. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
+
+`just test-quick` is fast — no nix build, no separate dev server needed.

--- a/agents/.apm/instructions/workflow.instructions.md
+++ b/agents/.apm/instructions/workflow.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: Core workflow conventions — execute pipeline commands, CI, formatting, testing, git, feature discoverability, external libraries
+description: Core workflow conventions — pipeline commands, formatting, git, feature discoverability, external libraries
 applyTo: "**"
 ---
 
@@ -8,7 +8,6 @@ applyTo: "**"
 - Use `/do` to execute tasks end-to-end: sync → research → hickey → branch+PR → implement → check → docs → police → fmt → commit → test → CI → update-pr → done. Each step has a verification check.
 - For standalone quality checks, run `/code-police` (includes rules checklist + fact-check + elegance passes).
 - Run `just fmt` (formatting) before declaring done.
-- **Quick e2e tests**: Run `just test-quick` (or `just test-quick features/foo.feature:42` for a single scenario) to verify UI changes. Fast — no nix build, no separate dev server.
 - **Prefer external libraries over hand-rolled code**: Use well-maintained SolidJS-native libraries (Corvu, solid-sonner, @solid-primitives, etc.) to reduce custom code surface area. Less code to maintain = fewer bugs.
 
 ## Execute Pipeline Commands
@@ -22,72 +21,6 @@ These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
 ### Format command
 
 `just fmt`
-
-### Test command
-
-Run `just test-quick` with only the `.feature` files relevant to the changed code paths (e.g., `just test-quick features/worktree.feature`). Use `git diff master...HEAD --name-only` to identify changed files and match them to feature files.
-
-If changes are purely server-internal with no UI impact, unit tests may suffice — skip e2e if no relevant scenarios exist.
-
-### CI command
-
-Run `just ci` via the **Monitor** tool with this filter so each finishing CI step becomes one event:
-
-```
-just ci 2>&1 | grep --line-buffered -oE 'context="ci/[^"]+" -f description="[^"]+"'
-```
-
-Each event corresponds to one GitHub status post by `just ci`. The `description` field encodes the step state:
-
-- `srid · running` → step started
-- `srid · Ns · <log path>` → step finished successfully
-- `srid · failed after Ns · <log path>` → step failed
-
-`just ci` is bound to the Monitor's lifetime — **stopping the monitor kills `just ci` mid-run**. Let it run to completion.
-
-> **Brittleness:** the regex depends on `just ci` literally invoking `gh api ... context="ci/X" -f description="..."` on stdout. If that internal format ever changes, Monitor will silently emit zero events. The cleaner long-term fix is a `just ci::events` wrapper recipe that owns the event format. If you refactor the just recipe's status posting, update this filter too.
-
-**Verification**: After `just ci` exits, confirm that **every expected context** reported success — not just that the ones which did report are green. Silence (a missing context) means the step never ran.
-
-1. Get the expected contexts: `just ci::_contexts` (one per line, e.g. `nix@x86_64-linux`).
-2. Query posted statuses and cross-check:
-
-```bash
-export EXPECTED=$(just ci::_contexts | sed 's/^/ci\//')
-export POSTED=$(gh api "repos/<owner>/<repo>/statuses/<sha>" \
-  --jq '[.[] | select(.context | startswith("ci/"))] | group_by(.context) | map(max_by(.updated_at)) | .[] | "\(.context) \(.state)"')
-
-# Check for missing contexts (expected but never posted)
-echo "$EXPECTED" | while read ctx; do
-  echo "$POSTED" | grep -q "^$ctx " || echo "MISSING: $ctx"
-done
-
-# Check for non-success contexts
-echo "$POSTED" | grep -v ' success$' || true
-```
-
-Both checks must pass: no `MISSING` lines and no non-success states. If any context is missing, the step was blocked before it could post — investigate why (see #471 for a prior example).
-
-**On failure** — read the log file (path is in the event's description) to diagnose.
-
-**Retry individual steps**: `just ci::<step>` (e.g., `just ci::e2e`). Single-step retries are short enough to run via `Bash(run_in_background)` — Monitor only pays off for full `just ci` runs.
-
-**Log flaky tests**: If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
-
-## Local CI
-
-`just ci` builds and tests across all systems. It:
-
-- Runs preflight checks (clean worktree, commit pushed)
-- Builds on x86_64-linux and aarch64-darwin in parallel
-- Posts GitHub commit statuses per step
-- Prints a summary table at the end
-
-Run it via **Monitor** (see CI command above) for live step-by-step visibility. **Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.
-
-Individual steps: `just ci::nix-toplevel`, `just ci::e2e`, etc.
-Target a specific system: `CI_SYSTEM=x86_64-linux just ci::e2e`
-Logs are saved to `.logs/<short-sha>/<step>@<system>.log`.
 
 ## Feature Discoverability (Tips)
 

--- a/agents/.apm/skills/ci/SKILL.md
+++ b/agents/.apm/skills/ci/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: ci
+description: Run local CI (`just ci`) and verify all steps passed. Use when building, testing across systems, checking commit statuses, retrying failed CI steps, or diagnosing CI failures. Triggers on "run CI", "check CI", "CI failed", "retry CI", "build and test".
+---
+
+# CI
+
+Run `just ci` and verify every expected step reported success.
+
+## Running
+
+Run `just ci` via the **Monitor** tool with this filter so each finishing CI step becomes one event:
+
+```
+just ci 2>&1 | grep --line-buffered -oE 'context="ci/[^"]+" -f description="[^"]+"'
+```
+
+Each event corresponds to one GitHub status post by `just ci`. The `description` field encodes the step state:
+
+- `srid · running` → step started
+- `srid · Ns · <log path>` → step finished successfully
+- `srid · failed after Ns · <log path>` → step failed
+
+`just ci` is bound to the Monitor's lifetime — **stopping the monitor kills `just ci` mid-run**. Let it run to completion.
+
+> **Brittleness:** the regex depends on `just ci` literally invoking `gh api ... context="ci/X" -f description="..."` on stdout. If that internal format ever changes, Monitor will silently emit zero events. The cleaner long-term fix is a `just ci::events` wrapper recipe that owns the event format. If you refactor the just recipe's status posting, update this filter too.
+
+## Verification
+
+After `just ci` exits, confirm that **every expected context** reported success — not just that the ones which did report are green. Silence (a missing context) means the step never ran.
+
+1. Get the expected contexts: `just ci::_contexts` (one per line, e.g. `nix@x86_64-linux`).
+2. Query posted statuses and cross-check:
+
+```bash
+export EXPECTED=$(just ci::_contexts | sed 's/^/ci\//')
+export POSTED=$(gh api "repos/<owner>/<repo>/statuses/<sha>" \
+  --jq '[.[] | select(.context | startswith("ci/"))] | group_by(.context) | map(max_by(.updated_at)) | .[] | "\(.context) \(.state)"')
+
+# Check for missing contexts (expected but never posted)
+echo "$EXPECTED" | while read ctx; do
+  echo "$POSTED" | grep -q "^$ctx " || echo "MISSING: $ctx"
+done
+
+# Check for non-success contexts
+echo "$POSTED" | grep -v ' success$' || true
+```
+
+Both checks must pass: no `MISSING` lines and no non-success states. If any context is missing, the step was blocked before it could post — investigate why (see #471 for a prior example).
+
+## On failure
+
+Read the log file (path is in the event's description) to diagnose.
+
+## Retrying individual steps
+
+`just ci::<step>` (e.g., `just ci::e2e`). Single-step retries are short enough to run via `Bash(run_in_background)` — Monitor only pays off for full `just ci` runs.
+
+## Flaky tests
+
+If a test fails once but passes on retry, post a comment on [issue #320](https://github.com/juspay/kolu/issues/320) capturing the failing scenario, platform, error excerpt, and the PR where it was observed. This keeps the flaky-test log current without manual curation.
+
+## Reference
+
+`just ci` builds and tests across all systems. It:
+
+- Runs preflight checks (clean worktree, commit pushed)
+- Builds on x86_64-linux and aarch64-darwin in parallel
+- Posts GitHub commit statuses per step
+- Prints a summary table at the end
+
+Individual steps: `just ci::nix-toplevel`, `just ci::e2e`, etc.
+Target a specific system: `CI_SYSTEM=x86_64-linux just ci::e2e`
+Logs are saved to `.logs/<short-sha>/<step>@<system>.log`.
+
+**Never pipe CI to `tail` or `head`** — broken pipes kill the CI process mid-run.

--- a/agents/.apm/skills/test/SKILL.md
+++ b/agents/.apm/skills/test/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: test
+description: Run e2e tests relevant to the current changes. Selects `.feature` files based on `git diff`, runs `just test-quick`, and skips e2e when changes are server-only with no UI impact. Triggers on "run tests", "test this", "check if it works", "e2e", "test the changes".
+---
+
+# Test
+
+Run e2e tests scoped to the current branch's changes.
+
+## Steps
+
+1. **Identify changed files**: Run `git diff master...HEAD --name-only` to list files changed on this branch.
+2. **Select relevant feature files**: Match changed files to `.feature` files under `tests/features/`. Use file names, component names, and domain knowledge to find the right scenarios.
+3. **Decide whether to run e2e**:
+   - If changes touch `client/src/`, `tests/`, or `common/src/` — run the matching feature files.
+   - If changes are purely server-internal (`server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
+4. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
+
+`just test-quick` is fast — no nix build, no separate dev server needed.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-12T13:32:34.725553+00:00'
+generated_at: '2026-04-12T14:02:02.429862+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -16,6 +16,8 @@ dependencies:
   - .claude/rules/streaming.md
   - .claude/rules/toast-conventions.md
   - .claude/rules/workflow.md
+  - .claude/skills/ci
+  - .claude/skills/test
   source: local
   local_path: ./agents
 - repo_url: anthropics/skills


### PR DESCRIPTION
## Summary

The CI and test sections in `workflow.instructions.md` were **operational procedures** (Monitor filters, verification scripts, retry logic, feature-file selection) hiding inside a rules file. This extracts them into dedicated skills under `agents/.apm/skills/`:

- **`ci` skill** — owns the full `just ci` lifecycle: Monitor filter, verification cross-check against `just ci::_contexts`, retry commands, failure diagnosis, and flaky-test logging to #320
- **`test` skill** — owns e2e test selection: `git diff`-based feature-file matching, `just test-quick` invocation, skip-when-server-only logic

The skill resolver auto-matches intent to description — no explicit `/ci` or `/test` invocation needed. `workflow.instructions.md` shrinks from ~100 lines to ~30, keeping only declarative rules (pipeline overview, check/fmt one-liners, git conventions, tips, library preference).

## Test plan
- [ ] Verify `just ai::apm-sync` passes (vendored `.claude/` matches sources)
- [ ] Verify `just ci::fmt` passes
- [ ] In a fresh conversation, ask "run CI" and confirm the ci skill resolves
- [ ] In a fresh conversation, ask "run tests" and confirm the test skill resolves