### PR TITLE
Browse the full repo file tree from the Code tab

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "@corvu/resizable": "^0.2.5",
     "@corvu/tooltip": "^0.2.2",
     "@git-diff-view/solid": "^0.1.3",
+    "highlight.js": "^11.11.1",
     "@orpc/client": "^1.13.13",
     "@orpc/contract": "^1.13.13",
     "@solid-primitives/event-listener": "^2.4.5",

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -444,9 +444,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                       const highlighted = createMemo(() => {
                         const path = selectedPath() ?? "";
                         const ext = path.split(".").pop() ?? "";
-                        const lang = hljs.getLanguage(ext)
-                          ? ext
-                          : undefined;
+                        const lang = hljs.getLanguage(ext) ? ext : undefined;
                         return lang
                           ? hljs.highlight(fc().content, { language: lang })
                           : hljs.highlightAuto(fc().content);

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -176,8 +176,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
       void refetchStatus();
       if (selectedPath()) void refetchDiff();
     } else {
-      // File browser: increment a counter to trigger re-fetch of root entries.
-      setBrowseRefreshCount((c) => c + 1);
+      void refetchBrowseRoot();
     }
   };
 
@@ -192,15 +191,12 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   };
 
   // --- File browser state ---
-  const [browseRefreshCount, setBrowseRefreshCount] = createSignal(0);
 
   /** Root entries for the file browser. */
