### PR TITLE
ci: add nix run smoke-test step

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -24,14 +24,14 @@ _local:
 _linux:
     CI_SYSTEM=x86_64-linux just ci::nix ci::_linux-fanout || true
 
-# Runs home-manager and e2e in parallel after nix has completed.
+# Runs home-manager, e2e, and run in parallel after nix has completed.
 # Within the same just process, their `: nix` deps are already satisfied,
 # so nix is not rebuilt.
 [parallel]
-_linux-fanout: home-manager e2e
+_linux-fanout: home-manager e2e run
 
 _darwin:
-    CI_SYSTEM=aarch64-darwin just ci::nix ci::e2e || true
+    CI_SYSTEM=aarch64-darwin just ci::nix ci::e2e ci::run || true
 
 nix:
     just ci::_devour-flake nix --override-input flake .
@@ -44,6 +44,10 @@ typecheck:
 
 e2e: nix
     just ci::_run e2e just test
+
+# Smoke-test `nix run .` works
+run: nix
+    just ci::_run run nix run . --help
 
 # Run vitest unit tests (server + client)
 unit:

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -49,7 +49,7 @@ e2e: nix
 
 # Smoke-test `nix run .` works
 run: nix
-    just ci::_run run nix run . --help
+    just ci::_run run nix run . -- --help
 
 # Run vitest unit tests (server + client)
 unit:

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -24,14 +24,16 @@ _local:
 _linux:
     CI_SYSTEM=x86_64-linux just ci::nix ci::_linux-fanout || true
 
-# Runs home-manager, e2e, and run in parallel after nix has completed.
-# Within the same just process, their `: nix` deps are already satisfied,
-# so nix is not rebuilt.
+# Runs post-nix steps in parallel. Within the same just process, their
+# `: nix` deps are already satisfied, so nix is not rebuilt.
 [parallel]
 _linux-fanout: home-manager e2e run
 
+[parallel]
+_darwin-fanout: e2e run
+
 _darwin:
-    CI_SYSTEM=aarch64-darwin just ci::nix ci::e2e ci::run || true
+    CI_SYSTEM=aarch64-darwin just ci::nix ci::_darwin-fanout || true
 
 nix:
     just ci::_devour-flake nix --override-input flake .


### PR DESCRIPTION
Adds a new `run` CI step that runs `nix run . --help` after the `nix` step on both systems. It joins `home-manager` and `e2e` in the post-nix parallel fanout on Linux, and runs sequentially after `nix`/`e2e` on Darwin. Because `run` depends on `nix` within the same just process, the cached build is reused — no rebuild cost.

This catches regressions where the package builds fine but `nix run` is broken (missing `meta.mainProgram`, bad entrypoint, broken wrapper).

## Test plan
- [ ] `just ci::_contexts` lists `run@x86_64-linux` and `run@aarch64-darwin`
- [ ] Full CI run posts `success` statuses for both new contexts