### PR TITLE
Poll clipboard state in e2e tests instead of asserting synchronously

### DIFF
--- a/.claude/rules/code-police-rules.md
+++ b/.claude/rules/code-police-rules.md
@@ -71,3 +71,10 @@ Every `createSubscription` call must include an `onError` handler to surface fai
 Bad: `const sub = createSubscription(() => stream.state());`
 Good: `const sub = createSubscription(() => stream.state(), { onError: (err) => toast.error(\`Server state error: ${err.message}\`) });`
 _Rationale_: oRPC application errors (`ORPCError`) are not retried by `ClientRetryPlugin`, so the stream dies permanently. Without `onError`, the failure is invisible — the user gets a blank or stale UI with no toast, no console warning, nothing.
+
+### e2e-poll-async-state
+
+E2e step definitions must never assert synchronously on state that changes asynchronously (clipboard, DOM content, reactive UI updates). Use `page.waitForFunction()` with `POLL_TIMEOUT` to poll until the expected condition is met.
+Bad: `const text = await page.evaluate(() => navigator.clipboard.readText()); assert.ok(text.includes(expected));`
+Good: `await page.waitForFunction((exp) => navigator.clipboard.readText().then(t => t.includes(exp)), expected, { timeout: POLL_TIMEOUT });`
+_Rationale_: A bare `page.evaluate()` + `assert` is a race condition — the async operation (clipboard write, SolidJS reactivity flush, DOM update) may not have completed by the time the read fires. This passes on fast machines (x86_64-linux) and fails on slower ones (aarch64-darwin). The fix was applied in commit `36c82cd` for command palette tests; this rule prevents the pattern from recurring.

--- a/agents/.apm/instructions/code-police-rules.instructions.md
+++ b/agents/.apm/instructions/code-police-rules.instructions.md
@@ -71,3 +71,10 @@ Every `createSubscription` call must include an `onError` handler to surface fai
 Bad: `const sub = createSubscription(() => stream.state());`
 Good: `const sub = createSubscription(() => stream.state(), { onError: (err) => toast.error(\`Server state error: ${err.message}\`) });`
 _Rationale_: oRPC application errors (`ORPCError`) are not retried by `ClientRetryPlugin`, so the stream dies permanently. Without `onError`, the failure is invisible — the user gets a blank or stale UI with no toast, no console warning, nothing.
+
+### e2e-poll-async-state
+
+E2e step definitions must never assert synchronously on state that changes asynchronously (clipboard, DOM content, reactive UI updates). Use `page.waitForFunction()` with `POLL_TIMEOUT` to poll until the expected condition is met.
+Bad: `const text = await page.evaluate(() => navigator.clipboard.readText()); assert.ok(text.includes(expected));`
+Good: `await page.waitForFunction((exp) => navigator.clipboard.readText().then(t => t.includes(exp)), expected, { timeout: POLL_TIMEOUT });`
+_Rationale_: A bare `page.evaluate()` + `assert` is a race condition — the async operation (clipboard write, SolidJS reactivity flush, DOM update) may not have completed by the time the read fires. This passes on fast machines (x86_64-linux) and fails on slower ones (aarch64-darwin). The fix was applied in commit `36c82cd` for command palette tests; this rule prevents the pattern from recurring.

--- a/packages/tests/step_definitions/copy_pane_text_steps.ts
+++ b/packages/tests/step_definitions/copy_pane_text_steps.ts
@@ -1,6 +1,5 @@
 import { Then } from "@cucumber/cucumber";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
-import * as assert from "node:assert";
 
 Then(
   "a toast should appear with text {string}",
@@ -16,10 +15,10 @@ Then(
 Then(
   "the clipboard should contain {string}",
   async function (this: KoluWorld, expected: string) {
-    const text = await this.page.evaluate(() => navigator.clipboard.readText());
-    assert.ok(
-      text.includes(expected),
-      `Expected clipboard to contain "${expected}" but got: ${text.slice(0, 200)}`,
+    await this.page.waitForFunction(
+      (exp) => navigator.clipboard.readText().then((t) => t.includes(exp)),
+      expected,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );
@@ -27,10 +26,10 @@ Then(
 Then(
   "the clipboard should not contain {string}",
   async function (this: KoluWorld, unexpected: string) {
-    const text = await this.page.evaluate(() => navigator.clipboard.readText());
-    assert.ok(
-      !text.includes(unexpected),
-      `Expected clipboard NOT to contain "${unexpected}" but it does`,
+    await this.page.waitForFunction(
+      (unexp) => navigator.clipboard.readText().then((t) => !t.includes(unexp)),
+      unexpected,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );


### PR DESCRIPTION
**Clipboard e2e steps now poll with `page.waitForFunction()` instead of doing a one-shot read-and-assert**, fixing the consistent OSC 52 test failure on aarch64-darwin. The old pattern called `navigator.clipboard.readText()` once and immediately asserted — a race condition that x86_64-linux always won but darwin never did.

The fix follows the exact pattern established in `36c82cd` (command palette navigation) and used throughout the test suite: poll with `POLL_TIMEOUT` until the async state settles. *Both the "should contain" and "should not contain" steps are fixed — the negative assertion had the same latent race, just hadn't been triggered yet.*

Also adds an **`e2e-poll-async-state` code-police rule** so this class of bug gets caught during `/code-police` reviews going forward. The rule lives in the APM-managed instruction file and was regenerated via `just ai::apm`.

Closes #548