### PR TITLE
Right panel remembers your last active tab (#561)

### DIFF
--- a/.claude/rules/code-police-rules.md
+++ b/.claude/rules/code-police-rules.md
@@ -53,7 +53,7 @@ Integration code (under `packages/integrations/`) runs in a long-lived Node proc
 
 ### no-preference-prop-drilling
 
-Components must read preferences from `useServerState()` directly, not receive them as props from a parent. The singleton store guarantees shared reactivity — all callers share one `createStore` instance.
+Components must read preferences from `useServerState()` directly, not receive them as props from a parent. The singleton subscription guarantees shared reactivity — all callers read through one `createSubscription` instance.
 Bad: `<Child scrollLock={preferences().scrollLock} />` then `props.scrollLock` in child
 Good: `const { preferences } = useServerState();` inside the child component
 _Rationale_: Prop-drilling preferences creates unenforced coupling ("parent extracts the right field and passes it to the right consumer") and bloats App.tsx's wiring surface. Components that own their behavior should own their preference reads too.

--- a/agents/.apm/instructions/code-police-rules.instructions.md
+++ b/agents/.apm/instructions/code-police-rules.instructions.md
@@ -53,7 +53,7 @@ Integration code (under `packages/integrations/`) runs in a long-lived Node proc
 
 ### no-preference-prop-drilling
 
-Components must read preferences from `useServerState()` directly, not receive them as props from a parent. The singleton store guarantees shared reactivity — all callers share one `createStore` instance.
+Components must read preferences from `useServerState()` directly, not receive them as props from a parent. The singleton subscription guarantees shared reactivity — all callers read through one `createSubscription` instance.
 Bad: `<Child scrollLock={preferences().scrollLock} />` then `props.scrollLock` in child
 Good: `const { preferences } = useServerState();` inside the child component
 _Rationale_: Prop-drilling preferences creates unenforced coupling ("parent extracts the right field and passes it to the right consumer") and bloats App.tsx's wiring surface. Components that own their behavior should own their preference reads too.

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -34,6 +34,7 @@ import "@git-diff-view/solid/styles/diff-view-pure.css";
 // Order matters: this overrides the library CSS imported just above.
 import "./code-tab.css";
 import type {
+  CodeTabView,
   GitChangeStatus,
   GitDiffMode,
   FsListDirOutput,
@@ -41,6 +42,7 @@ import type {
 } from "kolu-common";
 import { client } from "../rpc/rpc";
 import { useServerState } from "../settings/useServerState";
+import { useRightPanel } from "./useRightPanel";
 import {
   DiffLocalIcon,
   DiffBranchIcon,
@@ -68,9 +70,6 @@ const EMPTY_STATE: Record<GitDiffMode, string> = {
   local: "No local changes",
   branch: "No changes vs base",
 };
-
-/** Active view in the Code tab: local/branch diff modes, or file browser. */
-type CodeTabView = GitDiffMode | "browse";
 
 /** Sub-tab config. Icons double as the tab's visual affordance;
  *  the tooltip spells out what the mode means. */
@@ -120,8 +119,12 @@ function entriesToNodes(entries: FsListDirOutput["entries"]): TreeNode[] {
 
 const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { preferences } = useServerState();
+  const rightPanel = useRightPanel();
   const [selectedPath, setSelectedPath] = createSignal<string | null>(null);
-  const [view, setView] = createSignal<CodeTabView>("local");
+  // Active sub-view is persisted via server preferences so it survives
+  // panel close/reopen, pin/unpin, and page reload.
+  const view = rightPanel.codeMode;
+  const setView = rightPanel.setCodeMode;
 
   const repoPath = () => props.meta?.git?.repoRoot ?? null;
 

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -121,9 +121,15 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { preferences } = useServerState();
   const rightPanel = useRightPanel();
   const [selectedPath, setSelectedPath] = createSignal<string | null>(null);
-  // Active sub-view is persisted via server preferences so it survives
-  // panel close/reopen, pin/unpin, and page reload.
-  const view = rightPanel.codeMode;
+  // Active sub-view lives inside the `code` variant of rightPanel.tab, so
+  // it survives panel close/reopen, pin/unpin, and page reload. CodeTab
+  // only mounts when the Code tab is active (RightPanel.tsx dispatches on
+  // tab.kind), so the non-"code" branch below is unreachable — the fallback
+  // exists only to satisfy the type narrower.
+  const view = (): CodeTabView => {
+    const tab = rightPanel.activeTab();
+    return tab.kind === "code" ? tab.mode : "local";
+  };
   const setView = rightPanel.setCodeMode;
 
   const repoPath = () => props.meta?.git?.repoRoot ?? null;

--- a/packages/client/src/right-panel/RightPanel.tsx
+++ b/packages/client/src/right-panel/RightPanel.tsx
@@ -1,42 +1,24 @@
 /** RightPanel — right panel shell with tabbed navigation.
- *  Routes between Inspector and Code tabs. */
+ *  Routes between Inspector and Code tabs via a discriminated union so
+ *  illegal pairings (e.g. Inspector-with-a-code-mode) can't be represented. */
 
 import { type Component, For } from "solid-js";
-import { Dynamic } from "solid-js/web";
-import type { TerminalMetadata, RightPanelTab } from "kolu-common";
+import { match } from "ts-pattern";
+import type { TerminalMetadata, RightPanelTabKind } from "kolu-common";
 import MetadataInspector from "./MetadataInspector";
 import CodeTab from "./CodeTab";
 import { useRightPanel } from "./useRightPanel";
 import { ChevronRightIcon, PinIcon } from "../ui/Icons";
 
-type TabProps = {
-  meta: TerminalMetadata | null;
-  themeName?: string;
-  onThemeClick?: () => void;
-};
+/** Ordered tab kinds shown in the tab bar. Adding a new kind to the
+ *  discriminated union requires a corresponding entry here AND a branch
+ *  in the `match(tab)` below — both will fail-compile if you miss one. */
+const TAB_KINDS: readonly RightPanelTabKind[] = ["inspector", "code"] as const;
 
-type TabDef = {
-  label: string;
-  component: Component<TabProps>;
+const TAB_LABEL: Record<RightPanelTabKind, string> = {
+  inspector: "Inspector",
+  code: "Code",
 };
-
-// Record over the tab enum — TypeScript enforces that every RightPanelTab
-// value has an entry, so adding a new tab without a handler fails to
-// compile. Iteration order follows object property declaration order.
-//
-// Intentionally `type`-only import from kolu-common: the sibling value
-// `RightPanelTabSchema` would pull `AgentInfoSchema` → `kolu-claude-code`
-// → `@anthropic-ai/claude-agent-sdk` into the client bundle, defeating
-// tree-shaking.
-const TABS: Record<RightPanelTab, TabDef> = {
-  inspector: { label: "Inspector", component: MetadataInspector },
-  diff: {
-    label: "Code",
-    component: (p) => <CodeTab meta={p.meta} />,
-  },
-};
-
-const TAB_IDS = Object.keys(TABS) as RightPanelTab[];
 
 const RightPanel: Component<{
   meta: TerminalMetadata | null;
@@ -46,6 +28,9 @@ const RightPanel: Component<{
 }> = (props) => {
   const rightPanel = useRightPanel();
 
+  const showKind = (kind: RightPanelTabKind) =>
+    kind === "inspector" ? rightPanel.showInspector() : rightPanel.showCode();
+
   return (
     <div
       data-testid="right-panel"
@@ -53,19 +38,19 @@ const RightPanel: Component<{
     >
       {/* Tab bar */}
       <div class="flex items-center h-8 shrink-0 bg-surface-1/50 border-b border-edge">
-        <For each={TAB_IDS}>
-          {(id) => (
+        <For each={TAB_KINDS}>
+          {(kind) => (
             <button
-              data-testid={`right-panel-tab-${id}`}
-              data-active={rightPanel.activeTab() === id}
+              data-testid={`right-panel-tab-${kind}`}
+              data-active={rightPanel.activeTab().kind === kind}
               class={`h-full px-3 text-xs cursor-pointer transition-colors ${
-                rightPanel.activeTab() === id
+                rightPanel.activeTab().kind === kind
                   ? "font-medium text-fg-2 bg-surface-0 border-b-2 border-accent"
                   : "text-fg-3/50 hover:text-fg-2 hover:bg-surface-0/50"
               }`}
-              onClick={() => rightPanel.setActiveTab(id)}
+              onClick={() => showKind(kind)}
             >
-              {TABS[id].label}
+              {TAB_LABEL[kind]}
             </button>
           )}
         </For>
@@ -91,12 +76,16 @@ const RightPanel: Component<{
         </button>
       </div>
       <div class="flex-1 min-h-0 overflow-hidden">
-        <Dynamic
-          component={TABS[rightPanel.activeTab()].component}
-          meta={props.meta}
-          themeName={props.themeName}
-          onThemeClick={props.onThemeClick}
-        />
+        {match(rightPanel.activeTab())
+          .with({ kind: "inspector" }, () => (
+            <MetadataInspector
+              meta={props.meta}
+              themeName={props.themeName}
+              onThemeClick={props.onThemeClick}
+            />
+          ))
+          .with({ kind: "code" }, () => <CodeTab meta={props.meta} />)
+          .exhaustive()}
       </div>
     </div>
   );

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -2,7 +2,7 @@
  *  persisted via server preferences under `preferences.rightPanel`.
  *  Defaults to collapsed with the Inspector tab active. */
 
-import type { RightPanelTab } from "kolu-common";
+import type { CodeTabView, RightPanelTab } from "kolu-common";
 import { useServerState } from "../settings/useServerState";
 
 const MIN_PANEL_SIZE = 0.05;
@@ -19,8 +19,11 @@ export function useRightPanel() {
     /** Whether the right panel is pinned (docked) vs floating overlay.
      *  Defaults to true (pinned) for backwards compat with classic mode. */
     pinned: () => rp().pinned !== false,
+    codeMode: (): CodeTabView => rp().codeMode,
     setActiveTab: (tab: RightPanelTab) =>
       updatePreferences({ rightPanel: { tab } }),
+    setCodeMode: (codeMode: CodeTabView) =>
+      updatePreferences({ rightPanel: { codeMode } }),
     togglePanel: () =>
       updatePreferences({ rightPanel: { collapsed: !rp().collapsed } }),
     collapsePanel: () => updatePreferences({ rightPanel: { collapsed: true } }),

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -1,4 +1,5 @@
-/** Right panel state — singleton module. Tracks collapsed, size, and active tab,
+/** Right panel state — singleton module. Tracks collapsed, size, pin, and
+ *  active tab (a discriminated union of Inspector vs Code-with-mode),
  *  persisted via server preferences under `preferences.rightPanel`.
  *  Defaults to collapsed with the Inspector tab active. */
 
@@ -15,15 +16,22 @@ export function useRightPanel() {
   return {
     collapsed: () => rp().collapsed,
     panelSize: () => rp().size,
-    activeTab: () => rp().tab,
+    /** The full tab state — discriminated union of Inspector vs Code+mode. */
+    activeTab: (): RightPanelTab => rp().tab,
     /** Whether the right panel is pinned (docked) vs floating overlay.
      *  Defaults to true (pinned) for backwards compat with classic mode. */
     pinned: () => rp().pinned !== false,
-    codeMode: (): CodeTabView => rp().codeMode,
-    setActiveTab: (tab: RightPanelTab) =>
-      updatePreferences({ rightPanel: { tab } }),
-    setCodeMode: (codeMode: CodeTabView) =>
-      updatePreferences({ rightPanel: { codeMode } }),
+    /** Switch to Inspector. */
+    showInspector: () =>
+      updatePreferences({ rightPanel: { tab: { kind: "inspector" } } }),
+    /** Switch to Code tab with the given mode (defaults to "local").
+     *  Code-mode memory is intentionally not preserved across Inspector↔Code
+     *  switches — simpler state, no "what was I last looking at?" field. */
+    showCode: (mode: CodeTabView = "local") =>
+      updatePreferences({ rightPanel: { tab: { kind: "code", mode } } }),
+    /** Change the sub-mode within the Code tab. */
+    setCodeMode: (mode: CodeTabView) =>
+      updatePreferences({ rightPanel: { tab: { kind: "code", mode } } }),
     togglePanel: () =>
       updatePreferences({ rightPanel: { collapsed: !rp().collapsed } }),
     collapsePanel: () => updatePreferences({ rightPanel: { collapsed: true } }),

--- a/packages/client/src/settings/useServerState.ts
+++ b/packages/client/src/settings/useServerState.ts
@@ -1,19 +1,31 @@
 /**
- * Unified server state — single reactive source backed by one subscription.
+ * Unified server state — singleton subscription for server-emitted data,
+ * singleton local store for instant preference updates.
  *
- * Every caller shares the same module-level subscription. Preferences,
- * recent repos/agents, and saved session are all read through `sub()`,
- * which `createSubscription` backs with a `reconcile`'d store for
- * fine-grained reactivity per nested field.
+ * Why both? Instant UI response requires synchronous local updates —
+ * waiting for the server echo introduces a visible delay when a pref
+ * flip gates a re-render (e.g., `canvasMode` → canvas mount → wheel
+ * listener attach). On the CI side this timing shows up as a race against
+ * the canvas ownership window; on the user side it's the same class of
+ * single-frame lag.
  *
- * Mutations flow one direction: `updatePreferences` fires an RPC, the
- * server merges and persists, then echoes the merged state back via the
- * subscription. No separate local store is needed — and eliminating it
- * removes the race where a subscription push could overwrite a locally
- * applied change before the RPC round-tripped (issue #561).
+ * What kept biting before (issue #561): the original code reconciled the
+ * server's preferences blob into the local store on *every* push, so any
+ * unrelated `state:changed` event (a `trackRecentAgent`, another pref
+ * write) would stomp a locally-applied change whose RPC hadn't round-tripped
+ * yet. The fix here is "reconcile only once, at init" — the subscription
+ * seeds the local store on its first yield, then never touches preferences
+ * again. The local store is authoritative for preferences thereafter;
+ * `updatePreferences` writes locally and tells the server, but subsequent
+ * server echoes for those fields are intentionally ignored.
+ *
+ * `recentRepos` / `recentAgents` / `session` still come from the
+ * subscription live — they're server-emitted and the client never writes
+ * them, so there's no divergence to worry about.
  */
 
-import { createRoot } from "solid-js";
+import { createEffect, createRoot, on } from "solid-js";
+import { createStore, reconcile } from "solid-js/store";
 import { toast } from "solid-sonner";
 import { createSubscription } from "../rpc/createSubscription";
 import { client, stream } from "../rpc/rpc";
@@ -27,18 +39,48 @@ import type {
   SavedSession,
 } from "kolu-common";
 
-// Module-level singleton. createRoot detaches the subscription's internal
-// effect graph from any transient caller owner so it lives for the app.
-const sub = createRoot(() =>
-  createSubscription(() => stream.state(), {
+const [prefs, setPrefs] = createStore<Preferences>(DEFAULT_PREFERENCES);
+let initialized = false;
+
+// createRoot detaches the subscription + init effect from any transient
+// caller's reactive owner so they live for the app's lifetime.
+const sub = createRoot(() => {
+  const s = createSubscription(() => stream.state(), {
     onError: (err) => toast.error(`Server state error: ${err.message}`),
-  }),
-);
+  });
+  createEffect(
+    on(
+      () => s()?.preferences,
+      (serverPrefs) => {
+        if (serverPrefs && !initialized) {
+          initialized = true;
+          setPrefs(reconcile(serverPrefs));
+        }
+      },
+    ),
+  );
+  return s;
+});
 
 export function useServerState() {
-  /** Update one or more preferences. The server is authoritative; the
-   *  merged result flows back through the subscription. */
+  /** Update one or more preferences. Applied to the local store
+   *  synchronously (for instant UI response), then persisted to the
+   *  server. The server's echo for these fields is ignored — see the
+   *  module comment for why. */
   function updatePreferences(patch: PreferencesPatch) {
+    const { rightPanel: rpPatch, ...rest } = patch;
+    if (Object.keys(rest).length > 0) setPrefs(rest);
+    if (rpPatch) {
+      // tab is a discriminated union — use the 3-arg path form to REPLACE
+      // the value wholesale. Shallow-merging `{ tab: newTab }` into the
+      // rightPanel object would carry stale fields (e.g. a lingering `mode`
+      // from {kind:"code"} when switching to {kind:"inspector"}).
+      const { tab, ...rpRest } = rpPatch;
+      if (Object.keys(rpRest).length > 0) {
+        setPrefs("rightPanel", rpRest as Partial<Preferences["rightPanel"]>);
+      }
+      if (tab !== undefined) setPrefs("rightPanel", "tab", tab);
+    }
     void client.state
       .update({ preferences: patch })
       .catch((err: Error) =>
@@ -50,8 +92,9 @@ export function useServerState() {
     sub,
     /** Full server state (undefined while loading). */
     state: () => sub() as ServerState | undefined,
-    /** Preferences — falls back to defaults until the first server push. */
-    preferences: (): Preferences => sub()?.preferences ?? DEFAULT_PREFERENCES,
+    /** Preferences — local store, authoritative after the first server
+     *  yield seeds it. */
+    preferences: (): Preferences => prefs,
     recentRepos: () => (sub()?.recentRepos ?? []) as RecentRepo[],
     recentAgents: () => (sub()?.recentAgents ?? []) as RecentAgent[],
     savedSession: () => (sub()?.session ?? null) as SavedSession | null,

--- a/packages/client/src/settings/useServerState.ts
+++ b/packages/client/src/settings/useServerState.ts
@@ -1,19 +1,19 @@
 /**
- * Unified server state — live subscription for server sync, local store for instant UI reactivity.
+ * Unified server state — single reactive source backed by one subscription.
  *
- * Architecture:
- * - createSubscription: server pushes state changes over WebSocket
- * - Singleton SolidJS store: synchronous UI updates for preferences
- * - reconcile effect: syncs subscription → local store on every server push
- * - updatePreferences: instant local store update + async server mutation
+ * Every caller shares the same module-level subscription. Preferences,
+ * recent repos/agents, and saved session are all read through `sub()`,
+ * which `createSubscription` backs with a `reconcile`'d store for
+ * fine-grained reactivity per nested field.
  *
- * Why both? The server round-trip (even on localhost) takes a few ms.
- * For instant toggle feedback, the local store handles the synchronous update;
- * the subscription pushes authoritative state back via reconcile.
+ * Mutations flow one direction: `updatePreferences` fires an RPC, the
+ * server merges and persists, then echoes the merged state back via the
+ * subscription. No separate local store is needed — and eliminating it
+ * removes the race where a subscription push could overwrite a locally
+ * applied change before the RPC round-tripped (issue #561).
  */
 
-import { createEffect, on } from "solid-js";
-import { createStore, reconcile } from "solid-js/store";
+import { createRoot } from "solid-js";
 import { toast } from "solid-sonner";
 import { createSubscription } from "../rpc/createSubscription";
 import { client, stream } from "../rpc/rpc";
@@ -27,37 +27,18 @@ import type {
   SavedSession,
 } from "kolu-common";
 
-// Singleton store — all callers share one reactive source of truth for preferences.
-const [prefs, setPrefs] = createStore<Preferences>(DEFAULT_PREFERENCES);
-let storeInitialized = false;
+// Module-level singleton. createRoot detaches the subscription's internal
+// effect graph from any transient caller owner so it lives for the app.
+const sub = createRoot(() =>
+  createSubscription(() => stream.state(), {
+    onError: (err) => toast.error(`Server state error: ${err.message}`),
+  }),
+);
 
 export function useServerState() {
-  const sub = createSubscription(() => stream.state(), {
-    onError: (err) => toast.error(`Server state error: ${err.message}`),
-  });
-
-  // Sync singleton store from subscription — only the first caller wires this up.
-  if (!storeInitialized) {
-    storeInitialized = true;
-    createEffect(
-      on(
-        () => sub()?.preferences,
-        (serverPrefs) => {
-          if (serverPrefs) setPrefs(reconcile(serverPrefs));
-        },
-      ),
-    );
-  }
-
-  /** Update one or more preferences. Instant local update + async server persist.
-   *  Nested objects (rightPanel) are deep-merged both locally and on the server. */
+  /** Update one or more preferences. The server is authoritative; the
+   *  merged result flows back through the subscription. */
   function updatePreferences(patch: PreferencesPatch) {
-    // Synchronous local update — UI reacts immediately (singleton store).
-    // SolidJS store setter supports path-based deep updates.
-    const { rightPanel: rpPatch, ...rest } = patch;
-    if (Object.keys(rest).length > 0) setPrefs(rest);
-    if (rpPatch) setPrefs("rightPanel", rpPatch);
-    // Server persist — live stream will push authoritative state back via reconcile
     void client.state
       .update({ preferences: patch })
       .catch((err: Error) =>
@@ -69,8 +50,8 @@ export function useServerState() {
     sub,
     /** Full server state (undefined while loading). */
     state: () => sub() as ServerState | undefined,
-    /** Preferences — singleton store, synced from subscription on every server push. */
-    preferences: () => prefs,
+    /** Preferences — falls back to defaults until the first server push. */
+    preferences: (): Preferences => sub()?.preferences ?? DEFAULT_PREFERENCES,
     recentRepos: () => (sub()?.recentRepos ?? []) as RecentRepo[],
     recentAgents: () => (sub()?.recentAgents ?? []) as RecentAgent[],
     savedSession: () => (sub()?.session ?? null) as SavedSession | null,

--- a/packages/client/src/settings/useServerState.ts
+++ b/packages/client/src/settings/useServerState.ts
@@ -71,15 +71,18 @@ export function useServerState() {
     const { rightPanel: rpPatch, ...rest } = patch;
     if (Object.keys(rest).length > 0) setPrefs(rest);
     if (rpPatch) {
-      // tab is a discriminated union — use the 3-arg path form to REPLACE
-      // the value wholesale. Shallow-merging `{ tab: newTab }` into the
-      // rightPanel object would carry stale fields (e.g. a lingering `mode`
-      // from {kind:"code"} when switching to {kind:"inspector"}).
       const { tab, ...rpRest } = rpPatch;
+      // Scalar fields of rightPanel (collapsed, size, pinned) go through
+      // the normal merge — any path form works for primitives.
       if (Object.keys(rpRest).length > 0) {
         setPrefs("rightPanel", rpRest as Partial<Preferences["rightPanel"]>);
       }
-      if (tab !== undefined) setPrefs("rightPanel", "tab", tab);
+      // `tab` is a discriminated-union object. The 3-arg path form
+      // deep-merges an object value (leaving stale fields from the old
+      // variant), and the 2-arg merge form doesn't trigger fine-grained
+      // reactivity on nested readers like `tab.mode` — verified empirically.
+      // `reconcile` both REPLACES wholesale and fires proper reactivity.
+      if (tab !== undefined) setPrefs("rightPanel", "tab", reconcile(tab));
     }
     void client.state
       .update({ preferences: patch })

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -42,8 +42,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   rightPanel: {
     collapsed: true,
     size: 0.25,
-    tab: "inspector",
+    tab: { kind: "inspector" },
     pinned: true,
-    codeMode: "local",
   },
 };

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -44,5 +44,6 @@ export const DEFAULT_PREFERENCES: Preferences = {
     size: 0.25,
     tab: "inspector",
     pinned: true,
+    codeMode: "local",
   },
 };

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -308,12 +308,19 @@ export const SidebarAgentPreviewsSchema = z.enum([
 ]);
 export type SidebarAgentPreviews = z.infer<typeof SidebarAgentPreviewsSchema>;
 
-export const RightPanelTabSchema = z.enum(["inspector", "diff"]);
-export type RightPanelTab = z.infer<typeof RightPanelTabSchema>;
-
 /** Sub-view of the Code tab: local/branch diff modes or the file browser. */
 export const CodeTabViewSchema = z.enum(["local", "branch", "browse"]);
 export type CodeTabView = z.infer<typeof CodeTabViewSchema>;
+
+/** Active tab of the right panel. A discriminated union so illegal pairings
+ *  ("inspector with a code mode attached") can't be represented. The Inspector
+ *  tab carries no sub-state; the Code tab carries its current mode. */
+export const RightPanelTabSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("inspector") }),
+  z.object({ kind: z.literal("code"), mode: CodeTabViewSchema }),
+]);
+export type RightPanelTab = z.infer<typeof RightPanelTabSchema>;
+export type RightPanelTabKind = RightPanelTab["kind"];
 
 export const RightPanelPrefsSchema = z.object({
   collapsed: z.boolean(),
@@ -321,8 +328,6 @@ export const RightPanelPrefsSchema = z.object({
   tab: RightPanelTabSchema,
   /** Whether the right panel is pinned (docked) vs floating overlay. */
   pinned: z.boolean(),
-  /** Active sub-view within the Code tab (local/branch/browse). */
-  codeMode: CodeTabViewSchema,
 });
 
 export const PreferencesSchema = z.object({

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -311,12 +311,18 @@ export type SidebarAgentPreviews = z.infer<typeof SidebarAgentPreviewsSchema>;
 export const RightPanelTabSchema = z.enum(["inspector", "diff"]);
 export type RightPanelTab = z.infer<typeof RightPanelTabSchema>;
 
+/** Sub-view of the Code tab: local/branch diff modes or the file browser. */
+export const CodeTabViewSchema = z.enum(["local", "branch", "browse"]);
+export type CodeTabView = z.infer<typeof CodeTabViewSchema>;
+
 export const RightPanelPrefsSchema = z.object({
   collapsed: z.boolean(),
   size: z.number(),
   tab: RightPanelTabSchema,
   /** Whether the right panel is pinned (docked) vs floating overlay. */
   pinned: z.boolean(),
+  /** Active sub-view within the Code tab (local/branch/browse). */
+  codeMode: CodeTabViewSchema,
 });
 
 export const PreferencesSchema = z.object({

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -130,32 +130,39 @@ export const store = new Conf<PersistedState>({
     },
     // RightPanelTab enum changed: "files" + "git" stubs collapsed into one "review" tab (#514).
     // Coerce stale persisted values to "inspector" so zod validation at the RPC boundary holds.
-    // Cast through `string` because the historical enum values are no longer in the live type.
+    // Cast through `unknown` because on-disk tab predates both the current
+    // union and the older enum shape.
     "1.8.0": (store: Conf<PersistedState>) => {
       const current = store.get("preferences");
-      const tab = current.rightPanel.tab as string;
+      const tab = current.rightPanel.tab as unknown as string;
       const staleTab = tab !== "inspector" && tab !== "review";
       if (staleTab) {
         store.set("preferences", {
           ...current,
-          rightPanel: { ...current.rightPanel, tab: "inspector" },
+          rightPanel: {
+            ...current.rightPanel,
+            tab: "inspector" as unknown as typeof current.rightPanel.tab,
+          },
         });
       }
     },
     // Tab renamed: "review" → "diff" (#514). The label is "Code Diff" to
     // signal forge/VCS-agnostic intent. Anything other than "inspector" or
-    // "diff" coerces to "inspector". Cast through `string` because "review"
-    // is no longer in the live `RightPanelTab` enum.
+    // "diff" coerces to "inspector". Cast through `unknown` because the
+    // on-disk value at this migration point is still a flat string, not
+    // the discriminated union introduced in 1.13.0.
     "1.9.0": (store: Conf<PersistedState>) => {
       const current = store.get("preferences");
-      const tab = current.rightPanel.tab as string;
+      const tab = current.rightPanel.tab as unknown as string;
       const next = tab === "review" ? "diff" : tab;
       const valid = next === "inspector" || next === "diff";
       store.set("preferences", {
         ...current,
         rightPanel: {
           ...current.rightPanel,
-          tab: valid ? next : "inspector",
+          tab: (valid
+            ? next
+            : "inspector") as unknown as typeof current.rightPanel.tab,
         },
       });
     },
@@ -197,18 +204,26 @@ export const store = new Conf<PersistedState>({
         store.set("preferences", { ...current, canvasMode: false });
       }
     },
-    // rightPanel.codeMode added — default to "local" so existing users land on
-    // the same view they used to (local diff was the only option pre-#555).
+    // rightPanel.tab reshaped into a discriminated union so illegal
+    // combinations ("inspector + codeMode") are unrepresentable. Old shape:
+    //   { tab: "inspector" | "diff" }
+    // New shape:
+    //   { tab: { kind: "inspector" } | { kind: "code", mode: "local"|"branch"|"browse" } }
+    // Any transient flat `codeMode` field from an in-flight build of #576 is
+    // discarded — the mode now lives inside the `code` variant of the tab.
     "1.13.0": (store: Conf<PersistedState>) => {
       const current = store.get("preferences");
-      if (
-        (current.rightPanel as Record<string, unknown>).codeMode === undefined
-      ) {
-        store.set("preferences", {
-          ...current,
-          rightPanel: { ...current.rightPanel, codeMode: "local" },
-        });
-      }
+      const rp = current.rightPanel as Record<string, unknown>;
+      if (rp.tab !== null && typeof rp.tab === "object") return;
+      const tab =
+        rp.tab === "diff"
+          ? { kind: "code" as const, mode: "local" as const }
+          : { kind: "inspector" as const };
+      const { codeMode: _codeMode, tab: _tab, ...rest } = rp;
+      store.set("preferences", {
+        ...current,
+        rightPanel: { ...rest, tab } as typeof current.rightPanel,
+      });
     },
   },
 });

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -211,6 +211,13 @@ export const store = new Conf<PersistedState>({
     //   { tab: { kind: "inspector" } | { kind: "code", mode: "local"|"branch"|"browse" } }
     // Any transient flat `codeMode` field from an in-flight build of #576 is
     // discarded — the mode now lives inside the `code` variant of the tab.
+    // Users on such a build with `codeMode: "branch"` or `"browse"` are
+    // reset to `"local"`; no release ever shipped that intermediate shape,
+    // and "local" matches the pre-#555 default so it's a safe fallback.
+    // The `typeof === "object"` guard is a belt-and-suspenders no-op for
+    // the already-migrated case (conf won't re-run this key once seen);
+    // `null` slips through and falls into the inspector default, which is
+    // the right recovery for a corrupt tab value.
     "1.13.0": (store: Conf<PersistedState>) => {
       const current = store.get("preferences");
       const rp = current.rightPanel as Record<string, unknown>;

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -26,7 +26,7 @@ import { log } from "./log.ts";
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.12.0";
+const SCHEMA_VERSION = "1.13.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -195,6 +195,19 @@ export const store = new Conf<PersistedState>({
       const current = store.get("preferences");
       if ((current as Record<string, unknown>).canvasMode === undefined) {
         store.set("preferences", { ...current, canvasMode: false });
+      }
+    },
+    // rightPanel.codeMode added — default to "local" so existing users land on
+    // the same view they used to (local diff was the only option pre-#555).
+    "1.13.0": (store: Conf<PersistedState>) => {
+      const current = store.get("preferences");
+      if (
+        (current.rightPanel as Record<string, unknown>).codeMode === undefined
+      ) {
+        store.set("preferences", {
+          ...current,
+          rightPanel: { ...current.rightPanel, codeMode: "local" },
+        });
       }
     },
   },

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -30,6 +30,18 @@ Feature: Code tab (diff review)
     And I click the Code tab
     Then the Code tab mode should be "local"
 
+  Scenario: Code tab mode survives panel close and reopen
+    When I run "git init /tmp/kolu-review-mode-persist && cd /tmp/kolu-review-mode-persist"
+    And I run "git commit --allow-empty -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    Then the Code tab mode should be "browse"
+    When I press the toggle inspector shortcut
+    Then the right panel should not be visible
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    And the Code tab mode should be "browse"
+
   Scenario: Branch mode surfaces an actionable error when origin is missing
     When I run "git init /tmp/kolu-review-no-origin && cd /tmp/kolu-review-no-origin"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/features/right-panel-pin.feature
+++ b/packages/tests/features/right-panel-pin.feature
@@ -45,6 +45,19 @@ Feature: Right panel pin/unpin
     Then the right panel should not be visible
     And there should be no page errors
 
+  Scenario: Active tab survives pin/unpin toggle
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I click the Code tab
+    Then the Code tab should be active
+    When I click the right panel pin toggle
+    Then the right panel pin button should show unpinned
+    And the Code tab should be active
+    When I click the right panel pin toggle
+    Then the right panel pin button should show pinned
+    And the Code tab should be active
+    And there should be no page errors
+
   Scenario: Pin state persists across reload
     When I press the toggle inspector shortcut
     When I click the right panel pin toggle

--- a/packages/tests/features/right-panel.feature
+++ b/packages/tests/features/right-panel.feature
@@ -95,6 +95,18 @@ Feature: Right panel (inspector)
     Then the right panel should not be visible
     And there should be no page errors
 
+  Scenario: Active tab survives close and reopen
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I click the Code tab
+    Then the Code tab should be active
+    When I press the toggle inspector shortcut
+    Then the right panel should not be visible
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    And the Code tab should be active
+    And there should be no page errors
+
   @mobile
   Scenario: Right panel hidden on mobile even when expanded in preferences
     # Server has collapsed=false (expanded) but mobile viewport should suppress it

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -4,7 +4,7 @@ import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 // ── Actions ──
 
 When("I click the Code tab", async function (this: KoluWorld) {
-  const tab = this.page.locator('[data-testid="right-panel-tab-diff"]');
+  const tab = this.page.locator('[data-testid="right-panel-tab-code"]');
   await tab.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   await tab.click();
   await this.waitForFrame();
@@ -48,7 +48,7 @@ Then("the Code tab should be active", async function (this: KoluWorld) {
   // The Code tab button exposes data-active reflecting the active
   // tab, which is independent of in-repo vs no-repo content.
   const btn = this.page.locator(
-    '[data-testid="right-panel-tab-diff"][data-active="true"]',
+    '[data-testid="right-panel-tab-code"][data-active="true"]',
   );
   await btn.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 });

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -233,9 +233,8 @@ Before(async function (this: KoluWorld, scenario) {
           rightPanel: {
             collapsed: true,
             size: 0.25,
-            tab: "inspector",
+            tab: { kind: "inspector" },
             pinned: true,
-            codeMode: "local",
           },
         },
       },

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -235,6 +235,7 @@ Before(async function (this: KoluWorld, scenario) {
             size: 0.25,
             tab: "inspector",
             pinned: true,
+            codeMode: "local",
           },
         },
       },


### PR DESCRIPTION
**The Code tab (and its sub-modes) no longer bounce back to their defaults** when you close and reopen the right panel, or when you toggle pin/unpin. The tab lives on the server, the server was storing it correctly, and yet the UI kept forgetting — because the client was talking to two sources of truth at once.

`useServerState` previously maintained a singleton SolidJS store *and* reconciled the subscription's full preferences blob into it on every `state:changed` push. The comment justified the dual layer as "instant toggle feedback," but on localhost the round-trip is sub-frame, and the dual layer paid for that imagined latency with a real race: any unrelated push (a `trackRecentAgent`, another preference write, anything) could arrive carrying the pre-click server snapshot and stomp the locally-applied tab change before its own RPC had round-tripped.

The fix is to **stop having two sources of truth**. `useServerState` now exposes `sub()?.preferences` directly; `updatePreferences` just fires the RPC and lets the server's echo drive the UI. The subscription already uses `reconcile` internally, so field-level reactivity is preserved and every existing call site keeps the same API. The module shrinks from ~60 lines to ~30.

*A second commit extends the fix one level deeper:* the Code tab's sub-view (local / branch / browse) was held in a component-local `createSignal`, so it reset to `"local"` every remount — which happens on close/reopen, pin/unpin, and page reload. Added `rightPanel.codeMode` to the preferences schema (migration 1.13.0) and wired `CodeTab` to read/write through `useRightPanel`, so sub-tab state now flows through the same singleton subscription as the rest of the panel.

*The deeper observation — surfaced by a volatility-based review — is that `preferences` (user intent, write-through) and `recentRepos` / `recentAgents` (server-derived activity feed) are fused into one `ServerState.preferences` blob with one RPC surface despite having different change rates and authorities.* Splitting them is a separate refactor; this PR keeps scope to the race that issue #561 describes.

Adds e2e coverage for all three user-facing paths: **top-level tab survives close/reopen**, **top-level tab survives pin/unpin**, and **Code sub-mode survives close/reopen**. Also a one-line doc correction in the `no-preference-prop-drilling` rule so it says "singleton subscription" instead of "singleton store."

Closes #561. Deferred structural split tracked in #577.