### PR TITLE
fix: hoist Resizable sizes ternary into createMemo (Part 2 root cause, #610)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,6 +4,7 @@ import {
   type Component,
   createSignal,
   createEffect,
+  createMemo,
   on,
   Show,
   For,
@@ -554,24 +555,37 @@ const App: Component = () => {
                       <ScreenshotIcon />
                     </button>
                   )}
-                  renderTileBody={(id, active) => (
-                    <TerminalContent
-                      terminalId={id as TerminalId}
-                      visible={true}
-                      focused={active()}
-                      theme={getTerminalTheme(id as TerminalId)}
-                      searchOpen={active() && searchOpen()}
-                      onSearchOpenChange={setSearchOpen}
-                      subTerminalIds={store.getSubTerminalIds(id as TerminalId)}
-                      getMetadata={store.getMetadata}
-                      onCreateSubTerminal={(parentId, cwd) =>
-                        void crud.handleCreateSubTerminal(parentId, cwd)
-                      }
-                      onCloseTerminal={closeTerminal}
-                      activeMeta={store.activeMeta()}
-                      onFocus={() => store.setActiveId(id as TerminalId)}
-                    />
-                  )}
+                  renderTileBody={(id, active) => {
+                    // Hoisted to avoid the same per-read `_$memo` leak as
+                    // the `sizes` and sub-`visible` memos elsewhere. The
+                    // `searchOpen` prop eventually reaches SearchBar's
+                    // capture-phase `makeEventListener` handler — outside
+                    // any Solid owner — and each getter read under a null
+                    // owner orphans a fresh memo.
+                    const tileSearchOpen = createMemo(
+                      () => active() && searchOpen(),
+                    );
+                    return (
+                      <TerminalContent
+                        terminalId={id as TerminalId}
+                        visible={true}
+                        focused={active()}
+                        theme={getTerminalTheme(id as TerminalId)}
+                        searchOpen={tileSearchOpen()}
+                        onSearchOpenChange={setSearchOpen}
+                        subTerminalIds={store.getSubTerminalIds(
+                          id as TerminalId,
+                        )}
+                        getMetadata={store.getMetadata}
+                        onCreateSubTerminal={(parentId, cwd) =>
+                          void crud.handleCreateSubTerminal(parentId, cwd)
+                        }
+                        onCloseTerminal={closeTerminal}
+                        activeMeta={store.activeMeta()}
+                        onFocus={() => store.setActiveId(id as TerminalId)}
+                      />
+                    );
+                  }}
                 />
               </RightPanelLayout>
             </Show>

--- a/packages/client/src/right-panel/RightPanelLayout.tsx
+++ b/packages/client/src/right-panel/RightPanelLayout.tsx
@@ -4,7 +4,7 @@
  *  On mobile viewports the right panel is disabled entirely — there's no
  *  toggle icon and the screen is too narrow for a useful side panel. */
 
-import { type Component, type JSX, Show } from "solid-js";
+import { type Component, type JSX, Show, createMemo } from "solid-js";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import Resizable from "@corvu/resizable";
 import RightPanel from "./RightPanel";
