### PR TITLE
Decouple canvas from terminal types, extract gesture primitive

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -15,6 +15,7 @@ import Header from "./Header";
 import PwaInstallBar from "./PwaInstallBar";
 import Sidebar from "./sidebar/Sidebar";
 import TerminalContent from "./terminal/TerminalContent";
+import TerminalMeta from "./terminal/TerminalMeta";
 import TerminalCanvas from "./canvas/TerminalCanvas";
 import MobileKeyBar from "./MobileKeyBar";
 import CommandPalette from "./CommandPalette";
@@ -510,20 +511,40 @@ const App: Component = () => {
                 onThemeClick={() => openPaletteGroup("Theme")}
               >
                 <TerminalCanvas
-                  terminalIds={store.terminalIds()}
+                  tileIds={store.terminalIds()}
                   activeId={store.activeId()}
-                  getMetadata={store.getMetadata}
-                  getDisplayInfo={store.getDisplayInfo}
-                  getTerminalTheme={getTerminalTheme}
-                  onSelect={store.setActiveId}
-                  onCloseTerminal={closeTerminal}
-                  onCreateSubTerminal={(parentId, cwd) =>
-                    void crud.handleCreateSubTerminal(parentId, cwd)
-                  }
-                  activeMeta={store.activeMeta()}
-                  searchOpen={searchOpen()}
-                  onSearchOpenChange={setSearchOpen}
-                  subTerminalIds={store.getSubTerminalIds}
+                  getTileTheme={(id) => {
+                    const t = getTerminalTheme(id as TerminalId);
+                    return {
+                      bg: t.background ?? "var(--color-surface-1)",
+                      fg: t.foreground ?? "var(--color-fg)",
+                    };
+                  }}
+                  onSelect={(id) => store.setActiveId(id as TerminalId)}
+                  onClose={(id) => closeTerminal(id as TerminalId)}
+                  renderTileTitle={(id) => (
+                    <TerminalMeta
+                      info={store.getDisplayInfo(id as TerminalId)}
+                    />
+                  )}
+                  renderTileBody={(id, active) => (
+                    <TerminalContent
+                      terminalId={id as TerminalId}
+                      visible={true}
+                      focused={active}
+                      theme={getTerminalTheme(id as TerminalId)}
+                      searchOpen={active && searchOpen()}
+                      onSearchOpenChange={setSearchOpen}
+                      subTerminalIds={store.getSubTerminalIds(id as TerminalId)}
+                      getMetadata={store.getMetadata}
+                      onCreateSubTerminal={(parentId, cwd) =>
+                        void crud.handleCreateSubTerminal(parentId, cwd)
+                      }
+                      onCloseTerminal={closeTerminal}
+                      activeMeta={store.activeMeta()}
+                      onFocus={() => store.setActiveId(id as TerminalId)}
+                    />
+                  )}
                 />
               </RightPanelLayout>
             </Show>

--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -1,121 +1,99 @@
 /** Single tile on the canvas — separated so createDraggable gets its own
  *  reactive owner per tile (required by solid-dnd). Shell only: positioning,
- *  title bar, resize handle. Terminal rendering delegated to TerminalContent. */
+ *  title bar, resize handle. Content is injected via render props — the
+ *  canvas module has no knowledge of what renders inside a tile. */
 
-import type { Component } from "solid-js";
+import type { Component, JSX } from "solid-js";
 import { createDraggable } from "@thisbeyond/solid-dnd";
-import type { ITheme } from "@xterm/xterm";
-import TerminalContent from "../terminal/TerminalContent";
-import TerminalMeta from "../terminal/TerminalMeta";
 import { ResizeGripIcon } from "../ui/Icons";
 import type { TileLayout } from "./useCanvasLayouts";
-import type { TerminalDisplayInfo } from "../terminal/terminalDisplay";
-import type { TerminalId, TerminalMetadata } from "kolu-common";
+
+/** Minimal theme info for tile chrome (title bar, border, resize handle). */
+export interface TileTheme {
+  bg: string;
+  fg: string;
+}
 
 const DEFAULT_W = 700;
 const DEFAULT_H = 500;
 
 const CanvasTile: Component<{
-  id: TerminalId;
-  parent: {
-    activeId: TerminalId | null;
-    getTerminalTheme: (id: TerminalId) => ITheme;
-    getDisplayInfo: (id: TerminalId) => TerminalDisplayInfo | undefined;
-    getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
-    onSelect: (id: TerminalId) => void;
-    onCloseTerminal: (id: TerminalId) => void;
-    onCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
-    activeMeta: TerminalMetadata | null;
-    searchOpen: boolean;
-    onSearchOpenChange: (open: boolean) => void;
-    subTerminalIds: (id: TerminalId) => TerminalId[];
-  };
+  id: string;
+  active: boolean;
+  theme: TileTheme;
+  onSelect: () => void;
+  onClose: () => void;
+  renderTitle: () => JSX.Element;
+  renderBody: () => JSX.Element;
   layouts: Record<string, TileLayout>;
-  startResize: (id: TerminalId, e: PointerEvent) => void;
+  startResize: (id: string, e: PointerEvent) => void;
   zoom: () => number;
 }> = (props) => {
   const { id } = props;
   const draggable = createDraggable(id);
-  const isActive = () => props.parent.activeId === id;
-  const theme = () => props.parent.getTerminalTheme(id);
   const layout = () =>
     props.layouts[id] ?? { x: 0, y: 0, w: DEFAULT_W, h: DEFAULT_H };
 
-  const themeBg = () => theme().background ?? "var(--color-surface-1)";
-  const themeFg = () => theme().foreground ?? "var(--color-fg)";
+  const bg = () => props.theme.bg;
+  const fg = () => props.theme.fg;
 
   return (
     <div
       ref={draggable.ref}
       class="absolute flex flex-col rounded-xl overflow-hidden border transition-shadow duration-200"
       classList={{
-        "border-accent/60 shadow-xl": isActive(),
-        "border-edge/40 hover:border-edge/60": !isActive(),
+        "border-accent/60 shadow-xl": props.active,
+        "border-edge/40 hover:border-edge/60": !props.active,
       }}
       style={{
         left: `${layout().x}px`,
         top: `${layout().y}px`,
         width: `${layout().w}px`,
         height: `${layout().h}px`,
-        "background-color": themeBg(),
-        "z-index": isActive() ? 10 : 1,
-        opacity: isActive() ? 1 : 0.92,
-        "box-shadow": isActive()
+        "background-color": bg(),
+        "z-index": props.active ? 10 : 1,
+        opacity: props.active ? 1 : 0.92,
+        "box-shadow": props.active
           ? `0 8px 32px rgba(0,0,0,0.4), 0 0 0 1px var(--color-accent)`
           : `0 2px 8px rgba(0,0,0,0.2)`,
         // Drag transform is screen-space — divide by zoom so the tile
         // moves at the correct rate in the scaled canvas coordinate system.
         transform: `translate(${draggable.transform.x / props.zoom()}px, ${draggable.transform.y / props.zoom()}px)`,
       }}
-      onMouseDown={() => props.parent.onSelect(id)}
+      onMouseDown={() => props.onSelect()}
     >
-      {/* Title bar — uses terminal foreground at low opacity for guaranteed
-       *  contrast against the terminal background, regardless of theme. */}
+      {/* Title bar — uses tile foreground at low opacity for guaranteed
+       *  contrast against the tile background, regardless of theme. */}
       <div
         class="flex items-center gap-2 px-3 py-1.5 shrink-0 cursor-grab active:cursor-grabbing select-none"
         style={{
-          "background-color": `color-mix(in oklch, ${themeFg()} 8%, ${themeBg()})`,
-          "border-bottom": `1px solid color-mix(in oklch, ${themeFg()} 12%, ${themeBg()})`,
-          "--color-fg": themeFg(),
-          "--color-fg-2": `color-mix(in oklch, ${themeFg()} 75%, ${themeBg()})`,
-          "--color-fg-3": `color-mix(in oklch, ${themeFg()} 55%, ${themeBg()})`,
+          "background-color": `color-mix(in oklch, ${fg()} 8%, ${bg()})`,
+          "border-bottom": `1px solid color-mix(in oklch, ${fg()} 12%, ${bg()})`,
+          "--color-fg": fg(),
+          "--color-fg-2": `color-mix(in oklch, ${fg()} 75%, ${bg()})`,
+          "--color-fg-3": `color-mix(in oklch, ${fg()} 55%, ${bg()})`,
         }}
         {...draggable.dragActivators}
       >
-        <div class="flex-1 min-w-0">
-          <TerminalMeta info={props.parent.getDisplayInfo(id)} />
-        </div>
+        <div class="flex-1 min-w-0">{props.renderTitle()}</div>
         <button
           class="flex items-center justify-center w-7 h-7 rounded-lg transition-colors cursor-pointer shrink-0 pointer-events-auto hover:bg-black/20 text-sm"
           style={{
-            color: `color-mix(in oklch, ${themeFg()} 50%, ${themeBg()})`,
+            color: `color-mix(in oklch, ${fg()} 50%, ${bg()})`,
           }}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
-            props.parent.onCloseTerminal(id);
+            props.onClose();
           }}
-          title="Close terminal"
+          title="Close"
         >
           ×
         </button>
       </div>
 
-      {/* Terminal content — shared with focus mode */}
-      <TerminalContent
-        terminalId={id}
-        visible={true}
-        focused={isActive()}
-        theme={theme()}
-        searchOpen={isActive() && props.parent.searchOpen}
-        onSearchOpenChange={props.parent.onSearchOpenChange}
-        subTerminalIds={props.parent.subTerminalIds(id)}
-        getMetadata={props.parent.getMetadata}
-        onCreateSubTerminal={props.parent.onCreateSubTerminal}
-        onCloseTerminal={props.parent.onCloseTerminal}
-        activeMeta={props.parent.activeMeta}
-        onFocus={() => props.parent.onSelect(id)}
-      />
+      {/* Tile body — injected by caller */}
+      {props.renderBody()}
 
       {/* Resize handle — bottom-right corner, larger hit area */}
       <div
@@ -125,7 +103,7 @@ const CanvasTile: Component<{
         <span
           class="absolute bottom-0.5 right-0.5"
           style={{
-            color: `color-mix(in oklch, ${themeFg()} 40%, ${themeBg()})`,
+            color: `color-mix(in oklch, ${fg()} 40%, ${bg()})`,
           }}
         >
           <ResizeGripIcon />

--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -86,7 +86,7 @@ const CanvasTile: Component<{
             e.stopPropagation();
             props.onClose();
           }}
-          title="Close"
+          title="Close terminal"
         >
           ×
         </button>

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -1,11 +1,13 @@
-/** TerminalCanvas — freeform 2D canvas where terminals can be dragged
- *  and resized like desktop windows. Pan via two-finger scroll / trackpad,
- *  zoom via Ctrl+scroll / pinch. Tiles snap to the visual grid on drag end.
+/** TerminalCanvas — freeform 2D canvas where tiles can be dragged and resized
+ *  like desktop windows. Pan via two-finger scroll / trackpad, zoom via
+ *  Ctrl+scroll / pinch. Tiles snap to the visual grid on drag end.
+ *
+ *  The canvas is domain-agnostic — it manages tile positioning, drag, resize,
+ *  pan, and zoom. What renders inside each tile (title bar content, body) is
+ *  injected via render props by the caller.
  *
  *  Drag uses @thisbeyond/solid-dnd (same library as the sidebar) for
  *  gesture handling — decouples sensing from position application.
- *  Resize uses raw pointer events with AbortController for cleanup
- *  (resize is not a drag-to-position gesture, so solid-dnd doesn't fit).
  *
  *  Pan/zoom viewport logic lives in viewport/ — decomposed by volatility
  *  axis (gestures, transforms, coordinates) per Lowy analysis. */
@@ -17,19 +19,18 @@ import {
   createSignal,
   on,
   batch,
+  type JSX,
 } from "solid-js";
 import {
   DragDropProvider,
   DragDropSensors,
   type DragEvent,
 } from "@thisbeyond/solid-dnd";
-import type { ITheme } from "@xterm/xterm";
 import { useCanvasLayouts, type TileLayout } from "./useCanvasLayouts";
 import { useCanvasViewport } from "./viewport/useCanvasViewport";
-import CanvasTile from "./CanvasTile";
+import { capturePointerGesture } from "./viewport/capturePointerGesture";
+import CanvasTile, { type TileTheme } from "./CanvasTile";
 import CanvasZoomToolbar from "./CanvasZoomToolbar";
-import type { TerminalDisplayInfo } from "../terminal/terminalDisplay";
-import type { TerminalId, TerminalMetadata } from "kolu-common";
 
 const DEFAULT_W = 700;
 const DEFAULT_H = 500;
@@ -38,28 +39,23 @@ const MIN_W = 300;
 const MIN_H = 200;
 
 const TerminalCanvas: Component<{
-  terminalIds: TerminalId[];
-  activeId: TerminalId | null;
-  getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
-  getDisplayInfo: (id: TerminalId) => TerminalDisplayInfo | undefined;
-  getTerminalTheme: (id: TerminalId) => ITheme;
-  onSelect: (id: TerminalId) => void;
-  onCloseTerminal: (id: TerminalId) => void;
-  onCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
-  activeMeta: TerminalMetadata | null;
-  searchOpen: boolean;
-  onSearchOpenChange: (open: boolean) => void;
-  subTerminalIds: (id: TerminalId) => TerminalId[];
+  tileIds: string[];
+  activeId: string | null;
+  getTileTheme: (id: string) => TileTheme;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+  renderTileTitle: (id: string) => JSX.Element;
+  renderTileBody: (id: string, active: boolean) => JSX.Element;
 }> = (props) => {
   const { layouts, setLayouts, reportLayout } = useCanvasLayouts();
   const viewport = useCanvasViewport();
 
-  // Auto-assign layout for new terminals and clean up removed ones
+  // Auto-assign layout for new tiles and clean up removed ones
   createEffect(
     on(
-      () => props.terminalIds,
+      () => props.tileIds,
       (ids) => {
-        const idSet = new Set(ids as string[]);
+        const idSet = new Set(ids);
         batch(() => {
           for (const key of Object.keys(layouts)) {
             if (!idSet.has(key)) setLayouts(key, undefined!);
@@ -106,14 +102,14 @@ const TerminalCanvas: Component<{
         x: viewport.snapToGrid(l.x + dx),
         y: viewport.snapToGrid(l.y + dy),
       });
-      reportLayout(id as TerminalId);
+      reportLayout(id);
     }
     setDragDelta({ x: 0, y: 0 });
   }
 
   /** Snap size to grid and report to server. Separated from the pointerup
    *  listener so state application isn't tangled with event cleanup. */
-  function commitResize(id: TerminalId) {
+  function commitResize(id: string) {
     const cur = layouts[id];
     if (cur) {
       setLayouts(id, {
@@ -127,8 +123,8 @@ const TerminalCanvas: Component<{
 
   /** Start resizing a tile from the bottom-right corner.
    *  Pointer deltas are in screen-space — normalize by zoom. */
-  let resizeAbort: AbortController | null = null;
-  function startResize(id: TerminalId, e: PointerEvent) {
+  let abortResize: (() => void) | null = null;
+  function startResize(id: string, e: PointerEvent) {
     e.preventDefault();
     e.stopPropagation();
     const l = layouts[id];
@@ -140,13 +136,9 @@ const TerminalCanvas: Component<{
     const origX = l.x;
     const origY = l.y;
 
-    resizeAbort?.abort();
-    resizeAbort = new AbortController();
-    const { signal } = resizeAbort;
-
-    window.addEventListener(
-      "pointermove",
-      (ev) => {
+    abortResize?.();
+    abortResize = capturePointerGesture({
+      onMove: (ev) => {
         const { dx, dy } = viewport.normalizeDelta(
           ev.clientX - startX,
           ev.clientY - startY,
@@ -158,16 +150,11 @@ const TerminalCanvas: Component<{
           h: Math.max(MIN_H, origH + dy),
         });
       },
-      { signal },
-    );
-    window.addEventListener(
-      "pointerup",
-      () => {
-        resizeAbort?.abort();
+      onEnd: () => {
+        abortResize = null;
         commitResize(id);
       },
-      { signal },
-    );
+    });
   }
 
   // Auto-center when viewport is at the default origin (pan=0, zoom=1)
@@ -178,7 +165,7 @@ const TerminalCanvas: Component<{
     viewport.panX() === 0 && viewport.panY() === 0 && viewport.zoom() === 1;
 
   createEffect(() => {
-    const ids = props.terminalIds;
+    const ids = props.tileIds;
     if (ids.length === 0 || !isDefaultViewport()) return;
     const allLayouts: TileLayout[] = [];
     for (const id of ids) {
@@ -213,11 +200,18 @@ const TerminalCanvas: Component<{
             transform: viewport.canvasTransform(),
           }}
         >
-          <For each={props.terminalIds}>
+          <For each={props.tileIds}>
             {(id) => (
               <CanvasTile
                 id={id}
-                parent={props}
+                active={props.activeId === id}
+                theme={props.getTileTheme(id)}
+                onSelect={() => props.onSelect(id)}
+                onClose={() => props.onClose(id)}
+                renderTitle={() => props.renderTileTitle(id)}
+                renderBody={() =>
+                  props.renderTileBody(id, props.activeId === id)
+                }
                 layouts={layouts}
                 startResize={startResize}
                 zoom={viewport.zoom}
@@ -229,7 +223,7 @@ const TerminalCanvas: Component<{
         <CanvasZoomToolbar
           onFitAll={() => {
             const allLayouts: TileLayout[] = [];
-            for (const id of props.terminalIds) {
+            for (const id of props.tileIds) {
               const l = layouts[id];
               if (l) allLayouts.push(l);
             }

--- a/packages/client/src/canvas/useCanvasLayouts.ts
+++ b/packages/client/src/canvas/useCanvasLayouts.ts
@@ -3,7 +3,7 @@
  *  Shared between TerminalCanvas (rendering) and useSessionRestore (seeding). */
 
 import { createStore } from "solid-js/store";
-import type { CanvasLayout, TerminalId } from "kolu-common";
+import type { CanvasLayout } from "kolu-common";
 import { client } from "../rpc/rpc";
 
 export type TileLayout = CanvasLayout;
@@ -11,7 +11,7 @@ export type TileLayout = CanvasLayout;
 const [layouts, setLayouts] = createStore<Record<string, TileLayout>>({});
 
 /** Report a tile's layout to the server for session persistence. */
-function reportLayout(id: TerminalId) {
+function reportLayout(id: string) {
   const l = layouts[id];
   if (!l) return;
   void client.terminal.setCanvasLayout({ id, layout: l }).catch(() => {

--- a/packages/client/src/canvas/viewport/capturePointerGesture.ts
+++ b/packages/client/src/canvas/viewport/capturePointerGesture.ts
@@ -1,0 +1,30 @@
+/** Reusable pointer gesture lifecycle — captures pointer move/up events on
+ *  `window` with automatic AbortController cleanup. Used by both tile resize
+ *  and middle-mouse pan to avoid duplicating the same plumbing. */
+
+export interface PointerGestureHandlers {
+  onMove: (e: PointerEvent) => void;
+  onEnd: (e: PointerEvent) => void;
+}
+
+/** Start capturing pointer events globally. Returns an abort function that
+ *  removes all listeners. Calling `capture` again from the same call-site
+ *  should abort the previous gesture first (caller's responsibility). */
+export function capturePointerGesture(
+  handlers: PointerGestureHandlers,
+): () => void {
+  const abort = new AbortController();
+  const { signal } = abort;
+
+  window.addEventListener("pointermove", handlers.onMove, { signal });
+  window.addEventListener(
+    "pointerup",
+    (e) => {
+      abort.abort();
+      handlers.onEnd(e);
+    },
+    { signal },
+  );
+
+  return () => abort.abort();
+}

--- a/packages/client/src/canvas/viewport/gestures.ts
+++ b/packages/client/src/canvas/viewport/gestures.ts
@@ -2,6 +2,8 @@
  *  Owns event listener lifecycle (AbortController cleanup).
  *  Emits pan/zoom deltas via callbacks; knows nothing about state or CSS. */
 
+import { capturePointerGesture } from "./capturePointerGesture";
+
 const ZOOM_SPEED = 0.002;
 
 export interface GestureCallbacks {
@@ -37,48 +39,36 @@ export function installGestures(
   );
 
   // Middle-mouse drag pan
-  let panDragAbort: AbortController | null = null;
+  let abortPanDrag: (() => void) | null = null;
 
   el.addEventListener(
     "pointerdown",
     (e) => {
       if (e.button !== 1) return;
       e.preventDefault();
-      panDragAbort?.abort();
-      panDragAbort = new AbortController();
-      const dragSignal = panDragAbort.signal;
-      const startX = e.clientX;
-      const startY = e.clientY;
+      abortPanDrag?.();
       el.style.cursor = "grabbing";
 
-      // Track cumulative delta so each move is relative to start
-      let lastX = startX;
-      let lastY = startY;
+      let lastX = e.clientX;
+      let lastY = e.clientY;
 
-      window.addEventListener(
-        "pointermove",
-        (ev) => {
+      abortPanDrag = capturePointerGesture({
+        onMove: (ev) => {
           callbacks.onPan(-(ev.clientX - lastX), -(ev.clientY - lastY));
           lastX = ev.clientX;
           lastY = ev.clientY;
         },
-        { signal: dragSignal },
-      );
-      window.addEventListener(
-        "pointerup",
-        () => {
-          panDragAbort?.abort();
-          panDragAbort = null;
+        onEnd: () => {
+          abortPanDrag = null;
           el.style.cursor = "";
         },
-        { signal: dragSignal },
-      );
+      });
     },
     { signal },
   );
 
   return () => {
-    panDragAbort?.abort();
+    abortPanDrag?.();
     abort.abort();
   };
 }


### PR DESCRIPTION
**Canvas tiles no longer know they contain terminals.** `CanvasTile` and `TerminalCanvas` accepted terminal-specific imports (`TerminalContent`, `TerminalMeta`, `ITheme`, `TerminalId`, `TerminalMetadata`) directly — the canvas was a generic 2D workspace in spirit but a terminal-specific layout in practice. Now the canvas module takes render props (`renderTileTitle`, `renderTileBody`) and a minimal `TileTheme` (`{bg, fg}`), with all terminal wiring pushed to the call site in `App.tsx`.

Separately, **tile resize and middle-mouse pan shared identical `AbortController` + `addEventListener`/`removeEventListener` plumbing** that's now extracted into a `capturePointerGesture` helper. _Both call sites (resize in `TerminalCanvas`, pan drag in `viewport/gestures.ts`) now call the same 15-line function instead of duplicating the lifecycle bookkeeping._

Both refactors were identified during the phase 2 Hickey/Lowy analysis and deferred as non-blocking structural improvements. Closes the two refactor items in #559.

> The `canvas/` directory now has zero imports from `terminal/` or `kolu-common` terminal types. The only remaining `kolu-common` import is `CanvasLayout` (a layout geometry type, not terminal-specific).