### PR TITLE
Fix dialog widths on mobile viewports

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -263,8 +263,12 @@ const App: Component = () => {
         open={shortcutsHelpOpen()}
         onOpenChange={withRefocus(setShortcutsHelpOpen)}
       />
-      <ModalDialog open={aboutOpen()} onOpenChange={withRefocus(setAboutOpen)}>
-        <Dialog.Content class="w-full bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-6 max-w-sm text-sm">
+      <ModalDialog
+        open={aboutOpen()}
+        onOpenChange={withRefocus(setAboutOpen)}
+        size="sm"
+      >
+        <Dialog.Content class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-6 text-sm">
           <div class="flex items-center gap-2 mb-3">
             <img src="/favicon.svg" alt="kolu" class="w-6 h-6" />
             <span class="font-semibold text-fg">{appTitle()}</span>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -264,7 +264,7 @@ const App: Component = () => {
         onOpenChange={withRefocus(setShortcutsHelpOpen)}
       />
       <ModalDialog open={aboutOpen()} onOpenChange={withRefocus(setAboutOpen)}>
-        <Dialog.Content class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-6 max-w-sm text-sm">
+        <Dialog.Content class="w-full bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-6 max-w-sm text-sm">
           <div class="flex items-center gap-2 mb-3">
             <img src="/favicon.svg" alt="kolu" class="w-6 h-6" />
             <span class="font-semibold text-fg">{appTitle()}</span>

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -35,7 +35,7 @@ const CloseConfirm: Component<{
       initialFocusEl={cancelRef}
     >
       <Dialog.Content
-        class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 max-w-sm text-sm space-y-4"
+        class="w-full bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 max-w-sm text-sm space-y-4"
         data-testid="close-confirm"
         style={{ "background-color": "var(--color-surface-1)" }}
       >

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -33,9 +33,10 @@ const CloseConfirm: Component<{
         if (!open) props.onCancel();
       }}
       initialFocusEl={cancelRef}
+      size="sm"
     >
       <Dialog.Content
-        class="w-full bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 max-w-sm text-sm space-y-4"
+        class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 text-sm space-y-4"
         data-testid="close-confirm"
         style={{ "background-color": "var(--color-surface-1)" }}
       >

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -290,7 +290,7 @@ const CommandPalette: Component<{
       <Dialog.Content
         forceMount
         data-testid="command-palette"
-        class="w-full max-w-md bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
+        class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
         style={{
           height: "24rem",
           // Firefox workaround: bg-surface-1 utility intermittently fails

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -290,7 +290,7 @@ const CommandPalette: Component<{
       <Dialog.Content
         forceMount
         data-testid="command-palette"
-        class="w-md bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
+        class="w-full max-w-md bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col"
         style={{
           height: "24rem",
           // Firefox workaround: bg-surface-1 utility intermittently fails

--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -37,10 +37,10 @@ const ShortcutsHelp: Component<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }> = (props) => (
-  <ModalDialog open={props.open} onOpenChange={props.onOpenChange}>
+  <ModalDialog open={props.open} onOpenChange={props.onOpenChange} size="sm">
     <Dialog.Content
       data-testid="shortcuts-help"
-      class="w-full max-w-sm bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden"
+      class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden"
       style={{ "background-color": "var(--color-surface-1)" }}
     >
       <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">

--- a/packages/client/src/ui/ModalDialog.tsx
+++ b/packages/client/src/ui/ModalDialog.tsx
@@ -54,7 +54,7 @@ const ModalDialog: Component<{
         }}
       />
       <div
-        class="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] pointer-events-none"
+        class="fixed inset-0 z-50 flex items-start justify-center px-4 pt-[15vh] pointer-events-none"
         classList={{ hidden: !props.open }}
       >
         <div class="pointer-events-auto">{props.children}</div>

--- a/packages/client/src/ui/ModalDialog.tsx
+++ b/packages/client/src/ui/ModalDialog.tsx
@@ -22,6 +22,11 @@ export function refocusTerminal() {
     ?.click();
 }
 
+// Width cap for the dialog. Applied to the flex-item wrapper (not Dialog.Content)
+// so the child's `w-full` resolves against a definite parent width — otherwise
+// `w-full` on a content-auto flex item collapses to min-content on desktop.
+const SIZE_CLASS = { sm: "max-w-sm", md: "max-w-md" } as const;
+
 const ModalDialog: Component<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -31,6 +36,8 @@ const ModalDialog: Component<{
   initialFocusEl?: HTMLElement;
   /** Disable Corvu's built-in focus trapping (for custom keyboard navigation). */
   trapFocus?: boolean;
+  /** Max width cap — "sm" (24rem) for confirms/help, "md" (28rem) for command palette. Defaults to "md". */
+  size?: "sm" | "md";
   children: JSX.Element;
 }> = (props) => (
   <Dialog
@@ -57,7 +64,11 @@ const ModalDialog: Component<{
         class="fixed inset-0 z-50 flex items-start justify-center px-4 pt-[15vh] pointer-events-none"
         classList={{ hidden: !props.open }}
       >
-        <div class="pointer-events-auto">{props.children}</div>
+        <div
+          class={`pointer-events-auto w-full ${SIZE_CLASS[props.size ?? "md"]}`}
+        >
+          {props.children}
+        </div>
       </div>
     </Dialog.Portal>
   </Dialog>


### PR DESCRIPTION
**Dialogs now scale to mobile viewports** instead of overflowing iPhone-sized screens. The command palette previously used a fixed `w-md` (448px) that was wider than a 390px iPhone viewport, and the other dialogs capped at `max-w-sm` without `w-full`, so they sized to intrinsic content rather than the responsive cap.

The `ModalDialog` positioning wrapper now adds `px-4` so every dialog gets consistent side gutters on narrow screens, and each `Dialog.Content` adopts the standard `w-full max-w-X` Tailwind idiom — *flex-shrink handles the overflow case automatically, so dialogs gracefully shrink to fit the viewport while keeping their desktop max-widths*.

Affects the command palette, close-terminal confirm, shortcuts help, and about dialog.

### Try it locally

```sh
nix run github:juspay/kolu/fix-mobile-dialog-width
```