### PR TITLE
fix: waiting-agent breathing glow — animate background alpha, not element opacity

### DIFF
--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -148,16 +148,15 @@ body {
 }
 
 .card-border-wrap.card-spin-waiting {
-  background: var(--card-color);
   animation: border-breathe 2.5s ease-in-out infinite;
 }
 
 @keyframes border-breathe {
   0%,
   100% {
-    opacity: 0.2;
+    background: oklch(from var(--card-color) l c h / 0.25);
   }
   50% {
-    opacity: 0.6;
+    background: oklch(from var(--card-color) l c h / 0.7);
   }
 }

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -148,15 +148,15 @@ body {
 }
 
 .card-border-wrap.card-spin-waiting {
-  animation: border-breathe 2.5s ease-in-out infinite;
+  animation: border-breathe 1.6s ease-in-out infinite;
 }
 
 @keyframes border-breathe {
   0%,
   100% {
-    background: oklch(from var(--card-color) l c h / 0.25);
+    background: oklch(from var(--card-color) l c h / 0.1);
   }
   50% {
-    background: oklch(from var(--card-color) l c h / 0.7);
+    background: oklch(from var(--card-color) l calc(c * 1.2) h / 0.9);
   }
 }


### PR DESCRIPTION
## Summary

The `border-breathe` keyframes from #551 animated `opacity` on the whole `.card-border-wrap` element, fading **all card content** (text, icons, everything) to near-invisible during the pulse cycle.

- Switched to animating the `background` color's alpha channel instead, so only the border glow breathes while content stays fully readable.
- Made the throb more overt: faster cycle (**2.5 s → 1.6 s**), wider alpha swing (**0.1 → 0.9**), and a **chroma boost** at peak so the color really pops.

## Test plan

- [ ] Verify waiting agent cards have a bold, visible breathing border glow
- [ ] Verify card text/content remains fully opaque throughout the animation
- [ ] Confirm active agent shimmer is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)