### PR TITLE
docs: explain why pnpmDeps hash differs per platform

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,11 @@ let
     pname = "kolu";
     version = "0.1.0";
     inherit src;
+    # Hashes differ by platform by design: pnpm-lock.yaml contains platform-gated
+    # optionalDependencies (@esbuild/*, @img/sharp-*, @rollup/*, etc.) that
+    # fetchPnpmDeps resolves against the current stdenv. Darwin pulls the
+    # darwin-* tarballs; Linux pulls linux-*. Different tarball set → different
+    # content hash. Do not try to unify these. See juspay/kolu#507.
     hash =
       if pkgs.stdenv.isDarwin
       then "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248="


### PR DESCRIPTION
## Summary
- Adds a comment above the `pnpmDeps.hash` branch in `default.nix` so future contributors (and LLMs) don't try to unify the Darwin/Linux hashes.
- The split is inherent: `pnpm-lock.yaml` contains platform-gated `optionalDependencies` (`@esbuild/*`, `@img/sharp-*`, `@rollup/*`, …), so `fetchPnpmDeps` resolves a different tarball set per stdenv → different content hash.
- Follow-up doc-only to juspay/kolu#507.

## Test plan
- [x] `just fmt` — no changes needed
- [x] `just check` — typecheck clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)