### PR TITLE
Drop canvas zoom-to-fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ An alternative to the default single-terminal focus layout — all terminals flo
 
 - **Infinite pan & zoom** — two-finger scroll / trackpad to pan, pinch or <kbd>Ctrl+scroll</kbd> to zoom. No boundaries — the canvas extends freely in every direction via CSS `transform: translate() scale()` (Figma/Excalidraw model)
 - **Snap-to-grid** — tiles snap to a 24px grid on drag and resize for tidy layouts
-- **Keyboard navigation** — <kbd>Cmd/Ctrl+Shift+1</kbd> zoom to fit all tiles, <kbd>Cmd/Ctrl+Shift+2</kbd> centers on the active tile
+- **Keyboard navigation** — <kbd>Cmd/Ctrl+Shift+2</kbd> centers on the active tile
 - **Per-tile theming** — title bars derive their colors from each terminal's theme for guaranteed contrast
 - **Desktop-only** — mobile devices always use focus mode; canvas mode preference is persisted server-side
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -38,7 +38,6 @@ import { useSidebar } from "./sidebar/useSidebar";
 import { useShortcuts } from "./input/useShortcuts";
 import { useSubPanel } from "./terminal/useSubPanel";
 import { useCanvasViewport } from "./canvas/viewport/useCanvasViewport";
-import type { TileLayout } from "./canvas/TileLayout";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import { useColorScheme } from "./settings/useColorScheme";
 import { useServerState } from "./settings/useServerState";
@@ -137,15 +136,6 @@ const App: Component = () => {
     exportSessionAsPdf(id, store.getMetadata(id));
   }
 
-  function handleCanvasFitAll() {
-    if (!canvasMode()) return;
-    const tiles = store
-      .terminalIds()
-      .map((id) => store.getMetadata(id)?.canvasLayout)
-      .filter((t): t is TileLayout => t !== undefined);
-    canvasViewport.fitAll(tiles);
-  }
-
   function handleCanvasCenterActive() {
     if (!canvasMode()) return;
     const id = store.activeId();
@@ -178,7 +168,6 @@ const App: Component = () => {
     handleCopyTerminalText: () => void crud.handleCopyTerminalText(),
     handleExportSessionAsPdf,
     toggleRightPanel: rightPanel.togglePanel,
-    canvasFitAll: handleCanvasFitAll,
     canvasCenterActive: handleCanvasCenterActive,
   });
 
