### PR TITLE
Deduplicate DEFAULT_PREFERENCES into kolu-common

### DIFF
--- a/client/src/settings/useServerState.ts
+++ b/client/src/settings/useServerState.ts
@@ -17,7 +17,7 @@ import { createStore, reconcile } from "solid-js/store";
 import { toast } from "solid-sonner";
 import { createSubscription } from "../rpc/createSubscription";
 import { client, stream } from "../rpc/rpc";
-import { DEFAULT_PREFERENCES } from "kolu-common";
+import { DEFAULT_PREFERENCES } from "kolu-common/config";
 import type {
   ServerState,
   Preferences,

--- a/client/src/settings/useServerState.ts
+++ b/client/src/settings/useServerState.ts
@@ -17,6 +17,7 @@ import { createStore, reconcile } from "solid-js/store";
 import { toast } from "solid-sonner";
 import { createSubscription } from "../rpc/createSubscription";
 import { client, stream } from "../rpc/rpc";
+import { DEFAULT_PREFERENCES } from "kolu-common";
 import type {
   ServerState,
   Preferences,
@@ -24,16 +25,6 @@ import type {
   RecentAgent,
   SavedSession,
 } from "kolu-common";
-
-const DEFAULT_PREFERENCES: Preferences = {
-  seenTips: [],
-  startupTips: true,
-  randomTheme: true,
-  scrollLock: true,
-  activityAlerts: true,
-  colorScheme: "dark",
-  sidebarAgentPreviews: "attention",
-};
 
 // Singleton store — all callers share one reactive source of truth for preferences.
 const [prefs, setPrefs] = createStore<Preferences>(DEFAULT_PREFERENCES);

--- a/common/src/config.ts
+++ b/common/src/config.ts
@@ -1,3 +1,5 @@
+import type { Preferences } from "./index";
+
 /**
  * Centralized config defaults for kolu.
  *
@@ -26,3 +28,16 @@ export const ACTIVITY_IDLE_THRESHOLD_S = 5;
 
 /** Rolling window for activity history (ms). Both server and client use this. */
 export const ACTIVITY_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Default preference values — single source of truth for server and client. */
+export const DEFAULT_PREFERENCES: Preferences = {
+  seenTips: [],
+  startupTips: true,
+  randomTheme: true,
+  scrollLock: true,
+  activityAlerts: true,
+  colorScheme: "dark",
+  sidebarAgentPreviews: "attention",
+  rightPanelCollapsed: true,
+  rightPanelSize: 0.25,
+};

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -261,18 +261,6 @@ export const PreferencesSchema = z.object({
   rightPanelSize: z.number(),
 });
 
-export const DEFAULT_PREFERENCES: Preferences = {
-  seenTips: [],
-  startupTips: true,
-  randomTheme: true,
-  scrollLock: true,
-  activityAlerts: true,
-  colorScheme: "dark",
-  sidebarAgentPreviews: "attention",
-  rightPanelCollapsed: true,
-  rightPanelSize: 0.25,
-};
-
 // --- Server state ---
 
 /** What conf stores to disk — survives server restart. */

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -259,6 +259,16 @@ export const PreferencesSchema = z.object({
   sidebarAgentPreviews: SidebarAgentPreviewsSchema,
 });
 
+export const DEFAULT_PREFERENCES: Preferences = {
+  seenTips: [],
+  startupTips: true,
+  randomTheme: true,
+  scrollLock: true,
+  activityAlerts: true,
+  colorScheme: "dark",
+  sidebarAgentPreviews: "attention",
+};
+
 // --- Server state ---
 
 /** What conf stores to disk — survives server restart. */

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -8,7 +8,7 @@
 
 import fs from "node:fs";
 import Conf from "conf";
-import { DEFAULT_PREFERENCES } from "kolu-common";
+import { DEFAULT_PREFERENCES } from "kolu-common/config";
 import type {
   Preferences,
   RecentRepo,

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -8,10 +8,10 @@
 
 import fs from "node:fs";
 import Conf from "conf";
+import { DEFAULT_PREFERENCES } from "kolu-common";
 import type {
   RecentRepo,
   RecentAgent,
-  Preferences,
   PersistedState,
   ServerState,
   ServerStatePatch,
@@ -25,16 +25,6 @@ import { log } from "./log.ts";
  * whose keys are > the last-seen version and ≤ this value.
  */
 const SCHEMA_VERSION = "1.5.0";
-
-const DEFAULT_PREFERENCES: Preferences = {
-  seenTips: [],
-  startupTips: true,
-  randomTheme: true,
-  scrollLock: true,
-  activityAlerts: true,
-  colorScheme: "dark",
-  sidebarAgentPreviews: "attention",
-};
 
 export const store = new Conf<PersistedState>({
   projectName: "kolu",

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import Conf from "conf";
 import { DEFAULT_PREFERENCES } from "kolu-common";
 import type {
+  Preferences,
   RecentRepo,
   RecentAgent,
   PersistedState,


### PR DESCRIPTION
**Preference defaults now live in one place** — `kolu-common`, right next to the `PreferencesSchema` they satisfy. Both server and client import from there instead of maintaining identical copies.

Previously, `DEFAULT_PREFERENCES` was defined independently in `server/src/state.ts` and `client/src/settings/useServerState.ts`. Every new preference field required updating both in sync — an unenforced invariant maintained by convention. _Silent divergence was one forgetful edit away._

Closes #495