### PR TITLE
Select the actual WebGL canvas, not xterm's link layer (#591)

### DIFF
--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -139,9 +139,20 @@ const Terminal: Component<{
       webgl = w;
       // Capture the canvas the addon just appended so we can explicitly
       // release its GPU context on unload — see unloadWebgl.
+      //
+      // xterm's WebglRenderer constructor appends the LinkRenderLayer's 2D
+      // canvas (`class="xterm-link-layer"`) to `.xterm-screen` before it
+      // appends its own WebGL canvas (which has no class). A bare
+      // `querySelector(".xterm-screen canvas")` returns the first match in
+      // document order — the link layer — whose `getContext("webgl2")`
+      // returns null, silently short-circuiting the `loseContext()` chain in
+      // `unloadWebgl()`. Diagnosed via #595's `webglTracker`:
+      // `contextsLost` stayed at 0 despite `loseContext-called` events
+      // firing for every disposed canvas (#591). Exclude the link layer
+      // explicitly so we grab the real WebGL canvas.
       webglCanvas =
         terminal.element?.querySelector<HTMLCanvasElement>(
-          ".xterm-screen canvas",
+          ".xterm-screen canvas:not(.xterm-link-layer)",
         ) ?? null;
       // Register for lifecycle observation (#591 debug). No-op if no canvas.
       if (webglCanvas)


### PR DESCRIPTION
**`loseContext()` in `unloadWebgl()` has been a silent no-op in production ever since PR #578 shipped.** The querySelector in `loadWebgl` used `.xterm-screen canvas`, which returns the _first_ canvas in document order — xterm's `LinkRenderLayer` 2D canvas (`class="xterm-link-layer"`), appended by the `WebglRenderer` constructor before the bare WebGL canvas. `getContext("webgl2")` on a 2D canvas returns `null`, the rest of the chain short-circuits on optional chaining, and the explicit GPU release PR #578 was designed around just… doesn't happen. GPU cleanup has been waiting on GC the whole time, which is exactly the pre-#578 behavior.

Diagnosed by **PR #595's `webglTracker`** at runtime, not by reading more spec. The production snapshot showed `contextsLost: 0` over a session where `loseContext-called` fired for every disposed canvas, and the recent-events tape had zero `contextlost` / `contextrestored` DOM events. A heap snapshot on the dev instance confirmed the `WeakRef` in tracker entries was pointing at `<canvas class="xterm-link-layer">` — not the bare class-less canvas xterm's WebglRenderer actually renders to. _The instrumentation from #595 paid for itself in one investigation cycle._

The fix is three characters of CSS: narrow the selector to `.xterm-screen canvas:not(.xterm-link-layer)`, which picks the class-less canvas xterm appends last.

> **Verification once deployed.** Open Diagnostic info after a dozen focus swaps. `contextsLost` should climb to match `disposed`. The event tape should contain `contextlost` entries with `defaultPrevented: true` (xterm's own listener runs — fine, `w.dispose()` tears it down immediately after). `aliveDetached` should stay near 0. Chrome Task Manager's _GPU Memory_ on the kolu tab should plateau around ~30 MB instead of climbing toward ~500 MB.

Closes #591. Builds on #595.

### Try it locally

```sh
nix run github:juspay/kolu/fix/webgl-canvas-selector
```