### PR TITLE
refactor(git): kolu-git owns the resolve+watch compose loop

### DIFF
--- a/packages/integrations/git/README.md
+++ b/packages/integrations/git/README.md
@@ -20,19 +20,21 @@ Functions accept `log?: Logger` (from `anyagent`). Pass a pino child logger in p
 
 ## Modules
 
-| Module         | Exports                                                       | Purpose                                        |
-| -------------- | ------------------------------------------------------------- | ---------------------------------------------- |
-| `schemas.ts`   | `GitInfoSchema`, `GitDiffOutputSchema`, etc.                  | Zod schemas (re-exported by `kolu-common`)     |
-| `resolve.ts`   | `resolveGitInfo`, `watchGitHead`, `gitInfoEqual`, `hasGitDir` | Repo context resolution + `.git/HEAD` watching |
-| `worktree.ts`  | `worktreeCreate`, `worktreeRemove`, `detectDefaultBranch`     | Worktree lifecycle                             |
-| `review.ts`    | `getStatus`, `getDiff`, `parseNameStatus`                     | Diff review (local + branch modes)             |
-| `safe-path.ts` | `resolveUnder`                                                | Path traversal guard                           |
-| `errors.ts`    | `GitError`, `GitResult`, `ok`, `err`                          | Sum-type error types and constructors          |
+| Module         | Exports                                                                           | Purpose                                                                  |
+| -------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `schemas.ts`   | `GitInfoSchema`, `GitDiffOutputSchema`, etc.                                      | Zod schemas (re-exported by `kolu-common`)                               |
+| `resolve.ts`   | `resolveGitInfo`, `watchGitHead`, `gitInfoEqual`, `hasGitDir`, `subscribeGitInfo` | Repo context resolution + `.git/HEAD` watching + combined subscribe loop |
+| `worktree.ts`  | `worktreeCreate`, `worktreeRemove`, `detectDefaultBranch`                         | Worktree lifecycle                                                       |
+| `review.ts`    | `getStatus`, `getDiff`, `parseNameStatus`                                         | Diff review (local + branch modes)                                       |
+| `safe-path.ts` | `resolveUnder`                                                                    | Path traversal guard                                                     |
+| `errors.ts`    | `GitError`, `GitResult`, `ok`, `err`                                              | Sum-type error types and constructors                                    |
 
 ## Server integration
 
-The server keeps a thin provider adapter in `meta/git.ts` that:
+The server's `meta/git.ts` is a thin adapter around `subscribeGitInfo`:
 
-1. Calls `resolveGitInfo()` / `watchGitHead()` from this package
-2. Bridges results into the metadata event system (`updateServerMetadata`, `publishForTerminal`)
-3. Distinguishes `NOT_A_REPO` (expected, debug) from `GIT_FAILED` (unexpected, error)
+1. Calls `subscribeGitInfo(cwd, onChange)` — the integration owns the resolve + `.git/HEAD` watch + re-resolve loop, including dedup via `gitInfoEqual` and `git init` detection (same-cwd `setCwd` on a not-yet-a-repo checks `.git` and re-resolves if it appeared)
+2. On change, bridges results into the metadata event system (`updateServerMetadata`, `publishForTerminal("git", …)`) and tracks the repo in the recents list
+3. On terminal cwd change (via the `cwd:` channel), calls `watcher.setCwd(next)` — the integration swaps the watched directory
+
+`NOT_A_REPO` (expected, debug) is distinguished from `GIT_FAILED` (unexpected, error) inside `subscribeGitInfo` — the callback receives `GitInfo | null` either way, but only real failures are logged at error level.

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -41,6 +41,7 @@ export {
   watchGitHead,
   gitInfoEqual,
   hasGitDir,
+  subscribeGitInfo,
 } from "./resolve.ts";
 
 // Worktree operations

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -168,3 +168,79 @@ export function gitInfoEqual(a: GitInfo | null, b: GitInfo | null): boolean {
     a.worktreePath === b.worktreePath
   );
 }
