### PR TITLE
Register onCleanup synchronously to stop mode-toggle orphans (#591)

### DIFF
--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -109,6 +109,14 @@ const Terminal: Component<{
   let webglCanvas: HTMLCanvasElement | null = null;
   let webglTrackerId: number | null = null;
   let disposeDiagnostics: (() => void) | null = null;
+  /** True once this component's reactive owner has been disposed. Set by the
+   *  synchronously-registered `onCleanup` below. The async `onMount` body
+   *  checks this after each `await` and bails rather than creating xterm /
+   *  WebGL state that no cleanup path can reach — the root of the #591
+   *  orphan-canvas leak (SolidJS `onCleanup` registered inside a disposed
+   *  owner is a silent no-op, so onCleanup inside the async body would not
+   *  run when an `<Show>` toggle disposes the owner during a mode switch). */
+  let disposed = false;
   const [hasWebgl, setHasWebgl] = createSignal(false);
 
   /** Clear WebGL texture atlas to fix font rendering corruption (issue #239). */
@@ -307,11 +315,30 @@ const Terminal: Component<{
     ),
   );
 
+  // Cleanup registered SYNCHRONOUSLY at component body top — NOT inside the
+  // async `onMount` below. If the reactive owner disposes during `onMount`'s
+  // `await document.fonts.load(...)` (e.g. an `<Show>` toggle swapping between
+  // canvas and focus modes), any `onCleanup` registered after the await is a
+  // silent no-op — the owner's cleanup list was already iterated at disposal.
+  // The `disposed` flag is the bail signal for the async body below. Without
+  // this, each mode-toggle race leaks a Terminal component instance
+  // (orphan xterm + WebGL canvas + scrollback buffer) — the residual #591
+  // leak after PRs #578/#596.
+  onCleanup(() => {
+    disposed = true;
+    streamAbort?.abort();
+    unregisterTerminalRefs(props.terminalId);
+    disposeDiagnostics?.();
+    unloadWebgl();
+    terminal?.dispose();
+  });
+
   onMount(async () => {
     // Wait for the terminal font to load before measuring cell dimensions.
     // Without this, the first terminal may mount before the font is available,
     // causing xterm to measure with the fallback monospace font — wrong metrics.
     await document.fonts.load(`1em ${FONT_FAMILY}`);
+    if (disposed) return;
 
     const term = new XTerm({
       fontFamily: FONT_FAMILY,
@@ -599,17 +626,10 @@ const Terminal: Component<{
       { capture: true },
     );
 
-    onCleanup(() => {
-      streamAbort?.abort();
-      unregisterTerminalRefs(props.terminalId);
-      disposeDiagnostics?.();
-      // Release GPU context explicitly on unmount too — xterm's dispose
-      // detaches the canvas but doesn't call WEBGL_lose_context, same as
-      // the load/unload path. Without this, closing a tile (or leaving
-      // canvas mode) leaks a context until Chrome GCs the detached canvas.
-      unloadWebgl();
-      terminal?.dispose();
-    });
+    // Cleanup is registered synchronously near the top of the component body
+    // (see comment there). It references `terminal`, `webgl`, and the local
+    // refs via closure, and handles null state if this onMount body never ran
+    // to completion.
   });
 
   return (


### PR DESCRIPTION
**Canvas↔focus mode toggles were leaking one entire Terminal component per toggle** — orphan xterm + WebGL canvas + scrollback buffer, each bypassing the unloadWebgl path entirely. That's why production kept creeping back toward 1+ GB footprint even after the #578 + #596 WebGL fixes landed. The scrollback-loss UX bug you flagged (`bufferLen == rows` on resized tiles after a mode switch) is the same remount pattern at work.

Diagnosed at runtime with **PR #595's webglTracker** plus a heap-snapshot walk of its `Entry` objects. After reproducing on the dev server, the signature was unmistakable: every orphan entry's `events` array contained only `{kind: "create"}`. No `loseContext-called`. No `dispose`. `unloadWebgl` was never called for those canvases — so the GPU context was never released and the whole Terminal component (with its xterm, addons, and buffer) stayed retained.

Root cause is a ten-line window in `Terminal.tsx`. The `onCleanup` handler that runs `unloadWebgl()` + `terminal?.dispose()` was registered **inside** `onMount`'s async body, _after_ `await document.fonts.load(...)`. When a `<Show>` toggle between canvas and focus modes disposes the component's reactive owner **during** that await, the subsequent `onCleanup(...)` call lands in an already-disposed owner — which SolidJS treats as a silent no-op (the cleanup array was already iterated at disposal). The rest of the async body then proceeds: it creates the xterm, it calls `loadWebgl()`, and the WebGL canvas now has no cleanup path wired at all. One orphan per race.

The fix is to **register `onCleanup` synchronously at the component body top**, not inside the async `onMount`. The cleanup references `terminal`/`webgl`/`streamAbort` through closure and handles the case where the async body never ran (all null). A new `disposed` flag, set by the cleanup handler, lets the async body bail after its await if the owner has already been torn down — so no xterm/WebGL canvas is created for a doomed component in the first place.

### Verification

Via heap-snapshot walks of `webglTracker`'s live `Entry` objects on the dev server — counting `disposed` (event tape has `{kind:"dispose"}`) vs `undisposed` (only `{kind:"create"}`, i.e. orphans):

| Scenario | Entries | Disposed | Undisposed | Orphans |
|---|---|---|---|---|
| **Before fix** — 6 canvas↔focus toggles | 101 | 94 | 7 | **6** (all on active tile's terminalId) |
| **After fix** — 20 mode toggles × 100+ focus swaps stress | 117 | 116 | 1 (active) | **0** |
| **After fix** — 20× (Ctrl+Enter + close-dialog confirm) | 21 | 21 | 0 | **0** |
| **After fix** — 25× (Ctrl+Enter + Ctrl+D) | 46 | 46 | 0 | **0** |

Closes #591. Builds on #578, #592, #595, #596.

### Try it locally

```sh
nix run github:juspay/kolu/fix/terminal-async-onmount-cleanup-race
```