### PR TITLE
Canvas posture hook + tile title actions component

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,7 +3,7 @@
  *  Per #622 the workspace is mode-less: desktop is always the canvas; mobile
  *  is a single fullscreen tile with swipe nav. Per-terminal chrome (theme
  *  pill, agent indicator, screenshot, split toggle) lives on the tile title
- *  bar via `renderTileTitleActions`. The header is intentionally minimal. */
+ *  bar via `canvas/TileTitleActions`. The header is intentionally minimal. */
 
 import {
   type Component,
@@ -20,10 +20,10 @@ import { isMobile } from "./useMobile";
 import ChromeBar from "./ChromeBar";
 import TerminalContent from "./terminal/TerminalContent";
 import TerminalMeta from "./terminal/TerminalMeta";
-import AgentIndicator from "./terminal/AgentIndicator";
 import TerminalCanvas from "./canvas/TerminalCanvas";
 import CanvasWatermark from "./canvas/CanvasWatermark";
 import PillTree from "./canvas/PillTree";
+import TileTitleActions from "./canvas/TileTitleActions";
 import { groupByRepo, flatPillOrder } from "./canvas/pillTreeOrder";
 import MobileTileView from "./MobileTileView";
 import MobileKeyBar from "./MobileKeyBar";
@@ -40,8 +40,6 @@ import { exportSessionAsPdf } from "./exportSessionAsPdf";
 import { screenshotTerminal } from "./screenshotTerminal";
 import WebcamOverlay from "./recorder/WebcamOverlay";
 import { useRecorder } from "./recorder/useRecorder";
-import { ScreenshotIcon, SearchIcon } from "./ui/Icons";
-import Tip from "./ui/Tip";
 
 import type { TerminalId } from "kolu-common";
 import { client, wsStatus, serverProcessId } from "./rpc/rpc";
@@ -51,16 +49,12 @@ import { useThemeManager } from "./useThemeManager";
 import { useShortcuts } from "./input/useShortcuts";
 import { useSubPanel } from "./terminal/useSubPanel";
 import { useCanvasViewport } from "./canvas/viewport/useCanvasViewport";
+import { useViewPosture } from "./canvas/useViewPosture";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import { useColorScheme } from "./settings/useColorScheme";
 import { useTips } from "./settings/useTips";
-import { CONTEXTUAL_TIPS, pillTreeSwitchTip } from "./settings/tips";
+import { pillTreeSwitchTip } from "./settings/tips";
 import { toggleMinimap } from "./canvas/CanvasMinimap";
-
-/** Tile chrome buttons share this affordance. Theme pill is wider — it shows
- *  the theme name. Other buttons are square. */
-const TILE_BUTTON_CLASS =
-  "flex items-center justify-center h-7 rounded-lg transition-colors cursor-pointer shrink-0 pointer-events-auto hover:bg-black/20 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50";
 
 const App: Component = () => {
   const { store, crud, session, worktree, alerts } = useTerminals();
@@ -83,6 +77,7 @@ const App: Component = () => {
   const rightPanel = useRightPanel();
   const { colorScheme, setColorScheme } = useColorScheme();
   const canvasViewport = useCanvasViewport();
+  const posture = useViewPosture();
   const { showTipOnce } = useTips();
 
   // Pill-tree-grouped order — single source for the desktop pill tree AND
@@ -289,125 +284,6 @@ const App: Component = () => {
     }
   }
 
-  /** Per-tile chrome rendered into the CanvasTile title bar.
-   *  Order (left → right between title and close): agent indicator, theme
-   *  pill, split toggle, search, screenshot. */
-  function renderTileTitleActions(id: TerminalId) {
-    const meta = store.getMetadata(id);
-    const themeName = () =>
-      store.activeId() === id ? activeThemeName() : meta?.themeName;
-    const subCount = () => store.getSubTerminalIds(id).length;
-    const splitExpanded = () =>
-      subCount() > 0 && !subPanel.getSubPanel(id).collapsed;
-    return (
-      <>
-        <Show when={meta?.agent}>
-          {(agent) => (
-            <button
-              class={`${TILE_BUTTON_CLASS} px-2`}
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation();
-                store.setActiveId(id);
-                rightPanel.expandPanel();
-              }}
-              title="Open inspector"
-            >
-              <AgentIndicator agent={agent()} />
-            </button>
-          )}
-        </Show>
-        <Show when={themeName()}>
-          {(name) => (
-            <Tip label={`Theme: ${name()}`}>
-              <button
-                data-testid="tile-theme-pill"
-                class={`${TILE_BUTTON_CLASS} px-2 max-w-[14ch] truncate text-xs`}
-                style={{ color: "var(--color-fg-3, currentColor)" }}
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  store.setActiveId(id);
-                  openPaletteGroup("Theme");
-                  setTimeout(
-                    () => showTipOnce(CONTEXTUAL_TIPS.themeFromPalette),
-                    500,
-                  );
-                }}
-              >
-                {name()}
-              </button>
-            </Tip>
-          )}
-        </Show>
-        <Tip label={subCount() > 0 ? "Toggle split" : "Add split"}>
-          <button
-            data-testid="tile-split-toggle"
-            class={`${TILE_BUTTON_CLASS} gap-1 px-1.5`}
-            classList={{ "bg-black/20": splitExpanded() }}
-            style={{ color: "var(--color-fg-3, currentColor)" }}
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation();
-              store.setActiveId(id);
-              handleToggleSubPanel(id);
-            }}
-            aria-label="Toggle split"
-          >
-            <svg
-              class="w-3.5 h-3.5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              stroke-width="2"
-              aria-hidden="true"
-            >
-              <rect x="3" y="3" width="18" height="18" rx="2" />
-              <line x1="3" y1="13" x2="21" y2="13" />
-            </svg>
-            <Show when={subCount() > 0}>
-              <span
-                data-testid="sub-count"
-                class="text-[0.65rem] tabular-nums leading-none"
-              >
-                {subCount()}
-              </span>
-            </Show>
-          </button>
-        </Tip>
-        <Tip label="Find in terminal">
-          <button
-            data-testid="tile-find"
-            class={`${TILE_BUTTON_CLASS} w-7`}
-            style={{ color: "var(--color-fg-3, currentColor)" }}
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation();
-              store.setActiveId(id);
-              setSearchOpen(true);
-            }}
-            aria-label="Find in terminal"
-          >
-            <SearchIcon />
-          </button>
-        </Tip>
-        <button
-          class={`${TILE_BUTTON_CLASS} w-7`}
-          style={{ color: "var(--color-fg-3, currentColor)" }}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            handleScreenshotTerminal(id);
-          }}
-          title="Screenshot terminal"
-          data-testid="screenshot-button"
-        >
-          <ScreenshotIcon />
-        </button>
-      </>
-    );
-  }
-
   /** Canvas tile body — every tile stays mounted (`visible={true}`) so
    *  inactive xterms keep their grid sized correctly; only the focused tile
    *  takes keyboard focus. */
