### PR TITLE
fix(git): bare repo with sibling dirs shouldn't surface '.worktrees' as a repo

### DIFF
--- a/packages/server/src/meta/git.test.ts
+++ b/packages/server/src/meta/git.test.ts
@@ -127,4 +127,50 @@ describe("resolveGitInfo", () => {
     expect(info).not.toBeNull();
     expect(info!.branch).toBe("HEAD");
   });
+
+  it("resolves a bare repo when cwd is the bare dir", async () => {
+    // Canonical bare repo: `/tmp/foo` is itself bare; cwd == bare dir.
+    const dir = path.join(tmpDir, "plain-bare");
+    fs.mkdirSync(dir, { recursive: true });
+    await simpleGit(dir).init(true);
+
+    const info = await resolveGitInfo(dir);
+    expect(info).not.toBeNull();
+    expect(info!.repoName).toBe("plain-bare");
+    expect(info!.repoRoot).toBe(fs.realpathSync(dir));
+    expect(info!.mainRepoRoot).toBe(fs.realpathSync(dir));
+  });
+
+  it("resolves a bare repo with .git-suffix convention", async () => {
+    // `/tmp/foo.git` — bare repo dir suffixed with `.git`. Expected
+    // repoName strips the suffix.
+    const dir = path.join(tmpDir, "suffixed.git");
+    fs.mkdirSync(dir, { recursive: true });
+    await simpleGit(dir).init(true);
+
+    const info = await resolveGitInfo(dir);
+    expect(info).not.toBeNull();
+    expect(info!.repoName).toBe("suffixed");
+    expect(info!.repoRoot).toBe(fs.realpathSync(dir));
+  });
+
+  it("resolves a sibling of a `.git` bare repo (project-layout)", async () => {
+    // Project layout: `/tmp/proj/.git` is bare, siblings like
+    // `/tmp/proj/.worktrees/` are normal directories. `cd` into a sibling
+    // must NOT report the sibling's basename as the repo name — that's
+    // how `.worktrees` ended up in the recent-repos palette. The
+    // repoName must come from the bare repo's location, not cwd.
+    const proj = path.join(tmpDir, "proj");
+    const gitDir = path.join(proj, ".git");
+    fs.mkdirSync(gitDir, { recursive: true });
+    await simpleGit(gitDir).init(true);
+    const sibling = path.join(proj, ".worktrees");
+    fs.mkdirSync(sibling, { recursive: true });
+
+    const info = await resolveGitInfo(sibling);
+    expect(info).not.toBeNull();
+    expect(info!.repoName).toBe("proj");
+    expect(info!.repoName).not.toBe(".worktrees");
+    expect(info!.mainRepoRoot).toBe(fs.realpathSync(proj));
+  });
 });

--- a/packages/server/src/meta/git.ts
+++ b/packages/server/src/meta/git.ts
@@ -38,13 +38,31 @@ export async function resolveGitInfo(cwd: string): Promise<GitInfo | null> {
   try {
     const git = simpleGit(cwd);
     // Bare repos (core.bare=true) have no work tree, so `--show-toplevel`
-    // throws on them. Detect up front and return a GitInfo rooted at cwd —
-    // the palette consumer treats the result as "a repo you can spawn a
-    // worktree from," which is exactly right for a bare repo.
+    // throws on them. Detect up front and return a GitInfo rooted at the
+    // bare repo's own location — the palette consumer treats the result as
+    // "a repo you can spawn a worktree from," which is exactly right.
     const isBare =
       (await git.raw(["rev-parse", "--is-bare-repository"])).trim() === "true";
     if (isBare) {
-      const realCwd = fs.realpathSync(cwd);
+      // Derive the repo location from `--git-dir`, not cwd. For a canonical
+      // bare repo (`/tmp/foo` bare, cwd == bare dir) the two coincide. For
+      // project layouts where a bare `.git` sits inside a working dir
+      // (`/home/user/proj/.git` with sibling `proj/.worktrees/`), cwd can be
+      // anywhere around `.git` — falling back to `basename(cwd)` would
+      // report the wrong name (e.g. `.worktrees`).
+      const gitDirAbs = fs.realpathSync(
+        path.resolve(cwd, (await git.raw(["rev-parse", "--git-dir"])).trim()),
+      );
+      const gitDirBase = path.basename(gitDirAbs);
+      // Three shapes:
+      //   /proj/.git        → root /proj,        name proj
+      //   /foo.git          → root /foo.git,     name foo
+      //   /foo (bare dir)   → root /foo,         name foo
+      const isDotGit = gitDirBase === ".git";
+      const repoRoot = isDotGit ? path.dirname(gitDirAbs) : gitDirAbs;
+      const repoName = isDotGit
+        ? path.basename(repoRoot)
+        : gitDirBase.replace(/\.git$/, "");
       let branch: string;
       try {
         branch = (await git.raw(["symbolic-ref", "--short", "HEAD"])).trim();
@@ -53,12 +71,12 @@ export async function resolveGitInfo(cwd: string): Promise<GitInfo | null> {
         branch = (await git.revparse(["--abbrev-ref", "HEAD"])).trim();
       }
       return {
-        repoRoot: realCwd,
-        repoName: path.basename(realCwd),
-        worktreePath: realCwd,
+        repoRoot,
+        repoName,
+        worktreePath: repoRoot,
         branch,
         isWorktree: false,
-        mainRepoRoot: realCwd,
+        mainRepoRoot: repoRoot,
       };
     }
     const repoRoot = (await git.revparse(["--show-toplevel"])).trim();


### PR DESCRIPTION
**The command palette's "New terminal" sub-menu started listing `.worktrees` as a recent repo** when kolu itself is checked out with a bare `.git` and sibling worktrees (`/home/srid/code/kolu/.git` + `/home/srid/code/kolu/.worktrees/<branch>`). `cd`ing into the `.worktrees` parent dir tripped the bare-repo branch of `resolveGitInfo`, which took `basename(cwd)` as the repo name — giving `.worktrees` instead of `kolu`.

The bare branch was conflating _"cwd happens to resolve to a bare repo"_ with _"cwd is the bare repo"_. For a canonical bare repo (`/tmp/foo` bare, cwd == bare dir) the shortcut worked by accident. For the _project-layout_ case (bare `.git` nested inside a working directory, siblings like `.worktrees/`) and the _`.git`-suffix convention_ (`/tmp/foo.git`), the shortcut was wrong.

> This PR lands the **failing tests first** — three bare-repo shapes in `git.test.ts`, two of which fail against current `main`. The follow-up commit derives the repo name from `--git-dir` instead of cwd, so all three pass.

### Try it locally

```sh
nix run github:juspay/kolu/lost-set
```