### PR TITLE
Surface gh provider status in UI; prep for bkt

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -149,6 +149,7 @@ let
       --add-flags "${koluStamped}/packages/server/src/index.ts" \
       --set KOLU_CLIENT_DIST "${koluStamped}/packages/client/dist" \
       --set KOLU_CLIPBOARD_SHIM_DIR "${koluEnv.KOLU_CLIPBOARD_SHIM_DIR}" \
+      --set KOLU_GH_BIN "${koluEnv.KOLU_GH_BIN}" \
       --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs pkgs.git pkgs.gh ]} \
       --run 'if [ -n "''${KOLU_DIAG_DIR:-}" ]; then
                KOLU_DIAG_DIR="$KOLU_DIAG_DIR/$(date +%Y%m%dT%H%M%S)-$$"

--- a/nix/env.nix
+++ b/nix/env.nix
@@ -9,4 +9,8 @@
 {
   KOLU_FONTS_DIR          = pkgs.kolu-fonts;
   KOLU_CLIPBOARD_SHIM_DIR = "${pkgs.kolu-clipboard-shims}/bin";
+  # Pinned gh binary — the server's GitHub provider reads this and falls
+  # back to PATH lookup when unset (dev shells, non-Nix installs). See
+  # packages/server/src/meta/github.ts for the read site.
+  KOLU_GH_BIN             = "${pkgs.gh}/bin/gh";
 }

--- a/nix/env.nix
+++ b/nix/env.nix
@@ -9,8 +9,9 @@
 {
   KOLU_FONTS_DIR          = pkgs.kolu-fonts;
   KOLU_CLIPBOARD_SHIM_DIR = "${pkgs.kolu-clipboard-shims}/bin";
-  # Pinned gh binary — the server's GitHub provider reads this and falls
-  # back to PATH lookup when unset (dev shells, non-Nix installs). See
-  # packages/server/src/meta/github.ts for the read site.
+  # Pinned gh binary — the server's GitHub provider consumes this directly.
+  # Required, not optional: github.ts throws at startup if unset. Set here so
+  # both the packaged wrapper (default.nix) and the dev shell (shell.nix)
+  # pick it up via `koluEnv`.
   KOLU_GH_BIN             = "${pkgs.gh}/bin/gh";
 }

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -7,7 +7,8 @@ import Dialog from "@corvu/dialog";
 import ModalDialog from "./ui/ModalDialog";
 import { PrStateIcon, WorktreeIcon } from "./ui/Icons";
 import ChecksIndicator from "./terminal/ChecksIndicator";
