### PR TITLE
test(flake): ralph loop for e2e flake hardening (#440)

### DIFF
--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -287,20 +287,36 @@ Before(async function (this: KoluWorld, scenario) {
 });
 
 After(async function (this: KoluWorld, scenario) {
-  // Screenshot on failure
-  if (scenario.result?.status === Status.FAILED) {
-    const dir = path.resolve(
-      import.meta.dirname,
-      "..",
-      "reports",
-      "screenshots",
-    );
-    fs.mkdirSync(dir, { recursive: true });
-    const name = scenario.pickle.name.replace(/\s+/g, "-").toLowerCase();
-    await this.page.screenshot({
-      path: path.join(dir, `${name}.png`),
-      fullPage: true,
-    });
+  // Screenshot on failure — guarded so a dead page (e.g. ECONNRESET during
+  // the scenario) doesn't cascade into a TypeError in the After hook, which
+  // would otherwise turn one flake into two. Same rationale applies to the
+  // context.close() below: if the browser context is already torn down, the
+  // close() call can reject and mask the original scenario failure in
+  // reports. See juspay/kolu#320 (commit bec1500) for the cascade trace.
+  if (scenario.result?.status === Status.FAILED && this.page) {
+    try {
+      const dir = path.resolve(
+        import.meta.dirname,
+        "..",
+        "reports",
+        "screenshots",
+      );
+      fs.mkdirSync(dir, { recursive: true });
+      const name = scenario.pickle.name.replace(/\s+/g, "-").toLowerCase();
+      await this.page.screenshot({
+        path: path.join(dir, `${name}.png`),
+        fullPage: true,
+      });
+    } catch {
+      // Page/context may already be dead (ECONNRESET, browser crash).
+      // Swallow — the original scenario failure is what matters.
+    }
   }
-  if (this.context) await this.context.close();
+  if (this.context) {
+    try {
+      await this.context.close();
+    } catch {
+      // Context may already be closed by a prior crash.
+    }
+  }
 });


### PR DESCRIPTION
## Summary

Ralph loop for fixing flaky e2e tests, per #440. Each commit on this PR is one iteration: fix a flake class (test-only, no timeout bumps), record e2e measurements in the commit message, repeat.

## Iteration log

### #1 — `85aa80c` — After-hook cleanup guard
- **Flake class**: `TypeError: Cannot read properties of undefined (reading 'screenshot')` in `hooks.ts` After hook, cascading from scenario-level ECONNRESET. Documented in #320 (commit bec1500).
- **Fix**: `this.page`-presence check + try/catch around screenshot, try/catch around `context.close()`. Cleanup no longer masks original failure.
- **Scope**: 1 file, `packages/tests/support/hooks.ts`, +22/-4 lines. No server/client/common touched.

## Scope constraints (from #440)

- Changes must live in `packages/tests/` or test infra (e.g. `nix/home/example/flake.nix`).
- No timeout bumps — the fix must change the *shape* of the wait or guard (polling, defensive cleanup), not extend the budget.
- No server/client/common code.

## Deferred

- **chokidar inotify overflow** (the biggest flake class: claude-code indicator scenarios under `CUCUMBER_PARALLEL=8`) — fundamentally requires server-side `fs.watch` re-arm on queue overflow. Out of scope for a tests-only PR. Per-worker temp dirs (#402) already mitigates partially.

## Test plan

- [ ] CI e2e runs 4× in a row show no regression from the cleanup-guard change
- [ ] After-hook no longer surfaces `TypeError: Cannot read properties of undefined` when the underlying scenario dies from ECONNRESET or page crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)