@@ -31,6 +31,20 @@ const RightPanelLayout: Component<{
   /** Whether the right panel should render (desktop only, not collapsed). */
   const showPanel = () => !isMobile() && !rightPanel.collapsed();
 
+  /** Hoisted to avoid Solid's JSX-inline-ternary compiler transform:
+   *  writing `sizes={cond ? a : b}` inline compiles the condition into a
+   *  FRESH `_$memo(() => cond)()` call on every prop read. `@corvu/resizable`
+   *  reads `props.sizes` inside `untrack`, which nulls the reactive Owner —
+   *  every one of those freshly-created memos becomes an orphan that never
+   *  disposes and permanently subscribes to the preferences signal
+   *  (Kolu #610 Part 2 root cause). Keeping the ternary inside a hoisted
+   *  `createMemo` makes it a single owned memo, not a per-read factory. */
+  const sizes = createMemo(() =>
+    rightPanel.collapsed()
+      ? [1, 0]
+      : [1 - rightPanel.panelSize(), rightPanel.panelSize()],
+  );
+
   return (
     <Show
       when={!isMobile() && rightPanel.pinned()}
@@ -55,11 +69,7 @@ const RightPanelLayout: Component<{
       <div class="flex-1 min-h-0 min-w-0 flex overflow-hidden">
         <Resizable
           orientation="horizontal"
-          sizes={
-            rightPanel.collapsed()
-              ? [1, 0]
-              : [1 - rightPanel.panelSize(), rightPanel.panelSize()]
-          }
+          sizes={sizes()}
           onSizesChange={(sizes) => {
             if (sizes[1] !== undefined) rightPanel.setPanelSize(sizes[1]);
           }}

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -4,7 +4,7 @@
  *  Used by both TerminalPane (focus mode) and CanvasTile (canvas mode).
  *  Owns sub-panel state internally — callers provide only the shell. */
 
-import { type Component, Show, For } from "solid-js";
+import { type Component, Show, For, createMemo } from "solid-js";
 import Resizable from "@corvu/resizable";
 import type { ITheme } from "@xterm/xterm";
 import Terminal from "./Terminal";
@@ -50,6 +50,16 @@ const TerminalContent: Component<{
     activeSubTab() === subId &&
     focusTarget() === "sub";
 
+  /** Hoisted to avoid Solid's JSX-inline-ternary compiler transform — see
+   *  `RightPanelLayout.tsx` for the full explanation. `@corvu/resizable`
+   *  reads `props.sizes` inside `untrack`, so an inline ternary here leaks
+   *  a fresh memo on every read. */
+  const sizes = createMemo(() =>
+    isExpanded()
+      ? [1 - panelState().panelSize, panelState().panelSize]
+      : [1, 0],
+  );
+
   function handleSizesChange(sizes: number[]) {
     // Persist the bottom panel size when user drags the handle.
     // Ignore tiny values — the Resizable fires onSizesChange with [1, 0]
@@ -73,11 +83,7 @@ const TerminalContent: Component<{
   return (
     <Resizable
       orientation="vertical"
-      sizes={
-        isExpanded()
-          ? [1 - panelState().panelSize, panelState().panelSize]
-          : [1, 0]
-      }
+      sizes={sizes()}
       onSizesChange={handleSizesChange}
       class="flex-1 min-h-0"
     >

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -137,20 +137,29 @@ const TerminalContent: Component<{
         </Show>
         <div class="flex-1 min-h-0">
           <For each={props.subTerminalIds}>
-            {(subId) => (
-              <Terminal
-                terminalId={subId}
-                visible={
-                  props.visible && isExpanded() && activeSubTab() === subId
-                }
-                focused={shouldFocusSub(subId)}
-                theme={props.theme}
-                searchOpen={false}
-                onSearchOpenChange={() => {}}
-                onFocus={handleSubFocus}
-                isSub
-              />
-            )}
+            {(subId) => {
+              // Hoisted createMemo — same rationale as the `sizes` memo
+              // above. Inline `visible={a && b && c}` compiles to a JSX
+              // getter that calls `_$memo(() => expr)()` on every read,
+              // creating a fresh memo per access. `<Terminal>` reads this
+              // from a ResizeObserver callback (no Solid owner), so each
+              // read orphans a memo that never disposes.
+              const visible = createMemo(
+                () => props.visible && isExpanded() && activeSubTab() === subId,
+              );
+              return (
+                <Terminal
+                  terminalId={subId}
+                  visible={visible()}
+                  focused={shouldFocusSub(subId)}
+                  theme={props.theme}
+                  searchOpen={false}
+                  onSearchOpenChange={() => {}}
+                  onFocus={handleSubFocus}
+                  isSub
+                />
+              );
+            }}
           </For>
         </div>
       </Resizable.Panel>


### PR DESCRIPTION
Closes **Part 2** of #610. Ships the Part 2 root cause: mode-toggle memory growth after Part 1 (#607 + #609) was driven by ~50 orphan SolidJS computations per toggle, all tracing to exactly two call sites.

## Root cause

Solid's JSX compiler wraps ternary *conditions* inside prop expressions in a fresh `_$memo(() => cond)()` per-getter-call. The compiled form of:

```tsx
<Resizable sizes={rightPanel.collapsed() ? [1, 0] : [1 - rp.panelSize(), rp.panelSize()]}>
```

is:

```js
get sizes() {
  return _$memo(() => !!rightPanel.collapsed())() ? [1, 0] : [1 - rp.panelSize(), rp.panelSize()];
}
```

`@corvu/resizable` reads `props.sizes` inside `@corvu/utils`'s `controllableSignal`, which wraps the read in `untrack(() => ...)`. `untrack` nulls Solid's reactive `Owner`. Every `_$memo(...)` call under `Owner === null` creates an **ownerless computation** — Solid's dev build warns `"computations created outside a createRoot or render will never be disposed"` on each one. Each orphan subscribes to the signals it transitively reads (preferences → rightPanel.collapsed / .panelSize) and stays in those signals' observers array forever.

## Evidence

Reproduction on headless dev (via chrome-devtools MCP):

1. Restored 4-terminal session, toggled Focus↔Canvas 30×.
2. Read `/proc/[pid]/smaps_rollup` Private-MF: 140 MB → 209 MB (+2.3 MB/toggle, linear).
3. Heap snapshot analysis showed 6000 orphan computations stuck in the terminalIds signal's 6600-entry observers array, all with `owner: null` and `sources: [13 entries]`.
4. Patched SolidJS's `createComputation` to capture the stack when Owner was null. **100%** of per-toggle orphans traced to the `get sizes()` getters in `RightPanelLayout.tsx:58` and `TerminalContent.tsx:76`.

Stack trace excerpt:

```
Error: ORPHAN
  at createComputation
  at createMemo
  at memo (chunk-DKO6X433.js:552 — Solid's dom-expressions memo helper)
  at get sizes (RightPanelLayout.tsx:58)
  at resolveSources
  at Object.value (@corvu/resizable/dist/index.jsx:1182)
  at isControlled (@corvu/utils/controllableSignal.jsx:4)
  at untrack  ← here
```

## Fix

Hoist the ternary into an explicit `createMemo` owned by the component:

```tsx
const sizes = createMemo(() =>
  rightPanel.collapsed()
    ? [1, 0]
    : [1 - rightPanel.panelSize(), rightPanel.panelSize()],
);
<Resizable sizes={sizes()} />
```

The compiler now generates a trivial `get sizes() { return sizes(); }` — no per-read memo creation. `sizes` is a single stable memo that disposes on unmount, releasing its observer entries.

## Measured effect (4 terminals, 40 Focus↔Canvas toggles, forced GC)

| Metric                                             | Before     | After          |
| -------------------------------------------------- | ---------- | -------------- |
| Orphan computations per toggle                     | ~50        | **0**          |
| Private process memory per toggle                  | +2.3 MB    | +0.25 MB       |
| Observers on terminalIds signal (30 toggles)       | 6600       | ~600 (bounded) |
| `Solid warn: computations created outside …` fires | continuous | none           |

Residual ~0.25 MB/toggle is legitimate V8 heap growth + DOM churn.

## Test plan

- [x] `just check`, `just fmt`
- [x] Heap-snapshot reproduction: 0 new orphans per toggle
- [x] Process memory stable under extended toggling (40 toggles → +10 MB only)
- [ ] CI green across all systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Part 3 (62c7d1a) — same root cause, two more sites

After Part 2 deployed (commit b36f6d4), user still observed ~1 GB growth over 10–20 mode toggles with 8 terminals fullscreen on a Mac Studio Display. Mac heap snapshot (297 MB V8) showed **35,985 observers on the terminal-list signal** — a different call site with the same compiler pattern.

**Diagnosis.** Re-applied the "patch `createComputation` to capture `new Error().stack` when `Owner === null`" technique on dev. Two call sites surfaced:

- `packages/client/src/terminal/TerminalContent.tsx:143-145` — `visible={props.visible && isExpanded() && activeSubTab() === subId}` on the sub-`<Terminal>` inside `<For each={props.subTerminalIds}>`. Read from Terminal.tsx's **ResizeObserver callback** (xterm fit) — no Solid owner.
- `packages/client/src/App.tsx:563` — `searchOpen={active() && searchOpen()}` on `<TerminalContent>` in canvas-mode `renderTileBody`. Read from SearchBar's **capture-phase `makeEventListener` keydown handler** — no Solid owner.

Both compile to `get prop() { return _$memo(() => expr)() && … }` — fresh memo per read. On the user's Mac heap the dominant orphan read exactly these signals: terminalIdList ×9, 8 metadata objects, 8 parentId property signals (5 top-level + 3 sub-terminals), sub-panel state ×2, one boolean. That's `hasSubs() && isExpanded()` + `activeSubTab() === subId` resolving through the `subTerminalIds` prop chain.

**Fix.** Same hoisting pattern as `sizes`: wrap each expression in a local `createMemo` inside the render callback, pass `prop={memo()}`.

**Verified.** Same dev repro (`new Error().stack` harness): 25 canvas toggles + search open/close + resize + header toggles + sidebar + right-panel produced **0 orphans** after the fix (previously produced orphans at both sites). Extrapolating to the Mac reproduction: the 35,811-of-35,985-observer pattern matches the sub-`visible` site's fingerprint.
