### PR TITLE
Distinct sidebar animations for active vs waiting agents

### DIFF
--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -135,20 +135,16 @@ body {
 
 /* Spinning states — all use --card-color (the terminal's repo color) */
 .card-border-wrap.card-spin-active {
-  background: conic-gradient(
-    from var(--spin-angle),
-    transparent 0%,
-    var(--card-color) 25%,
-    transparent 50%,
-    oklch(from var(--card-color) l c h / 0.3) 75%,
-    transparent 100%
-  );
-  animation: border-spin 2s linear infinite, border-spin-pulse 1.2s ease-in-out infinite;
-}
-
-@keyframes border-spin-pulse {
-  0%, 100% { opacity: 0.5; }
-  50% { opacity: 1; }
+  background:
+    conic-gradient(
+      from var(--spin-angle),
+      transparent 0%,
+      oklch(from var(--card-color) l calc(c * 1.3) h) 8%,
+      transparent 16%,
+      transparent 100%
+    ),
+    oklch(from var(--card-color) l c h / 0.4);
+  animation: border-spin 2s linear infinite;
 }
 
 .card-border-wrap.card-spin-waiting {

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -147,14 +147,11 @@ body {
 }
 
 .card-border-wrap.card-spin-waiting {
-  background: conic-gradient(
-    from var(--spin-angle),
-    transparent 0%,
-    var(--card-color) 20%,
-    transparent 40%,
-    var(--card-color) 60%,
-    transparent 80%,
-    var(--card-color) 100%
-  );
-  animation: border-spin 1.2s linear infinite;
+  background: var(--card-color);
+  animation: border-breathe 2.5s ease-in-out infinite;
+}
+
+@keyframes border-breathe {
+  0%, 100% { opacity: 0.2; }
+  50% { opacity: 0.6; }
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -137,12 +137,18 @@ body {
 .card-border-wrap.card-spin-active {
   background: conic-gradient(
     from var(--spin-angle),
-    oklch(from var(--card-color) l c h / 0.15) 0%,
-    var(--card-color) 4%,
-    oklch(from var(--card-color) l c h / 0.15) 10%,
-    oklch(from var(--card-color) l c h / 0.15) 100%
+    transparent 0%,
+    var(--card-color) 25%,
+    transparent 50%,
+    oklch(from var(--card-color) l c h / 0.3) 75%,
+    transparent 100%
   );
-  animation: border-spin 1.5s linear infinite;
+  animation: border-spin 2s linear infinite, border-spin-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes border-spin-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
 }
 
 .card-border-wrap.card-spin-waiting {

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -147,11 +147,12 @@ body {
 }
 
 .card-border-wrap.card-spin-waiting {
-  background: oklch(from var(--card-color) l c h / 0.4);
-  animation: border-pulse 3s ease-in-out infinite;
-}
-
-@keyframes border-pulse {
-  0%, 100% { background: oklch(from var(--card-color) l c h / 0.15); }
-  50% { background: oklch(from var(--card-color) l c h / 0.5); }
+  background: conic-gradient(
+    from var(--spin-angle),
+    transparent 0%,
+    var(--card-color) 3%,
+    transparent 6%,
+    transparent 100%
+  );
+  animation: border-spin 4s linear infinite;
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -147,12 +147,11 @@ body {
 }
 
 .card-border-wrap.card-spin-waiting {
-  background: conic-gradient(
-    from var(--spin-angle),
-    transparent 0%,
-    var(--card-color) 3%,
-    transparent 6%,
-    transparent 100%
-  );
-  animation: border-spin 4s linear infinite;
+  background: var(--card-color);
+  animation: border-breathe 2.5s ease-in-out infinite;
+}
+
+@keyframes border-breathe {
+  0%, 100% { opacity: 0.2; }
+  50% { opacity: 0.6; }
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -147,11 +147,10 @@ body {
 }
 
 .card-border-wrap.card-spin-waiting {
-  background: var(--card-color);
-  animation: border-breathe 2.5s ease-in-out infinite;
-}
-
-@keyframes border-breathe {
-  0%, 100% { opacity: 0.2; }
-  50% { opacity: 0.6; }
+  background: repeating-conic-gradient(
+    from var(--spin-angle),
+    var(--card-color) 0deg 8deg,
+    transparent 8deg 20deg
+  );
+  animation: border-spin 6s linear infinite;
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -147,10 +147,11 @@ body {
 }
 
 .card-border-wrap.card-spin-waiting {
-  background: repeating-conic-gradient(
-    from var(--spin-angle),
-    var(--card-color) 0deg 8deg,
-    transparent 8deg 20deg
-  );
-  animation: border-spin 6s linear infinite;
+  background: oklch(from var(--card-color) l c h / 0.4);
+  animation: border-pulse 3s ease-in-out infinite;
+}
+
+@keyframes border-pulse {
+  0%, 100% { background: oklch(from var(--card-color) l c h / 0.15); }
+  50% { background: oklch(from var(--card-color) l c h / 0.5); }
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -153,6 +153,11 @@ body {
 }
 
 @keyframes border-breathe {
-  0%, 100% { opacity: 0.2; }
-  50% { opacity: 0.6; }
+  0%,
+  100% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 0.6;
+  }
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -137,10 +137,10 @@ body {
 .card-border-wrap.card-spin-active {
   background: conic-gradient(
     from var(--spin-angle),
-    transparent 0%,
-    var(--card-color) 15%,
-    transparent 30%,
-    transparent 100%
+    oklch(from var(--card-color) l c h / 0.15) 0%,
+    var(--card-color) 4%,
+    oklch(from var(--card-color) l c h / 0.15) 10%,
+    oklch(from var(--card-color) l c h / 0.15) 100%
   );
   animation: border-spin 1.5s linear infinite;
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -138,12 +138,11 @@ body {
   background: conic-gradient(
     from var(--spin-angle),
     transparent 0%,
-    var(--card-color) 25%,
-    transparent 50%,
-    oklch(from var(--card-color) l c h / 0.3) 75%,
+    var(--card-color) 15%,
+    transparent 30%,
     transparent 100%
   );
-  animation: border-spin 3s linear infinite;
+  animation: border-spin 1.5s linear infinite;
 }
 
 .card-border-wrap.card-spin-waiting {


### PR DESCRIPTION
## Summary

- **Active**: solid glow + shimmer — persistent dim `--card-color` border with a bright boosted-chroma highlight sweeping over it (2s). Reads as *working*.
- **Waiting**: breathing glow — no rotation, just the border color pulsing opacity (0.2→0.6 over 2.5s). Reads as *alive but idle*.

Previously both states used spinning conic gradients at different speeds, making them hard to distinguish at a glance.

## Test plan

- [ ] Verify active agent card shows shimmer animation
- [ ] Verify waiting agent card shows breathing glow (no spin)
- [ ] Check both animations use the correct repo `--card-color`
- [ ] Confirm idle cards (no agent) have no animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)