### PR TITLE
Settings toggle to pin the terminal renderer to DOM

### DIFF
--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -10,7 +10,7 @@ import SegmentedControl, {
 } from "../ui/SegmentedControl";
 import { useServerState } from "./useServerState";
 import { useColorScheme, type ColorScheme } from "./useColorScheme";
-import type { SidebarAgentPreviews } from "kolu-common";
+import type { Preferences, SidebarAgentPreviews } from "kolu-common";
 
 const SCHEME_OPTIONS: readonly SegmentedControlOption<ColorScheme>[] = [
   { value: "light", label: "Light" },
@@ -29,6 +29,15 @@ const PREVIEW_OPTIONS: readonly SegmentedControlOption<SidebarAgentPreviews>[] =
     { value: "agents", label: "Agents" },
     { value: "all", label: "All" },
   ];
+
+/** WebGL = system chooses per tile (WebGL on focused, DOM on others).
+ *  DOM = force DOM everywhere; no font shift on focus swap. */
+const RENDERER_OPTIONS: readonly SegmentedControlOption<
+  Preferences["terminalRenderer"]
+>[] = [
+  { value: "auto", label: "WebGL" },
+  { value: "dom", label: "DOM" },
+];
 
 const SettingsPopover: Component<{
   open: boolean;
@@ -130,6 +139,16 @@ const SettingsPopover: Component<{
               value={preferences().sidebarAgentPreviews}
               onChange={(v) => updatePreferences({ sidebarAgentPreviews: v })}
               testIdPrefix="sidebar-agent-previews"
+            />
+          </div>
+          {/* Terminal renderer — WebGL (focused tile) vs DOM everywhere */}
+          <div class="flex items-center justify-between gap-3 text-sm">
+            <span class="text-fg-2">Renderer</span>
+            <SegmentedControl
+              options={RENDERER_OPTIONS}
+              value={preferences().terminalRenderer}
+              onChange={(v) => updatePreferences({ terminalRenderer: v })}
+              testIdPrefix="terminal-renderer"
             />
           </div>
           {/* Startup tips */}

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -110,11 +110,16 @@ const Terminal: Component<{
     webgl?.clearTextureAtlas();
   }
 
-  /** Only the focused+visible tile holds a WebGL context — Chrome's per-tab
-   *  limit (~16) is quickly exhausted in canvas mode where every tile renders
-   *  simultaneously (issue #575). Non-focused tiles fall back to xterm's
-   *  built-in DOM renderer via `WebglAddon.dispose()`. */
-  const shouldUseWebgl = () => props.visible && props.focused !== false;
+  /** Capability: only the focused+visible tile is allowed to hold a WebGL
+   *  context — Chrome's per-tab limit (~16) is quickly exhausted in canvas
+   *  mode where every tile renders simultaneously (issue #575). Non-focused
+   *  tiles fall back to xterm's built-in DOM renderer via `WebglAddon.dispose()`. */
+  const canUseWebgl = () => props.visible && props.focused !== false;
+  /** Policy: user can opt out of WebGL entirely from settings. DOM-everywhere
+   *  trades scrolling throughput for a stable font on focus swap (the WebGL
+   *  atlas and the DOM renderer rasterize text differently). */
+  const wantsWebgl = () => preferences().terminalRenderer === "auto";
+  const shouldUseWebgl = () => canUseWebgl() && wantsWebgl();
 
   function loadWebgl() {
     if (!terminal || webgl) return;

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -39,6 +39,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   colorScheme: "dark",
   sidebarAgentPreviews: "attention",
   canvasMode: false,
+  terminalRenderer: "auto",
   rightPanel: {
     collapsed: true,
     size: 0.25,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -343,6 +343,11 @@ export const PreferencesSchema = z.object({
   /** Canvas mode shows all terminals as freeform draggable tiles.
    *  Focus mode shows one terminal at a time with a sidebar. */
   canvasMode: z.boolean(),
+  /** Renderer policy. `auto` lets the system choose (WebGL on the focused+
+   *  visible tile, DOM elsewhere — Chrome's per-tab GL context budget makes
+   *  WebGL-everywhere unsafe). `dom` forces DOM everywhere, eliminating the
+   *  font-rendering shift on focus swap at the cost of WebGL throughput. */
+  terminalRenderer: z.enum(["auto", "dom"]),
   rightPanel: RightPanelPrefsSchema,
 });
 

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -26,7 +26,7 @@ import { log } from "./log.ts";
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.13.0";
+const SCHEMA_VERSION = "1.14.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -231,6 +231,14 @@ export const store = new Conf<PersistedState>({
         ...current,
         rightPanel: { ...rest, tab } as typeof current.rightPanel,
       });
+    },
+    // terminalRenderer preference added — default to "auto" (existing behavior:
+    // WebGL on focused+visible tile, DOM elsewhere).
+    "1.14.0": (store: Conf<PersistedState>) => {
+      const current = store.get("preferences");
+      if ((current as Record<string, unknown>).terminalRenderer === undefined) {
+        store.set("preferences", { ...current, terminalRenderer: "auto" });
+      }
     },
   },
 });