+
+/**
+ * Subscribe to the GitInfo stream for a cwd. Owns the full resolve + watch
+ * + re-resolve loop: initial resolve, `.git/HEAD` watcher, debounced re-
+ * resolve on HEAD change, dedup via `gitInfoEqual`, and `git init` detection
+ * (a same-cwd `setCwd` call on a not-yet-a-repo checks `.git` existence and
+ * re-resolves if it appeared since the last resolve).
+ *
+ * `onChange` fires once per actual change — never for a dedup miss. Initial
+ * resolve is best-effort: if the cwd isn't a git repo at start, the watcher
+ * sits idle (HEAD watch is a no-op on non-git dirs per `watchGitHead`) until
+ * `setCwd` tells it to re-check.
+ *
+ * Callers are the sole source of truth for current GitInfo — never re-read
+ * the value elsewhere to drive control flow. The returned handle's `stop()`
+ * tears down the HEAD watcher; `setCwd(next)` swaps the watched directory.
+ */
+export function subscribeGitInfo(
+  initialCwd: string,
+  onChange: (info: GitInfo | null) => void,
+  log?: Logger,
+): { setCwd(next: string): void; stop(): void } {
+  let currentCwd = initialCwd;
+  let currentInfo: GitInfo | null = null;
+  let stopHead = watchGitHead(currentCwd, handleHeadChange, log);
+
+  function handleHeadChange(): void {
+    void resolve();
+  }
+
+  async function resolve(): Promise<void> {
+    const result = await resolveGitInfo(currentCwd, log);
+    const next: GitInfo | null = result.ok ? result.value : null;
+    if (!result.ok && result.error.code !== "NOT_A_REPO") {
+      log?.error(
+        { code: result.error.code, cwd: currentCwd },
+        "git resolution failed",
+      );
+    }
+    if (gitInfoEqual(next, currentInfo)) return;
+    // null → non-null: the HEAD watcher started as a no-op (missing `.git`);
+    // restart it so branch switches in the newly-appeared repo propagate.
+    if (currentInfo === null && next !== null) {
+      stopHead();
+      stopHead = watchGitHead(currentCwd, handleHeadChange, log);
+    }
+    currentInfo = next;
+    onChange(next);
+  }
+
+  // Initial resolve — covers repos that exist at subscribe time.
+  void resolve();
+
+  return {
+    setCwd(next: string): void {
+      if (next === currentCwd) {
+        // Same cwd — only act if the repo state might have changed from
+        // outside. Today that's exactly one case: we thought this dir wasn't
+        // a repo and `.git` has since appeared (e.g. `git init`). The HEAD
+        // watcher was a no-op, so there's no other signal that would trigger
+        // a re-resolve on its own.
+        if (currentInfo === null && hasGitDir(next)) {
+          void resolve();
+        }
+        return;
+      }
+      currentCwd = next;
+      stopHead();
+      stopHead = watchGitHead(next, handleHeadChange, log);
+      void resolve();
+    },
+    stop(): void {
+      stopHead();
+    },
+  };
+}

--- a/packages/server/src/meta/git.ts
+++ b/packages/server/src/meta/git.ts
@@ -1,102 +1,53 @@
 /**
- * Git metadata provider — resolves repo/branch info and watches .git/HEAD.
+ * Git metadata provider — thin adapter around `subscribeGitInfo` from
+ * kolu-git. The resolve + HEAD-watch + re-resolve loop lives in the
+ * integration; this file wires the loop into the server's channels:
  *
- * Subscribes to "cwd:<id>" (not the aggregated "metadata" channel).
- * Publishes on "git:<id>" so downstream providers (github) react without cycles.
+ *   cwd:<id>        → watcher.setCwd
+ *   onChange(info)  → trackRecentRepo + updateServerMetadata + publish git:<id>
  *
- * Three triggers:
- * 1. CWD change (via cwd channel) → re-resolves + restarts HEAD watcher
- * 2. .git/HEAD change (via fs.watch) → re-resolves on branch switch/checkout
- * 3. CWD event in a non-git dir where .git now exists → detects `git init`
+ * Downstream providers (github) subscribe to `git:<id>` for branch/repo
+ * deltas without needing to know about cwd-change semantics.
  */
 
-import type { GitInfo } from "kolu-common";
-import {
-  resolveGitInfo,
-  watchGitHead,
-  gitInfoEqual,
-  hasGitDir,
-} from "kolu-git";
+import { subscribeGitInfo } from "kolu-git";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal, publishForTerminal } from "../publisher.ts";
 import { updateServerMetadata } from "./index.ts";
 import { log } from "../log.ts";
 import { trackRecentRepo } from "../activity.ts";
 
