### PR TITLE
Browser region: iframe attached to a terminal (#633 Phase 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ pnpm monorepo:
 
 All traffic flows over a single WebSocket (`/rpc/ws`) via [oRPC](https://orpc.dev/). The contract in `packages/common/` is shared by both sides — types checked at compile time, payloads validated by Zod at runtime. Two communication patterns:
 
-| Pattern            | Semantics                                  | Client integration                    | Used for                                               |
-| ------------------ | ------------------------------------------ | ------------------------------------- | ------------------------------------------------------ |
-| Request / response | one-shot RPC call                          | plain `client.*` calls                | `terminal.create`, `terminal.kill`, `terminal.reorder` |
-| Subscription       | server pushes values over WebSocket stream | `createSubscription` → SolidJS signal | Terminal list, metadata, server state                  |
+| Pattern            | Semantics                                  | Client integration                    | Used for                                                                            |
+| ------------------ | ------------------------------------------ | ------------------------------------- | ----------------------------------------------------------------------------------- |
+| Request / response | one-shot RPC call                          | plain `client.*` calls                | `terminal.create`, `terminal.kill`, `terminal.reorder`, `terminal.setBrowser`       |
+| Subscription       | server pushes values over WebSocket stream | `createSubscription` → SolidJS signal | Terminal list, metadata (carries sub-panel + attached browser region), server state |
 
 Subscriptions use [`createSubscription`](packages/client/src/rpc/createSubscription.ts) — a 150-line primitive that converts an `AsyncIterable` into a SolidJS signal via `createStore` + `reconcile` for fine-grained reactivity. Per-terminal subscriptions use SolidJS's `mapArray` for automatic lifecycle management.
 
@@ -219,7 +219,7 @@ flowchart TB
 
 **Persistence** — sessions auto-save to `~/.config/kolu/state.json` via [`conf`](https://github.com/sindresorhus/conf), debounced at 500 ms[^persistence].
 
-[^persistence]: Schema is versioned with explicit migrations. Stores CWD, sort order, and parent relationships per terminal.
+[^persistence]: Schema is versioned with explicit migrations. Stores CWD, sort order, and parent relationships per terminal, plus the optional **right-side browser region** attached to each terminal (#633) — an iframe + URL persisted on the owning terminal's metadata, peer to the existing bottom sub-panel.
 
 [PartySocket](https://docs.partykit.io/reference/partysocket-api/) handles WebSocket auto-reconnect; the `stream` namespace in `packages/client/src/rpc/rpc.ts` routes every async-iterator procedure through oRPC's [`ClientRetryPlugin`](https://orpc.dev/docs/plugins/client-retry) so consumers transparently re-subscribe after a drop — every server-side streaming handler is already snapshot-then-deltas and the reducer in `useTerminalMetadata.ts` pattern-matches an `ActivityStreamEvent` discriminated union (`snapshot` replaces, `delta` appends) so re-subscribe resume is structural, not defensive. Transport events (`connecting` / `connected` / `disconnected` / `reconnected` / `restarted`) are exposed as a single `ServerLifecycleEvent` signal, and `TransportOverlay` pattern-matches it into one dim-backdrop card: `disconnected` shows "Reconnecting…" (the backdrop is pointer-events-none, so users can still scroll and read buffers underneath), and `restarted` swaps to "Server updated" with the Reload button inline in the card.
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -220,13 +220,20 @@ const App: Component = () => {
     setPaletteOpen(true);
   }
 
-  /** Attach the right-side browser region to a terminal (#633). Opens
-   *  with a default initial URL when none is yet set. No-op if already
-   *  attached — the right affordance then is to focus its URL bar, which
-   *  happens because BrowserRegion auto-focuses on mount. */
-  function handleOpenBrowser(id: TerminalId) {
+  /** Toggle the right-side browser region on a terminal (#633): attach
+   *  it with a default initial URL when absent, detach it when present.
+   *  Mirrors `handleToggleSubPanel`'s open-or-close shape — the chrome
+   *  button is a single affordance that reflects current state. */
+  function handleToggleBrowser(id: TerminalId) {
     const existing = store.getMetadata(id)?.browser;
-    if (existing && !existing.collapsed) return;
+    if (existing && !existing.collapsed) {
+      void client.terminal
+        .clearBrowser({ id })
+        .catch((err: Error) =>
+          toast.error(`Failed to close browser: ${err.message}`),
+        );
+      return;
+    }
     void client.terminal
       .setBrowser({
         id,
@@ -239,7 +246,9 @@ const App: Component = () => {
       );
   }
 
-  /** Detach the right-side browser region (closes its panel). */
+  /** Detach the right-side browser region. The region's own × calls this
+   *  directly (plumbed through `TerminalContent.onCloseBrowser`); the
+   *  title-bar globe button goes through `handleToggleBrowser` instead. */
   function handleCloseBrowser(id: TerminalId) {
     void client.terminal
       .clearBrowser({ id })
@@ -569,7 +578,7 @@ const App: Component = () => {
                         onToggleSubPanel={handleToggleSubPanel}
                         onOpenSearch={() => setSearchOpen(true)}
                         onScreenshot={handleScreenshotTerminal}
-                        onOpenBrowser={handleOpenBrowser}
+                        onToggleBrowser={handleToggleBrowser}
                       />
                     )}
                     renderTileBody={renderCanvasTileBody}

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -14,7 +14,7 @@ import {
   Show,
 } from "solid-js";
 import { Title } from "@solidjs/meta";
-import { Toaster } from "solid-sonner";
+import { Toaster, toast } from "solid-sonner";
 import { match } from "ts-pattern";
 import { isMobile } from "./useMobile";
 import ChromeBar from "./ChromeBar";
@@ -220,6 +220,34 @@ const App: Component = () => {
     setPaletteOpen(true);
   }
 
+  /** Attach the right-side browser region to a terminal (#633). Opens
+   *  with a default initial URL when none is yet set. No-op if already
+   *  attached — the right affordance then is to focus its URL bar, which
+   *  happens because BrowserRegion auto-focuses on mount. */
+  function handleOpenBrowser(id: TerminalId) {
+    const existing = store.getMetadata(id)?.browser;
+    if (existing && !existing.collapsed) return;
+    void client.terminal
+      .setBrowser({
+        id,
+        browser: existing
+          ? { ...existing, collapsed: false }
+          : { url: "", collapsed: false, panelSize: 0.5 },
+      })
+      .catch((err: Error) =>
+        toast.error(`Failed to open browser: ${err.message}`),
+      );
+  }
+
+  /** Detach the right-side browser region (closes its panel). */
+  function handleCloseBrowser(id: TerminalId) {
+    void client.terminal
+      .clearBrowser({ id })
+      .catch((err: Error) =>
+        toast.error(`Failed to close browser: ${err.message}`),
+      );
+  }
+
   /** Close a terminal. Top-level terminals show a confirmation dialog;
    *  splits (sub-terminals) are killed directly — they are ephemeral
    *  sub-panes, like browser tabs, and should never pop the worktree
@@ -304,6 +332,7 @@ const App: Component = () => {
         onCloseTerminal={closeTerminal}
         activeMeta={store.activeMeta()}
         onFocus={() => store.setActiveId(id)}
+        onCloseBrowser={handleCloseBrowser}
       />
     );
   }
@@ -326,6 +355,7 @@ const App: Component = () => {
         }
         onCloseTerminal={closeTerminal}
         activeMeta={store.activeMeta()}
+        onCloseBrowser={handleCloseBrowser}
       />
     );
   }
@@ -539,6 +569,7 @@ const App: Component = () => {
                         onToggleSubPanel={handleToggleSubPanel}
                         onOpenSearch={() => setSearchOpen(true)}
                         onScreenshot={handleScreenshotTerminal}
+                        onOpenBrowser={handleOpenBrowser}
                       />
                     )}
                     renderTileBody={renderCanvasTileBody}

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -14,7 +14,7 @@ import {
   Show,
 } from "solid-js";
 import { Title } from "@solidjs/meta";
-import { Toaster, toast } from "solid-sonner";
+import { Toaster } from "solid-sonner";
 import { match } from "ts-pattern";
 import { isMobile } from "./useMobile";
 import ChromeBar from "./ChromeBar";
@@ -220,43 +220,6 @@ const App: Component = () => {
     setPaletteOpen(true);
   }
 
-  /** Toggle the right-side browser region on a terminal (#633): attach
-   *  it with a default initial URL when absent, detach it when present.
-   *  Mirrors `handleToggleSubPanel`'s open-or-close shape — the chrome
-   *  button is a single affordance that reflects current state. */
-  function handleToggleBrowser(id: TerminalId) {
-    const existing = store.getMetadata(id)?.browser;
-    if (existing && !existing.collapsed) {
-      void client.terminal
-        .clearBrowser({ id })
-        .catch((err: Error) =>
-          toast.error(`Failed to close browser: ${err.message}`),
-        );
-      return;
-    }
-    void client.terminal
-      .setBrowser({
-        id,
-        browser: existing
-          ? { ...existing, collapsed: false }
-          : { url: "", collapsed: false, panelSize: 0.5 },
-      })
-      .catch((err: Error) =>
-        toast.error(`Failed to open browser: ${err.message}`),
-      );
-  }
-
-  /** Detach the right-side browser region. The region's own × calls this
-   *  directly (plumbed through `TerminalContent.onCloseBrowser`); the
-   *  title-bar globe button goes through `handleToggleBrowser` instead. */
-  function handleCloseBrowser(id: TerminalId) {
-    void client.terminal
-      .clearBrowser({ id })
-      .catch((err: Error) =>
-        toast.error(`Failed to close browser: ${err.message}`),
-      );
-  }
-
   /** Close a terminal. Top-level terminals show a confirmation dialog;
    *  splits (sub-terminals) are killed directly — they are ephemeral
    *  sub-panes, like browser tabs, and should never pop the worktree
@@ -341,7 +304,6 @@ const App: Component = () => {
         onCloseTerminal={closeTerminal}
         activeMeta={store.activeMeta()}
         onFocus={() => store.setActiveId(id)}
-        onCloseBrowser={handleCloseBrowser}
       />
     );
   }
@@ -364,7 +326,6 @@ const App: Component = () => {
         }
         onCloseTerminal={closeTerminal}
         activeMeta={store.activeMeta()}
-        onCloseBrowser={handleCloseBrowser}
       />
     );
   }
@@ -578,7 +539,6 @@ const App: Component = () => {
                         onToggleSubPanel={handleToggleSubPanel}
                         onOpenSearch={() => setSearchOpen(true)}
                         onScreenshot={handleScreenshotTerminal}
-                        onToggleBrowser={handleToggleBrowser}
                       />
                     )}
                     renderTileBody={renderCanvasTileBody}

--- a/packages/client/src/browser/BrowserRegion.tsx
+++ b/packages/client/src/browser/BrowserRegion.tsx
@@ -1,0 +1,243 @@
+/** BrowserRegion — right-side iframe region attached to a terminal (#633).
+ *
+ *  Peer to the bottom sub-panel: one region per terminal, spans the full
+ *  tile height, renders the iframe + minimal chrome (URL bar, reload,
+ *  open-externally, close). The URL and the collapsed/panelSize bits live
+ *  on the terminal's metadata (`meta.browser`), written via
+ *  `terminal.setBrowser` / `terminal.clearBrowser`.
+ *
+ *  Detection: on URL commit, calls `terminal.probeBrowserUrl` to check
+ *  `X-Frame-Options` / CSP `frame-ancestors` headers server-side. When
+ *  blocked, swaps the iframe body for a "Open in a new tab" fallback.
+ *  Regardless of probe result the header always offers an "open
+ *  externally" button so the escape hatch is unconditional. */
+
+import { type Component, Show, createEffect, createSignal, on } from "solid-js";
+import type { TerminalId, BrowserRegion } from "kolu-common";
+import { toast } from "solid-sonner";
+import { client } from "../rpc/rpc";
+import { resolveTileUrl } from "./resolveTileUrl";
+import { OpenExternalIcon, ReloadIcon, GlobeIcon } from "../ui/Icons";
+import Tip from "../ui/Tip";
+
+/** Bump this counter on the iframe `src` attribute to force a reload
+ *  without recreating the element — `location.reload()` on a cross-origin
+ *  iframe throws, so this is the safe equivalent. */
+function appendReloadNonce(url: string, nonce: number): string {
+  if (nonce === 0) return url;
+  try {
+    const u = new URL(url);
+    u.searchParams.set("__kolu_reload", String(nonce));
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+const CHROME_BUTTON_CLASS =
+  "flex items-center justify-center h-7 rounded-lg transition-colors cursor-pointer shrink-0 pointer-events-auto hover:bg-black/20 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50";
+
+const BrowserRegionComponent: Component<{
+  terminalId: TerminalId;
+  browser: BrowserRegion;
+  onDetach: () => void;
+}> = (props) => {
+  const rawUrl = () => props.browser.url;
+  const resolved = () => resolveTileUrl(rawUrl());
+  const [reloadNonce, setReloadNonce] = createSignal(0);
+  const src = () => appendReloadNonce(resolved(), reloadNonce());
+  const [draft, setDraft] = createSignal(rawUrl());
+
+  // Keep the URL-bar draft in sync with the committed URL (e.g. session
+  // restore or cross-client update); only reset when the draft equals the
+  // previous committed value so in-flight user edits aren't clobbered.
+  let lastCommitted = rawUrl();
+  createEffect(
+    on(rawUrl, (next) => {
+      if (draft() === lastCommitted) setDraft(next);
+      lastCommitted = next;
+    }),
+  );
+
+  const [probe, setProbe] = createSignal<{
+    blocked: boolean;
+    reason?: string;
+  } | null>(null);
+
+  // Probe whenever the resolved URL changes — using the resolved form so
+  // protocol-less input (`news.ycombinator.com`) is checked and rendered
+  // as the absolute https:// form, not a relative path that would recurse
+  // Kolu into itself.
+  createEffect(
+    on(resolved, async (url) => {
+      if (!url) {
+        setProbe(null);
+        return;
+      }
+      setProbe(null);
+      try {
+        const result = await client.terminal.probeBrowserUrl({ url });
+        if (resolved() === url) setProbe(result);
+      } catch {
+        // Probe failure isn't worth a toast — the iframe itself surfaces
+        // the real network/CORS error. Keep probe null so we render the
+        // iframe and let the browser handle it.
+      }
+    }),
+  );
+
+  function commit() {
+    const next = draft().trim();
+    if (next === "" || next === rawUrl()) return;
+    void client.terminal
+      .setBrowser({
+        id: props.terminalId,
+        browser: { ...props.browser, url: next },
+      })
+      .catch((err: Error) =>
+        toast.error(`Failed to set browser URL: ${err.message}`),
+      );
+  }
+
+  const hostLabel = () => {
+    try {
+      return new URL(resolved()).host || rawUrl();
+    } catch {
+      return rawUrl() || "new browser";
+    }
+  };
+
+  return (
+    <div
+      data-testid="browser-region"
+      data-terminal-id={props.terminalId}
+      class="h-full flex flex-col overflow-hidden bg-surface-1"
+    >
+      {/* Browser chrome header — URL bar, reload, open-externally, close. */}
+      <div
+        class="flex items-center gap-2 px-2 py-1.5 shrink-0 select-none bg-surface-2/60"
+        style={{ "border-bottom": "1px solid var(--color-edge)" }}
+      >
+        <div
+          class="flex items-center gap-1.5 min-w-0 text-fg-2 text-xs font-medium truncate pl-1"
+          data-testid="browser-region-title"
+        >
+          <GlobeIcon class="w-3.5 h-3.5 shrink-0" />
+          <span class="truncate">{hostLabel()}</span>
+        </div>
+        <input
+          data-testid="browser-region-url"
+          type="text"
+          spellcheck={false}
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          placeholder="https://…"
+          value={draft()}
+          onInput={(e) => setDraft(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+              e.currentTarget.blur();
+            }
+          }}
+          onBlur={commit}
+          class="h-7 flex-1 min-w-0 px-2 rounded-lg text-xs font-mono bg-black/20 border border-transparent hover:border-edge focus:border-accent focus:outline-none"
+          style={{ color: "var(--color-fg, currentColor)" }}
+        />
+        <Tip label="Reload">
+          <button
+            data-testid="browser-region-reload"
+            class={`${CHROME_BUTTON_CLASS} w-7`}
+            style={{ color: "var(--color-fg-3, currentColor)" }}
+            onClick={() => setReloadNonce((n) => n + 1)}
+            aria-label="Reload"
+          >
+            <ReloadIcon />
+          </button>
+        </Tip>
+        <Tip label="Open in a new tab">
+          <a
+            data-testid="browser-region-open-externally"
+            href={rawUrl() || "about:blank"}
+            target="_blank"
+            rel="noopener noreferrer"
+            class={`${CHROME_BUTTON_CLASS} w-7`}
+            style={{ color: "var(--color-fg-3, currentColor)" }}
+            aria-label="Open in a new tab"
+          >
+            <OpenExternalIcon />
+          </a>
+        </Tip>
+        <Tip label="Close browser">
+          <button
+            data-testid="browser-region-close"
+            class={`${CHROME_BUTTON_CLASS} w-7`}
+            style={{ color: "var(--color-fg-3, currentColor)" }}
+            onClick={() => props.onDetach()}
+            aria-label="Close browser"
+          >
+            ×
+          </button>
+        </Tip>
+      </div>
+
+      {/* Body — iframe or blocked fallback. */}
+      <Show
+        when={probe()?.blocked}
+        fallback={
+          <Show
+            when={rawUrl()}
+            fallback={
+              <div
+                data-testid="browser-region-empty"
+                class="flex-1 flex items-center justify-center text-fg-3 text-sm"
+              >
+                Enter a URL above
+              </div>
+            }
+          >
+            {/* `allow-same-origin` + `allow-scripts` defeats sandboxing for
+             *  same-origin docs, but is required for real-world use (logged-
+             *  in Grafana, docs sites with cookies). Kolu is single-user and
+             *  the user has opted into framing a specific URL. Cross-origin
+             *  iframes ignore `allow-same-origin` anyway, so the risk is
+             *  limited to pages served from Kolu's own origin. */}
+            <iframe
+              data-testid="browser-region-iframe"
+              src={src()}
+              class="flex-1 min-h-0 w-full bg-white"
+              referrerpolicy="no-referrer"
+              sandbox="allow-forms allow-popups allow-scripts allow-same-origin allow-downloads"
+            />
+          </Show>
+        }
+      >
+        <div
+          data-testid="browser-region-blocked"
+          class="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-center text-fg-2 text-sm"
+        >
+          <div class="font-medium text-fg">
+            This site refuses to be embedded
+          </div>
+          <div class="text-fg-3 text-xs font-mono">
+            {probe()?.reason ?? "frame-ancestors blocked"}
+          </div>
+          <a
+            data-testid="browser-region-open-externally-fallback"
+            href={rawUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-edge hover:border-edge-bright bg-surface-1 hover:bg-surface-2 transition-colors"
+          >
+            <OpenExternalIcon />
+            <span>Open in a new tab</span>
+          </a>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default BrowserRegionComponent;

--- a/packages/client/src/browser/BrowserRegion.tsx
+++ b/packages/client/src/browser/BrowserRegion.tsx
@@ -12,13 +12,21 @@
  *  Regardless of probe result the header always offers an "open
  *  externally" button so the escape hatch is unconditional. */
 
-import { type Component, Show, createEffect, createSignal, on } from "solid-js";
+import {
+  type Component,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  on,
+} from "solid-js";
 import type { TerminalId, BrowserRegion } from "kolu-common";
 import { toast } from "solid-sonner";
 import { client } from "../rpc/rpc";
 import { resolveTileUrl } from "./resolveTileUrl";
 import { OpenExternalIcon, ReloadIcon, GlobeIcon } from "../ui/Icons";
 import Tip from "../ui/Tip";
+import { TILE_BUTTON_CLASS } from "../ui/tileButton";
 
 /** Bump this counter on the iframe `src` attribute to force a reload
  *  without recreating the element — `location.reload()` on a cross-origin
@@ -34,28 +42,25 @@ function appendReloadNonce(url: string, nonce: number): string {
   }
 }
 
-const CHROME_BUTTON_CLASS =
-  "flex items-center justify-center h-7 rounded-lg transition-colors cursor-pointer shrink-0 pointer-events-auto hover:bg-black/20 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50";
-
 const BrowserRegionComponent: Component<{
   terminalId: TerminalId;
   browser: BrowserRegion;
-  onDetach: () => void;
 }> = (props) => {
   const rawUrl = () => props.browser.url;
-  const resolved = () => resolveTileUrl(rawUrl());
+  const resolved = createMemo(() => resolveTileUrl(rawUrl()));
   const [reloadNonce, setReloadNonce] = createSignal(0);
-  const src = () => appendReloadNonce(resolved(), reloadNonce());
+  const src = createMemo(() => appendReloadNonce(resolved(), reloadNonce()));
   const [draft, setDraft] = createSignal(rawUrl());
 
   // Keep the URL-bar draft in sync with the committed URL (e.g. session
-  // restore or cross-client update); only reset when the draft equals the
-  // previous committed value so in-flight user edits aren't clobbered.
-  let lastCommitted = rawUrl();
+  // restore or cross-client update); only reset when the draft matches
+  // the previous committed value so in-flight user edits aren't clobbered.
+  // `on`'s `prevInput` parameter gives us the last rawUrl without a
+  // module-local mutable; we return `next` from the effect so the second
+  // run sees the prior committed value cleanly.
   createEffect(
-    on(rawUrl, (next) => {
-      if (draft() === lastCommitted) setDraft(next);
-      lastCommitted = next;
+    on(rawUrl, (next, prev) => {
+      if (prev !== undefined && draft() === prev) setDraft(next);
     }),
   );
 
@@ -99,13 +104,21 @@ const BrowserRegionComponent: Component<{
       );
   }
 
-  const hostLabel = () => {
+  function detach() {
+    void client.terminal
+      .clearBrowser({ id: props.terminalId })
+      .catch((err: Error) =>
+        toast.error(`Failed to close browser: ${err.message}`),
+      );
+  }
+
+  const hostLabel = createMemo(() => {
     try {
       return new URL(resolved()).host || rawUrl();
     } catch {
       return rawUrl() || "new browser";
     }
-  };
+  });
 
   return (
     <div
@@ -149,7 +162,7 @@ const BrowserRegionComponent: Component<{
         <Tip label="Reload">
           <button
             data-testid="browser-region-reload"
-            class={`${CHROME_BUTTON_CLASS} w-7`}
+            class={`${TILE_BUTTON_CLASS} w-7`}
             style={{ color: "var(--color-fg-3, currentColor)" }}
             onClick={() => setReloadNonce((n) => n + 1)}
             aria-label="Reload"
@@ -163,7 +176,7 @@ const BrowserRegionComponent: Component<{
             href={rawUrl() || "about:blank"}
             target="_blank"
             rel="noopener noreferrer"
-            class={`${CHROME_BUTTON_CLASS} w-7`}
+            class={`${TILE_BUTTON_CLASS} w-7`}
             style={{ color: "var(--color-fg-3, currentColor)" }}
             aria-label="Open in a new tab"
           >
@@ -173,9 +186,9 @@ const BrowserRegionComponent: Component<{
         <Tip label="Close browser">
           <button
             data-testid="browser-region-close"
-            class={`${CHROME_BUTTON_CLASS} w-7`}
+            class={`${TILE_BUTTON_CLASS} w-7`}
             style={{ color: "var(--color-fg-3, currentColor)" }}
-            onClick={() => props.onDetach()}
+            onClick={() => detach()}
             aria-label="Close browser"
           >
             ×

--- a/packages/client/src/browser/resolveTileUrl.test.ts
+++ b/packages/client/src/browser/resolveTileUrl.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { resolveTileUrl } from "./resolveTileUrl";
+
+describe("resolveTileUrl", () => {
+  it("passes https:// and http:// URLs through unchanged", () => {
+    expect(resolveTileUrl("https://example.com")).toBe("https://example.com");
+    expect(resolveTileUrl("http://localhost:3000/path?q=1")).toBe(
+      "http://localhost:3000/path?q=1",
+    );
+  });
+
+  it("prepends https:// when the URL has no scheme", () => {
+    expect(resolveTileUrl("news.ycombinator.com")).toBe(
+      "https://news.ycombinator.com",
+    );
+    expect(resolveTileUrl("example.com/path")).toBe("https://example.com/path");
+  });
+
+  it("keeps non-http scheme URLs untouched", () => {
+    expect(resolveTileUrl("about:blank")).toBe("about:blank");
+    expect(resolveTileUrl("data:text/html,<h1>hi</h1>")).toBe(
+      "data:text/html,<h1>hi</h1>",
+    );
+    expect(resolveTileUrl("file:///tmp/x.html")).toBe("file:///tmp/x.html");
+  });
+
+  it("trims whitespace before normalizing", () => {
+    expect(resolveTileUrl("  example.com  ")).toBe("https://example.com");
+    expect(resolveTileUrl(" https://x.dev ")).toBe("https://x.dev");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(resolveTileUrl("")).toBe("");
+    expect(resolveTileUrl("   ")).toBe("");
+  });
+});

--- a/packages/client/src/browser/resolveTileUrl.ts
+++ b/packages/client/src/browser/resolveTileUrl.ts
@@ -1,0 +1,28 @@
+/** Resolve a user-entered URL to an `iframe src` (issue #633).
+ *
+ *  Phase 0: normalize only. Phase 1 will rewrite `http://localhost:NNNN` →
+ *  `https://NNNN.preview.<host>/` through the Hono reverse proxy so that
+ *  Vite HMR WebSockets and absolute asset paths just work. Phase 2 feeds
+ *  user-selected URLs from terminal stdout scans through the same seam.
+ *
+ *  This single-file seam is the Lowy encapsulation of the "URL resolution
+ *  strategy" volatility — later phases change `resolveTileUrl` only; no
+ *  tile schema, no RPC contract, no consumer site moves.
+ *
+ *  Normalization detail: a protocol-less URL (`news.ycombinator.com`)
+ *  becomes a *relative* iframe `src` against the current origin, which
+ *  makes Kolu's SPA router serve Kolu itself inside the iframe — an
+ *  infinite-recursion trap. Prepend `https://` when no scheme is present
+ *  so the iframe loads the intended remote site. Inputs that already
+ *  carry a scheme (`https:`, `http:`, `about:`, `data:`, `blob:`,
+ *  `file:`) pass through unchanged. */
+export function resolveTileUrl(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed === "") return trimmed;
+  return hasScheme(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+/** RFC 3986 scheme: `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":"`. */
+function hasScheme(url: string): boolean {
+  return /^[a-z][a-z0-9+\-.]*:/i.test(url);
+}

--- a/packages/client/src/browser/resolveTileUrl.ts
+++ b/packages/client/src/browser/resolveTileUrl.ts
@@ -19,10 +19,8 @@
 export function resolveTileUrl(url: string): string {
   const trimmed = url.trim();
   if (trimmed === "") return trimmed;
-  return hasScheme(trimmed) ? trimmed : `https://${trimmed}`;
-}
-
-/** RFC 3986 scheme: `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":"`. */
-function hasScheme(url: string): boolean {
-  return /^[a-z][a-z0-9+\-.]*:/i.test(url);
+  // `URL.canParse(x)` without a base returns true only for absolute URLs
+  // (those carrying a scheme). Matches the intent of "does this already
+  // have a scheme?" without hand-rolling the RFC 3986 regex.
+  return URL.canParse(trimmed) ? trimmed : `https://${trimmed}`;
 }

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -10,6 +10,7 @@
  *  orchestration layer. Extracted from App.tsx per kolu#626. */
 
 import { type Component, Show } from "solid-js";
+import { toast } from "solid-sonner";
 import type { TerminalId } from "kolu-common";
 import AgentIndicator from "../terminal/AgentIndicator";
 import { useTerminalStore } from "../terminal/useTerminalStore";
@@ -18,6 +19,7 @@ import { useSubPanel } from "../terminal/useSubPanel";
 import { useThemeManager } from "../useThemeManager";
 import { useTips } from "../settings/useTips";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
+import { client } from "../rpc/rpc";
 import {
   GlobeIcon,
   ScreenshotIcon,
@@ -25,11 +27,10 @@ import {
   SplitToggleIcon,
 } from "../ui/Icons";
 import Tip from "../ui/Tip";
+import { TILE_BUTTON_CLASS } from "../ui/tileButton";
 
-/** Tile chrome buttons share this affordance. Theme pill is wider — it shows
- *  the theme name. Other buttons are square. */
-const TILE_BUTTON_CLASS =
-  "flex items-center justify-center h-7 rounded-lg transition-colors cursor-pointer shrink-0 pointer-events-auto hover:bg-black/20 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50";
+/** Default right-side browser panel fraction on first attach. */
+const DEFAULT_BROWSER_PANEL_SIZE = 0.5;
 
 const TileTitleActions: Component<{
   id: TerminalId;
@@ -42,10 +43,6 @@ const TileTitleActions: Component<{
   onOpenSearch: () => void;
   /** Screenshot the given terminal. */
   onScreenshot: (id: TerminalId) => void;
-  /** Toggle the right-side browser region on this terminal (#633):
-   *  attach it when absent, detach it when present. Mirrors the
-   *  split-terminal toggle's open-or-close semantics. */
-  onToggleBrowser: (id: TerminalId) => void;
 }> = (props) => {
   const store = useTerminalStore();
   const rightPanel = useRightPanel();
@@ -59,8 +56,30 @@ const TileTitleActions: Component<{
   const subCount = () => store.getSubTerminalIds(props.id).length;
   const splitExpanded = () =>
     subCount() > 0 && !subPanel.getSubPanel(props.id).collapsed;
-  const browserAttached = () =>
-    meta()?.browser !== undefined && !meta()?.browser?.collapsed;
+  const browserAttached = () => meta()?.browser !== undefined;
+
+  /** Toggle the right-side browser region (#633): attach with a blank
+   *  URL when absent, detach when present. Mirrors the split-terminal
+   *  toggle. Calls `client.terminal.*` directly per the solidjs rule —
+   *  App.tsx stays a thin layout shell. */
+  function toggleBrowser() {
+    if (browserAttached()) {
+      void client.terminal
+        .clearBrowser({ id: props.id })
+        .catch((err: Error) =>
+          toast.error(`Failed to close browser: ${err.message}`),
+        );
+      return;
+    }
+    void client.terminal
+      .setBrowser({
+        id: props.id,
+        browser: { url: "", panelSize: DEFAULT_BROWSER_PANEL_SIZE },
+      })
+      .catch((err: Error) =>
+        toast.error(`Failed to open browser: ${err.message}`),
+      );
+  }
 
   return (
     <>
@@ -113,7 +132,7 @@ const TileTitleActions: Component<{
           onClick={(e) => {
             e.stopPropagation();
             store.setActiveId(props.id);
-            props.onToggleBrowser(props.id);
+            toggleBrowser();
           }}
           aria-label={browserAttached() ? "Close browser" : "Open browser"}
           aria-pressed={browserAttached()}

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -18,7 +18,12 @@ import { useSubPanel } from "../terminal/useSubPanel";
 import { useThemeManager } from "../useThemeManager";
 import { useTips } from "../settings/useTips";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
-import { ScreenshotIcon, SearchIcon, SplitToggleIcon } from "../ui/Icons";
+import {
+  GlobeIcon,
+  ScreenshotIcon,
+  SearchIcon,
+  SplitToggleIcon,
+} from "../ui/Icons";
 import Tip from "../ui/Tip";
 
 /** Tile chrome buttons share this affordance. Theme pill is wider — it shows
@@ -37,6 +42,8 @@ const TileTitleActions: Component<{
   onOpenSearch: () => void;
   /** Screenshot the given terminal. */
   onScreenshot: (id: TerminalId) => void;
+  /** Attach the right-side browser region to this terminal (#633). */
+  onOpenBrowser: (id: TerminalId) => void;
 }> = (props) => {
   const store = useTerminalStore();
   const rightPanel = useRightPanel();
@@ -50,6 +57,8 @@ const TileTitleActions: Component<{
   const subCount = () => store.getSubTerminalIds(props.id).length;
   const splitExpanded = () =>
     subCount() > 0 && !subPanel.getSubPanel(props.id).collapsed;
+  const browserAttached = () =>
+    meta()?.browser !== undefined && !meta()?.browser?.collapsed;
 
   return (
     <>
@@ -92,6 +101,24 @@ const TileTitleActions: Component<{
           </Tip>
         )}
       </Show>
+      <Tip label={browserAttached() ? "Browser open" : "Open browser →"}>
+        <button
+          data-testid="tile-open-browser"
+          class={`${TILE_BUTTON_CLASS} w-7`}
+          classList={{ "bg-black/20": browserAttached() }}
+          style={{ color: "var(--color-fg-3, currentColor)" }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            store.setActiveId(props.id);
+            props.onOpenBrowser(props.id);
+          }}
+          aria-label="Open browser"
+          disabled={browserAttached()}
+        >
+          <GlobeIcon />
+        </button>
+      </Tip>
       <Tip label={subCount() > 0 ? "Toggle split" : "Add split"}>
         <button
           data-testid="tile-split-toggle"

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -42,8 +42,10 @@ const TileTitleActions: Component<{
   onOpenSearch: () => void;
   /** Screenshot the given terminal. */
   onScreenshot: (id: TerminalId) => void;
-  /** Attach the right-side browser region to this terminal (#633). */
-  onOpenBrowser: (id: TerminalId) => void;
+  /** Toggle the right-side browser region on this terminal (#633):
+   *  attach it when absent, detach it when present. Mirrors the
+   *  split-terminal toggle's open-or-close semantics. */
+  onToggleBrowser: (id: TerminalId) => void;
 }> = (props) => {
   const store = useTerminalStore();
   const rightPanel = useRightPanel();
@@ -101,9 +103,9 @@ const TileTitleActions: Component<{
           </Tip>
         )}
       </Show>
-      <Tip label={browserAttached() ? "Browser open" : "Open browser →"}>
+      <Tip label={browserAttached() ? "Close browser" : "Open browser →"}>
         <button
-          data-testid="tile-open-browser"
+          data-testid="tile-toggle-browser"
           class={`${TILE_BUTTON_CLASS} w-7`}
           classList={{ "bg-black/20": browserAttached() }}
           style={{ color: "var(--color-fg-3, currentColor)" }}
@@ -111,10 +113,10 @@ const TileTitleActions: Component<{
           onClick={(e) => {
             e.stopPropagation();
             store.setActiveId(props.id);
-            props.onOpenBrowser(props.id);
+            props.onToggleBrowser(props.id);
           }}
-          aria-label="Open browser"
-          disabled={browserAttached()}
+          aria-label={browserAttached() ? "Close browser" : "Open browser"}
+          aria-pressed={browserAttached()}
         >
           <GlobeIcon />
         </button>

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -1,5 +1,5 @@
 /** TerminalContent — shared terminal rendering: main terminal + resizable
- *  sub-panel with tab bar and child terminals.
+ *  bottom sub-panel + optional right-side browser region (#633).
  *
  *  Used by CanvasTile (desktop) and MobileTileView (mobile). Owns
  *  sub-panel state internally — callers provide only the shell. */
@@ -10,6 +10,9 @@ import type { ITheme } from "@xterm/xterm";
 import Terminal from "./Terminal";
 import SubPanelTabBar from "./SubPanelTabBar";
 import { useSubPanel } from "./useSubPanel";
+import BrowserRegion from "../browser/BrowserRegion";
+import { client } from "../rpc/rpc";
+import { toast } from "solid-sonner";
 import type { TerminalId, TerminalMetadata } from "kolu-common";
 
 const TerminalContent: Component<{
@@ -32,6 +35,8 @@ const TerminalContent: Component<{
   /** Called when user focuses any terminal in this pane (click, keyboard).
    *  Canvas mode uses this to set the active tile. */
   onFocus?: () => void;
+  /** Detach the right-side browser region from this terminal (#633). */
+  onCloseBrowser?: (id: TerminalId) => void;
 }> = (props) => {
   const subPanel = useSubPanel();
 
@@ -69,7 +74,39 @@ const TerminalContent: Component<{
     props.onFocus?.();
   }
 
-  return (
+  // Right-side browser region state — optional, per-terminal, comes from
+  // the same metadata stream as subPanel. Reads through the same getter
+  // the caller passes so the component doesn't bind to a specific store.
+  const browser = () => props.getMetadata(props.terminalId)?.browser;
+  const hasBrowser = () => {
+    const b = browser();
+    return b !== undefined && !b.collapsed;
+  };
+
+  function handleBrowserSizesChange(sizes: number[]) {
+    const b = browser();
+    if (!b) return;
+    // sizes[1] is the browser's fraction (right panel). Ignore tiny
+    // intermediate values the same way the vertical split does.
+    const next = sizes[1];
+    if (
+      next === undefined ||
+      next < 0.05 ||
+      Math.abs(next - b.panelSize) < 0.01
+    ) {
+      return;
+    }
+    void client.terminal
+      .setBrowser({
+        id: props.terminalId,
+        browser: { ...b, panelSize: next },
+      })
+      .catch((err: Error) =>
+        toast.error(`Failed to save browser layout: ${err.message}`),
+      );
+  }
+
+  const verticalSplit = () => (
     <Resizable
       orientation="vertical"
       sizes={
@@ -148,6 +185,47 @@ const TerminalContent: Component<{
         </div>
       </Resizable.Panel>
     </Resizable>
+  );
+
+  // Outer horizontal split: terminal+sub-panel on the left, browser on
+  // the right. When no browser is attached, just render the vertical
+  // split directly — no wrapper overhead. The browser's own panelSize
+  // lives on terminal metadata so it survives reload (see #633 pivot).
+  return (
+    <Show when={hasBrowser() && browser()} fallback={verticalSplit()} keyed>
+      {(b) => (
+        <Resizable
+          orientation="horizontal"
+          sizes={[1 - b.panelSize, b.panelSize]}
+          onSizesChange={handleBrowserSizesChange}
+          class="flex-1 min-h-0"
+        >
+          <Resizable.Panel
+            as="div"
+            class="min-h-0 overflow-hidden flex flex-col"
+            minSize={0.2}
+          >
+            {verticalSplit()}
+          </Resizable.Panel>
+          <Resizable.Handle
+            data-testid="browser-resize-handle"
+            class="shrink-0 w-0 relative before:absolute before:inset-y-0 before:-left-1 before:w-2 before:cursor-col-resize before:hover:bg-accent/30 before:transition-colors"
+            aria-label="Resize browser region"
+          />
+          <Resizable.Panel
+            as="div"
+            class="min-h-0 overflow-hidden"
+            minSize={0.15}
+          >
+            <BrowserRegion
+              terminalId={props.terminalId}
+              browser={b}
+              onDetach={() => props.onCloseBrowser?.(props.terminalId)}
+            />
+          </Resizable.Panel>
+        </Resizable>
+      )}
+    </Show>
   );
 };
 

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -35,8 +35,6 @@ const TerminalContent: Component<{
   /** Called when user focuses any terminal in this pane (click, keyboard).
    *  Canvas mode uses this to set the active tile. */
   onFocus?: () => void;
-  /** Detach the right-side browser region from this terminal (#633). */
-  onCloseBrowser?: (id: TerminalId) => void;
 }> = (props) => {
   const subPanel = useSubPanel();
 
@@ -78,10 +76,6 @@ const TerminalContent: Component<{
   // the same metadata stream as subPanel. Reads through the same getter
   // the caller passes so the component doesn't bind to a specific store.
   const browser = () => props.getMetadata(props.terminalId)?.browser;
-  const hasBrowser = () => {
-    const b = browser();
-    return b !== undefined && !b.collapsed;
-  };
 
   function handleBrowserSizesChange(sizes: number[]) {
     const b = browser();
@@ -192,7 +186,7 @@ const TerminalContent: Component<{
   // split directly — no wrapper overhead. The browser's own panelSize
   // lives on terminal metadata so it survives reload (see #633 pivot).
   return (
-    <Show when={hasBrowser() && browser()} fallback={verticalSplit()} keyed>
+    <Show when={browser()} fallback={verticalSplit()} keyed>
       {(b) => (
         <Resizable
           orientation="horizontal"
@@ -217,11 +211,7 @@ const TerminalContent: Component<{
             class="min-h-0 overflow-hidden"
             minSize={0.15}
           >
-            <BrowserRegion
-              terminalId={props.terminalId}
-              browser={b}
-              onDetach={() => props.onCloseBrowser?.(props.terminalId)}
-            />
+            <BrowserRegion terminalId={props.terminalId} browser={b} />
           </Resizable.Panel>
         </Resizable>
       )}

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -159,6 +159,14 @@ export function useSessionRestore(deps: {
         if (t.subPanel) {
           subPanel.seedPanel(newId, t.subPanel);
         }
+        if (t.browser) {
+          // Right-side browser region (#633) rides on the terminal now.
+          void client.terminal
+            .setBrowser({ id: newId, browser: t.browser })
+            .catch((err: Error) =>
+              toast.error(`Failed to restore browser: ${err.message}`),
+            );
+        }
       }
       // Restore active terminal
       if (session.activeTerminalId) {

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -506,3 +506,52 @@ export const PlusIcon: Component<{ class?: string }> = (props) => (
     <path stroke-linecap="round" d="M12 5v14M5 12h14" />
   </svg>
 );
+
+export const ReloadIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M21 12a9 9 0 0 1-15.4 6.4L3 16" />
+    <path d="M3 12a9 9 0 0 1 15.4-6.4L21 8" />
+    <path d="M21 3v5h-5" />
+    <path d="M3 21v-5h5" />
+  </svg>
+);
+
+export const OpenExternalIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M15 3h6v6" />
+    <path d="M10 14L21 3" />
+    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+  </svg>
+);
+
+export const GlobeIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3.5 h-3.5"}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    stroke-width="1.75"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3 12h18" />
+    <path d="M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18z" />
+  </svg>
+);

--- a/packages/client/src/ui/tileButton.ts
+++ b/packages/client/src/ui/tileButton.ts
@@ -1,0 +1,7 @@
+/** Shared Tailwind class string for tile chrome buttons.
+ *
+ *  One affordance shape — used by `TileTitleActions` (terminal chrome)
+ *  and `BrowserRegion` chrome. Consolidated so a hover/focus tweak to
+ *  the pill style flows to every tile-chrome surface. */
+export const TILE_BUTTON_CLASS =
+  "flex items-center justify-center h-7 rounded-lg transition-colors cursor-pointer shrink-0 pointer-events-auto hover:bg-black/20 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50";

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -22,6 +22,10 @@ import {
   TerminalMetadataSchema,
   TerminalPasteImageInputSchema,
   TerminalScreenTextInputSchema,
+  TerminalSetBrowserInputSchema,
+  TerminalClearBrowserInputSchema,
+  TerminalProbeBrowserUrlInputSchema,
+  TerminalProbeBrowserUrlOutputSchema,
   ServerInfoSchema,
   WorktreeCreateInputSchema,
   WorktreeCreateOutputSchema,
@@ -81,6 +85,14 @@ export const contract = oc.router({
     setParent: oc.input(TerminalSetParentInputSchema).output(z.void()),
     // Kill and remove all terminals (test-only: reset server state between scenarios)
     killAll: oc.output(z.void()),
+    // Attach or update the right-side browser region on a terminal (#633).
+    setBrowser: oc.input(TerminalSetBrowserInputSchema).output(z.void()),
+    // Detach the right-side browser region from a terminal.
+    clearBrowser: oc.input(TerminalClearBrowserInputSchema).output(z.void()),
+    // HEAD-probe a URL for XFO / CSP frame-ancestors restrictions.
+    probeBrowserUrl: oc
+      .input(TerminalProbeBrowserUrlInputSchema)
+      .output(TerminalProbeBrowserUrlOutputSchema),
   },
   git: {
     worktreeCreate: oc

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -115,6 +115,21 @@ export const SubPanelStateSchema = z.object({
   panelSize: z.number(),
 });
 
+/** Browser-region state attached to a terminal tile (issue #633).
+ *
+ *  A terminal may carry a 0-or-1 right-side browser iframe, peer to its
+ *  optional bottom sub-panel. Lives on client metadata because the write
+ *  authority is user input (URL bar) — same class of state as `subPanel`.
+ *
+ *  `panelSize` is the browser's fraction of the tile's horizontal width
+ *  (0–1). `collapsed` is kept as a bit independent of presence so the
+ *  user can temporarily hide the browser without losing the URL. */
+export const BrowserRegionSchema = z.object({
+  url: z.string(),
+  collapsed: z.boolean(),
+  panelSize: z.number(),
+});
+
 /**
  * Server-derived metadata — populated by providers from external state
  * (git working tree, PTY foreground process, agent CLI transcripts).
@@ -152,6 +167,10 @@ export const TerminalClientMetadataSchema = z.object({
   canvasLayout: CanvasLayoutSchema.optional(),
   /** Sub-panel collapsed/size state — client-reported, used for session restore. */
   subPanel: SubPanelStateSchema.optional(),
+  /** Right-side browser iframe attached to this terminal (#633). Absent
+   *  when no browser is attached; peer to `subPanel` which sits at the
+   *  bottom. One browser max per terminal. */
+  browser: BrowserRegionSchema.optional(),
 });
 
 /**
@@ -169,6 +188,34 @@ export const TerminalInfoSchema = z.object({
   id: TerminalIdSchema,
   pid: z.number(),
   meta: TerminalMetadataSchema,
+});
+
+// --- Terminal-attached browser region (issue #633) ---
+
+/** Attach or update the right-side browser region on a terminal. */
+export const TerminalSetBrowserInputSchema = z.object({
+  id: TerminalIdSchema,
+  browser: BrowserRegionSchema,
+});
+
+/** Detach the browser region from a terminal. */
+export const TerminalClearBrowserInputSchema = z.object({
+  id: TerminalIdSchema,
+});
+
+/** HEAD-probe a URL for XFO / CSP frame-ancestors restrictions. Server-
+ *  side so the client isn't exposed to the target's CORS policy. */
+export const TerminalProbeBrowserUrlInputSchema = z.object({
+  url: z.string(),
+});
+
+export const TerminalProbeBrowserUrlOutputSchema = z.object({
+  /** True if the HEAD probe found `X-Frame-Options: DENY|SAMEORIGIN` or a
+   *  restrictive `Content-Security-Policy: frame-ancestors 'none'|'self'`.
+   *  Treated as a hint — the UI always offers an "Open externally" escape. */
+  blocked: z.boolean(),
+  /** Short reason for display when blocked (e.g. "X-Frame-Options: DENY"). */
+  reason: z.string().optional(),
 });
 
 export const TerminalResizeInputSchema = z.object({
@@ -287,6 +334,8 @@ export const SavedTerminalSchema = z.object({
       panelSize: z.number(),
     })
     .optional(),
+  /** Browser region attached to this terminal at save time (#633). */
+  browser: BrowserRegionSchema.optional(),
 });
 
 export const SavedSessionSchema = z.object({
@@ -380,6 +429,10 @@ export type RecentRepo = z.infer<typeof RecentRepoSchema>;
 export type RecentAgent = z.infer<typeof RecentAgentSchema>;
 export type SavedTerminal = z.infer<typeof SavedTerminalSchema>;
 export type SavedSession = z.infer<typeof SavedSessionSchema>;
+export type BrowserRegion = z.infer<typeof BrowserRegionSchema>;
+export type TerminalProbeBrowserUrlOutput = z.infer<
+  typeof TerminalProbeBrowserUrlOutputSchema
+>;
 export type ColorScheme = z.infer<typeof ColorSchemeSchema>;
 export type Preferences = z.infer<typeof PreferencesSchema>;
 export type PreferencesPatch = z.infer<typeof PreferencesPatchSchema>;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -120,13 +120,12 @@ export const SubPanelStateSchema = z.object({
  *  A terminal may carry a 0-or-1 right-side browser iframe, peer to its
  *  optional bottom sub-panel. Lives on client metadata because the write
  *  authority is user input (URL bar) — same class of state as `subPanel`.
+ *  Absence of the field IS the "collapsed" state; there's no separate bit.
  *
  *  `panelSize` is the browser's fraction of the tile's horizontal width
- *  (0–1). `collapsed` is kept as a bit independent of presence so the
- *  user can temporarily hide the browser without losing the URL. */
+ *  (0–1), persisted across reloads. */
 export const BrowserRegionSchema = z.object({
   url: z.string(),
-  collapsed: z.boolean(),
   panelSize: z.number(),
 });
 

--- a/packages/server/src/browserProbe.test.ts
+++ b/packages/server/src/browserProbe.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { parseFramingHeaders } from "./browserProbe.ts";
+
+describe("parseFramingHeaders", () => {
+  it("reports blocked on X-Frame-Options: DENY (any case)", () => {
+    expect(parseFramingHeaders({ xFrameOptions: "DENY" })).toEqual({
+      blocked: true,
+      reason: "X-Frame-Options: deny",
+    });
+    expect(parseFramingHeaders({ xFrameOptions: "deny" })).toEqual({
+      blocked: true,
+      reason: "X-Frame-Options: deny",
+    });
+  });
+
+  it("reports blocked on X-Frame-Options: SAMEORIGIN", () => {
+    expect(parseFramingHeaders({ xFrameOptions: "SAMEORIGIN" })).toEqual({
+      blocked: true,
+      reason: "X-Frame-Options: sameorigin",
+    });
+  });
+
+  it("ignores X-Frame-Options values other than DENY/SAMEORIGIN", () => {
+    // ALLOW-FROM is deprecated and browsers ignore it — we match the browser.
+    expect(
+      parseFramingHeaders({ xFrameOptions: "ALLOW-FROM https://example.com" }),
+    ).toEqual({ blocked: false });
+  });
+
+  it("reports blocked on CSP frame-ancestors 'none'", () => {
+    expect(
+      parseFramingHeaders({
+        contentSecurityPolicy:
+          "default-src 'self'; frame-ancestors 'none'; script-src 'self'",
+      }),
+    ).toEqual({ blocked: true, reason: "CSP frame-ancestors 'none'" });
+  });
+
+  it("reports blocked on CSP frame-ancestors 'self'", () => {
+    expect(
+      parseFramingHeaders({
+        contentSecurityPolicy: "frame-ancestors 'self'",
+      }),
+    ).toEqual({ blocked: true, reason: "CSP frame-ancestors 'self'" });
+  });
+
+  it("passes CSP frame-ancestors with an explicit origin through", () => {
+    // Not 'none' / 'self' — we can't tell if our origin is allowed, so we
+    // don't block proactively. The iframe load will handle it.
+    expect(
+      parseFramingHeaders({
+        contentSecurityPolicy: "frame-ancestors https://example.com",
+      }),
+    ).toEqual({ blocked: false });
+  });
+
+  it("returns unblocked when no restrictive headers are present", () => {
+    expect(parseFramingHeaders({})).toEqual({ blocked: false });
+    expect(
+      parseFramingHeaders({
+        xFrameOptions: null,
+        contentSecurityPolicy: null,
+      }),
+    ).toEqual({ blocked: false });
+    expect(
+      parseFramingHeaders({
+        contentSecurityPolicy: "default-src 'self'; script-src 'self'",
+      }),
+    ).toEqual({ blocked: false });
+  });
+});

--- a/packages/server/src/browserProbe.ts
+++ b/packages/server/src/browserProbe.ts
@@ -1,0 +1,72 @@
+/** HEAD-probe a URL to detect framing restrictions (#633).
+ *
+ *  Server-side so the client isn't exposed to the target's CORS policy
+ *  (a browser-side fetch of an opaque response can't read headers).
+ *  Callers (the terminal's `probeBrowserUrl` handler) treat the result
+ *  as a hint — the UI always offers an "Open externally" fallback. */
+
+import { log } from "./log.ts";
+
+/** Pure header parser — extracted so unit tests can cover the directive-
+ *  split logic and case-handling without spinning up fetch. Returns
+ *  `blocked: true` with a short reason when `X-Frame-Options: DENY|
+ *  SAMEORIGIN` or a restrictive `Content-Security-Policy: frame-ancestors
+ *  'none'|'self'` is present. */
+export function parseFramingHeaders(headers: {
+  xFrameOptions?: string | null;
+  contentSecurityPolicy?: string | null;
+}): { blocked: boolean; reason?: string } {
+  const xfo = headers.xFrameOptions?.toLowerCase().trim();
+  if (xfo === "deny" || xfo === "sameorigin") {
+    return { blocked: true, reason: `X-Frame-Options: ${xfo}` };
+  }
+  // CSP is a semicolon-separated list of directives; parse per directive
+  // rather than with a single regex so `'none'` / `'self'` tokens match
+  // cleanly (the single-quote boundaries break `\b` word-boundary anchors).
+  for (const directive of (headers.contentSecurityPolicy ?? "").split(";")) {
+    const trimmed = directive.trim();
+    if (!/^frame-ancestors\b/i.test(trimmed)) continue;
+    const sources = trimmed.slice("frame-ancestors".length).trim().split(/\s+/);
+    for (const src of sources) {
+      if (src === "'none'" || src === "'self'") {
+        return { blocked: true, reason: `CSP frame-ancestors ${src}` };
+      }
+    }
+  }
+  return { blocked: false };
+}
+
+/** HEAD-probe a URL to detect framing restrictions. Network errors /
+ *  timeouts return `blocked: false` — the iframe load itself will surface
+ *  that failure, and the UI always offers an "Open externally" escape. */
+export async function probeFraming(
+  url: string,
+): Promise<{ blocked: boolean; reason?: string }> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { blocked: false };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { blocked: false };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(url, {
+      method: "HEAD",
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    return parseFramingHeaders({
+      xFrameOptions: res.headers.get("x-frame-options"),
+      contentSecurityPolicy: res.headers.get("content-security-policy"),
+    });
+  } catch (err) {
+    log.debug({ err, url }, "browser url probe failed");
+    return { blocked: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -20,8 +20,11 @@ import {
   setActiveTerminalId,
   setTerminalParent,
   reorderTerminals,
+  setBrowserOnTerminal,
+  clearBrowserOnTerminal,
   type TerminalProcess,
 } from "./terminals.ts";
+import { probeFraming } from "./browserProbe.ts";
 import { saveClipboardImage } from "./clipboard.ts";
 import { subscribeForTerminal_, subscribeSystem_ } from "./publisher.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
@@ -187,6 +190,20 @@ export const appRouter = t.router({
     killAll: t.terminal.killAll.handler(async () => {
       killAllTerminals();
     }),
+
+    setBrowser: t.terminal.setBrowser.handler(async ({ input }) => {
+      requireTerminal(input.id);
+      setBrowserOnTerminal(input.id, input.browser);
+    }),
+
+    clearBrowser: t.terminal.clearBrowser.handler(async ({ input }) => {
+      requireTerminal(input.id);
+      clearBrowserOnTerminal(input.id);
+    }),
+
+    probeBrowserUrl: t.terminal.probeBrowserUrl.handler(async ({ input }) =>
+      probeFraming(input.url),
+    ),
 
     onMetadataChange: t.terminal.onMetadataChange.handler(async function* ({
       input,

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -45,7 +45,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.16.0";
+const SCHEMA_VERSION = "1.18.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -275,6 +275,23 @@ export const store = new Conf<PersistedState>({
     // widened enum, so no value transformation is required. The bump is
     // recorded here for the ladder's sake (see .claude/rules/state.md).
     "1.16.0": () => {},
+    // #633 Phase 0: `SavedSession.browserTiles` (free-floating browser
+    // canvas tiles) was added here. Harmless if present; 1.18.0 strips it.
+    "1.17.0": () => {},
+    // #633 Phase 0 pivot: free-floating browser canvas tiles are gone.
+    // Browsers now attach to a terminal as `SavedTerminal.browser`. Strip
+    // the obsolete `browserTiles` key from `session`; we do NOT try to
+    // migrate orphan browser tiles into terminals because SavedBrowserTile
+    // never carried an owning-terminal pointer. Users on 1.17.0 who opened
+    // browsers lose those URLs on upgrade — acceptable because the feature
+    // was unreleased (see PR #640 history).
+    "1.18.0": (store) => {
+      const session = store.get("session") as Record<string, unknown> | null;
+      if (session && "browserTiles" in session) {
+        const { browserTiles: _drop, ...rest } = session;
+        store.set("session", rest as unknown as typeof session);
+      }
+    },
   },
 });
 

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -19,7 +19,7 @@ import {
 import { publishForTerminal, publishSystem } from "./publisher.ts";
 import { parseAgentCommand } from "anyagent";
 import { trackRecentAgent } from "./activity.ts";
-import type { SavedTerminal } from "kolu-common";
+import type { SavedTerminal, BrowserRegion } from "kolu-common";
 
 /** Server-side terminal state. Owns a PtyHandle and embeds the wire-type TerminalInfo. */
 export interface TerminalProcess {
@@ -50,7 +50,9 @@ function nextSortOrder(parentId?: string): number {
   return max + SORT_GAP;
 }
 
-/** Build a session snapshot from current terminal + client-reported state. */
+/** Build a session snapshot from current terminal + client-reported state.
+ *  The optional right-side browser region (#633) rides along on each
+ *  terminal as `meta.browser`, so nothing extra is needed here. */
 export function snapshotSession(): {
   terminals: SavedTerminal[];
   activeTerminalId: string | null;
@@ -66,6 +68,7 @@ export function snapshotSession(): {
       ...(m.themeName && { themeName: m.themeName }),
       ...(m.canvasLayout && { canvasLayout: m.canvasLayout }),
       ...(m.subPanel && { subPanel: m.subPanel }),
+      ...(m.browser && { browser: m.browser }),
     };
   });
   return { terminals: snappedTerminals, activeTerminalId };
@@ -279,6 +282,29 @@ export function setCanvasLayout(
   if (!entry) return;
   updateClientMetadata(entry, id, (m) => {
     m.canvasLayout = layout;
+  });
+}
+
+/** Attach or update the right-side browser region (#633).
+ *  Writes through the same client-metadata path as `canvasLayout` /
+ *  `subPanel` — publishes a metadata event and triggers session autosave. */
+export function setBrowserOnTerminal(
+  id: TerminalId,
+  browser: BrowserRegion,
+): void {
+  const entry = terminals.get(id);
+  if (!entry) return;
+  updateClientMetadata(entry, id, (m) => {
+    m.browser = browser;
+  });
+}
+
+/** Detach the browser region from a terminal. */
+export function clearBrowserOnTerminal(id: TerminalId): void {
+  const entry = terminals.get(id);
+  if (!entry) return;
+  updateClientMetadata(entry, id, (m) => {
+    m.browser = undefined;
   });
 }
 

--- a/packages/tests/features/browser-region.feature
+++ b/packages/tests/features/browser-region.feature
@@ -1,0 +1,34 @@
+Feature: Terminal-attached browser region (Phase 0 of #633)
+  Each terminal may carry a 0-or-1 right-side browser iframe. Opens via the
+  tile's "Open browser" chrome button (peer to "Split terminal"), dies with
+  the terminal, closes on its own × without affecting the terminal. Tile
+  identity is just a URL; protocol-less input is normalized to https://
+  so the iframe doesn't resolve relatively into Kolu itself.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Open browser button attaches a browser region to the terminal
+    When I click the open-browser button on canvas tile 1
+    Then a browser region should be visible on canvas tile 1
+    And there should be no page errors
+
+  Scenario: Committing a URL loads the iframe
+    When I click the open-browser button on canvas tile 1
+    And I enter "https://example.com" into the terminal's browser URL bar
+    Then the browser region iframe src should contain "example.com"
+    And there should be no page errors
+
+  Scenario: Protocol-less URLs normalize to https:// (no Kolu recursion)
+    When I click the open-browser button on canvas tile 1
+    And I enter "example.com" into the terminal's browser URL bar
+    Then the browser region iframe src should contain "https://example.com"
+    And there should be no page errors
+
+  Scenario: Closing the browser region leaves the terminal intact
+    When I click the open-browser button on canvas tile 1
+    Then a browser region should be visible on canvas tile 1
+    When I click the close button on the browser region of canvas tile 1
+    Then no browser region should be visible on canvas tile 1
+    And there should be 1 canvas tile
+    And there should be no page errors

--- a/packages/tests/features/browser-region.feature
+++ b/packages/tests/features/browser-region.feature
@@ -32,3 +32,10 @@ Feature: Terminal-attached browser region (Phase 0 of #633)
     Then no browser region should be visible on canvas tile 1
     And there should be 1 canvas tile
     And there should be no page errors
+
+  Scenario: Globe button toggles the browser region (open → close)
+    When I click the open-browser button on canvas tile 1
+    Then a browser region should be visible on canvas tile 1
+    When I click the open-browser button on canvas tile 1
+    Then no browser region should be visible on canvas tile 1
+    And there should be no page errors

--- a/packages/tests/step_definitions/browser_region_steps.ts
+++ b/packages/tests/step_definitions/browser_region_steps.ts
@@ -2,7 +2,7 @@ import { When, Then } from "@cucumber/cucumber";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
 const CANVAS_TILE = '[data-testid="canvas-tile"]';
-const OPEN_BROWSER_BUTTON = '[data-testid="tile-open-browser"]';
+const TOGGLE_BROWSER_BUTTON = '[data-testid="tile-toggle-browser"]';
 const BROWSER_REGION = '[data-testid="browser-region"]';
 const BROWSER_REGION_URL = '[data-testid="browser-region-url"]';
 const BROWSER_REGION_IFRAME = '[data-testid="browser-region-iframe"]';
@@ -14,7 +14,7 @@ When(
     const button = this.page
       .locator(CANVAS_TILE)
       .nth(index - 1)
-      .locator(OPEN_BROWSER_BUTTON);
+      .locator(TOGGLE_BROWSER_BUTTON);
     await button.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     await button.click();
     await this.waitForFrame();

--- a/packages/tests/step_definitions/browser_region_steps.ts
+++ b/packages/tests/step_definitions/browser_region_steps.ts
@@ -1,0 +1,104 @@
+import { When, Then } from "@cucumber/cucumber";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+
+const CANVAS_TILE = '[data-testid="canvas-tile"]';
+const OPEN_BROWSER_BUTTON = '[data-testid="tile-open-browser"]';
+const BROWSER_REGION = '[data-testid="browser-region"]';
+const BROWSER_REGION_URL = '[data-testid="browser-region-url"]';
+const BROWSER_REGION_IFRAME = '[data-testid="browser-region-iframe"]';
+const BROWSER_REGION_CLOSE = '[data-testid="browser-region-close"]';
+
+When(
+  "I click the open-browser button on canvas tile {int}",
+  async function (this: KoluWorld, index: number) {
+    const button = this.page
+      .locator(CANVAS_TILE)
+      .nth(index - 1)
+      .locator(OPEN_BROWSER_BUTTON);
+    await button.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await button.click();
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "a browser region should be visible on canvas tile {int}",
+  async function (this: KoluWorld, index: number) {
+    await this.page.waitForFunction(
+      ({
+        tileSel,
+        regionSel,
+        idx,
+      }: {
+        tileSel: string;
+        regionSel: string;
+        idx: number;
+      }) => {
+        const tile = document.querySelectorAll(tileSel)[idx - 1];
+        return tile?.querySelector(regionSel) !== null;
+      },
+      { tileSel: CANVAS_TILE, regionSel: BROWSER_REGION, idx: index },
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+Then(
+  "no browser region should be visible on canvas tile {int}",
+  async function (this: KoluWorld, index: number) {
+    await this.page.waitForFunction(
+      ({
+        tileSel,
+        regionSel,
+        idx,
+      }: {
+        tileSel: string;
+        regionSel: string;
+        idx: number;
+      }) => {
+        const tile = document.querySelectorAll(tileSel)[idx - 1];
+        return tile?.querySelector(regionSel) == null;
+      },
+      { tileSel: CANVAS_TILE, regionSel: BROWSER_REGION, idx: index },
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+When(
+  "I enter {string} into the terminal's browser URL bar",
+  async function (this: KoluWorld, url: string) {
+    const input = this.page.locator(BROWSER_REGION_URL).first();
+    await input.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await input.fill(url);
+    await input.press("Enter");
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the browser region iframe src should contain {string}",
+  async function (this: KoluWorld, needle: string) {
+    await this.page.waitForFunction(
+      ({ sel, needle }: { sel: string; needle: string }) => {
+        const iframe = document.querySelector<HTMLIFrameElement>(sel);
+        return iframe !== null && iframe.src.includes(needle);
+      },
+      { sel: BROWSER_REGION_IFRAME, needle },
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+When(
+  "I click the close button on the browser region of canvas tile {int}",
+  async function (this: KoluWorld, index: number) {
+    const button = this.page
+      .locator(CANVAS_TILE)
+      .nth(index - 1)
+      .locator(BROWSER_REGION_CLOSE);
+    await button.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await button.click();
+    await this.waitForFrame();
+  },
+);


### PR DESCRIPTION
A terminal tile may now carry a **0-or-1 right-side browser iframe**, peer to the existing bottom sub-panel. Click "Open browser →" on the tile's chrome (next to "Split terminal"); the iframe opens to the right, closes via its own × without touching the terminal, and dies with the terminal when it goes away. Protocol-less URLs (`news.ycombinator.com`) are normalized to `https://…` in the `resolveTileUrl` seam so the iframe never resolves relatively into Kolu itself.

**Phase 0 pivot.** This PR was originally a free-floating browser canvas tile. Hitting real-world `X-Frame-Options: DENY` from every git forge, SaaS, and bank meant most free-floating tiles showed the fallback UI rather than content, while the reliable case — previewing a dev server next to the terminal running `pnpm dev` — is exactly terminal-coupled. The original issue's "browser is NOT a sub-panel of a terminal" commitment is explicitly overridden on this empirical ground; Lowy agreed the tradeoff flipped (analysis in the comments). The force-push replaces the earlier cut wholesale. See the initial `## Phase 0 pivot` comment below for the full reasoning.

**Architecture.** `BrowserRegionSchema { url, collapsed, panelSize }` lives on `TerminalClientMetadata.browser?`, shaped exactly like the existing `subPanel` optional. Three new `terminal.*` RPC methods (`setBrowser`, `clearBrowser`, `probeBrowserUrl`) replace the prior `browserTile.*` namespace. The browser's URL arrives through the existing `onMetadataChange` stream — no parallel subscription, no separate saved-session array, no tile-kind dispatch. Canvas is back to `TerminalId[]` throughout. *Layout-wise*, `TerminalContent` grows an outer horizontal `<Resizable>` that degenerates to zero overhead when no browser is attached.

**Carryovers from the earlier cut.** The `resolveTileUrl` seam (unchanged — Phase 1 edits its body), `parseFramingHeaders` + `probeFraming` (now `browserProbe.ts`), the iframe + XFO/CSP fallback UI, the URL-bar chrome. These were the genuinely portable pieces; the rest (free-floating canvas citizenship, parallel store, browser-tile contract) is gone.

> **Schema migration 1.18.0** strips the obsolete `browserTiles` key from saved sessions. Users who opened a Phase 0 browser tile on an in-flight build lose that URL on upgrade — acceptable because the feature was unreleased.

Closes #633 (Phase 0). Phase 1 (Hono localhost proxy) and Phase 2 (port discovery from stdout) follow on the same seam.

### Try it locally

```sh
nix run github:juspay/kolu/out-lust
```