### PR TITLE
feat(settings): self-documenting hints under every control

### DIFF
--- a/packages/client/src/settings/SettingRow.tsx
+++ b/packages/client/src/settings/SettingRow.tsx
@@ -1,0 +1,39 @@
+/** One row in SettingsPopover — label + control on top, optional hint underneath.
+ *  The hint is what makes the popover self-documenting: static strings for
+ *  toggles, per-value tables for segmented controls (see SettingsPopover.tsx).
+ *  `tone: "warn"` flags a trade-off (e.g. WebGL-every-tile context thrash). */
+
+import { type Component, type JSX, Show } from "solid-js";
+
+export type Hint = { text: string; tone?: "muted" | "warn" };
+
+const SettingRow: Component<{
+  label: string;
+  hint?: Hint;
+  children: JSX.Element;
+}> = (props) => (
+  <div class="text-sm">
+    <div class="flex items-center justify-between gap-3">
+      <span class="text-fg-2">{props.label}</span>
+      {props.children}
+    </div>
+    <Show when={props.hint}>
+      {(hint) => (
+        <p
+          class={
+            hint().tone === "warn"
+              ? "mt-1 text-xs text-warning"
+              : "mt-1 text-xs text-fg-3"
+          }
+        >
+          <Show when={hint().tone === "warn"}>
+            <span aria-hidden="true">⚠ </span>
+          </Show>
+          {hint().text}
+        </p>
+      )}
+    </Show>
+  </div>
+);
+
+export default SettingRow;

--- a/packages/client/src/settings/SettingRow.tsx
+++ b/packages/client/src/settings/SettingRow.tsx
@@ -1,37 +1,40 @@
 /** One row in SettingsPopover — label + control on top, optional hint underneath.
- *  The hint is what makes the popover self-documenting: static strings for
- *  toggles, per-value tables for segmented controls (see SettingsPopover.tsx).
- *  `tone: "warn"` flags a trade-off (e.g. WebGL-every-tile context thrash). */
+ *  Label is the hero (`text-fg font-medium`); hint recedes (`text-fg-3/70`) so
+ *  attention lands on the control, not the copy. TONE_CONFIG owns both the
+ *  color class and the glyph prefix so a new tone entry updates both in one
+ *  place. Default tone is "muted". */
 
 import { type Component, type JSX, Show } from "solid-js";
 
-export type Hint = { text: string; tone?: "muted" | "warn" };
+const TONE_CONFIG = {
+  muted: { colorClass: "text-fg-3/70", glyph: "" },
+  warn: { colorClass: "text-warning", glyph: "⚠ " },
+} as const;
+
+export type Hint = { text: string; tone?: keyof typeof TONE_CONFIG };
 
 const SettingRow: Component<{
   label: string;
   hint?: Hint;
   children: JSX.Element;
 }> = (props) => (
-  <div class="text-sm">
-    <div class="flex items-center justify-between gap-3">
-      <span class="text-fg-2">{props.label}</span>
+  <div>
+    <div class="flex items-center justify-between gap-4">
+      <span class="text-sm font-medium text-fg">{props.label}</span>
       {props.children}
     </div>
     <Show when={props.hint}>
-      {(hint) => (
-        <p
-          class={
-            hint().tone === "warn"
-              ? "mt-1 text-xs text-warning"
-              : "mt-1 text-xs text-fg-3"
-          }
-        >
-          <Show when={hint().tone === "warn"}>
-            <span aria-hidden="true">⚠ </span>
-          </Show>
-          {hint().text}
-        </p>
-      )}
+      {(hint) => {
+        const cfg = () => TONE_CONFIG[hint().tone ?? "muted"];
+        return (
+          <p class={`mt-1.5 text-xs leading-relaxed ${cfg().colorClass}`}>
+            <Show when={cfg().glyph}>
+              <span aria-hidden="true">{cfg().glyph}</span>
+            </Show>
+            {hint().text}
+          </p>
+        );
+      }}
     </Show>
   </div>
 );

--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -19,6 +19,7 @@ const SCHEME_OPTIONS: readonly SegmentedControlOption<ColorScheme>[] = [
   { value: "system", label: "System" },
 ];
 
+/** Reactive hint table — re-read on every color-scheme change. */
 const SCHEME_HINT: Record<ColorScheme, Hint> = {
   light: { text: "Light UI at all times." },
   dark: { text: "Dark UI at all times." },
@@ -37,6 +38,8 @@ const RENDERER_OPTIONS: readonly SegmentedControlOption<
   { value: "dom", label: "DOM" },
 ];
 