@@ -243,7 +232,6 @@ const App: Component = () => {
     handleCloseAll: () => void crud.handleCloseAll(),
     simulateAlert: alerts.simulateAlert,
     toggleRightPanel: rightPanel.togglePanel,
-    canvasFitAll: handleCanvasFitAll,
     canvasCenterActive: handleCanvasCenterActive,
     toggleMinimap,
     isCanvasMode: canvasMode,

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -4,8 +4,7 @@
 
 import { type Component, For, Show, createMemo, createSignal } from "solid-js";
 import { makePersisted } from "@solid-primitives/storage";
-import { MinimapIcon, ZoomToFitIcon } from "../ui/Icons";
-import { SHORTCUTS, formatKeybind } from "../input/keyboard";
+import { MinimapIcon } from "../ui/Icons";
 import { useCanvasViewport } from "./viewport/useCanvasViewport";
 import { startViewportDrag, handleMinimapClick } from "./minimapGestures";
 import type { TileLayout } from "./TileLayout";
@@ -33,7 +32,6 @@ const CanvasMinimap: Component<{
   activeId: string | null;
   layouts: Record<string, TileLayout>;
   getTileTheme: (id: string) => TileTheme;
-  onFitAll: () => void;
 }> = (props) => {
   const viewport = useCanvasViewport();
 
@@ -217,14 +215,6 @@ const CanvasMinimap: Component<{
           onClick={() => toggleMinimap()}
         >
           <MinimapIcon class="w-3.5 h-3.5" />
-        </button>
-        <div class="w-px h-5 bg-edge/30" />
-        <button
-          class="flex items-center justify-center w-8 h-8 text-fg-3 hover:text-fg hover:bg-surface-3/60 transition-colors cursor-pointer"
-          title={`Zoom to fit (${formatKeybind(SHORTCUTS.canvasFitAll.keybind)})`}
-          onClick={() => props.onFitAll()}
-        >
-          <ZoomToFitIcon class="w-3.5 h-3.5" />
         </button>
         <div class="w-px h-5 bg-edge/30" />
         <button

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -236,9 +236,9 @@ const TerminalCanvas: Component<{
     );
   }
 
-  // Auto-center when viewport is at the default origin (pan=0, zoom=1)
-  // and tiles exist. Derived from actual state, so it survives remounts
-  // and re-centers if the user resets zoom via the toolbar.
+  // On first mount at the default origin, pan so the tile bounding box is
+  // centered — prevents restored sessions (whose tiles may live far from
+  // (0,0)) from opening with the viewport empty.
   let containerRef!: HTMLDivElement;
   const isDefaultViewport = () =>
     viewport.panX() === 0 && viewport.panY() === 0 && viewport.zoom() === 1;
@@ -246,14 +246,21 @@ const TerminalCanvas: Component<{
   createEffect(() => {
     const ids = props.tileIds;
     if (ids.length === 0 || !isDefaultViewport()) return;
-    const allLayouts: TileLayout[] = [];
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
     for (const id of ids) {
       const l = layoutOf(id);
-      if (l) allLayouts.push(l);
+      if (!l) continue;
+      minX = Math.min(minX, l.x);
+      minY = Math.min(minY, l.y);
+      maxX = Math.max(maxX, l.x + l.w);
+      maxY = Math.max(maxY, l.y + l.h);
     }
-    if (allLayouts.length === 0) return;
+    if (!isFinite(minX)) return;
     requestAnimationFrame(() => {
-      viewport.fitAll(allLayouts);
+      viewport.panTo((minX + maxX) / 2, (minY + maxY) / 2);
     });
   });
 
@@ -304,14 +311,6 @@ const TerminalCanvas: Component<{
           activeId={props.activeId}
           layouts={layouts()}
           getTileTheme={props.getTileTheme}
-          onFitAll={() => {
-            const allLayouts: TileLayout[] = [];
-            for (const id of props.tileIds) {
-              const l = layoutOf(id);
-              if (l) allLayouts.push(l);
-            }
-            viewport.fitAll(allLayouts);
-          }}
         />
       </div>
     </DragDropProvider>

--- a/packages/client/src/canvas/viewport/transforms.ts
+++ b/packages/client/src/canvas/viewport/transforms.ts
@@ -2,8 +2,6 @@
  *  Encapsulates the zoom/pan algorithm so it can evolve (easing, constraints,
  *  undo) without touching gesture input or CSS generation. */
 
-import type { TileLayout } from "../TileLayout";
-
 export const MIN_ZOOM = 0.15;
 export const MAX_ZOOM = 3;
 export const GRID_SIZE = 24;
@@ -44,38 +42,6 @@ export function computeCenterPan(
     panX: centerX - viewportW / (2 * zoom),
     panY: centerY - viewportH / (2 * zoom),
   };
-}
-
-/** Compute pan+zoom that fits all tiles in the viewport with padding.
- *  Caps zoom at 1.0 — never magnifies beyond native size. */
-export function computeFitAll(
-  tiles: TileLayout[],
-  viewportW: number,
-  viewportH: number,
-): { panX: number; panY: number; zoom: number } {
-  if (tiles.length === 0) return { panX: 0, panY: 0, zoom: 1 };
-
-  let minX = Infinity,
-    minY = Infinity,
-    maxX = -Infinity,
-    maxY = -Infinity;
-  for (const t of tiles) {
-    minX = Math.min(minX, t.x);
-    minY = Math.min(minY, t.y);
-    maxX = Math.max(maxX, t.x + t.w);
-    maxY = Math.max(maxY, t.y + t.h);
-  }
-  if (!isFinite(minX)) return { panX: 0, panY: 0, zoom: 1 };
-
-  const PAD = 80;
-  const contentW = maxX - minX + PAD * 2;
-  const contentH = maxY - minY + PAD * 2;
-  const z = Math.min(
-    Math.max(Math.min(viewportW / contentW, viewportH / contentH), MIN_ZOOM),
-    1,
-  );
-  const pan = computeCenterPan(minX, minY, maxX, maxY, viewportW, viewportH, z);
-  return { panX: pan.panX, panY: pan.panY, zoom: z };
 }
 
 /** Compute new pan+zoom after zooming by a factor toward a point.

--- a/packages/client/src/canvas/viewport/useCanvasViewport.ts
+++ b/packages/client/src/canvas/viewport/useCanvasViewport.ts
@@ -10,7 +10,6 @@ import { installGestures } from "./gestures";
 import {
   clampZoom,
   computeCenterPan,
-  computeFitAll,
   normalizeDelta as normalizeDeltaPure,
   snapToGrid as snapToGridPure,
   zoomToCenter as zoomToCenterPure,
@@ -48,8 +47,6 @@ export interface CanvasViewport {
   ) => void;
   /** Divide a screen-space delta by zoom for canvas-space positioning. */
   normalizeDelta: (dx: number, dy: number) => { dx: number; dy: number };
-  /** Set pan+zoom so all tiles are centered in the viewport. */
-  fitAll: (tiles: TileLayout[]) => void;
   /** Set pan so a specific tile is centered. */
   centerOnTile: (tile: TileLayout) => void;
   /** Pan so canvas-space point (x, y) is centered in the viewport. */
@@ -101,18 +98,6 @@ function setContainerRef(
 
 function normalizeDelta(dx: number, dy: number) {
   return normalizeDeltaPure(dx, dy, zoom());
-}
-
-function fitAll(tiles: TileLayout[]) {
-  if (!containerEl) return;
-  const result = computeFitAll(
-    tiles,
-    containerEl.clientWidth,
-    containerEl.clientHeight,
-  );
-  setPanX(result.panX);
-  setPanY(result.panY);
-  setZoom(result.zoom);
 }
 
 function centerOnTile(tile: TileLayout) {
@@ -180,7 +165,6 @@ const viewport: CanvasViewport = {
   zoom,
   setContainerRef,
   normalizeDelta,
-  fitAll,
   centerOnTile,
   panTo,
   setPan,

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -60,7 +60,6 @@ export interface CommandDeps {
   // Right panel
   toggleRightPanel: () => void;
   // Canvas
-  canvasFitAll: () => void;
   canvasCenterActive: () => void;
   toggleMinimap: () => void;
   isCanvasMode: () => boolean;
@@ -164,11 +163,6 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
     },
     ...(deps.isCanvasMode()
       ? [
-          {
-            name: "Zoom to fit",
-            keybind: SHORTCUTS.canvasFitAll.keybind,
-            onSelect: () => deps.canvasFitAll(),
-          },
           {
             name: "Center on active tile",
             keybind: SHORTCUTS.canvasCenterActive.keybind,

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -146,10 +146,6 @@ export const SHORTCUTS = {
     keybind: { key: "b", code: "KeyB", mod: true },
     label: "Toggle inspector panel",
   },
-  canvasFitAll: {
-    keybind: { key: "1", code: "Digit1", mod: true, shift: true },
-    label: "Zoom to fit",
-  },
   canvasCenterActive: {
     keybind: { key: "2", code: "Digit2", mod: true, shift: true },
     label: "Center on active tile",

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -25,7 +25,6 @@ interface ShortcutDeps {
   handleCopyTerminalText: () => void;
   handleExportSessionAsPdf: () => void;
   toggleRightPanel: () => void;
-  canvasFitAll: () => void;
   canvasCenterActive: () => void;
 }
 
@@ -182,11 +181,6 @@ function dispatch(
 
   if (matchesKeybind(e, SHORTCUTS.toggleRightPanel.keybind)) {
     deps.toggleRightPanel();
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.canvasFitAll.keybind)) {
-    deps.canvasFitAll();
     return true;
   }
 

--- a/packages/client/src/settings/tips.ts
+++ b/packages/client/src/settings/tips.ts
@@ -71,10 +71,6 @@ export const AMBIENT_TIPS: readonly Tip[] = [
     text: "In Canvas mode, pinch or Ctrl+scroll to zoom. Two-finger scroll to pan.",
   },
   {
-    id: "amb-canvas-fit",
-    text: `In Canvas mode, ${formatKeybind(SHORTCUTS.canvasFitAll.keybind)} zooms to fit all tiles`,
-  },
-  {
     id: "amb-canvas-hand",
     text: "In Canvas mode, middle-click and drag to pan freely in any direction",
   },

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -291,22 +291,6 @@ export const MinimapIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
-/** File tree browser: folder icon — browse the full repo structure. */
-export const ZoomToFitIcon: Component<{ class?: string }> = (props) => (
-  <svg
-    class={props.class ?? "w-4 h-4"}
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    viewBox="0 0 24 24"
-  >
-    {/* Corner brackets — viewfinder/crop marks, "fit content in frame" */}
-    <path d="M2 7V2h5M17 2h5v5M22 17v5h-5M7 22H2v-5" />
-  </svg>
-);
-
 export const FileBrowseIcon: Component<{ class?: string }> = (props) => (
   <svg
     class={props.class ?? "w-3.5 h-3.5"}

--- a/packages/tests/features/canvas-mode.feature
+++ b/packages/tests/features/canvas-mode.feature
@@ -63,15 +63,6 @@ Feature: Canvas mode
     And the canvas tiles should be visible in the viewport
     And there should be no page errors
 
-  Scenario: Canvas fit-all keyboard shortcut
-    Given I create a terminal
-    When I click the canvas mode toggle
-    Then there should be 2 canvas tiles
-    When I zoom the canvas in
-    And I press the fit-all shortcut
-    Then the canvas tiles should be visible in the viewport
-    And there should be no page errors
-
   Scenario: New terminal opens at viewport center
     When I click the canvas mode toggle
     And I create a terminal with keyboard shortcut

--- a/packages/tests/step_definitions/canvas_mode_steps.ts
+++ b/packages/tests/step_definitions/canvas_mode_steps.ts
@@ -198,17 +198,6 @@ Then(
   },
 );
 
-When("I press the fit-all shortcut", async function (this: KoluWorld) {
-  // Mod+Shift+1 = fit all tiles in viewport
-  const modifier = process.platform === "darwin" ? "Meta" : "Control";
-  await this.page.keyboard.down(modifier);
-  await this.page.keyboard.down("Shift");
-  await this.page.keyboard.press("Digit1");
-  await this.page.keyboard.up("Shift");
-  await this.page.keyboard.up(modifier);
-  await this.waitForFrame();
-});
-
 Then(
   "the newest canvas tile should be centered in the viewport",
   async function (this: KoluWorld) {


### PR DESCRIPTION
**Canvas now opens at 100% zoom.** The old auto-fit-on-mount would shrink the viewport to show every tile — for anyone with wide content that meant opening at 70%, no matter how many times they reset. The dedicated `Cmd+Shift+1` shortcut, the minimap toolbar button, the command-palette entry, and the "fit all" tip are all gone with it. The minimap's `%` button (already tooltipped "Reset to 100%") stays as the single zoom-back control. Ties off the _Small features_ checkbox on #559.

The subtle piece: the auto-fit effect wasn't _only_ fitting zoom — it also centered the viewport on the tile bounding box, which is what originally fixed #562 ("canvas opens at (0,0) instead of the terminals"). Deleting it outright would regress restored sessions whose tiles live far from the origin. So the effect stays, but now calls `viewport.panTo(bboxMidpoint)` at `zoom=1` instead of `viewport.fitAll`. _New sessions cascade tiles near the viewport center, so this is a no-op there; restored sessions still land with tiles in view._

Everything else is deletion — `computeFitAll`, `fitAll` on the viewport API, `ZoomToFitIcon`, the `canvasFitAll` shortcut/command/handler wiring, the `amb-canvas-fit` tip, and the matching e2e scenario. The whole surface collapses together.