### PR TITLE
feat(mobile): drag gestures on chrome drawer

### DIFF
--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -21,6 +21,11 @@ const SWIPE_THRESHOLD = 60;
 /** Vertical drift cap — if the user moved more vertically than horizontally,
  *  treat the gesture as a scroll, not a swipe. */
 const VERTICAL_TOLERANCE_RATIO = 0.7;
+/** Minimum downward pull (px) on the handle before the drawer commits to
+ *  opening. Sits above the browser's tap-slop (≈10px so no click fires once
+ *  we cross it) and below a casual finger jitter so a real tap still opens
+ *  via `Drawer.Trigger`'s click path. */
+const PULL_OPEN_THRESHOLD = 24;
 
 const MobileTileView: Component<{
   /** Pill-tree-ordered ids — same source as the desktop pill tree, so swipe
@@ -43,6 +48,9 @@ const MobileTileView: Component<{
     y: number;
   } | null>(null);
   const [sheetOpen, setSheetOpen] = createSignal(false);
+  // Pull-handle drag state. Not reactive — only `onPullTouch*` reads it.
+  // `null` when no active pull gesture; otherwise the starting clientY.
+  let pullStartY: number | null = null;
 
   function navigate(direction: 1 | -1) {
     const ids = props.orderedIds;
@@ -91,14 +99,35 @@ const MobileTileView: Component<{
         onTouchEnd={onTouchEnd}
       >
         {/* Pull-handle row — drag-bar + compact identity strip. Tap to
-         *  open the drawer (Corvu's Trigger). `onTouchStart`
-         *  stopPropagation keeps the wrapper's horizontal-swipe handler
-         *  from treating a tap on the handle as a tile-cycle gesture. */}
+         *  open the drawer (Corvu's Trigger); downward-drag past
+         *  `PULL_OPEN_THRESHOLD` also opens, matching the affordance the
+         *  drag-grip suggests. `onTouchStart` stopPropagation keeps the
+         *  wrapper's horizontal-swipe handler from treating a tap on the
+         *  handle as a tile-cycle gesture. */}
         <Drawer.Trigger
           data-testid="mobile-pull-handle"
           class="flex flex-col items-center gap-1 px-3 py-1.5 shrink-0 border-b border-edge bg-surface-1 cursor-pointer active:bg-surface-2 transition-colors"
           aria-label="Open navigation"
-          onTouchStart={(e: TouchEvent) => e.stopPropagation()}
+          onTouchStart={(e: TouchEvent) => {
+            e.stopPropagation();
+            const t = e.touches[0];
+            pullStartY = t ? t.clientY : null;
+          }}
+          onTouchMove={(e: TouchEvent) => {
+            if (pullStartY === null || sheetOpen()) return;
+            const t = e.touches[0];
+            if (!t) return;
+            if (t.clientY - pullStartY >= PULL_OPEN_THRESHOLD) {
+              // preventDefault suppresses the synthesized click that would
+              // otherwise re-toggle the drawer closed via Drawer.Trigger.
+              e.preventDefault();
+              setSheetOpen(true);
+              pullStartY = null;
+            }
+          }}
+          onTouchEnd={() => {
+            pullStartY = null;
+          }}
         >
           <span class="w-10 h-1 rounded-full bg-fg-3/40" aria-hidden="true" />
           <div class="flex items-center gap-2 w-full">

--- a/packages/tests/features/mobile-drawer.feature
+++ b/packages/tests/features/mobile-drawer.feature
@@ -38,3 +38,22 @@ Feature: Mobile chrome drawer
     Then the command palette should be visible
     And the mobile chrome sheet should not be visible
     And there should be no page errors
+
+  @mobile
+  Scenario: Dragging down on the pull handle opens the drawer
+    # The grip visually invites a drag; this proves the drag gesture on the
+    # handle opens the sheet even when the touch never resolves to a click.
+    When I drag down on the mobile pull handle
+    Then the mobile chrome sheet should be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Dragging the sheet up past the dismiss threshold closes it
+    # Corvu attaches the drag-to-dismiss handlers to Drawer.Content; for a
+    # `side="top"` drawer the dismiss direction is upward. Open, drag the
+    # sheet up most of its height, release — the sheet should snap closed.
+    When I tap the mobile pull handle
+    Then the mobile chrome sheet should be visible
+    When I drag the mobile chrome sheet up to dismiss
+    Then the mobile chrome sheet should not be visible
+    And there should be no page errors

--- a/packages/tests/step_definitions/mobile_drawer_steps.ts
+++ b/packages/tests/step_definitions/mobile_drawer_steps.ts
@@ -1,5 +1,6 @@
 import { When, Then } from "@cucumber/cucumber";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import * as assert from "node:assert";
 
 const PULL_HANDLE = '[data-testid="mobile-pull-handle"]';
 const SHEET = '[data-testid="mobile-chrome-sheet"]';