-import { type TerminalId, type TerminalMetadata, prValue } from "kolu-common";
+import type { TerminalId, TerminalMetadata } from "kolu-common";
+import { prValue } from "kolu-common/pr";
 
 export interface CloseConfirmTarget {
   id: TerminalId;

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -7,7 +7,7 @@ import Dialog from "@corvu/dialog";
 import ModalDialog from "./ui/ModalDialog";
 import { PrStateIcon, WorktreeIcon } from "./ui/Icons";
 import ChecksIndicator from "./terminal/ChecksIndicator";
-import type { TerminalId, TerminalMetadata } from "kolu-common";
+import { type TerminalId, type TerminalMetadata, prValue } from "kolu-common";
 
 export interface CloseConfirmTarget {
   id: TerminalId;
@@ -86,7 +86,7 @@ const CloseConfirm: Component<{
             )}
           </Show>
 
-          <Show when={props.target?.meta.pr}>
+          <Show when={props.target ? prValue(props.target.meta.pr) : null}>
             {(pr) => (
               <a
                 href={pr().url}

--- a/packages/client/src/right-panel/MetadataInspector.tsx
+++ b/packages/client/src/right-panel/MetadataInspector.tsx
@@ -3,8 +3,17 @@
 
 import { type Component, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
-import type { TerminalMetadata } from "kolu-common";
-import { PrStateIcon, TerminalIcon, WorktreeIcon } from "../ui/Icons";
+import {
+  type TerminalMetadata,
+  prValue,
+  prUnavailableReason,
+} from "kolu-common";
+import {
+  PrStateIcon,
+  TerminalIcon,
+  WarningIcon,
+  WorktreeIcon,
+} from "../ui/Icons";
 import ChecksIndicator from "../terminal/ChecksIndicator";
 import { agentIcons, agentNames, stateLabels } from "../ui/agentDisplay";
 import Section from "../ui/Section";
@@ -71,7 +80,7 @@ const MetadataInspector: Component<{
           </Show>
 
           {/* Pull Request */}
-          <Show when={meta().pr}>
+          <Show when={prValue(meta().pr)}>
             {(pr) => (
               <Section title="Pull Request">
                 <div class="space-y-0.5">
@@ -98,6 +107,21 @@ const MetadataInspector: Component<{
                     )}
                   </Show>
                 </div>
+              </Section>
+            )}
+          </Show>
+          <Show when={prUnavailableReason(meta().pr)}>
+            {(reason) => (
+              <Section title="Pull Request">
+                <Row label="Status" variant="badge">
+                  <span
+                    data-testid="inspector-pr-unavailable"
+                    class="inline-flex items-center gap-1.5 text-fg-2"
+                  >
+                    <WarningIcon class="w-3.5 h-3.5" />
+                    <span>{reason()}</span>
+                  </span>
+                </Row>
               </Section>
             )}
           </Show>

--- a/packages/client/src/right-panel/MetadataInspector.tsx
+++ b/packages/client/src/right-panel/MetadataInspector.tsx
@@ -3,11 +3,8 @@
 
 import { type Component, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
-import {
-  type TerminalMetadata,
-  prValue,
-  prUnavailableReason,
-} from "kolu-common";
+import type { TerminalMetadata } from "kolu-common";
+import { prValue, prUnavailableReason } from "kolu-common/pr";
 import {
   PrStateIcon,
   TerminalIcon,

--- a/packages/client/src/right-panel/MetadataInspector.tsx
+++ b/packages/client/src/right-panel/MetadataInspector.tsx
@@ -4,10 +4,10 @@
 import { type Component, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
 import type { TerminalMetadata } from "kolu-common";
-import { prValue, prUnavailable } from "kolu-common/pr";
+import { prValue, prUnavailableSource } from "kolu-common/pr";
 import { PrStateIcon, TerminalIcon, WorktreeIcon } from "../ui/Icons";
 import ChecksIndicator from "../terminal/ChecksIndicator";
-import { PrUnavailableContent } from "../terminal/PrUnavailablePopover";
+import { ProviderUnavailableContent } from "../terminal/PrUnavailablePopover";
 import { agentIcons, agentNames, stateLabels } from "../ui/agentDisplay";
 import Section from "../ui/Section";
 import Row from "../ui/Row";
@@ -103,14 +103,14 @@ const MetadataInspector: Component<{
               </Section>
             )}
           </Show>
-          <Show when={prUnavailable(meta().pr)}>
-            {(unavail) => (
+          <Show when={prUnavailableSource(meta().pr)}>
+            {(source) => (
               <Section title="Pull Request">
                 <div
                   data-testid="inspector-pr-unavailable"
                   class="space-y-2 text-xs"
                 >
-                  <PrUnavailableContent code={unavail().code} />
+                  <ProviderUnavailableContent source={source()} />
                 </div>
               </Section>
             )}

--- a/packages/client/src/right-panel/MetadataInspector.tsx
+++ b/packages/client/src/right-panel/MetadataInspector.tsx
@@ -4,14 +4,10 @@
 import { type Component, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
 import type { TerminalMetadata } from "kolu-common";
-import { prValue, prUnavailableReason } from "kolu-common/pr";
-import {
-  PrStateIcon,
-  TerminalIcon,
-  WarningIcon,
-  WorktreeIcon,
-} from "../ui/Icons";
+import { prValue, prUnavailable } from "kolu-common/pr";
+import { PrStateIcon, TerminalIcon, WorktreeIcon } from "../ui/Icons";
 import ChecksIndicator from "../terminal/ChecksIndicator";
+import { PrUnavailableContent } from "../terminal/PrUnavailablePopover";
 import { agentIcons, agentNames, stateLabels } from "../ui/agentDisplay";
 import Section from "../ui/Section";
 import Row from "../ui/Row";
@@ -107,18 +103,15 @@ const MetadataInspector: Component<{
               </Section>
             )}
           </Show>
-          <Show when={prUnavailableReason(meta().pr)}>
-            {(reason) => (
+          <Show when={prUnavailable(meta().pr)}>
+            {(unavail) => (
               <Section title="Pull Request">
-                <Row label="Status" variant="badge">
-                  <span
-                    data-testid="inspector-pr-unavailable"
-                    class="inline-flex items-center gap-1.5 text-fg-2"
-                  >
-                    <WarningIcon class="w-3.5 h-3.5" />
-                    <span>{reason()}</span>
-                  </span>
-                </Row>
+                <div
+                  data-testid="inspector-pr-unavailable"
+                  class="space-y-2 text-xs"
+                >
+                  <PrUnavailableContent code={unavail().code} />
+                </div>
               </Section>
             )}
           </Show>

--- a/packages/client/src/terminal/PrUnavailablePopover.tsx
+++ b/packages/client/src/terminal/PrUnavailablePopover.tsx
@@ -1,0 +1,185 @@
+/** Recovery-instructions popover for `PrResult.kind === "unavailable"`.
+ *
+ *  Click the ⚠ on a terminal's title bar; this panel explains *why* the PR
+ *  lookup is broken and (when actionable) gives a copy-paste command to fix
+ *  it. Content dispatched per-`code` via `match(...).exhaustive()` so new
+ *  PrUnavailableCode variants force a compile-time edit here.
+ *
+ *  The inner dispatch is exported as `PrUnavailableContent` so the right-panel
+ *  inspector can render the same recovery UI inline (no click required — the
+ *  inspector has the real estate for it).
+ *
+ *  Portal + click-outside + Escape mirror `settings/SettingsPopover.tsx`'s
+ *  pattern — there is no Corvu Popover in the repo, and the settings panel is
+ *  the canonical reference for anchored floating UI. */
+
+import { type Component, Show, createSignal } from "solid-js";
+import { Portal } from "solid-js/web";
+import { makeEventListener } from "@solid-primitives/event-listener";
+import { match } from "ts-pattern";
+import type { PrUnavailableCode } from "kolu-common";
+
+const AUTH_COMMAND = "gh auth login -s repo,read:org";
+
+/** Dispatches per-`code` recovery content — heading, prose, optional copy
+ *  button. Shared between the popover (click-to-open, terminal title bar) and
+ *  the inspector (always-visible, right panel). */
+export const PrUnavailableContent: Component<{
+  code: PrUnavailableCode;
+}> = (props) => {
+  const [copied, setCopied] = createSignal(false);
+
+  const copy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Browsers block clipboard writes outside secure contexts / without a
+      // user gesture — falling through silently is acceptable here because
+      // the command string is still visible and selectable in the panel.
+    }
+  };
+
+  return match(props.code)
+    .with("not-authenticated", () => (
+      <>
+        <div class="font-medium text-fg">GitHub not authenticated</div>
+        <p class="text-fg-2 leading-relaxed">
+          Kolu reads PRs via <code class="font-mono">gh</code>. Run this once in
+          any terminal:
+        </p>
+        <CopyCommand
+          command={AUTH_COMMAND}
+          copied={copied()}
+          onCopy={() => copy(AUTH_COMMAND)}
+        />
+        <p class="text-fg-3 leading-relaxed">
+          Scopes <code class="font-mono">repo</code> and{" "}
+          <code class="font-mono">read:org</code> cover private repos and
+          org-owned PRs.
+        </p>
+      </>
+    ))
+    .with("not-installed", () => (
+      <>
+        <div class="font-medium text-fg">GitHub CLI not installed</div>
+        <p class="text-fg-2 leading-relaxed">
+          Kolu reads PRs via <code class="font-mono">gh</code>. Install it from{" "}
+          <a
+            href="https://cli.github.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-accent hover:underline"
+          >
+            cli.github.com
+          </a>{" "}
+          and relaunch kolu.
+        </p>
+        <p class="text-fg-3 leading-relaxed">
+          Nix installs bundle <code class="font-mono">gh</code> automatically —
+          if you see this, the wrapper isn't in use.
+        </p>
+      </>
+    ))
+    .with("timed-out", () => (
+      <>
+        <div class="font-medium text-fg">GitHub timed out</div>
+        <p class="text-fg-2 leading-relaxed">
+          <code class="font-mono">gh pr view</code> took longer than 5s. Kolu
+          will retry on the next branch change or polling tick.
+        </p>
+      </>
+    ))
+    .with("unknown", () => (
+      <>
+        <div class="font-medium text-fg">GitHub lookup failed</div>
+        <p class="text-fg-2 leading-relaxed">
+          An unrecognized error from <code class="font-mono">gh</code>. Check
+          kolu server logs for details; kolu will retry on the next branch
+          change.
+        </p>
+      </>
+    ))
+    .exhaustive();
+};
+
+const PrUnavailablePopover: Component<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerRef?: HTMLElement;
+  code: PrUnavailableCode;
+  reason: string;
+}> = (props) => {
+  let panelRef: HTMLDivElement | undefined;
+  const [pos, setPos] = createSignal({ top: 0, left: 0 });
+
+  const updatePos = () => {
+    if (!props.triggerRef) return;
+    const rect = props.triggerRef.getBoundingClientRect();
+    // Anchor below the trigger, aligned to its left edge, with viewport clamp
+    // so narrow tiles near the right edge don't clip the panel.
+    const panelWidth = 280;
+    const left = Math.min(rect.left, window.innerWidth - panelWidth - 8);
+    setPos({ top: rect.bottom + 4, left: Math.max(8, left) });
+  };
+
+  makeEventListener(document, "mousedown", (e) => {
+    if (
+      props.open &&
+      panelRef &&
+      !panelRef.contains(e.target as Node) &&
+      !props.triggerRef?.contains(e.target as Node)
+    ) {
+      props.onOpenChange(false);
+    }
+  });
+
+  makeEventListener(document, "keydown", (e) => {
+    if (props.open && e.key === "Escape") props.onOpenChange(false);
+  });
+
+  return (
+    <Show when={props.open}>
+      <Portal>
+        <div
+          ref={(el) => {
+            panelRef = el;
+            updatePos();
+          }}
+          data-testid="pr-unavailable-popover"
+          role="dialog"
+          aria-label={props.reason}
+          class="fixed z-50 bg-surface-1 border border-edge rounded-xl shadow-2xl shadow-black/50 p-3 w-[280px] space-y-2 text-xs"
+          style={{
+            top: `${pos().top}px`,
+            left: `${pos().left}px`,
+            "background-color": "var(--color-surface-1)",
+          }}
+        >
+          <PrUnavailableContent code={props.code} />
+        </div>
+      </Portal>
+    </Show>
+  );
+};
+
+const CopyCommand: Component<{
+  command: string;
+  copied: boolean;
+  onCopy: () => void;
+}> = (props) => (
+  <button
+    type="button"
+    onClick={props.onCopy}
+    class="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg bg-surface-2 hover:bg-surface-3 font-mono text-[11px] text-fg cursor-pointer transition-colors"
+    data-testid="pr-unavailable-copy"
+  >
+    <span class="truncate">{props.command}</span>
+    <span class="shrink-0 text-fg-3 text-[10px]">
+      {props.copied ? "copied" : "copy"}
+    </span>
+  </button>
+);
+
+export default PrUnavailablePopover;

--- a/packages/client/src/terminal/PrUnavailablePopover.tsx
+++ b/packages/client/src/terminal/PrUnavailablePopover.tsx
@@ -1,24 +1,10 @@
-/** Recovery-instructions popover for `PrResult.kind === "unavailable"`.
- *
- *  Click the ⚠ on a terminal's title bar; this panel explains *why* the PR
- *  lookup is broken and (when actionable) gives a copy-paste command to fix
- *  it. Dispatch happens in two layers:
- *
- *    1. `ProviderUnavailableContent` matches on `source.provider` — today
- *       only `"gh"`, but `.exhaustive()` will compile-error when bkt adds
- *       its schema arm. Each provider gets its own content component (see
- *       `GhUnavailableContent` below), so bkt's recovery UX can differ
- *       freely without fitting a shared mold.
- *    2. `GhUnavailableContent` matches on the gh code enum and renders
- *       per-failure prose + an optional copy-command button.
- *
- *  `ProviderUnavailableContent` is exported so the right-panel inspector can
- *  render the same recovery UI inline (no click required — the inspector has
- *  the real estate for it).
- *
- *  Portal + click-outside + Escape mirror `settings/SettingsPopover.tsx`'s
- *  pattern — there is no Corvu Popover in the repo, and the settings panel is
- *  the canonical reference for anchored floating UI. */
+/** Click-to-open recovery-instructions popover + button trigger for
+ *  `PrResult.kind === "unavailable"`. Dispatch happens in two layers:
+ *  `ProviderUnavailableContent` matches on `source.provider` (today only
+ *  `"gh"`), delegating to a per-provider content component so bkt's future
+ *  recovery UX doesn't need to fit a shared mold. Portal + click-outside +
+ *  Escape mirror `settings/SettingsPopover.tsx` — no Corvu Popover in the
+ *  repo, and the settings panel is the canonical anchored-floating pattern. */
 
 import { type Component, Show, createSignal } from "solid-js";
 import { Portal } from "solid-js/web";
@@ -26,12 +12,11 @@ import { makeEventListener } from "@solid-primitives/event-listener";
 import { match } from "ts-pattern";
 import type { GhUnavailableCode, PrUnavailableSource } from "kolu-common";
 import { reasonForSource } from "kolu-common/pr";
+import { writeTextToClipboard } from "./clipboard";
+import { WarningIcon } from "../ui/Icons";
 
 const AUTH_COMMAND = "gh auth login -s repo,read:org";
 
-/** Top-level dispatch: renders the appropriate per-provider content.
- *  Shared between the popover (click-to-open, terminal title bar) and the
- *  inspector (always-visible, right panel). */
 export const ProviderUnavailableContent: Component<{
   source: PrUnavailableSource;
 }> = (props) =>
@@ -41,9 +26,6 @@ export const ProviderUnavailableContent: Component<{
     ))
     .exhaustive();
 
-/** gh-specific recovery content. When bkt lands, a sibling
- *  `BktUnavailableContent` component handles its own codes; the dispatch in
- *  `ProviderUnavailableContent` grows one arm. */
 const GhUnavailableContent: Component<{ code: GhUnavailableCode }> = (
   props,
 ) => {
@@ -51,13 +33,13 @@ const GhUnavailableContent: Component<{ code: GhUnavailableCode }> = (
 
   const copy = async (text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeTextToClipboard(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
-      // Browsers block clipboard writes outside secure contexts / without a
-      // user gesture — falling through silently is acceptable here because
-      // the command string is still visible and selectable in the panel.
+      // Both clipboard paths (navigator.clipboard + execCommand fallback in
+      // writeTextToClipboard) failed — the command string is still visible
+      // and selectable in the panel, so silently continuing is acceptable.
     }
   };
 
@@ -200,5 +182,43 @@ const CopyCommand: Component<{
     </span>
   </button>
 );
+
+/** ⚠ button + its popover, one component per render site. Owns its own
+ *  open-state signal and trigger ref — canvas tile chrome and mobile
+ *  pull-handle show the icon for the same terminal simultaneously and each
+ *  must anchor their popover to their own trigger rather than share one. */
+export const PrUnavailableButton: Component<{
+  source: PrUnavailableSource;
+  testId: string;
+}> = (props) => {
+  const [open, setOpen] = createSignal(false);
+  const [triggerEl, setTriggerEl] = createSignal<HTMLButtonElement>();
+  const reason = () => reasonForSource(props.source);
+  return (
+    <>
+      <button
+        ref={setTriggerEl}
+        type="button"
+        data-testid={props.testId}
+        class="flex items-center text-fg-3 shrink-0 cursor-pointer hover:text-warning focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded"
+        title={reason()}
+        aria-label={reason()}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <WarningIcon class="w-3 h-3" />
+      </button>
+      <PrUnavailablePopover
+        open={open()}
+        onOpenChange={setOpen}
+        triggerRef={triggerEl()}
+        source={props.source}
+      />
+    </>
+  );
+};
 
 export default PrUnavailablePopover;

--- a/packages/client/src/terminal/PrUnavailablePopover.tsx
+++ b/packages/client/src/terminal/PrUnavailablePopover.tsx
@@ -2,12 +2,19 @@
  *
  *  Click the ⚠ on a terminal's title bar; this panel explains *why* the PR
  *  lookup is broken and (when actionable) gives a copy-paste command to fix
- *  it. Content dispatched per-`code` via `match(...).exhaustive()` so new
- *  PrUnavailableCode variants force a compile-time edit here.
+ *  it. Dispatch happens in two layers:
  *
- *  The inner dispatch is exported as `PrUnavailableContent` so the right-panel
- *  inspector can render the same recovery UI inline (no click required — the
- *  inspector has the real estate for it).
+ *    1. `ProviderUnavailableContent` matches on `source.provider` — today
+ *       only `"gh"`, but `.exhaustive()` will compile-error when bkt adds
+ *       its schema arm. Each provider gets its own content component (see
+ *       `GhUnavailableContent` below), so bkt's recovery UX can differ
+ *       freely without fitting a shared mold.
+ *    2. `GhUnavailableContent` matches on the gh code enum and renders
+ *       per-failure prose + an optional copy-command button.
+ *
+ *  `ProviderUnavailableContent` is exported so the right-panel inspector can
+ *  render the same recovery UI inline (no click required — the inspector has
+ *  the real estate for it).
  *
  *  Portal + click-outside + Escape mirror `settings/SettingsPopover.tsx`'s
  *  pattern — there is no Corvu Popover in the repo, and the settings panel is
@@ -17,16 +24,29 @@ import { type Component, Show, createSignal } from "solid-js";
 import { Portal } from "solid-js/web";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import { match } from "ts-pattern";
-import type { PrUnavailableCode } from "kolu-common";
+import type { GhUnavailableCode, PrUnavailableSource } from "kolu-common";
+import { reasonForSource } from "kolu-common/pr";
 
 const AUTH_COMMAND = "gh auth login -s repo,read:org";
 
-/** Dispatches per-`code` recovery content — heading, prose, optional copy
- *  button. Shared between the popover (click-to-open, terminal title bar) and
- *  the inspector (always-visible, right panel). */
-export const PrUnavailableContent: Component<{
-  code: PrUnavailableCode;
-}> = (props) => {
+/** Top-level dispatch: renders the appropriate per-provider content.
+ *  Shared between the popover (click-to-open, terminal title bar) and the
+ *  inspector (always-visible, right panel). */
+export const ProviderUnavailableContent: Component<{
+  source: PrUnavailableSource;
+}> = (props) =>
+  match(props.source)
+    .with({ provider: "gh" }, ({ code }) => (
+      <GhUnavailableContent code={code} />
+    ))
+    .exhaustive();
+
+/** gh-specific recovery content. When bkt lands, a sibling
+ *  `BktUnavailableContent` component handles its own codes; the dispatch in
+ *  `ProviderUnavailableContent` grows one arm. */
+const GhUnavailableContent: Component<{ code: GhUnavailableCode }> = (
+  props,
+) => {
   const [copied, setCopied] = createSignal(false);
 
   const copy = async (text: string) => {
@@ -108,8 +128,7 @@ const PrUnavailablePopover: Component<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
   triggerRef?: HTMLElement;
-  code: PrUnavailableCode;
-  reason: string;
+  source: PrUnavailableSource;
 }> = (props) => {
   let panelRef: HTMLDivElement | undefined;
   const [pos, setPos] = createSignal({ top: 0, left: 0 });
@@ -149,7 +168,7 @@ const PrUnavailablePopover: Component<{
           }}
           data-testid="pr-unavailable-popover"
           role="dialog"
-          aria-label={props.reason}
+          aria-label={reasonForSource(props.source)}
           class="fixed z-50 bg-surface-1 border border-edge rounded-xl shadow-2xl shadow-black/50 p-3 w-[280px] space-y-2 text-xs"
           style={{
             top: `${pos().top}px`,
@@ -157,7 +176,7 @@ const PrUnavailablePopover: Component<{
             "background-color": "var(--color-surface-1)",
           }}
         >
-          <PrUnavailableContent code={props.code} />
+          <ProviderUnavailableContent source={props.source} />
         </div>
       </Portal>
     </Show>

--- a/packages/client/src/terminal/PrUnavailablePopover.tsx
+++ b/packages/client/src/terminal/PrUnavailablePopover.tsx
@@ -10,6 +10,7 @@ import { type Component, Show, createSignal } from "solid-js";
 import { Portal } from "solid-js/web";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import { match } from "ts-pattern";
+import { toast } from "solid-sonner";
 import type { GhUnavailableCode, PrUnavailableSource } from "kolu-common";
 import { reasonForSource } from "kolu-common/pr";
 import { writeTextToClipboard } from "./clipboard";
@@ -36,10 +37,8 @@ const GhUnavailableContent: Component<{ code: GhUnavailableCode }> = (
       await writeTextToClipboard(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Both clipboard paths (navigator.clipboard + execCommand fallback in
-      // writeTextToClipboard) failed — the command string is still visible
-      // and selectable in the panel, so silently continuing is acceptable.
+    } catch (err) {
+      toast.error(`Couldn't copy: ${(err as Error).message}`);
     }
   };
 

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -124,14 +124,18 @@ const TerminalMeta: Component<{
                 </Show>
                 <Show when={prUnavailableReason(info().meta.pr)}>
                   {(reason) => (
-                    <Tip label={reason()}>
-                      <span
-                        data-testid="terminal-meta-pr-unavailable"
-                        class="flex items-center text-fg-3 shrink-0"
-                      >
-                        <WarningIcon class="w-3 h-3" />
-                      </span>
-                    </Tip>
+                    // Native `title` rather than <Tip>: Tip's Corvu trigger
+                    // applies `role="button"`, which Tailwind preflight styles
+                    // with `cursor: pointer` — a misleading affordance while
+                    // this element is not (yet) clickable. Swap back to Tip
+                    // when the recovery-instructions popover lands.
+                    <span
+                      data-testid="terminal-meta-pr-unavailable"
+                      class="flex items-center text-fg-3 shrink-0"
+                      title={reason()}
+                    >
+                      <WarningIcon class="w-3 h-3" />
+                    </span>
                   )}
                 </Show>
               </div>

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -10,12 +10,12 @@
  *  separate components, with shared bits (skeleton, agent progress)
  *  exported below for reuse. */
 
-import { type Component, Show, createSignal } from "solid-js";
-import { prValue, prUnavailableSource, reasonForSource } from "kolu-common/pr";
+import { type Component, Show } from "solid-js";
+import { prValue, prUnavailableSource } from "kolu-common/pr";
 import ChecksIndicator from "./ChecksIndicator";
 import Tip from "../ui/Tip";
-import { PrStateIcon, WarningIcon, WorktreeIcon } from "../ui/Icons";
-import PrUnavailablePopover from "./PrUnavailablePopover";
+import { PrStateIcon, WorktreeIcon } from "../ui/Icons";
+import { PrUnavailableButton } from "./PrUnavailablePopover";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 
 const TerminalMeta: Component<{
@@ -207,44 +207,6 @@ export const TerminalMetaCompact: Component<{
         </div>
       )}
     </Show>
-  );
-};
-
-/** ⚠ button that opens PrUnavailablePopover on click. Each render site owns
- *  its own open state + triggerRef — canvas tile chrome and mobile pull-handle
- *  show the icon simultaneously for the same terminal, and they should each
- *  anchor their popover to their own trigger rather than share one. */
-const PrUnavailableButton: Component<{
-  source: Parameters<typeof PrUnavailablePopover>[0]["source"];
-  testId: string;
-}> = (props) => {
-  const [open, setOpen] = createSignal(false);
-  const [triggerEl, setTriggerEl] = createSignal<HTMLButtonElement>();
-  const reason = () => reasonForSource(props.source);
-  return (
-    <>
-      <button
-        ref={setTriggerEl}
-        type="button"
-        data-testid={props.testId}
-        class="flex items-center text-fg-3 shrink-0 cursor-pointer hover:text-warning focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded"
-        title={reason()}
-        aria-label={reason()}
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen((v) => !v);
-        }}
-        onPointerDown={(e) => e.stopPropagation()}
-      >
-        <WarningIcon class="w-3 h-3" />
-      </button>
-      <PrUnavailablePopover
-        open={open()}
-        onOpenChange={setOpen}
-        triggerRef={triggerEl()}
-        source={props.source}
-      />
-    </>
   );
 };
 

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -11,7 +11,7 @@
  *  exported below for reuse. */
 
 import { type Component, Show, createSignal } from "solid-js";
-import { prValue, prUnavailable } from "kolu-common/pr";
+import { prValue, prUnavailableSource, reasonForSource } from "kolu-common/pr";
 import ChecksIndicator from "./ChecksIndicator";
 import Tip from "../ui/Tip";
 import { PrStateIcon, WarningIcon, WorktreeIcon } from "../ui/Icons";
@@ -123,11 +123,10 @@ const TerminalMeta: Component<{
                     </span>
                   )}
                 </Show>
-                <Show when={prUnavailable(info().meta.pr)}>
-                  {(unavail) => (
+                <Show when={prUnavailableSource(info().meta.pr)}>
+                  {(source) => (
                     <PrUnavailableButton
-                      code={unavail().code}
-                      reason={unavail().reason}
+                      source={source()}
                       testId="terminal-meta-pr-unavailable"
                     />
                   )}
@@ -189,11 +188,10 @@ export const TerminalMetaCompact: Component<{
               </a>
             )}
           </Show>
-          <Show when={prUnavailable(info().meta.pr)}>
-            {(unavail) => (
+          <Show when={prUnavailableSource(info().meta.pr)}>
+            {(source) => (
               <PrUnavailableButton
-                code={unavail().code}
-                reason={unavail().reason}
+                source={source()}
                 testId="terminal-meta-pr-unavailable-compact"
               />
             )}
@@ -217,12 +215,12 @@ export const TerminalMetaCompact: Component<{
  *  show the icon simultaneously for the same terminal, and they should each
  *  anchor their popover to their own trigger rather than share one. */
 const PrUnavailableButton: Component<{
-  code: Parameters<typeof PrUnavailablePopover>[0]["code"];
-  reason: string;
+  source: Parameters<typeof PrUnavailablePopover>[0]["source"];
   testId: string;
 }> = (props) => {
   const [open, setOpen] = createSignal(false);
   const [triggerEl, setTriggerEl] = createSignal<HTMLButtonElement>();
+  const reason = () => reasonForSource(props.source);
   return (
     <>
       <button
@@ -230,8 +228,8 @@ const PrUnavailableButton: Component<{
         type="button"
         data-testid={props.testId}
         class="flex items-center text-fg-3 shrink-0 cursor-pointer hover:text-warning focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded"
-        title={props.reason}
-        aria-label={props.reason}
+        title={reason()}
+        aria-label={reason()}
         onClick={(e) => {
           e.stopPropagation();
           setOpen((v) => !v);
@@ -244,8 +242,7 @@ const PrUnavailableButton: Component<{
         open={open()}
         onOpenChange={setOpen}
         triggerRef={triggerEl()}
-        code={props.code}
-        reason={props.reason}
+        source={props.source}
       />
     </>
   );

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -11,7 +11,7 @@
  *  exported below for reuse. */
 
 import { type Component, Show } from "solid-js";
-import { prValue, prUnavailableReason } from "kolu-common";
+import { prValue, prUnavailableReason } from "kolu-common/pr";
 import ChecksIndicator from "./ChecksIndicator";
 import Tip from "../ui/Tip";
 import { PrStateIcon, WarningIcon, WorktreeIcon } from "../ui/Icons";

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -11,9 +11,10 @@
  *  exported below for reuse. */
 
 import { type Component, Show } from "solid-js";
+import { prValue, prUnavailableReason } from "kolu-common";
 import ChecksIndicator from "./ChecksIndicator";
 import Tip from "../ui/Tip";
-import { PrStateIcon, WorktreeIcon } from "../ui/Icons";
+import { PrStateIcon, WarningIcon, WorktreeIcon } from "../ui/Icons";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 
 const TerminalMeta: Component<{
@@ -97,7 +98,7 @@ const TerminalMeta: Component<{
                     {git().branch}
                   </span>
                 </Tip>
-                <Show when={info().meta.pr}>
+                <Show when={prValue(info().meta.pr)}>
                   {(pr) => (
                     <span
                       class="flex items-center gap-1 text-fg-2 truncate min-w-0"
@@ -119,6 +120,18 @@ const TerminalMeta: Component<{
                       </a>
                       <span class="truncate">{pr().title}</span>
                     </span>
+                  )}
+                </Show>
+                <Show when={prUnavailableReason(info().meta.pr)}>
+                  {(reason) => (
+                    <Tip label={reason()}>
+                      <span
+                        data-testid="terminal-meta-pr-unavailable"
+                        class="flex items-center text-fg-3 shrink-0"
+                      >
+                        <WarningIcon class="w-3 h-3" />
+                      </span>
+                    </Tip>
                   )}
                 </Show>
               </div>
@@ -162,7 +175,7 @@ export const TerminalMetaCompact: Component<{
           </Show>
           {/* Anchor stops propagation so a tap on the PR doesn't toggle
            *  the enclosing Drawer.Trigger. */}
-          <Show when={info().meta.pr}>
+          <Show when={prValue(info().meta.pr)}>
             {(pr) => (
               <a
                 data-testid="terminal-meta-pr-compact"
@@ -176,6 +189,17 @@ export const TerminalMetaCompact: Component<{
               >
                 #{pr().number}
               </a>
+            )}
+          </Show>
+          <Show when={prUnavailableReason(info().meta.pr)}>
+            {(reason) => (
+              <span
+                data-testid="terminal-meta-pr-unavailable-compact"
+                class="flex items-center text-fg-3 shrink-0"
+                title={reason()}
+              >
+                <WarningIcon class="w-3 h-3" />
+              </span>
             )}
           </Show>
           <Show when={info().meta.agent?.taskProgress}>

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -10,11 +10,12 @@
  *  separate components, with shared bits (skeleton, agent progress)
  *  exported below for reuse. */
 
-import { type Component, Show } from "solid-js";
-import { prValue, prUnavailableReason } from "kolu-common/pr";
+import { type Component, Show, createSignal } from "solid-js";
+import { prValue, prUnavailable } from "kolu-common/pr";
 import ChecksIndicator from "./ChecksIndicator";
 import Tip from "../ui/Tip";
 import { PrStateIcon, WarningIcon, WorktreeIcon } from "../ui/Icons";
+import PrUnavailablePopover from "./PrUnavailablePopover";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 
 const TerminalMeta: Component<{
@@ -122,20 +123,13 @@ const TerminalMeta: Component<{
                     </span>
                   )}
                 </Show>
-                <Show when={prUnavailableReason(info().meta.pr)}>
-                  {(reason) => (
-                    // Native `title` rather than <Tip>: Tip's Corvu trigger
-                    // applies `role="button"`, which Tailwind preflight styles
-                    // with `cursor: pointer` — a misleading affordance while
-                    // this element is not (yet) clickable. Swap back to Tip
-                    // when the recovery-instructions popover lands.
-                    <span
-                      data-testid="terminal-meta-pr-unavailable"
-                      class="flex items-center text-fg-3 shrink-0"
-                      title={reason()}
-                    >
-                      <WarningIcon class="w-3 h-3" />
-                    </span>
+                <Show when={prUnavailable(info().meta.pr)}>
+                  {(unavail) => (
+                    <PrUnavailableButton
+                      code={unavail().code}
+                      reason={unavail().reason}
+                      testId="terminal-meta-pr-unavailable"
+                    />
                   )}
                 </Show>
               </div>
@@ -195,15 +189,13 @@ export const TerminalMetaCompact: Component<{
               </a>
             )}
           </Show>
-          <Show when={prUnavailableReason(info().meta.pr)}>
-            {(reason) => (
-              <span
-                data-testid="terminal-meta-pr-unavailable-compact"
-                class="flex items-center text-fg-3 shrink-0"
-                title={reason()}
-              >
-                <WarningIcon class="w-3 h-3" />
-              </span>
+          <Show when={prUnavailable(info().meta.pr)}>
+            {(unavail) => (
+              <PrUnavailableButton
+                code={unavail().code}
+                reason={unavail().reason}
+                testId="terminal-meta-pr-unavailable-compact"
+              />
             )}
           </Show>
           <Show when={info().meta.agent?.taskProgress}>
@@ -217,6 +209,45 @@ export const TerminalMetaCompact: Component<{
         </div>
       )}
     </Show>
+  );
+};
+
+/** ⚠ button that opens PrUnavailablePopover on click. Each render site owns
+ *  its own open state + triggerRef — canvas tile chrome and mobile pull-handle
+ *  show the icon simultaneously for the same terminal, and they should each
+ *  anchor their popover to their own trigger rather than share one. */
+const PrUnavailableButton: Component<{
+  code: Parameters<typeof PrUnavailablePopover>[0]["code"];
+  reason: string;
+  testId: string;
+}> = (props) => {
+  const [open, setOpen] = createSignal(false);
+  const [triggerEl, setTriggerEl] = createSignal<HTMLButtonElement>();
+  return (
+    <>
+      <button
+        ref={setTriggerEl}
+        type="button"
+        data-testid={props.testId}
+        class="flex items-center text-fg-3 shrink-0 cursor-pointer hover:text-warning focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded"
+        title={props.reason}
+        aria-label={props.reason}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <WarningIcon class="w-3 h-3" />
+      </button>
+      <PrUnavailablePopover
+        open={open()}
+        onOpenChange={setOpen}
+        triggerRef={triggerEl()}
+        code={props.code}
+        reason={props.reason}
+      />
+    </>
   );
 };
 

--- a/packages/client/src/terminal/terminalDisplay.test.ts
+++ b/packages/client/src/terminal/terminalDisplay.test.ts
@@ -10,7 +10,7 @@ function makeMeta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
     cwd: "/home/user/project",
     git: null,
-    pr: null,
+    pr: { kind: "pending" },
     agent: null,
     foreground: null,
     sortOrder: 0,

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -205,6 +205,26 @@ export const ResumeIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
+/** Warning triangle — small exclamation, used to flag degraded provider
+ *  state (e.g. `gh` not authenticated) in the terminal metadata strip and
+ *  inspector. Inherits `currentColor` so callers can tint it via `text-*`. */
+export const WarningIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M8 2.5L14 13H2L8 2.5Z" />
+    <path d="M8 6.5V9.5" />
+    <circle cx="8" cy="11.5" r="0.5" fill="currentColor" />
+  </svg>
+);
+
 /** Webcam icon — rounded rectangle with a lens. Toggles the PiP overlay. */
 export const WebcamIcon: Component<{ class?: string }> = (props) => (
   <svg

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -26,6 +26,7 @@
     "kolu-git": "workspace:*",
     "anyagent": "workspace:*",
     "kolu-opencode": "workspace:*",
+    "ts-pattern": "^5.9.0",
     "zod": "^4.3.6"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -11,7 +11,8 @@
     ".": "./src/index.ts",
     "./contract": "./src/contract.ts",
     "./errors": "./src/errors.ts",
-    "./config": "./src/config.ts"
+    "./config": "./src/config.ts",
+    "./pr": "./src/pr.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -75,22 +75,35 @@ import {
   GitHubPrStateSchema,
   GitHubPrInfoSchema,
   PrResultSchema,
-  PrUnavailableCodeSchema,
+  GhUnavailableCodeSchema,
+  GhUnavailableSchema,
+  PrUnavailableSourceSchema,
   prValue,
   prUnavailableReason,
-  prUnavailable,
+  prUnavailableSource,
+  reasonForGhCode,
+  reasonForSource,
 } from "./pr.ts";
 export {
   GitHubCheckStatusSchema,
   GitHubPrStateSchema,
   GitHubPrInfoSchema,
   PrResultSchema,
-  PrUnavailableCodeSchema,
+  GhUnavailableCodeSchema,
+  GhUnavailableSchema,
+  PrUnavailableSourceSchema,
   prValue,
   prUnavailableReason,
-  prUnavailable,
+  prUnavailableSource,
+  reasonForGhCode,
+  reasonForSource,
 };
-export type { GitHubPrInfo, PrResult, PrUnavailableCode } from "./pr.ts";
+export type {
+  GitHubPrInfo,
+  PrResult,
+  GhUnavailableCode,
+  PrUnavailableSource,
+} from "./pr.ts";
 
 // --- AI coding agent context ---
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -78,6 +78,7 @@ import {
   PrUnavailableCodeSchema,
   prValue,
   prUnavailableReason,
+  prUnavailable,
 } from "./pr.ts";
 export {
   GitHubCheckStatusSchema,
@@ -87,6 +88,7 @@ export {
   PrUnavailableCodeSchema,
   prValue,
   prUnavailableReason,
+  prUnavailable,
 };
 export type { GitHubPrInfo, PrResult, PrUnavailableCode } from "./pr.ts";
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -75,6 +75,7 @@ import {
   GitHubPrStateSchema,
   GitHubPrInfoSchema,
   PrResultSchema,
+  PrUnavailableCodeSchema,
   prValue,
   prUnavailableReason,
 } from "./pr.ts";
@@ -83,10 +84,11 @@ export {
   GitHubPrStateSchema,
   GitHubPrInfoSchema,
   PrResultSchema,
+  PrUnavailableCodeSchema,
   prValue,
   prUnavailableReason,
 };
-export type { GitHubPrInfo, PrResult } from "./pr.ts";
+export type { GitHubPrInfo, PrResult, PrUnavailableCode } from "./pr.ts";
 
 // --- AI coding agent context ---
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -66,57 +66,27 @@ export type {
 const TerminalIdSchema = z.string().uuid();
 
 // --- GitHub PR context ---
-
-export const GitHubCheckStatusSchema = z.enum(["pending", "pass", "fail"]);
-
-export const GitHubPrStateSchema = z.enum(["open", "closed", "merged"]);
-
-export const GitHubPrInfoSchema = z.object({
-  number: z.number(),
-  title: z.string(),
-  url: z.string(),
-  /** PR state: open, closed, or merged. */
-  state: GitHubPrStateSchema,
-  /** Combined CI status: pending, pass, or fail. Null if no checks configured. */
-  checks: GitHubCheckStatusSchema.nullable(),
-});
-
-/** PR resolution state.
- *
- *  Decomplects three distinct conditions that `GitHubPrInfo | null` used to
- *  collapse into one value:
- *    pending     — resolver is running (or stale after a branch change)
- *    ok          — resolver succeeded; a PR exists for this branch
- *    absent      — resolver succeeded; no PR for this branch (expected case)
- *    unavailable — resolver couldn't run (gh missing, not authenticated, timed out)
- *
- *  The UI needs to distinguish "absent" (nothing to show) from "unavailable"
- *  (show a warning with `reason`). Keeping the provenance in the same field
- *  as the value avoids a sibling-flag invariant.
- *
- *  Analogous schemas for git/agent/foreground are not introduced yet — their
- *  failure modes don't currently surface as user-actionable warnings. If they
- *  do, mirror this shape per-provider rather than inventing a cross-cutting
- *  status registry (see PR description for #148). */
-export const PrResultSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("pending") }),
-  z.object({ kind: z.literal("ok"), value: GitHubPrInfoSchema }),
-  z.object({ kind: z.literal("absent") }),
-  z.object({ kind: z.literal("unavailable"), reason: z.string() }),
-]);
-export type PrResult = z.infer<typeof PrResultSchema>;
-
-/** Extract the `GitHubPrInfo` when `kind === "ok"`, else `null`.
- *  Lets SolidJS `<Show when={prValue(meta.pr)}>` work without tripping on the
- *  object-truthy trap (every variant is a non-null object). */
-export function prValue(pr: PrResult): GitHubPrInfo | null {
-  return pr.kind === "ok" ? pr.value : null;
-}
-
-/** Extract the unavailability reason when `kind === "unavailable"`, else `null`. */
-export function prUnavailableReason(pr: PrResult): string | null {
-  return pr.kind === "unavailable" ? pr.reason : null;
-}
+// Schemas + helpers live in ./pr.ts so clients can runtime-import them via
+// `kolu-common/pr` without pulling the full kolu-common module graph
+// (which re-exports kolu-claude-code and transitively drags node-only
+// `@anthropic-ai/claude-agent-sdk` into the browser bundle).
+import {
+  GitHubCheckStatusSchema,
+  GitHubPrStateSchema,
+  GitHubPrInfoSchema,
+  PrResultSchema,
+  prValue,
+  prUnavailableReason,
+} from "./pr.ts";
+export {
+  GitHubCheckStatusSchema,
+  GitHubPrStateSchema,
+  GitHubPrInfoSchema,
+  PrResultSchema,
+  prValue,
+  prUnavailableReason,
+};
+export type { GitHubPrInfo, PrResult } from "./pr.ts";
 
 // --- AI coding agent context ---
 
@@ -398,7 +368,6 @@ export const PreferencesPatchSchema = PreferencesSchema.omit({
 export type TerminalInfo = z.infer<typeof TerminalInfoSchema>;
 export type TerminalId = TerminalInfo["id"];
 
-export type GitHubPrInfo = z.infer<typeof GitHubPrInfoSchema>;
 export type TaskProgress = z.infer<typeof TaskProgressSchema>;
 export type AgentKind = z.infer<typeof AgentKindSchema>;
 export type AgentInfo = z.infer<typeof AgentInfoSchema>;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -81,6 +81,43 @@ export const GitHubPrInfoSchema = z.object({
   checks: GitHubCheckStatusSchema.nullable(),
 });
 
+/** PR resolution state.
+ *
+ *  Decomplects three distinct conditions that `GitHubPrInfo | null` used to
+ *  collapse into one value:
+ *    pending     — resolver is running (or stale after a branch change)
+ *    ok          — resolver succeeded; a PR exists for this branch
+ *    absent      — resolver succeeded; no PR for this branch (expected case)
+ *    unavailable — resolver couldn't run (gh missing, not authenticated, timed out)
+ *
+ *  The UI needs to distinguish "absent" (nothing to show) from "unavailable"
+ *  (show a warning with `reason`). Keeping the provenance in the same field
+ *  as the value avoids a sibling-flag invariant.
+ *
+ *  Analogous schemas for git/agent/foreground are not introduced yet — their
+ *  failure modes don't currently surface as user-actionable warnings. If they
+ *  do, mirror this shape per-provider rather than inventing a cross-cutting
+ *  status registry (see PR description for #148). */
+export const PrResultSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("pending") }),
+  z.object({ kind: z.literal("ok"), value: GitHubPrInfoSchema }),
+  z.object({ kind: z.literal("absent") }),
+  z.object({ kind: z.literal("unavailable"), reason: z.string() }),
+]);
+export type PrResult = z.infer<typeof PrResultSchema>;
+
+/** Extract the `GitHubPrInfo` when `kind === "ok"`, else `null`.
+ *  Lets SolidJS `<Show when={prValue(meta.pr)}>` work without tripping on the
+ *  object-truthy trap (every variant is a non-null object). */
+export function prValue(pr: PrResult): GitHubPrInfo | null {
+  return pr.kind === "ok" ? pr.value : null;
+}
+
+/** Extract the unavailability reason when `kind === "unavailable"`, else `null`. */
+export function prUnavailableReason(pr: PrResult): string | null {
+  return pr.kind === "unavailable" ? pr.reason : null;
+}
+
 // --- AI coding agent context ---
 
 export const AgentKindSchema = z.enum(["claude-code", "opencode"]);
@@ -123,7 +160,8 @@ export const SubPanelStateSchema = z.object({
 export const TerminalServerMetadataSchema = z.object({
   cwd: z.string(),
   git: GitInfoSchema.nullable(),
-  pr: GitHubPrInfoSchema.nullable(),
+  /** GitHub PR resolution — discriminated union (see PrResultSchema). */
+  pr: PrResultSchema,
   /** AI coding agent status (Claude Code, OpenCode, etc.). */
   agent: AgentInfoSchema.nullable(),
   /** Foreground process name — detected via OSC 2 title change events. */

--- a/packages/common/src/pr.ts
+++ b/packages/common/src/pr.ts
@@ -78,3 +78,15 @@ export function prValue(pr: PrResult): GitHubPrInfo | null {
 export function prUnavailableReason(pr: PrResult): string | null {
   return pr.kind === "unavailable" ? pr.reason : null;
 }
+
+/** Extract the full unavailable payload (typed `code` + display `reason`) when
+ *  `kind === "unavailable"`, else `null`. Use this when the UI needs to
+ *  dispatch on code (e.g. render different recovery instructions per
+ *  failure); `prUnavailableReason` is enough for a plain string tooltip. */
+export function prUnavailable(
+  pr: PrResult,
+): { code: PrUnavailableCode; reason: string } | null {
+  return pr.kind === "unavailable"
+    ? { code: pr.code, reason: pr.reason }
+    : null;
+}

--- a/packages/common/src/pr.ts
+++ b/packages/common/src/pr.ts
@@ -13,6 +13,7 @@
  *  generalize when bkt's API dictates. See srid/agency#10. */
 
 import { z } from "zod";
+import { match } from "ts-pattern";
 
 export const GitHubCheckStatusSchema = z.enum(["pending", "pass", "fail"]);
 
@@ -84,20 +85,13 @@ export const PrUnavailableSourceSchema = z.discriminatedUnion("provider", [
 export type PrUnavailableSource = z.infer<typeof PrUnavailableSourceSchema>;
 
 /** Display string for any unavailable source — dispatches on provider to the
- *  provider's own reason lookup. The `never` fall-through gives compile-time
- *  exhaustiveness without pulling in `ts-pattern` (which isn't a kolu-common
- *  dependency — this module ships in the browser bundle). When bkt lands,
- *  adding a provider arm to `PrUnavailableSourceSchema` will compile-error
- *  the `never` branch here until a matching arm is added. */
+ *  provider's own reason lookup. `.exhaustive()` forces a compile error when
+ *  bkt adds its arm to `PrUnavailableSourceSchema` until a matching `.with`
+ *  lands here. */
 export function reasonForSource(source: PrUnavailableSource): string {
-  switch (source.provider) {
-    case "gh":
-      return reasonForGhCode(source.code);
-    default: {
-      const _exhaustive: never = source.provider;
-      return _exhaustive;
-    }
-  }
+  return match(source)
+    .with({ provider: "gh" }, ({ code }) => reasonForGhCode(code))
+    .exhaustive();
 }
 
 // --- PrResult ---

--- a/packages/common/src/pr.ts
+++ b/packages/common/src/pr.ts
@@ -23,6 +23,21 @@ export const GitHubPrInfoSchema = z.object({
 });
 export type GitHubPrInfo = z.infer<typeof GitHubPrInfoSchema>;
 
+/** Typed failure code for the `unavailable` PrResult variant.
+ *
+ *  A discriminator separate from the human-readable `reason` so UI callers
+ *  that want to dispatch per-failure (e.g. "show `gh auth login` button only
+ *  for `not-authenticated`") can `match(pr.code).exhaustive()` and get a
+ *  compile error if a new code is added without a handler — rather than
+ *  string-comparing the display text and silently breaking on typo. */
+export const PrUnavailableCodeSchema = z.enum([
+  "not-installed",
+  "not-authenticated",
+  "timed-out",
+  "unknown",
+]);
+export type PrUnavailableCode = z.infer<typeof PrUnavailableCodeSchema>;
+
 /** PR resolution state.
  *
  *  Decomplects distinct conditions that `GitHubPrInfo | null` used to
@@ -44,7 +59,11 @@ export const PrResultSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("pending") }),
   z.object({ kind: z.literal("ok"), value: GitHubPrInfoSchema }),
   z.object({ kind: z.literal("absent") }),
-  z.object({ kind: z.literal("unavailable"), reason: z.string() }),
+  z.object({
+    kind: z.literal("unavailable"),
+    code: PrUnavailableCodeSchema,
+    reason: z.string(),
+  }),
 ]);
 export type PrResult = z.infer<typeof PrResultSchema>;
 

--- a/packages/common/src/pr.ts
+++ b/packages/common/src/pr.ts
@@ -1,10 +1,16 @@
-/** GitHub PR metadata — schemas + helpers.
+/** PR metadata — schemas + helpers.
  *
  *  Lives in its own module (exposed as `kolu-common/pr`) so clients can
- *  runtime-import `prValue` / `prUnavailableReason` without dragging the
- *  full kolu-common module graph — which re-exports kolu-claude-code and
- *  transitively pulls `@anthropic-ai/claude-agent-sdk` (a Node-only package)
- *  into the browser bundle. */
+ *  runtime-import helpers without dragging the full kolu-common module graph
+ *  — which re-exports kolu-claude-code and transitively pulls
+ *  `@anthropic-ai/claude-agent-sdk` (a Node-only package) into the browser
+ *  bundle.
+ *
+ *  Provider tagging: the `unavailable` variant carries a `source` tagged by
+ *  `provider` so a future bkt (Bitbucket CLI) resolver can contribute its own
+ *  code namespace alongside gh's. `PrResult.ok`'s shape is still gh-specific
+ *  (`GitHubPrInfoSchema`) because we don't yet know bkt's PR response shape;
+ *  generalize when bkt's API dictates. See srid/agency#10. */
 
 import { z } from "zod";
 
@@ -23,20 +29,78 @@ export const GitHubPrInfoSchema = z.object({
 });
 export type GitHubPrInfo = z.infer<typeof GitHubPrInfoSchema>;
 
-/** Typed failure code for the `unavailable` PrResult variant.
+// --- gh-specific unavailable code ---
+
+/** Typed gh-failure code for the `unavailable` PrResult variant.
  *
- *  A discriminator separate from the human-readable `reason` so UI callers
- *  that want to dispatch per-failure (e.g. "show `gh auth login` button only
- *  for `not-authenticated`") can `match(pr.code).exhaustive()` and get a
- *  compile error if a new code is added without a handler — rather than
- *  string-comparing the display text and silently breaking on typo. */
-export const PrUnavailableCodeSchema = z.enum([
+ *  A discriminator separate from any human-readable display text so UI
+ *  callers that want to dispatch per-failure can `match(code).exhaustive()`
+ *  and get a compile error when a new code is added without a handler —
+ *  rather than string-comparing display text and silently breaking on typo.
+ *
+ *  Named with the `Gh` prefix so a parallel `BktUnavailableCodeSchema` lives
+ *  alongside this one when bkt lands; `PrUnavailableSourceSchema` already
+ *  reserves the `provider` discriminator for the tagged-union extension. */
+export const GhUnavailableCodeSchema = z.enum([
   "not-installed",
   "not-authenticated",
   "timed-out",
   "unknown",
 ]);
-export type PrUnavailableCode = z.infer<typeof PrUnavailableCodeSchema>;
+export type GhUnavailableCode = z.infer<typeof GhUnavailableCodeSchema>;
+
+/** Display text for a gh unavailable code — single source of truth. Defined
+ *  as a fresh `Record<GhUnavailableCode, string>` literal (not wrapped in
+ *  `match`) so TypeScript's required/excess-property checks enforce both
+ *  sides of exhaustiveness — adding a code without updating this table
+ *  fails compilation, and removing one leaves a dead key that also fails. */
+const GH_REASONS: Record<GhUnavailableCode, string> = {
+  "not-installed": "gh: not installed",
+  "not-authenticated": "gh: not authenticated",
+  "timed-out": "gh: timed out",
+  unknown: "gh: unknown error",
+};
+
+export function reasonForGhCode(code: GhUnavailableCode): string {
+  return GH_REASONS[code];
+}
+
+// --- Provider-tagged unavailable source ---
+
+export const GhUnavailableSchema = z.object({
+  provider: z.literal("gh"),
+  code: GhUnavailableCodeSchema,
+});
+
+/** Which provider classified the failure, plus that provider's typed code.
+ *
+ *  Today only `gh`; a sibling `BktUnavailableSchema` joins this union when
+ *  bkt support lands (srid/agency#10). UI dispatch sites that render
+ *  recovery instructions should `match(source.provider).exhaustive()` so
+ *  adding a new provider arm forces every render site to handle it. */
+export const PrUnavailableSourceSchema = z.discriminatedUnion("provider", [
+  GhUnavailableSchema,
+]);
+export type PrUnavailableSource = z.infer<typeof PrUnavailableSourceSchema>;
+
+/** Display string for any unavailable source — dispatches on provider to the
+ *  provider's own reason lookup. The `never` fall-through gives compile-time
+ *  exhaustiveness without pulling in `ts-pattern` (which isn't a kolu-common
+ *  dependency — this module ships in the browser bundle). When bkt lands,
+ *  adding a provider arm to `PrUnavailableSourceSchema` will compile-error
+ *  the `never` branch here until a matching arm is added. */
+export function reasonForSource(source: PrUnavailableSource): string {
+  switch (source.provider) {
+    case "gh":
+      return reasonForGhCode(source.code);
+    default: {
+      const _exhaustive: never = source.provider;
+      return _exhaustive;
+    }
+  }
+}
+
+// --- PrResult ---
 
 /** PR resolution state.
  *
@@ -45,11 +109,13 @@ export type PrUnavailableCode = z.infer<typeof PrUnavailableCodeSchema>;
  *    pending     — resolver is running (or stale after a branch change)
  *    ok          — resolver succeeded; a PR exists for this branch
  *    absent      — resolver succeeded; no PR for this branch (expected case)
- *    unavailable — resolver couldn't run (gh missing, not authenticated, timed out)
+ *    unavailable — resolver couldn't run; `source` carries the provider +
+ *                  typed failure code, and the display reason is derived by
+ *                  `reasonForSource`.
  *
  *  The UI needs to distinguish "absent" (nothing to show) from "unavailable"
- *  (show a warning with `reason`). Keeping the provenance in the same field
- *  as the value avoids a sibling-flag invariant.
+ *  (show a warning with recovery instructions). Keeping the provenance in
+ *  the same field as the value avoids a sibling-flag invariant.
  *
  *  Analogous schemas for git/agent/foreground are not introduced yet — their
  *  failure modes don't currently surface as user-actionable warnings. If they
@@ -61,8 +127,7 @@ export const PrResultSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("absent") }),
   z.object({
     kind: z.literal("unavailable"),
-    code: PrUnavailableCodeSchema,
-    reason: z.string(),
+    source: PrUnavailableSourceSchema,
   }),
 ]);
 export type PrResult = z.infer<typeof PrResultSchema>;
@@ -74,19 +139,14 @@ export function prValue(pr: PrResult): GitHubPrInfo | null {
   return pr.kind === "ok" ? pr.value : null;
 }
 
-/** Extract the unavailability reason when `kind === "unavailable"`, else `null`. */
+/** Extract the display reason when `kind === "unavailable"`, else `null`. */
 export function prUnavailableReason(pr: PrResult): string | null {
-  return pr.kind === "unavailable" ? pr.reason : null;
+  return pr.kind === "unavailable" ? reasonForSource(pr.source) : null;
 }
 
-/** Extract the full unavailable payload (typed `code` + display `reason`) when
- *  `kind === "unavailable"`, else `null`. Use this when the UI needs to
- *  dispatch on code (e.g. render different recovery instructions per
- *  failure); `prUnavailableReason` is enough for a plain string tooltip. */
-export function prUnavailable(
-  pr: PrResult,
-): { code: PrUnavailableCode; reason: string } | null {
-  return pr.kind === "unavailable"
-    ? { code: pr.code, reason: pr.reason }
-    : null;
+/** Extract the tagged source when `kind === "unavailable"`, else `null`. Use
+ *  this when the UI needs to dispatch on provider/code; `prUnavailableReason`
+ *  is enough for a plain string tooltip. */
+export function prUnavailableSource(pr: PrResult): PrUnavailableSource | null {
+  return pr.kind === "unavailable" ? pr.source : null;
 }

--- a/packages/common/src/pr.ts
+++ b/packages/common/src/pr.ts
@@ -1,0 +1,61 @@
+/** GitHub PR metadata — schemas + helpers.
+ *
+ *  Lives in its own module (exposed as `kolu-common/pr`) so clients can
+ *  runtime-import `prValue` / `prUnavailableReason` without dragging the
+ *  full kolu-common module graph — which re-exports kolu-claude-code and
+ *  transitively pulls `@anthropic-ai/claude-agent-sdk` (a Node-only package)
+ *  into the browser bundle. */
+
+import { z } from "zod";
+
+export const GitHubCheckStatusSchema = z.enum(["pending", "pass", "fail"]);
+
+export const GitHubPrStateSchema = z.enum(["open", "closed", "merged"]);
+
+export const GitHubPrInfoSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  url: z.string(),
+  /** PR state: open, closed, or merged. */
+  state: GitHubPrStateSchema,
+  /** Combined CI status: pending, pass, or fail. Null if no checks configured. */
+  checks: GitHubCheckStatusSchema.nullable(),
+});
+export type GitHubPrInfo = z.infer<typeof GitHubPrInfoSchema>;
+
+/** PR resolution state.
+ *
+ *  Decomplects distinct conditions that `GitHubPrInfo | null` used to
+ *  collapse into one value:
+ *    pending     — resolver is running (or stale after a branch change)
+ *    ok          — resolver succeeded; a PR exists for this branch
+ *    absent      — resolver succeeded; no PR for this branch (expected case)
+ *    unavailable — resolver couldn't run (gh missing, not authenticated, timed out)
+ *
+ *  The UI needs to distinguish "absent" (nothing to show) from "unavailable"
+ *  (show a warning with `reason`). Keeping the provenance in the same field
+ *  as the value avoids a sibling-flag invariant.
+ *
+ *  Analogous schemas for git/agent/foreground are not introduced yet — their
+ *  failure modes don't currently surface as user-actionable warnings. If they
+ *  do, mirror this shape per-provider rather than inventing a cross-cutting
+ *  status registry (see PR description for #148). */
+export const PrResultSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("pending") }),
+  z.object({ kind: z.literal("ok"), value: GitHubPrInfoSchema }),
+  z.object({ kind: z.literal("absent") }),
+  z.object({ kind: z.literal("unavailable"), reason: z.string() }),
+]);
+export type PrResult = z.infer<typeof PrResultSchema>;
+
+/** Extract the `GitHubPrInfo` when `kind === "ok"`, else `null`.
+ *  Lets SolidJS `<Show when={prValue(meta.pr)}>` work without tripping on the
+ *  object-truthy trap (every variant is a non-null object). */
+export function prValue(pr: PrResult): GitHubPrInfo | null {
+  return pr.kind === "ok" ? pr.value : null;
+}
+
+/** Extract the unavailability reason when `kind === "unavailable"`, else `null`. */
+export function prUnavailableReason(pr: PrResult): string | null {
+  return pr.kind === "unavailable" ? pr.reason : null;
+}

--- a/packages/server/src/meta/github.test.ts
+++ b/packages/server/src/meta/github.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { deriveCheckStatus, prInfoEqual } from "./github.ts";
-import type { GitHubPrInfo } from "kolu-common";
+import { deriveCheckStatus, prResultEqual, classifyGhError } from "./github.ts";
+import type { GitHubPrInfo, PrResult } from "kolu-common";
 
 describe("deriveCheckStatus", () => {
   it("returns null for undefined rollup", () => {
@@ -74,7 +74,7 @@ describe("deriveCheckStatus", () => {
   });
 });
 
-describe("prInfoEqual", () => {
+describe("prResultEqual", () => {
   const pr: GitHubPrInfo = {
     number: 1,
     title: "test",
@@ -82,22 +82,27 @@ describe("prInfoEqual", () => {
     state: "open",
     checks: "pass",
   };
+  const ok: PrResult = { kind: "ok", value: pr };
 
   it("returns true for identical references", () => {
-    expect(prInfoEqual(pr, pr)).toBe(true);
+    expect(prResultEqual(ok, ok)).toBe(true);
   });
 
-  it("returns true for both null", () => {
-    expect(prInfoEqual(null, null)).toBe(true);
+  it("returns true for both pending", () => {
+    expect(prResultEqual({ kind: "pending" }, { kind: "pending" })).toBe(true);
   });
 
-  it("returns false when one is null", () => {
-    expect(prInfoEqual(pr, null)).toBe(false);
-    expect(prInfoEqual(null, pr)).toBe(false);
+  it("returns true for both absent", () => {
+    expect(prResultEqual({ kind: "absent" }, { kind: "absent" })).toBe(true);
   });
 
-  it("returns true for equal values", () => {
-    expect(prInfoEqual(pr, { ...pr })).toBe(true);
+  it("returns false when kinds differ", () => {
+    expect(prResultEqual(ok, { kind: "absent" })).toBe(false);
+    expect(prResultEqual({ kind: "pending" }, { kind: "absent" })).toBe(false);
+  });
+
+  it("returns true for equal ok values", () => {
+    expect(prResultEqual(ok, { kind: "ok", value: { ...pr } })).toBe(true);
   });
 
   it.each([
@@ -106,6 +111,72 @@ describe("prInfoEqual", () => {
     { field: "state", value: "merged" },
     { field: "checks", value: "fail" },
   ] as const)("detects different $field", ({ field, value }) => {
-    expect(prInfoEqual(pr, { ...pr, [field]: value })).toBe(false);
+    expect(
+      prResultEqual(ok, { kind: "ok", value: { ...pr, [field]: value } }),
+    ).toBe(false);
+  });
+
+  it("compares unavailable reasons", () => {
+    const a: PrResult = { kind: "unavailable", reason: "gh: not installed" };
+    const b: PrResult = { kind: "unavailable", reason: "gh: not installed" };
+    const c: PrResult = {
+      kind: "unavailable",
+      reason: "gh: not authenticated",
+    };
+    expect(prResultEqual(a, b)).toBe(true);
+    expect(prResultEqual(a, c)).toBe(false);
+  });
+});
+
+describe("classifyGhError", () => {
+  it("classifies ENOENT as not installed", () => {
+    const result = classifyGhError({ code: "ENOENT" });
+    expect(result).toEqual({
+      kind: "unavailable",
+      reason: "gh: not installed",
+    });
+  });
+
+  it("classifies timeout (killed) as timed out", () => {
+    const result = classifyGhError({
+      killed: true,
+      signal: "SIGTERM",
+      code: null,
+    });
+    expect(result).toEqual({ kind: "unavailable", reason: "gh: timed out" });
+  });
+
+  it.each([
+    "You are not logged into any GitHub hosts. Run gh auth login to authenticate.",
+    "error connecting to github.com\nTry authentication with: gh auth login",
+    "authentication required",
+  ])("classifies auth-failure stderr %# as not authenticated", (stderr) => {
+    const result = classifyGhError({ code: 1, stderr });
+    expect(result).toEqual({
+      kind: "unavailable",
+      reason: "gh: not authenticated",
+    });
+  });
+
+  it("classifies gh's 'no pull requests found' as absent", () => {
+    const result = classifyGhError({
+      code: 1,
+      stderr: 'no pull requests found for branch "my-branch"',
+    });
+    expect(result).toEqual({ kind: "absent" });
+  });
+
+  it.each([
+    { input: new Error("JSON parse boom"), label: "Error instance" },
+    { input: "raw string", label: "raw string" },
+    {
+      input: { code: 1, stderr: "unexpected runtime error from gh" },
+      label: "unrecognized stderr",
+    },
+  ])("flags unrecognized $label as unavailable", ({ input }) => {
+    expect(classifyGhError(input)).toEqual({
+      kind: "unavailable",
+      reason: "gh: unknown error",
+    });
   });
 });

--- a/packages/server/src/meta/github.test.ts
+++ b/packages/server/src/meta/github.test.ts
@@ -116,56 +116,38 @@ describe("prResultEqual", () => {
     ).toBe(false);
   });
 
-  it("compares unavailable by code (stable across reason text changes)", () => {
+  it("compares unavailable by tagged source (provider + code)", () => {
     const a: PrResult = {
       kind: "unavailable",
-      code: "not-installed",
-      reason: "gh: not installed",
+      source: { provider: "gh", code: "not-installed" },
     };
     const b: PrResult = {
       kind: "unavailable",
-      code: "not-installed",
-      reason: "gh: not installed",
+      source: { provider: "gh", code: "not-installed" },
     };
     const c: PrResult = {
       kind: "unavailable",
-      code: "not-authenticated",
-      reason: "gh: not authenticated",
+      source: { provider: "gh", code: "not-authenticated" },
     };
-    // Same code + reason → equal.
     expect(prResultEqual(a, b)).toBe(true);
-    // Different code → not equal.
     expect(prResultEqual(a, c)).toBe(false);
-    // Same code, different reason text → still equal (code is the identity).
-    const aTweaked: PrResult = {
-      kind: "unavailable",
-      code: "not-installed",
-      reason: "gh CLI not found",
-    };
-    expect(prResultEqual(a, aTweaked)).toBe(true);
   });
 });
 
 describe("classifyGhError", () => {
   it("classifies ENOENT as not installed", () => {
-    const result = classifyGhError({ code: "ENOENT" });
-    expect(result).toEqual({
+    expect(classifyGhError({ code: "ENOENT" })).toEqual({
       kind: "unavailable",
-      code: "not-installed",
-      reason: "gh: not installed",
+      source: { provider: "gh", code: "not-installed" },
     });
   });
 
   it("classifies timeout (killed) as timed out", () => {
-    const result = classifyGhError({
-      killed: true,
-      signal: "SIGTERM",
-      code: null,
-    });
-    expect(result).toEqual({
+    expect(
+      classifyGhError({ killed: true, signal: "SIGTERM", code: null }),
+    ).toEqual({
       kind: "unavailable",
-      code: "timed-out",
-      reason: "gh: timed out",
+      source: { provider: "gh", code: "timed-out" },
     });
   });
 
@@ -174,20 +156,19 @@ describe("classifyGhError", () => {
     "error connecting to github.com\nTry authentication with: gh auth login",
     "authentication required",
   ])("classifies auth-failure stderr %# as not authenticated", (stderr) => {
-    const result = classifyGhError({ code: 1, stderr });
-    expect(result).toEqual({
+    expect(classifyGhError({ code: 1, stderr })).toEqual({
       kind: "unavailable",
-      code: "not-authenticated",
-      reason: "gh: not authenticated",
+      source: { provider: "gh", code: "not-authenticated" },
     });
   });
 
   it("classifies gh's 'no pull requests found' as absent", () => {
-    const result = classifyGhError({
-      code: 1,
-      stderr: 'no pull requests found for branch "my-branch"',
-    });
-    expect(result).toEqual({ kind: "absent" });
+    expect(
+      classifyGhError({
+        code: 1,
+        stderr: 'no pull requests found for branch "my-branch"',
+      }),
+    ).toEqual({ kind: "absent" });
   });
 
   it.each([
@@ -200,8 +181,7 @@ describe("classifyGhError", () => {
   ])("flags unrecognized $label as unavailable", ({ input }) => {
     expect(classifyGhError(input)).toEqual({
       kind: "unavailable",
-      code: "unknown",
-      reason: "gh: unknown error",
+      source: { provider: "gh", code: "unknown" },
     });
   });
 });

--- a/packages/server/src/meta/github.test.ts
+++ b/packages/server/src/meta/github.test.ts
@@ -116,15 +116,33 @@ describe("prResultEqual", () => {
     ).toBe(false);
   });
 
-  it("compares unavailable reasons", () => {
-    const a: PrResult = { kind: "unavailable", reason: "gh: not installed" };
-    const b: PrResult = { kind: "unavailable", reason: "gh: not installed" };
+  it("compares unavailable by code (stable across reason text changes)", () => {
+    const a: PrResult = {
+      kind: "unavailable",
+      code: "not-installed",
+      reason: "gh: not installed",
+    };
+    const b: PrResult = {
+      kind: "unavailable",
+      code: "not-installed",
+      reason: "gh: not installed",
+    };
     const c: PrResult = {
       kind: "unavailable",
+      code: "not-authenticated",
       reason: "gh: not authenticated",
     };
+    // Same code + reason → equal.
     expect(prResultEqual(a, b)).toBe(true);
+    // Different code → not equal.
     expect(prResultEqual(a, c)).toBe(false);
+    // Same code, different reason text → still equal (code is the identity).
+    const aTweaked: PrResult = {
+      kind: "unavailable",
+      code: "not-installed",
+      reason: "gh CLI not found",
+    };
+    expect(prResultEqual(a, aTweaked)).toBe(true);
   });
 });
 
@@ -133,6 +151,7 @@ describe("classifyGhError", () => {
     const result = classifyGhError({ code: "ENOENT" });
     expect(result).toEqual({
       kind: "unavailable",
+      code: "not-installed",
       reason: "gh: not installed",
     });
   });
@@ -143,7 +162,11 @@ describe("classifyGhError", () => {
       signal: "SIGTERM",
       code: null,
     });
-    expect(result).toEqual({ kind: "unavailable", reason: "gh: timed out" });
+    expect(result).toEqual({
+      kind: "unavailable",
+      code: "timed-out",
+      reason: "gh: timed out",
+    });
   });
 
   it.each([
@@ -154,6 +177,7 @@ describe("classifyGhError", () => {
     const result = classifyGhError({ code: 1, stderr });
     expect(result).toEqual({
       kind: "unavailable",
+      code: "not-authenticated",
       reason: "gh: not authenticated",
     });
   });
@@ -176,6 +200,7 @@ describe("classifyGhError", () => {
   ])("flags unrecognized $label as unavailable", ({ input }) => {
     expect(classifyGhError(input)).toEqual({
       kind: "unavailable",
+      code: "unknown",
       reason: "gh: unknown error",
     });
   });

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -13,6 +13,7 @@ import {
   GitHubPrStateSchema,
   type GitHubPrInfo,
   type GitInfo,
+  type PrResult,
 } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal } from "../publisher.ts";
@@ -108,6 +109,43 @@ interface GhPrViewResult {
   statusCheckRollup?: Parameters<typeof deriveCheckStatus>[0];
 }
 
+/** Classify a `gh pr view` failure.
+ *
+ *  `gh pr view` exits non-zero for a genuine "no PR on this branch" (common,
+ *  expected) AND for environmental failures (binary missing, not
+ *  authenticated, hit timeout). The original code collapsed all of these into
+ *  a single `null` — distinguish them here so the UI can surface the
+ *  actionable ones. Only a positive match on gh's "no pull requests found"
+ *  stderr counts as absent; anything else unrecognized is treated as
+ *  unavailable rather than silently shown as "no PR." */
+export function classifyGhError(err: unknown): PrResult {
+  const e = err as {
+    code?: string | number;
+    killed?: boolean;
+    signal?: string;
+    stderr?: string;
+  };
+  if (e.code === "ENOENT") {
+    return { kind: "unavailable", reason: "gh: not installed" };
+  }
+  // execFile sets killed=true when the timeout fires and sends SIGTERM.
+  if (e.killed === true || e.signal === "SIGTERM") {
+    return { kind: "unavailable", reason: "gh: timed out" };
+  }
+  const stderr = (e.stderr ?? "").toLowerCase();
+  if (
+    stderr.includes("not logged in") ||
+    stderr.includes("authentication") ||
+    stderr.includes("gh auth login")
+  ) {
+    return { kind: "unavailable", reason: "gh: not authenticated" };
+  }
+  if (stderr.includes("no pull requests found")) {
+    return { kind: "absent" };
+  }
+  return { kind: "unavailable", reason: "gh: unknown error" };
+}
+
 /**
  * Look up the GitHub PR for the current branch.
  *
@@ -116,7 +154,7 @@ interface GhPrViewResult {
  * --head <name>` which matches by branch name alone and picks up unrelated
  * fork PRs.
  */
-async function resolveGitHubPr(repoRoot: string): Promise<GitHubPrInfo | null> {
+async function resolveGitHubPr(repoRoot: string): Promise<PrResult> {
   try {
     const { stdout } = await execFileAsync(
       "gh",
@@ -125,34 +163,40 @@ async function resolveGitHubPr(repoRoot: string): Promise<GitHubPrInfo | null> {
     );
     const data = JSON.parse(stdout) as GhPrViewResult;
     return {
-      number: data.number,
-      title: data.title,
-      url: data.url,
-      state: GitHubPrStateSchema.parse(data.state.toLowerCase()),
-      checks: deriveCheckStatus(data.statusCheckRollup),
+      kind: "ok",
+      value: {
+        number: data.number,
+        title: data.title,
+        url: data.url,
+        state: GitHubPrStateSchema.parse(data.state.toLowerCase()),
+        checks: deriveCheckStatus(data.statusCheckRollup),
+      },
     };
   } catch (err) {
-    // gh pr view exits non-zero when no PR exists for the branch — expected.
-    // Also catches gh-not-installed / auth failures; debug-log so they're discoverable.
-    log.debug({ err: String(err) }, "no PR for current branch");
-    return null;
+    const result = classifyGhError(err);
+    log.debug({ err: String(err), result: result.kind }, "gh pr view failed");
+    return result;
   }
 }
 
-/** Compare two GitHubPrInfo values for equality. */
-export function prInfoEqual(
-  a: GitHubPrInfo | null,
-  b: GitHubPrInfo | null,
-): boolean {
+/** Compare two PR resolution states for equality. */
+export function prResultEqual(a: PrResult, b: PrResult): boolean {
   if (a === b) return true;
-  if (!a || !b) return false;
-  return (
-    a.number === b.number &&
-    a.title === b.title &&
-    a.url === b.url &&
-    a.state === b.state &&
-    a.checks === b.checks
-  );
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "ok" && b.kind === "ok") {
+    return (
+      a.value.number === b.value.number &&
+      a.value.title === b.value.title &&
+      a.value.url === b.value.url &&
+      a.value.state === b.value.state &&
+      a.value.checks === b.value.checks
+    );
+  }
+  if (a.kind === "unavailable" && b.kind === "unavailable") {
+    return a.reason === b.reason;
+  }
+  // "pending" and "absent" have no payload — kind equality is enough.
+  return true;
 }
 
 /**
@@ -188,13 +232,13 @@ export function startGitHubPrProvider(
     );
     lastBranch = branch;
     lastRepoRoot = repoRoot;
-    // Clear pr first — the previous value is tied to the old branch and is
+    // Mark pr pending — the previous value is tied to the old branch and is
     // now stale. If we still have a repo, the async resolve below will
-    // overwrite with the new branch's pr (or null). If we don't, the clear
-    // is the final state.
-    if (entry.info.meta.pr !== null) {
+    // overwrite with the new branch's result. If we don't, pending is the
+    // final state until a new repo is attached.
+    if (entry.info.meta.pr.kind !== "pending") {
       updateServerMetadata(entry, terminalId, (m) => {
-        m.pr = null;
+        m.pr = { kind: "pending" };
       });
     }
     if (branch && repoRoot) {
@@ -204,11 +248,16 @@ export function startGitHubPrProvider(
 
   async function resolve(repoRoot: string) {
     const pr = await resolveGitHubPr(repoRoot);
-    if (prInfoEqual(pr, entry.info.meta.pr)) return;
+    if (prResultEqual(pr, entry.info.meta.pr)) return;
     plog.debug(
-      pr
-        ? { pr: pr.number, title: pr.title, state: pr.state, checks: pr.checks }
-        : { pr: null },
+      pr.kind === "ok"
+        ? {
+            pr: pr.value.number,
+            title: pr.value.title,
+            state: pr.value.state,
+            checks: pr.value.checks,
+          }
+        : { pr: pr.kind },
       "pr info updated",
     );
     updateServerMetadata(entry, terminalId, (m) => {

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -4,6 +4,23 @@
  * Subscribes to "git:<id>" (not the aggregated "metadata" channel).
  * Publishes via updateServerMetadata() — no downstream providers depend on PR changes.
  * Also polls periodically (PRs can be created/updated externally at any time).
+ *
+ * ┌─ FUTURE: PrProvider extraction ──────────────────────────────────────┐
+ * │ When Bitbucket (`bkt`) support lands (srid/agency#10), the forge-    │
+ * │ specific bits here — `GH_BIN`, `gh pr view` invocation, gh-stderr    │
+ * │ classifier — get pulled behind a narrow `PrProvider` interface:      │
+ * │                                                                      │
+ * │   interface PrProvider {                                             │
+ * │     readonly kind: "gh" | "bkt";                                     │
+ * │     resolve(repoRoot: string): Promise<PrResult>;                    │
+ * │   }                                                                  │
+ * │                                                                      │
+ * │ Dispatch by forge detection (origin remote URL — same axis that      │
+ * │ `/do`'s forge step uses). `PrResult` stays shared; each impl owns    │
+ * │ its own classifier + pinned binary env var (`KOLU_GH_BIN`,           │
+ * │ `KOLU_BKT_BIN`). Don't extract before the second impl exists —       │
+ * │ the bkt stderr taxonomy is what will tell you where the seam goes.   │
+ * └──────────────────────────────────────────────────────────────────────┘
  */
 
 import { execFile } from "node:child_process";
@@ -24,6 +41,12 @@ const execFileAsync = promisify(execFile);
 
 const POLL_INTERVAL_MS = 30_000;
 const GH_TIMEOUT_MS = 5_000;
+
+/** Pinned `gh` binary path. The Nix wrapper sets `KOLU_GH_BIN` to the exact
+ *  `${pkgs.gh}/bin/gh` store path (see `nix/env.nix`) so the packaged kolu
+ *  runs a known gh regardless of the user's `PATH`. Dev shells and non-Nix
+ *  installs fall through to the bare name (PATH lookup). */
+const GH_BIN = process.env.KOLU_GH_BIN ?? "gh";
 
 /**
  * Derive combined check status from statusCheckRollup entries.
@@ -126,11 +149,19 @@ export function classifyGhError(err: unknown): PrResult {
     stderr?: string;
   };
   if (e.code === "ENOENT") {
-    return { kind: "unavailable", reason: "gh: not installed" };
+    return {
+      kind: "unavailable",
+      code: "not-installed",
+      reason: "gh: not installed",
+    };
   }
   // execFile sets killed=true when the timeout fires and sends SIGTERM.
   if (e.killed === true || e.signal === "SIGTERM") {
-    return { kind: "unavailable", reason: "gh: timed out" };
+    return {
+      kind: "unavailable",
+      code: "timed-out",
+      reason: "gh: timed out",
+    };
   }
   const stderr = (e.stderr ?? "").toLowerCase();
   if (
@@ -138,12 +169,20 @@ export function classifyGhError(err: unknown): PrResult {
     stderr.includes("authentication") ||
     stderr.includes("gh auth login")
   ) {
-    return { kind: "unavailable", reason: "gh: not authenticated" };
+    return {
+      kind: "unavailable",
+      code: "not-authenticated",
+      reason: "gh: not authenticated",
+    };
   }
   if (stderr.includes("no pull requests found")) {
     return { kind: "absent" };
   }
-  return { kind: "unavailable", reason: "gh: unknown error" };
+  return {
+    kind: "unavailable",
+    code: "unknown",
+    reason: "gh: unknown error",
+  };
 }
 
 /**
@@ -157,7 +196,7 @@ export function classifyGhError(err: unknown): PrResult {
 async function resolveGitHubPr(repoRoot: string): Promise<PrResult> {
   try {
     const { stdout } = await execFileAsync(
-      "gh",
+      GH_BIN,
       ["pr", "view", "--json", "number,title,url,state,statusCheckRollup"],
       { cwd: repoRoot, timeout: GH_TIMEOUT_MS },
     );
@@ -193,7 +232,9 @@ export function prResultEqual(a: PrResult, b: PrResult): boolean {
     );
   }
   if (a.kind === "unavailable" && b.kind === "unavailable") {
-    return a.reason === b.reason;
+    // Compare by code (the typed discriminator) — reason is display text
+    // derived 1:1 from code, so code-equality is the identity check.
+    return a.code === b.code;
   }
   // "pending" and "absent" have no payload — kind equality is enough.
   return true;

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -31,6 +31,7 @@ import {
   type GitHubPrInfo,
   type GitInfo,
   type PrResult,
+  type PrUnavailableSource,
 } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal } from "../publisher.ts";
@@ -148,20 +149,16 @@ export function classifyGhError(err: unknown): PrResult {
     signal?: string;
     stderr?: string;
   };
-  if (e.code === "ENOENT") {
-    return {
-      kind: "unavailable",
-      code: "not-installed",
-      reason: "gh: not installed",
-    };
-  }
+  const ghUnavailable = (
+    code: Extract<PrUnavailableSource, { provider: "gh" }>["code"],
+  ): PrResult => ({
+    kind: "unavailable",
+    source: { provider: "gh", code },
+  });
+  if (e.code === "ENOENT") return ghUnavailable("not-installed");
   // execFile sets killed=true when the timeout fires and sends SIGTERM.
   if (e.killed === true || e.signal === "SIGTERM") {
-    return {
-      kind: "unavailable",
-      code: "timed-out",
-      reason: "gh: timed out",
-    };
+    return ghUnavailable("timed-out");
   }
   const stderr = (e.stderr ?? "").toLowerCase();
   if (
@@ -169,20 +166,12 @@ export function classifyGhError(err: unknown): PrResult {
     stderr.includes("authentication") ||
     stderr.includes("gh auth login")
   ) {
-    return {
-      kind: "unavailable",
-      code: "not-authenticated",
-      reason: "gh: not authenticated",
-    };
+    return ghUnavailable("not-authenticated");
   }
   if (stderr.includes("no pull requests found")) {
     return { kind: "absent" };
   }
-  return {
-    kind: "unavailable",
-    code: "unknown",
-    reason: "gh: unknown error",
-  };
+  return ghUnavailable("unknown");
 }
 
 /**
@@ -232,9 +221,12 @@ export function prResultEqual(a: PrResult, b: PrResult): boolean {
     );
   }
   if (a.kind === "unavailable" && b.kind === "unavailable") {
-    // Compare by code (the typed discriminator) — reason is display text
-    // derived 1:1 from code, so code-equality is the identity check.
-    return a.code === b.code;
+    // Compare the tagged source: provider + code. Both are the typed
+    // discriminators; the display reason derives from them via
+    // `reasonForSource` and doesn't need its own comparison.
+    return (
+      a.source.provider === b.source.provider && a.source.code === b.source.code
+    );
   }
   // "pending" and "absent" have no payload — kind equality is enough.
   return true;

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -211,9 +211,29 @@ async function resolveGitHubPr(repoRoot: string): Promise<PrResult> {
     };
   } catch (err) {
     const result = classifyGhError(err);
-    log.debug({ err: String(err), result: result.kind }, "gh pr view failed");
+    logGhResolveFailure(err, result);
     return result;
   }
+}
+
+/** Route a failed `gh pr view` result to the appropriate log level.
+ *  absent = expected (branch has no PR) → debug.
+ *  unavailable with code `unknown` = an actual unexpected error → error.
+ *  unavailable with any other code = degraded-but-recoverable → warn. */
+function logGhResolveFailure(err: unknown, result: PrResult): void {
+  const ctx = { err: String(err), result: result.kind };
+  if (result.kind === "absent") {
+    log.debug(ctx, "gh pr view: no PR for branch");
+    return;
+  }
+  if (result.kind === "unavailable" && result.source.code === "unknown") {
+    log.error(ctx, "gh pr view: unknown error");
+    return;
+  }
+  log.warn(
+    result.kind === "unavailable" ? { ...ctx, code: result.source.code } : ctx,
+    "gh pr view: unavailable",
+  );
 }
 
 /** Compare two PR resolution states for equality. */

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -43,11 +43,20 @@ const execFileAsync = promisify(execFile);
 const POLL_INTERVAL_MS = 30_000;
 const GH_TIMEOUT_MS = 5_000;
 
-/** Pinned `gh` binary path. The Nix wrapper sets `KOLU_GH_BIN` to the exact
- *  `${pkgs.gh}/bin/gh` store path (see `nix/env.nix`) so the packaged kolu
- *  runs a known gh regardless of the user's `PATH`. Dev shells and non-Nix
- *  installs fall through to the bare name (PATH lookup). */
-const GH_BIN = process.env.KOLU_GH_BIN ?? "gh";
+/** Pinned `gh` binary path. `KOLU_GH_BIN` is set by both the packaged
+ *  wrapper and the dev shell via `nix/env.nix` → `shell.nix` / `default.nix`.
+ *  Nix is the only supported runtime; fail fast if the env var is missing
+ *  rather than silently falling through to PATH (which would resolve to a
+ *  different `gh` than the one kolu ships with). */
+const GH_BIN = (() => {
+  const v = process.env.KOLU_GH_BIN;
+  if (!v) {
+    throw new Error(
+      "KOLU_GH_BIN is not set. Run kolu through the Nix wrapper or `nix develop`.",
+    );
+  }
+  return v;
+})();
 
 /**
  * Derive combined check status from statusCheckRollup entries.

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -28,6 +28,7 @@ import type {
   TerminalServerMetadata,
   TerminalClientMetadata,
 } from "kolu-common";
+import { prValue, prUnavailableReason } from "kolu-common";
 import {
   type TerminalProcess,
   recomputeDisplaySuffixes,
@@ -50,7 +51,7 @@ export function createMetadata(
   return {
     cwd,
     git: null,
-    pr: null,
+    pr: { kind: "pending" },
     agent: null,
     foreground: null,
     sortOrder,
@@ -68,14 +69,18 @@ export function createMetadata(
  *  per-terminal stream stays in sync. */
 function publishMetadata(entry: TerminalProcess, terminalId: string): void {
   const m = entry.info.meta;
+  const pr = prValue(m.pr);
+  const prUnavailable = prUnavailableReason(m.pr);
   log.debug(
     {
       terminal: terminalId,
       cwd: m.cwd,
       repo: m.git?.repoName,
       branch: m.git?.branch,
-      pr: m.pr?.number ?? null,
-      checks: m.pr?.checks ?? null,
+      pr: pr?.number ?? null,
+      checks: pr?.checks ?? null,
+      prStatus: m.pr.kind,
+      ...(prUnavailable && { prUnavailable }),
       // Only include agent/foreground fields when present to avoid noisy null logs
       ...(m.agent && { agent: `${m.agent.kind}:${m.agent.state}` }),
       ...(m.foreground && { foreground: m.foreground.name }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       kolu-opencode:
         specifier: workspace:*
         version: link:../integrations/opencode
+      ts-pattern:
+        specifier: ^5.9.0
+        version: 5.9.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
When `gh pr view` failed — because gh wasn't installed, wasn't authenticated, or timed out — the sidebar showed the same silent blank as a branch that genuinely had no PR. **Kolu now distinguishes every reason `gh` can fail** and renders a click-to-open recovery popover with the fix: for the common `not-authenticated` case, a copy-button with `gh auth login -s repo,read:org` right there in the UI. Same recovery content renders inline in the right-panel inspector, always-visible.

The underlying fix is a decomplection. `pr: GitHubPrInfo | null` collapsed four distinct conditions — pending resolution, ok, absent, unavailable — into one value, and every consumer had to guess which. A four-variant discriminated union carries provenance alongside the value; the UI dispatches with `prValue` / `prUnavailableSource` helpers so SolidJS's `<Show when=...>` doesn't trip on the object-truthy trap. The classifier is positive-match only: anything it doesn't explicitly recognize as `"no pull requests found"` becomes `unavailable` with a typed code (`not-installed` | `not-authenticated` | `timed-out` | `unknown`), rather than silently masquerading as the healthy no-PR case.

_Provider-tagged for bkt._ The `unavailable` variant's wire shape is `{ kind: "unavailable", source: { provider: "gh", code: GhUnavailableCode } }` — a tagged union, even at N=1. When Bitbucket support lands ([srid/agency#10](https://github.com/srid/agency/issues/10)), `{ provider: "bkt", code: BktUnavailableCode }` joins the `PrUnavailableSourceSchema` union and every consumer's `.exhaustive()` / provider dispatch compile-errors until a matching arm lands. The popover already layers dispatch (`ProviderUnavailableContent` → per-provider `GhUnavailableContent`), so bkt gets its own content component as a one-line sibling — no schema or dispatch refactor. A `PrProvider` interface sketch lives in `github.ts`'s top comment to hand the boundary off cleanly; don't extract before bkt's classifier actually exists and tells you where the seam is.

> **`gh` is pinned via Nix.** `KOLU_GH_BIN` is required, not optional: `nix/env.nix` sets `${pkgs.gh}/bin/gh` and both the packaged wrapper (`default.nix`) and the dev shell (`shell.nix`) pick it up via `koluEnv`. The server throws at startup if the var is missing — Nix is the supported runtime; silently resolving a different `gh` from PATH would have been worse than failing loud.

> **Subpath split.** PR schemas + helpers live in `kolu-common/pr` rather than the root entry. Runtime-importing them from the main module transitively dragged `@anthropic-ai/claude-agent-sdk` (Node-only) into the browser bundle via the kolu-claude-code re-export chain, breaking `vite build`. The subpath keeps the helpers reachable without the heavy graph.

Closes #148. Related: srid/agency#10.