@@ -580,7 +456,7 @@ const App: Component = () => {
               groups={pillGroups()}
               onSelect={(id) => {
                 store.setActiveId(id);
-                if (!store.canvasMaximized()) {
+                if (!posture.maximized()) {
                   const layout = store.getMetadata(id)?.canvasLayout;
                   if (layout) canvasViewport.centerOnTile(layout);
                 }
@@ -656,7 +532,15 @@ const App: Component = () => {
                     renderTileTitle={(id) => (
                       <TerminalMeta info={store.getDisplayInfo(id)} />
                     )}
-                    renderTileTitleActions={renderTileTitleActions}
+                    renderTileTitleActions={(id) => (
+                      <TileTitleActions
+                        id={id}
+                        onOpenPaletteGroup={openPaletteGroup}
+                        onToggleSubPanel={handleToggleSubPanel}
+                        onOpenSearch={() => setSearchOpen(true)}
+                        onScreenshot={handleScreenshotTerminal}
+                      />
+                    )}
                     renderTileBody={renderCanvasTileBody}
                   />
                 ))

--- a/packages/client/src/ChromeBar.tsx
+++ b/packages/client/src/ChromeBar.tsx
@@ -24,7 +24,7 @@ import Tip from "./ui/Tip";
 import SettingsPopover from "./settings/SettingsPopover";
 import RecordButton from "./recorder/RecordButton";
 import { useRightPanel } from "./right-panel/useRightPanel";
-import { useTerminalStore } from "./terminal/useTerminalStore";
+import { useViewPosture } from "./canvas/useViewPosture";
 import type { WsStatus } from "./rpc/rpc";
 
 const statusStyles: Record<WsStatus, string> = {
@@ -42,18 +42,18 @@ const ChromeBar: Component<{
   pillTree: JSX.Element;
 }> = (props) => {
   const rightPanel = useRightPanel();
-  const store = useTerminalStore();
+  const posture = useViewPosture();
   let settingsTriggerRef!: HTMLButtonElement;
   const [settingsOpen, setSettingsOpen] = createSignal(false);
 
   // Dock when either the maximized terminal or the open right panel
   // would otherwise be covered by the overlay. See positioning comment.
-  const docked = () => store.canvasMaximized() || !rightPanel.collapsed();
+  const docked = () => posture.maximized() || !rightPanel.collapsed();
 
   return (
     <header
       data-testid="chrome-bar"
-      data-maximized={store.canvasMaximized() ? "" : undefined}
+      data-maximized={posture.maximized() ? "" : undefined}
       // pointer-events-none on the root so the transparent gaps don't
       // eat clicks meant for the canvas under the overlay. Interactive
       // children (identity row, pill tree, control cluster) re-enable

--- a/packages/client/src/canvas/PillTree.tsx
+++ b/packages/client/src/canvas/PillTree.tsx
@@ -20,6 +20,7 @@ import {
   repoColor,
 } from "./pillTreeOrder";
 import { useTileTheme } from "./useTileTheme";
+import { useViewPosture } from "./useViewPosture";
 import { MinimapIcon, PlusIcon } from "../ui/Icons";
 
 const BRANCHES_PER_ROW = 3;
@@ -49,11 +50,12 @@ const PillTree: Component<{
 }> = (props) => {
   const store = useTerminalStore();
   const tileTheme = useTileTheme();
+  const posture = useViewPosture();
 
   return (
     <div
       data-testid="pill-tree"
-      data-maximized={store.canvasMaximized() ? "" : undefined}
+      data-maximized={posture.maximized() ? "" : undefined}
       // Positioning is the caller's job (ChromeBar embeds this as a
       // flex child, mobile sheet renders its own vertical list).
       // The outer fills its slot; `justify-center` on the inner
@@ -78,15 +80,15 @@ const PillTree: Component<{
           // one tile, the tree is a peripheral nav affordance; but it
           // stays readable at a glance so "there's a canvas behind
           // this" remains legible without a hover.
-          "opacity-80": !store.canvasMaximized(),
-          "opacity-50": store.canvasMaximized(),
+          "opacity-80": !posture.maximized(),
+          "opacity-50": posture.maximized(),
         }}
       >
-        <Show when={store.canvasMaximized()}>
+        <Show when={posture.maximized()}>
           <button
             data-testid="pill-tree-exit-maximize"
             class="pointer-events-auto flex items-center justify-center w-6 h-6 rounded-lg shrink-0 cursor-pointer text-fg-2 hover:text-fg hover:bg-surface-2/80 transition-colors"
-            onClick={store.toggleCanvasMaximized}
+            onClick={posture.toggle}
             title="Show all on canvas"
           >
             <MinimapIcon class="w-3.5 h-3.5" />

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -39,6 +39,7 @@ import CanvasMinimap from "./CanvasMinimap";
 import CanvasWatermark from "./CanvasWatermark";
 import { useTerminalStore } from "../terminal/useTerminalStore";
 import { useTileTheme } from "./useTileTheme";
+import { useViewPosture } from "./useViewPosture";
 
 const DEFAULT_W = 800;
 const DEFAULT_H = 540;
@@ -81,6 +82,7 @@ const TerminalCanvas: Component<{
   const viewport = useCanvasViewport();
   const store = useTerminalStore();
   const tileTheme = useTileTheme();
+  const posture = useViewPosture();
 
   /** Pending per-tile layout overrides — used for three cases, all bridging
    *  a gap until the server's metadata echo arrives:
@@ -314,7 +316,7 @@ const TerminalCanvas: Component<{
               theme={tileTheme(id)}
               onSelect={() => props.onSelect(id)}
               onClose={() => props.onClose(id)}
-              onToggleMaximize={store.toggleCanvasMaximized}
+              onToggleMaximize={posture.toggle}
               renderTitle={() => props.renderTileTitle(id)}
               renderTitleActions={
                 props.renderTileTitleActions
@@ -334,7 +336,7 @@ const TerminalCanvas: Component<{
               {/* Tiled canvas — tiles live inside the pan/zoom transform.
                *  Hidden entirely when maximized; no reason to paint
                *  tiles the user can't see. */}
-              <Show when={!store.canvasMaximized()}>
+              <Show when={!posture.maximized()}>
                 <div
                   data-testid="canvas-transform"
                   style={{
@@ -350,7 +352,7 @@ const TerminalCanvas: Component<{
 
               {/* Maximized view — only the active tile, outside any
                *  transform, covering the canvas via `absolute inset-0`. */}
-              <Show when={store.canvasMaximized() && store.activeId()} keyed>
+              <Show when={posture.maximized() && store.activeId()} keyed>
                 {(id) => renderTile(id, true)}
               </Show>
             </>
@@ -359,7 +361,7 @@ const TerminalCanvas: Component<{
 
         {/* Minimap: spatial dashboard; hides in fullscreen-single-tile mode
          *  since there's nothing spatial to summarize. */}
-        <Show when={!store.canvasMaximized()}>
+        <Show when={!posture.maximized()}>
           <CanvasMinimap
             tileIds={props.tileIds}
             layouts={layouts()}

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -1,0 +1,153 @@
+/** Per-tile chrome rendered into the CanvasTile title bar.
+ *
+ *  Order (left → right between title and close): agent indicator, theme
+ *  pill, split toggle, search, screenshot.
+ *
+ *  Reads singleton state (store, sub-panel, theme manager, right panel,
+ *  tips) directly — per `no-preference-prop-drilling`. Only App-local
+ *  imperative actions (palette open, search open, screenshot) are drilled
+ *  as props because they are state setters whose ownership belongs at the
+ *  orchestration layer. Extracted from App.tsx per kolu#626. */
+
+import { type Component, Show } from "solid-js";
+import type { TerminalId } from "kolu-common";
+import AgentIndicator from "../terminal/AgentIndicator";
+import { useTerminalStore } from "../terminal/useTerminalStore";
+import { useRightPanel } from "../right-panel/useRightPanel";
+import { useSubPanel } from "../terminal/useSubPanel";
+import { useThemeManager } from "../useThemeManager";
+import { useTips } from "../settings/useTips";
+import { CONTEXTUAL_TIPS } from "../settings/tips";
+import { ScreenshotIcon, SearchIcon, SplitToggleIcon } from "../ui/Icons";
+import Tip from "../ui/Tip";
+
+/** Tile chrome buttons share this affordance. Theme pill is wider — it shows
+ *  the theme name. Other buttons are square. */
+const TILE_BUTTON_CLASS =
+  "flex items-center justify-center h-7 rounded-lg transition-colors cursor-pointer shrink-0 pointer-events-auto hover:bg-black/20 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50";
+
+const TileTitleActions: Component<{
+  id: TerminalId;
+  /** Open the command palette at a specific group (e.g. "Theme"). */
+  onOpenPaletteGroup: (group: string) => void;
+  /** Toggle the sub-panel for the given parent — App owns this because it
+   *  has to bridge to `crud.handleCreateSubTerminal` when no splits exist. */
+  onToggleSubPanel: (parentId: TerminalId) => void;
+  /** Open the in-tile search overlay. */
+  onOpenSearch: () => void;
+  /** Screenshot the given terminal. */
+  onScreenshot: (id: TerminalId) => void;
+}> = (props) => {
+  const store = useTerminalStore();
+  const rightPanel = useRightPanel();
+  const subPanel = useSubPanel();
+  const { activeThemeName } = useThemeManager();
+  const { showTipOnce } = useTips();
+
+  const meta = () => store.getMetadata(props.id);
+  const themeName = () =>
+    store.activeId() === props.id ? activeThemeName() : meta()?.themeName;
+  const subCount = () => store.getSubTerminalIds(props.id).length;
+  const splitExpanded = () =>
+    subCount() > 0 && !subPanel.getSubPanel(props.id).collapsed;
+
+  return (
+    <>
+      <Show when={meta()?.agent}>
+        {(agent) => (
+          <button
+            class={`${TILE_BUTTON_CLASS} px-2`}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              store.setActiveId(props.id);
+              rightPanel.expandPanel();
+            }}
+            title="Open inspector"
+          >
+            <AgentIndicator agent={agent()} />
+          </button>
+        )}
+      </Show>
+      <Show when={themeName()}>
+        {(name) => (
+          <Tip label={`Theme: ${name()}`}>
+            <button
+              data-testid="tile-theme-pill"
+              class={`${TILE_BUTTON_CLASS} px-2 max-w-[14ch] truncate text-xs`}
+              style={{ color: "var(--color-fg-3, currentColor)" }}
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                store.setActiveId(props.id);
+                props.onOpenPaletteGroup("Theme");
+                setTimeout(
+                  () => showTipOnce(CONTEXTUAL_TIPS.themeFromPalette),
+                  500,
+                );
+              }}
+            >
+              {name()}
+            </button>
+          </Tip>
+        )}
+      </Show>
+      <Tip label={subCount() > 0 ? "Toggle split" : "Add split"}>
+        <button
+          data-testid="tile-split-toggle"
+          class={`${TILE_BUTTON_CLASS} gap-1 px-1.5`}
+          classList={{ "bg-black/20": splitExpanded() }}
+          style={{ color: "var(--color-fg-3, currentColor)" }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            store.setActiveId(props.id);
+            props.onToggleSubPanel(props.id);
+          }}
+          aria-label="Toggle split"
+        >
+          <SplitToggleIcon />
+          <Show when={subCount() > 0}>
+            <span
+              data-testid="sub-count"
+              class="text-[0.65rem] tabular-nums leading-none"
+            >
+              {subCount()}
+            </span>
+          </Show>
+        </button>
+      </Tip>
+      <Tip label="Find in terminal">
+        <button
+          data-testid="tile-find"
+          class={`${TILE_BUTTON_CLASS} w-7`}
+          style={{ color: "var(--color-fg-3, currentColor)" }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            store.setActiveId(props.id);
+            props.onOpenSearch();
+          }}
+          aria-label="Find in terminal"
+        >
+          <SearchIcon />
+        </button>
+      </Tip>
+      <button
+        class={`${TILE_BUTTON_CLASS} w-7`}
+        style={{ color: "var(--color-fg-3, currentColor)" }}
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          props.onScreenshot(props.id);
+        }}
+        title="Screenshot terminal"
+        data-testid="screenshot-button"
+      >
+        <ScreenshotIcon />
+      </button>
+    </>
+  );
+};
+
+export default TileTitleActions;

--- a/packages/client/src/canvas/useViewPosture.ts
+++ b/packages/client/src/canvas/useViewPosture.ts
@@ -1,0 +1,28 @@
+/** Canvas display posture — desktop only. The single public seam for
+ *  `canvasMaximized`. Canvas readers (ChromeBar, TerminalCanvas, PillTree)
+ *  import this hook instead of reaching into `useTerminalStore`, so a
+ *  future enum upgrade (PiP, per-tile maximize) can be absorbed here
+ *  without rippling across every reader.
+ *
+ *  Scope is deliberately narrow: only `maximized` (the state) and
+ *  `toggle` (the single writer). Per-reader derivations like "show
+ *  minimap" or "pill-tree opacity" stay at the reader — naming hook
+ *  outputs after reader-specific behaviors would couple this interface
+ *  to their internals.
+ *
+ *  Mobile is a separate axis (device class, media query) handled one
+ *  level up in App.tsx (`MobileTileView` vs `TerminalCanvas`) and
+ *  deliberately stays out of this hook — different change frequency,
+ *  different reactivity source, different blast radius. Tracked: kolu#628. */
+
+import { useTerminalStore } from "../terminal/useTerminalStore";
+
+export function useViewPosture() {
+  const store = useTerminalStore();
+  return {
+    /** True when the active tile is rendered fullscreen over the canvas. */
+    maximized: store.canvasMaximized,
+    /** Toggle between tiled canvas and maximized. Single writer. */
+    toggle: store.toggleCanvasMaximized,
+  } as const;
+}

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -240,6 +240,21 @@ export const RecordIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
+/** Rectangle with a horizontal divider — tile split-toggle button. */
+export const SplitToggleIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    stroke-width="2"
+    aria-hidden="true"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="3" y1="13" x2="21" y2="13" />
+  </svg>
+);
+
 /** Camera icon — terminal screenshot button. */
 export const ScreenshotIcon: Component<{ class?: string }> = (props) => (
   <svg

--- a/packages/client/src/useViewState.ts
+++ b/packages/client/src/useViewState.ts
@@ -39,12 +39,13 @@ export function useViewState() {
     }),
   );
 
-  /** The single writer for `canvasMaximized`. Two call sites invoke it
-   *  (CanvasTile maximize button, PillTree minimap-icon-as-restore);
-   *  every other consumer (ChromeBar dock decision, TerminalCanvas
-   *  branch gate, PillTree opacity) is a passive reader. If a third
-   *  writer ever appears, route it through here so the source-of-truth
-   *  stays singular. Tracked: kolu#628. */
+  /** The single writer for `canvasMaximized`. Canvas readers reach this
+   *  via `useViewPosture()` (`packages/client/src/canvas/useViewPosture.ts`)
+   *  — the posture hook is the public seam so a future enum upgrade
+   *  (PiP, per-tile maximize) can be absorbed there without rippling
+   *  across readers. Treat `canvasMaximized` / `toggleCanvasMaximized`
+   *  on the store as internal-to-posture; new call sites should import
+   *  the hook instead. Tracked: kolu#628. */
   function toggleCanvasMaximized() {
     setCanvasMaximizedSignal((prev) => !prev);
   }


### PR DESCRIPTION
`store.canvasMaximized()` had **seven readers each re-deriving what "maximized" meant for their own concern** — ChromeBar's dock rule, TerminalCanvas's branch gate, PillTree's opacity tier and restore button, App's pan suppression on pill-select. Any third display mode (PiP, per-tile maximize, mobile auto-maximize) would have required auditing every site. `useViewPosture()` becomes the single seam: readers import `{ maximized, toggle }` and the boolean stays internal to the hook, so an enum upgrade lands in one place.

The hook surface is deliberately minimal — _just the two things that are actually posture._ An earlier sketch returned `{ chromeDocked, pillTreeOpacity, showMinimap, showTiled, ... }`, but Lowy review flagged these as reader-specific derivations: naming outputs after reader concerns would re-couple the hook's interface to each consumer's internals, and `chromeDocked` specifically crossed into a separate volatility (right-panel state). The chrome's dock composition now lives where it belongs, in ChromeBar.

_Mobile stays a separate axis._ `isMobile()` is a media query (device class); `canvasMaximized` is a persisted user preference. Different change frequencies, different reactivity sources. App.tsx still branches `<MobileTileView>` vs `<TerminalCanvas>` at the top — folding mobile into a posture enum would force canvas branches to handle a case they never render.

Also extracts **`renderTileTitleActions` (~120-line inline closure) into `canvas/TileTitleActions.tsx`** per kolu#626. The component reads singletons directly (store, sub-panel, theme manager, right panel, tips); only App-local imperative setters (palette open, search open, screenshot, split toggle) are drilled — these are stable action signatures owned by the orchestration layer. App.tsx drops from 672 to 556 lines. The inline split-toggle SVG moves into `SplitToggleIcon` in the icon registry (a pre-existing `icons-in-registry` violation carried forward from the original closure).

> **Deferred:** `CanvasTileBody` and `MobileTileBody` extractions from #626. Lowy flagged them as functional boundaries rather than shared volatility — the two call sites pass structurally different `visible`/`focused` values and a unified wrapper would couple independently-evolving rendering strategies.

No behavior change. Typecheck green across all 10 workspace packages. 54 scenarios / 317 steps pass across `canvas.feature`, `pill-tree.feature`, `terminal-screenshot.feature`, `sub-terminal.feature`, `theme.feature`.

Closes #628. Addresses #626 (partial).