### PR TITLE
Dev state dir is now per-worktree, not global

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ packages/client/public/fonts
 .worktrees
 .logs/
 .do-results.json
+.kolu-dev/

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "scripts": {
-    "dev": "KOLU_STATE_DIR=\"${XDG_CONFIG_HOME:-$HOME/.config}/kolu-dev\" node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
+    "dev": "KOLU_STATE_DIR=\"$(git rev-parse --show-toplevel)/.kolu-dev\" node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
     "typecheck": "tsc --noEmit",
     "test:unit": "KOLU_STATE_DIR=\"${TMPDIR:-/tmp}/kolu-unit-test-$$/state\" vitest run"
   },

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -32,7 +32,7 @@ const SCHEMA_VERSION = "1.8.0";
 // with no env would silently clobber whatever happens to live at conf's
 // default path, so we refuse. Each entrypoint picks its own location:
 //   nix-built kolu → ~/.config/kolu (production)
-//   pnpm dev       → ~/.config/kolu-dev
+//   pnpm dev       → <worktree-root>/.kolu-dev (per-worktree, gitignored)
 //   tests          → an ephemeral $TMPDIR path
 const stateDir = process.env.KOLU_STATE_DIR;
 if (!stateDir) {


### PR DESCRIPTION
**Dev server state now lives in `<worktree>/.kolu-dev/`** instead of the global `~/.config/kolu-dev`. Running `pnpm dev` in two worktrees no longer clobbers the same state file — each gets its own, gitignored directory.

The path is resolved via `git rev-parse --show-toplevel` rather than `$PWD` because *the justfile `cd`s into `packages/server/` before invoking the script* — a bare `$PWD` would silently put state in the wrong place.

> Production (`~/.config/kolu`) and test (`$TMPDIR`) paths are unchanged.