### PR TITLE
Crash on missing KOLU_STATE_SUFFIX

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -121,6 +121,7 @@ let
       --set KOLU_CLIENT_DIST "${koluStamped}/packages/client/dist" \
       --set KOLU_CLIPBOARD_SHIM_DIR "${koluEnv.KOLU_CLIPBOARD_SHIM_DIR}" \
       --set KOLU_RANDOM_WORDS "${koluEnv.KOLU_RANDOM_WORDS}" \
+      --set KOLU_STATE_SUFFIX "prod" \
       --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs pkgs.git pkgs.gh ]} \
       --run 'if [ -n "''${KOLU_DIAG_DIR:-}" ]; then
                KOLU_DIAG_DIR="$KOLU_DIAG_DIR/$(date +%Y%m%dT%H%M%S)-$$"

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -27,10 +27,24 @@ import { log } from "./log.ts";
  */
 const SCHEMA_VERSION = "1.8.0";
 
+// KOLU_STATE_SUFFIX isolates state per environment:
+//   "prod" → production (~/.config/kolu) — only the nix-built binary sets this.
+//   "dev"  → ~/.config/kolu-dev (just dev).
+//   "test…" → ~/.config/kolu-test… (e2e + unit tests set their own suffixes).
+// Unset/empty crashes rather than silently clobbering production state.
+const suffixEnv = process.env.KOLU_STATE_SUFFIX;
+if (suffixEnv === undefined || suffixEnv === "") {
+  throw new Error(
+    "KOLU_STATE_SUFFIX must be set. Use 'prod' to target production " +
+      "state (~/.config/kolu); only the nix-built kolu binary is allowed " +
+      "to do that. Dev/test entrypoints set their own non-'prod' suffix.",
+  );
+}
+const projectSuffix = suffixEnv === "prod" ? "" : suffixEnv;
+
 export const store = new Conf<PersistedState>({
   projectName: "kolu",
-  // KOLU_STATE_SUFFIX isolates state per environment (e.g. "test" → ~/.config/kolu-test)
-  projectSuffix: process.env.KOLU_STATE_SUFFIX ?? "",
+  projectSuffix,
   projectVersion: SCHEMA_VERSION,
   defaults: {
     recentRepos: [],


### PR DESCRIPTION
Running the server from source without scoping its state — `tsx packages/server/src/index.ts` from a worktree, an installed binary on a branch without the right wrapper, anything that doesn't set `KOLU_STATE_SUFFIX` — silently wrote to the same `~/.config/kolu/config.json` the production `kolu` binary uses. Nobody noticed until PR #515 narrowed `RightPanelTabSchema` to `[inspector, review]`: a pre-existing `tab: "files"` in that shared state file made `state.get` fail zod output validation and surface at the client as an opaque `Event iterator validation failed`, leaving the subscription hanging — so `recentRepos()` returns `[]` and the "New terminal" palette shows no repos.

**The fix is upstream of that symptom.** Sharing the production state file with dev/ad-hoc runs was the actual bug; the 1.8.0 migration only helped if it ran against your state in the first place. This PR replaces the silent fallback with a hard crash.

- `state.ts` now throws at module load if `KOLU_STATE_SUFFIX` is unset or empty. No `?? ""`, no "helpful" default.
- Production uses the sentinel `KOLU_STATE_SUFFIX="prod"`, which maps to conf's `projectSuffix=""` and therefore the real `~/.config/kolu`. `default.nix`'s `makeWrapper` invocation bakes this in, so only the nix-built binary reaches production state.
- `just dev` (`kolu-dev`), `pnpm test:unit` (`kolu-test`), and the e2e hooks (`kolu-test-<uuid>-<worker>`) already set their own non-`prod` suffixes, so nothing else changes.

Run the server from source without an explicit suffix now and you get a stack trace, not a silently corrupted production state file.

### Try it locally

```sh
nix run github:juspay/kolu/fix/require-kolu-id
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)