### PR TITLE
Code tab: tree layout for changed files

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -30,12 +30,28 @@ import { DiffView, DiffModeEnum } from "@git-diff-view/solid";
 import "@git-diff-view/solid/styles/diff-view-pure.css";
 // Order matters: this overrides the library CSS imported just above.
 import "./code-tab.css";
-import type { GitDiffMode, TerminalMetadata } from "kolu-common";
+import type {
+  GitChangeStatus,
+  GitDiffMode,
+  TerminalMetadata,
+} from "kolu-common";
 import { client } from "../rpc/rpc";
 import { useServerState } from "../settings/useServerState";
 import { DiffLocalIcon, DiffBranchIcon } from "../ui/Icons";
 import { buildFileTree } from "../ui/buildFileTree";
 import FileTree from "../ui/FileTree";
+
+/** Color class for each git status letter. */
+const STATUS_COLOR: Record<GitChangeStatus, string> = {
+  M: "text-warning",
+  A: "text-ok",
+  D: "text-danger",
+  R: "text-fg-3",
+  C: "text-fg-3",
+  U: "text-danger",
+  T: "text-warning",
+  "?": "text-ok",
+};
 
 const EMPTY_STATE: Record<GitDiffMode, string> = {
   local: "No local changes",
@@ -197,7 +213,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                       }
                       renderBadge={(node) =>
                         node.kind === "file" ? (
-                          <span class="text-fg-3/70 w-3 text-center">
+                          <span
+                            class={`w-3 text-center ${STATUS_COLOR[node.status]}`}
+                          >
                             {node.status}
                           </span>
                         ) : null

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -16,6 +16,7 @@
 import {
   type Component,
   createEffect,
+  createMemo,
   createResource,
   createSignal,
   For,
@@ -33,6 +34,8 @@ import type { GitDiffMode, TerminalMetadata } from "kolu-common";
 import { client } from "../rpc/rpc";
 import { useServerState } from "../settings/useServerState";
 import { DiffLocalIcon, DiffBranchIcon } from "../ui/Icons";
+import { buildFileTree } from "../ui/buildFileTree";
+import FileTree from "../ui/FileTree";
 
 const EMPTY_STATE: Record<GitDiffMode, string> = {
   local: "No local changes",
@@ -172,43 +175,37 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
               </div>
             </Match>
             <Match when={status()}>
-              {(s) => (
-                <Show
-                  when={s().files.length > 0}
-                  fallback={
-                    <div
-                      class="px-2 py-4 text-fg-3/50 text-center"
-                      data-testid="diff-empty"
-                    >
-                      {EMPTY_STATE[mode()]}
-                    </div>
-                  }
-                >
-                  <For each={s().files}>
-                    {(f) => (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          // Re-click on the active row collapses the diff.
-                          setSelectedPath((p) => (p === f.path ? null : f.path))
-                        }
-                        class="flex w-full items-center gap-2 px-2 py-0.5 text-left font-mono text-fg hover:bg-surface-1 cursor-pointer"
-                        classList={{
-                          "bg-surface-1": selectedPath() === f.path,
-                        }}
-                        data-testid="diff-file-item"
-                        data-path={f.path}
-                        data-active={selectedPath() === f.path}
+              {(s) => {
+                const tree = createMemo(() => buildFileTree(s().files));
+                return (
+                  <Show
+                    when={s().files.length > 0}
+                    fallback={
+                      <div
+                        class="px-2 py-4 text-fg-3/50 text-center"
+                        data-testid="diff-empty"
                       >
-                        <span class="text-fg-3/70 w-3 shrink-0 text-center">
-                          {f.status}
-                        </span>
-                        <span class="truncate min-w-0">{f.path}</span>
-                      </button>
-                    )}
-                  </For>
-                </Show>
-              )}
+                        {EMPTY_STATE[mode()]}
+                      </div>
+                    }
+                  >
+                    <FileTree
+                      nodes={tree()}
+                      selectedPath={selectedPath()}
+                      onSelect={(path) =>
+                        setSelectedPath((p) => (p === path ? null : path))
+                      }
+                      renderBadge={(node) =>
+                        node.kind === "file" ? (
+                          <span class="text-fg-3/70 w-3 text-center">
+                            {node.status}
+                          </span>
+                        ) : null
+                      }
+                    />
+                  </Show>
+                );
+              }}
             </Match>
           </Switch>
         </div>

--- a/packages/client/src/ui/FileTree.tsx
+++ b/packages/client/src/ui/FileTree.tsx
@@ -1,0 +1,122 @@
+import {
+  type Component,
+  type JSX,
+  createEffect,
+  createSignal,
+  For,
+  on,
+  Show,
+} from "solid-js";
+import type { TreeNode } from "./buildFileTree";
+import { collectDirPaths } from "./buildFileTree";
+
+/** Generic collapsible file tree. Reusable across Code tab modes
+ *  (changed-file list, future file browser). */
+export type FileTreeProps = {
+  /** Root nodes of the tree. */
+  nodes: TreeNode[];
+  /** Currently selected file path (highlighted row). */
+  selectedPath: string | null;
+  /** Called when a file node is clicked. */
+  onSelect: (path: string) => void;
+  /** Optional render for the trailing badge (e.g. git status letter). */
+  renderBadge?: (node: TreeNode) => JSX.Element;
+};
+
+const FileTree: Component<FileTreeProps> = (props) => {
+  // Expand all directories by default; rebuild when the tree changes.
+  const [expanded, setExpanded] = createSignal<Set<string>>(new Set());
+  createEffect(
+    on(
+      () => props.nodes,
+      (nodes) => setExpanded(collectDirPaths(nodes)),
+    ),
+  );
+
+  const toggle = (path: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  return (
+    <div data-testid="file-tree">
+      <TreeLevel
+        nodes={props.nodes}
+        depth={0}
+        expanded={expanded()}
+        selectedPath={props.selectedPath}
+        onToggle={toggle}
+        onSelect={props.onSelect}
+        renderBadge={props.renderBadge}
+      />
+    </div>
+  );
+};
+
+type TreeLevelProps = {
+  nodes: TreeNode[];
+  depth: number;
+  expanded: Set<string>;
+  selectedPath: string | null;
+  onToggle: (path: string) => void;
+  onSelect: (path: string) => void;
+  renderBadge?: (node: TreeNode) => JSX.Element;
+};
+
+const TreeLevel: Component<TreeLevelProps> = (props) => (
+  <For each={props.nodes}>
+    {(node) => (
+      <>
+        <button
+          type="button"
+          onClick={() =>
+            node.kind === "dir"
+              ? props.onToggle(node.path)
+              : props.onSelect(node.path)
+          }
+          class="flex w-full items-center gap-1 px-2 py-0.5 text-left font-mono text-fg hover:bg-surface-1 cursor-pointer"
+          classList={{
+            "bg-surface-1":
+              node.kind === "file" && props.selectedPath === node.path,
+          }}
+          style={{ "padding-left": `${props.depth * 12 + 8}px` }}
+          data-testid={node.kind === "dir" ? "file-tree-dir" : "file-tree-file"}
+          data-path={node.path}
+          data-active={node.kind === "file" && props.selectedPath === node.path}
+        >
+          <span class="w-3 shrink-0 text-center text-fg-3/50 text-[10px]">
+            {node.kind === "dir"
+              ? props.expanded.has(node.path)
+                ? "\u25BE"
+                : "\u25B8"
+              : ""}
+          </span>
+          <span class="truncate min-w-0">
+            {node.name}
+            {node.kind === "dir" ? "/" : ""}
+          </span>
+          <Show when={props.renderBadge}>
+            {(badge) => <span class="ml-auto shrink-0">{badge()(node)}</span>}
+          </Show>
+        </button>
+        <Show when={node.kind === "dir" && props.expanded.has(node.path)}>
+          <TreeLevel
+            nodes={node.kind === "dir" ? node.children : []}
+            depth={props.depth + 1}
+            expanded={props.expanded}
+            selectedPath={props.selectedPath}
+            onToggle={props.onToggle}
+            onSelect={props.onSelect}
+            renderBadge={props.renderBadge}
+          />
+        </Show>
+      </>
+    )}
+  </For>
+);
+
+export default FileTree;

--- a/packages/client/src/ui/FileTree.tsx
+++ b/packages/client/src/ui/FileTree.tsx
@@ -84,7 +84,7 @@ const TreeLevel: Component<TreeLevelProps> = (props) => (
               node.kind === "file" && props.selectedPath === node.path,
           }}
           style={{ "padding-left": `${props.depth * 12 + 8}px` }}
-          data-testid={node.kind === "dir" ? "file-tree-dir" : "file-tree-file"}
+          data-testid={node.kind === "dir" ? "file-tree-dir" : "diff-file-item"}
           data-path={node.path}
           data-active={node.kind === "file" && props.selectedPath === node.path}
         >

--- a/packages/client/src/ui/buildFileTree.test.ts
+++ b/packages/client/src/ui/buildFileTree.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { buildFileTree, collectDirPaths } from "./buildFileTree";
 import type { TreeNode } from "./buildFileTree";
-import type { GitChangedFile } from "kolu-common";
+import type { GitChangedFile, GitChangeStatus } from "kolu-common";
 
-const file = (path: string, status = "M" as const): GitChangedFile => ({
+const file = (path: string, status: GitChangeStatus = "M"): GitChangedFile => ({
   path,
   status,
 });

--- a/packages/client/src/ui/buildFileTree.test.ts
+++ b/packages/client/src/ui/buildFileTree.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { buildFileTree, collectDirPaths } from "./buildFileTree";
+import type { TreeNode } from "./buildFileTree";
+import type { GitChangedFile } from "kolu-common";
+
+const file = (path: string, status = "M" as const): GitChangedFile => ({
+  path,
+  status,
+});
+
+describe("buildFileTree", () => {
+  it("returns empty array for no files", () => {
+    expect(buildFileTree([])).toEqual([]);
+  });
+
+  it("puts a root-level file at the top level", () => {
+    const tree = buildFileTree([file("README.md")]);
+    expect(tree).toEqual([
+      { kind: "file", name: "README.md", path: "README.md", status: "M" },
+    ]);
+  });
+
+  it("groups files under directory nodes", () => {
+    const tree = buildFileTree([
+      file("src/a.ts"),
+      file("src/b.ts"),
+    ]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]!.kind).toBe("dir");
+    expect(tree[0]!.name).toBe("src");
+    const dir = tree[0] as Extract<TreeNode, { kind: "dir" }>;
+    expect(dir.children).toHaveLength(2);
+    expect(dir.children[0]!.name).toBe("a.ts");
+    expect(dir.children[1]!.name).toBe("b.ts");
+  });
+
+  it("sorts directories before files, alphabetically within each group", () => {
+    const tree = buildFileTree([
+      file("z.ts"),
+      file("a/x.ts"),
+      file("b/y.ts"),
+      file("a.ts"),
+    ]);
+    expect(tree.map((n) => n.name)).toEqual(["a", "b", "a.ts", "z.ts"]);
+  });
+
+  it("collapses single-child directory chains", () => {
+    const tree = buildFileTree([file("a/b/c/d.ts")]);
+    expect(tree).toHaveLength(1);
+    const dir = tree[0] as Extract<TreeNode, { kind: "dir" }>;
+    // a/b/c collapsed into one node
+    expect(dir.kind).toBe("dir");
+    expect(dir.name).toBe("a/b/c");
+    expect(dir.path).toBe("a/b/c");
+    expect(dir.children).toHaveLength(1);
+    expect(dir.children[0]!.name).toBe("d.ts");
+  });
+
+  it("does not collapse when a directory has multiple children", () => {
+    const tree = buildFileTree([
+      file("a/b/x.ts"),
+      file("a/c/y.ts"),
+    ]);
+    expect(tree).toHaveLength(1);
+    const a = tree[0] as Extract<TreeNode, { kind: "dir" }>;
+    expect(a.name).toBe("a");
+    expect(a.children).toHaveLength(2);
+    expect(a.children[0]!.name).toBe("b");
+    expect(a.children[1]!.name).toBe("c");
+  });
+
+  it("preserves file status", () => {
+    const tree = buildFileTree([file("x.ts", "A"), file("y.ts", "D")]);
+    const f0 = tree[0] as Extract<TreeNode, { kind: "file" }>;
+    const f1 = tree[1] as Extract<TreeNode, { kind: "file" }>;
+    expect(f0.status).toBe("A");
+    expect(f1.status).toBe("D");
+  });
+});
+
+describe("collectDirPaths", () => {
+  it("collects all directory paths", () => {
+    const tree = buildFileTree([
+      file("src/a.ts"),
+      file("src/utils/b.ts"),
+      file("lib/c.ts"),
+    ]);
+    const paths = collectDirPaths(tree);
+    expect(paths).toEqual(new Set(["src", "src/utils", "lib"]));
+  });
+});

--- a/packages/client/src/ui/buildFileTree.test.ts
+++ b/packages/client/src/ui/buildFileTree.test.ts
@@ -21,10 +21,7 @@ describe("buildFileTree", () => {
   });
 
   it("groups files under directory nodes", () => {
-    const tree = buildFileTree([
-      file("src/a.ts"),
-      file("src/b.ts"),
-    ]);
+    const tree = buildFileTree([file("src/a.ts"), file("src/b.ts")]);
     expect(tree).toHaveLength(1);
     expect(tree[0]!.kind).toBe("dir");
     expect(tree[0]!.name).toBe("src");
@@ -57,10 +54,7 @@ describe("buildFileTree", () => {
   });
 
   it("does not collapse when a directory has multiple children", () => {
-    const tree = buildFileTree([
-      file("a/b/x.ts"),
-      file("a/c/y.ts"),
-    ]);
+    const tree = buildFileTree([file("a/b/x.ts"), file("a/c/y.ts")]);
     expect(tree).toHaveLength(1);
     const a = tree[0] as Extract<TreeNode, { kind: "dir" }>;
     expect(a.name).toBe("a");

--- a/packages/client/src/ui/buildFileTree.ts
+++ b/packages/client/src/ui/buildFileTree.ts
@@ -1,0 +1,104 @@
+import type { GitChangedFile, GitChangeStatus } from "kolu-common";
+
+/** A file leaf in the tree. */
+export type FileNode = {
+  kind: "file";
+  name: string;
+  path: string;
+  status: GitChangeStatus;
+};
+
+/** A directory branch in the tree. */
+export type DirNode = {
+  kind: "dir";
+  name: string;
+  path: string;
+  children: TreeNode[];
+};
+
+export type TreeNode = FileNode | DirNode;
+
+/** Build a hierarchical tree from a flat list of changed files.
+ *
+ *  - Groups files by path segments into nested directories.
+ *  - Sorts directories first, then files, alphabetically within each group.
+ *  - Auto-collapses single-child directory chains (VS Code style):
+ *    `packages/server/src` becomes one node when each intermediate
+ *    directory has exactly one child and that child is also a directory. */
+export function buildFileTree(files: GitChangedFile[]): TreeNode[] {
+  // Intermediate mutable structure for building.
+  type MutableDir = {
+    children: Map<string, MutableDir>;
+    files: Map<string, GitChangedFile>;
+  };
+
+  const root: MutableDir = { children: new Map(), files: new Map() };
+
+  for (const file of files) {
+    const segments = file.path.split("/");
+    let current = root;
+    for (let i = 0; i < segments.length - 1; i++) {
+      const seg = segments[i]!;
+      if (!current.children.has(seg)) {
+        current.children.set(seg, { children: new Map(), files: new Map() });
+      }
+      current = current.children.get(seg)!;
+    }
+    current.files.set(segments.at(-1)!, file);
+  }
+
+  function toTreeNodes(dir: MutableDir, prefix: string): TreeNode[] {
+    const dirs: DirNode[] = [];
+    const leaves: FileNode[] = [];
+
+    for (const [name, child] of [...dir.children.entries()].sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    )) {
+      const path = prefix ? `${prefix}/${name}` : name;
+      const children = toTreeNodes(child, path);
+      dirs.push({ kind: "dir", name, path, children });
+    }
+
+    for (const [name, file] of [...dir.files.entries()].sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    )) {
+      leaves.push({ kind: "file", name, path: file.path, status: file.status });
+    }
+
+    return [...dirs, ...leaves];
+  }
+
+  return collapseChains(toTreeNodes(root, ""));
+}
+
+/** Recursively collapse single-child directory chains.
+ *  `a/` → `b/` → `c/` → [files] becomes `a/b/c/` → [files]. */
+function collapseChains(nodes: TreeNode[]): TreeNode[] {
+  return nodes.map((node) => {
+    if (node.kind === "file") return node;
+    const collapsed = collapseChains(node.children);
+    const only = collapsed.length === 1 ? collapsed[0]! : null;
+    if (only?.kind === "dir") {
+      return {
+        kind: "dir" as const,
+        name: `${node.name}/${only.name}`,
+        path: only.path,
+        children: only.children,
+      };
+    }
+    return { ...node, children: collapsed };
+  });
+}
+
+/** Collect all directory paths in a tree (for default-expand-all). */
+export function collectDirPaths(nodes: TreeNode[]): Set<string> {
+  const paths = new Set<string>();
+  const walk = (n: TreeNode) => {
+    if (n.kind === "dir") {
+      paths.add(n.path);
+      n.children.forEach(walk);
+    }
+  };
+  nodes.forEach(walk);
+  return paths;
+}

--- a/packages/client/src/ui/buildFileTree.ts
+++ b/packages/client/src/ui/buildFileTree.ts
@@ -3,19 +3,26 @@ import type { GitChangedFile, GitChangeStatus } from "kolu-common";
 /** A file leaf in the tree. */
 export type FileNode = {
   kind: "file";
+  /** Display name (basename, or collapsed chain like `src/utils`). */
   name: string;
+  /** Path relative to repo root (e.g. `src/utils/helpers.ts`). */
   path: string;
+  /** Git change status (M, A, D, etc.). */
   status: GitChangeStatus;
 };
 
 /** A directory branch in the tree. */
 export type DirNode = {
   kind: "dir";
+  /** Display name (basename, or collapsed chain like `packages/server/src`). */
   name: string;
+  /** Path relative to repo root for the deepest segment of this node. */
   path: string;
+  /** Child nodes — directories first, then files, alphabetically. */
   children: TreeNode[];
 };
 
+/** Discriminated union for tree nodes. Use `node.kind` to narrow. */
 export type TreeNode = FileNode | DirNode;
 
 /** Build a hierarchical tree from a flat list of changed files.

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -49,3 +49,25 @@ Feature: Code tab (diff review)
     Then the Code tab should render a diff view
     When I click the changed file "note.txt" in the Code tab
     Then the Code tab should not render a diff view
+
+  Scenario: Groups files into a directory tree
+    When I run "git init /tmp/kolu-review-tree && cd /tmp/kolu-review-tree"
+    And I run "git commit --allow-empty -m init"
+    And I run "mkdir -p src/components && printf 'a\n' > src/index.ts && printf 'b\n' > src/components/Button.tsx"
+    And I click the Code tab
+    And I click the refresh button in the Code tab
+    Then the Code tab should show a directory node "src"
+    And the Code tab should list a changed file "src/index.ts"
+    And the Code tab should list a changed file "src/components/Button.tsx"
+
+  Scenario: Collapsing a directory hides its children
+    When I run "git init /tmp/kolu-review-collapse && cd /tmp/kolu-review-collapse"
+    And I run "git commit --allow-empty -m init"
+    And I run "mkdir -p pkg && printf 'x\n' > pkg/a.ts && printf 'y\n' > pkg/b.ts"
+    And I click the Code tab
+    And I click the refresh button in the Code tab
+    Then the Code tab should list a changed file "pkg/a.ts"
+    When I click the directory node "pkg" in the Code tab
+    Then the Code tab should not list a changed file "pkg/a.ts"
+    When I click the directory node "pkg" in the Code tab
+    Then the Code tab should list a changed file "pkg/a.ts"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -80,6 +80,38 @@ Then(
 );
 
 Then(
+  "the Code tab should show a directory node {string}",
+  async function (this: KoluWorld, path: string) {
+    const dir = this.page.locator(
+      `[data-testid="file-tree-dir"][data-path="${path}"]`,
+    );
+    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+When(
+  "I click the directory node {string} in the Code tab",
+  async function (this: KoluWorld, path: string) {
+    const dir = this.page.locator(
+      `[data-testid="file-tree-dir"][data-path="${path}"]`,
+    );
+    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await dir.click();
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the Code tab should not list a changed file {string}",
+  async function (this: KoluWorld, path: string) {
+    const item = this.page.locator(
+      `[data-testid="diff-file-item"][data-path="${path}"]`,
+    );
+    await item.waitFor({ state: "detached", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
   "the Code tab should render a diff view",
   async function (this: KoluWorld) {
     // Assert an actual rendered diff row, not just the wrapper div —


### PR DESCRIPTION
**The flat file list in the Code tab is now a collapsible directory tree.** Files are grouped by parent directories — `packages/server/src/git-review.ts` renders under `packages/server/src/` instead of as one long path. Single-child directory chains auto-collapse VS Code-style, so `packages/server/src` becomes one node when each intermediate has only one child.

The tree component (`FileTree`) is generic and reusable — it takes a `TreeNode[]` discriminated union (`FileNode | DirNode`) with expand/collapse state, selection, and optional badge rendering. *Phase 7 (full file browser) will plug into the same component with a lazy `loadChildren` callback; the data model was designed with that in mind.*

A pure `buildFileTree()` function handles the flat-to-tree transformation: path segmentation, directory grouping, alphabetical sorting (directories first), and chain collapsing. All client-side — no new RPC, no schema change.

Closes #514 phase 3.