### PR TITLE
Give the right panel a visual identity

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -37,7 +37,12 @@ import type {
 } from "kolu-common";
 import { client } from "../rpc/rpc";
 import { useServerState } from "../settings/useServerState";
-import { DiffLocalIcon, DiffBranchIcon } from "../ui/Icons";
+import {
+  DiffLocalIcon,
+  DiffBranchIcon,
+  FileDiffIcon,
+  GitBranchIcon,
+} from "../ui/Icons";
 import { buildFileTree } from "../ui/buildFileTree";
 import FileTree from "../ui/FileTree";
 
@@ -136,9 +141,10 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
       when={repoPath()}
       fallback={
         <div
-          class="flex items-center justify-center h-full text-fg-3/50 text-[11px]"
+          class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2 text-[11px]"
           data-testid="diff-no-repo"
         >
+          <GitBranchIcon class="w-8 h-8 opacity-40" />
           Not in a git repository
         </div>
       }
@@ -147,24 +153,26 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         class="flex flex-col h-full min-h-0 text-[11px]"
         data-testid="diff-tab"
       >
-        <div class="flex items-center h-6 px-1 bg-surface-1/30 border-b border-edge shrink-0 gap-0.5">
-          <For each={MODE_TABS}>
-            {(tab) => (
-              <button
-                type="button"
-                onClick={() => setMode(tab.mode)}
-                title={tab.tooltip}
-                class="flex items-center justify-center w-6 h-6 text-fg-3/50 hover:text-fg-2 cursor-pointer rounded-sm data-[active=true]:text-fg data-[active=true]:bg-surface-2/60"
-                data-testid={`diff-mode-${tab.mode}`}
-                data-active={mode() === tab.mode}
-                aria-pressed={mode() === tab.mode}
-              >
-                <Dynamic component={tab.icon} class="w-3 h-3" />
-              </button>
-            )}
-          </For>
+        <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-1">
+          <div class="flex items-center bg-surface-2/40 rounded p-0.5 gap-0.5">
+            <For each={MODE_TABS}>
+              {(tab) => (
+                <button
+                  type="button"
+                  onClick={() => setMode(tab.mode)}
+                  title={tab.tooltip}
+                  class="flex items-center justify-center w-5 h-5 text-fg-3/50 hover:text-fg-2 cursor-pointer rounded transition-colors data-[active=true]:text-fg data-[active=true]:bg-surface-0 data-[active=true]:shadow-sm"
+                  data-testid={`diff-mode-${tab.mode}`}
+                  data-active={mode() === tab.mode}
+                  aria-pressed={mode() === tab.mode}
+                >
+                  <Dynamic component={tab.icon} class="w-3 h-3" />
+                </button>
+              )}
+            </For>
+          </div>
           <span
-            class="text-fg-3/50 text-[10px] font-mono truncate min-w-0 ml-1.5"
+            class="text-fg-3/50 text-[10px] font-mono truncate min-w-0 ml-1"
             data-testid="diff-mode-label"
             data-mode={mode()}
           >
@@ -174,7 +182,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
           <button
             type="button"
             onClick={handleRefresh}
-            class="text-fg-3/50 hover:text-fg-2 cursor-pointer px-1 shrink-0"
+            class="text-fg-3/40 hover:text-fg-2 cursor-pointer px-1 shrink-0 transition-colors"
             aria-label="Refresh changed files"
             data-testid="diff-refresh"
           >
@@ -216,9 +224,12 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                       renderBadge={(node) =>
                         node.kind === "file" ? (
                           <span
-                            class={`w-3 text-center ${STATUS_COLOR[node.status]}`}
+                            class={`inline-flex items-center gap-1 ${STATUS_COLOR[node.status]}`}
                           >
-                            {node.status}
+                            <span class="w-1.5 h-1.5 rounded-full bg-current opacity-70" />
+                            <span class="text-[10px] font-medium">
+                              {node.status}
+                            </span>
                           </span>
                         ) : null
                       }
