### PR TITLE
Record the tab with mic, webcam PiP, and pause/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ Detects [OpenCode](https://github.com/anomalyco/opencode) sessions and shows the
 
 - <kbd>Ctrl+V</kbd> pastes images into Claude Code via server-side clipboard shims
 
+### Screen recording
+
+Record the Kolu tab — whole canvas or a single maximized terminal — with microphone and optional webcam PiP, straight to a local `.webm` file. Chromium-only (uses the File System Access API).
+
+- **One-click setup popover** — mic picker with live 8-segment RMS level meter, webcam toggle + device picker + circular preview, all in a compact popover anchored to the chrome-bar record button
+- **Streaming to disk** — chunks flow from `MediaRecorder` into a `FileSystemWritableFileStream` continuously, so memory stays flat regardless of recording length. A partial `.webm` survives a browser crash (recoverable with ffmpeg)
+- **Duration-fix pass** — Chrome's `MediaRecorder` omits the WebM `SegmentInfo.Duration` header in streaming mode, which makes players show a ~1 second duration. At stop, the saved file is read back, patched via [`fix-webm-duration`](https://github.com/yusitnikov/fix-webm-duration), and rewritten
+- **Pause / resume** — <kbd>⌘⇧.</kbd> toggles; the segmented recording capsule in the chrome bar shifts red → amber and the breathing halo suppresses while paused
+- **Webcam PiP overlay** — when enabled, a circular mirrored `<video>` pins to the bottom-right above maximized tiles but below the chrome bar, and is baked into the recording by the tab-capture stream (no offscreen compositing)
+- **Browser picker collapses** — `getDisplayMedia({ preferCurrentTab: true, selfBrowserSurface: "include" })` turns the multi-surface picker into a single "Share this tab" confirmation
+
 ## Architecture
 
 pnpm monorepo:

--- a/agents/ai.just
+++ b/agents/ai.just
@@ -1,9 +1,15 @@
 # Run recipes from project root, not agents/
 set working-directory := '..'
 
+# Enter nix develop only when not already inside it — mirrors the root
+# justfile's pattern. `uvx` lives in the devshell (see shell.nix), so
+# these recipes need to enter it when invoked from a bare shell (e.g.
+# `just ci` → `just ai::apm-sync`).
+nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accept-flake-config -c' }
+
 # Pinned to juspay's fork while the hook-idempotency fix (microsoft/apm#708)
 # is unreleased upstream. Revert to `microsoft/apm` once the fix lands.
-apm_cmd := 'uvx --from git+https://github.com/microsoft/apm apm'
+apm_cmd := nix_shell + ' uvx --from git+https://github.com/microsoft/apm apm'
 
 # Deploy APM primitives to .claude/ (rules, commands, skills, hooks)
 apm:

--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-pdwV7svJnvCSmHd+O/KbXWjCf3oABv6vOLgKX6ttkDc=";
+    hash = "sha256-VXMh+I6dHB1/Dj8g9iw91dZsJWcnplswmpe4+abei7E=";
     fetcherVersion = 3;
   };
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,6 +33,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "fix-webm-duration": "^1.0.6",
     "highlight.js": "^11.11.1",
     "partysocket": "^1.1.16",
     "solid-js": "^1.9.0",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -38,6 +38,8 @@ import CloseConfirm, { type CloseConfirmTarget } from "./CloseConfirm";
 import { createCommands } from "./commands";
 import { exportSessionAsPdf } from "./exportSessionAsPdf";
 import { screenshotTerminal } from "./screenshotTerminal";
+import WebcamOverlay from "./recorder/WebcamOverlay";
+import { useRecorder } from "./recorder/useRecorder";
 import { ScreenshotIcon, SearchIcon } from "./ui/Icons";
 import Tip from "./ui/Tip";
 
@@ -202,6 +204,7 @@ const App: Component = () => {
     handleScreenshotTerminal: () => handleScreenshotTerminal(),
     toggleRightPanel: rightPanel.togglePanel,
     canvasCenterActive: handleCanvasCenterActive,
+    toggleRecordingPause: () => useRecorder().togglePause(),
   });
 
   function openPalette() {
@@ -466,6 +469,7 @@ const App: Component = () => {
     >
       <Title>{appTitle()}</Title>
       <TransportOverlay />
+      <WebcamOverlay />
       <Toaster
         position="bottom-right"
         theme={colorScheme()}

--- a/packages/client/src/ChromeBar.tsx
+++ b/packages/client/src/ChromeBar.tsx
@@ -22,6 +22,7 @@ import { formatKeybind, SHORTCUTS } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
 import Tip from "./ui/Tip";
 import SettingsPopover from "./settings/SettingsPopover";
+import RecordButton from "./recorder/RecordButton";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import { useTerminalStore } from "./terminal/useTerminalStore";
 import type { WsStatus } from "./rpc/rpc";
@@ -106,6 +107,7 @@ const ChromeBar: Component<{
        *  area covered when the cluster overlaps the right panel pass
        *  clicks through; each button re-enables pointer-events-auto. */}
       <div class="flex items-center gap-2 shrink-0">
+        <RecordButton />
         <Tip
           label={`Toggle inspector (${formatKeybind(SHORTCUTS.toggleRightPanel.keybind)})`}
         >

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -144,6 +144,25 @@ body {
     oklch(from var(--card-color) l calc(c * 1.5) h / 0.7);
 }
 
+/* ── Record capsule ─────────────────────────────────────────── */
+/* A soft box-shadow halo that grows outward and fades, emulating
+ * the universal "live indicator" pulse. Uses ease-out so the ring
+ * feels like a gentle emission, not a hard beat. Paused state
+ * drops the animation entirely. */
+@keyframes record-capsule-breathe {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-danger) 50%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 6px
+      color-mix(in srgb, var(--color-danger) 0%, transparent);
+  }
+}
+
+.record-capsule-live {
+  animation: record-capsule-breathe 2s ease-out infinite;
+}
+
 /* ── Canvas grid background ─────────────────────────────────── */
 /* Fine line grid gives spatial grounding to the freeform canvas.
    Lines use the edge color at low opacity so they adapt to light/dark themes. */

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -150,6 +150,10 @@ export const SHORTCUTS = {
     keybind: { key: "C", code: "KeyC", mod: true, shift: true },
     label: "Center on active tile",
   },
