### PR TITLE
Count WebGL zombie canvases in Diagnostic info (#591)

### DIFF
--- a/packages/client/src/DiagnosticInfo.tsx
+++ b/packages/client/src/DiagnosticInfo.tsx
@@ -13,6 +13,7 @@ import { usePreferences } from "./settings/usePreferences";
 import { wsStatus, serverProcessId } from "./rpc/rpc";
 import { getDiagnostics } from "./terminal/useTerminalDiagnostics";
 import { getTerminalRefs } from "./terminal/terminalRefs";
+import { webglLifecycleSnapshot } from "./terminal/webglTracker";
 import type { TerminalId } from "kolu-common";
 
 /** WebGL2 support detection creates a throwaway canvas + WebGL context
@@ -93,6 +94,7 @@ const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
         atlas: refs?.probes.webglAtlas() ?? null,
       };
     }),
+    webgl: webglLifecycleSnapshot(),
   }));
 
   function copyJson() {
@@ -236,6 +238,75 @@ const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
                   </div>
                 )}
               </For>
+            </div>
+          </Show>
+        </Section>
+
+        {/* Debug-only instrumentation for #591 (WebGL zombie-context leak).
+            Remove this section when the leak is root-caused and fixed. */}
+        <Section title="WebGL lifecycle">
+          <div class="space-y-0.5">
+            <Row label="Created">
+              <span class="font-mono text-fg tabular-nums">
+                {snapshot().webgl.totalCreated}
+              </span>
+            </Row>
+            <Row label="Disposed">
+              <span class="font-mono text-fg tabular-nums">
+                {snapshot().webgl.disposed}
+              </span>
+            </Row>
+            <Row label="In DOM">
+              <span class="font-mono text-fg tabular-nums">
+                {snapshot().webgl.aliveInDom}
+              </span>
+            </Row>
+            <Row label="Zombies">
+              <span
+                class={`font-mono tabular-nums ${
+                  snapshot().webgl.aliveDetached > 0
+                    ? "text-danger font-semibold"
+                    : "text-fg"
+                }`}
+              >
+                {snapshot().webgl.aliveDetached}
+              </span>
+            </Row>
+            <Row label="GCed">
+              <span class="font-mono text-fg-3 tabular-nums">
+                {snapshot().webgl.gced}
+              </span>
+            </Row>
+            <Row label="Lost">
+              <span class="font-mono text-fg-3 tabular-nums">
+                {snapshot().webgl.contextsLost}
+              </span>
+            </Row>
+          </div>
+          <Show when={snapshot().webgl.recentEvents.length > 0}>
+            <div class="mt-2 pt-2 border-t border-edge/50">
+              <div class="text-[10px] text-fg-3/70 mb-1">Recent events</div>
+              <div class="space-y-0.5 text-[10px] font-mono">
+                <For each={snapshot().webgl.recentEvents}>
+                  {(ev) => (
+                    <div class="grid grid-cols-[8ch_5ch_1fr] items-baseline gap-2">
+                      <span class="text-fg-3/60 tabular-nums">
+                        {new Date(ev.ts).toISOString().slice(11, 23)}
+                      </span>
+                      <span class="text-fg-3">#{ev.canvasId}</span>
+                      <span class="text-fg-2">
+                        {ev.kind}
+                        {ev.kind === "contextlost" && (
+                          <span class="text-fg-3/70">
+                            {" "}
+                            (defaultPrevented={String(ev.defaultPrevented)})
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  )}
+                </For>
+              </div>
             </div>
           </Show>
         </Section>

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -43,6 +43,11 @@ import { refitOnTabVisible } from "../refitOnTabVisible";
 import { viewportDimensions, setViewportDimensions } from "../useViewport";
 import { registerTerminalRefs, unregisterTerminalRefs } from "./terminalRefs";
 import { registerDiagnostics } from "./useTerminalDiagnostics";
+import {
+  trackCreate,
+  trackDispose,
+  trackLoseContextCalled,
+} from "./webglTracker";
 
 /** Fire-and-forget an async iterable, silently swallowing AbortErrors (expected on unmount). */
 function consumeStream<T>(
@@ -102,6 +107,7 @@ const Terminal: Component<{
   let streamAbort: AbortController | null = null;
   let webgl: WebglAddon | null = null;
   let webglCanvas: HTMLCanvasElement | null = null;
+  let webglTrackerId: number | null = null;
   let disposeDiagnostics: (() => void) | null = null;
   const [hasWebgl, setHasWebgl] = createSignal(false);
 
@@ -137,6 +143,9 @@ const Terminal: Component<{
         terminal.element?.querySelector<HTMLCanvasElement>(
           ".xterm-screen canvas",
         ) ?? null;
+      // Register for lifecycle observation (#591 debug). No-op if no canvas.
+      if (webglCanvas)
+        webglTrackerId = trackCreate(props.terminalId, webglCanvas);
       setHasWebgl(true);
     } catch {
       // WebGL unavailable — xterm's DOM renderer is the fallback
@@ -159,12 +168,17 @@ const Terminal: Component<{
     // evicting live contexts — including the focused tile's — producing a
     // flicker across every tile. loseContext() releases GPU memory in the
     // current microtask, keeping the live set at 1.
+    if (webglTrackerId !== null) trackLoseContextCalled(webglTrackerId);
     webglCanvas
       ?.getContext("webgl2")
       ?.getExtension("WEBGL_lose_context")
       ?.loseContext();
     webglCanvas = null;
     w.dispose();
+    if (webglTrackerId !== null) {
+      trackDispose(webglTrackerId);
+      webglTrackerId = null;
+    }
   }
 
   // Main terminals inherit the viewport grid while they're hidden.

--- a/packages/client/src/terminal/webglTracker.ts
+++ b/packages/client/src/terminal/webglTracker.ts
@@ -1,0 +1,181 @@
+/** Debug-only lifecycle ledger for WebGL canvases created by xterm's
+ *  WebglAddon. **Temporary: remove when #591 (zombie-context leak) is
+ *  root-caused and fixed.**
+ *
+ *  Purpose: prior fix attempts reasoned from xterm source + spec docs and
+ *  made the leak worse. This module observes instead of guesses. It keeps
+ *  a `WeakRef` to every canvas created and, on snapshot, counts how many
+ *  are still reachable in JS while detached from the DOM — the literal
+ *  zombie-context count. Paired with a per-canvas event tape of
+ *  `webglcontextlost` / `webglcontextrestored` firings, it answers the
+ *  questions that spec reading alone cannot:
+ *
+ *  - After `loseContext()`, does `gl.isContextLost()` flip to true?
+ *  - Does the browser fire `webglcontextrestored` after we asked to lose?
+ *  - Does xterm's inline listener call `e.preventDefault()` before ours?
+ *
+ *  Strictly observational — never calls `preventDefault`,
+ *  `stopPropagation`, or mutates the canvas / context / addon. Safe to
+ *  ship to prod. */
+
+import type { TerminalId } from "kolu-common";
+
+/** Discriminated union: `defaultPrevented` is only meaningful for the
+ *  `contextlost` event (it reads `e.defaultPrevented` at bubble phase,
+ *  telling us whether an earlier listener — xterm's inline one — called
+ *  `preventDefault()` asking the browser to attempt restoration). */
+export type WebglEvent =
+  | {
+      ts: number;
+      kind: "create" | "dispose" | "loseContext-called" | "contextrestored";
+    }
+  | { ts: number; kind: "contextlost"; defaultPrevented: boolean };
+
+interface Entry {
+  id: number;
+  terminalId: TerminalId;
+  canvasRef: WeakRef<HTMLCanvasElement>;
+  createdAt: number;
+  disposedAt: number | null;
+  loseContextCalledAt: number | null;
+  /** Capped at MAX_EVENTS_PER_ENTRY (FIFO via shift-before-push). */
+  events: WebglEvent[];
+}
+
+/** Cap to prevent long-running sessions from accumulating state forever.
+ *  One entry per WebglAddon construction — Terminal.tsx focus switches are
+ *  the dominant source, so 100 entries buys a long session history. */
+const MAX_ENTRIES = 100;
+/** Per-canvas event count is naturally bounded (~5 events per canvas in
+ *  the happy path: create, loseContext-called, contextlost, [restored],
+ *  dispose). Cap is a safety net for repeated lost/restored cycles. */
+const MAX_EVENTS_PER_ENTRY = 20;
+/** How many events the snapshot returns as a flattened, time-sorted tail. */
+const RECENT_EVENTS_VIEW = 30;
+
+const entries: Entry[] = [];
+let nextId = 1;
+
+function pushEvent(entry: Entry, ev: WebglEvent): void {
+  entry.events.push(ev);
+  if (entry.events.length > MAX_EVENTS_PER_ENTRY) entry.events.shift();
+}
+
+/** Register a canvas for lifecycle observation. Returns an id that
+ *  subsequent `trackLoseContextCalled` / `trackDispose` calls use to
+ *  correlate. Also attaches bubble-phase DOM listeners for
+ *  `webglcontextlost` / `webglcontextrestored`. The listener closures
+ *  capture only the module-scoped `entry` object (no strong canvas
+ *  reference), so the WeakRef remains the canvas's only incoming
+ *  reference and GC can still collect it. */
+export function trackCreate(
+  terminalId: TerminalId,
+  canvas: HTMLCanvasElement,
+): number {
+  const id = nextId++;
+  const now = Date.now();
+  const entry: Entry = {
+    id,
+    terminalId,
+    canvasRef: new WeakRef(canvas),
+    createdAt: now,
+    disposedAt: null,
+    loseContextCalledAt: null,
+    events: [{ ts: now, kind: "create" }],
+  };
+  entries.push(entry);
+  if (entries.length > MAX_ENTRIES) entries.shift();
+
+  canvas.addEventListener("webglcontextlost", (e) => {
+    pushEvent(entry, {
+      ts: Date.now(),
+      kind: "contextlost",
+      defaultPrevented: e.defaultPrevented,
+    });
+  });
+  canvas.addEventListener("webglcontextrestored", () => {
+    pushEvent(entry, { ts: Date.now(), kind: "contextrestored" });
+  });
+
+  return id;
+}
+
+// When the FIFO cap evicts an entry, later `trackLoseContextCalled` /
+// `trackDispose` calls for that id find nothing and silently return —
+// that's intended: we've deliberately chosen to lose history older than
+// MAX_ENTRIES rather than grow without bound.
+
+export function trackLoseContextCalled(id: number): void {
+  const e = entries.find((x) => x.id === id);
+  if (!e) return;
+  const now = Date.now();
+  e.loseContextCalledAt = now;
+  pushEvent(e, { ts: now, kind: "loseContext-called" });
+}
+
+export function trackDispose(id: number): void {
+  const e = entries.find((x) => x.id === id);
+  if (!e) return;
+  const now = Date.now();
+  e.disposedAt = now;
+  pushEvent(e, { ts: now, kind: "dispose" });
+}
+
+export interface WebglLifecycleSnapshot {
+  totalCreated: number;
+  disposed: number;
+  /** Deref returned a canvas AND canvas.isConnected — normal live state. */
+  aliveInDom: number;
+  /** Deref returned a canvas AND !canvas.isConnected — **zombie count**.
+   *  Non-zero = confirmed leak. */
+  aliveDetached: number;
+  /** Deref returned undefined — canvas was GC'd. */
+  gced: number;
+  /** Canvas exists AND `gl.isContextLost()` returns true. */
+  contextsLost: number;
+  /** Flattened, time-sorted tail across all entries. */
+  recentEvents: (WebglEvent & { canvasId: number; terminalId: TerminalId })[];
+}
+
+/** Walk entries, deref each WeakRef, count the states, and return a
+ *  snapshot. Cheap — O(entries) with no DOM mutations. Safe to call from
+ *  the DiagnosticInfo snapshot memo. */
+export function webglLifecycleSnapshot(): WebglLifecycleSnapshot {
+  let aliveInDom = 0;
+  let aliveDetached = 0;
+  let gced = 0;
+  let contextsLost = 0;
+  const allEvents: (WebglEvent & {
+    canvasId: number;
+    terminalId: TerminalId;
+  })[] = [];
+
+  for (const e of entries) {
+    for (const ev of e.events) {
+      allEvents.push({ ...ev, canvasId: e.id, terminalId: e.terminalId });
+    }
+    const canvas = e.canvasRef.deref();
+    if (!canvas) {
+      gced++;
+      continue;
+    }
+    if (canvas.isConnected) aliveInDom++;
+    else aliveDetached++;
+    // Second `getContext("webgl2")` on an established canvas returns the
+    // existing context object without creating a new one — safe to probe.
+    const gl = canvas.getContext("webgl2");
+    if (gl && gl.isContextLost()) contextsLost++;
+  }
+
+  allEvents.sort((a, b) => a.ts - b.ts);
+
+  return {
+    totalCreated: entries.length,
+    disposed: entries.filter((e) => e.disposedAt !== null).length,
+    aliveInDom,
+    aliveDetached,
+    gced,
+    contextsLost,
+    recentEvents: allEvents.slice(-RECENT_EVENTS_VIEW),
+  };
+}


### PR DESCRIPTION
**The Diagnostic info dialog now shows exactly how many WebGL canvases are detached from the DOM but still alive in JS memory** — the literal zombie-context count. Paired with a per-canvas event tape (`webglcontextlost` / `webglcontextrestored` with `defaultPrevented`, plus our own `loseContext-called` / `dispose` markers), it answers the questions #591's investigation keeps bumping into and can't get from specs or xterm source: _does `loseContext()` actually release? Does the browser restore afterwards? Does xterm's inline listener preventDefault before ours fires?_

The tracker is a small imperative module (`packages/client/src/terminal/webglTracker.ts`) that holds a **`WeakRef` to every canvas** xterm's `WebglAddon` creates. When the Diagnostic dialog opens it walks the ledger, derefs each ref, and reports `aliveInDom` vs `aliveDetached` vs `gced`, plus whether each live context reports `gl.isContextLost()`. _Non-zero zombie count = #591 confirmed live and measurable, not inferred._ FIFO-capped at 100 entries × 20 events per canvas so long sessions don't grow unbounded.

> This PR is **instrumentation, not a fix**. The previous attempt at a fix (#594) reasoned from xterm source + browser spec docs and made the leak worse, and got closed unmerged. The lesson: reason from measurement, not from memory. The module is marked _remove-when-#591-is-root-caused_ in its header — once the numbers point at the actual retainer, the tracker comes out in the same PR that lands the fix.

> **Strictly observational.** The tracker never calls `preventDefault` or `stopPropagation`, never mutates the canvas or context or addon, and its bubble-phase listeners only read `e.defaultPrevented` — they don't modify event propagation. Safe to ship to prod for measurement.

See #591. Supersedes the approach in #594.

### Try it locally

```sh
nix run github:juspay/kolu/feat/webgl-lifecycle-tracker
```