### PR TITLE
Canvas mode opens centered on terminals, not at (0,0)

### DIFF
--- a/packages/client/src/terminal/TerminalCanvas.tsx
+++ b/packages/client/src/terminal/TerminalCanvas.tsx
@@ -180,11 +180,14 @@ const TerminalCanvas: Component<{
     }
     if (!isFinite(minX)) return;
     hasScrolled = true;
-    // Center of the bounding box, offset by the canvas padding
+    // Center of the bounding box, offset by the canvas padding.
+    // Defer to next frame so the container has layout dimensions.
     const centerX = CANVAS_PAD + (minX + maxX) / 2;
     const centerY = CANVAS_PAD + (minY + maxY) / 2;
-    containerRef.scrollLeft = centerX - containerRef.clientWidth / 2;
-    containerRef.scrollTop = centerY - containerRef.clientHeight / 2;
+    requestAnimationFrame(() => {
+      containerRef.scrollLeft = centerX - containerRef.clientWidth / 2;
+      containerRef.scrollTop = centerY - containerRef.clientHeight / 2;
+    });
   });
 
   return (

--- a/packages/client/src/terminal/TerminalCanvas.tsx
+++ b/packages/client/src/terminal/TerminalCanvas.tsx
@@ -159,10 +159,39 @@ const TerminalCanvas: Component<{
     };
   };
 
+  // On mount, scroll the container so the bounding box of all terminals
+  // is centered in the viewport (fixes #562 — canvas opening at 0,0).
+  let containerRef!: HTMLDivElement;
+  let hasScrolled = false;
+  createEffect(() => {
+    const ids = props.terminalIds;
+    if (ids.length === 0 || hasScrolled) return;
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+    for (const id of ids) {
+      const l = layouts[id];
+      if (!l) continue;
+      minX = Math.min(minX, l.x);
+      minY = Math.min(minY, l.y);
+      maxX = Math.max(maxX, l.x + l.w);
+      maxY = Math.max(maxY, l.y + l.h);
+    }
+    if (!isFinite(minX)) return;
+    hasScrolled = true;
+    // Center of the bounding box, offset by the canvas padding
+    const centerX = CANVAS_PAD + (minX + maxX) / 2;
+    const centerY = CANVAS_PAD + (minY + maxY) / 2;
+    containerRef.scrollLeft = centerX - containerRef.clientWidth / 2;
+    containerRef.scrollTop = centerY - containerRef.clientHeight / 2;
+  });
+
   return (
     <DragDropProvider onDragMove={handleDragMove} onDragEnd={handleDragEnd}>
       <DragDropSensors />
       <div
+        ref={containerRef}
         data-testid="canvas-container"
         class="flex-1 min-h-0 overflow-auto relative canvas-grid-bg"
       >

--- a/packages/tests/features/canvas-mode.feature
+++ b/packages/tests/features/canvas-mode.feature
@@ -51,6 +51,11 @@ Feature: Canvas mode
     And the canvas grid background should be visible
     And there should be no page errors
 
+  Scenario: Canvas opens scrolled to terminals
+    When I click the canvas mode toggle
+    Then the canvas tiles should be visible in the viewport
+    And there should be no page errors
+
   @mobile
   Scenario: Canvas mode toggle is hidden on mobile
     Then the canvas mode toggle should not be visible

--- a/packages/tests/step_definitions/canvas_mode_steps.ts
+++ b/packages/tests/step_definitions/canvas_mode_steps.ts
@@ -117,4 +117,31 @@ When(
   },
 );
 
+Then(
+  "the canvas tiles should be visible in the viewport",
+  async function (this: KoluWorld) {
+    await this.page.waitForFunction(
+      (sel: string) => {
+        const container = document.querySelector(sel);
+        if (!container) return false;
+        const tile = container.querySelector(
+          "[data-terminal-id][data-visible]",
+        );
+        if (!tile) return false;
+        const cRect = container.getBoundingClientRect();
+        const tRect = tile.getBoundingClientRect();
+        // Tile's top-left corner should be within the visible container area
+        return (
+          tRect.left >= cRect.left &&
+          tRect.top >= cRect.top &&
+          tRect.left < cRect.right &&
+          tRect.top < cRect.bottom
+        );
+      },
+      CANVAS_SELECTOR,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // "the close confirmation should be visible" is defined in worktree_steps.ts


### PR DESCRIPTION
**Canvas now auto-scrolls to center the bounding box of all terminals** when you switch into canvas mode. Previously the viewport started at the top-left origin, showing 1000px of empty grid margin — you had to scroll down and right to find your terminals.

The fix adds a one-shot `createEffect` that computes the bounding box of all tile layouts and sets `scrollLeft`/`scrollTop` to center it. *The scroll is deferred to `requestAnimationFrame` so the container has layout dimensions before the calculation runs.* A `hasScrolled` flag ensures subsequent terminal additions don't re-center the view.

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)