-/**
- * Start the git metadata provider for a terminal entry.
- * Subscribes to "cwd" channel, publishes on "git" channel.
- * Resolves git info on CWD change and HEAD change, emits only on value change.
- */
 export function startGitProvider(
   entry: TerminalProcess,
   terminalId: string,
 ): () => void {
   const plog = log.child({ provider: "git", terminal: terminalId });
-  const meta = entry.info.meta;
-  let lastCwd = meta.cwd;
-  let stopHeadWatch = watchGitHead(meta.cwd, handleHeadChange, plog);
+  plog.debug({ cwd: entry.info.meta.cwd }, "started");
 
-  plog.debug({ cwd: lastCwd }, "started");
-
-  // Resolve immediately for initial CWD
-  void resolve(meta.cwd);
-
-  function onCwdChange(newCwd: string) {
-    if (newCwd === lastCwd) {
-      // CWD unchanged — check for `git init` in current dir
-      if (entry.info.meta.git === null && hasGitDir(newCwd)) {
-        void resolve(newCwd);
-      }
-      return;
-    }
-    plog.debug({ from: lastCwd, to: newCwd }, "cwd changed, re-resolving");
-    lastCwd = newCwd;
-    // Restart HEAD watcher for new directory
-    stopHeadWatch();
-    stopHeadWatch = watchGitHead(newCwd, handleHeadChange, plog);
-    void resolve(newCwd);
-  }
-
-  function handleHeadChange() {
-    plog.debug("HEAD changed, re-resolving");
-    void resolve(lastCwd);
-  }
-
-  async function resolve(cwd: string) {
-    const result = await resolveGitInfo(cwd, plog);
-    const git: GitInfo | null = result.ok ? result.value : null;
-    if (!result.ok && result.error.code !== "NOT_A_REPO") {
-      plog.error({ code: result.error.code }, "git resolution failed");
-    }
-    const m = entry.info.meta;
-    if (gitInfoEqual(git, m.git)) return;
-    // Start HEAD watcher when a repo appears (e.g. after `git init`)
-    if (m.git === null && git !== null) {
-      stopHeadWatch();
-      stopHeadWatch = watchGitHead(cwd, handleHeadChange, plog);
-    }
-    // Track repo in persistent recent repos list
-    if (git) trackRecentRepo(git.mainRepoRoot, git.repoName);
-    // Write git only — the pr slot is owned by the github provider, which
-    // subscribes to the `git:` channel below and clears/re-resolves on change.
-    updateServerMetadata(entry, terminalId, (m) => {
-      m.git = git;
-    });
-    plog.debug(
-      { repo: git?.repoName, branch: git?.branch },
-      "git info updated",
-    );
-    // Notify downstream providers (github) via dedicated channel
-    publishForTerminal("git", terminalId, git);
-  }
+  const watcher = subscribeGitInfo(
+    entry.info.meta.cwd,
+    (git) => {
+      if (git) trackRecentRepo(git.mainRepoRoot, git.repoName);
+      updateServerMetadata(entry, terminalId, (m) => {
+        m.git = git;
+      });
+      publishForTerminal("git", terminalId, git);
+      plog.debug(
+        { repo: git?.repoName, branch: git?.branch },
+        "git info updated",
+      );
+    },
+    plog,
+  );
 
   const abort = new AbortController();
-  subscribeForTerminal("cwd", terminalId, abort.signal, onCwdChange);
+  subscribeForTerminal("cwd", terminalId, abort.signal, (cwd) =>
+    watcher.setCwd(cwd),
+  );
 
   return () => {
     abort.abort();
-    stopHeadWatch();
+    watcher.stop();
     plog.debug("stopped");
   };
 }


### PR DESCRIPTION
**The git integration now owns its resolve + `.git/HEAD` watch + re-resolve loop** as a single `subscribeGitInfo(cwd, onChange) => {setCwd, stop}` export from `kolu-git`. The server's `meta/git.ts` shrinks to a thin adapter that wires the `cwd:` channel into `watcher.setCwd` and forwards `onChange` to the metadata publish + `git:` channel fan-out.

This closes the last remaining slice of item 4 in #601 — the companion piece to #603's `AgentProvider` unification. Before this, `kolu-git` exposed pure primitives (`resolveGitInfo`, `watchGitHead`, `hasGitDir`, `gitInfoEqual`) that the server composed by hand into a stateful reconcile loop, while the agent integrations had already been standardized behind a single contract. The compose loop was integration-domain logic leaking into a server adapter.

_`AgentProvider` deliberately stays different from `subscribeGitInfo` — agents have a first-class session-identity axis (replace the watcher when `sessionKey` changes) that git doesn't have, so a unified `ValueWatcher<Deps, Output>` would be false reuse._ A focused Hickey+Lowy review (re-run on the concrete sketch before implementation) both landed on this conclusion.

> **Behavior-preserving.** No schema changes, no user-visible output changes, no e2e-contract changes. The adapter's `onChange` fires exactly when the old server code would have published. `meta/github.ts` is untouched — its `lastBranch`/`lastRepoRoot` dedup uses a narrower equality key than `gitInfoEqual` (branch+repoRoot vs branch+repoRoot+worktreePath), so the cache still earns its keep.

`hasGitDir`-based `git init` detection moves inside `subscribeGitInfo` — the server no longer imports it. All four existing primitives stay exported for tests and future consumers; the extraction is purely additive at the public-API layer.

### Try it locally

```sh
nix run github:juspay/kolu/refactor/git-subscribe-extraction
```