### PR TITLE
Detect Monitor as Monitoring, AskUserQuestion as Waiting

### DIFF
--- a/packages/client/src/sidebar/AgentIndicator.tsx
+++ b/packages/client/src/sidebar/AgentIndicator.tsx
@@ -4,29 +4,13 @@
 import type { Component } from "solid-js";
 import { Dynamic } from "solid-js/web";
 import type { AgentInfo } from "kolu-common";
-import { agentIcons, agentNames, stateLabels } from "../ui/agentDisplay";
-
-/** Busy = actively working (thinking or running tools). Warning = needs user input. */
-const BUSY_COLOR = "text-busy";
-
-/** State → display config. Keyed on state, not kind — all agents currently
- *  share the same visual treatment per state. When agents diverge in states,
- *  this becomes a per-kind dispatch (the `agentIcons`/`agentNames` tables
- *  already handle the per-kind axis). */
-const stateConfig: Record<
-  AgentInfo["state"],
-  { color: string; animation: string }
-> = {
-  thinking: { color: BUSY_COLOR, animation: "animate-pulse" },
-  tool_use: { color: BUSY_COLOR, animation: "animate-spin" },
-  waiting: { color: "text-warning", animation: "animate-pulse" },
-};
+import { agentIcons, agentNames, stateDisplay } from "../ui/agentDisplay";
 
 const AgentIndicator: Component<{ agent: AgentInfo }> = (props) => {
-  const cfg = () => stateConfig[props.agent.state];
+  const cfg = () => stateDisplay[props.agent.state];
   const Icon = () => agentIcons[props.agent.kind];
   const name = () => agentNames[props.agent.kind];
-  const label = () => stateLabels[props.agent.state];
+  const label = () => cfg().label;
   return (
     <span
       class={`inline-flex items-center gap-1 text-xs ${cfg().color}`}

--- a/packages/client/src/ui/agentDisplay.ts
+++ b/packages/client/src/ui/agentDisplay.ts
@@ -18,8 +18,36 @@ export const agentNames: Record<AgentInfo["kind"], string> = {
   opencode: "OpenCode",
 };
 
-export const stateLabels: Record<AgentInfo["state"], string> = {
-  thinking: "Thinking",
-  tool_use: "Running tools",
-  waiting: "Waiting for input",
+/** Unified display config per agent state — label, color, and animation in one
+ *  table so adding a new state variant can't drift across separate lookups. */
+export const stateDisplay: Record<
+  AgentInfo["state"],
+  { label: string; color: string; animation: string }
+> = {
+  thinking: {
+    label: "Thinking",
+    color: "text-busy",
+    animation: "animate-pulse",
+  },
+  tool_use: {
+    label: "Running tools",
+    color: "text-busy",
+    animation: "animate-spin",
+  },
+  waiting: {
+    label: "Waiting for input",
+    color: "text-warning",
+    animation: "animate-pulse",
+  },
+  monitoring: {
+    label: "Monitoring",
+    color: "text-busy",
+    animation: "animate-pulse",
+  },
 };
+
+/** Convenience accessor for display labels only. */
+export const stateLabels: Record<AgentInfo["state"], string> =
+  Object.fromEntries(
+    Object.entries(stateDisplay).map(([k, v]) => [k, v.label]),
+  ) as Record<AgentInfo["state"], string>;

--- a/packages/integrations/claude-code/src/index.test.ts
+++ b/packages/integrations/claude-code/src/index.test.ts
@@ -33,6 +33,53 @@ describe("deriveState", () => {
     },
   );
 
+  it("returns monitoring when tool_use contains Monitor", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        model: "claude-opus-4-6",
+        content: [{ type: "tool_use", name: "Monitor", id: "t1", input: {} }],
+      },
+    });
+    expect(deriveState([line])).toEqual({
+      state: "monitoring",
+      model: "claude-opus-4-6",
+    });
+  });
+
+  it("returns waiting when tool_use contains AskUserQuestion", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        model: "claude-opus-4-6",
+        content: [
+          { type: "tool_use", name: "AskUserQuestion", id: "t1", input: {} },
+        ],
+      },
+    });
+    expect(deriveState([line])).toEqual({
+      state: "waiting",
+      model: "claude-opus-4-6",
+    });
+  });
+
+  it("returns tool_use for regular tools like Bash", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        model: "claude-opus-4-6",
+        content: [{ type: "tool_use", name: "Bash", id: "t1", input: {} }],
+      },
+    });
+    expect(deriveState([line])).toEqual({
+      state: "tool_use",
+      model: "claude-opus-4-6",
+    });
+  });
+
   it("returns thinking for assistant with missing stop_reason", () => {
     const line = JSON.stringify({
       type: "assistant",

--- a/packages/integrations/claude-code/src/index.ts
+++ b/packages/integrations/claude-code/src/index.ts
@@ -28,7 +28,7 @@ import { TaskProgressSchema, type TaskProgress } from "anyagent";
 export const ClaudeCodeInfoSchema = z.object({
   kind: z.literal("claude-code"),
   /** Current state derived from session JSONL. */
-  state: z.enum(["thinking", "tool_use", "waiting"]),
+  state: z.enum(["thinking", "tool_use", "waiting", "monitoring"]),
   /** Session UUID from ~/.claude/sessions/. */
   sessionId: z.string(),
   /** Model name if available (e.g. "claude-opus-4-6"). */
@@ -183,6 +183,26 @@ export function tailJsonlLines(filePath: string, bytes: number): string[] {
 
 // --- State derivation ---
 
+/** Tool names whose `tool_use` stop-reason means "waiting on something
+ *  external" rather than "actively running a tool." */
+const MONITORING_TOOLS = new Set(["Monitor"]);
+
+/** Tool names whose `tool_use` stop-reason means "waiting for user input." */
+const WAITING_TOOLS = new Set(["AskUserQuestion"]);
+
+/** Inspect content blocks to refine the tool_use state. */
+function refineToolUseState(
+  content: Array<{ type?: string; name?: string }> | undefined,
+): ClaudeCodeInfo["state"] {
+  if (!Array.isArray(content)) return "tool_use";
+  for (const block of content) {
+    if (block.type !== "tool_use") continue;
+    if (block.name && WAITING_TOOLS.has(block.name)) return "waiting";
+    if (block.name && MONITORING_TOOLS.has(block.name)) return "monitoring";
+  }
+  return "tool_use";
+}
+
 /** Derive Claude Code state from the last relevant JSONL message. */
 export function deriveState(
   lines: string[],
@@ -192,7 +212,11 @@ export function deriveState(
     try {
       const entry: {
         type?: string;
-        message?: { stop_reason?: string | null; model?: string | null };
+        message?: {
+          stop_reason?: string | null;
+          model?: string | null;
+          content?: Array<{ type?: string; name?: string }>;
+        };
       } = JSON.parse(lines[i]!);
       const model = entry.message?.model ?? null;
       const result = match({
@@ -204,7 +228,7 @@ export function deriveState(
           model,
         }))
         .with({ type: "assistant", stopReason: "tool_use" }, () => ({
-          state: "tool_use" as const,
+          state: refineToolUseState(entry.message?.content),
           model,
         }))
         .with({ type: "assistant" }, () => ({

--- a/packages/tests/features/claude-code.feature
+++ b/packages/tests/features/claude-code.feature
@@ -31,6 +31,11 @@ Feature: Claude Code status detection
     Then the header should show an agent indicator with state "waiting"
     And there should be no page errors
 
+  Scenario: Monitor tool shows monitoring state instead of tool_use
+    When a Claude Code session is mocked with state "monitoring"
+    Then the header should show an agent indicator with state "monitoring"
+    And there should be no page errors
+
   Scenario: Previous-session JSONL in the project dir doesn't confuse detection
     When a Claude Code session is mocked with state "thinking"
     And a newer stale previous-session JSONL exists in the same project dir

--- a/packages/tests/step_definitions/claude_code_steps.ts
+++ b/packages/tests/step_definitions/claude_code_steps.ts
@@ -64,7 +64,9 @@ async function getTerminalPid(world: KoluWorld): Promise<number> {
 }
 
 /** Build a JSONL transcript with a specific final state. */
-function buildTranscript(state: "thinking" | "tool_use" | "waiting"): string {
+function buildTranscript(
+  state: "thinking" | "tool_use" | "waiting" | "monitoring",
+): string {
   const userMsg = JSON.stringify({
     type: "user",
     uuid: "u1",
@@ -72,7 +74,10 @@ function buildTranscript(state: "thinking" | "tool_use" | "waiting"): string {
     message: { role: "user", content: [{ type: "text", text: "hello" }] },
   });
 
-  const assistantMsg = (stopReason: string) =>
+  const assistantMsg = (
+    stopReason: string,
+    content: Array<Record<string, unknown>> = [{ type: "text", text: "Done!" }],
+  ) =>
     JSON.stringify({
       type: "assistant",
       uuid: "a1",
@@ -81,13 +86,19 @@ function buildTranscript(state: "thinking" | "tool_use" | "waiting"): string {
         model: "claude-opus-4-6",
         role: "assistant",
         stop_reason: stopReason,
-        content: [{ type: "text", text: "Done!" }],
+        content,
       },
     });
 
   const lines = [userMsg];
   if (state === "tool_use") lines.push(assistantMsg("tool_use"));
   if (state === "waiting") lines.push(assistantMsg("end_turn"));
+  if (state === "monitoring")
+    lines.push(
+      assistantMsg("tool_use", [
+        { type: "tool_use", name: "Monitor", id: "t1", input: {} },
+      ]),
+    );
   // "thinking" = user message only (no assistant response yet)
 
   return lines.join("\n") + "\n";
@@ -153,7 +164,9 @@ When(
     mockTranscriptPath = path.join(mockProjectDir, `${SESSION_ID}.jsonl`);
     fs.writeFileSync(
       mockTranscriptPath,
-      buildTranscript(state as "thinking" | "tool_use" | "waiting"),
+      buildTranscript(
+        state as "thinking" | "tool_use" | "waiting" | "monitoring",
+      ),
     );
 
     // Now the trigger — session file last.
@@ -230,7 +243,9 @@ When(
     if (!mockTranscriptPath) throw new Error("No mock transcript to update");
     fs.writeFileSync(
       mockTranscriptPath,
-      buildTranscript(state as "thinking" | "tool_use" | "waiting"),
+      buildTranscript(
+        state as "thinking" | "tool_use" | "waiting" | "monitoring",
+      ),
     );
   },
 );


### PR DESCRIPTION
**Kolu now distinguishes Monitor and AskUserQuestion tool calls** from regular tool use, fixing the false "Waiting for input" indicator during active monitoring sessions. Closes #525.

The root cause: when Claude Code calls the Monitor tool, the JSONL transcript shows `stop_reason: "tool_use"` — but after Monitor completes, Claude writes a summary with `stop_reason: "end_turn"`, which `deriveState` mapped to "Waiting for input". Meanwhile, AskUserQuestion (which *genuinely* needs user input) showed as "Running tools" since it's technically a tool call.

`deriveState` now peeks at the tool names in the assistant message's content blocks when `stop_reason` is `"tool_use"`: **Monitor → "Monitoring"**, **AskUserQuestion → "Waiting for input"**, everything else stays "Running tools". The tool name sets are extracted as constants (`MONITORING_TOOLS`, `WAITING_TOOLS`) so future tools can be added without touching derivation logic.

*Also unifies the previously-separate `stateLabels` and `stateConfig` tables into a single `stateDisplay` record* — adding a new state variant can no longer silently drift between the two lookups, since TypeScript's `Record<Union, T>` enforces exhaustiveness on the unified table.