### PR TITLE
Components read preferences directly instead of prop-drilling

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -165,6 +165,8 @@ Otherwise: implement the planned changes. Prefer simplicity. Do the boring obvio
 
 **Verify**: Code changes match the planned approach. All distinct user-facing paths have test coverage.
 
+**Incremental commit**: After verification, commit and push all changes (unless `--no-git`).
+
 ---
 
 ### check
@@ -174,7 +176,7 @@ Read the project's instructions to find the check command — a fast static-corr
 This is the cheapest gate in the pipeline, so it runs first — fail fast on broken code before any downstream step does work over it. If no check command is documented, skip this step with a note.
 
 **Verify**: Check ran without errors, or no command configured.
-**If failed** (max 3 attempts): Fix the errors and re-run check. Do not fall back to **implement** — the agent is already in fix mode and the failure is local to just-written code.
+**If failed** (max 3 attempts): Fix the errors, commit and push the fix (unless `--no-git`), then re-run check. Do not fall back to **implement** — the agent is already in fix mode and the failure is local to just-written code.
 
 ---
 
@@ -185,7 +187,7 @@ Read the project's instructions to find which documentation files to keep in syn
 If no documentation files are documented, skip this step with a note.
 
 **Verify**: Docs match current code.
-**If outdated** (max 3 attempts): Fix the outdated sections and re-verify.
+**If outdated** (max 3 attempts): Fix the outdated sections, commit and push (unless `--no-git`), then re-verify.
 
 ---
 
@@ -202,7 +204,7 @@ When `/code-police` asks about scope: **changes in the current branch/PR only**.
 **For followup entry points**: Run hickey on the full cumulative diff (`origin/HEAD...HEAD`) as part of police. Followups skip the normal hickey step (jumping straight to implement), so this is the only structural review the cumulative PR changes get. It catches complexity that accumulates silently across multiple small followups — e.g., a component gaining 12 new props across 5 followups without any structural review catching the prop-drilling pattern. Any findings with **"Fix in this PR"** actions are police violations — fix them before proceeding.
 
 **Verify**: All 3 passes clean ("All clear") AND all hickey "Fix in this PR" actions addressed in the diff.
-**If violations found** (max 3 attempts): Fix the violations and re-invoke `/code-police`.
+**If violations found** (max 3 attempts): Fix the violations, commit and push the fixes (unless `--no-git`), then re-invoke `/code-police`.
 
 ---
 
@@ -214,15 +216,17 @@ If no format command is documented, skip this step with a note.
 
 **Verify**: Format command ran without error, or no command configured.
 
+**Incremental commit**: If the formatter made changes, commit and push them (unless `--no-git`).
+
 ---
 
 ### commit
 
 **If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. Move to **test**. The working-tree changes stay uncommitted — that is the point.
 
-Create a NEW commit (never amend) with a conventional commit message. Push to the PR branch.
+Final catch-all commit. If earlier incremental commits already captured everything, `git status` will be clean — record this step as `passed` with verification noting no uncommitted changes remain. Otherwise, create a NEW commit (never amend) with a conventional commit message and push to the PR branch.
 
-**Verify**: `git log -1` shows a new commit on the feature branch, and it's pushed to remote.
+**Verify**: No uncommitted changes remain. Latest commit is pushed to remote.
 
 ---
 
@@ -235,7 +239,7 @@ Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and dete
 If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, skip with a note.
 
 **Verify**: Tests pass (exit code 0), or no relevant tests to run.
-**If failed** (max 4 attempts): Analyze the failure. If flaky, re-run. If real: fix → go to **fmt**, then retry.
+**If failed** (max 4 attempts): Analyze the failure. If flaky, re-run. If real: fix → **fmt** → commit and push (unless `--no-git`) → retry.
 
 ---
 
@@ -347,6 +351,7 @@ COMMENT
 - **Never skip steps.** Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
 - **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
