### PR TITLE
Unmount closing terminal before kill RPC resolves

### DIFF
--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -129,10 +129,16 @@ export function useTerminalCrud(deps: {
   }
 
   async function handleKill(id: TerminalId) {
+    // Unmount the `<Terminal>` synchronously so xterm disposes before any
+    // reactive effect can fire another `client.terminal.resize` for this id.
+    // Without this, the closing terminal's resize listener (Terminal.tsx)
+    // races the kill RPC and the server logs `TerminalNotFoundError`.
+    store.markClosing(id);
     try {
       await client.terminal.kill({ id });
     } catch {
-      // Terminal may already be gone
+      // Terminal may already be gone — the mask auto-expires when the
+      // server's list subscription stops including the id.
     }
     removeAndAutoSwitch(id);
   }

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -129,10 +129,16 @@ export function useTerminalCrud(deps: {
   }
 
   async function handleKill(id: TerminalId) {
-    // Unmount the `<Terminal>` synchronously so xterm disposes before any
-    // reactive effect can fire another `client.terminal.resize` for this id.
-    // Without this, the closing terminal's resize listener (Terminal.tsx)
-    // races the kill RPC and the server logs `TerminalNotFoundError`.
+    // Auto-switch BEFORE masking: removeAndAutoSwitch reads store.terminalIds()
+    // to pick the next active by index, which needs to still include the
+    // dying id. If we masked first, the lookup would miss and activeId
+    // would flip to null — leaving no terminal visible during the kill RPC.
+    removeAndAutoSwitch(id);
+    // Now mask: `<Terminal>` unmounts synchronously, xterm disposes before
+    // any reactive effect can fire another `client.terminal.resize` for
+    // this id. Without this, the closing terminal's resize listener
+    // (Terminal.tsx) races the kill RPC and the server logs
+    // `TerminalNotFoundError`.
     store.markClosing(id);
     try {
       await client.terminal.kill({ id });
@@ -140,7 +146,6 @@ export function useTerminalCrud(deps: {
       // Terminal may already be gone — the mask auto-expires when the
       // server's list subscription stops including the id.
     }
-    removeAndAutoSwitch(id);
   }
 
   /** Kill a terminal and all its sub-terminals (instead of promoting them). */

--- a/packages/client/src/terminal/useTerminalMetadata.ts
+++ b/packages/client/src/terminal/useTerminalMetadata.ts
@@ -14,7 +14,7 @@
  *  a reactive owner per item and disposes it when the item leaves the list.
  *  No manual Map, AbortController, or version signals needed. */
 
-import { type Accessor, createMemo, mapArray } from "solid-js";
+import { type Accessor, createMemo, createSignal, mapArray } from "solid-js";
 import { match } from "ts-pattern";
 import {
   createSubscription,
@@ -50,10 +50,42 @@ export function useTerminalMetadata(deps: {
   listSub: Subscription<TerminalInfo[]>;
   activeId: Accessor<TerminalId | null>;
 }) {
-  /** Terminal IDs derived from the live list subscription. */
-  const terminalIdList = createMemo(
-    () => deps.listSub()?.map((t) => t.id) ?? [],
+  // Optimistic "closing" mask. `handleKill` marks a terminal synchronously
+  // before the kill RPC resolves; the terminal is filtered from
+  // `terminalIdList` immediately so `mapArray`/`<For>` dispose the
+  // `<Terminal>` component, and its `onCleanup` disposes xterm. This stops
+  // any further `term.onResize` → `client.terminal.resize` RPCs from racing
+  // the in-flight kill — the server would otherwise log
+  // `TerminalNotFoundError` on a resize for a just-killed id.
+  //
+  // The mask is a memo intersected with the live list, so entries
+  // auto-expire the moment the server's list subscription drops the id.
+  // No explicit unmask is needed for the expected paths (kill succeeds, or
+  // fails with TerminalNotFoundError because the terminal already exited).
+  const [pendingClose, setPendingClose] = createSignal<Set<TerminalId>>(
+    new Set(),
   );
+
+  /** Terminal IDs derived from the live list subscription,
+   *  excluding those marked for optimistic close. */
+  const terminalIdList = createMemo(() => {
+    const ids = deps.listSub()?.map((t) => t.id) ?? [];
+    const pending = pendingClose();
+    return pending.size === 0 ? ids : ids.filter((id) => !pending.has(id));
+  });
+
+  /** Hide a terminal from the UI synchronously, before the kill RPC resolves. */
+  function markClosing(id: TerminalId): void {
+    setPendingClose((prev) => {
+      if (prev.has(id)) return prev;
+      // Drop entries the server has already removed — a cheap pruning step
+      // at write time keeps the set bounded without a separate effect.
+      const live = new Set(deps.listSub()?.map((t) => t.id) ?? []);
+      const next = new Set([...prev].filter((x) => live.has(x)));
+      next.add(id);
+      return next;
+    });
+  }
 
   // mapArray creates a reactive owner per terminal ID.
   // When an ID leaves the list, its owner is disposed → onCleanup fires →
@@ -157,5 +189,6 @@ export function useTerminalMetadata(deps: {
     activeMeta,
     getDisplayInfo,
     terminalLabel,
+    markClosing,
   };
 }


### PR DESCRIPTION
Closing a terminal in the UI raced the in-flight `terminal.kill` RPC and **the server logged `TerminalNotFoundError` on every close**. The visible sibling's `ResizeObserver` fired a viewport update, the closing terminal's viewport effect called `term.resize()`, xterm's `onResize` listener published dimensions to a just-killed id, and the server's `requireTerminal` threw.

The root cause was that the `<Terminal>` component stayed reactive through the full WebSocket round-trip — `listSub` is server-driven, so nothing on the client removed the terminal until the list update arrived. This PR introduces an **optimistic closing mask** in `useTerminalMetadata`: `handleKill` calls `store.markClosing(id)` synchronously, the id is filtered from `terminalIdList`, and `mapArray` disposes the reactive owner → `onCleanup` disposes xterm — all before the kill RPC's first microtask. Any further `term.onResize` is now structurally impossible for that id.

*The mask auto-expires via intersection with `listSub`, so both kill-success and `TerminalNotFoundError` paths (terminal already exited) self-clean without an explicit unmask step — no flash when the server-push arrives.* `removeAndAutoSwitch` runs **before** the mask so its index-based next-active lookup still sees the dying id; otherwise `activeId` flips to null and no terminal stays visible through the RPC window. The second commit fixes exactly that regression — `kill.feature` caught it immediately.

### Try it locally

```sh
nix run github:juspay/kolu/fix/terminal-resize-race-on-close
```