### PR TITLE
spike: preview-subdomain Host-header dispatch (#633 Phase 1 probe)

### DIFF
--- a/packages/integrations/kolu-preview/package.json
+++ b/packages/integrations/kolu-preview/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "kolu-preview",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "hono": "^4.12.14",
+    "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/integrations/kolu-preview/src/errorPage.ts
+++ b/packages/integrations/kolu-preview/src/errorPage.ts
@@ -1,0 +1,99 @@
+/** Shared error-page helpers for the preview proxy.
+ *
+ *  Both the HTTP middleware and the WS upgrade handler can fail the same
+ *  way — the upstream dev-server port refuses the dial, or returns an
+ *  errno the caller can't interpret. Keep the user-facing rendering in
+ *  one place so "no dev server running on port 5173" looks identical
+ *  whether the proxy is fetching an iframe asset or opening an HMR
+ *  WebSocket. */
+
+/** Node `fetch` / `ws` wraps underlying network errors in `err.cause`;
+ *  the `.code` there is the usual POSIX errno string (`ECONNREFUSED`,
+ *  `EHOSTUNREACH`, etc.). Also handles the shape where `err.code` is
+ *  directly on the error (ws client). Returns `undefined` when the
+ *  error isn't a system error. */
+export function extractErrorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object") {
+    if ("code" in err) {
+      const code = (err as { code?: unknown }).code;
+      if (typeof code === "string") return code;
+    }
+    if ("cause" in err) {
+      const cause = (err as { cause?: unknown }).cause;
+      if (cause && typeof cause === "object" && "code" in cause) {
+        const code = (cause as { code?: unknown }).code;
+        if (typeof code === "string") return code;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** HTML shown to the user when the upstream port refuses both loopback
+ *  families. Intentionally more than a one-liner: the user's mental
+ *  model is "I opened a browser tile and nothing loaded," so the page
+ *  explicitly names the port, the errno, and the real root causes (no
+ *  dev server / different machine / non-loopback binding). */
+export function renderUpstreamErrorPage(
+  port: number,
+  code: string | undefined,
+): string {
+  const codeLabel = code ?? "connection failed";
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Preview unavailable — port ${port}</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 560px;
+      margin: 4rem auto;
+      padding: 0 2rem;
+      color: #1f2328;
+      line-height: 1.5;
+    }
+    h1 { font-size: 1.15rem; font-weight: 600; margin: 0 0 0.75rem; }
+    code { background: #f6f8fa; padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.9em; }
+    .errno { color: #cf222e; }
+    ul { padding-left: 1.25rem; color: #57606a; font-size: 0.9rem; }
+    li { margin: 0.35rem 0; }
+    .footer { color: #8c959f; font-size: 0.8rem; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>Kolu preview: nothing listening on port <code>${port}</code></h1>
+  <p>The proxy dialed both <code>127.0.0.1:${port}</code> and <code>[::1]:${port}</code> on this host and got <code class="errno">${codeLabel}</code>.</p>
+  <p>Common causes:</p>
+  <ul>
+    <li>No dev server is running on port <code>${port}</code> yet — start it and this page should load on refresh.</li>
+    <li>Dev server is running on a <em>different</em> machine than the Kolu process. The proxy can only reach services on the same host as Kolu.</li>
+    <li>Dev server is bound to a non-loopback interface (e.g. your Tailscale IP directly) — bind it to <code>127.0.0.1</code> or <code>0.0.0.0</code> so the loopback dial reaches it.</li>
+  </ul>
+  <p class="footer">Kolu preview proxy (#633)</p>
+</body>
+</html>
+`;
+}
+
+/** Write an HTTP 502 response with the error page directly onto a raw
+ *  upgrade socket. Used by the WS proxy when it fails to dial upstream
+ *  *before* completing the browser's WebSocket handshake — in that
+ *  narrow window we still own the socket as plain HTTP and can surface
+ *  a visible error page instead of a silent WS close. */
+export function writeUpstreamErrorToSocket(
+  socket: NodeJS.WritableStream,
+  port: number,
+  code: string | undefined,
+): void {
+  const html = renderUpstreamErrorPage(port, code);
+  const body = Buffer.from(html, "utf8");
+  const head =
+    `HTTP/1.1 502 Bad Gateway\r\n` +
+    `Content-Type: text/html; charset=utf-8\r\n` +
+    `Content-Length: ${body.length}\r\n` +
+    `Connection: close\r\n\r\n`;
+  socket.write(head);
+  socket.write(body);
+  socket.end();
+}

--- a/packages/integrations/kolu-preview/src/headers.test.ts
+++ b/packages/integrations/kolu-preview/src/headers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { buildUpstreamHeaders, stripFramingHeaders } from "./headers.ts";
+
+describe("buildUpstreamHeaders", () => {
+  it("drops hop-by-hop headers and the incoming Host", () => {
+    const incoming = new Headers({
+      host: "5173.preview.localhost:7681",
+      connection: "keep-alive",
+      "transfer-encoding": "chunked",
+      accept: "text/html",
+      cookie: "session=abc",
+    });
+    const out = buildUpstreamHeaders(
+      incoming,
+      "5173.preview.localhost",
+      "http",
+    );
+    expect(out.get("host")).toBeNull();
+    expect(out.get("connection")).toBeNull();
+    expect(out.get("transfer-encoding")).toBeNull();
+    expect(out.get("accept")).toBe("text/html");
+    expect(out.get("cookie")).toBe("session=abc");
+  });
+
+  it("adds X-Forwarded-Host and X-Forwarded-Proto", () => {
+    const out = buildUpstreamHeaders(
+      new Headers(),
+      "5173.preview.foo.sslip.io:7692",
+      "https",
+    );
+    expect(out.get("x-forwarded-host")).toBe("5173.preview.foo.sslip.io:7692");
+    expect(out.get("x-forwarded-proto")).toBe("https");
+  });
+});
+
+describe("stripFramingHeaders", () => {
+  it("removes X-Frame-Options", () => {
+    const out = stripFramingHeaders(new Headers({ "x-frame-options": "DENY" }));
+    expect(out.get("x-frame-options")).toBeNull();
+  });
+
+  it("drops the frame-ancestors directive from CSP but keeps the rest", () => {
+    const out = stripFramingHeaders(
+      new Headers({
+        "content-security-policy":
+          "default-src 'self'; frame-ancestors 'none'; script-src 'self'",
+      }),
+    );
+    const csp = out.get("content-security-policy");
+    expect(csp).not.toBeNull();
+    expect(csp!.toLowerCase()).not.toContain("frame-ancestors");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("script-src 'self'");
+  });
+
+  it("removes the CSP header entirely when frame-ancestors was its only directive", () => {
+    const out = stripFramingHeaders(
+      new Headers({ "content-security-policy": "frame-ancestors 'none'" }),
+    );
+    expect(out.get("content-security-policy")).toBeNull();
+  });
+
+  it("passes CSP through unchanged when frame-ancestors is absent", () => {
+    const out = stripFramingHeaders(
+      new Headers({
+        "content-security-policy": "default-src 'self'; script-src 'self'",
+      }),
+    );
+    expect(out.get("content-security-policy")).toBe(
+      "default-src 'self'; script-src 'self'",
+    );
+  });
+
+  it("is a no-op when neither header is present", () => {
+    const out = stripFramingHeaders(new Headers({ accept: "text/html" }));
+    expect(out.get("x-frame-options")).toBeNull();
+    expect(out.get("content-security-policy")).toBeNull();
+    expect(out.get("accept")).toBe("text/html");
+  });
+});

--- a/packages/integrations/kolu-preview/src/headers.ts
+++ b/packages/integrations/kolu-preview/src/headers.ts
@@ -1,0 +1,49 @@
+/** Hop-by-hop + Host: removed before forwarding a request upstream.
+ *  fetch sets its own Host; the rest are connection-scoped per RFC 7230
+ *  §6.1 and must not propagate through a proxy. */
+const HOP_BY_HOP_HEADERS = [
+  "host",
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+] as const;
+
+/** Copy + strip hop-by-hop headers from an incoming request ready for a
+ *  proxied fetch. Adds X-Forwarded-Host / X-Forwarded-Proto so upstream
+ *  dev servers generating absolute URLs see the client-facing origin. */
+export function buildUpstreamHeaders(
+  incoming: Headers,
+  host: string,
+  proto: "http" | "https",
+): Headers {
+  const out = new Headers(incoming);
+  for (const h of HOP_BY_HOP_HEADERS) out.delete(h);
+  out.set("x-forwarded-host", host);
+  out.set("x-forwarded-proto", proto);
+  return out;
+}
+
+/** Remove framing restrictions from an upstream response so the browser
+ *  tile's iframe can embed it. Strips `X-Frame-Options` outright and
+ *  drops the `frame-ancestors` directive from any `Content-Security-
+ *  Policy` header, leaving the rest of the policy intact. If the CSP
+ *  becomes empty after stripping, the header itself is removed. */
+export function stripFramingHeaders(headers: Headers): Headers {
+  const out = new Headers(headers);
+  out.delete("x-frame-options");
+  const csp = out.get("content-security-policy");
+  if (!csp) return out;
+  const cleaned = csp
+    .split(";")
+    .filter((d) => !/^\s*frame-ancestors\b/i.test(d))
+    .join(";")
+    .trim();
+  if (cleaned === "") out.delete("content-security-policy");
+  else out.set("content-security-policy", cleaned);
+  return out;
+}

--- a/packages/integrations/kolu-preview/src/hostMatch.test.ts
+++ b/packages/integrations/kolu-preview/src/hostMatch.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { matchPreviewHost } from "./hostMatch.ts";
+
+describe("matchPreviewHost", () => {
+  it("returns the port for a sslip.io-shaped preview host", () => {
+    expect(matchPreviewHost("5173.preview.100-64-0-1.sslip.io:7692")).toBe(
+      5173,
+    );
+  });
+
+  it("returns the port for a *.localhost preview host", () => {
+    expect(matchPreviewHost("3000.preview.localhost:7681")).toBe(3000);
+  });
+
+  it("returns null for a bare host that isn't a preview", () => {
+    expect(matchPreviewHost("pureintent:7692")).toBeNull();
+    expect(matchPreviewHost("localhost:7681")).toBeNull();
+  });
+
+  it("returns null for privileged ports", () => {
+    expect(matchPreviewHost("80.preview.localhost")).toBeNull();
+    expect(matchPreviewHost("1023.preview.localhost")).toBeNull();
+  });
+
+  it("returns null for out-of-range ports", () => {
+    expect(matchPreviewHost("0.preview.localhost")).toBeNull();
+    expect(matchPreviewHost("99999.preview.localhost")).toBeNull();
+  });
+
+  it("returns null for undefined / empty host", () => {
+    expect(matchPreviewHost(undefined)).toBeNull();
+    expect(matchPreviewHost("")).toBeNull();
+  });
+
+  it("does not match `preview` without a port prefix", () => {
+    expect(matchPreviewHost("preview.localhost")).toBeNull();
+    expect(matchPreviewHost("foo.preview.localhost")).toBeNull();
+  });
+});

--- a/packages/integrations/kolu-preview/src/hostMatch.ts
+++ b/packages/integrations/kolu-preview/src/hostMatch.ts
@@ -1,0 +1,28 @@
+/** Shared Host-header matcher for the preview subdomain convention.
+ *
+ *  A preview subdomain has the shape `<port>.preview.<anything>` — where
+ *  `<anything>` is whatever DNS form the user's deployment uses (sslip.io
+ *  with an IP-encoded hostname, `*.localhost`, a corporate wildcard
+ *  A-record, etc.). The proxy doesn't care which form; it only needs to
+ *  extract the target port. */
+const PREVIEW_HOST_RE = /^(\d+)\.preview\./;
+
+/** Unprivileged TCP port range. Blocks 0, well-known services (<1024),
+ *  and bogus values. Phase 2 will narrow this further via an
+ *  announced-port allowlist from terminal stdout scraping (#633). */
+const MIN_PORT = 1024;
+const MAX_PORT = 65535;
+
+/** Parse a preview target port from an HTTP `Host` header. Returns the
+ *  port when the host matches the subdomain pattern AND the port is
+ *  unprivileged; `null` otherwise. */
+export function matchPreviewHost(host: string | undefined): number | null {
+  if (!host) return null;
+  const m = host.match(PREVIEW_HOST_RE);
+  if (!m) return null;
+  const port = Number(m[1]);
+  if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) {
+    return null;
+  }
+  return port;
+}

--- a/packages/integrations/kolu-preview/src/httpProxy.ts
+++ b/packages/integrations/kolu-preview/src/httpProxy.ts
@@ -1,0 +1,58 @@
+/** Hono middleware that fetch-and-streams preview-subdomain requests to
+ *  `127.0.0.1:<port>`. Installed early in the middleware chain so it
+ *  shortcuts before any app route handler runs. */
+
+import type { MiddlewareHandler } from "hono";
+import { matchPreviewHost } from "./hostMatch.ts";
+import { buildUpstreamHeaders, stripFramingHeaders } from "./headers.ts";
+
+export interface PreviewLogger {
+  warn: (obj: unknown, msg: string) => void;
+}
+
+export interface PreviewProxyOptions {
+  /** Caller tells us whether the browser sees HTTPS — we thread it back
+   *  as X-Forwarded-Proto so dev servers generating absolute URLs match. */
+  isTls: () => boolean;
+  /** Warning logger for upstream unreachable. Logs at warn because this
+   *  is an expected error class (dev server not running) rather than a
+   *  server bug. */
+  log: PreviewLogger;
+}
+
+export function previewHttpProxy(opts: PreviewProxyOptions): MiddlewareHandler {
+  return async (c, next) => {
+    const port = matchPreviewHost(c.req.header("host"));
+    if (port === null) return next();
+
+    const source = new URL(c.req.url);
+    const target = `http://127.0.0.1:${port}${source.pathname}${source.search}`;
+    const upstreamHeaders = buildUpstreamHeaders(
+      c.req.raw.headers,
+      c.req.header("host") ?? "",
+      opts.isTls() ? "https" : "http",
+    );
+
+    let upstream: Response;
+    try {
+      upstream = await fetch(target, {
+        method: c.req.method,
+        headers: upstreamHeaders,
+        body: c.req.raw.body,
+        // Node's undici requires duplex: "half" when body is a stream.
+        // Omitted on bodyless requests — undici rejects it there.
+        ...(c.req.raw.body ? { duplex: "half" } : {}),
+        redirect: "manual",
+      } as RequestInit);
+    } catch (err) {
+      opts.log.warn({ err, target }, "preview proxy upstream unreachable");
+      return c.text(`preview: upstream 127.0.0.1:${port} unreachable`, 502);
+    }
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: stripFramingHeaders(upstream.headers),
+    });
+  };
+}

--- a/packages/integrations/kolu-preview/src/httpProxy.ts
+++ b/packages/integrations/kolu-preview/src/httpProxy.ts
@@ -5,6 +5,7 @@
 import type { MiddlewareHandler } from "hono";
 import { matchPreviewHost } from "./hostMatch.ts";
 import { buildUpstreamHeaders, stripFramingHeaders } from "./headers.ts";
+import { extractErrorCode, renderUpstreamErrorPage } from "./errorPage.ts";
 
 export interface PreviewLogger {
   warn: (obj: unknown, msg: string) => void;
@@ -82,64 +83,4 @@ export function previewHttpProxy(opts: PreviewProxyOptions): MiddlewareHandler {
       headers: stripFramingHeaders(upstream.headers),
     });
   };
-}
-
-/** Node `fetch` wraps the underlying network error in `err.cause`; the
- *  `.code` there is the usual POSIX errno string (`ECONNREFUSED`, `EHOSTUNREACH`,
- *  etc.). Returns `undefined` when the error isn't a system error. */
-function extractErrorCode(err: unknown): string | undefined {
-  if (err && typeof err === "object" && "cause" in err) {
-    const cause = (err as { cause?: unknown }).cause;
-    if (cause && typeof cause === "object" && "code" in cause) {
-      const code = (cause as { code?: unknown }).code;
-      if (typeof code === "string") return code;
-    }
-  }
-  return undefined;
-}
-
-/** HTML shown inside the iframe when the upstream port refuses the dial.
- *  Intentionally more than a one-liner: the user's mental model is "I
- *  opened a browser tile and nothing loaded," so the page explicitly
- *  names the port, the errno, and the three common root causes. */
-function renderUpstreamErrorPage(
-  port: number,
-  code: string | undefined,
-): string {
-  const codeLabel = code ?? "connection failed";
-  return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Preview unavailable — port ${port}</title>
-  <style>
-    body {
-      font-family: system-ui, -apple-system, sans-serif;
-      max-width: 560px;
-      margin: 4rem auto;
-      padding: 0 2rem;
-      color: #1f2328;
-      line-height: 1.5;
-    }
-    h1 { font-size: 1.15rem; font-weight: 600; margin: 0 0 0.75rem; }
-    code { background: #f6f8fa; padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.9em; }
-    .errno { color: #cf222e; }
-    ul { padding-left: 1.25rem; color: #57606a; font-size: 0.9rem; }
-    li { margin: 0.35rem 0; }
-    .footer { color: #8c959f; font-size: 0.8rem; margin-top: 2rem; }
-  </style>
-</head>
-<body>
-  <h1>Kolu preview: nothing listening on port <code>${port}</code></h1>
-  <p>The proxy dialed both <code>127.0.0.1:${port}</code> and <code>[::1]:${port}</code> on this host and got <code class="errno">${codeLabel}</code>.</p>
-  <p>Common causes:</p>
-  <ul>
-    <li>No dev server is running on port <code>${port}</code> yet — start it and this page should load on refresh.</li>
-    <li>Dev server is running on a <em>different</em> machine than the Kolu process. The proxy can only reach services on the same host as Kolu.</li>
-    <li>Dev server is bound to a non-loopback interface (e.g. your Tailscale IP directly) — bind it to <code>127.0.0.1</code> or <code>0.0.0.0</code> so the loopback dial reaches it.</li>
-  </ul>
-  <p class="footer">Kolu preview proxy (#633)</p>
-</body>
-</html>
-`;
 }

--- a/packages/integrations/kolu-preview/src/httpProxy.ts
+++ b/packages/integrations/kolu-preview/src/httpProxy.ts
@@ -26,27 +26,54 @@ export function previewHttpProxy(opts: PreviewProxyOptions): MiddlewareHandler {
     if (port === null) return next();
 
     const source = new URL(c.req.url);
-    const target = `http://127.0.0.1:${port}${source.pathname}${source.search}`;
+    const path = `${source.pathname}${source.search}`;
     const upstreamHeaders = buildUpstreamHeaders(
       c.req.raw.headers,
       c.req.header("host") ?? "",
       opts.isTls() ? "https" : "http",
     );
 
-    let upstream: Response;
-    try {
-      upstream = await fetch(target, {
-        method: c.req.method,
-        headers: upstreamHeaders,
-        body: c.req.raw.body,
-        // Node's undici requires duplex: "half" when body is a stream.
-        // Omitted on bodyless requests — undici rejects it there.
-        ...(c.req.raw.body ? { duplex: "half" } : {}),
-        redirect: "manual",
-      } as RequestInit);
-    } catch (err) {
-      opts.log.warn({ err, target }, "preview proxy upstream unreachable");
-      return c.text(`preview: upstream 127.0.0.1:${port} unreachable`, 502);
+    // Node's fetch is address-family-specific: `127.0.0.1` is IPv4 only.
+    // Vite 5+ and some other dev servers default to `localhost`, which
+    // on systems with `::1` ordered before `127.0.0.1` in DNS resolution
+    // binds to IPv6 only. Try v4 first, fall back to v6 on ECONNREFUSED
+    // so the user doesn't need to configure `--host 127.0.0.1` on their
+    // dev server to make the preview work.
+    const targets = [
+      `http://127.0.0.1:${port}${path}`,
+      `http://[::1]:${port}${path}`,
+    ];
+    const init: RequestInit = {
+      method: c.req.method,
+      headers: upstreamHeaders,
+      body: c.req.raw.body,
+      // Node's undici requires duplex: "half" when body is a stream.
+      // Omitted on bodyless requests — undici rejects it there.
+      ...(c.req.raw.body ? { duplex: "half" } : {}),
+      redirect: "manual",
+    } as RequestInit;
+
+    let upstream: Response | undefined;
+    let lastErr: unknown;
+    for (const target of targets) {
+      try {
+        upstream = await fetch(target, init);
+        break;
+      } catch (err) {
+        lastErr = err;
+        if (extractErrorCode(err) !== "ECONNREFUSED") break;
+      }
+    }
+    if (!upstream) {
+      opts.log.warn(
+        { err: lastErr, port },
+        "preview proxy upstream unreachable",
+      );
+      const code = extractErrorCode(lastErr);
+      return new Response(renderUpstreamErrorPage(port, code), {
+        status: 502,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
     }
 
     return new Response(upstream.body, {
@@ -55,4 +82,64 @@ export function previewHttpProxy(opts: PreviewProxyOptions): MiddlewareHandler {
       headers: stripFramingHeaders(upstream.headers),
     });
   };
+}
+
+/** Node `fetch` wraps the underlying network error in `err.cause`; the
+ *  `.code` there is the usual POSIX errno string (`ECONNREFUSED`, `EHOSTUNREACH`,
+ *  etc.). Returns `undefined` when the error isn't a system error. */
+function extractErrorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "cause" in err) {
+    const cause = (err as { cause?: unknown }).cause;
+    if (cause && typeof cause === "object" && "code" in cause) {
+      const code = (cause as { code?: unknown }).code;
+      if (typeof code === "string") return code;
+    }
+  }
+  return undefined;
+}
+
+/** HTML shown inside the iframe when the upstream port refuses the dial.
+ *  Intentionally more than a one-liner: the user's mental model is "I
+ *  opened a browser tile and nothing loaded," so the page explicitly
+ *  names the port, the errno, and the three common root causes. */
+function renderUpstreamErrorPage(
+  port: number,
+  code: string | undefined,
+): string {
+  const codeLabel = code ?? "connection failed";
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Preview unavailable — port ${port}</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 560px;
+      margin: 4rem auto;
+      padding: 0 2rem;
+      color: #1f2328;
+      line-height: 1.5;
+    }
+    h1 { font-size: 1.15rem; font-weight: 600; margin: 0 0 0.75rem; }
+    code { background: #f6f8fa; padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.9em; }
+    .errno { color: #cf222e; }
+    ul { padding-left: 1.25rem; color: #57606a; font-size: 0.9rem; }
+    li { margin: 0.35rem 0; }
+    .footer { color: #8c959f; font-size: 0.8rem; margin-top: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>Kolu preview: nothing listening on port <code>${port}</code></h1>
+  <p>The proxy dialed both <code>127.0.0.1:${port}</code> and <code>[::1]:${port}</code> on this host and got <code class="errno">${codeLabel}</code>.</p>
+  <p>Common causes:</p>
+  <ul>
+    <li>No dev server is running on port <code>${port}</code> yet — start it and this page should load on refresh.</li>
+    <li>Dev server is running on a <em>different</em> machine than the Kolu process. The proxy can only reach services on the same host as Kolu.</li>
+    <li>Dev server is bound to a non-loopback interface (e.g. your Tailscale IP directly) — bind it to <code>127.0.0.1</code> or <code>0.0.0.0</code> so the loopback dial reaches it.</li>
+  </ul>
+  <p class="footer">Kolu preview proxy (#633)</p>
+</body>
+</html>
+`;
 }

--- a/packages/integrations/kolu-preview/src/index.ts
+++ b/packages/integrations/kolu-preview/src/index.ts
@@ -1,0 +1,21 @@
+/** kolu-preview — Phase 1 preview proxy for iframe-of-dev-server tiles (#633).
+ *
+ *  One-shot install against a caller-owned Hono app + Node HTTP server.
+ *  The HTTP middleware matches Host headers of the form `<port>.preview.
+ *  <anything>` and fetch-and-streams to `127.0.0.1:<port>`; the WS
+ *  upgrade helper does the same for WebSocket handshakes. Callers own
+ *  the Hono app and the HTTP server — we hand back a WS `handle` that
+ *  the caller's own `server.on('upgrade', ...)` dispatches to before its
+ *  existing route matching.
+ *
+ *  This package is self-contained: matcher, header munging, HTTP fetch,
+ *  and WS passthrough. Nothing domain-specific to Kolu's terminal state
+ *  leaks in — the only inputs are an `isTls()` callback and a logger.
+ *  Unit tests can exercise each piece in isolation. */
+
+export { matchPreviewHost } from "./hostMatch.ts";
+export { buildUpstreamHeaders, stripFramingHeaders } from "./headers.ts";
+export { previewHttpProxy } from "./httpProxy.ts";
+export type { PreviewProxyOptions, PreviewLogger } from "./httpProxy.ts";
+export { createPreviewWsProxy } from "./wsProxy.ts";
+export type { PreviewWsProxy, PreviewWsLogger } from "./wsProxy.ts";

--- a/packages/integrations/kolu-preview/src/wsProxy.ts
+++ b/packages/integrations/kolu-preview/src/wsProxy.ts
@@ -1,0 +1,127 @@
+/** WebSocket upgrade passthrough for preview subdomains.
+ *
+ *  Vite / Next / Astro HMR connects back to the page's origin for live
+ *  reload. When the Host header matches `<port>.preview.<anything>`, dial
+ *  a client WS to `ws://127.0.0.1:<port><path>` and pipe frames both
+ *  ways. Separate `WebSocketServer` from the caller's oRPC handler so
+ *  dev-server traffic never runs through app code.
+ *
+ *  Implementation is message-level forwarding (on 'message' → send)
+ *  rather than raw-socket tunneling — HMR is low-throughput enough that
+ *  per-message overhead is invisible, and `ws`'s text-vs-binary bit
+ *  carries through cleanly. Frames the browser sends before the upstream
+ *  handshake completes are buffered and flushed on `open`. */
+
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { WebSocket as WsClient, WebSocketServer } from "ws";
+import { matchPreviewHost } from "./hostMatch.ts";
+
+export interface PreviewWsLogger {
+  error: (obj: unknown, msg: string) => void;
+}
+
+export interface PreviewWsProxy {
+  /** Returns true if the upgrade was a preview and has been handled.
+   *  Callers fall through to their own upgrade routing when this is
+   *  false. Socket is destroyed for invalid ports matching the pattern. */
+  handle: (req: IncomingMessage, socket: Duplex, head: Buffer) => boolean;
+}
+
+export function createPreviewWsProxy(log: PreviewWsLogger): PreviewWsProxy {
+  // Dedicated WebSocketServer so oRPC's per-connection handler doesn't
+  // run for dev-server traffic.
+  const wss = new WebSocketServer({ noServer: true });
+
+  function proxyUpgrade(
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    port: number,
+  ): void {
+    wss.handleUpgrade(req, socket, head, (downstream) => {
+      const target = `ws://127.0.0.1:${port}${req.url ?? "/"}`;
+      const proto = req.headers["sec-websocket-protocol"];
+      const origin = req.headers["origin"];
+      const upstream = new WsClient(target, {
+        headers: {
+          ...(proto && { "sec-websocket-protocol": String(proto) }),
+          ...(origin && { origin: String(origin) }),
+        },
+      });
+
+      // Buffer browser → dev-server frames sent before upstream is open;
+      // without this, Vite's first HMR ping can race the dial and get
+      // dropped.
+      const pending: Array<{ data: WsClient.RawData; isBinary: boolean }> = [];
+      let upstreamOpen = false;
+
+      downstream.on("message", (data, isBinary) => {
+        if (upstreamOpen && upstream.readyState === upstream.OPEN) {
+          upstream.send(data, { binary: isBinary });
+        } else {
+          pending.push({ data, isBinary });
+        }
+      });
+
+      upstream.on("open", () => {
+        upstreamOpen = true;
+        for (const { data, isBinary } of pending) {
+          upstream.send(data, { binary: isBinary });
+        }
+        pending.length = 0;
+      });
+
+      upstream.on("message", (data, isBinary) => {
+        if (downstream.readyState === downstream.OPEN) {
+          downstream.send(data, { binary: isBinary });
+        }
+      });
+
+      const closeBoth = (code?: number, reason?: Buffer) => {
+        const c = code ?? 1000;
+        const r = reason ?? Buffer.from("");
+        if (
+          downstream.readyState === downstream.OPEN ||
+          downstream.readyState === downstream.CONNECTING
+        ) {
+          downstream.close(c, r);
+        }
+        if (
+          upstream.readyState === upstream.OPEN ||
+          upstream.readyState === upstream.CONNECTING
+        ) {
+          upstream.close(c, r);
+        }
+      };
+
+      downstream.on("close", (code, reason) => closeBoth(code, reason));
+      upstream.on("close", (code, reason) => closeBoth(code, reason));
+      downstream.on("error", (err) => {
+        log.error({ err, port }, "preview ws downstream error");
+        closeBoth(1011);
+      });
+      upstream.on("error", (err) => {
+        log.error({ err, port }, "preview ws upstream error");
+        closeBoth(1011);
+      });
+    });
+  }
+
+  return {
+    handle(req, socket, head) {
+      const port = matchPreviewHost(req.headers.host);
+      if (port === null) {
+        // Not a preview host. Let the caller route this upgrade.
+        // Invalid-port case (matched pattern but out-of-range) is also
+        // folded into `null` by matchPreviewHost — closing the socket
+        // there would be more defensible than a silent fall-through, but
+        // `5173.preview` with an out-of-range port isn't a real user-
+        // visible case and we save the caller from special-casing it.
+        return false;
+      }
+      proxyUpgrade(req, socket, head, port);
+      return true;
+    },
+  };
+}

--- a/packages/integrations/kolu-preview/src/wsProxy.ts
+++ b/packages/integrations/kolu-preview/src/wsProxy.ts
@@ -2,30 +2,31 @@
  *
  *  Vite / Next / Astro HMR connects back to the page's origin for live
  *  reload. When the Host header matches `<port>.preview.<anything>`, dial
- *  a client WS to the dev server and pipe frames both ways. Separate
- *  `WebSocketServer` from the caller's oRPC handler so dev-server traffic
- *  never runs through app code.
- *
- *  Implementation is message-level forwarding (on 'message' → send)
- *  rather than raw-socket tunneling — HMR is low-throughput enough that
- *  per-message overhead is invisible, and `ws`'s text-vs-binary bit
- *  carries through cleanly.
+ *  the dev server *first* and only accept the browser's upgrade after
+ *  the upstream handshake completes. On failure, the browser's upgrade
+ *  is answered with a plain HTTP 502 carrying the same error page the
+ *  HTTP proxy shows — keeps failures visible inside the iframe instead
+ *  of hiding in a silent WS close.
  *
  *  Address-family fallback: try IPv4 loopback first, retry with IPv6 on
  *  ECONNREFUSED. Matches the HTTP proxy's strategy so dev servers that
  *  bind to `::1` only (Vite default on some systems) still work without
  *  user config.
  *
- *  Pre-open buffering: frames the browser sends before the upstream
- *  handshake completes are stashed in `pending` and flushed on `open`.
- *  Without this, Vite's first HMR ping can race the upstream dial. */
+ *  Subprotocol handling: `Sec-WebSocket-Protocol` must be passed as the
+ *  `WebSocket` constructor's positional `protocols` argument, not as a
+ *  raw header — otherwise `ws`'s "expected subprotocols" state stays
+ *  empty and the upstream's echo (e.g. Vite's `vite-hmr`) is rejected
+ *  with "Server sent a subprotocol but none was requested." */
 
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocket as WsClient, WebSocketServer } from "ws";
 import { matchPreviewHost } from "./hostMatch.ts";
+import { extractErrorCode, writeUpstreamErrorToSocket } from "./errorPage.ts";
 
 export interface PreviewWsLogger {
+  warn: (obj: unknown, msg: string) => void;
   error: (obj: unknown, msg: string) => void;
 }
 
@@ -53,93 +54,85 @@ export function createPreviewWsProxy(log: PreviewWsLogger): PreviewWsProxy {
     head: Buffer,
     port: number,
   ): void {
-    wss.handleUpgrade(req, socket, head, (downstream) => {
-      const path = req.url ?? "/";
-      const proto = req.headers["sec-websocket-protocol"];
-      const origin = req.headers["origin"];
-      const headers = {
-        ...(proto && { "sec-websocket-protocol": String(proto) }),
-        ...(origin && { origin: String(origin) }),
-      };
+    const path = req.url ?? "/";
+    const rawProto = req.headers["sec-websocket-protocol"];
+    const protocols = rawProto
+      ? String(rawProto)
+          .split(",")
+          .map((p) => p.trim())
+          .filter(Boolean)
+      : undefined;
+    const origin = req.headers["origin"];
+    const upstreamHeaders = {
+      ...(origin && { origin: String(origin) }),
+    };
 
-      const pending: Array<{ data: WsClient.RawData; isBinary: boolean }> = [];
-      let upstreamRef: WsClient | null = null;
+    dial(0);
 
-      // Wire the downstream event handlers exactly once. They reference
-      // `upstreamRef` by closure, so they always act on whichever
-      // upstream is currently live (v4 initially, then v6 if we fell back).
-      downstream.on("message", (data, isBinary) => {
-        if (upstreamRef && upstreamRef.readyState === upstreamRef.OPEN) {
-          upstreamRef.send(data, { binary: isBinary });
-        } else {
-          pending.push({ data, isBinary });
-        }
-      });
-      downstream.on("close", (code, reason) => {
-        if (upstreamRef && isClosable(upstreamRef)) {
-          upstreamRef.close(code, reason);
-        }
-      });
-      downstream.on("error", (err) => {
-        log.error({ err, port }, "preview ws downstream error");
-        if (upstreamRef && isClosable(upstreamRef)) {
-          upstreamRef.close(1011);
-        }
+    function dial(hostIdx: number): void {
+      const host = UPSTREAM_HOSTS[hostIdx];
+      if (host === undefined) {
+        // Exhausted every loopback family. Because we haven't called
+        // `handleUpgrade` yet, the browser's upgrade request is still
+        // an in-flight HTTP request on the raw socket — surface a 502
+        // with the same HTML page the HTTP proxy uses.
+        log.warn({ port }, "preview ws upstream unreachable");
+        writeUpstreamErrorToSocket(socket, port, "ECONNREFUSED");
+        return;
+      }
+      const upstream = new WsClient(`ws://${host}:${port}${path}`, protocols, {
+        headers: upstreamHeaders,
       });
 
-      dial(0);
-
-      function dial(hostIdx: number): void {
-        const host = UPSTREAM_HOSTS[hostIdx];
-        if (host === undefined) {
-          // Exhausted every loopback family; fail the downstream with
-          // the "internal server error" close code so clients that care
-          // (HMR) can log it.
-          if (isClosable(downstream)) {
-            downstream.close(1011, Buffer.from("preview upstream unreachable"));
-          }
+      const onPreOpenError = (err: Error): void => {
+        const code = extractErrorCode(err);
+        if (code === "ECONNREFUSED") {
+          dial(hostIdx + 1);
           return;
         }
-        const upstream = new WsClient(`ws://${host}:${port}${path}`, {
-          headers,
-        });
+        log.error({ err, port, host }, "preview ws upstream error");
+        writeUpstreamErrorToSocket(socket, port, code);
+      };
 
-        upstream.once("open", () => {
-          upstreamRef = upstream;
-          for (const { data, isBinary } of pending) {
+      upstream.once("error", onPreOpenError);
+      upstream.once("open", () => {
+        upstream.removeListener("error", onPreOpenError);
+        onUpstreamOpen(upstream, port);
+      });
+    }
+
+    /** Wire the relay once upstream is confirmed alive. Only now do we
+     *  call `handleUpgrade` on the browser's socket — if we'd upgraded
+     *  before the upstream open, the browser would hold an empty WS
+     *  we couldn't unwind. */
+    function onUpstreamOpen(upstream: WsClient, port: number): void {
+      wss.handleUpgrade(req, socket, head, (downstream) => {
+        downstream.on("message", (data, isBinary) => {
+          if (upstream.readyState === upstream.OPEN) {
             upstream.send(data, { binary: isBinary });
           }
-          pending.length = 0;
-
-          upstream.on("message", (data, isBinary) => {
-            if (downstream.readyState === downstream.OPEN) {
-              downstream.send(data, { binary: isBinary });
-            }
-          });
-          upstream.on("close", (code, reason) => {
-            if (isClosable(downstream)) downstream.close(code, reason);
-          });
-          upstream.on("error", (err) => {
-            log.error({ err, port, host }, "preview ws upstream error");
-            if (isClosable(downstream)) downstream.close(1011);
-          });
         });
-
-        // Pre-open error: retry v6 on ECONNREFUSED, otherwise give up.
-        // Once `open` fires, `upstreamRef` is set and the "real" error
-        // handler wired above takes over.
-        upstream.once("error", (err) => {
-          if (upstreamRef !== null) return;
-          const code = (err as NodeJS.ErrnoException).code;
-          if (code === "ECONNREFUSED") {
-            dial(hostIdx + 1);
-            return;
+        upstream.on("message", (data, isBinary) => {
+          if (downstream.readyState === downstream.OPEN) {
+            downstream.send(data, { binary: isBinary });
           }
-          log.error({ err, port, host }, "preview ws upstream error");
+        });
+        downstream.on("close", (code, reason) => {
+          if (isClosable(upstream)) upstream.close(code, reason);
+        });
+        upstream.on("close", (code, reason) => {
+          if (isClosable(downstream)) downstream.close(code, reason);
+        });
+        downstream.on("error", (err) => {
+          log.error({ err, port }, "preview ws downstream error");
+          if (isClosable(upstream)) upstream.close(1011);
+        });
+        upstream.on("error", (err) => {
+          log.error({ err, port }, "preview ws upstream error");
           if (isClosable(downstream)) downstream.close(1011);
         });
-      }
-    });
+      });
+    }
   }
 
   return {

--- a/packages/integrations/kolu-preview/src/wsProxy.ts
+++ b/packages/integrations/kolu-preview/src/wsProxy.ts
@@ -2,15 +2,23 @@
  *
  *  Vite / Next / Astro HMR connects back to the page's origin for live
  *  reload. When the Host header matches `<port>.preview.<anything>`, dial
- *  a client WS to `ws://127.0.0.1:<port><path>` and pipe frames both
- *  ways. Separate `WebSocketServer` from the caller's oRPC handler so
- *  dev-server traffic never runs through app code.
+ *  a client WS to the dev server and pipe frames both ways. Separate
+ *  `WebSocketServer` from the caller's oRPC handler so dev-server traffic
+ *  never runs through app code.
  *
  *  Implementation is message-level forwarding (on 'message' → send)
  *  rather than raw-socket tunneling — HMR is low-throughput enough that
  *  per-message overhead is invisible, and `ws`'s text-vs-binary bit
- *  carries through cleanly. Frames the browser sends before the upstream
- *  handshake completes are buffered and flushed on `open`. */
+ *  carries through cleanly.
+ *
+ *  Address-family fallback: try IPv4 loopback first, retry with IPv6 on
+ *  ECONNREFUSED. Matches the HTTP proxy's strategy so dev servers that
+ *  bind to `::1` only (Vite default on some systems) still work without
+ *  user config.
+ *
+ *  Pre-open buffering: frames the browser sends before the upstream
+ *  handshake completes are stashed in `pending` and flushed on `open`.
+ *  Without this, Vite's first HMR ping can race the upstream dial. */
 
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
@@ -24,8 +32,14 @@ export interface PreviewWsLogger {
 export interface PreviewWsProxy {
   /** Returns true if the upgrade was a preview and has been handled.
    *  Callers fall through to their own upgrade routing when this is
-   *  false. Socket is destroyed for invalid ports matching the pattern. */
+   *  false. */
   handle: (req: IncomingMessage, socket: Duplex, head: Buffer) => boolean;
+}
+
+const UPSTREAM_HOSTS = ["127.0.0.1", "[::1]"] as const;
+
+function isClosable(ws: WsClient): boolean {
+  return ws.readyState === ws.OPEN || ws.readyState === ws.CONNECTING;
 }
 
 export function createPreviewWsProxy(log: PreviewWsLogger): PreviewWsProxy {
@@ -40,86 +54,98 @@ export function createPreviewWsProxy(log: PreviewWsLogger): PreviewWsProxy {
     port: number,
   ): void {
     wss.handleUpgrade(req, socket, head, (downstream) => {
-      const target = `ws://127.0.0.1:${port}${req.url ?? "/"}`;
+      const path = req.url ?? "/";
       const proto = req.headers["sec-websocket-protocol"];
       const origin = req.headers["origin"];
-      const upstream = new WsClient(target, {
-        headers: {
-          ...(proto && { "sec-websocket-protocol": String(proto) }),
-          ...(origin && { origin: String(origin) }),
-        },
-      });
+      const headers = {
+        ...(proto && { "sec-websocket-protocol": String(proto) }),
+        ...(origin && { origin: String(origin) }),
+      };
 
-      // Buffer browser → dev-server frames sent before upstream is open;
-      // without this, Vite's first HMR ping can race the dial and get
-      // dropped.
       const pending: Array<{ data: WsClient.RawData; isBinary: boolean }> = [];
-      let upstreamOpen = false;
+      let upstreamRef: WsClient | null = null;
 
+      // Wire the downstream event handlers exactly once. They reference
+      // `upstreamRef` by closure, so they always act on whichever
+      // upstream is currently live (v4 initially, then v6 if we fell back).
       downstream.on("message", (data, isBinary) => {
-        if (upstreamOpen && upstream.readyState === upstream.OPEN) {
-          upstream.send(data, { binary: isBinary });
+        if (upstreamRef && upstreamRef.readyState === upstreamRef.OPEN) {
+          upstreamRef.send(data, { binary: isBinary });
         } else {
           pending.push({ data, isBinary });
         }
       });
-
-      upstream.on("open", () => {
-        upstreamOpen = true;
-        for (const { data, isBinary } of pending) {
-          upstream.send(data, { binary: isBinary });
-        }
-        pending.length = 0;
-      });
-
-      upstream.on("message", (data, isBinary) => {
-        if (downstream.readyState === downstream.OPEN) {
-          downstream.send(data, { binary: isBinary });
+      downstream.on("close", (code, reason) => {
+        if (upstreamRef && isClosable(upstreamRef)) {
+          upstreamRef.close(code, reason);
         }
       });
-
-      const closeBoth = (code?: number, reason?: Buffer) => {
-        const c = code ?? 1000;
-        const r = reason ?? Buffer.from("");
-        if (
-          downstream.readyState === downstream.OPEN ||
-          downstream.readyState === downstream.CONNECTING
-        ) {
-          downstream.close(c, r);
-        }
-        if (
-          upstream.readyState === upstream.OPEN ||
-          upstream.readyState === upstream.CONNECTING
-        ) {
-          upstream.close(c, r);
-        }
-      };
-
-      downstream.on("close", (code, reason) => closeBoth(code, reason));
-      upstream.on("close", (code, reason) => closeBoth(code, reason));
       downstream.on("error", (err) => {
         log.error({ err, port }, "preview ws downstream error");
-        closeBoth(1011);
+        if (upstreamRef && isClosable(upstreamRef)) {
+          upstreamRef.close(1011);
+        }
       });
-      upstream.on("error", (err) => {
-        log.error({ err, port }, "preview ws upstream error");
-        closeBoth(1011);
-      });
+
+      dial(0);
+
+      function dial(hostIdx: number): void {
+        const host = UPSTREAM_HOSTS[hostIdx];
+        if (host === undefined) {
+          // Exhausted every loopback family; fail the downstream with
+          // the "internal server error" close code so clients that care
+          // (HMR) can log it.
+          if (isClosable(downstream)) {
+            downstream.close(1011, Buffer.from("preview upstream unreachable"));
+          }
+          return;
+        }
+        const upstream = new WsClient(`ws://${host}:${port}${path}`, {
+          headers,
+        });
+
+        upstream.once("open", () => {
+          upstreamRef = upstream;
+          for (const { data, isBinary } of pending) {
+            upstream.send(data, { binary: isBinary });
+          }
+          pending.length = 0;
+
+          upstream.on("message", (data, isBinary) => {
+            if (downstream.readyState === downstream.OPEN) {
+              downstream.send(data, { binary: isBinary });
+            }
+          });
+          upstream.on("close", (code, reason) => {
+            if (isClosable(downstream)) downstream.close(code, reason);
+          });
+          upstream.on("error", (err) => {
+            log.error({ err, port, host }, "preview ws upstream error");
+            if (isClosable(downstream)) downstream.close(1011);
+          });
+        });
+
+        // Pre-open error: retry v6 on ECONNREFUSED, otherwise give up.
+        // Once `open` fires, `upstreamRef` is set and the "real" error
+        // handler wired above takes over.
+        upstream.once("error", (err) => {
+          if (upstreamRef !== null) return;
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === "ECONNREFUSED") {
+            dial(hostIdx + 1);
+            return;
+          }
+          log.error({ err, port, host }, "preview ws upstream error");
+          if (isClosable(downstream)) downstream.close(1011);
+        });
+      }
     });
   }
 
   return {
     handle(req, socket, head) {
       const port = matchPreviewHost(req.headers.host);
-      if (port === null) {
-        // Not a preview host. Let the caller route this upgrade.
-        // Invalid-port case (matched pattern but out-of-range) is also
-        // folded into `null` by matchPreviewHost — closing the socket
-        // there would be more defensible than a silent fall-through, but
-        // `5173.preview` with an out-of-range port isn't a real user-
-        // visible case and we save the caller from special-casing it.
-        return false;
-      }
+      if (port === null) return false;
       proxyUpgrade(req, socket, head, port);
       return true;
     },

--- a/packages/integrations/kolu-preview/tsconfig.json
+++ b/packages/integrations/kolu-preview/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,6 +29,7 @@
     "kolu-common": "workspace:*",
     "kolu-git": "workspace:*",
     "kolu-opencode": "workspace:*",
+    "kolu-preview": "workspace:*",
     "node-pty": "^1.0.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,12 +6,11 @@ import { RPCHandler } from "@orpc/server/fetch";
 import { RPCHandler as WsRPCHandler } from "@orpc/server/ws";
 import { LoggingHandlerPlugin } from "@orpc/experimental-pino";
 import { pinoLogger } from "hono-pino";
-import { WebSocket as WsClient, WebSocketServer } from "ws";
+import { WebSocketServer } from "ws";
 import { resolve } from "node:path";
-import type { IncomingMessage } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
-import type { Duplex } from "node:stream";
 import { DEFAULT_PORT } from "kolu-common/config";
+import { previewHttpProxy, createPreviewWsProxy } from "kolu-preview";
 import { appRouter } from "./router.ts";
 import { log } from "./log.ts";
 import { initSessionAutoSave } from "./session.ts";
@@ -88,89 +87,16 @@ app.use(
 
 // --- Phase 1 preview proxy (#633) ---
 // Requests whose Host header looks like `<port>.preview.<anything>` are
-// proxied to `127.0.0.1:<port>`. Dev-server preview alongside the terminal
-// running it — e.g. `pureintent:7692` serves Kolu, and
-// `5173.preview.100-122-32-106.sslip.io:7692` proxies the Vite dev server.
-//
-// Why subdomain and not path-prefix: Vite/Next/Astro HMR assume absolute
-// paths for assets and WebSocket URLs. A path-prefix proxy breaks them; a
-// subdomain proxy preserves the illusion of a dedicated origin.
-//
-// Framing headers (`X-Frame-Options`, CSP `frame-ancestors`) are stripped
-// from the upstream response so the iframe can embed the dev server.
-// Safe because the proxy only talks to `127.0.0.1` and the browser tile
-// already documents that sandbox is relaxed for trusted localhost content.
-const PREVIEW_HOST_RE = /^(\d+)\.preview\./;
-app.use(async (c, next) => {
-  const host = c.req.header("host") ?? "";
-  const match = host.match(PREVIEW_HOST_RE);
-  if (!match) return next();
-  const port = Number(match[1]);
-  // Unprivileged port range only. Blocks 0, well-known services (<1024),
-  // and bogus values. Stronger SSRF controls (announced-port allowlist)
-  // land with Phase 2.
-  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
-    return c.text(`preview: invalid port ${match[1]}`, 400);
-  }
-
-  const source = new URL(c.req.url);
-  const target = `http://127.0.0.1:${port}${source.pathname}${source.search}`;
-
-  // Strip hop-by-hop + the incoming Host; fetch sets its own.
-  const upstreamHeaders = new Headers(c.req.raw.headers);
-  for (const hdr of [
-    "host",
-    "connection",
-    "keep-alive",
-    "proxy-authenticate",
-    "proxy-authorization",
-    "te",
-    "trailers",
-    "transfer-encoding",
-    "upgrade",
-  ]) {
-    upstreamHeaders.delete(hdr);
-  }
-  upstreamHeaders.set("x-forwarded-host", host);
-  upstreamHeaders.set("x-forwarded-proto", tlsOptions ? "https" : "http");
-
-  let upstream: Response;
-  try {
-    upstream = await fetch(target, {
-      method: c.req.method,
-      headers: upstreamHeaders,
-      body: c.req.raw.body,
-      // Node's undici requires duplex: "half" when body is a stream.
-      // Without this, fetch throws TypeError for request bodies.
-      ...(c.req.raw.body ? { duplex: "half" } : {}),
-      redirect: "manual",
-    } as RequestInit);
-  } catch (err) {
-    log.warn({ err, target }, "preview proxy upstream unreachable");
-    return c.text(`preview: upstream 127.0.0.1:${port} unreachable`, 502);
-  }
-
-  // Remove restrictive framing directives so the iframe embeds cleanly.
-  // Dev servers rarely set these, but some middleware stacks do.
-  const responseHeaders = new Headers(upstream.headers);
-  responseHeaders.delete("x-frame-options");
-  const csp = responseHeaders.get("content-security-policy");
-  if (csp) {
-    const cleaned = csp
-      .split(";")
-      .filter((d) => !/^\s*frame-ancestors\b/i.test(d))
-      .join(";")
-      .trim();
-    if (cleaned === "") responseHeaders.delete("content-security-policy");
-    else responseHeaders.set("content-security-policy", cleaned);
-  }
-
-  return new Response(upstream.body, {
-    status: upstream.status,
-    statusText: upstream.statusText,
-    headers: responseHeaders,
-  });
-});
+// proxied to `127.0.0.1:<port>` — dev-server preview alongside the
+// terminal running it. Implementation lives in kolu-preview; the middle-
+// ware installs before app routes so it shortcuts cleanly.
+let tlsEnabled = false;
+app.use(
+  previewHttpProxy({
+    isTls: () => tlsEnabled,
+    log: { warn: (obj, msg) => log.warn(obj, msg) },
+  }),
+);
 
 // --- oRPC plugins ---
 const rpcPlugins = [
@@ -261,6 +187,7 @@ if (clientDist) {
 // --- TLS setup ---
 const { host, port } = argv.flags;
 const tlsOptions = await resolveTlsOptions(argv.flags);
+tlsEnabled = !!tlsOptions;
 
 // --- Start server ---
 const server = serve(
@@ -316,104 +243,14 @@ wss.on("connection", (ws) => {
 });
 
 // --- Phase 1 preview WebSocket passthrough (#633) ---
-// Preview subdomains need WS upgrades too — Vite / Next HMR connects back
-// to the page's origin for live reload. Dial a client WS to the upstream
-// dev server and pipe frames both ways. Separate WebSocketServer instance
-// so we don't attach oRPC's connection handler to these sockets.
-const previewWss = new WebSocketServer({ noServer: true });
-
-function proxyPreviewWsUpgrade(
-  req: IncomingMessage,
-  socket: Duplex,
-  head: Buffer,
-  port: number,
-): void {
-  previewWss.handleUpgrade(req, socket, head, (downstream) => {
-    const target = `ws://127.0.0.1:${port}${req.url ?? "/"}`;
-    const proto = req.headers["sec-websocket-protocol"];
-    const origin = req.headers["origin"];
-    const upstream = new WsClient(target, {
-      headers: {
-        ...(proto && { "sec-websocket-protocol": String(proto) }),
-        ...(origin && { origin: String(origin) }),
-      },
-    });
-
-    // Pipe downstream → upstream once upstream is open. Buffer any frames
-    // the browser sends before the upstream handshake completes.
-    const pending: Array<{ data: WsClient.RawData; isBinary: boolean }> = [];
-    let upstreamOpen = false;
-
-    downstream.on("message", (data, isBinary) => {
-      if (upstreamOpen && upstream.readyState === upstream.OPEN) {
-        upstream.send(data, { binary: isBinary });
-      } else {
-        pending.push({ data, isBinary });
-      }
-    });
-
-    upstream.on("open", () => {
-      upstreamOpen = true;
-      for (const { data, isBinary } of pending) {
-        upstream.send(data, { binary: isBinary });
-      }
-      pending.length = 0;
-    });
-
-    upstream.on("message", (data, isBinary) => {
-      if (downstream.readyState === downstream.OPEN) {
-        downstream.send(data, { binary: isBinary });
-      }
-    });
-
-    const closeBoth = (code?: number, reason?: Buffer) => {
-      const c = code ?? 1000;
-      const r = reason ?? Buffer.from("");
-      if (
-        downstream.readyState === downstream.OPEN ||
-        downstream.readyState === downstream.CONNECTING
-      ) {
-        downstream.close(c, r);
-      }
-      if (
-        upstream.readyState === upstream.OPEN ||
-        upstream.readyState === upstream.CONNECTING
-      ) {
-        upstream.close(c, r);
-      }
-    };
-
-    downstream.on("close", (code, reason) => closeBoth(code, reason));
-    upstream.on("close", (code, reason) => closeBoth(code, reason));
-    downstream.on("error", (err) => {
-      log.error({ err, port }, "preview ws downstream error");
-      closeBoth(1011);
-    });
-    upstream.on("error", (err) => {
-      log.error({ err, port }, "preview ws upstream error");
-      closeBoth(1011);
-    });
-  });
-}
+// HMR needs WS too. Preview subdomain upgrades are handed to kolu-preview
+// *before* oRPC's own ws routing, so dev-server traffic never hits app code.
+const previewWs = createPreviewWsProxy({
+  error: (obj, msg) => log.error(obj, msg),
+});
 
 server.on("upgrade", (req, socket, head) => {
-  // Preview subdomain takes priority over path-based oRPC WS. Same Host-
-  // header pattern as the HTTP proxy middleware — keep the two in sync.
-  const host = req.headers.host ?? "";
-  const previewMatch = host.match(PREVIEW_HOST_RE);
-  if (previewMatch) {
-    const previewPort = Number(previewMatch[1]);
-    if (
-      !Number.isInteger(previewPort) ||
-      previewPort < 1024 ||
-      previewPort > 65535
-    ) {
-      socket.destroy();
-      return;
-    }
-    proxyPreviewWsUpgrade(req, socket, head, previewPort);
-    return;
-  }
+  if (previewWs.handle(req, socket, head)) return;
 
   const url = new URL(req.url ?? "", `http://${req.headers.host}`);
   if (url.pathname === "/rpc/ws") {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -84,6 +84,32 @@ app.use(
   }),
 );
 
+// --- SPIKE: Phase 1 subdomain dispatch test (#633 Phase 1) ---
+// Matches Host headers of the form `<port>.preview.<anything>` and returns
+// a debug page. Confirms: (1) sslip.io DNS resolves the IP-encoded subdomain,
+// (2) the browser reaches Kolu's Hono server at the same bound port, (3) the
+// Host header survives the hop. Throw-away — delete once Phase 1 replaces it
+// with a real proxy.
+app.use(async (c, next) => {
+  const host = c.req.header("host") ?? "";
+  const match = host.match(/^(\d+)\.preview\./);
+  if (!match) return next();
+  const port = match[1];
+  return c.html(
+    `<!doctype html>
+<html>
+<head><title>kolu preview spike</title></head>
+<body style="font-family: monospace; padding: 2rem; background: #111; color: #0f0">
+  <h1>✓ preview dispatch works</h1>
+  <p>target port: <b>${port}</b></p>
+  <p>host header: <b>${host}</b></p>
+  <p>request path: <b>${c.req.path}</b></p>
+  <p>next step: extend this handler to proxy to <code>127.0.0.1:${port}</code>.</p>
+</body>
+</html>`,
+  );
+});
+
 // --- oRPC plugins ---
 const rpcPlugins = [
   new LoggingHandlerPlugin({

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -84,30 +84,90 @@ app.use(
   }),
 );
 
-// --- SPIKE: Phase 1 subdomain dispatch test (#633 Phase 1) ---
-// Matches Host headers of the form `<port>.preview.<anything>` and returns
-// a debug page. Confirms: (1) sslip.io DNS resolves the IP-encoded subdomain,
-// (2) the browser reaches Kolu's Hono server at the same bound port, (3) the
-// Host header survives the hop. Throw-away — delete once Phase 1 replaces it
-// with a real proxy.
+// --- Phase 1 preview proxy (#633) ---
+// Requests whose Host header looks like `<port>.preview.<anything>` are
+// proxied to `127.0.0.1:<port>`. Dev-server preview alongside the terminal
+// running it — e.g. `pureintent:7692` serves Kolu, and
+// `5173.preview.100-122-32-106.sslip.io:7692` proxies the Vite dev server.
+//
+// Why subdomain and not path-prefix: Vite/Next/Astro HMR assume absolute
+// paths for assets and WebSocket URLs. A path-prefix proxy breaks them; a
+// subdomain proxy preserves the illusion of a dedicated origin.
+//
+// Framing headers (`X-Frame-Options`, CSP `frame-ancestors`) are stripped
+// from the upstream response so the iframe can embed the dev server.
+// Safe because the proxy only talks to `127.0.0.1` and the browser tile
+// already documents that sandbox is relaxed for trusted localhost content.
+const PREVIEW_HOST_RE = /^(\d+)\.preview\./;
 app.use(async (c, next) => {
   const host = c.req.header("host") ?? "";
-  const match = host.match(/^(\d+)\.preview\./);
+  const match = host.match(PREVIEW_HOST_RE);
   if (!match) return next();
-  const port = match[1];
-  return c.html(
-    `<!doctype html>
-<html>
-<head><title>kolu preview spike</title></head>
-<body style="font-family: monospace; padding: 2rem; background: #111; color: #0f0">
-  <h1>✓ preview dispatch works</h1>
-  <p>target port: <b>${port}</b></p>
-  <p>host header: <b>${host}</b></p>
-  <p>request path: <b>${c.req.path}</b></p>
-  <p>next step: extend this handler to proxy to <code>127.0.0.1:${port}</code>.</p>
-</body>
-</html>`,
-  );
+  const port = Number(match[1]);
+  // Unprivileged port range only. Blocks 0, well-known services (<1024),
+  // and bogus values. Stronger SSRF controls (announced-port allowlist)
+  // land with Phase 2.
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    return c.text(`preview: invalid port ${match[1]}`, 400);
+  }
+
+  const source = new URL(c.req.url);
+  const target = `http://127.0.0.1:${port}${source.pathname}${source.search}`;
+
+  // Strip hop-by-hop + the incoming Host; fetch sets its own.
+  const upstreamHeaders = new Headers(c.req.raw.headers);
+  for (const hdr of [
+    "host",
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+  ]) {
+    upstreamHeaders.delete(hdr);
+  }
+  upstreamHeaders.set("x-forwarded-host", host);
+  upstreamHeaders.set("x-forwarded-proto", tlsOptions ? "https" : "http");
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method: c.req.method,
+      headers: upstreamHeaders,
+      body: c.req.raw.body,
+      // Node's undici requires duplex: "half" when body is a stream.
+      // Without this, fetch throws TypeError for request bodies.
+      ...(c.req.raw.body ? { duplex: "half" } : {}),
+      redirect: "manual",
+    } as RequestInit);
+  } catch (err) {
+    log.warn({ err, target }, "preview proxy upstream unreachable");
+    return c.text(`preview: upstream 127.0.0.1:${port} unreachable`, 502);
+  }
+
+  // Remove restrictive framing directives so the iframe embeds cleanly.
+  // Dev servers rarely set these, but some middleware stacks do.
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("x-frame-options");
+  const csp = responseHeaders.get("content-security-policy");
+  if (csp) {
+    const cleaned = csp
+      .split(";")
+      .filter((d) => !/^\s*frame-ancestors\b/i.test(d))
+      .join(";")
+      .trim();
+    if (cleaned === "") responseHeaders.delete("content-security-policy");
+    else responseHeaders.set("content-security-policy", cleaned);
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
 });
 
 // --- oRPC plugins ---

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -246,6 +246,7 @@ wss.on("connection", (ws) => {
 // HMR needs WS too. Preview subdomain upgrades are handed to kolu-preview
 // *before* oRPC's own ws routing, so dev-server traffic never hits app code.
 const previewWs = createPreviewWsProxy({
+  warn: (obj, msg) => log.warn(obj, msg),
   error: (obj, msg) => log.error(obj, msg),
 });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,9 +6,11 @@ import { RPCHandler } from "@orpc/server/fetch";
 import { RPCHandler as WsRPCHandler } from "@orpc/server/ws";
 import { LoggingHandlerPlugin } from "@orpc/experimental-pino";
 import { pinoLogger } from "hono-pino";
-import { WebSocketServer } from "ws";
+import { WebSocket as WsClient, WebSocketServer } from "ws";
 import { resolve } from "node:path";
+import type { IncomingMessage } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
+import type { Duplex } from "node:stream";
 import { DEFAULT_PORT } from "kolu-common/config";
 import { appRouter } from "./router.ts";
 import { log } from "./log.ts";
@@ -313,7 +315,106 @@ wss.on("connection", (ws) => {
   });
 });
 
+// --- Phase 1 preview WebSocket passthrough (#633) ---
+// Preview subdomains need WS upgrades too — Vite / Next HMR connects back
+// to the page's origin for live reload. Dial a client WS to the upstream
+// dev server and pipe frames both ways. Separate WebSocketServer instance
+// so we don't attach oRPC's connection handler to these sockets.
+const previewWss = new WebSocketServer({ noServer: true });
+
+function proxyPreviewWsUpgrade(
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+  port: number,
+): void {
+  previewWss.handleUpgrade(req, socket, head, (downstream) => {
+    const target = `ws://127.0.0.1:${port}${req.url ?? "/"}`;
+    const proto = req.headers["sec-websocket-protocol"];
+    const origin = req.headers["origin"];
+    const upstream = new WsClient(target, {
+      headers: {
+        ...(proto && { "sec-websocket-protocol": String(proto) }),
+        ...(origin && { origin: String(origin) }),
+      },
+    });
+
+    // Pipe downstream → upstream once upstream is open. Buffer any frames
+    // the browser sends before the upstream handshake completes.
+    const pending: Array<{ data: WsClient.RawData; isBinary: boolean }> = [];
+    let upstreamOpen = false;
+
+    downstream.on("message", (data, isBinary) => {
+      if (upstreamOpen && upstream.readyState === upstream.OPEN) {
+        upstream.send(data, { binary: isBinary });
+      } else {
+        pending.push({ data, isBinary });
+      }
+    });
+
+    upstream.on("open", () => {
+      upstreamOpen = true;
+      for (const { data, isBinary } of pending) {
+        upstream.send(data, { binary: isBinary });
+      }
+      pending.length = 0;
+    });
+
+    upstream.on("message", (data, isBinary) => {
+      if (downstream.readyState === downstream.OPEN) {
+        downstream.send(data, { binary: isBinary });
+      }
+    });
+
+    const closeBoth = (code?: number, reason?: Buffer) => {
+      const c = code ?? 1000;
+      const r = reason ?? Buffer.from("");
+      if (
+        downstream.readyState === downstream.OPEN ||
+        downstream.readyState === downstream.CONNECTING
+      ) {
+        downstream.close(c, r);
+      }
+      if (
+        upstream.readyState === upstream.OPEN ||
+        upstream.readyState === upstream.CONNECTING
+      ) {
+        upstream.close(c, r);
+      }
+    };
+
+    downstream.on("close", (code, reason) => closeBoth(code, reason));
+    upstream.on("close", (code, reason) => closeBoth(code, reason));
+    downstream.on("error", (err) => {
+      log.error({ err, port }, "preview ws downstream error");
+      closeBoth(1011);
+    });
+    upstream.on("error", (err) => {
+      log.error({ err, port }, "preview ws upstream error");
+      closeBoth(1011);
+    });
+  });
+}
+
 server.on("upgrade", (req, socket, head) => {
+  // Preview subdomain takes priority over path-based oRPC WS. Same Host-
+  // header pattern as the HTTP proxy middleware — keep the two in sync.
+  const host = req.headers.host ?? "";
+  const previewMatch = host.match(PREVIEW_HOST_RE);
+  if (previewMatch) {
+    const previewPort = Number(previewMatch[1]);
+    if (
+      !Number.isInteger(previewPort) ||
+      previewPort < 1024 ||
+      previewPort > 65535
+    ) {
+      socket.destroy();
+      return;
+    }
+    proxyPreviewWsUpgrade(req, socket, head, previewPort);
+    return;
+  }
+
   const url = new URL(req.url ?? "", `http://${req.headers.host}`);
   if (url.pathname === "/rpc/ws") {
     wss.handleUpgrade(req, socket, head, (ws) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,28 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/integrations/kolu-preview:
+    dependencies:
+      hono:
+        specifier: ^4.12.14
+        version: 4.12.14
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/integrations/opencode:
     dependencies:
       anyagent:
@@ -322,6 +344,9 @@ importers:
       kolu-opencode:
         specifier: workspace:*
         version: link:../integrations/opencode
+      kolu-preview:
+        specifier: workspace:*
+        version: link:../integrations/kolu-preview
       node-pty:
         specifier: ^1.0.0
         version: 1.1.0(patch_hash=50f459cfc12675225bca395a9aab75c311e4cd6206f9c4990e818932465c8cd6)


### PR DESCRIPTION
**Stacked on top of #640.** A throw-away route that matches any Host header of the form `<port>.preview.<anything>` and returns a green debug page. The whole point is to verify three assumptions *before* we invest in the Phase 1 proxy implementation.

### What we're checking

1. **sslip.io DNS resolves IP-encoded subdomains.** `5173.preview.100-64-0-1.sslip.io` should return `100.64.0.1` without any local DNS setup — that's sslip.io's whole job.
2. **The browser reaches Kolu's Hono server on its existing bound port.** One socket, Host-header dispatch — no second listener, no wildcard binding, no cert gymnastics.
3. **The Host header survives the Tailscale hop.** Important for deployments where Kolu is reached via a Tailscale hostname (e.g. `pureintent:7692`). The preview subdomain's DNS goes through sslip.io to the Tailscale IP; Kolu sees the `5173.preview.<ip>.sslip.io` Host header and can dispatch.

### How to test

Kolu needs to be running. Any bound IP that's routable from your browser works — `127.0.0.1`, LAN, or Tailscale CGNAT.

```
# if kolu is on 127.0.0.1:7681
open http://5173.preview.127-0-0-1.sslip.io:7681/

# if kolu is on a Tailscale IP 100.64.0.1:7692 (pureintent)
open http://5173.preview.100-64-0-1.sslip.io:7692/
```

Expected: a green debug page showing the matched port (`5173`) and the full Host header as Hono received it. If the browser can't resolve the subdomain at all → sslip.io isn't returning records for your case (report back). If the subdomain resolves but the request times out → firewall/Tailscale ACL blocking the hop. If the page renders but the port or Host look wrong → our regex/Hono handler is at fault.

### What happens next

If the three checks pass, the next commit extends this stub into a real HTTP proxy (fetch-and-stream to `127.0.0.1:<port>`), then WS upgrade passthrough for HMR. If any of the three fails, we stop here and reconsider — nip.io vs sslip.io, path-based vs subdomain, DNS resolver quirks.

*Delete this branch once Phase 1 lands.*

### Try it locally

```sh
nix run github:juspay/kolu/spike/preview-subdomain
```