### PR TITLE
Catch corrupt conf state early and tell the user about it

### DIFF
--- a/.claude/rules/code-police-rules.md
+++ b/.claude/rules/code-police-rules.md
@@ -64,3 +64,10 @@ Actual errors (failed I/O, failed queries, unexpected exceptions, callback throw
 Bad: `log.warn({ err }, "query failed")` / `log.debug({ err }, "scan failed")`
 Good: `log.error({ err }, "query failed")`
 _Rationale_: Operators filter on `error` level for alerting. An actual failure logged at `warn` or `debug` is invisible in production. The `Logger` type in `kolu-integration-common` includes all four levels (`debug`, `info`, `warn`, `error`) — use the right one.
+
+### subscription-must-surface-errors
+
+Every `createSubscription` consumer must watch `sub.error()` and surface failures to the user (typically via `toast.error()`). A subscription whose `.error()` signal is never read silently swallows server-side failures — the stream dies and the user sees stale/missing data with no indication of what went wrong.
+Bad: `const sub = createSubscription(() => stream.state()); /* sub.error() never read */`
+Good: `createEffect(on(() => sub.error(), (err) => { if (err) toast.error(\`Server state error: ${err.message}\`); }));`
+_Rationale_: oRPC application errors (`ORPCError`) are not retried by `ClientRetryPlugin`, so the stream dies permanently. Without reading `.error()`, the failure is invisible — the user gets a blank or stale UI with no toast, no console warning, nothing.

--- a/agents/.apm/instructions/code-police-rules.instructions.md
+++ b/agents/.apm/instructions/code-police-rules.instructions.md
@@ -64,3 +64,10 @@ Actual errors (failed I/O, failed queries, unexpected exceptions, callback throw
 Bad: `log.warn({ err }, "query failed")` / `log.debug({ err }, "scan failed")`
 Good: `log.error({ err }, "query failed")`
 _Rationale_: Operators filter on `error` level for alerting. An actual failure logged at `warn` or `debug` is invisible in production. The `Logger` type in `kolu-integration-common` includes all four levels (`debug`, `info`, `warn`, `error`) — use the right one.
+
+### subscription-must-surface-errors
+
+Every `createSubscription` consumer must watch `sub.error()` and surface failures to the user (typically via `toast.error()`). A subscription whose `.error()` signal is never read silently swallows server-side failures — the stream dies and the user sees stale/missing data with no indication of what went wrong.
+Bad: `const sub = createSubscription(() => stream.state()); /* sub.error() never read */`
+Good: `createEffect(on(() => sub.error(), (err) => { if (err) toast.error(\`Server state error: ${err.message}\`); }));`
+_Rationale_: oRPC application errors (`ORPCError`) are not retried by `ClientRetryPlugin`, so the stream dies permanently. Without reading `.error()`, the failure is invisible — the user gets a blank or stale UI with no toast, no console warning, nothing.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-13T18:28:30.591593+00:00'
+generated_at: '2026-04-15T01:25:41.930081+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -50,7 +50,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 2be6f137464a3339ad0cd42afc46caecced81b75
+  resolved_commit: 9d043d9aa57aa8aad0c34b3ccd3adbefd0395fc1
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-15T01:25:41.930081+00:00'
+generated_at: '2026-04-13T18:28:30.591593+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -50,7 +50,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 9d043d9aa57aa8aad0c34b3ccd3adbefd0395fc1
+  resolved_commit: 2be6f137464a3339ad0cd42afc46caecced81b75
   resolved_ref: master
   package_type: apm_package
   deployed_files:

--- a/packages/client/src/settings/useServerState.ts
+++ b/packages/client/src/settings/useServerState.ts
@@ -45,6 +45,15 @@ export function useServerState() {
         },
       ),
     );
