### PR TITLE
Fix stale file paths in APM rule sources

### DIFF
--- a/.claude/rules/streaming.md
+++ b/.claude/rules/streaming.md
@@ -9,7 +9,7 @@ Three invariants an agent editing any single file would otherwise miss. They are
 
 ### 1. Route client calls through the `stream` namespace
 
-Every async-iterator RPC the client consumes goes through `client/src/rpc.ts`'s `stream` object, not `client.*` directly. The wrapper bakes in `STREAM_RETRY` context so `ClientRetryPlugin` can transparently re-subscribe on WebSocket reconnect.
+Every async-iterator RPC the client consumes goes through `client/src/rpc/rpc.ts`'s `stream` object, not `client.*` directly. The wrapper bakes in `STREAM_RETRY` context so `ClientRetryPlugin` can transparently re-subscribe on WebSocket reconnect.
 
 **When adding a new streaming procedure** (to `common/src/contract.ts` + `server/src/router.ts`), also add a corresponding entry to the `stream` object. Consumers MUST use `stream.xxx(...)` — calling `client.xxx(...)` directly silently loses reconnect handling.
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -24,7 +24,7 @@ These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
 
 ## Feature Discoverability (Tips)
 
-When adding a new user-facing feature or shortcut, consider adding a tip so users discover it. See `tips.ts` and `useTips.ts` for the registry and API.
+When adding a new user-facing feature or shortcut, consider adding a tip so users discover it. See `settings/tips.ts` and `settings/useTips.ts` for the registry and API.
 
 ## Git
 

--- a/agents/.apm/instructions/streaming.instructions.md
+++ b/agents/.apm/instructions/streaming.instructions.md
@@ -9,7 +9,7 @@ Three invariants an agent editing any single file would otherwise miss. They are
 
 ### 1. Route client calls through the `stream` namespace
 
-Every async-iterator RPC the client consumes goes through `client/src/rpc.ts`'s `stream` object, not `client.*` directly. The wrapper bakes in `STREAM_RETRY` context so `ClientRetryPlugin` can transparently re-subscribe on WebSocket reconnect.
+Every async-iterator RPC the client consumes goes through `client/src/rpc/rpc.ts`'s `stream` object, not `client.*` directly. The wrapper bakes in `STREAM_RETRY` context so `ClientRetryPlugin` can transparently re-subscribe on WebSocket reconnect.
 
 **When adding a new streaming procedure** (to `common/src/contract.ts` + `server/src/router.ts`), also add a corresponding entry to the `stream` object. Consumers MUST use `stream.xxx(...)` — calling `client.xxx(...)` directly silently loses reconnect handling.
 

--- a/agents/.apm/instructions/workflow.instructions.md
+++ b/agents/.apm/instructions/workflow.instructions.md
@@ -24,7 +24,7 @@ These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
 
 ## Feature Discoverability (Tips)
 
-When adding a new user-facing feature or shortcut, consider adding a tip so users discover it. See `tips.ts` and `useTips.ts` for the registry and API.
+When adding a new user-facing feature or shortcut, consider adding a tip so users discover it. See `settings/tips.ts` and `settings/useTips.ts` for the registry and API.
 
 ## Git
 


### PR DESCRIPTION
## Summary
- Update `client/src/rpc.ts` → `client/src/rpc/rpc.ts` in `streaming.instructions.md`
- Update `tips.ts` / `useTips.ts` → `settings/tips.ts` / `settings/useTips.ts` in `workflow.instructions.md`
- Regenerated `.claude/rules/` via `apm install`

Fixes #489

## Test plan
- [x] Verify referenced paths exist in the codebase
- [x] `apm install` regenerates cleanly