### PR TITLE
File browser: worktree-scoped fuzzy search + tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Detects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions r
 
 **Debugging detection:** the command palette has a `Debug → Show Claude transcript` entry (visible only when the active terminal has a Claude session) that opens a side-by-side view of the server's state-change log next to the raw JSONL events from disk since monitoring began. Use it when state seems stuck or transitions feel missed.
 
+### File Browser
+
+- Fuzzy file search (<kbd>Cmd/Ctrl+O</kbd>) — scoped to the active terminal's workspace root, ranked by fuzzy score with match highlighting
+- Collapsible file tree in the sidebar — lazy directory listing with git status decorations (modified/untracked/added dots)
+- Read-only peek modal — select a file to view its contents with line numbers, up to 1MB
+- Live sync via `fs.watch` — no manual refresh after agents create or modify files
+
 ### Theming
 
 - 200+ color schemes from [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes), switchable at runtime
@@ -84,13 +91,14 @@ Detects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions r
 
 ## Architecture
 
-pnpm monorepo, three packages:
+pnpm monorepo, four packages:
 
-| Package   | Stack                                                                                                                                            |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `common/` | [oRPC](https://orpc.dev/) contract + [Zod](https://zod.dev/) schemas                                                                             |
-| `server/` | [Hono](https://hono.dev/) + [node-pty](https://github.com/microsoft/node-pty) + [@xterm/headless](https://www.npmjs.com/package/@xterm/headless) |
-| `client/` | [SolidJS](https://www.solidjs.com/) + [xterm.js](https://xtermjs.org/) + [Tailwind CSS v4](https://tailwindcss.com/)                             |
+| Package         | Stack                                                                                                                                            |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `common/`       | [oRPC](https://orpc.dev/) contract + [Zod](https://zod.dev/) schemas                                                                             |
+| `workspace-fs/` | File indexing, fuzzy scoring, git status, and `fs.watch` — consumed by the server                                                                |
+| `server/`       | [Hono](https://hono.dev/) + [node-pty](https://github.com/microsoft/node-pty) + [@xterm/headless](https://www.npmjs.com/package/@xterm/headless) |
+| `client/`       | [SolidJS](https://www.solidjs.com/) + [xterm.js](https://xtermjs.org/) + [Tailwind CSS v4](https://tailwindcss.com/)                             |
 
 ### Communication
 

--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "highlight.js": "^11.11.1",
+    "marked": "^18.0.0",
     "partysocket": "^1.1.16",
     "solid-js": "^1.9.0",
     "solid-sonner": "^0.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "highlight.js": "^11.11.1",
     "partysocket": "^1.1.16",
     "solid-js": "^1.9.0",
     "solid-sonner": "^0.2.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -403,8 +403,6 @@ const App: Component = () => {
           onReorder={crud.reorderTerminals}
           open={sidebarOpen()}
           onClose={closeSidebar}
-          fileTreeOpen={fileBrowser.fileTreeOpen()}
-          onToggleFileTree={() => fileBrowser.setFileTreeOpen((v) => !v)}
           fileTreeRoot={() => store.activeMeta()?.git?.repoRoot ?? null}
           onOpenFile={(root, path) => void fileBrowser.openPeek(root, path)}
         />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,9 @@ import Sidebar from "./Sidebar";
 import TerminalPane from "./TerminalPane";
 import MobileKeyBar from "./MobileKeyBar";
 import CommandPalette from "./CommandPalette";
+import FileSearch from "./FileSearch";
+import FilePeek from "./FilePeek";
+import FileTree from "./FileTree";
 import ShortcutsHelp from "./ShortcutsHelp";
 import ClaudeTranscriptDialog from "./ClaudeTranscriptDialog";
 import ModalDialog, { refocusTerminal } from "./ModalDialog";
@@ -36,6 +39,7 @@ import { useShortcuts } from "./useShortcuts";
 import { useSubPanel } from "./useSubPanel";
 import { useColorScheme } from "./useColorScheme";
 import { useTips } from "./useTips";
+import { useFileBrowser } from "./useFileBrowser";
 
 const App: Component = () => {
   const { preferences, updatePreferences } = useServerState();
@@ -70,6 +74,7 @@ const App: Component = () => {
   const { sidebarOpen, toggleSidebar, closeSidebar } = useSidebar();
   const subPanel = useSubPanel();
   const { colorScheme, setColorScheme } = useColorScheme();
+  const fileBrowser = useFileBrowser();
 
   // Fetch hostname from server; used in document title and header
   const [hostname, setHostname] = createSignal<string>();
@@ -130,6 +135,7 @@ const App: Component = () => {
     setPaletteOpen,
     setShortcutsHelpOpen,
     setSearchOpen,
+    setFileSearchOpen: fileBrowser.setFileSearchOpen,
     toggleSubPanel: (parentId) => subPanel.togglePanel(parentId),
     getSubTerminalIds: store.getSubTerminalIds,
     cycleSubTab: (parentId, direction) =>
@@ -195,6 +201,7 @@ const App: Component = () => {
     handleRandomizeTheme,
     setShortcutsHelpOpen,
     setAboutOpen,
+    setFileSearchOpen: fileBrowser.setFileSearchOpen,
     handleCreateWorktree: (repoPath, initialCommand) =>
       void worktree.handleCreateWorktree(repoPath, initialCommand),
     handleClose: () => {
@@ -257,6 +264,20 @@ const App: Component = () => {
         onOpenChange={handlePaletteOpenChange}
         initialGroup={paletteInitialGroup()}
         transparentOverlay={isPreviewingTheme()}
+      />
+      <FileSearch
+        open={fileBrowser.fileSearchOpen()}
+        onOpenChange={fileBrowser.setFileSearchOpen}
+        activeMeta={store.activeMeta}
+        onOpenFile={(root, path) => void fileBrowser.openPeek(root, path)}
+      />
+      <FilePeek
+        open={fileBrowser.filePeekOpen()}
+        onOpenChange={(open) => {
+          if (!open) fileBrowser.closePeek();
+        }}
+        filePath={fileBrowser.peekFile()?.path ?? null}
+        content={fileBrowser.peekFile()?.content ?? null}
       />
       <ShortcutsHelp
         open={shortcutsHelpOpen()}
@@ -382,6 +403,10 @@ const App: Component = () => {
           onReorder={crud.reorderTerminals}
           open={sidebarOpen()}
           onClose={closeSidebar}
+          fileTreeOpen={fileBrowser.fileTreeOpen()}
+          onToggleFileTree={() => fileBrowser.setFileTreeOpen((v) => !v)}
+          fileTreeRoot={() => store.activeMeta()?.git?.repoRoot ?? null}
+          onOpenFile={(root, path) => void fileBrowser.openPeek(root, path)}
         />
         {/* min-w-0: override flex min-width:auto so terminal area shrinks below canvas intrinsic size */}
         <div class="flex-1 min-h-0 min-w-0 flex flex-col">

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,11 +17,9 @@ import TerminalPane from "./TerminalPane";
 import MobileKeyBar from "./MobileKeyBar";
 import CommandPalette from "./CommandPalette";
 import FileSearch from "./FileSearch";
-import FilePeek from "./FilePeek";
-import DiffModal from "./DiffModal";
-import FileTree from "./FileTree";
+import RightPanel from "./RightPanel";
+import Resizable from "@corvu/resizable";
 import ShortcutsHelp from "./ShortcutsHelp";
-import ClaudeTranscriptDialog from "./ClaudeTranscriptDialog";
 import ModalDialog, { refocusTerminal } from "./ModalDialog";
 import Dialog from "@corvu/dialog";
 import EmptyState from "./EmptyState";
@@ -102,9 +100,6 @@ const App: Component = () => {
   // About dialog state
   const [aboutOpen, setAboutOpen] = createSignal(false);
 
-  // Claude transcript debug dialog state
-  const [claudeTranscriptOpen, setClaudeTranscriptOpen] = createSignal(false);
-
   // Close confirmation — snapshot ID + meta + split count at open time to prevent
   // stale-target bugs if the user switches terminals while the dialog is open.
   const [closeConfirmTarget, setCloseConfirmTarget] =
@@ -137,6 +132,7 @@ const App: Component = () => {
     setShortcutsHelpOpen,
     setSearchOpen,
     setFileSearchOpen: fileBrowser.setFileSearchOpen,
+    toggleRightPanel: fileBrowser.toggleRightPanel,
     toggleSubPanel: (parentId) => subPanel.togglePanel(parentId),
     getSubTerminalIds: store.getSubTerminalIds,
     cycleSubTab: (parentId, direction) =>
@@ -211,7 +207,7 @@ const App: Component = () => {
     },
     handleCloseAll: () => void crud.handleCloseAll(),
     simulateAlert: alerts.simulateAlert,
-    setClaudeTranscriptOpen,
+    setClaudeTranscriptOpen: () => fileBrowser.openTranscript(),
   });
 
   // Reset state on close and return focus to terminal
@@ -272,31 +268,9 @@ const App: Component = () => {
         activeMeta={store.activeMeta}
         onOpenFile={(root, path) => void fileBrowser.openPeek(root, path)}
       />
-      <FilePeek
-        open={fileBrowser.filePeekOpen()}
-        onOpenChange={(open) => {
-          if (!open) fileBrowser.closePeek();
-        }}
-        filePath={fileBrowser.peekFile()?.path ?? null}
-        root={store.activeMeta()?.git?.repoRoot ?? null}
-        content={fileBrowser.peekFile()?.content ?? null}
-      />
-      <DiffModal
-        open={fileBrowser.diffOpen()}
-        onOpenChange={(open) => {
-          if (!open) fileBrowser.closeDiff();
-        }}
-        root={fileBrowser.diffTarget()?.root ?? null}
-        filePath={fileBrowser.diffTarget()?.filePath ?? null}
-      />
       <ShortcutsHelp
         open={shortcutsHelpOpen()}
         onOpenChange={withRefocus(setShortcutsHelpOpen)}
-      />
-      <ClaudeTranscriptDialog
-        open={claudeTranscriptOpen()}
-        onOpenChange={withRefocus(setClaudeTranscriptOpen)}
-        terminalId={store.activeId}
       />
       <ModalDialog open={aboutOpen()} onOpenChange={withRefocus(setAboutOpen)}>
         <Dialog.Content class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-6 max-w-sm text-sm">
@@ -413,54 +387,90 @@ const App: Component = () => {
           onReorder={crud.reorderTerminals}
           open={sidebarOpen()}
           onClose={closeSidebar}
-          fileTreeRoot={() => store.activeMeta()?.git?.repoRoot ?? null}
-          onOpenFile={(root, path) => void fileBrowser.openPeek(root, path)}
-          onOpenDiff={(root, path) => fileBrowser.openDiff(root, path)}
         />
-        {/* min-w-0: override flex min-width:auto so terminal area shrinks below canvas intrinsic size */}
-        <div class="flex-1 min-h-0 min-w-0 flex flex-col">
-          <div
-            class="flex-1 min-h-0 overflow-hidden"
-            style={{ "background-color": activeTheme().background }}
-            data-testid="terminal-viewport"
-          >
-            <Show
-              when={!session.isLoading()}
-              fallback={
-                <div class="flex items-center justify-center h-full text-fg-3 text-sm">
-                  Connecting...
-                </div>
-              }
+        {/* Terminal + right panel — resizable horizontal split.
+         *  min-w-0 on the outer div prevents flex min-width:auto from
+         *  blocking shrinking below canvas intrinsic size. */}
+        <Resizable
+          orientation="horizontal"
+          sizes={fileBrowser.rightPanelOpen() ? [0.65, 0.35] : [1, 0]}
+          class="flex-1 min-h-0 min-w-0"
+        >
+          <Resizable.Panel as="div" class="min-w-0 flex flex-col" minSize={0.3}>
+            <div
+              class="flex-1 min-h-0 overflow-hidden"
+              style={{ "background-color": activeTheme().background }}
+              data-testid="terminal-viewport"
             >
-              <Show when={store.terminalIds().length === 0}>
-                <EmptyState
-                  savedSession={session.savedSession() ?? undefined}
-                  onRestore={() => void session.handleRestoreSession()}
-                />
-              </Show>
-              <For each={store.terminalIds()}>
-                {(id) => (
-                  <TerminalPane
-                    terminalId={id}
-                    visible={store.activeId() === id}
-                    theme={getTerminalTheme(id)}
-                    searchOpen={searchOpen()}
-                    onSearchOpenChange={setSearchOpen}
-                    subTerminalIds={store.getSubTerminalIds(id)}
-                    getMetadata={store.getMetadata}
-                    onCreateSubTerminal={(parentId, cwd) =>
-                      void crud.handleCreateSubTerminal(parentId, cwd)
-                    }
-                    onCloseTerminal={closeTerminal}
-                    activeMeta={store.activeMeta()}
-                    scrollLockEnabled={scrollLock()}
+              <Show
+                when={!session.isLoading()}
+                fallback={
+                  <div class="flex items-center justify-center h-full text-fg-3 text-sm">
+                    Connecting...
+                  </div>
+                }
+              >
+                <Show when={store.terminalIds().length === 0}>
+                  <EmptyState
+                    savedSession={session.savedSession() ?? undefined}
+                    onRestore={() => void session.handleRestoreSession()}
                   />
-                )}
-              </For>
+                </Show>
+                <For each={store.terminalIds()}>
+                  {(id) => (
+                    <TerminalPane
+                      terminalId={id}
+                      visible={store.activeId() === id}
+                      theme={getTerminalTheme(id)}
+                      searchOpen={searchOpen()}
+                      onSearchOpenChange={setSearchOpen}
+                      subTerminalIds={store.getSubTerminalIds(id)}
+                      getMetadata={store.getMetadata}
+                      onCreateSubTerminal={(parentId, cwd) =>
+                        void crud.handleCreateSubTerminal(parentId, cwd)
+                      }
+                      onCloseTerminal={closeTerminal}
+                      activeMeta={store.activeMeta()}
+                      scrollLockEnabled={scrollLock()}
+                    />
+                  )}
+                </For>
+              </Show>
+            </div>
+            <MobileKeyBar activeId={store.activeId} />
+          </Resizable.Panel>
+
+          <Show when={fileBrowser.rightPanelOpen()}>
+            <Resizable.Handle
+              class="shrink-0 w-1 bg-edge hover:bg-accent-bright transition-colors cursor-col-resize"
+              aria-label="Resize right panel"
+            />
+          </Show>
+
+          <Resizable.Panel
+            as="div"
+            class="min-w-0 overflow-hidden"
+            minSize={0}
+            collapsible
+            collapsedSize={0}
+          >
+            <Show when={fileBrowser.rightPanelOpen()}>
+              <RightPanel
+                view={fileBrowser.rightPanelView()}
+                onViewChange={fileBrowser.setRightPanelView}
+                fileTreeRoot={() => store.activeMeta()?.git?.repoRoot ?? null}
+                onOpenFile={(root, path) =>
+                  void fileBrowser.openPeek(root, path)
+                }
+                onOpenDiff={(root, path) => fileBrowser.openDiff(root, path)}
+                peekFile={fileBrowser.peekFile()}
+                diffTarget={fileBrowser.diffTarget()}
+                onBack={fileBrowser.goBack}
+                terminalId={store.activeId}
+              />
             </Show>
-          </div>
-          <MobileKeyBar activeId={store.activeId} />
-        </div>
+          </Resizable.Panel>
+        </Resizable>
       </div>
     </div>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import MobileKeyBar from "./MobileKeyBar";
 import CommandPalette from "./CommandPalette";
 import FileSearch from "./FileSearch";
 import FilePeek from "./FilePeek";
+import DiffModal from "./DiffModal";
 import FileTree from "./FileTree";
 import ShortcutsHelp from "./ShortcutsHelp";
 import ClaudeTranscriptDialog from "./ClaudeTranscriptDialog";
@@ -280,6 +281,14 @@ const App: Component = () => {
         root={store.activeMeta()?.git?.repoRoot ?? null}
         content={fileBrowser.peekFile()?.content ?? null}
       />
+      <DiffModal
+        open={fileBrowser.diffOpen()}
+        onOpenChange={(open) => {
+          if (!open) fileBrowser.closeDiff();
+        }}
+        root={fileBrowser.diffTarget()?.root ?? null}
+        filePath={fileBrowser.diffTarget()?.filePath ?? null}
+      />
       <ShortcutsHelp
         open={shortcutsHelpOpen()}
         onOpenChange={withRefocus(setShortcutsHelpOpen)}
@@ -406,6 +415,7 @@ const App: Component = () => {
           onClose={closeSidebar}
           fileTreeRoot={() => store.activeMeta()?.git?.repoRoot ?? null}
           onOpenFile={(root, path) => void fileBrowser.openPeek(root, path)}
+          onOpenDiff={(root, path) => fileBrowser.openDiff(root, path)}
         />
         {/* min-w-0: override flex min-width:auto so terminal area shrinks below canvas intrinsic size */}
         <div class="flex-1 min-h-0 min-w-0 flex flex-col">

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import {
   createSignal,
   createEffect,
   on,
+  onCleanup,
   Show,
   For,
 } from "solid-js";
@@ -28,7 +29,8 @@ import { createCommands } from "./commands";
 import { exportSessionAsPdf } from "./exportSessionAsPdf";
 
 import type { TerminalId } from "kolu-common";
-import { client, wsStatus, serverProcessId } from "./rpc";
+import { client, stream, wsStatus, serverProcessId } from "./rpc";
+import { toast } from "solid-sonner";
 import TransportOverlay from "./TransportOverlay";
 import { useTerminals } from "./useTerminals";
 import { useServerState } from "./useServerState";
@@ -74,6 +76,48 @@ const App: Component = () => {
   const subPanel = useSubPanel();
   const { colorScheme, setColorScheme } = useColorScheme();
   const fileBrowser = useFileBrowser();
+
+  // --- Live filesystem change stream ---
+  // Subscribes to fs.onChange for the active workspace root.
+  // Increments a counter that triggers FileTree/GitChanges to refresh.
+  const [fsRefreshSignal, setFsRefreshSignal] = createSignal(0);
+  createEffect(
+    on(
+      () => store.activeMeta()?.git?.repoRoot ?? null,
+      (root) => {
+        if (!root) return;
+        const ac = new AbortController();
+        onCleanup(() => ac.abort());
+        void (async () => {
+          try {
+            const iter = await stream.fsOnChange(root, ac.signal);
+            for await (const _ of iter) {
+              setFsRefreshSignal((n) => n + 1);
+            }
+          } catch {
+            // Stream ended (abort or reconnect) — handled by retry plugin
+          }
+        })();
+      },
+    ),
+  );
+
+  // --- Stage/unstage file actions ---
+  function handleStageFile(root: string, filePath: string) {
+    void client.fs
+      .stage({ root, filePath })
+      .catch((err: Error) =>
+        toast.error(`Failed to stage ${filePath}: ${err.message}`),
+      );
+  }
+
+  function handleUnstageFile(root: string, filePath: string) {
+    void client.fs
+      .unstage({ root, filePath })
+      .catch((err: Error) =>
+        toast.error(`Failed to unstage ${filePath}: ${err.message}`),
+      );
+  }
 
   // Fetch hostname from server; used in document title and header
   const [hostname, setHostname] = createSignal<string>();
@@ -267,6 +311,7 @@ const App: Component = () => {
         onOpenChange={fileBrowser.setFileSearchOpen}
         activeMeta={store.activeMeta}
         onOpenFile={(root, path) => void fileBrowser.openPeek(root, path)}
+        onPreviewFile={(root, path) => void fileBrowser.openPeek(root, path)}
       />
       <ShortcutsHelp
         open={shortcutsHelpOpen()}
@@ -475,11 +520,15 @@ const App: Component = () => {
                   void fileBrowser.openPeek(root, path)
                 }
                 onOpenDiff={(root, path) => fileBrowser.openDiff(root, path)}
+                onOpenBlame={(root, path) => fileBrowser.openBlame(root, path)}
                 peekFile={fileBrowser.peekFile()}
                 diffTarget={fileBrowser.diffTarget()}
                 originLabel={fileBrowser.originLabel()}
                 onBack={fileBrowser.goBack}
                 terminalId={store.activeId}
+                onStageFile={handleStageFile}
+                onUnstageFile={handleUnstageFile}
+                refreshSignal={fsRefreshSignal}
               />
             </Show>
           </Resizable.Panel>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -395,7 +395,17 @@ const App: Component = () => {
          *  blocking shrinking below canvas intrinsic size. */}
         <Resizable
           orientation="horizontal"
-          sizes={fileBrowser.rightPanelOpen() ? [0.65, 0.35] : [1, 0]}
+          sizes={
+            fileBrowser.rightPanelOpen()
+              ? [1 - fileBrowser.rightPanelSize(), fileBrowser.rightPanelSize()]
+              : [1, 0]
+          }
+          onSizesChange={(sizes) => {
+            // Persist user's drag so the panel remembers its width
+            if (sizes[1] !== undefined && sizes[1] > 0.05) {
+              fileBrowser.setRightPanelSize(sizes[1]);
+            }
+          }}
           class="flex-1 min-h-0 min-w-0"
         >
           <Resizable.Panel as="div" class="min-w-0 flex flex-col" minSize={0.3}>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -340,6 +340,8 @@ const App: Component = () => {
         themeName={activeThemeName()}
         meta={store.activeMeta()}
         onToggleSidebar={toggleSidebar}
+        onToggleRightPanel={fileBrowser.toggleRightPanel}
+        rightPanelOpen={fileBrowser.rightPanelOpen()}
         onSearch={() => setSearchOpen(true)}
         appTitle={appTitle()}
         randomTheme={randomTheme()}
@@ -465,6 +467,7 @@ const App: Component = () => {
                 onOpenDiff={(root, path) => fileBrowser.openDiff(root, path)}
                 peekFile={fileBrowser.peekFile()}
                 diffTarget={fileBrowser.diffTarget()}
+                originLabel={fileBrowser.originLabel()}
                 onBack={fileBrowser.goBack}
                 terminalId={store.activeId}
               />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -277,6 +277,7 @@ const App: Component = () => {
           if (!open) fileBrowser.closePeek();
         }}
         filePath={fileBrowser.peekFile()?.path ?? null}
+        root={store.activeMeta()?.git?.repoRoot ?? null}
         content={fileBrowser.peekFile()?.content ?? null}
       />
       <ShortcutsHelp

--- a/client/src/DiffModal.tsx
+++ b/client/src/DiffModal.tsx
@@ -1,0 +1,212 @@
+/**
+ * Full-width diff modal — shows unified diff for a single file with
+ * syntax-colored add/remove lines, line numbers, and hunk headers.
+ * Opened from the Changes sidebar tab or when selecting a modified file
+ * in file search.
+ */
+
+import {
+  type Component,
+  createSignal,
+  createEffect,
+  on,
+  For,
+  Show,
+} from "solid-js";
+import Dialog from "@corvu/dialog";
+import ModalDialog from "./ModalDialog";
+import { client } from "./rpc";
+import { match } from "ts-pattern";
+import type { FsFileDiffOutput, DiffHunk } from "kolu-common";
+
+const DiffModal: Component<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  root: string | null;
+  filePath: string | null;
+}> = (props) => {
+  const [diff, setDiff] = createSignal<FsFileDiffOutput | null>(null);
+  const [loading, setLoading] = createSignal(false);
+
+  createEffect(
+    on(
+      () => [props.root, props.filePath, props.open] as const,
+      ([root, filePath, open]) => {
+        setDiff(null);
+        if (!root || !filePath || !open) return;
+        setLoading(true);
+        void client.fs
+          .fileDiff({ root, filePath })
+          .then(setDiff)
+          .catch((err: unknown) => {
+            console.warn("Failed to load diff:", err);
+          })
+          .finally(() => setLoading(false));
+      },
+    ),
+  );
+
+  const totalAdded = () =>
+    diff()?.hunks.reduce(
+      (n, h) => n + h.lines.filter((l) => l.kind === "add").length,
+      0,
+    ) ?? 0;
+  const totalRemoved = () =>
+    diff()?.hunks.reduce(
+      (n, h) => n + h.lines.filter((l) => l.kind === "remove").length,
+      0,
+    ) ?? 0;
+
+  return (
+    <ModalDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <Dialog.Content
+        data-testid="diff-modal"
+        class="w-4xl max-w-[95vw] bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
+        style={{
+          height: "min(40rem, 85vh)",
+          "background-color": "var(--color-surface-1)",
+        }}
+      >
+        {/* Header */}
+        <div class="flex items-center justify-between px-4 py-2.5 border-b border-edge">
+          <div class="flex items-center gap-2 min-w-0">
+            <svg
+              class="w-4 h-4 text-fg-3 shrink-0"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path d="M4 2v12M12 2v12M4 6h8M4 10h8" />
+            </svg>
+            <span class="text-sm text-fg truncate font-mono">
+              {props.filePath}
+            </span>
+            <Show when={diff()}>
+              <span class="shrink-0 text-xs text-green-400 font-mono">
+                +{totalAdded()}
+              </span>
+              <span class="shrink-0 text-xs text-red-400 font-mono">
+                -{totalRemoved()}
+              </span>
+            </Show>
+          </div>
+          <button
+            class="text-fg-3 hover:text-fg transition-colors shrink-0"
+            onClick={() => props.onOpenChange(false)}
+            title="Close"
+          >
+            <svg
+              class="w-4 h-4"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M4 4l8 8M12 4l-8 8" />
+            </svg>
+          </button>
+        </div>
+        {/* Diff content */}
+        <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
+          <Show
+            when={!loading()}
+            fallback={<div class="p-4 text-fg-3">Loading diff...</div>}
+          >
+            <Show
+              when={diff()?.hunks.length}
+              fallback={
+                <div class="p-4 text-fg-3 italic">No changes to display</div>
+              }
+            >
+              <table class="w-full border-collapse">
+                <tbody>
+                  <For each={diff()!.hunks}>
+                    {(hunk, hunkIdx) => (
+                      <>
+                        {/* Hunk separator */}
+                        <Show when={hunkIdx() > 0}>
+                          <tr>
+                            <td
+                              colspan="4"
+                              class="h-2 bg-surface-0 border-y border-edge/30"
+                            />
+                          </tr>
+                        </Show>
+                        {/* Hunk header */}
+                        <tr class="bg-blue-500/5">
+                          <td
+                            colspan="4"
+                            class="px-4 py-1 text-fg-3 text-[0.7rem] select-none"
+                          >
+                            @@ -{hunk.oldStart},{hunk.oldCount} +{hunk.newStart}
+                            ,{hunk.newCount} @@
+                          </td>
+                        </tr>
+                        {/* Diff lines */}
+                        <For each={hunk.lines}>
+                          {(line) => {
+                            const style = match(line.kind)
+                              .with("add", () => ({
+                                bg: "bg-green-500/10",
+                                marker: "+",
+                                markerColor: "text-green-400",
+                                textColor: "text-green-200",
+                              }))
+                              .with("remove", () => ({
+                                bg: "bg-red-500/10",
+                                marker: "-",
+                                markerColor: "text-red-400",
+                                textColor: "text-red-200",
+                              }))
+                              .with("context", () => ({
+                                bg: "",
+                                marker: " ",
+                                markerColor: "text-fg-3",
+                                textColor: "text-fg-2",
+                              }))
+                              .exhaustive();
+                            return (
+                              <tr class={`${style.bg} hover:brightness-110`}>
+                                {/* Old line number */}
+                                <td class="w-12 text-right pr-1 pl-3 text-fg-3/50 select-none">
+                                  {line.oldLine ?? ""}
+                                </td>
+                                {/* New line number */}
+                                <td class="w-12 text-right pr-2 text-fg-3/50 select-none border-r border-edge/20">
+                                  {line.newLine ?? ""}
+                                </td>
+                                {/* +/- marker */}
+                                <td
+                                  class={`w-6 text-center select-none ${style.markerColor}`}
+                                >
+                                  {style.marker}
+                                </td>
+                                {/* Content */}
+                                <td
+                                  class={`pr-4 whitespace-pre ${style.textColor}`}
+                                >
+                                  {line.content || " "}
+                                </td>
+                              </tr>
+                            );
+                          }}
+                        </For>
+                      </>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+            </Show>
+          </Show>
+        </div>
+        {/* Footer hint */}
+        <div class="px-4 py-2 text-[0.7rem] text-fg-3 border-t border-edge">
+          <kbd class="text-fg-3">esc</kbd> close
+        </div>
+      </Dialog.Content>
+    </ModalDialog>
+  );
+};
+
+export default DiffModal;

--- a/client/src/FilePeek.tsx
+++ b/client/src/FilePeek.tsx
@@ -1,13 +1,99 @@
 /**
- * File peek modal — read-only view of file contents with line numbers.
+ * File peek modal — read-only view of file contents with line numbers
+ * and syntax highlighting via highlight.js (lazy-loaded on first open).
  * Deliberately no editing — Kolu is terminal-first, the file browser's
  * job is navigation and context, not authoring.
  */
 
-import { type Component, Show, For, createMemo } from "solid-js";
+import {
+  type Component,
+  Show,
+  For,
+  createMemo,
+  createSignal,
+  createEffect,
+  on,
+} from "solid-js";
 import Dialog from "@corvu/dialog";
 import ModalDialog from "./ModalDialog";
 import type { FsReadFileOutput } from "kolu-common";
+
+/** Map file extension to highlight.js language name. */
+const EXT_TO_LANG: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  rs: "rust",
+  go: "go",
+  rb: "ruby",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  fish: "bash",
+  json: "json",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "ini",
+  md: "markdown",
+  html: "xml",
+  htm: "xml",
+  xml: "xml",
+  svg: "xml",
+  css: "css",
+  scss: "scss",
+  sql: "sql",
+  nix: "nix",
+  hs: "haskell",
+  ex: "elixir",
+  exs: "elixir",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  hpp: "cpp",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  lua: "lua",
+  vim: "vim",
+  dockerfile: "dockerfile",
+  makefile: "makefile",
+  feature: "gherkin",
+};
+
+function getLang(filePath: string): string | undefined {
+  const name = filePath.split("/").pop()?.toLowerCase() ?? "";
+  // Handle extensionless files like Dockerfile, Makefile
+  if (EXT_TO_LANG[name]) return EXT_TO_LANG[name];
+  const ext = name.split(".").pop() ?? "";
+  return EXT_TO_LANG[ext];
+}
+
+/** Lazy-load highlight.js and highlight code. Returns HTML lines. */
+async function highlightLines(
+  code: string,
+  lang: string | undefined,
+): Promise<string[]> {
+  const hljs = (await import("highlight.js")).default;
+  let html: string;
+  if (lang) {
+    try {
+      html = hljs.highlight(code, {
+        language: lang,
+        ignoreIllegals: true,
+      }).value;
+    } catch {
+      // Language not registered — fall back to auto-detect
+      html = hljs.highlightAuto(code).value;
+    }
+  } else {
+    html = hljs.highlightAuto(code).value;
+  }
+  return html.split("\n");
+}
 
 const FilePeek: Component<{
   open: boolean;
@@ -15,15 +101,31 @@ const FilePeek: Component<{
   filePath: string | null;
   content: FsReadFileOutput | null;
 }> = (props) => {
-  const lines = createMemo(() => {
+  const rawLines = createMemo(() => {
     if (!props.content) return [];
     return props.content.content.split("\n");
   });
 
   const lineNumWidth = createMemo(() => {
-    const count = lines().length;
+    const count = rawLines().length;
     return Math.max(String(count).length, 3);
   });
+
+  // Highlighted HTML lines — populated async after content loads
+  const [hlLines, setHlLines] = createSignal<string[] | null>(null);
+
+  // Trigger highlighting when content or filePath changes
+  createEffect(
+    on(
+      () => [props.content, props.filePath] as const,
+      ([content, filePath]) => {
+        setHlLines(null);
+        if (!content || !filePath) return;
+        const lang = getLang(filePath);
+        void highlightLines(content.content, lang).then(setHlLines);
+      },
+    ),
+  );
 
   return (
     <ModalDialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -86,20 +188,35 @@ const FilePeek: Component<{
           >
             <table class="w-full border-collapse">
               <tbody>
-                <For each={lines()}>
-                  {(line, i) => (
-                    <tr class="hover:bg-surface-2 transition-colors">
-                      <td
-                        class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-3 select-none border-r border-edge"
-                        style={{ width: `${lineNumWidth() + 2}ch` }}
-                      >
-                        {i() + 1}
-                      </td>
-                      <td class="pl-3 pr-4 whitespace-pre text-fg">
-                        {line || " "}
-                      </td>
-                    </tr>
-                  )}
+                <For each={rawLines()}>
+                  {(line, i) => {
+                    const highlighted = () => hlLines()?.[i()];
+                    return (
+                      <tr class="hover:bg-surface-2 transition-colors">
+                        <td
+                          class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-3 select-none border-r border-edge"
+                          style={{ width: `${lineNumWidth() + 2}ch` }}
+                        >
+                          {i() + 1}
+                        </td>
+                        <Show
+                          when={highlighted()}
+                          fallback={
+                            <td class="pl-3 pr-4 whitespace-pre text-fg">
+                              {line || " "}
+                            </td>
+                          }
+                        >
+                          {(html) => (
+                            <td
+                              class="pl-3 pr-4 whitespace-pre text-fg"
+                              innerHTML={html() || " "}
+                            />
+                          )}
+                        </Show>
+                      </tr>
+                    );
+                  }}
                 </For>
               </tbody>
             </table>

--- a/client/src/FilePeek.tsx
+++ b/client/src/FilePeek.tsx
@@ -1,0 +1,119 @@
+/**
+ * File peek modal — read-only view of file contents with line numbers.
+ * Deliberately no editing — Kolu is terminal-first, the file browser's
+ * job is navigation and context, not authoring.
+ */
+
+import { type Component, Show, For, createMemo } from "solid-js";
+import Dialog from "@corvu/dialog";
+import ModalDialog from "./ModalDialog";
+import type { FsReadFileOutput } from "kolu-common";
+
+const FilePeek: Component<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  filePath: string | null;
+  content: FsReadFileOutput | null;
+}> = (props) => {
+  const lines = createMemo(() => {
+    if (!props.content) return [];
+    return props.content.content.split("\n");
+  });
+
+  const lineNumWidth = createMemo(() => {
+    const count = lines().length;
+    return Math.max(String(count).length, 3);
+  });
+
+  return (
+    <ModalDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <Dialog.Content
+        data-testid="file-peek"
+        class="w-3xl max-w-[90vw] bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
+        style={{
+          height: "min(36rem, 80vh)",
+          "background-color": "var(--color-surface-1)",
+        }}
+      >
+        {/* Header */}
+        <div class="flex items-center justify-between px-4 py-2.5 border-b border-edge">
+          <div class="flex items-center gap-2 min-w-0">
+            <svg
+              class="w-4 h-4 text-fg-3 shrink-0"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
+              <path d="M3 1h7l4 4v10a1 1 0 01-1 1H3a1 1 0 01-1-1V2a1 1 0 011-1zm6 0v4h4" />
+            </svg>
+            <span class="text-sm text-fg truncate font-mono">
+              {props.filePath}
+            </span>
+          </div>
+          <div class="flex items-center gap-3 text-xs text-fg-3 shrink-0">
+            <Show when={props.content}>
+              {(c) => (
+                <>
+                  <span>{c().lineCount} lines</span>
+                  <span>{formatBytes(c().byteLength)}</span>
+                  <Show when={c().truncated}>
+                    <span class="text-yellow-400">truncated</span>
+                  </Show>
+                </>
+              )}
+            </Show>
+            <button
+              class="text-fg-3 hover:text-fg transition-colors"
+              onClick={() => props.onOpenChange(false)}
+              title="Close"
+            >
+              <svg
+                class="w-4 h-4"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path d="M4 4l8 8M12 4l-8 8" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        {/* Content */}
+        <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
+          <Show
+            when={props.content}
+            fallback={<div class="p-4 text-fg-3">Loading...</div>}
+          >
+            <table class="w-full border-collapse">
+              <tbody>
+                <For each={lines()}>
+                  {(line, i) => (
+                    <tr class="hover:bg-surface-2 transition-colors">
+                      <td
+                        class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-3 select-none border-r border-edge"
+                        style={{ width: `${lineNumWidth() + 2}ch` }}
+                      >
+                        {i() + 1}
+                      </td>
+                      <td class="pl-3 pr-4 whitespace-pre text-fg">
+                        {line || " "}
+                      </td>
+                    </tr>
+                  )}
+                </For>
+              </tbody>
+            </table>
+          </Show>
+        </div>
+      </Dialog.Content>
+    </ModalDialog>
+  );
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default FilePeek;

--- a/client/src/FilePeek.tsx
+++ b/client/src/FilePeek.tsx
@@ -1,6 +1,7 @@
 /**
- * File peek modal — read-only view of file contents with line numbers
- * and syntax highlighting via highlight.js (lazy-loaded on first open).
+ * File peek modal — read-only view of file contents with line numbers,
+ * syntax highlighting via highlight.js (lazy-loaded), and git gutter
+ * markers showing which lines are added/modified/deleted.
  * Deliberately no editing — Kolu is terminal-first, the file browser's
  * job is navigation and context, not authoring.
  */
@@ -16,7 +17,8 @@ import {
 } from "solid-js";
 import Dialog from "@corvu/dialog";
 import ModalDialog from "./ModalDialog";
-import type { FsReadFileOutput } from "kolu-common";
+import { client } from "./rpc";
+import type { FsReadFileOutput, FsFileDiffOutput } from "kolu-common";
 
 /** Map file extension to highlight.js language name. */
 const EXT_TO_LANG: Record<string, string> = {
@@ -66,7 +68,6 @@ const EXT_TO_LANG: Record<string, string> = {
 
 function getLang(filePath: string): string | undefined {
   const name = filePath.split("/").pop()?.toLowerCase() ?? "";
-  // Handle extensionless files like Dockerfile, Makefile
   if (EXT_TO_LANG[name]) return EXT_TO_LANG[name];
   const ext = name.split(".").pop() ?? "";
   return EXT_TO_LANG[ext];
@@ -95,10 +96,32 @@ async function highlightLines(
   return html.split("\n");
 }
 
+/** Git gutter marker type for a given line number. */
+type GutterMark = "added" | "modified" | "deleted-below" | null;
+
+function buildGutterMap(diff: FsFileDiffOutput): Map<number, GutterMark> {
+  const map = new Map<number, GutterMark>();
+  for (const line of diff.addedLines) map.set(line, "added");
+  for (const line of diff.modifiedLines) map.set(line, "modified");
+  for (const line of diff.deletedAfterLines) {
+    // Only set if not already marked as add/modify
+    if (!map.has(line)) map.set(line, "deleted-below");
+  }
+  return map;
+}
+
+const GUTTER_COLORS: Record<string, string> = {
+  added: "bg-green-500",
+  modified: "bg-blue-400",
+  "deleted-below": "bg-red-500",
+};
+
 const FilePeek: Component<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
   filePath: string | null;
+  /** Workspace root — needed for fetching diff. */
+  root: string | null;
   content: FsReadFileOutput | null;
 }> = (props) => {
   const rawLines = createMemo(() => {
@@ -114,15 +137,34 @@ const FilePeek: Component<{
   // Highlighted HTML lines — populated async after content loads
   const [hlLines, setHlLines] = createSignal<string[] | null>(null);
 
-  // Trigger highlighting when content or filePath changes
+  // Git diff data for gutter markers
+  const [diffData, setDiffData] = createSignal<FsFileDiffOutput | null>(null);
+  const gutterMap = createMemo(() =>
+    diffData() ? buildGutterMap(diffData()!) : new Map<number, GutterMark>(),
+  );
+
+  // Trigger highlighting + diff fetch when content/filePath changes
   createEffect(
     on(
-      () => [props.content, props.filePath] as const,
-      ([content, filePath]) => {
+      () => [props.content, props.filePath, props.root] as const,
+      ([content, filePath, root]) => {
         setHlLines(null);
+        setDiffData(null);
         if (!content || !filePath) return;
+
+        // Syntax highlighting
         const lang = getLang(filePath);
         void highlightLines(content.content, lang).then(setHlLines);
+
+        // Git diff for gutter (best-effort — skip if no root or file is clean)
+        if (root) {
+          void client.fs
+            .fileDiff({ root, filePath })
+            .then(setDiffData)
+            .catch(() => {
+              // No diff available — file might not be in a git repo
+            });
+        }
       },
     ),
   );
@@ -190,14 +232,27 @@ const FilePeek: Component<{
               <tbody>
                 <For each={rawLines()}>
                   {(line, i) => {
+                    const lineNum = () => i() + 1;
                     const highlighted = () => hlLines()?.[i()];
+                    const gutter = () => gutterMap().get(lineNum()) ?? null;
                     return (
                       <tr class="hover:bg-surface-2 transition-colors">
+                        {/* Git gutter — thin colored strip left of line numbers */}
+                        <td class="w-1 p-0">
+                          <Show when={gutter()}>
+                            {(mark) => (
+                              <div
+                                class={`w-0.5 h-full ${GUTTER_COLORS[mark()]}`}
+                                title={mark()}
+                              />
+                            )}
+                          </Show>
+                        </td>
                         <td
-                          class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-3 select-none border-r border-edge"
+                          class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-2 select-none border-r border-edge"
                           style={{ width: `${lineNumWidth() + 2}ch` }}
                         >
-                          {i() + 1}
+                          {lineNum()}
                         </td>
                         <Show
                           when={highlighted()}

--- a/client/src/FileSearch.tsx
+++ b/client/src/FileSearch.tsx
@@ -1,0 +1,318 @@
+/**
+ * File search overlay — fuzzy file finder scoped to the active workspace.
+ * Triggered by Cmd+O. Query-driven: sends query to server, displays ranked results.
+ */
+
+import {
+  type Component,
+  type Accessor,
+  createSignal,
+  createEffect,
+  on,
+  For,
+  Show,
+} from "solid-js";
+import { makeEventListener } from "@solid-primitives/event-listener";
+import Dialog from "@corvu/dialog";
+import ModalDialog from "./ModalDialog";
+import { formatKeybind, SHORTCUTS } from "./keyboard";
+import Kbd from "./Kbd";
+import type { FsSearchResult, TerminalMetadata } from "kolu-common";
+import { client } from "./rpc";
+import { gitStatusTextColor } from "./gitStatusColor";
+
+/** Render a file path with highlighted match positions. */
+const HighlightedPath: Component<{
+  path: string;
+  matches: number[];
+}> = (props) => {
+  const segments = () => {
+    const matchSet = new Set(props.matches);
+    const result: Array<{ text: string; matched: boolean }> = [];
+    let current = "";
+    let isMatch = false;
+
+    for (let i = 0; i < props.path.length; i++) {
+      const charMatch = matchSet.has(i);
+      if (charMatch !== isMatch && current) {
+        result.push({ text: current, matched: isMatch });
+        current = "";
+      }
+      current += props.path[i];
+      isMatch = charMatch;
+    }
+    if (current) result.push({ text: current, matched: isMatch });
+    return result;
+  };
+
+  return (
+    <span class="truncate">
+      <For each={segments()}>
+        {(seg) =>
+          seg.matched ? (
+            <span class="text-accent font-semibold">{seg.text}</span>
+          ) : (
+            <span>{seg.text}</span>
+          )
+        }
+      </For>
+    </span>
+  );
+};
+
+const FileSearch: Component<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeMeta: Accessor<TerminalMetadata | null>;
+  onOpenFile: (root: string, filePath: string) => void;
+}> = (props) => {
+  let inputRef!: HTMLInputElement;
+  const [query, setQuery] = createSignal("");
+  const [results, setResults] = createSignal<FsSearchResult[]>([]);
+  const [selectedIndex, setSelectedIndex] = createSignal(0);
+  const [searching, setSearching] = createSignal(false);
+  let mouseActive = false;
+  let searchVersion = 0;
+
+  const root = () => {
+    const meta = props.activeMeta();
+    return meta?.git?.repoRoot ?? null;
+  };
+
+  // Search on query change (debounced)
+  let searchTimer: ReturnType<typeof setTimeout> | undefined;
+  createEffect(
+    on(query, (q) => {
+      clearTimeout(searchTimer);
+      const currentRoot = root();
+      if (!currentRoot) {
+        setResults([]);
+        return;
+      }
+      const version = ++searchVersion;
+      if (!q) {
+        // Empty query: show all files (up to limit)
+        setSearching(true);
+        void client.fs
+          .search({ root: currentRoot, query: "", limit: 50 })
+          .then((res) => {
+            if (searchVersion === version) {
+              setResults(res);
+              setSearching(false);
+            }
+          })
+          .catch((err: unknown) => {
+            // Best-effort: search fails silently (e.g. workspace gone) — user sees "No matching files"
+            console.warn("File search failed:", err);
+            setSearching(false);
+          });
+        return;
+      }
+      searchTimer = setTimeout(() => {
+        setSearching(true);
+        void client.fs
+          .search({ root: currentRoot, query: q, limit: 50 })
+          .then((res) => {
+            if (searchVersion === version) {
+              setResults(res);
+              setSelectedIndex(0);
+              setSearching(false);
+            }
+          })
+          .catch((err: unknown) => {
+            console.warn("File search failed:", err);
+            setSearching(false);
+          });
+      }, 80);
+    }),
+  );
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (!props.open) return;
+    const items = results();
+    const key = e.key;
+    switch (key) {
+      case "ArrowDown":
+        if (items.length === 0) return;
+        setSelectedIndex((i) => Math.min(i + 1, items.length - 1));
+        break;
+      case "ArrowUp":
+        if (items.length === 0) return;
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+        break;
+      case "Tab":
+        if (items.length === 0) return;
+        setSelectedIndex((i) =>
+          e.shiftKey
+            ? (i - 1 + items.length) % items.length
+            : (i + 1) % items.length,
+        );
+        break;
+      case "Enter": {
+        const selected = items[selectedIndex()];
+        const currentRoot = root();
+        if (selected && currentRoot) {
+          props.onOpenChange(false);
+          props.onOpenFile(currentRoot, selected.path);
+        }
+        break;
+      }
+      case "Escape":
+        props.onOpenChange(false);
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  makeEventListener(window, "keydown", handleKeyDown, { capture: true });
+
+  // Reset on open
+  createEffect(
+    on(
+      () => props.open,
+      (isOpen) => {
+        if (isOpen) {
+          setQuery("");
+          setResults([]);
+          setSelectedIndex(0);
+          mouseActive = false;
+          searchVersion++;
+          // Trigger initial load
+          const currentRoot = root();
+          if (currentRoot) {
+            void client.fs
+              .search({ root: currentRoot, query: "", limit: 50 })
+              .then(setResults)
+              .catch(() => {
+                // Best-effort initial load — workspace may not exist yet
+              });
+          }
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => inputRef.focus()),
+          );
+        }
+      },
+    ),
+  );
+
+  return (
+    <ModalDialog open={props.open} onOpenChange={props.onOpenChange}>
+      <Dialog.Content
+        forceMount
+        data-testid="file-search"
+        class="w-lg bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
+        style={{
+          height: "28rem",
+          "background-color": "var(--color-surface-1)",
+        }}
+      >
+        <div class="flex items-center gap-2 px-4 py-3 border-b border-edge">
+          <svg
+            class="w-4 h-4 text-fg-3 shrink-0"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <circle cx="7" cy="7" r="5" />
+            <path d="M11 11l3.5 3.5" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search files..."
+            class="flex-1 bg-transparent text-fg text-sm outline-none placeholder-fg-3"
+            value={query()}
+            onInput={(e) => setQuery(e.currentTarget.value)}
+          />
+          <Kbd>{formatKeybind(SHORTCUTS.fileBrowser.keybind)}</Kbd>
+        </div>
+        <div
+          class="flex-1 min-h-0 overflow-y-auto"
+          onMouseMove={() => (mouseActive = true)}
+        >
+          <Show
+            when={root()}
+            fallback={
+              <div class="px-4 py-3 text-sm text-fg-3">
+                No workspace detected — open a terminal in a git repository
+              </div>
+            }
+          >
+            <Show
+              when={results().length > 0}
+              fallback={
+                <div class="px-4 py-3 text-sm text-fg-3">
+                  {searching() ? "Searching..." : "No matching files"}
+                </div>
+              }
+            >
+              <ul class="py-1">
+                <For each={results()}>
+                  {(file, i) => (
+                    <li
+                      ref={(el) => {
+                        createEffect(() => {
+                          if (selectedIndex() === i())
+                            el.scrollIntoView({ block: "nearest" });
+                        });
+                      }}
+                      class="flex items-center gap-2 px-4 py-1.5 text-sm cursor-pointer transition-colors duration-150"
+                      classList={{
+                        "bg-surface-3 text-fg": selectedIndex() === i(),
+                        "text-fg-2 hover:bg-surface-2": selectedIndex() !== i(),
+                      }}
+                      onMouseEnter={() => mouseActive && setSelectedIndex(i())}
+                      onClick={() => {
+                        const currentRoot = root();
+                        if (currentRoot) {
+                          props.onOpenChange(false);
+                          props.onOpenFile(currentRoot, file.path);
+                        }
+                      }}
+                    >
+                      {/* Git status dot */}
+                      <Show when={file.gitStatus}>
+                        {(status) => (
+                          <span
+                            class={`shrink-0 w-2 h-2 rounded-full ${gitStatusTextColor[status()] ?? "text-fg-3"}`}
+                            style={{ "background-color": "currentColor" }}
+                            title={status()}
+                          />
+                        )}
+                      </Show>
+                      <Show when={!file.gitStatus}>
+                        <span class="shrink-0 w-2" />
+                      </Show>
+                      {/* File path with match highlights */}
+                      <HighlightedPath
+                        path={file.path}
+                        matches={file.matches}
+                      />
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </Show>
+          </Show>
+        </div>
+        <div class="px-4 py-2 text-[0.7rem] text-fg-3 border-t border-edge flex items-center gap-3">
+          <span>
+            <kbd class="text-fg-3">↑↓</kbd> navigate
+          </span>
+          <span>
+            <kbd class="text-fg-3">↵</kbd> open
+          </span>
+          <span>
+            <kbd class="text-fg-3">esc</kbd> close
+          </span>
+        </div>
+      </Dialog.Content>
+    </ModalDialog>
+  );
+};
+
+export default FileSearch;

--- a/client/src/FileSearch.tsx
+++ b/client/src/FileSearch.tsx
@@ -65,6 +65,8 @@ const FileSearch: Component<{
   onOpenChange: (open: boolean) => void;
   activeMeta: Accessor<TerminalMetadata | null>;
   onOpenFile: (root: string, filePath: string) => void;
+  /** Optional: preview a file without committing (on arrow key). */
+  onPreviewFile?: (root: string, filePath: string) => void;
 }> = (props) => {
   let inputRef!: HTMLInputElement;
   const [query, setQuery] = createSignal("");
@@ -131,22 +133,40 @@ const FileSearch: Component<{
     if (!props.open) return;
     const items = results();
     const key = e.key;
+    function previewSelected(idx: number) {
+      const selected = items[idx];
+      const currentRoot = root();
+      if (selected && currentRoot && props.onPreviewFile) {
+        props.onPreviewFile(currentRoot, selected.path);
+      }
+    }
+
     switch (key) {
       case "ArrowDown":
         if (items.length === 0) return;
-        setSelectedIndex((i) => Math.min(i + 1, items.length - 1));
+        setSelectedIndex((i) => {
+          const next = Math.min(i + 1, items.length - 1);
+          previewSelected(next);
+          return next;
+        });
         break;
       case "ArrowUp":
         if (items.length === 0) return;
-        setSelectedIndex((i) => Math.max(i - 1, 0));
+        setSelectedIndex((i) => {
+          const prev = Math.max(i - 1, 0);
+          previewSelected(prev);
+          return prev;
+        });
         break;
       case "Tab":
         if (items.length === 0) return;
-        setSelectedIndex((i) =>
-          e.shiftKey
+        setSelectedIndex((i) => {
+          const next = e.shiftKey
             ? (i - 1 + items.length) % items.length
-            : (i + 1) % items.length,
-        );
+            : (i + 1) % items.length;
+          previewSelected(next);
+          return next;
+        });
         break;
       case "Enter": {
         const selected = items[selectedIndex()];

--- a/client/src/FileTree.tsx
+++ b/client/src/FileTree.tsx
@@ -1,0 +1,235 @@
+/**
+ * File tree — collapsible sidebar section showing the workspace file hierarchy.
+ * Fetches directory contents lazily on expand. Git status decorations on entries.
+ * Expand/collapse state is ephemeral — no persistence.
+ */
+
+import {
+  type Component,
+  type Accessor,
+  createSignal,
+  createEffect,
+  on,
+  For,
+  Show,
+} from "solid-js";
+import { createStore, produce } from "solid-js/store";
+import { client } from "./rpc";
+import { gitStatusBgColor } from "./gitStatusColor";
+import type { FileEntry } from "kolu-common";
+
+interface DirState {
+  entries: FileEntry[];
+  loading: boolean;
+}
+
+const FileTreeEntry: Component<{
+  entry: FileEntry;
+  root: string;
+  depth: number;
+  expanded: Record<string, DirState | undefined>;
+  onToggle: (path: string) => void;
+  onOpenFile: (path: string) => void;
+}> = (props) => {
+  const isDir = () => props.entry.kind === "directory";
+  const isExpanded = () => !!props.expanded[props.entry.path];
+  const dirState = () => props.expanded[props.entry.path];
+
+  return (
+    <>
+      <button
+        class="flex items-center gap-1 w-full text-left px-2 py-0.5 text-xs hover:bg-surface-2 transition-colors group"
+        style={{ "padding-left": `${props.depth * 12 + 8}px` }}
+        onClick={() =>
+          isDir()
+            ? props.onToggle(props.entry.path)
+            : props.onOpenFile(props.entry.path)
+        }
+      >
+        {/* Expand/collapse chevron for directories */}
+        <Show when={isDir()} fallback={<span class="w-3 shrink-0" />}>
+          <svg
+            class="w-3 h-3 text-fg-3 shrink-0 transition-transform"
+            classList={{ "rotate-90": isExpanded() }}
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M4 2l4 4-4 4" />
+          </svg>
+        </Show>
+        {/* Icon */}
+        <Show
+          when={isDir()}
+          fallback={
+            <svg
+              class="w-3.5 h-3.5 text-fg-3 shrink-0"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
+              <path
+                d="M4 1h8a1 1 0 011 1v12a1 1 0 01-1 1H4a1 1 0 01-1-1V2a1 1 0 011-1z"
+                opacity="0.5"
+              />
+            </svg>
+          }
+        >
+          <svg
+            class="w-3.5 h-3.5 text-fg-3 shrink-0"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+          >
+            <path
+              d="M1 3h5l2 2h7v9a1 1 0 01-1 1H2a1 1 0 01-1-1V3z"
+              opacity="0.5"
+            />
+          </svg>
+        </Show>
+        {/* Name */}
+        <span class="truncate text-fg-2 group-hover:text-fg">
+          {props.entry.name}
+        </span>
+        {/* Git status dot */}
+        <Show when={props.entry.gitStatus}>
+          {(status) => (
+            <span
+              class={`shrink-0 w-1.5 h-1.5 rounded-full ml-auto ${gitStatusBgColor[status()] ?? ""}`}
+              title={status()}
+            />
+          )}
+        </Show>
+      </button>
+      {/* Expanded children */}
+      <Show when={isDir() && isExpanded() && dirState()}>
+        {(state) => (
+          <Show
+            when={!state().loading}
+            fallback={
+              <div
+                class="text-[0.65rem] text-fg-3 py-0.5"
+                style={{ "padding-left": `${(props.depth + 1) * 12 + 8}px` }}
+              >
+                Loading...
+              </div>
+            }
+          >
+            <For each={state().entries}>
+              {(child) => (
+                <FileTreeEntry
+                  entry={child}
+                  root={props.root}
+                  depth={props.depth + 1}
+                  expanded={props.expanded}
+                  onToggle={props.onToggle}
+                  onOpenFile={props.onOpenFile}
+                />
+              )}
+            </For>
+            <Show when={state().entries.length === 0}>
+              <div
+                class="text-[0.65rem] text-fg-3 italic py-0.5"
+                style={{
+                  "padding-left": `${(props.depth + 1) * 12 + 8}px`,
+                }}
+              >
+                Empty
+              </div>
+            </Show>
+          </Show>
+        )}
+      </Show>
+    </>
+  );
+};
+
+const FileTree: Component<{
+  root: Accessor<string | null>;
+  onOpenFile: (root: string, filePath: string) => void;
+}> = (props) => {
+  const [expanded, setExpanded] = createStore<
+    Record<string, DirState | undefined>
+  >({});
+  const [rootEntries, setRootEntries] = createSignal<FileEntry[]>([]);
+  const [loading, setLoading] = createSignal(false);
+
+  // Fetch root directory when root changes
+  createEffect(
+    on(props.root, (root) => {
+      setRootEntries([]);
+      // Clear expanded state when root changes
+      setExpanded({});
+      if (!root) return;
+      setLoading(true);
+      void client.fs
+        .listDir({ root, dirPath: "" })
+        .then(setRootEntries)
+        .catch(() => {
+          // Best-effort: root listing fails if workspace is removed while tree is open
+        })
+        .finally(() => setLoading(false));
+    }),
+  );
+
+  function handleToggle(path: string) {
+    const currentRoot = props.root();
+    if (!currentRoot) return;
+
+    if (expanded[path]) {
+      // Collapse
+      setExpanded(
+        produce((state) => {
+          delete state[path];
+        }),
+      );
+    } else {
+      // Expand — fetch contents
+      setExpanded(path, { entries: [], loading: true });
+      void client.fs
+        .listDir({ root: currentRoot, dirPath: path })
+        .then((entries) => {
+          setExpanded(path, { entries, loading: false });
+        })
+        .catch(() => {
+          setExpanded(path, { entries: [], loading: false });
+        });
+    }
+  }
+
+  return (
+    <div class="py-1">
+      <Show
+        when={!loading()}
+        fallback={
+          <div class="px-3 py-2 text-xs text-fg-3">Loading files...</div>
+        }
+      >
+        <Show
+          when={rootEntries().length > 0}
+          fallback={
+            <Show when={props.root()}>
+              <div class="px-3 py-2 text-xs text-fg-3 italic">
+                No files found
+              </div>
+            </Show>
+          }
+        >
+          <For each={rootEntries()}>
+            {(entry) => (
+              <FileTreeEntry
+                entry={entry}
+                root={props.root()!}
+                depth={0}
+                expanded={expanded}
+                onToggle={handleToggle}
+                onOpenFile={(path) => props.onOpenFile(props.root()!, path)}
+              />
+            )}
+          </For>
+        </Show>
+      </Show>
+    </div>
+  );
+};
+
+export default FileTree;

--- a/client/src/FileTree.tsx
+++ b/client/src/FileTree.tsx
@@ -1,7 +1,7 @@
 /**
- * File tree — collapsible sidebar section showing the workspace file hierarchy.
+ * File tree — collapsible section showing the workspace file hierarchy.
  * Fetches directory contents lazily on expand. Git status decorations on entries.
- * Expand/collapse state is ephemeral — no persistence.
+ * Keyboard navigation: j/k to move, Enter to open/expand, h/l for collapse/expand, Esc to deselect.
  */
 
 import {
@@ -30,6 +30,9 @@ const FileTreeEntry: Component<{
   expanded: Record<string, DirState | undefined>;
   onToggle: (path: string) => void;
   onOpenFile: (path: string) => void;
+  selected: boolean;
+  flatIndex: number;
+  onSelect: (idx: number) => void;
 }> = (props) => {
   const isDir = () => props.entry.kind === "directory";
   const isExpanded = () => !!props.expanded[props.entry.path];
@@ -38,13 +41,21 @@ const FileTreeEntry: Component<{
   return (
     <>
       <button
-        class="flex items-center gap-1 w-full text-left px-2 py-0.5 text-xs hover:bg-surface-2 transition-colors group"
+        class="flex items-center gap-1 w-full text-left px-2 py-0.5 text-xs transition-colors group"
+        classList={{
+          "bg-accent/15 text-fg": props.selected,
+          "hover:bg-surface-2": !props.selected,
+        }}
         style={{ "padding-left": `${props.depth * 12 + 8}px` }}
-        onClick={() =>
-          isDir()
-            ? props.onToggle(props.entry.path)
-            : props.onOpenFile(props.entry.path)
-        }
+        onClick={() => {
+          props.onSelect(props.flatIndex);
+          if (isDir()) {
+            props.onToggle(props.entry.path);
+          } else {
+            props.onOpenFile(props.entry.path);
+          }
+        }}
+        data-tree-index={props.flatIndex}
       >
         {/* Expand/collapse chevron for directories */}
         <Show when={isDir()} fallback={<span class="w-3 shrink-0" />}>
@@ -115,16 +126,23 @@ const FileTreeEntry: Component<{
             }
           >
             <For each={state().entries}>
-              {(child) => (
-                <FileTreeEntry
-                  entry={child}
-                  root={props.root}
-                  depth={props.depth + 1}
-                  expanded={props.expanded}
-                  onToggle={props.onToggle}
-                  onOpenFile={props.onOpenFile}
-                />
-              )}
+              {(child) => {
+                // Calculate flat index for this child — it's computed from position in the flat list
+                // We use data attributes for lookup instead
+                return (
+                  <FileTreeEntry
+                    entry={child}
+                    root={props.root}
+                    depth={props.depth + 1}
+                    expanded={props.expanded}
+                    onToggle={props.onToggle}
+                    onOpenFile={props.onOpenFile}
+                    selected={false}
+                    flatIndex={-1}
+                    onSelect={props.onSelect}
+                  />
+                );
+              }}
             </For>
             <Show when={state().entries.length === 0}>
               <div
@@ -146,29 +164,49 @@ const FileTreeEntry: Component<{
 const FileTree: Component<{
   root: Accessor<string | null>;
   onOpenFile: (root: string, filePath: string) => void;
+  /** Refresh signal — increments when fs changes are detected. */
+  refreshSignal?: Accessor<number>;
 }> = (props) => {
   const [expanded, setExpanded] = createStore<
     Record<string, DirState | undefined>
   >({});
   const [rootEntries, setRootEntries] = createSignal<FileEntry[]>([]);
   const [loading, setLoading] = createSignal(false);
+  const [selectedIdx, setSelectedIdx] = createSignal(-1);
+  let containerRef!: HTMLDivElement;
+
+  function fetchRoot(root: string) {
+    setLoading(true);
+    void client.fs
+      .listDir({ root, dirPath: "" })
+      .then(setRootEntries)
+      .catch(() => {
+        // Best-effort: root listing fails if workspace is removed while tree is open
+      })
+      .finally(() => setLoading(false));
+  }
 
   // Fetch root directory when root changes
   createEffect(
     on(props.root, (root) => {
       setRootEntries([]);
-      // Clear expanded state when root changes
       setExpanded({});
+      setSelectedIdx(-1);
       if (!root) return;
-      setLoading(true);
-      void client.fs
-        .listDir({ root, dirPath: "" })
-        .then(setRootEntries)
-        .catch(() => {
-          // Best-effort: root listing fails if workspace is removed while tree is open
-        })
-        .finally(() => setLoading(false));
+      fetchRoot(root);
     }),
+  );
+
+  // Refresh when fs changes
+  createEffect(
+    on(
+      () => props.refreshSignal?.(),
+      () => {
+        const root = props.root();
+        if (root) fetchRoot(root);
+      },
+      { defer: true },
+    ),
   );
 
   function handleToggle(path: string) {
@@ -196,8 +234,64 @@ const FileTree: Component<{
     }
   }
 
+  // Keyboard navigation
+  function handleKeyDown(e: KeyboardEvent) {
+    const buttons = containerRef?.querySelectorAll(
+      "button[data-tree-index]",
+    ) as NodeListOf<HTMLButtonElement>;
+    if (!buttons || buttons.length === 0) return;
+    const total = buttons.length;
+    const current = selectedIdx();
+
+    switch (e.key) {
+      case "j":
+      case "ArrowDown": {
+        e.preventDefault();
+        const next = Math.min(current + 1, total - 1);
+        setSelectedIdx(next);
+        buttons[next]?.scrollIntoView({ block: "nearest" });
+        break;
+      }
+      case "k":
+      case "ArrowUp": {
+        e.preventDefault();
+        const prev = Math.max(current - 1, 0);
+        setSelectedIdx(prev);
+        buttons[prev]?.scrollIntoView({ block: "nearest" });
+        break;
+      }
+      case "Enter":
+      case "l":
+      case "ArrowRight": {
+        if (current >= 0 && current < total) {
+          e.preventDefault();
+          buttons[current]?.click();
+        }
+        break;
+      }
+      case "h":
+      case "ArrowLeft": {
+        // Collapse current directory
+        if (current >= 0 && current < total) {
+          e.preventDefault();
+          buttons[current]?.click();
+        }
+        break;
+      }
+      case "Escape": {
+        setSelectedIdx(-1);
+        break;
+      }
+    }
+  }
+
   return (
-    <div class="py-1">
+    <div
+      ref={containerRef}
+      class="py-1 outline-none"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
       <Show
         when={!loading()}
         fallback={
@@ -215,7 +309,7 @@ const FileTree: Component<{
           }
         >
           <For each={rootEntries()}>
-            {(entry) => (
+            {(entry, i) => (
               <FileTreeEntry
                 entry={entry}
                 root={props.root()!}
@@ -223,6 +317,9 @@ const FileTree: Component<{
                 expanded={expanded}
                 onToggle={handleToggle}
                 onOpenFile={(path) => props.onOpenFile(props.root()!, path)}
+                selected={selectedIdx() === i()}
+                flatIndex={i()}
+                onSelect={setSelectedIdx}
               />
             )}
           </For>

--- a/client/src/GitChanges.tsx
+++ b/client/src/GitChanges.tsx
@@ -3,6 +3,8 @@
  * between "list only" (click to open diff in panel) and "full diff"
  * (all diffs expanded inline). Selective mode lets you expand individual
  * files without committing to the full-diff view.
+ *
+ * Stage/unstage buttons per file. Keyboard nav with j/k.
  */
 
 import {
@@ -133,30 +135,53 @@ const InlineDiff: Component<{ root: string; filePath: string }> = (props) => {
 const GitChanges: Component<{
   root: Accessor<string | null>;
   onOpenDiff: (root: string, filePath: string) => void;
+  onStageFile: (root: string, filePath: string) => void;
+  onUnstageFile: (root: string, filePath: string) => void;
+  /** Refresh signal — increments when fs changes are detected. */
+  refreshSignal?: Accessor<number>;
 }> = (props) => {
   const [changedFiles, setChangedFiles] = createSignal<FsSearchResult[]>([]);
   const [loading, setLoading] = createSignal(false);
-  /** "list" = click opens in panel; "full" = all diffs inline; "selective" = individual toggles. */
+  /** "list" = click opens in panel; "full" = all diffs inline. */
   const [mode, setMode] = createSignal<"list" | "full">("list");
   /** Which files are individually expanded (used in list mode). */
   const [expanded, setExpanded] = createStore<Record<string, boolean>>({});
+  const [selectedIdx, setSelectedIdx] = createSignal(-1);
+  let containerRef!: HTMLDivElement;
+
+  function fetchChanges(root: string) {
+    setLoading(true);
+    void client.fs
+      .search({ root, query: "", limit: 500 })
+      .then((results) => {
+        setChangedFiles(results.filter((f) => f.gitStatus !== null));
+      })
+      .catch(() => {
+        // Best-effort: workspace may not exist
+      })
+      .finally(() => setLoading(false));
+  }
 
   createEffect(
     on(props.root, (root) => {
       setChangedFiles([]);
       setExpanded({});
+      setSelectedIdx(-1);
       if (!root) return;
-      setLoading(true);
-      void client.fs
-        .search({ root, query: "", limit: 500 })
-        .then((results) => {
-          setChangedFiles(results.filter((f) => f.gitStatus !== null));
-        })
-        .catch(() => {
-          // Best-effort: workspace may not exist
-        })
-        .finally(() => setLoading(false));
+      fetchChanges(root);
     }),
+  );
+
+  // Refresh when fs changes
+  createEffect(
+    on(
+      () => props.refreshSignal?.(),
+      () => {
+        const root = props.root();
+        if (root) fetchChanges(root);
+      },
+      { defer: true },
+    ),
   );
 
   function toggleFile(path: string) {
@@ -167,8 +192,88 @@ const GitChanges: Component<{
     );
   }
 
+  // Keyboard navigation
+  function handleKeyDown(e: KeyboardEvent) {
+    const items = changedFiles();
+    if (items.length === 0) return;
+    const current = selectedIdx();
+
+    switch (e.key) {
+      case "j":
+      case "ArrowDown": {
+        e.preventDefault();
+        const next = Math.min(current + 1, items.length - 1);
+        setSelectedIdx(next);
+        containerRef
+          ?.querySelectorAll("[data-change-index]")
+          [next]?.scrollIntoView({ block: "nearest" });
+        break;
+      }
+      case "k":
+      case "ArrowUp": {
+        e.preventDefault();
+        const prev = Math.max(current - 1, 0);
+        setSelectedIdx(prev);
+        containerRef
+          ?.querySelectorAll("[data-change-index]")
+          [prev]?.scrollIntoView({ block: "nearest" });
+        break;
+      }
+      case "Enter": {
+        const file = items[current];
+        const root = props.root();
+        if (file && root) {
+          e.preventDefault();
+          props.onOpenDiff(root, file.path);
+        }
+        break;
+      }
+      case "l":
+      case "ArrowRight": {
+        const file = items[current];
+        if (file) {
+          e.preventDefault();
+          if (!expanded[file.path]) toggleFile(file.path);
+        }
+        break;
+      }
+      case "h":
+      case "ArrowLeft": {
+        const file = items[current];
+        if (file) {
+          e.preventDefault();
+          if (expanded[file.path]) toggleFile(file.path);
+        }
+        break;
+      }
+      case "s": {
+        // Stage/unstage with 's' key
+        const file = items[current];
+        const root = props.root();
+        if (file && root) {
+          e.preventDefault();
+          if (file.staging === "staged") {
+            props.onUnstageFile(root, file.path);
+          } else {
+            props.onStageFile(root, file.path);
+          }
+        }
+        break;
+      }
+      case "Escape": {
+        setSelectedIdx(-1);
+        break;
+      }
+    }
+  }
+
   return (
-    <div class="py-1">
+    <div
+      ref={containerRef}
+      class="py-1 outline-none"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
       <Show
         when={!loading()}
         fallback={
@@ -209,12 +314,18 @@ const GitChanges: Component<{
             </button>
           </div>
           <For each={changedFiles()}>
-            {(file) => {
+            {(file, i) => {
               const showDiff = () => mode() === "full" || !!expanded[file.path];
               return (
-                <div>
-                  <div class="flex items-center gap-1 w-full text-left px-2 py-1 text-xs hover:bg-surface-2 transition-colors group">
-                    {/* Expand toggle (in list mode) */}
+                <div data-change-index={i()}>
+                  <div
+                    class="flex items-center gap-1 w-full text-left px-2 py-1 text-xs transition-colors group"
+                    classList={{
+                      "bg-accent/15": selectedIdx() === i(),
+                      "hover:bg-surface-2": selectedIdx() !== i(),
+                    }}
+                  >
+                    {/* Expand toggle */}
                     <button
                       class="shrink-0 w-3 text-fg-3 hover:text-fg transition-colors"
                       onClick={() => toggleFile(file.path)}
@@ -249,15 +360,16 @@ const GitChanges: Component<{
                       }
                     >
                       {file.staging === "staged"
-                        ? "●"
+                        ? "\u25CF"
                         : file.staging === "partial"
-                          ? "◐"
+                          ? "\u25D0"
                           : ""}
                     </span>
                     {/* File path — click opens in panel diff view */}
                     <button
                       class="truncate text-fg-2 group-hover:text-fg text-left min-w-0 flex-1"
                       onClick={() => {
+                        setSelectedIdx(i());
                         const root = props.root();
                         if (root) props.onOpenDiff(root, file.path);
                       }}
@@ -268,6 +380,33 @@ const GitChanges: Component<{
                         </span>
                         {file.name}
                       </Show>
+                    </button>
+                    {/* Stage/unstage button */}
+                    <button
+                      class="shrink-0 text-[0.55rem] px-1 py-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity"
+                      classList={{
+                        "text-green-400 hover:bg-green-500/10":
+                          file.staging !== "staged",
+                        "text-yellow-400 hover:bg-yellow-500/10":
+                          file.staging === "staged",
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        const root = props.root();
+                        if (!root) return;
+                        if (file.staging === "staged") {
+                          props.onUnstageFile(root, file.path);
+                        } else {
+                          props.onStageFile(root, file.path);
+                        }
+                      }}
+                      title={
+                        file.staging === "staged"
+                          ? "Unstage file"
+                          : "Stage file"
+                      }
+                    >
+                      {file.staging === "staged" ? "Unstage" : "Stage"}
                     </button>
                   </div>
                   {/* Inline diff — shown when expanded */}

--- a/client/src/GitChanges.tsx
+++ b/client/src/GitChanges.tsx
@@ -1,6 +1,8 @@
 /**
- * Git changes sidebar list — shows modified/added/deleted files.
- * Clicking a file opens the diff in a full-width modal (DiffModal).
+ * Git changes list — shows modified/added/deleted files with a toggle
+ * between "list only" (click to open diff in panel) and "full diff"
+ * (all diffs expanded inline). Selective mode lets you expand individual
+ * files without committing to the full-diff view.
  */
 
 import {
@@ -12,8 +14,10 @@ import {
   For,
   Show,
 } from "solid-js";
+import { createStore, produce } from "solid-js/store";
+import { match } from "ts-pattern";
 import { client } from "./rpc";
-import type { FsSearchResult } from "kolu-common";
+import type { FsSearchResult, FsFileDiffOutput } from "kolu-common";
 
 const STATUS_LABEL: Record<string, string> = {
   modified: "M",
@@ -31,17 +35,116 @@ const STATUS_COLOR: Record<string, string> = {
   untracked: "text-green-300",
 };
 
+/** Inline diff for a single file — fetches and renders on mount. */
+const InlineDiff: Component<{ root: string; filePath: string }> = (props) => {
+  const [diff, setDiff] = createSignal<FsFileDiffOutput | null>(null);
+  const [loading, setLoading] = createSignal(true);
+
+  createEffect(
+    on(
+      () => [props.root, props.filePath] as const,
+      ([root, filePath]) => {
+        setLoading(true);
+        void client.fs
+          .fileDiff({ root, filePath })
+          .then(setDiff)
+          .catch(() => {})
+          .finally(() => setLoading(false));
+      },
+    ),
+  );
+
+  return (
+    <div class="border-t border-edge/30 bg-surface-0">
+      <Show
+        when={!loading()}
+        fallback={
+          <div class="px-3 py-1 text-[0.6rem] text-fg-3">Loading...</div>
+        }
+      >
+        <Show
+          when={diff()?.hunks.length}
+          fallback={
+            <div class="px-3 py-1 text-[0.6rem] text-fg-3 italic">No diff</div>
+          }
+        >
+          <div class="font-mono text-[0.6rem] leading-4">
+            <For each={diff()!.hunks}>
+              {(hunk) => (
+                <>
+                  <div class="px-2 py-0.5 text-fg-3 bg-blue-500/5 select-none">
+                    @@ -{hunk.oldStart},{hunk.oldCount} +{hunk.newStart},
+                    {hunk.newCount} @@
+                  </div>
+                  <For each={hunk.lines}>
+                    {(line) => {
+                      const s = match(line.kind)
+                        .with("add", () => ({
+                          bg: "bg-green-500/10",
+                          m: "+",
+                          mc: "text-green-400",
+                          tc: "text-green-200",
+                        }))
+                        .with("remove", () => ({
+                          bg: "bg-red-500/10",
+                          m: "-",
+                          mc: "text-red-400",
+                          tc: "text-red-200",
+                        }))
+                        .with("context", () => ({
+                          bg: "",
+                          m: " ",
+                          mc: "text-fg-3",
+                          tc: "text-fg-2",
+                        }))
+                        .exhaustive();
+                      return (
+                        <div class={`flex ${s.bg}`}>
+                          <span class="shrink-0 w-7 text-right pr-1 text-fg-3/50 select-none">
+                            {line.oldLine ?? ""}
+                          </span>
+                          <span class="shrink-0 w-7 text-right pr-1 text-fg-3/50 select-none">
+                            {line.newLine ?? ""}
+                          </span>
+                          <span
+                            class={`shrink-0 w-3 text-center select-none ${s.mc}`}
+                          >
+                            {s.m}
+                          </span>
+                          <span
+                            class={`whitespace-pre overflow-hidden ${s.tc}`}
+                          >
+                            {line.content || " "}
+                          </span>
+                        </div>
+                      );
+                    }}
+                  </For>
+                </>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Show>
+    </div>
+  );
+};
+
 const GitChanges: Component<{
   root: Accessor<string | null>;
   onOpenDiff: (root: string, filePath: string) => void;
 }> = (props) => {
   const [changedFiles, setChangedFiles] = createSignal<FsSearchResult[]>([]);
   const [loading, setLoading] = createSignal(false);
+  /** "list" = click opens in panel; "full" = all diffs inline; "selective" = individual toggles. */
+  const [mode, setMode] = createSignal<"list" | "full">("list");
+  /** Which files are individually expanded (used in list mode). */
+  const [expanded, setExpanded] = createStore<Record<string, boolean>>({});
 
-  // Fetch changed files when root changes
   createEffect(
     on(props.root, (root) => {
       setChangedFiles([]);
+      setExpanded({});
       if (!root) return;
       setLoading(true);
       void client.fs
@@ -55,6 +158,14 @@ const GitChanges: Component<{
         .finally(() => setLoading(false));
     }),
   );
+
+  function toggleFile(path: string) {
+    setExpanded(
+      produce((s) => {
+        s[path] = !s[path];
+      }),
+    );
+  }
 
   return (
     <div class="py-1">
@@ -74,53 +185,98 @@ const GitChanges: Component<{
             </Show>
           }
         >
-          <div class="px-3 py-1.5 text-[0.65rem] text-fg-3 font-medium uppercase tracking-wider">
-            {changedFiles().length} changed{" "}
-            {changedFiles().length === 1 ? "file" : "files"}
+          {/* Header with count + mode toggle */}
+          <div class="flex items-center justify-between px-3 py-1.5">
+            <span class="text-[0.65rem] text-fg-3 font-medium uppercase tracking-wider">
+              {changedFiles().length} changed{" "}
+              {changedFiles().length === 1 ? "file" : "files"}
+            </span>
+            <button
+              class="text-[0.6rem] px-1.5 py-0.5 rounded transition-colors"
+              classList={{
+                "text-accent bg-accent/10": mode() === "full",
+                "text-fg-3 hover:text-fg-2 hover:bg-surface-2":
+                  mode() !== "full",
+              }}
+              onClick={() => setMode((m) => (m === "full" ? "list" : "full"))}
+              title={
+                mode() === "full"
+                  ? "Collapse all diffs"
+                  : "Expand all diffs inline"
+              }
+            >
+              {mode() === "full" ? "Collapse all" : "Expand all"}
+            </button>
           </div>
           <For each={changedFiles()}>
-            {(file) => (
-              <button
-                class="flex items-center gap-1.5 w-full text-left px-2 py-1 text-xs hover:bg-surface-2 transition-colors group"
-                onClick={() => {
-                  const root = props.root();
-                  if (root) props.onOpenDiff(root, file.path);
-                }}
-              >
-                {/* Status badge */}
-                <span
-                  class={`shrink-0 text-[0.6rem] font-bold w-3 text-center ${STATUS_COLOR[file.gitStatus!] ?? "text-fg-3"}`}
-                >
-                  {STATUS_LABEL[file.gitStatus!] ?? "?"}
-                </span>
-                {/* Staging indicator */}
-                <span
-                  class="shrink-0 text-[0.55rem] w-1.5"
-                  title={
-                    file.staging === "staged"
-                      ? "Staged"
-                      : file.staging === "partial"
-                        ? "Partially staged"
-                        : "Unstaged"
-                  }
-                >
-                  {file.staging === "staged"
-                    ? "●"
-                    : file.staging === "partial"
-                      ? "◐"
-                      : ""}
-                </span>
-                {/* File path — basename bold, directory muted */}
-                <span class="truncate text-fg-2 group-hover:text-fg">
-                  <Show when={file.path.includes("/")} fallback={file.name}>
-                    <span class="text-fg-3">
-                      {file.path.slice(0, file.path.lastIndexOf("/") + 1)}
+            {(file) => {
+              const showDiff = () => mode() === "full" || !!expanded[file.path];
+              return (
+                <div>
+                  <div class="flex items-center gap-1 w-full text-left px-2 py-1 text-xs hover:bg-surface-2 transition-colors group">
+                    {/* Expand toggle (in list mode) */}
+                    <button
+                      class="shrink-0 w-3 text-fg-3 hover:text-fg transition-colors"
+                      onClick={() => toggleFile(file.path)}
+                      title={showDiff() ? "Collapse" : "Expand inline"}
+                    >
+                      <svg
+                        class="w-2.5 h-2.5 transition-transform"
+                        classList={{ "rotate-90": showDiff() }}
+                        viewBox="0 0 12 12"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path d="M4 2l4 4-4 4" />
+                      </svg>
+                    </button>
+                    {/* Status badge */}
+                    <span
+                      class={`shrink-0 text-[0.6rem] font-bold w-3 text-center ${STATUS_COLOR[file.gitStatus!] ?? "text-fg-3"}`}
+                    >
+                      {STATUS_LABEL[file.gitStatus!] ?? "?"}
                     </span>
-                    {file.name}
+                    {/* Staging indicator */}
+                    <span
+                      class="shrink-0 text-[0.55rem] w-1.5"
+                      title={
+                        file.staging === "staged"
+                          ? "Staged"
+                          : file.staging === "partial"
+                            ? "Partially staged"
+                            : "Unstaged"
+                      }
+                    >
+                      {file.staging === "staged"
+                        ? "●"
+                        : file.staging === "partial"
+                          ? "◐"
+                          : ""}
+                    </span>
+                    {/* File path — click opens in panel diff view */}
+                    <button
+                      class="truncate text-fg-2 group-hover:text-fg text-left min-w-0 flex-1"
+                      onClick={() => {
+                        const root = props.root();
+                        if (root) props.onOpenDiff(root, file.path);
+                      }}
+                    >
+                      <Show when={file.path.includes("/")} fallback={file.name}>
+                        <span class="text-fg-3">
+                          {file.path.slice(0, file.path.lastIndexOf("/") + 1)}
+                        </span>
+                        {file.name}
+                      </Show>
+                    </button>
+                  </div>
+                  {/* Inline diff — shown when expanded */}
+                  <Show when={showDiff() && props.root()}>
+                    <InlineDiff root={props.root()!} filePath={file.path} />
                   </Show>
-                </span>
-              </button>
-            )}
+                </div>
+              );
+            }}
           </For>
         </Show>
       </Show>

--- a/client/src/GitChanges.tsx
+++ b/client/src/GitChanges.tsx
@@ -1,6 +1,6 @@
 /**
- * Git changes view — lists modified/added/deleted files in the workspace
- * and shows inline diffs when expanded. Lives in the sidebar "Changes" tab.
+ * Git changes sidebar list — shows modified/added/deleted files.
+ * Clicking a file opens the diff in a full-width modal (DiffModal).
  */
 
 import {
@@ -13,112 +13,8 @@ import {
   Show,
 } from "solid-js";
 import { client } from "./rpc";
-import { gitStatusBgColor } from "./gitStatusColor";
-import type {
-  FsSearchResult,
-  FsFileDiffOutput,
-  DiffHunk,
-  DiffLine,
-} from "kolu-common";
-import { match } from "ts-pattern";
+import type { FsSearchResult } from "kolu-common";
 
-/** Inline diff view for a single file. */
-const DiffView: Component<{
-  root: string;
-  filePath: string;
-}> = (props) => {
-  const [diff, setDiff] = createSignal<FsFileDiffOutput | null>(null);
-  const [loading, setLoading] = createSignal(true);
-
-  createEffect(
-    on(
-      () => [props.root, props.filePath] as const,
-      ([root, filePath]) => {
-        setLoading(true);
-        setDiff(null);
-        void client.fs
-          .fileDiff({ root, filePath })
-          .then(setDiff)
-          .catch(() => {})
-          .finally(() => setLoading(false));
-      },
-    ),
-  );
-
-  return (
-    <div class="border-t border-edge/50 bg-surface-0">
-      <Show
-        when={!loading()}
-        fallback={
-          <div class="px-3 py-1 text-[0.65rem] text-fg-3">Loading diff...</div>
-        }
-      >
-        <Show
-          when={diff()?.hunks.length}
-          fallback={
-            <div class="px-3 py-1 text-[0.65rem] text-fg-3 italic">
-              No changes
-            </div>
-          }
-        >
-          <For each={diff()!.hunks}>{(hunk) => <HunkView hunk={hunk} />}</For>
-        </Show>
-      </Show>
-    </div>
-  );
-};
-
-/** Renders a single diff hunk with add/remove/context lines. */
-const HunkView: Component<{ hunk: DiffHunk }> = (props) => (
-  <div class="font-mono text-[0.65rem] leading-4">
-    {/* Hunk header */}
-    <div class="px-2 py-0.5 text-fg-3 bg-surface-1/50 select-none">
-      @@ -{props.hunk.oldStart},{props.hunk.oldCount} +{props.hunk.newStart},
-      {props.hunk.newCount} @@
-    </div>
-    <For each={props.hunk.lines}>
-      {(line) => {
-        const style = match(line.kind)
-          .with("add", () => ({
-            bg: "bg-green-500/10",
-            marker: "+",
-            markerColor: "text-green-400",
-          }))
-          .with("remove", () => ({
-            bg: "bg-red-500/10",
-            marker: "-",
-            markerColor: "text-red-400",
-          }))
-          .with("context", () => ({
-            bg: "",
-            marker: " ",
-            markerColor: "text-fg-3",
-          }))
-          .exhaustive();
-        return (
-          <div class={`flex ${style.bg}`}>
-            <span class="shrink-0 w-4 text-right pr-1 text-fg-3 select-none">
-              {line.oldLine ?? ""}
-            </span>
-            <span class="shrink-0 w-4 text-right pr-1 text-fg-3 select-none">
-              {line.newLine ?? ""}
-            </span>
-            <span
-              class={`shrink-0 w-3 text-center select-none ${style.markerColor}`}
-            >
-              {style.marker}
-            </span>
-            <span class="whitespace-pre overflow-hidden text-fg-2">
-              {line.content || " "}
-            </span>
-          </div>
-        );
-      }}
-    </For>
-  </div>
-);
-
-/** Status label for display. */
 const STATUS_LABEL: Record<string, string> = {
   modified: "M",
   added: "A",
@@ -137,33 +33,28 @@ const STATUS_COLOR: Record<string, string> = {
 
 const GitChanges: Component<{
   root: Accessor<string | null>;
-  onOpenFile: (root: string, filePath: string) => void;
+  onOpenDiff: (root: string, filePath: string) => void;
 }> = (props) => {
   const [changedFiles, setChangedFiles] = createSignal<FsSearchResult[]>([]);
   const [loading, setLoading] = createSignal(false);
-  const [expandedFile, setExpandedFile] = createSignal<string | null>(null);
 
   // Fetch changed files when root changes
   createEffect(
     on(props.root, (root) => {
       setChangedFiles([]);
-      setExpandedFile(null);
       if (!root) return;
       setLoading(true);
       void client.fs
         .search({ root, query: "", limit: 500 })
         .then((results) => {
-          // Filter to only files with git status (i.e. changed files)
           setChangedFiles(results.filter((f) => f.gitStatus !== null));
         })
-        .catch(() => {})
+        .catch(() => {
+          // Best-effort: workspace may not exist
+        })
         .finally(() => setLoading(false));
     }),
   );
-
-  function toggleDiff(path: string) {
-    setExpandedFile((current) => (current === path ? null : path));
-  }
 
   return (
     <div class="py-1">
@@ -189,45 +80,46 @@ const GitChanges: Component<{
           </div>
           <For each={changedFiles()}>
             {(file) => (
-              <div>
-                <button
-                  class="flex items-center gap-1.5 w-full text-left px-2 py-1 text-xs hover:bg-surface-2 transition-colors group"
-                  onClick={() => toggleDiff(file.path)}
+              <button
+                class="flex items-center gap-1.5 w-full text-left px-2 py-1 text-xs hover:bg-surface-2 transition-colors group"
+                onClick={() => {
+                  const root = props.root();
+                  if (root) props.onOpenDiff(root, file.path);
+                }}
+              >
+                {/* Status badge */}
+                <span
+                  class={`shrink-0 text-[0.6rem] font-bold w-3 text-center ${STATUS_COLOR[file.gitStatus!] ?? "text-fg-3"}`}
                 >
-                  {/* Expand chevron */}
-                  <svg
-                    class="w-2.5 h-2.5 text-fg-3 shrink-0 transition-transform"
-                    classList={{
-                      "rotate-90": expandedFile() === file.path,
-                    }}
-                    viewBox="0 0 12 12"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <path d="M4 2l4 4-4 4" />
-                  </svg>
-                  {/* Status badge */}
-                  <span
-                    class={`shrink-0 text-[0.6rem] font-bold w-3 text-center ${STATUS_COLOR[file.gitStatus!] ?? "text-fg-3"}`}
-                  >
-                    {STATUS_LABEL[file.gitStatus!] ?? "?"}
-                  </span>
-                  {/* File name (just the basename, with dir in muted) */}
-                  <span class="truncate text-fg-2 group-hover:text-fg">
-                    <Show when={file.path.includes("/")} fallback={file.name}>
-                      <span class="text-fg-3">
-                        {file.path.slice(0, file.path.lastIndexOf("/") + 1)}
-                      </span>
-                      {file.name}
-                    </Show>
-                  </span>
-                </button>
-                {/* Inline diff — shown when expanded */}
-                <Show when={expandedFile() === file.path && props.root()}>
-                  <DiffView root={props.root()!} filePath={file.path} />
-                </Show>
-              </div>
+                  {STATUS_LABEL[file.gitStatus!] ?? "?"}
+                </span>
+                {/* Staging indicator */}
+                <span
+                  class="shrink-0 text-[0.55rem] w-1.5"
+                  title={
+                    file.staging === "staged"
+                      ? "Staged"
+                      : file.staging === "partial"
+                        ? "Partially staged"
+                        : "Unstaged"
+                  }
+                >
+                  {file.staging === "staged"
+                    ? "●"
+                    : file.staging === "partial"
+                      ? "◐"
+                      : ""}
+                </span>
+                {/* File path — basename bold, directory muted */}
+                <span class="truncate text-fg-2 group-hover:text-fg">
+                  <Show when={file.path.includes("/")} fallback={file.name}>
+                    <span class="text-fg-3">
+                      {file.path.slice(0, file.path.lastIndexOf("/") + 1)}
+                    </span>
+                    {file.name}
+                  </Show>
+                </span>
+              </button>
             )}
           </For>
         </Show>

--- a/client/src/GitChanges.tsx
+++ b/client/src/GitChanges.tsx
@@ -1,0 +1,239 @@
+/**
+ * Git changes view — lists modified/added/deleted files in the workspace
+ * and shows inline diffs when expanded. Lives in the sidebar "Changes" tab.
+ */
+
+import {
+  type Component,
+  type Accessor,
+  createSignal,
+  createEffect,
+  on,
+  For,
+  Show,
+} from "solid-js";
+import { client } from "./rpc";
+import { gitStatusBgColor } from "./gitStatusColor";
+import type {
+  FsSearchResult,
+  FsFileDiffOutput,
+  DiffHunk,
+  DiffLine,
+} from "kolu-common";
+import { match } from "ts-pattern";
+
+/** Inline diff view for a single file. */
+const DiffView: Component<{
+  root: string;
+  filePath: string;
+}> = (props) => {
+  const [diff, setDiff] = createSignal<FsFileDiffOutput | null>(null);
+  const [loading, setLoading] = createSignal(true);
+
+  createEffect(
+    on(
+      () => [props.root, props.filePath] as const,
+      ([root, filePath]) => {
+        setLoading(true);
+        setDiff(null);
+        void client.fs
+          .fileDiff({ root, filePath })
+          .then(setDiff)
+          .catch(() => {})
+          .finally(() => setLoading(false));
+      },
+    ),
+  );
+
+  return (
+    <div class="border-t border-edge/50 bg-surface-0">
+      <Show
+        when={!loading()}
+        fallback={
+          <div class="px-3 py-1 text-[0.65rem] text-fg-3">Loading diff...</div>
+        }
+      >
+        <Show
+          when={diff()?.hunks.length}
+          fallback={
+            <div class="px-3 py-1 text-[0.65rem] text-fg-3 italic">
+              No changes
+            </div>
+          }
+        >
+          <For each={diff()!.hunks}>{(hunk) => <HunkView hunk={hunk} />}</For>
+        </Show>
+      </Show>
+    </div>
+  );
+};
+
+/** Renders a single diff hunk with add/remove/context lines. */
+const HunkView: Component<{ hunk: DiffHunk }> = (props) => (
+  <div class="font-mono text-[0.65rem] leading-4">
+    {/* Hunk header */}
+    <div class="px-2 py-0.5 text-fg-3 bg-surface-1/50 select-none">
+      @@ -{props.hunk.oldStart},{props.hunk.oldCount} +{props.hunk.newStart},
+      {props.hunk.newCount} @@
+    </div>
+    <For each={props.hunk.lines}>
+      {(line) => {
+        const style = match(line.kind)
+          .with("add", () => ({
+            bg: "bg-green-500/10",
+            marker: "+",
+            markerColor: "text-green-400",
+          }))
+          .with("remove", () => ({
+            bg: "bg-red-500/10",
+            marker: "-",
+            markerColor: "text-red-400",
+          }))
+          .with("context", () => ({
+            bg: "",
+            marker: " ",
+            markerColor: "text-fg-3",
+          }))
+          .exhaustive();
+        return (
+          <div class={`flex ${style.bg}`}>
+            <span class="shrink-0 w-4 text-right pr-1 text-fg-3 select-none">
+              {line.oldLine ?? ""}
+            </span>
+            <span class="shrink-0 w-4 text-right pr-1 text-fg-3 select-none">
+              {line.newLine ?? ""}
+            </span>
+            <span
+              class={`shrink-0 w-3 text-center select-none ${style.markerColor}`}
+            >
+              {style.marker}
+            </span>
+            <span class="whitespace-pre overflow-hidden text-fg-2">
+              {line.content || " "}
+            </span>
+          </div>
+        );
+      }}
+    </For>
+  </div>
+);
+
+/** Status label for display. */
+const STATUS_LABEL: Record<string, string> = {
+  modified: "M",
+  added: "A",
+  deleted: "D",
+  renamed: "R",
+  untracked: "U",
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  modified: "text-yellow-400",
+  added: "text-green-400",
+  deleted: "text-red-400",
+  renamed: "text-blue-400",
+  untracked: "text-green-300",
+};
+
+const GitChanges: Component<{
+  root: Accessor<string | null>;
+  onOpenFile: (root: string, filePath: string) => void;
+}> = (props) => {
+  const [changedFiles, setChangedFiles] = createSignal<FsSearchResult[]>([]);
+  const [loading, setLoading] = createSignal(false);
+  const [expandedFile, setExpandedFile] = createSignal<string | null>(null);
+
+  // Fetch changed files when root changes
+  createEffect(
+    on(props.root, (root) => {
+      setChangedFiles([]);
+      setExpandedFile(null);
+      if (!root) return;
+      setLoading(true);
+      void client.fs
+        .search({ root, query: "", limit: 500 })
+        .then((results) => {
+          // Filter to only files with git status (i.e. changed files)
+          setChangedFiles(results.filter((f) => f.gitStatus !== null));
+        })
+        .catch(() => {})
+        .finally(() => setLoading(false));
+    }),
+  );
+
+  function toggleDiff(path: string) {
+    setExpandedFile((current) => (current === path ? null : path));
+  }
+
+  return (
+    <div class="py-1">
+      <Show
+        when={!loading()}
+        fallback={
+          <div class="px-3 py-2 text-xs text-fg-3">Loading changes...</div>
+        }
+      >
+        <Show
+          when={changedFiles().length > 0}
+          fallback={
+            <Show when={props.root()}>
+              <div class="px-3 py-4 text-xs text-fg-3 italic text-center">
+                No uncommitted changes
+              </div>
+            </Show>
+          }
+        >
+          <div class="px-3 py-1.5 text-[0.65rem] text-fg-3 font-medium uppercase tracking-wider">
+            {changedFiles().length} changed{" "}
+            {changedFiles().length === 1 ? "file" : "files"}
+          </div>
+          <For each={changedFiles()}>
+            {(file) => (
+              <div>
+                <button
+                  class="flex items-center gap-1.5 w-full text-left px-2 py-1 text-xs hover:bg-surface-2 transition-colors group"
+                  onClick={() => toggleDiff(file.path)}
+                >
+                  {/* Expand chevron */}
+                  <svg
+                    class="w-2.5 h-2.5 text-fg-3 shrink-0 transition-transform"
+                    classList={{
+                      "rotate-90": expandedFile() === file.path,
+                    }}
+                    viewBox="0 0 12 12"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path d="M4 2l4 4-4 4" />
+                  </svg>
+                  {/* Status badge */}
+                  <span
+                    class={`shrink-0 text-[0.6rem] font-bold w-3 text-center ${STATUS_COLOR[file.gitStatus!] ?? "text-fg-3"}`}
+                  >
+                    {STATUS_LABEL[file.gitStatus!] ?? "?"}
+                  </span>
+                  {/* File name (just the basename, with dir in muted) */}
+                  <span class="truncate text-fg-2 group-hover:text-fg">
+                    <Show when={file.path.includes("/")} fallback={file.name}>
+                      <span class="text-fg-3">
+                        {file.path.slice(0, file.path.lastIndexOf("/") + 1)}
+                      </span>
+                      {file.name}
+                    </Show>
+                  </span>
+                </button>
+                {/* Inline diff — shown when expanded */}
+                <Show when={expandedFile() === file.path && props.root()}>
+                  <DiffView root={props.root()!} filePath={file.path} />
+                </Show>
+              </div>
+            )}
+          </For>
+        </Show>
+      </Show>
+    </div>
+  );
+};
+
+export default GitChanges;

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -33,6 +33,8 @@ const Header: Component<{
   themeName?: string;
   meta?: TerminalMetadata | null;
   onToggleSidebar?: () => void;
+  onToggleRightPanel?: () => void;
+  rightPanelOpen?: boolean;
   onSearch?: () => void;
   appTitle?: string;
   randomTheme?: boolean;
@@ -143,6 +145,31 @@ const Header: Component<{
             </button>
           </Tip>
         )}
+        <Tip
+          label={`Toggle panel (${formatKeybind(SHORTCUTS.toggleRightPanel.keybind)})`}
+        >
+          <button
+            data-testid="right-panel-toggle"
+            class="h-7 w-7 flex items-center justify-center rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+            classList={{
+              "text-accent bg-surface-3": !!props.rightPanelOpen,
+              "text-fg-2 hover:text-fg hover:bg-surface-2":
+                !props.rightPanelOpen,
+            }}
+            onClick={() => props.onToggleRightPanel?.()}
+          >
+            <svg
+              class="w-4 h-4"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <rect x="1" y="2" width="14" height="12" rx="2" />
+              <line x1="10" y1="2" x2="10" y2="14" />
+            </svg>
+          </button>
+        </Tip>
         <Tip
           label={`Find in terminal (${formatKeybind(SHORTCUTS.findInTerminal.keybind)})`}
         >

--- a/client/src/RightPanel.tsx
+++ b/client/src/RightPanel.tsx
@@ -16,6 +16,7 @@ import {
   Show,
 } from "solid-js";
 import { match } from "ts-pattern";
+import { marked } from "marked";
 import FileTree from "./FileTree";
 import GitChanges from "./GitChanges";
 import { client } from "./rpc";
@@ -493,6 +494,11 @@ function escapeHtml(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
+/** Render markdown to HTML. Synchronous — marked is fast enough for inline use. */
+function renderMarkdown(text: string): string {
+  return marked.parse(text, { async: false, breaks: true }) as string;
+}
+
 const TranscriptView: Component<{
   terminalId: Accessor<TerminalId | null>;
 }> = (props) => {
@@ -520,8 +526,7 @@ const TranscriptView: Component<{
       }
       const blocks = (msg.blocks ?? [])
         .map((b) => {
-          if (b.kind === "text")
-            return `<div style="white-space:pre-wrap">${escapeHtml(b.text)}</div>`;
+          if (b.kind === "text") return renderMarkdown(b.text);
           if (b.kind === "tool_use")
             return `<div style="margin:8px 0;padding:8px 12px;background:#f3f4f6;border-radius:4px;font-family:monospace;font-size:12px">
               <div style="color:#6366f1;font-weight:600;margin-bottom:4px">${escapeHtml(b.name)}</div>
@@ -538,6 +543,12 @@ const TranscriptView: Component<{
 
     const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Claude Session</title>
 <style>body{font-family:-apple-system,system-ui,sans-serif;max-width:800px;margin:0 auto;padding:24px;color:#1f2937;font-size:14px;line-height:1.6}
+code{background:#f3f4f6;padding:2px 6px;border-radius:3px;font-size:0.9em;font-family:ui-monospace,monospace}
+pre{background:#f3f4f6;padding:12px 16px;border-radius:6px;overflow-x:auto;font-size:0.85em;margin:8px 0}
+pre code{background:none;padding:0}
+blockquote{border-left:3px solid #d1d5db;padding-left:12px;margin:8px 0;color:#6b7280}
+h1,h2,h3{margin:12px 0 4px;font-weight:600}
+ul,ol{padding-left:24px}
 @media print{body{padding:12px}}</style></head>
 <body><h1 style="font-size:18px;border-bottom:1px solid #e5e7eb;padding-bottom:12px;margin-bottom:8px">Claude Session Transcript</h1>
 ${lines.join("\n")}</body></html>`;
@@ -602,9 +613,10 @@ ${lines.join("\n")}</body></html>`;
                             {(block) =>
                               match(block)
                                 .with({ kind: "text" }, (b) => (
-                                  <div class="text-xs text-fg whitespace-pre-wrap leading-relaxed">
-                                    {b.text}
-                                  </div>
+                                  <div
+                                    class="text-xs text-fg leading-relaxed prose prose-xs prose-invert max-w-none"
+                                    innerHTML={renderMarkdown(b.text)}
+                                  />
                                 ))
                                 .with({ kind: "tool_use" }, (b) => (
                                   <details class="text-[0.65rem]">

--- a/client/src/RightPanel.tsx
+++ b/client/src/RightPanel.tsx
@@ -388,6 +388,13 @@ const DiffView: Component<{
 
 // --- Inline Transcript View ---
 
+/** State color for Claude state indicators. */
+const STATE_STYLE: Record<string, { dot: string; label: string }> = {
+  thinking: { dot: "bg-accent animate-pulse", label: "Thinking" },
+  tool_use: { dot: "bg-yellow-400 animate-pulse", label: "Tool use" },
+  waiting: { dot: "bg-fg-3", label: "Waiting" },
+};
+
 const TranscriptView: Component<{
   terminalId: Accessor<TerminalId | null>;
 }> = (props) => {
@@ -396,10 +403,24 @@ const TranscriptView: Component<{
     (id) => client.claude.getTranscript({ id }),
   );
 
+  /** Print the transcript section using the browser's print dialog. */
+  function handlePrint() {
+    window.print();
+  }
+
   return (
     <div class="flex flex-col h-full">
-      <div class="px-3 py-2 border-b border-edge text-xs font-semibold text-fg">
-        Claude transcript
+      <div class="flex items-center justify-between px-3 py-2 border-b border-edge">
+        <span class="text-xs font-semibold text-fg">Claude Session</span>
+        <Show when={snapshot()}>
+          <button
+            class="text-[0.65rem] text-fg-3 hover:text-fg transition-colors px-2 py-0.5 rounded bg-surface-2 hover:bg-surface-3"
+            onClick={handlePrint}
+            title="Print / Save as PDF"
+          >
+            Print
+          </button>
+        </Show>
       </div>
       <Show
         when={snapshot()}
@@ -414,49 +435,79 @@ const TranscriptView: Component<{
         }
       >
         {(snap) => (
-          <>
-            <div class="px-3 py-1.5 border-b border-edge text-[0.65rem] text-fg-3 font-mono break-all">
-              <div>{snap().transcriptPath}</div>
-              <div>since {new Date(snap().startedAt).toLocaleTimeString()}</div>
+          <div
+            class="flex-1 overflow-auto px-4 py-3 space-y-3 print:bg-white print:text-black"
+            data-testid="transcript-content"
+          >
+            {/* Session header */}
+            <div class="text-[0.65rem] text-fg-3 font-mono border-b border-edge pb-2">
+              <div class="truncate">{snap().transcriptPath}</div>
+              <div>Started: {new Date(snap().startedAt).toLocaleString()}</div>
+              <div>
+                {snap().stateChanges.length} transitions ·{" "}
+                {snap().rawEvents.length} events
+              </div>
             </div>
-            <div class="flex-1 grid grid-cols-2 min-h-0">
-              <section class="flex flex-col min-h-0 border-r border-edge">
-                <header class="px-3 py-1.5 text-[0.65rem] font-semibold text-fg-2 border-b border-edge">
-                  Server ({snap().stateChanges.length})
-                </header>
-                <pre class="flex-1 overflow-auto px-3 py-1.5 text-[0.6rem] font-mono text-fg whitespace-pre-wrap">
-                  <For
-                    each={snap().stateChanges}
-                    fallback={
-                      <span class="text-fg-3">No transitions yet.</span>
-                    }
-                  >
-                    {(change) => (
-                      <div>
-                        {new Date(change.ts).toLocaleTimeString()}{" "}
-                        {change.info
-                          ? `${change.info.state}${change.info.model ? ` (${change.info.model})` : ""}`
-                          : "session ended"}
+
+            {/* Timeline — each state change as a card */}
+            <div class="space-y-1.5">
+              <For
+                each={snap().stateChanges}
+                fallback={
+                  <div class="text-xs text-fg-3 italic py-2">
+                    No state transitions recorded yet.
+                  </div>
+                }
+              >
+                {(change) => {
+                  const style = () =>
+                    change.info
+                      ? (STATE_STYLE[change.info.state] ?? {
+                          dot: "bg-fg-3",
+                          label: change.info.state,
+                        })
+                      : { dot: "bg-red-400", label: "Session ended" };
+                  return (
+                    <div class="flex items-start gap-2 text-xs py-1 px-2 rounded hover:bg-surface-2 transition-colors print:hover:bg-transparent">
+                      <span
+                        class={`shrink-0 w-2 h-2 rounded-full mt-1 ${style().dot}`}
+                      />
+                      <div class="min-w-0">
+                        <span class="text-fg font-medium">{style().label}</span>
+                        <Show when={change.info?.model}>
+                          <span class="text-fg-3 ml-1.5">
+                            {change.info!.model}
+                          </span>
+                        </Show>
+                        <Show when={change.info?.summary}>
+                          <div class="text-fg-2 text-[0.65rem] truncate mt-0.5">
+                            {change.info!.summary}
+                          </div>
+                        </Show>
+                        <div class="text-fg-3 text-[0.6rem] font-mono mt-0.5">
+                          {new Date(change.ts).toLocaleTimeString()}
+                        </div>
                       </div>
-                    )}
-                  </For>
-                </pre>
-              </section>
-              <section class="flex flex-col min-h-0">
-                <header class="px-3 py-1.5 text-[0.65rem] font-semibold text-fg-2 border-b border-edge">
-                  Disk ({snap().rawEvents.length})
-                </header>
-                <pre class="flex-1 overflow-auto px-3 py-1.5 text-[0.6rem] font-mono text-fg whitespace-pre-wrap">
-                  <For
-                    each={snap().rawEvents}
-                    fallback={<span class="text-fg-3">No events yet.</span>}
-                  >
+                    </div>
+                  );
+                }}
+              </For>
+            </div>
+
+            {/* Raw events — collapsed by default */}
+            <Show when={snap().rawEvents.length > 0}>
+              <details class="text-[0.6rem] print:hidden">
+                <summary class="text-fg-3 cursor-pointer hover:text-fg-2 py-1">
+                  Raw JSONL ({snap().rawEvents.length} events)
+                </summary>
+                <pre class="mt-1 overflow-auto font-mono text-fg-3 whitespace-pre-wrap max-h-48 bg-surface-0 rounded p-2">
+                  <For each={snap().rawEvents}>
                     {(ev) => <div>{JSON.stringify(ev)}</div>}
                   </For>
                 </pre>
-              </section>
-            </div>
-          </>
+              </details>
+            </Show>
+          </div>
         )}
       </Show>
     </div>

--- a/client/src/RightPanel.tsx
+++ b/client/src/RightPanel.tsx
@@ -386,14 +386,112 @@ const DiffView: Component<{
   );
 };
 
-// --- Inline Transcript View ---
+// --- Session Conversation View ---
 
-/** State color for Claude state indicators. */
-const STATE_STYLE: Record<string, { dot: string; label: string }> = {
-  thinking: { dot: "bg-accent animate-pulse", label: "Thinking" },
-  tool_use: { dot: "bg-yellow-400 animate-pulse", label: "Tool use" },
-  waiting: { dot: "bg-fg-3", label: "Waiting" },
+/** Extract user text from a user message's content field. */
+function extractUserText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c: Record<string, unknown>) => {
+        if (c.type === "tool_result")
+          return `[Tool result: ${String(c.content ?? "").slice(0, 200)}]`;
+        return String(c.text ?? c.content ?? "");
+      })
+      .join("\n");
+  }
+  return "";
+}
+
+/** Extract renderable blocks from an assistant message's content array. */
+function extractAssistantBlocks(
+  content: unknown[],
+): Array<
+  | { kind: "text"; text: string }
+  | { kind: "tool_use"; name: string; input: string }
+  | { kind: "thinking"; text: string }
+> {
+  const blocks: Array<
+    | { kind: "text"; text: string }
+    | { kind: "tool_use"; name: string; input: string }
+    | { kind: "thinking"; text: string }
+  > = [];
+  for (const item of content) {
+    const c = item as Record<string, unknown>;
+    if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
+      blocks.push({ kind: "text", text: c.text });
+    } else if (c.type === "tool_use" && typeof c.name === "string") {
+      blocks.push({
+        kind: "tool_use",
+        name: c.name,
+        input: JSON.stringify(c.input, null, 2).slice(0, 500),
+      });
+    } else if (
+      c.type === "thinking" &&
+      typeof c.thinking === "string" &&
+      c.thinking.trim()
+    ) {
+      blocks.push({ kind: "thinking", text: c.thinking.slice(0, 300) });
+    }
+  }
+  return blocks;
+}
+
+type ConversationMsg = {
+  role: "user" | "assistant";
+  timestamp: string;
+  text?: string;
+  blocks?: ReturnType<typeof extractAssistantBlocks>;
+  model?: string;
 };
+
+/** Parse raw JSONL events into a conversation thread (user + assistant messages only). */
+function parseConversation(events: unknown[]): ConversationMsg[] {
+  const messages: ConversationMsg[] = [];
+  for (const ev of events) {
+    const e = ev as Record<string, unknown>;
+    const ts = typeof e.timestamp === "string" ? e.timestamp : "";
+    if (e.type === "user" && e.message) {
+      const msg = e.message as Record<string, unknown>;
+      const text = extractUserText(msg.content);
+      // Skip internal tool results
+      if (text && !text.startsWith("[Tool result:")) {
+        messages.push({ role: "user", timestamp: ts, text });
+      }
+    } else if (e.type === "assistant" && e.message) {
+      const msg = e.message as Record<string, unknown>;
+      if (Array.isArray(msg.content)) {
+        const blocks = extractAssistantBlocks(msg.content);
+        if (blocks.length > 0) {
+          messages.push({
+            role: "assistant",
+            timestamp: ts,
+            blocks,
+            model: typeof msg.model === "string" ? msg.model : undefined,
+          });
+        }
+      }
+    }
+  }
+  return messages;
+}
+
+function formatTime(ts: string): string {
+  if (!ts) return "";
+  try {
+    return new Date(ts).toLocaleTimeString();
+  } catch {
+    return ts;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
 
 const TranscriptView: Component<{
   terminalId: Accessor<TerminalId | null>;
@@ -403,113 +501,151 @@ const TranscriptView: Component<{
     (id) => client.claude.getTranscript({ id }),
   );
 
-  /** Print the transcript section using the browser's print dialog. */
+  const conversation = createMemo(() => {
+    const snap = snapshot();
+    if (!snap) return [];
+    return parseConversation(snap.rawEvents);
+  });
+
+  /** Open a standalone HTML page with the conversation, ready for print/PDF. */
   function handlePrint() {
-    window.print();
+    const msgs = conversation();
+    if (msgs.length === 0) return;
+
+    const lines = msgs.map((msg) => {
+      if (msg.role === "user") {
+        return `<div style="margin:16px 0;padding:12px 16px;background:#f0f4f8;border-radius:8px;border-left:3px solid #3b82f6">
+          <div style="font-size:11px;color:#6b7280;margin-bottom:4px">You &middot; ${escapeHtml(formatTime(msg.timestamp))}</div>
+          <div style="white-space:pre-wrap">${escapeHtml(msg.text ?? "")}</div></div>`;
+      }
+      const blocks = (msg.blocks ?? [])
+        .map((b) => {
+          if (b.kind === "text")
+            return `<div style="white-space:pre-wrap">${escapeHtml(b.text)}</div>`;
+          if (b.kind === "tool_use")
+            return `<div style="margin:8px 0;padding:8px 12px;background:#f3f4f6;border-radius:4px;font-family:monospace;font-size:12px">
+              <div style="color:#6366f1;font-weight:600;margin-bottom:4px">${escapeHtml(b.name)}</div>
+              <pre style="margin:0;overflow:auto;font-size:11px;color:#4b5563">${escapeHtml(b.input)}</pre></div>`;
+          if (b.kind === "thinking")
+            return `<div style="margin:4px 0;padding:8px;color:#9ca3af;font-style:italic;font-size:12px;border-left:2px solid #d1d5db">${escapeHtml(b.text)}${b.text.length >= 300 ? "..." : ""}</div>`;
+          return "";
+        })
+        .join("");
+      return `<div style="margin:16px 0;padding:12px 16px;background:#faf5ff;border-radius:8px;border-left:3px solid #8b5cf6">
+        <div style="font-size:11px;color:#6b7280;margin-bottom:4px">Claude${msg.model ? ` &middot; ${escapeHtml(msg.model)}` : ""} &middot; ${escapeHtml(formatTime(msg.timestamp))}</div>
+        ${blocks}</div>`;
+    });
+
+    const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Claude Session</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;max-width:800px;margin:0 auto;padding:24px;color:#1f2937;font-size:14px;line-height:1.6}
+@media print{body{padding:12px}}</style></head>
+<body><h1 style="font-size:18px;border-bottom:1px solid #e5e7eb;padding-bottom:12px;margin-bottom:8px">Claude Session Transcript</h1>
+${lines.join("\n")}</body></html>`;
+
+    const win = window.open("", "_blank");
+    if (win) {
+      win.document.write(html);
+      win.document.close();
+      setTimeout(() => win.print(), 300);
+    }
   }
 
   return (
-    <div class="flex flex-col h-full">
+    <div class="flex flex-col h-full" data-testid="transcript-view">
       <div class="flex items-center justify-between px-3 py-2 border-b border-edge">
-        <span class="text-xs font-semibold text-fg">Claude Session</span>
-        <Show when={snapshot()}>
+        <span class="text-xs font-semibold text-fg">Session</span>
+        <Show when={conversation().length > 0}>
           <button
             class="text-[0.65rem] text-fg-3 hover:text-fg transition-colors px-2 py-0.5 rounded bg-surface-2 hover:bg-surface-3"
             onClick={handlePrint}
-            title="Print / Save as PDF"
+            title="Open printable transcript in new tab"
           >
             Print
           </button>
         </Show>
       </div>
-      <Show
-        when={snapshot()}
-        fallback={
-          <div class="flex-1 flex items-center justify-center text-fg-3 text-xs px-4 text-center">
-            {snapshot.loading
-              ? "Loading..."
-              : snapshot.error instanceof Error
-                ? `Failed: ${snapshot.error.message}`
-                : "No active Claude session for this terminal."}
-          </div>
-        }
-      >
-        {(snap) => (
-          <div
-            class="flex-1 overflow-auto px-4 py-3 space-y-3 print:bg-white print:text-black"
-            data-testid="transcript-content"
-          >
-            {/* Session header */}
-            <div class="text-[0.65rem] text-fg-3 font-mono border-b border-edge pb-2">
-              <div class="truncate">{snap().transcriptPath}</div>
-              <div>Started: {new Date(snap().startedAt).toLocaleString()}</div>
-              <div>
-                {snap().stateChanges.length} transitions ·{" "}
-                {snap().rawEvents.length} events
+      <div class="flex-1 min-h-0 overflow-auto">
+        <Show
+          when={!snapshot.loading}
+          fallback={<div class="p-4 text-xs text-fg-3">Loading session...</div>}
+        >
+          <Show
+            when={conversation().length > 0}
+            fallback={
+              <div class="flex-1 flex items-center justify-center text-fg-3 text-xs px-4 py-8 text-center">
+                {snapshot.error instanceof Error
+                  ? `Failed: ${snapshot.error.message}`
+                  : "No active Claude session for this terminal."}
               </div>
-            </div>
-
-            {/* Timeline — each state change as a card */}
-            <div class="space-y-1.5">
-              <For
-                each={snap().stateChanges}
-                fallback={
-                  <div class="text-xs text-fg-3 italic py-2">
-                    No state transitions recorded yet.
-                  </div>
-                }
-              >
-                {(change) => {
-                  const style = () =>
-                    change.info
-                      ? (STATE_STYLE[change.info.state] ?? {
-                          dot: "bg-fg-3",
-                          label: change.info.state,
-                        })
-                      : { dot: "bg-red-400", label: "Session ended" };
-                  return (
-                    <div class="flex items-start gap-2 text-xs py-1 px-2 rounded hover:bg-surface-2 transition-colors print:hover:bg-transparent">
-                      <span
-                        class={`shrink-0 w-2 h-2 rounded-full mt-1 ${style().dot}`}
-                      />
-                      <div class="min-w-0">
-                        <span class="text-fg font-medium">{style().label}</span>
-                        <Show when={change.info?.model}>
-                          <span class="text-fg-3 ml-1.5">
-                            {change.info!.model}
+            }
+          >
+            <div class="px-3 py-2 space-y-3">
+              <For each={conversation()}>
+                {(msg) => (
+                  <Show
+                    when={msg.role === "user"}
+                    fallback={
+                      /* Assistant message */
+                      <div class="rounded-lg border border-edge/50 overflow-hidden">
+                        <div class="px-3 py-1.5 bg-surface-0 text-[0.6rem] text-fg-3 flex items-center gap-1.5">
+                          <span class="w-1.5 h-1.5 rounded-full bg-accent shrink-0" />
+                          <span class="font-medium">Claude</span>
+                          <Show when={msg.model}>
+                            <span class="text-fg-3/60">{msg.model}</span>
+                          </Show>
+                          <span class="ml-auto">
+                            {formatTime(msg.timestamp)}
                           </span>
-                        </Show>
-                        <Show when={change.info?.summary}>
-                          <div class="text-fg-2 text-[0.65rem] truncate mt-0.5">
-                            {change.info!.summary}
-                          </div>
-                        </Show>
-                        <div class="text-fg-3 text-[0.6rem] font-mono mt-0.5">
-                          {new Date(change.ts).toLocaleTimeString()}
+                        </div>
+                        <div class="px-3 py-2 space-y-2">
+                          <For each={msg.blocks ?? []}>
+                            {(block) =>
+                              match(block)
+                                .with({ kind: "text" }, (b) => (
+                                  <div class="text-xs text-fg whitespace-pre-wrap leading-relaxed">
+                                    {b.text}
+                                  </div>
+                                ))
+                                .with({ kind: "tool_use" }, (b) => (
+                                  <details class="text-[0.65rem]">
+                                    <summary class="text-accent cursor-pointer hover:underline font-mono">
+                                      {b.name}
+                                    </summary>
+                                    <pre class="mt-1 p-2 bg-surface-0 rounded text-fg-3 font-mono overflow-auto max-h-32 text-[0.6rem]">
+                                      {b.input}
+                                    </pre>
+                                  </details>
+                                ))
+                                .with({ kind: "thinking" }, (b) => (
+                                  <div class="text-[0.65rem] text-fg-3 italic border-l-2 border-edge pl-2">
+                                    {b.text}
+                                    {b.text.length >= 300 ? "..." : ""}
+                                  </div>
+                                ))
+                                .exhaustive()
+                            }
+                          </For>
                         </div>
                       </div>
+                    }
+                  >
+                    {/* User message */}
+                    <div class="rounded-lg bg-accent/10 border border-accent/20 px-3 py-2">
+                      <div class="text-[0.6rem] text-fg-3 mb-1 flex items-center gap-1.5">
+                        <span class="font-medium">You</span>
+                        <span class="ml-auto">{formatTime(msg.timestamp)}</span>
+                      </div>
+                      <div class="text-xs text-fg whitespace-pre-wrap leading-relaxed">
+                        {msg.text}
+                      </div>
                     </div>
-                  );
-                }}
+                  </Show>
+                )}
               </For>
             </div>
-
-            {/* Raw events — collapsed by default */}
-            <Show when={snap().rawEvents.length > 0}>
-              <details class="text-[0.6rem] print:hidden">
-                <summary class="text-fg-3 cursor-pointer hover:text-fg-2 py-1">
-                  Raw JSONL ({snap().rawEvents.length} events)
-                </summary>
-                <pre class="mt-1 overflow-auto font-mono text-fg-3 whitespace-pre-wrap max-h-48 bg-surface-0 rounded p-2">
-                  <For each={snap().rawEvents}>
-                    {(ev) => <div>{JSON.stringify(ev)}</div>}
-                  </For>
-                </pre>
-              </details>
-            </Show>
-          </div>
-        )}
-      </Show>
+          </Show>
+        </Show>
+      </div>
     </div>
   );
 };

--- a/client/src/RightPanel.tsx
+++ b/client/src/RightPanel.tsx
@@ -119,11 +119,37 @@ function formatBytes(bytes: number): string {
 
 // --- Inline Peek View ---
 
+/** Breadcrumb header for detail views — shows "Origin › filename" with back nav. */
+const DetailBreadcrumb: Component<{
+  origin: string;
+  filePath: string;
+  onBack: () => void;
+  children?: any;
+}> = (props) => (
+  <div class="flex items-center gap-1.5 px-3 py-2 border-b border-edge shrink-0 min-w-0">
+    <button
+      class="text-fg-3 hover:text-accent transition-colors text-xs shrink-0"
+      onClick={props.onBack}
+    >
+      {props.origin}
+    </button>
+    <span class="text-fg-3 text-xs shrink-0">›</span>
+    <span class="text-xs text-fg truncate font-mono">{props.filePath}</span>
+    <Show when={props.children}>
+      <span class="ml-auto shrink-0 flex items-center gap-1.5">
+        {props.children}
+      </span>
+    </Show>
+  </div>
+);
+
 const PeekView: Component<{
   filePath: string;
   root: string;
   content: FsReadFileOutput;
   onBack: () => void;
+  /** Label for the breadcrumb origin (e.g. "Files" or "Changes"). */
+  originLabel: string;
 }> = (props) => {
   const rawLines = createMemo(() => props.content.content.split("\n"));
   const lineNumWidth = createMemo(() =>
@@ -156,30 +182,16 @@ const PeekView: Component<{
 
   return (
     <div class="flex flex-col h-full">
-      {/* Header */}
-      <div class="flex items-center gap-2 px-3 py-2 border-b border-edge shrink-0">
-        <button
-          class="text-fg-3 hover:text-fg transition-colors"
-          onClick={props.onBack}
-          title="Back"
-        >
-          <svg
-            class="w-3.5 h-3.5"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path d="M8 2L4 6l4 4" />
-          </svg>
-        </button>
-        <span class="text-xs text-fg truncate font-mono">{props.filePath}</span>
-        <span class="ml-auto text-[0.65rem] text-fg-3 shrink-0">
+      <DetailBreadcrumb
+        origin={props.originLabel}
+        filePath={props.filePath}
+        onBack={props.onBack}
+      >
+        <span class="text-[0.65rem] text-fg-3">
           {props.content.lineCount} lines ·{" "}
           {formatBytes(props.content.byteLength)}
         </span>
-      </div>
-      {/* Content */}
+      </DetailBreadcrumb>
       <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
         <table class="w-full border-collapse">
           <tbody>
@@ -238,6 +250,7 @@ const DiffView: Component<{
   root: string;
   filePath: string;
   onBack: () => void;
+  originLabel: string;
 }> = (props) => {
   const [diff, setDiff] = createSignal<FsFileDiffOutput | null>(null);
   const [loading, setLoading] = createSignal(true);
@@ -270,34 +283,20 @@ const DiffView: Component<{
 
   return (
     <div class="flex flex-col h-full">
-      {/* Header */}
-      <div class="flex items-center gap-2 px-3 py-2 border-b border-edge shrink-0">
-        <button
-          class="text-fg-3 hover:text-fg transition-colors"
-          onClick={props.onBack}
-          title="Back"
-        >
-          <svg
-            class="w-3.5 h-3.5"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path d="M8 2L4 6l4 4" />
-          </svg>
-        </button>
-        <span class="text-xs text-fg truncate font-mono">{props.filePath}</span>
+      <DetailBreadcrumb
+        origin={props.originLabel}
+        filePath={props.filePath}
+        onBack={props.onBack}
+      >
         <Show when={diff()}>
-          <span class="text-[0.65rem] text-green-400 font-mono shrink-0">
+          <span class="text-[0.65rem] text-green-400 font-mono">
             +{totalAdded()}
           </span>
-          <span class="text-[0.65rem] text-red-400 font-mono shrink-0">
+          <span class="text-[0.65rem] text-red-400 font-mono">
             -{totalRemoved()}
           </span>
         </Show>
-      </div>
-      {/* Diff content */}
+      </DetailBreadcrumb>
       <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
         <Show
           when={!loading()}
@@ -478,6 +477,8 @@ const RightPanel: Component<{
     content: FsReadFileOutput;
   } | null;
   diffTarget: { root: string; filePath: string } | null;
+  /** Label of the list view the user navigated from (for breadcrumb). */
+  originLabel: string;
   onBack: () => void;
   terminalId: Accessor<TerminalId | null>;
 }> = (props) => {
@@ -572,6 +573,7 @@ const RightPanel: Component<{
                   root={file().root}
                   content={file().content}
                   onBack={props.onBack}
+                  originLabel={props.originLabel}
                 />
               )}
             </Show>
@@ -583,6 +585,7 @@ const RightPanel: Component<{
                   root={target().root}
                   filePath={target().filePath}
                   onBack={props.onBack}
+                  originLabel={props.originLabel}
                 />
               )}
             </Show>

--- a/client/src/RightPanel.tsx
+++ b/client/src/RightPanel.tsx
@@ -1,0 +1,605 @@
+/**
+ * Right panel — resizable sidebar hosting Files, Changes, Peek, Diff,
+ * and Claude Transcript views inline. Content stays visible alongside
+ * the terminal — no modals needed for file/diff context.
+ */
+
+import {
+  type Component,
+  type Accessor,
+  createSignal,
+  createEffect,
+  createMemo,
+  createResource,
+  on,
+  For,
+  Show,
+} from "solid-js";
+import { match } from "ts-pattern";
+import FileTree from "./FileTree";
+import GitChanges from "./GitChanges";
+import { client } from "./rpc";
+import { gitStatusBgColor } from "./gitStatusColor";
+import { formatKeybind, SHORTCUTS } from "./keyboard";
+import Kbd from "./Kbd";
+import type {
+  FsReadFileOutput,
+  FsFileDiffOutput,
+  DiffHunk,
+  TerminalId,
+} from "kolu-common";
+import type { RightPanelView } from "./useFileBrowser";
+
+// --- Syntax highlighting (shared with former FilePeek) ---
+
+const EXT_TO_LANG: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  rs: "rust",
+  go: "go",
+  rb: "ruby",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  json: "json",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "ini",
+  md: "markdown",
+  html: "xml",
+  xml: "xml",
+  css: "css",
+  scss: "scss",
+  sql: "sql",
+  nix: "nix",
+  hs: "haskell",
+  c: "c",
+  cpp: "cpp",
+  java: "java",
+  dockerfile: "dockerfile",
+  feature: "gherkin",
+};
+
+function getLang(filePath: string): string | undefined {
+  const name = filePath.split("/").pop()?.toLowerCase() ?? "";
+  if (EXT_TO_LANG[name]) return EXT_TO_LANG[name];
+  const ext = name.split(".").pop() ?? "";
+  return EXT_TO_LANG[ext];
+}
+
+async function highlightLines(
+  code: string,
+  lang: string | undefined,
+): Promise<string[]> {
+  const hljs = (await import("highlight.js")).default;
+  let html: string;
+  if (lang) {
+    try {
+      html = hljs.highlight(code, {
+        language: lang,
+        ignoreIllegals: true,
+      }).value;
+    } catch {
+      html = hljs.highlightAuto(code).value;
+    }
+  } else {
+    html = hljs.highlightAuto(code).value;
+  }
+  return html.split("\n");
+}
+
+type GutterMark = "added" | "modified" | "deleted-below" | null;
+
+function buildGutterMap(diff: FsFileDiffOutput): Map<number, GutterMark> {
+  const map = new Map<number, GutterMark>();
+  for (const line of diff.addedLines) map.set(line, "added");
+  for (const line of diff.modifiedLines) map.set(line, "modified");
+  for (const line of diff.deletedAfterLines) {
+    if (!map.has(line)) map.set(line, "deleted-below");
+  }
+  return map;
+}
+
+const GUTTER_COLORS: Record<string, string> = {
+  added: "bg-green-500",
+  modified: "bg-blue-400",
+  "deleted-below": "bg-red-500",
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// --- Inline Peek View ---
+
+const PeekView: Component<{
+  filePath: string;
+  root: string;
+  content: FsReadFileOutput;
+  onBack: () => void;
+}> = (props) => {
+  const rawLines = createMemo(() => props.content.content.split("\n"));
+  const lineNumWidth = createMemo(() =>
+    Math.max(String(rawLines().length).length, 3),
+  );
+
+  const [hlLines, setHlLines] = createSignal<string[] | null>(null);
+  const [diffData, setDiffData] = createSignal<FsFileDiffOutput | null>(null);
+  const gutterMap = createMemo(() =>
+    diffData() ? buildGutterMap(diffData()!) : new Map<number, GutterMark>(),
+  );
+
+  createEffect(
+    on(
+      () => [props.content, props.filePath, props.root] as const,
+      ([content, filePath, root]) => {
+        setHlLines(null);
+        setDiffData(null);
+        const lang = getLang(filePath);
+        void highlightLines(content.content, lang).then(setHlLines);
+        void client.fs
+          .fileDiff({ root, filePath })
+          .then(setDiffData)
+          .catch(() => {
+            // No diff available
+          });
+      },
+    ),
+  );
+
+  return (
+    <div class="flex flex-col h-full">
+      {/* Header */}
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-edge shrink-0">
+        <button
+          class="text-fg-3 hover:text-fg transition-colors"
+          onClick={props.onBack}
+          title="Back"
+        >
+          <svg
+            class="w-3.5 h-3.5"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M8 2L4 6l4 4" />
+          </svg>
+        </button>
+        <span class="text-xs text-fg truncate font-mono">{props.filePath}</span>
+        <span class="ml-auto text-[0.65rem] text-fg-3 shrink-0">
+          {props.content.lineCount} lines ·{" "}
+          {formatBytes(props.content.byteLength)}
+        </span>
+      </div>
+      {/* Content */}
+      <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
+        <table class="w-full border-collapse">
+          <tbody>
+            <For each={rawLines()}>
+              {(line, i) => {
+                const lineNum = () => i() + 1;
+                const highlighted = () => hlLines()?.[i()];
+                const gutter = () => gutterMap().get(lineNum()) ?? null;
+                return (
+                  <tr class="hover:bg-surface-2 transition-colors">
+                    <td class="w-1 p-0">
+                      <Show when={gutter()}>
+                        {(mark) => (
+                          <div
+                            class={`w-0.5 h-full ${GUTTER_COLORS[mark()]}`}
+                            title={mark()}
+                          />
+                        )}
+                      </Show>
+                    </td>
+                    <td
+                      class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-2 select-none border-r border-edge"
+                      style={{ width: `${lineNumWidth() + 2}ch` }}
+                    >
+                      {lineNum()}
+                    </td>
+                    <Show
+                      when={highlighted()}
+                      fallback={
+                        <td class="pl-3 pr-4 whitespace-pre text-fg">
+                          {line || " "}
+                        </td>
+                      }
+                    >
+                      {(html) => (
+                        <td
+                          class="pl-3 pr-4 whitespace-pre text-fg"
+                          innerHTML={html() || " "}
+                        />
+                      )}
+                    </Show>
+                  </tr>
+                );
+              }}
+            </For>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+// --- Inline Diff View ---
+
+const DiffView: Component<{
+  root: string;
+  filePath: string;
+  onBack: () => void;
+}> = (props) => {
+  const [diff, setDiff] = createSignal<FsFileDiffOutput | null>(null);
+  const [loading, setLoading] = createSignal(true);
+
+  createEffect(
+    on(
+      () => [props.root, props.filePath] as const,
+      ([root, filePath]) => {
+        setDiff(null);
+        setLoading(true);
+        void client.fs
+          .fileDiff({ root, filePath })
+          .then(setDiff)
+          .catch((err: unknown) => console.warn("Failed to load diff:", err))
+          .finally(() => setLoading(false));
+      },
+    ),
+  );
+
+  const totalAdded = () =>
+    diff()?.hunks.reduce(
+      (n, h) => n + h.lines.filter((l) => l.kind === "add").length,
+      0,
+    ) ?? 0;
+  const totalRemoved = () =>
+    diff()?.hunks.reduce(
+      (n, h) => n + h.lines.filter((l) => l.kind === "remove").length,
+      0,
+    ) ?? 0;
+
+  return (
+    <div class="flex flex-col h-full">
+      {/* Header */}
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-edge shrink-0">
+        <button
+          class="text-fg-3 hover:text-fg transition-colors"
+          onClick={props.onBack}
+          title="Back"
+        >
+          <svg
+            class="w-3.5 h-3.5"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M8 2L4 6l4 4" />
+          </svg>
+        </button>
+        <span class="text-xs text-fg truncate font-mono">{props.filePath}</span>
+        <Show when={diff()}>
+          <span class="text-[0.65rem] text-green-400 font-mono shrink-0">
+            +{totalAdded()}
+          </span>
+          <span class="text-[0.65rem] text-red-400 font-mono shrink-0">
+            -{totalRemoved()}
+          </span>
+        </Show>
+      </div>
+      {/* Diff content */}
+      <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
+        <Show
+          when={!loading()}
+          fallback={<div class="p-4 text-fg-3">Loading diff...</div>}
+        >
+          <Show
+            when={diff()?.hunks.length}
+            fallback={
+              <div class="p-4 text-fg-3 italic">No changes to display</div>
+            }
+          >
+            <table class="w-full border-collapse">
+              <tbody>
+                <For each={diff()!.hunks}>
+                  {(hunk, hunkIdx) => (
+                    <>
+                      <Show when={hunkIdx() > 0}>
+                        <tr>
+                          <td
+                            colspan="4"
+                            class="h-2 bg-surface-0 border-y border-edge/30"
+                          />
+                        </tr>
+                      </Show>
+                      <tr class="bg-blue-500/5">
+                        <td
+                          colspan="4"
+                          class="px-3 py-1 text-fg-3 text-[0.65rem] select-none"
+                        >
+                          @@ -{hunk.oldStart},{hunk.oldCount} +{hunk.newStart},
+                          {hunk.newCount} @@
+                        </td>
+                      </tr>
+                      <For each={hunk.lines}>
+                        {(line) => {
+                          const style = match(line.kind)
+                            .with("add", () => ({
+                              bg: "bg-green-500/10",
+                              marker: "+",
+                              markerColor: "text-green-400",
+                              textColor: "text-green-200",
+                            }))
+                            .with("remove", () => ({
+                              bg: "bg-red-500/10",
+                              marker: "-",
+                              markerColor: "text-red-400",
+                              textColor: "text-red-200",
+                            }))
+                            .with("context", () => ({
+                              bg: "",
+                              marker: " ",
+                              markerColor: "text-fg-3",
+                              textColor: "text-fg-2",
+                            }))
+                            .exhaustive();
+                          return (
+                            <tr class={`${style.bg} hover:brightness-110`}>
+                              <td class="w-8 text-right pr-1 pl-2 text-fg-3/50 select-none text-[0.6rem]">
+                                {line.oldLine ?? ""}
+                              </td>
+                              <td class="w-8 text-right pr-1 text-fg-3/50 select-none text-[0.6rem] border-r border-edge/20">
+                                {line.newLine ?? ""}
+                              </td>
+                              <td
+                                class={`w-4 text-center select-none text-[0.65rem] ${style.markerColor}`}
+                              >
+                                {style.marker}
+                              </td>
+                              <td
+                                class={`pr-3 whitespace-pre ${style.textColor}`}
+                              >
+                                {line.content || " "}
+                              </td>
+                            </tr>
+                          );
+                        }}
+                      </For>
+                    </>
+                  )}
+                </For>
+              </tbody>
+            </table>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+// --- Inline Transcript View ---
+
+const TranscriptView: Component<{
+  terminalId: Accessor<TerminalId | null>;
+}> = (props) => {
+  const [snapshot] = createResource(
+    () => props.terminalId(),
+    (id) => client.claude.getTranscript({ id }),
+  );
+
+  return (
+    <div class="flex flex-col h-full">
+      <div class="px-3 py-2 border-b border-edge text-xs font-semibold text-fg">
+        Claude transcript
+      </div>
+      <Show
+        when={snapshot()}
+        fallback={
+          <div class="flex-1 flex items-center justify-center text-fg-3 text-xs px-4 text-center">
+            {snapshot.loading
+              ? "Loading..."
+              : snapshot.error instanceof Error
+                ? `Failed: ${snapshot.error.message}`
+                : "No active Claude session for this terminal."}
+          </div>
+        }
+      >
+        {(snap) => (
+          <>
+            <div class="px-3 py-1.5 border-b border-edge text-[0.65rem] text-fg-3 font-mono break-all">
+              <div>{snap().transcriptPath}</div>
+              <div>since {new Date(snap().startedAt).toLocaleTimeString()}</div>
+            </div>
+            <div class="flex-1 grid grid-cols-2 min-h-0">
+              <section class="flex flex-col min-h-0 border-r border-edge">
+                <header class="px-3 py-1.5 text-[0.65rem] font-semibold text-fg-2 border-b border-edge">
+                  Server ({snap().stateChanges.length})
+                </header>
+                <pre class="flex-1 overflow-auto px-3 py-1.5 text-[0.6rem] font-mono text-fg whitespace-pre-wrap">
+                  <For
+                    each={snap().stateChanges}
+                    fallback={
+                      <span class="text-fg-3">No transitions yet.</span>
+                    }
+                  >
+                    {(change) => (
+                      <div>
+                        {new Date(change.ts).toLocaleTimeString()}{" "}
+                        {change.info
+                          ? `${change.info.state}${change.info.model ? ` (${change.info.model})` : ""}`
+                          : "session ended"}
+                      </div>
+                    )}
+                  </For>
+                </pre>
+              </section>
+              <section class="flex flex-col min-h-0">
+                <header class="px-3 py-1.5 text-[0.65rem] font-semibold text-fg-2 border-b border-edge">
+                  Disk ({snap().rawEvents.length})
+                </header>
+                <pre class="flex-1 overflow-auto px-3 py-1.5 text-[0.6rem] font-mono text-fg whitespace-pre-wrap">
+                  <For
+                    each={snap().rawEvents}
+                    fallback={<span class="text-fg-3">No events yet.</span>}
+                  >
+                    {(ev) => <div>{JSON.stringify(ev)}</div>}
+                  </For>
+                </pre>
+              </section>
+            </div>
+          </>
+        )}
+      </Show>
+    </div>
+  );
+};
+
+// --- Main Right Panel ---
+
+const RightPanel: Component<{
+  view: RightPanelView;
+  onViewChange: (view: RightPanelView) => void;
+  fileTreeRoot: Accessor<string | null>;
+  onOpenFile: (root: string, filePath: string) => void;
+  onOpenDiff: (root: string, filePath: string) => void;
+  peekFile: {
+    path: string;
+    root: string;
+    content: FsReadFileOutput;
+  } | null;
+  diffTarget: { root: string; filePath: string } | null;
+  onBack: () => void;
+  terminalId: Accessor<TerminalId | null>;
+}> = (props) => {
+  const isListView = () =>
+    props.view === "files" ||
+    props.view === "changes" ||
+    props.view === "transcript";
+
+  return (
+    <div
+      data-testid="right-panel"
+      class="flex flex-col h-full bg-surface-1 border-l border-edge"
+    >
+      {/* Tab bar — only for list views */}
+      <Show when={isListView()}>
+        <div class="flex shrink-0 border-b border-edge">
+          <button
+            class="flex-1 px-2 py-1.5 text-[0.65rem] font-medium transition-colors text-center"
+            classList={{
+              "text-fg border-b-2 border-accent": props.view === "files",
+              "text-fg-3 hover:text-fg-2": props.view !== "files",
+            }}
+            onClick={() => props.onViewChange("files")}
+          >
+            Files
+          </button>
+          <button
+            class="flex-1 px-2 py-1.5 text-[0.65rem] font-medium transition-colors text-center"
+            classList={{
+              "text-fg border-b-2 border-accent": props.view === "changes",
+              "text-fg-3 hover:text-fg-2": props.view !== "changes",
+            }}
+            onClick={() => props.onViewChange("changes")}
+          >
+            Changes
+          </button>
+          <button
+            class="flex-1 px-2 py-1.5 text-[0.65rem] font-medium transition-colors text-center"
+            classList={{
+              "text-fg border-b-2 border-accent": props.view === "transcript",
+              "text-fg-3 hover:text-fg-2": props.view !== "transcript",
+            }}
+            onClick={() => props.onViewChange("transcript")}
+          >
+            Transcript
+          </button>
+        </div>
+      </Show>
+
+      {/* Content */}
+      <div class="flex-1 min-h-0">
+        {match(props.view)
+          .with("files", () => (
+            <div class="h-full overflow-y-auto">
+              <Show
+                when={props.fileTreeRoot()}
+                fallback={
+                  <div class="px-3 py-4 text-xs text-fg-3 italic">
+                    Open a terminal in a git repository to browse files
+                  </div>
+                }
+              >
+                <FileTree
+                  root={props.fileTreeRoot}
+                  onOpenFile={props.onOpenFile}
+                />
+              </Show>
+            </div>
+          ))
+          .with("changes", () => (
+            <div class="h-full overflow-y-auto">
+              <Show
+                when={props.fileTreeRoot()}
+                fallback={
+                  <div class="px-3 py-4 text-xs text-fg-3 italic">
+                    Open a terminal in a git repository to see changes
+                  </div>
+                }
+              >
+                <GitChanges
+                  root={props.fileTreeRoot}
+                  onOpenDiff={props.onOpenDiff}
+                />
+              </Show>
+            </div>
+          ))
+          .with("peek", () => (
+            <Show when={props.peekFile}>
+              {(file) => (
+                <PeekView
+                  filePath={file().path}
+                  root={file().root}
+                  content={file().content}
+                  onBack={props.onBack}
+                />
+              )}
+            </Show>
+          ))
+          .with("diff", () => (
+            <Show when={props.diffTarget}>
+              {(target) => (
+                <DiffView
+                  root={target().root}
+                  filePath={target().filePath}
+                  onBack={props.onBack}
+                />
+              )}
+            </Show>
+          ))
+          .with("transcript", () => (
+            <TranscriptView terminalId={props.terminalId} />
+          ))
+          .exhaustive()}
+      </div>
+
+      {/* Footer */}
+      <div class="shrink-0 px-3 py-1.5 border-t border-edge text-[0.65rem] text-fg-3 flex items-center gap-2">
+        <Kbd>{formatKeybind(SHORTCUTS.toggleRightPanel.keybind)}</Kbd>
+        <span>toggle panel</span>
+      </div>
+    </div>
+  );
+};
+
+export default RightPanel;

--- a/client/src/RightPanel.tsx
+++ b/client/src/RightPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Right panel — resizable sidebar hosting Files, Changes, Peek, Diff,
+ * Right panel — resizable sidebar hosting Files, Changes, Peek, Diff, Blame,
  * and Claude Transcript views inline. Content stays visible alongside
  * the terminal — no modals needed for file/diff context.
  */
@@ -26,7 +26,8 @@ import Kbd from "./Kbd";
 import type {
   FsReadFileOutput,
   FsFileDiffOutput,
-  DiffHunk,
+  FsBlameOutput,
+  BlameLine,
   TerminalId,
 } from "kolu-common";
 import type { RightPanelView } from "./useFileBrowser";
@@ -73,24 +74,27 @@ function getLang(filePath: string): string | undefined {
   return EXT_TO_LANG[ext];
 }
 
+async function highlightCode(
+  code: string,
+  lang: string | undefined,
+): Promise<string> {
+  const hljs = (await import("highlight.js")).default;
+  if (lang) {
+    try {
+      return hljs.highlight(code, { language: lang, ignoreIllegals: true })
+        .value;
+    } catch {
+      return hljs.highlightAuto(code).value;
+    }
+  }
+  return hljs.highlightAuto(code).value;
+}
+
 async function highlightLines(
   code: string,
   lang: string | undefined,
 ): Promise<string[]> {
-  const hljs = (await import("highlight.js")).default;
-  let html: string;
-  if (lang) {
-    try {
-      html = hljs.highlight(code, {
-        language: lang,
-        ignoreIllegals: true,
-      }).value;
-    } catch {
-      html = hljs.highlightAuto(code).value;
-    }
-  } else {
-    html = hljs.highlightAuto(code).value;
-  }
+  const html = await highlightCode(code, lang);
   return html.split("\n");
 }
 
@@ -120,7 +124,7 @@ function formatBytes(bytes: number): string {
 
 // --- Inline Peek View ---
 
-/** Breadcrumb header for detail views — shows "Origin › filename" with back nav. */
+/** Breadcrumb header for detail views — shows "Origin > filename" with back nav. */
 const DetailBreadcrumb: Component<{
   origin: string;
   filePath: string;
@@ -134,7 +138,7 @@ const DetailBreadcrumb: Component<{
     >
       {props.origin}
     </button>
-    <span class="text-fg-3 text-xs shrink-0">›</span>
+    <span class="text-fg-3 text-xs shrink-0">&rsaquo;</span>
     <span class="text-xs text-fg truncate font-mono">{props.filePath}</span>
     <Show when={props.children}>
       <span class="ml-auto shrink-0 flex items-center gap-1.5">
@@ -144,11 +148,60 @@ const DetailBreadcrumb: Component<{
   </div>
 );
 
+/** Search-in-file bar for peek view. */
+const SearchInFile: Component<{
+  visible: boolean;
+  onClose: () => void;
+  onSearch: (query: string) => void;
+}> = (props) => {
+  let inputRef!: HTMLInputElement;
+
+  createEffect(() => {
+    if (props.visible) {
+      requestAnimationFrame(() => inputRef?.focus());
+    }
+  });
+
+  return (
+    <Show when={props.visible}>
+      <div class="flex items-center gap-2 px-3 py-1.5 bg-surface-2 border-b border-edge">
+        <svg
+          class="w-3 h-3 text-fg-3 shrink-0"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+        >
+          <circle cx="7" cy="7" r="5" />
+          <path d="M11 11l3.5 3.5" />
+        </svg>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Find in file..."
+          class="flex-1 bg-transparent text-xs text-fg outline-none placeholder-fg-3"
+          onInput={(e) => props.onSearch(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              props.onClose();
+              e.preventDefault();
+            }
+          }}
+        />
+        <button class="text-fg-3 hover:text-fg text-xs" onClick={props.onClose}>
+          &times;
+        </button>
+      </div>
+    </Show>
+  );
+};
+
 const PeekView: Component<{
   filePath: string;
   root: string;
   content: FsReadFileOutput;
   onBack: () => void;
+  onOpenBlame: (root: string, filePath: string) => void;
   /** Label for the breadcrumb origin (e.g. "Files" or "Changes"). */
   originLabel: string;
 }> = (props) => {
@@ -162,6 +215,19 @@ const PeekView: Component<{
   const gutterMap = createMemo(() =>
     diffData() ? buildGutterMap(diffData()!) : new Map<number, GutterMark>(),
   );
+
+  // Search-in-file state
+  const [searchVisible, setSearchVisible] = createSignal(false);
+  const [searchQuery, setSearchQuery] = createSignal("");
+  const searchMatches = createMemo(() => {
+    const q = searchQuery().toLowerCase();
+    if (!q) return new Set<number>();
+    const matches = new Set<number>();
+    rawLines().forEach((line, i) => {
+      if (line.toLowerCase().includes(q)) matches.add(i + 1);
+    });
+    return matches;
+  });
 
   createEffect(
     on(
@@ -181,71 +247,125 @@ const PeekView: Component<{
     ),
   );
 
+  // Intercept Cmd+F for search-in-file
+  function handleKeyDown(e: KeyboardEvent) {
+    const mod = navigator.platform.includes("Mac") ? e.metaKey : e.ctrlKey;
+    if (mod && e.key === "f") {
+      e.preventDefault();
+      e.stopPropagation();
+      setSearchVisible(true);
+    }
+  }
+
   return (
-    <div class="flex flex-col h-full">
+    <div class="flex flex-col h-full" onKeyDown={handleKeyDown} tabIndex={-1}>
       <DetailBreadcrumb
         origin={props.originLabel}
         filePath={props.filePath}
         onBack={props.onBack}
       >
+        <button
+          class="text-[0.6rem] text-fg-3 hover:text-accent transition-colors px-1"
+          onClick={() => props.onOpenBlame(props.root, props.filePath)}
+          title="Show git blame"
+        >
+          Blame
+        </button>
         <span class="text-[0.65rem] text-fg-3">
-          {props.content.lineCount} lines ·{" "}
+          {props.content.lineCount} lines &middot;{" "}
           {formatBytes(props.content.byteLength)}
         </span>
       </DetailBreadcrumb>
-      <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
-        <table class="w-full border-collapse">
-          <tbody>
-            <For each={rawLines()}>
-              {(line, i) => {
-                const lineNum = () => i() + 1;
-                const highlighted = () => hlLines()?.[i()];
-                const gutter = () => gutterMap().get(lineNum()) ?? null;
-                return (
-                  <tr class="hover:bg-surface-2 transition-colors">
-                    <td class="w-1 p-0">
-                      <Show when={gutter()}>
-                        {(mark) => (
-                          <div
-                            class={`w-0.5 h-full ${GUTTER_COLORS[mark()]}`}
-                            title={mark()}
+      {/* Binary file — show image or info */}
+      <Show when={props.content.binary}>
+        <div class="flex-1 flex items-center justify-center p-4">
+          <Show
+            when={props.content.mimeType?.startsWith("image/")}
+            fallback={
+              <div class="text-center text-fg-3 text-sm">
+                <div class="mb-2">Binary file</div>
+                <div class="text-[0.65rem]">
+                  {props.content.mimeType ?? "unknown type"} &middot;{" "}
+                  {formatBytes(props.content.byteLength)}
+                </div>
+              </div>
+            }
+          >
+            <img
+              src={`data:${props.content.mimeType};base64,${props.content.content}`}
+              alt={props.filePath}
+              class="max-w-full max-h-full object-contain rounded border border-edge"
+            />
+          </Show>
+        </div>
+      </Show>
+      <Show when={!props.content.binary}>
+        <SearchInFile
+          visible={searchVisible()}
+          onClose={() => {
+            setSearchVisible(false);
+            setSearchQuery("");
+          }}
+          onSearch={setSearchQuery}
+        />
+        <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
+          <table class="w-full border-collapse">
+            <tbody>
+              <For each={rawLines()}>
+                {(line, i) => {
+                  const lineNum = () => i() + 1;
+                  const highlighted = () => hlLines()?.[i()];
+                  const gutter = () => gutterMap().get(lineNum()) ?? null;
+                  const isSearchHit = () => searchMatches().has(lineNum());
+                  return (
+                    <tr
+                      class="hover:bg-surface-2 transition-colors"
+                      classList={{ "bg-yellow-500/15": isSearchHit() }}
+                    >
+                      <td class="w-1 p-0">
+                        <Show when={gutter()}>
+                          {(mark) => (
+                            <div
+                              class={`w-0.5 h-full ${GUTTER_COLORS[mark()]}`}
+                              title={mark()}
+                            />
+                          )}
+                        </Show>
+                      </td>
+                      <td
+                        class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-2 select-none border-r border-edge"
+                        style={{ width: `${lineNumWidth() + 2}ch` }}
+                      >
+                        {lineNum()}
+                      </td>
+                      <Show
+                        when={highlighted()}
+                        fallback={
+                          <td class="pl-3 pr-4 whitespace-pre text-fg">
+                            {line || " "}
+                          </td>
+                        }
+                      >
+                        {(html) => (
+                          <td
+                            class="pl-3 pr-4 whitespace-pre text-fg"
+                            innerHTML={html() || " "}
                           />
                         )}
                       </Show>
-                    </td>
-                    <td
-                      class="sticky left-0 bg-surface-1 text-fg-3 text-right pr-3 pl-2 select-none border-r border-edge"
-                      style={{ width: `${lineNumWidth() + 2}ch` }}
-                    >
-                      {lineNum()}
-                    </td>
-                    <Show
-                      when={highlighted()}
-                      fallback={
-                        <td class="pl-3 pr-4 whitespace-pre text-fg">
-                          {line || " "}
-                        </td>
-                      }
-                    >
-                      {(html) => (
-                        <td
-                          class="pl-3 pr-4 whitespace-pre text-fg"
-                          innerHTML={html() || " "}
-                        />
-                      )}
-                    </Show>
-                  </tr>
-                );
-              }}
-            </For>
-          </tbody>
-        </table>
-      </div>
+                    </tr>
+                  );
+                }}
+              </For>
+            </tbody>
+          </table>
+        </div>
+      </Show>
     </div>
   );
 };
 
-// --- Inline Diff View ---
+// --- Inline Diff View (with sticky hunk headers) ---
 
 const DiffView: Component<{
   root: string;
@@ -322,7 +442,8 @@ const DiffView: Component<{
                           />
                         </tr>
                       </Show>
-                      <tr class="bg-blue-500/5">
+                      {/* Sticky hunk header */}
+                      <tr class="bg-blue-500/5 sticky top-0 z-10">
                         <td
                           colspan="4"
                           class="px-3 py-1 text-fg-3 text-[0.65rem] select-none"
@@ -377,6 +498,101 @@ const DiffView: Component<{
                       </For>
                     </>
                   )}
+                </For>
+              </tbody>
+            </table>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+// --- Blame View ---
+
+const BlameView: Component<{
+  root: string;
+  filePath: string;
+  onBack: () => void;
+  originLabel: string;
+}> = (props) => {
+  const [blame, setBlame] = createSignal<FsBlameOutput | null>(null);
+  const [loading, setLoading] = createSignal(true);
+
+  createEffect(
+    on(
+      () => [props.root, props.filePath] as const,
+      ([root, filePath]) => {
+        setBlame(null);
+        setLoading(true);
+        void client.fs
+          .blame({ root, filePath })
+          .then(setBlame)
+          .catch((err: unknown) => console.warn("Failed to load blame:", err))
+          .finally(() => setLoading(false));
+      },
+    ),
+  );
+
+  return (
+    <div class="flex flex-col h-full">
+      <DetailBreadcrumb
+        origin={props.originLabel}
+        filePath={props.filePath}
+        onBack={props.onBack}
+      >
+        <span class="text-[0.65rem] text-fg-3">Blame</span>
+      </DetailBreadcrumb>
+      <div class="flex-1 min-h-0 overflow-auto font-mono text-xs leading-5">
+        <Show
+          when={!loading()}
+          fallback={<div class="p-4 text-fg-3">Loading blame...</div>}
+        >
+          <Show
+            when={(blame()?.lines.length ?? 0) > 0}
+            fallback={
+              <div class="p-4 text-fg-3 italic">
+                No blame data (untracked file?)
+              </div>
+            }
+          >
+            <table class="w-full border-collapse">
+              <tbody>
+                <For each={blame()!.lines}>
+                  {(bl, i) => {
+                    const prevSha = () =>
+                      i() > 0 ? blame()!.lines[i() - 1]?.sha : null;
+                    const isNewGroup = () => bl.sha !== prevSha();
+                    return (
+                      <tr
+                        class="hover:bg-surface-2"
+                        classList={{
+                          "border-t border-edge/30": isNewGroup(),
+                        }}
+                      >
+                        {/* Blame info — only show on first line of a group */}
+                        <td class="w-20 pl-2 pr-1 text-[0.55rem] text-fg-3 truncate select-none align-top">
+                          <Show when={isNewGroup()}>
+                            <span class="text-accent/80" title={bl.summary}>
+                              {bl.sha}
+                            </span>
+                          </Show>
+                        </td>
+                        <td class="w-16 pr-1 text-[0.55rem] text-fg-3/60 truncate select-none align-top">
+                          <Show when={isNewGroup()}>
+                            {bl.author.split(" ")[0]}
+                          </Show>
+                        </td>
+                        <td class="w-16 pr-1 text-[0.55rem] text-fg-3/40 select-none align-top">
+                          <Show when={isNewGroup()}>{bl.date}</Show>
+                        </td>
+                        <td class="w-8 text-right pr-2 text-fg-3/50 select-none text-[0.6rem]">
+                          {bl.line}
+                        </td>
+                        <td class="pl-2 pr-3 whitespace-pre text-fg-2"> </td>
+                      </tr>
+                    );
+                  }}
                 </For>
               </tbody>
             </table>
@@ -444,6 +660,7 @@ type ConversationMsg = {
   text?: string;
   blocks?: ReturnType<typeof extractAssistantBlocks>;
   model?: string;
+  toolCallCount?: number;
 };
 
 /** Parse raw JSONL events into a conversation thread (user + assistant messages only). */
@@ -463,12 +680,16 @@ function parseConversation(events: unknown[]): ConversationMsg[] {
       const msg = e.message as Record<string, unknown>;
       if (Array.isArray(msg.content)) {
         const blocks = extractAssistantBlocks(msg.content);
+        const toolCallCount = blocks.filter(
+          (b) => b.kind === "tool_use",
+        ).length;
         if (blocks.length > 0) {
           messages.push({
             role: "assistant",
             timestamp: ts,
             blocks,
             model: typeof msg.model === "string" ? msg.model : undefined,
+            toolCallCount,
           });
         }
       }
@@ -494,10 +715,45 @@ function escapeHtml(s: string): string {
     .replace(/"/g, "&quot;");
 }
 
-/** Render markdown to HTML. Synchronous — marked is fast enough for inline use. */
+/** Render markdown to HTML with syntax-highlighted code blocks. */
 function renderMarkdown(text: string): string {
   return marked.parse(text, { async: false, breaks: true }) as string;
 }
+
+/** Highlight code blocks in already-rendered markdown HTML.
+ *  Finds <pre><code class="language-xxx"> blocks and applies hljs. */
+async function highlightCodeBlocks(container: HTMLElement): Promise<void> {
+  const hljs = (await import("highlight.js")).default;
+  const codeBlocks = container.querySelectorAll("pre code[class*='language-']");
+  for (const block of codeBlocks) {
+    hljs.highlightElement(block as HTMLElement);
+  }
+  // Also auto-detect unclassed code blocks
+  const plainBlocks = container.querySelectorAll(
+    "pre code:not([class*='language-']):not(.hljs)",
+  );
+  for (const block of plainBlocks) {
+    hljs.highlightElement(block as HTMLElement);
+  }
+}
+
+/** Component that renders markdown with syntax-highlighted code blocks. */
+const MarkdownContent: Component<{ text: string }> = (props) => {
+  let ref!: HTMLDivElement;
+
+  createEffect(() => {
+    const html = renderMarkdown(props.text);
+    ref.innerHTML = html;
+    void highlightCodeBlocks(ref);
+  });
+
+  return (
+    <div
+      ref={ref}
+      class="text-xs text-fg leading-relaxed prose-xs max-w-none"
+    />
+  );
+};
 
 const TranscriptView: Component<{
   terminalId: Accessor<TerminalId | null>;
@@ -506,6 +762,7 @@ const TranscriptView: Component<{
     () => props.terminalId(),
     (id) => client.claude.getTranscript({ id }),
   );
+  const [toolCallsExpanded, setToolCallsExpanded] = createSignal(false);
 
   const conversation = createMemo(() => {
     const snap = snapshot();
@@ -513,10 +770,10 @@ const TranscriptView: Component<{
     return parseConversation(snap.rawEvents);
   });
 
-  /** Open a standalone HTML page with the conversation, ready for print/PDF. */
-  function handlePrint() {
+  /** Generate a standalone HTML page string from conversation. */
+  function generateHtml(): string {
     const msgs = conversation();
-    if (msgs.length === 0) return;
+    if (msgs.length === 0) return "";
 
     const lines = msgs.map((msg) => {
       if (msg.role === "user") {
@@ -528,9 +785,8 @@ const TranscriptView: Component<{
         .map((b) => {
           if (b.kind === "text") return renderMarkdown(b.text);
           if (b.kind === "tool_use")
-            return `<div style="margin:8px 0;padding:8px 12px;background:#f3f4f6;border-radius:4px;font-family:monospace;font-size:12px">
-              <div style="color:#6366f1;font-weight:600;margin-bottom:4px">${escapeHtml(b.name)}</div>
-              <pre style="margin:0;overflow:auto;font-size:11px;color:#4b5563">${escapeHtml(b.input)}</pre></div>`;
+            return `<details style="margin:8px 0"><summary style="cursor:pointer;color:#6366f1;font-weight:600;font-family:monospace;font-size:12px">${escapeHtml(b.name)}</summary>
+              <pre style="margin:4px 0;padding:8px 12px;background:#f3f4f6;border-radius:4px;font-size:11px;color:#4b5563;overflow:auto">${escapeHtml(b.input)}</pre></details>`;
           if (b.kind === "thinking")
             return `<div style="margin:4px 0;padding:8px;color:#9ca3af;font-style:italic;font-size:12px;border-left:2px solid #d1d5db">${escapeHtml(b.text)}${b.text.length >= 300 ? "..." : ""}</div>`;
           return "";
@@ -541,7 +797,7 @@ const TranscriptView: Component<{
         ${blocks}</div>`;
     });
 
-    const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Claude Session</title>
+    return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Claude Session</title>
 <style>body{font-family:-apple-system,system-ui,sans-serif;max-width:800px;margin:0 auto;padding:24px;color:#1f2937;font-size:14px;line-height:1.6}
 code{background:#f3f4f6;padding:2px 6px;border-radius:3px;font-size:0.9em;font-family:ui-monospace,monospace}
 pre{background:#f3f4f6;padding:12px 16px;border-radius:6px;overflow-x:auto;font-size:0.85em;margin:8px 0}
@@ -552,7 +808,12 @@ ul,ol{padding-left:24px}
 @media print{body{padding:12px}}</style></head>
 <body><h1 style="font-size:18px;border-bottom:1px solid #e5e7eb;padding-bottom:12px;margin-bottom:8px">Claude Session Transcript</h1>
 ${lines.join("\n")}</body></html>`;
+  }
 
+  /** Open a standalone HTML page with the conversation, ready for print/PDF. */
+  function handlePrint() {
+    const html = generateHtml();
+    if (!html) return;
     const win = window.open("", "_blank");
     if (win) {
       win.document.write(html);
@@ -561,18 +822,40 @@ ${lines.join("\n")}</body></html>`;
     }
   }
 
+  /** Download the transcript as a standalone HTML file. */
+  function handleDownloadHtml() {
+    const html = generateHtml();
+    if (!html) return;
+    const blob = new Blob([html], { type: "text/html" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `claude-session-${new Date().toISOString().slice(0, 10)}.html`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div class="flex flex-col h-full" data-testid="transcript-view">
       <div class="flex items-center justify-between px-3 py-2 border-b border-edge">
         <span class="text-xs font-semibold text-fg">Session</span>
         <Show when={conversation().length > 0}>
-          <button
-            class="text-[0.65rem] text-fg-3 hover:text-fg transition-colors px-2 py-0.5 rounded bg-surface-2 hover:bg-surface-3"
-            onClick={handlePrint}
-            title="Open printable transcript in new tab"
-          >
-            Print
-          </button>
+          <div class="flex items-center gap-1">
+            <button
+              class="text-[0.65rem] text-fg-3 hover:text-fg transition-colors px-2 py-0.5 rounded bg-surface-2 hover:bg-surface-3"
+              onClick={handlePrint}
+              title="Open printable transcript in new tab"
+            >
+              Print
+            </button>
+            <button
+              class="text-[0.65rem] text-fg-3 hover:text-fg transition-colors px-2 py-0.5 rounded bg-surface-2 hover:bg-surface-3"
+              onClick={handleDownloadHtml}
+              title="Download as HTML file"
+            >
+              Save HTML
+            </button>
+          </div>
         </Show>
       </div>
       <div class="flex-1 min-h-0 overflow-auto">
@@ -609,34 +892,76 @@ ${lines.join("\n")}</body></html>`;
                           </span>
                         </div>
                         <div class="px-3 py-2 space-y-2">
-                          <For each={msg.blocks ?? []}>
-                            {(block) =>
-                              match(block)
-                                .with({ kind: "text" }, (b) => (
-                                  <div
-                                    class="text-xs text-fg leading-relaxed prose prose-xs prose-invert max-w-none"
-                                    innerHTML={renderMarkdown(b.text)}
-                                  />
-                                ))
-                                .with({ kind: "tool_use" }, (b) => (
-                                  <details class="text-[0.65rem]">
-                                    <summary class="text-accent cursor-pointer hover:underline font-mono">
-                                      {b.name}
-                                    </summary>
-                                    <pre class="mt-1 p-2 bg-surface-0 rounded text-fg-3 font-mono overflow-auto max-h-32 text-[0.6rem]">
-                                      {b.input}
-                                    </pre>
-                                  </details>
-                                ))
-                                .with({ kind: "thinking" }, (b) => (
-                                  <div class="text-[0.65rem] text-fg-3 italic border-l-2 border-edge pl-2">
-                                    {b.text}
-                                    {b.text.length >= 300 ? "..." : ""}
-                                  </div>
-                                ))
-                                .exhaustive()
+                          {/* Collapsible tool calls */}
+                          <Show
+                            when={
+                              (msg.toolCallCount ?? 0) > 0 &&
+                              !toolCallsExpanded()
                             }
-                          </For>
+                          >
+                            <For
+                              each={
+                                msg.blocks?.filter((b) => b.kind === "text") ??
+                                []
+                              }
+                            >
+                              {(block) =>
+                                match(block)
+                                  .with({ kind: "text" }, (b) => (
+                                    <MarkdownContent text={b.text} />
+                                  ))
+                                  .otherwise(() => null)
+                              }
+                            </For>
+                            <button
+                              class="text-[0.6rem] text-accent hover:underline"
+                              onClick={() => setToolCallsExpanded(true)}
+                            >
+                              Show {msg.toolCallCount} tool call
+                              {(msg.toolCallCount ?? 0) > 1 ? "s" : ""}
+                            </button>
+                          </Show>
+                          {/* Expanded: show all blocks */}
+                          <Show
+                            when={
+                              (msg.toolCallCount ?? 0) === 0 ||
+                              toolCallsExpanded()
+                            }
+                          >
+                            <For each={msg.blocks ?? []}>
+                              {(block) =>
+                                match(block)
+                                  .with({ kind: "text" }, (b) => (
+                                    <MarkdownContent text={b.text} />
+                                  ))
+                                  .with({ kind: "tool_use" }, (b) => (
+                                    <details class="text-[0.65rem]">
+                                      <summary class="text-accent cursor-pointer hover:underline font-mono">
+                                        {b.name}
+                                      </summary>
+                                      <pre class="mt-1 p-2 bg-surface-0 rounded text-fg-3 font-mono overflow-auto max-h-32 text-[0.6rem]">
+                                        {b.input}
+                                      </pre>
+                                    </details>
+                                  ))
+                                  .with({ kind: "thinking" }, (b) => (
+                                    <div class="text-[0.65rem] text-fg-3 italic border-l-2 border-edge pl-2">
+                                      {b.text}
+                                      {b.text.length >= 300 ? "..." : ""}
+                                    </div>
+                                  ))
+                                  .exhaustive()
+                              }
+                            </For>
+                            <Show when={toolCallsExpanded()}>
+                              <button
+                                class="text-[0.6rem] text-fg-3 hover:text-fg"
+                                onClick={() => setToolCallsExpanded(false)}
+                              >
+                                Collapse tool calls
+                              </button>
+                            </Show>
+                          </Show>
                         </div>
                       </div>
                     }
@@ -670,6 +995,7 @@ const RightPanel: Component<{
   fileTreeRoot: Accessor<string | null>;
   onOpenFile: (root: string, filePath: string) => void;
   onOpenDiff: (root: string, filePath: string) => void;
+  onOpenBlame: (root: string, filePath: string) => void;
   peekFile: {
     path: string;
     root: string;
@@ -680,6 +1006,12 @@ const RightPanel: Component<{
   originLabel: string;
   onBack: () => void;
   terminalId: Accessor<TerminalId | null>;
+  /** Callback to stage a file. */
+  onStageFile: (root: string, filePath: string) => void;
+  /** Callback to unstage a file. */
+  onUnstageFile: (root: string, filePath: string) => void;
+  /** Refresh signal — increments when fs changes are detected. */
+  refreshSignal?: Accessor<number>;
 }> = (props) => {
   const isListView = () =>
     props.view === "files" ||
@@ -743,6 +1075,7 @@ const RightPanel: Component<{
                 <FileTree
                   root={props.fileTreeRoot}
                   onOpenFile={props.onOpenFile}
+                  refreshSignal={props.refreshSignal}
                 />
               </Show>
             </div>
@@ -760,6 +1093,9 @@ const RightPanel: Component<{
                 <GitChanges
                   root={props.fileTreeRoot}
                   onOpenDiff={props.onOpenDiff}
+                  onStageFile={props.onStageFile}
+                  onUnstageFile={props.onUnstageFile}
+                  refreshSignal={props.refreshSignal}
                 />
               </Show>
             </div>
@@ -772,6 +1108,7 @@ const RightPanel: Component<{
                   root={file().root}
                   content={file().content}
                   onBack={props.onBack}
+                  onOpenBlame={props.onOpenBlame}
                   originLabel={props.originLabel}
                 />
               )}
@@ -781,6 +1118,18 @@ const RightPanel: Component<{
             <Show when={props.diffTarget}>
               {(target) => (
                 <DiffView
+                  root={target().root}
+                  filePath={target().filePath}
+                  onBack={props.onBack}
+                  originLabel={props.originLabel}
+                />
+              )}
+            </Show>
+          ))
+          .with("blame", () => (
+            <Show when={props.diffTarget}>
+              {(target) => (
+                <BlameView
                   root={target().root}
                   filePath={target().filePath}
                   onBack={props.onBack}

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -25,6 +25,7 @@ import { useTips } from "./useTips";
 import { sidebarSwitchTip } from "./tips";
 import { formatKeybind, SHORTCUTS } from "./keyboard";
 import FileTree from "./FileTree";
+import GitChanges from "./GitChanges";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 import type {
   AgentInfo,
@@ -327,7 +328,7 @@ const Sidebar: Component<{
   fileTreeRoot: Accessor<string | null>;
   onOpenFile: (root: string, filePath: string) => void;
 }> = (props) => {
-  type SidebarTab = "terminals" | "files";
+  type SidebarTab = "terminals" | "files" | "changes";
   const [activeTab, setActiveTab] = createSignal<SidebarTab>("terminals");
   const { showTipOnce } = useTips();
 
@@ -402,6 +403,19 @@ const Sidebar: Component<{
             onClick={() => setActiveTab("files")}
           >
             Files
+          </button>
+          <div class="w-px my-1.5 bg-edge" />
+          <button
+            data-testid="sidebar-tab-changes"
+            class="flex-1 p-2 text-xs font-medium transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+            classList={{
+              "text-fg bg-surface-2": activeTab() === "changes",
+              "text-fg-3 hover:text-fg-2 hover:bg-surface-2/50":
+                activeTab() !== "changes",
+            }}
+            onClick={() => setActiveTab("changes")}
+          >
+            Changes
           </button>
         </div>
 
@@ -519,6 +533,25 @@ const Sidebar: Component<{
               }
             >
               <FileTree
+                root={props.fileTreeRoot}
+                onOpenFile={props.onOpenFile}
+              />
+            </Show>
+          </div>
+        </Show>
+
+        {/* Changes tab */}
+        <Show when={activeTab() === "changes"}>
+          <div class="flex-1 min-h-0 overflow-y-auto sidebar-scroll">
+            <Show
+              when={props.fileTreeRoot()}
+              fallback={
+                <div class="px-3 py-4 text-xs text-fg-3 italic">
+                  Open a terminal in a git repository to see changes
+                </div>
+              }
+            >
+              <GitChanges
                 root={props.fileTreeRoot}
                 onOpenFile={props.onOpenFile}
               />

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -324,11 +324,11 @@ const Sidebar: Component<{
   onReorder: (ids: TerminalId[]) => void;
   open: boolean;
   onClose: () => void;
-  fileTreeOpen: boolean;
-  onToggleFileTree: () => void;
   fileTreeRoot: Accessor<string | null>;
   onOpenFile: (root: string, filePath: string) => void;
 }> = (props) => {
+  type SidebarTab = "terminals" | "files";
+  const [activeTab, setActiveTab] = createSignal<SidebarTab>("terminals");
   const { showTipOnce } = useTips();
 
   function handleSelect(id: TerminalId) {
@@ -376,132 +376,153 @@ const Sidebar: Component<{
           "translate-x-0": props.open,
         }}
       >
-        <Tip label="New terminal" class="w-full">
-          <div class="flex m-1.5 rounded-2xl bg-surface-1 overflow-hidden">
-            <button
-              data-testid="create-terminal"
-              class="flex-1 p-2 text-sm text-fg-2 hover:text-fg hover:bg-surface-2 transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
-              onClick={props.onCreate}
-            >
-              + New terminal
-            </button>
-            <div class="w-px my-1.5 bg-edge" />
-            <button
-              data-testid="new-terminal-menu"
-              class="px-2.5 text-fg-3 hover:text-fg hover:bg-surface-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
-              onClick={props.onNewTerminalMenu}
-              title="More options"
-            >
-              <svg
-                class="w-3 h-3"
-                viewBox="0 0 12 12"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <path d="M3 5l3 3 3-3" />
-              </svg>
-            </button>
-          </div>
-        </Tip>
-        <nav class="flex-1 min-h-0 overflow-y-auto py-0.5 sidebar-scroll">
-          <DragDropProvider
-            collisionDetector={closestCenter}
-            onDragStart={({ draggable }) => {
-              setActiveItem(draggable.id as TerminalId);
-              setDragFrom(
-                props.terminalIds.indexOf(draggable.id as TerminalId),
-              );
+        {/* Tab bar — switches between Terminals and Files */}
+        <div class="flex m-1.5 rounded-2xl bg-surface-1 overflow-hidden">
+          <button
+            data-testid="sidebar-tab-terminals"
+            class="flex-1 p-2 text-xs font-medium transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+            classList={{
+              "text-fg bg-surface-2": activeTab() === "terminals",
+              "text-fg-3 hover:text-fg-2 hover:bg-surface-2/50":
+                activeTab() !== "terminals",
             }}
-            onDragOver={({ droppable }) =>
-              setDropTarget(droppable ? (droppable.id as TerminalId) : null)
-            }
-            onDragEnd={handleDragEnd}
+            onClick={() => setActiveTab("terminals")}
           >
-            <DragDropSensors />
-            <SortableProvider ids={props.terminalIds}>
-              <For each={props.terminalIds}>
-                {(id, index) => {
-                  const edge = (): "above" | "below" | null => {
-                    const from = dragFrom();
-                    const target = dropTarget();
-                    if (from === null || target !== id) return null;
-                    const toIdx = index();
-                    return from > toIdx ? "above" : "below";
-                  };
-                  return (
-                    <SidebarEntry
-                      id={id}
-                      isActive={props.activeId === id}
-                      metadata={props.getMetadata(id)}
-                      unread={props.isUnread(id)}
-                      displayInfo={props.getDisplayInfo(id)}
-                      terminalTheme={props.getTerminalTheme(id)}
-                      previewMode={props.previewMode}
-                      onSelect={handleSelect}
-                      onClose={props.onCloseTerminal}
-                      dropEdge={edge()}
-                    />
-                  );
-                }}
-              </For>
-            </SortableProvider>
-            <DragOverlay>
-              <Show when={activeItem()}>
-                {(dragId) => {
-                  const d = () => props.getDisplayInfo(dragId());
-                  return (
-                    <div class="py-1.5 px-2.5 text-sm bg-surface-2 border border-edge rounded-2xl shadow-lg">
-                      <span style={{ color: d()?.repoColor }}>
-                        {d()?.name ?? "terminal"}
-                      </span>
-                    </div>
-                  );
-                }}
-              </Show>
-            </DragOverlay>
-          </DragDropProvider>
-        </nav>
-        {/* File tree — collapsible section scoped to active workspace */}
-        <Show when={props.fileTreeRoot()}>
-          <div class="border-t border-edge">
-            <button
-              class="flex items-center gap-1.5 w-full px-3 py-1.5 text-xs text-fg-3 hover:text-fg-2 transition-colors"
-              onClick={props.onToggleFileTree}
-            >
-              <svg
-                class="w-3 h-3 transition-transform"
-                classList={{ "rotate-90": props.fileTreeOpen }}
-                viewBox="0 0 12 12"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+            Terminals
+          </button>
+          <div class="w-px my-1.5 bg-edge" />
+          <button
+            data-testid="sidebar-tab-files"
+            class="flex-1 p-2 text-xs font-medium transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+            classList={{
+              "text-fg bg-surface-2": activeTab() === "files",
+              "text-fg-3 hover:text-fg-2 hover:bg-surface-2/50":
+                activeTab() !== "files",
+            }}
+            onClick={() => setActiveTab("files")}
+          >
+            Files
+          </button>
+        </div>
+
+        {/* Terminals tab */}
+        <Show when={activeTab() === "terminals"}>
+          <Tip label="New terminal" class="w-full">
+            <div class="flex mx-1.5 rounded-2xl bg-surface-1 overflow-hidden">
+              <button
+                data-testid="create-terminal"
+                class="flex-1 p-2 text-sm text-fg-2 hover:text-fg hover:bg-surface-2 transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+                onClick={props.onCreate}
               >
-                <path d="M4 2l4 4-4 4" />
-              </svg>
-              Files
-            </button>
-            <Show when={props.fileTreeOpen}>
-              <div class="max-h-64 overflow-y-auto">
-                <FileTree
-                  root={props.fileTreeRoot}
-                  onOpenFile={props.onOpenFile}
-                />
-              </div>
-            </Show>
-          </div>
+                + New terminal
+              </button>
+              <div class="w-px my-1.5 bg-edge" />
+              <button
+                data-testid="new-terminal-menu"
+                class="px-2.5 text-fg-3 hover:text-fg hover:bg-surface-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+                onClick={props.onNewTerminalMenu}
+                title="More options"
+              >
+                <svg
+                  class="w-3 h-3"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M3 5l3 3 3-3" />
+                </svg>
+              </button>
+            </div>
+          </Tip>
+          <nav class="flex-1 min-h-0 overflow-y-auto py-0.5 sidebar-scroll">
+            <DragDropProvider
+              collisionDetector={closestCenter}
+              onDragStart={({ draggable }) => {
+                setActiveItem(draggable.id as TerminalId);
+                setDragFrom(
+                  props.terminalIds.indexOf(draggable.id as TerminalId),
+                );
+              }}
+              onDragOver={({ droppable }) =>
+                setDropTarget(droppable ? (droppable.id as TerminalId) : null)
+              }
+              onDragEnd={handleDragEnd}
+            >
+              <DragDropSensors />
+              <SortableProvider ids={props.terminalIds}>
+                <For each={props.terminalIds}>
+                  {(id, index) => {
+                    const edge = (): "above" | "below" | null => {
+                      const from = dragFrom();
+                      const target = dropTarget();
+                      if (from === null || target !== id) return null;
+                      const toIdx = index();
+                      return from > toIdx ? "above" : "below";
+                    };
+                    return (
+                      <SidebarEntry
+                        id={id}
+                        isActive={props.activeId === id}
+                        metadata={props.getMetadata(id)}
+                        unread={props.isUnread(id)}
+                        displayInfo={props.getDisplayInfo(id)}
+                        terminalTheme={props.getTerminalTheme(id)}
+                        previewMode={props.previewMode}
+                        onSelect={handleSelect}
+                        onClose={props.onCloseTerminal}
+                        dropEdge={edge()}
+                      />
+                    );
+                  }}
+                </For>
+              </SortableProvider>
+              <DragOverlay>
+                <Show when={activeItem()}>
+                  {(dragId) => {
+                    const d = () => props.getDisplayInfo(dragId());
+                    return (
+                      <div class="py-1.5 px-2.5 text-sm bg-surface-2 border border-edge rounded-2xl shadow-lg">
+                        <span style={{ color: d()?.repoColor }}>
+                          {d()?.name ?? "terminal"}
+                        </span>
+                      </div>
+                    );
+                  }}
+                </Show>
+              </DragOverlay>
+            </DragDropProvider>
+          </nav>
+          {/* Sticky footer hint */}
+          <Show when={props.terminalIds.length > 1}>
+            <div
+              data-testid="sidebar-footer-hint"
+              class="shrink-0 px-3 py-2 border-t border-edge text-[0.7rem] text-fg-3 flex items-center gap-1.5"
+            >
+              <Kbd>{formatKeybind(SHORTCUTS.cycleTerminalMru.keybind)}</Kbd>
+              <span>cycle terminals</span>
+            </div>
+          </Show>
         </Show>
-        {/* Sticky footer hint — surfaces the MRU cycle keybind without
-         *  needing the user to discover it via the shortcuts help dialog. */}
-        <Show when={props.terminalIds.length > 1}>
-          <div
-            data-testid="sidebar-footer-hint"
-            class="shrink-0 px-3 py-2 border-t border-edge text-[0.7rem] text-fg-3 flex items-center gap-1.5"
-          >
-            <Kbd>{formatKeybind(SHORTCUTS.cycleTerminalMru.keybind)}</Kbd>
-            <span>cycle terminals</span>
+
+        {/* Files tab */}
+        <Show when={activeTab() === "files"}>
+          <div class="flex-1 min-h-0 overflow-y-auto sidebar-scroll">
+            <Show
+              when={props.fileTreeRoot()}
+              fallback={
+                <div class="px-3 py-4 text-xs text-fg-3 italic">
+                  Open a terminal in a git repository to browse files
+                </div>
+              }
+            >
+              <FileTree
+                root={props.fileTreeRoot}
+                onOpenFile={props.onOpenFile}
+              />
+            </Show>
           </div>
         </Show>
       </aside>

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -24,6 +24,7 @@ import TerminalPreview from "./TerminalPreview";
 import { useTips } from "./useTips";
 import { sidebarSwitchTip } from "./tips";
 import { formatKeybind, SHORTCUTS } from "./keyboard";
+import FileTree from "./FileTree";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 import type {
   AgentInfo,
@@ -31,6 +32,7 @@ import type {
   TerminalId,
   TerminalMetadata,
 } from "kolu-common";
+import type { Accessor } from "solid-js";
 import type { ITheme } from "@xterm/xterm";
 import { viewportDimensions } from "./useViewport";
 
@@ -322,6 +324,10 @@ const Sidebar: Component<{
   onReorder: (ids: TerminalId[]) => void;
   open: boolean;
   onClose: () => void;
+  fileTreeOpen: boolean;
+  onToggleFileTree: () => void;
+  fileTreeRoot: Accessor<string | null>;
+  onOpenFile: (root: string, filePath: string) => void;
 }> = (props) => {
   const { showTipOnce } = useTips();
 
@@ -458,6 +464,35 @@ const Sidebar: Component<{
             </DragOverlay>
           </DragDropProvider>
         </nav>
+        {/* File tree — collapsible section scoped to active workspace */}
+        <Show when={props.fileTreeRoot()}>
+          <div class="border-t border-edge">
+            <button
+              class="flex items-center gap-1.5 w-full px-3 py-1.5 text-xs text-fg-3 hover:text-fg-2 transition-colors"
+              onClick={props.onToggleFileTree}
+            >
+              <svg
+                class="w-3 h-3 transition-transform"
+                classList={{ "rotate-90": props.fileTreeOpen }}
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path d="M4 2l4 4-4 4" />
+              </svg>
+              Files
+            </button>
+            <Show when={props.fileTreeOpen}>
+              <div class="max-h-64 overflow-y-auto">
+                <FileTree
+                  root={props.fileTreeRoot}
+                  onOpenFile={props.onOpenFile}
+                />
+              </div>
+            </Show>
+          </div>
+        </Show>
         {/* Sticky footer hint — surfaces the MRU cycle keybind without
          *  needing the user to discover it via the shortcuts help dialog. */}
         <Show when={props.terminalIds.length > 1}>

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -327,6 +327,7 @@ const Sidebar: Component<{
   onClose: () => void;
   fileTreeRoot: Accessor<string | null>;
   onOpenFile: (root: string, filePath: string) => void;
+  onOpenDiff: (root: string, filePath: string) => void;
 }> = (props) => {
   type SidebarTab = "terminals" | "files" | "changes";
   const [activeTab, setActiveTab] = createSignal<SidebarTab>("terminals");
@@ -553,7 +554,7 @@ const Sidebar: Component<{
             >
               <GitChanges
                 root={props.fileTreeRoot}
-                onOpenFile={props.onOpenFile}
+                onOpenDiff={props.onOpenDiff}
               />
             </Show>
           </div>

--- a/client/src/Sidebar.tsx
+++ b/client/src/Sidebar.tsx
@@ -24,8 +24,6 @@ import TerminalPreview from "./TerminalPreview";
 import { useTips } from "./useTips";
 import { sidebarSwitchTip } from "./tips";
 import { formatKeybind, SHORTCUTS } from "./keyboard";
-import FileTree from "./FileTree";
-import GitChanges from "./GitChanges";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 import type {
   AgentInfo,
@@ -33,7 +31,6 @@ import type {
   TerminalId,
   TerminalMetadata,
 } from "kolu-common";
-import type { Accessor } from "solid-js";
 import type { ITheme } from "@xterm/xterm";
 import { viewportDimensions } from "./useViewport";
 
@@ -325,12 +322,7 @@ const Sidebar: Component<{
   onReorder: (ids: TerminalId[]) => void;
   open: boolean;
   onClose: () => void;
-  fileTreeRoot: Accessor<string | null>;
-  onOpenFile: (root: string, filePath: string) => void;
-  onOpenDiff: (root: string, filePath: string) => void;
 }> = (props) => {
-  type SidebarTab = "terminals" | "files" | "changes";
-  const [activeTab, setActiveTab] = createSignal<SidebarTab>("terminals");
   const { showTipOnce } = useTips();
 
   function handleSelect(id: TerminalId) {
@@ -378,185 +370,102 @@ const Sidebar: Component<{
           "translate-x-0": props.open,
         }}
       >
-        {/* Tab bar — switches between Terminals and Files */}
-        <div class="flex m-1.5 rounded-2xl bg-surface-1 overflow-hidden">
-          <button
-            data-testid="sidebar-tab-terminals"
-            class="flex-1 p-2 text-xs font-medium transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
-            classList={{
-              "text-fg bg-surface-2": activeTab() === "terminals",
-              "text-fg-3 hover:text-fg-2 hover:bg-surface-2/50":
-                activeTab() !== "terminals",
-            }}
-            onClick={() => setActiveTab("terminals")}
-          >
-            Terminals
-          </button>
-          <div class="w-px my-1.5 bg-edge" />
-          <button
-            data-testid="sidebar-tab-files"
-            class="flex-1 p-2 text-xs font-medium transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
-            classList={{
-              "text-fg bg-surface-2": activeTab() === "files",
-              "text-fg-3 hover:text-fg-2 hover:bg-surface-2/50":
-                activeTab() !== "files",
-            }}
-            onClick={() => setActiveTab("files")}
-          >
-            Files
-          </button>
-          <div class="w-px my-1.5 bg-edge" />
-          <button
-            data-testid="sidebar-tab-changes"
-            class="flex-1 p-2 text-xs font-medium transition-colors text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
-            classList={{
-              "text-fg bg-surface-2": activeTab() === "changes",
-              "text-fg-3 hover:text-fg-2 hover:bg-surface-2/50":
-                activeTab() !== "changes",
-            }}
-            onClick={() => setActiveTab("changes")}
-          >
-            Changes
-          </button>
-        </div>
-
-        {/* Terminals tab */}
-        <Show when={activeTab() === "terminals"}>
-          <Tip label="New terminal" class="w-full">
-            <div class="flex mx-1.5 rounded-2xl bg-surface-1 overflow-hidden">
-              <button
-                data-testid="create-terminal"
-                class="flex-1 p-2 text-sm text-fg-2 hover:text-fg hover:bg-surface-2 transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
-                onClick={props.onCreate}
+        <Tip label="New terminal" class="w-full">
+          <div class="flex m-1.5 rounded-2xl bg-surface-1 overflow-hidden">
+            <button
+              data-testid="create-terminal"
+              class="flex-1 p-2 text-sm text-fg-2 hover:text-fg hover:bg-surface-2 transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+              onClick={props.onCreate}
+            >
+              + New terminal
+            </button>
+            <div class="w-px my-1.5 bg-edge" />
+            <button
+              data-testid="new-terminal-menu"
+              class="px-2.5 text-fg-3 hover:text-fg hover:bg-surface-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
+              onClick={props.onNewTerminalMenu}
+              title="More options"
+            >
+              <svg
+                class="w-3 h-3"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
               >
-                + New terminal
-              </button>
-              <div class="w-px my-1.5 bg-edge" />
-              <button
-                data-testid="new-terminal-menu"
-                class="px-2.5 text-fg-3 hover:text-fg hover:bg-surface-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/50"
-                onClick={props.onNewTerminalMenu}
-                title="More options"
-              >
-                <svg
-                  class="w-3 h-3"
-                  viewBox="0 0 12 12"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path d="M3 5l3 3 3-3" />
-                </svg>
-              </button>
-            </div>
-          </Tip>
-          <nav class="flex-1 min-h-0 overflow-y-auto py-0.5 sidebar-scroll">
-            <DragDropProvider
-              collisionDetector={closestCenter}
-              onDragStart={({ draggable }) => {
-                setActiveItem(draggable.id as TerminalId);
-                setDragFrom(
-                  props.terminalIds.indexOf(draggable.id as TerminalId),
-                );
-              }}
-              onDragOver={({ droppable }) =>
-                setDropTarget(droppable ? (droppable.id as TerminalId) : null)
-              }
-              onDragEnd={handleDragEnd}
-            >
-              <DragDropSensors />
-              <SortableProvider ids={props.terminalIds}>
-                <For each={props.terminalIds}>
-                  {(id, index) => {
-                    const edge = (): "above" | "below" | null => {
-                      const from = dragFrom();
-                      const target = dropTarget();
-                      if (from === null || target !== id) return null;
-                      const toIdx = index();
-                      return from > toIdx ? "above" : "below";
-                    };
-                    return (
-                      <SidebarEntry
-                        id={id}
-                        isActive={props.activeId === id}
-                        metadata={props.getMetadata(id)}
-                        unread={props.isUnread(id)}
-                        displayInfo={props.getDisplayInfo(id)}
-                        terminalTheme={props.getTerminalTheme(id)}
-                        previewMode={props.previewMode}
-                        onSelect={handleSelect}
-                        onClose={props.onCloseTerminal}
-                        dropEdge={edge()}
-                      />
-                    );
-                  }}
-                </For>
-              </SortableProvider>
-              <DragOverlay>
-                <Show when={activeItem()}>
-                  {(dragId) => {
-                    const d = () => props.getDisplayInfo(dragId());
-                    return (
-                      <div class="py-1.5 px-2.5 text-sm bg-surface-2 border border-edge rounded-2xl shadow-lg">
-                        <span style={{ color: d()?.repoColor }}>
-                          {d()?.name ?? "terminal"}
-                        </span>
-                      </div>
-                    );
-                  }}
-                </Show>
-              </DragOverlay>
-            </DragDropProvider>
-          </nav>
-          {/* Sticky footer hint */}
-          <Show when={props.terminalIds.length > 1}>
-            <div
-              data-testid="sidebar-footer-hint"
-              class="shrink-0 px-3 py-2 border-t border-edge text-[0.7rem] text-fg-3 flex items-center gap-1.5"
-            >
-              <Kbd>{formatKeybind(SHORTCUTS.cycleTerminalMru.keybind)}</Kbd>
-              <span>cycle terminals</span>
-            </div>
-          </Show>
-        </Show>
-
-        {/* Files tab */}
-        <Show when={activeTab() === "files"}>
-          <div class="flex-1 min-h-0 overflow-y-auto sidebar-scroll">
-            <Show
-              when={props.fileTreeRoot()}
-              fallback={
-                <div class="px-3 py-4 text-xs text-fg-3 italic">
-                  Open a terminal in a git repository to browse files
-                </div>
-              }
-            >
-              <FileTree
-                root={props.fileTreeRoot}
-                onOpenFile={props.onOpenFile}
-              />
-            </Show>
+                <path d="M3 5l3 3 3-3" />
+              </svg>
+            </button>
           </div>
-        </Show>
-
-        {/* Changes tab */}
-        <Show when={activeTab() === "changes"}>
-          <div class="flex-1 min-h-0 overflow-y-auto sidebar-scroll">
-            <Show
-              when={props.fileTreeRoot()}
-              fallback={
-                <div class="px-3 py-4 text-xs text-fg-3 italic">
-                  Open a terminal in a git repository to see changes
-                </div>
-              }
-            >
-              <GitChanges
-                root={props.fileTreeRoot}
-                onOpenDiff={props.onOpenDiff}
-              />
-            </Show>
+        </Tip>
+        <nav class="flex-1 min-h-0 overflow-y-auto py-0.5 sidebar-scroll">
+          <DragDropProvider
+            collisionDetector={closestCenter}
+            onDragStart={({ draggable }) => {
+              setActiveItem(draggable.id as TerminalId);
+              setDragFrom(
+                props.terminalIds.indexOf(draggable.id as TerminalId),
+              );
+            }}
+            onDragOver={({ droppable }) =>
+              setDropTarget(droppable ? (droppable.id as TerminalId) : null)
+            }
+            onDragEnd={handleDragEnd}
+          >
+            <DragDropSensors />
+            <SortableProvider ids={props.terminalIds}>
+              <For each={props.terminalIds}>
+                {(id, index) => {
+                  const edge = (): "above" | "below" | null => {
+                    const from = dragFrom();
+                    const target = dropTarget();
+                    if (from === null || target !== id) return null;
+                    const toIdx = index();
+                    return from > toIdx ? "above" : "below";
+                  };
+                  return (
+                    <SidebarEntry
+                      id={id}
+                      isActive={props.activeId === id}
+                      metadata={props.getMetadata(id)}
+                      unread={props.isUnread(id)}
+                      displayInfo={props.getDisplayInfo(id)}
+                      terminalTheme={props.getTerminalTheme(id)}
+                      previewMode={props.previewMode}
+                      onSelect={handleSelect}
+                      onClose={props.onCloseTerminal}
+                      dropEdge={edge()}
+                    />
+                  );
+                }}
+              </For>
+            </SortableProvider>
+            <DragOverlay>
+              <Show when={activeItem()}>
+                {(dragId) => {
+                  const d = () => props.getDisplayInfo(dragId());
+                  return (
+                    <div class="py-1.5 px-2.5 text-sm bg-surface-2 border border-edge rounded-2xl shadow-lg">
+                      <span style={{ color: d()?.repoColor }}>
+                        {d()?.name ?? "terminal"}
+                      </span>
+                    </div>
+                  );
+                }}
+              </Show>
+            </DragOverlay>
+          </DragDropProvider>
+        </nav>
+        {/* Sticky footer hint */}
+        <Show when={props.terminalIds.length > 1}>
+          <div
+            data-testid="sidebar-footer-hint"
+            class="shrink-0 px-3 py-2 border-t border-edge text-[0.7rem] text-fg-3 flex items-center gap-1.5"
+          >
+            <Kbd>{formatKeybind(SHORTCUTS.cycleTerminalMru.keybind)}</Kbd>
+            <span>cycle terminals</span>
           </div>
         </Show>
       </aside>

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -56,6 +56,7 @@ export interface CommandDeps {
   // Dialogs
   setShortcutsHelpOpen: (open: boolean) => void;
   setAboutOpen: (open: boolean) => void;
+  setFileSearchOpen: (open: boolean) => void;
   // Worktree
   handleCreateWorktree: (repoPath: string, initialCommand?: string) => void;
   handleClose: () => void;
@@ -197,6 +198,15 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             name: "Random theme",
             keybind: SHORTCUTS.randomizeTheme.keybind,
             onSelect: () => deps.handleRandomizeTheme(),
+          },
+        ]
+      : []),
+    ...(deps.activeId() !== null
+      ? [
+          {
+            name: "Browse files",
+            keybind: SHORTCUTS.fileBrowser.keybind,
+            onSelect: () => deps.setFileSearchOpen(true),
           },
         ]
       : []),

--- a/client/src/gitStatusColor.ts
+++ b/client/src/gitStatusColor.ts
@@ -1,0 +1,19 @@
+/** Git status → Tailwind color classes, shared by FileSearch and FileTree. */
+
+/** Text color variant (for dots using `background-color: currentColor`). */
+export const gitStatusTextColor: Record<string, string> = {
+  modified: "text-yellow-400",
+  added: "text-green-400",
+  deleted: "text-red-400",
+  renamed: "text-blue-400",
+  untracked: "text-green-300",
+};
+
+/** Background color variant (for direct background dots). */
+export const gitStatusBgColor: Record<string, string> = {
+  modified: "bg-yellow-400",
+  added: "bg-green-400",
+  deleted: "bg-red-400",
+  renamed: "bg-blue-400",
+  untracked: "bg-green-300",
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,6 @@
 @import "kolu-fonts";
 @import "tailwindcss";
+@import "highlight.js/styles/github-dark.css" layer(hljs);
 
 /* Suppress the browser's pull-to-refresh and scroll-chaining at the
  * document level. Without this, swiping down at the top of the

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -12,29 +12,6 @@ body {
   overscroll-behavior: contain;
 }
 
-/* Print styles — when printing the Claude transcript, hide everything
- * except the transcript content and let it flow naturally. */
-@media print {
-  header,
-  aside,
-  [data-testid="terminal-viewport"],
-  [data-testid="sidebar"],
-  [data-corvu-resizable-handle],
-  .print\\:hidden {
-    display: none !important;
-  }
-  [data-testid="right-panel"] {
-    position: fixed !important;
-    inset: 0 !important;
-    width: 100% !important;
-    border: none !important;
-  }
-  [data-testid="transcript-content"] {
-    background: white !important;
-    color: black !important;
-  }
-}
-
 /*
  * @theme registers color names with Tailwind and generates :root CSS custom properties.
  * Values here double as the dark palette — :root:not(.dark) overrides them for light mode.

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -12,6 +12,29 @@ body {
   overscroll-behavior: contain;
 }
 
+/* Print styles — when printing the Claude transcript, hide everything
+ * except the transcript content and let it flow naturally. */
+@media print {
+  header,
+  aside,
+  [data-testid="terminal-viewport"],
+  [data-testid="sidebar"],
+  [data-corvu-resizable-handle],
+  .print\\:hidden {
+    display: none !important;
+  }
+  [data-testid="right-panel"] {
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100% !important;
+    border: none !important;
+  }
+  [data-testid="transcript-content"] {
+    background: white !important;
+    color: black !important;
+  }
+}
+
 /*
  * @theme registers color names with Tailwind and generates :root CSS custom properties.
  * Values here double as the dark palette — :root:not(.dark) overrides them for light mode.

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -12,6 +12,72 @@ body {
   overscroll-behavior: contain;
 }
 
+/* Minimal prose styles for markdown rendered in the transcript view.
+ * Avoids pulling in @tailwindcss/typography for a handful of elements. */
+.prose-xs h1,
+.prose-xs h2,
+.prose-xs h3 {
+  font-weight: 600;
+  margin: 0.75em 0 0.25em;
+}
+.prose-xs h1 {
+  font-size: 1.1em;
+}
+.prose-xs h2 {
+  font-size: 1em;
+}
+.prose-xs h3 {
+  font-size: 0.95em;
+}
+.prose-xs p {
+  margin: 0.4em 0;
+}
+.prose-xs ul,
+.prose-xs ol {
+  padding-left: 1.5em;
+  margin: 0.4em 0;
+}
+.prose-xs li {
+  margin: 0.15em 0;
+}
+.prose-xs code {
+  background: var(--color-surface-0);
+  padding: 0.15em 0.35em;
+  border-radius: 3px;
+  font-size: 0.9em;
+  font-family: ui-monospace, monospace;
+}
+.prose-xs pre {
+  background: var(--color-surface-0);
+  padding: 0.75em 1em;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin: 0.5em 0;
+  font-size: 0.85em;
+}
+.prose-xs pre code {
+  background: none;
+  padding: 0;
+}
+.prose-xs strong {
+  font-weight: 600;
+}
+.prose-xs a {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+.prose-xs blockquote {
+  border-left: 2px solid var(--color-edge);
+  padding-left: 0.75em;
+  margin: 0.5em 0;
+  color: var(--color-fg-2);
+}
+.prose-xs hr {
+  border: none;
+  border-top: 1px solid var(--color-edge);
+  margin: 0.75em 0;
+}
+
 /*
  * @theme registers color names with Tailwind and generates :root CSS custom properties.
  * Values here double as the dark palette — :root:not(.dark) overrides them for light mode.

--- a/client/src/keyboard.ts
+++ b/client/src/keyboard.ts
@@ -146,6 +146,10 @@ export const SHORTCUTS = {
     keybind: { key: "o", code: "KeyO", mod: true },
     label: "Browse files",
   },
+  toggleRightPanel: {
+    keybind: { key: "b", code: "KeyB", mod: true },
+    label: "Toggle right panel",
+  },
 } as const satisfies Record<string, Shortcut>;
 
 /**

--- a/client/src/keyboard.ts
+++ b/client/src/keyboard.ts
@@ -142,6 +142,10 @@ export const SHORTCUTS = {
     keybind: { key: "p", code: "KeyP", mod: true },
     label: "Export session as PDF",
   },
+  fileBrowser: {
+    keybind: { key: "o", code: "KeyO", mod: true },
+    label: "Browse files",
+  },
 } as const satisfies Record<string, Shortcut>;
 
 /**

--- a/client/src/rpc.ts
+++ b/client/src/rpc.ts
@@ -87,6 +87,9 @@ export const stream = {
         context: { ...STREAM_RETRY, onRetry: opts.onRetry },
       },
     ),
+  /** Stream filesystem change notifications for a workspace root. */
+  fsOnChange: (root: string, signal?: AbortSignal) =>
+    client.fs.onChange({ root }, { signal, context: STREAM_RETRY }),
 };
 
 /**

--- a/client/src/useFileBrowser.ts
+++ b/client/src/useFileBrowser.ts
@@ -27,6 +27,8 @@ const [fileSearchOpen, setFileSearchOpen] = createSignal(false);
 const [rightPanelOpen, setRightPanelOpen] = createSignal(false);
 const [rightPanelView, setRightPanelView] =
   createSignal<RightPanelView>("files");
+/** User's preferred panel width as a fraction (0..1). Persisted across open/close. */
+const [rightPanelSize, setRightPanelSize] = createSignal(0.35);
 
 /** Tracks which list view the user drilled in from, so "back" returns there. */
 let listOrigin: ListOrigin = "files";
@@ -120,5 +122,7 @@ export function useFileBrowser() {
     openTranscript,
     goBack,
     originLabel,
+    rightPanelSize,
+    setRightPanelSize,
   } as const;
 }

--- a/client/src/useFileBrowser.ts
+++ b/client/src/useFileBrowser.ts
@@ -1,6 +1,6 @@
 /**
- * File browser state — shared between FileSearch (palette) and FileTree (sidebar).
- * Scoped to the active terminal's workspace root. Queries are server-driven.
+ * File browser state — shared between FileSearch (palette), FileTree (sidebar),
+ * GitChanges (sidebar), and DiffModal. Queries are server-driven.
  */
 
 import { createSignal } from "solid-js";
@@ -14,6 +14,11 @@ const [filePeekOpen, setFilePeekOpen] = createSignal(false);
 const [peekFile, setPeekFile] = createSignal<{
   path: string;
   content: FsReadFileOutput;
+} | null>(null);
+const [diffOpen, setDiffOpen] = createSignal(false);
+const [diffTarget, setDiffTarget] = createSignal<{
+  root: string;
+  filePath: string;
 } | null>(null);
 
 export function useFileBrowser() {
@@ -34,6 +39,16 @@ export function useFileBrowser() {
     setPeekFile(null);
   }
 
+  function openDiff(root: string, filePath: string): void {
+    setDiffTarget({ root, filePath });
+    setDiffOpen(true);
+  }
+
+  function closeDiff(): void {
+    setDiffOpen(false);
+    setDiffTarget(null);
+  }
+
   return {
     fileSearchOpen,
     setFileSearchOpen,
@@ -41,5 +56,9 @@ export function useFileBrowser() {
     peekFile,
     openPeek,
     closePeek,
+    diffOpen,
+    diffTarget,
+    openDiff,
+    closeDiff,
   } as const;
 }

--- a/client/src/useFileBrowser.ts
+++ b/client/src/useFileBrowser.ts
@@ -17,6 +17,7 @@ export type RightPanelView =
   | "changes"
   | "peek"
   | "diff"
+  | "blame"
   | "transcript";
 
 /** List views the user can navigate back to from peek/diff. */
@@ -87,10 +88,19 @@ export function useFileBrowser() {
     showView("transcript");
   }
 
-  /** Navigate back from peek/diff to the list view the user came from. */
+  function openBlame(root: string, filePath: string): void {
+    const current = rightPanelView();
+    if (current === "files" || current === "changes") {
+      listOrigin = current;
+    }
+    setDiffTarget({ root, filePath });
+    showView("blame");
+  }
+
+  /** Navigate back from peek/diff/blame to the list view the user came from. */
   function goBack(): void {
     const view = rightPanelView();
-    if (view === "peek" || view === "diff") {
+    if (view === "peek" || view === "diff" || view === "blame") {
       setPeekFile(null);
       setDiffTarget(null);
       setRightPanelView(listOrigin);
@@ -119,6 +129,7 @@ export function useFileBrowser() {
     diffTarget,
     openPeek,
     openDiff,
+    openBlame,
     openTranscript,
     goBack,
     originLabel,

--- a/client/src/useFileBrowser.ts
+++ b/client/src/useFileBrowser.ts
@@ -1,6 +1,9 @@
 /**
- * File browser state — shared between FileSearch (palette), FileTree (sidebar),
- * GitChanges (sidebar), and DiffModal. Queries are server-driven.
+ * File browser + right panel state — shared singleton.
+ *
+ * The right panel hosts Files, Changes, Peek, Diff, and Claude Transcript
+ * views inline. State here drives which view is active and what content
+ * is displayed. The panel itself is resizable via Corvu in the layout.
  */
 
 import { createSignal } from "solid-js";
@@ -8,25 +11,49 @@ import { toast } from "solid-sonner";
 import { client } from "./rpc";
 import type { FsReadFileOutput } from "kolu-common";
 
-// Singleton state — created once, used by all consumers.
+/** Which view the right panel is showing. */
+export type RightPanelView =
+  | "files"
+  | "changes"
+  | "peek"
+  | "diff"
+  | "transcript";
+
+// Singleton state
 const [fileSearchOpen, setFileSearchOpen] = createSignal(false);
-const [filePeekOpen, setFilePeekOpen] = createSignal(false);
+const [rightPanelOpen, setRightPanelOpen] = createSignal(false);
+const [rightPanelView, setRightPanelView] =
+  createSignal<RightPanelView>("files");
+
+// Peek state
 const [peekFile, setPeekFile] = createSignal<{
   path: string;
+  root: string;
   content: FsReadFileOutput;
 } | null>(null);
-const [diffOpen, setDiffOpen] = createSignal(false);
+
+// Diff state
 const [diffTarget, setDiffTarget] = createSignal<{
   root: string;
   filePath: string;
 } | null>(null);
 
 export function useFileBrowser() {
+  function toggleRightPanel(): void {
+    setRightPanelOpen((v) => !v);
+  }
+
+  /** Open the right panel to a specific view. */
+  function showView(view: RightPanelView): void {
+    setRightPanelView(view);
+    setRightPanelOpen(true);
+  }
+
   async function openPeek(root: string, filePath: string): Promise<void> {
     try {
       const content = await client.fs.readFile({ root, filePath });
-      setPeekFile({ path: filePath, content });
-      setFilePeekOpen(true);
+      setPeekFile({ path: filePath, root, content });
+      showView("peek");
     } catch (err: unknown) {
       toast.error(
         `Failed to read file: ${err instanceof Error ? err.message : String(err)}`,
@@ -34,31 +61,39 @@ export function useFileBrowser() {
     }
   }
 
-  function closePeek(): void {
-    setFilePeekOpen(false);
-    setPeekFile(null);
-  }
-
   function openDiff(root: string, filePath: string): void {
     setDiffTarget({ root, filePath });
-    setDiffOpen(true);
+    showView("diff");
   }
 
-  function closeDiff(): void {
-    setDiffOpen(false);
-    setDiffTarget(null);
+  function openTranscript(): void {
+    showView("transcript");
+  }
+
+  /** Navigate back from peek/diff to the previous list view. */
+  function goBack(): void {
+    const view = rightPanelView();
+    if (view === "peek" || view === "diff") {
+      setPeekFile(null);
+      setDiffTarget(null);
+      setRightPanelView("files");
+    }
   }
 
   return {
     fileSearchOpen,
     setFileSearchOpen,
-    filePeekOpen,
+    rightPanelOpen,
+    setRightPanelOpen,
+    rightPanelView,
+    setRightPanelView,
+    toggleRightPanel,
+    showView,
     peekFile,
-    openPeek,
-    closePeek,
-    diffOpen,
     diffTarget,
+    openPeek,
     openDiff,
-    closeDiff,
+    openTranscript,
+    goBack,
   } as const;
 }

--- a/client/src/useFileBrowser.ts
+++ b/client/src/useFileBrowser.ts
@@ -1,0 +1,48 @@
+/**
+ * File browser state — shared between FileSearch (palette) and FileTree (sidebar).
+ * Scoped to the active terminal's workspace root. Queries are server-driven.
+ */
+
+import { createSignal } from "solid-js";
+import { toast } from "solid-sonner";
+import { client } from "./rpc";
+import type { FsReadFileOutput } from "kolu-common";
+
+// Singleton state — created once, used by all consumers.
+const [fileSearchOpen, setFileSearchOpen] = createSignal(false);
+const [fileTreeOpen, setFileTreeOpen] = createSignal(false);
+const [filePeekOpen, setFilePeekOpen] = createSignal(false);
+const [peekFile, setPeekFile] = createSignal<{
+  path: string;
+  content: FsReadFileOutput;
+} | null>(null);
+
+export function useFileBrowser() {
+  async function openPeek(root: string, filePath: string): Promise<void> {
+    try {
+      const content = await client.fs.readFile({ root, filePath });
+      setPeekFile({ path: filePath, content });
+      setFilePeekOpen(true);
+    } catch (err: unknown) {
+      toast.error(
+        `Failed to read file: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  function closePeek(): void {
+    setFilePeekOpen(false);
+    setPeekFile(null);
+  }
+
+  return {
+    fileSearchOpen,
+    setFileSearchOpen,
+    fileTreeOpen,
+    setFileTreeOpen,
+    filePeekOpen,
+    peekFile,
+    openPeek,
+    closePeek,
+  } as const;
+}

--- a/client/src/useFileBrowser.ts
+++ b/client/src/useFileBrowser.ts
@@ -10,7 +10,6 @@ import type { FsReadFileOutput } from "kolu-common";
 
 // Singleton state — created once, used by all consumers.
 const [fileSearchOpen, setFileSearchOpen] = createSignal(false);
-const [fileTreeOpen, setFileTreeOpen] = createSignal(false);
 const [filePeekOpen, setFilePeekOpen] = createSignal(false);
 const [peekFile, setPeekFile] = createSignal<{
   path: string;
@@ -38,8 +37,6 @@ export function useFileBrowser() {
   return {
     fileSearchOpen,
     setFileSearchOpen,
-    fileTreeOpen,
-    setFileTreeOpen,
     filePeekOpen,
     peekFile,
     openPeek,

--- a/client/src/useFileBrowser.ts
+++ b/client/src/useFileBrowser.ts
@@ -19,11 +19,17 @@ export type RightPanelView =
   | "diff"
   | "transcript";
 
+/** List views the user can navigate back to from peek/diff. */
+type ListOrigin = "files" | "changes";
+
 // Singleton state
 const [fileSearchOpen, setFileSearchOpen] = createSignal(false);
 const [rightPanelOpen, setRightPanelOpen] = createSignal(false);
 const [rightPanelView, setRightPanelView] =
   createSignal<RightPanelView>("files");
+
+/** Tracks which list view the user drilled in from, so "back" returns there. */
+let listOrigin: ListOrigin = "files";
 
 // Peek state
 const [peekFile, setPeekFile] = createSignal<{
@@ -50,6 +56,11 @@ export function useFileBrowser() {
   }
 
   async function openPeek(root: string, filePath: string): Promise<void> {
+    // Remember where we came from — if already on a list view, save it
+    const current = rightPanelView();
+    if (current === "files" || current === "changes") {
+      listOrigin = current;
+    }
     try {
       const content = await client.fs.readFile({ root, filePath });
       setPeekFile({ path: filePath, root, content });
@@ -62,6 +73,10 @@ export function useFileBrowser() {
   }
 
   function openDiff(root: string, filePath: string): void {
+    const current = rightPanelView();
+    if (current === "files" || current === "changes") {
+      listOrigin = current;
+    }
     setDiffTarget({ root, filePath });
     showView("diff");
   }
@@ -70,15 +85,24 @@ export function useFileBrowser() {
     showView("transcript");
   }
 
-  /** Navigate back from peek/diff to the previous list view. */
+  /** Navigate back from peek/diff to the list view the user came from. */
   function goBack(): void {
     const view = rightPanelView();
     if (view === "peek" || view === "diff") {
       setPeekFile(null);
       setDiffTarget(null);
-      setRightPanelView("files");
+      setRightPanelView(listOrigin);
     }
   }
+
+  /** Human-readable label for the list view the user drilled in from. */
+  const originLabel = (): string => {
+    const labels: Record<ListOrigin, string> = {
+      files: "Files",
+      changes: "Changes",
+    };
+    return labels[listOrigin];
+  };
 
   return {
     fileSearchOpen,
@@ -95,5 +119,6 @@ export function useFileBrowser() {
     openDiff,
     openTranscript,
     goBack,
+    originLabel,
   } as const;
 }

--- a/client/src/useShortcuts.ts
+++ b/client/src/useShortcuts.ts
@@ -18,6 +18,7 @@ interface ShortcutDeps {
   setPaletteOpen: Setter<boolean>;
   setShortcutsHelpOpen: Setter<boolean>;
   setSearchOpen: Setter<boolean>;
+  setFileSearchOpen: Setter<boolean>;
   toggleSubPanel: (parentId: TerminalId) => void;
   getSubTerminalIds: (parentId: TerminalId) => TerminalId[];
   cycleSubTab: (parentId: TerminalId, direction: 1 | -1) => void;
@@ -181,6 +182,11 @@ function dispatch(
 
   if (matchesKeybind(e, SHORTCUTS.exportSessionAsPdf.keybind)) {
     deps.handleExportSessionAsPdf();
+    return true;
+  }
+
+  if (matchesKeybind(e, SHORTCUTS.fileBrowser.keybind)) {
+    deps.setFileSearchOpen((v) => !v);
     return true;
   }
 

--- a/client/src/useShortcuts.ts
+++ b/client/src/useShortcuts.ts
@@ -19,6 +19,7 @@ interface ShortcutDeps {
   setShortcutsHelpOpen: Setter<boolean>;
   setSearchOpen: Setter<boolean>;
   setFileSearchOpen: Setter<boolean>;
+  toggleRightPanel: () => void;
   toggleSubPanel: (parentId: TerminalId) => void;
   getSubTerminalIds: (parentId: TerminalId) => TerminalId[];
   cycleSubTab: (parentId: TerminalId, direction: 1 | -1) => void;
@@ -187,6 +188,11 @@ function dispatch(
 
   if (matchesKeybind(e, SHORTCUTS.fileBrowser.keybind)) {
     deps.setFileSearchOpen((v) => !v);
+    return true;
+  }
+
+  if (matchesKeybind(e, SHORTCUTS.toggleRightPanel.keybind)) {
+    deps.toggleRightPanel();
     return true;
   }
 

--- a/common/package.json
+++ b/common/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@orpc/contract": "^1.13.13",
     "kolu-claude-code": "workspace:*",
+    "kolu-workspace-fs": "workspace:*",
     "zod": "^4.3.6"
   }
 }

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -37,6 +37,9 @@ import {
   FsChangeEventSchema,
   FsFileDiffInputSchema,
   FsFileDiffOutputSchema,
+  FsBlameInputSchema,
+  FsBlameOutputSchema,
+  FsStageInputSchema,
 } from "./index";
 import { z } from "zod";
 
@@ -115,6 +118,12 @@ export const contract = oc.router({
     readFile: oc.input(FsReadFileInputSchema).output(FsReadFileOutputSchema),
     // Get parsed unified diff for a file against HEAD
     fileDiff: oc.input(FsFileDiffInputSchema).output(FsFileDiffOutputSchema),
+    // Get git blame for a file
+    blame: oc.input(FsBlameInputSchema).output(FsBlameOutputSchema),
+    // Stage a file (git add)
+    stage: oc.input(FsStageInputSchema).output(z.void()),
+    // Unstage a file (git reset HEAD)
+    unstage: oc.input(FsStageInputSchema).output(z.void()),
     // Stream change notifications for a workspace root — yields whenever the file index updates
     onChange: oc
       .input(FsWatchInputSchema)

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -35,6 +35,8 @@ import {
   FsReadFileOutputSchema,
   FsWatchInputSchema,
   FsChangeEventSchema,
+  FsFileDiffInputSchema,
+  FsFileDiffOutputSchema,
 } from "./index";
 import { z } from "zod";
 
@@ -111,6 +113,8 @@ export const contract = oc.router({
     listDir: oc.input(FsListDirInputSchema).output(z.array(FileEntrySchema)),
     // Read file contents (up to 1MB, truncated beyond)
     readFile: oc.input(FsReadFileInputSchema).output(FsReadFileOutputSchema),
+    // Get parsed unified diff for a file against HEAD
+    fileDiff: oc.input(FsFileDiffInputSchema).output(FsFileDiffOutputSchema),
     // Stream change notifications for a workspace root — yields whenever the file index updates
     onChange: oc
       .input(FsWatchInputSchema)

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -27,6 +27,14 @@ import {
   ServerStateSchema,
   ServerStatePatchSchema,
   ClaudeTranscriptDebugSchema,
+  FsSearchInputSchema,
+  FsSearchResultSchema,
+  FsListDirInputSchema,
+  FileEntrySchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
+  FsWatchInputSchema,
+  FsChangeEventSchema,
 } from "./index";
 import { z } from "zod";
 
@@ -95,5 +103,17 @@ export const contract = oc.router({
     update: oc.input(ServerStatePatchSchema).output(z.void()),
     // Reset state (test-only: seed/clear state between scenarios)
     test__set: oc.input(ServerStatePatchSchema).output(z.void()),
+  },
+  fs: {
+    // Fuzzy search files in a workspace root
+    search: oc.input(FsSearchInputSchema).output(z.array(FsSearchResultSchema)),
+    // List entries in a directory (one level deep)
+    listDir: oc.input(FsListDirInputSchema).output(z.array(FileEntrySchema)),
+    // Read file contents (up to 1MB, truncated beyond)
+    readFile: oc.input(FsReadFileInputSchema).output(FsReadFileOutputSchema),
+    // Stream change notifications for a workspace root — yields whenever the file index updates
+    onChange: oc
+      .input(FsWatchInputSchema)
+      .output(eventIterator(FsChangeEventSchema)),
   },
 });

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -26,6 +26,10 @@ import {
   FsFileDiffOutputSchema,
   DiffLineSchema,
   DiffHunkSchema,
+  BlameLineSchema,
+  FsBlameInputSchema,
+  FsBlameOutputSchema,
+  FsStageInputSchema,
 } from "kolu-workspace-fs/schemas";
 
 // Re-export integration schemas so consumers import from kolu-common only.
@@ -51,6 +55,10 @@ export {
   FsFileDiffOutputSchema,
   DiffLineSchema,
   DiffHunkSchema,
+  BlameLineSchema,
+  FsBlameInputSchema,
+  FsBlameOutputSchema,
+  FsStageInputSchema,
 };
 
 // --- Zod schemas ---
@@ -357,3 +365,7 @@ export type FsFileDiffInput = z.infer<typeof FsFileDiffInputSchema>;
 export type FsFileDiffOutput = z.infer<typeof FsFileDiffOutputSchema>;
 export type DiffLine = z.infer<typeof DiffLineSchema>;
 export type DiffHunk = z.infer<typeof DiffHunkSchema>;
+export type BlameLine = z.infer<typeof BlameLineSchema>;
+export type FsBlameInput = z.infer<typeof FsBlameInputSchema>;
+export type FsBlameOutput = z.infer<typeof FsBlameOutputSchema>;
+export type FsStageInput = z.infer<typeof FsStageInputSchema>;

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   FileGitStatusSchema,
+  FileStagingSchema,
   FileEntrySchema,
   FsSearchResultSchema,
   FsSearchInputSchema,
@@ -37,6 +38,7 @@ export {
 
 export {
   FileGitStatusSchema,
+  FileStagingSchema,
   FileEntrySchema,
   FsSearchResultSchema,
   FsSearchInputSchema,
@@ -343,6 +345,7 @@ export type ServerState = z.infer<typeof ServerStateSchema>;
 export type ServerStatePatch = z.infer<typeof ServerStatePatchSchema>;
 
 export type FileGitStatus = z.infer<typeof FileGitStatusSchema>;
+export type FileStaging = z.infer<typeof FileStagingSchema>;
 export type FileEntry = z.infer<typeof FileEntrySchema>;
 export type FsSearchResult = z.infer<typeof FsSearchResultSchema>;
 export type FsSearchInput = z.infer<typeof FsSearchInputSchema>;

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -11,12 +11,36 @@ import {
   ClaudeTranscriptDebugSchema,
 } from "kolu-claude-code";
 
+import {
+  FileGitStatusSchema,
+  FileEntrySchema,
+  FsSearchResultSchema,
+  FsSearchInputSchema,
+  FsListDirInputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
+  FsWatchInputSchema,
+  FsChangeEventSchema,
+} from "kolu-workspace-fs/schemas";
+
 // Re-export integration schemas so consumers import from kolu-common only.
 export {
   ClaudeCodeInfoSchema,
   TaskProgressSchema,
   ClaudeStateChangeSchema,
   ClaudeTranscriptDebugSchema,
+};
+
+export {
+  FileGitStatusSchema,
+  FileEntrySchema,
+  FsSearchResultSchema,
+  FsSearchInputSchema,
+  FsListDirInputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
+  FsWatchInputSchema,
+  FsChangeEventSchema,
 };
 
 // --- Zod schemas ---
@@ -309,3 +333,12 @@ export type Preferences = z.infer<typeof PreferencesSchema>;
 export type PersistedState = z.infer<typeof PersistedStateSchema>;
 export type ServerState = z.infer<typeof ServerStateSchema>;
 export type ServerStatePatch = z.infer<typeof ServerStatePatchSchema>;
+
+export type FileGitStatus = z.infer<typeof FileGitStatusSchema>;
+export type FileEntry = z.infer<typeof FileEntrySchema>;
+export type FsSearchResult = z.infer<typeof FsSearchResultSchema>;
+export type FsSearchInput = z.infer<typeof FsSearchInputSchema>;
+export type FsListDirInput = z.infer<typeof FsListDirInputSchema>;
+export type FsReadFileInput = z.infer<typeof FsReadFileInputSchema>;
+export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
+export type FsChangeEvent = z.infer<typeof FsChangeEventSchema>;

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -21,6 +21,10 @@ import {
   FsReadFileOutputSchema,
   FsWatchInputSchema,
   FsChangeEventSchema,
+  FsFileDiffInputSchema,
+  FsFileDiffOutputSchema,
+  DiffLineSchema,
+  DiffHunkSchema,
 } from "kolu-workspace-fs/schemas";
 
 // Re-export integration schemas so consumers import from kolu-common only.
@@ -41,6 +45,10 @@ export {
   FsReadFileOutputSchema,
   FsWatchInputSchema,
   FsChangeEventSchema,
+  FsFileDiffInputSchema,
+  FsFileDiffOutputSchema,
+  DiffLineSchema,
+  DiffHunkSchema,
 };
 
 // --- Zod schemas ---
@@ -342,3 +350,7 @@ export type FsListDirInput = z.infer<typeof FsListDirInputSchema>;
 export type FsReadFileInput = z.infer<typeof FsReadFileInputSchema>;
 export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
 export type FsChangeEvent = z.infer<typeof FsChangeEventSchema>;
+export type FsFileDiffInput = z.infer<typeof FsFileDiffInputSchema>;
+export type FsFileDiffOutput = z.infer<typeof FsFileDiffOutputSchema>;
+export type DiffLine = z.infer<typeof DiffLineSchema>;
+export type DiffHunk = z.infer<typeof DiffHunkSchema>;

--- a/default.nix
+++ b/default.nix
@@ -21,6 +21,7 @@ let
       ./tsconfig.base.json
       ./common
       ./integrations
+      ./workspace-fs
       ./server
       ./client
       # pnpm.patchedDependencies entries — read by pnpm during install and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      marked:
+        specifier: ^18.0.0
+        version: 18.0.0
       partysocket:
         specifier: ^1.1.16
         version: 1.1.16
@@ -2931,6 +2934,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.0:
+    resolution: {integrity: sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6731,6 +6739,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.0: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       partysocket:
         specifier: ^1.1.16
         version: 1.1.16
@@ -2571,6 +2574,10 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono-pino@0.10.3:
     resolution: {integrity: sha512-n0RNPIFOoq25Fg8b4D5gus4sVqI0z+8I17ibl96+p43d07UnZ0EMM/It0qSgfc7UtaC+XP5FkFmRHwBp6owsNA==}
@@ -6425,6 +6432,8 @@ snapshots:
       function-bind: 1.1.2
 
   help-me@5.0.0: {}
+
+  highlight.js@11.11.1: {}
 
   hono-pino@0.10.3(hono@4.12.12)(pino@10.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       kolu-claude-code:
         specifier: workspace:*
         version: link:../integrations/claude-code
+      kolu-workspace-fs:
+        specifier: workspace:*
+        version: link:../workspace-fs
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -208,6 +211,9 @@ importers:
       kolu-common:
         specifier: workspace:*
         version: link:../common
+      kolu-workspace-fs:
+        specifier: workspace:*
+        version: link:../workspace-fs
       node-pty:
         specifier: ^1.0.0
         version: 1.1.0(patch_hash=50f459cfc12675225bca395a9aab75c311e4cd6206f9c4990e818932465c8cd6)
@@ -266,6 +272,22 @@ importers:
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
+
+  workspace-fs:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - common
   - integrations/claude-code
+  - workspace-fs
   - server
   - client
   - tests

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "hono-pino": "^0.10.3",
     "kolu-claude-code": "workspace:*",
     "kolu-common": "workspace:*",
+    "kolu-workspace-fs": "workspace:*",
     "node-pty": "^1.0.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -256,6 +256,15 @@ export const appRouter = t.router({
         WorkspaceFsService.release(input.root);
       }
     }),
+    fileDiff: t.fs.fileDiff.handler(async ({ input }) => {
+      const svc = WorkspaceFsService.acquire(input.root);
+      try {
+        await svc.waitReady();
+        return await svc.fileDiff(input.filePath);
+      } finally {
+        WorkspaceFsService.release(input.root);
+      }
+    }),
     /**
      * Stream filesystem change notifications for a workspace root.
      * Yields an initial event immediately, then yields on each change batch.

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -29,6 +29,7 @@ import {
   updateServerState,
 } from "./state.ts";
 import { log } from "./log.ts";
+import { WorkspaceFsService } from "kolu-workspace-fs";
 
 const t = implement(contract);
 
@@ -225,6 +226,86 @@ export const appRouter = t.router({
     }),
     test__set: t.state.test__set.handler(async ({ input }) => {
       testSetServerState(input);
+    }),
+  },
+  fs: {
+    search: t.fs.search.handler(async ({ input }) => {
+      const svc = WorkspaceFsService.acquire(input.root);
+      try {
+        await svc.waitReady();
+        return svc.search(input.query, input.limit);
+      } finally {
+        WorkspaceFsService.release(input.root);
+      }
+    }),
+    listDir: t.fs.listDir.handler(async ({ input }) => {
+      const svc = WorkspaceFsService.acquire(input.root);
+      try {
+        await svc.waitReady();
+        return svc.listDir(input.dirPath);
+      } finally {
+        WorkspaceFsService.release(input.root);
+      }
+    }),
+    readFile: t.fs.readFile.handler(async ({ input }) => {
+      const svc = WorkspaceFsService.acquire(input.root);
+      try {
+        await svc.waitReady();
+        return await svc.readFile(input.filePath);
+      } finally {
+        WorkspaceFsService.release(input.root);
+      }
+    }),
+    /**
+     * Stream filesystem change notifications for a workspace root.
+     * Yields an initial event immediately, then yields on each change batch.
+     */
+    onChange: t.fs.onChange.handler(async function* ({ input, signal }) {
+      const svc = WorkspaceFsService.acquire(input.root);
+      let unsub: (() => void) | null = null;
+      try {
+        await svc.waitReady();
+        yield { updatedAt: Date.now() };
+
+        // Convert callback-based onChange to async iterator
+        let waiting: ((value: void) => void) | null = null;
+        let pending = false;
+
+        unsub = svc.onChange(() => {
+          if (waiting) {
+            const resolve = waiting;
+            waiting = null;
+            resolve();
+          } else {
+            pending = true;
+          }
+        });
+
+        signal?.addEventListener("abort", () => {
+          // Unblock any pending await so the loop exits
+          if (waiting) {
+            waiting();
+            waiting = null;
+          }
+        });
+
+        while (!signal?.aborted) {
+          if (pending) {
+            pending = false;
+            yield { updatedAt: Date.now() };
+          } else {
+            await new Promise<void>((resolve) => {
+              waiting = resolve;
+            });
+            if (!signal?.aborted) {
+              yield { updatedAt: Date.now() };
+            }
+          }
+        }
+      } finally {
+        unsub?.();
+        WorkspaceFsService.release(input.root);
+      }
     }),
   },
 });

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -265,6 +265,33 @@ export const appRouter = t.router({
         WorkspaceFsService.release(input.root);
       }
     }),
+    blame: t.fs.blame.handler(async ({ input }) => {
+      const svc = WorkspaceFsService.acquire(input.root);
+      try {
+        await svc.waitReady();
+        return await svc.blame(input.filePath);
+      } finally {
+        WorkspaceFsService.release(input.root);
+      }
+    }),
+    stage: t.fs.stage.handler(async ({ input }) => {
+      const svc = WorkspaceFsService.acquire(input.root);
+      try {
+        await svc.waitReady();
+        await svc.stageFile(input.filePath);
+      } finally {
+        WorkspaceFsService.release(input.root);
+      }
+    }),
+    unstage: t.fs.unstage.handler(async ({ input }) => {
+      const svc = WorkspaceFsService.acquire(input.root);
+      try {
+        await svc.waitReady();
+        await svc.unstageFile(input.filePath);
+      } finally {
+        WorkspaceFsService.release(input.root);
+      }
+    }),
     /**
      * Stream filesystem change notifications for a workspace root.
      * Yields an initial event immediately, then yields on each change batch.

--- a/workspace-fs/package.json
+++ b/workspace-fs/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "kolu-workspace-fs",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts",
+    "./scorer": "./src/scorer.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/workspace-fs/src/index.ts
+++ b/workspace-fs/src/index.ts
@@ -1,0 +1,28 @@
+// workspace-fs: file indexing, search, and watching for git workspaces.
+// Schemas are re-exported from kolu-common for client consumption.
+
+export {
+  FileGitStatusSchema,
+  FileEntrySchema,
+  FsSearchResultSchema,
+  FsSearchInputSchema,
+  FsListDirInputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
+  FsWatchInputSchema,
+  FsChangeEventSchema,
+} from "./schemas.ts";
+
+export type {
+  FileGitStatus,
+  FileEntry,
+  FsSearchResult,
+  FsSearchInput,
+  FsListDirInput,
+  FsReadFileInput,
+  FsReadFileOutput,
+  FsChangeEvent,
+} from "./schemas.ts";
+
+export { fuzzyScore, type FuzzyResult } from "./scorer.ts";
+export { WorkspaceFsService } from "./service.ts";

--- a/workspace-fs/src/index.ts
+++ b/workspace-fs/src/index.ts
@@ -11,6 +11,10 @@ export {
   FsReadFileOutputSchema,
   FsWatchInputSchema,
   FsChangeEventSchema,
+  FsFileDiffInputSchema,
+  FsFileDiffOutputSchema,
+  DiffLineSchema,
+  DiffHunkSchema,
 } from "./schemas.ts";
 
 export type {
@@ -22,6 +26,10 @@ export type {
   FsReadFileInput,
   FsReadFileOutput,
   FsChangeEvent,
+  FsFileDiffInput,
+  FsFileDiffOutput,
+  DiffLine,
+  DiffHunk,
 } from "./schemas.ts";
 
 export { fuzzyScore, type FuzzyResult } from "./scorer.ts";

--- a/workspace-fs/src/index.ts
+++ b/workspace-fs/src/index.ts
@@ -16,6 +16,10 @@ export {
   FsFileDiffOutputSchema,
   DiffLineSchema,
   DiffHunkSchema,
+  BlameLineSchema,
+  FsBlameInputSchema,
+  FsBlameOutputSchema,
+  FsStageInputSchema,
 } from "./schemas.ts";
 
 export type {
@@ -32,6 +36,10 @@ export type {
   FsFileDiffOutput,
   DiffLine,
   DiffHunk,
+  BlameLine,
+  FsBlameInput,
+  FsBlameOutput,
+  FsStageInput,
 } from "./schemas.ts";
 
 export { fuzzyScore, type FuzzyResult } from "./scorer.ts";

--- a/workspace-fs/src/index.ts
+++ b/workspace-fs/src/index.ts
@@ -3,6 +3,7 @@
 
 export {
   FileGitStatusSchema,
+  FileStagingSchema,
   FileEntrySchema,
   FsSearchResultSchema,
   FsSearchInputSchema,
@@ -19,6 +20,7 @@ export {
 
 export type {
   FileGitStatus,
+  FileStaging,
   FileEntry,
   FsSearchResult,
   FsSearchInput,

--- a/workspace-fs/src/schemas.ts
+++ b/workspace-fs/src/schemas.ts
@@ -1,0 +1,90 @@
+/**
+ * Zod schemas for workspace filesystem types.
+ * Consumed by kolu-common for re-export and contract definition.
+ */
+
+import { z } from "zod";
+
+/** Git status of a tracked or untracked file. */
+export const FileGitStatusSchema = z.enum([
+  "modified",
+  "added",
+  "deleted",
+  "renamed",
+  "untracked",
+]);
+
+/** A single file or directory entry with optional git status. */
+export const FileEntrySchema = z.object({
+  /** Path relative to the workspace root. */
+  path: z.string(),
+  /** Basename of the file or directory. */
+  name: z.string(),
+  kind: z.enum(["file", "directory"]),
+  /** Git status, or null if clean/untracked-directory. */
+  gitStatus: FileGitStatusSchema.nullable(),
+});
+
+/** A ranked search result with match positions for highlighting. */
+export const FsSearchResultSchema = z.object({
+  path: z.string(),
+  name: z.string(),
+  gitStatus: FileGitStatusSchema.nullable(),
+  /** Fuzzy match score — higher is better. */
+  score: z.number(),
+  /** Character indices in `path` that matched the query. */
+  matches: z.array(z.number()),
+});
+
+/** Input for file search. */
+export const FsSearchInputSchema = z.object({
+  root: z.string(),
+  query: z.string(),
+  limit: z.number().int().positive().optional(),
+});
+
+/** Input for directory listing. */
+export const FsListDirInputSchema = z.object({
+  root: z.string(),
+  /** Directory path relative to root. Empty string = root itself. */
+  dirPath: z.string(),
+});
+
+/** Input for reading file contents. */
+export const FsReadFileInputSchema = z.object({
+  root: z.string(),
+  /** File path relative to root. */
+  filePath: z.string(),
+});
+
+/** Output for file read — content + metadata. */
+export const FsReadFileOutputSchema = z.object({
+  content: z.string(),
+  /** Number of lines in the file. */
+  lineCount: z.number(),
+  /** File size in bytes. */
+  byteLength: z.number(),
+  /** Whether the content was truncated (file > 1MB). */
+  truncated: z.boolean(),
+});
+
+/** Input for watching a workspace root. */
+export const FsWatchInputSchema = z.object({
+  root: z.string(),
+});
+
+/** Lightweight change notification — client re-fetches on demand. */
+export const FsChangeEventSchema = z.object({
+  /** Timestamp of the change batch. */
+  updatedAt: z.number(),
+});
+
+// Derived types
+export type FileGitStatus = z.infer<typeof FileGitStatusSchema>;
+export type FileEntry = z.infer<typeof FileEntrySchema>;
+export type FsSearchResult = z.infer<typeof FsSearchResultSchema>;
+export type FsSearchInput = z.infer<typeof FsSearchInputSchema>;
+export type FsListDirInput = z.infer<typeof FsListDirInputSchema>;
+export type FsReadFileInput = z.infer<typeof FsReadFileInputSchema>;
+export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
+export type FsChangeEvent = z.infer<typeof FsChangeEventSchema>;

--- a/workspace-fs/src/schemas.ts
+++ b/workspace-fs/src/schemas.ts
@@ -68,6 +68,42 @@ export const FsReadFileOutputSchema = z.object({
   truncated: z.boolean(),
 });
 
+/** Input for file diff. */
+export const FsFileDiffInputSchema = z.object({
+  root: z.string(),
+  filePath: z.string(),
+});
+
+/** A single line in a diff hunk. */
+export const DiffLineSchema = z.object({
+  kind: z.enum(["context", "add", "remove"]),
+  content: z.string(),
+  /** Line number in the new file (null for removed lines). */
+  newLine: z.number().nullable(),
+  /** Line number in the old file (null for added lines). */
+  oldLine: z.number().nullable(),
+});
+
+/** A diff hunk with header and lines. */
+export const DiffHunkSchema = z.object({
+  oldStart: z.number(),
+  oldCount: z.number(),
+  newStart: z.number(),
+  newCount: z.number(),
+  lines: z.array(DiffLineSchema),
+});
+
+/** Output for file diff — parsed unified diff. */
+export const FsFileDiffOutputSchema = z.object({
+  hunks: z.array(DiffHunkSchema),
+  /** Set of new-file line numbers that are additions. */
+  addedLines: z.array(z.number()),
+  /** Set of new-file line numbers that have modifications (changed from old). */
+  modifiedLines: z.array(z.number()),
+  /** Line numbers in new file right after a deletion (gutter marker position). */
+  deletedAfterLines: z.array(z.number()),
+});
+
 /** Input for watching a workspace root. */
 export const FsWatchInputSchema = z.object({
   root: z.string(),
@@ -88,3 +124,7 @@ export type FsListDirInput = z.infer<typeof FsListDirInputSchema>;
 export type FsReadFileInput = z.infer<typeof FsReadFileInputSchema>;
 export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
 export type FsChangeEvent = z.infer<typeof FsChangeEventSchema>;
+export type FsFileDiffInput = z.infer<typeof FsFileDiffInputSchema>;
+export type FsFileDiffOutput = z.infer<typeof FsFileDiffOutputSchema>;
+export type DiffLine = z.infer<typeof DiffLineSchema>;
+export type DiffHunk = z.infer<typeof DiffHunkSchema>;

--- a/workspace-fs/src/schemas.ts
+++ b/workspace-fs/src/schemas.ts
@@ -72,6 +72,10 @@ export const FsReadFileOutputSchema = z.object({
   byteLength: z.number(),
   /** Whether the content was truncated (file > 1MB). */
   truncated: z.boolean(),
+  /** True if the file appears to be binary (content is base64-encoded for images). */
+  binary: z.boolean().optional(),
+  /** MIME type hint for binary files (e.g. "image/png"). */
+  mimeType: z.string().optional(),
 });
 
 /** Input for file diff. */
@@ -121,6 +125,36 @@ export const FsChangeEventSchema = z.object({
   updatedAt: z.number(),
 });
 
+/** A single blame entry for a line range. */
+export const BlameLineSchema = z.object({
+  /** Line number (1-based). */
+  line: z.number(),
+  /** Commit SHA (short). */
+  sha: z.string(),
+  author: z.string(),
+  /** ISO date string. */
+  date: z.string(),
+  /** Commit summary. */
+  summary: z.string(),
+});
+
+/** Input for file blame. */
+export const FsBlameInputSchema = z.object({
+  root: z.string(),
+  filePath: z.string(),
+});
+
+/** Output for file blame. */
+export const FsBlameOutputSchema = z.object({
+  lines: z.array(BlameLineSchema),
+});
+
+/** Input for staging a file. */
+export const FsStageInputSchema = z.object({
+  root: z.string(),
+  filePath: z.string(),
+});
+
 // Derived types
 export type FileGitStatus = z.infer<typeof FileGitStatusSchema>;
 export type FileEntry = z.infer<typeof FileEntrySchema>;
@@ -135,3 +169,7 @@ export type FsFileDiffInput = z.infer<typeof FsFileDiffInputSchema>;
 export type FsFileDiffOutput = z.infer<typeof FsFileDiffOutputSchema>;
 export type DiffLine = z.infer<typeof DiffLineSchema>;
 export type DiffHunk = z.infer<typeof DiffHunkSchema>;
+export type BlameLine = z.infer<typeof BlameLineSchema>;
+export type FsBlameInput = z.infer<typeof FsBlameInputSchema>;
+export type FsBlameOutput = z.infer<typeof FsBlameOutputSchema>;
+export type FsStageInput = z.infer<typeof FsStageInputSchema>;

--- a/workspace-fs/src/schemas.ts
+++ b/workspace-fs/src/schemas.ts
@@ -14,6 +14,9 @@ export const FileGitStatusSchema = z.enum([
   "untracked",
 ]);
 
+/** Whether a change is staged, unstaged, or both. */
+export const FileStagingSchema = z.enum(["staged", "unstaged", "partial"]);
+
 /** A single file or directory entry with optional git status. */
 export const FileEntrySchema = z.object({
   /** Path relative to the workspace root. */
@@ -23,6 +26,8 @@ export const FileEntrySchema = z.object({
   kind: z.enum(["file", "directory"]),
   /** Git status, or null if clean/untracked-directory. */
   gitStatus: FileGitStatusSchema.nullable(),
+  /** Whether the change is staged, unstaged, or partially staged. Null if clean. */
+  staging: FileStagingSchema.nullable(),
 });
 
 /** A ranked search result with match positions for highlighting. */
@@ -30,6 +35,7 @@ export const FsSearchResultSchema = z.object({
   path: z.string(),
   name: z.string(),
   gitStatus: FileGitStatusSchema.nullable(),
+  staging: FileStagingSchema.nullable(),
   /** Fuzzy match score — higher is better. */
   score: z.number(),
   /** Character indices in `path` that matched the query. */
@@ -124,6 +130,7 @@ export type FsListDirInput = z.infer<typeof FsListDirInputSchema>;
 export type FsReadFileInput = z.infer<typeof FsReadFileInputSchema>;
 export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
 export type FsChangeEvent = z.infer<typeof FsChangeEventSchema>;
+export type FileStaging = z.infer<typeof FileStagingSchema>;
 export type FsFileDiffInput = z.infer<typeof FsFileDiffInputSchema>;
 export type FsFileDiffOutput = z.infer<typeof FsFileDiffOutputSchema>;
 export type DiffLine = z.infer<typeof DiffLineSchema>;

--- a/workspace-fs/src/scorer.test.ts
+++ b/workspace-fs/src/scorer.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyScore } from "./scorer";
+
+describe("fuzzyScore", () => {
+  it("returns null for non-matching queries", () => {
+    expect(fuzzyScore("xyz", "abc.ts")).toBeNull();
+  });
+
+  it("returns score 0 for empty query", () => {
+    const result = fuzzyScore("", "src/foo.ts");
+    expect(result).toEqual({ score: 0, matches: [] });
+  });
+
+  it("matches all characters in order", () => {
+    const result = fuzzyScore("ft", "foo.ts");
+    expect(result).not.toBeNull();
+    expect(result!.matches).toHaveLength(2);
+  });
+
+  it("returns null when query is longer than target", () => {
+    expect(fuzzyScore("abcdef", "abc")).toBeNull();
+  });
+
+  it("rewards word-start matches over mid-word", () => {
+    const wordStart = fuzzyScore("fb", "foo-bar.ts");
+    const midWord = fuzzyScore("fb", "afob.ts");
+    expect(wordStart).not.toBeNull();
+    expect(midWord).not.toBeNull();
+    expect(wordStart!.score).toBeGreaterThan(midWord!.score);
+  });
+
+  it("rewards consecutive matches", () => {
+    const consecutive = fuzzyScore("foo", "foo.ts");
+    const scattered = fuzzyScore("foo", "fxoxo.ts");
+    expect(consecutive).not.toBeNull();
+    expect(scattered).not.toBeNull();
+    expect(consecutive!.score).toBeGreaterThan(scattered!.score);
+  });
+
+  it("matches are case-insensitive", () => {
+    const result = fuzzyScore("FOO", "foo.ts");
+    expect(result).not.toBeNull();
+  });
+
+  it("shorter paths score higher for same match quality", () => {
+    const short = fuzzyScore("f", "f.ts");
+    const long = fuzzyScore("f", "very/deep/nested/f.ts");
+    expect(short).not.toBeNull();
+    expect(long).not.toBeNull();
+    expect(short!.score).toBeGreaterThan(long!.score);
+  });
+});

--- a/workspace-fs/src/scorer.ts
+++ b/workspace-fs/src/scorer.ts
@@ -1,0 +1,116 @@
+/**
+ * Fuzzy file-path scorer — matches query characters in order against
+ * a file path, rewarding word boundaries, consecutive runs, and exact
+ * prefixes. Returns null for non-matches.
+ *
+ * Inspired by VS Code's fuzzyScorer but stripped to essentials.
+ */
+
+export interface FuzzyResult {
+  score: number;
+  /** Indices into the target string that matched. */
+  matches: number[];
+}
+
+// Bonus weights
+const BONUS_CONSECUTIVE = 5;
+const BONUS_WORD_START = 8;
+const BONUS_CAMEL = 4;
+const BONUS_FIRST_CHAR = 10;
+const PENALTY_GAP = -1;
+
+function isSeparator(ch: string): boolean {
+  return ch === "/" || ch === "\\" || ch === "." || ch === "-" || ch === "_";
+}
+
+function isUpperCase(ch: string): boolean {
+  return ch >= "A" && ch <= "Z";
+}
+
+function isWordStart(target: string, i: number): boolean {
+  if (i === 0) return true;
+  const prev = target[i - 1]!;
+  if (isSeparator(prev)) return true;
+  // camelCase boundary
+  if (isUpperCase(target[i]!) && !isUpperCase(prev)) return true;
+  return false;
+}
+
+/**
+ * Score a query against a target path. Returns null if the query
+ * doesn't match (not all characters found in order).
+ */
+export function fuzzyScore(query: string, target: string): FuzzyResult | null {
+  const qLower = query.toLowerCase();
+  const tLower = target.toLowerCase();
+  const qLen = qLower.length;
+  const tLen = tLower.length;
+
+  if (qLen === 0) return { score: 0, matches: [] };
+  if (qLen > tLen) return null;
+
+  // Quick check: all query chars exist in target (in order)
+  let qi = 0;
+  for (let ti = 0; ti < tLen && qi < qLen; ti++) {
+    if (tLower[ti] === qLower[qi]) qi++;
+  }
+  if (qi < qLen) return null;
+
+  // Greedy forward pass with best-match heuristic:
+  // prefer word-start positions over mid-word matches.
+  const matches: number[] = [];
+  qi = 0;
+  let score = 0;
+  let lastMatch = -1;
+
+  for (let ti = 0; ti < tLen && qi < qLen; ti++) {
+    if (tLower[ti] !== qLower[qi]) continue;
+
+    // Look ahead: is there a word-start match for this query char?
+    if (!isWordStart(target, ti)) {
+      let found = false;
+      for (let ahead = ti + 1; ahead < tLen; ahead++) {
+        if (tLower[ahead] === qLower[qi] && isWordStart(target, ahead)) {
+          // Skip to the word-start match
+          // Add gap penalty for skipped chars
+          score += (ahead - ti - 1) * PENALTY_GAP;
+          ti = ahead;
+          found = true;
+          break;
+        }
+        // Don't look too far ahead — cap at 8 chars
+        if (ahead - ti > 8) break;
+      }
+      if (!found) {
+        // Use current position
+      }
+    }
+
+    matches.push(ti);
+
+    // Scoring
+    if (qi === 0 && ti === 0) score += BONUS_FIRST_CHAR;
+    if (isWordStart(target, ti)) {
+      score += BONUS_WORD_START;
+      if (isUpperCase(target[ti]!) && ti > 0 && !isUpperCase(target[ti - 1]!)) {
+        score += BONUS_CAMEL;
+      }
+    }
+    if (lastMatch >= 0 && ti === lastMatch + 1) {
+      score += BONUS_CONSECUTIVE;
+    }
+    if (lastMatch >= 0 && ti > lastMatch + 1) {
+      score += (ti - lastMatch - 1) * PENALTY_GAP;
+    }
+
+    lastMatch = ti;
+    qi++;
+  }
+
+  if (qi < qLen) return null;
+
+  // Normalize: shorter paths score higher for same match quality
+  score -= Math.floor(tLen / 10);
+
+  return { score, matches };
+}

--- a/workspace-fs/src/service.ts
+++ b/workspace-fs/src/service.ts
@@ -18,6 +18,7 @@ import { fuzzyScore } from "./scorer.ts";
 import type {
   FileEntry,
   FileGitStatus,
+  FileStaging,
   FsSearchResult,
   DiffHunk,
   DiffLine,
@@ -34,6 +35,7 @@ interface IndexedFile {
   path: string; // relative to root, forward slashes
   name: string;
   gitStatus: FileGitStatus | null;
+  staging: FileStaging | null;
 }
 
 /** Reference-counted service pool — one instance per workspace root. */
@@ -98,6 +100,7 @@ export class WorkspaceFsService {
         path: f.path,
         name: f.name,
         gitStatus: f.gitStatus,
+        staging: f.staging,
         score: 0,
         matches: [],
       }));
@@ -111,6 +114,7 @@ export class WorkspaceFsService {
           path: file.path,
           name: file.name,
           gitStatus: file.gitStatus,
+          staging: file.staging,
           score: result.score,
           matches: result.matches,
         });
@@ -139,6 +143,7 @@ export class WorkspaceFsService {
           name: file.name,
           kind: "file",
           gitStatus: file.gitStatus,
+          staging: file.staging,
         });
       } else {
         // Subdirectory — aggregate git status
@@ -150,12 +155,14 @@ export class WorkspaceFsService {
             name: dirName,
             kind: "directory",
             gitStatus: file.gitStatus,
+            staging: file.staging,
           });
         } else if (file.gitStatus) {
           // If any child is modified, mark the directory
           const existing = seen.get(dirName)!;
           if (!existing.gitStatus) {
             existing.gitStatus = file.gitStatus;
+            existing.staging = file.staging;
           }
         }
       }
@@ -279,11 +286,15 @@ export class WorkspaceFsService {
         this.getGitStatus(),
       ]);
 
-      this.files = allFiles.map((path) => ({
-        path,
-        name: basename(path),
-        gitStatus: statusMap.get(path) ?? null,
-      }));
+      this.files = allFiles.map((path) => {
+        const info = statusMap.get(path);
+        return {
+          path,
+          name: basename(path),
+          gitStatus: info?.status ?? null,
+          staging: info?.staging ?? null,
+        };
+      });
     } catch {
       // Git commands can fail (not a git repo, etc.) — keep existing index
     }
@@ -313,14 +324,19 @@ export class WorkspaceFsService {
     return [...files].sort();
   }
 
-  private async getGitStatus(): Promise<Map<string, FileGitStatus>> {
+  private async getGitStatus(): Promise<
+    Map<string, { status: FileGitStatus; staging: FileStaging }>
+  > {
     const { stdout } = await execFileAsync(
       "git",
       ["status", "--porcelain", "-z"],
       { cwd: this.root, maxBuffer: 10 * 1024 * 1024 },
     );
 
-    const statuses = new Map<string, FileGitStatus>();
+    const statuses = new Map<
+      string,
+      { status: FileGitStatus; staging: FileStaging }
+    >();
     // porcelain -z format: XY<space>path\0 (or XY<space>path\0path\0 for renames)
     const entries = stdout.split("\0");
     for (let i = 0; i < entries.length; i++) {
@@ -331,7 +347,9 @@ export class WorkspaceFsService {
       const path = posixPath(entry.slice(3));
 
       const status = parseGitStatus(xy);
-      if (status) statuses.set(path, status);
+      if (status) {
+        statuses.set(path, { status, staging: parseStaging(xy) });
+      }
 
       // Renames have an extra path (the old name)
       if (xy[0] === "R" || xy[1] === "R") i++;
@@ -514,4 +532,19 @@ function parseGitStatus(xy: string): FileGitStatus | null {
   if (index === "M" || working === "M") return "modified";
   if (index === " " && working === " ") return null;
   return "modified"; // fallback for other states (C, U, etc.)
+}
+
+/** Derive staging state from porcelain XY columns.
+ *  X = index (staged changes), Y = working tree (unstaged changes).
+ *  " " means no change in that column. */
+function parseStaging(xy: string): FileStaging {
+  const index = xy[0]!;
+  const working = xy[1]!;
+
+  if (index === "?" && working === "?") return "unstaged"; // untracked = unstaged
+  const hasStaged = index !== " " && index !== "?";
+  const hasUnstaged = working !== " " && working !== "?";
+  if (hasStaged && hasUnstaged) return "partial";
+  if (hasStaged) return "staged";
+  return "unstaged";
 }

--- a/workspace-fs/src/service.ts
+++ b/workspace-fs/src/service.ts
@@ -15,7 +15,14 @@ import { watch, type FSWatcher } from "node:fs";
 import { join, dirname, basename, sep, posix, resolve } from "node:path";
 import { promisify } from "node:util";
 import { fuzzyScore } from "./scorer.ts";
-import type { FileEntry, FileGitStatus, FsSearchResult } from "./schemas.ts";
+import type {
+  FileEntry,
+  FileGitStatus,
+  FsSearchResult,
+  DiffHunk,
+  DiffLine,
+  FsFileDiffOutput,
+} from "./schemas.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -205,6 +212,60 @@ export class WorkspaceFsService {
     };
   }
 
+  /** Get parsed unified diff for a file against HEAD. */
+  async fileDiff(filePath: string): Promise<FsFileDiffOutput> {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["diff", "HEAD", "--", filePath],
+      { cwd: this.root, maxBuffer: 10 * 1024 * 1024 },
+    ).catch(() => ({ stdout: "" }));
+
+    if (!stdout.trim()) {
+      // No diff — file might be untracked, check git status
+      const { stdout: statusOut } = await execFileAsync(
+        "git",
+        ["status", "--porcelain", "--", filePath],
+        { cwd: this.root },
+      ).catch(() => ({ stdout: "" }));
+
+      if (statusOut.startsWith("??")) {
+        // Untracked file — entire file is "added"
+        const content = await this.readFile(filePath);
+        const lines = content.content.split("\n");
+        const addedLines = lines.map((_, i) => i + 1);
+        const hunkLines: DiffLine[] = lines.map((line, i) => ({
+          kind: "add" as const,
+          content: line,
+          newLine: i + 1,
+          oldLine: null,
+        }));
+        return {
+          hunks: [
+            {
+              oldStart: 0,
+              oldCount: 0,
+              newStart: 1,
+              newCount: lines.length,
+              lines: hunkLines,
+            },
+          ],
+          addedLines,
+          modifiedLines: [],
+          deletedAfterLines: [],
+        };
+      }
+
+      return {
+        hunks: [],
+        addedLines: [],
+        modifiedLines: [],
+        deletedAfterLines: [],
+      };
+    }
+
+    return parseDiff(stdout);
+  }
+
   /** Subscribe to change notifications. Returns unsubscribe function. */
   onChange(listener: ChangeListener): () => void {
     this.listeners.add(listener);
@@ -331,6 +392,115 @@ export class WorkspaceFsService {
 
 function posixPath(p: string): string {
   return p.replaceAll("\\", "/");
+}
+
+/** Parse unified diff output into structured hunks + gutter info. */
+function parseDiff(raw: string): FsFileDiffOutput {
+  const hunks: DiffHunk[] = [];
+  const addedLines: number[] = [];
+  const modifiedLines: number[] = [];
+  const deletedAfterLines: number[] = [];
+
+  const lines = raw.split("\n");
+  let i = 0;
+
+  // Skip diff header lines (diff --git, index, ---, +++)
+  while (i < lines.length && !lines[i]!.startsWith("@@")) i++;
+
+  while (i < lines.length) {
+    const hunkHeader = lines[i]!.match(
+      /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/,
+    );
+    if (!hunkHeader) {
+      i++;
+      continue;
+    }
+
+    const oldStart = parseInt(hunkHeader[1]!);
+    const oldCount = parseInt(hunkHeader[2] ?? "1");
+    const newStart = parseInt(hunkHeader[3]!);
+    const newCount = parseInt(hunkHeader[4] ?? "1");
+
+    const hunkLines: DiffLine[] = [];
+    let oldLine = oldStart;
+    let newLine = newStart;
+    i++;
+
+    // Track consecutive remove+add runs within a hunk to detect modifications
+    let removeRun: number[] = [];
+    let addRun: number[] = [];
+
+    function flushRuns() {
+      if (removeRun.length > 0 && addRun.length > 0) {
+        // Paired removes + adds = modifications
+        const paired = Math.min(removeRun.length, addRun.length);
+        for (let j = 0; j < paired; j++) modifiedLines.push(addRun[j]!);
+        // Extra adds beyond the paired count are pure additions
+        for (let j = paired; j < addRun.length; j++)
+          addedLines.push(addRun[j]!);
+        // Extra removes beyond paired = deletions
+        if (removeRun.length > addRun.length) {
+          // Mark the line after the last add as a deletion marker
+          const markerLine =
+            addRun.length > 0 ? addRun[addRun.length - 1]! : newLine;
+          deletedAfterLines.push(markerLine);
+        }
+      } else if (removeRun.length > 0) {
+        // Pure deletions
+        deletedAfterLines.push(newLine);
+      } else if (addRun.length > 0) {
+        // Pure additions
+        for (const l of addRun) addedLines.push(l);
+      }
+      removeRun = [];
+      addRun = [];
+    }
+
+    while (i < lines.length && !lines[i]!.startsWith("@@")) {
+      const line = lines[i]!;
+      if (line.startsWith("+")) {
+        if (removeRun.length === 0 && addRun.length === 0) {
+          // Starting a new run
+        }
+        addRun.push(newLine);
+        hunkLines.push({
+          kind: "add",
+          content: line.slice(1),
+          newLine,
+          oldLine: null,
+        });
+        newLine++;
+      } else if (line.startsWith("-")) {
+        removeRun.push(oldLine);
+        hunkLines.push({
+          kind: "remove",
+          content: line.slice(1),
+          newLine: null,
+          oldLine,
+        });
+        oldLine++;
+      } else if (line.startsWith(" ") || line === "") {
+        flushRuns();
+        hunkLines.push({
+          kind: "context",
+          content: line.slice(1),
+          newLine,
+          oldLine,
+        });
+        newLine++;
+        oldLine++;
+      } else {
+        // End of diff (e.g. "\ No newline at end of file")
+        break;
+      }
+      i++;
+    }
+    flushRuns();
+
+    hunks.push({ oldStart, oldCount, newStart, newCount, lines: hunkLines });
+  }
+
+  return { hunks, addedLines, modifiedLines, deletedAfterLines };
 }
 
 function parseGitStatus(xy: string): FileGitStatus | null {

--- a/workspace-fs/src/service.ts
+++ b/workspace-fs/src/service.ts
@@ -1,0 +1,347 @@
+/**
+ * WorkspaceFsService — indexes a git workspace's files and provides
+ * search, directory listing, and file reading. One instance per
+ * workspace root, reference-counted via acquire/release.
+ *
+ * File index is built from `git ls-files` (tracked) +
+ * `git ls-files --others --exclude-standard` (untracked).
+ * Git status decorations from `git status --porcelain`.
+ * Live updates via `fs.watch` with recursive option.
+ */
+
+import { execFile } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { watch, type FSWatcher } from "node:fs";
+import { join, dirname, basename, sep, posix, resolve } from "node:path";
+import { promisify } from "node:util";
+import { fuzzyScore } from "./scorer.ts";
+import type { FileEntry, FileGitStatus, FsSearchResult } from "./schemas.ts";
+
+const execFileAsync = promisify(execFile);
+
+const MAX_FILE_SIZE = 1024 * 1024; // 1MB read limit
+
+type ChangeListener = () => void;
+
+interface IndexedFile {
+  path: string; // relative to root, forward slashes
+  name: string;
+  gitStatus: FileGitStatus | null;
+}
+
+/** Reference-counted service pool — one instance per workspace root. */
+const pool = new Map<
+  string,
+  { service: WorkspaceFsService; refCount: number }
+>();
+
+export class WorkspaceFsService {
+  readonly root: string;
+  private files: IndexedFile[] = [];
+  private watcher: FSWatcher | null = null;
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private listeners = new Set<ChangeListener>();
+  private ready: Promise<void>;
+
+  private constructor(root: string) {
+    this.root = root;
+    this.ready = this.refresh();
+    this.startWatcher();
+  }
+
+  /** Acquire a service for the given root. Shares existing instances. */
+  static acquire(root: string): WorkspaceFsService {
+    const existing = pool.get(root);
+    if (existing) {
+      existing.refCount++;
+      return existing.service;
+    }
+    const service = new WorkspaceFsService(root);
+    pool.set(root, { service, refCount: 1 });
+    return service;
+  }
+
+  /** Release a reference. Disposes when refcount hits zero (after grace period). */
+  static release(root: string): void {
+    const entry = pool.get(root);
+    if (!entry) return;
+    entry.refCount--;
+    if (entry.refCount <= 0) {
+      // Grace period: keep alive for 5s in case user switches back
+      setTimeout(() => {
+        const current = pool.get(root);
+        if (current && current.refCount <= 0) {
+          current.service.dispose();
+          pool.delete(root);
+        }
+      }, 5000);
+    }
+  }
+
+  /** Wait for the initial file index to be ready. */
+  async waitReady(): Promise<void> {
+    await this.ready;
+  }
+
+  /** Search files by fuzzy query. Returns top N results sorted by score. */
+  search(query: string, limit = 50): FsSearchResult[] {
+    if (!query) {
+      // Empty query: return recent/all files up to limit
+      return this.files.slice(0, limit).map((f) => ({
+        path: f.path,
+        name: f.name,
+        gitStatus: f.gitStatus,
+        score: 0,
+        matches: [],
+      }));
+    }
+
+    const results: FsSearchResult[] = [];
+    for (const file of this.files) {
+      const result = fuzzyScore(query, file.path);
+      if (result) {
+        results.push({
+          path: file.path,
+          name: file.name,
+          gitStatus: file.gitStatus,
+          score: result.score,
+          matches: result.matches,
+        });
+      }
+    }
+
+    results.sort((a, b) => b.score - a.score);
+    return results.slice(0, limit);
+  }
+
+  /** List entries in a directory (one level deep). */
+  listDir(dirPath: string): FileEntry[] {
+    const prefix = dirPath ? dirPath.replace(/\/$/, "") + "/" : "";
+    const seen = new Map<string, FileEntry>();
+
+    for (const file of this.files) {
+      if (!file.path.startsWith(prefix)) continue;
+
+      const rest = file.path.slice(prefix.length);
+      const slashIdx = rest.indexOf("/");
+
+      if (slashIdx === -1) {
+        // Direct child file
+        seen.set(file.name, {
+          path: file.path,
+          name: file.name,
+          kind: "file",
+          gitStatus: file.gitStatus,
+        });
+      } else {
+        // Subdirectory — aggregate git status
+        const dirName = rest.slice(0, slashIdx);
+        const dirFullPath = prefix + dirName;
+        if (!seen.has(dirName)) {
+          seen.set(dirName, {
+            path: dirFullPath,
+            name: dirName,
+            kind: "directory",
+            gitStatus: file.gitStatus,
+          });
+        } else if (file.gitStatus) {
+          // If any child is modified, mark the directory
+          const existing = seen.get(dirName)!;
+          if (!existing.gitStatus) {
+            existing.gitStatus = file.gitStatus;
+          }
+        }
+      }
+    }
+
+    // Sort: directories first, then alphabetical
+    return [...seen.values()].sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "directory" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }
+
+  /** Read file contents. Truncates at 1MB. Rejects paths that escape the root. */
+  async readFile(filePath: string): Promise<{
+    content: string;
+    lineCount: number;
+    byteLength: number;
+    truncated: boolean;
+  }> {
+    const absPath = resolve(this.root, filePath);
+    // Prevent path traversal (e.g. ../../etc/passwd)
+    if (!absPath.startsWith(this.root + sep) && absPath !== this.root) {
+      throw new Error(`Path escapes workspace root: ${filePath}`);
+    }
+    const stats = await stat(absPath);
+
+    if (stats.size > MAX_FILE_SIZE) {
+      const { createReadStream } = await import("node:fs");
+      const content = await new Promise<string>((resolve, reject) => {
+        let data = "";
+        const stream = createReadStream(absPath, {
+          encoding: "utf-8",
+          start: 0,
+          end: MAX_FILE_SIZE - 1,
+        });
+        stream.on("data", (chunk) => (data += String(chunk)));
+        stream.on("end", () => resolve(data));
+        stream.on("error", reject);
+      });
+      return {
+        content,
+        lineCount: content.split("\n").length,
+        byteLength: stats.size,
+        truncated: true,
+      };
+    }
+
+    const content = await readFile(absPath, "utf-8");
+    return {
+      content,
+      lineCount: content.split("\n").length,
+      byteLength: stats.size,
+      truncated: false,
+    };
+  }
+
+  /** Subscribe to change notifications. Returns unsubscribe function. */
+  onChange(listener: ChangeListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private async refresh(): Promise<void> {
+    try {
+      const [allFiles, statusMap] = await Promise.all([
+        this.getFileList(),
+        this.getGitStatus(),
+      ]);
+
+      this.files = allFiles.map((path) => ({
+        path,
+        name: basename(path),
+        gitStatus: statusMap.get(path) ?? null,
+      }));
+    } catch {
+      // Git commands can fail (not a git repo, etc.) — keep existing index
+    }
+  }
+
+  private async getFileList(): Promise<string[]> {
+    // Tracked + untracked (respecting .gitignore)
+    const [tracked, untracked] = await Promise.all([
+      execFileAsync("git", ["ls-files", "-z", "--cached"], {
+        cwd: this.root,
+        maxBuffer: 50 * 1024 * 1024,
+      }),
+      execFileAsync(
+        "git",
+        ["ls-files", "-z", "--others", "--exclude-standard"],
+        { cwd: this.root, maxBuffer: 50 * 1024 * 1024 },
+      ),
+    ]);
+
+    const files = new Set<string>();
+    for (const output of [tracked.stdout, untracked.stdout]) {
+      for (const entry of output.split("\0")) {
+        const path = entry.trim();
+        if (path) files.add(posixPath(path));
+      }
+    }
+    return [...files].sort();
+  }
+
+  private async getGitStatus(): Promise<Map<string, FileGitStatus>> {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["status", "--porcelain", "-z"],
+      { cwd: this.root, maxBuffer: 10 * 1024 * 1024 },
+    );
+
+    const statuses = new Map<string, FileGitStatus>();
+    // porcelain -z format: XY<space>path\0 (or XY<space>path\0path\0 for renames)
+    const entries = stdout.split("\0");
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]!;
+      if (entry.length < 3) continue;
+
+      const xy = entry.slice(0, 2);
+      const path = posixPath(entry.slice(3));
+
+      const status = parseGitStatus(xy);
+      if (status) statuses.set(path, status);
+
+      // Renames have an extra path (the old name)
+      if (xy[0] === "R" || xy[1] === "R") i++;
+    }
+
+    return statuses;
+  }
+
+  private startWatcher(): void {
+    try {
+      this.watcher = watch(
+        this.root,
+        { recursive: true },
+        (_event, filename) => {
+          if (!filename) return;
+          // Ignore .git directory changes
+          if (filename.startsWith(".git" + sep) || filename === ".git") return;
+
+          this.scheduleRefresh();
+        },
+      );
+      this.watcher.on("error", () => {
+        // Watcher can fail on some platforms — degrade gracefully
+        this.watcher?.close();
+        this.watcher = null;
+      });
+    } catch {
+      // fs.watch not available with recursive on this platform
+    }
+  }
+
+  private scheduleRefresh(): void {
+    if (this.refreshTimer) return;
+    this.refreshTimer = setTimeout(async () => {
+      this.refreshTimer = null;
+      await this.refresh();
+      for (const listener of this.listeners) {
+        try {
+          listener();
+        } catch {
+          // Listener threw — ignore
+        }
+      }
+    }, 150);
+  }
+
+  private dispose(): void {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    this.watcher?.close();
+    this.watcher = null;
+    this.listeners.clear();
+    this.files = [];
+  }
+}
+
+function posixPath(p: string): string {
+  return p.replaceAll("\\", "/");
+}
+
+function parseGitStatus(xy: string): FileGitStatus | null {
+  const index = xy[0]!;
+  const working = xy[1]!;
+
+  if (index === "?" && working === "?") return "untracked";
+  if (index === "A" || working === "A") return "added";
+  if (index === "D" || working === "D") return "deleted";
+  if (index === "R" || working === "R") return "renamed";
+  if (index === "M" || working === "M") return "modified";
+  if (index === " " && working === " ") return null;
+  return "modified"; // fallback for other states (C, U, etc.)
+}

--- a/workspace-fs/src/service.ts
+++ b/workspace-fs/src/service.ts
@@ -23,6 +23,8 @@ import type {
   DiffHunk,
   DiffLine,
   FsFileDiffOutput,
+  BlameLine,
+  FsBlameOutput,
 } from "./schemas.ts";
 
 const execFileAsync = promisify(execFile);
@@ -175,12 +177,15 @@ export class WorkspaceFsService {
     });
   }
 
-  /** Read file contents. Truncates at 1MB. Rejects paths that escape the root. */
+  /** Read file contents. Truncates at 1MB. Rejects paths that escape the root.
+   *  Binary files (images) are returned as base64-encoded content with a mimeType hint. */
   async readFile(filePath: string): Promise<{
     content: string;
     lineCount: number;
     byteLength: number;
     truncated: boolean;
+    binary?: boolean;
+    mimeType?: string;
   }> {
     const absPath = resolve(this.root, filePath);
     // Prevent path traversal (e.g. ../../etc/passwd)
@@ -188,6 +193,31 @@ export class WorkspaceFsService {
       throw new Error(`Path escapes workspace root: ${filePath}`);
     }
     const stats = await stat(absPath);
+
+    // Check for binary/image files by extension
+    const mime = getMimeType(filePath);
+    if (mime) {
+      // Binary file — return base64-encoded (cap at 5MB for images)
+      if (stats.size > 5 * 1024 * 1024) {
+        return {
+          content: "",
+          lineCount: 0,
+          byteLength: stats.size,
+          truncated: true,
+          binary: true,
+          mimeType: mime,
+        };
+      }
+      const buf = await readFile(absPath);
+      return {
+        content: buf.toString("base64"),
+        lineCount: 0,
+        byteLength: stats.size,
+        truncated: false,
+        binary: true,
+        mimeType: mime,
+      };
+    }
 
     if (stats.size > MAX_FILE_SIZE) {
       const { createReadStream } = await import("node:fs");
@@ -271,6 +301,34 @@ export class WorkspaceFsService {
     }
 
     return parseDiff(stdout);
+  }
+
+  /** Get git blame for a file. Returns per-line blame info. */
+  async blame(filePath: string): Promise<FsBlameOutput> {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["blame", "--porcelain", "--", filePath],
+      { cwd: this.root, maxBuffer: 10 * 1024 * 1024 },
+    ).catch(() => ({ stdout: "" }));
+
+    if (!stdout.trim()) return { lines: [] };
+    return parseBlame(stdout);
+  }
+
+  /** Stage a file (git add). */
+  async stageFile(filePath: string): Promise<void> {
+    await execFileAsync("git", ["add", "--", filePath], { cwd: this.root });
+    this.scheduleRefresh();
+  }
+
+  /** Unstage a file (git reset HEAD). */
+  async unstageFile(filePath: string): Promise<void> {
+    await execFileAsync("git", ["reset", "HEAD", "--", filePath], {
+      cwd: this.root,
+    }).catch(() => {
+      // reset fails on initial commit — ignore
+    });
+    this.scheduleRefresh();
   }
 
   /** Subscribe to change notifications. Returns unsubscribe function. */
@@ -519,6 +577,84 @@ function parseDiff(raw: string): FsFileDiffOutput {
   }
 
   return { hunks, addedLines, modifiedLines, deletedAfterLines };
+}
+
+/** Known binary/image MIME types by extension. */
+const MIME_TYPES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  ico: "image/x-icon",
+  bmp: "image/bmp",
+  avif: "image/avif",
+};
+
+function getMimeType(filePath: string): string | undefined {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  return MIME_TYPES[ext];
+}
+
+/** Parse `git blame --porcelain` output into structured line data. */
+function parseBlame(raw: string): FsBlameOutput {
+  const lines: BlameLine[] = [];
+  const commitInfo = new Map<
+    string,
+    { author: string; date: string; summary: string }
+  >();
+
+  const rawLines = raw.split("\n");
+  let i = 0;
+
+  while (i < rawLines.length) {
+    const headerMatch = rawLines[i]?.match(
+      /^([0-9a-f]{40})\s+(\d+)\s+(\d+)(?:\s+(\d+))?$/,
+    );
+    if (!headerMatch) {
+      i++;
+      continue;
+    }
+
+    const sha = headerMatch[1]!.slice(0, 8);
+    const lineNum = parseInt(headerMatch[3]!);
+    i++;
+
+    // Parse header fields until content line
+    let author = "";
+    let date = "";
+    let summary = "";
+
+    while (i < rawLines.length && !rawLines[i]?.startsWith("\t")) {
+      const line = rawLines[i]!;
+      if (line.startsWith("author ")) author = line.slice(7);
+      else if (line.startsWith("author-time ")) {
+        const ts = parseInt(line.slice(12));
+        date = new Date(ts * 1000).toISOString().slice(0, 10);
+      } else if (line.startsWith("summary ")) summary = line.slice(8);
+      i++;
+    }
+
+    // Skip content line
+    if (i < rawLines.length && rawLines[i]?.startsWith("\t")) i++;
+
+    // Cache commit info for repeated SHAs
+    if (author || summary) {
+      commitInfo.set(sha, { author, date, summary });
+    }
+
+    const info = commitInfo.get(sha) ?? { author: "", date: "", summary: "" };
+    lines.push({
+      line: lineNum,
+      sha,
+      author: info.author,
+      date: info.date,
+      summary: info.summary,
+    });
+  }
+
+  return { lines };
 }
 
 function parseGitStatus(xy: string): FileGitStatus | null {

--- a/workspace-fs/tsconfig.json
+++ b/workspace-fs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Prototype PR for file browser and right panel features (see #479 for phased implementation plan). This PR will not be merged — it serves as a reference implementation.

### Features implemented
- **3-column layout** with Corvu resizable horizontal split
- **File tree** with lazy directory expansion, git status dots
- **Fuzzy file search** (Cmd+O) with match highlighting
- **File peek** with syntax highlighting (highlight.js) and git gutter markers
- **Diff viewer** with inline unified diffs, sticky hunk headers
- **Git changes tab** with expand all/collapse, per-file inline diffs, staging indicators
- **Session transcript viewer** with markdown rendering, syntax-highlighted code blocks, collapsible tool calls, print/save-as-HTML
- **Blame view** with per-line git blame, grouped by commit
- **Stage/unstage actions** per-file in changes tab (+ 's' keyboard shortcut)
- **Binary file handling** — images shown as thumbnails, other binaries show type info
- **Search-in-file** (Cmd+F in peek view) with line highlighting
- **Keyboard navigation** — j/k/arrows in file tree and changes list
- **File preview on arrow** — search results preview as you navigate
- **Live filesystem updates** via fs.onChange streaming endpoint
- **Breadcrumb navigation** with smart go-back (returns to origin tab)
- **Header toggle** for right panel (Cmd+B)

### Architecture
- `workspace-fs/` — new package: file indexing, fuzzy scorer, git status/diff/blame parsing, fs.watch, reference-counted service pool
- Contract-first design: Zod schemas → oRPC contract → server router → typed client
- Endpoints: `fs.search`, `fs.listDir`, `fs.readFile`, `fs.fileDiff`, `fs.blame`, `fs.stage`, `fs.unstage`, `fs.onChange` (streaming)

Closes #460