### PR TITLE
ci: detect stale pnpmDeps hash via nix build --rebuild

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -36,20 +36,20 @@ _darwin:
     CI_SYSTEM=aarch64-darwin just ci::nix ci::_darwin-fanout || true
 
 # Verify the declared pnpmDeps hash in default.nix matches what
-# fetchPnpmDeps actually produces from the current pnpm-lock.yaml. The
-# first `nix build` realizes the output path (from substituter or fresh);
-# `--rebuild` then forces re-execution and compares, so a stale declared
-# hash cannot be silently satisfied by a cached artifact at that hash in
-# the binary cache (cache.nixos.asia). Runs on one system — the hash is
-# platform-independent (pnpm install --force bypasses os/cpu/libc gating).
+# fetchPnpmDeps actually produces from the current pnpm-lock.yaml.
+#
+# Two builds are required, not one: `nix build --rebuild` errors with
+# "outputs ... are not valid, so checking is not possible" when the store
+# path doesn't exist yet. The first `nix build` realizes the path (from
+# substituter or fresh fetch); --rebuild then forces re-execution and
+# compares, so a stale cached artifact at the declared hash (local store
+# or cache.nixos.asia) can't silently satisfy a hash that no longer
+# matches the lockfile.
+#
+# Runs on one system — hash is platform-independent (pnpm install --force
+# bypasses os/cpu/libc gating, see default.nix pnpmDeps comment).
 pnpm-hash-fresh:
-    just ci::_run pnpm-hash-fresh just ci::_pnpm-hash-fresh-do
-
-_pnpm-hash-fresh-do:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    nix build .#pnpmDeps --no-link
-    nix build --rebuild .#pnpmDeps --no-link
+    just ci::_run pnpm-hash-fresh "sh -c 'nix build .#pnpmDeps --no-link && nix build --rebuild .#pnpmDeps --no-link'"
 
 nix:
     just ci::_devour-flake nix --override-input flake .

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -22,7 +22,7 @@ _local:
     just ci::fmt ci::typecheck ci::unit ci::apm-sync || true
 
 _linux:
-    CI_SYSTEM=x86_64-linux just ci::nix ci::_linux-fanout || true
+    CI_SYSTEM=x86_64-linux just ci::pnpm-hash-fresh ci::nix ci::_linux-fanout || true
 
 # Runs post-nix steps in parallel. Within the same just process, their
 # `: nix` deps are already satisfied, so nix is not rebuilt.
@@ -34,6 +34,22 @@ _darwin-fanout: e2e run
 
 _darwin:
     CI_SYSTEM=aarch64-darwin just ci::nix ci::_darwin-fanout || true
+
+# Verify the declared pnpmDeps hash in default.nix matches what
+# fetchPnpmDeps actually produces from the current pnpm-lock.yaml. The
+# first `nix build` realizes the output path (from substituter or fresh);
+# `--rebuild` then forces re-execution and compares, so a stale declared
+# hash cannot be silently satisfied by a cached artifact at that hash in
+# the binary cache (cache.nixos.asia). Runs on one system — the hash is
+# platform-independent (pnpm install --force bypasses os/cpu/libc gating).
+pnpm-hash-fresh:
+    just ci::_run pnpm-hash-fresh just ci::_pnpm-hash-fresh-do
+
+_pnpm-hash-fresh-do:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    nix build .#pnpmDeps --no-link
+    nix build --rebuild .#pnpmDeps --no-link
 
 nix:
     just ci::_devour-flake nix --override-input flake .

--- a/default.nix
+++ b/default.nix
@@ -44,7 +44,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248=";
+    hash = "sha256-+0F68vGWwafQiKRThCuaCGYYDinYE0qwMhNd27UrPOI=";
     fetcherVersion = 3;
   };
 

--- a/default.nix
+++ b/default.nix
@@ -37,15 +37,14 @@ let
     pname = "kolu";
     version = "0.1.0";
     inherit src;