@@ -46,5 +47,114 @@ Then(
     await this.page
       .locator(SHEET)
       .waitFor({ state: "hidden", timeout: POLL_TIMEOUT });
+  },
+);
+
+When("I drag down on the mobile pull handle", async function (this: KoluWorld) {
+  const box = await this.page.locator(PULL_HANDLE).boundingBox();
+  assert.ok(box, "Pull handle has no bounding box");
+  const x = box.x + box.width / 2;
+  const startY = box.y + box.height / 2;
+  // Downward drag well past `PULL_OPEN_THRESHOLD` (24px). MobileTileView
+  // commits to opening as soon as `touchmove` crosses the threshold, so the
+  // single move below is enough; the trailing `touchend` just tidies state.
+  const endY = startY + 60;
+  // Ship plain-JS source string — tsx/esbuild instruments nested function
+  // declarations with `__name` debug helpers that don't exist in the
+  // browser (see mobile_swipe_steps.ts for the same workaround).
+  const src = `
+    (() => {
+      const target = document.querySelector(${JSON.stringify(PULL_HANDLE)});
+      if (!target) throw new Error("pull handle not found");
+      const mkTouch = (y) => new Touch({
+        identifier: 1, target, clientX: ${x}, clientY: y,
+        pageX: ${x}, pageY: y, screenX: ${x}, screenY: y,
+        radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1,
+      });
+      target.dispatchEvent(new TouchEvent("touchstart", {
+        cancelable: true, bubbles: true,
+        touches: [mkTouch(${startY})],
+        targetTouches: [mkTouch(${startY})],
+        changedTouches: [mkTouch(${startY})],
+      }));
+      target.dispatchEvent(new TouchEvent("touchmove", {
+        cancelable: true, bubbles: true,
+        touches: [mkTouch(${endY})],
+        targetTouches: [mkTouch(${endY})],
+        changedTouches: [mkTouch(${endY})],
+      }));
+      target.dispatchEvent(new TouchEvent("touchend", {
+        cancelable: true, bubbles: true,
+        touches: [], targetTouches: [],
+        changedTouches: [mkTouch(${endY})],
+      }));
+    })()
+  `;
+  await this.page.evaluate(src);
+  await this.waitForFrame();
+});
+
+When(
+  "I drag the mobile chrome sheet up to dismiss",
+  async function (this: KoluWorld) {
+    // Corvu wires drag-to-dismiss on Drawer.Content: element-level
+    // `pointerdown` + `touchstart` capture the drag start; `touchmove` and
+    // `touchend` listeners live on `document`, picking up bubbled events.
+    // For `side="top"`, the dismiss direction is upward — drag the sheet
+    // most of its height to land on the "closed" snap point.
+    const box = await this.page.locator(SHEET).boundingBox();
+    assert.ok(box, "Mobile chrome sheet has no bounding box");
+    // Anchor the drag near the top of the sheet (the drag-grip area) so the
+    // touch target is draggable per Corvu's `locationIsDraggable` walk —
+    // pill rows and control buttons stop pointerdown propagation.
+    const x = box.x + box.width / 2;
+    const startY = box.y + 10;
+    // Drag well past the sheet's own height so Corvu's closest-snap-point
+    // calculation lands on "closed" (offset === drawerSize). Negative
+    // clientY is valid for synthetic events — the browser doesn't clamp.
+    const endY = startY - box.height * 1.5 - 40;
+    const stepCount = 8;
+    const ys: number[] = [];
+    for (let i = 1; i <= stepCount; i++) {
+      ys.push(startY + ((endY - startY) * i) / stepCount);
+    }
+    const src = `
+      (() => {
+        const target = document.querySelector(${JSON.stringify(SHEET)});
+        if (!target) throw new Error("mobile chrome sheet not found");
+        const mkTouch = (y) => new Touch({
+          identifier: 1, target, clientX: ${x}, clientY: y,
+          pageX: ${x}, pageY: y, screenX: ${x}, screenY: y,
+          radiusX: 1, radiusY: 1, rotationAngle: 0, force: 1,
+        });
+        target.dispatchEvent(new PointerEvent("pointerdown", {
+          bubbles: true, cancelable: true,
+          pointerType: "touch", pointerId: 1,
+          button: 0, buttons: 1,
+          clientX: ${x}, clientY: ${startY},
+        }));
+        target.dispatchEvent(new TouchEvent("touchstart", {
+          cancelable: true, bubbles: true,
+          touches: [mkTouch(${startY})],
+          targetTouches: [mkTouch(${startY})],
+          changedTouches: [mkTouch(${startY})],
+        }));
+        for (const y of ${JSON.stringify(ys)}) {
+          target.dispatchEvent(new TouchEvent("touchmove", {
+            cancelable: true, bubbles: true,
+            touches: [mkTouch(y)],
+            targetTouches: [mkTouch(y)],
+            changedTouches: [mkTouch(y)],
+          }));
+        }
+        target.dispatchEvent(new TouchEvent("touchend", {
+          cancelable: true, bubbles: true,
+          touches: [], targetTouches: [],
+          changedTouches: [mkTouch(${endY})],
+        }));
+      })()
+    `;
+    await this.page.evaluate(src);
+    await this.waitForFrame();
   },
 );


### PR DESCRIPTION
Follow-up to #629, #627.

The pull-handle's drag-grip visual was *aspirational* — only a tap opened the drawer. On the flip side, Corvu's `Drawer.Content` already supported drag-to-dismiss, but no e2e scenario exercised it. This PR closes both gaps.

## What changed

**Drag-to-open** (new behavior). `MobileTileView` now tracks `touchstart`/`touchmove` on the pull-handle. Once downward travel clears a 24px threshold, `setSheetOpen(true)` commits *and* `preventDefault()` suppresses the synthesized click that would otherwise re-toggle the drawer closed. The existing tap path (via `Drawer.Trigger`'s click) is untouched — sub-threshold taps still open.

**Drag-to-dismiss** (existing Corvu gesture, now tested). For a `side="top"` drawer the dismiss direction is up. The new scenario opens via tap, synthesizes `pointerdown` + a multi-step `touchmove` up past the sheet's own height, and asserts `[data-testid="mobile-chrome-sheet"]` goes hidden. Had to send clientY well negative — a modest upward delta snaps back open because Corvu's nearest-snap-point calc is distance-based, not threshold-based.

## Test plan

- [x] `just test-quick features/mobile-drawer.feature` — 6/6 pass (4 original + 2 new)
- [ ] `just ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)