### PR TITLE
Persist right panel state server-side, default to collapsed

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -358,8 +358,6 @@ const App: Component = () => {
           const id = store.activeId();
           if (id) handleToggleSubPanel(id);
         }}
-        rightPanelCollapsed={rightPanel.collapsed()}
-        onToggleRightPanel={rightPanel.togglePanel}
       />
       {/* relative: anchor for sidebar's absolute overlay on mobile.
        *  --active-terminal-{bg,fg} published here so child components

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -461,10 +461,6 @@ const App: Component = () => {
               as="div"
               class="min-w-0 min-h-0 overflow-hidden"
               minSize={0}
-              collapsible
-              collapsedSize={0}
-              onCollapse={() => rightPanel.collapsePanel()}
-              onExpand={() => rightPanel.expandPanel()}
             >
               <Show when={!rightPanel.collapsed()}>
                 <RightPanel

--- a/client/src/Header.tsx
+++ b/client/src/Header.tsx
@@ -10,6 +10,7 @@ import AgentIndicator from "./sidebar/AgentIndicator";
 import SettingsPopover from "./settings/SettingsPopover";
 import { useTips } from "./settings/useTips";
 import { CONTEXTUAL_TIPS } from "./settings/tips";
+import { useRightPanel } from "./inspector/useRightPanel";
 import type { WsStatus } from "./rpc/rpc";
 import type { TerminalMetadata } from "kolu-common";
 
@@ -80,11 +81,10 @@ const Header: Component<{
   hasSubPanel?: boolean;
   subPanelExpanded?: boolean;
   onToggleSubPanel?: () => void;
-  rightPanelCollapsed?: boolean;
-  onToggleRightPanel?: () => void;
 }> = (rawProps) => {
   const props = mergeProps({ status: "connecting" as const }, rawProps);
   const { showTipOnce } = useTips();
+  const rightPanel = useRightPanel();
   let settingsTriggerRef!: HTMLButtonElement;
   const [settingsOpen, setSettingsOpen] = createSignal(false);
 
@@ -140,9 +140,9 @@ const Header: Component<{
           />
           <PanelToggleIcon
             orientation="right"
-            active={!props.rightPanelCollapsed}
+            active={!rightPanel.collapsed()}
             label={`Toggle inspector (${formatKeybind(SHORTCUTS.toggleRightPanel.keybind)})`}
-            onClick={() => props.onToggleRightPanel?.()}
+            onClick={() => rightPanel.togglePanel()}
           />
         </div>
         {props.themeName && (

--- a/client/src/inspector/useRightPanel.ts
+++ b/client/src/inspector/useRightPanel.ts
@@ -1,37 +1,24 @@
-/** Right panel state — singleton module. Tracks collapsed and size, persisted across sessions.
- *  Open by default on desktop (sm breakpoint), collapsed on mobile. */
+/** Right panel state — singleton module. Tracks collapsed and size, persisted via server preferences.
+ *  Defaults to collapsed. User's explicit choice sticks regardless of viewport. */
 
-import { createSignal } from "solid-js";
-import { makePersisted } from "@solid-primitives/storage";
-import { makeEventListener } from "@solid-primitives/event-listener";
+import { useServerState } from "../settings/useServerState";
 
-const SM_QUERY = window.matchMedia("(min-width: 640px)");
-const DEFAULT_PANEL_SIZE = 0.25;
-
-const [collapsed, setCollapsed] = makePersisted(
-  createSignal(!SM_QUERY.matches),
-  { name: "kolu-right-panel-collapsed" },
-);
-
-const [panelSize, setPanelSize] = makePersisted(
-  createSignal(DEFAULT_PANEL_SIZE),
-  { name: "kolu-right-panel-size" },
-);
-
-// Auto-collapse on mobile, auto-expand on desktop when viewport crosses sm breakpoint
-makeEventListener(SM_QUERY, "change", (e: MediaQueryListEvent) =>
-  setCollapsed(!e.matches),
-);
+const MIN_PANEL_SIZE = 0.05;
 
 export function useRightPanel() {
+  const { preferences, updatePreferences } = useServerState();
+
   return {
-    collapsed,
-    panelSize,
-    togglePanel: () => setCollapsed((prev) => !prev),
-    collapsePanel: () => setCollapsed(true),
-    expandPanel: () => setCollapsed(false),
+    collapsed: () => preferences().rightPanelCollapsed,
+    panelSize: () => preferences().rightPanelSize,
+    togglePanel: () =>
+      updatePreferences({
+        rightPanelCollapsed: !preferences().rightPanelCollapsed,
+      }),
+    collapsePanel: () => updatePreferences({ rightPanelCollapsed: true }),
+    expandPanel: () => updatePreferences({ rightPanelCollapsed: false }),
     setPanelSize: (size: number) => {
-      if (size > 0.05) setPanelSize(size);
+      if (size > MIN_PANEL_SIZE) updatePreferences({ rightPanelSize: size });
     },
   } as const;
 }

--- a/client/src/settings/useServerState.ts
+++ b/client/src/settings/useServerState.ts
@@ -33,6 +33,8 @@ const DEFAULT_PREFERENCES: Preferences = {
   activityAlerts: true,
   colorScheme: "dark",
   sidebarAgentPreviews: "attention",
+  rightPanelCollapsed: true,
+  rightPanelSize: 0.25,
 };
 
 // Singleton store — all callers share one reactive source of truth for preferences.

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -257,6 +257,8 @@ export const PreferencesSchema = z.object({
   activityAlerts: z.boolean(),
   colorScheme: ColorSchemeSchema,
   sidebarAgentPreviews: SidebarAgentPreviewsSchema,
+  rightPanelCollapsed: z.boolean(),
+  rightPanelSize: z.number(),
 });
 
 // --- Server state ---

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -24,7 +24,7 @@ import { log } from "./log.ts";
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.5.0";
+const SCHEMA_VERSION = "1.6.0";
 
 const DEFAULT_PREFERENCES: Preferences = {
   seenTips: [],
@@ -34,6 +34,8 @@ const DEFAULT_PREFERENCES: Preferences = {
   activityAlerts: true,
   colorScheme: "dark",
   sidebarAgentPreviews: "attention",
+  rightPanelCollapsed: true,
+  rightPanelSize: 0.25,
 };
 
 export const store = new Conf<PersistedState>({
@@ -98,6 +100,16 @@ export const store = new Conf<PersistedState>({
       if (!store.has("recentAgents")) {
         store.set("recentAgents", []);
       }
+    },
+    // rightPanelCollapsed + rightPanelSize added — old preference blobs lack these fields.
+    "1.6.0": (store: Conf<PersistedState>) => {
+      const current = store.get("preferences") as
+        | Partial<Preferences>
+        | undefined;
+      store.set("preferences", {
+        ...DEFAULT_PREFERENCES,
+        ...current,
+      });
     },
   },
 });

--- a/tests/features/cwd.feature
+++ b/tests/features/cwd.feature
@@ -4,6 +4,8 @@ Feature: Header CWD display
 
   Background:
     Given the terminal is ready
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
 
   Scenario: Header shows CWD after cd
     When I run "cd /tmp"

--- a/tests/features/git-context.feature
+++ b/tests/features/git-context.feature
@@ -4,6 +4,8 @@ Feature: Git context in header and sidebar
 
   Background:
     Given the terminal is ready
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
 
   Scenario: Header and sidebar show branch in a git repo
     When I run "git init /tmp/kolu-git-test"

--- a/tests/features/recent-repos.feature
+++ b/tests/features/recent-repos.feature
@@ -4,6 +4,8 @@ Feature: Recent repos in command palette
 
   Background:
     Given the terminal is ready
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
 
   Scenario: Recent repo appears in "New terminal" picker after visiting a git repo
     When I set up a git repo at "/tmp/kolu-recent-test"

--- a/tests/features/right-panel.feature
+++ b/tests/features/right-panel.feature
@@ -1,22 +1,27 @@
 Feature: Right panel (inspector)
   Collapsible right panel with metadata inspector, toggled via Cmd+B or header icon.
+  Defaults to collapsed.
 
   Background:
     Given the terminal is ready
 
+  Scenario: Right panel starts collapsed by default
+    Then the right panel should not be visible
+    And there should be no page errors
+
   Scenario: Toggle right panel with keyboard shortcut
-    Then the right panel should be visible
-    When I press the toggle inspector shortcut
     Then the right panel should not be visible
     When I press the toggle inspector shortcut
     Then the right panel should be visible
+    When I press the toggle inspector shortcut
+    Then the right panel should not be visible
     And there should be no page errors
 
   Scenario: Panel toggle icon in header toggles inspector
     When I click the inspector toggle icon in the header
-    Then the right panel should not be visible
-    When I click the inspector toggle icon in the header
     Then the right panel should be visible
+    When I click the inspector toggle icon in the header
+    Then the right panel should not be visible
     And there should be no page errors
 
   Scenario: Sidebar toggle icon in header toggles sidebar
@@ -28,7 +33,6 @@ Feature: Right panel (inspector)
     And there should be no page errors
 
   Scenario: Agent click in header expands inspector
-    When I press the toggle inspector shortcut
     Then the right panel should not be visible
     When I run "echo agent-expand-test"
     # Agent indicator may not be present without a real agent, so we
@@ -39,22 +43,26 @@ Feature: Right panel (inspector)
     And there should be no page errors
 
   Scenario: Inspector shows CWD
+    When I press the toggle inspector shortcut
     Then the right panel should be visible
     And the inspector should show a CWD section
     And there should be no page errors
 
   Scenario: Inspector shows git branch in a git repo
     When I run "git init /tmp/kolu-inspector-git && cd /tmp/kolu-inspector-git"
+    When I press the toggle inspector shortcut
     Then the right panel should be visible
     And the inspector should show a git branch section
     And there should be no page errors
 
   Scenario: Inspector shows theme name
+    When I press the toggle inspector shortcut
     Then the right panel should be visible
     And the inspector should show a theme section
     And there should be no page errors
 
   Scenario: Clicking theme in inspector opens palette to Theme group
+    When I press the toggle inspector shortcut
     Then the right panel should be visible
     When I click the theme name in the inspector
     Then the command palette should be visible
@@ -62,22 +70,24 @@ Feature: Right panel (inspector)
     And there should be no page errors
 
   Scenario: Resize handle visible when panel is expanded
+    When I press the toggle inspector shortcut
     Then the right panel should be visible
     And the right panel resize handle should be visible
     And there should be no page errors
 
   Scenario: Right panel state persists across refresh
     When I press the toggle inspector shortcut
-    Then the right panel should not be visible
+    Then the right panel should be visible
     When I refresh the page
-    Then the right panel should not be visible
+    Then the right panel should be visible
     When I press the toggle inspector shortcut
-    Then the right panel should be visible
+    Then the right panel should not be visible
     When I refresh the page
-    Then the right panel should be visible
+    Then the right panel should not be visible
     And there should be no page errors
 
   Scenario: Toggle inspector via command palette
+    When I press the toggle inspector shortcut
     Then the right panel should be visible
     When I open the command palette
     And I type "Toggle inspector" in the palette

--- a/tests/features/worktree-agent.feature
+++ b/tests/features/worktree-agent.feature
@@ -11,6 +11,8 @@ Feature: Agent-aware worktree creation
 
   Background:
     Given the terminal is ready
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
 
   Scenario: Agent sub-palette appears under a recent repo when agents exist
     # `claude` is not installed in the test env, but the preexec hook

--- a/tests/features/worktree.feature
+++ b/tests/features/worktree.feature
@@ -4,6 +4,8 @@ Feature: Git worktree management
 
   Background:
     Given the terminal is ready
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
 
   Scenario: Create terminal in a new worktree via command palette
     When I set up a git repo at "/tmp/kolu-wt-test"

--- a/tests/support/hooks.ts
+++ b/tests/support/hooks.ts
@@ -225,6 +225,8 @@ Before(async function (this: KoluWorld, scenario) {
           activityAlerts: true,
           colorScheme: "dark",
           sidebarAgentPreviews: "attention",
+          rightPanelCollapsed: true,
+          rightPanelSize: 0.25,
         },
       },
     }),


### PR DESCRIPTION
**Right panel now defaults to collapsed** and persists its state (collapsed/expanded + width) in server-side preferences instead of browser localStorage. Closes #486.

Previously the panel opened by default on desktop viewports and saved its state per-browser via `makePersisted`. This meant a fresh user saw the panel open immediately (before they knew what it was), and the preference didn't survive across browsers or localStorage clears. Moving to the same `useServerState()` pattern that color scheme and other preferences use gives consistent persistence at `~/.config/kolu/state.json`.

The viewport-based auto-toggle (collapse on mobile, expand on desktop when crossing the 640px breakpoint) is removed entirely — *the user's explicit choice now sticks regardless of viewport width*. This eliminates a subtle fight where resizing the window would silently overwrite the saved preference.

> Adds schema migration `1.6.0` for existing state files that lack the new preference fields.