### PR TITLE
fix: platform-specific pnpm deps hash for Linux support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,8 @@ let
     pname = "kolu";
     version = "0.1.0";
     inherit src;
-    hash = if pkgs.stdenv.isDarwin
+    hash =
+      if pkgs.stdenv.isDarwin
       then "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248="
       else "sha256-+0F68vGWwafQiKRThCuaCGYYDinYE0qwMhNd27UrPOI=";
     fetcherVersion = 3;

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,9 @@ let
     pname = "kolu";
     version = "0.1.0";
     inherit src;
-    hash = "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248=";
+    hash = if pkgs.stdenv.isDarwin
+      then "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248="
+      else "sha256-+0F68vGWwafQiKRThCuaCGYYDinYE0qwMhNd27UrPOI=";
     fetcherVersion = 3;
   };
 


### PR DESCRIPTION
## Summary
- The `pnpmDeps` hash in `default.nix` was hardcoded for Darwin, causing a hash mismatch when building on Linux (x86_64-linux)
- Uses a platform conditional (`pkgs.stdenv.isDarwin`) to select the correct hash per platform

## Error on Linux
```
error: hash mismatch in fixed-output derivation 'kolu-pnpm-deps.drv':
         specified: sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248=
            got:    sha256-+0F68vGWwafQiKRThCuaCGYYDinYE0qwMhNd27UrPOI=
```

## Test plan
- [x] Verified the Linux hash by building on x86_64-linux
- [ ] Verify Darwin build is unaffected (existing hash preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)