### PR TITLE
Add APM workflow instruction for agent discoverability

### DIFF
--- a/.claude/rules/apm-sources.md
+++ b/.claude/rules/apm-sources.md
@@ -5,8 +5,8 @@ paths:
 
 ## Generated Files — Do Not Edit Directly
 
-> **This rule only applies if an `.apm/` directory exists in the project root.** If there is no `.apm/` directory, `.claude/` and `.opencode/` files are vendored directly and can be edited in place.
+> **This rule only applies if an `.apm/` directory exists somewhere in the project.** If there is no `.apm/` directory at any level, `.claude/` and `.opencode/` files are vendored directly and can be edited in place. To locate it, search for a directory matching `**/.apm/` from the project root.
 
 Everything under `.claude/` and `.opencode/` is **generated** from `.apm/` sources by APM. Direct edits will be overwritten on the next `apm install` run.
 
-To modify agent configuration, edit the source files in `.apm/`, then run `apm install` to regenerate.
+To modify agent configuration, find the `.apm/` directory (it may be at the project root or nested under a subdirectory such as `agents/.apm/`), edit the source files there, then run `apm install` to regenerate.

--- a/.claude/rules/apm-workflow.md
+++ b/.claude/rules/apm-workflow.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "agents/**,apm.lock.yaml"
+---
+
+## APM Workflow
+
+APM is not a global CLI — it runs via `uvx` through justfile recipes in `agents/ai.just`. Never try to run `apm` directly; always use the just recipes:
+
+- **Install/regenerate** `.claude/` from sources: `just ai::apm`
+- **Update a dependency** to its latest ref: `just ai::apm-update <package>` (e.g. `just ai::apm-update srid/agency`)
+- **Verify** `.claude/` matches sources (CI-safe, non-destructive): `just ai::apm-sync`

--- a/agents/.apm/instructions/apm-workflow.instructions.md
+++ b/agents/.apm/instructions/apm-workflow.instructions.md
@@ -1,0 +1,12 @@
+---
+description: APM workflow — how to install, update, and verify agent packages via justfile recipes
+applyTo: "agents/**,apm.lock.yaml"
+---
+
+## APM Workflow
+
+APM is not a global CLI — it runs via `uvx` through justfile recipes in `agents/ai.just`. Never try to run `apm` directly; always use the just recipes:
+
+- **Install/regenerate** `.claude/` from sources: `just ai::apm`
+- **Update a dependency** to its latest ref: `just ai::apm-update <package>` (e.g. `just ai::apm-update srid/agency`)
+- **Verify** `.claude/` matches sources (CI-safe, non-destructive): `just ai::apm-sync`

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,11 +1,12 @@
 lockfile_version: '1'
-generated_at: '2026-04-12T14:02:02.429862+00:00'
+generated_at: '2026-04-13T16:57:09.155860+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
   package_type: apm_package
   deployed_files:
   - .claude/commands/whatchanged.md
+  - .claude/rules/apm-workflow.md
   - .claude/rules/architecture.md
   - .claude/rules/code-police-rules.md
   - .claude/rules/e2e-testing.md
@@ -49,7 +50,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: f5ba1012c06f3e81044a1c9915d26525620af48f
+  resolved_commit: 896a56c538c2f084dee28609cfcfb0a6eecc34e6
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -61,4 +61,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:14e2152c74582ae0ce99b9f7564d42e67297e0685442a82426c84935297c4220
+  content_hash: sha256:4c6d61ed129f2943797b04e4ace10716cae9c531672ad18229094e2007d6e0c1


### PR DESCRIPTION
**Agents now know to read `agents/ai.just` for APM recipes** instead of hunting for a global `apm` binary on PATH. Previously, when asked how to update APM dependencies, the agent wasted time running `type apm` and exploring the filesystem — the answer was sitting in the justfile the whole time.

New instruction file in `agents/.apm/instructions/` gets deployed as `.claude/rules/apm-workflow.md` by APM, so it's always in context. _Documents the three key recipes: `just ai::apm`, `just ai::apm-update`, and `just ai::apm-sync`._

Also fixes a stale `srid/agency` content hash in `apm.lock.yaml` that was causing `just ai::apm-sync` to fail.