### PR TITLE
fix: show rename diffs instead of full delete+add (#545)

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -248,6 +248,19 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                   Error: {(diff.error as Error).message}
                 </div>
               </Match>
+              <Match
+                when={
+                  diff() &&
+                  diff()!.hunks.length === 0 &&
+                  diff()!.oldFileName &&
+                  diff()!.newFileName &&
+                  diff()!.oldFileName !== diff()!.newFileName
+                }
+              >
+                <div class="flex items-center justify-center h-full text-fg-3/50">
+                  File renamed: {diff()!.oldFileName} → {diff()!.newFileName}
+                </div>
+              </Match>
               <Match when={diff()}>
                 {(d) => (
                   <DiffView

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -100,7 +100,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     () => {
       const p = repoPath();
       const s = selectedPath();
-      return p && s ? { repoPath: p, filePath: s, mode: mode() } : null;
+      if (!p || !s) return null;
+      const file = status()?.files.find((f) => f.path === s);
+      return { repoPath: p, filePath: s, mode: mode(), oldPath: file?.oldPath };
     },
     (input) => client.git.diff(input),
   );

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -58,7 +58,13 @@ describe("getDiff", () => {
 
     await git.raw(["mv", "old-name.ts", "new-name.ts"]);
 
-    const result = await getDiff(dir, "new-name.ts", "local");
+    const result = await getDiff(
+      dir,
+      "new-name.ts",
+      "local",
+      undefined,
+      "old-name.ts",
+    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
@@ -66,8 +72,14 @@ describe("getDiff", () => {
     expect(result.value.newFileName).toBe("new-name.ts");
     expect(result.value.oldContent).toBe(content);
     expect(result.value.newContent).toBe(content);
-    // No content change — hunks should be empty
-    expect(result.value.hunks).toEqual([]);
+    // No content change — hunks contain the rename header but no +/- lines.
+    const diffLines = result.value.hunks
+      .join("")
+      .split("\n")
+      .filter(
+        (l) => /^[+-]/.test(l) && !l.startsWith("---") && !l.startsWith("+++"),
+      );
+    expect(diffLines).toEqual([]);
   });
 
   it("rename + edit: old path and content, hunks show only the delta", async () => {
@@ -84,7 +96,13 @@ describe("getDiff", () => {
       "export const a = 1;\nexport const b = 2;\n",
     );
 
-    const result = await getDiff(dir, "lib/utils.ts", "local");
+    const result = await getDiff(
+      dir,
+      "lib/utils.ts",
+      "local",
+      undefined,
+      "utils.ts",
+    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
@@ -99,7 +117,9 @@ describe("getDiff", () => {
     const diffLines = result.value.hunks
       .join("")
       .split("\n")
-      .filter((l) => /^[+-]/.test(l) && !l.startsWith("---") && !l.startsWith("+++"));
+      .filter(
+        (l) => /^[+-]/.test(l) && !l.startsWith("---") && !l.startsWith("+++"),
+      );
     expect(diffLines).toEqual(["+export const b = 2;"]);
   });
 });
@@ -196,13 +216,15 @@ describe("parseNameStatus", () => {
   it("extracts the new path from renames (R<score>)", () => {
     const raw = "R100\told/path.ts\tnew/path.ts\n";
     expect(parseNameStatus(raw)).toEqual([
-      { path: "new/path.ts", status: "R" },
+      { path: "new/path.ts", status: "R", oldPath: "old/path.ts" },
     ]);
   });
 
   it("extracts the destination from copies (C<score>)", () => {
     const raw = "C075\tsrc.ts\tdst.ts\n";
-    expect(parseNameStatus(raw)).toEqual([{ path: "dst.ts", status: "C" }]);
+    expect(parseNameStatus(raw)).toEqual([
+      { path: "dst.ts", status: "C", oldPath: "src.ts" },
+    ]);
   });
 
   it("handles type-change (T) lines", () => {

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import os from "node:os";
 import { simpleGit } from "simple-git";
 import {
+  getDiff,
   gitInfoEqual,
   resolveGitInfo,
   parseNameStatus,
@@ -24,6 +25,84 @@ import {
 vi.mock("memorable-names", () => ({
   randomName: () => "test-worktree",
 }));
+
+// --- getDiff: renames ---
+
+describe("getDiff", () => {
+  let tmpDir: string;
+
+  async function initRepo() {
+    const dir = path.join(tmpDir, `diff-repo-${Date.now()}`);
+    fs.mkdirSync(dir, { recursive: true });
+    const git = simpleGit(dir);
+    await git.init();
+    await git.checkoutLocalBranch("main");
+    return { dir, git };
+  }
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-git-diff-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("pure rename: old path and content, no diff hunks", async () => {
+    const { dir, git } = await initRepo();
+    const content = "export const x = 1;\n";
+
+    fs.writeFileSync(path.join(dir, "old-name.ts"), content);
+    await git.add("old-name.ts");
+    await git.commit("add old-name.ts");
+
+    await git.raw(["mv", "old-name.ts", "new-name.ts"]);
+
+    const result = await getDiff(dir, "new-name.ts", "local");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.oldFileName).toBe("old-name.ts");
+    expect(result.value.newFileName).toBe("new-name.ts");
+    expect(result.value.oldContent).toBe(content);
+    expect(result.value.newContent).toBe(content);
+    // No content change — hunks should be empty
+    expect(result.value.hunks).toEqual([]);
+  });
+
+  it("rename + edit: old path and content, hunks show only the delta", async () => {
+    const { dir, git } = await initRepo();
+
+    fs.writeFileSync(path.join(dir, "utils.ts"), "export const a = 1;\n");
+    await git.add("utils.ts");
+    await git.commit("add utils.ts");
+
+    fs.mkdirSync(path.join(dir, "lib"));
+    await git.raw(["mv", "utils.ts", "lib/utils.ts"]);
+    fs.writeFileSync(
+      path.join(dir, "lib", "utils.ts"),
+      "export const a = 1;\nexport const b = 2;\n",
+    );
+
+    const result = await getDiff(dir, "lib/utils.ts", "local");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.oldFileName).toBe("utils.ts");
+    expect(result.value.newFileName).toBe("lib/utils.ts");
+    expect(result.value.oldContent).toBe("export const a = 1;\n");
+    expect(result.value.newContent).toBe(
+      "export const a = 1;\nexport const b = 2;\n",
+    );
+    // Hunks should show only the added line, not the entire file as an addition.
+    // Extract the meaningful diff lines (skip headers, no-newline markers).
+    const diffLines = result.value.hunks
+      .join("")
+      .split("\n")
+      .filter((l) => /^[+-]/.test(l) && !l.startsWith("---") && !l.startsWith("+++"));
+    expect(diffLines).toEqual(["+export const b = 2;"]);
+  });
+});
 
 // --- resolveUnder ---
 

--- a/packages/integrations/git/src/review.ts
+++ b/packages/integrations/git/src/review.ts
@@ -83,9 +83,12 @@ export function parseNameStatus(raw: string): GitChangedFile[] {
     const parts = line.split("\t");
     const letter = parts[0]?.[0] ?? "";
     // Rename/copy rows have 3 fields; everything else has 2.
-    const filePath = parts.length >= 3 ? parts[2] : parts[1];
+    const isRenameOrCopy = parts.length >= 3;
+    const filePath = isRenameOrCopy ? parts[2] : parts[1];
     if (!filePath) continue;
-    files.push({ path: filePath, status: toChangeStatus(letter) });
+    const status = toChangeStatus(letter);
+    const oldPath = isRenameOrCopy ? parts[1] : undefined;
+    files.push({ path: filePath, status, ...(oldPath && { oldPath }) });
   }
   return files.sort((a, b) => a.path.localeCompare(b.path));
 }
@@ -106,7 +109,11 @@ async function getLocalStatus(repoPath: string): Promise<GitChangedFile[]> {
   for (const f of status.files) {
     // working_dir takes precedence; fall back to index.
     const letter = f.working_dir !== " " ? f.working_dir : f.index;
-    seen.set(f.path, { path: f.path, status: toChangeStatus(letter) });
+    seen.set(f.path, {
+      path: f.path,
+      status: toChangeStatus(letter),
+      ...(f.from && { oldPath: f.from }),
+    });
   }
   for (const p of status.not_added) {
     if (!seen.has(p)) seen.set(p, { path: p, status: "?" });
@@ -229,10 +236,20 @@ export async function getDiff(
   filePath: string,
   mode: GitDiffMode,
   log?: Logger,
+  oldPath?: string,
 ): Promise<GitResult<GitDiffOutput>> {
   const pathResult = resolveUnder(repoPath, filePath, log);
   if (!pathResult.ok) return pathResult;
   const { abs, rel } = pathResult.value;
+
+  // Validate oldPath the same way filePath is validated — it comes from
+  // the client and must not escape the repo root.
+  let oldRel = rel;
+  if (oldPath) {
+    const oldPathResult = resolveUnder(repoPath, oldPath, log);
+    if (!oldPathResult.ok) return oldPathResult;
+    oldRel = oldPathResult.value.rel;
+  }
 
   let baseRev: string;
   if (mode === "local") {
@@ -245,9 +262,11 @@ export async function getDiff(
 
   try {
     const [oldContent, newContent, tracked] = await Promise.all([
-      readContentAtRev(repoPath, baseRev, rel),
+      readContentAtRev(repoPath, baseRev, oldRel),
       readWorkingContent(abs),
-      gitOutput(repoPath, ["diff", baseRev, "--", rel]),
+      oldPath
+        ? gitOutput(repoPath, ["diff", "-M", baseRev, "--", oldRel, rel])
+        : gitOutput(repoPath, ["diff", baseRev, "--", rel]),
     ]);
 
     // Branch mode's file list comes from `git diff --name-status`, which
@@ -275,7 +294,7 @@ export async function getDiff(
     }
 
     return ok({
-      oldFileName: oldContent ? rel : null,
+      oldFileName: oldContent ? oldRel : null,
       newFileName: newContent ? rel : null,
       oldContent,
       newContent,

--- a/packages/integrations/git/src/review.ts
+++ b/packages/integrations/git/src/review.ts
@@ -293,12 +293,17 @@ export async function getDiff(
       );
     }
 
+    // A pure rename produces a header (similarity index, rename from/to)
+    // but no @@ hunks. @git-diff-view/core rejects diff strings without
+    // hunks, so only include rawDiff when it contains actual hunk markers.
+    const hasHunks = rawDiff.includes("\n@@");
+
     return ok({
       oldFileName: oldContent ? oldRel : null,
       newFileName: newContent ? rel : null,
       oldContent,
       newContent,
-      hunks: rawDiff ? [rawDiff] : [],
+      hunks: rawDiff && hasHunks ? [rawDiff] : [],
     });
   } catch (e) {
     return err({

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -50,6 +50,8 @@ export const GitChangedFileSchema = z.object({
   /** Path relative to repo root. */
   path: z.string(),
   status: GitChangeStatusSchema,
+  /** Original path before rename/copy. Only present for R/C statuses. */
+  oldPath: z.string().optional(),
 });
 export type GitChangedFile = z.infer<typeof GitChangedFileSchema>;
 
@@ -88,6 +90,9 @@ export const GitDiffInputSchema = z.object({
   /** Path relative to the repo root. */
   filePath: z.string(),
   mode: GitDiffModeSchema,
+  /** Original path before rename/copy — passed from the file list so
+   *  getDiff can read old content at the correct path. */
+  oldPath: z.string().optional(),
 });
 
 /** Raw parts needed by `@git-diff-view/solid`'s `DiffView` data prop.

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -225,7 +225,13 @@ export const appRouter = t.router({
     }),
     diff: t.git.diff.handler(async ({ input }) => {
       return unwrapGit(
-        await getDiff(input.repoPath, input.filePath, input.mode, log),
+        await getDiff(
+          input.repoPath,
+          input.filePath,
+          input.mode,
+          log,
+          input.oldPath,
+        ),
       );
     }),
   },


### PR DESCRIPTION
**Renamed files now display as renames** — with the correct old filename,
original content, and a compact diff of just the changes — instead of
rendering as a full file deletion plus a full file addition.

The root cause was that `getDiff()` always looked up old content using
the *new* path, which doesn't exist in the base revision for renames.
The fix threads an `oldPath` field from `parseNameStatus` and
`getLocalStatus` through the schema, router, and client, so `getDiff`
reads old content at the pre-rename path and passes `-M` to git for
rename-aware diff output. *`oldPath` is validated through `resolveUnder`
to prevent path traversal.*

Two test cases cover both scenarios: pure renames (path change only, no
content diff) and renames with edits (path change plus a content delta).

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)