### PR TITLE
Expose GPU/JS memory facts in Debug → Diagnostic info

### DIFF
--- a/packages/client/src/DiagnosticInfo.tsx
+++ b/packages/client/src/DiagnosticInfo.tsx
@@ -12,15 +12,54 @@ import Row from "./ui/Row";
 import { usePreferences } from "./settings/usePreferences";
 import { wsStatus, serverProcessId } from "./rpc/rpc";
 import { getDiagnostics } from "./terminal/useTerminalDiagnostics";
+import { getTerminalRefs } from "./terminal/terminalRefs";
 import type { TerminalId } from "kolu-common";
+
+/** WebGL2 support detection creates a throwaway canvas + WebGL context
+ *  that lingers on a detached node until GC. Compute once at module load
+ *  so re-opening this dialog doesn't burn one context per open — the exact
+ *  zombie-context pattern this dialog exists to diagnose (#591). */
+const WEBGL2_SUPPORTED = (() => {
+  const canvas = document.createElement("canvas");
+  return !!canvas.getContext("webgl2");
+})();
 
 /** One-shot browser facts read at first render. Stable for the session,
  *  so no reactive source needed — keeps this module's dependency surface
  *  small. */
 function browserFacts() {
-  const canvas = document.createElement("canvas");
-  const gl2 = !!canvas.getContext("webgl2");
-  return { userAgent: navigator.userAgent, webgl2Supported: gl2 };
+  return {
+    userAgent: navigator.userAgent,
+    webgl2Supported: WEBGL2_SUPPORTED,
+    crossOriginIsolated: self.crossOriginIsolated,
+    devicePixelRatio: window.devicePixelRatio,
+  };
+}
+
+/** `performance.memory` is Chromium-only and missing from the DOM type
+ *  definitions — isolate the narrow cast and the MB rounding here so the
+ *  snapshot memo stays free of both. Returns null on non-Chromium browsers. */
+function readJsHeap(): {
+  usedMB: number;
+  totalMB: number;
+  limitMB: number;
+} | null {
+  const mem = (
+    performance as {
+      memory?: {
+        usedJSHeapSize: number;
+        totalJSHeapSize: number;
+        jsHeapSizeLimit: number;
+      };
+    }
+  ).memory;
+  if (!mem) return null;
+  const mb = (n: number) => Math.round((n / 1_048_576) * 10) / 10;
+  return {
+    usedMB: mb(mem.usedJSHeapSize),
+    totalMB: mb(mem.totalJSHeapSize),
+    limitMB: mb(mem.jsHeapSizeLimit),
+  };
 }
 
 const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
@@ -37,13 +76,23 @@ const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
       serverProcessId: serverProcessId(),
       activeId: props.activeId,
       terminalCount: getDiagnostics().length,
+      jsHeap: readJsHeap(),
+      domNodes: document.getElementsByTagName("*").length,
+      canvases: document.querySelectorAll("canvas").length,
     },