+  toggleRecordingPause: {
+    keybind: { key: " ", code: "Space", mod: true, shift: true },
+    label: "Pause / resume recording",
+  },
 } as const satisfies Record<string, Shortcut>;
 
 /**

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -151,7 +151,7 @@ export const SHORTCUTS = {
     label: "Center on active tile",
   },
   toggleRecordingPause: {
-    keybind: { key: " ", code: "Space", mod: true, shift: true },
+    keybind: { key: ".", code: "Period", mod: true, shift: true },
     label: "Pause / resume recording",
   },
 } as const satisfies Record<string, Shortcut>;

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -26,6 +26,7 @@ interface ShortcutDeps {
   handleScreenshotTerminal: () => void;
   toggleRightPanel: () => void;
   canvasCenterActive: () => void;
+  toggleRecordingPause: () => void;
 }
 
 /** MRU cycling state — a frozen snapshot is taken on the first Tab press while
@@ -186,6 +187,11 @@ function dispatch(
 
   if (matchesKeybind(e, SHORTCUTS.canvasCenterActive.keybind)) {
     deps.canvasCenterActive();
+    return true;
+  }
+
+  if (matchesKeybind(e, SHORTCUTS.toggleRecordingPause.keybind)) {
+    deps.toggleRecordingPause();
     return true;
   }
 

--- a/packages/client/src/recorder/LevelMeter.tsx
+++ b/packages/client/src/recorder/LevelMeter.tsx
@@ -1,0 +1,44 @@
+/** Horizontal mic level meter — eight segments, lit proportionally to
+ *  the 0..1 level. Used both in the setup popover and as a thin strip
+ *  inside the recording pill in the chrome bar. */
+
+import { type Component, For } from "solid-js";
+
+const SEGMENTS = 8;
+
+const LevelMeter: Component<{
+  level: number;
+  /** Tailwind sizing class — e.g. "h-2" (popover), "h-1" (recording pill). */
+  class?: string;
+}> = (props) => {
+  // Segment i lights when level ≥ (i+1)/SEGMENTS. We bias the last two
+  // segments toward amber/red so a clipping signal reads as "too loud"
+  // rather than just "loud".
+  return (
+    <div class={`flex items-stretch gap-[2px] ${props.class ?? "h-1.5"}`}>
+      <For each={Array.from({ length: SEGMENTS })}>
+        {(_, i) => {
+          const threshold = (i() + 1) / SEGMENTS;
+          const lit = () => props.level >= threshold;
+          const color = () => {
+            if (i() >= SEGMENTS - 1) return "bg-danger";
+            if (i() >= SEGMENTS - 3) return "bg-warning";
+            return "bg-ok";
+          };
+          return (
+            <div
+              class="flex-1 rounded-[1px] transition-opacity"
+              classList={{
+                [color()]: lit(),
+                "bg-edge opacity-40": !lit(),
+                "opacity-100": lit(),
+              }}
+            />
+          );
+        }}
+      </For>
+    </div>
+  );
+};
+
+export default LevelMeter;

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -44,6 +44,9 @@ const RecordButton: Component = () => {
     recorder.phase() === "setup" ? "Recording setup" : "Record workspace";
 
   const onIdleClick = () => {
+    console.log("[recorder] RecordButton.onIdleClick", {
+      phase: recorder.phase(),
+    });
     if (recorder.phase() === "setup") recorder.cancelSetup();
     else void recorder.openSetup();
   };

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -17,6 +17,7 @@
  *  Hidden when the File System Access API isn't available. */
 
 import { type Component, Match, Switch, Show, createSignal } from "solid-js";
+import { match } from "ts-pattern";
 import {
   formatElapsed,
   isRecordingSupported,
@@ -56,6 +57,25 @@ const RecordButton: Component = () => {
 
   const webcamLabel = () =>
     recorder.webcamEnabled() ? "Hide webcam" : "Show webcam";
+
+  // Exhaustive over live/paused × webcamEnabled. ts-pattern's
+  // `.exhaustive()` fires a compile error if Phase ever grows.
+  const webcamBtnAccent = () =>
+    match({
+      phase: recorder.phase() as "recording" | "paused",
+      on: recorder.webcamEnabled(),
+    })
+      .with(
+        { phase: "recording", on: false },
+        () => "text-danger hover:bg-danger/15",
+      )
+      .with({ phase: "recording", on: true }, () => "text-danger bg-danger/15")
+      .with(
+        { phase: "paused", on: false },
+        () => "text-warning hover:bg-warning/20",
+      )
+      .with({ phase: "paused", on: true }, () => "text-warning bg-warning/20")
+      .exhaustive();
 
   return (
     <>
@@ -148,17 +168,7 @@ const RecordButton: Component = () => {
           <Tip label={webcamLabel()} class="flex">
             <button
               data-testid="record-webcam"
-              class="w-7 flex items-center justify-center transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-              classList={{
-                "text-danger hover:bg-danger/15":
-                  isLive() && !recorder.webcamEnabled(),
-                "text-danger bg-danger/15":
-                  isLive() && recorder.webcamEnabled(),
-                "text-warning hover:bg-warning/20":
-                  isPaused() && !recorder.webcamEnabled(),
-                "text-warning bg-warning/20":
-                  isPaused() && recorder.webcamEnabled(),
-              }}
+              class={`w-7 flex items-center justify-center transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 ${webcamBtnAccent()}`}
               onClick={() => void recorder.toggleWebcam()}
               aria-label={webcamLabel()}
               aria-pressed={recorder.webcamEnabled()}

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -1,0 +1,55 @@
+/** Workspace record button — lives in the ChromeBar's right cluster.
+ *
+ *  Idle: small red record dot. Recording: pulsing dot + elapsed mm:ss in a
+ *  danger-tinted pill. Hidden on browsers without File System Access API. */
+
+import { type Component, Show } from "solid-js";
+import { isRecordingSupported, useRecorder } from "./useRecorder";
+import { RecordIcon } from "../ui/Icons";
+import Tip from "../ui/Tip";
+
+function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+const RecordButton: Component = () => {
+  if (!isRecordingSupported()) return null;
+  const recorder = useRecorder();
+  const label = () =>
+    recorder.isRecording() ? "Stop recording" : "Record workspace";
+  return (
+    <div class="pointer-events-auto">
+      <Tip label={label()}>
+        <button
+          data-testid="record-toggle"
+          data-recording={recorder.isRecording() ? "" : undefined}
+          class="h-7 flex items-center gap-1.5 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+          classList={{
+            "w-7 justify-center text-danger hover:bg-surface-2":
+              !recorder.isRecording(),
+            "px-2 bg-danger/15 text-danger hover:bg-danger/25":
+              recorder.isRecording(),
+          }}
+          onClick={() =>
+            recorder.isRecording()
+              ? void recorder.stop()
+              : void recorder.start()
+          }
+          aria-label={label()}
+        >
+          <Show when={recorder.isRecording()} fallback={<RecordIcon />}>
+            <span class="w-2 h-2 rounded-full bg-danger animate-pulse" />
+            <span class="text-xs tabular-nums">
+              {formatElapsed(recorder.elapsedMs())}
+            </span>
+          </Show>
+        </button>
+      </Tip>
+    </div>
+  );
+};
+
+export default RecordButton;

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -17,18 +17,15 @@
  *  Hidden when the File System Access API isn't available. */
 
 import { type Component, Match, Switch, Show, createSignal } from "solid-js";
-import { isRecordingSupported, useRecorder } from "./useRecorder";
+import {
+  formatElapsed,
+  isRecordingSupported,
+  useRecorder,
+} from "./useRecorder";
 import RecordPopover from "./RecordPopover";
 import { RecordIcon, PauseIcon, ResumeIcon, WebcamIcon } from "../ui/Icons";
 import Tip from "../ui/Tip";
 import { formatKeybind, SHORTCUTS } from "../input/keyboard";
-
-function formatElapsed(ms: number): string {
-  const total = Math.floor(ms / 1000);
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
-}
 
 const RecordButton: Component = () => {
   if (!isRecordingSupported()) return null;
@@ -48,9 +45,6 @@ const RecordButton: Component = () => {
     recorder.phase() === "setup" ? "Recording setup" : "Record workspace";
 
   const onIdleClick = () => {
-    console.log("[recorder] RecordButton.onIdleClick", {
-      phase: recorder.phase(),
-    });
     if (recorder.phase() === "setup") recorder.cancelSetup();
     else void recorder.openSetup();
   };
@@ -88,10 +82,6 @@ const RecordButton: Component = () => {
           </div>
         }
       >
-        {/* Segmented capsule. Internal dividers come from `divide-x`
-         *  tinted to match the current (live/paused) accent. The
-         *  capsule itself owns the halo animation — children handle
-         *  only their hover states. */}
         <div
           data-testid="record-active"
           data-phase={recorder.phase()}
@@ -125,9 +115,6 @@ const RecordButton: Component = () => {
             </button>
           </Tip>
 
-          {/* Status section — the whole segment is the stop button.
-           *  Live: static dot + elapsed mm:ss.
-           *  Paused: tiny "PAUSED" caps chip + frozen elapsed. */}
           <Tip label="Stop recording" class="flex">
             <button
               data-testid="record-stop"

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -158,7 +158,7 @@ const RecordButton: Component = () => {
                   Paused
                 </span>
               </Show>
-              <span class="text-xs font-medium tabular-nums leading-none">
+              <span class="text-xs font-mono font-medium tabular-nums leading-none">
                 {formatElapsed(recorder.elapsedMs())}
               </span>
             </button>

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -16,7 +16,7 @@
  *
  *  Hidden when the File System Access API isn't available. */
 
-import { type Component, Match, Switch, Show } from "solid-js";
+import { type Component, Match, Switch, Show, createSignal } from "solid-js";
 import { isRecordingSupported, useRecorder } from "./useRecorder";
 import RecordPopover from "./RecordPopover";
 import { RecordIcon, PauseIcon, ResumeIcon, WebcamIcon } from "../ui/Icons";
@@ -33,7 +33,11 @@ function formatElapsed(ms: number): string {
 const RecordButton: Component = () => {
   if (!isRecordingSupported()) return null;
   const recorder = useRecorder();
-  let triggerRef: HTMLButtonElement | undefined;
+  // Signal-based ref so the popover can re-read the current DOM node
+  // reactively. A plain `let` ref wouldn't track re-mounts of the
+  // idle button after recording↔idle cycles — the popover ended up
+  // positioned against a detached node, rendering off-screen.
+  const [triggerEl, setTriggerEl] = createSignal<HTMLButtonElement>();
 
   const isActive = () =>
     recorder.phase() === "recording" || recorder.phase() === "paused";
@@ -67,7 +71,7 @@ const RecordButton: Component = () => {
           <div class="pointer-events-auto">
             <Tip label={idleLabel()}>
               <button
-                ref={triggerRef}
+                ref={setTriggerEl}
                 data-testid="record-toggle"
                 data-phase={recorder.phase()}
                 class="h-7 w-7 flex items-center justify-center rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
@@ -177,7 +181,7 @@ const RecordButton: Component = () => {
           </Tip>
         </div>
       </Show>
-      <RecordPopover triggerRef={triggerRef} />
+      <RecordPopover triggerRef={triggerEl()} />
     </>
   );
 };

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -1,11 +1,24 @@
-/** Workspace record button. Idle: single RecordIcon that opens the setup
- *  popover. Recording/paused: three-button cluster — pause toggle, a
- *  status pill (click to stop), and a webcam toggle. */
+/** Workspace record button.
+ *
+ *  Two visual states:
+ *
+ *    idle / setup  — a single 28×28 square holding the camcorder icon.
+ *    recording /   — a segmented capsule: [pause · dot+time · webcam].
+ *    paused         When live, a soft outer halo breathes outward
+ *                   (see `.record-capsule-live` in index.css). When
+ *                   paused, the capsule shifts red→amber and the halo
+ *                   is suppressed; the middle section reads "PAUSED"
+ *                   in place of the level strip.
+ *
+ *  Click targets: the pause/webcam ends toggle their respective state;
+ *  the middle section is the stop button. Keyboard: `⌘⇧.` toggles
+ *  pause↔resume (registered as `toggleRecordingPause`).
+ *
+ *  Hidden when the File System Access API isn't available. */
 
 import { type Component, Match, Switch, Show } from "solid-js";
 import { isRecordingSupported, useRecorder } from "./useRecorder";
 import RecordPopover from "./RecordPopover";
-import LevelMeter from "./LevelMeter";
 import { RecordIcon, PauseIcon, ResumeIcon, WebcamIcon } from "../ui/Icons";
 import Tip from "../ui/Tip";
 import { formatKeybind, SHORTCUTS } from "../input/keyboard";
@@ -24,11 +37,11 @@ const RecordButton: Component = () => {
 
   const isActive = () =>
     recorder.phase() === "recording" || recorder.phase() === "paused";
+  const isLive = () => recorder.phase() === "recording";
+  const isPaused = () => recorder.phase() === "paused";
 
-  const idleLabel = () => {
-    if (recorder.phase() === "setup") return "Recording setup";
-    return "Record workspace";
-  };
+  const idleLabel = () =>
+    recorder.phase() === "setup" ? "Recording setup" : "Record workspace";
 
   const onIdleClick = () => {
     if (recorder.phase() === "setup") recorder.cancelSetup();
@@ -36,9 +49,12 @@ const RecordButton: Component = () => {
   };
 
   const pauseLabel = () =>
-    recorder.phase() === "paused"
+    isPaused()
       ? `Resume (${formatKeybind(SHORTCUTS.toggleRecordingPause.keybind)})`
       : `Pause (${formatKeybind(SHORTCUTS.toggleRecordingPause.keybind)})`;
+
+  const webcamLabel = () =>
+    recorder.webcamEnabled() ? "Hide webcam" : "Show webcam";
 
   return (
     <>
@@ -65,80 +81,92 @@ const RecordButton: Component = () => {
           </div>
         }
       >
+        {/* Segmented capsule. Internal dividers come from `divide-x`
+         *  tinted to match the current (live/paused) accent. The
+         *  capsule itself owns the halo animation — children handle
+         *  only their hover states. */}
         <div
-          class="pointer-events-auto flex items-center gap-1"
           data-testid="record-active"
           data-phase={recorder.phase()}
+          class="pointer-events-auto flex items-stretch h-7 rounded-lg overflow-hidden"
+          classList={{
+            "bg-danger/10 divide-x divide-danger/20 record-capsule-live":
+              isLive(),
+            "bg-warning/10 divide-x divide-warning/25": isPaused(),
+          }}
         >
           {/* Pause / resume */}
-          <Tip label={pauseLabel()}>
+          <Tip label={pauseLabel()} class="flex">
             <button
               data-testid="record-pause"
-              class="h-7 w-7 flex items-center justify-center text-fg-2 hover:text-fg hover:bg-surface-2 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              class="w-7 flex items-center justify-center transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              classList={{
+                "text-danger hover:bg-danger/15": isLive(),
+                "text-warning hover:bg-warning/20": isPaused(),
+              }}
               onClick={() => recorder.togglePause()}
               aria-label={pauseLabel()}
             >
               <Switch>
-                <Match when={recorder.phase() === "recording"}>
+                <Match when={isLive()}>
                   <PauseIcon />
                 </Match>
-                <Match when={recorder.phase() === "paused"}>
+                <Match when={isPaused()}>
                   <ResumeIcon />
                 </Match>
               </Switch>
             </button>
           </Tip>
 
-          {/* Status pill — click to stop. Color shifts amber when paused
-           *  so the frozen timer has an obvious explanation. */}
-          <Tip label="Stop recording">
+          {/* Status section — the whole segment is the stop button.
+           *  Live: static dot + elapsed mm:ss.
+           *  Paused: tiny "PAUSED" caps chip + frozen elapsed. */}
+          <Tip label="Stop recording" class="flex">
             <button
               data-testid="record-stop"
-              class="h-7 flex items-center gap-1.5 px-2 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              class="flex items-center gap-1.5 px-2.5 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
               classList={{
-                "bg-danger/15 text-danger hover:bg-danger/25":
-                  recorder.phase() === "recording",
-                "bg-warning/15 text-warning hover:bg-warning/25":
-                  recorder.phase() === "paused",
+                "text-danger hover:bg-danger/15": isLive(),
+                "text-warning hover:bg-warning/20": isPaused(),
               }}
               onClick={() => void recorder.stop()}
               aria-label="Stop recording"
             >
               <span
-                class="w-2 h-2 rounded-full"
+                class="w-1.5 h-1.5 rounded-full"
                 classList={{
-                  "bg-danger animate-pulse": recorder.phase() === "recording",
-                  "bg-warning": recorder.phase() === "paused",
+                  "bg-danger": isLive(),
+                  "bg-warning": isPaused(),
                 }}
               />
-              <span class="text-xs tabular-nums">
-                {formatElapsed(recorder.elapsedMs())}
-              </span>
-              <Show when={recorder.phase() === "recording"}>
-                <LevelMeter level={recorder.micLevel()} class="h-1 w-10" />
-              </Show>
-              <Show when={recorder.phase() === "paused"}>
-                <span class="text-xs font-medium uppercase tracking-wider">
+              <Show when={isPaused()}>
+                <span class="text-[0.625rem] font-semibold uppercase tracking-[0.12em] leading-none">
                   Paused
                 </span>
               </Show>
+              <span class="text-xs font-medium tabular-nums leading-none">
+                {formatElapsed(recorder.elapsedMs())}
+              </span>
             </button>
           </Tip>
 
-          {/* Webcam toggle — usable during recording and paused. */}
-          <Tip label={recorder.webcamEnabled() ? "Hide webcam" : "Show webcam"}>
+          {/* Webcam toggle — end cap. */}
+          <Tip label={webcamLabel()} class="flex">
             <button
               data-testid="record-webcam"
-              class="h-7 w-7 flex items-center justify-center rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              class="w-7 flex items-center justify-center transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
               classList={{
-                "bg-surface-2 text-fg": recorder.webcamEnabled(),
-                "text-fg-2 hover:text-fg hover:bg-surface-2":
-                  !recorder.webcamEnabled(),
+                "text-danger hover:bg-danger/15":
+                  isLive() && !recorder.webcamEnabled(),
+                "text-danger bg-danger/15":
+                  isLive() && recorder.webcamEnabled(),
+                "text-warning hover:bg-warning/20":
+                  isPaused() && !recorder.webcamEnabled(),
+                "text-warning bg-warning/20":
+                  isPaused() && recorder.webcamEnabled(),
               }}
               onClick={() => void recorder.toggleWebcam()}
-              aria-label={
-                recorder.webcamEnabled() ? "Hide webcam" : "Show webcam"
-              }
+              aria-label={webcamLabel()}
               aria-pressed={recorder.webcamEnabled()}
             >
               <WebcamIcon />

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -1,10 +1,12 @@
-/** Workspace record button — lives in the ChromeBar's right cluster.
- *
- *  Idle: small red record dot. Recording: pulsing dot + elapsed mm:ss in a
- *  danger-tinted pill. Hidden on browsers without File System Access API. */
+/** Workspace record button. Opens a setup popover from idle (mic select
+ *  + level meter); while recording, shows a pulsing danger pill with
+ *  elapsed time and a mini level meter. Hidden when the File System
+ *  Access API isn't available. */
 
-import { type Component, Show } from "solid-js";
+import { type Component, Show, Match, Switch } from "solid-js";
 import { isRecordingSupported, useRecorder } from "./useRecorder";
+import RecordPopover from "./RecordPopover";
+import LevelMeter from "./LevelMeter";
 import { RecordIcon } from "../ui/Icons";
 import Tip from "../ui/Tip";
 
@@ -18,37 +20,58 @@ function formatElapsed(ms: number): string {
 const RecordButton: Component = () => {
   if (!isRecordingSupported()) return null;
   const recorder = useRecorder();
-  const label = () =>
-    recorder.isRecording() ? "Stop recording" : "Record workspace";
+  let triggerRef: HTMLButtonElement | undefined;
+
+  const label = () => {
+    if (recorder.phase() === "recording") return "Stop recording";
+    if (recorder.phase() === "setup") return "Recording setup";
+    return "Record workspace";
+  };
+
+  const onClick = () => {
+    if (recorder.phase() === "recording") void recorder.stop();
+    else if (recorder.phase() === "setup") recorder.cancelSetup();
+    else void recorder.openSetup();
+  };
+
   return (
-    <div class="pointer-events-auto">
-      <Tip label={label()}>
-        <button
-          data-testid="record-toggle"
-          data-recording={recorder.isRecording() ? "" : undefined}
-          class="h-7 flex items-center gap-1.5 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-          classList={{
-            "w-7 justify-center text-danger hover:bg-surface-2":
-              !recorder.isRecording(),
-            "px-2 bg-danger/15 text-danger hover:bg-danger/25":
-              recorder.isRecording(),
-          }}
-          onClick={() =>
-            recorder.isRecording()
-              ? void recorder.stop()
-              : void recorder.start()
-          }
-          aria-label={label()}
-        >
-          <Show when={recorder.isRecording()} fallback={<RecordIcon />}>
-            <span class="w-2 h-2 rounded-full bg-danger animate-pulse" />
-            <span class="text-xs tabular-nums">
-              {formatElapsed(recorder.elapsedMs())}
-            </span>
-          </Show>
-        </button>
-      </Tip>
-    </div>
+    <>
+      <div class="pointer-events-auto">
+        <Tip label={label()}>
+          <button
+            ref={triggerRef}
+            data-testid="record-toggle"
+            data-phase={recorder.phase()}
+            class="h-7 flex items-center gap-1.5 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+            classList={{
+              "w-7 justify-center text-danger hover:bg-surface-2":
+                recorder.phase() === "idle",
+              "px-2 bg-surface-2 text-danger": recorder.phase() === "setup",
+              "px-2 bg-danger/15 text-danger hover:bg-danger/25":
+                recorder.phase() === "recording",
+            }}
+            onClick={onClick}
+            aria-label={label()}
+          >
+            <Switch fallback={<RecordIcon />}>
+              <Match when={recorder.phase() === "recording"}>
+                <span class="w-2 h-2 rounded-full bg-danger animate-pulse" />
+                <span class="text-xs tabular-nums">
+                  {formatElapsed(recorder.elapsedMs())}
+                </span>
+                <Show when={recorder.micLevel() >= 0}>
+                  <LevelMeter level={recorder.micLevel()} class="h-1 w-10" />
+                </Show>
+              </Match>
+              <Match when={recorder.phase() === "setup"}>
+                <RecordIcon />
+              </Match>
+            </Switch>
+          </button>
+        </Tip>
+      </div>
+      <RecordPopover triggerRef={triggerRef} />
+    </>
   );
 };
 

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -1,14 +1,14 @@
-/** Workspace record button. Opens a setup popover from idle (mic select
- *  + level meter); while recording, shows a pulsing danger pill with
- *  elapsed time and a mini level meter. Hidden when the File System
- *  Access API isn't available. */
+/** Workspace record button. Idle: single RecordIcon that opens the setup
+ *  popover. Recording/paused: three-button cluster — pause toggle, a
+ *  status pill (click to stop), and a webcam toggle. */
 
-import { type Component, Show, Match, Switch } from "solid-js";
+import { type Component, Match, Switch, Show } from "solid-js";
 import { isRecordingSupported, useRecorder } from "./useRecorder";
 import RecordPopover from "./RecordPopover";
 import LevelMeter from "./LevelMeter";
-import { RecordIcon } from "../ui/Icons";
+import { RecordIcon, PauseIcon, ResumeIcon, WebcamIcon } from "../ui/Icons";
 import Tip from "../ui/Tip";
+import { formatKeybind, SHORTCUTS } from "../input/keyboard";
 
 function formatElapsed(ms: number): string {
   const total = Math.floor(ms / 1000);
@@ -22,54 +22,130 @@ const RecordButton: Component = () => {
   const recorder = useRecorder();
   let triggerRef: HTMLButtonElement | undefined;
 
-  const label = () => {
-    if (recorder.phase() === "recording") return "Stop recording";
+  const isActive = () =>
+    recorder.phase() === "recording" || recorder.phase() === "paused";
+
+  const idleLabel = () => {
     if (recorder.phase() === "setup") return "Recording setup";
     return "Record workspace";
   };
 
-  const onClick = () => {
-    if (recorder.phase() === "recording") void recorder.stop();
-    else if (recorder.phase() === "setup") recorder.cancelSetup();
+  const onIdleClick = () => {
+    if (recorder.phase() === "setup") recorder.cancelSetup();
     else void recorder.openSetup();
   };
 
+  const pauseLabel = () =>
+    recorder.phase() === "paused"
+      ? `Resume (${formatKeybind(SHORTCUTS.toggleRecordingPause.keybind)})`
+      : `Pause (${formatKeybind(SHORTCUTS.toggleRecordingPause.keybind)})`;
+
   return (
     <>
-      <div class="pointer-events-auto">
-        <Tip label={label()}>
-          <button
-            ref={triggerRef}
-            data-testid="record-toggle"
-            data-phase={recorder.phase()}
-            class="h-7 flex items-center gap-1.5 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-            classList={{
-              "w-7 justify-center text-danger hover:bg-surface-2":
-                recorder.phase() === "idle",
-              "px-2 bg-surface-2 text-danger": recorder.phase() === "setup",
-              "px-2 bg-danger/15 text-danger hover:bg-danger/25":
-                recorder.phase() === "recording",
-            }}
-            onClick={onClick}
-            aria-label={label()}
-          >
-            <Switch fallback={<RecordIcon />}>
-              <Match when={recorder.phase() === "recording"}>
-                <span class="w-2 h-2 rounded-full bg-danger animate-pulse" />
-                <span class="text-xs tabular-nums">
-                  {formatElapsed(recorder.elapsedMs())}
-                </span>
-                <Show when={recorder.micLevel() >= 0}>
-                  <LevelMeter level={recorder.micLevel()} class="h-1 w-10" />
-                </Show>
-              </Match>
-              <Match when={recorder.phase() === "setup"}>
+      <Show
+        when={isActive()}
+        fallback={
+          <div class="pointer-events-auto">
+            <Tip label={idleLabel()}>
+              <button
+                ref={triggerRef}
+                data-testid="record-toggle"
+                data-phase={recorder.phase()}
+                class="h-7 w-7 flex items-center justify-center rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+                classList={{
+                  "text-danger hover:bg-surface-2": recorder.phase() === "idle",
+                  "bg-surface-2 text-danger": recorder.phase() === "setup",
+                }}
+                onClick={onIdleClick}
+                aria-label={idleLabel()}
+              >
                 <RecordIcon />
-              </Match>
-            </Switch>
-          </button>
-        </Tip>
-      </div>
+              </button>
+            </Tip>
+          </div>
+        }
+      >
+        <div
+          class="pointer-events-auto flex items-center gap-1"
+          data-testid="record-active"
+          data-phase={recorder.phase()}
+        >
+          {/* Pause / resume */}
+          <Tip label={pauseLabel()}>
+            <button
+              data-testid="record-pause"
+              class="h-7 w-7 flex items-center justify-center text-fg-2 hover:text-fg hover:bg-surface-2 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              onClick={() => recorder.togglePause()}
+              aria-label={pauseLabel()}
+            >
+              <Switch>
+                <Match when={recorder.phase() === "recording"}>
+                  <PauseIcon />
+                </Match>
+                <Match when={recorder.phase() === "paused"}>
+                  <ResumeIcon />
+                </Match>
+              </Switch>
+            </button>
+          </Tip>
+
+          {/* Status pill — click to stop. Color shifts amber when paused
+           *  so the frozen timer has an obvious explanation. */}
+          <Tip label="Stop recording">
+            <button
+              data-testid="record-stop"
+              class="h-7 flex items-center gap-1.5 px-2 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              classList={{
+                "bg-danger/15 text-danger hover:bg-danger/25":
+                  recorder.phase() === "recording",
+                "bg-warning/15 text-warning hover:bg-warning/25":
+                  recorder.phase() === "paused",
+              }}
+              onClick={() => void recorder.stop()}
+              aria-label="Stop recording"
+            >
+              <span
+                class="w-2 h-2 rounded-full"
+                classList={{
+                  "bg-danger animate-pulse": recorder.phase() === "recording",
+                  "bg-warning": recorder.phase() === "paused",
+                }}
+              />
+              <span class="text-xs tabular-nums">
+                {formatElapsed(recorder.elapsedMs())}
+              </span>
+              <Show when={recorder.phase() === "recording"}>
+                <LevelMeter level={recorder.micLevel()} class="h-1 w-10" />
+              </Show>
+              <Show when={recorder.phase() === "paused"}>
+                <span class="text-xs font-medium uppercase tracking-wider">
+                  Paused
+                </span>
+              </Show>
+            </button>
+          </Tip>
+
+          {/* Webcam toggle — usable during recording and paused. */}
+          <Tip label={recorder.webcamEnabled() ? "Hide webcam" : "Show webcam"}>
+            <button
+              data-testid="record-webcam"
+              class="h-7 w-7 flex items-center justify-center rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              classList={{
+                "bg-surface-2 text-fg": recorder.webcamEnabled(),
+                "text-fg-2 hover:text-fg hover:bg-surface-2":
+                  !recorder.webcamEnabled(),
+              }}
+              onClick={() => void recorder.toggleWebcam()}
+              aria-label={
+                recorder.webcamEnabled() ? "Hide webcam" : "Show webcam"
+              }
+              aria-pressed={recorder.webcamEnabled()}
+            >
+              <WebcamIcon />
+            </button>
+          </Tip>
+        </div>
+      </Show>
       <RecordPopover triggerRef={triggerRef} />
     </>
   );

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -27,7 +27,7 @@ function formatElapsed(ms: number): string {
   const total = Math.floor(ms / 1000);
   const m = Math.floor(total / 60);
   const s = total % 60;
-  return `${m}:${s.toString().padStart(2, "0")}`;
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
 }
 
 const RecordButton: Component = () => {

--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -167,14 +167,19 @@ const RecordPopover: Component<{
               </select>
             </Show>
             <Show when={recorder.webcamStream()}>
-              <div class="rounded-lg overflow-hidden border border-edge aspect-video bg-surface-2">
-                <video
-                  ref={webcamVideoRef}
-                  autoplay
-                  muted
-                  playsinline
-                  class="w-full h-full object-cover scale-x-[-1]"
-                />
+              {/* Preview mirrors the overlay shape (circle) so the user
+               *  sees what will appear in the recording, not a different
+               *  framing. Centered in a neutral strip for breathing room. */}
+              <div class="flex justify-center py-1">
+                <div class="w-32 h-32 rounded-full overflow-hidden ring-1 ring-edge bg-surface-2">
+                  <video
+                    ref={webcamVideoRef}
+                    autoplay
+                    muted
+                    playsinline
+                    class="w-full h-full object-cover scale-x-[-1]"
+                  />
+                </div>
               </div>
             </Show>
           </div>

--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -31,6 +31,14 @@ const RecordPopover: Component<{
     setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
   };
 
+  // Reposition whenever the popover opens OR the trigger element
+  // reference changes. With signal-backed trigger ref from RecordButton,
+  // remounts of the idle button (after record↔idle cycles) flow through
+  // here so the popover doesn't end up anchored to a detached element.
+  createEffect(() => {
+    if (open() && props.triggerRef) updatePos();
+  });
+
   // Keep the preview `<video>` in sync with the webcam stream signal.
   createEffect(() => {
     const s = recorder.webcamStream();

--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -1,12 +1,19 @@
-/** Pre-record setup popover — mic device selector + live level meter +
- *  "Start recording" commit button. Appears when the chrome-bar record
- *  button is clicked from idle. */
+/** Pre-record setup popover — mic + webcam device selectors, live level
+ *  meter, webcam preview, "Start recording" commit button. Appears when
+ *  the chrome-bar record button is clicked from idle. */
 
-import { type Component, Show, For, createSignal } from "solid-js";
+import {
+  type Component,
+  Show,
+  For,
+  createSignal,
+  createEffect,
+} from "solid-js";
 import { Portal } from "solid-js/web";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import { useRecorder } from "./useRecorder";
 import LevelMeter from "./LevelMeter";
+import Toggle from "../ui/Toggle";
 
 const RecordPopover: Component<{
   triggerRef?: HTMLElement;
@@ -15,6 +22,7 @@ const RecordPopover: Component<{
   const open = () => recorder.phase() === "setup";
 
   let panelRef: HTMLDivElement | undefined;
+  let webcamVideoRef: HTMLVideoElement | undefined;
   const [pos, setPos] = createSignal({ top: 0, right: 0 });
 
   const updatePos = () => {
@@ -22,6 +30,12 @@ const RecordPopover: Component<{
     const rect = props.triggerRef.getBoundingClientRect();
     setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
   };
+
+  // Keep the preview `<video>` in sync with the webcam stream signal.
+  createEffect(() => {
+    const s = recorder.webcamStream();
+    if (webcamVideoRef) webcamVideoRef.srcObject = s;
+  });
 
   // Click outside → cancel setup. Ignore clicks on the trigger itself
   // so toggling-via-trigger doesn't double-dispatch.
@@ -40,9 +54,10 @@ const RecordPopover: Component<{
     if (open() && e.key === "Escape") recorder.cancelSetup();
   });
 
-  const showSelector = () => recorder.micDevices().length > 1;
+  const showMicSelector = () => recorder.micDevices().length > 1;
+  const showWebcamSelector = () => recorder.webcamDevices().length > 1;
 
-  const selectedLabel = () => {
+  const selectedMicLabel = () => {
     const id = recorder.micDeviceId();
     const dev = recorder.micDevices().find((d) => d.deviceId === id);
     return dev?.label || "System default";
@@ -57,7 +72,7 @@ const RecordPopover: Component<{
             updatePos();
           }}
           data-testid="record-popover"
-          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[260px] space-y-3"
+          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[280px] space-y-3"
           style={{
             top: `${pos().top}px`,
             right: `${pos().right}px`,
@@ -66,7 +81,7 @@ const RecordPopover: Component<{
         >
           <div class="text-sm font-medium text-fg">Record workspace</div>
 
-          {/* Mic selector — only when there's a real choice to make. */}
+          {/* Mic */}
           <div class="space-y-1.5">
             <div class="flex items-center justify-between text-xs text-fg-2">
               <span>Microphone</span>
@@ -77,10 +92,13 @@ const RecordPopover: Component<{
               </Show>
             </div>
             <Show
-              when={showSelector()}
+              when={showMicSelector()}
               fallback={
-                <div class="text-sm text-fg-2 truncate" title={selectedLabel()}>
-                  {selectedLabel()}
+                <div
+                  class="text-sm text-fg-2 truncate"
+                  title={selectedMicLabel()}
+                >
+                  {selectedMicLabel()}
                 </div>
               }
             >
@@ -105,6 +123,60 @@ const RecordPopover: Component<{
               </select>
             </Show>
             <LevelMeter level={recorder.micLevel()} class="h-2" />
+          </div>
+
+          {/* Webcam */}
+          <div class="space-y-1.5 pt-1 border-t border-edge">
+            <label class="flex items-center justify-between gap-3 cursor-pointer text-xs text-fg-2 pt-2">
+              <span>Webcam overlay</span>
+              <Toggle
+                testId="record-webcam-toggle"
+                enabled={recorder.webcamEnabled()}
+                onChange={() => {
+                  void recorder.toggleWebcam();
+                }}
+              />
+            </label>
+            <Show when={recorder.webcamError()}>
+              <div
+                class="text-xs text-danger"
+                data-testid="record-webcam-error"
+              >
+                {recorder.webcamError()}
+              </div>
+            </Show>
+            <Show when={recorder.webcamEnabled() && showWebcamSelector()}>
+              <select
+                data-testid="record-webcam-select"
+                class="w-full h-7 px-2 text-sm bg-surface-2 border border-edge rounded-lg text-fg cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+                value={recorder.webcamDeviceId()}
+                onChange={(e) => {
+                  void recorder.changeWebcam(e.currentTarget.value);
+                }}
+              >
+                <option value="default">System default</option>
+                <For each={recorder.webcamDevices()}>
+                  {(d) => (
+                    <Show when={d.deviceId && d.deviceId !== "default"}>
+                      <option value={d.deviceId}>
+                        {d.label || `Camera ${d.deviceId.slice(0, 6)}`}
+                      </option>
+                    </Show>
+                  )}
+                </For>
+              </select>
+            </Show>
+            <Show when={recorder.webcamStream()}>
+              <div class="rounded-lg overflow-hidden border border-edge aspect-video bg-surface-2">
+                <video
+                  ref={webcamVideoRef}
+                  autoplay
+                  muted
+                  playsinline
+                  class="w-full h-full object-cover scale-x-[-1]"
+                />
+              </div>
+            </Show>
           </div>
 
           <div class="flex items-center justify-end gap-2 pt-1">

--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -1,0 +1,134 @@
+/** Pre-record setup popover — mic device selector + live level meter +
+ *  "Start recording" commit button. Appears when the chrome-bar record
+ *  button is clicked from idle. */
+
+import { type Component, Show, For, createSignal } from "solid-js";
+import { Portal } from "solid-js/web";
+import { makeEventListener } from "@solid-primitives/event-listener";
+import { useRecorder } from "./useRecorder";
+import LevelMeter from "./LevelMeter";
+
+const RecordPopover: Component<{
+  triggerRef?: HTMLElement;
+}> = (props) => {
+  const recorder = useRecorder();
+  const open = () => recorder.phase() === "setup";
+
+  let panelRef: HTMLDivElement | undefined;
+  const [pos, setPos] = createSignal({ top: 0, right: 0 });
+
+  const updatePos = () => {
+    if (!props.triggerRef) return;
+    const rect = props.triggerRef.getBoundingClientRect();
+    setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
+  };
+
+  // Click outside → cancel setup. Ignore clicks on the trigger itself
+  // so toggling-via-trigger doesn't double-dispatch.
+  makeEventListener(document, "mousedown", (e) => {
+    if (!open()) return;
+    if (
+      panelRef &&
+      !panelRef.contains(e.target as Node) &&
+      !props.triggerRef?.contains(e.target as Node)
+    ) {
+      recorder.cancelSetup();
+    }
+  });
+
+  makeEventListener(document, "keydown", (e) => {
+    if (open() && e.key === "Escape") recorder.cancelSetup();
+  });
+
+  const showSelector = () => recorder.micDevices().length > 1;
+
+  const selectedLabel = () => {
+    const id = recorder.micDeviceId();
+    const dev = recorder.micDevices().find((d) => d.deviceId === id);
+    return dev?.label || "System default";
+  };
+
+  return (
+    <Show when={open()}>
+      <Portal>
+        <div
+          ref={(el) => {
+            panelRef = el;
+            updatePos();
+          }}
+          data-testid="record-popover"
+          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[260px] space-y-3"
+          style={{
+            top: `${pos().top}px`,
+            right: `${pos().right}px`,
+            "background-color": "var(--color-surface-1)",
+          }}
+        >
+          <div class="text-sm font-medium text-fg">Record workspace</div>
+
+          {/* Mic selector — only when there's a real choice to make. */}
+          <div class="space-y-1.5">
+            <div class="flex items-center justify-between text-xs text-fg-2">
+              <span>Microphone</span>
+              <Show when={recorder.micError()}>
+                <span class="text-danger" data-testid="record-mic-error">
+                  {recorder.micError()}
+                </span>
+              </Show>
+            </div>
+            <Show
+              when={showSelector()}
+              fallback={
+                <div class="text-sm text-fg-2 truncate" title={selectedLabel()}>
+                  {selectedLabel()}
+                </div>
+              }
+            >
+              <select
+                data-testid="record-mic-select"
+                class="w-full h-7 px-2 text-sm bg-surface-2 border border-edge rounded-lg text-fg cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+                value={recorder.micDeviceId()}
+                onChange={(e) => {
+                  void recorder.changeMic(e.currentTarget.value);
+                }}
+              >
+                <option value="default">System default</option>
+                <For each={recorder.micDevices()}>
+                  {(d) => (
+                    <Show when={d.deviceId && d.deviceId !== "default"}>
+                      <option value={d.deviceId}>
+                        {d.label || `Microphone ${d.deviceId.slice(0, 6)}`}
+                      </option>
+                    </Show>
+                  )}
+                </For>
+              </select>
+            </Show>
+            <LevelMeter level={recorder.micLevel()} class="h-2" />
+          </div>
+
+          <div class="flex items-center justify-end gap-2 pt-1">
+            <button
+              data-testid="record-cancel"
+              class="h-7 px-3 text-sm text-fg-2 hover:text-fg rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              onClick={() => recorder.cancelSetup()}
+            >
+              Cancel
+            </button>
+            <button
+              data-testid="record-start"
+              class="h-7 px-3 text-sm text-white bg-danger hover:bg-danger/90 rounded-lg transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              onClick={() => {
+                void recorder.startRecording();
+              }}
+            >
+              Start recording
+            </button>
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+};
+
+export default RecordPopover;

--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -15,6 +15,32 @@ import { useRecorder } from "./useRecorder";
 import LevelMeter from "./LevelMeter";
 import Toggle from "../ui/Toggle";
 
+const DeviceSelect: Component<{
+  testId: string;
+  devices: MediaDeviceInfo[];
+  selectedId: string;
+  fallbackLabel: (shortId: string) => string;
+  onChange: (id: string) => void;
+}> = (props) => (
+  <select
+    data-testid={props.testId}
+    class="w-full h-7 px-2 text-sm bg-surface-2 border border-edge rounded-lg text-fg cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+    value={props.selectedId}
+    onChange={(e) => props.onChange(e.currentTarget.value)}
+  >
+    <option value="default">System default</option>
+    <For each={props.devices}>
+      {(d) => (
+        <Show when={d.deviceId && d.deviceId !== "default"}>
+          <option value={d.deviceId}>
+            {d.label || props.fallbackLabel(d.deviceId.slice(0, 6))}
+          </option>
+        </Show>
+      )}
+    </For>
+  </select>
+);
+
 const RecordPopover: Component<{
   triggerRef?: HTMLElement;
 }> = (props) => {
@@ -110,25 +136,13 @@ const RecordPopover: Component<{
                 </div>
               }
             >
-              <select
-                data-testid="record-mic-select"
-                class="w-full h-7 px-2 text-sm bg-surface-2 border border-edge rounded-lg text-fg cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-                value={recorder.micDeviceId()}
-                onChange={(e) => {
-                  void recorder.changeMic(e.currentTarget.value);
-                }}
-              >
-                <option value="default">System default</option>
-                <For each={recorder.micDevices()}>
-                  {(d) => (
-                    <Show when={d.deviceId && d.deviceId !== "default"}>
-                      <option value={d.deviceId}>
-                        {d.label || `Microphone ${d.deviceId.slice(0, 6)}`}
-                      </option>
-                    </Show>
-                  )}
-                </For>
-              </select>
+              <DeviceSelect
+                testId="record-mic-select"
+                devices={recorder.micDevices()}
+                selectedId={recorder.micDeviceId()}
+                fallbackLabel={(s) => `Microphone ${s}`}
+                onChange={(id) => void recorder.changeMic(id)}
+              />
             </Show>
             <LevelMeter level={recorder.micLevel()} class="h-2" />
           </div>
@@ -154,30 +168,15 @@ const RecordPopover: Component<{
               </div>
             </Show>
             <Show when={recorder.webcamEnabled() && showWebcamSelector()}>
-              <select
-                data-testid="record-webcam-select"
-                class="w-full h-7 px-2 text-sm bg-surface-2 border border-edge rounded-lg text-fg cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-                value={recorder.webcamDeviceId()}
-                onChange={(e) => {
-                  void recorder.changeWebcam(e.currentTarget.value);
-                }}
-              >
-                <option value="default">System default</option>
-                <For each={recorder.webcamDevices()}>
-                  {(d) => (
-                    <Show when={d.deviceId && d.deviceId !== "default"}>
-                      <option value={d.deviceId}>
-                        {d.label || `Camera ${d.deviceId.slice(0, 6)}`}
-                      </option>
-                    </Show>
-                  )}
-                </For>
-              </select>
+              <DeviceSelect
+                testId="record-webcam-select"
+                devices={recorder.webcamDevices()}
+                selectedId={recorder.webcamDeviceId()}
+                fallbackLabel={(s) => `Camera ${s}`}
+                onChange={(id) => void recorder.changeWebcam(id)}
+              />
             </Show>
             <Show when={recorder.webcamStream()}>
-              {/* Preview mirrors the overlay shape (circle) so the user
-               *  sees what will appear in the recording, not a different
-               *  framing. Centered in a neutral strip for breathing room. */}
               <div class="flex justify-center py-1">
                 <div class="w-32 h-32 rounded-full overflow-hidden ring-1 ring-edge bg-surface-2">
                   <video

--- a/packages/client/src/recorder/WebcamOverlay.tsx
+++ b/packages/client/src/recorder/WebcamOverlay.tsx
@@ -27,7 +27,7 @@ const WebcamOverlay: Component = () => {
     <Show when={recorder.webcamStream()}>
       <div
         data-testid="webcam-overlay"
-        class="fixed bottom-5 right-5 z-40 w-44 h-44 rounded-full overflow-hidden shadow-2xl shadow-black/60 ring-1 ring-white/10 pointer-events-none"
+        class="fixed bottom-5 right-5 z-[45] w-44 h-44 rounded-full overflow-hidden shadow-2xl shadow-black/60 ring-1 ring-white/10 pointer-events-none"
       >
         <video
           ref={videoRef}

--- a/packages/client/src/recorder/WebcamOverlay.tsx
+++ b/packages/client/src/recorder/WebcamOverlay.tsx
@@ -1,0 +1,44 @@
+/** Fixed-corner webcam overlay (picture-in-picture).
+ *
+ *  Renders a small mirrored `<video>` in the bottom-right of the viewport
+ *  whenever the recorder has a live webcam stream. Because we capture the
+ *  whole tab via `getDisplayMedia`, the browser already bakes this DOM
+ *  element into the recording — no offscreen compositing required.
+ *
+ *  Visible across all phases that own a webcam stream: setup, recording,
+ *  paused. The recorder closes the stream on stop or when the user
+ *  toggles webcam off, which unmounts the overlay. */
+
+import { type Component, Show, createEffect } from "solid-js";
+import { useRecorder } from "./useRecorder";
+
+const WebcamOverlay: Component = () => {
+  const recorder = useRecorder();
+  let videoRef: HTMLVideoElement | undefined;
+
+  // Reassign srcObject whenever the stream changes. Setting it via JSX
+  // attribute doesn't work for MediaStream — has to be imperative.
+  createEffect(() => {
+    const s = recorder.webcamStream();
+    if (videoRef) videoRef.srcObject = s;
+  });
+
+  return (
+    <Show when={recorder.webcamStream()}>
+      <div
+        data-testid="webcam-overlay"
+        class="fixed bottom-4 right-4 z-40 w-48 h-36 rounded-xl overflow-hidden shadow-2xl shadow-black/50 border border-edge pointer-events-none"
+      >
+        <video
+          ref={videoRef}
+          autoplay
+          muted
+          playsinline
+          class="w-full h-full object-cover scale-x-[-1]"
+        />
+      </div>
+    </Show>
+  );
+};
+
+export default WebcamOverlay;

--- a/packages/client/src/recorder/WebcamOverlay.tsx
+++ b/packages/client/src/recorder/WebcamOverlay.tsx
@@ -27,7 +27,7 @@ const WebcamOverlay: Component = () => {
     <Show when={recorder.webcamStream()}>
       <div
         data-testid="webcam-overlay"
-        class="fixed bottom-4 right-4 z-40 w-48 h-36 rounded-xl overflow-hidden shadow-2xl shadow-black/50 border border-edge pointer-events-none"
+        class="fixed bottom-5 right-5 z-40 w-44 h-44 rounded-full overflow-hidden shadow-2xl shadow-black/60 ring-1 ring-white/10 pointer-events-none"
       >
         <video
           ref={videoRef}

--- a/packages/client/src/recorder/mic.ts
+++ b/packages/client/src/recorder/mic.ts
@@ -1,0 +1,113 @@
+/** Mic domain: device inventory, selected input, and the live preview
+ *  (audio stream + AnalyserNode + rAF-driven RMS level meter).
+ *
+ *  Module-level singleton — only one preview can be open at a time;
+ *  opening a new one closes the previous. */
+
+import { createMemo, createSignal } from "solid-js";
+
+export type MicState =
+  | { kind: "off" }
+  | { kind: "error"; message: string }
+  | { kind: "live" };
+
+const [devices, setDevices] = createSignal<MediaDeviceInfo[]>([]);
+const [selectedId, setSelectedId] = createSignal<string>("default");
+const [state, setState] = createSignal<MicState>({ kind: "off" });
+const [level, setLevel] = createSignal(0);
+
+const errorMessage = createMemo(() => {
+  const s = state();
+  return s.kind === "error" ? s.message : null;
+});
+
+export const mic = {
+  devices,
+  selectedId,
+  state,
+  level,
+  errorMessage,
+};
+
+interface Preview {
+  stream: MediaStream;
+  ctx: AudioContext;
+  source: MediaStreamAudioSourceNode;
+  analyser: AnalyserNode;
+  buf: Float32Array<ArrayBuffer>;
+  raf: number;
+}
+let preview: Preview | null = null;
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export async function openMicPreview(deviceId: string): Promise<void> {
+  closeMicPreview();
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: deviceId === "default" ? true : { deviceId: { exact: deviceId } },
+      video: false,
+    });
+    const ctx = new AudioContext();
+    const source = ctx.createMediaStreamSource(stream);
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 512;
+    source.connect(analyser);
+    // Explicit ArrayBuffer backing keeps the narrow generic that
+    // `getFloatTimeDomainData` expects in lib.dom.
+    const buf = new Float32Array(new ArrayBuffer(analyser.fftSize * 4));
+    const tick = () => {
+      if (!preview) return;
+      preview.analyser.getFloatTimeDomainData(preview.buf);
+      let sum = 0;
+      for (let i = 0; i < preview.buf.length; i++) {
+        const v = preview.buf[i]!;
+        sum += v * v;
+      }
+      // Light nonlinear shaping so talking registers visibly without
+      // clipping on louder syllables.
+      const rms = Math.sqrt(sum / preview.buf.length);
+      const next = Math.min(1, Math.pow(rms, 0.5) * 2);
+      if (Math.abs(next - level()) > 0.01) setLevel(next);
+      preview.raf = requestAnimationFrame(tick);
+    };
+    preview = {
+      stream,
+      ctx,
+      source,
+      analyser,
+      buf,
+      raf: requestAnimationFrame(tick),
+    };
+    setState({ kind: "live" });
+  } catch (err) {
+    setState({ kind: "error", message: errMsg(err) });
+    throw err;
+  }
+}
+
+export function closeMicPreview(): void {
+  if (!preview) return;
+  cancelAnimationFrame(preview.raf);
+  preview.source.disconnect();
+  void preview.ctx.close();
+  for (const t of preview.stream.getTracks()) t.stop();
+  preview = null;
+  setState({ kind: "off" });
+  setLevel(0);
+}
+
+/** Non-reactive snapshot used when composing the MediaRecorder stream. */
+export function micPreviewStream(): MediaStream | null {
+  return preview?.stream ?? null;
+}
+
+export function setMicSelectedId(id: string): void {
+  setSelectedId(id);
+}
+
+export function setMicDevices(list: MediaDeviceInfo[]): void {
+  setDevices(list);
+}

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -491,33 +491,8 @@ async function stopRecording(): Promise<void> {
     await patched.write(out);
     await patched.close();
 
-    // Open action re-reads the saved file from disk on click — we keep
-    // only the small `FileSystemFileHandle` reference in the closure,
-    // not the full blob. Browsers still require a blob URL to open a
-    // new tab (FSA hides the real path), but it lives only long enough
-    // for window.open to navigate.
-    const handle = a.handle;
     toast.success(
       `Recording saved · ${formatSeconds(Math.round(durationMs / 1000))}`,
-      {
-        description: handle.name,
-        duration: 30_000,
-        action: {
-          label: "Open",
-          onClick: () => {
-            void (async () => {
-              try {
-                const file = await handle.getFile();
-                const url = URL.createObjectURL(file);
-                window.open(url, "_blank", "noopener,noreferrer");
-                setTimeout(() => URL.revokeObjectURL(url), 60_000);
-              } catch (err) {
-                toast.error(`Open failed: ${errMsg(err)}`);
-              }
-            })();
-          },
-        },
-      },
     );
   } catch (err) {
     toast.error(`Save failed: ${errMsg(err)}`);

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -24,6 +24,7 @@
 
 import { createSignal } from "solid-js";
 import { toast } from "solid-sonner";
+import fixWebmDuration from "fix-webm-duration";
 
 interface SaveFilePickerOptions {
   suggestedName?: string;
@@ -80,7 +81,16 @@ let preview: Preview | null = null;
 
 interface Active {
   recorder: MediaRecorder;
-  writable: FileSystemWritableFileStream;
+  /** User-picked save destination. We hold the handle through the whole
+   *  session and only `createWritable()` on stop, after we've fixed the
+   *  WebM duration header — Chrome's MediaRecorder in streaming mode
+   *  omits the duration EBML, which leaves players showing "0:01" for
+   *  arbitrarily long files. See `stopRecording` for the fix-up. */
+  handle: FileSystemFileHandle;
+  /** All timeslice chunks emitted by the MediaRecorder. Concatenated
+   *  into a single Blob at stop time so `fix-webm-duration` can patch
+   *  the header. Memory cost ≈ 1–2 MB/min for terminal video. */
+  chunks: Blob[];
   tracks: MediaStreamTrack[];
   ticker: number;
   /** Anchor used by the ticker: `elapsed = performance.now() - anchor`.
@@ -303,7 +313,6 @@ function cancelSetup(): void {
 async function startRecording(): Promise<void> {
   if (phase() !== "setup" || !preview) return;
 
-  let sink: FileSystemWritableFileStream | null = null;
   const displayTracks: MediaStreamTrack[] = [];
   try {
     const handle = await window.showSaveFilePicker({
@@ -312,8 +321,6 @@ async function startRecording(): Promise<void> {
         { description: "WebM video", accept: { "video/webm": [".webm"] } },
       ],
     });
-    sink = await handle.createWritable();
-    const writable = sink;
 
     const display = await navigator.mediaDevices.getDisplayMedia({
       video: true,
@@ -329,8 +336,9 @@ async function startRecording(): Promise<void> {
       ...preview.stream.getAudioTracks(),
     ]);
     const recorder = new MediaRecorder(stream, { mimeType: MIME });
+    const chunks: Blob[] = [];
     recorder.ondataavailable = (ev) => {
-      if (ev.data.size > 0) void writable.write(ev.data);
+      if (ev.data.size > 0) chunks.push(ev.data);
     };
     // Browser's own "stop sharing" bar ends the video track — treat it
     // like a normal stop so the file closes cleanly.
@@ -346,7 +354,8 @@ async function startRecording(): Promise<void> {
     }, 250);
     active = {
       recorder,
-      writable,
+      handle,
+      chunks,
       tracks: [...displayTracks, ...preview.stream.getTracks()],
       ticker,
       anchor,
@@ -358,7 +367,6 @@ async function startRecording(): Promise<void> {
     toast.success("Recording started");
   } catch (err) {
     for (const t of displayTracks) t.stop();
-    if (sink) await sink.close().catch(() => {});
     if (!isAbort(err)) toast.error(`Recording failed: ${errMsg(err)}`);
     // Stay in setup so the user can retry without re-granting mic/webcam.
   }
@@ -413,6 +421,8 @@ async function stopRecording(): Promise<void> {
   clearInterval(a.ticker);
   setElapsedMs(0);
 
+  const durationMs = a.pauseElapsed ?? performance.now() - a.anchor;
+
   await new Promise<void>((resolve) => {
     a.recorder.addEventListener("stop", () => resolve(), { once: true });
     try {
@@ -425,8 +435,23 @@ async function stopRecording(): Promise<void> {
   closePreview();
   closeWebcam();
   setWebcamEnabledSignal(false);
+
   try {
-    await a.writable.close();
+    // Chrome's MediaRecorder streams WebM without a SegmentInfo.Duration
+    // header, so players show an arbitrary length (often 0:01). Patch the
+    // header with the real elapsed duration before writing. If the fix
+    // fails for any reason, fall back to the raw blob — a playable file
+    // with wrong duration beats no file at all.
+    const raw = new Blob(a.chunks, { type: MIME });
+    let out: Blob;
+    try {
+      out = await fixWebmDuration(raw, durationMs, { logger: false });
+    } catch {
+      out = raw;
+    }
+    const writable = await a.handle.createWritable();
+    await writable.write(out);
+    await writable.close();
     toast.success("Recording saved");
   } catch (err) {
     toast.error(`Save failed: ${errMsg(err)}`);

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -493,6 +493,7 @@ async function stopRecording(): Promise<void> {
 
     toast.success(
       `Recording saved · ${formatSeconds(Math.round(durationMs / 1000))}`,
+      { description: a.handle.name },
     );
   } catch (err) {
     toast.error(`Save failed: ${errMsg(err)}`);

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -178,7 +178,8 @@ async function openPreview(deviceId: string): Promise<void> {
       // Light nonlinear shaping so talking registers visibly without
       // clipping on louder syllables.
       const rms = Math.sqrt(sum / preview.buf.length);
-      setMicLevel(Math.min(1, Math.pow(rms, 0.5) * 2));
+      const next = Math.min(1, Math.pow(rms, 0.5) * 2);
+      if (Math.abs(next - micLevel()) > 0.01) setMicLevel(next);
       preview.raf = requestAnimationFrame(tick);
     };
     preview = {
@@ -275,26 +276,12 @@ async function refreshDevices(): Promise<void> {
 // ── Setup phase ─────────────────────────────────────────────────────────
 
 async function openSetup(): Promise<void> {
-  console.log("[recorder] openSetup.enter", {
-    phase: phase(),
-    hasPreview: !!preview,
-    hasActive: !!active,
-  });
-  if (phase() !== "idle") {
-    console.log("[recorder] openSetup.skip phase not idle");
-    return;
-  }
+  if (phase() !== "idle") return;
   setPhase("setup");
   try {
     await openPreview(micDeviceId());
     await refreshDevices();
-    console.log("[recorder] openSetup.ok");
   } catch (err) {
-    console.log("[recorder] openSetup.error", {
-      isAbort: isAbort(err),
-      msg: errMsg(err),
-      err,
-    });
     if (!isAbort(err)) toast.error(`Microphone: ${errMsg(err)}`);
     setPhase("idle");
   }
@@ -357,16 +344,12 @@ async function startRecording(): Promise<void> {
     };
     // Browser's own "stop sharing" bar ends the video track — treat it
     // like a normal stop so the file closes cleanly.
-    display.getVideoTracks()[0]?.addEventListener("ended", () => {
-      void stopRecording();
-    });
+    display
+      .getVideoTracks()[0]
+      ?.addEventListener("ended", () => void stopRecording(), { once: true });
 
     const anchor = performance.now();
-    const ticker = window.setInterval(() => {
-      // When paused, the ticker is cancelled — so a live tick implies
-      // `active.pauseElapsed === null`. Safe to compute from the anchor.
-      if (active) setElapsedMs(performance.now() - active.anchor);
-    }, 250);
+    const ticker = window.setInterval(tickElapsed, 250);
     active = {
       recorder,
       handle,
@@ -423,10 +406,18 @@ function togglePause(): void {
       a.anchor = performance.now() - a.pauseElapsed;
       a.pauseElapsed = null;
     }
-    a.ticker = window.setInterval(() => {
-      if (active) setElapsedMs(performance.now() - active.anchor);
-    }, 250);
+    a.ticker = window.setInterval(tickElapsed, 250);
     setPhase("recording");
+  }
+}
+
+/** Ticker body — guarded against same-second no-ops so downstream
+ *  memos don't re-flush 4× per displayed tick. */
+function tickElapsed(): void {
+  if (!active) return;
+  const next = performance.now() - active.anchor;
+  if (Math.floor(next / 1000) !== Math.floor(elapsedMs() / 1000)) {
+    setElapsedMs(next);
   }
 }
 
@@ -475,33 +466,29 @@ async function stopRecording(): Promise<void> {
     // `fix-webm-duration` is not a streaming patcher); during recording,
     // memory stayed flat.
     const raw = await a.handle.getFile();
-    const fixLog: string[] = [];
     let out: Blob = raw;
     try {
-      out = await fixWebmDuration(raw, durationMs, {
-        logger: (msg: string) => fixLog.push(msg),
-      });
+      out = await fixWebmDuration(raw, durationMs);
     } catch (err) {
-      fixLog.push(`error: ${errMsg(err)}`);
+      toast.warning(`Duration patch failed: ${errMsg(err)}`);
     }
-    console.log("[recorder] webm-duration-fix", { durationMs, fixLog });
     // Fresh `createWritable()` defaults to truncating the file, so the
     // patched blob replaces the streamed bytes wholesale.
     const patched = await a.handle.createWritable();
     await patched.write(out);
     await patched.close();
 
-    toast.success(
-      `Recording saved · ${formatSeconds(Math.round(durationMs / 1000))}`,
-      { description: a.handle.name },
-    );
+    toast.success(`Recording saved · ${formatElapsed(durationMs)}`, {
+      description: a.handle.name,
+    });
   } catch (err) {
     toast.error(`Save failed: ${errMsg(err)}`);
   }
 }
 
-function formatSeconds(total: number): string {
+export function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
   const m = Math.floor(total / 60);
   const s = total % 60;
-  return `${m}:${s.toString().padStart(2, "0")}`;
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
 }

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -1,21 +1,26 @@
-/** Workspace screen + mic recording with pre-record mic setup.
+/** Workspace screen + mic (+ optional webcam) recording with pre-record
+ *  setup and pause/resume.
  *
  *  Capture target: the current browser tab via
  *  `getDisplayMedia({ preferCurrentTab: true, selfBrowserSurface: "include" })`.
- *  That collapses the browser's multi-surface picker into a single
- *  "Share this tab" confirmation. The recording then contains the whole
- *  Kolu UI — chrome bar, pill tree, canvas, everything — so if the user
- *  wants to record a single terminal they just maximize it first.
+ *  The browser's multi-surface picker collapses to a single "Share this
+ *  tab" confirmation. The recording contains the whole Kolu UI — chrome
+ *  bar, pill tree, canvas, and (if enabled) a fixed-corner webcam overlay
+ *  baked into the DOM. If the user wants to record one terminal they
+ *  just maximize it first.
  *
  *  Phases:
  *    idle     → nothing going on.
- *    setup    → mic stream is open for device preview + level meter.
- *               The user can pick a different mic before committing.
- *    recording → MediaRecorder is streaming 2s WebM (VP9/Opus) chunks
- *               directly into an FSA-picked file handle.
+ *    setup    → mic stream open for device preview + level meter.
+ *               Optional webcam stream open if the user toggled it on.
+ *    recording → MediaRecorder streams 2s WebM (VP9/Opus) chunks into
+ *               the FSA-picked file handle.
+ *    paused   → MediaRecorder.pause() — no chunks emitted; elapsed timer
+ *               freezes. Webcam + mic streams stay open for preview
+ *               continuity.
  *
  *  Chromium-only by design (`showSaveFilePicker`, `preferCurrentTab`,
- *  FSA). `isRecordingSupported()` hides the entry points elsewhere. */
+ *  FSA). `isRecordingSupported()` hides entry points elsewhere. */
 
 import { createSignal } from "solid-js";
 import { toast } from "solid-sonner";
@@ -47,7 +52,7 @@ declare global {
 const MIME = "video/webm;codecs=vp9,opus";
 const TIMESLICE_MS = 2000;
 
-type Phase = "idle" | "setup" | "recording";
+type Phase = "idle" | "setup" | "recording" | "paused";
 
 const [phase, setPhase] = createSignal<Phase>("idle");
 const [elapsedMs, setElapsedMs] = createSignal(0);
@@ -55,6 +60,13 @@ const [micDevices, setMicDevices] = createSignal<MediaDeviceInfo[]>([]);
 const [micDeviceId, setMicDeviceIdSignal] = createSignal<string>("default");
 const [micLevel, setMicLevel] = createSignal(0);
 const [micError, setMicError] = createSignal<string | null>(null);
+
+const [webcamEnabled, setWebcamEnabledSignal] = createSignal(false);
+const [webcamStream, setWebcamStream] = createSignal<MediaStream | null>(null);
+const [webcamDevices, setWebcamDevices] = createSignal<MediaDeviceInfo[]>([]);
+const [webcamDeviceId, setWebcamDeviceIdSignal] =
+  createSignal<string>("default");
+const [webcamError, setWebcamError] = createSignal<string | null>(null);
 
 interface Preview {
   stream: MediaStream;
@@ -71,6 +83,11 @@ interface Active {
   writable: FileSystemWritableFileStream;
   tracks: MediaStreamTrack[];
   ticker: number;
+  /** Anchor used by the ticker: `elapsed = performance.now() - anchor`.
+   *  Mutated on resume to subtract paused duration. */
+  anchor: number;
+  /** Snapshot taken at pause; restored on resume by rewinding `anchor`. */
+  pauseElapsed: number | null;
 }
 let active: Active | null = null;
 
@@ -93,10 +110,18 @@ export function useRecorder() {
     micDeviceId,
     micLevel,
     micError,
+    webcamEnabled,
+    webcamStream,
+    webcamDevices,
+    webcamDeviceId,
+    webcamError,
     openSetup,
     changeMic,
+    toggleWebcam,
+    changeWebcam,
     cancelSetup,
     startRecording,
+    togglePause,
     stop: stopRecording,
   };
 }
@@ -113,9 +138,11 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// ── Mic preview ─────────────────────────────────────────────────────────
+
 /** Open a mic stream for the given deviceId and attach an AnalyserNode.
- *  Runs an rAF loop that publishes the current RMS level to `micLevel`
- *  (0..1, roughly). Re-entrant: closes any existing preview first. */
+ *  Runs an rAF loop that publishes the current RMS level to `micLevel`.
+ *  Re-entrant: closes any existing preview first. */
 async function openPreview(deviceId: string): Promise<void> {
   closePreview();
   try {
@@ -170,19 +197,74 @@ function closePreview(): void {
   setMicLevel(0);
 }
 
-/** Populate the device list once permission is granted. Before the first
- *  successful getUserMedia, device labels are empty strings. */
+// ── Webcam ──────────────────────────────────────────────────────────────
+
+/** Open a webcam stream on the given deviceId. Re-entrant. */
+async function openWebcam(deviceId: string): Promise<void> {
+  closeWebcam();
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: deviceId === "default" ? true : { deviceId: { exact: deviceId } },
+      audio: false,
+    });
+    setWebcamStream(stream);
+    setWebcamError(null);
+  } catch (err) {
+    setWebcamError(errMsg(err));
+    throw err;
+  }
+}
+
+function closeWebcam(): void {
+  const s = webcamStream();
+  if (!s) return;
+  for (const t of s.getTracks()) t.stop();
+  setWebcamStream(null);
+}
+
+async function toggleWebcam(): Promise<void> {
+  if (webcamEnabled()) {
+    setWebcamEnabledSignal(false);
+    closeWebcam();
+    return;
+  }
+  try {
+    await openWebcam(webcamDeviceId());
+    await refreshDevices();
+    setWebcamEnabledSignal(true);
+  } catch (err) {
+    if (!isAbort(err)) toast.error(`Webcam: ${errMsg(err)}`);
+    setWebcamEnabledSignal(false);
+  }
+}
+
+async function changeWebcam(deviceId: string): Promise<void> {
+  setWebcamDeviceIdSignal(deviceId);
+  if (!webcamEnabled()) return;
+  try {
+    await openWebcam(deviceId);
+  } catch (err) {
+    if (!isAbort(err)) toast.error(`Webcam: ${errMsg(err)}`);
+  }
+}
+
+// ── Device enumeration ──────────────────────────────────────────────────
+
+/** Populate both device lists. Labels are only populated after the
+ *  relevant getUserMedia permission has been granted. */
 async function refreshDevices(): Promise<void> {
   try {
     const all = await navigator.mediaDevices.enumerateDevices();
     setMicDevices(all.filter((d) => d.kind === "audioinput"));
+    setWebcamDevices(all.filter((d) => d.kind === "videoinput"));
   } catch {
-    setMicDevices([]);
+    // Leave current lists as-is — an enumeration failure shouldn't wipe
+    // a previously-populated list.
   }
 }
 
-/** Enter setup phase: open preview on the default mic, enumerate devices.
- *  Called when the chrome-bar record button is clicked from idle. */
+// ── Setup phase ─────────────────────────────────────────────────────────
+
 async function openSetup(): Promise<void> {
   if (phase() !== "idle") return;
   setPhase("setup");
@@ -208,12 +290,16 @@ async function changeMic(deviceId: string): Promise<void> {
 function cancelSetup(): void {
   if (phase() !== "setup") return;
   closePreview();
+  closeWebcam();
+  setWebcamEnabledSignal(false);
   setPhase("idle");
 }
 
+// ── Recording phase ─────────────────────────────────────────────────────
+
 /** Commit: save-picker → screen-picker → MediaRecorder over the existing
  *  preview audio stream. If anything goes wrong mid-flight, return to
- *  setup phase with the preview still live so the user can retry. */
+ *  setup phase with preview + webcam still live so the user can retry. */
 async function startRecording(): Promise<void> {
   if (phase() !== "setup" || !preview) return;
 
@@ -252,19 +338,19 @@ async function startRecording(): Promise<void> {
       void stopRecording();
     });
 
-    const startedAt = performance.now();
-    const ticker = window.setInterval(
-      () => setElapsedMs(performance.now() - startedAt),
-      250,
-    );
-    // Keep `preview` alive — its analyser keeps feeding the level meter,
-    // and we deliberately don't re-open a second mic stream (one device
-    // handle for preview + record).
+    const anchor = performance.now();
+    const ticker = window.setInterval(() => {
+      // When paused, the ticker is cancelled — so a live tick implies
+      // `active.pauseElapsed === null`. Safe to compute from the anchor.
+      if (active) setElapsedMs(performance.now() - active.anchor);
+    }, 250);
     active = {
       recorder,
       writable,
       tracks: [...displayTracks, ...preview.stream.getTracks()],
       ticker,
+      anchor,
+      pauseElapsed: null,
     };
     setElapsedMs(0);
     setPhase("recording");
@@ -274,7 +360,38 @@ async function startRecording(): Promise<void> {
     for (const t of displayTracks) t.stop();
     if (sink) await sink.close().catch(() => {});
     if (!isAbort(err)) toast.error(`Recording failed: ${errMsg(err)}`);
-    // Stay in setup so the user can retry without re-granting mic.
+    // Stay in setup so the user can retry without re-granting mic/webcam.
+  }
+}
+
+function togglePause(): void {
+  const a = active;
+  if (!a) return;
+  if (phase() === "recording") {
+    try {
+      a.recorder.pause();
+    } catch {
+      return;
+    }
+    clearInterval(a.ticker);
+    a.pauseElapsed = performance.now() - a.anchor;
+    setElapsedMs(a.pauseElapsed);
+    setPhase("paused");
+  } else if (phase() === "paused") {
+    try {
+      a.recorder.resume();
+    } catch {
+      return;
+    }
+    // Rewind the anchor so `now - anchor` resumes from the paused snapshot.
+    if (a.pauseElapsed !== null) {
+      a.anchor = performance.now() - a.pauseElapsed;
+      a.pauseElapsed = null;
+    }
+    a.ticker = window.setInterval(() => {
+      if (active) setElapsedMs(performance.now() - active.anchor);
+    }, 250);
+    setPhase("recording");
   }
 }
 
@@ -296,6 +413,8 @@ async function stopRecording(): Promise<void> {
   });
   for (const t of a.tracks) t.stop();
   closePreview();
+  closeWebcam();
+  setWebcamEnabledSignal(false);
   try {
     await a.writable.close();
     toast.success("Recording saved");

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -1,19 +1,25 @@
-/** Workspace screen + mic recording.
+/** Workspace screen + mic recording with pre-record mic setup.
  *
- *  Flow: save-as picker → screen picker (tab/window/screen) → mic prompt.
- *  A `MediaRecorder` streams 2-second WebM chunks directly into the file
- *  handle via the File System Access API, so memory stays flat regardless
- *  of recording length.
+ *  Capture target: the current browser tab via
+ *  `getDisplayMedia({ preferCurrentTab: true, selfBrowserSurface: "include" })`.
+ *  That collapses the browser's multi-surface picker into a single
+ *  "Share this tab" confirmation. The recording then contains the whole
+ *  Kolu UI — chrome bar, pill tree, canvas, everything — so if the user
+ *  wants to record a single terminal they just maximize it first.
  *
- *  Chromium-only by design — `showSaveFilePicker` isn't in Firefox/Safari,
- *  and we deliberately skip in-memory fallbacks to keep the code simple.
- *  `isRecordingSupported()` gates the UI so the button is hidden elsewhere. */
+ *  Phases:
+ *    idle     → nothing going on.
+ *    setup    → mic stream is open for device preview + level meter.
+ *               The user can pick a different mic before committing.
+ *    recording → MediaRecorder is streaming 2s WebM (VP9/Opus) chunks
+ *               directly into an FSA-picked file handle.
+ *
+ *  Chromium-only by design (`showSaveFilePicker`, `preferCurrentTab`,
+ *  FSA). `isRecordingSupported()` hides the entry points elsewhere. */
 
 import { createSignal } from "solid-js";
 import { toast } from "solid-sonner";
 
-// File System Access API's `showSaveFilePicker` is not in lib.dom yet.
-// The handle/writable types are, so we only need to declare the entry point.
 interface SaveFilePickerOptions {
   suggestedName?: string;
   types?: Array<{
@@ -27,13 +33,38 @@ declare global {
       options?: SaveFilePickerOptions,
     ): Promise<FileSystemFileHandle>;
   }
+  interface MediaDevices {
+    getDisplayMedia(
+      constraints?: DisplayMediaStreamOptions & {
+        preferCurrentTab?: boolean;
+        selfBrowserSurface?: "include" | "exclude";
+        systemAudio?: "include" | "exclude";
+      },
+    ): Promise<MediaStream>;
+  }
 }
 
 const MIME = "video/webm;codecs=vp9,opus";
 const TIMESLICE_MS = 2000;
 
-const [isRecording, setIsRecording] = createSignal(false);
+type Phase = "idle" | "setup" | "recording";
+
+const [phase, setPhase] = createSignal<Phase>("idle");
 const [elapsedMs, setElapsedMs] = createSignal(0);
+const [micDevices, setMicDevices] = createSignal<MediaDeviceInfo[]>([]);
+const [micDeviceId, setMicDeviceIdSignal] = createSignal<string>("default");
+const [micLevel, setMicLevel] = createSignal(0);
+const [micError, setMicError] = createSignal<string | null>(null);
+
+interface Preview {
+  stream: MediaStream;
+  ctx: AudioContext;
+  analyser: AnalyserNode;
+  source: MediaStreamAudioSourceNode;
+  raf: number;
+  buf: Float32Array<ArrayBuffer>;
+}
+let preview: Preview | null = null;
 
 interface Active {
   recorder: MediaRecorder;
@@ -41,7 +72,6 @@ interface Active {
   tracks: MediaStreamTrack[];
   ticker: number;
 }
-
 let active: Active | null = null;
 
 export function isRecordingSupported(): boolean {
@@ -57,10 +87,17 @@ export function isRecordingSupported(): boolean {
 
 export function useRecorder() {
   return {
-    isRecording,
+    phase,
     elapsedMs,
-    start,
-    stop,
+    micDevices,
+    micDeviceId,
+    micLevel,
+    micError,
+    openSetup,
+    changeMic,
+    cancelSetup,
+    startRecording,
+    stop: stopRecording,
   };
 }
 
@@ -72,11 +109,116 @@ function isAbort(err: unknown): boolean {
   return err instanceof DOMException && err.name === "AbortError";
 }
 
-async function start(): Promise<void> {
-  if (active) return;
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Open a mic stream for the given deviceId and attach an AnalyserNode.
+ *  Runs an rAF loop that publishes the current RMS level to `micLevel`
+ *  (0..1, roughly). Re-entrant: closes any existing preview first. */
+async function openPreview(deviceId: string): Promise<void> {
+  closePreview();
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: deviceId === "default" ? true : { deviceId: { exact: deviceId } },
+      video: false,
+    });
+    const ctx = new AudioContext();
+    const source = ctx.createMediaStreamSource(stream);
+    const analyser = ctx.createAnalyser();
+    analyser.fftSize = 512;
+    source.connect(analyser);
+    // Explicit ArrayBuffer backing keeps the narrow generic that
+    // `getFloatTimeDomainData` expects in lib.dom.
+    const buf = new Float32Array(new ArrayBuffer(analyser.fftSize * 4));
+    const tick = () => {
+      if (!preview) return;
+      preview.analyser.getFloatTimeDomainData(preview.buf);
+      let sum = 0;
+      for (let i = 0; i < preview.buf.length; i++) {
+        const v = preview.buf[i]!;
+        sum += v * v;
+      }
+      // Light nonlinear shaping so talking registers visibly without
+      // clipping on louder syllables.
+      const rms = Math.sqrt(sum / preview.buf.length);
+      setMicLevel(Math.min(1, Math.pow(rms, 0.5) * 2));
+      preview.raf = requestAnimationFrame(tick);
+    };
+    preview = {
+      stream,
+      ctx,
+      analyser,
+      source,
+      raf: requestAnimationFrame(tick),
+      buf,
+    };
+    setMicError(null);
+  } catch (err) {
+    setMicError(errMsg(err));
+    throw err;
+  }
+}
+
+function closePreview(): void {
+  if (!preview) return;
+  cancelAnimationFrame(preview.raf);
+  preview.source.disconnect();
+  void preview.ctx.close();
+  for (const t of preview.stream.getTracks()) t.stop();
+  preview = null;
+  setMicLevel(0);
+}
+
+/** Populate the device list once permission is granted. Before the first
+ *  successful getUserMedia, device labels are empty strings. */
+async function refreshDevices(): Promise<void> {
+  try {
+    const all = await navigator.mediaDevices.enumerateDevices();
+    setMicDevices(all.filter((d) => d.kind === "audioinput"));
+  } catch {
+    setMicDevices([]);
+  }
+}
+
+/** Enter setup phase: open preview on the default mic, enumerate devices.
+ *  Called when the chrome-bar record button is clicked from idle. */
+async function openSetup(): Promise<void> {
+  if (phase() !== "idle") return;
+  setPhase("setup");
+  try {
+    await openPreview(micDeviceId());
+    await refreshDevices();
+  } catch (err) {
+    if (!isAbort(err)) toast.error(`Microphone: ${errMsg(err)}`);
+    setPhase("idle");
+  }
+}
+
+async function changeMic(deviceId: string): Promise<void> {
+  if (phase() !== "setup") return;
+  setMicDeviceIdSignal(deviceId);
+  try {
+    await openPreview(deviceId);
+  } catch (err) {
+    if (!isAbort(err)) toast.error(`Microphone: ${errMsg(err)}`);
+  }
+}
+
+function cancelSetup(): void {
+  if (phase() !== "setup") return;
+  closePreview();
+  setPhase("idle");
+}
+
+/** Commit: save-picker → screen-picker → MediaRecorder over the existing
+ *  preview audio stream. If anything goes wrong mid-flight, return to
+ *  setup phase with the preview still live so the user can retry. */
+async function startRecording(): Promise<void> {
+  if (phase() !== "setup" || !preview) return;
 
   let sink: FileSystemWritableFileStream | null = null;
-  const tracks: MediaStreamTrack[] = [];
+  const displayTracks: MediaStreamTrack[] = [];
   try {
     const handle = await window.showSaveFilePicker({
       suggestedName: `kolu-${timestamp()}.webm`,
@@ -90,27 +232,24 @@ async function start(): Promise<void> {
     const display = await navigator.mediaDevices.getDisplayMedia({
       video: true,
       audio: false,
+      preferCurrentTab: true,
+      selfBrowserSurface: "include",
+      systemAudio: "exclude",
     });
-    tracks.push(...display.getTracks());
-
-    const mic = await navigator.mediaDevices.getUserMedia({
-      audio: true,
-      video: false,
-    });
-    tracks.push(...mic.getTracks());
+    displayTracks.push(...display.getTracks());
 
     const stream = new MediaStream([
       ...display.getVideoTracks(),
-      ...mic.getAudioTracks(),
+      ...preview.stream.getAudioTracks(),
     ]);
     const recorder = new MediaRecorder(stream, { mimeType: MIME });
     recorder.ondataavailable = (ev) => {
       if (ev.data.size > 0) void writable.write(ev.data);
     };
     // Browser's own "stop sharing" bar ends the video track — treat it
-    // like a normal stop so the file is closed cleanly.
+    // like a normal stop so the file closes cleanly.
     display.getVideoTracks()[0]?.addEventListener("ended", () => {
-      void stop();
+      void stopRecording();
     });
 
     const startedAt = performance.now();
@@ -118,26 +257,32 @@ async function start(): Promise<void> {
       () => setElapsedMs(performance.now() - startedAt),
       250,
     );
-    active = { recorder, writable, tracks, ticker };
+    // Keep `preview` alive — its analyser keeps feeding the level meter,
+    // and we deliberately don't re-open a second mic stream (one device
+    // handle for preview + record).
+    active = {
+      recorder,
+      writable,
+      tracks: [...displayTracks, ...preview.stream.getTracks()],
+      ticker,
+    };
     setElapsedMs(0);
-    setIsRecording(true);
+    setPhase("recording");
     recorder.start(TIMESLICE_MS);
     toast.success("Recording started");
   } catch (err) {
-    for (const t of tracks) t.stop();
+    for (const t of displayTracks) t.stop();
     if (sink) await sink.close().catch(() => {});
-    if (!isAbort(err)) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error(`Recording failed: ${msg}`);
-    }
+    if (!isAbort(err)) toast.error(`Recording failed: ${errMsg(err)}`);
+    // Stay in setup so the user can retry without re-granting mic.
   }
 }
 
-async function stop(): Promise<void> {
+async function stopRecording(): Promise<void> {
   const a = active;
   if (!a) return;
   active = null;
-  setIsRecording(false);
+  setPhase("idle");
   clearInterval(a.ticker);
   setElapsedMs(0);
 
@@ -150,11 +295,11 @@ async function stop(): Promise<void> {
     }
   });
   for (const t of a.tracks) t.stop();
+  closePreview();
   try {
     await a.writable.close();
     toast.success("Recording saved");
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    toast.error(`Save failed: ${msg}`);
+    toast.error(`Save failed: ${errMsg(err)}`);
   }
 }

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -439,28 +439,49 @@ async function stopRecording(): Promise<void> {
   try {
     // Chrome's MediaRecorder streams WebM without a SegmentInfo.Duration
     // header, so players show an arbitrary length (often 0:01). Patch the
-    // header before writing. Logger messages are captured into the toast
-    // so we can see whether the library found the section to patch.
+    // header before writing. Logger messages go to console for diagnosis;
+    // the toast surfaces filename + an Open action via blob URL.
     const raw = new Blob(a.chunks, { type: MIME });
     const fixLog: string[] = [];
     let out: Blob = raw;
-    let fixNote = "";
     try {
       out = await fixWebmDuration(raw, durationMs, {
         logger: (msg: string) => fixLog.push(msg),
       });
-      fixNote = fixLog.join(" · ") || "no log";
     } catch (err) {
-      fixNote = `error: ${errMsg(err)}`;
+      fixLog.push(`error: ${errMsg(err)}`);
     }
     console.log("[recorder] webm-duration-fix", { durationMs, fixLog });
     const writable = await a.handle.createWritable();
     await writable.write(out);
     await writable.close();
-    toast.success(`Recording saved (${Math.round(durationMs / 1000)}s)`, {
-      description: fixNote,
-    });
+
+    // Blob URL = one-click preview. Browsers hide the full filesystem
+    // path (FSA security), so the filename is the best locator we can
+    // show. Revoke the URL after five minutes — long enough for the
+    // user to click, short enough not to hold a reference forever.
+    const url = URL.createObjectURL(out);
+    setTimeout(() => URL.revokeObjectURL(url), 5 * 60_000);
+    toast.success(
+      `Recording saved · ${formatSeconds(Math.round(durationMs / 1000))}`,
+      {
+        description: a.handle.name,
+        duration: 30_000,
+        action: {
+          label: "Open",
+          onClick: () => {
+            window.open(url, "_blank", "noopener,noreferrer");
+          },
+        },
+      },
+    );
   } catch (err) {
     toast.error(`Save failed: ${errMsg(err)}`);
   }
+}
+
+function formatSeconds(total: number): string {
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
 }

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -1,0 +1,160 @@
+/** Workspace screen + mic recording.
+ *
+ *  Flow: save-as picker → screen picker (tab/window/screen) → mic prompt.
+ *  A `MediaRecorder` streams 2-second WebM chunks directly into the file
+ *  handle via the File System Access API, so memory stays flat regardless
+ *  of recording length.
+ *
+ *  Chromium-only by design — `showSaveFilePicker` isn't in Firefox/Safari,
+ *  and we deliberately skip in-memory fallbacks to keep the code simple.
+ *  `isRecordingSupported()` gates the UI so the button is hidden elsewhere. */
+
+import { createSignal } from "solid-js";
+import { toast } from "solid-sonner";
+
+// File System Access API's `showSaveFilePicker` is not in lib.dom yet.
+// The handle/writable types are, so we only need to declare the entry point.
+interface SaveFilePickerOptions {
+  suggestedName?: string;
+  types?: Array<{
+    description?: string;
+    accept: Record<string, string | string[]>;
+  }>;
+}
+declare global {
+  interface Window {
+    showSaveFilePicker(
+      options?: SaveFilePickerOptions,
+    ): Promise<FileSystemFileHandle>;
+  }
+}
+
+const MIME = "video/webm;codecs=vp9,opus";
+const TIMESLICE_MS = 2000;
+
+const [isRecording, setIsRecording] = createSignal(false);
+const [elapsedMs, setElapsedMs] = createSignal(0);
+
+interface Active {
+  recorder: MediaRecorder;
+  writable: FileSystemWritableFileStream;
+  tracks: MediaStreamTrack[];
+  ticker: number;
+}
+
+let active: Active | null = null;
+
+export function isRecordingSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.showSaveFilePicker === "function" &&
+    !!navigator.mediaDevices?.getDisplayMedia &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof MediaRecorder !== "undefined" &&
+    MediaRecorder.isTypeSupported(MIME)
+  );
+}
+
+export function useRecorder() {
+  return {
+    isRecording,
+    elapsedMs,
+    start,
+    stop,
+  };
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function isAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+async function start(): Promise<void> {
+  if (active) return;
+
+  let sink: FileSystemWritableFileStream | null = null;
+  const tracks: MediaStreamTrack[] = [];
+  try {
+    const handle = await window.showSaveFilePicker({
+      suggestedName: `kolu-${timestamp()}.webm`,
+      types: [
+        { description: "WebM video", accept: { "video/webm": [".webm"] } },
+      ],
+    });
+    sink = await handle.createWritable();
+    const writable = sink;
+
+    const display = await navigator.mediaDevices.getDisplayMedia({
+      video: true,
+      audio: false,
+    });
+    tracks.push(...display.getTracks());
+
+    const mic = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+      video: false,
+    });
+    tracks.push(...mic.getTracks());
+
+    const stream = new MediaStream([
+      ...display.getVideoTracks(),
+      ...mic.getAudioTracks(),
+    ]);
+    const recorder = new MediaRecorder(stream, { mimeType: MIME });
+    recorder.ondataavailable = (ev) => {
+      if (ev.data.size > 0) void writable.write(ev.data);
+    };
+    // Browser's own "stop sharing" bar ends the video track — treat it
+    // like a normal stop so the file is closed cleanly.
+    display.getVideoTracks()[0]?.addEventListener("ended", () => {
+      void stop();
+    });
+
+    const startedAt = performance.now();
+    const ticker = window.setInterval(
+      () => setElapsedMs(performance.now() - startedAt),
+      250,
+    );
+    active = { recorder, writable, tracks, ticker };
+    setElapsedMs(0);
+    setIsRecording(true);
+    recorder.start(TIMESLICE_MS);
+    toast.success("Recording started");
+  } catch (err) {
+    for (const t of tracks) t.stop();
+    if (sink) await sink.close().catch(() => {});
+    if (!isAbort(err)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Recording failed: ${msg}`);
+    }
+  }
+}
+
+async function stop(): Promise<void> {
+  const a = active;
+  if (!a) return;
+  active = null;
+  setIsRecording(false);
+  clearInterval(a.ticker);
+  setElapsedMs(0);
+
+  await new Promise<void>((resolve) => {
+    a.recorder.addEventListener("stop", () => resolve(), { once: true });
+    try {
+      a.recorder.stop();
+    } catch {
+      resolve();
+    }
+  });
+  for (const t of a.tracks) t.stop();
+  try {
+    await a.writable.close();
+    toast.success("Recording saved");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    toast.error(`Save failed: ${msg}`);
+  }
+}

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -276,6 +276,11 @@ async function refreshDevices(): Promise<void> {
 // ── Setup phase ─────────────────────────────────────────────────────────
 
 async function openSetup(): Promise<void> {
+  console.debug("[recorder] openSetup", {
+    phase: phase(),
+    hasPreview: !!preview,
+    hasActive: !!active,
+  });
   if (phase() !== "idle") return;
   setPhase("setup");
   try {
@@ -423,14 +428,23 @@ async function stopRecording(): Promise<void> {
 
   const durationMs = a.pauseElapsed ?? performance.now() - a.anchor;
 
-  await new Promise<void>((resolve) => {
-    a.recorder.addEventListener("stop", () => resolve(), { once: true });
-    try {
-      a.recorder.stop();
-    } catch {
-      resolve();
-    }
-  });
+  // Race-safe recorder shutdown. If `recorder.state` is already
+  // "inactive" (e.g. display track ended fired our handler which
+  // re-entered stopRecording after MediaRecorder already auto-stopped),
+  // calling stop() throws AND the stop event has already fired — so a
+  // naive `await new Promise(...)` with an addEventListener hangs
+  // forever, blocking the rest of cleanup (`closePreview` et al) and
+  // leaking the mic stream into the next session.
+  if (a.recorder.state !== "inactive") {
+    await new Promise<void>((resolve) => {
+      a.recorder.addEventListener("stop", () => resolve(), { once: true });
+      try {
+        a.recorder.stop();
+      } catch {
+        resolve();
+      }
+    });
+  }
   for (const t of a.tracks) t.stop();
   closePreview();
   closeWebcam();

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -276,17 +276,26 @@ async function refreshDevices(): Promise<void> {
 // ── Setup phase ─────────────────────────────────────────────────────────
 
 async function openSetup(): Promise<void> {
-  console.debug("[recorder] openSetup", {
+  console.log("[recorder] openSetup.enter", {
     phase: phase(),
     hasPreview: !!preview,
     hasActive: !!active,
   });
-  if (phase() !== "idle") return;
+  if (phase() !== "idle") {
+    console.log("[recorder] openSetup.skip phase not idle");
+    return;
+  }
   setPhase("setup");
   try {
     await openPreview(micDeviceId());
     await refreshDevices();
+    console.log("[recorder] openSetup.ok");
   } catch (err) {
+    console.log("[recorder] openSetup.error", {
+      isAbort: isAbort(err),
+      msg: errMsg(err),
+      err,
+    });
     if (!isAbort(err)) toast.error(`Microphone: ${errMsg(err)}`);
     setPhase("idle");
   }

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -81,16 +81,15 @@ let preview: Preview | null = null;
 
 interface Active {
   recorder: MediaRecorder;
-  /** User-picked save destination. We hold the handle through the whole
-   *  session and only `createWritable()` on stop, after we've fixed the
-   *  WebM duration header — Chrome's MediaRecorder in streaming mode
-   *  omits the duration EBML, which leaves players showing "0:01" for
-   *  arbitrarily long files. See `stopRecording` for the fix-up. */
+  /** User-picked save destination. Kept for the post-stop read-back +
+   *  duration patch cycle. */
   handle: FileSystemFileHandle;
-  /** All timeslice chunks emitted by the MediaRecorder. Concatenated
-   *  into a single Blob at stop time so `fix-webm-duration` can patch
-   *  the header. Memory cost ≈ 1–2 MB/min for terminal video. */
-  chunks: Blob[];
+  /** Streaming sink for WebM chunks during recording — keeps memory
+   *  flat regardless of duration. At stop, we close this, read the
+   *  completed file back via `handle.getFile()`, patch the WebM
+   *  SegmentInfo.Duration header that Chrome's MediaRecorder omits
+   *  in streaming mode, and overwrite with a fresh writable. */
+  writable: FileSystemWritableFileStream;
   tracks: MediaStreamTrack[];
   ticker: number;
   /** Anchor used by the ticker: `elapsed = performance.now() - anchor`.
@@ -328,6 +327,7 @@ async function startRecording(): Promise<void> {
   if (phase() !== "setup" || !preview) return;
 
   const displayTracks: MediaStreamTrack[] = [];
+  let openedWritable: FileSystemWritableFileStream | null = null;
   try {
     const handle = await window.showSaveFilePicker({
       suggestedName: `kolu-${timestamp()}.webm`,
@@ -335,6 +335,8 @@ async function startRecording(): Promise<void> {
         { description: "WebM video", accept: { "video/webm": [".webm"] } },
       ],
     });
+    const writable = await handle.createWritable();
+    openedWritable = writable;
 
     const display = await navigator.mediaDevices.getDisplayMedia({
       video: true,
@@ -350,9 +352,8 @@ async function startRecording(): Promise<void> {
       ...preview.stream.getAudioTracks(),
     ]);
     const recorder = new MediaRecorder(stream, { mimeType: MIME });
-    const chunks: Blob[] = [];
     recorder.ondataavailable = (ev) => {
-      if (ev.data.size > 0) chunks.push(ev.data);
+      if (ev.data.size > 0) void writable.write(ev.data);
     };
     // Browser's own "stop sharing" bar ends the video track — treat it
     // like a normal stop so the file closes cleanly.
@@ -369,18 +370,20 @@ async function startRecording(): Promise<void> {
     active = {
       recorder,
       handle,
-      chunks,
+      writable,
       tracks: [...displayTracks, ...preview.stream.getTracks()],
       ticker,
       anchor,
       pauseElapsed: null,
     };
+    openedWritable = null; // ownership transferred to `active`
     setElapsedMs(0);
     setPhase("recording");
     recorder.start(TIMESLICE_MS);
     toast.success("Recording started");
   } catch (err) {
     for (const t of displayTracks) t.stop();
+    if (openedWritable) await openedWritable.close().catch(() => {});
     if (!isAbort(err)) toast.error(`Recording failed: ${errMsg(err)}`);
     // Stay in setup so the user can retry without re-granting mic/webcam.
   }
@@ -460,11 +463,18 @@ async function stopRecording(): Promise<void> {
   setWebcamEnabledSignal(false);
 
   try {
+    // Close the streaming writable so every pending `write()` queued
+    // from `ondataavailable` is flushed to disk before we read the
+    // file back for the duration-fix pass.
+    await a.writable.close();
+
     // Chrome's MediaRecorder streams WebM without a SegmentInfo.Duration
-    // header, so players show an arbitrary length (often 0:01). Patch the
-    // header before writing. Logger messages go to console for diagnosis;
-    // the toast surfaces filename + an Open action via blob URL.
-    const raw = new Blob(a.chunks, { type: MIME });
+    // header, so players show an arbitrary length (often 0:01). Read
+    // the just-flushed file back into memory, patch the header, and
+    // overwrite. Peak memory is the full file briefly (unavoidable —
+    // `fix-webm-duration` is not a streaming patcher); during recording,
+    // memory stayed flat.
+    const raw = await a.handle.getFile();
     const fixLog: string[] = [];
     let out: Blob = raw;
     try {
@@ -475,9 +485,11 @@ async function stopRecording(): Promise<void> {
       fixLog.push(`error: ${errMsg(err)}`);
     }
     console.log("[recorder] webm-duration-fix", { durationMs, fixLog });
-    const writable = await a.handle.createWritable();
-    await writable.write(out);
-    await writable.close();
+    // Fresh `createWritable()` defaults to truncating the file, so the
+    // patched blob replaces the streamed bytes wholesale.
+    const patched = await a.handle.createWritable();
+    await patched.write(out);
+    await patched.close();
 
     // Blob URL = one-click preview. Browsers hide the full filesystem
     // path (FSA security), so the filename is the best locator we can

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -491,21 +491,30 @@ async function stopRecording(): Promise<void> {
     await patched.write(out);
     await patched.close();
 
-    // Blob URL = one-click preview. Browsers hide the full filesystem
-    // path (FSA security), so the filename is the best locator we can
-    // show. Revoke the URL after five minutes — long enough for the
-    // user to click, short enough not to hold a reference forever.
-    const url = URL.createObjectURL(out);
-    setTimeout(() => URL.revokeObjectURL(url), 5 * 60_000);
+    // Open action re-reads the saved file from disk on click — we keep
+    // only the small `FileSystemFileHandle` reference in the closure,
+    // not the full blob. Browsers still require a blob URL to open a
+    // new tab (FSA hides the real path), but it lives only long enough
+    // for window.open to navigate.
+    const handle = a.handle;
     toast.success(
       `Recording saved · ${formatSeconds(Math.round(durationMs / 1000))}`,
       {
-        description: a.handle.name,
+        description: handle.name,
         duration: 30_000,
         action: {
           label: "Open",
           onClick: () => {
-            window.open(url, "_blank", "noopener,noreferrer");
+            void (async () => {
+              try {
+                const file = await handle.getFile();
+                const url = URL.createObjectURL(file);
+                window.open(url, "_blank", "noopener,noreferrer");
+                setTimeout(() => URL.revokeObjectURL(url), 60_000);
+              } catch (err) {
+                toast.error(`Open failed: ${errMsg(err)}`);
+              }
+            })();
           },
         },
       },

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -28,6 +28,7 @@
 
 import { batch, createMemo, createSignal } from "solid-js";
 import { toast } from "solid-sonner";
+import { P, match } from "ts-pattern";
 import fixWebmDuration from "fix-webm-duration";
 import {
   closeMicPreview,
@@ -254,42 +255,46 @@ async function startRecording(): Promise<void> {
 function togglePause(): void {
   const s = session;
   if (!s) return;
-  if (phase() === "recording") {
-    // Belt-and-suspenders pause: pause the encoder AND disable every
-    // source track so nothing sneaks through under browsers' varying
-    // interpretations of the paused state.
-    try {
-      s.recorder.pause();
-    } catch (err) {
-      toast.error(`Pause failed: ${errMsg(err)}`);
-      return;
-    }
-    for (const t of s.tracks) t.enabled = false;
-    stopTicker();
-    setPausedAt(performance.now());
-    setPhase("paused");
-  } else if (phase() === "paused") {
-    for (const t of s.tracks) t.enabled = true;
-    try {
-      s.recorder.resume();
-    } catch (err) {
-      toast.error(`Resume failed: ${errMsg(err)}`);
-      return;
-    }
-    // Rewind anchor by the paused duration so the memo picks back up
-    // from where it froze.
-    batch(() => {
-      const p = pausedAt();
-      const a = anchor();
-      if (p !== null && a !== null) {
-        setAnchor(performance.now() - (p - a));
+  match(phase())
+    .with("recording", () => {
+      // Belt-and-suspenders pause: pause the encoder AND disable every
+      // source track so nothing sneaks through under browsers' varying
+      // interpretations of the paused state.
+      try {
+        s.recorder.pause();
+      } catch (err) {
+        toast.error(`Pause failed: ${errMsg(err)}`);
+        return;
       }
-      setPausedAt(null);
-      setNow(performance.now());
-    });
-    startTicker();
-    setPhase("recording");
-  }
+      for (const t of s.tracks) t.enabled = false;
+      stopTicker();
+      setPausedAt(performance.now());
+      setPhase("paused");
+    })
+    .with("paused", () => {
+      for (const t of s.tracks) t.enabled = true;
+      try {
+        s.recorder.resume();
+      } catch (err) {
+        toast.error(`Resume failed: ${errMsg(err)}`);
+        return;
+      }
+      // Rewind anchor by the paused duration so the memo picks back up
+      // from where it froze.
+      batch(() => {
+        const p = pausedAt();
+        const a = anchor();
+        if (p !== null && a !== null) {
+          setAnchor(performance.now() - (p - a));
+        }
+        setPausedAt(null);
+        setNow(performance.now());
+      });
+      startTicker();
+      setPhase("recording");
+    })
+    .with(P.union("idle", "setup"), () => {})
+    .exhaustive();
 }
 
 function startTicker(): void {

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -20,11 +20,30 @@
  *               continuity.
  *
  *  Chromium-only by design (`showSaveFilePicker`, `preferCurrentTab`,
- *  FSA). `isRecordingSupported()` hides entry points elsewhere. */
+ *  FSA). `isRecordingSupported()` hides entry points elsewhere.
+ *
+ *  Structure: this file owns recording-session lifecycle + phase + the
+ *  elapsed-time clock, and re-exports a flat facade via `useRecorder()`.
+ *  Mic and webcam domains live in their own modules. */
 
-import { createSignal } from "solid-js";
+import { batch, createMemo, createSignal } from "solid-js";
 import { toast } from "solid-sonner";
 import fixWebmDuration from "fix-webm-duration";
+import {
+  closeMicPreview,
+  mic,
+  micPreviewStream,
+  openMicPreview,
+  setMicDevices,
+  setMicSelectedId,
+} from "./mic";
+import {
+  changeWebcam,
+  closeWebcam,
+  setWebcamDevices,
+  toggleWebcam,
+  webcam,
+} from "./webcam";
 
 interface SaveFilePickerOptions {
   suggestedName?: string;
@@ -53,52 +72,32 @@ declare global {
 const MIME = "video/webm;codecs=vp9,opus";
 const TIMESLICE_MS = 2000;
 
-type Phase = "idle" | "setup" | "recording" | "paused";
+export type Phase = "idle" | "setup" | "recording" | "paused";
 
 const [phase, setPhase] = createSignal<Phase>("idle");
-const [elapsedMs, setElapsedMs] = createSignal(0);
-const [micDevices, setMicDevices] = createSignal<MediaDeviceInfo[]>([]);
-const [micDeviceId, setMicDeviceIdSignal] = createSignal<string>("default");
-const [micLevel, setMicLevel] = createSignal(0);
-const [micError, setMicError] = createSignal<string | null>(null);
 
-const [webcamEnabled, setWebcamEnabledSignal] = createSignal(false);
-const [webcamStream, setWebcamStream] = createSignal<MediaStream | null>(null);
-const [webcamDevices, setWebcamDevices] = createSignal<MediaDeviceInfo[]>([]);
-const [webcamDeviceId, setWebcamDeviceIdSignal] =
-  createSignal<string>("default");
-const [webcamError, setWebcamError] = createSignal<string | null>(null);
+/** Recording clock. `anchor` is the logical start; `pausedAt` freezes
+ *  the clock while paused; `now` ticks from a 1Hz interval while live.
+ *  `elapsedMs` is a memo over the three — no explicit setter, no
+ *  ordering discipline. */
+const [anchor, setAnchor] = createSignal<number | null>(null);
+const [pausedAt, setPausedAt] = createSignal<number | null>(null);
+const [now, setNow] = createSignal(performance.now());
 
-interface Preview {
-  stream: MediaStream;
-  ctx: AudioContext;
-  analyser: AnalyserNode;
-  source: MediaStreamAudioSourceNode;
-  raf: number;
-  buf: Float32Array<ArrayBuffer>;
-}
-let preview: Preview | null = null;
+const elapsedMs = createMemo<number>(() => {
+  const a = anchor();
+  if (a === null) return 0;
+  return (pausedAt() ?? now()) - a;
+});
 
-interface Active {
+interface Session {
   recorder: MediaRecorder;
-  /** User-picked save destination. Kept for the post-stop read-back +
-   *  duration patch cycle. */
   handle: FileSystemFileHandle;
-  /** Streaming sink for WebM chunks during recording — keeps memory
-   *  flat regardless of duration. At stop, we close this, read the
-   *  completed file back via `handle.getFile()`, patch the WebM
-   *  SegmentInfo.Duration header that Chrome's MediaRecorder omits
-   *  in streaming mode, and overwrite with a fresh writable. */
   writable: FileSystemWritableFileStream;
   tracks: MediaStreamTrack[];
-  ticker: number;
-  /** Anchor used by the ticker: `elapsed = performance.now() - anchor`.
-   *  Mutated on resume to subtract paused duration. */
-  anchor: number;
-  /** Snapshot taken at pause; restored on resume by rewinding `anchor`. */
-  pauseElapsed: number | null;
 }
-let active: Active | null = null;
+let session: Session | null = null;
+let ticker: number | null = null;
 
 export function isRecordingSupported(): boolean {
   return (
@@ -115,15 +114,15 @@ export function useRecorder() {
   return {
     phase,
     elapsedMs,
-    micDevices,
-    micDeviceId,
-    micLevel,
-    micError,
-    webcamEnabled,
-    webcamStream,
-    webcamDevices,
-    webcamDeviceId,
-    webcamError,
+    micDevices: mic.devices,
+    micDeviceId: mic.selectedId,
+    micLevel: mic.level,
+    micError: mic.errorMessage,
+    webcamEnabled: webcam.enabled,
+    webcamStream: webcam.stream,
+    webcamDevices: webcam.devices,
+    webcamDeviceId: webcam.selectedId,
+    webcamError: webcam.errorMessage,
     openSetup,
     changeMic,
     toggleWebcam,
@@ -147,119 +146,6 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-// ── Mic preview ─────────────────────────────────────────────────────────
-
-/** Open a mic stream for the given deviceId and attach an AnalyserNode.
- *  Runs an rAF loop that publishes the current RMS level to `micLevel`.
- *  Re-entrant: closes any existing preview first. */
-async function openPreview(deviceId: string): Promise<void> {
-  closePreview();
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({
-      audio: deviceId === "default" ? true : { deviceId: { exact: deviceId } },
-      video: false,
-    });
-    const ctx = new AudioContext();
-    const source = ctx.createMediaStreamSource(stream);
-    const analyser = ctx.createAnalyser();
-    analyser.fftSize = 512;
-    source.connect(analyser);
-    // Explicit ArrayBuffer backing keeps the narrow generic that
-    // `getFloatTimeDomainData` expects in lib.dom.
-    const buf = new Float32Array(new ArrayBuffer(analyser.fftSize * 4));
-    const tick = () => {
-      if (!preview) return;
-      preview.analyser.getFloatTimeDomainData(preview.buf);
-      let sum = 0;
-      for (let i = 0; i < preview.buf.length; i++) {
-        const v = preview.buf[i]!;
-        sum += v * v;
-      }
-      // Light nonlinear shaping so talking registers visibly without
-      // clipping on louder syllables.
-      const rms = Math.sqrt(sum / preview.buf.length);
-      const next = Math.min(1, Math.pow(rms, 0.5) * 2);
-      if (Math.abs(next - micLevel()) > 0.01) setMicLevel(next);
-      preview.raf = requestAnimationFrame(tick);
-    };
-    preview = {
-      stream,
-      ctx,
-      analyser,
-      source,
-      raf: requestAnimationFrame(tick),
-      buf,
-    };
-    setMicError(null);
-  } catch (err) {
-    setMicError(errMsg(err));
-    throw err;
-  }
-}
-
-function closePreview(): void {
-  if (!preview) return;
-  cancelAnimationFrame(preview.raf);
-  preview.source.disconnect();
-  void preview.ctx.close();
-  for (const t of preview.stream.getTracks()) t.stop();
-  preview = null;
-  setMicLevel(0);
-}
-
-// ── Webcam ──────────────────────────────────────────────────────────────
-
-/** Open a webcam stream on the given deviceId. Re-entrant. */
-async function openWebcam(deviceId: string): Promise<void> {
-  closeWebcam();
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({
-      video: deviceId === "default" ? true : { deviceId: { exact: deviceId } },
-      audio: false,
-    });
-    setWebcamStream(stream);
-    setWebcamError(null);
-  } catch (err) {
-    setWebcamError(errMsg(err));
-    throw err;
-  }
-}
-
-function closeWebcam(): void {
-  const s = webcamStream();
-  if (!s) return;
-  for (const t of s.getTracks()) t.stop();
-  setWebcamStream(null);
-}
-
-async function toggleWebcam(): Promise<void> {
-  if (webcamEnabled()) {
-    setWebcamEnabledSignal(false);
-    closeWebcam();
-    return;
-  }
-  try {
-    await openWebcam(webcamDeviceId());
-    await refreshDevices();
-    setWebcamEnabledSignal(true);
-  } catch (err) {
-    if (!isAbort(err)) toast.error(`Webcam: ${errMsg(err)}`);
-    setWebcamEnabledSignal(false);
-  }
-}
-
-async function changeWebcam(deviceId: string): Promise<void> {
-  setWebcamDeviceIdSignal(deviceId);
-  if (!webcamEnabled()) return;
-  try {
-    await openWebcam(deviceId);
-  } catch (err) {
-    if (!isAbort(err)) toast.error(`Webcam: ${errMsg(err)}`);
-  }
-}
-
-// ── Device enumeration ──────────────────────────────────────────────────
-
 /** Populate both device lists. Labels are only populated after the
  *  relevant getUserMedia permission has been granted. */
 async function refreshDevices(): Promise<void> {
@@ -273,13 +159,11 @@ async function refreshDevices(): Promise<void> {
   }
 }
 
-// ── Setup phase ─────────────────────────────────────────────────────────
-
 async function openSetup(): Promise<void> {
   if (phase() !== "idle") return;
   setPhase("setup");
   try {
-    await openPreview(micDeviceId());
+    await openMicPreview(mic.selectedId());
     await refreshDevices();
   } catch (err) {
     if (!isAbort(err)) toast.error(`Microphone: ${errMsg(err)}`);
@@ -289,9 +173,9 @@ async function openSetup(): Promise<void> {
 
 async function changeMic(deviceId: string): Promise<void> {
   if (phase() !== "setup") return;
-  setMicDeviceIdSignal(deviceId);
+  setMicSelectedId(deviceId);
   try {
-    await openPreview(deviceId);
+    await openMicPreview(deviceId);
   } catch (err) {
     if (!isAbort(err)) toast.error(`Microphone: ${errMsg(err)}`);
   }
@@ -299,19 +183,15 @@ async function changeMic(deviceId: string): Promise<void> {
 
 function cancelSetup(): void {
   if (phase() !== "setup") return;
-  closePreview();
+  closeMicPreview();
   closeWebcam();
-  setWebcamEnabledSignal(false);
   setPhase("idle");
 }
 
-// ── Recording phase ─────────────────────────────────────────────────────
-
-/** Commit: save-picker → screen-picker → MediaRecorder over the existing
- *  preview audio stream. If anything goes wrong mid-flight, return to
- *  setup phase with preview + webcam still live so the user can retry. */
 async function startRecording(): Promise<void> {
-  if (phase() !== "setup" || !preview) return;
+  if (phase() !== "setup") return;
+  const preview = micPreviewStream();
+  if (!preview) return;
 
   const displayTracks: MediaStreamTrack[] = [];
   let openedWritable: FileSystemWritableFileStream | null = null;
@@ -336,7 +216,7 @@ async function startRecording(): Promise<void> {
 
     const stream = new MediaStream([
       ...display.getVideoTracks(),
-      ...preview.stream.getAudioTracks(),
+      ...preview.getAudioTracks(),
     ]);
     const recorder = new MediaRecorder(stream, { mimeType: MIME });
     recorder.ondataavailable = (ev) => {
@@ -348,19 +228,19 @@ async function startRecording(): Promise<void> {
       .getVideoTracks()[0]
       ?.addEventListener("ended", () => void stopRecording(), { once: true });
 
-    const anchor = performance.now();
-    const ticker = window.setInterval(tickElapsed, 250);
-    active = {
+    session = {
       recorder,
       handle,
       writable,
-      tracks: [...displayTracks, ...preview.stream.getTracks()],
-      ticker,
-      anchor,
-      pauseElapsed: null,
+      tracks: [...displayTracks, ...preview.getTracks()],
     };
-    openedWritable = null; // ownership transferred to `active`
-    setElapsedMs(0);
+    openedWritable = null; // ownership transferred to `session`
+    batch(() => {
+      setAnchor(performance.now());
+      setPausedAt(null);
+      setNow(performance.now());
+    });
+    startTicker();
     setPhase("recording");
     recorder.start(TIMESLICE_MS);
     toast.success("Recording started");
@@ -368,118 +248,115 @@ async function startRecording(): Promise<void> {
     for (const t of displayTracks) t.stop();
     if (openedWritable) await openedWritable.close().catch(() => {});
     if (!isAbort(err)) toast.error(`Recording failed: ${errMsg(err)}`);
-    // Stay in setup so the user can retry without re-granting mic/webcam.
   }
 }
 
 function togglePause(): void {
-  const a = active;
-  if (!a) return;
+  const s = session;
+  if (!s) return;
   if (phase() === "recording") {
-    // Belt-and-suspenders pause:
-    //  1. MediaRecorder.pause() — spec-correct, stops encoding entirely.
-    //  2. Disable every source track. If a browser in some build emits
-    //     frames anyway during `paused` state, the content is at least
-    //     black + silent. Re-enabled on resume before the recorder resumes
-    //     so the first post-pause chunk has live content.
+    // Belt-and-suspenders pause: pause the encoder AND disable every
+    // source track so nothing sneaks through under browsers' varying
+    // interpretations of the paused state.
     try {
-      a.recorder.pause();
+      s.recorder.pause();
     } catch (err) {
       toast.error(`Pause failed: ${errMsg(err)}`);
       return;
     }
-    for (const t of a.tracks) t.enabled = false;
-    clearInterval(a.ticker);
-    a.pauseElapsed = performance.now() - a.anchor;
-    setElapsedMs(a.pauseElapsed);
+    for (const t of s.tracks) t.enabled = false;
+    stopTicker();
+    setPausedAt(performance.now());
     setPhase("paused");
   } else if (phase() === "paused") {
-    for (const t of a.tracks) t.enabled = true;
+    for (const t of s.tracks) t.enabled = true;
     try {
-      a.recorder.resume();
+      s.recorder.resume();
     } catch (err) {
       toast.error(`Resume failed: ${errMsg(err)}`);
       return;
     }
-    // Rewind the anchor so `now - anchor` resumes from the paused snapshot.
-    if (a.pauseElapsed !== null) {
-      a.anchor = performance.now() - a.pauseElapsed;
-      a.pauseElapsed = null;
-    }
-    a.ticker = window.setInterval(tickElapsed, 250);
+    // Rewind anchor by the paused duration so the memo picks back up
+    // from where it froze.
+    batch(() => {
+      const p = pausedAt();
+      const a = anchor();
+      if (p !== null && a !== null) {
+        setAnchor(performance.now() - (p - a));
+      }
+      setPausedAt(null);
+      setNow(performance.now());
+    });
+    startTicker();
     setPhase("recording");
   }
 }
 
-/** Ticker body — guarded against same-second no-ops so downstream
- *  memos don't re-flush 4× per displayed tick. */
-function tickElapsed(): void {
-  if (!active) return;
-  const next = performance.now() - active.anchor;
-  if (Math.floor(next / 1000) !== Math.floor(elapsedMs() / 1000)) {
-    setElapsedMs(next);
+function startTicker(): void {
+  stopTicker();
+  ticker = window.setInterval(() => setNow(performance.now()), 1000);
+}
+
+function stopTicker(): void {
+  if (ticker !== null) {
+    clearInterval(ticker);
+    ticker = null;
   }
 }
 
 async function stopRecording(): Promise<void> {
-  const a = active;
-  if (!a) return;
-  active = null;
+  const s = session;
+  if (!s) return;
+  session = null;
   setPhase("idle");
-  clearInterval(a.ticker);
-  setElapsedMs(0);
+  stopTicker();
 
-  const durationMs = a.pauseElapsed ?? performance.now() - a.anchor;
+  // Capture ms-precise duration BEFORE zeroing the clock (the memo's
+  // last cached value is up to 1s stale at a sub-second ticker).
+  const durationMs =
+    (pausedAt() ?? performance.now()) - (anchor() ?? performance.now());
+  batch(() => {
+    setAnchor(null);
+    setPausedAt(null);
+  });
 
-  // Race-safe recorder shutdown. If `recorder.state` is already
-  // "inactive" (e.g. display track ended fired our handler which
-  // re-entered stopRecording after MediaRecorder already auto-stopped),
-  // calling stop() throws AND the stop event has already fired — so a
-  // naive `await new Promise(...)` with an addEventListener hangs
-  // forever, blocking the rest of cleanup (`closePreview` et al) and
-  // leaking the mic stream into the next session.
-  if (a.recorder.state !== "inactive") {
+  // Race-safe recorder shutdown. If `state` is already "inactive" (e.g.
+  // the display track ended and re-entered stopRecording after
+  // MediaRecorder auto-stopped), calling stop() throws AND the stop
+  // event has already fired — a naive `await new Promise(...)` would
+  // hang forever, blocking cleanup and leaking the mic stream.
+  if (s.recorder.state !== "inactive") {
     await new Promise<void>((resolve) => {
-      a.recorder.addEventListener("stop", () => resolve(), { once: true });
+      s.recorder.addEventListener("stop", () => resolve(), { once: true });
       try {
-        a.recorder.stop();
+        s.recorder.stop();
       } catch {
         resolve();
       }
     });
   }
-  for (const t of a.tracks) t.stop();
-  closePreview();
+  for (const t of s.tracks) t.stop();
+  closeMicPreview();
   closeWebcam();
-  setWebcamEnabledSignal(false);
 
   try {
-    // Close the streaming writable so every pending `write()` queued
-    // from `ondataavailable` is flushed to disk before we read the
-    // file back for the duration-fix pass.
-    await a.writable.close();
+    await s.writable.close();
 
     // Chrome's MediaRecorder streams WebM without a SegmentInfo.Duration
-    // header, so players show an arbitrary length (often 0:01). Read
-    // the just-flushed file back into memory, patch the header, and
-    // overwrite. Peak memory is the full file briefly (unavoidable —
-    // `fix-webm-duration` is not a streaming patcher); during recording,
-    // memory stayed flat.
-    const raw = await a.handle.getFile();
+    // header — players show ~1 second. Read back, patch, rewrite.
+    const raw = await s.handle.getFile();
     let out: Blob = raw;
     try {
       out = await fixWebmDuration(raw, durationMs);
     } catch (err) {
       toast.warning(`Duration patch failed: ${errMsg(err)}`);
     }
-    // Fresh `createWritable()` defaults to truncating the file, so the
-    // patched blob replaces the streamed bytes wholesale.
-    const patched = await a.handle.createWritable();
+    const patched = await s.handle.createWritable();
     await patched.write(out);
     await patched.close();
 
     toast.success(`Recording saved · ${formatElapsed(durationMs)}`, {
-      description: a.handle.name,
+      description: s.handle.name,
     });
   } catch (err) {
     toast.error(`Save failed: ${errMsg(err)}`);

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -439,20 +439,27 @@ async function stopRecording(): Promise<void> {
   try {
     // Chrome's MediaRecorder streams WebM without a SegmentInfo.Duration
     // header, so players show an arbitrary length (often 0:01). Patch the
-    // header with the real elapsed duration before writing. If the fix
-    // fails for any reason, fall back to the raw blob — a playable file
-    // with wrong duration beats no file at all.
+    // header before writing. Logger messages are captured into the toast
+    // so we can see whether the library found the section to patch.
     const raw = new Blob(a.chunks, { type: MIME });
-    let out: Blob;
+    const fixLog: string[] = [];
+    let out: Blob = raw;
+    let fixNote = "";
     try {
-      out = await fixWebmDuration(raw, durationMs, { logger: false });
-    } catch {
-      out = raw;
+      out = await fixWebmDuration(raw, durationMs, {
+        logger: (msg: string) => fixLog.push(msg),
+      });
+      fixNote = fixLog.join(" · ") || "no log";
+    } catch (err) {
+      fixNote = `error: ${errMsg(err)}`;
     }
+    console.log("[recorder] webm-duration-fix", { durationMs, fixLog });
     const writable = await a.handle.createWritable();
     await writable.write(out);
     await writable.close();
-    toast.success("Recording saved");
+    toast.success(`Recording saved (${Math.round(durationMs / 1000)}s)`, {
+      description: fixNote,
+    });
   } catch (err) {
     toast.error(`Save failed: ${errMsg(err)}`);
   }

--- a/packages/client/src/recorder/useRecorder.ts
+++ b/packages/client/src/recorder/useRecorder.ts
@@ -368,19 +368,29 @@ function togglePause(): void {
   const a = active;
   if (!a) return;
   if (phase() === "recording") {
+    // Belt-and-suspenders pause:
+    //  1. MediaRecorder.pause() — spec-correct, stops encoding entirely.
+    //  2. Disable every source track. If a browser in some build emits
+    //     frames anyway during `paused` state, the content is at least
+    //     black + silent. Re-enabled on resume before the recorder resumes
+    //     so the first post-pause chunk has live content.
     try {
       a.recorder.pause();
-    } catch {
+    } catch (err) {
+      toast.error(`Pause failed: ${errMsg(err)}`);
       return;
     }
+    for (const t of a.tracks) t.enabled = false;
     clearInterval(a.ticker);
     a.pauseElapsed = performance.now() - a.anchor;
     setElapsedMs(a.pauseElapsed);
     setPhase("paused");
   } else if (phase() === "paused") {
+    for (const t of a.tracks) t.enabled = true;
     try {
       a.recorder.resume();
-    } catch {
+    } catch (err) {
+      toast.error(`Resume failed: ${errMsg(err)}`);
       return;
     }
     // Rewind the anchor so `now - anchor` resumes from the paused snapshot.

--- a/packages/client/src/recorder/webcam.ts
+++ b/packages/client/src/recorder/webcam.ts
@@ -1,0 +1,97 @@
+/** Webcam domain: device inventory, selected camera, and the live stream.
+ *
+ *  State lives in one discriminated union — the invariant "enabled ⇒
+ *  stream is non-null" is type-enforced rather than maintained by
+ *  imperative discipline across three parallel signals. */
+
+import { createMemo, createSignal } from "solid-js";
+import { toast } from "solid-sonner";
+
+export type WebcamState =
+  | { kind: "off" }
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "active"; stream: MediaStream };
+
+const [devices, setDevices] = createSignal<MediaDeviceInfo[]>([]);
+const [selectedId, setSelectedId] = createSignal<string>("default");
+const [state, setState] = createSignal<WebcamState>({ kind: "off" });
+
+const enabled = createMemo(() => {
+  const s = state();
+  return s.kind === "active" || s.kind === "loading";
+});
+const stream = createMemo(() => {
+  const s = state();
+  return s.kind === "active" ? s.stream : null;
+});
+const errorMessage = createMemo(() => {
+  const s = state();
+  return s.kind === "error" ? s.message : null;
+});
+
+export const webcam = {
+  devices,
+  selectedId,
+  state,
+  enabled,
+  stream,
+  errorMessage,
+};
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+export async function openWebcam(deviceId: string): Promise<void> {
+  closeWebcam();
+  setState({ kind: "loading" });
+  try {
+    const s = await navigator.mediaDevices.getUserMedia({
+      video: deviceId === "default" ? true : { deviceId: { exact: deviceId } },
+      audio: false,
+    });
+    setState({ kind: "active", stream: s });
+  } catch (err) {
+    setState({ kind: "error", message: errMsg(err) });
+    throw err;
+  }
+}
+
+export function closeWebcam(): void {
+  const s = state();
+  if (s.kind === "active") {
+    for (const t of s.stream.getTracks()) t.stop();
+  }
+  setState({ kind: "off" });
+}
+
+export async function toggleWebcam(): Promise<void> {
+  if (enabled()) {
+    closeWebcam();
+    return;
+  }
+  try {
+    await openWebcam(selectedId());
+  } catch (err) {
+    if (!isAbort(err)) toast.error(`Webcam: ${errMsg(err)}`);
+  }
+}
+
+export async function changeWebcam(deviceId: string): Promise<void> {
+  setSelectedId(deviceId);
+  if (!enabled()) return;
+  try {
+    await openWebcam(deviceId);
+  } catch (err) {
+    if (!isAbort(err)) toast.error(`Webcam: ${errMsg(err)}`);
+  }
+}
+
+export function setWebcamDevices(list: MediaDeviceInfo[]): void {
+  setDevices(list);
+}

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -180,6 +180,48 @@ export const MenuIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
+/** Pause icon — two vertical bars. Used inside the recording pill. */
+export const PauseIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <rect x="4" y="3" width="3" height="10" rx="0.5" />
+    <rect x="9" y="3" width="3" height="10" rx="0.5" />
+  </svg>
+);
+
+/** Resume/play icon — right-pointing triangle. Mirrors `PauseIcon`. */
+export const ResumeIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path d="M5 3l8 5-8 5z" />
+  </svg>
+);
+
+/** Webcam icon — rounded rectangle with a lens. Toggles the PiP overlay. */
+export const WebcamIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.75"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="2.5" y="5" width="19" height="13" rx="3" />
+    <circle cx="12" cy="11.5" r="3" />
+  </svg>
+);
+
 /** Video camera — workspace record button. Paired with `ScreenshotIcon`
  *  (still camera = snapshot, camcorder = recording). */
 export const RecordIcon: Component<{ class?: string }> = (props) => (

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -180,15 +180,21 @@ export const MenuIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
-/** Record dot — filled circle, used for the workspace record button. */
+/** Video camera — workspace record button. Paired with `ScreenshotIcon`
+ *  (still camera = snapshot, camcorder = recording). */
 export const RecordIcon: Component<{ class?: string }> = (props) => (
   <svg
     class={props.class ?? "w-3.5 h-3.5"}
-    viewBox="0 0 16 16"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.75"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     aria-hidden="true"
   >
-    <circle cx="8" cy="8" r="5" />
+    <rect x="2.5" y="7" width="13" height="10" rx="2" />
+    <path d="M15.5 11l5-3v8l-5-3z" />
   </svg>
 );
 

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -180,6 +180,18 @@ export const MenuIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
+/** Record dot — filled circle, used for the workspace record button. */
+export const RecordIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <circle cx="8" cy="8" r="5" />
+  </svg>
+);
+
 /** Camera icon — terminal screenshot button. */
 export const ScreenshotIcon: Component<{ class?: string }> = (props) => (
   <svg

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@xterm/xterm':
         specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
         version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
+      fix-webm-duration:
+        specifier: ^1.0.6
+        version: 1.0.6
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -2554,6 +2557,9 @@ packages:
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
+
+  fix-webm-duration@1.0.6:
+    resolution: {integrity: sha512-zVAqi4gE+8ywxJuAyV/rlJVX6CMtvyapEbQx6jyoeX9TMjdqAlt/FdG5d7rXSSkDVzTvS0H7CtwzHcH/vh4FPA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -6460,6 +6466,8 @@ snapshots:
       - supports-color
 
   find-up-simple@1.0.1: {}
+
+  fix-webm-duration@1.0.6: {}
 
   for-each@0.3.5:
     dependencies:

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,9 @@ pkgs.mkShell {
     pnpm
     tsx
     nixpkgs-fmt
+    # `uv` provides `uvx`, used by agents/ai.just to run APM from
+    # git+https without a global install (see ci::apm-sync).
+    uv
     # prettier is provided by pnpm (same version) — no need for a nix copy.
     # Use `pnpm exec prettier` or ensure `just install` has been run.
     # node-gyp toolchain — required by `pnpm install` to recompile node-pty

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -50,6 +50,12 @@ const features = [
     title: 'Terminals done right',
     body: 'xterm.js with WebGL rendering, clickable URLs, inline images (sixel, iTerm2, kitty), splits, tabs, 200+ themes, and a mobile key bar for touch devices.',
   },
+  {
+    num: '07',
+    key: 'recording',
+    title: 'Record your workspace',
+    body: 'One click in the chrome bar captures the whole Kolu tab with microphone and optional webcam PiP, streamed straight to a local .webm. Pause/resume with ⌘⇧., mic picker with live level meter, circular webcam overlay baked into the recording.',
+  },
 ];
 ---
 
@@ -122,7 +128,7 @@ const features = [
   <section class="mx-auto max-w-[68rem] px-6 py-20">
     <div class="mb-14 flex items-baseline justify-between">
       <p class="eyebrow">what you get</p>
-      <p class="mono text-[0.72rem] text-ink-faint">06 features</p>
+      <p class="mono text-[0.72rem] text-ink-faint">07 features</p>
     </div>
 
     <ul class="grid md:grid-cols-2 gap-px bg-rule">


### PR DESCRIPTION
**One click in the chrome bar captures the whole Kolu tab** with microphone and optional webcam picture-in-picture, streamed straight to a local `.webm`. The record button slides open a pre-record popover for mic/webcam device selection with a live 8-segment RMS level meter; committing invokes the browser's tab picker once, and recording begins.

Chunks flow from `MediaRecorder` (VP9/Opus at 2s timeslice) into a `FileSystemWritableFileStream` continuously, so *memory stays flat regardless of duration* — a three-hour debugging session records as cheaply as a thirty-second clip. A partial `.webm` survives a browser crash and is recoverable with ffmpeg. At stop, the saved file is read back, patched via [`fix-webm-duration`](https://github.com/yusitnikov/fix-webm-duration) to repair the `SegmentInfo.Duration` header that Chrome's streaming `MediaRecorder` omits, and rewritten in place — without this step players show ~1 second on multi-minute files.

**Pause/resume rides on `⌘⇧.`** The chrome-bar recording state is a segmented capsule — _pause · mm:ss · webcam toggle_ — with a breathing halo while live that suppresses and shifts red → amber while paused. *The webcam overlay is circular and mirrored, pinned above maximized tiles but below the chrome bar, and baked into the recording by the tab-capture stream (no offscreen compositing).*

Chromium-only by design. `showSaveFilePicker`, `preferCurrentTab`, and FSA streaming writables aren't in Firefox/Safari, so `isRecordingSupported()` hides the entry point rather than bolting on a Blob-in-RAM fallback that would silently cap long recordings.

> A structural review (Hickey + Lowy lenses) is [archived in the PR comments](https://github.com/juspay/kolu/pull/632#issuecomment-4276976830) — no finding crossed the merge bar; revisit if the recorder grows past local-only capture.

### Test plan

- [ ] Start → record a few seconds in a terminal → stop → player shows correct duration and plays audio
- [ ] Cancel the save picker → no screen-picker prompt, state resets
- [ ] Cancel the screen picker → no empty file lingers
- [ ] Deny microphone → error toast, clean state
- [ ] Click the browser's own "Stop sharing" bar → file closes as if stopped from the button
- [ ] Long recording (>20 min) → memory flat, file grows linearly, duration correct after stop
- [ ] Pause/resume via `⌘⇧.` → capsule shifts red→amber, halo suppresses, elapsed freezes, resume seamless
- [ ] Toggle webcam mid-recording → overlay appears/disappears, baked into recorded file

### Try it locally

```sh
nix run github:juspay/kolu/undue-area
```