+- **Commit early, commit often.** Unless `--no-git` is set, create a NEW commit and push immediately after each of these events (the **commit** step is just the final one): after **implement** completes, after **check** fixes, after **docs** changes, after **police** fixes, after **fmt** changes, after **test** fixes — any time there are staged or unstaged changes worth preserving. Use conventional commit messages scoped to what just happened (e.g., `fix: resolve type errors from check`, `style: apply formatter`). This keeps the remote branch up-to-date and preserves incremental progress. **Project-level workflow instructions may override this** — if the project documents a different commit strategy (e.g., squash-only, single-commit PRs), follow that instead.
 - **Background for CI.** Run CI with `run_in_background: true`.
 - **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey pause.
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.

--- a/.claude/rules/code-police-rules.md
+++ b/.claude/rules/code-police-rules.md
@@ -51,6 +51,13 @@ Integration code (under `integrations/`) runs in a long-lived Node process — p
 - **Directory watchers must be shared.** Multiple callers watching the same directory (e.g. `SESSIONS_DIR`) must go through a refcounted singleton, not each install their own `fs.watch`. N watchers = N duplicate callbacks = N-fold cost per event.
 - **Debug-only collections must be bounded.** Arrays that accumulate diagnostic state (e.g. `stateChanges`) need a cap with `shift()`-before-`push()` eviction (see `MAX_STATE_CHANGES`).
 
