### PR TITLE
fix(xterm): patch IntersectionObserver retention (-367 MB/30 mode-toggles)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-B+bX+aTMJScRbZC55ATPAnL8tJG5QAm6fkkABpTaljY=";
+    hash = "sha256-pdwV7svJnvCSmHd+O/KbXWjCf3oABv6vOLgKX6ttkDc=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
       "yaml": "^2.8.3",
       "defu": "^6.1.5",
       "@anthropic-ai/sdk": "^0.81.0",
-      "@xterm/xterm": "github:juspay/xterm.js#fix/dispose-leaks-built",
-      "@xterm/addon-webgl": "github:juspay/xterm.js#fix/dispose-leaks-built&path:/addons/addon-webgl"
+      "@xterm/xterm": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built",
+      "@xterm/addon-webgl": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl"
     },
     "patchedDependencies": {
       "node-pty@1.1.0": "patches/node-pty@1.1.0.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ overrides:
   yaml: ^2.8.3
   defu: ^6.1.5
   '@anthropic-ai/sdk': ^0.81.0
-  '@xterm/xterm': github:juspay/xterm.js#fix/dispose-leaks-built
-  '@xterm/addon-webgl': github:juspay/xterm.js#fix/dispose-leaks-built&path:/addons/addon-webgl
+  '@xterm/xterm': github:juspay/xterm.js#fix/kolu-xterm-fixes-built
+  '@xterm/addon-webgl': github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
 
 patchedDependencies:
   node-pty@1.1.0:
@@ -89,11 +89,11 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       '@xterm/addon-webgl':
-        specifier: github:juspay/xterm.js#fix/dispose-leaks-built&path:/addons/addon-webgl
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7#path:/addons/addon-webgl
+        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/dispose-leaks-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7
+        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -357,8 +357,8 @@ importers:
   packages/terminal-themes:
     dependencies:
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/dispose-leaks-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7
+        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
     devDependencies:
       typescript:
         specifier: ^5.8.0
@@ -2048,15 +2048,15 @@ packages:
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7#path:/addons/addon-webgl':
-    resolution: {path: /addons/addon-webgl, tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7}
+  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl':
+    resolution: {path: /addons/addon-webgl, tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c}
     version: 0.19.0
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7':
-    resolution: {tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7}
+  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c':
+    resolution: {tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c}
     version: 6.0.0
 
   accepts@2.0.0:
@@ -5853,11 +5853,11 @@ snapshots:
 
   '@xterm/addon-web-links@0.12.0': {}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7#path:/addons/addon-webgl': {}
+  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl': {}
 
   '@xterm/headless@6.0.0': {}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7': {}
+  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c': {}
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the canvas/focus-toggle memory leak that was pushing production pureintent to 1.2 GB Memory Footprint. The leak is upstream in `xterm.js`; this PR bumps the `pnpm.overrides` pointer to a fork branch that stacks one additional fix on top of `fix/dispose-leaks-built`.

**Upstream tracking:** xtermjs/xterm.js#5820 (issue), xtermjs/xterm.js#5821 (PR).

## The leak

`RenderService._registerIntersectionObserver` creates an `IntersectionObserver` whose callback closes over `this` directly. Although `_observerDisposable` calls `observer.disconnect()` on dispose, the retained callback chain keeps `this` (RenderService) alive in practice — along with `_coreService → _bufferService → buffers → BufferLine → Uint32Array` cell data.

Heap-snapshot diff across 30 mount/unmount cycles of 7 `Terminal` instances:

| Class | Δ count | Δ bytes |
|---|---|---|
| `native:system / JSArrayBufferData` | +175,594 | **+220 MB** |
| `object:Uint32Array` | +175,594 | +10 MB |
| `object:ArrayBuffer` | +175,594 | +9 MB |
| `object:BufferLine` | +175,594 | +5 MB |

Every retained `Uint32Array` traced through the same retainer signature: global `IntersectionObserver` registry → callback closure → `RenderService` → service graph → BufferLines. 175,594 = 30 toggles × 7 terminals × ~830 scrollback lines — basically the full buffer of every disposed `Terminal` pinned past `terminal.dispose()`.

The fix wraps `this` in a `WeakRef`. Functional semantics preserved: while RenderService is alive, `deref()` returns it and the handler runs unchanged. Once no strong refs remain, the callback is a no-op and the BufferService graph can GC.

## Ground-truth measurement

Local `kolu@zest` (fresh tab, 30 canvas↔focus toggles, 7 terminals restored from session):

| Metric | Before | After |
|---|---|---|
| Memory Footprint Δ / 30 toggles | **+367 MB** | **−3 MB** |
| JS live Δ | +66 MB | ~0 |
| BufferLine instances retained | +175,594 | ~0 |

Also verified the `fix/dispose-leaks` fix (upstream #5817) still ships — the stacked fork branch contains both.

## Alternatives considered

- **Chase why `disconnect()` isn't releasing the callback.** Could be DevTools instrumentation, a Chrome extension patching `window.IntersectionObserver`, a native registry quirk — unclear, and likely environment-dependent. The WeakRef wrap is defensive and preserves semantics regardless of root cause.
- **Null out `_coreService` / `_bufferService` in `RenderService.dispose()`.** Narrower scope but requires a dispose override. WeakRef is cleaner — no new dispose path, just a smaller capture surface.

## Test plan

- [x] `just check` passes
- [x] Local fresh tab + 30 mode-toggles: Memory Footprint flat (verified via Chrome Task Manager)
- [x] Deploy to `pureintent`, retest footprint delta on production prod-like build
- [ ] Upstream xtermjs/xterm.js#5821 lands → drop fork override for this specific fix in a follow-up

🤖 Diagnosis assisted by [Claude Code](https://claude.com/claude-code)