@@ -235,8 +246,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
           <Show
             when={selectedPath()}
             fallback={
-              <div class="flex items-center justify-center h-full text-fg-3/50">
-                Select a file to view its diff
+              <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
+                <FileDiffIcon class="w-8 h-8 opacity-40" />
+                <span class="text-[11px]">Select a file to view its diff</span>
               </div>
             }
           >

--- a/packages/client/src/right-panel/MetadataInspector.tsx
+++ b/packages/client/src/right-panel/MetadataInspector.tsx
@@ -4,16 +4,33 @@
 import { type Component, type JSX, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
 import type { TerminalMetadata } from "kolu-common";
-import { PrStateIcon, WorktreeIcon } from "../ui/Icons";
+import { PrStateIcon, TerminalIcon, WorktreeIcon } from "../ui/Icons";
 import ChecksIndicator from "../sidebar/ChecksIndicator";
 import { agentIcons, agentNames, stateLabels } from "../ui/agentDisplay";
 import Section from "./Section";
 
-/** Label–value pair with dim label and bright value. */
-const Row: Component<{ label: string; children: JSX.Element }> = (props) => (
+/** Label–value pair with dim label and bright value.
+ *  `variant` codifies styling rules for special rows:
+ *  - "badge": pill background for status indicators (CI, agent state)
+ *  - "tag": mono accent background for identity values (branch name) */
+const Row: Component<{
+  label: string;
+  variant?: "default" | "badge" | "tag";
+  children: JSX.Element;
+}> = (props) => (
   <div class="flex items-baseline gap-3 text-[11px] leading-snug py-0.5">
     <span class="text-fg-3/70 shrink-0 w-14 text-right">{props.label}</span>
-    <span class="text-fg-2 min-w-0 break-words">{props.children}</span>
+    <span
+      class={`min-w-0 break-words ${
+        props.variant === "badge"
+          ? "text-fg-2 inline-flex items-center gap-1.5 bg-surface-2/60 px-1.5 py-px rounded-full text-[10px]"
+          : props.variant === "tag"
+            ? "text-fg font-mono bg-accent/10 px-1.5 py-px rounded-sm text-[10px]"
+            : "text-fg-2"
+      }`}
+    >
+      {props.children}
+    </span>
   </div>
 );
 
@@ -26,7 +43,8 @@ const MetadataInspector: Component<{
     <Show
       when={props.meta}
       fallback={
-        <div class="flex items-center justify-center h-full text-fg-3/50 text-[11px]">
+        <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2 text-[11px]">
+          <TerminalIcon class="w-8 h-8 opacity-40" />
           No terminal selected
         </div>
       }
@@ -46,15 +64,17 @@ const MetadataInspector: Component<{
           {/* Git */}
           <Show when={meta().git}>
             {(git) => (
-              <Section title="Git" data-testid="inspector-branch">
+              <Section
+                title="Git"
+                accent="border-accent"
+                data-testid="inspector-branch"
+              >
                 <div class="space-y-0.5">
-                  <Row label="Branch">
-                    <span class="font-mono text-fg">
-                      {git().branch}
-                      <Show when={git().isWorktree}>
-                        <WorktreeIcon class="inline w-3 h-3 ml-1 text-fg-3/50" />
-                      </Show>
-                    </span>
+                  <Row label="Branch" variant="tag">
+                    {git().branch}
+                    <Show when={git().isWorktree}>
+                      <WorktreeIcon class="inline w-3 h-3 ml-1 text-fg-3/50" />
+                    </Show>
                   </Row>
                   <Row label="Repo">
                     <span class="text-fg">{git().repoName}</span>
@@ -95,11 +115,9 @@ const MetadataInspector: Component<{
                   </Row>
                   <Show when={pr().checks}>
                     {(checks) => (
-                      <Row label="CI">
-                        <span class="inline-flex items-center gap-1.5">
-                          <ChecksIndicator status={checks()} />
-                          <span class="capitalize text-fg">{checks()}</span>
-                        </span>
+                      <Row label="CI" variant="badge">
+                        <ChecksIndicator status={checks()} />
+                        <span class="capitalize">{checks()}</span>
                       </Row>
                     )}
                   </Show>
@@ -111,7 +129,7 @@ const MetadataInspector: Component<{
           {/* Agent */}
           <Show when={meta().agent}>
             {(agent) => (
-              <Section title="Agent">
+              <Section title="Agent" accent="border-busy">
                 <div class="space-y-0.5">
                   <Row label="Kind">
                     <span class="inline-flex items-center gap-1.5">
@@ -124,10 +142,8 @@ const MetadataInspector: Component<{
                       </span>
                     </span>
                   </Row>
-                  <Row label="State">
-                    <span class="text-fg">
-                      {stateLabels[agent().state] ?? agent().state}
-                    </span>
+                  <Row label="State" variant="badge">
+                    {stateLabels[agent().state] ?? agent().state}
                   </Row>
                   <Show when={agent().summary}>
                     {(summary) => (

--- a/packages/client/src/right-panel/RightPanel.tsx
+++ b/packages/client/src/right-panel/RightPanel.tsx
@@ -7,6 +7,7 @@ import type { TerminalMetadata, RightPanelTab } from "kolu-common";
 import MetadataInspector from "./MetadataInspector";
 import CodeTab from "./CodeTab";
 import { useRightPanel } from "./useRightPanel";
+import { ChevronRightIcon } from "../ui/Icons";
 
 type TabProps = {
   meta: TerminalMetadata | null;
@@ -48,10 +49,10 @@ const RightPanel: Component<{
   return (
     <div
       data-testid="right-panel"
-      class="flex flex-col h-full min-w-0 overflow-hidden bg-surface-0 border-l border-edge"
+      class="flex flex-col h-full min-w-0 overflow-hidden bg-gradient-to-b from-surface-0 to-surface-1/20 border-l border-edge"
     >
       {/* Tab bar */}
-      <div class="flex items-center h-8 shrink-0 bg-surface-1/50">
+      <div class="flex items-center h-8 shrink-0 bg-surface-1/50 border-b border-edge">
         <For each={TAB_IDS}>
           {(id) => (
             <button
@@ -59,8 +60,8 @@ const RightPanel: Component<{
               data-active={rightPanel.activeTab() === id}
               class={`h-full px-3 text-xs cursor-pointer transition-colors ${
                 rightPanel.activeTab() === id
-                  ? "font-medium text-fg-2 border-b border-accent"
-                  : "text-fg-3/50 hover:text-fg-2"
+                  ? "font-medium text-fg-2 bg-surface-0 border-b-2 border-accent"
+                  : "text-fg-3/50 hover:text-fg-2 hover:bg-surface-0/50"
               }`}
               onClick={() => rightPanel.setActiveTab(id)}
             >
@@ -70,11 +71,11 @@ const RightPanel: Component<{
         </For>
         <div class="flex-1" />
         <button
-          class="px-2 h-full text-fg-3/50 hover:text-fg transition-colors cursor-pointer"
+          class="px-2 h-full text-fg-3/40 hover:text-fg-2 transition-colors cursor-pointer"
           onClick={props.onToggle}
           aria-label="Collapse panel"
         >
-          <span class="text-[10px]">▸</span>
+          <ChevronRightIcon class="w-3.5 h-3.5" />
         </button>
       </div>
       <div class="flex-1 min-h-0 overflow-hidden">

--- a/packages/client/src/right-panel/Section.tsx
+++ b/packages/client/src/right-panel/Section.tsx
@@ -4,11 +4,13 @@ import type { Component, JSX } from "solid-js";
 
 const Section: Component<{
   title: string;
+  /** Accent color class for the left border (e.g. "border-accent"). */
+  accent?: string;
   "data-testid"?: string;
   children: JSX.Element;
 }> = (props) => (
   <div
-    class="py-3 px-3 border-b border-edge"
+    class={`py-3 px-3 border-b border-edge ${props.accent ? `border-l-2 ${props.accent}` : ""}`}
     data-testid={props["data-testid"]}
   >
     <div class="text-[9px] font-bold uppercase tracking-[0.15em] text-fg-3/60 mb-2">

--- a/packages/client/src/ui/FileTree.tsx
+++ b/packages/client/src/ui/FileTree.tsx
@@ -78,10 +78,13 @@ const TreeLevel: Component<TreeLevelProps> = (props) => (
               ? props.onToggle(node.path)
               : props.onSelect(node.path)
           }
-          class="flex w-full items-center gap-1 px-2 py-0.5 text-left font-mono text-fg hover:bg-surface-1 cursor-pointer"
+          class="flex w-full items-center gap-1 px-2 py-0.5 text-left font-mono text-fg hover:bg-surface-2/40 cursor-pointer transition-colors"
           classList={{
-            "bg-surface-1":
+            "bg-surface-2/50 border-l-2 border-accent":
               node.kind === "file" && props.selectedPath === node.path,
+            "border-l-2 border-transparent": !(
+              node.kind === "file" && props.selectedPath === node.path
+            ),
           }}
           style={{ "padding-left": `${props.depth * 12 + 8}px` }}
           data-testid={node.kind === "dir" ? "file-tree-dir" : "diff-file-item"}

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -20,6 +20,19 @@ export const ChevronDownIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
+export const ChevronRightIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  >
+    <path d="M6 4L10 8L6 12" />
+  </svg>
+);
+
 export const ChevronUpIcon: Component<{ class?: string }> = (props) => (
   <svg
     class={props.class ?? "w-3.5 h-3.5"}
@@ -242,6 +255,50 @@ export const PrStateIcon: Component<{
     </span>
   );
 };
+
+/** Terminal prompt icon — empty-state placeholder for "no terminal selected". */
+export const TerminalIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <polyline points="4 17 10 11 4 5" />
+    <line x1="12" y1="19" x2="20" y2="19" />
+  </svg>
+);
+
+/** File with diff line — empty-state placeholder for "select a file". */
+export const FileDiffIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <polyline points="14 2 14 8 20 8" />
+    <line x1="9" y1="15" x2="15" y2="15" />
+  </svg>
+);
+
+/** Git branch icon (filled) — empty-state placeholder for "not a git repo". */
+export const GitBranchIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 16 16"
+    fill="currentColor"
+  >
+    <path d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm6.5 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zM5 12.75a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm-1.25-7.5v5.256a2.25 2.25 0 1 0 1.5 0V7.121A5.69 5.69 0 0 0 9.5 9.5a3.5 3.5 0 0 0 3.5-3.5V5.372a2.25 2.25 0 1 0-1.5 0V6a2 2 0 0 1-2 2 4.19 4.19 0 0 1-3.75-2.846V5.25zM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5z" />
+  </svg>
+);
 
 export const WorktreeIcon: Component<{ class?: string }> = (props) => (
   <svg


### PR DESCRIPTION
**The right panel (Inspector + Code tabs) gets visual hierarchy, accent borders, and badge styling** instead of the uniform 11px monochrome text it had before. The panel felt like scaffolding that was never designed — every section looked identical, selection states were nearly invisible, and empty states were bare text.

Key changes: *Git and Agent sections* now have colored left-border accents that draw the eye to the most-used metadata. Branch names render as teal tag pills, CI status and agent state as rounded badge pills — both via a new `variant` prop on the internal `Row` component that codifies the styling in the type system rather than sprinkling ad-hoc classes. The tab bar has a proper active-state background wash with a thicker accent underline. The Code tab's mode toggle is now a pill-shaped segmented control with `shadow-sm` on the active button. File tree selection uses a left accent bar with higher-contrast background (`bg-surface-2/50` vs the old barely-visible `bg-surface-1`).

*Empty states* — "no terminal selected", "not a git repo", "select a file" — each get a contextual SVG icon above the text. All four new icons (`TerminalIcon`, `FileDiffIcon`, `GitBranchIcon`, `ChevronRightIcon`) live in `Icons.tsx` alongside the existing icon catalog. The panel background shifts from flat `bg-surface-0` to a subtle top-to-bottom gradient for depth.

> All changes are Tailwind-only styling — no new dependencies, no new state, no behavioral changes. E2e tests (20 scenarios, 146 steps) pass unchanged.