### PR TITLE
Split Renderer setting: Auto (default) vs always-on WebGL

### DIFF
--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -18,12 +18,15 @@ const SCHEME_OPTIONS: readonly SegmentedControlOption<ColorScheme>[] = [
   { value: "system", label: "System" },
 ];
 
-/** WebGL = system chooses per tile (WebGL on focused, DOM on others).
- *  DOM = force DOM everywhere; no font shift on focus swap. */
+/** Auto  = system chooses per tile (WebGL on focused, DOM on others).
+ *  WebGL = WebGL on every tile (higher throughput; reintroduces #575
+ *          context-budget risk with many terminals).
+ *  DOM   = force DOM everywhere; no font shift on focus swap. */
 const RENDERER_OPTIONS: readonly SegmentedControlOption<
   Preferences["terminalRenderer"]
 >[] = [
-  { value: "auto", label: "WebGL" },
+  { value: "auto", label: "Auto" },
+  { value: "webgl", label: "WebGL" },
   { value: "dom", label: "DOM" },
 ];
 
@@ -119,7 +122,8 @@ const SettingsPopover: Component<{
               onChange={(on) => updatePreferences({ activityAlerts: on })}
             />
           </label>
-          {/* Terminal renderer — WebGL (focused tile) vs DOM everywhere */}
+          {/* Terminal renderer — Auto (WebGL on focused tile), WebGL (all
+           *  tiles), or DOM (all tiles). */}
           <div class="flex items-center justify-between gap-3 text-sm">
             <span class="text-fg-2">Renderer</span>
             <SegmentedControl

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -17,6 +17,7 @@ import {
   runWithOwner,
 } from "solid-js";
 import { createResizeObserver } from "@solid-primitives/resize-observer";
+import { match } from "ts-pattern";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import { Terminal as XTerm, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -190,11 +191,16 @@ const Terminal: Component<{
    *  mode where every tile renders simultaneously (issue #575). Non-focused
    *  tiles fall back to xterm's built-in DOM renderer via `WebglAddon.dispose()`. */
   const canUseWebgl = () => props.visible && props.focused !== false;
-  /** Policy: user can opt out of WebGL entirely from settings. DOM-everywhere
-   *  trades scrolling throughput for a stable font on focus swap (the WebGL
-   *  atlas and the DOM renderer rasterize text differently). */
-  const wantsWebgl = () => preferences().terminalRenderer === "auto";
-  const shouldUseWebgl = () => canUseWebgl() && wantsWebgl();
+  /** Dispatch on user renderer policy:
+   *  - `auto`: honor the capability gate (WebGL on focused+visible only).
+   *  - `webgl`: WebGL on every tile (opt-in; reintroduces #575 risk at scale).
+   *  - `dom`: force DOM everywhere (stable font on focus swap, lower GPU). */
+  const shouldUseWebgl = () =>
+    match(preferences().terminalRenderer)
+      .with("auto", canUseWebgl)
+      .with("webgl", () => true)
+      .with("dom", () => false)
+      .exhaustive();
 
   function loadWebgl() {
     if (!terminal || webgl) return;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -333,9 +333,11 @@ export const PreferencesSchema = z.object({
   colorScheme: ColorSchemeSchema,
   /** Renderer policy. `auto` lets the system choose (WebGL on the focused+
    *  visible tile, DOM elsewhere — Chrome's per-tab GL context budget makes
-   *  WebGL-everywhere unsafe). `dom` forces DOM everywhere, eliminating the
-   *  font-rendering shift on focus swap at the cost of WebGL throughput. */
-  terminalRenderer: z.enum(["auto", "dom"]),
+   *  WebGL-everywhere unsafe at scale). `webgl` forces WebGL on every tile
+   *  (higher throughput, but reintroduces the #575 context-budget risk with
+   *  many terminals). `dom` forces DOM everywhere, eliminating the font-
+   *  rendering shift on focus swap at the cost of WebGL throughput. */
+  terminalRenderer: z.enum(["auto", "webgl", "dom"]),
   rightPanel: RightPanelPrefsSchema,
 });
 

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -45,7 +45,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.15.0";
+const SCHEMA_VERSION = "1.16.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -270,6 +270,11 @@ export const store = new Conf<PersistedState>({
       const { canvasMode: _cm, sidebarAgentPreviews: _sap, ...rest } = current;
       store.set("preferences", rest as Preferences);
     },
+    // terminalRenderer enum widened from ["auto","dom"] to ["auto","webgl","dom"].
+    // Existing on-disk values ("auto" and "dom") are valid literals of the
+    // widened enum, so no value transformation is required. The bump is
+    // recorded here for the ladder's sake (see .claude/rules/state.md).
+    "1.16.0": () => {},
   },
 });
 

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -131,6 +131,16 @@ Feature: Canvas workspace
     And the focused canvas tile should use the webgl renderer
     And there should be no page errors
 
+  Scenario: Renderer preference "webgl" forces WebGL on every tile
+    Given I create a terminal
+    Then there should be 2 canvas tiles
+    And exactly 1 canvas tile should use the webgl renderer
+    When I click the settings button
+    Then the settings popover should be visible
+    When I click the "webgl" renderer button
+    Then exactly 2 canvas tiles should use the webgl renderer
+    And there should be no page errors
+
   Scenario: Double-clicking the title bar maximizes the tile
     Given I create a terminal
     Then there should be 2 canvas tiles


### PR DESCRIPTION
**Settings → Renderer grows a third option, *Auto*, which becomes the new default and preserves today's behavior** (WebGL on the focused+visible tile, DOM elsewhere). The existing "WebGL" label now means exactly what it says — WebGL on every tile. The motivation is narrow and pragmatic: I want to compare Auto vs always-on WebGL in production without nudging existing users off the policy that kept Chrome's per-tab GL context budget (#575) from exploding.

Existing users stay on internal `"auto"` because that's what they were already stored as — the old "WebGL" label was always backed by `"auto"`, so there is nothing to transform at the value level. *The SCHEMA_VERSION bump and no-op 1.16.0 migration are there purely to record the widened enum on the ladder, per `state.md`.* Dispatch in `Terminal.tsx` is reworked as an exhaustive `match()` so a future fourth mode becomes a compile error, not a silent fallthrough.

> **Deferred:** #636 — the new "WebGL" option reintroduces the #575 context-budget risk with no user-visible warning. Follow-up will add a tooltip clarifying that *Auto* is recommended for >~16 terminals.

### Try it locally

```sh
nix run github:juspay/kolu/feat/renderer-auto-option
```