### PR TITLE
Stop leaking test state dirs into ~/.config

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -121,8 +121,8 @@ let
       --set KOLU_CLIENT_DIST "${koluStamped}/packages/client/dist" \
       --set KOLU_CLIPBOARD_SHIM_DIR "${koluEnv.KOLU_CLIPBOARD_SHIM_DIR}" \
       --set KOLU_RANDOM_WORDS "${koluEnv.KOLU_RANDOM_WORDS}" \
-      --set KOLU_STATE_SUFFIX "prod" \
       --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs pkgs.git pkgs.gh ]} \
+      --run 'export KOLU_STATE_DIR="''${KOLU_STATE_DIR:-''${XDG_CONFIG_HOME:-$HOME/.config}/kolu}"' \
       --run 'if [ -n "''${KOLU_DIAG_DIR:-}" ]; then
                KOLU_DIAG_DIR="$KOLU_DIAG_DIR/$(date +%Y%m%dT%H%M%S)-$$"
                if ! mkdir -p "$KOLU_DIAG_DIR" || ! cd "$KOLU_DIAG_DIR"; then

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {
-    "dev": "KOLU_STATE_SUFFIX=dev node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
+    "dev": "KOLU_STATE_DIR=\"${XDG_CONFIG_HOME:-$HOME/.config}/kolu-dev\" node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
     "typecheck": "tsc --noEmit",
     "test:unit": "KOLU_STATE_DIR=\"${TMPDIR:-/tmp}/kolu-unit-test-$$/state\" vitest run"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "KOLU_STATE_SUFFIX=dev node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
     "typecheck": "tsc --noEmit",
-    "test:unit": "KOLU_STATE_DIR=\"${TMPDIR:-/tmp}/kolu-unit-test-state-$$\" vitest run"
+    "test:unit": "KOLU_STATE_DIR=\"${TMPDIR:-/tmp}/kolu-unit-test-$$/state\" vitest run"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.13",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "KOLU_STATE_SUFFIX=dev node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
     "typecheck": "tsc --noEmit",
-    "test:unit": "KOLU_STATE_SUFFIX=test vitest run"
+    "test:unit": "KOLU_STATE_DIR=\"${TMPDIR:-/tmp}/kolu-unit-test-state-$$\" vitest run"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.13",

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -7,9 +7,9 @@ import {
 } from "./session.ts";
 import type { SavedTerminal } from "kolu-common";
 
-// KOLU_STATE_SUFFIX is set via vitest env (see vitest.config.ts or inline env)
-// to isolate test state from real user state. The state.ts module reads it at load time.
-// We rely on the test runner passing KOLU_STATE_SUFFIX=test (set in package.json script).
+// KOLU_STATE_DIR is set by the `test:unit` script in package.json to route
+// conf state into $TMPDIR, keeping ~/.config clean. state.ts reads it at
+// module load — no extra setup is needed here.
 
 const terminal: SavedTerminal = {
   id: "term-1",

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -27,24 +27,36 @@ import { log } from "./log.ts";
  */
 const SCHEMA_VERSION = "1.8.0";
 
-// KOLU_STATE_SUFFIX isolates state per environment:
-//   "prod" → production (~/.config/kolu) — only the nix-built binary sets this.
-//   "dev"  → ~/.config/kolu-dev (just dev).
-//   "test…" → ~/.config/kolu-test… (e2e + unit tests set their own suffixes).
-// Unset/empty crashes rather than silently clobbering production state.
-const suffixEnv = process.env.KOLU_STATE_SUFFIX;
-if (suffixEnv === undefined || suffixEnv === "") {
+// State location is resolved from one of two env vars:
+//   KOLU_STATE_DIR   — explicit absolute directory. Used by tests to route
+//                      state to $TMPDIR instead of polluting ~/.config.
+//                      Takes precedence over SUFFIX.
+//   KOLU_STATE_SUFFIX — env-paths label:
+//                      "prod" → ~/.config/kolu (only the nix-built binary)
+//                      "dev"  → ~/.config/kolu-dev (just dev)
+// At least one must be set — a silent fallback would clobber production state.
+function resolveStateLocation():
+  | { cwd: string }
+  | { projectName: string; projectSuffix: string } {
+  const stateDir = process.env.KOLU_STATE_DIR;
+  if (stateDir) return { cwd: stateDir };
+  const suffixEnv = process.env.KOLU_STATE_SUFFIX;
+  if (suffixEnv) {
+    return {
+      projectName: "kolu",
+      projectSuffix: suffixEnv === "prod" ? "" : suffixEnv,
+    };
+  }
   throw new Error(
-    "KOLU_STATE_SUFFIX must be set. Use 'prod' to target production " +
-      "state (~/.config/kolu); only the nix-built kolu binary is allowed " +
-      "to do that. Dev/test entrypoints set their own non-'prod' suffix.",
+    "KOLU_STATE_DIR or KOLU_STATE_SUFFIX must be set. Use SUFFIX='prod' " +
+      "to target production state (~/.config/kolu); only the nix-built kolu " +
+      "binary is allowed to do that. Dev sets SUFFIX='dev'; tests set " +
+      "KOLU_STATE_DIR to an ephemeral $TMPDIR path.",
   );
 }
-const projectSuffix = suffixEnv === "prod" ? "" : suffixEnv;
 
 export const store = new Conf<PersistedState>({
-  projectName: "kolu",
-  projectSuffix,
+  ...resolveStateLocation(),
   projectVersion: SCHEMA_VERSION,
   defaults: {
     recentRepos: [],

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -42,6 +42,8 @@ if (!stateDir) {
   );
 }
 
+log.info({ path: stateDir }, "state directory");
+
 export const store = new Conf<PersistedState>({
   cwd: stateDir,
   projectVersion: SCHEMA_VERSION,

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -27,36 +27,23 @@ import { log } from "./log.ts";
  */
 const SCHEMA_VERSION = "1.8.0";
 
-// State location is resolved from one of two env vars:
-//   KOLU_STATE_DIR   — explicit absolute directory. Used by tests to route
-//                      state to $TMPDIR instead of polluting ~/.config.
-//                      Takes precedence over SUFFIX.
-//   KOLU_STATE_SUFFIX — env-paths label:
-//                      "prod" → ~/.config/kolu (only the nix-built binary)
-//                      "dev"  → ~/.config/kolu-dev (just dev)
-// At least one must be set — a silent fallback would clobber production state.
-function resolveStateLocation():
-  | { cwd: string }
-  | { projectName: string; projectSuffix: string } {
-  const stateDir = process.env.KOLU_STATE_DIR;
-  if (stateDir) return { cwd: stateDir };
-  const suffixEnv = process.env.KOLU_STATE_SUFFIX;
-  if (suffixEnv) {
-    return {
-      projectName: "kolu",
-      projectSuffix: suffixEnv === "prod" ? "" : suffixEnv,
-    };
-  }
+// Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
+// with no env would silently clobber whatever happens to live at conf's
+// default path, so we refuse. Each entrypoint picks its own location:
+//   nix-built kolu → ~/.config/kolu (production)
+//   pnpm dev       → ~/.config/kolu-dev
+//   tests          → an ephemeral $TMPDIR path
+const stateDir = process.env.KOLU_STATE_DIR;
+if (!stateDir) {
   throw new Error(
-    "KOLU_STATE_DIR or KOLU_STATE_SUFFIX must be set. Use SUFFIX='prod' " +
-      "to target production state (~/.config/kolu); only the nix-built kolu " +
-      "binary is allowed to do that. Dev sets SUFFIX='dev'; tests set " +
-      "KOLU_STATE_DIR to an ephemeral $TMPDIR path.",
+    "KOLU_STATE_DIR must be set to an absolute directory. The nix-built " +
+      "kolu wrapper, `pnpm dev`, and the test harness each set their own — " +
+      "bare launches are rejected to avoid clobbering production state.",
   );
 }
 
 export const store = new Conf<PersistedState>({
-  ...resolveStateLocation(),
+  cwd: stateDir,
   projectVersion: SCHEMA_VERSION,
   defaults: {
     recentRepos: [],

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -23,14 +23,21 @@ import { spawn } from "node:child_process";
 
 const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0");
 
-/** Create a unique $TMPDIR path tagged with `prefix`, the parent pid, and
- *  the worker id. `mkdtempSync`'s random suffix already prevents collisions;
- *  pid + workerId in the name make it easy to spot which concurrent test run
- *  owns a dir (`ps`, `lsof`) and to scope manual cleanup. */
-const mkWorkerTmpDir = (prefix: string) =>
-  fs.mkdtempSync(
-    path.join(os.tmpdir(), `${prefix}-${process.pid}-w${workerId}-`),
-  );
+/** One base $TMPDIR per worker holds everything this test run creates:
+ *  the kolu server's state dir and the Claude Code mock harness's
+ *  sessions/projects dirs. Nesting keeps /tmp tidy (one entry per run
+ *  instead of three) and makes cleanup a single recursive remove.
+ *  Pid + workerId in the name let `ps`/`lsof` identify which concurrent
+ *  run owns the tree; `mkdtempSync`'s random suffix prevents collisions. */
+const testBaseDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), `kolu-test-${process.pid}-w${workerId}-`),
+);
+
+const mkSubDir = (name: string) => {
+  const dir = path.join(testBaseDir, name);
+  fs.mkdirSync(dir);
+  return dir;
+};
 
 /** Per-worker temp dirs for the Claude Code mock harness — see
  *  `claude_code_steps.ts`. Sharing one dir across all eight cucumber
@@ -38,16 +45,15 @@ const mkWorkerTmpDir = (prefix: string) =>
  *  enough inotify pressure on the server's `fs.watch(SESSIONS_DIR)` that
  *  events get dropped under load and detection silently misses the mock
  *  session. Each worker getting its own dir eliminates the contention. */
-const claudeSessionsDir = mkWorkerTmpDir("kolu-claude-sessions");
-const claudeProjectsDir = mkWorkerTmpDir("kolu-claude-projects");
+const claudeSessionsDir = mkSubDir("claude-sessions");
+const claudeProjectsDir = mkSubDir("claude-projects");
 process.env.KOLU_CLAUDE_SESSIONS_DIR = claudeSessionsDir;
 process.env.KOLU_CLAUDE_PROJECTS_DIR = claudeProjectsDir;
 
 /** Per-worker ephemeral state dir for the kolu server under test. Routing
- *  to $TMPDIR keeps test state out of `~/.config` and makes cleanup
- *  trivial — the OS sweeps /tmp, and `AfterAll` removes the dir
- *  explicitly on graceful shutdown. */
-const koluStateDir = mkWorkerTmpDir("kolu-state");
+ *  to $TMPDIR keeps test state out of `~/.config`; nesting under
+ *  `testBaseDir` means the whole run's scratch space cleans up together. */
+const koluStateDir = mkSubDir("state");
 
 let baseUrl: string;
 let browser: Browser;
@@ -191,19 +197,17 @@ AfterAll(async function () {
   if (browser) await browser.close();
   keepAliveAgent.destroy();
   killServer();
-  // Remove the per-worker temp dirs created with `mkdtempSync` above. Without
+  // Remove the per-worker base dir created with `mkdtempSync` above. Without
   // this, every `just test` invocation leaks ~100–200MB of JSONL transcripts
-  // and session files into /tmp/kolu-claude-*, and a long ralph loop or CI
+  // and session files into /tmp/kolu-test-*, and a long ralph loop or CI
   // server will eventually fill /tmp or /. Discovered during the #440
   // hardening loop — the halt at 0 bytes free was directly caused by this.
-  for (const dir of [claudeSessionsDir, claudeProjectsDir, koluStateDir]) {
-    try {
-      fs.rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // Best-effort cleanup — if something already removed the dir (or we
-      // don't have permission for some reason) there's nothing productive
-      // to do in a test teardown. The OS will clean /tmp eventually.
-    }
+  try {
+    fs.rmSync(testBaseDir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup — if something already removed the tree (or we
+    // don't have permission for some reason) there's nothing productive
+    // to do in a test teardown. The OS will clean /tmp eventually.
   }
 });
 

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -14,7 +14,6 @@ import { chromium } from "playwright";
 import type { Browser } from "playwright";
 import getPort from "get-port";
 import { KoluWorld } from "./world.ts";
-import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
@@ -24,12 +23,14 @@ import { spawn } from "node:child_process";
 
 const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0");
 
-/** Per-run unique tag used for state isolation across parallel worktrees
- *  on the same host. A pid alone isn't enough — pids recycle, and two
- *  back-to-back runs can reuse the same pid within a second. A UUID
- *  generated once at module load is unique per test-process instance
- *  and never collides with anything else on disk. */
-const runTag = crypto.randomUUID();
+/** Create a unique $TMPDIR path tagged with `prefix`, the parent pid, and
+ *  the worker id. `mkdtempSync`'s random suffix already prevents collisions;
+ *  pid + workerId in the name make it easy to spot which concurrent test run
+ *  owns a dir (`ps`, `lsof`) and to scope manual cleanup. */
+const mkWorkerTmpDir = (prefix: string) =>
+  fs.mkdtempSync(
+    path.join(os.tmpdir(), `${prefix}-${process.pid}-w${workerId}-`),
+  );
 
 /** Per-worker temp dirs for the Claude Code mock harness — see
  *  `claude_code_steps.ts`. Sharing one dir across all eight cucumber
@@ -37,14 +38,16 @@ const runTag = crypto.randomUUID();
  *  enough inotify pressure on the server's `fs.watch(SESSIONS_DIR)` that
  *  events get dropped under load and detection silently misses the mock
  *  session. Each worker getting its own dir eliminates the contention. */
-const claudeSessionsDir = fs.mkdtempSync(
-  path.join(os.tmpdir(), `kolu-claude-sessions-${workerId}-`),
-);
-const claudeProjectsDir = fs.mkdtempSync(
-  path.join(os.tmpdir(), `kolu-claude-projects-${workerId}-`),
-);
+const claudeSessionsDir = mkWorkerTmpDir("kolu-claude-sessions");
+const claudeProjectsDir = mkWorkerTmpDir("kolu-claude-projects");
 process.env.KOLU_CLAUDE_SESSIONS_DIR = claudeSessionsDir;
 process.env.KOLU_CLAUDE_PROJECTS_DIR = claudeProjectsDir;
+
+/** Per-worker ephemeral state dir for the kolu server under test. Routing
+ *  to $TMPDIR keeps test state out of `~/.config` and makes cleanup
+ *  trivial — the OS sweeps /tmp, and `AfterAll` removes the dir
+ *  explicitly on graceful shutdown. */
+const koluStateDir = mkWorkerTmpDir("kolu-state");
 
 let baseUrl: string;
 let browser: Browser;
@@ -160,14 +163,11 @@ BeforeAll(async function () {
         stdio: "pipe",
         env: {
           ...process.env,
-          // Use a per-run UUID tag so parallel test runs across different
-          // worktrees don't collide on ~/.config/kolu-test-.../config.json.
-          // Cucumber worker IDs are 0/1/2/3 per process — identical across
-          // worktrees — so two e2e runs on the same host would otherwise
-          // trample each other's state mid-scenario. pid alone isn't
-          // enough: pids recycle and back-to-back runs can reuse them.
-          // A UUID generated once at module load is collision-free.
-          KOLU_STATE_SUFFIX: `test-${runTag}-${workerId}`,
+          // Route server state to an ephemeral $TMPDIR path so test runs
+          // never touch ~/.config and the dir can be wiped in AfterAll.
+          // `mkdtempSync`'s random suffix guarantees no collisions across
+          // parallel workers or worktrees.
+          KOLU_STATE_DIR: koluStateDir,
           KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
           KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
         },
@@ -196,7 +196,7 @@ AfterAll(async function () {
   // and session files into /tmp/kolu-claude-*, and a long ralph loop or CI
   // server will eventually fill /tmp or /. Discovered during the #440
   // hardening loop — the halt at 0 bytes free was directly caused by this.
-  for (const dir of [claudeSessionsDir, claudeProjectsDir]) {
+  for (const dir of [claudeSessionsDir, claudeProjectsDir, koluStateDir]) {
     try {
       fs.rmSync(dir, { recursive: true, force: true });
     } catch {


### PR DESCRIPTION
**Test runs now keep all scratch state under `$TMPDIR`**, and `KOLU_STATE_SUFFIX` is gone entirely — replaced by a single `KOLU_STATE_DIR` env var that takes an explicit directory.

Previously, tests passed a unique `KOLU_STATE_SUFFIX` per run, which `conf`'s `env-paths` resolved under `~/.config/kolu-test-<uuid>-<worker>/`. Those dirs were never cleaned up — `ls ~/.config/kolu-test* | wc -l` hit **737** on my machine. The fix collapses the two env vars (`KOLU_STATE_SUFFIX` + `KOLU_STATE_DIR`) into just `KOLU_STATE_DIR`. Each entrypoint picks its own location:

- **nix wrapper** (`default.nix`): `${XDG_CONFIG_HOME:-$HOME/.config}/kolu` — computed at runtime via `--run`
- **`pnpm dev`**: `${XDG_CONFIG_HOME:-$HOME/.config}/kolu-dev`
- **e2e tests**: `mkdtempSync` a base dir per worker under `os.tmpdir()` — `/tmp/kolu-test-<pid>-w<worker>-<rand>/` — with `state/`, `claude-sessions/`, `claude-projects/` nested inside. `AfterAll` wipes the whole tree.
- **unit tests**: `$TMPDIR/kolu-unit-test-$$/state/`

_macOS production installs lose `env-paths`' `Library/Preferences` convention_ — state now lands at `~/.config/kolu` on all platforms. Persisted state is reconstructible (recent-repos, session, preferences) so the one-time reset on upgrade is acceptable.

> **Cleanup of existing cruft is manual** — this PR only stops the bleeding:
> ```sh
> find ~/.config -maxdepth 1 -name 'kolu-test-*' -exec rm -rf {} +
> ```