-    # Hashes differ by platform by design: pnpm-lock.yaml contains platform-gated
-    # optionalDependencies (@esbuild/*, @img/sharp-*, @rollup/*, etc.) that
-    # fetchPnpmDeps resolves against the current stdenv. Darwin pulls the
-    # darwin-* tarballs; Linux pulls linux-*. Different tarball set → different
-    # content hash. Do not try to unify these. See juspay/kolu#507.
-    hash =
-      if pkgs.stdenv.isDarwin
-      then "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248="
-      else "sha256-+0F68vGWwafQiKRThCuaCGYYDinYE0qwMhNd27UrPOI=";
+    # Platform-independent. fetchPnpmDeps runs `pnpm install --force`, which
+    # sets includeIncompatiblePackages=true and bypasses pnpm's os/cpu/libc
+    # gating (pkg-manager/headless/src/index.ts:260 in pnpm 10.32.1), so
+    # Darwin and Linux populate byte-identical pnpm stores. `just ci::pnpm-
+    # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
+    # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
+    # binary cache can't silently satisfy a hash that no longer matches.
+    hash = "sha256-uDUcuuFr9K01/SbJjlBnQ8xv5HWf/4oaUXEo2Ts1248=";
     fetcherVersion = 3;
   };
 
@@ -135,5 +134,5 @@ let
   '';
 in
 {
-  inherit default koluEnv;
+  inherit default koluEnv pnpmDeps;
 }


### PR DESCRIPTION
Two changes that together make pnpmDeps hash drift CI-visible instead of silent.

## 1. Collapse to a single pnpmDeps hash (`default.nix`)

Prior code branched on `pkgs.stdenv.isDarwin` with the rationale that platform-gated `optionalDependencies` in `pnpm-lock.yaml` force per-platform tarball sets. That's how pnpm works *by default*, but `fetchPnpmDeps` runs `pnpm install --force`, which wires `includeIncompatiblePackages = opts.force` into the headless installer (`pkg-manager/headless/src/index.ts:260` in pnpm 10.32.1). That short-circuits pnpm's cpu/os/libc gating in `lockfile/filtering/src/filterLockfileByImportersAndEngine.ts:165`, so both Darwin and Linux fetch the full cross-platform set and populate byte-identical stores.

Empirically verified: building `pnpmDeps` on x86_64-linux and aarch64-darwin both produce `sha256-+0F68vGWwafQiKRThCuaCGYYDinYE0qwMhNd27UrPOI=`. On Darwin, nix even reports `got: sha256-+0F68v...` despite the declared hash being the Darwin-specific `sha256-uDUcu...` — which means the latter was stale, not a platform artifact. This reverts the platform split added in juspay/kolu#509.

Also exposes `pnpmDeps` via the flake so the new CI step below can target `.#pnpmDeps` directly.

## 2. `ci::pnpm-hash-fresh` in `ci/mod.just`

Guards against a real pitfall of fixed-output derivations: if someone bumps `pnpm-lock.yaml` without updating the hash, and a cached artifact at the old declared hash still lives in `cache.nixos.asia/oss` (which `flake.nix:14` lists as a substituter), a plain `nix build` happily pulls the stale artifact and the build continues against **stale dependencies**, invisible in CI. This is exactly what happened in juspay/kolu#502 — CI went green with a stale Darwin hash because the cached artifact satisfied it.

The new step sidesteps this by running:

    nix build .#pnpmDeps --no-link                # realize (substituter or fresh)
    nix build --rebuild .#pnpmDeps --no-link      # re-execute and compare

`--rebuild` forces `fetchPnpmDeps` to run the installer again and compares the fresh output to the already-realized path. If the declared hash no longer matches what the current lockfile produces — regardless of whether the stored path came from cache or local build — it errors with a `hash mismatch`. Wired into the `x86_64-linux` lane before `ci::nix`; runs only once since the hash is platform-independent.

## Related

- juspay/kolu#502 — the PR whose CI silently passed on a stale Darwin hash; this is the concrete failure mode being guarded against.
- juspay/kolu#509 — added the per-platform hash branching this PR reverts, on the (incorrect) assumption that the stores differ by platform.