### PR TITLE
Document the #591 memory hunt + a perf-diagnose skill

### DIFF
--- a/.claude/skills/perf-diagnose/SKILL.md
+++ b/.claude/skills/perf-diagnose/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: perf-diagnose
+description: Diagnose Kolu client-side performance issues (memory leaks, high GPU, slow interactions) using chrome-devtools MCP + the Debug → Diagnostic info dialog. Triggers on "memory leak", "GPU memory", "tab bloat", "why is kolu slow", "debug performance", "zombie canvas", "WebGL leak", or any #591-shaped issue.
+---
+
+# Performance diagnosis
+
+## Ground rule: facts over guesses
+
+**Every claim must cite evidence from a live measurement: Chrome Task Manager screenshot, Diagnostic-info JSON, or a parsed heap snapshot.** No reasoning from xterm source, no reasoning from WebGL spec, no "probably" or "I suspect". PR [#594](https://github.com/juspay/kolu/pull/594) regressed production to 1.1 GB GPU because its fix was reasoned from spec reading without runtime verification — the same code paths the author was reasoning about were silently no-ops. The [#595](https://github.com/juspay/kolu/pull/595) `webglTracker` exists so you can stop guessing.
+
+If you find yourself about to write "probably", "likely", "should", or "I think", stop. Get the next measurement first. If you write a PR description based on a hypothesis, the reader can't tell which parts were observed vs invented; neither can you three days later.
+
+## Prerequisites
+
+Need chrome-devtools MCP and a running dev server on `http://localhost:5173`. If the dev server isn't running, **ask the user before continuing** (via `AskUserQuestion`): "Start `just dev` in a terminal? Required to reproduce memory pathologies with the tracker attached." Don't silently run it — it ties up a terminal.
+
+## The three signals
+
+Always triangulate with all three:
+
+1. **Chrome Task Manager** (user shares screenshot). Three columns matter: `Memory Footprint`, `GPU Memory`, `JavaScript Memory live/total`. The "live" JS number is post-GC — use it, not `usedJSHeapSize`.
+2. **Debug → Diagnostic info dialog** (command palette → Debug → Diagnostic info → Copy JSON). Gives per-terminal state, JS heap, and the **WebGL lifecycle** section: `totalCreated`, `disposed`, `aliveInDom`, `aliveDetached`, `gced`, `contextsLost`. Events tape has the last 30 `create / loseContext-called / dispose / contextlost / contextrestored` events with `defaultPrevented` flags.
+3. **Heap snapshot** via `mcp__chrome-devtools__take_memory_snapshot` to `/tmp/kolu.heapsnapshot`. Chrome forces a major GC before capturing.
+
+## WebGL invariants
+
+If the Diagnostic dialog shows any of these, something is wrong:
+
+- `aliveDetached > 0 && contextsLost < aliveDetached` — canvases held alive with **live** WebGL contexts. This is the #591 leak shape.
+- `totalCreated - disposed > aliveInDom` — orphan entries whose `onCleanup` never fired. Events tape for an orphan contains only `{kind: "create"}`. Usually an async-onMount-cleanup-race (fixed in #598; if it resurfaces, look for another `await` before `onCleanup(...)` registers).
+- `contextlost` events with `defaultPrevented: true` but disposal happened seconds earlier — xterm's context-restoration listener is running and allocating new GL state on a detached canvas. That's a zombie-regen pattern.
+
+Healthy steady-state: `contextsLost == aliveDetached` (every zombie's GPU released) and `totalCreated - disposed == aliveInDom` (only the active tile is undisposed).
+
+## Reproduction recipe
+
+Focus swaps alone rarely leak. What does:
+
+1. **Canvas ↔ focus mode toggles** — `<Show>` re-creates all Terminal component subtrees. Rapid toggling during async-onMount was #591's dominant trigger.
+2. **Create + close churn** — `Ctrl+Enter` to create, click the × button + confirm OR `Ctrl+D` to close. Short cycles stress the onMount/onCleanup race window.
+3. **Rapid-focus across many tiles** — needs ~10+ tiles in canvas mode to expose context-budget pressure.
+
+Combine all three over ~2 minutes of scripted churn before reading the dialog.
+
+## Heap snapshot analysis (no Python on Nix devshell — use Node)
+
+Heap snapshots are big JSON. Parse with Node:
+
+```js
+const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+const { nodes, edges, strings } = data;
+const nodeTypes = data.snapshot.meta.node_types[0];   // ['hidden','array','string','object','code','closure',...,'native',...]
+const edgeTypes = data.snapshot.meta.edge_types[0];   // ['context','element','property','internal','hidden','shortcut','weak']
+// node_fields: [type, name, id, self_size, edge_count, detachedness]
+// edge_fields: [type, name_or_index, to_node]
+```
+
+Useful queries:
+
+- **Detached canvases**: iterate nodes, filter `type === 'native'` and `name` starts with `<canvas`, bucket by `detachedness` (1=attached, 2=detached, 0=unknown).
+- **webglTracker entries**: iterate `type === 'object'` nodes whose properties include `canvasRef + disposedAt + loseContextCalledAt`. Check `disposedAt` type: `'hidden'` = null (undisposed), `'number'` = disposed. Follow `canvasRef`'s `weak` edge to the canvas target.
+- **Retainer chain**: build reverse-edge map (parent lookups), walk up from a leaked node. Filter out `synthetic` `(Traced handles)` and browser-internal `(Client heap)` edges — real retainers are `property` or `element` edges from `object`/`closure`/`array` nodes.
+
+Production bundles are minified; xterm class names appear as `yg`, `e3`, etc. Recognize by property shape (e.g. an object with a `canvas` property pointing to a 512×512 canvas is a `TextureAtlasPage`).
+
+## Interpreting the gap
+
+Tab `Memory Footprint` = JS live + GPU + renderer baseline + **detached DOM bitmap memory** (native). Last bucket is invisible to both JS heap and GPU counters. Rough budget for Kolu:
+
+- 1 live WebGL context ≈ 30 MB GPU
+- Compositor layers for N canvas-mode tiles ≈ N × 20–30 MB GPU
+- Chrome renderer baseline ≈ 100–150 MB
+- Everything else = detached DOM or V8 code/isolate
+
+If JS heap is collectable (forced GC drops it) and WebGL invariants are clean, remaining footprint is either V8 lazy GC or detached-bitmap lag — benign unless it grows unbounded over hours.
+
+## Chrome Task Manager vs `performance.memory`
+
+- `performance.memory.usedJSHeapSize` = bytes allocated, includes uncollected garbage. Grows between GCs.
+- Task Manager `JavaScript Memory (N live)` = live set after last major GC. Use this for steady-state.
+
+The gap between them is collectable garbage, not a leak.
+
+## Quick manual GC
+
+User can force a major GC from DevTools → Memory tab → trash-can icon, or by taking a heap snapshot (Chrome always GCs before capture). If `performance.memory.usedJSHeapSize` drops sharply after that, the "growth" was just lazy collection.
+
+## Prior art
+
+- #591 — the original memory issue
+- #592 — diagnostic dialog (JS heap, DOM, per-terminal buffer/scrollback, WebGL atlas dims)
+- #594 — spec-reasoning fix that regressed; closed unmerged
+- #595 — webglTracker WeakRef-based lifecycle ledger
+- #596 — querySelector fix: target WebGL canvas, not xterm-link-layer
+- #598 — async-onMount cleanup race (the root cause after all the above)

--- a/agents/.apm/skills/perf-diagnose/SKILL.md
+++ b/agents/.apm/skills/perf-diagnose/SKILL.md
@@ -48,10 +48,10 @@ Combine all three over ~2 minutes of scripted churn before reading the dialog.
 Heap snapshots are big JSON. Parse with Node:
 
 ```js
-const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+const data = JSON.parse(fs.readFileSync(path, "utf8"));
 const { nodes, edges, strings } = data;
-const nodeTypes = data.snapshot.meta.node_types[0];   // ['hidden','array','string','object','code','closure',...,'native',...]
-const edgeTypes = data.snapshot.meta.edge_types[0];   // ['context','element','property','internal','hidden','shortcut','weak']
+const nodeTypes = data.snapshot.meta.node_types[0]; // ['hidden','array','string','object','code','closure',...,'native',...]
+const edgeTypes = data.snapshot.meta.edge_types[0]; // ['context','element','property','internal','hidden','shortcut','weak']
 // node_fields: [type, name, id, self_size, edge_count, detachedness]
 // edge_fields: [type, name_or_index, to_node]
 ```

--- a/agents/.apm/skills/perf-diagnose/SKILL.md
+++ b/agents/.apm/skills/perf-diagnose/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: perf-diagnose
+description: Diagnose Kolu client-side performance issues (memory leaks, high GPU, slow interactions) using chrome-devtools MCP + the Debug → Diagnostic info dialog. Triggers on "memory leak", "GPU memory", "tab bloat", "why is kolu slow", "debug performance", "zombie canvas", "WebGL leak", or any #591-shaped issue.
+---
+
+# Performance diagnosis
+
+## Ground rule: facts over guesses
+
+**Every claim must cite evidence from a live measurement: Chrome Task Manager screenshot, Diagnostic-info JSON, or a parsed heap snapshot.** No reasoning from xterm source, no reasoning from WebGL spec, no "probably" or "I suspect". PR [#594](https://github.com/juspay/kolu/pull/594) regressed production to 1.1 GB GPU because its fix was reasoned from spec reading without runtime verification — the same code paths the author was reasoning about were silently no-ops. The [#595](https://github.com/juspay/kolu/pull/595) `webglTracker` exists so you can stop guessing.
+
+If you find yourself about to write "probably", "likely", "should", or "I think", stop. Get the next measurement first. If you write a PR description based on a hypothesis, the reader can't tell which parts were observed vs invented; neither can you three days later.
+
+## Prerequisites
+
+Need chrome-devtools MCP and a running dev server on `http://localhost:5173`. If the dev server isn't running, **ask the user before continuing** (via `AskUserQuestion`): "Start `just dev` in a terminal? Required to reproduce memory pathologies with the tracker attached." Don't silently run it — it ties up a terminal.
+
+## The three signals
+
+Always triangulate with all three:
+
+1. **Chrome Task Manager** (user shares screenshot). Three columns matter: `Memory Footprint`, `GPU Memory`, `JavaScript Memory live/total`. The "live" JS number is post-GC — use it, not `usedJSHeapSize`.
+2. **Debug → Diagnostic info dialog** (command palette → Debug → Diagnostic info → Copy JSON). Gives per-terminal state, JS heap, and the **WebGL lifecycle** section: `totalCreated`, `disposed`, `aliveInDom`, `aliveDetached`, `gced`, `contextsLost`. Events tape has the last 30 `create / loseContext-called / dispose / contextlost / contextrestored` events with `defaultPrevented` flags.
+3. **Heap snapshot** via `mcp__chrome-devtools__take_memory_snapshot` to `/tmp/kolu.heapsnapshot`. Chrome forces a major GC before capturing.
+
+## WebGL invariants
+
+If the Diagnostic dialog shows any of these, something is wrong:
+
+- `aliveDetached > 0 && contextsLost < aliveDetached` — canvases held alive with **live** WebGL contexts. This is the #591 leak shape.
+- `totalCreated - disposed > aliveInDom` — orphan entries whose `onCleanup` never fired. Events tape for an orphan contains only `{kind: "create"}`. Usually an async-onMount-cleanup-race (fixed in #598; if it resurfaces, look for another `await` before `onCleanup(...)` registers).
+- `contextlost` events with `defaultPrevented: true` but disposal happened seconds earlier — xterm's context-restoration listener is running and allocating new GL state on a detached canvas. That's a zombie-regen pattern.
+
+Healthy steady-state: `contextsLost == aliveDetached` (every zombie's GPU released) and `totalCreated - disposed == aliveInDom` (only the active tile is undisposed).
+
+## Reproduction recipe
+
+Focus swaps alone rarely leak. What does:
+
+1. **Canvas ↔ focus mode toggles** — `<Show>` re-creates all Terminal component subtrees. Rapid toggling during async-onMount was #591's dominant trigger.
+2. **Create + close churn** — `Ctrl+Enter` to create, click the × button + confirm OR `Ctrl+D` to close. Short cycles stress the onMount/onCleanup race window.
+3. **Rapid-focus across many tiles** — needs ~10+ tiles in canvas mode to expose context-budget pressure.
+
+Combine all three over ~2 minutes of scripted churn before reading the dialog.
+
+## Heap snapshot analysis (no Python on Nix devshell — use Node)
+
+Heap snapshots are big JSON. Parse with Node:
+
+```js
+const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+const { nodes, edges, strings } = data;
+const nodeTypes = data.snapshot.meta.node_types[0];   // ['hidden','array','string','object','code','closure',...,'native',...]
+const edgeTypes = data.snapshot.meta.edge_types[0];   // ['context','element','property','internal','hidden','shortcut','weak']
+// node_fields: [type, name, id, self_size, edge_count, detachedness]
+// edge_fields: [type, name_or_index, to_node]
+```
+
+Useful queries:
+
+- **Detached canvases**: iterate nodes, filter `type === 'native'` and `name` starts with `<canvas`, bucket by `detachedness` (1=attached, 2=detached, 0=unknown).
+- **webglTracker entries**: iterate `type === 'object'` nodes whose properties include `canvasRef + disposedAt + loseContextCalledAt`. Check `disposedAt` type: `'hidden'` = null (undisposed), `'number'` = disposed. Follow `canvasRef`'s `weak` edge to the canvas target.
+- **Retainer chain**: build reverse-edge map (parent lookups), walk up from a leaked node. Filter out `synthetic` `(Traced handles)` and browser-internal `(Client heap)` edges — real retainers are `property` or `element` edges from `object`/`closure`/`array` nodes.
+
+Production bundles are minified; xterm class names appear as `yg`, `e3`, etc. Recognize by property shape (e.g. an object with a `canvas` property pointing to a 512×512 canvas is a `TextureAtlasPage`).
+
+## Interpreting the gap
+
+Tab `Memory Footprint` = JS live + GPU + renderer baseline + **detached DOM bitmap memory** (native). Last bucket is invisible to both JS heap and GPU counters. Rough budget for Kolu:
+
+- 1 live WebGL context ≈ 30 MB GPU
+- Compositor layers for N canvas-mode tiles ≈ N × 20–30 MB GPU
+- Chrome renderer baseline ≈ 100–150 MB
+- Everything else = detached DOM or V8 code/isolate
+
+If JS heap is collectable (forced GC drops it) and WebGL invariants are clean, remaining footprint is either V8 lazy GC or detached-bitmap lag — benign unless it grows unbounded over hours.
+
+## Chrome Task Manager vs `performance.memory`
+
+- `performance.memory.usedJSHeapSize` = bytes allocated, includes uncollected garbage. Grows between GCs.
+- Task Manager `JavaScript Memory (N live)` = live set after last major GC. Use this for steady-state.
+
+The gap between them is collectable garbage, not a leak.
+
+## Quick manual GC
+
+User can force a major GC from DevTools → Memory tab → trash-can icon, or by taking a heap snapshot (Chrome always GCs before capture). If `performance.memory.usedJSHeapSize` drops sharply after that, the "growth" was just lazy collection.
+
+## Prior art
+
+- #591 — the original memory issue
+- #592 — diagnostic dialog (JS heap, DOM, per-terminal buffer/scrollback, WebGL atlas dims)
+- #594 — spec-reasoning fix that regressed; closed unmerged
+- #595 — webglTracker WeakRef-based lifecycle ledger
+- #596 — querySelector fix: target WebGL canvas, not xterm-link-layer
+- #598 — async-onMount cleanup race (the root cause after all the above)

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-16T23:17:30.259556+00:00'
+generated_at: '2026-04-17T12:31:31.891315+00:00'
 apm_version: 0.8.11
 dependencies:
 - repo_url: _local/agents
@@ -20,6 +20,7 @@ dependencies:
   - .claude/rules/workflow.md
   - .claude/skills/ci
   - .claude/skills/hk
+  - .claude/skills/perf-diagnose
   - .claude/skills/test
   source: local
   local_path: ./agents

--- a/docs/webgl-memory-learnings.md
+++ b/docs/webgl-memory-learnings.md
@@ -17,14 +17,14 @@ Chrome's per-tab WebGL-context budget is ~16. Past that, the browser evicts the 
 
 ## Attempt history
 
-| # | PR | What it claimed to fix | What actually happened |
-| --- | --- | --- | --- |
-| 1 | [#578](https://github.com/juspay/kolu/pull/578) | Only the focused+visible tile holds a `WebglAddon`; add explicit `loseContext()` on dispose. | Correct design. But two latent bugs — a wrong canvas selector and an async-onMount race — made both mechanisms silently no-ops in production. The leak continued; nobody noticed for weeks because the warnings only surfaced after hours of accumulation. |
-| 2 | [#592](https://github.com/juspay/kolu/pull/592) | Expose JS heap / DOM / canvas / atlas counts in the `Debug → Diagnostic info` dialog. | First step toward factual observation. Not a fix. |
-| 3 | [#594](https://github.com/juspay/kolu/pull/594) | Swap the order inside `unloadWebgl`: `dispose()` before `loseContext()`, so xterm's `webglcontextlost` listener is unregistered before the event fires, avoiding `preventDefault`-driven restoration. | **Regressed**. GPU climbed to 1.1 GB (nearly 2× pre-fix peak) within minutes of real use. The whole reasoning chain was spec-based: the listener existed but was never receiving events on the canvas the code was calling `loseContext()` on. Closed unmerged. Lesson: _reasoning from source isn't observation_. |
-| 4 | [#595](https://github.com/juspay/kolu/pull/595) | `webglTracker` — a WeakRef-based ledger with `aliveDetached`, `contextsLost`, and an event tape per canvas. Surfaced in the diagnostic dialog. | The instrument that made the next two fixes possible. First runtime data from prod confirmed `contextsLost: 0` despite `loseContext-called: 8` — i.e. the explicit release had never actually been happening. |
-| 5 | [#596](https://github.com/juspay/kolu/pull/596) | `.xterm-screen canvas` was matching xterm's link-layer canvas (first in document order), so `getContext("webgl2")` on it returned null and the entire `loseContext()` chain short-circuited. Narrowed to `:not(.xterm-link-layer)`. | Found in minutes once a heap snapshot on dev showed the `WeakRef` target was `<canvas class="xterm-link-layer">`. Closed the WebGL-context leak. GPU dropped; JS heap kept creeping up during mode toggles. |
-| 6 | [#598](https://github.com/juspay/kolu/pull/598) | `onCleanup` was registered inside `onMount`'s async body, **after** `await document.fonts.load(...)`. Canvas↔focus mode toggles disposed the reactive owner during that await; `onCleanup` in a disposed owner is a silent no-op in SolidJS. Each race orphaned a whole Terminal component (xterm + addons + buffer + WebGL canvas). | Diagnosed by walking heap-snapshot `Entry` objects: orphans had only `{kind: "create"}` in their event tape — `unloadWebgl` never ran for them. Fix: register `onCleanup` synchronously at the component body top with a `disposed` flag that the async body checks after its await. |
+| #   | PR                                              | What it claimed to fix                                                                                                                                                                                                                                                                                                               | What actually happened                                                                                                                                                                                                                                                                                             |
+| --- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | [#578](https://github.com/juspay/kolu/pull/578) | Only the focused+visible tile holds a `WebglAddon`; add explicit `loseContext()` on dispose.                                                                                                                                                                                                                                         | Correct design. But two latent bugs — a wrong canvas selector and an async-onMount race — made both mechanisms silently no-ops in production. The leak continued; nobody noticed for weeks because the warnings only surfaced after hours of accumulation.                                                         |
+| 2   | [#592](https://github.com/juspay/kolu/pull/592) | Expose JS heap / DOM / canvas / atlas counts in the `Debug → Diagnostic info` dialog.                                                                                                                                                                                                                                                | First step toward factual observation. Not a fix.                                                                                                                                                                                                                                                                  |
+| 3   | [#594](https://github.com/juspay/kolu/pull/594) | Swap the order inside `unloadWebgl`: `dispose()` before `loseContext()`, so xterm's `webglcontextlost` listener is unregistered before the event fires, avoiding `preventDefault`-driven restoration.                                                                                                                                | **Regressed**. GPU climbed to 1.1 GB (nearly 2× pre-fix peak) within minutes of real use. The whole reasoning chain was spec-based: the listener existed but was never receiving events on the canvas the code was calling `loseContext()` on. Closed unmerged. Lesson: _reasoning from source isn't observation_. |
+| 4   | [#595](https://github.com/juspay/kolu/pull/595) | `webglTracker` — a WeakRef-based ledger with `aliveDetached`, `contextsLost`, and an event tape per canvas. Surfaced in the diagnostic dialog.                                                                                                                                                                                       | The instrument that made the next two fixes possible. First runtime data from prod confirmed `contextsLost: 0` despite `loseContext-called: 8` — i.e. the explicit release had never actually been happening.                                                                                                      |
+| 5   | [#596](https://github.com/juspay/kolu/pull/596) | `.xterm-screen canvas` was matching xterm's link-layer canvas (first in document order), so `getContext("webgl2")` on it returned null and the entire `loseContext()` chain short-circuited. Narrowed to `:not(.xterm-link-layer)`.                                                                                                  | Found in minutes once a heap snapshot on dev showed the `WeakRef` target was `<canvas class="xterm-link-layer">`. Closed the WebGL-context leak. GPU dropped; JS heap kept creeping up during mode toggles.                                                                                                        |
+| 6   | [#598](https://github.com/juspay/kolu/pull/598) | `onCleanup` was registered inside `onMount`'s async body, **after** `await document.fonts.load(...)`. Canvas↔focus mode toggles disposed the reactive owner during that await; `onCleanup` in a disposed owner is a silent no-op in SolidJS. Each race orphaned a whole Terminal component (xterm + addons + buffer + WebGL canvas). | Diagnosed by walking heap-snapshot `Entry` objects: orphans had only `{kind: "create"}` in their event tape — `unloadWebgl` never ran for them. Fix: register `onCleanup` synchronously at the component body top with a `disposed` flag that the async body checks after its await.                               |
 
 ## The core lesson: reason from measurement
 
@@ -44,11 +44,11 @@ Once we looked at the actual `WeakRef.deref()` on dev, the `:not(.xterm-link-lay
 
 Task Manager's `Tabs & extensions` view has three columns that matter. Always read all three together:
 
-| Column | What it measures |
-| --- | --- |
-| `Memory Footprint` | Whole-tab process memory: JS + GPU + renderer baseline + detached-bitmap native memory + V8 code cache |
-| `GPU Memory` | Textures, render buffers, compositor layers. WebGL contexts show up here. |
-| `JavaScript Memory` | `total (N live)` — the `live` parenthetical is post-GC, use that for steady state. |
+| Column              | What it measures                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
+| `Memory Footprint`  | Whole-tab process memory: JS + GPU + renderer baseline + detached-bitmap native memory + V8 code cache |
+| `GPU Memory`        | Textures, render buffers, compositor layers. WebGL contexts show up here.                              |
+| `JavaScript Memory` | `total (N live)` — the `live` parenthetical is post-GC, use that for steady state.                     |
 
 `performance.memory.usedJSHeapSize` (what the Diagnostic dialog's `jsHeapUsedMB` shows) is a pre-GC number. It can be 3-4x the Task Manager `live` count if V8 hasn't swept recently. Forcing a major GC from DevTools → Memory → trash-can icon drops it to the live number — that gap is collectable garbage, not a leak.
 
@@ -64,11 +64,11 @@ The diff `Memory Footprint - JS live - GPU` is often ~300–500 MB of "Chrome ov
 
 Violations and what they mean:
 
-| Violation | Diagnosis |
-| --- | --- |
+| Violation                                                                                    | Diagnosis                                                                                                                    |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `totalCreated − disposed > 1` and delta entries have only `{kind: "create"}` in their events | Async-onMount-cleanup-race (#598 pattern). An `await` in `onMount` before `onCleanup(...)` let the owner dispose in between. |
-| `aliveDetached > contextsLost` | `loseContext()` isn't firing. Check the canvas selector (#596) or xterm's preventDefault interfering. |
-| `contextlost` events have `defaultPrevented: true` and time-adjacent to active use | xterm's listener ran before disposal — will schedule a 3 s restoration timer. Not necessarily broken but worth noting. |
+| `aliveDetached > contextsLost`                                                               | `loseContext()` isn't firing. Check the canvas selector (#596) or xterm's preventDefault interfering.                        |
+| `contextlost` events have `defaultPrevented: true` and time-adjacent to active use           | xterm's listener ran before disposal — will schedule a 3 s restoration timer. Not necessarily broken but worth noting.       |
 
 ## The async-onMount-cleanup-race pattern
 
@@ -77,7 +77,7 @@ Generalizable beyond Kolu. If you see this shape in SolidJS:
 ```ts
 onMount(async () => {
   await somethingAsync();
-  createExpensiveResource();         // allocates GPU / native / etc
+  createExpensiveResource(); // allocates GPU / native / etc
   onCleanup(() => disposeResource()); // ← race window
 });
 ```
@@ -90,12 +90,12 @@ Fix shape:
 let disposed = false;
 onCleanup(() => {
   disposed = true;
-  disposeResource();               // handles the null case where await never completed
+  disposeResource(); // handles the null case where await never completed
 });
 
 onMount(async () => {
   await somethingAsync();
-  if (disposed) return;            // bail rather than allocate doomed resources
+  if (disposed) return; // bail rather than allocate doomed resources
   createExpensiveResource();
 });
 ```
@@ -106,11 +106,11 @@ The `onCleanup` registers synchronously during the component body's first reacti
 
 Focus swaps alone don't reproduce most of these — they don't trigger component unmounts in canvas mode (tiles stay mounted, only `props.focused` changes). What does:
 
-| Scenario | Triggers |
-| --- | --- |
-| Canvas ↔ focus mode toggle | Full subtree replacement via `<Show>`. Dominant #598 reproduction. |
+| Scenario                                                       | Triggers                                                                                    |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Canvas ↔ focus mode toggle                                     | Full subtree replacement via `<Show>`. Dominant #598 reproduction.                          |
 | Terminal close (X button + confirm, or `Ctrl+D` via shell EOF) | Server pushes removal → client removes the ID from `<For>` → that tile's Terminal unmounts. |
-| `Ctrl+Enter` (new terminal) immediately followed by `Ctrl+D` | Rapid create+close stresses the `await document.fonts.load` window. |
+| `Ctrl+Enter` (new terminal) immediately followed by `Ctrl+D`   | Rapid create+close stresses the `await document.fonts.load` window.                         |
 
 A workload of "20× Ctrl+Enter + Ctrl+D" on dev goes from reproducing ~6 orphans per cycle (pre-#598) to 0 orphans (post-#598). Use this as the regression test.
 

--- a/docs/webgl-memory-learnings.md
+++ b/docs/webgl-memory-learnings.md
@@ -1,0 +1,128 @@
+# WebGL memory learnings ([#591](https://github.com/juspay/kolu/issues/591))
+
+Notes from a multi-day investigation of the Kolu tab growing past 1 GB over a normal session. Two of the five fix attempts were wrong; the right two came from observing runtime state instead of reasoning from xterm source. The history is preserved here because the _wrong_ turns encode lessons that the code doesn't.
+
+## The symptom
+
+Users reported the kolu@pureintent tab growing from ~300 MB to ~2 GB over hours of use, with console warnings:
+
+```
+WARNING: Too many active WebGL contexts. Oldest context will be lost.
+WebGL: INVALID_OPERATION: delete: object does not belong to this context
+webglcontextlost event received
+webglcontextrestored event received
+```
+
+Chrome's per-tab WebGL-context budget is ~16. Past that, the browser evicts the oldest.
+
+## Attempt history
+
+| # | PR | What it claimed to fix | What actually happened |
+| --- | --- | --- | --- |
+| 1 | [#578](https://github.com/juspay/kolu/pull/578) | Only the focused+visible tile holds a `WebglAddon`; add explicit `loseContext()` on dispose. | Correct design. But two latent bugs — a wrong canvas selector and an async-onMount race — made both mechanisms silently no-ops in production. The leak continued; nobody noticed for weeks because the warnings only surfaced after hours of accumulation. |
+| 2 | [#592](https://github.com/juspay/kolu/pull/592) | Expose JS heap / DOM / canvas / atlas counts in the `Debug → Diagnostic info` dialog. | First step toward factual observation. Not a fix. |
+| 3 | [#594](https://github.com/juspay/kolu/pull/594) | Swap the order inside `unloadWebgl`: `dispose()` before `loseContext()`, so xterm's `webglcontextlost` listener is unregistered before the event fires, avoiding `preventDefault`-driven restoration. | **Regressed**. GPU climbed to 1.1 GB (nearly 2× pre-fix peak) within minutes of real use. The whole reasoning chain was spec-based: the listener existed but was never receiving events on the canvas the code was calling `loseContext()` on. Closed unmerged. Lesson: _reasoning from source isn't observation_. |
+| 4 | [#595](https://github.com/juspay/kolu/pull/595) | `webglTracker` — a WeakRef-based ledger with `aliveDetached`, `contextsLost`, and an event tape per canvas. Surfaced in the diagnostic dialog. | The instrument that made the next two fixes possible. First runtime data from prod confirmed `contextsLost: 0` despite `loseContext-called: 8` — i.e. the explicit release had never actually been happening. |
+| 5 | [#596](https://github.com/juspay/kolu/pull/596) | `.xterm-screen canvas` was matching xterm's link-layer canvas (first in document order), so `getContext("webgl2")` on it returned null and the entire `loseContext()` chain short-circuited. Narrowed to `:not(.xterm-link-layer)`. | Found in minutes once a heap snapshot on dev showed the `WeakRef` target was `<canvas class="xterm-link-layer">`. Closed the WebGL-context leak. GPU dropped; JS heap kept creeping up during mode toggles. |
+| 6 | [#598](https://github.com/juspay/kolu/pull/598) | `onCleanup` was registered inside `onMount`'s async body, **after** `await document.fonts.load(...)`. Canvas↔focus mode toggles disposed the reactive owner during that await; `onCleanup` in a disposed owner is a silent no-op in SolidJS. Each race orphaned a whole Terminal component (xterm + addons + buffer + WebGL canvas). | Diagnosed by walking heap-snapshot `Entry` objects: orphans had only `{kind: "create"}` in their event tape — `unloadWebgl` never ran for them. Fix: register `onCleanup` synchronously at the component body top with a `disposed` flag that the async body checks after its await. |
+
+## The core lesson: reason from measurement
+
+The #594 attempt reasoned from xterm source + WebGL spec docs:
+
+> _xterm's `webglcontextlost` listener calls `preventDefault()` → browser attempts restoration → we get a zombie context. Fix: dispose before loseContext so the listener is unregistered first._
+
+Plausible, but **wrong** — and it made things worse in prod. The webglTracker in #595 showed the real pathology with three runtime facts that spec reading couldn't have given:
+
+1. `contextsLost: 0` despite `loseContext-called: 8`. The explicit release wasn't happening at all.
+2. Event tape had no `contextlost` DOM events. The listener was never firing.
+3. `canvasRef` WeakRef target was `<canvas class="xterm-link-layer">` — the wrong canvas.
+
+Once we looked at the actual `WeakRef.deref()` on dev, the `:not(.xterm-link-layer)` fix was obvious in minutes.
+
+## Chrome Task Manager is the ground truth
+
+Task Manager's `Tabs & extensions` view has three columns that matter. Always read all three together:
+
+| Column | What it measures |
+| --- | --- |
+| `Memory Footprint` | Whole-tab process memory: JS + GPU + renderer baseline + detached-bitmap native memory + V8 code cache |
+| `GPU Memory` | Textures, render buffers, compositor layers. WebGL contexts show up here. |
+| `JavaScript Memory` | `total (N live)` — the `live` parenthetical is post-GC, use that for steady state. |
+
+`performance.memory.usedJSHeapSize` (what the Diagnostic dialog's `jsHeapUsedMB` shows) is a pre-GC number. It can be 3-4x the Task Manager `live` count if V8 hasn't swept recently. Forcing a major GC from DevTools → Memory → trash-can icon drops it to the live number — that gap is collectable garbage, not a leak.
+
+The diff `Memory Footprint - JS live - GPU` is often ~300–500 MB of "Chrome overhead + detached bitmaps." That's expected for a long-running SPA and isn't chaseable without a heap snapshot that explicitly enumerates detached DOM.
+
+## webglTracker invariants
+
+`DiagnosticInfo` dialog shows a `WebGL lifecycle` section (added in #595). Steady-state values for a healthy session:
+
+- `totalCreated − disposed == aliveInDom == 1` — the only undisposed entry is the currently-active tile.
+- `contextsLost == aliveDetached` — every detached canvas has its WebGL context released. Non-zero `aliveDetached` is fine as long as contexts are released; V8 will GC the shells under pressure.
+- Every `contextlost` event in the tape has `defaultPrevented: false` — meaning xterm's context-restoration listener was torn down by `w.dispose()` before the async event dispatched.
+
+Violations and what they mean:
+
+| Violation | Diagnosis |
+| --- | --- |
+| `totalCreated − disposed > 1` and delta entries have only `{kind: "create"}` in their events | Async-onMount-cleanup-race (#598 pattern). An `await` in `onMount` before `onCleanup(...)` let the owner dispose in between. |
+| `aliveDetached > contextsLost` | `loseContext()` isn't firing. Check the canvas selector (#596) or xterm's preventDefault interfering. |
+| `contextlost` events have `defaultPrevented: true` and time-adjacent to active use | xterm's listener ran before disposal — will schedule a 3 s restoration timer. Not necessarily broken but worth noting. |
+
+## The async-onMount-cleanup-race pattern
+
+Generalizable beyond Kolu. If you see this shape in SolidJS:
+
+```ts
+onMount(async () => {
+  await somethingAsync();
+  createExpensiveResource();         // allocates GPU / native / etc
+  onCleanup(() => disposeResource()); // ← race window
+});
+```
+
+...and the component can be unmounted (via `<Show>` toggle, `<For>` key change, parent re-render) _during_ the `await`, you have a leak. `onCleanup` inside a disposed reactive owner is a **silent no-op** — the handler is pushed to a cleanup array that was already iterated at disposal. The resource is then created with no cleanup path wired.
+
+Fix shape:
+
+```ts
+let disposed = false;
+onCleanup(() => {
+  disposed = true;
+  disposeResource();               // handles the null case where await never completed
+});
+
+onMount(async () => {
+  await somethingAsync();
+  if (disposed) return;            // bail rather than allocate doomed resources
+  createExpensiveResource();
+});
+```
+
+The `onCleanup` registers synchronously during the component body's first reactive scope, where the owner is guaranteed valid. The `disposed` flag is the bail signal for the async body.
+
+## Reproduction recipes
+
+Focus swaps alone don't reproduce most of these — they don't trigger component unmounts in canvas mode (tiles stay mounted, only `props.focused` changes). What does:
+
+| Scenario | Triggers |
+| --- | --- |
+| Canvas ↔ focus mode toggle | Full subtree replacement via `<Show>`. Dominant #598 reproduction. |
+| Terminal close (X button + confirm, or `Ctrl+D` via shell EOF) | Server pushes removal → client removes the ID from `<For>` → that tile's Terminal unmounts. |
+| `Ctrl+Enter` (new terminal) immediately followed by `Ctrl+D` | Rapid create+close stresses the `await document.fonts.load` window. |
+
+A workload of "20× Ctrl+Enter + Ctrl+D" on dev goes from reproducing ~6 orphans per cycle (pre-#598) to 0 orphans (post-#598). Use this as the regression test.
+
+## Tooling notes
+
+- **chrome-devtools MCP** is the easiest way to introspect a local dev instance. `take_memory_snapshot` forces a major GC before capture, so snapshots always reflect the live set.
+- **Heap snapshot parsing**: no Python on the Nix devshell; use Node. Schema is in `data.snapshot.meta` (node_fields, edge_fields, node_types). Minified production bundles mangle class names — recognize xterm objects by property shape (e.g. an object with a `canvas` property pointing to a 512×512 atlas canvas is a `TextureAtlasPage`).
+- **Retainer chains**: build a reverse-edge map (node → parents). Ignore `synthetic (Traced handles)` and `native (Client heap)` edges — those are V8/browser internals. The real retention usually comes through `property` edges from plain objects.
+
+## Pointers
+
+- Tracker source: `packages/client/src/terminal/webglTracker.ts`
+- Dialog: `packages/client/src/DiagnosticInfo.tsx`
+- WebGL lifecycle functions: `loadWebgl` / `unloadWebgl` in `packages/client/src/terminal/Terminal.tsx`
+- Skill runbook: `agents/.apm/skills/perf-diagnose/SKILL.md`


### PR DESCRIPTION
Two artifacts capturing what we learned during the [#591](https://github.com/juspay/kolu/issues/591) hunt. Neither changes behavior — both are about making the next investigation faster.

**`docs/webgl-memory-learnings.md`** is the full attempt history, with PR links. It deliberately preserves the _wrong_ turns — [#594](https://github.com/juspay/kolu/pull/594) regressing production to 1.1 GB GPU because the fix was reasoned from xterm source and WebGL spec rather than runtime observation — because those attempts encode lessons that the code itself doesn't. It also covers the Task-Manager-vs-`performance.memory` distinction (live vs. total), the webglTracker invariants you can read off the diagnostic dialog, the async-onMount-cleanup-race pattern that was behind [#598](https://github.com/juspay/kolu/pull/598), and reproduction recipes that reliably expose each class of leak on the dev server.

**`agents/.apm/skills/perf-diagnose/SKILL.md`** is the runbook for next time. It leads with a hard ground rule: _every claim must cite evidence from Chrome Task Manager, the `Debug → Diagnostic info` JSON, or a parsed heap snapshot._ No spec-reasoning, no "probably", no "I think". It points at the [webglTracker](https://github.com/juspay/kolu/pull/595) + heap-snapshot workflow explicitly, prompts the user to start `just dev` if it's not already running, and includes heap-snapshot parsing tips (Node, not Python — there's no Python on the Nix devshell).

> _This was a five-PR arc ([#578](https://github.com/juspay/kolu/pull/578), [#592](https://github.com/juspay/kolu/pull/592), [#595](https://github.com/juspay/kolu/pull/595), [#596](https://github.com/juspay/kolu/pull/596), [#598](https://github.com/juspay/kolu/pull/598)) with one closed-unmerged regression ([#594](https://github.com/juspay/kolu/pull/594)). The pattern — instrument first, then fix — is what we want to make cheap to re-apply._