### PR TITLE
Dispose WebglAddon before releasing its GPU context (#591)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <img src="packages/client/favicon.svg" width="64" alt="kolu icon" />
 </p>
 
+
 # kolu
 
 A browser cockpit for coding agents. Bring your own CLI, run them anywhere.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
   <img src="packages/client/favicon.svg" width="64" alt="kolu icon" />
 </p>
 
-
 # kolu
 
 A browser cockpit for coding agents. Bring your own CLI, run them anywhere.

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -146,25 +146,33 @@ const Terminal: Component<{
   function unloadWebgl() {
     const w = webgl;
     if (!w) return;
-    // Null out first: `loseContext()` below fires `webglcontextlost`
-    // synchronously, which re-enters this function via the addon's
-    // `onContextLoss` listener. The guard above short-circuits the reentry.
+    // Null out first so any reentry (onContextLoss → unloadWebgl) short-circuits.
     webgl = null;
     setHasWebgl(false);
-    // Explicitly release the GPU context. xterm's dispose() removes the
-    // canvas from the DOM but does NOT call WEBGL_lose_context.loseContext(),
-    // so Chrome keeps the context alive on the detached canvas until GC.
-    // Rapid focus changes create contexts faster than GC runs and overflow
-    // Chrome's ~16-context-per-tab budget, at which point Chrome starts
-    // evicting live contexts — including the focused tile's — producing a
-    // flicker across every tile. loseContext() releases GPU memory in the
-    // current microtask, keeping the live set at 1.
-    webglCanvas
+    // Order matters: dispose BEFORE loseContext.
+    //
+    // xterm's WebglRenderer registers a `webglcontextlost` DOM listener on the
+    // canvas that calls `e.preventDefault()` (addons/addon-webgl/src/WebglRenderer.ts).
+    // `preventDefault()` asks the browser to keep the canvas eligible for
+    // context restoration — and Chrome does restore, firing `webglcontextrestored`,
+    // which xterm catches and uses to re-initialize WebGL state on the already-
+    // detached canvas. Result: one zombie context per focus switch. Over an
+    // hour of use, Chrome's ~16-context-per-tab budget fills and the
+    // "Too many active WebGL contexts" warnings from #591 start firing, with
+    // ~500 MB of GPU memory stranded on detached canvases.
+    //
+    // Disposing first tears down xterm's Disposable chain (which is what owns
+    // the `webglcontextlost` listener), so the subsequent `loseContext()` is
+    // observed by nobody, the browser doesn't attempt restoration, and the
+    // GPU memory is released in the current microtask. Keeps the live-context
+    // count at 1. (#591)
+    const canvas = webglCanvas;
+    webglCanvas = null;
+    w.dispose();
+    canvas
       ?.getContext("webgl2")
       ?.getExtension("WEBGL_lose_context")
       ?.loseContext();
-    webglCanvas = null;
-    w.dispose();
   }
 
   // Main terminals inherit the viewport grid while they're hidden.


### PR DESCRIPTION
**The reason kolu tabs bleed ~500 MB of GPU memory over a session is one line of ordering in `unloadWebgl()`.** The old code called `loseContext()` first and `w.dispose()` after. At that moment xterm's own `webglcontextlost` DOM listener on the canvas is still registered, and it calls `e.preventDefault()` — the browser takes that as _"please keep this canvas eligible for restoration"_, fires `webglcontextrestored` moments later, and xterm dutifully re-initializes WebGL state on the already-detached canvas. **One zombie context per focus switch.** After an hour of normal use Chrome's ~16-context-per-tab budget is full, the _Too many active WebGL contexts_ warnings from #591 start firing, and ~500 MB of GPU memory sits stranded on canvases that nothing in the DOM references anymore.

This PR just swaps the order: **`w.dispose()` first, `loseContext()` after.** Disposing tears down xterm's `Disposable` chain (that's what owns the `webglcontextlost` listener — see `@xterm/addon-webgl/WebglRenderer.ts:120`, `this._register(addDisposableListener(...))`), so the subsequent `loseContext()` fires into a canvas nobody is listening on, the browser doesn't try to restore, and the GPU memory is actually released _in the current microtask_. Live context count stays at 1, exactly as PR #578's original design intended.

> _#578 added the explicit `loseContext()` call because `WebglAddon.dispose()` alone doesn't free the GPU context — the browser leaves it alive on the detached canvas until GC._ **That reasoning was correct, just running against xterm's preventDefault.** Fixing the order preserves #578's intent.

The diagnostic dialog from #592 should now show the `canvases` count staying flat at 3 across many focus switches, instead of the renderer process slowly accumulating detached WebGL2 canvases. Chrome Task Manager's _GPU Memory_ on the kolu tab should plateau near ~30 MB (one live context, its atlas textures) rather than climbing toward ~500 MB.

Closes #591.

### Try it locally

```sh
nix run github:juspay/kolu/fix/webgl-dispose-before-losecontext
```