### PR TITLE
Show theme-switch tip after creating a terminal

### DIFF
--- a/packages/client/src/settings/tips.ts
+++ b/packages/client/src/settings/tips.ts
@@ -30,6 +30,10 @@ export const CONTEXTUAL_TIPS = {
     id: "worktree",
     text: `${formatKeybind(SHORTCUTS.commandPalette.keybind)} → New terminal → worktree for parallel sessions`,
   },
+  themeSwitch: {
+    id: "theme-switch",
+    text: `Tip: ${formatKeybind(SHORTCUTS.shuffleTheme.keybind)} cycles through terminal themes`,
+  },
 } as const satisfies Record<string, Tip>;
 
 export const AMBIENT_TIPS: readonly Tip[] = [

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -122,6 +122,7 @@ export function useTerminalCrud(deps: {
     store.setActiveId(info.id);
     deps.subscribeExit(info.id);
     if (theme) setThemeName(info.id, theme);
+    showTipOnce(CONTEXTUAL_TIPS.themeSwitch);
     return info.id;
   }
 


### PR DESCRIPTION
**New terminals now surface a one-time tip** about cycling themes with `⌘J` (or `Ctrl+J` on Linux). The notification uses the existing contextual tips system — it fires once, gets marked as seen, and never shows again.

This helps users discover the theme-shuffle shortcut right when they're looking at a fresh terminal and might want to customize it. *The tip text uses `formatKeybind` so it renders the correct modifier for the user's platform.*