### PR TITLE
feat(agents): kolu-specific perf rules + agency no-unbounded-growth

### DIFF
--- a/.claude/rules/code-police-rules.md
+++ b/.claude/rules/code-police-rules.md
@@ -42,6 +42,15 @@ Also encouraged inside `match`:
 
 **Exception — pure A→B mappings**: When the dispatch is a static lookup with no per-arm logic (no closures, no computation, no shared handlers), prefer `Record<Union, T>`. A fresh `Record<Union, T>` literal is already exhaustive at the type level — TypeScript's required-property check fires if a union member is added, and its excess-property check fires if one is removed (verified against `tsc`). Wrapping the table in `match` adds closures and indirection without removing any failure mode. Example: `const styles: Record<WsStatus, string> = { open: "bg-ok", closed: "bg-danger", connecting: "bg-warning" }`. The excess-property half of the guarantee only holds for _fresh_ literals written directly at the typed declaration — if the table is built into a variable first and then assigned, only the required-key half survives. Two-variant booleans / nullable checks where `?:` reads cleaner are also fine to leave alone.
 
+### integration-perf-hygiene
+
+Integration code (under `integrations/`) runs in a long-lived Node process — performance bugs compound over hours. Apply the general `no-unbounded-growth` rule with these kolu-specific reinforcements:
+
+- **`fs.watch` callbacks must debounce.** Claude streams tokens continuously; on Linux `fs.watch` fires multiple events per write. Any handler that does I/O, parsing, or allocation must use a trailing-edge debounce (see `TRANSCRIPT_DEBOUNCE_MS` in `session-watcher.ts`). A bare handler is only acceptable if the work is O(1) and allocation-free.
+- **File reads must stream in chunks.** Transcripts grow without bound. Never `Buffer.alloc(fileSize)` or read an entire file into memory when the consumer processes it incrementally — use chunked reads with a remainder carried across calls (see `scanTasksIncremental` pattern).
+- **Directory watchers must be shared.** Multiple callers watching the same directory (e.g. `SESSIONS_DIR`) must go through a refcounted singleton, not each install their own `fs.watch`. N watchers = N duplicate callbacks = N-fold cost per event.
+- **Debug-only collections must be bounded.** Arrays that accumulate diagnostic state (e.g. `stateChanges`) need a cap with `shift()`-before-`push()` eviction (see `MAX_STATE_CHANGES`).
+
 ### errors-must-log-at-error
 
 Actual errors (failed I/O, failed queries, unexpected exceptions, callback throws) must log at `error` level, not `warn` or `debug`. Reserve `warn` for degraded-but-recoverable states (e.g. a non-critical fallback path). Reserve `debug` for expected-absent conditions (e.g. file not found on a machine that doesn't have the tool installed).

--- a/.claude/skills/code-police/SKILL.md
+++ b/.claude/skills/code-police/SKILL.md
@@ -41,6 +41,17 @@ Aggressively remove unused code. No commented-out blocks, no "just in case" left
 Never silently swallow errors. Empty `catch {}` blocks, bare `catch: pass`, and `|| true` hide failures. At minimum, log the error. If the catch is intentional (best-effort operation), add a comment explaining _why_ the error is safe to ignore.
 _Rationale_: Silent swallowing masks bugs — failures disappear without a trace, making debugging impossible.
 
+### no-unbounded-growth
+
+Collections, buffers, and listeners that grow with usage must have a bound or a cleanup path. Common violations:
+
+- **Unbounded arrays/lists** — pushed in a callback or event handler with no cap or eviction. Ask: _can this grow forever during a long-running session?_
+- **Missing debounce on high-frequency sources** — `fs.watch`, `resize`, `scroll`, `mousemove`, WebSocket `onmessage`, or any event that can fire many times per second. Each invocation that does non-trivial work (I/O, parsing, DOM mutation, allocation) needs a debounce or throttle. A bare handler is only acceptable if the work is O(1) and allocation-free.
+- **Large allocations in hot paths** — reading an entire file/stream into a single buffer when the consumer processes it incrementally. Prefer streaming/chunked reads when the data source can grow without bound.
+- **Duplicated watchers/listeners** — N callers each installing their own watcher on the same resource instead of sharing one. Each duplicate multiplies callback cost and file-descriptor usage.
+
+_Rationale_: LLM-generated code defaults to the simplest correct implementation, which is often O(n) in session lifetime. These patterns silently degrade performance over hours/days and surface as "the app got slow" with no obvious cause. The fix is almost always straightforward (cap, debounce, stream, share) but must be applied at write time — it's rarely caught in review because the code is functionally correct.
+
 ### comments-why-not-what
 
 Add comments where the _why_ isn't obvious from the code. Don't comment the _what_. Also comment where the _what_ isn't obvious — non-obvious guards, CSS workarounds, platform-specific behavior. Non-obvious workarounds (temp files, wrapper scripts, env var shims) must have a comment explaining why they exist.
@@ -64,6 +75,7 @@ Flag:
 - **Inaccurate fallbacks** — defaults masking misconfiguration, "sensible defaults" that aren't sensible for the failure case, fallback paths that silently degrade correctness.
 - **Wishful thinking** — assumptions about input shape without validation at boundaries, code that "can't fail" but actually can, race conditions papered over with comments.
 - **Logic errors** — always-true/false conditions, off-by-one, wrong operators, shadowed variables.
+- **Slow leaks** — collections that grow without bound, event handlers doing heavy work on every fire without debounce, watchers/listeners registered per-caller instead of shared, buffers sized to the full input when streaming would work.
 
 For each finding: file, line, one-line risk, concrete fix. If no issues, say so — don't invent problems.
 

--- a/agents/.apm/instructions/code-police-rules.instructions.md
+++ b/agents/.apm/instructions/code-police-rules.instructions.md
@@ -42,6 +42,15 @@ Also encouraged inside `match`:
 
 **Exception — pure A→B mappings**: When the dispatch is a static lookup with no per-arm logic (no closures, no computation, no shared handlers), prefer `Record<Union, T>`. A fresh `Record<Union, T>` literal is already exhaustive at the type level — TypeScript's required-property check fires if a union member is added, and its excess-property check fires if one is removed (verified against `tsc`). Wrapping the table in `match` adds closures and indirection without removing any failure mode. Example: `const styles: Record<WsStatus, string> = { open: "bg-ok", closed: "bg-danger", connecting: "bg-warning" }`. The excess-property half of the guarantee only holds for _fresh_ literals written directly at the typed declaration — if the table is built into a variable first and then assigned, only the required-key half survives. Two-variant booleans / nullable checks where `?:` reads cleaner are also fine to leave alone.
 
+### integration-perf-hygiene
+
+Integration code (under `integrations/`) runs in a long-lived Node process — performance bugs compound over hours. Apply the general `no-unbounded-growth` rule with these kolu-specific reinforcements:
+
+- **`fs.watch` callbacks must debounce.** Claude streams tokens continuously; on Linux `fs.watch` fires multiple events per write. Any handler that does I/O, parsing, or allocation must use a trailing-edge debounce (see `TRANSCRIPT_DEBOUNCE_MS` in `session-watcher.ts`). A bare handler is only acceptable if the work is O(1) and allocation-free.
+- **File reads must stream in chunks.** Transcripts grow without bound. Never `Buffer.alloc(fileSize)` or read an entire file into memory when the consumer processes it incrementally — use chunked reads with a remainder carried across calls (see `scanTasksIncremental` pattern).
+- **Directory watchers must be shared.** Multiple callers watching the same directory (e.g. `SESSIONS_DIR`) must go through a refcounted singleton, not each install their own `fs.watch`. N watchers = N duplicate callbacks = N-fold cost per event.
+- **Debug-only collections must be bounded.** Arrays that accumulate diagnostic state (e.g. `stateChanges`) need a cap with `shift()`-before-`push()` eviction (see `MAX_STATE_CHANGES`).
+
 ### errors-must-log-at-error
 
 Actual errors (failed I/O, failed queries, unexpected exceptions, callback throws) must log at `error` level, not `warn` or `debug`. Reserve `warn` for degraded-but-recoverable states (e.g. a non-critical fallback path). Reserve `debug` for expected-absent conditions (e.g. file not found on a machine that doesn't have the tool installed).

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -49,7 +49,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 42dd082e95daacc090b13da3b09373c55ccf51c0
+  resolved_commit: 8d8acad6a1b0fbaa9fb7d63ab213f1404c52e9c8
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -60,4 +60,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:ca8a3d21307fe49f6eee2bb807a02d3d46000aff1de99de71b91172166e11944
+  content_hash: sha256:375b7ad8958739809412e6d0181c267ca342e6c23270e635d7b78927ebb398fe


### PR DESCRIPTION
Companion to srid/agency#48 (already merged). Two layers of performance vetting now active in code-police:

**General (from agency):** New `no-unbounded-growth` rule catches unbounded collections, missing debounce on high-frequency events, large allocations in hot paths, and duplicated watchers/listeners. Also adds a "slow leaks" bullet to the Pass 2 fact-check.

**Kolu-specific (this PR):** New `integration-perf-hygiene` rule in `code-police-rules` reinforces the general rule with patterns specific to `integrations/` code — `fs.watch` debouncing, chunked transcript reads, shared `SESSIONS_DIR` watchers, and bounded `stateChanges` arrays. All derived from the #465 post-mortem.

Ref: #480