### PR TITLE
Fix clipboard crash in non-secure contexts

### DIFF
--- a/client/src/useTerminalCrud.ts
+++ b/client/src/useTerminalCrud.ts
@@ -131,11 +131,28 @@ export function useTerminalCrud(deps: {
     if (id === null) return;
     try {
       const text = await client.terminal.screenText({ id });
-      await navigator.clipboard.writeText(text);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        // Fallback for non-secure contexts (HTTP on non-localhost)
+        // where navigator.clipboard is undefined.
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        try {
+          textarea.select();
+          const ok = document.execCommand("copy");
+          if (!ok) throw new Error("clipboard access blocked");
+        } finally {
+          document.body.removeChild(textarea);
+        }
+      }
       toast.success("Copied terminal text to clipboard");
     } catch (err) {
       console.error("Failed to copy terminal text:", err);
-      toast.error("Failed to copy terminal text");
+      toast.error(`Failed to copy terminal text: ${(err as Error).message}`);
     }
   }
 


### PR DESCRIPTION
**`navigator.clipboard` is `undefined` when Kolu is served over plain HTTP to a non-localhost address**, so the "Copy terminal text" command throws `TypeError: Cannot read properties of undefined (reading 'writeText')`. This worked before only because users happened to access via `localhost` or HTTPS.

The fix guards with optional chaining and falls back to the classic `document.execCommand('copy')` + hidden textarea trick when the Clipboard API isn't available. _The fallback is deprecated but universally supported, and the alternative — forcing TLS just to copy text — is a worse trade-off._ The catch toast now surfaces `err.message` instead of swallowing it.