### PR TITLE
test(e2e): expand mobile coverage (drawer, soft keyboard, sub-terminals)

### DIFF
--- a/packages/tests/features/mobile-drawer.feature
+++ b/packages/tests/features/mobile-drawer.feature
@@ -1,0 +1,40 @@
+Feature: Mobile chrome drawer
+  On mobile the persistent pill tree and chrome bar are replaced by a
+  pull-down drawer (`MobileChromeSheet`). Tapping the pull-handle opens
+  it; tapping a pill switches the active terminal and dismisses the
+  drawer; tapping the backdrop dismisses without switching.
+
+  Background:
+    Given the terminal is ready
+
+  @mobile
+  Scenario: Pull-handle opens the chrome drawer
+    When I tap the mobile pull handle
+    Then the mobile chrome sheet should be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Selecting a pill in the drawer switches active terminal and closes
+    Given I run "echo from-t0"
+    And I create a terminal
+    When I tap the mobile pull handle
+    And I tap the inactive mobile pill branch
+    Then the active terminal should show "from-t0"
+    And the mobile chrome sheet should not be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tapping the backdrop dismisses the drawer
+    When I tap the mobile pull handle
+    Then the mobile chrome sheet should be visible
+    When I tap the mobile chrome backdrop
+    Then the mobile chrome sheet should not be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Palette button in drawer opens the command palette
+    When I tap the mobile pull handle
+    And I tap the palette button in the drawer
+    Then the command palette should be visible
+    And the mobile chrome sheet should not be visible
+    And there should be no page errors

--- a/packages/tests/features/mobile-soft-keyboard.feature
+++ b/packages/tests/features/mobile-soft-keyboard.feature
@@ -1,0 +1,37 @@
+Feature: Mobile soft keyboard
+  `MobileKeyBar` is the only path on a touch device for keys the on-screen
+  keyboard can't reliably send: Esc, Tab, arrows, Ctrl-C, slash, Enter.
+  Each button writes its escape sequence directly to the PTY via
+  `client.terminal.sendInput`, bypassing xterm's keyboard layer entirely
+  — so the round-trip we want to assert is button → server → shell echo.
+
+  Background:
+    Given the terminal is ready
+
+  @mobile
+  Scenario: Soft key bar is visible on mobile
+    Then the mobile soft key bar should be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tapping the slash key sends slashes to the active terminal
+    When I tap the mobile key "slash"
+    And I tap the mobile key "slash"
+    And I tap the mobile key "slash"
+    Then the active terminal should show "///"
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tapping Ctrl-C interrupts a running command
+    Given I run "sleep 30"
+    When I tap the mobile key "ctrl-c"
+    Then the active terminal should show "^C"
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tapping ↑ then ⏎ recalls and resubmits the previous command
+    Given I run "echo soft-recall-marker"
+    When I tap the mobile key "up"
+    And I tap the mobile key "enter"
+    Then the active terminal should show "soft-recall-marker" 3 times
+    And there should be no page errors

--- a/packages/tests/features/mobile-sub-terminal.feature
+++ b/packages/tests/features/mobile-sub-terminal.feature
@@ -1,0 +1,25 @@
+Feature: Mobile sub-terminals
+  Sub-terminals (per-tile splits) live inside `TerminalContent`, which
+  mobile mounts via `MobileTileView.renderBody`. They're reachable on
+  mobile via the same Toggle-terminal-split palette command as on desktop
+  — verifying the wiring works under the mobile viewport guards mobile
+  users from regressions in the split feature.
+
+  Background:
+    Given the terminal is ready
+
+  @mobile
+  Scenario: Create sub-terminal via command palette on mobile
+    When I create a sub-terminal via command palette
+    Then the sub-panel should be visible
+    And the sub-terminal should have keyboard focus
+    And there should be no page errors
+
+  @mobile
+  Scenario: Sub-terminal output persists across mobile tile swipe
+    When I create a sub-terminal via command palette
+    And I run "echo mobile-sub-marker" in the sub-terminal
+    And I create a terminal
+    And I swipe left on the mobile tile view
+    Then the sub-terminal screen should contain "mobile-sub-marker"
+    And there should be no page errors