--- a/packages/tests/features/preferences.feature
+++ b/packages/tests/features/preferences.feature
@@ -35,3 +35,13 @@ Feature: Server-side preferences
     Then the settings popover should be visible
     Then the activity alerts toggle should be disabled
     And there should be no page errors
+
+  Scenario: Terminal renderer preference swaps the active tile and persists
+    Then the terminal renderer should be "webgl"
+    When I click the settings button
+    Then the settings popover should be visible
+    When I click the "dom" renderer button
+    Then the terminal renderer should be "dom"
+    When I reload the page and wait for ready
+    Then the terminal renderer should be "dom"
+    And there should be no page errors

--- a/packages/tests/step_definitions/preferences_steps.ts
+++ b/packages/tests/step_definitions/preferences_steps.ts
@@ -35,3 +35,25 @@ Then(
     );
   },
 );
+
+When(
+  "I click the {string} renderer button",
+  async function (this: KoluWorld, value: string) {
+    await this.page.click(`[data-testid="terminal-renderer-${value}"]`);
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the terminal renderer should be {string}",
+  async function (this: KoluWorld, renderer: string) {
+    await this.page.waitForFunction(
+      (expected) =>
+        document
+          .querySelector("[data-visible][data-terminal-id]")
+          ?.getAttribute("data-renderer") === expected,
+      renderer,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);


### PR DESCRIPTION
**Switching focus between canvas tiles visibly changes font rendering** because the WebGL→DOM handoff swaps two rasterization paths (texture-atlas glyphs vs native browser text) — the same string ends up with different stroke weights and edges depending on which tile holds focus. The new **Renderer** control in Settings lets you pin DOM everywhere to eliminate the shift, trading WebGL's scrolling throughput for a stable typeface.

The default `auto` preserves today's behavior: only the focused+visible tile holds a WebGL context (Chrome's per-tab GL context budget makes WebGL-everywhere unsafe — see #575). `dom` forces DOM on every tile, focused or not.

The renderer-decision predicate in `Terminal.tsx` is now *named in two halves* — `canUseWebgl()` for the visibility/focus capability gate and `wantsWebgl()` for the user-policy gate, composed at one site as `shouldUseWebgl()`. Both onMount and the reactive effect use that single composition, so the two transition paths can't drift. Schema migration `1.14.0` backfills existing prefs with `auto` so nothing changes for current users.

> Why CSS hacks won't fix this: `-webkit-font-smoothing` is a macOS-only no-op on Chromium Linux, and modern Chromium preserves LCD subpixel-AA on composited layers — verified empirically with a pixel-diff. The two rasterizers genuinely produce different glyphs, and there's no setting to align them. Renderer-policy at the user's discretion is the honest fix.

### Try it locally

```sh
nix run github:juspay/kolu/bald-mass
```