### PR TITLE
test: cover untracked files alongside tracked changes in Code tab (#552)

### DIFF
--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -13,6 +13,7 @@ import os from "node:os";
 import { simpleGit } from "simple-git";
 import {
   getDiff,
+  getStatus,
   gitInfoEqual,
   resolveGitInfo,
   parseNameStatus,
@@ -441,6 +442,55 @@ describe("resolveGitInfo", () => {
     expect(result.value.repoName).toBe("proj");
     expect(result.value.repoName).not.toBe(".worktrees");
     expect(result.value.mainRepoRoot).toBe(fs.realpathSync(proj));
+  });
+});
+
+// --- getStatus: untracked files (#552) ---
+
+describe("getStatus local mode includes untracked files alongside tracked changes", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-git-status-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns both modified tracked files and untracked files", async () => {
+    const dir = path.join(tmpDir, "mixed-status");
+    fs.mkdirSync(dir, { recursive: true });
+    const git = simpleGit(dir);
+    await git.init();
+    await git.checkoutLocalBranch("main");
+
+    // Create and commit a tracked file
+    fs.writeFileSync(path.join(dir, "tracked.txt"), "initial\n");
+    await git.add("tracked.txt");
+    await git.commit("add tracked file");
+
+    // Modify the tracked file (unstaged)
+    fs.writeFileSync(path.join(dir, "tracked.txt"), "modified\n");
+
+    // Create an untracked file
+    fs.writeFileSync(path.join(dir, "untracked.txt"), "new\n");
+
+    const result = await getStatus(dir, "local");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const paths = result.value.files.map((f) => f.path);
+    expect(paths).toContain("tracked.txt");
+    expect(paths).toContain("untracked.txt");
+
+    // Verify statuses
+    const tracked = result.value.files.find((f) => f.path === "tracked.txt");
+    const untracked = result.value.files.find(
+      (f) => f.path === "untracked.txt",
+    );
+    expect(tracked?.status).toBe("M");
+    expect(untracked?.status).toBe("?");
   });
 });
 

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -50,6 +50,17 @@ Feature: Code tab (diff review)
     When I click the changed file "note.txt" in the Code tab
     Then the Code tab should not render a diff view
 
+  Scenario: Untracked files appear alongside modified tracked files
+    When I run "git init /tmp/kolu-review-untracked && cd /tmp/kolu-review-untracked"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'initial\n' > tracked.txt && git add tracked.txt && git commit -m 'add tracked'"
+    And I run "printf 'modified\n' > tracked.txt"
+    And I run "printf 'new\n' > untracked.txt"
+    And I click the Code tab
+    And I click the refresh button in the Code tab
+    Then the Code tab should list a changed file "tracked.txt"
+    And the Code tab should list a changed file "untracked.txt"
+
   Scenario: Groups files into a directory tree
     When I run "git init /tmp/kolu-review-tree && cd /tmp/kolu-review-tree"
     And I run "git commit --allow-empty -m init"


### PR DESCRIPTION
## Summary

Adds **regression tests** for #552 — ensures untracked files appear in the Code tab when the repo also has modified tracked files. Both e2e and unit layers confirm `getLocalStatus()` correctly merges `simple-git`'s `status.files` and `status.not_added`.

The original report is not reproducible in the current codebase — likely caused by a stale view, branch mode (which excludes untracked files by design), or an environment-specific `simple-git` edge case.

### Tests added
- **e2e** (`code-tab.feature`): Scenario that commits a tracked file, modifies it, creates an untracked file alongside it, and asserts both appear
- **unit** (`index.test.ts`): Direct `getStatus("local")` call verifying both `M` and `?` status files are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)