### PR TITLE
Open new canvas terminals at viewport center

### DIFF
--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -60,18 +60,23 @@ const TerminalCanvas: Component<{
           for (const key of Object.keys(layouts)) {
             if (!idSet.has(key)) setLayouts(key, undefined!);
           }
-          let nextIndex = 0;
+          // Viewport center in canvas-space — stable within this batch
+          const cx =
+            viewport.panX() + containerRef.clientWidth / (2 * viewport.zoom());
+          const cy =
+            viewport.panY() + containerRef.clientHeight / (2 * viewport.zoom());
+          let newIndex = 0;
           for (const id of ids) {
             if (!layouts[id]) {
-              const offset = nextIndex * CASCADE_OFFSET;
+              const offset = newIndex * CASCADE_OFFSET;
               setLayouts(id, {
-                x: 20 + offset,
-                y: 20 + offset,
+                x: viewport.snapToGrid(cx - DEFAULT_W / 2 + offset),
+                y: viewport.snapToGrid(cy - DEFAULT_H / 2 + offset),
                 w: DEFAULT_W,
                 h: DEFAULT_H,
               });
+              newIndex++;
             }
-            nextIndex++;
           }
         });
       },

--- a/packages/tests/features/canvas-mode.feature
+++ b/packages/tests/features/canvas-mode.feature
@@ -72,6 +72,11 @@ Feature: Canvas mode
     Then the canvas tiles should be visible in the viewport
     And there should be no page errors
 
+  Scenario: New terminal opens at viewport center
+    When I click the canvas mode toggle
+    And I create a terminal
+    Then the newest canvas tile should be centered in the viewport
+
   @mobile
   Scenario: Canvas mode toggle is hidden on mobile
     Then the canvas mode toggle should not be visible

--- a/packages/tests/features/canvas-mode.feature
+++ b/packages/tests/features/canvas-mode.feature
@@ -74,8 +74,9 @@ Feature: Canvas mode
 
   Scenario: New terminal opens at viewport center
     When I click the canvas mode toggle
-    And I create a terminal
-    Then the newest canvas tile should be centered in the viewport
+    And I create a terminal with keyboard shortcut
+    Then there should be 2 canvas tiles
+    And the newest canvas tile should be centered in the viewport
 
   @mobile
   Scenario: Canvas mode toggle is hidden on mobile

--- a/packages/tests/step_definitions/canvas_mode_steps.ts
+++ b/packages/tests/step_definitions/canvas_mode_steps.ts
@@ -204,4 +204,35 @@ When("I press the fit-all shortcut", async function (this: KoluWorld) {
   await this.waitForFrame();
 });
 
+Then(
+  "the newest canvas tile should be centered in the viewport",
+  async function (this: KoluWorld) {
+    await this.page.waitForFunction(
+      (sel: string) => {
+        const container = document.querySelector(sel);
+        if (!container) return false;
+        const tiles = container.querySelectorAll(
+          "[data-terminal-id][data-visible]",
+        );
+        if (tiles.length < 2) return false;
+        const tile = tiles[tiles.length - 1] as HTMLElement;
+        const cRect = container.getBoundingClientRect();
+        const tRect = tile.getBoundingClientRect();
+        // Tile center vs container center — allow tolerance for grid snapping
+        const tileCx = tRect.left + tRect.width / 2 - cRect.left;
+        const tileCy = tRect.top + tRect.height / 2 - cRect.top;
+        const viewCx = cRect.width / 2;
+        const viewCy = cRect.height / 2;
+        const tolerance = 40; // grid snap (24px) + rounding
+        return (
+          Math.abs(tileCx - viewCx) < tolerance &&
+          Math.abs(tileCy - viewCy) < tolerance
+        );
+      },
+      CANVAS_SELECTOR,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // "the close confirmation should be visible" is defined in worktree_steps.ts

--- a/packages/tests/step_definitions/canvas_mode_steps.ts
+++ b/packages/tests/step_definitions/canvas_mode_steps.ts
@@ -235,4 +235,15 @@ Then(
   },
 );
 
+When(
+  "I create a terminal with keyboard shortcut",
+  async function (this: KoluWorld) {
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await this.page.keyboard.down(modifier);
+    await this.page.keyboard.press("t");
+    await this.page.keyboard.up(modifier);
+    await this.waitForFrame();
+  },
+);
+
 // "the close confirmation should be visible" is defined in worktree_steps.ts


### PR DESCRIPTION
**New terminals now spawn at the center of the current canvas viewport** instead of cascading from the top-left corner. When the user pans or zooms the canvas and hits Cmd+Enter (or Cmd+T / Cmd+Shift+Enter), the tile appears right where they're looking — not off-screen at position `(20, 20)`.

The fix replaces the static cascade offset with a viewport-center calculation in canvas-space: `panX + containerWidth / (2 × zoom)`. Grid snapping still applies, so tiles land on clean coordinates. _Multiple simultaneous new tiles (rare) still cascade relative to each other to avoid perfect overlap._

Part of #559 (known bug: viewport-center positioning)

> E2e test uses `Cmd+T` to create the terminal in canvas mode — the sidebar-based `createTerminal()` helper times out in canvas mode because its focus-wait logic wasn't designed for the multi-tile context.