+/** Reactive hint table — re-read on every renderer change. "warn" tone flags
+ *  the WebGL-every-tile context-thrash trade-off surfaced in #636. */
 const RENDERER_HINT: Record<Preferences["terminalRenderer"], Hint> = {
   auto: { text: "WebGL on focused tiles, DOM elsewhere." },
   webgl: {
@@ -44,19 +47,6 @@ const RENDERER_HINT: Record<Preferences["terminalRenderer"], Hint> = {
     tone: "warn",
   },
   dom: { text: "DOM renderer; lowest GPU, stable font on focus." },
-};
-
-const SHUFFLE_HINT: Hint = {
-  text: "New terminals pick a distinct background tint.",
-};
-const SCROLL_LOCK_HINT: Hint = {
-  text: "Hold new output while scrolled up; release at bottom.",
-};
-const ACTIVITY_ALERTS_HINT: Hint = {
-  text: "Sound + notification when a background terminal finishes.",
-};
-const STARTUP_TIPS_HINT: Hint = {
-  text: "Show a random tip when Kolu launches.",
 };
 
 const SettingsPopover: Component<{
@@ -105,7 +95,7 @@ const SettingsPopover: Component<{
             updatePos();
           }}
           data-testid="settings-popover"
-          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[240px] space-y-3"
+          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-4 min-w-[280px] space-y-4"
           style={{
             top: `${pos().top}px`,
             right: `${pos().right}px`,
@@ -120,21 +110,34 @@ const SettingsPopover: Component<{
               testIdPrefix="color-scheme"
             />
           </SettingRow>
-          <SettingRow label="Shuffle theme" hint={SHUFFLE_HINT}>
+          <SettingRow
+            label="Shuffle theme"
+            hint={{ text: "New terminals pick a distinct background tint." }}
+          >
             <Toggle
               testId="shuffle-theme-toggle"
               enabled={preferences().shuffleTheme}
               onChange={(on) => updatePreferences({ shuffleTheme: on })}
             />
           </SettingRow>
-          <SettingRow label="Scroll lock" hint={SCROLL_LOCK_HINT}>
+          <SettingRow
+            label="Scroll lock"
+            hint={{
+              text: "Hold new output while scrolled up; release at bottom.",
+            }}
+          >
             <Toggle
               testId="scroll-lock-toggle"
               enabled={preferences().scrollLock}
               onChange={(on) => updatePreferences({ scrollLock: on })}
             />
           </SettingRow>
-          <SettingRow label="Activity alerts" hint={ACTIVITY_ALERTS_HINT}>
+          <SettingRow
+            label="Activity alerts"
+            hint={{
+              text: "Sound + notification when a background terminal finishes.",
+            }}
+          >
             <Toggle
               testId="activity-alerts-toggle"
               enabled={preferences().activityAlerts}
@@ -152,7 +155,10 @@ const SettingsPopover: Component<{
               testIdPrefix="terminal-renderer"
             />
           </SettingRow>
-          <SettingRow label="Startup tips" hint={STARTUP_TIPS_HINT}>
+          <SettingRow
+            label="Startup tips"
+            hint={{ text: "Show a random tip when Kolu launches." }}
+          >
             <Toggle
               testId="startup-tips-toggle"
               enabled={preferences().startupTips}

--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -8,6 +8,7 @@ import Toggle from "../ui/Toggle";
 import SegmentedControl, {
   type SegmentedControlOption,
 } from "../ui/SegmentedControl";
+import SettingRow, { type Hint } from "./SettingRow";
 import { usePreferences } from "./usePreferences";
 import { useColorScheme, type ColorScheme } from "./useColorScheme";
 import type { Preferences } from "kolu-common";
@@ -17,6 +18,12 @@ const SCHEME_OPTIONS: readonly SegmentedControlOption<ColorScheme>[] = [
   { value: "dark", label: "Dark" },
   { value: "system", label: "System" },
 ];
+
+const SCHEME_HINT: Record<ColorScheme, Hint> = {
+  light: { text: "Light UI at all times." },
+  dark: { text: "Dark UI at all times." },
+  system: { text: "Match your OS appearance." },
+};
 
 /** Auto  = system chooses per tile (WebGL on focused, DOM on others).
  *  WebGL = WebGL on every tile (higher throughput; reintroduces #575
@@ -29,6 +36,28 @@ const RENDERER_OPTIONS: readonly SegmentedControlOption<
   { value: "webgl", label: "WebGL" },
   { value: "dom", label: "DOM" },
 ];
+
+const RENDERER_HINT: Record<Preferences["terminalRenderer"], Hint> = {
+  auto: { text: "WebGL on focused tiles, DOM elsewhere." },
+  webgl: {
+    text: "WebGL on every tile — may thrash past ~16 terminals.",
+    tone: "warn",
+  },
+  dom: { text: "DOM renderer; lowest GPU, stable font on focus." },
+};
+
+const SHUFFLE_HINT: Hint = {
+  text: "New terminals pick a distinct background tint.",
+};
+const SCROLL_LOCK_HINT: Hint = {
+  text: "Hold new output while scrolled up; release at bottom.",
+};
+const ACTIVITY_ALERTS_HINT: Hint = {
+  text: "Sound + notification when a background terminal finishes.",
+};
+const STARTUP_TIPS_HINT: Hint = {
+  text: "Show a random tip when Kolu launches.",
+};
 
 const SettingsPopover: Component<{
   open: boolean;
@@ -76,72 +105,60 @@ const SettingsPopover: Component<{
             updatePos();
           }}
           data-testid="settings-popover"
-          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[200px] space-y-3"
+          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[240px] space-y-3"
           style={{
             top: `${pos().top}px`,
             right: `${pos().right}px`,
             "background-color": "var(--color-surface-1)",
           }}
         >
-          {/* Color scheme */}
-          <div class="flex items-center justify-between gap-3 text-sm">
-            <span class="text-fg-2">Theme</span>
+          <SettingRow label="Theme" hint={SCHEME_HINT[colorScheme()]}>
             <SegmentedControl
               options={SCHEME_OPTIONS}
               value={colorScheme()}
               onChange={setColorScheme}
               testIdPrefix="color-scheme"
             />
-          </div>
-          {/* Shuffle theme — auto-pick a perceptually-distinct background
-           *  for each new terminal so the sidebar at rest looks variegated
-           *  instead of a sea of look-alikes. */}
-          <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
-            <span class="text-fg-2">Shuffle theme</span>
+          </SettingRow>
+          <SettingRow label="Shuffle theme" hint={SHUFFLE_HINT}>
             <Toggle
               testId="shuffle-theme-toggle"
               enabled={preferences().shuffleTheme}
               onChange={(on) => updatePreferences({ shuffleTheme: on })}
             />
-          </label>
-          {/* Scroll lock */}
-          <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
-            <span class="text-fg-2">Scroll lock</span>
+          </SettingRow>
+          <SettingRow label="Scroll lock" hint={SCROLL_LOCK_HINT}>
             <Toggle
               testId="scroll-lock-toggle"
               enabled={preferences().scrollLock}
               onChange={(on) => updatePreferences({ scrollLock: on })}
             />
-          </label>
-          {/* Activity alerts */}
-          <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
-            <span class="text-fg-2">Activity alerts</span>
+          </SettingRow>
+          <SettingRow label="Activity alerts" hint={ACTIVITY_ALERTS_HINT}>
             <Toggle
               testId="activity-alerts-toggle"
               enabled={preferences().activityAlerts}
               onChange={(on) => updatePreferences({ activityAlerts: on })}
             />
-          </label>
-          {/* Terminal renderer — Auto (WebGL on focused tile), WebGL (all
-           *  tiles), or DOM (all tiles). */}
-          <div class="flex items-center justify-between gap-3 text-sm">
-            <span class="text-fg-2">Renderer</span>
+          </SettingRow>
+          <SettingRow
+            label="Renderer"
+            hint={RENDERER_HINT[preferences().terminalRenderer]}
+          >
             <SegmentedControl
               options={RENDERER_OPTIONS}
               value={preferences().terminalRenderer}
               onChange={(v) => updatePreferences({ terminalRenderer: v })}
               testIdPrefix="terminal-renderer"
             />
-          </div>
-          {/* Startup tips */}
-          <label class="flex items-center justify-between gap-3 cursor-pointer text-sm">
-            <span class="text-fg-2">Startup tips</span>
+          </SettingRow>
+          <SettingRow label="Startup tips" hint={STARTUP_TIPS_HINT}>
             <Toggle
               testId="startup-tips-toggle"
               enabled={preferences().startupTips}
               onChange={(on) => updatePreferences({ startupTips: on })}
             />
-          </label>
+          </SettingRow>
         </div>
       </Portal>
     </Show>


### PR DESCRIPTION
Every row in the settings popover now carries a short helper line, turning a grid of opaque toggles into something a new user can read. The hint copy is keyed to the control's current value for the two segmented rows — *Theme* flips between "Light UI at all times" / "Dark UI at all times" / "Match your OS appearance", and *Renderer* moves from the neutral *Auto* / *DOM* descriptions into a warning-toned ⚠ line the moment you pick *WebGL*, calling out the ~16-tile GPU-context ceiling that [#636](https://github.com/juspay/kolu/issues/636) asked us to surface.

The toggles (*Shuffle theme*, *Scroll lock*, *Activity alerts*, *Startup tips*) get one static sentence each — enough to answer "what does this actually do?" without opening the source.

To keep the popover from turning into a wall of repeated flex containers, the label + control + optional hint shape is now one `SettingRow` component. Hints are typed `{ text; tone?: "muted" | "warn" }` with `muted` as default, so adding a new setting is `<SettingRow label=... hint={...}><Toggle .../></SettingRow>` and the warn styling is just a field flip.

Closes #636.

## Test plan

- [ ] Open settings popover; every row shows a hint line below the control.
- [ ] Theme hint updates when switching between Light / Dark / System.
- [ ] Renderer hint updates between the three modes; *WebGL* shows ⚠ + amber text.
- [ ] Hint text remains legible in both light and dark themes.
- [ ] `just check` passes; existing e2e tests for settings still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)