### PR TITLE
feat(mobile): add manual soft keyboard toggle via VirtualKeyboard API

### DIFF
--- a/client/src/MobileKeyBar.tsx
+++ b/client/src/MobileKeyBar.tsx
@@ -7,7 +7,7 @@
  *  sequences straight to the PTY via client.terminal.sendInput, with
  *  a 10ms haptic tick on devices that support navigator.vibrate. */
 
-import { type Component, For, Show } from "solid-js";
+import { type Component, For, Show, createSignal, onCleanup } from "solid-js";
 import { createMediaQuery } from "@solid-primitives/media";
 import { client } from "./rpc";
 import type { TerminalId } from "kolu-common";
@@ -31,10 +31,24 @@ const KEYS: readonly Key[] = [
   { label: "⏎", data: "\r", testId: "enter" },
 ];
 
+/** Whether the browser supports the VirtualKeyboard API (Chrome 94+). */
+const hasVirtualKeyboard = "virtualKeyboard" in navigator;
+
 const MobileKeyBar: Component<{
   activeId: () => TerminalId | null;
 }> = (props) => {
   const isCoarse = createMediaQuery("(pointer: coarse)");
+
+  // Derive soft-keyboard visibility from the browser's ground truth
+  // so the toggle stays in sync even when dismissed via Android's
+  // back gesture or system navigation.
+  const [kbVisible, setKbVisible] = createSignal(false);
+  if (hasVirtualKeyboard) {
+    const vk = navigator.virtualKeyboard!;
+    const onGeometry = () => setKbVisible(vk.boundingRect.height > 0);
+    vk.addEventListener("geometrychange", onGeometry);
+    onCleanup(() => vk.removeEventListener("geometrychange", onGeometry));
+  }
 
   function send(data: string) {
     const id = props.activeId();
@@ -45,12 +59,34 @@ const MobileKeyBar: Component<{
     void client.terminal.sendInput({ id, data });
   }
 
+  function toggleKeyboard() {
+    if (!hasVirtualKeyboard) return;
+    const vk = navigator.virtualKeyboard!;
+    if (kbVisible()) vk.hide();
+    else vk.show();
+  }
+
   return (
     <Show when={isCoarse()}>
       <div
         class="flex gap-1 px-2 py-1.5 bg-surface-1 border-t border-edge overflow-x-auto"
         data-testid="mobile-key-bar"
       >
+        <Show when={hasVirtualKeyboard}>
+          <button
+            type="button"
+            onPointerDown={(e) => {
+              e.preventDefault();
+              toggleKeyboard();
+            }}
+            class="shrink-0 min-w-[2.5rem] px-2 py-1.5 text-xs rounded-md bg-surface-2 text-fg-2 hover:bg-surface-3 active:bg-surface-3 transition-colors cursor-pointer font-mono"
+            classList={{ "!bg-accent-2/20 !text-accent-2": kbVisible() }}
+            data-testid="mobile-key-keyboard-toggle"
+            title={kbVisible() ? "Hide keyboard" : "Show keyboard"}
+          >
+            ⌨
+          </button>
+        </Show>
         <For each={KEYS}>
           {(key) => (
             <button

--- a/client/src/Terminal.tsx
+++ b/client/src/Terminal.tsx
@@ -273,6 +273,13 @@ const Terminal: Component<{
         screen.setAttribute("aria-readonly", "true");
         screen.style.caretColor = "transparent";
         screen.style.outline = "none";
+        // Chrome 94+ on Android: prevent the soft keyboard from
+        // auto-showing on focus so users with an external keyboard
+        // aren't forced to dismiss it every tap.  MobileKeyBar
+        // provides a toggle button that calls show()/hide().
+        if ("virtualKeyboard" in navigator) {
+          screen.setAttribute("virtualkeyboardpolicy", "manual");
+        }
       }
     }
     // Expose for e2e tests: read buffer content at viewport position.

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -5,3 +5,15 @@ interface Navigator {
   setAppBadge(count?: number): Promise<void>;
   clearAppBadge(): Promise<void>;
 }
+
+// VirtualKeyboard API (Chrome 94+) — not yet in TypeScript's lib.dom.
+interface VirtualKeyboard extends EventTarget {
+  readonly boundingRect: DOMRect;
+  overlaysContent: boolean;
+  show(): void;
+  hide(): void;
+}
+
+interface Navigator {
+  readonly virtualKeyboard?: VirtualKeyboard;
+}


### PR DESCRIPTION
**Android's soft keyboard pops up on every tap** even when a Bluetooth or USB keyboard is connected — there's no web API to detect external keyboards, but Chrome's VirtualKeyboard API lets us take manual control.

Sets `virtualkeyboardpolicy="manual"` on the contenteditable `.xterm-screen` element, which prevents the soft keyboard from auto-showing on focus. A new **keyboard toggle button** in the MobileKeyBar lets users summon or dismiss the soft keyboard on demand. Keyboard visibility state is derived from the browser's `geometrychange` event — _not a local boolean_ — so it stays in sync even when the user dismisses via Android's back gesture.

> Feature-detected: only activates when `navigator.virtualKeyboard` exists (Chrome 94+ on Android). iOS Safari and other browsers keep the current auto-show behavior unchanged.