-  const [browseRoot] = createResource(
+  const [browseRoot, { refetch: refetchBrowseRoot }] = createResource(
     () => {
       const p = repoPath();
       if (!p || view() !== "browse") return null;
-      // Track refresh count so manual refresh re-fetches.
-      browseRefreshCount();
       return { repoPath: p, dirPath: "" };
     },
     async (input) => {

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -52,6 +52,26 @@ import { buildFileTree } from "../ui/buildFileTree";
 import type { TreeNode } from "../ui/buildFileTree";
 import FileTree from "../ui/FileTree";
 
+/** Map file extensions to highlight.js language names where they differ. */
+const EXT_TO_LANG: Record<string, string> = {
+  md: "markdown",
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  yml: "yaml",
+  sh: "bash",
+  zsh: "bash",
+  rs: "rust",
+  py: "python",
+  rb: "ruby",
+  kt: "kotlin",
+  cs: "csharp",
+  hs: "haskell",
+  ex: "elixir",
+  exs: "elixir",
+};
+
 /** Color class for each git status letter. */
 const STATUS_COLOR: Record<GitChangeStatus, string> = {
   M: "text-warning",
@@ -450,7 +470,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                       const highlighted = createMemo(() => {
                         const path = selectedPath() ?? "";
                         const ext = path.split(".").pop() ?? "";
-                        const lang = hljs.getLanguage(ext) ? ext : undefined;
+                        const lang =
+                          EXT_TO_LANG[ext] ??
+                          (hljs.getLanguage(ext) ? ext : undefined);
                         return lang
                           ? hljs.highlight(fc().content, { language: lang })
                           : hljs.highlightAuto(fc().content);

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -196,6 +196,17 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     return entriesToNodes(result.entries);
   };
 
+  /** File content for the selected file in browse mode. */
+  const [fileContent] = createResource(
+    () => {
+      const p = repoPath();
+      const s = selectedPath();
+      if (!p || !s || view() !== "browse") return null;
+      return { repoPath: p, filePath: s };
+    },
+    (input) => client.fs.readFile(input),
+  );
+
   return (
     <Show
       when={repoPath()}
@@ -376,7 +387,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
           {/* === File browser mode === */}
           <Match when={!isDiffView()}>
             <div
-              class="flex-1 min-h-0 overflow-y-auto"
+              class="shrink-0 max-h-[35%] overflow-y-auto border-b border-edge"
               data-testid="file-browser"
             >
               <Switch
@@ -409,6 +420,46 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                   )}
                 </Match>
               </Switch>
+            </div>
+            <div
+              class="flex-1 min-h-0 overflow-auto"
+              data-testid="file-content"
+            >
+              <Show
+                when={selectedPath()}
+                fallback={
+                  <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
+                    <FileDiffIcon class="w-8 h-8 opacity-40" />
+                    <span class="text-[11px]">
+                      Select a file to view its content
+                    </span>
+                  </div>
+                }
+              >
+                <Switch
+                  fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}
+                >
+                  <Match when={fileContent.error}>
+                    <div class="px-2 py-1 text-danger">
+                      Error: {(fileContent.error as Error).message}
+                    </div>
+                  </Match>
+                  <Match when={fileContent()}>
+                    {(fc) => (
+                      <>
+                        <Show when={fc().truncated}>
+                          <div class="px-2 py-1 text-warning text-[10px] border-b border-edge bg-surface-1/30">
+                            File truncated (exceeds 1 MB)
+                          </div>
+                        </Show>
+                        <pre class="px-2 py-1 font-mono text-fg whitespace-pre-wrap break-all">
+                          {fc().content}
+                        </pre>
+                      </>
+                    )}
+                  </Match>
+                </Switch>
+              </Show>
             </div>
           </Match>
         </Switch>

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -100,6 +100,14 @@ const VIEW_TABS: {
   },
 ];
 
+/** Empty-state placeholder shown when no file is selected. */
+const FileSelectHint: Component<{ label: string }> = (props) => (
+  <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
+    <FileDiffIcon class="w-8 h-8 opacity-40" />
+    <span class="text-[11px]">{props.label}</span>
+  </div>
+);
+
 /** Convert fs.listDir entries to TreeNode[]. */
 function entriesToNodes(entries: FsListDirOutput["entries"]): TreeNode[] {
   return entries.map(
@@ -322,12 +330,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
               <Show
                 when={selectedPath()}
                 fallback={
-                  <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
-                    <FileDiffIcon class="w-8 h-8 opacity-40" />
-                    <span class="text-[11px]">
-                      Select a file to view its diff
-                    </span>
-                  </div>
+                  <FileSelectHint label="Select a file to view its diff" />
                 }
               >
                 <Switch
@@ -425,12 +428,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
               <Show
                 when={selectedPath()}
                 fallback={
-                  <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
-                    <FileDiffIcon class="w-8 h-8 opacity-40" />
-                    <span class="text-[11px]">
-                      Select a file to view its content
-                    </span>
-                  </div>
+                  <FileSelectHint label="Select a file to view its content" />
                 }
               >
                 <Switch

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -9,6 +9,8 @@
  *     branch will ship, same answer GitHub's "Files changed" tab gives).
  *     Branch mode is forge-agnostic; it runs the same git commands
  *     locally and never calls out to a forge API.
+ *   - Phase 4: full file tree browser — 3rd sub-tab showing the repo's
+ *     entire file tree (lazy-loaded, git-filtered).
  *
  * Stays narrow by design — no inline comments, no agent handoff. Those
  * land in later phases. */
@@ -33,6 +35,7 @@ import "./code-tab.css";
 import type {
   GitChangeStatus,
   GitDiffMode,
+  FsListDirOutput,
   TerminalMetadata,
 } from "kolu-common";
 import { client } from "../rpc/rpc";
@@ -40,10 +43,12 @@ import { useServerState } from "../settings/useServerState";
 import {
   DiffLocalIcon,
   DiffBranchIcon,
+  FileBrowseIcon,
   FileDiffIcon,
   GitBranchIcon,
 } from "../ui/Icons";
 import { buildFileTree } from "../ui/buildFileTree";
+import type { TreeNode } from "../ui/buildFileTree";
 import FileTree from "../ui/FileTree";
 
 /** Color class for each git status letter. */
@@ -63,40 +68,67 @@ const EMPTY_STATE: Record<GitDiffMode, string> = {
   branch: "No changes vs base",
 };
 
-/** Sub-tab config for each diff mode. Icons double as the tab's visual
- *  affordance; the tooltip spells out what the mode means. The label
- *  is a short context string shown in the header after the icons. */
-const MODE_TABS: {
-  mode: GitDiffMode;
+/** Active view in the Code tab: local/branch diff modes, or file browser. */
+type CodeTabView = GitDiffMode | "browse";
+
+/** Sub-tab config. Icons double as the tab's visual affordance;
+ *  the tooltip spells out what the mode means. */
+const VIEW_TABS: {
+  view: CodeTabView;
   icon: Component<{ class?: string }>;
   tooltip: string;
   label: string;
 }[] = [
   {
-    mode: "local",
+    view: "local",
     icon: DiffLocalIcon,
     tooltip: "Local changes (vs HEAD)",
     label: "vs HEAD",
   },
   {
-    mode: "branch",
+    view: "branch",
     icon: DiffBranchIcon,
     tooltip: "Branch diff (vs origin/<default>)",
     label: "vs branch base",
   },
+  {
+    view: "browse",
+    icon: FileBrowseIcon,
+    tooltip: "File tree browser",
+    label: "Files",
+  },
 ];
+
+/** Convert fs.listDir entries to TreeNode[]. */
+function entriesToNodes(entries: FsListDirOutput["entries"]): TreeNode[] {
+  return entries.map(
+    (e): TreeNode =>
+      e.isDirectory
+        ? { kind: "dir", name: e.name, path: e.path, children: [] }
+        : { kind: "file", name: e.name, path: e.path },
+  );
+}
 
 const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { preferences } = useServerState();
   const [selectedPath, setSelectedPath] = createSignal<string | null>(null);
-  const [mode, setMode] = createSignal<GitDiffMode>("local");
+  const [view, setView] = createSignal<CodeTabView>("local");
 
   const repoPath = () => props.meta?.git?.repoRoot ?? null;
+
+  /** Whether the current view is a diff mode (local/branch). */
+  const isDiffView = () => view() !== "browse";
+  /** The GitDiffMode for diff views (undefined in browse mode). */
+  const diffMode = () => {
+    const v = view();
+    return v === "browse" ? undefined : v;
+  };
 
   const [status, { refetch: refetchStatus }] = createResource(
     () => {
       const p = repoPath();
-      return p ? { repoPath: p, mode: mode() } : null;
+      const m = diffMode();
+      return p && m ? { repoPath: p, mode: m } : null;
     },
     (input) => client.git.status(input),
   );
@@ -105,35 +137,63 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     () => {
       const p = repoPath();
       const s = selectedPath();
-      if (!p || !s) return null;
+      const m = diffMode();
+      if (!p || !s || !m) return null;
       const file = status()?.files.find((f) => f.path === s);
-      return { repoPath: p, filePath: s, mode: mode(), oldPath: file?.oldPath };
+      return { repoPath: p, filePath: s, mode: m, oldPath: file?.oldPath };
     },
     (input) => client.git.diff(input),
   );
 
-  // Reset selection when the repo or mode changes — the previous file's
-  // path may not exist in the new context (different repo, different diff
-  // base), and stale selection would surface as a spurious error row.
+  // Reset selection when the repo or view changes.
   createEffect(
-    on([repoPath, mode], () => setSelectedPath(null), { defer: true }),
+    on([repoPath, view], () => setSelectedPath(null), { defer: true }),
   );
 
   const handleRefresh = () => {
-    void refetchStatus();
-    if (selectedPath()) void refetchDiff();
+    if (isDiffView()) {
+      void refetchStatus();
+      if (selectedPath()) void refetchDiff();
+    } else {
+      // File browser: increment a counter to trigger re-fetch of root entries.
+      setBrowseRefreshCount((c) => c + 1);
+    }
   };
 
   const diffTheme = () =>
     preferences().colorScheme === "light" ? "light" : "dark";
 
-  /** Context label shown after the icon tabs — resolves to the actual
-   *  base ref name once status returns (e.g. `origin/master`), falling
-   *  back to the static label from MODE_TABS until then. */
+  /** Context label shown after the icon tabs. */
   const headerLabel = () => {
-    const tab = MODE_TABS.find((t) => t.mode === mode())!;
-    if (mode() === "local") return tab.label;
+    const tab = VIEW_TABS.find((t) => t.view === view())!;
+    if (view() === "local" || view() === "browse") return tab.label;
     return status()?.base?.ref ? `vs ${status()!.base!.ref}` : tab.label;
+  };
+
+  // --- File browser state ---
+  const [browseRefreshCount, setBrowseRefreshCount] = createSignal(0);
+
+  /** Root entries for the file browser. */
+  const [browseRoot] = createResource(
+    () => {
+      const p = repoPath();
+      if (!p || view() !== "browse") return null;
+      // Track refresh count so manual refresh re-fetches.
+      browseRefreshCount();
+      return { repoPath: p, dirPath: "" };
+    },
+    async (input) => {
+      const result = await client.fs.listDir(input);
+      return entriesToNodes(result.entries);
+    },
+  );
+
+  /** Load children for a directory in browse mode. */
+  const loadBrowseChildren = async (dirPath: string): Promise<TreeNode[]> => {
+    const p = repoPath();
+    if (!p) return [];
+    const result = await client.fs.listDir({ repoPath: p, dirPath });
+    return entriesToNodes(result.entries);
   };
 
   return (
@@ -155,16 +215,16 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
       >
         <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-1">
           <div class="flex items-center bg-surface-2/40 rounded p-0.5 gap-0.5">
-            <For each={MODE_TABS}>
+            <For each={VIEW_TABS}>
               {(tab) => (
                 <button
                   type="button"
-                  onClick={() => setMode(tab.mode)}
+                  onClick={() => setView(tab.view)}
                   title={tab.tooltip}
                   class="flex items-center justify-center w-5 h-5 text-fg-3/50 hover:text-fg-2 cursor-pointer rounded transition-colors data-[active=true]:text-fg data-[active=true]:bg-surface-0 data-[active=true]:shadow-sm"
-                  data-testid={`diff-mode-${tab.mode}`}
-                  data-active={mode() === tab.mode}
-                  aria-pressed={mode() === tab.mode}
+                  data-testid={`diff-mode-${tab.view}`}
+                  data-active={view() === tab.view}
+                  aria-pressed={view() === tab.view}
                 >
                   <Dynamic component={tab.icon} class="w-3 h-3" />
                 </button>
@@ -174,7 +234,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
           <span
             class="text-fg-3/50 text-[10px] font-mono truncate min-w-0 ml-1"
             data-testid="diff-mode-label"
-            data-mode={mode()}
+            data-mode={view()}
           >
             {headerLabel()}
           </span>
@@ -183,121 +243,175 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
             type="button"
             onClick={handleRefresh}
             class="text-fg-3/40 hover:text-fg-2 cursor-pointer px-1 shrink-0 transition-colors"
-            aria-label="Refresh changed files"
+            aria-label="Refresh"
             data-testid="diff-refresh"
           >
             ↻
           </button>
         </div>
 
-        <div
-          class="shrink-0 max-h-[35%] overflow-y-auto border-b border-edge"
-          data-testid="diff-file-list"
-        >
-          <Switch fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}>
-            <Match when={status.error}>
-              <div class="px-2 py-1 text-danger" data-testid="diff-error">
-                Error: {(status.error as Error).message}
-              </div>
-            </Match>
-            <Match when={status()}>
-              {(s) => {
-                const tree = createMemo(() => buildFileTree(s().files));
-                return (
-                  <Show
-                    when={s().files.length > 0}
-                    fallback={
-                      <div
-                        class="px-2 py-4 text-fg-3/50 text-center"
-                        data-testid="diff-empty"
-                      >
-                        {EMPTY_STATE[mode()]}
-                      </div>
-                    }
-                  >
-                    <FileTree
-                      nodes={tree()}
-                      selectedPath={selectedPath()}
-                      onSelect={(path) =>
-                        setSelectedPath((p) => (p === path ? null : path))
-                      }
-                      renderBadge={(node) =>
-                        node.kind === "file" ? (
-                          <span
-                            class={`inline-flex items-center gap-1 ${STATUS_COLOR[node.status]}`}
-                          >
-                            <span class="w-1.5 h-1.5 rounded-full bg-current opacity-70" />
-                            <span class="text-[10px] font-medium">
-                              {node.status}
-                            </span>
-                          </span>
-                        ) : null
-                      }
-                    />
-                  </Show>
-                );
-              }}
-            </Match>
-          </Switch>
-        </div>
-
-        {/* Gutter tightening lives in diff-tab.css — see comment there. */}
-        <div class="flex-1 min-h-0 overflow-auto" data-testid="diff-content">
-          <Show
-            when={selectedPath()}
-            fallback={
-              <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
-                <FileDiffIcon class="w-8 h-8 opacity-40" />
-                <span class="text-[11px]">Select a file to view its diff</span>
-              </div>
-            }
-          >
-            <Switch
-              fallback={<div class="px-2 py-1 text-fg-3/50">Loading diff…</div>}
+        <Switch>
+          {/* === Diff modes (local / branch) === */}
+          <Match when={isDiffView()}>
+            <div
+              class="shrink-0 max-h-[35%] overflow-y-auto border-b border-edge"
+              data-testid="diff-file-list"
             >
-              <Match when={diff.error}>
-                <div class="px-2 py-1 text-danger">
-                  Error: {(diff.error as Error).message}
-                </div>
-              </Match>
-              <Match
-                when={
-                  diff() &&
-                  diff()!.hunks.length === 0 &&
-                  diff()!.oldFileName &&
-                  diff()!.newFileName &&
-                  diff()!.oldFileName !== diff()!.newFileName
+              <Switch
+                fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}
+              >
+                <Match when={status.error}>
+                  <div class="px-2 py-1 text-danger" data-testid="diff-error">
+                    Error: {(status.error as Error).message}
+                  </div>
+                </Match>
+                <Match when={status()}>
+                  {(s) => {
+                    const tree = createMemo(() => buildFileTree(s().files));
+                    return (
+                      <Show
+                        when={s().files.length > 0}
+                        fallback={
+                          <div
+                            class="px-2 py-4 text-fg-3/50 text-center"
+                            data-testid="diff-empty"
+                          >
+                            {EMPTY_STATE[diffMode()!]}
+                          </div>
+                        }
+                      >
+                        <FileTree
+                          nodes={tree()}
+                          selectedPath={selectedPath()}
+                          onSelect={(path) =>
+                            setSelectedPath((p) => (p === path ? null : path))
+                          }
+                          renderBadge={(node) =>
+                            node.kind === "file" && node.status ? (
+                              <span
+                                class={`inline-flex items-center gap-1 ${STATUS_COLOR[node.status]}`}
+                              >
+                                <span class="w-1.5 h-1.5 rounded-full bg-current opacity-70" />
+                                <span class="text-[10px] font-medium">
+                                  {node.status}
+                                </span>
+                              </span>
+                            ) : null
+                          }
+                        />
+                      </Show>
+                    );
+                  }}
+                </Match>
+              </Switch>
+            </div>
+
+            {/* Gutter tightening lives in diff-tab.css — see comment there. */}
+            <div
+              class="flex-1 min-h-0 overflow-auto"
+              data-testid="diff-content"
+            >
+              <Show
+                when={selectedPath()}
+                fallback={
+                  <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
+                    <FileDiffIcon class="w-8 h-8 opacity-40" />
+                    <span class="text-[11px]">
+                      Select a file to view its diff
+                    </span>
+                  </div>
                 }
               >
-                <div class="flex items-center justify-center h-full text-fg-3/50">
-                  File renamed: {diff()!.oldFileName} → {diff()!.newFileName}
-                </div>
-              </Match>
-              <Match when={diff()}>
-                {(d) => (
-                  <DiffView
-                    data={{
-                      oldFile: {
-                        fileName: d().oldFileName,
-                        content: d().oldContent,
-                      },
-                      newFile: {
-                        fileName: d().newFileName,
-                        content: d().newContent,
-                      },
-                      hunks: d().hunks,
-                    }}
-                    diffViewMode={DiffModeEnum.Unified}
-                    diffViewHighlight
-                    diffViewTheme={diffTheme()}
-                    diffViewFontSize={11}
-                    diffViewWrap
-                  />
-                )}
-              </Match>
-            </Switch>
-          </Show>
-        </div>
+                <Switch
+                  fallback={
+                    <div class="px-2 py-1 text-fg-3/50">Loading diff…</div>
+                  }
+                >
+                  <Match when={diff.error}>
+                    <div class="px-2 py-1 text-danger">
+                      Error: {(diff.error as Error).message}
+                    </div>
+                  </Match>
+                  <Match
+                    when={
+                      diff() &&
+                      diff()!.hunks.length === 0 &&
+                      diff()!.oldFileName &&
+                      diff()!.newFileName &&
+                      diff()!.oldFileName !== diff()!.newFileName
+                    }
+                  >
+                    <div class="flex items-center justify-center h-full text-fg-3/50">
+                      File renamed: {diff()!.oldFileName} →{" "}
+                      {diff()!.newFileName}
+                    </div>
+                  </Match>
+                  <Match when={diff()}>
+                    {(d) => (
+                      <DiffView
+                        data={{
+                          oldFile: {
+                            fileName: d().oldFileName,
+                            content: d().oldContent,
+                          },
+                          newFile: {
+                            fileName: d().newFileName,
+                            content: d().newContent,
+                          },
+                          hunks: d().hunks,
+                        }}
+                        diffViewMode={DiffModeEnum.Unified}
+                        diffViewHighlight
+                        diffViewTheme={diffTheme()}
+                        diffViewFontSize={11}
+                        diffViewWrap
+                      />
+                    )}
+                  </Match>
+                </Switch>
+              </Show>
+            </div>
+          </Match>
+
+          {/* === File browser mode === */}
+          <Match when={!isDiffView()}>
+            <div
+              class="flex-1 min-h-0 overflow-y-auto"
+              data-testid="file-browser"
+            >
+              <Switch
+                fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}
+              >
+                <Match when={browseRoot.error}>
+                  <div class="px-2 py-1 text-danger">
+                    Error: {(browseRoot.error as Error).message}
+                  </div>
+                </Match>
+                <Match when={browseRoot()}>
+                  {(nodes) => (
+                    <Show
+                      when={nodes().length > 0}
+                      fallback={
+                        <div class="px-2 py-4 text-fg-3/50 text-center">
+                          Empty directory
+                        </div>
+                      }
+                    >
+                      <FileTree
+                        nodes={nodes()}
+                        selectedPath={selectedPath()}
+                        onSelect={(path) =>
+                          setSelectedPath((p) => (p === path ? null : path))
+                        }
+                        loadChildren={loadBrowseChildren}
+                      />
+                    </Show>
+                  )}
+                </Match>
+              </Switch>
+            </div>
+          </Match>
+        </Switch>
       </div>
     </Show>
   );

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -52,26 +52,6 @@ import { buildFileTree } from "../ui/buildFileTree";
 import type { TreeNode } from "../ui/buildFileTree";
 import FileTree from "../ui/FileTree";
 
-/** Map file extensions to highlight.js language names where they differ. */
-const EXT_TO_LANG: Record<string, string> = {
-  md: "markdown",
-  ts: "typescript",
-  tsx: "typescript",
-  js: "javascript",
-  jsx: "javascript",
-  yml: "yaml",
-  sh: "bash",
-  zsh: "bash",
-  rs: "rust",
-  py: "python",
-  rb: "ruby",
-  kt: "kotlin",
-  cs: "csharp",
-  hs: "haskell",
-  ex: "elixir",
-  exs: "elixir",
-};
-
 /** Color class for each git status letter. */
 const STATUS_COLOR: Record<GitChangeStatus, string> = {
   M: "text-warning",
@@ -466,9 +446,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                       const highlighted = createMemo(() => {
                         const path = selectedPath() ?? "";
                         const ext = path.split(".").pop() ?? "";
-                        const lang =
-                          EXT_TO_LANG[ext] ??
-                          (hljs.getLanguage(ext) ? ext : undefined);
+                        const lang = hljs.getLanguage(ext)
+                          ? ext
+                          : undefined;
                         return lang
                           ? hljs.highlight(fc().content, { language: lang })
                           : hljs.highlightAuto(fc().content);

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -28,6 +28,7 @@ import {
   Switch,
 } from "solid-js";
 import { Dynamic } from "solid-js/web";
+import hljs from "highlight.js";
 import { DiffView, DiffModeEnum } from "@git-diff-view/solid";
 import "@git-diff-view/solid/styles/diff-view-pure.css";
 // Order matters: this overrides the library CSS imported just above.
@@ -445,18 +446,34 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                     </div>
                   </Match>
                   <Match when={fileContent()}>
-                    {(fc) => (
-                      <>
-                        <Show when={fc().truncated}>
-                          <div class="px-2 py-1 text-warning text-[10px] border-b border-edge bg-surface-1/30">
-                            File truncated (exceeds 1 MB)
-                          </div>
-                        </Show>
-                        <pre class="px-2 py-1 font-mono text-fg whitespace-pre-wrap break-all">
-                          {fc().content}
-                        </pre>
-                      </>
-                    )}
+                    {(fc) => {
+                      const highlighted = createMemo(() => {
+                        const path = selectedPath() ?? "";
+                        const ext = path.split(".").pop() ?? "";
+                        const lang = hljs.getLanguage(ext) ? ext : undefined;
+                        return lang
+                          ? hljs.highlight(fc().content, { language: lang })
+                          : hljs.highlightAuto(fc().content);
+                      });
+                      return (
+                        <>
+                          <Show when={fc().truncated}>
+                            <div class="px-2 py-1 text-warning text-[10px] border-b border-edge bg-surface-1/30">
+                              File truncated (exceeds 1 MB)
+                            </div>
+                          </Show>
+                          <pre
+                            class="px-2 py-1 font-mono text-[11px] text-fg whitespace-pre-wrap break-all leading-relaxed"
+                            style={{ "tab-size": "2" }}
+                          >
+                            <code
+                              class="hljs"
+                              innerHTML={highlighted().value}
+                            />
+                          </pre>
+                        </>
+                      );
+                    }}
                   </Match>
                 </Switch>
               </Show>

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -488,6 +488,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                             class="px-2 py-1 font-mono text-[11px] text-fg whitespace-pre-wrap break-all leading-relaxed"
                             style={{ "tab-size": "2" }}
                           >
+                            {/* Safe: highlight.js escapes HTML entities before
+                                wrapping tokens in <span> tags. The input is file
+                                content read from the user's own repo. */}
                             <code
                               class="hljs"
                               innerHTML={highlighted().value}

--- a/packages/client/src/right-panel/code-tab.css
+++ b/packages/client/src/right-panel/code-tab.css
@@ -1,3 +1,81 @@
+/* ── highlight.js token colors for the file browser code viewer ──
+ * Minimal set covering the most common token types. Uses CSS custom
+ * properties scoped by .dark / :not(.dark) to follow kolu's theme. */
+
+[data-testid="file-content"] .hljs {
+  background: transparent;
+}
+
+/* ── Dark palette ── */
+:root.dark [data-testid="file-content"] .hljs-keyword {
+  color: #ff7b72;
+}
+:root.dark [data-testid="file-content"] .hljs-string,
+:root.dark [data-testid="file-content"] .hljs-regexp {
+  color: #a5d6ff;
+}
+:root.dark [data-testid="file-content"] .hljs-number,
+:root.dark [data-testid="file-content"] .hljs-literal {
+  color: #79c0ff;
+}
+:root.dark [data-testid="file-content"] .hljs-comment,
+:root.dark [data-testid="file-content"] .hljs-doctag {
+  color: #8b949e;
+}
+:root.dark [data-testid="file-content"] .hljs-title,
+:root.dark [data-testid="file-content"] .hljs-function {
+  color: #d2a8ff;
+}
+:root.dark [data-testid="file-content"] .hljs-type,
+:root.dark [data-testid="file-content"] .hljs-built_in {
+  color: #ffa657;
+}
+:root.dark [data-testid="file-content"] .hljs-attr,
+:root.dark [data-testid="file-content"] .hljs-attribute {
+  color: #79c0ff;
+}
+:root.dark [data-testid="file-content"] .hljs-meta {
+  color: #8b949e;
+}
+:root.dark [data-testid="file-content"] .hljs-tag {
+  color: #7ee787;
+}
+
+/* ── Light palette ── */
+:root:not(.dark) [data-testid="file-content"] .hljs-keyword {
+  color: #cf222e;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-string,
+:root:not(.dark) [data-testid="file-content"] .hljs-regexp {
+  color: #0a3069;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-number,
+:root:not(.dark) [data-testid="file-content"] .hljs-literal {
+  color: #0550ae;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-comment,
+:root:not(.dark) [data-testid="file-content"] .hljs-doctag {
+  color: #6e7781;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-title,
+:root:not(.dark) [data-testid="file-content"] .hljs-function {
+  color: #8250df;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-type,
+:root:not(.dark) [data-testid="file-content"] .hljs-built_in {
+  color: #953800;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-attr,
+:root:not(.dark) [data-testid="file-content"] .hljs-attribute {
+  color: #0550ae;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-meta {
+  color: #6e7781;
+}
+:root:not(.dark) [data-testid="file-content"] .hljs-tag {
+  color: #116329;
+}
+
 /*
  * Vendor overrides for `@git-diff-view/solid` to fit a narrow side panel.
  *

--- a/packages/client/src/ui/FileTree.tsx
+++ b/packages/client/src/ui/FileTree.tsx
@@ -61,17 +61,22 @@ const FileTree: Component<FileTreeProps> = (props) => {
     });
 
     // Lazy-load children on first expand when loadChildren is provided.
-    if (isExpanding && props.loadChildren && !childrenCache().has(path) && !loading().has(path)) {
+    if (
+      isExpanding &&
+      props.loadChildren &&
+      !childrenCache().has(path) &&
+      !loading().has(path)
+    ) {
       setLoading((prev) => new Set(prev).add(path));
       props.loadChildren(path).then(
         (children) => {
           setChildrenCache((prev) => {
-          const next = new Map(prev).set(path, children);
-          while (next.size > MAX_CACHE_ENTRIES) {
-            next.delete(next.keys().next().value!);
-          }
-          return next;
-        });
+            const next = new Map(prev).set(path, children);
+            while (next.size > MAX_CACHE_ENTRIES) {
+              next.delete(next.keys().next().value!);
+            }
+            return next;
+          });
           setLoading((prev) => {
             const next = new Set(prev);
             next.delete(path);

--- a/packages/client/src/ui/FileTree.tsx
+++ b/packages/client/src/ui/FileTree.tsx
@@ -61,7 +61,7 @@ const FileTree: Component<FileTreeProps> = (props) => {
     });
 
     // Lazy-load children on first expand when loadChildren is provided.
-    if (isExpanding && props.loadChildren && !childrenCache().has(path)) {
+    if (isExpanding && props.loadChildren && !childrenCache().has(path) && !loading().has(path)) {
       setLoading((prev) => new Set(prev).add(path));
       props.loadChildren(path).then(
         (children) => {

--- a/packages/client/src/ui/FileTree.tsx
+++ b/packages/client/src/ui/FileTree.tsx
@@ -11,7 +11,7 @@ import type { TreeNode } from "./buildFileTree";
 import { collectDirPaths } from "./buildFileTree";
 
 /** Generic collapsible file tree. Reusable across Code tab modes
- *  (changed-file list, future file browser). */
+ *  (changed-file list, file browser). */
 export type FileTreeProps = {
   /** Root nodes of the tree. */
   nodes: TreeNode[];
@@ -21,25 +21,64 @@ export type FileTreeProps = {
   onSelect: (path: string) => void;
   /** Optional render for the trailing badge (e.g. git status letter). */
   renderBadge?: (node: TreeNode) => JSX.Element;
+  /** Optional async loader for directory children. When provided, directories
+   *  start with empty children and load on first expand (file browser mode).
+   *  When omitted, children are taken from the node (git-changes mode). */
+  loadChildren?: (path: string) => Promise<TreeNode[]>;
 };
 
 const FileTree: Component<FileTreeProps> = (props) => {
-  // Expand all directories by default; rebuild when the tree changes.
+  // Expand all directories by default when no loadChildren (git-changes mode);
+  // start collapsed when loadChildren is set (file browser mode).
   const [expanded, setExpanded] = createSignal<Set<string>>(new Set());
   createEffect(
     on(
       () => props.nodes,
-      (nodes) => setExpanded(collectDirPaths(nodes)),
+      (nodes) =>
+        setExpanded(
+          props.loadChildren ? new Set<string>() : collectDirPaths(nodes),
+        ),
     ),
   );
 
+  // Cache of lazily loaded children keyed by directory path.
+  const [childrenCache, setChildrenCache] = createSignal<
+    Map<string, TreeNode[]>
+  >(new Map());
+  // Tracks directories currently being loaded.
+  const [loading, setLoading] = createSignal<Set<string>>(new Set());
+
   const toggle = (path: string) => {
+    const isExpanding = !expanded().has(path);
     setExpanded((prev) => {
       const next = new Set(prev);
       if (next.has(path)) next.delete(path);
       else next.add(path);
       return next;
     });
+
+    // Lazy-load children on first expand when loadChildren is provided.
+    if (isExpanding && props.loadChildren && !childrenCache().has(path)) {
+      setLoading((prev) => new Set(prev).add(path));
+      props.loadChildren(path).then(
+        (children) => {
+          setChildrenCache((prev) => new Map(prev).set(path, children));
+          setLoading((prev) => {
+            const next = new Set(prev);
+            next.delete(path);
+            return next;
+          });
+        },
+        () => {
+          // Clear loading state on failure so the user can retry by collapsing/expanding.
+          setLoading((prev) => {
+            const next = new Set(prev);
+            next.delete(path);
+            return next;
+          });
+        },
+      );
+    }
   };
 
   return (
@@ -52,6 +91,9 @@ const FileTree: Component<FileTreeProps> = (props) => {
         onToggle={toggle}
         onSelect={props.onSelect}
         renderBadge={props.renderBadge}
+        childrenCache={childrenCache()}
+        loading={loading()}
+        loadChildren={props.loadChildren}
       />
     </div>
   );
@@ -65,60 +107,81 @@ type TreeLevelProps = {
   onToggle: (path: string) => void;
   onSelect: (path: string) => void;
   renderBadge?: (node: TreeNode) => JSX.Element;
+  childrenCache: Map<string, TreeNode[]>;
+  loading: Set<string>;
+  loadChildren?: (path: string) => Promise<TreeNode[]>;
 };
 
 const TreeLevel: Component<TreeLevelProps> = (props) => (
   <For each={props.nodes}>
-    {(node) => (
-      <>
-        <button
-          type="button"
-          onClick={() =>
-            node.kind === "dir"
-              ? props.onToggle(node.path)
-              : props.onSelect(node.path)
-          }
-          class="flex w-full items-center gap-1 px-2 py-0.5 text-left font-mono text-fg hover:bg-surface-2/40 cursor-pointer transition-colors"
-          classList={{
-            "bg-surface-2/50 border-l-2 border-accent":
-              node.kind === "file" && props.selectedPath === node.path,
-            "border-l-2 border-transparent": !(
+    {(node) => {
+      const children = () => {
+        if (node.kind !== "dir") return [];
+        // In loadChildren mode, use cached children (or empty if not loaded yet).
+        if (props.loadChildren) return props.childrenCache.get(node.path) ?? [];
+        return node.children;
+      };
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              node.kind === "dir"
+                ? props.onToggle(node.path)
+                : props.onSelect(node.path)
+            }
+            class="flex w-full items-center gap-1 px-2 py-0.5 text-left font-mono text-fg hover:bg-surface-2/40 cursor-pointer transition-colors"
+            classList={{
+              "bg-surface-2/50 border-l-2 border-accent":
+                node.kind === "file" && props.selectedPath === node.path,
+              "border-l-2 border-transparent": !(
+                node.kind === "file" && props.selectedPath === node.path
+              ),
+            }}
+            style={{ "padding-left": `${props.depth * 12 + 8}px` }}
+            data-testid={
+              node.kind === "dir" ? "file-tree-dir" : "diff-file-item"
+            }
+            data-path={node.path}
+            data-active={
               node.kind === "file" && props.selectedPath === node.path
-            ),
-          }}
-          style={{ "padding-left": `${props.depth * 12 + 8}px` }}
-          data-testid={node.kind === "dir" ? "file-tree-dir" : "diff-file-item"}
-          data-path={node.path}
-          data-active={node.kind === "file" && props.selectedPath === node.path}
-        >
-          <span class="w-3 shrink-0 text-center text-fg-3/50 text-[10px]">
-            {node.kind === "dir"
-              ? props.expanded.has(node.path)
-                ? "\u25BE"
-                : "\u25B8"
-              : ""}
-          </span>
-          <span class="truncate min-w-0">
-            {node.name}
-            {node.kind === "dir" ? "/" : ""}
-          </span>
-          <Show when={props.renderBadge}>
-            {(badge) => <span class="ml-auto shrink-0">{badge()(node)}</span>}
+            }
+          >
+            <span class="w-3 shrink-0 text-center text-fg-3/50 text-[10px]">
+              {node.kind === "dir"
+                ? props.loading.has(node.path)
+                  ? "\u2026"
+                  : props.expanded.has(node.path)
+                    ? "\u25BE"
+                    : "\u25B8"
+                : ""}
+            </span>
+            <span class="truncate min-w-0">
+              {node.name}
+              {node.kind === "dir" ? "/" : ""}
+            </span>
+            <Show when={props.renderBadge}>
+              {(badge) => <span class="ml-auto shrink-0">{badge()(node)}</span>}
+            </Show>
+          </button>
+          <Show when={node.kind === "dir" && props.expanded.has(node.path)}>
+            <TreeLevel
+              nodes={children()}
+              depth={props.depth + 1}
+              expanded={props.expanded}
+              selectedPath={props.selectedPath}
+              onToggle={props.onToggle}
+              onSelect={props.onSelect}
+              renderBadge={props.renderBadge}
+              childrenCache={props.childrenCache}
+              loading={props.loading}
+              loadChildren={props.loadChildren}
+            />
           </Show>
-        </button>
-        <Show when={node.kind === "dir" && props.expanded.has(node.path)}>
-          <TreeLevel
-            nodes={node.kind === "dir" ? node.children : []}
-            depth={props.depth + 1}
-            expanded={props.expanded}
-            selectedPath={props.selectedPath}
-            onToggle={props.onToggle}
-            onSelect={props.onSelect}
-            renderBadge={props.renderBadge}
-          />
-        </Show>
-      </>
-    )}
+        </>
+      );
+    }}
   </For>
 );
 

--- a/packages/client/src/ui/FileTree.tsx
+++ b/packages/client/src/ui/FileTree.tsx
@@ -42,6 +42,9 @@ const FileTree: Component<FileTreeProps> = (props) => {
   );
 
   // Cache of lazily loaded children keyed by directory path.
+  // Capped to prevent unbounded growth in large repos; oldest entries
+  // are evicted first (Map preserves insertion order).
+  const MAX_CACHE_ENTRIES = 200;
   const [childrenCache, setChildrenCache] = createSignal<
     Map<string, TreeNode[]>
   >(new Map());
@@ -62,7 +65,13 @@ const FileTree: Component<FileTreeProps> = (props) => {
       setLoading((prev) => new Set(prev).add(path));
       props.loadChildren(path).then(
         (children) => {
-          setChildrenCache((prev) => new Map(prev).set(path, children));
+          setChildrenCache((prev) => {
+          const next = new Map(prev).set(path, children);
+          while (next.size > MAX_CACHE_ENTRIES) {
+            next.delete(next.keys().next().value!);
+          }
+          return next;
+        });
           setLoading((prev) => {
             const next = new Set(prev);
             next.delete(path);

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -272,6 +272,17 @@ export const TerminalIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
+/** File tree browser: folder icon — browse the full repo structure. */
+export const FileBrowseIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 16 16"
+    fill="currentColor"
+  >
+    <path d="M1.75 1A1.75 1.75 0 0 0 0 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0 0 16 13.25v-8.5A1.75 1.75 0 0 0 14.25 3H7.5a.25.25 0 0 1-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75z" />
+  </svg>
+);
+
 /** File with diff line — empty-state placeholder for "select a file". */
 export const FileDiffIcon: Component<{ class?: string }> = (props) => (
   <svg

--- a/packages/client/src/ui/buildFileTree.ts
+++ b/packages/client/src/ui/buildFileTree.ts
@@ -7,8 +7,8 @@ export type FileNode = {
   name: string;
   /** Path relative to repo root (e.g. `src/utils/helpers.ts`). */
   path: string;
-  /** Git change status (M, A, D, etc.). */
-  status: GitChangeStatus;
+  /** Git change status (M, A, D, etc.). Present in diff modes, absent in browse mode. */
+  status?: GitChangeStatus;
 };
 
 /** A directory branch in the tree. */

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -30,6 +30,8 @@ import {
   GitDiffOutputSchema,
   ServerStateSchema,
   ServerStatePatchSchema,
+  FsListDirInputSchema,
+  FsListDirOutputSchema,
 } from "./index";
 import { z } from "zod";
 
@@ -90,6 +92,11 @@ export const contract = oc.router({
      *  Base depends on mode — HEAD in local mode, merge-base with
      *  `origin/<defaultBranch>` in branch mode. */
     diff: oc.input(GitDiffInputSchema).output(GitDiffOutputSchema),
+  },
+  fs: {
+    /** List entries in a directory, filtered by git (tracked + untracked-but-not-ignored).
+     *  Used by the Code tab's file tree browser. */
+    listDir: oc.input(FsListDirInputSchema).output(FsListDirOutputSchema),
   },
   state: {
     // Stream server state changes (preferences, recent repos, session). Yields current state immediately.

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -32,6 +32,8 @@ import {
   ServerStatePatchSchema,
   FsListDirInputSchema,
   FsListDirOutputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
 } from "./index";
 import { z } from "zod";
 
@@ -97,6 +99,8 @@ export const contract = oc.router({
     /** List entries in a directory, filtered by git (tracked + untracked-but-not-ignored).
      *  Used by the Code tab's file tree browser. */
     listDir: oc.input(FsListDirInputSchema).output(FsListDirOutputSchema),
+    /** Read a file's UTF-8 content, path-traversal guarded. */
+    readFile: oc.input(FsReadFileInputSchema).output(FsReadFileOutputSchema),
   },
   state: {
     // Stream server state changes (preferences, recent repos, session). Yields current state immediately.

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -23,6 +23,8 @@ import {
   FsListDirInputSchema,
   FsDirEntrySchema,
   FsListDirOutputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
 } from "kolu-git";
 
 // Re-export integration schemas so consumers import from kolu-common only.
@@ -45,6 +47,8 @@ export {
   FsListDirInputSchema,
   FsDirEntrySchema,
   FsListDirOutputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
 };
 export type {
   GitInfo,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,6 +20,9 @@ import {
   GitStatusOutputSchema,
   GitDiffInputSchema,
   GitDiffOutputSchema,
+  FsListDirInputSchema,
+  FsDirEntrySchema,
+  FsListDirOutputSchema,
 } from "kolu-git";
 
 // Re-export integration schemas so consumers import from kolu-common only.
@@ -39,6 +42,9 @@ export {
   GitStatusOutputSchema,
   GitDiffInputSchema,
   GitDiffOutputSchema,
+  FsListDirInputSchema,
+  FsDirEntrySchema,
+  FsListDirOutputSchema,
 };
 export type {
   GitInfo,
@@ -48,6 +54,7 @@ export type {
   GitBaseRef,
   GitStatusOutput,
   GitDiffOutput,
+  FsListDirOutput,
 } from "kolu-git";
 
 // --- Zod schemas ---

--- a/packages/integrations/git/src/browse.test.ts
+++ b/packages/integrations/git/src/browse.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { simpleGit } from "simple-git";
+import { listDir, readFile } from "./browse.ts";
+
+describe("listDir", () => {
+  let tmpDir: string;
+
+  async function initRepo(name: string) {
+    const dir = path.join(tmpDir, name);
+    fs.mkdirSync(dir, { recursive: true });
+    const git = simpleGit(dir);
+    await git.init();
+    await git.checkoutLocalBranch("main");
+    return { dir, git };
+  }
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-browse-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists tracked files and directories at the root", async () => {
+    const { dir, git } = await initRepo("tracked-root");
+    fs.mkdirSync(path.join(dir, "src"));
+    fs.writeFileSync(path.join(dir, "README.md"), "hello");
+    fs.writeFileSync(path.join(dir, "src/index.ts"), "export {}");
+    await git.add(".");
+    await git.commit("initial");
+
+    const result = await listDir(dir, "");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const names = result.value.map((e) => e.name);
+    expect(names).toContain("README.md");
+    expect(names).toContain("src");
+
+    const src = result.value.find((e) => e.name === "src");
+    expect(src?.isDirectory).toBe(true);
+    expect(src?.path).toBe("src");
+
+    const readme = result.value.find((e) => e.name === "README.md");
+    expect(readme?.isDirectory).toBe(false);
+  });
+
+  it("lists entries in a subdirectory", async () => {
+    const { dir, git } = await initRepo("subdir");
+    fs.mkdirSync(path.join(dir, "pkg/lib"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "pkg/index.ts"), "x");
+    fs.writeFileSync(path.join(dir, "pkg/lib/util.ts"), "y");
+    await git.add(".");
+    await git.commit("initial");
+
+    const result = await listDir(dir, "pkg");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.map((e) => e.name)).toEqual(["lib", "index.ts"]);
+    expect(result.value[0]?.isDirectory).toBe(true);
+    expect(result.value[0]?.path).toBe("pkg/lib");
+    expect(result.value[1]?.path).toBe("pkg/index.ts");
+  });
+
+  it("includes untracked-but-not-ignored files", async () => {
+    const { dir, git } = await initRepo("untracked");
+    fs.writeFileSync(path.join(dir, "tracked.ts"), "a");
+    await git.add(".");
+    await git.commit("initial");
+
+    // Create an untracked file after commit
+    fs.writeFileSync(path.join(dir, "untracked.ts"), "b");
+
+    const result = await listDir(dir, "");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const names = result.value.map((e) => e.name);
+    expect(names).toContain("tracked.ts");
+    expect(names).toContain("untracked.ts");
+  });
+
+  it("excludes gitignored files", async () => {
+    const { dir, git } = await initRepo("ignored");
+    fs.writeFileSync(path.join(dir, ".gitignore"), "build/\n*.log\n");
+    fs.writeFileSync(path.join(dir, "keep.ts"), "a");
+    await git.add(".");
+    await git.commit("initial");
+
+    // Create ignored files
+    fs.mkdirSync(path.join(dir, "build"));
+    fs.writeFileSync(path.join(dir, "build/out.js"), "x");
+    fs.writeFileSync(path.join(dir, "debug.log"), "y");
+
+    const result = await listDir(dir, "");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const names = result.value.map((e) => e.name);
+    expect(names).toContain("keep.ts");
+    expect(names).not.toContain("build");
+    expect(names).not.toContain("debug.log");
+  });
+
+  it("sorts directories first, then files, alphabetically", async () => {
+    const { dir, git } = await initRepo("sort-order");
+    fs.mkdirSync(path.join(dir, "zebra"));
+    fs.mkdirSync(path.join(dir, "alpha"));
+    fs.writeFileSync(path.join(dir, "zebra/z.ts"), "z");
+    fs.writeFileSync(path.join(dir, "alpha/a.ts"), "a");
+    fs.writeFileSync(path.join(dir, "middle.ts"), "m");
+    fs.writeFileSync(path.join(dir, "aaa.ts"), "a");
+    await git.add(".");
+    await git.commit("initial");
+
+    const result = await listDir(dir, "");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const names = result.value.map((e) => e.name);
+    // Directories first (alphabetical), then files (alphabetical)
+    expect(names).toEqual(["alpha", "zebra", "aaa.ts", "middle.ts"]);
+  });
+
+  it("rejects path traversal", async () => {
+    const { dir } = await initRepo("traversal");
+    const result = await listDir(dir, "../etc");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+    }
+  });
+
+  it("works in an empty repo (no commits)", async () => {
+    const { dir } = await initRepo("empty");
+    // Create an untracked file — no HEAD exists yet
+    fs.writeFileSync(path.join(dir, "new.ts"), "x");
+
+    const result = await listDir(dir, "");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.map((e) => e.name)).toContain("new.ts");
+  });
+});
+
+describe("readFile", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-readfile-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads file content", async () => {
+    fs.writeFileSync(path.join(tmpDir, "hello.txt"), "world\n");
+    const result = await readFile(tmpDir, "hello.txt");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.content).toBe("world\n");
+    expect(result.value.truncated).toBe(false);
+  });
+
+  it("rejects path traversal", async () => {
+    const result = await readFile(tmpDir, "../../etc/passwd");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+    }
+  });
+
+  it("returns error for non-existent file", async () => {
+    const result = await readFile(tmpDir, "nope.txt");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("GIT_FAILED");
+    }
+  });
+});

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -142,6 +142,8 @@ export async function readFile(
   try {
     const buf = await fsReadFile(resolved.value.abs);
     if (buf.length > MAX_READ_BYTES) {
+      // May split a multi-byte UTF-8 sequence at the boundary; Node
+      // replaces the incomplete trailing character with U+FFFD.
       return ok({
         content: buf.subarray(0, MAX_READ_BYTES).toString("utf-8"),
         truncated: true,

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -1,13 +1,14 @@
-/** Git-filtered directory listing.
+/** File tree browsing — git-filtered directory listing and file reading.
  *
  *  Uses `git ls-tree` for tracked files and `git ls-files --others
  *  --exclude-standard` for untracked-but-not-ignored files. This
  *  avoids listing `node_modules/`, `.git/`, build artifacts, etc. */
 
+import { readFile as fsReadFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { Logger } from "anyagent";
-import { type GitResult, ok } from "./errors.ts";
+import { type GitResult, ok, err } from "./errors.ts";
 import { resolveUnder } from "./safe-path.ts";
 
 const execFileAsync = promisify(execFile);
@@ -119,4 +120,36 @@ export async function listDir(
   });
 
   return ok(sorted);
+}
+
+/** Max file size to read (1 MB). Larger files get a truncation notice. */
+const MAX_READ_BYTES = 1_048_576;
+
+/** Read a file's UTF-8 content, guarded against path traversal.
+ *
+ *  @param repoPath  Absolute path to the repo root.
+ *  @param filePath  Path relative to repo root.
+ *  @param log       Optional logger. */
+export async function readFile(
+  repoPath: string,
+  filePath: string,
+  log?: Logger,
+): Promise<GitResult<{ content: string; truncated: boolean }>> {
+  const resolved = resolveUnder(repoPath, filePath, log);
+  if (!resolved.ok)
+    return resolved as GitResult<{ content: string; truncated: boolean }>;
+
+  try {
+    const buf = await fsReadFile(resolved.value.abs);
+    if (buf.length > MAX_READ_BYTES) {
+      return ok({
+        content: buf.subarray(0, MAX_READ_BYTES).toString("utf-8"),
+        truncated: true,
+      });
+    }
+    return ok({ content: buf.toString("utf-8"), truncated: false });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return err({ code: "GIT_FAILED", message: `Failed to read file: ${msg}` });
+  }
 }

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -1,0 +1,122 @@
+/** Git-filtered directory listing.
+ *
+ *  Uses `git ls-tree` for tracked files and `git ls-files --others
+ *  --exclude-standard` for untracked-but-not-ignored files. This
+ *  avoids listing `node_modules/`, `.git/`, build artifacts, etc. */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { Logger } from "anyagent";
+import { type GitResult, ok } from "./errors.ts";
+import { resolveUnder } from "./safe-path.ts";
+
+const execFileAsync = promisify(execFile);
+
+export type DirEntry = {
+  name: string;
+  isDirectory: boolean;
+  /** Path relative to repo root. */
+  path: string;
+};
+
+/** List entries in a directory, filtered by git (tracked + untracked-but-not-ignored).
+ *
+ *  @param repoPath  Absolute path to the repo root.
+ *  @param dirPath   Path relative to repo root (empty string for root).
+ *  @param log       Optional logger. */
+export async function listDir(
+  repoPath: string,
+  dirPath: string,
+  log?: Logger,
+): Promise<GitResult<DirEntry[]>> {
+  // Validate path doesn't escape repo root.
+  if (dirPath !== "") {
+    const check = resolveUnder(repoPath, dirPath, log);
+    if (!check.ok) return check as GitResult<DirEntry[]>;
+  }
+
+  const entries = new Map<string, DirEntry>();
+
+  // 1. Tracked entries via `git ls-tree` (gives type info in one call).
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["ls-tree", `HEAD:${dirPath}`],
+      { cwd: repoPath },
+    );
+    for (const line of stdout.split("\n")) {
+      if (!line) continue;
+      // Format: <mode> <type> <hash>\t<name>
+      const tabIdx = line.indexOf("\t");
+      if (tabIdx === -1) continue;
+      const name = line.slice(tabIdx + 1);
+      const type = line.slice(0, tabIdx).split(" ")[1];
+      const entryPath = dirPath ? `${dirPath}/${name}` : name;
+      entries.set(name, {
+        name,
+        isDirectory: type === "tree",
+        path: entryPath,
+      });
+    }
+  } catch (e: unknown) {
+    // ls-tree fails if HEAD doesn't exist (empty repo) or path doesn't exist
+    // in HEAD — expected, we'll still get untracked files below.
+    const msg = e instanceof Error ? e.message : String(e);
+    const expected =
+      msg.includes("Not a valid object name") || msg.includes("not a tree");
+    if (!expected) {
+      log?.error({ err: e, dirPath }, "ls-tree failed unexpectedly");
+    }
+  }
+
+  // 2. Untracked-but-not-ignored entries in this directory.
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      [
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "--directory",
+        "--no-empty-directory",
+        dirPath ? `${dirPath}/` : ".",
+      ],
+      { cwd: repoPath },
+    );
+    const prefix = dirPath ? `${dirPath}/` : "";
+    for (const line of stdout.split("\n")) {
+      if (!line) continue;
+      if (dirPath && !line.startsWith(prefix)) continue;
+      const relative = dirPath ? line.slice(prefix.length) : line;
+      // Immediate children only.
+      const slashIdx = relative.indexOf("/");
+      if (slashIdx === -1) {
+        // File
+        if (!entries.has(relative)) {
+          entries.set(relative, {
+            name: relative,
+            isDirectory: false,
+            path: line,
+          });
+        }
+      } else if (slashIdx === relative.length - 1) {
+        // Directory (trailing slash from --directory)
+        const name = relative.slice(0, -1);
+        if (!entries.has(name)) {
+          const entryPath = dirPath ? `${dirPath}/${name}` : name;
+          entries.set(name, { name, isDirectory: true, path: entryPath });
+        }
+      }
+    }
+  } catch (e: unknown) {
+    log?.error({ err: e, dirPath }, "ls-files --others failed");
+  }
+
+  // Sort: directories first, then files, alphabetically.
+  const sorted = [...entries.values()].sort((a, b) => {
+    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  return ok(sorted);
+}

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -23,6 +23,8 @@ export {
   FsListDirInputSchema,
   FsDirEntrySchema,
   FsListDirOutputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
   type GitInfo,
   type GitChangeStatus,
   type GitChangedFile,
@@ -52,7 +54,7 @@ export {
 export { getStatus, getDiff, parseNameStatus } from "./review.ts";
 
 // File tree browsing
-export { listDir } from "./browse.ts";
+export { listDir, readFile } from "./browse.ts";
 
 // Path security
 export { resolveUnder } from "./safe-path.ts";

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -20,6 +20,9 @@ export {
   GitStatusOutputSchema,
   GitDiffInputSchema,
   GitDiffOutputSchema,
+  FsListDirInputSchema,
+  FsDirEntrySchema,
+  FsListDirOutputSchema,
   type GitInfo,
   type GitChangeStatus,
   type GitChangedFile,
@@ -27,6 +30,7 @@ export {
   type GitBaseRef,
   type GitStatusOutput,
   type GitDiffOutput,
+  type FsListDirOutput,
 } from "./schemas.ts";
 
 // Repository resolution
@@ -46,6 +50,9 @@ export {
 
 // Diff review
 export { getStatus, getDiff, parseNameStatus } from "./review.ts";
+
+// File tree browsing
+export { listDir } from "./browse.ts";
 
 // Path security
 export { resolveUnder } from "./safe-path.ts";

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -132,6 +132,19 @@ export const FsListDirOutputSchema = z.object({
 });
 export type FsListDirOutput = z.infer<typeof FsListDirOutputSchema>;
 
+export const FsReadFileInputSchema = z.object({
+  /** Absolute path to the repo root. */
+  repoPath: z.string(),
+  /** Path relative to repo root. */
+  filePath: z.string(),
+});
+
+export const FsReadFileOutputSchema = z.object({
+  content: z.string(),
+  /** True if the file exceeded the size limit and was truncated. */
+  truncated: z.boolean(),
+});
+
 // --- Derived types ---
 
 export type GitInfo = z.infer<typeof GitInfoSchema>;

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -111,6 +111,27 @@ export const GitDiffOutputSchema = z.object({
 });
 export type GitDiffOutput = z.infer<typeof GitDiffOutputSchema>;
 
+// --- File tree browsing ---
+
+export const FsListDirInputSchema = z.object({
+  /** Absolute path to the repo root. */
+  repoPath: z.string(),
+  /** Path relative to repo root (empty string for root). */
+  dirPath: z.string(),
+});
+
+export const FsDirEntrySchema = z.object({
+  name: z.string(),
+  isDirectory: z.boolean(),
+  /** Path relative to repo root. */
+  path: z.string(),
+});
+
+export const FsListDirOutputSchema = z.object({
+  entries: z.array(FsDirEntrySchema),
+});
+export type FsListDirOutput = z.infer<typeof FsListDirOutputSchema>;
+
 // --- Derived types ---
 
 export type GitInfo = z.infer<typeof GitInfoSchema>;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -28,6 +28,7 @@ import {
   getStatus,
   getDiff,
   listDir,
+  readFile,
   type GitResult,
 } from "kolu-git";
 import {
@@ -240,6 +241,9 @@ export const appRouter = t.router({
     listDir: t.fs.listDir.handler(async ({ input }) => ({
       entries: unwrapGit(await listDir(input.repoPath, input.dirPath, log)),
     })),
+    readFile: t.fs.readFile.handler(async ({ input }) =>
+      unwrapGit(await readFile(input.repoPath, input.filePath, log)),
+    ),
   },
   state: {
     get: t.state.get.handler(async function* ({ signal }) {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -27,6 +27,7 @@ import {
   worktreeRemove,
   getStatus,
   getDiff,
+  listDir,
   type GitResult,
 } from "kolu-git";
 import {
@@ -234,6 +235,11 @@ export const appRouter = t.router({
         ),
       );
     }),
+  },
+  fs: {
+    listDir: t.fs.listDir.handler(async ({ input }) => ({
+      entries: unwrapGit(await listDir(input.repoPath, input.dirPath, log)),
+    })),
   },
   state: {
     get: t.state.get.handler(async function* ({ signal }) {

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -82,3 +82,34 @@ Feature: Code tab (diff review)
     Then the Code tab should not list a changed file "pkg/a.ts"
     When I click the directory node "pkg" in the Code tab
     Then the Code tab should list a changed file "pkg/a.ts"
+
+  # --- File browser (phase 4) ---
+
+  Scenario: File browser shows the repo file tree
+    When I run "git init /tmp/kolu-browse-tree && cd /tmp/kolu-browse-tree"
+    And I run "mkdir -p src && printf 'a\n' > README.md && printf 'b\n' > src/index.ts"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    Then the Code tab mode should be "browse"
+    And the file browser should show a directory "src"
+    And the file browser should show a file "README.md"
+
+  Scenario: File browser shows file content on click
+    When I run "git init /tmp/kolu-browse-content && cd /tmp/kolu-browse-content"
+    And I run "printf 'hello world\n' > greeting.txt"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    When I click the file "greeting.txt" in the file browser
+    Then the file content should contain "hello world"
+
+  Scenario: File browser expands directories lazily
+    When I run "git init /tmp/kolu-browse-expand && cd /tmp/kolu-browse-expand"
+    And I run "mkdir -p lib && printf 'x\n' > lib/util.ts"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    Then the file browser should show a directory "lib"
+    When I click the directory "lib" in the file browser
+    Then the file browser should show a file "lib/util.ts"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -146,6 +146,68 @@ Then(
   },
 );
 
+// ── File browser actions ──
+
+When(
+  "I click the file {string} in the file browser",
+  async function (this: KoluWorld, path: string) {
+    const item = this.page.locator(
+      `[data-testid="file-browser"] [data-testid="diff-file-item"][data-path="${path}"]`,
+    );
+    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await item.click();
+    await this.waitForFrame();
+  },
+);
+
+When(
+  "I click the directory {string} in the file browser",
+  async function (this: KoluWorld, path: string) {
+    const dir = this.page.locator(
+      `[data-testid="file-browser"] [data-testid="file-tree-dir"][data-path="${path}"]`,
+    );
+    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await dir.click();
+    await this.waitForFrame();
+  },
+);
+
+// ── File browser assertions ──
+
+Then(
+  "the file browser should show a directory {string}",
+  async function (this: KoluWorld, path: string) {
+    const dir = this.page.locator(
+      `[data-testid="file-browser"] [data-testid="file-tree-dir"][data-path="${path}"]`,
+    );
+    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the file browser should show a file {string}",
+  async function (this: KoluWorld, path: string) {
+    const item = this.page.locator(
+      `[data-testid="file-browser"] [data-testid="diff-file-item"][data-path="${path}"]`,
+    );
+    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the file content should contain {string}",
+  async function (this: KoluWorld, expected: string) {
+    await this.page.waitForFunction(
+      (exp: string) => {
+        const el = document.querySelector('[data-testid="file-content"]');
+        return el?.textContent?.includes(exp) ?? false;
+      },
+      expected,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 Then(
   "the Code tab should show a missing-origin error",
   async function (this: KoluWorld) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       partysocket:
         specifier: ^1.1.16
         version: 1.1.16(react@19.2.5)


### PR DESCRIPTION
**A third sub-tab in the Code tab shows the repo's entire file tree**, lazy-loaded and git-filtered. Click the folder icon alongside the existing local-diff and branch-diff icons to switch to browse mode. Directories expand on click, fetching children from the server on demand.

The listing uses `git ls-tree` for tracked files and `git ls-files --others --exclude-standard` for untracked-but-not-ignored entries — so `node_modules/`, `.git/`, and build artifacts stay out of sight. _The same `FileTree` component from phase 3 powers both the changed-file tree and the file browser_, extended with an optional `loadChildren` prop for async directory expansion.

> `FileNode.status` is now optional — browse-mode files have no git change status, so they don't carry a fake `"M"`. The diff-mode badge render guards for this.

Phase 4 of #514.