--- a/packages/tests/step_definitions/mobile_drawer_steps.ts
+++ b/packages/tests/step_definitions/mobile_drawer_steps.ts
@@ -1,0 +1,50 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+
+const PULL_HANDLE = '[data-testid="mobile-pull-handle"]';
+const SHEET = '[data-testid="mobile-chrome-sheet"]';
+const BACKDROP = '[data-testid="mobile-chrome-backdrop"]';
+const PILL_BRANCH = '[data-testid="mobile-pill-branch"]';
+// MobileChromeSheet reuses the same `palette-trigger` testid as the desktop
+// ChromeBar's palette button. Scope to the open sheet to disambiguate.
+const PALETTE_BTN = `${SHEET} [data-testid="palette-trigger"]`;
+
+When("I tap the mobile pull handle", async function (this: KoluWorld) {
+  await this.page.locator(PULL_HANDLE).tap();
+});
+
+When("I tap the mobile chrome backdrop", async function (this: KoluWorld) {
+  await this.page.locator(BACKDROP).tap();
+});
+
+When("I tap the inactive mobile pill branch", async function (this: KoluWorld) {
+  // The drawer always shows every terminal; one carries `data-active`. The
+  // other(s) are tap targets to switch. With the two-terminal background
+  // (one auto + one explicit create) there is exactly one inactive pill.
+  await this.page.locator(`${PILL_BRANCH}:not([data-active])`).first().tap();
+});
+
+When(
+  "I tap the palette button in the drawer",
+  async function (this: KoluWorld) {
+    await this.page.locator(PALETTE_BTN).tap();
+  },
+);
+
+Then(
+  "the mobile chrome sheet should be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(SHEET)
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the mobile chrome sheet should not be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(SHEET)
+      .waitFor({ state: "hidden", timeout: POLL_TIMEOUT });
+  },
+);

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -1,0 +1,54 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import { ACTIVE_TERMINAL } from "../support/buffer.ts";
+
+const KEY_BAR = '[data-testid="mobile-key-bar"]';
+const KEY = (testId: string) => `[data-testid="mobile-key-${testId}"]`;
+
+When(
+  "I tap the mobile key {string}",
+  async function (this: KoluWorld, testId: string) {
+    await this.page.locator(KEY(testId)).tap();
+    // Each tap fires `client.terminal.sendInput` which is fire-and-forget at
+    // the call site. Yield a frame so the WebSocket frame leaves before the
+    // next step runs — keeps multi-key sequences ordered.
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the mobile soft key bar should be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(KEY_BAR)
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the active terminal should show {string} {int} time(s)",
+  async function (this: KoluWorld, expected: string, count: number) {
+    // Poll the buffer for at-least-N occurrences. Used to verify history
+    // recall + Enter — after run, the buffer holds the typed line + output;
+    // after recall + submit, both pairs appear, so the marker count grows
+    // from 2 to 4. Asserting >= N tolerates extra renders.
+    await this.page.waitForFunction(
+      ([sel, exp, n]) => {
+        const buf: string = (
+          window as Window & {
+            __readXtermBuffer?: (s: string, i: number) => string;
+          }
+        ).__readXtermBuffer!(sel, 0);
+        let occurrences = 0;
+        let idx = 0;
+        while ((idx = buf.indexOf(exp, idx)) !== -1) {
+          occurrences++;
+          idx += exp.length;
+        }
+        return occurrences >= n;
+      },
+      [ACTIVE_TERMINAL, expected, count] as const,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);


### PR DESCRIPTION
Closes #627.

The mobile e2e suite covered swipe nav, vertical touch-scroll, and a handful of "this should not render on mobile" checks — but the **interaction surfaces** were untouched. The pull-down chrome drawer (`MobileChromeSheet`), the soft keyboard (`MobileKeyBar`), and sub-terminals on a fullscreen mobile tile all had zero `@mobile` scenarios despite shipping with dedicated `data-testid`s.

This PR fills those holes, one commit per concern. No mobile component bugs were uncovered — the pull-handle trigger, the drawer's tap-to-select pill, the soft key → `sendInput` → PTY round-trip, and sub-terminal persistence across a swipe-driven active-id change all worked on the first run.

## What's covered now

- **Drawer** (4 scenarios): pull-handle opens sheet; pill tap switches terminal and dismisses; backdrop tap dismisses; palette button opens the command palette.
- **Soft keyboard** (4 scenarios): bar visible under `(pointer: coarse)`; printable-key dispatch via slash×3; control-byte dispatch via Ctrl-C interrupting a `sleep 30`; arrow + Enter history recall (round-trip through `sendInput` → PTY → readline).
- **Sub-terminals on mobile** (2 scenarios): create-via-palette; output persistence across a tile swipe.

## Test plan

- [x] `just test-quick features/mobile-drawer.feature` — 4/4 pass
- [x] `just test-quick features/mobile-soft-keyboard.feature` — 4/4 pass
- [x] `just test-quick features/mobile-sub-terminal.feature` — 2/2 pass
- [x] `just ci` — all 10 contexts green on 28e0c05

🤖 Generated with [Claude Code](https://claude.com/claude-code)