+### no-preference-prop-drilling
+
+Components must read preferences from `useServerState()` directly, not receive them as props from a parent. The singleton store guarantees shared reactivity — all callers share one `createStore` instance.
+Bad: `<Child scrollLock={preferences().scrollLock} />` then `props.scrollLock` in child
+Good: `const { preferences } = useServerState();` inside the child component
+_Rationale_: Prop-drilling preferences creates unenforced coupling ("parent extracts the right field and passes it to the right consumer") and bloats App.tsx's wiring surface. Components that own their behavior should own their preference reads too.
+
 ### errors-must-log-at-error
 
 Actual errors (failed I/O, failed queries, unexpected exceptions, callback throws) must log at `error` level, not `warn` or `debug`. Reserve `warn` for degraded-but-recoverable states (e.g. a non-critical fallback path). Reserve `debug` for expected-absent conditions (e.g. file not found on a machine that doesn't have the tool installed).

--- a/.claude/skills/hickey/SKILL.md
+++ b/.claude/skills/hickey/SKILL.md
@@ -135,7 +135,9 @@ After completing all layers, **invoke `/fact-check` on your own output**. The fa
 - Bogus "essential complexity" labels without a concrete simplified alternative
 - Claims about code behavior that you didn't verify by reading the code
 
-**Also flag scope-based dismissals.** "Out of scope for this PR", "pre-existing issue", "appropriate scope for a bug fix", and "follow-up refactor" are not simplicity judgments — they are process judgments that let findings evaporate between hickey and implementation. If you find yourself writing one, either fix the finding in this PR or create an issue and defer it. The Actions section enforces this — if you can't fill it in, you're dismissing the finding.
+**Also flag scope-based dismissals.** "Out of scope for this PR", "pre-existing issue", "appropriate scope for a bug fix", "orthogonal", and "follow-up refactor" are not simplicity judgments — they are process judgments that let findings evaporate between hickey and implementation. If you find yourself writing one, either fix the finding in this PR or create an issue and defer it. The Actions section enforces this — if you can't fill it in, you're dismissing the finding.
+
+**Flag orphaned pre-existing/orthogonal findings.** Any finding described as "pre-existing" or "orthogonal" during analysis that does not appear in the Actions section with a **Defer `#<issue-number>`** disposition is a dismissal, not a deferral. The fact-check pass must catch these: scan the full evaluation for the words "pre-existing", "orthogonal", "already existed", or "not introduced by this PR" — each occurrence must have a corresponding Actions entry with an issue link. No exceptions.
 
 **Also flag your own output for phrase shapes that mean you stopped reasoning one step early.** These aren't findings you talked yourself out of — they're findings you never let form. If any of these phrase shapes appear in your evaluation, re-open the question they're dismissing:
 
@@ -160,9 +162,9 @@ If fact-check finds issues with your evaluation, revise before presenting to the
 5. **Severity** — For each finding: blast radius, change friction, reasoning load.
 6. **Simplifications** — Concrete alternative for every finding.
 7. **Fact-check result** — Output of `/fact-check` on this evaluation, including the phrase-shape check.
-8. **Actions** — One entry per finding. Each must be dispositioned as exactly one of:
+8. **Actions** — One entry per finding. **Every finding from every layer must appear here** — including findings labeled "pre-existing", "orthogonal", or "not introduced by this PR". A finding that never reaches this section has been dismissed, not deferred. Each must be dispositioned as exactly one of:
    - **Fix in this PR**: one-line description of what the implementation step must do. This is the default — prefer it.
-   - **Defer `#<issue-number>`**: create a GitHub/forge issue for the finding first, then reference it here. "Out of scope" without an issue link is a dismissal, not a deferral. If you can't be bothered to create the issue, the finding belongs in this PR.
+   - **Defer `#<issue-number>`**: create a GitHub/forge issue for the finding first, then reference it here. "Out of scope" without an issue link is a dismissal, not a deferral. If you can't be bothered to create the issue, the finding belongs in this PR. **When running autonomously (via `/do`)**, you MUST actually create the issue (`gh issue create` or equivalent) before writing the Defer entry — do not leave it for the user. When running interactively, you may prompt the user to create the issue.
 
    "No findings" → "No actions." But if findings exist and the actions list is empty, the evaluation is incomplete.
 

--- a/agents/.apm/instructions/code-police-rules.instructions.md
+++ b/agents/.apm/instructions/code-police-rules.instructions.md
@@ -51,6 +51,13 @@ Integration code (under `integrations/`) runs in a long-lived Node process — p
 - **Directory watchers must be shared.** Multiple callers watching the same directory (e.g. `SESSIONS_DIR`) must go through a refcounted singleton, not each install their own `fs.watch`. N watchers = N duplicate callbacks = N-fold cost per event.
 - **Debug-only collections must be bounded.** Arrays that accumulate diagnostic state (e.g. `stateChanges`) need a cap with `shift()`-before-`push()` eviction (see `MAX_STATE_CHANGES`).
 
+### no-preference-prop-drilling
+
+Components must read preferences from `useServerState()` directly, not receive them as props from a parent. The singleton store guarantees shared reactivity — all callers share one `createStore` instance.
+Bad: `<Child scrollLock={preferences().scrollLock} />` then `props.scrollLock` in child
+Good: `const { preferences } = useServerState();` inside the child component
+_Rationale_: Prop-drilling preferences creates unenforced coupling ("parent extracts the right field and passes it to the right consumer") and bloats App.tsx's wiring surface. Components that own their behavior should own their preference reads too.
+
 ### errors-must-log-at-error
 
 Actual errors (failed I/O, failed queries, unexpected exceptions, callback throws) must log at `error` level, not `warn` or `debug`. Reserve `warn` for degraded-but-recoverable states (e.g. a non-critical fallback path). Reserve `debug` for expected-absent conditions (e.g. file not found on a machine that doesn't have the tool installed).

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-13T17:15:47.540273+00:00'
+generated_at: '2026-04-13T17:31:15.766641+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -50,7 +50,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: c9ab1385f9cffb5ccd728220a741db774aed0c78
+  resolved_commit: 68923230c5b19d297c8a5aa99e1601e3a61250c4
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -61,4 +61,4 @@ dependencies:
   - .claude/skills/code-police
   - .claude/skills/forge-pr
   - .claude/skills/hickey
-  content_hash: sha256:4c6d61ed129f2943797b04e4ace10716cae9c531672ad18229094e2007d6e0c1
+  content_hash: sha256:5e469f1b205bd9eaef6a1977e783ab9fbeddba80384f9d5a9b1e54e91e2dcf4f

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-13T16:57:09.155860+00:00'
+generated_at: '2026-04-13T17:15:47.540273+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -50,7 +50,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 896a56c538c2f084dee28609cfcfb0a6eecc34e6
+  resolved_commit: c9ab1385f9cffb5ccd728220a741db774aed0c78
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,6 @@ import type { TerminalId } from "kolu-common";
 import { client, wsStatus, serverProcessId } from "./rpc/rpc";
 import TransportOverlay from "./rpc/TransportOverlay";
 import { useTerminals } from "./terminal/useTerminals";
-import { useServerState } from "./settings/useServerState";
 import { useThemeManager } from "./useThemeManager";
 import { useSidebar } from "./sidebar/useSidebar";
 import { useShortcuts } from "./input/useShortcuts";
@@ -41,16 +40,7 @@ import { useColorScheme } from "./settings/useColorScheme";
 import { useTips } from "./settings/useTips";
 
 const App: Component = () => {
-  const { preferences, updatePreferences } = useServerState();
-  const randomTheme = () => preferences().randomTheme;
-  const scrollLock = () => preferences().scrollLock;
-  const activityAlerts = () => preferences().activityAlerts;
-  const sidebarAgentPreviews = () => preferences().sidebarAgentPreviews;
-
-  const { store, crud, session, worktree, alerts } = useTerminals({
-    randomTheme,
-    activityAlerts,
-  });
+  const { store, crud, session, worktree, alerts } = useTerminals();
 
   // Expose for e2e test access
   (window as any).__koluSimulateAlert = alerts.simulateAlert;
@@ -391,7 +381,6 @@ const App: Component = () => {
           isUnread={store.isUnread}
           getDisplayInfo={store.getDisplayInfo}
           getTerminalTheme={getTerminalTheme}
-          previewMode={sidebarAgentPreviews()}
           onSelect={store.setActiveId}
           onCloseTerminal={closeTerminal}
           onCreate={() => crud.handleCreate()}
@@ -454,7 +443,6 @@ const App: Component = () => {
                         }
                         onCloseTerminal={closeTerminal}
                         activeMeta={store.activeMeta()}
-                        scrollLockEnabled={scrollLock()}
                       />
                     )}
                   </For>

--- a/client/src/sidebar/Sidebar.tsx
+++ b/client/src/sidebar/Sidebar.tsx
@@ -21,6 +21,7 @@ import Tip from "../ui/Tip";
 import Kbd from "../ui/Kbd";
 import TerminalMeta from "../terminal/TerminalMeta";
 import TerminalPreview from "../terminal/TerminalPreview";
+import { useServerState } from "../settings/useServerState";
 import { useTips } from "../settings/useTips";
 import { sidebarSwitchTip } from "../settings/tips";
 import { formatKeybind, SHORTCUTS } from "../input/keyboard";
@@ -83,8 +84,6 @@ const SidebarEntry: Component<{
   unread: boolean;
   displayInfo: TerminalDisplayInfo | undefined;
   terminalTheme: ITheme;
-  /** Preview mode — see {@link shouldShowPreview} for the semantics. */
-  previewMode: SidebarAgentPreviews;
   onSelect: (id: TerminalId) => void;
   onClose: (id: TerminalId) => void;
   dropEdge: "above" | "below" | null;
@@ -98,11 +97,12 @@ const SidebarEntry: Component<{
    *  match the main terminal exactly. Returns the current viewport dims
    *  when the card should render, otherwise `undefined` — lets the JSX
    *  `Show` narrow the type in the rendered branch. */
+  const { preferences } = useServerState();
   const showPreview = () => {
     const vp = viewportDimensions();
     if (!vp) return undefined;
     return shouldShowPreview(
-      props.previewMode,
+      preferences().sidebarAgentPreviews,
       props.metadata?.agent != null,
       props.unread,
     )
@@ -314,7 +314,6 @@ const Sidebar: Component<{
   isUnread: (id: TerminalId) => boolean;
   getDisplayInfo: (id: TerminalId) => TerminalDisplayInfo | undefined;
   getTerminalTheme: (id: TerminalId) => ITheme;
-  previewMode: SidebarAgentPreviews;
   onSelect: (id: TerminalId) => void;
   onCloseTerminal: (id: TerminalId) => void;
   onCreate: () => void;
@@ -433,7 +432,6 @@ const Sidebar: Component<{
                       unread={props.isUnread(id)}
                       displayInfo={props.getDisplayInfo(id)}
                       terminalTheme={props.getTerminalTheme(id)}
-                      previewMode={props.previewMode}
                       onSelect={handleSelect}
                       onClose={props.onCloseTerminal}
                       dropEdge={edge()}

--- a/client/src/terminal/Terminal.tsx
+++ b/client/src/terminal/Terminal.tsx
@@ -36,6 +36,7 @@ import SearchBar from "./SearchBar";
 import ScrollToBottom from "./ScrollToBottom";
 import { createZoom } from "../input/zoom";
 import { createScrollLock } from "../scrollLock";
+import { useServerState } from "../settings/useServerState";
 import { refitOnTabVisible } from "../refitOnTabVisible";
 import { viewportDimensions, setViewportDimensions } from "../useViewport";
 import { registerTerminalRefs, unregisterTerminalRefs } from "./terminalRefs";
@@ -78,8 +79,6 @@ const Terminal: Component<{
   onSearchOpenChange: (open: boolean) => void;
   /** Fired when the user interacts with this terminal (click/keyboard focus). */
   onFocus?: () => void;
-  /** When true, viewport freezes when user scrolls up (default: true). */
-  scrollLockEnabled?: boolean;
   /** When true, this terminal lives in a sub-panel — it owns its own grid
    *  (its container is independent of the main viewport) and stays out of
    *  the viewport signal. Also used for e2e test selectors. */
@@ -89,7 +88,8 @@ const Terminal: Component<{
   let terminal: XTerm | null = null;
   let fitAddon: FitAddon | null = null;
   const [searchAddon, setSearchAddon] = createSignal<SearchAddon | null>(null);
-  const scrollLock = createScrollLock(() => props.scrollLockEnabled);
+  const { preferences } = useServerState();
+  const scrollLock = createScrollLock(() => preferences().scrollLock);
   let fitRaf = 0;
 
   /** Debounce fit() to one call per animation frame — ResizeObserver fires rapidly. */

--- a/client/src/terminal/TerminalPane.tsx
+++ b/client/src/terminal/TerminalPane.tsx
@@ -19,7 +19,6 @@ const TerminalPane: Component<{
   onCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
   onCloseTerminal: (id: TerminalId) => void;
   activeMeta: TerminalMetadata | null;
-  scrollLockEnabled?: boolean;
 }> = (props) => {
   const subPanel = useSubPanel();
 
@@ -72,7 +71,6 @@ const TerminalPane: Component<{
             searchOpen={props.searchOpen}
             onSearchOpenChange={props.onSearchOpenChange}
             onFocus={() => subPanel.setFocusTarget(props.terminalId, "main")}
-            scrollLockEnabled={props.scrollLockEnabled}
           />
         </Resizable.Panel>
 
@@ -130,7 +128,6 @@ const TerminalPane: Component<{
                   onFocus={() =>
                     subPanel.setFocusTarget(props.terminalId, "sub")
                   }
-                  scrollLockEnabled={props.scrollLockEnabled}
                   isSub
                 />
               )}

--- a/client/src/terminal/useTerminalAlerts.ts
+++ b/client/src/terminal/useTerminalAlerts.ts
@@ -3,13 +3,13 @@
 
 import { type Accessor, createEffect, on } from "solid-js";
 import type { TerminalId, TerminalMetadata } from "kolu-common";
+import { useServerState } from "../settings/useServerState";
 import {
   fireActivityAlert,
   requestNotificationPermission,
 } from "./useActivityAlerts";
 
 export function useTerminalAlerts(deps: {
-  activityAlerts: Accessor<boolean>;
   activeId: Accessor<TerminalId | null>;
   getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
   isUnread: (id: TerminalId) => boolean;
@@ -17,8 +17,11 @@ export function useTerminalAlerts(deps: {
   terminalIds: Accessor<TerminalId[]>;
   terminalLabel: (id: TerminalId) => string;
 }) {
+  const { preferences } = useServerState();
+  const activityAlerts = () => preferences().activityAlerts;
+
   // Request browser notification permission eagerly when alerts are enabled
-  if (deps.activityAlerts()) requestNotificationPermission();
+  if (activityAlerts()) requestNotificationPermission();
 
   // Badge the PWA dock icon with the unread agent count (Badging API).
   // Clears automatically when the user visits all unread terminals.
@@ -53,8 +56,7 @@ export function useTerminalAlerts(deps: {
     prev: string | undefined,
     next: string | undefined,
   ) {
-    if (!deps.activityAlerts() || next !== "waiting" || prev === "waiting")
-      return;
+    if (!activityAlerts() || next !== "waiting" || prev === "waiting") return;
     const isBackground = id !== deps.activeId();
     if (isBackground) deps.markUnread(id);
     if (isBackground || document.hidden)
@@ -62,7 +64,7 @@ export function useTerminalAlerts(deps: {
   }
 
   function simulateAlert() {
-    if (!deps.activityAlerts()) return;
+    if (!activityAlerts()) return;
     const inactive = deps.terminalIds().filter((id) => id !== deps.activeId());
     if (inactive.length === 0) return;
     const id = inactive[Math.floor(Math.random() * inactive.length)]!;

--- a/client/src/terminal/useTerminalCrud.ts
+++ b/client/src/terminal/useTerminalCrud.ts
@@ -3,24 +3,24 @@
  *  Uses plain oRPC client calls. Server signals propagate list/metadata
  *  changes via the live subscriptions — no optimistic cache needed. */
 
-import type { Accessor } from "solid-js";
 import { toast } from "solid-sonner";
 import { availableThemes } from "../theme";
 import { client } from "../rpc/rpc";
 import { useSubPanel } from "./useSubPanel";
 import { useTips } from "../settings/useTips";
+import { useServerState } from "../settings/useServerState";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
 import type { TerminalId } from "kolu-common";
 import type { TerminalStore } from "./useTerminalStore";
 
 export function useTerminalCrud(deps: {
   store: TerminalStore;
-  randomTheme: Accessor<boolean>;
   subscribeExit: (id: TerminalId) => void;
 }) {
   const { store } = deps;
   const subPanel = useSubPanel();
   const { showTipOnce } = useTips();
+  const { preferences } = useServerState();
 
   /** The terminal the user is currently interacting with —
    *  the active sub-tab when a split has focus, otherwise the workspace root. */
@@ -99,7 +99,7 @@ export function useTerminalCrud(deps: {
       toast.error(`Failed to create terminal: ${err.message}`);
       throw err;
     });
-    const themeName = deps.randomTheme()
+    const themeName = preferences().randomTheme
       ? availableThemes[Math.floor(Math.random() * availableThemes.length)]!
           .name
       : undefined;

--- a/client/src/terminal/useTerminals.ts
+++ b/client/src/terminal/useTerminals.ts
@@ -9,7 +9,6 @@
  *  New features should go in the appropriate module (or a new one),
  *  not back into this composition root. See #221, #242. */
 
-import type { Accessor } from "solid-js";
 import { toast } from "solid-sonner";
 import type { TerminalId } from "kolu-common";
 import { stream } from "../rpc/rpc";
@@ -20,14 +19,10 @@ import { useSessionRestore } from "./useSessionRestore";
 import { useWorktreeOps } from "./useWorktreeOps";
 import { useTerminalAlerts } from "./useTerminalAlerts";
 
-export function useTerminals(deps: {
-  randomTheme: Accessor<boolean>;
-  activityAlerts: Accessor<boolean>;
-}) {
+export function useTerminals() {
   const store = useTerminalStore();
 
   const alerts = useTerminalAlerts({
-    activityAlerts: deps.activityAlerts,
     activeId: store.activeId,
     getMetadata: store.getMetadata,
     isUnread: store.isUnread,
@@ -68,7 +63,6 @@ export function useTerminals(deps: {
 
   const crud = useTerminalCrud({
     store,
-    randomTheme: deps.randomTheme,
     subscribeExit,
   });
 


### PR DESCRIPTION
**Components now call `useServerState()` directly** to read preferences instead of receiving them as props threaded through App.tsx. The singleton store guarantees all callers share one reactive source — no new subscriptions, no extra reactive owners.

Four prop-drilling chains eliminated: `randomTheme` (App → useTerminals → useTerminalCrud), `activityAlerts` (App → useTerminals → useTerminalAlerts), `sidebarAgentPreviews` (App → Sidebar → SidebarEntry), and `scrollLock` (App → TerminalPane → Terminal). Each consumer now reads the preference it needs at the point of use, matching the pattern already established by `SettingsPopover` in #483.

App.tsx sheds four accessor extractions and the corresponding prop wiring — *it stays a thin layout shell instead of a preference distribution hub.* A new `no-preference-prop-drilling` code-police rule prevents the pattern from recurring.

Closes #484