### PR TITLE
docs(perf): Chapter 3 + Task-Manager-first diagnosis in perf-diagnose skill

### DIFF
--- a/.claude/skills/perf-diagnose/SKILL.md
+++ b/.claude/skills/perf-diagnose/SKILL.md
@@ -15,6 +15,27 @@ Prior art: [#594](https://github.com/juspay/kolu/pull/594) regressed production 
 
 If you find yourself about to write "probably" / "likely" / "I think", stop. Get the next measurement first. Hypothesis-based PR descriptions are indistinguishable from evidence-based ones three days later, including to yourself.
 
+## Ground truth: Task Manager `Memory Footprint`, not proxies
+
+The ONLY metric that counts as proof of a memory-leak fix is **Chrome Task Manager `Memory Footprint`** on a fresh tab with a reproducible toggle sequence. Everything else is a proxy:
+
+- `performance.memory.usedJSHeapSize` includes uncollected garbage and can drift 3–4× from the live set.
+- `system/Context` / `closure:*` counts in a heap snapshot track SolidJS reactive-scope growth — correlate weakly with footprint. A change can reduce Context growth 89% and move footprint zero. See Chapter 3 in `memory-learnings.md`.
+- `yn._isDisposed` distribution only separates two specific leak shapes; it won't catch native / DOM / GPU retention.
+
+**Before claiming any fix works, run a fresh-tab Task Manager A/B.** Open the tab, note footprint, toggle N times, note footprint. If the Δ didn't drop, the proxy you optimized wasn't the load-bearing retention.
+
+### Quiet-session A/B to isolate legitimate activity
+
+A non-zero footprint Δ isn't automatically a leak. Agent terminals streaming output grow xterm scrollback buffers — that's the program doing its job. Before declaring a new leak:
+
+1. Close or idle all streaming terminals.
+2. Take the baseline on the quiet session.
+3. Run the reproducer.
+4. Compare.
+
+[#618](https://github.com/juspay/kolu/issues/618) was filed on a +69 MB/30-toggles residual after #617. Quiet-session A/B showed 0 MB / 30 toggles — the +69 was all agent stream activity.
+
 ## Prerequisites
 
 A running dev server on `http://localhost:5173` + chrome-devtools MCP. If the dev server isn't running, **ask the user before starting it** (`AskUserQuestion`): "Start `just dev` myself? Required to reproduce memory pathologies with the tracker attached." Don't silently run it — it ties up a terminal.
@@ -30,14 +51,15 @@ A running dev server on `http://localhost:5173` + chrome-devtools MCP. If the de
    - `__kolu.lifecycle()` — `{ mounts, cleanups }` for Terminal.tsx (disposal audit)
 4. **Heap snapshot** via `mcp__chrome-devtools__take_memory_snapshot` to `/tmp/kolu.heapsnapshot`. Chrome forces a major GC before capturing — snapshots reflect the live set.
 
-## Two leak shapes — distinguish these first
+## Three leak shapes — distinguish these first
 
 Before digging into any specific retention chain, figure out which shape you have. They have different fixes.
 
-| Shape                                             | How to tell                                                                                                                                   | Fix pattern                                                                                  |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| **Cleanup doesn't run** (#598 class)              | `__kolu.lifecycle()` shows `mounts - cleanups > live`. Orphan entry's event tape has only `{kind: "create"}` — no `dispose` event ever fires. | Register `onCleanup` synchronously before any `await`; bail with `if (disposed)` post-await. |
-| **Cleanup runs but memory retained** (#606 class) | `lifecycle()` math works. `scripts/check-yn-disposed.mjs` shows all retained `yn` have `_store._isDisposed=true`. `Rn` count > live count.    | Null captured refs in component scope (#607) OR register disposables (#609).                 |
+| Shape                                               | How to tell                                                                                                                                                                                                                                                                                                                                                                                                | Fix pattern                                                                                                                                                                                                                   |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cleanup doesn't run** (#598 class)                | `__kolu.lifecycle()` shows `mounts - cleanups > live`. Orphan entry's event tape has only `{kind: "create"}` — no `dispose` event ever fires.                                                                                                                                                                                                                                                              | Register `onCleanup` synchronously before any `await`; bail with `if (disposed)` post-await.                                                                                                                                  |
+| **Cleanup runs but memory retained** (#606 class)   | `lifecycle()` math works. `scripts/check-yn-disposed.mjs` shows all retained `yn` have `_store._isDisposed=true`. `Rn` count > live count.                                                                                                                                                                                                                                                                 | Null captured refs in component scope (#607) OR register disposables (#609).                                                                                                                                                  |
+| **Callback retained past `dispose()`** (#617 class) | `diff-heap.mjs` shows a large native class (`JSArrayBufferData`, `Uint32Array`, `SVGAnimated*`, etc.) growing. `find-retainers.mjs` traces it through a `Window.<ObserverCtor>` → Map/registry → callback closure → a disposed service object. Happens when the browser's observer registry (or a DevTools/extension wrapper) retains the callback closure past our explicit `observer.disconnect()` call. | Wrap the captured `this` in `WeakRef` inside the callback. `observer.disconnect()` stays as-is; the WeakRef is defensive for when it doesn't fully release. See #617 for the xterm `RenderService.IntersectionObserver` case. |
 
 ## WebGL lifecycle invariants
 
@@ -56,7 +78,7 @@ Violation patterns:
 | Retained `yn._store._isDisposed=true`                                   | Cleanup runs, memory pinned externally. Run `orphan-paths.mjs` to find the pin.                            |
 | `contextlost` with `defaultPrevented: true` time-adjacent to active use | xterm's listener ran before disposal — schedules a 3 s restoration timer.                                  |
 
-## Heap-snapshot analyzers (three durable scripts)
+## Heap-snapshot analyzers (five durable scripts)
 
 `docs/perf-investigations/scripts/`. Run as:
 
@@ -64,11 +86,17 @@ Violation patterns:
 node --max-old-space-size=8192 script.mjs path/to/snapshot.heapsnapshot
 ```
 
-Use in order:
+Use in order — **start with `diff-heap.mjs`**. It runs across a baseline/post pair and names the leaking class in one line; everything after that is a targeted retainer walk on that one class.
 
-1. **`count-rn.mjs`** — instance-count histogram for xterm classes. If counts grossly exceed live terminal count → retention. Fastest first-check.
-2. **`check-yn-disposed.mjs`** — distribution of `yn._store._isDisposed`. This single output tells you which of the two leak shapes you have. If all retained are `true`, cleanup ran and the leak is post-dispose (go to #3). If some are `false`, cleanup didn't run (look for async-onMount race).
-3. **`orphan-paths.mjs`** — BFS from GC roots to every orphaned `Rn`, grouped by path signature. Prints the full retainer chain per path. This is the analyzer that definitively identifies the pin site.
+1. **`diff-heap.mjs baseline.heapsnapshot post.heapsnapshot`** — aggregates `self_size` bytes per class in each snapshot and prints the top classes by byte growth. Sort by bytes, not count: a 220 MB `Uint32Array` leak (#617) drowns any number of 40-byte `Context` churn. First tool to reach for on any retention investigation.
+2. **`find-retainers.mjs snap.heapsnapshot <type> <name>`** — BFS from GC roots to every instance of the target class, groups by retainer-path signature, prints the dominant chain. Call with the class that `diff-heap.mjs` flagged (e.g. `native Uint32Array` or `closure debouncedFit`). This identifies the pin site definitively.
+3. **`count-rn.mjs`** — instance-count histogram for xterm classes (`Rn`, `Dl`, `Qt`, etc.). Useful once you've narrowed the investigation to xterm, as a quick "do the counts look sane for the live terminal count" sanity check.
+4. **`check-yn-disposed.mjs`** — distribution of `yn._store._isDisposed`. Separates "cleanup doesn't run" from "cleanup runs but memory retained" (#598 vs #606). If all retained `yn` are `true`, cleanup ran and the leak is post-dispose.
+5. **`orphan-paths.mjs`** — special-case of `find-retainers.mjs` pre-filtered to orphan `Rn` (disposed-but-retained xterm `Terminal`s). Use when you already know the leak is xterm-shaped.
+
+### Rule of thumb: sort by bytes, follow the heaviest
+
+The dominant byte-growth class is almost always the one retaining everything else through its closure chain. Fixing a small-byte class while the heaviest is still leaking gets you zero footprint improvement. Chapter 3 in `memory-learnings.md` is the full cautionary tale on this.
 
 Minified class names shift between xterm versions (e.g. `Ht` in one build is `CursorBlinkStateManager` in addon-webgl). Verify by outgoing-edge shape:
 
@@ -81,14 +109,17 @@ Minified class names shift between xterm versions (e.g. `Ht` in one build is `Cu
 
 Focus swaps alone rarely leak. What does:
 
-| Scenario                                         | Triggers                                                               |
-| ------------------------------------------------ | ---------------------------------------------------------------------- |
-| **6× Focus↔Canvas mode toggle** with 4 terminals | The canonical Chapter-2 repro. Pre-#607+#609: 24 orphans. Post-fix: 0. |
-| Terminal close (`×` + confirm, or `Ctrl+D`)      | Server removal → `<For>` unmounts the tile → Terminal disposes.        |
-| `Ctrl+Enter` + `Ctrl+D` rapid-fire               | Stresses the `await document.fonts.load` window in onMount.            |
-| 20× `Ctrl+Enter`+`Ctrl+D`                        | Regression test. Pre-#598: ~6 orphans per cycle. Post-#598: 0.         |
+| Scenario                                            | Triggers                                                                                                                                  |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **30× Focus↔Canvas mode toggle** with 6–7 terminals | The canonical Chapter-3 repro. Pre-#617: +220 MB of `Uint32Array` (BufferLines) on native side, +367 MB Memory Footprint. Post-fix: flat. |
+| **6× Focus↔Canvas mode toggle** with 4 terminals    | The canonical Chapter-2 repro. Pre-#607+#609: 24 orphans. Post-fix: 0.                                                                    |
+| Terminal close (`×` + confirm, or `Ctrl+D`)         | Server removal → `<For>` unmounts the tile → Terminal disposes.                                                                           |
+| `Ctrl+Enter` + `Ctrl+D` rapid-fire                  | Stresses the `await document.fonts.load` window in onMount.                                                                               |
+| 20× `Ctrl+Enter`+`Ctrl+D`                           | Regression test. Pre-#598: ~6 orphans per cycle. Post-#598: 0.                                                                            |
 
 Combine over ~1–2 minutes of scripted churn before reading the dialog.
+
+**Always run the repro on a quiet session** (all agent terminals idle, no streaming output) for leak measurements. Active scrollback growth from live agents will inflate the Δ by tens of MB and look indistinguishable from retention. See the quiet-session A/B section above.
 
 ## Interpreting the gap (footprint - JS - GPU)
 
@@ -133,6 +164,10 @@ Once upstream merges + releases, the override collapses to a plain version bump 
 - #605 — per-terminal bufferBytes + aliveCanvases
 - #606 — Chapter 2 tracking issue (mode-toggle retention)
 - #607 — Kolu-side `fitAddon`/`searchAddon` null-out + `window.__kolu` hook
-- #609 — xterm-side patch via `juspay/xterm.js` fork
+- #609 — xterm-side patch via `juspay/xterm.js` fork (CursorBlinkStateManager + \_pausedResizeTask)
 - #610 — master tracking issue for all memory work
-- xtermjs/xterm.js#5817 + #5818 — upstream issue + PR
+- #614 — Chapter 3's wrong turn (closed unmerged); six commits chasing `system/Context` count proxy with no Task Manager effect
+- #617 — Chapter 3's fix: WeakRef in `RenderService`'s IntersectionObserver callback. Production: −81% Memory Footprint growth per 30 toggles.
+- #618 — residual-leak follow-up, closed as "legitimate agent-stream activity" after quiet-session A/B
+- xtermjs/xterm.js#5817 + #5818 — upstream issue + PR for #609
+- xtermjs/xterm.js#5820 + #5821 — upstream issue + PR for #617

--- a/agents/.apm/skills/perf-diagnose/SKILL.md
+++ b/agents/.apm/skills/perf-diagnose/SKILL.md
@@ -15,6 +15,27 @@ Prior art: [#594](https://github.com/juspay/kolu/pull/594) regressed production 
 
 If you find yourself about to write "probably" / "likely" / "I think", stop. Get the next measurement first. Hypothesis-based PR descriptions are indistinguishable from evidence-based ones three days later, including to yourself.
 
+## Ground truth: Task Manager `Memory Footprint`, not proxies
+
+The ONLY metric that counts as proof of a memory-leak fix is **Chrome Task Manager `Memory Footprint`** on a fresh tab with a reproducible toggle sequence. Everything else is a proxy:
+
+- `performance.memory.usedJSHeapSize` includes uncollected garbage and can drift 3–4× from the live set.
+- `system/Context` / `closure:*` counts in a heap snapshot track SolidJS reactive-scope growth — correlate weakly with footprint. A change can reduce Context growth 89% and move footprint zero. See Chapter 3 in `memory-learnings.md`.
+- `yn._isDisposed` distribution only separates two specific leak shapes; it won't catch native / DOM / GPU retention.
+
+**Before claiming any fix works, run a fresh-tab Task Manager A/B.** Open the tab, note footprint, toggle N times, note footprint. If the Δ didn't drop, the proxy you optimized wasn't the load-bearing retention.
+
+### Quiet-session A/B to isolate legitimate activity
+
+A non-zero footprint Δ isn't automatically a leak. Agent terminals streaming output grow xterm scrollback buffers — that's the program doing its job. Before declaring a new leak:
+
+1. Close or idle all streaming terminals.
+2. Take the baseline on the quiet session.
+3. Run the reproducer.
+4. Compare.
+
+[#618](https://github.com/juspay/kolu/issues/618) was filed on a +69 MB/30-toggles residual after #617. Quiet-session A/B showed 0 MB / 30 toggles — the +69 was all agent stream activity.
+
 ## Prerequisites
 
 A running dev server on `http://localhost:5173` + chrome-devtools MCP. If the dev server isn't running, **ask the user before starting it** (`AskUserQuestion`): "Start `just dev` myself? Required to reproduce memory pathologies with the tracker attached." Don't silently run it — it ties up a terminal.
@@ -30,14 +51,15 @@ A running dev server on `http://localhost:5173` + chrome-devtools MCP. If the de
    - `__kolu.lifecycle()` — `{ mounts, cleanups }` for Terminal.tsx (disposal audit)
 4. **Heap snapshot** via `mcp__chrome-devtools__take_memory_snapshot` to `/tmp/kolu.heapsnapshot`. Chrome forces a major GC before capturing — snapshots reflect the live set.
 
-## Two leak shapes — distinguish these first
+## Three leak shapes — distinguish these first
 
 Before digging into any specific retention chain, figure out which shape you have. They have different fixes.
 
-| Shape                                             | How to tell                                                                                                                                   | Fix pattern                                                                                  |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| **Cleanup doesn't run** (#598 class)              | `__kolu.lifecycle()` shows `mounts - cleanups > live`. Orphan entry's event tape has only `{kind: "create"}` — no `dispose` event ever fires. | Register `onCleanup` synchronously before any `await`; bail with `if (disposed)` post-await. |
-| **Cleanup runs but memory retained** (#606 class) | `lifecycle()` math works. `scripts/check-yn-disposed.mjs` shows all retained `yn` have `_store._isDisposed=true`. `Rn` count > live count.    | Null captured refs in component scope (#607) OR register disposables (#609).                 |
+| Shape                                               | How to tell                                                                                                                                                                                                                                                                                                                                                                                                | Fix pattern                                                                                                                                                                                                                   |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cleanup doesn't run** (#598 class)                | `__kolu.lifecycle()` shows `mounts - cleanups > live`. Orphan entry's event tape has only `{kind: "create"}` — no `dispose` event ever fires.                                                                                                                                                                                                                                                              | Register `onCleanup` synchronously before any `await`; bail with `if (disposed)` post-await.                                                                                                                                  |
+| **Cleanup runs but memory retained** (#606 class)   | `lifecycle()` math works. `scripts/check-yn-disposed.mjs` shows all retained `yn` have `_store._isDisposed=true`. `Rn` count > live count.                                                                                                                                                                                                                                                                 | Null captured refs in component scope (#607) OR register disposables (#609).                                                                                                                                                  |
+| **Callback retained past `dispose()`** (#617 class) | `diff-heap.mjs` shows a large native class (`JSArrayBufferData`, `Uint32Array`, `SVGAnimated*`, etc.) growing. `find-retainers.mjs` traces it through a `Window.<ObserverCtor>` → Map/registry → callback closure → a disposed service object. Happens when the browser's observer registry (or a DevTools/extension wrapper) retains the callback closure past our explicit `observer.disconnect()` call. | Wrap the captured `this` in `WeakRef` inside the callback. `observer.disconnect()` stays as-is; the WeakRef is defensive for when it doesn't fully release. See #617 for the xterm `RenderService.IntersectionObserver` case. |
 
 ## WebGL lifecycle invariants
 
@@ -56,7 +78,7 @@ Violation patterns:
 | Retained `yn._store._isDisposed=true`                                   | Cleanup runs, memory pinned externally. Run `orphan-paths.mjs` to find the pin.                            |
 | `contextlost` with `defaultPrevented: true` time-adjacent to active use | xterm's listener ran before disposal — schedules a 3 s restoration timer.                                  |
 
-## Heap-snapshot analyzers (three durable scripts)
+## Heap-snapshot analyzers (five durable scripts)
 
 `docs/perf-investigations/scripts/`. Run as:
 
@@ -64,11 +86,17 @@ Violation patterns:
 node --max-old-space-size=8192 script.mjs path/to/snapshot.heapsnapshot
 ```
 
-Use in order:
+Use in order — **start with `diff-heap.mjs`**. It runs across a baseline/post pair and names the leaking class in one line; everything after that is a targeted retainer walk on that one class.
 
-1. **`count-rn.mjs`** — instance-count histogram for xterm classes. If counts grossly exceed live terminal count → retention. Fastest first-check.
-2. **`check-yn-disposed.mjs`** — distribution of `yn._store._isDisposed`. This single output tells you which of the two leak shapes you have. If all retained are `true`, cleanup ran and the leak is post-dispose (go to #3). If some are `false`, cleanup didn't run (look for async-onMount race).
-3. **`orphan-paths.mjs`** — BFS from GC roots to every orphaned `Rn`, grouped by path signature. Prints the full retainer chain per path. This is the analyzer that definitively identifies the pin site.
+1. **`diff-heap.mjs baseline.heapsnapshot post.heapsnapshot`** — aggregates `self_size` bytes per class in each snapshot and prints the top classes by byte growth. Sort by bytes, not count: a 220 MB `Uint32Array` leak (#617) drowns any number of 40-byte `Context` churn. First tool to reach for on any retention investigation.
+2. **`find-retainers.mjs snap.heapsnapshot <type> <name>`** — BFS from GC roots to every instance of the target class, groups by retainer-path signature, prints the dominant chain. Call with the class that `diff-heap.mjs` flagged (e.g. `native Uint32Array` or `closure debouncedFit`). This identifies the pin site definitively.
+3. **`count-rn.mjs`** — instance-count histogram for xterm classes (`Rn`, `Dl`, `Qt`, etc.). Useful once you've narrowed the investigation to xterm, as a quick "do the counts look sane for the live terminal count" sanity check.
+4. **`check-yn-disposed.mjs`** — distribution of `yn._store._isDisposed`. Separates "cleanup doesn't run" from "cleanup runs but memory retained" (#598 vs #606). If all retained `yn` are `true`, cleanup ran and the leak is post-dispose.
+5. **`orphan-paths.mjs`** — special-case of `find-retainers.mjs` pre-filtered to orphan `Rn` (disposed-but-retained xterm `Terminal`s). Use when you already know the leak is xterm-shaped.
+
+### Rule of thumb: sort by bytes, follow the heaviest
+
+The dominant byte-growth class is almost always the one retaining everything else through its closure chain. Fixing a small-byte class while the heaviest is still leaking gets you zero footprint improvement. Chapter 3 in `memory-learnings.md` is the full cautionary tale on this.
 
 Minified class names shift between xterm versions (e.g. `Ht` in one build is `CursorBlinkStateManager` in addon-webgl). Verify by outgoing-edge shape:
 
@@ -81,14 +109,17 @@ Minified class names shift between xterm versions (e.g. `Ht` in one build is `Cu
 
 Focus swaps alone rarely leak. What does:
 
-| Scenario                                         | Triggers                                                               |
-| ------------------------------------------------ | ---------------------------------------------------------------------- |
-| **6× Focus↔Canvas mode toggle** with 4 terminals | The canonical Chapter-2 repro. Pre-#607+#609: 24 orphans. Post-fix: 0. |
-| Terminal close (`×` + confirm, or `Ctrl+D`)      | Server removal → `<For>` unmounts the tile → Terminal disposes.        |
-| `Ctrl+Enter` + `Ctrl+D` rapid-fire               | Stresses the `await document.fonts.load` window in onMount.            |
-| 20× `Ctrl+Enter`+`Ctrl+D`                        | Regression test. Pre-#598: ~6 orphans per cycle. Post-#598: 0.         |
+| Scenario                                            | Triggers                                                                                                                                  |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **30× Focus↔Canvas mode toggle** with 6–7 terminals | The canonical Chapter-3 repro. Pre-#617: +220 MB of `Uint32Array` (BufferLines) on native side, +367 MB Memory Footprint. Post-fix: flat. |
+| **6× Focus↔Canvas mode toggle** with 4 terminals    | The canonical Chapter-2 repro. Pre-#607+#609: 24 orphans. Post-fix: 0.                                                                    |
+| Terminal close (`×` + confirm, or `Ctrl+D`)         | Server removal → `<For>` unmounts the tile → Terminal disposes.                                                                           |
+| `Ctrl+Enter` + `Ctrl+D` rapid-fire                  | Stresses the `await document.fonts.load` window in onMount.                                                                               |
+| 20× `Ctrl+Enter`+`Ctrl+D`                           | Regression test. Pre-#598: ~6 orphans per cycle. Post-#598: 0.                                                                            |
 
 Combine over ~1–2 minutes of scripted churn before reading the dialog.
+
+**Always run the repro on a quiet session** (all agent terminals idle, no streaming output) for leak measurements. Active scrollback growth from live agents will inflate the Δ by tens of MB and look indistinguishable from retention. See the quiet-session A/B section above.
 
 ## Interpreting the gap (footprint - JS - GPU)
 
@@ -133,6 +164,10 @@ Once upstream merges + releases, the override collapses to a plain version bump 
 - #605 — per-terminal bufferBytes + aliveCanvases
 - #606 — Chapter 2 tracking issue (mode-toggle retention)
 - #607 — Kolu-side `fitAddon`/`searchAddon` null-out + `window.__kolu` hook
-- #609 — xterm-side patch via `juspay/xterm.js` fork
+- #609 — xterm-side patch via `juspay/xterm.js` fork (CursorBlinkStateManager + \_pausedResizeTask)
 - #610 — master tracking issue for all memory work
-- xtermjs/xterm.js#5817 + #5818 — upstream issue + PR
+- #614 — Chapter 3's wrong turn (closed unmerged); six commits chasing `system/Context` count proxy with no Task Manager effect
+- #617 — Chapter 3's fix: WeakRef in `RenderService`'s IntersectionObserver callback. Production: −81% Memory Footprint growth per 30 toggles.
+- #618 — residual-leak follow-up, closed as "legitimate agent-stream activity" after quiet-session A/B
+- xtermjs/xterm.js#5817 + #5818 — upstream issue + PR for #609
+- xtermjs/xterm.js#5820 + #5821 — upstream issue + PR for #617

--- a/docs/perf-investigations/memory-learnings.md
+++ b/docs/perf-investigations/memory-learnings.md
@@ -294,13 +294,182 @@ Catalogued under "Async-initialization cleanup registration" in
 
 ---
 
+## Chapter 3 — [#617](https://github.com/juspay/kolu/pull/617): the leak that wasn't in any `Context`
+
+Post-#609 production still grew ~1 GB/hour. WebGL ledger was clean.
+Heap snapshots showed lots of SolidJS `system/Context` objects accumulating
+across canvas↔focus mode toggles — looked like the residual disposal
+retention Chapter 2 didn't catch. The fix turned out to be one WeakRef
+in xterm.js core. Everything in between was a three-day false trail.
+
+### The wrong turn — [#614](https://github.com/juspay/kolu/pull/614) (closed without merge)
+
+Symptom was +55 MB `usedJSHeapSize` per 30 canvas↔focus toggles on
+dev. I ran `orphan-paths.mjs`-style retainer walks from a dev heap
+snapshot, kept finding `system/Context` growth traced to inline JSX
+handlers (`$$click`, `$$pointerdown`) sharing V8 Contexts with
+component locals. Six incremental commits landed on the branch:
+
+| Commit    | Intervention                                               | Context Δ / 30 toggles |
+| --------- | ---------------------------------------------------------- | ---------------------- |
+| `ed28a5a` | Terminal container `onClick` moved to module-level handler | +11,025 → —            |
+| `83a2b40` | `@corvu/resizable` → 140-line custom `Splitter`            | +11,025 → +4,896       |
+| `cf2de56` | CanvasTile resize handles → delegation                     | +4,896 → +3,462        |
+| `ae015da` | SubPanelTabBar inline handlers → delegation                | +3,462 → +2,308        |
+| `c71bca5` | `@thisbeyond/solid-dnd` → 70-line `createDrag`             | +2,308 → +1,651        |
+| `16c3c50` | CanvasTile pure render, all events delegated to parent     | +1,651 → +1,208        |
+
+Cumulative: `system/Context` growth down 89%. `closure:native_bind`
+out of the top-25. Looked like a clear staircase of wins.
+
+Deploy to production. Chrome Task Manager Memory Footprint: **unchanged**.
++367 MB / 30 toggles on a fresh `pureintent` tab, essentially the same
+as before the first commit. The whole refactoring was a proxy chase —
+none of the six commits moved the metric that mattered.
+
+### The right turn — byte-delta heap diff, not Context count
+
+Started over with a clean master + a fresh production heap-snapshot
+pair (before / after 30 toggles). First call wasn't `count-rn.mjs` or
+`orphan-paths.mjs` — it was `diff-heap.mjs`, aggregated by **self-size
+bytes**, not count. One line of output:
+
+```
+Δcount = 175,594   Δbytes = 220,963,752 (220 MB)   native:system / JSArrayBufferData
+Δcount = 175,594   Δbytes =  10,535,640            object:Uint32Array
+Δcount = 175,594   Δbytes =   9,130,888            object:ArrayBuffer
+Δcount = 175,594   Δbytes =   5,619,008            object:Z1     ← xterm BufferLine
+```
+
+175,594 `Uint32Array` over 30 toggles = 30 × 7 terminals × ~830 lines
+per terminal. Basically every disposed xterm `Terminal`'s full
+scrollback was being held past `terminal.dispose()`. At 1.3 KB per
+BufferLine this was the entire +367 MB right there.
+
+`find-retainers.mjs` on the target `Uint32Array` class — every single
+instance traced through the same chain:
+
+```
+Window.IntersectionObserver (registry)
+  → callback closure
+  → Context → RenderService (minified ep)
+  → _coreService → _bufferService
+  → buffers._normal.lines._array
+  → BufferLine → Uint32Array
+```
+
+[xterm core's `RenderService`](https://github.com/xtermjs/xterm.js/blob/master/src/browser/services/RenderService.ts)
+wires an `IntersectionObserver` to pause rendering when the terminal
+is off-screen. The callback `e => this._handleIntersectionChange(...)`
+closes over `this`. `_observerDisposable.value = toDisposable(() =>
+observer.disconnect())` and `_observerDisposable` is `_register`'d —
+so on `RenderService.dispose()` the disposable chain should call
+`disconnect()` and the whole thing should GC.
+
+In practice the callback closure lived past `disconnect()`. Unclear
+exactly why — possibly a DevTools Recorder or extension patching
+`window.IntersectionObserver` with a polling Map wrapper; possibly a
+Chromium native-registry quirk; possibly something else entirely.
+Whatever held onto the callback kept `this` (RenderService) reachable,
+which kept the whole service graph alive.
+
+### The fix
+
+Wrap `this` in a `WeakRef` so the callback holds only a weak
+reference ([xtermjs/xterm.js#5820](https://github.com/xtermjs/xterm.js/issues/5820),
+[PR #5821](https://github.com/xtermjs/xterm.js/pull/5821)):
+
+```diff
+ private _registerIntersectionObserver(w, screenElement): void {
+   if ('IntersectionObserver' in w) {
+-    const observer = new w.IntersectionObserver(
+-      e => this._handleIntersectionChange(e[e.length - 1]),
+-      { threshold: 0 }
+-    );
++    const weakSelf = new WeakRef(this);
++    const observer = new w.IntersectionObserver(
++      e => weakSelf.deref()?._handleIntersectionChange(e[e.length - 1]),
++      { threshold: 0 }
++    );
+     observer.observe(screenElement);
+     this._observerDisposable.value = toDisposable(() => observer.disconnect());
+   }
+ }
+```
+
+While RenderService has live strong refs (which it does for any open
+Terminal), `deref()` returns it and the handler runs. Once no strong
+refs remain, the callback is a no-op and the BufferService graph is
+free to GC — which is what the explicit `disconnect()` was supposed
+to guarantee but doesn't in practice.
+
+Delivered downstream via the juspay/xterm.js fork pattern from #609,
+stacked on top of `fix/dispose-leaks` as
+`fix/kolu-xterm-fixes-built`. Kolu's `pnpm.overrides` points at the
+combined branch until the upstream WeakRef PR lands.
+
+### Post-fix numbers
+
+Production `pureintent`, fresh tab, 7 terminals restored from session:
+
+| Metric                          | Pre-#617    | Post-#617  |
+| ------------------------------- | ----------- | ---------- |
+| Memory Footprint Δ / 30 toggles | **+367 MB** | **+69 MB** |
+| `BufferLine` instances retained | +175,594    | ~0         |
+
+The residual +69 MB was isolated to legitimate activity (agents
+streaming output during the measurement window) via a quiet-session
+A/B on [#618](https://github.com/juspay/kolu/issues/618): on a
+fully-idle session, Task Manager is completely flat across 30
+toggles.
+
+### Lessons (the reason this chapter exists)
+
+The whole #614 branch was the cautionary tale. Five things worth
+internalising:
+
+1. **Chrome Task Manager `Memory Footprint` is the ground truth.
+   `system/Context` count, `closure` count, `performance.memory.
+usedJSHeapSize` — these are all proxies.** Proxies can diverge
+   from the truth by a factor of 100× or more: #614 reduced Contexts
+   by 89% with zero effect on Footprint. Never claim a fix works
+   until a fresh-tab Task Manager A/B confirms it.
+
+2. **Start with `diff-heap.mjs` sorted by `dBytes`, not by count.**
+   The class that leaks `N` instances of a 1.3 KB object drowns out
+   the class that leaks 1000 instances of a 40-byte Context. Count
+   histograms (`count-rn.mjs`) are useful once you already know which
+   class matters; they're a bad first look.
+
+3. **Native-side classes (`JSArrayBufferData`, `Uint32Array`, SVG\*,
+   HTMLElement) hide from `performance.memory` but show up in Task
+   Manager.** If the retainer chain ends at a native class, the
+   proxies won't tell you.
+
+4. **Quiet-session A/B to isolate leaks from legitimate activity.**
+   On kolu, agent terminals streaming output continuously grow
+   scrollback — that's not a leak, that's the program doing its job.
+   A +69 MB / 30-toggle measurement on an active session looked like
+   remaining retention; with agents idle it dropped to flat. Always
+   take the baseline on a quiet session.
+
+5. **`disconnect()` / `dispose()` aren't always enough.** Callbacks
+   registered with `IntersectionObserver`, `MutationObserver`,
+   `ResizeObserver`, `EventTarget.addEventListener`, etc., can be
+   retained past their explicit teardown by something you don't
+   control — DevTools instrumentation, extensions, native registries.
+   For callbacks that close over heavy state, wrap `this` in `WeakRef`
+   defensively. Function behaviour is preserved; retention is not.
+
+---
+
 ## Part 2 — next chapter (after #609 deploy)
 
 Production data from the #607-only build showed footprint still
 climbing ~1 GB/hour with the WebGL ledger clean (`aliveDetached: 0,
-gced: 99/99`). Remaining growth is not a disposal-leak signature —
-it's V8 heap retention + native backing stores + possibly xterm glyph
-atlas accumulation. Tracked in [#610](https://github.com/juspay/kolu/issues/610).
+gced: 99/99`). **Resolved by #617** — the remaining growth was the
+xterm IntersectionObserver retention described in Chapter 3. Tracked
+in [#610](https://github.com/juspay/kolu/issues/610).
 
 ---
 

--- a/docs/perf-investigations/scripts/diff-heap.mjs
+++ b/docs/perf-investigations/scripts/diff-heap.mjs
@@ -1,0 +1,84 @@
+// Diff two heap snapshots by class-name self-size aggregate.
+// Prints the top classes that GREW the most in bytes / in count between
+// `baseline` and `post`. Use it as the first step in any retention
+// investigation — one line of output usually names the culprit class.
+//
+// Usage:
+//   node --max-old-space-size=8192 diff-heap.mjs baseline.heapsnapshot post.heapsnapshot
+//
+// Chapter 3 (#614) was driven almost entirely by this diff + the retainer
+// walk in `find-retainers.mjs`. Classes to watch after a 30× canvas↔focus
+// toggle repro on a clean build:
+//
+//   system/Context      — SolidJS reactive-scope records (per-Computation)
+//   closure:*           — generic closures; native_bind is often a
+//                         Computation's .fn in disguise
+//   native:SVGAnimated* — sparkline / ActivityGraph bytes
+//   native:SVGRectElement / SVGPathElement — same
+//   object:Object       — component props objects, store records
+//
+// Count growth rarely points to the leak alone — pair it with
+// `find-retainers.mjs` to walk the retainer chain and identify the pin
+// site (e.g. a `$$click` on a `data-tile-id` div).
+
+import fs from "node:fs";
+
+function load(path) {
+  const snap = JSON.parse(fs.readFileSync(path, "utf8"));
+  const m = snap.snapshot.meta;
+  const NF = m.node_fields.length;
+  const nTypes = m.node_types[0];
+  const NODES = snap.nodes,
+    STR = snap.strings;
+  const N = NODES.length / NF;
+  const typeI = m.node_fields.indexOf("type"),
+    nameI = m.node_fields.indexOf("name"),
+    sizeI = m.node_fields.indexOf("self_size");
+  const byKey = new Map(); // key = "type:name" -> { count, bytes }
+  for (let i = 0; i < N; i++) {
+    const type = nTypes[NODES[i * NF + typeI]];
+    const name = STR[NODES[i * NF + nameI]] || "";
+    const size = NODES[i * NF + sizeI];
+    const key = `${type}:${name}`;
+    const e = byKey.get(key) || { count: 0, bytes: 0 };
+    e.count++;
+    e.bytes += size;
+    byKey.set(key, e);
+  }
+  return byKey;
+}
+
+const A = load(process.argv[2]);
+const B = load(process.argv[3]);
+const keys = new Set([...A.keys(), ...B.keys()]);
+const rows = [];
+for (const k of keys) {
+  const a = A.get(k) || { count: 0, bytes: 0 };
+  const b = B.get(k) || { count: 0, bytes: 0 };
+  rows.push({
+    key: k,
+    aCount: a.count,
+    bCount: b.count,
+    dCount: b.count - a.count,
+    aBytes: a.bytes,
+    bBytes: b.bytes,
+    dBytes: b.bytes - a.bytes,
+  });
+}
+rows.sort((x, y) => y.dBytes - x.dBytes);
+console.log("Top 25 classes by byte growth:");
+console.log("  dBytes        dCount   aCount→bCount   key");
+for (const r of rows.slice(0, 25)) {
+  if (r.dBytes <= 0) break;
+  console.log(
+    `  ${String(r.dBytes).padStart(10)}  ${String(r.dCount).padStart(7)}   ${String(r.aCount).padStart(6)} → ${String(r.bCount).padStart(6)}   ${r.key}`,
+  );
+}
+console.log("\nTop 10 classes by COUNT growth (>=50 new instances):");
+rows.sort((x, y) => y.dCount - x.dCount);
+for (const r of rows.slice(0, 20)) {
+  if (r.dCount < 50) break;
+  console.log(
+    `  Δcount=${String(r.dCount).padStart(6)}   Δbytes=${String(r.dBytes).padStart(10)}   ${r.aCount} → ${r.bCount}   ${r.key}`,
+  );
+}

--- a/docs/perf-investigations/scripts/find-retainers.mjs
+++ b/docs/perf-investigations/scripts/find-retainers.mjs
@@ -1,0 +1,176 @@
+// Walk GC-root-to-target retainer paths for a heap-snapshot target class
+// or node-name. Groups results by tail-of-path signature and prints one
+// sample chain per signature, sorted by count — so the dominant retention
+// shape is the first output.
+//
+// Usage:
+//   node --max-old-space-size=8192 find-retainers.mjs snap.heapsnapshot <type> <name>
+//
+// Common invocations:
+//   find-retainers.mjs snap.heapsnapshot native SVGRectElement
+//   find-retainers.mjs snap.heapsnapshot closure debouncedFit
+//   find-retainers.mjs snap.heapsnapshot object 'system / Context'
+//
+// Pair with `diff-heap.mjs` — that script points at the growing class,
+// this one tells you what's holding onto it.
+//
+// Chapter 3 (#614) pattern to recognize in output:
+//
+//   ... → Object.getMetadata → native_bind → Object { observers: Array }
+//   → Array[N] → Object { fn } → closure → Context chain
+//   → <div data-tile-id=...> → ... → SVG etc
+//
+// That "native_bind → observers Array" signature means a SolidJS
+// signal's subscriber list has accumulated unremoved observers — a
+// Computation that should have disposed didn't. Walk up from `<div
+// data-tile-id>` to find the inline handler (`$$click`, `$$pointerdown`,
+// etc.) whose closure Context is the actual pin.
+
+import fs from "node:fs";
+
+if (process.argv.length < 5) {
+  console.error("Usage: find-retainers.mjs <snap> <targetType> <targetName>");
+  process.exit(1);
+}
+const [, , SNAP_PATH, TARGET_TYPE, TARGET_NAME] = process.argv;
+
+const snap = JSON.parse(fs.readFileSync(SNAP_PATH, "utf8"));
+const m = snap.snapshot.meta;
+const NF = m.node_fields.length,
+  EF = m.edge_fields.length;
+const nTypes = m.node_types[0],
+  eTypes = m.edge_types[0];
+const NODES = snap.nodes,
+  EDGES = snap.edges,
+  STR = snap.strings;
+const N = NODES.length / NF;
+const typeI = m.node_fields.indexOf("type"),
+  nameI = m.node_fields.indexOf("name");
+const idI = m.node_fields.indexOf("id"),
+  sizeI = m.node_fields.indexOf("self_size");
+const ecI = m.node_fields.indexOf("edge_count");
+const etI = m.edge_fields.indexOf("type"),
+  enI = m.edge_fields.indexOf("name_or_index"),
+  toI = m.edge_fields.indexOf("to_node");
+
+const off = new Uint32Array(N + 1);
+{
+  let o = 0;
+  for (let i = 0; i < N; i++) {
+    off[i] = o;
+    o += NODES[i * NF + ecI];
+  }
+  off[N] = o;
+}
+function desc(i) {
+  return {
+    i,
+    id: NODES[i * NF + idI],
+    size: NODES[i * NF + sizeI],
+    type: nTypes[NODES[i * NF + typeI]],
+    name: STR[NODES[i * NF + nameI]],
+  };
+}
+function edgeLabel(et, en) {
+  return et === "property" ||
+    et === "internal" ||
+    et === "shortcut" ||
+    et === "weak"
+    ? `${et}:${STR[en]}`
+    : `${et}:[${en}]`;
+}
+
+// BFS from root (node 0), non-weak edges only.
+const dist = new Int32Array(N).fill(-1);
+const predNode = new Int32Array(N).fill(-1);
+const predEdge = new Int32Array(N).fill(-1);
+dist[0] = 0;
+let queue = [0];
+while (queue.length) {
+  const nxt = [];
+  for (const from of queue) {
+    const start = off[from],
+      cnt = NODES[from * NF + ecI];
+    for (let k = 0; k < cnt; k++) {
+      const eIdx = start + k;
+      const et = eTypes[EDGES[eIdx * EF + etI]];
+      if (et === "weak") continue;
+      const to = EDGES[eIdx * EF + toI] / NF;
+      if (to < 0 || to >= N || dist[to] >= 0) continue;
+      dist[to] = dist[from] + 1;
+      predNode[to] = from;
+      predEdge[to] = eIdx;
+      nxt.push(to);
+    }
+  }
+  queue = nxt;
+}
+
+// Find target instances.
+const targets = [];
+for (let i = 0; i < N; i++) {
+  if (
+    nTypes[NODES[i * NF + typeI]] === TARGET_TYPE &&
+    STR[NODES[i * NF + nameI]] === TARGET_NAME
+  ) {
+    targets.push(i);
+  }
+}
+console.log(`${TARGET_TYPE}:${TARGET_NAME} count: ${targets.length}`);
+
+function pathOf(i) {
+  const steps = [];
+  let cur = i;
+  while (predNode[cur] >= 0) {
+    const eIdx = predEdge[cur],
+      from = predNode[cur];
+    const et = eTypes[EDGES[eIdx * EF + etI]],
+      en = EDGES[eIdx * EF + enI];
+    steps.unshift({
+      from,
+      to: cur,
+      label: edgeLabel(et, en),
+      fromDesc: desc(from),
+    });
+    cur = from;
+  }
+  return steps;
+}
+
+function isInteresting(d) {
+  if (d.type === "synthetic" && !d.name) return false;
+  if (d.type === "hidden") return false;
+  if (d.type === "code") return false;
+  if (d.name === "system / Context") return false;
+  if (d.name === "system / Map") return false;
+  if (d.name === "system / PropertyArray") return false;
+  return true;
+}
+
+// Group by tail-of-path signature (last 8 interesting hops).
+const byPath = new Map();
+for (const t of targets) {
+  const steps = pathOf(t);
+  const sig = steps
+    .filter((s) => isInteresting(s.fromDesc))
+    .slice(-8)
+    .map((s) => `${s.fromDesc.type}:${s.fromDesc.name}|${s.label}`)
+    .join(" → ");
+  if (!byPath.has(sig)) byPath.set(sig, []);
+  byPath.get(sig).push(t);
+}
+
+console.log(`Distinct path signatures: ${byPath.size}\n`);
+const sorted = [...byPath.entries()].sort((a, b) => b[1].length - a[1].length);
+for (const [_sig, members] of sorted.slice(0, 5)) {
+  console.log(`\n=== ${members.length}× ${TARGET_NAME} ===`);
+  const steps = pathOf(members[0]);
+  console.log(`Sample (id=${desc(members[0]).id}):`);
+  for (let j = 0; j < Math.min(steps.length, 30); j++) {
+    const s = steps[j];
+    const toDesc = desc(s.to);
+    console.log(
+      `  [${j}] ${s.fromDesc.type}:${s.fromDesc.name}  --${s.label}-->  ${toDesc.type}:${toDesc.name}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Documents the Chapter 3 investigation so future agents don't burn three days chasing proxy metrics the way we did.

**Source of truth edits** (regenerated into `.claude/` via `just ai::apm`):

- `docs/perf-investigations/memory-learnings.md` — new Chapter 3 section covering #614 (closed without merge, the false trail) and #617 (the one-line WeakRef that actually moved Task Manager Memory Footprint by −81%).
- `agents/.apm/skills/perf-diagnose/SKILL.md` — runbook additions:
  - New "Ground truth: Task Manager Memory Footprint, not proxies" rule at the top. `performance.memory`, `system/Context` count, and `closure:*` count are all proxies — they can drift 100× from Task Manager and mislead you into declaring a fix that does nothing.
  - New "Quiet-session A/B" step. Active agent terminals grow scrollback buffers legitimately; a busy-session measurement looks indistinguishable from retention.
  - New **third** leak shape: "Callback retained past `dispose()`". When a `Window.<Observer>` native registry (or a DevTools extension wrapping it) holds the callback closure past the explicit `observer.disconnect()`, the callback keeps `this` (and its whole service graph) reachable. Fix pattern: wrap `this` in `WeakRef` inside the callback.
  - Promoted `diff-heap.mjs` + `find-retainers.mjs` to the top of the analyzer list with "start here" language. Sort heap diffs by **bytes**, not count — a 220 MB `Uint32Array` leak drowns any number of 40-byte Context churn.

**New committed tooling** (had been sitting untracked):

- `docs/perf-investigations/scripts/diff-heap.mjs` — per-class byte-delta between two heap snapshots.
- `docs/perf-investigations/scripts/find-retainers.mjs` — BFS from GC roots to every instance of a target class, grouped by path signature.

## Why

The three-day version of the story: I jumped straight to heap snapshots, found tens of thousands of retained `system/Context` objects, and shipped six refactoring commits on #614 that reduced that count 89%. Task Manager didn't move. The actual load-bearing retention was a single `IntersectionObserver` callback in `xterm`'s `RenderService` holding 220 MB of `Uint32Array` BufferLines. One heap diff sorted by bytes (not count) named the culprit in one line of output; one `WeakRef` wrap fixed it.

Codifying these so the next agent doesn't re-tread the path.

## Test plan

- [x] `just fmt` clean
- [x] `just ai::apm` regenerated `.claude/skills/perf-diagnose/SKILL.md` to match APM source
- [ ] `ci/apm-sync` validates `.claude/` matches sources
- [ ] `ci/fmt` + `ci/nix` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
