### PR TITLE
Resize canvas tiles from any edge or corner

### DIFF
--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -1,14 +1,14 @@
 /** Single tile on the canvas — separated so createDraggable gets its own
  *  reactive owner per tile (required by solid-dnd). Shell only: positioning,
- *  title bar, resize handle. Content is injected via render props — the
+ *  title bar, resize handles. Content is injected via render props — the
  *  canvas module has no knowledge of what renders inside a tile. */
 
-import type { Component, JSX } from "solid-js";
+import { type Component, For, type JSX } from "solid-js";
 import { createDraggable } from "@thisbeyond/solid-dnd";
-import { ResizeGripIcon } from "../ui/Icons";
 import type { TileLayout } from "./TileLayout";
+import { RESIZE_HANDLES, type ResizeDirection } from "./resizeGeometry";
 
-/** Minimal theme info for tile chrome (title bar, border, resize handle). */
+/** Minimal theme info for tile chrome (title bar, border). */
 export interface TileTheme {
   bg: string;
   fg: string;
@@ -26,7 +26,11 @@ const CanvasTile: Component<{
   renderTitle: () => JSX.Element;
   renderBody: () => JSX.Element;
   layouts: Record<string, TileLayout>;
-  startResize: (id: string, e: PointerEvent) => void;
+  startResize: (
+    id: string,
+    direction: ResizeDirection,
+    e: PointerEvent,
+  ) => void;
   zoom: () => number;
 }> = (props) => {
   const { id } = props;
@@ -95,20 +99,19 @@ const CanvasTile: Component<{
       {/* Tile body — injected by caller */}
       {props.renderBody()}
 
-      {/* Resize handle — bottom-right corner, larger hit area */}
-      <div
-        class="absolute bottom-0 right-0 w-6 h-6 cursor-nwse-resize opacity-0 hover:opacity-100 transition-opacity"
-        onPointerDown={(e) => props.startResize(id, e)}
-      >
-        <span
-          class="absolute bottom-0.5 right-0.5"
-          style={{
-            color: `color-mix(in oklch, ${fg()} 40%, ${bg()})`,
-          }}
-        >
-          <ResizeGripIcon />
-        </span>
-      </div>
+      {/* Resize handles — 4 edges + 4 corners. Invisible; cursor change is the
+       *  affordance. Corners are declared after edges in the record so DOM
+       *  order paints them on top of the edge strips they overlap. */}
+      <For each={Object.entries(RESIZE_HANDLES)}>
+        {([direction, handle]) => (
+          <div
+            class={`absolute ${handle.position} ${handle.cursor}`}
+            onPointerDown={(e) =>
+              props.startResize(id, direction as ResizeDirection, e)
+            }
+          />
+        )}
+      </For>
     </div>
   );
 };

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -31,6 +31,7 @@ import {
 import type { TileLayout } from "./TileLayout";
 import { useCanvasViewport } from "./viewport/useCanvasViewport";
 import { capturePointerGesture } from "./viewport/capturePointerGesture";
+import { applyResize, type ResizeDirection } from "./resizeGeometry";
 import CanvasTile, { type TileTheme } from "./CanvasTile";
 import CanvasMinimap from "./CanvasMinimap";
 
@@ -181,20 +182,21 @@ const TerminalCanvas: Component<{
     setDragDelta({ x: 0, y: 0 });
   }
 
-  /** Start resizing a tile from the bottom-right corner.
+  /** Start resizing a tile from the given edge or corner.
    *  Pointer deltas are in screen-space — normalize by zoom. */
   let abortResize: AbortController | null = null;
-  function startResize(id: string, e: PointerEvent) {
+  function startResize(
+    id: string,
+    direction: ResizeDirection,
+    e: PointerEvent,
+  ) {
     e.preventDefault();
     e.stopPropagation();
-    const l = layoutOf(id);
-    if (!l) return;
+    const origin = layoutOf(id);
+    if (!origin) return;
     const startX = e.clientX;
     const startY = e.clientY;
-    const origW = l.w;
-    const origH = l.h;
-    const origX = l.x;
-    const origY = l.y;
+    const limits = { minW: MIN_W, minH: MIN_H };
 
     abortResize?.abort();
     abortResize = new AbortController();
@@ -205,26 +207,26 @@ const TerminalCanvas: Component<{
             ev.clientX - startX,
             ev.clientY - startY,
           );
-          setPendingLayout(id, {
-            x: origX,
-            y: origY,
-            w: Math.max(MIN_W, origW + dx),
-            h: Math.max(MIN_H, origH + dy),
-          });
+          setPendingLayout(id, applyResize(origin, direction, dx, dy, limits));
         },
-        onEnd: () => {
+        onEnd: (ev) => {
           abortResize = null;
-          const live = pending()[id];
-          if (live) {
-            const snapped: TileLayout = {
-              x: live.x,
-              y: live.y,
-              w: viewport.snapToGrid(live.w),
-              h: viewport.snapToGrid(live.h),
-            };
-            setPendingLayout(id, snapped);
-            props.onLayoutChange(id, snapped);
-          }
+          // No motion — skip commit so a bare click doesn't round-trip the server.
+          if (!pending()[id]) return;
+          const { dx, dy } = viewport.normalizeDelta(
+            ev.clientX - startX,
+            ev.clientY - startY,
+          );
+          const snapped = applyResize(
+            origin,
+            direction,
+            dx,
+            dy,
+            limits,
+            viewport.snapToGrid,
+          );
+          setPendingLayout(id, snapped);
+          props.onLayoutChange(id, snapped);
         },
       },
       abortResize,

--- a/packages/client/src/canvas/resizeGeometry.ts
+++ b/packages/client/src/canvas/resizeGeometry.ts
@@ -1,0 +1,99 @@
+/** Resize geometry for canvas tiles — pure, data-driven.
+ *
+ *  `RESIZE_HANDLES` is the single source of truth: each of the 8 directions
+ *  maps to a cursor class and absolute-position class string. Drives both the
+ *  `<For>` over handles in `CanvasTile` and the delta-to-rect transform in
+ *  `applyResize`. Adding or changing a direction is a one-entry edit.
+ *
+ *  `applyResize` is a pure function — no viewport/zoom knowledge, no pending
+ *  state. Caller normalizes the pointer delta to canvas-space first. */
+
+import type { TileLayout } from "./TileLayout";
+
+export type ResizeDirection = "n" | "s" | "e" | "w" | "nw" | "ne" | "sw" | "se";
+
+export interface ResizeHandle {
+  /** Tailwind cursor class (e.g. `cursor-ns-resize`). */
+  cursor: string;
+  /** Tailwind absolute-position classes placing the hit area. */
+  position: string;
+}
+
+/** Edges are inset from the corners so the corner squares own those hotspots.
+ *  Corners are rendered later in DOM order than edges so overlap favors them. */
+export const RESIZE_HANDLES: Record<ResizeDirection, ResizeHandle> = {
+  n: { cursor: "cursor-ns-resize", position: "top-0 left-3 right-3 h-1.5" },
+  s: { cursor: "cursor-ns-resize", position: "bottom-0 left-3 right-3 h-1.5" },
+  e: { cursor: "cursor-ew-resize", position: "top-3 bottom-3 right-0 w-1.5" },
+  w: { cursor: "cursor-ew-resize", position: "top-3 bottom-3 left-0 w-1.5" },
+  nw: { cursor: "cursor-nwse-resize", position: "top-0 left-0 w-3 h-3" },
+  ne: { cursor: "cursor-nesw-resize", position: "top-0 right-0 w-3 h-3" },
+  sw: { cursor: "cursor-nesw-resize", position: "bottom-0 left-0 w-3 h-3" },
+  se: { cursor: "cursor-nwse-resize", position: "bottom-0 right-0 w-3 h-3" },
+};
+
+export interface ResizeLimits {
+  minW: number;
+  minH: number;
+}
+
+/** Which edges each direction moves. Lifted out of `applyResize` so the fresh
+ *  `Record<ResizeDirection, …>` literal fails to compile if the union ever
+ *  gains or loses a variant without matching axis entries. */
+interface DirectionAxes {
+  horiz: "w" | "e" | null;
+  vert: "n" | "s" | null;
+}
+
+const DIRECTION_AXES: Record<ResizeDirection, DirectionAxes> = {
+  n: { horiz: null, vert: "n" },
+  s: { horiz: null, vert: "s" },
+  e: { horiz: "e", vert: null },
+  w: { horiz: "w", vert: null },
+  nw: { horiz: "w", vert: "n" },
+  ne: { horiz: "e", vert: "n" },
+  sw: { horiz: "w", vert: "s" },
+  se: { horiz: "e", vert: "s" },
+};
+
+/** Compute a new tile rect from a pointer delta applied to a snapshot origin.
+ *  `dx`/`dy` are already in canvas-space (caller normalizes by viewport zoom).
+ *  West/north edges shift `x`/`y` so the opposite edge stays pinned.
+ *
+ *  `snap` (optional) is applied to the *moving edge*, not to width/height, so
+ *  grid-snap on release keeps the pinned edge where the user left it. */
+export function applyResize(
+  origin: TileLayout,
+  direction: ResizeDirection,
+  dx: number,
+  dy: number,
+  { minW, minH }: ResizeLimits,
+  snap: (n: number) => number = (n) => n,
+): TileLayout {
+  const { horiz, vert } = DIRECTION_AXES[direction];
+
+  let x = origin.x;
+  let y = origin.y;
+  let w = origin.w;
+  let h = origin.h;
+
+  if (horiz === "e") {
+    const rightEdge = snap(origin.x + origin.w + dx);
+    w = Math.max(minW, rightEdge - origin.x);
+  } else if (horiz === "w") {
+    const leftEdge = snap(origin.x + dx);
+    w = Math.max(minW, origin.x + origin.w - leftEdge);
+    x = origin.x + origin.w - w;
+  }
+
+  if (vert === "s") {
+    const bottomEdge = snap(origin.y + origin.h + dy);
+    h = Math.max(minH, bottomEdge - origin.y);
+  } else if (vert === "n") {
+    const topEdge = snap(origin.y + dy);
+    h = Math.max(minH, origin.y + origin.h - topEdge);
+    y = origin.y + origin.h - h;
+  }
+
+  return { x, y, w, h };
+}

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -352,22 +352,6 @@ export const PinIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
-/** Resize grip — 6-dot triangle for corner resize handles. */
-export const ResizeGripIcon: Component<{ class?: string }> = (props) => (
-  <svg
-    class={props.class ?? "w-3.5 h-3.5"}
-    viewBox="0 0 14 14"
-    fill="currentColor"
-  >
-    <circle cx="12" cy="12" r="1.3" />
-    <circle cx="8" cy="12" r="1.3" />
-    <circle cx="12" cy="8" r="1.3" />
-    <circle cx="4" cy="12" r="1.3" />
-    <circle cx="8" cy="8" r="1.3" />
-    <circle cx="12" cy="4" r="1.3" />
-  </svg>
-);
-
 export const WorktreeIcon: Component<{ class?: string }> = (props) => (
   <svg
     class={props.class ?? "w-3 h-3"}


### PR DESCRIPTION
**Canvas tiles can now be resized from any of the 8 edges or corners**, not just the bottom-right. Hover near any edge or corner and the cursor changes to indicate the resize direction — `n`/`s`/`e`/`w` for edges, the two diagonals for corners. Closes the Phase 4 checkbox on #559.

A single `RESIZE_HANDLES` record pairs each direction with its Tailwind cursor and position class, and a pure `applyResize(origin, direction, dx, dy, limits)` computes the new rect — _west and north edges pin the opposite edge while they move_, so dragging the left edge doesn't drift the right. Grid-snap on release snaps the **moving edge**, not width/height, so the pinned edge stays where the user left it.

_Also fixes a latent single-corner bug where `snapToGrid` could round a tile one step below `MIN_W`/`MIN_H`._ The old `ResizeGripIcon` is gone: the cursor change is the new affordance, and a corner grip doesn't generalize to 8 edges.