### PR TITLE
refactor(meta): fence TerminalMetadata by write authority

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -115,7 +115,12 @@ export const SubPanelStateSchema = z.object({
   panelSize: z.number(),
 });
 
-export const TerminalMetadataSchema = z.object({
+/**
+ * Server-derived metadata — populated by providers from external state
+ * (git working tree, PTY foreground process, agent CLI transcripts).
+ * Write authority: server-side metadata providers, via `updateServerMetadata`.
+ */
+export const TerminalServerMetadataSchema = z.object({
   cwd: z.string(),
   git: GitInfoSchema.nullable(),
   pr: GitHubPrInfoSchema.nullable(),
@@ -123,6 +128,15 @@ export const TerminalMetadataSchema = z.object({
   agent: AgentInfoSchema.nullable(),
   /** Foreground process name — detected via OSC 2 title change events. */
   foreground: ForegroundSchema.nullable(),
+});
+
+/**
+ * Client-owned metadata — set by client RPC handlers, persisted server-side
+ * for session restore and multi-client sync. Write authority: client RPCs,
+ * via `updateClientMetadata` (or direct mutation for paths that intentionally
+ * skip the metadata publish, like sub-panel state).
+ */
+export const TerminalClientMetadataSchema = z.object({
   themeName: z.string().optional(),
   /** If set, this terminal is a sub-terminal of the given parent. */
   parentId: z.string().optional(),
@@ -133,6 +147,15 @@ export const TerminalMetadataSchema = z.object({
   /** Sub-panel collapsed/size state — client-reported, used for session restore. */
   subPanel: SubPanelStateSchema.optional(),
 });
+
+/**
+ * Unified wire shape — merge of the server-derived and client-owned halves.
+ * Flat for backwards-compat with existing consumers; code that only needs
+ * one half should import the sub-schema so the dependency is explicit.
+ */
+export const TerminalMetadataSchema = TerminalServerMetadataSchema.merge(
+  TerminalClientMetadataSchema,
+);
 
 // --- Activity ---
 
@@ -379,6 +402,12 @@ export type AgentInfo = z.infer<typeof AgentInfoSchema>;
 export type ClaudeCodeInfo = z.infer<typeof ClaudeCodeInfoSchema>;
 export type OpenCodeInfo = z.infer<typeof OpenCodeInfoSchema>;
 export type Foreground = z.infer<typeof ForegroundSchema>;
+export type TerminalServerMetadata = z.infer<
+  typeof TerminalServerMetadataSchema
+>;
+export type TerminalClientMetadata = z.infer<
+  typeof TerminalClientMetadataSchema
+>;
 export type TerminalMetadata = z.infer<typeof TerminalMetadataSchema>;
 export type RecentRepo = z.infer<typeof RecentRepoSchema>;
 export type RecentAgent = z.infer<typeof RecentAgentSchema>;

--- a/packages/integrations/claude-code/src/index.ts
+++ b/packages/integrations/claude-code/src/index.ts
@@ -2,7 +2,7 @@
  * Claude Code integration — pure functions and IO helpers for detecting
  * Claude Code sessions and deriving state from JSONL transcripts.
  *
- * No dependency on server internals (no updateMetadata, no TerminalProcess).
+ * No dependency on server internals (no updateServerMetadata, no TerminalProcess).
  * The server's provider imports these and wires them into the metadata system.
  *
  * Detection: reads ~/.claude/sessions/{pid}.json to find sessions, then

--- a/packages/integrations/git/README.md
+++ b/packages/integrations/git/README.md
@@ -34,5 +34,5 @@ Functions accept `log?: Logger` (from `anyagent`). Pass a pino child logger in p
 The server keeps a thin provider adapter in `meta/git.ts` that:
 
 1. Calls `resolveGitInfo()` / `watchGitHead()` from this package
-2. Bridges results into the metadata event system (`updateMetadata`, `publishForTerminal`)
+2. Bridges results into the metadata event system (`updateServerMetadata`, `publishForTerminal`)
 3. Distinguishes `NOT_A_REPO` (expected, debug) from `GIT_FAILED` (unexpected, error)

--- a/packages/integrations/opencode/src/index.ts
+++ b/packages/integrations/opencode/src/index.ts
@@ -2,7 +2,7 @@
  * OpenCode integration — pure functions and IO helpers for detecting
  * OpenCode sessions and deriving state from its SQLite database.
  *
- * No dependency on server internals (no updateMetadata, no TerminalProcess).
+ * No dependency on server internals (no updateServerMetadata, no TerminalProcess).
  * The server's provider imports these and wires them into the metadata system.
  *
  * Architecture: OpenCode (TUI mode) is a single process that owns

--- a/packages/server/src/meta/agent.ts
+++ b/packages/server/src/meta/agent.ts
@@ -20,7 +20,7 @@ import type {
 } from "anyagent";
 import type { AgentInfo } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
-import { updateMetadata } from "./index.ts";
+import { updateServerMetadata } from "./index.ts";
 import { subscribeForTerminal } from "../publisher.ts";
 import { log } from "../log.ts";
 
@@ -100,7 +100,7 @@ export function startAgentProvider<Session, Info extends AgentInfoShape>(
       // Only clear metadata if the terminal's agent is ours to clear.
       // Other providers of different kinds share the same `m.agent` slot.
       if (entry.info.meta.agent?.kind === provider.kind) {
-        updateMetadata(entry, terminalId, (m) => {
+        updateServerMetadata(entry, terminalId, (m) => {
           m.agent = null;
         });
       }
@@ -113,7 +113,7 @@ export function startAgentProvider<Session, Info extends AgentInfoShape>(
       watcher: provider.createWatcher(
         next,
         (info) => {
-          updateMetadata(entry, terminalId, (m) => {
+          updateServerMetadata(entry, terminalId, (m) => {
             // Widen Info to AgentInfo — every concrete Info variant is a
             // member of the AgentInfo discriminated union by construction
             // (its schema is one of the union's branches). The cast lives

--- a/packages/server/src/meta/git.ts
+++ b/packages/server/src/meta/git.ts
@@ -19,7 +19,7 @@ import {
 } from "kolu-git";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal, publishForTerminal } from "../publisher.ts";
-import { updateMetadata } from "./index.ts";
+import { updateServerMetadata } from "./index.ts";
 import { log } from "../log.ts";
 import { trackRecentRepo } from "../activity.ts";
 
@@ -78,10 +78,10 @@ export function startGitProvider(
     }
     // Track repo in persistent recent repos list
     if (git) trackRecentRepo(git.mainRepoRoot, git.repoName);
-    // Clear PR when git context changes (branch switch) — PR provider will re-resolve
-    updateMetadata(entry, terminalId, (m) => {
+    // Write git only — the pr slot is owned by the github provider, which
+    // subscribes to the `git:` channel below and clears/re-resolves on change.
+    updateServerMetadata(entry, terminalId, (m) => {
       m.git = git;
-      m.pr = null;
     });
     plog.debug(
       { repo: git?.repoName, branch: git?.branch },

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -2,7 +2,7 @@
  * GitHub PR metadata provider — resolves PR info for the current branch.
  *
  * Subscribes to "git:<id>" (not the aggregated "metadata" channel).
- * Publishes via updateMetadata() — no downstream providers depend on PR changes.
+ * Publishes via updateServerMetadata() — no downstream providers depend on PR changes.
  * Also polls periodically (PRs can be created/updated externally at any time).
  */
 
@@ -16,7 +16,7 @@ import {
 } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal } from "../publisher.ts";
-import { updateMetadata } from "./index.ts";
+import { updateServerMetadata } from "./index.ts";
 import { log } from "../log.ts";
 
 const execFileAsync = promisify(execFile);
@@ -157,23 +157,26 @@ export function prInfoEqual(
 
 /**
  * Start the GitHub PR metadata provider for a terminal entry.
- * Subscribes to "git" channel for branch changes, polls every 30s.
+ *
+ * Subscribes to the `git:` channel — the git provider publishes its
+ * current state (including the initial resolve) on that channel, so there
+ * is no need to peek at `entry.info.meta.git` at startup. Also polls
+ * every 30s to pick up PRs created/updated externally.
+ *
+ * This provider owns the `pr` slot end-to-end: it clears `pr` immediately
+ * on any branch change (so stale pr info doesn't linger while the async
+ * `gh pr view` is in flight) and writes the new value when the resolve
+ * completes.
  */
 export function startGitHubPrProvider(
   entry: TerminalProcess,
   terminalId: string,
 ): () => void {
   const plog = log.child({ provider: "github-pr", terminal: terminalId });
-  const meta = entry.info.meta;
-  let lastBranch: string | undefined = meta.git?.branch;
-  let lastRepoRoot: string | undefined = meta.git?.repoRoot;
+  let lastBranch: string | undefined;
+  let lastRepoRoot: string | undefined;
 
-  plog.debug({ branch: lastBranch }, "started");
-
-  // Resolve immediately if we have git context
-  if (lastBranch && lastRepoRoot) {
-    void resolve(lastRepoRoot);
-  }
+  plog.debug("started");
 
   function onGitChange(git: GitInfo | null) {
     const branch = git?.branch;
@@ -185,15 +188,17 @@ export function startGitHubPrProvider(
     );
     lastBranch = branch;
     lastRepoRoot = repoRoot;
+    // Clear pr first — the previous value is tied to the old branch and is
+    // now stale. If we still have a repo, the async resolve below will
+    // overwrite with the new branch's pr (or null). If we don't, the clear
+    // is the final state.
+    if (entry.info.meta.pr !== null) {
+      updateServerMetadata(entry, terminalId, (m) => {
+        m.pr = null;
+      });
+    }
     if (branch && repoRoot) {
       void resolve(repoRoot);
-    } else {
-      // No longer in a git repo
-      if (entry.info.meta.pr !== null) {
-        updateMetadata(entry, terminalId, (m) => {
-          m.pr = null;
-        });
-      }
     }
   }
 
@@ -206,7 +211,7 @@ export function startGitHubPrProvider(
         : { pr: null },
       "pr info updated",
     );
-    updateMetadata(entry, terminalId, (m) => {
+    updateServerMetadata(entry, terminalId, (m) => {
       m.pr = pr;
     });
   }

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -7,7 +7,13 @@
  *   title:<id>  →  process provider  ────────→  metadata:<id>
  *   title:<id> + agent external-change signal  →  agent provider (×N)  →  metadata:<id>
  *
- * Each provider calls updateMetadata() to atomically mutate+publish.
+ * Providers publish server-derived fields via `updateServerMetadata`; client
+ * RPC handlers persist client-owned fields via `updateClientMetadata` (or
+ * direct mutation for paths that skip the metadata publish). Both functions
+ * share the same publish/auto-save path — the type difference is a
+ * compile-time fence so a provider cannot accidentally write canvasLayout
+ * and an RPC handler cannot accidentally write git.
+ *
  * No provider subscribes to the aggregated "metadata" channel — that's client-facing only.
  *
  * Agent-detection providers (claude-code, opencode, future aider/codex/…)
@@ -17,7 +23,11 @@
  * server-side adapter file.
  */
 
-import type { TerminalMetadata } from "kolu-common";
+import type {
+  TerminalMetadata,
+  TerminalServerMetadata,
+  TerminalClientMetadata,
+} from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
 import { publishForTerminal, publishSystem } from "../publisher.ts";
 import { claudeCodeProvider } from "kolu-claude-code";
@@ -43,15 +53,11 @@ export function createMetadata(
   };
 }
 
-/** Atomically mutate metadata, publish the snapshot to subscribers, and
- *  trigger a debounced session auto-save. Single place to audit —
- *  impossible to forget either the client publish or the session save. */
-export function updateMetadata(
-  entry: TerminalProcess,
-  terminalId: string,
-  mutate: (meta: TerminalMetadata) => void,
-): void {
-  mutate(entry.info.meta);
+/** Log + publish the current metadata snapshot and trigger debounced
+ *  session auto-save. Shared tail for both `updateServerMetadata` and
+ *  `updateClientMetadata` so the publish/audit path is identical regardless
+ *  of who wrote the fields. */
+function publishMetadata(entry: TerminalProcess, terminalId: string): void {
   const m = entry.info.meta;
   log.debug(
     {
@@ -69,6 +75,32 @@ export function updateMetadata(
   );
   publishForTerminal("metadata", terminalId, { ...m });
   publishSystem("terminals:dirty", {});
+}
+
+/** Atomically mutate server-derived metadata (cwd, git, pr, agent,
+ *  foreground) and publish. The mutator is narrowed to
+ *  `TerminalServerMetadata` so providers cannot accidentally write
+ *  client-owned fields. */
+export function updateServerMetadata(
+  entry: TerminalProcess,
+  terminalId: string,
+  mutate: (meta: TerminalServerMetadata) => void,
+): void {
+  mutate(entry.info.meta);
+  publishMetadata(entry, terminalId);
+}
+
+/** Atomically mutate client-owned metadata (themeName, parentId, sortOrder,
+ *  canvasLayout, subPanel) and publish. The mutator is narrowed to
+ *  `TerminalClientMetadata` so RPC handlers cannot accidentally overwrite
+ *  provider-owned state. */
+export function updateClientMetadata(
+  entry: TerminalProcess,
+  terminalId: string,
+  mutate: (meta: TerminalClientMetadata) => void,
+): void {
+  mutate(entry.info.meta);
+  publishMetadata(entry, terminalId);
 }
 
 /**

--- a/packages/server/src/meta/process.ts
+++ b/packages/server/src/meta/process.ts
@@ -11,7 +11,7 @@
 import path from "node:path";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal } from "../publisher.ts";
-import { updateMetadata } from "./index.ts";
+import { updateServerMetadata } from "./index.ts";
 import { log } from "../log.ts";
 
 /** node-pty may return a full path (e.g. `/nix/store/.../bin/opencode` on NixOS).
@@ -41,7 +41,7 @@ export function startProcessProvider(
     );
     lastName = name;
     lastTitle = newTitle;
-    updateMetadata(entry, terminalId, (m) => {
+    updateServerMetadata(entry, terminalId, (m) => {
       m.foreground = { name, title: newTitle };
     });
   }

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -21,7 +21,8 @@ import {
 } from "./clipboard.ts";
 import {
   createMetadata,
-  updateMetadata,
+  updateServerMetadata,
+  updateClientMetadata,
   startProviders,
 } from "./meta/index.ts";
 import { publishForTerminal, publishSystem } from "./publisher.ts";
@@ -181,7 +182,7 @@ export function createTerminal(cwd?: string, parentId?: string): TerminalInfo {
       onCwd: (newCwd) => {
         const entry = terminals.get(id);
         if (entry) {
-          updateMetadata(entry, id, (m) => {
+          updateServerMetadata(entry, id, (m) => {
             m.cwd = newCwd;
           });
           publishForTerminal("cwd", id, newCwd);
@@ -267,7 +268,7 @@ export function setTerminalParent(
   const entry = terminals.get(id);
   if (entry) {
     const newParent = parentId ?? undefined;
-    updateMetadata(entry, id, (m) => {
+    updateClientMetadata(entry, id, (m) => {
       m.parentId = newParent;
       m.sortOrder = nextSortOrder(newParent);
     });
@@ -283,7 +284,7 @@ export function setCanvasLayout(
 ): void {
   const entry = terminals.get(id);
   if (!entry) return;
-  updateMetadata(entry, id, (m) => {
+  updateClientMetadata(entry, id, (m) => {
     m.canvasLayout = layout;
   });
 }
@@ -317,7 +318,7 @@ export function setActiveTerminalId(id: TerminalId | null): void {
 export function setTerminalTheme(id: TerminalId, themeName: string): void {
   const entry = terminals.get(id);
   if (entry) {
-    updateMetadata(entry, id, (m) => {
+    updateClientMetadata(entry, id, (m) => {
       m.themeName = themeName;
     });
   }
@@ -328,7 +329,7 @@ export function reorderTerminals(ids: TerminalId[]): void {
   for (let i = 0; i < ids.length; i++) {
     const entry = terminals.get(ids[i]!);
     if (entry) {
-      updateMetadata(entry, ids[i]!, (m) => {
+      updateClientMetadata(entry, ids[i]!, (m) => {
         m.sortOrder = (i + 1) * SORT_GAP;
       });
     }


### PR DESCRIPTION
**`TerminalMetadata` now has a compile-time fence** between the two populations of code that write to it: metadata providers (server-derived fields — `cwd`, `git`, `pr`, `agent`, `foreground`) and client RPC handlers (user-owned fields — `themeName`, `parentId`, `sortOrder`, `canvasLayout`, `subPanel`). A provider that tries to clobber `canvasLayout`, or an RPC handler that tries to overwrite `git`, no longer compiles. Closes items 2 and 6 of #601.

At the schema source, `TerminalMetadataSchema` is now the merge of `TerminalServerMetadataSchema` and `TerminalClientMetadataSchema` — the wire shape is unchanged so all 25 downstream consumers are untouched. The teeth come from replacing the single `updateMetadata` mutator with two narrowed variants, `updateServerMetadata` and `updateClientMetadata`, sharing a private `publishMetadata` tail so the publish/audit path stays identical. Every provider call site migrated to the server variant; every RPC-handler write path (`setCanvasLayout`, `setTerminalTheme`, `setTerminalParent`, `reorderTerminals`) migrated to the client variant. _This was Lowy's ranked option 1 from the design pass: ship the split with a fence rather than land advisory schema that the compiler wouldn't enforce._

Along for the ride: the **github provider now owns the `pr` slot end-to-end**. Previously `meta/git.ts` cleared `m.pr = null` on branch change as a cross-slot cache-invalidation signal; now `meta/github.ts` clears it itself inside `onGitChange` before kicking off the async `gh pr view`. The dead initial-state peek at `entry.info.meta.git?.branch` is also gone — new terminals have `meta.git = null` when the github provider starts, so the `git:` channel subscription already handles the "terminal just booted" and "cwd changed" cases uniformly.

> _Accepted trade-off:_ on branch change, the metadata channel now emits two publishes (git update carrying stale pr, then pr clear) instead of one atomic update. The window between them is microtasks-only — no paint cycle fires between, so the UI never shows the transient state — but the invariant is weaker than before. Kept for the cleaner ownership boundary; documented in the github provider's doc comment.

### Try it locally

```sh
nix run github:juspay/kolu/refactor/metadata-authority-split
```