### PR TITLE
Restore terminal order and theme on session restore

### DIFF
--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -11,7 +11,7 @@ import type { TerminalStore } from "./useTerminalStore";
 export function useSessionRestore(deps: {
   store: TerminalStore;
   subscribeExit: (id: TerminalId) => void;
-  handleCreate: (cwd?: string) => Promise<TerminalId>;
+  handleCreate: (cwd?: string, themeName?: string) => Promise<TerminalId>;
   handleCreateSubTerminal: (
     parentId: TerminalId,
     cwd?: string,
@@ -106,10 +106,18 @@ export function useSessionRestore(deps: {
     );
     try {
       const oldToNew = new Map<string, TerminalId>();
-      const topLevel = session.terminals.filter((t) => !t.parentId);
-      const subTerminals = session.terminals.filter((t) => t.parentId);
+      const bySortOrder = (
+        a: { sortOrder?: number },
+        b: { sortOrder?: number },
+      ) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0);
+      const topLevel = session.terminals
+        .filter((t) => !t.parentId)
+        .sort(bySortOrder);
+      const subTerminals = session.terminals
+        .filter((t) => t.parentId)
+        .sort(bySortOrder);
       for (const t of topLevel) {
-        const newId = await deps.handleCreate(t.cwd);
+        const newId = await deps.handleCreate(t.cwd, t.themeName);
         oldToNew.set(t.id, newId);
       }
       for (const t of subTerminals) {

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -91,21 +91,28 @@ export function useTerminalCrud(deps: {
   }
 
   /** Create a new terminal on the server and make it active.
-   *  Returns the new terminal ID (for session restore mapping). */
-  async function handleCreate(cwd?: string): Promise<TerminalId> {
+   *  Returns the new terminal ID (for session restore mapping).
+   *  When `themeName` is provided (e.g. session restore), it overrides
+   *  the random-theme preference so only one setTheme RPC fires. */
+  async function handleCreate(
+    cwd?: string,
+    themeName?: string,
+  ): Promise<TerminalId> {
     if (store.activeMeta()?.git) showTipOnce(CONTEXTUAL_TIPS.worktree);
 
     const info = await client.terminal.create({ cwd }).catch((err: Error) => {
       toast.error(`Failed to create terminal: ${err.message}`);
       throw err;
     });
-    const themeName = preferences().randomTheme
-      ? availableThemes[Math.floor(Math.random() * availableThemes.length)]!
-          .name
-      : undefined;
+    const theme =
+      themeName ??
+      (preferences().randomTheme
+        ? availableThemes[Math.floor(Math.random() * availableThemes.length)]!
+            .name
+        : undefined);
     store.setActiveId(info.id);
     deps.subscribeExit(info.id);
-    if (themeName) setThemeName(info.id, themeName);
+    if (theme) setThemeName(info.id, theme);
     return info.id;
   }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -215,6 +215,8 @@ export const SavedTerminalSchema = z.object({
   branch: z.string().optional(),
   /** Ordering within group at save time. */
   sortOrder: z.number().optional(),
+  /** Theme name at save time. */
+  themeName: z.string().optional(),
 });
 
 export const SavedSessionSchema = z.object({

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -13,7 +13,7 @@
 
 import type { TerminalMetadata } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
-import { publishForTerminal } from "../publisher.ts";
+import { publishForTerminal, publishSystem } from "../publisher.ts";
 import { startGitProvider } from "./git.ts";
 import { startGitHubPrProvider } from "./github.ts";
 import { startClaudeCodeProvider } from "./claude.ts";
@@ -36,8 +36,9 @@ export function createMetadata(
   };
 }
 
-/** Atomically mutate metadata and publish the snapshot to all subscribers.
- *  Single place to audit — impossible to forget the publish. */
+/** Atomically mutate metadata, publish the snapshot to subscribers, and
+ *  trigger a debounced session auto-save. Single place to audit —
+ *  impossible to forget either the client publish or the session save. */
 export function updateMetadata(
   entry: TerminalProcess,
   terminalId: string,
@@ -60,6 +61,7 @@ export function updateMetadata(
     "metadata publish",
   );
   publishForTerminal("metadata", terminalId, { ...m });
+  publishSystem("session:changed", {});
 }
 
 /**

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -69,6 +69,17 @@ describe("session persistence", () => {
     expect(session!.terminals[2]!.parentId).toBe("a");
   });
 
+  it("preserves themeName on round-trip", () => {
+    const terminals: SavedTerminal[] = [
+      { id: "a", cwd: "/a", sortOrder: 0, themeName: "Dracula" },
+      { id: "b", cwd: "/b", sortOrder: 1 },
+    ];
+    saveSession(terminals);
+    const session = getSavedSession();
+    expect(session!.terminals[0]!.themeName).toBe("Dracula");
+    expect(session!.terminals[1]!.themeName).toBeUndefined();
+  });
+
   it("clearSavedSession removes the session", () => {
     saveSession([terminal]);
     expect(getSavedSession()).not.toBeNull();

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -110,6 +110,7 @@ export function snapshotSession(): SavedTerminal[] {
       ...(m.parentId && { parentId: m.parentId }),
       ...(m.git && { repoName: m.git.repoName, branch: m.git.branch }),
       sortOrder: m.sortOrder,
+      ...(m.themeName && { themeName: m.themeName }),
     };
   });
 }

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -274,6 +274,7 @@ export function setTerminalTheme(id: TerminalId, themeName: string): void {
     updateMetadata(entry, id, (m) => {
       m.themeName = themeName;
     });
+    emitChanged();
   }
 }
 
@@ -288,6 +289,7 @@ export function reorderTerminals(ids: TerminalId[]): void {
     }
   }
   log.debug({ count: ids.length }, "terminals reordered");
+  emitChanged();
   emitListChanged();
 }
 

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -178,7 +178,6 @@ export function createTerminal(cwd?: string, parentId?: string): TerminalInfo {
             m.cwd = newCwd;
           });
           publishForTerminal("cwd", id, newCwd);
-          emitChanged();
         }
       },
     },
@@ -274,7 +273,6 @@ export function setTerminalTheme(id: TerminalId, themeName: string): void {
     updateMetadata(entry, id, (m) => {
       m.themeName = themeName;
     });
-    emitChanged();
   }
 }
 
@@ -289,7 +287,6 @@ export function reorderTerminals(ids: TerminalId[]): void {
     }
   }
   log.debug({ count: ids.length }, "terminals reordered");
-  emitChanged();
   emitListChanged();
 }
 

--- a/packages/tests/features/session-restore.feature
+++ b/packages/tests/features/session-restore.feature
@@ -11,3 +11,21 @@ Feature: Session restore
     When I click the restore button
     Then there should be 2 sidebar entries
     And there should be no page errors
+
+  Scenario: Restored terminals preserve their original sidebar order
+    Given a saved session with reversed sort order
+    When I open the app
+    Then the session restore card should be visible
+    When I click the restore button
+    Then there should be 3 sidebar entries
+    And the sidebar entries should be in sort order
+    And there should be no page errors
+
+  Scenario: Restored terminals preserve their theme
+    Given a saved session with theme "Dracula"
+    When I open the app
+    Then the session restore card should be visible
+    When I click the restore button
+    Then there should be 1 sidebar entries
+    And the header should show theme "Dracula"
+    And there should be no page errors

--- a/packages/tests/step_definitions/session_restore_steps.ts
+++ b/packages/tests/step_definitions/session_restore_steps.ts
@@ -6,6 +6,7 @@ import {
 } from "../support/world.ts";
 import * as assert from "node:assert";
 import * as os from "node:os";
+import type { SavedTerminal } from "kolu-common";
 
 /** Post the saved-session payload to the server. Used both at scenario
  *  setup (Given) and as a self-heal in the assertion. Idempotent. */
@@ -14,15 +15,23 @@ async function postSavedSession(
   count: number,
 ): Promise<void> {
   const dirs = [os.homedir(), os.tmpdir(), "/"].slice(0, count);
+  await postSavedSessionPayload(
+    page,
+    dirs.map((cwd, i) => ({ id: String(i), cwd })),
+  );
+}
+
+/** Post an arbitrary saved-session terminal list. */
+async function postSavedSessionPayload(
+  page: KoluWorld["page"],
+  terminals: SavedTerminal[],
+): Promise<void> {
   const resp = await page.request.fetch("/rpc/state/test__set", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     data: JSON.stringify({
       json: {
-        session: {
-          terminals: dirs.map((cwd, i) => ({ id: String(i), cwd })),
-          savedAt: Date.now(),
-        },
+        session: { terminals, savedAt: Date.now() },
       },
     }),
   });
@@ -64,7 +73,9 @@ Then(
     // because Playwright's isVisible() can throw on transient DOM states during
     // mount — treating those as "not visible" just routes to the self-heal below.
     if (await card.isVisible().catch(() => false)) return;
-    if (this.savedSessionTerminalCount !== undefined) {
+    if (this.savedSessionTerminals) {
+      await postSavedSessionPayload(this.page, this.savedSessionTerminals);
+    } else if (this.savedSessionTerminalCount !== undefined) {
       await postSavedSession(this.page, this.savedSessionTerminalCount);
     }
     await card.waitFor({ state: "visible", timeout: 10000 });
@@ -113,5 +124,61 @@ Then(
       expected,
       `Expected ${expected} sidebar entries, got ${actual}`,
     );
+  },
+);
+
+// --- Ordering scenario ---
+
+/** Directories used for the reversed-sort-order scenario.
+ *  Array order is alphabetical; sortOrder is assigned in reverse so that
+ *  a correct restore should produce sidebar order /etc, /tmp, /var
+ *  (sortOrder 1000, 2000, 3000) even though the array is /etc, /tmp, /var. */
+const ORDERED_DIRS = ["/etc", "/tmp", "/var"];
+
+Given(
+  "a saved session with reversed sort order",
+  async function (this: KoluWorld) {
+    this.savedSessionTerminalCount = ORDERED_DIRS.length;
+    // Array order: /etc(3000), /tmp(2000), /var(1000)
+    // Expected sidebar order after restore: /var, /tmp, /etc (ascending sortOrder)
+    const terminals = ORDERED_DIRS.map((cwd, i) => ({
+      id: String(i),
+      cwd,
+      sortOrder: (ORDERED_DIRS.length - i) * 1000,
+    }));
+    this.savedSessionTerminals = terminals;
+    await postSavedSessionPayload(this.page, terminals);
+  },
+);
+
+Then(
+  "the sidebar entries should be in sort order",
+  async function (this: KoluWorld) {
+    const entries = this.page.locator(SIDEBAR_ENTRY_SELECTOR);
+    const count = await entries.count();
+    const titles: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const title = await entries.nth(i).getAttribute("title");
+      titles.push(title ?? "");
+    }
+    // Ascending sortOrder: /var(1000), /tmp(2000), /etc(3000)
+    const expected = [...ORDERED_DIRS].reverse();
+    assert.deepStrictEqual(
+      titles,
+      expected,
+      `Sidebar order ${JSON.stringify(titles)} doesn't match expected ${JSON.stringify(expected)}`,
+    );
+  },
+);
+
+// --- Theme restore scenario ---
+
+Given(
+  "a saved session with theme {string}",
+  async function (this: KoluWorld, themeName: string) {
+    this.savedSessionTerminalCount = 1;
+    const terminals = [{ id: "0", cwd: os.homedir(), themeName }];
+    this.savedSessionTerminals = terminals;
+    await postSavedSessionPayload(this.page, terminals);
   },
 );

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -31,6 +31,7 @@ export class KoluWorld extends World {
 
   // Stashed state for comparison across steps
   savedSessionTerminalCount?: number;
+  savedSessionTerminals?: import("kolu-common").SavedTerminal[];
   savedCanvas?: { x: number; y: number; width: number; height: number };
   previousCanvas?: { x: number; y: number; width: number; height: number };
   savedFontSize?: number;


### PR DESCRIPTION
**Session restore now preserves the original sidebar ordering and per-terminal themes.** Previously, restored terminals appeared in whatever order the server's internal `Map` happened to iterate — ignoring the `sortOrder` that was faithfully saved. Themes were never persisted at all, so every restore either got the default theme or a fresh random one.

The fix sorts saved terminals by `sortOrder` before recreating them, and threads the saved `themeName` through `handleCreate` so the restored theme takes precedence over random-theme assignment — *one RPC per terminal instead of a double-set.*

Two new e2e scenarios cover both paths: one seeds terminals with reversed sort orders and asserts the sidebar matches, the other seeds a terminal with a specific theme and verifies it survives the round-trip. A unit test covers `themeName` persistence in the session store.

Closes #481

### Try it locally

```sh
nix run github:juspay/kolu/fix/session-restore-ordering
```