+    // Surface subscription errors (e.g. schema mismatch) so they don't vanish silently.
+    createEffect(
+      on(
+        () => sub.error(),
+        (err) => {
+          if (err) toast.error(`Server state error: ${err.message}`);
+        },
+      ),
+    );
   }
 
   /** Update one or more preferences. Instant local update + async server persist.

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -145,29 +145,10 @@ export const store = new Conf<PersistedState>({
   },
 });
 
-/** Validate the store against the Zod schema and throw a descriptive error
- *  instead of letting oRPC's generic "Event iterator validation failed" be
- *  the first signal. Called on every read; writes are covered because
- *  updateServerState() publishes via getServerState() after mutating. */
-function assertStoreValid(): void {
-  const result = PersistedStateSchema.safeParse(store.store);
-  if (result.success) return;
-  const summary = result.error.issues
-    .map((i) => `${i.path.join(".")}: ${i.message}`)
-    .join("; ");
-  const msg = `Persisted state does not match schema (${summary}). Delete ${store.path} to reset to defaults.`;
-  log.error({ issues: result.error.issues, path: store.path }, msg);
-  throw new Error(msg);
-}
-
-// Early validation so corrupt state shows up in journalctl immediately at
-// startup, not only when the first client connects. The throw is caught here
-// — runtime calls to assertStoreValid() in getServerState() will re-throw.
-// TODO: remove try/catch and let the server crash once error propagation is confirmed.
-try {
-  assertStoreValid();
-} catch {
-  // Already logged inside assertStoreValid().
+/** Format Zod issues into a one-line diagnostic with a recovery hint. */
+function formatStateError(issues: { path: PropertyKey[]; message: string }[]): string {
+  const summary = issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
+  return `Persisted state does not match schema (${summary}). Delete ${store.path} to reset to defaults.`;
 }
 
 /** Check if a path exists on disk. */
@@ -254,15 +235,22 @@ function getRecentAgents(): RecentAgent[] {
 
 // --- Server state ---
 
-/** Get the full server state. Throws if persisted state fails schema validation. */
+/** Get the full server state. Validates against the Zod schema so callers
+ *  get a descriptive error instead of oRPC's generic validation failure. */
 export function getServerState(): ServerState {
-  assertStoreValid();
-  return {
+  const state = {
     recentRepos: getRecentRepos(),
     recentAgents: getRecentAgents(),
     session: store.get("session"),
     preferences: store.get("preferences"),
   };
+  const result = PersistedStateSchema.safeParse(state);
+  if (!result.success) {
+    const msg = formatStateError(result.error.issues);
+    log.error({ issues: result.error.issues, path: store.path }, msg);
+    throw new Error(msg);
+  }
+  return result.data;
 }
 
 /** Merge a partial update into the current state.
@@ -284,6 +272,15 @@ export function updateServerState(patch: ServerStatePatch): void {
   }
   // Notify live query subscribers
   publishSystem("state:changed", getServerState());
+}
+
+// Early validation so corrupt state shows up in journalctl immediately at
+// startup, not only when the first client connects.
+// TODO: remove try/catch and let the server crash once error propagation is confirmed.
+try {
+  getServerState();
+} catch {
+  // Already logged inside getServerState().
 }
 
 /** Test-only: apply a full patch including `recentRepos` and `recentAgents`.

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -146,8 +146,12 @@ export const store = new Conf<PersistedState>({
 });
 
 /** Format Zod issues into a one-line diagnostic with a recovery hint. */
-function formatStateError(issues: { path: PropertyKey[]; message: string }[]): string {
-  const summary = issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
+function formatStateError(
+  issues: { path: PropertyKey[]; message: string }[],
+): string {
+  const summary = issues
+    .map((i) => `${i.path.join(".")}: ${i.message}`)
+    .join("; ");
   return `Persisted state does not match schema (${summary}). Delete ${store.path} to reset to defaults.`;
 }
 

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -147,7 +147,8 @@ export const store = new Conf<PersistedState>({
 
 /** Validate the store against the Zod schema and throw a descriptive error
  *  instead of letting oRPC's generic "Event iterator validation failed" be
- *  the first signal. Called on every read so runtime mutations are caught too. */
+ *  the first signal. Called on every read; writes are covered because
+ *  updateServerState() publishes via getServerState() after mutating. */
 function assertStoreValid(): void {
   const result = PersistedStateSchema.safeParse(store.store);
   if (result.success) return;
@@ -157,6 +158,16 @@ function assertStoreValid(): void {
   const msg = `Persisted state does not match schema (${summary}). Delete ${store.path} to reset to defaults.`;
   log.error({ issues: result.error.issues, path: store.path }, msg);
   throw new Error(msg);
+}
+
+// Early validation so corrupt state shows up in journalctl immediately at
+// startup, not only when the first client connects. The throw is caught here
+// — runtime calls to assertStoreValid() in getServerState() will re-throw.
+// TODO: remove try/catch and let the server crash once error propagation is confirmed.
+try {
+  assertStoreValid();
+} catch {
+  // Already logged inside assertStoreValid().
 }
 
 /** Check if a path exists on disk. */

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -151,14 +151,23 @@ export const store = new Conf<PersistedState>({
 // TODO: crash the server here once client-side error propagation is confirmed working.
 const _stateCheck = PersistedStateSchema.safeParse(store.store);
 if (!_stateCheck.success) {
+  const summary = _stateCheck.error.issues
+    .map((i) => `${i.path.join(".")}: ${i.message}`)
+    .join("; ");
   log.error(
     {
       issues: _stateCheck.error.issues,
       path: store.path,
     },
-    `Persisted state does not match schema. Delete ${store.path} to reset to defaults.`,
+    `Persisted state does not match schema. Delete ${store.path} to reset to defaults. (${summary})`,
   );
 }
+
+// Stored so getServerState() can throw a descriptive error instead of
+// returning invalid data and letting oRPC's generic validator be first.
+const _stateCorruptMessage = _stateCheck.success
+  ? null
+  : `Persisted state corrupt (${_stateCheck.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")}). Delete ${store.path} to reset.`;
 
 /** Check if a path exists on disk. */
 function existsOnDisk(path: string): boolean {
@@ -244,8 +253,11 @@ function getRecentAgents(): RecentAgent[] {
 
 // --- Server state ---
 
-/** Get the full server state. */
+/** Get the full server state. Throws if persisted state failed schema validation at startup. */
 export function getServerState(): ServerState {
+  if (_stateCorruptMessage) {
+    throw new Error(_stateCorruptMessage);
+  }
   return {
     recentRepos: getRecentRepos(),
     recentAgents: getRecentAgents(),

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -145,29 +145,19 @@ export const store = new Conf<PersistedState>({
   },
 });
 
-// Validate persisted state against the Zod schema. A mismatch means either a
-// version downgrade (newer build wrote fields the current schema doesn't know)
-// or on-disk corruption. Log the full Zod issues so the user can diagnose.
-// TODO: crash the server here once client-side error propagation is confirmed working.
-const _stateCheck = PersistedStateSchema.safeParse(store.store);
-if (!_stateCheck.success) {
-  const summary = _stateCheck.error.issues
+/** Validate the store against the Zod schema and throw a descriptive error
+ *  instead of letting oRPC's generic "Event iterator validation failed" be
+ *  the first signal. Called on every read so runtime mutations are caught too. */
+function assertStoreValid(): void {
+  const result = PersistedStateSchema.safeParse(store.store);
+  if (result.success) return;
+  const summary = result.error.issues
     .map((i) => `${i.path.join(".")}: ${i.message}`)
     .join("; ");
-  log.error(
-    {
-      issues: _stateCheck.error.issues,
-      path: store.path,
-    },
-    `Persisted state does not match schema. Delete ${store.path} to reset to defaults. (${summary})`,
-  );
+  const msg = `Persisted state does not match schema (${summary}). Delete ${store.path} to reset to defaults.`;
+  log.error({ issues: result.error.issues, path: store.path }, msg);
+  throw new Error(msg);
 }
-
-// Stored so getServerState() can throw a descriptive error instead of
-// returning invalid data and letting oRPC's generic validator be first.
-const _stateCorruptMessage = _stateCheck.success
-  ? null
-  : `Persisted state corrupt (${_stateCheck.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")}). Delete ${store.path} to reset.`;
 
 /** Check if a path exists on disk. */
 function existsOnDisk(path: string): boolean {
@@ -253,11 +243,9 @@ function getRecentAgents(): RecentAgent[] {
 
 // --- Server state ---
 
-/** Get the full server state. Throws if persisted state failed schema validation at startup. */
+/** Get the full server state. Throws if persisted state fails schema validation. */
 export function getServerState(): ServerState {
-  if (_stateCorruptMessage) {
-    throw new Error(_stateCorruptMessage);
-  }
+  assertStoreValid();
   return {
     recentRepos: getRecentRepos(),
     recentAgents: getRecentAgents(),

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -9,13 +9,14 @@
 import fs from "node:fs";
 import Conf from "conf";
 import { DEFAULT_PREFERENCES } from "kolu-common/config";
-import type {
-  Preferences,
-  RecentRepo,
-  RecentAgent,
-  PersistedState,
-  ServerState,
-  ServerStatePatch,
+import {
+  PersistedStateSchema,
+  type Preferences,
+  type RecentRepo,
+  type RecentAgent,
+  type PersistedState,
+  type ServerState,
+  type ServerStatePatch,
 } from "kolu-common";
 import { publishSystem } from "./publisher.ts";
 import { log } from "./log.ts";
@@ -143,6 +144,21 @@ export const store = new Conf<PersistedState>({
     },
   },
 });
+
+// Validate persisted state against the Zod schema. A mismatch means either a
+// version downgrade (newer build wrote fields the current schema doesn't know)
+// or on-disk corruption. Log the full Zod issues so the user can diagnose.
+// TODO: crash the server here once client-side error propagation is confirmed working.
+const _stateCheck = PersistedStateSchema.safeParse(store.store);
+if (!_stateCheck.success) {
+  log.error(
+    {
+      issues: _stateCheck.error.issues,
+      path: store.path,
+    },
+    `Persisted state does not match schema. Delete ${store.path} to reset to defaults.`,
+  );
+}
 
 /** Check if a path exists on disk. */
 function existsOnDisk(path: string): boolean {


### PR DESCRIPTION
**Persisted state schema mismatches now produce a clear server log and a client-side toast** instead of a cryptic oRPC `EVENT_ITERATOR_VALIDATION_FAILED` error buried in journalctl with zero client-side indication.

The root cause: running a newer build (e.g. an unmerged feature branch) stamps a higher migration version into `~/.config/kolu/config.json`. When an older production build reads it, `conf` skips all migrations (stored version > project version) and the data shape silently diverges from the Zod schema. oRPC's `eventIterator` validation then rejects every `state.get` yield — but the error surfaces as a generic 500 with no user-facing signal.

Server-side, a `PersistedStateSchema.safeParse()` runs right after `new Conf(...)` and logs the full Zod issues plus the conf file path so the user knows exactly what's wrong and can delete it to reset. _Currently log-only with a TODO to crash once client error propagation is confirmed — this lets us test the full error path end-to-end first._

Client-side, `useServerState` now watches `sub.error()` and fires `toast.error()` with the actual message. Previously, `createSubscription` captured errors in its `.error()` signal but **no consumer ever read it** — the stream died silently and the UI showed stale/empty data.

Also adds a `subscription-must-surface-errors` code-police rule so this class of silent failure gets caught in future reviews. Existing violations in `useTerminalMetadata` and `useTerminalStore` are tracked in #528.