-    terminals: getDiagnostics().map((d) => ({
-      id: d.id,
-      cols: d.cols,
-      rows: d.rows,
-      renderer: d.renderer,
-    })),
+    terminals: getDiagnostics().map((d) => {
+      const refs = getTerminalRefs(d.id);
+      const bufferLen = refs?.xterm.buffer.active.length ?? null;
+      return {
+        id: d.id,
+        cols: d.cols,
+        rows: d.rows,
+        renderer: d.renderer,
+        bufferLen,
+        scrollback: bufferLen !== null ? bufferLen - d.rows : null,
+        atlas: refs?.probes.webglAtlas() ?? null,
+      };
+    }),
   }));
 
   function copyJson() {
@@ -74,6 +123,11 @@ const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
             <Row label="WebGL 2">
               <span class={browser.webgl2Supported ? "text-ok" : "text-danger"}>
                 {browser.webgl2Supported ? "available" : "unavailable"}
+              </span>
+            </Row>
+            <Row label="DPR">
+              <span class="font-mono text-fg-3">
+                {browser.devicePixelRatio}
               </span>
             </Row>
             <Row label="UA">
@@ -109,33 +163,75 @@ const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
             <Row label="Count">
               <span class="font-mono text-fg">{getDiagnostics().length}</span>
             </Row>
+            <Show when={snapshot().session.jsHeap}>
+              {(heap) => (
+                <Row label="JS heap">
+                  <span class="font-mono text-fg">
+                    {heap().usedMB} / {heap().totalMB} MB
+                    <span class="text-fg-3/70"> (limit {heap().limitMB})</span>
+                  </span>
+                </Row>
+              )}
+            </Show>
+            <Row label="DOM">
+              <span class="font-mono text-fg">
+                {snapshot().session.domNodes}
+              </span>
+            </Row>
+            <Row label="Canvases">
+              <span class="font-mono text-fg">
+                {snapshot().session.canvases}
+              </span>
+            </Row>
+            <Row label="COI">
+              <span
+                class={browser.crossOriginIsolated ? "text-ok" : "text-fg-3"}
+              >
+                {browser.crossOriginIsolated ? "yes" : "no"}
+              </span>
+            </Row>
           </div>
         </Section>
 
         <Section title="Terminals">
           <Show
-            when={getDiagnostics().length > 0}
+            when={snapshot().terminals.length > 0}
             fallback={
               <div class="text-[11px] text-fg-3/60 italic">No terminals</div>
             }
           >
-            <div class="space-y-0.5">
-              <For each={getDiagnostics()}>
+            <div class="space-y-1">
+              <For each={snapshot().terminals}>
                 {(d) => (
-                  <div class="grid grid-cols-[9ch_8ch_1fr_auto] items-baseline gap-3 text-[11px] font-mono">
-                    <span class="text-fg-3/70">{d.id.slice(0, 8)}</span>
-                    <span class="text-fg-2 tabular-nums">
-                      {d.cols}×{d.rows}
-                    </span>
-                    <span
-                      class={
-                        d.renderer === "webgl" ? "text-accent" : "text-fg-2"
-                      }
-                    >
-                      {d.renderer}
-                    </span>
-                    <Show when={props.activeId === d.id}>
-                      <span class="text-[10px] text-fg-3/70">active</span>
+                  <div class="text-[11px] font-mono space-y-0.5">
+                    <div class="grid grid-cols-[9ch_8ch_1fr_auto] items-baseline gap-3">
+                      <span class="text-fg-3/70">{d.id.slice(0, 8)}</span>
+                      <span class="text-fg-2 tabular-nums">
+                        {d.cols}×{d.rows}
+                      </span>
+                      <span
+                        class={
+                          d.renderer === "webgl" ? "text-accent" : "text-fg-2"
+                        }
+                      >
+                        {d.renderer}
+                      </span>
+                      <Show when={props.activeId === d.id}>
+                        <span class="text-[10px] text-fg-3/70">active</span>
+                      </Show>
+                    </div>
+                    <Show when={d.scrollback !== null}>
+                      <div class="pl-[9ch] text-[10px] text-fg-3/60 tabular-nums">
+                        scrollback: {d.scrollback}
+                        <Show when={d.atlas}>
+                          {(a) => (
+                            <span>
+                              {" "}
+                              · atlas: {a().w}×{a().h}
+                            </span>
+                          )}
+                        </Show>
+                      </div>
                     </Show>
                   </div>
                 )}

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -356,6 +356,12 @@ const Terminal: Component<{
     registerTerminalRefs(props.terminalId, {
       xterm: term,
       serialize: serializeAddon,
+      probes: {
+        webglAtlas: () => {
+          const a = webgl?.textureAtlas;
+          return a ? { w: a.width, h: a.height } : null;
+        },
+      },
     });
     // Diagnostics subscribes to hasWebgl via accessor — keeps hasWebgl
     // the single source of truth, no imperative updater to forget.

--- a/packages/client/src/terminal/terminalRefs.ts
+++ b/packages/client/src/terminal/terminalRefs.ts
@@ -12,9 +12,21 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 import type { SerializeAddon } from "@xterm/addon-serialize";
 import type { TerminalId } from "kolu-common";
 
+/** Volatile per-terminal probes. Unlike the stable `xterm`/`serialize`
+ *  handles above, these accessors may return null even during the terminal's
+ *  lifetime (e.g. `webglAtlas` when the tile is unfocused and no WebGL addon
+ *  is live). Namespaced under `probes` so the volatility contrast stays
+ *  visible in the type. */
+export interface TerminalProbes {
+  /** Dimensions of the live WebGL texture atlas canvas, or null if the
+   *  terminal currently has no WebGL addon. */
+  webglAtlas: () => { w: number; h: number } | null;
+}
+
 export interface TerminalRefs {
   xterm: XTerm;
   serialize: SerializeAddon;
+  probes: TerminalProbes;
 }
 
 const refs = new Map<TerminalId, TerminalRefs>();


### PR DESCRIPTION
**The Debug → Diagnostic info dialog now surfaces the memory and WebGL axes that were invisible before** — JS heap (used/total/limit), DOM node count, canvas count, per-terminal scrollback depth, and, for the focused WebGL tile, the char-atlas canvas dimensions. Copy-JSON becomes a forensic-grade payload a user can paste into a bug report and pair with Chrome's Task Manager numbers to see the whole picture in one glance.

Motivated by **issue #591** (WebGL _zombie-context_ leak — kolu tabs growing from 300 MB to ~2 GB over hours). Live monitoring showed the kolu PWA sitting at 622 MB total footprint with **500 MB of GPU memory** but only 55 MB of JS heap — _six times_ the next-highest tab's GPU use, matching a ~16 × ~30 MB zombie-context ceiling almost exactly. The JS side told us nothing; the leak lives outside the heap. This dialog now shows enough to confirm that gap without reaching for DevTools.

A small structural side note: the per-terminal `webglAtlas` probe is volatile (it flips on/off as focus moves between tiles), while `TerminalRefs` so far only held permanent-lifetime handles (`xterm`, `serialize`). The PR namespaces the volatile accessors under a new `probes: { webglAtlas }` sub-object so the _stability contrast stays visible in the type_ and the next diagnostic probe doesn't quietly land next to `xterm` as a grab-bag field. While touching the area, I also hoisted the WebGL2-support probe to module scope — the old code created a throwaway WebGL2 context on every dialog mount, which is itself a tiny zombie-context leak. _The exact pattern #591 exists to diagnose, fixed in passing._

> This PR is diagnostic tooling, not the fix. The prevailing hypothesis (from the #591 investigation) is that `Terminal.tsx`'s `unloadWebgl()` needs to call `w.dispose()` _before_ `loseContext()` — xterm's `webglcontextlost` listener `preventDefault()`s while the addon is still registered, which likely keeps contexts alive past their disposal. That fix is out of scope here.

> **Deferred:** Centralized GPU/WebGL introspection surface (future `MAX_TEXTURE_SIZE`, `WEBGL_debug_renderer_info`, etc.) — today's `webglAtlas` is the first probe; probe #2 should get a dedicated home rather than accreting onto `TerminalProbes`.

See #591.

### Try it locally

```sh
nix run github:juspay/kolu/feat/diagnostic-memory-fields
```