### PR TITLE
Stop tests from silently hitting production state

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -102,8 +102,11 @@ let
       sed -i 's/${koluCommitPlaceholder}/${commitHash}/g' {} +
   '';
 
-  # Runtime wrapper around tsx with env vars and PATH baked in.
-  default = pkgs.runCommand "kolu"
+  # Base wrapper: tsx + env vars + PATH. Does NOT set KOLU_STATE_DIR —
+  # callers must provide it (state.ts crashes with a clear error if missing).
+  # Tests use this directly so a missing KOLU_STATE_DIR crashes immediately
+  # instead of silently falling back to the production ~/.config/kolu path.
+  koluBin = pkgs.runCommand "kolu-bin"
     {
       nativeBuildInputs = [ pkgs.makeWrapper ];
       meta.mainProgram = "kolu";
@@ -122,7 +125,6 @@ let
       --set KOLU_CLIPBOARD_SHIM_DIR "${koluEnv.KOLU_CLIPBOARD_SHIM_DIR}" \
       --set KOLU_RANDOM_WORDS "${koluEnv.KOLU_RANDOM_WORDS}" \
       --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs pkgs.git pkgs.gh ]} \
-      --run 'export KOLU_STATE_DIR="''${KOLU_STATE_DIR:-''${XDG_CONFIG_HOME:-$HOME/.config}/kolu}"' \
       --run 'if [ -n "''${KOLU_DIAG_DIR:-}" ]; then
                KOLU_DIAG_DIR="$KOLU_DIAG_DIR/$(date +%Y%m%dT%H%M%S)-$$"
                if ! mkdir -p "$KOLU_DIAG_DIR" || ! cd "$KOLU_DIAG_DIR"; then
@@ -133,7 +135,21 @@ let
                export NODE_OPTIONS="--heapsnapshot-near-heap-limit=3 --heapsnapshot-signal=SIGUSR2 ''${NODE_OPTIONS:-}"
              fi'
   '';
+
+  # Production wrapper: koluBin + default KOLU_STATE_DIR.
+  # Used by `nix run .` and the NixOS service. Sets the state dir
+  # unconditionally — no `:-` override, so tests can't accidentally
+  # inherit the production path.
+  default = pkgs.runCommand "kolu"
+    {
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      meta.mainProgram = "kolu";
+    } ''
+    mkdir -p $out/bin
+    makeWrapper ${koluBin}/bin/kolu $out/bin/kolu \
+      --run 'export KOLU_STATE_DIR="''${XDG_CONFIG_HOME:-$HOME/.config}/kolu"'
+  '';
 in
 {
-  inherit default koluEnv pnpmDeps;
+  inherit default koluBin koluEnv pnpmDeps;
 }

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ test-unit: install
 test: install
     #!/usr/bin/env bash
     set -euo pipefail
-    KOLU_SERVER="${KOLU_SERVER:-$(nix build --print-out-paths)/bin/kolu}"
+    KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --print-out-paths)/bin/kolu}"
     cd packages/tests
     {{ nix_shell }} pnpm install
     KOLU_SERVER="$KOLU_SERVER" CUCUMBER_PARALLEL={{ cucumber_parallel }} {{ nix_shell }} pnpm test


### PR DESCRIPTION
**Tests now use a `koluBin` wrapper that has no `KOLU_STATE_DIR` default**, so a missing env var crashes immediately instead of silently falling back to `~/.config/kolu`. The production wrapper (`nix run .`) sets the state dir unconditionally — no `:-` override.

Previously, the single nix wrapper set `KOLU_STATE_DIR` with a bash `:-` fallback to the production path. Tests were supposed to override this via `hooks.ts` spawn env, but the pattern was fragile — if any code path failed to pass the override, tests would silently read and write production state. _The `:-` also made the wrapper hard to debug: you had to trace `${KOLU_STATE_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/kolu}` across nix, bash, and Node to understand which path was actually used._

The split is compositional: `default` wraps `koluBin` and adds only the state dir. New env vars go into `koluBin` (the foundation), not `default`.

Closes #530

### Try it locally

```sh
nix run github:juspay/kolu/refactor/split-kolu-wrapper
```