### PR TITLE
Extract kolu-github integration package (thin server adapter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,18 @@ Record the Kolu tab — whole canvas or a single maximized terminal — with mic
 
 pnpm monorepo:
 
-| Package                              | Stack                                                                                                                                            |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `packages/common/`                   | [oRPC](https://orpc.dev/) contract + [Zod](https://zod.dev/) schemas                                                                             |
-| `packages/server/`                   | [Hono](https://hono.dev/) + [node-pty](https://github.com/microsoft/node-pty) + [@xterm/headless](https://www.npmjs.com/package/@xterm/headless) |
-| `packages/client/`                   | [SolidJS](https://www.solidjs.com/) + [xterm.js](https://xtermjs.org/) + [Tailwind CSS v4](https://tailwindcss.com/)                             |
-| `packages/integrations/claude-code/` | Claude Code detection — JSONL transcript tailing + Claude Agent SDK; exports a `claudeCodeProvider` `AgentProvider`                              |
-| `packages/integrations/anyagent/`    | Agent-agnostic shared contract (`AgentProvider` interface, `agentInfoEqual`), types (Logger, TaskProgress), and agent CLI parsing                |
-| `packages/integrations/opencode/`    | OpenCode detection — reads OpenCode's SQLite database via Node's built-in `node:sqlite`; exports an `opencodeProvider` `AgentProvider`           |
-| `packages/terminal-themes/`          | Terminal color scheme catalog + perceptual-distance picker — themes checked-in as JSON                                                           |
-| `packages/memorable-names/`          | ADJ-NOUN random name generator — word lists checked-in as JSON                                                                                   |
+| Package                              | Stack                                                                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/common/`                   | [oRPC](https://orpc.dev/) contract + [Zod](https://zod.dev/) schemas                                                                               |
+| `packages/server/`                   | [Hono](https://hono.dev/) + [node-pty](https://github.com/microsoft/node-pty) + [@xterm/headless](https://www.npmjs.com/package/@xterm/headless)   |
+| `packages/client/`                   | [SolidJS](https://www.solidjs.com/) + [xterm.js](https://xtermjs.org/) + [Tailwind CSS v4](https://tailwindcss.com/)                               |
+| `packages/integrations/claude-code/` | Claude Code detection — JSONL transcript tailing + Claude Agent SDK; exports a `claudeCodeProvider` `AgentProvider`                                |
+| `packages/integrations/anyagent/`    | Agent-agnostic shared contract (`AgentProvider` interface, `agentInfoEqual`), types (Logger, TaskProgress), and agent CLI parsing                  |
+| `packages/integrations/opencode/`    | OpenCode detection — reads OpenCode's SQLite database via Node's built-in `node:sqlite`; exports an `opencodeProvider` `AgentProvider`             |
+| `packages/integrations/git/`         | Pure git operations — `simple-git` wrapper: repo resolution, worktree lifecycle, diff review, path security; schemas re-exported by `kolu-common`  |
+| `packages/integrations/github/`      | GitHub PR schemas + pure helpers (`deriveCheckStatus`, `classifyGhError`, `prResultEqual`); server wraps with `gh pr view` spawn via `KOLU_GH_BIN` |
+| `packages/terminal-themes/`          | Terminal color scheme catalog + perceptual-distance picker — themes checked-in as JSON                                                             |
+| `packages/memorable-names/`          | ADJ-NOUN random name generator — word lists checked-in as JSON                                                                                     |
 
 ### Communication
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,6 +24,7 @@
     "@orpc/contract": "^1.13.13",
     "kolu-claude-code": "workspace:*",
     "kolu-git": "workspace:*",
+    "kolu-github": "workspace:*",
     "anyagent": "workspace:*",
     "kolu-opencode": "workspace:*",
     "ts-pattern": "^5.9.0",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -66,10 +66,9 @@ export type {
 const TerminalIdSchema = z.string().uuid();
 
 // --- GitHub PR context ---
-// Schemas + helpers live in ./pr.ts so clients can runtime-import them via
-// `kolu-common/pr` without pulling the full kolu-common module graph
-// (which re-exports kolu-claude-code and transitively drags node-only
-// `@anthropic-ai/claude-agent-sdk` into the browser bundle).
+// Owned by kolu-github (mirrors the kolu-git re-export pattern above). The
+// `kolu-common/pr` subpath also re-exports these for browser clients that
+// want to avoid pulling kolu-claude-code → @anthropic-ai/claude-agent-sdk.
 import {
   GitHubCheckStatusSchema,
   GitHubPrStateSchema,
@@ -83,7 +82,7 @@ import {
   prUnavailableSource,
   reasonForGhCode,
   reasonForSource,
-} from "./pr.ts";
+} from "kolu-github";
 export {
   GitHubCheckStatusSchema,
   GitHubPrStateSchema,
@@ -103,7 +102,7 @@ export type {
   PrResult,
   GhUnavailableCode,
   PrUnavailableSource,
-} from "./pr.ts";
+} from "kolu-github";
 
 // --- AI coding agent context ---
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -82,7 +82,7 @@ import {
   prUnavailableSource,
   reasonForGhCode,
   reasonForSource,
-} from "kolu-github";
+} from "kolu-github/schemas";
 export {
   GitHubCheckStatusSchema,
   GitHubPrStateSchema,
@@ -102,7 +102,7 @@ export type {
   PrResult,
   GhUnavailableCode,
   PrUnavailableSource,
-} from "kolu-github";
+} from "kolu-github/schemas";
 
 // --- AI coding agent context ---
 

--- a/packages/common/src/pr.ts
+++ b/packages/common/src/pr.ts
@@ -1,146 +1,33 @@
-/** PR metadata — schemas + helpers.
+/** `kolu-common/pr` subpath — re-exports PR schemas and neutral helpers
+ *  from `kolu-github` so browser clients can runtime-import them without
+ *  pulling the full `kolu-common` barrel (which re-exports `kolu-claude-code`
+ *  and transitively drags the Node-only `@anthropic-ai/claude-agent-sdk`
+ *  into the browser bundle).
  *
- *  Lives in its own module (exposed as `kolu-common/pr`) so clients can
- *  runtime-import helpers without dragging the full kolu-common module graph
- *  — which re-exports kolu-claude-code and transitively pulls
- *  `@anthropic-ai/claude-agent-sdk` (a Node-only package) into the browser
- *  bundle.
- *
- *  Provider tagging: the `unavailable` variant carries a `source` tagged by
- *  `provider` so a future bkt (Bitbucket CLI) resolver can contribute its own
- *  code namespace alongside gh's. `PrResult.ok`'s shape is still gh-specific
- *  (`GitHubPrInfoSchema`) because we don't yet know bkt's PR response shape;
- *  generalize when bkt's API dictates. See srid/agency#10. */
+ *  Surface kept narrow on purpose: only schemas, types, and display helpers.
+ *  Classifiers (`classifyGhError`, `deriveCheckStatus`, `prResultEqual`)
+ *  live in `kolu-github` and stay server-internal — importing them from
+ *  here would blur the provider-neutral boundary this subpath represents. */
 
-import { z } from "zod";
-import { match } from "ts-pattern";
-
-export const GitHubCheckStatusSchema = z.enum(["pending", "pass", "fail"]);
-
-export const GitHubPrStateSchema = z.enum(["open", "closed", "merged"]);
-
-export const GitHubPrInfoSchema = z.object({
-  number: z.number(),
-  title: z.string(),
-  url: z.string(),
-  /** PR state: open, closed, or merged. */
-  state: GitHubPrStateSchema,
-  /** Combined CI status: pending, pass, or fail. Null if no checks configured. */
-  checks: GitHubCheckStatusSchema.nullable(),
-});
-export type GitHubPrInfo = z.infer<typeof GitHubPrInfoSchema>;
-
-// --- gh-specific unavailable code ---
-
-/** Typed gh-failure code for the `unavailable` PrResult variant.
- *
- *  A discriminator separate from any human-readable display text so UI
- *  callers that want to dispatch per-failure can `match(code).exhaustive()`
- *  and get a compile error when a new code is added without a handler —
- *  rather than string-comparing display text and silently breaking on typo.
- *
- *  Named with the `Gh` prefix so a parallel `BktUnavailableCodeSchema` lives
- *  alongside this one when bkt lands; `PrUnavailableSourceSchema` already
- *  reserves the `provider` discriminator for the tagged-union extension. */
-export const GhUnavailableCodeSchema = z.enum([
-  "not-installed",
-  "not-authenticated",
-  "timed-out",
-  "unknown",
-]);
-export type GhUnavailableCode = z.infer<typeof GhUnavailableCodeSchema>;
-
-/** Display text for a gh unavailable code — single source of truth. Defined
- *  as a fresh `Record<GhUnavailableCode, string>` literal (not wrapped in
- *  `match`) so TypeScript's required/excess-property checks enforce both
- *  sides of exhaustiveness — adding a code without updating this table
- *  fails compilation, and removing one leaves a dead key that also fails. */
-const GH_REASONS: Record<GhUnavailableCode, string> = {
-  "not-installed": "gh: not installed",
-  "not-authenticated": "gh: not authenticated",
-  "timed-out": "gh: timed out",
-  unknown: "gh: unknown error",
-};
-
-export function reasonForGhCode(code: GhUnavailableCode): string {
-  return GH_REASONS[code];
-}
-
-// --- Provider-tagged unavailable source ---
-
-export const GhUnavailableSchema = z.object({
-  provider: z.literal("gh"),
-  code: GhUnavailableCodeSchema,
-});
-
-/** Which provider classified the failure, plus that provider's typed code.
- *
- *  Today only `gh`; a sibling `BktUnavailableSchema` joins this union when
- *  bkt support lands (srid/agency#10). UI dispatch sites that render
- *  recovery instructions should `match(source.provider).exhaustive()` so
- *  adding a new provider arm forces every render site to handle it. */
-export const PrUnavailableSourceSchema = z.discriminatedUnion("provider", [
+export {
+  GitHubCheckStatusSchema,
+  GitHubPrStateSchema,
+  GitHubPrInfoSchema,
+  GhUnavailableCodeSchema,
   GhUnavailableSchema,
-]);
-export type PrUnavailableSource = z.infer<typeof PrUnavailableSourceSchema>;
-
-/** Display string for any unavailable source — dispatches on provider to the
- *  provider's own reason lookup. `.exhaustive()` forces a compile error when
- *  bkt adds its arm to `PrUnavailableSourceSchema` until a matching `.with`
- *  lands here. */
-export function reasonForSource(source: PrUnavailableSource): string {
-  return match(source)
-    .with({ provider: "gh" }, ({ code }) => reasonForGhCode(code))
-    .exhaustive();
-}
-
-// --- PrResult ---
-
-/** PR resolution state.
- *
- *  Decomplects distinct conditions that `GitHubPrInfo | null` used to
- *  collapse into one value:
- *    pending     — resolver is running (or stale after a branch change)
- *    ok          — resolver succeeded; a PR exists for this branch
- *    absent      — resolver succeeded; no PR for this branch (expected case)
- *    unavailable — resolver couldn't run; `source` carries the provider +
- *                  typed failure code, and the display reason is derived by
- *                  `reasonForSource`.
- *
- *  The UI needs to distinguish "absent" (nothing to show) from "unavailable"
- *  (show a warning with recovery instructions). Keeping the provenance in
- *  the same field as the value avoids a sibling-flag invariant.
- *
- *  Analogous schemas for git/agent/foreground are not introduced yet — their
- *  failure modes don't currently surface as user-actionable warnings. If they
- *  do, mirror this shape per-provider rather than inventing a cross-cutting
- *  status registry (see PR description for #148). */
-export const PrResultSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("pending") }),
-  z.object({ kind: z.literal("ok"), value: GitHubPrInfoSchema }),
-  z.object({ kind: z.literal("absent") }),
-  z.object({
-    kind: z.literal("unavailable"),
-    source: PrUnavailableSourceSchema,
-  }),
-]);
-export type PrResult = z.infer<typeof PrResultSchema>;
-
-/** Extract the `GitHubPrInfo` when `kind === "ok"`, else `null`.
- *  Lets SolidJS `<Show when={prValue(meta.pr)}>` work without tripping on the
- *  object-truthy trap (every variant is a non-null object). */
-export function prValue(pr: PrResult): GitHubPrInfo | null {
-  return pr.kind === "ok" ? pr.value : null;
-}
-
-/** Extract the display reason when `kind === "unavailable"`, else `null`. */
-export function prUnavailableReason(pr: PrResult): string | null {
-  return pr.kind === "unavailable" ? reasonForSource(pr.source) : null;
-}
-
-/** Extract the tagged source when `kind === "unavailable"`, else `null`. Use
- *  this when the UI needs to dispatch on provider/code; `prUnavailableReason`
- *  is enough for a plain string tooltip. */
-export function prUnavailableSource(pr: PrResult): PrUnavailableSource | null {
-  return pr.kind === "unavailable" ? pr.source : null;
-}
+  PrUnavailableSourceSchema,
+  PrResultSchema,
+  reasonForGhCode,
+  reasonForSource,
+  prValue,
+  prUnavailableReason,
+  prUnavailableSource,
+} from "kolu-github";
+export type {
+  GitHubCheckStatus,
+  GitHubPrState,
+  GitHubPrInfo,
+  GhUnavailableCode,
+  PrUnavailableSource,
+  PrResult,
+} from "kolu-github";

--- a/packages/common/src/pr.ts
+++ b/packages/common/src/pr.ts
@@ -1,13 +1,14 @@
 /** `kolu-common/pr` subpath — re-exports PR schemas and neutral helpers
- *  from `kolu-github` so browser clients can runtime-import them without
- *  pulling the full `kolu-common` barrel (which re-exports `kolu-claude-code`
- *  and transitively drags the Node-only `@anthropic-ai/claude-agent-sdk`
- *  into the browser bundle).
+ *  from `kolu-github`'s browser-safe `./schemas` entry (no node imports).
  *
- *  Surface kept narrow on purpose: only schemas, types, and display helpers.
- *  Classifiers (`classifyGhError`, `deriveCheckStatus`, `prResultEqual`)
- *  live in `kolu-github` and stay server-internal — importing them from
- *  here would blur the provider-neutral boundary this subpath represents. */
+ *  Two layers of narrowing:
+ *  1. We import from `kolu-github/schemas`, not the main barrel — the main
+ *     barrel also exports `resolve.ts` which pulls `node:util` /
+ *     `node:child_process` and blows up vite's browser build.
+ *  2. Classifiers (`classifyGhError`, `deriveCheckStatus`, `prResultEqual`)
+ *     live in `kolu-github`'s main barrel and stay server-internal —
+ *     importing them through this subpath would blur the provider-neutral
+ *     boundary. */
 
 export {
   GitHubCheckStatusSchema,
@@ -22,7 +23,7 @@ export {
   prValue,
   prUnavailableReason,
   prUnavailableSource,
-} from "kolu-github";
+} from "kolu-github/schemas";
 export type {
   GitHubCheckStatus,
   GitHubPrState,
@@ -30,4 +31,4 @@ export type {
   GhUnavailableCode,
   PrUnavailableSource,
   PrResult,
-} from "kolu-github";
+} from "kolu-github/schemas";

--- a/packages/integrations/github/README.md
+++ b/packages/integrations/github/README.md
@@ -1,0 +1,27 @@
+# kolu-github
+
+GitHub PR resolution — Zod schemas, gh-error classifier, CI-status deriver. Pure leaf package (deps: zod + ts-pattern).
+
+## Modules
+
+| Module       | Exports                                                                                   | Purpose                                   |
+| ------------ | ----------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `schemas.ts` | `GitHubPrInfoSchema`, `PrResultSchema`, `PrUnavailableSourceSchema`, `reasonForSource`, … | Zod schemas + provider-neutral `PrResult` |
+| `github.ts`  | `deriveCheckStatus`, `classifyGhError`, `prResultEqual`                                   | Pure helpers — no I/O                     |
+
+## Neutral-vs-gh-specific layout
+
+`PrResult.ok.value` is `GitHubPrInfo`-shaped today. Rather than invert the package dep direction (`kolu-common` → `kolu-github` would become circular), the provider-neutral scaffolding (`PrResult`, `PrUnavailableSourceSchema`, `reasonForSource`, extractors) lives in this package alongside the gh-specific schemas. When a second provider (`bkt`) lands — [srid/agency#10](https://github.com/srid/agency/issues/10) — promote the neutrals to their own leaf (or to `kolu-common`) and have each provider package import them. The FUTURE box in `packages/server/src/meta/github.ts` sketches the `PrProvider` interface the dispatch will take.
+
+## Server integration
+
+The server's `meta/github.ts` wraps `classifyGhError` and `deriveCheckStatus` with process spawning via `KOLU_GH_BIN` (pinned by Nix in `nix/env.nix`). It subscribes to each terminal's `git:` channel, calls `gh pr view` on branch changes, and publishes `PrResult` through the metadata publisher.
+
+## Consumer imports
+
+- Server & non-browser code: `import { … } from "kolu-github"` directly, or via `kolu-common` re-exports.
+- Browser code: `import { … } from "kolu-common/pr"` — subpath re-export that avoids dragging `kolu-claude-code` → `@anthropic-ai/claude-agent-sdk` (Node-only) into the browser bundle.
+
+## Stderr fragility
+
+`classifyGhError` pattern-matches gh CLI stderr strings (`"not logged in"`, `"authentication"`, `"no pull requests found"`). gh's error messages are not versioned — a wording change across major versions silently falls through to `"unknown"`. The parametrized table tests in `github.test.ts` pin the current strings and are the regression tripwire.

--- a/packages/integrations/github/README.md
+++ b/packages/integrations/github/README.md
@@ -4,10 +4,11 @@ GitHub PR resolution — Zod schemas, gh-error classifier, CI-status deriver. Pu
 
 ## Modules
 
-| Module       | Exports                                                                                   | Purpose                                   |
-| ------------ | ----------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `schemas.ts` | `GitHubPrInfoSchema`, `PrResultSchema`, `PrUnavailableSourceSchema`, `reasonForSource`, … | Zod schemas + provider-neutral `PrResult` |
-| `github.ts`  | `deriveCheckStatus`, `classifyGhError`, `prResultEqual`                                   | Pure helpers — no I/O                     |
+| Module       | Exports                                                                                   | Purpose                                                         |
+| ------------ | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `schemas.ts` | `GitHubPrInfoSchema`, `PrResultSchema`, `PrUnavailableSourceSchema`, `reasonForSource`, … | Zod schemas + provider-neutral `PrResult`                       |
+| `github.ts`  | `deriveCheckStatus`, `classifyGhError`, `prResultEqual`                                   | Pure helpers — no I/O                                           |
+| `resolve.ts` | `resolveGitHubPr`, `subscribeGitHubPr`                                                    | `gh pr view` spawn + branch-change watcher with 30s poll (Node) |
 
 ## Neutral-vs-gh-specific layout
 
@@ -15,7 +16,13 @@ GitHub PR resolution — Zod schemas, gh-error classifier, CI-status deriver. Pu
 
 ## Server integration
 
-The server's `meta/github.ts` wraps `classifyGhError` and `deriveCheckStatus` with process spawning via `KOLU_GH_BIN` (pinned by Nix in `nix/env.nix`). It subscribes to each terminal's `git:` channel, calls `gh pr view` on branch changes, and publishes `PrResult` through the metadata publisher.
+The server's `meta/github.ts` is a thin adapter around `subscribeGitHubPr`:
+
+1. Calls `subscribeGitHubPr(onChange, log)` — the integration owns the `gh pr view` spawn, branch-change dedup, pending-on-branch-change emission, the 30s polling loop, and failure classification/logging.
+2. On each terminal's `git:` channel emit, calls `watcher.setGit(repoRoot, branch)` — the integration handles dedup internally.
+3. On `onChange`, publishes the resolved `PrResult` into terminal metadata via `updateServerMetadata`.
+
+`KOLU_GH_BIN` is pinned by Nix in `nix/env.nix` and read lazily by `resolve.ts` (first call, not at module load — so browser bundles that reach through `kolu-common/pr` don't blow up on `process.env` access).
 
 ## Consumer imports
 

--- a/packages/integrations/github/package.json
+++ b/packages/integrations/github/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "kolu-github",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "ts-pattern": "^5.9.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/integrations/github/package.json
+++ b/packages/integrations/github/package.json
@@ -8,7 +8,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/integrations/github/package.json
+++ b/packages/integrations/github/package.json
@@ -15,6 +15,7 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
+    "anyagent": "workspace:*",
     "ts-pattern": "^5.9.0",
     "zod": "^4.3.6"
   },

--- a/packages/integrations/github/src/github.test.ts
+++ b/packages/integrations/github/src/github.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { deriveCheckStatus, prResultEqual, classifyGhError } from "./github.ts";
-import type { GitHubPrInfo, PrResult } from "kolu-common";
+import type { GitHubPrInfo, PrResult } from "./schemas.ts";
 
 describe("deriveCheckStatus", () => {
   it("returns null for undefined rollup", () => {

--- a/packages/integrations/github/src/github.ts
+++ b/packages/integrations/github/src/github.ts
@@ -1,0 +1,148 @@
+/** Pure gh-CLI helpers — no I/O, no node-only APIs. The server's
+ *  `meta/github.ts` adapter wraps these with process spawning and channel
+ *  publisher wiring. */
+
+import { match, P } from "ts-pattern";
+import type { GitHubPrInfo, PrResult, PrUnavailableSource } from "./schemas.ts";
+
+/**
+ * Derive combined check status from GitHub's statusCheckRollup entries.
+ *
+ * The rollup contains two GraphQL types, discriminated by `__typename`:
+ *
+ * CheckRun — GitHub Actions / Apps
+ *   status:     QUEUED | IN_PROGRESS | COMPLETED | WAITING | PENDING | REQUESTED
+ *   conclusion: SUCCESS | FAILURE | CANCELLED | NEUTRAL | SKIPPED | STALE
+ *               | STARTUP_FAILURE | TIMED_OUT | ACTION_REQUIRED | null (not yet completed)
+ *
+ * StatusContext — commit statuses (set via REST status API)
+ *   state: SUCCESS | PENDING | FAILURE | ERROR | EXPECTED
+ *
+ * See: https://docs.github.com/en/graphql/reference/unions#statuscheckrollupcontext
+ */
+type CheckOutcome = "fail" | "pending" | "pass";
+
+function classifyCheck(check: {
+  __typename?: string;
+  status?: string;
+  conclusion?: string;
+  state?: string;
+}): CheckOutcome {
+  if (check.__typename === "StatusContext") {
+    return match(check.state?.toUpperCase())
+      .with(P.union("FAILURE", "ERROR"), () => "fail" as const)
+      .with(P.union("PENDING", "EXPECTED"), () => "pending" as const)
+      .otherwise(() => "pass" as const);
+  }
+  // CheckRun: anything not COMPLETED is still pending.
+  if (check.status?.toUpperCase() !== "COMPLETED") return "pending";
+  return match(check.conclusion?.toUpperCase())
+    .with(
+      P.union(
+        "FAILURE",
+        "CANCELLED",
+        "TIMED_OUT",
+        "STARTUP_FAILURE",
+        "ACTION_REQUIRED",
+        "STALE",
+      ),
+      () => "fail" as const,
+    )
+    .otherwise(() => "pass" as const);
+}
+
+export function deriveCheckStatus(
+  rollup:
+    | Array<{
+        __typename?: string;
+        status?: string;
+        conclusion?: string;
+        state?: string;
+      }>
+    | undefined,
+): GitHubPrInfo["checks"] {
+  if (!rollup || rollup.length === 0) return null;
+  // "fail" is terminal — short-circuit; "pending" is sticky until something fails.
+  let worst: CheckOutcome = "pass";
+  for (const check of rollup) {
+    const outcome = classifyCheck(check);
+    if (outcome === "fail") return "fail";
+    if (outcome === "pending") worst = "pending";
+  }
+  return worst;
+}
+
+/** Classify a `gh pr view` failure.
+ *
+ *  `gh pr view` exits non-zero for a genuine "no PR on this branch" (common,
+ *  expected) AND for environmental failures (binary missing, not
+ *  authenticated, hit timeout). The original code collapsed all of these into
+ *  a single `null` — distinguish them here so the UI can surface the
+ *  actionable ones. Only a positive match on gh's "no pull requests found"
+ *  stderr counts as absent; anything else unrecognized is treated as
+ *  unavailable rather than silently shown as "no PR."
+ *
+ *  FRAGILE: gh's stderr messages are not versioned. If gh rewords
+ *  "not logged in" / "authentication" / "no pull requests found", matches
+ *  fall through to `unknown` and the UI loses the actionable recovery copy.
+ *  The parametrized table tests in `github.test.ts` pin the current strings;
+ *  if gh bumps a major and they drift, those tests are the tripwire. */
+export function classifyGhError(err: unknown): PrResult {
+  const e = err as {
+    code?: string | number;
+    killed?: boolean;
+    signal?: string;
+    stderr?: string;
+  };
+  const ghUnavailable = (
+    code: Extract<PrUnavailableSource, { provider: "gh" }>["code"],
+  ): PrResult => ({
+    kind: "unavailable",
+    source: { provider: "gh", code },
+  });
+  if (e.code === "ENOENT") return ghUnavailable("not-installed");
+  // execFile sets killed=true when the timeout fires and sends SIGTERM.
+  if (e.killed === true || e.signal === "SIGTERM") {
+    return ghUnavailable("timed-out");
+  }
+  const stderr = (e.stderr ?? "").toLowerCase();
+  if (
+    stderr.includes("not logged in") ||
+    stderr.includes("authentication") ||
+    stderr.includes("gh auth login")
+  ) {
+    return ghUnavailable("not-authenticated");
+  }
+  if (stderr.includes("no pull requests found")) {
+    return { kind: "absent" };
+  }
+  return ghUnavailable("unknown");
+}
+
+/** Compare two PR resolution states for equality. Reads gh-shaped fields
+ *  on `ok.value` — lives with the gh schemas rather than alongside
+ *  provider-neutral `PrResult` scaffolding. Generalize when a second
+ *  provider forces `ok.value` to widen. */
+export function prResultEqual(a: PrResult, b: PrResult): boolean {
+  if (a === b) return true;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "ok" && b.kind === "ok") {
+    return (
+      a.value.number === b.value.number &&
+      a.value.title === b.value.title &&
+      a.value.url === b.value.url &&
+      a.value.state === b.value.state &&
+      a.value.checks === b.value.checks
+    );
+  }
+  if (a.kind === "unavailable" && b.kind === "unavailable") {
+    // Compare the tagged source: provider + code. Both are the typed
+    // discriminators; the display reason derives from them via
+    // `reasonForSource` and doesn't need its own comparison.
+    return (
+      a.source.provider === b.source.provider && a.source.code === b.source.code
+    );
+  }
+  // "pending" and "absent" have no payload — kind equality is enough.
+  return true;
+}

--- a/packages/integrations/github/src/index.ts
+++ b/packages/integrations/github/src/index.ts
@@ -29,3 +29,9 @@ export type {
 } from "./schemas.ts";
 
 export { deriveCheckStatus, classifyGhError, prResultEqual } from "./github.ts";
+
+export {
+  resolveGitHubPr,
+  subscribeGitHubPr,
+  type GitHubPrWatcher,
+} from "./resolve.ts";

--- a/packages/integrations/github/src/index.ts
+++ b/packages/integrations/github/src/index.ts
@@ -1,0 +1,31 @@
+/** kolu-github — GitHub PR resolution schemas and pure helpers.
+ *
+ *  Leaf package: depends only on zod + ts-pattern. The server's
+ *  `meta/github.ts` wraps these with process spawning (via `KOLU_GH_BIN`)
+ *  and the channel publisher. See top comment in `schemas.ts` for the
+ *  neutral-vs-gh-specific layout rationale. */
+
+export {
+  GitHubCheckStatusSchema,
+  GitHubPrStateSchema,
+  GitHubPrInfoSchema,
+  GhUnavailableCodeSchema,
+  GhUnavailableSchema,
+  PrUnavailableSourceSchema,
+  PrResultSchema,
+  reasonForGhCode,
+  reasonForSource,
+  prValue,
+  prUnavailableReason,
+  prUnavailableSource,
+} from "./schemas.ts";
+export type {
+  GitHubCheckStatus,
+  GitHubPrState,
+  GitHubPrInfo,
+  GhUnavailableCode,
+  PrUnavailableSource,
+  PrResult,
+} from "./schemas.ts";
+
+export { deriveCheckStatus, classifyGhError, prResultEqual } from "./github.ts";

--- a/packages/integrations/github/src/resolve.ts
+++ b/packages/integrations/github/src/resolve.ts
@@ -1,0 +1,181 @@
+/** Runtime resolver — spawns `gh pr view`, classifies failures, owns the
+ *  branch-change + polling loop. Node-only (uses `node:child_process`);
+ *  browser-bound callers should import only from `./schemas.ts` via the
+ *  `kolu-common/pr` subpath, which re-exports schemas + display helpers but
+ *  not this module. */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { Logger } from "anyagent";
+import { GitHubPrStateSchema, type PrResult } from "./schemas.ts";
+import { classifyGhError, deriveCheckStatus, prResultEqual } from "./github.ts";
+
+const execFileAsync = promisify(execFile);
+
+const POLL_INTERVAL_MS = 30_000;
+const GH_TIMEOUT_MS = 5_000;
+
+/** Lazy lookup for the pinned `gh` binary path. Reads `KOLU_GH_BIN` set by
+ *  the Nix wrapper / dev shell (see `nix/env.nix`). Throws on first call —
+ *  not at module load — so importing this file into a browser bundle
+ *  doesn't blow up on `process.env` access; the runtime error surfaces at
+ *  the first resolve attempt, where it belongs. */
+let ghBinCached: string | null = null;
+function getGhBin(): string {
+  if (ghBinCached !== null) return ghBinCached;
+  const v = process.env.KOLU_GH_BIN;
+  if (!v) {
+    throw new Error(
+      "KOLU_GH_BIN is not set. Run kolu through the Nix wrapper or `nix develop`.",
+    );
+  }
+  ghBinCached = v;
+  return v;
+}
+
+/** Shape returned by `gh pr view --json ...`. */
+interface GhPrViewResult {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  statusCheckRollup?: Parameters<typeof deriveCheckStatus>[0];
+}
+
+/** Look up the GitHub PR for the current branch.
+ *
+ *  Uses `gh pr view` which resolves via git remote tracking — it finds the
+ *  PR opened from this repo (or fork) for the current branch, unlike
+ *  `gh pr list --head <name>` which matches by branch name alone and picks
+ *  up unrelated fork PRs.
+ *
+ *  Logs failures at the appropriate level when a logger is passed:
+ *  absent→debug (expected), unknown→error (actual bug), other→warn
+ *  (degraded-but-recoverable). */
+export async function resolveGitHubPr(
+  repoRoot: string,
+  log?: Logger,
+): Promise<PrResult> {
+  try {
+    const { stdout } = await execFileAsync(
+      getGhBin(),
+      ["pr", "view", "--json", "number,title,url,state,statusCheckRollup"],
+      { cwd: repoRoot, timeout: GH_TIMEOUT_MS },
+    );
+    const data = JSON.parse(stdout) as GhPrViewResult;
+    return {
+      kind: "ok",
+      value: {
+        number: data.number,
+        title: data.title,
+        url: data.url,
+        state: GitHubPrStateSchema.parse(data.state.toLowerCase()),
+        checks: deriveCheckStatus(data.statusCheckRollup),
+      },
+    };
+  } catch (err) {
+    const result = classifyGhError(err);
+    if (log) logGhResolveFailure(err, result, log);
+    return result;
+  }
+}
+
+/** Route a failed `gh pr view` result to the appropriate log level.
+ *  absent = expected (branch has no PR) → debug.
+ *  unavailable with code `unknown` = an actual unexpected error → error.
+ *  unavailable with any other code = degraded-but-recoverable → warn. */
+function logGhResolveFailure(
+  err: unknown,
+  result: PrResult,
+  log: Logger,
+): void {
+  const ctx = { err: String(err), result: result.kind };
+  if (result.kind === "absent") {
+    log.debug(ctx, "gh pr view: no PR for branch");
+    return;
+  }
+  if (result.kind === "unavailable" && result.source.code === "unknown") {
+    log.error(ctx, "gh pr view: unknown error");
+    return;
+  }
+  log.warn(
+    result.kind === "unavailable" ? { ...ctx, code: result.source.code } : ctx,
+    "gh pr view: unavailable",
+  );
+}
+
+/** Watcher handle returned by `subscribeGitHubPr`. */
+export interface GitHubPrWatcher {
+  /** Feed the latest git state. Repo+branch dedup happens internally; a
+   *  real change triggers a synchronous `{ kind: "pending" }` emit followed
+   *  by an async resolve that emits the result. Pass `null`s when the
+   *  terminal leaves a repo. */
+  setGit: (repoRoot: string | null, branch: string | null) => void;
+  /** Cancel the poll timer and stop accepting updates. */
+  stop: () => void;
+}
+
+/** Subscribe to GitHub PR changes for a terminal.
+ *
+ *  Mirrors `kolu-git`'s `subscribeGitInfo` shape: the caller wires the
+ *  watcher to its own git source (channel subscription, signal, whatever)
+ *  via `setGit`, and receives resolved `PrResult` values through `onChange`.
+ *
+ *  Owns: branch-change dedup (via `prResultEqual`), pending emission on
+ *  branch change (so stale PR info doesn't linger while `gh pr view` is in
+ *  flight), and a 30s polling loop that re-resolves on the last-seen
+ *  repo/branch (PRs can be created/updated externally).
+ *
+ *  Does not own: the git source, metadata publishing, terminal lifecycle —
+ *  those stay with the caller. */
+export function subscribeGitHubPr(
+  onChange: (pr: PrResult) => void,
+  log?: Logger,
+): GitHubPrWatcher {
+  let lastBranch: string | null = null;
+  let lastRepoRoot: string | null = null;
+  let lastPr: PrResult = { kind: "pending" };
+  let stopped = false;
+
+  function emit(pr: PrResult): void {
+    if (stopped || prResultEqual(pr, lastPr)) return;
+    lastPr = pr;
+    onChange(pr);
+  }
+
+  async function fetchAndEmit(repoRoot: string): Promise<void> {
+    const pr = await resolveGitHubPr(repoRoot, log);
+    emit(pr);
+  }
+
+  function setGit(repoRoot: string | null, branch: string | null): void {
+    if (branch === lastBranch && repoRoot === lastRepoRoot) return;
+    log?.debug(
+      { from: lastBranch, to: branch },
+      "branch changed, re-resolving",
+    );
+    lastBranch = branch;
+    lastRepoRoot = repoRoot;
+    // Emit pending so stale PR info doesn't linger while resolve is in
+    // flight. If we already last-emitted pending, dedup inside `emit`
+    // makes this a no-op.
+    emit({ kind: "pending" });
+    if (branch && repoRoot) void fetchAndEmit(repoRoot);
+  }
+
+  const pollTimer = setInterval(() => {
+    if (lastBranch && lastRepoRoot) {
+      log?.debug({ branch: lastBranch }, "poll tick");
+      void fetchAndEmit(lastRepoRoot);
+    }
+  }, POLL_INTERVAL_MS);
+
+  return {
+    setGit,
+    stop: () => {
+      stopped = true;
+      clearInterval(pollTimer);
+      log?.debug({ branch: lastBranch }, "stopped");
+    },
+  };
+}

--- a/packages/integrations/github/src/schemas.ts
+++ b/packages/integrations/github/src/schemas.ts
@@ -1,0 +1,146 @@
+/** Zod schemas + pure helpers for GitHub PR metadata.
+ *
+ *  Owns both the gh-specific shapes (`GitHubPrInfoSchema`, `Gh*`) and — for
+ *  now — the provider-neutral `PrResult` / `PrUnavailableSource` scaffolding.
+ *  The neutrals live here because `PrResult.ok.value` is `GitHubPrInfo`-
+ *  shaped today and would invert the package dep direction if split out
+ *  (`kolu-common` → `kolu-github`). When a second provider (`bkt`) lands —
+ *  srid/agency#10 — promote the neutrals to their own leaf (or to
+ *  `kolu-common`) and have each provider package import them. */
+
+import { z } from "zod";
+import { match } from "ts-pattern";
+
+// --- GitHub PR info ---
+
+export const GitHubCheckStatusSchema = z.enum(["pending", "pass", "fail"]);
+export type GitHubCheckStatus = z.infer<typeof GitHubCheckStatusSchema>;
+
+export const GitHubPrStateSchema = z.enum(["open", "closed", "merged"]);
+export type GitHubPrState = z.infer<typeof GitHubPrStateSchema>;
+
+export const GitHubPrInfoSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  url: z.string(),
+  /** PR state: open, closed, or merged. */
+  state: GitHubPrStateSchema,
+  /** Combined CI status: pending, pass, or fail. Null if no checks configured. */
+  checks: GitHubCheckStatusSchema.nullable(),
+});
+export type GitHubPrInfo = z.infer<typeof GitHubPrInfoSchema>;
+
+// --- gh-specific unavailable code ---
+
+/** Typed gh-failure code for the `unavailable` PrResult variant.
+ *
+ *  A discriminator separate from any human-readable display text so UI
+ *  callers that want to dispatch per-failure can `match(code).exhaustive()`
+ *  and get a compile error when a new code is added without a handler —
+ *  rather than string-comparing display text and silently breaking on typo.
+ *
+ *  Named with the `Gh` prefix so a parallel `BktUnavailableCodeSchema` lives
+ *  alongside this one when bkt lands; `PrUnavailableSourceSchema` already
+ *  reserves the `provider` discriminator for the tagged-union extension. */
+export const GhUnavailableCodeSchema = z.enum([
+  "not-installed",
+  "not-authenticated",
+  "timed-out",
+  "unknown",
+]);
+export type GhUnavailableCode = z.infer<typeof GhUnavailableCodeSchema>;
+
+/** Display text for a gh unavailable code — single source of truth. Defined
+ *  as a fresh `Record<GhUnavailableCode, string>` literal (not wrapped in
+ *  `match`) so TypeScript's required/excess-property checks enforce both
+ *  sides of exhaustiveness — adding a code without updating this table
+ *  fails compilation, and removing one leaves a dead key that also fails. */
+const GH_REASONS: Record<GhUnavailableCode, string> = {
+  "not-installed": "gh: not installed",
+  "not-authenticated": "gh: not authenticated",
+  "timed-out": "gh: timed out",
+  unknown: "gh: unknown error",
+};
+
+export function reasonForGhCode(code: GhUnavailableCode): string {
+  return GH_REASONS[code];
+}
+
+// --- Provider-tagged unavailable source ---
+
+export const GhUnavailableSchema = z.object({
+  provider: z.literal("gh"),
+  code: GhUnavailableCodeSchema,
+});
+
+/** Which provider classified the failure, plus that provider's typed code.
+ *
+ *  Today only `gh`; a sibling `BktUnavailableSchema` joins this union when
+ *  bkt support lands (srid/agency#10). UI dispatch sites that render
+ *  recovery instructions should `match(source.provider).exhaustive()` so
+ *  adding a new provider arm forces every render site to handle it. */
+export const PrUnavailableSourceSchema = z.discriminatedUnion("provider", [
+  GhUnavailableSchema,
+]);
+export type PrUnavailableSource = z.infer<typeof PrUnavailableSourceSchema>;
+
+/** Display string for any unavailable source — dispatches on provider to the
+ *  provider's own reason lookup. `.exhaustive()` forces a compile error when
+ *  bkt adds its arm to `PrUnavailableSourceSchema` until a matching `.with`
+ *  lands here. */
+export function reasonForSource(source: PrUnavailableSource): string {
+  return match(source)
+    .with({ provider: "gh" }, ({ code }) => reasonForGhCode(code))
+    .exhaustive();
+}
+
+// --- PrResult ---
+
+/** PR resolution state.
+ *
+ *  Decomplects distinct conditions that `GitHubPrInfo | null` used to
+ *  collapse into one value:
+ *    pending     — resolver is running (or stale after a branch change)
+ *    ok          — resolver succeeded; a PR exists for this branch
+ *    absent      — resolver succeeded; no PR for this branch (expected case)
+ *    unavailable — resolver couldn't run; `source` carries the provider +
+ *                  typed failure code, and the display reason is derived by
+ *                  `reasonForSource`.
+ *
+ *  The UI needs to distinguish "absent" (nothing to show) from "unavailable"
+ *  (show a warning with recovery instructions). Keeping the provenance in
+ *  the same field as the value avoids a sibling-flag invariant.
+ *
+ *  Analogous schemas for git/agent/foreground are not introduced yet — their
+ *  failure modes don't currently surface as user-actionable warnings. If they
+ *  do, mirror this shape per-provider rather than inventing a cross-cutting
+ *  status registry (see PR description for juspay/kolu#148). */
+export const PrResultSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("pending") }),
+  z.object({ kind: z.literal("ok"), value: GitHubPrInfoSchema }),
+  z.object({ kind: z.literal("absent") }),
+  z.object({
+    kind: z.literal("unavailable"),
+    source: PrUnavailableSourceSchema,
+  }),
+]);
+export type PrResult = z.infer<typeof PrResultSchema>;
+
+/** Extract the `GitHubPrInfo` when `kind === "ok"`, else `null`.
+ *  Lets SolidJS `<Show when={prValue(meta.pr)}>` work without tripping on the
+ *  object-truthy trap (every variant is a non-null object). */
+export function prValue(pr: PrResult): GitHubPrInfo | null {
+  return pr.kind === "ok" ? pr.value : null;
+}
+
+/** Extract the display reason when `kind === "unavailable"`, else `null`. */
+export function prUnavailableReason(pr: PrResult): string | null {
+  return pr.kind === "unavailable" ? reasonForSource(pr.source) : null;
+}
+
+/** Extract the tagged source when `kind === "unavailable"`, else `null`. Use
+ *  this when the UI needs to dispatch on provider/code; `prUnavailableReason`
+ *  is enough for a plain string tooltip. */
+export function prUnavailableSource(pr: PrResult): PrUnavailableSource | null {
+  return pr.kind === "unavailable" ? pr.source : null;
+}

--- a/packages/integrations/github/tsconfig.json
+++ b/packages/integrations/github/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
     "kolu-claude-code": "workspace:*",
     "kolu-common": "workspace:*",
     "kolu-git": "workspace:*",
+    "kolu-github": "workspace:*",
     "kolu-opencode": "workspace:*",
     "node-pty": "^1.0.0",
     "pino": "^10.3.1",

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -1,175 +1,41 @@
 /**
- * GitHub PR metadata provider — resolves PR info for the current branch.
+ * GitHub PR metadata provider — thin adapter around `kolu-github`.
  *
- * Subscribes to "git:<id>" (not the aggregated "metadata" channel).
- * Publishes via updateServerMetadata() — no downstream providers depend on PR changes.
- * Also polls periodically (PRs can be created/updated externally at any time).
+ * The integration owns everything gh-specific: `KOLU_GH_BIN` lookup, the
+ * `gh pr view` spawn, branch-change dedup, the 30s polling loop, failure
+ * classification and routing. This file just wires the watcher to the
+ * server's `git:` channel and pushes resolved `PrResult` values into
+ * terminal metadata via `updateServerMetadata`.
  *
  * ┌─ FUTURE: PrProvider extraction ──────────────────────────────────────┐
- * │ When Bitbucket (`bkt`) support lands (srid/agency#10), the forge-    │
- * │ specific bits — the `gh`/`bkt` binary, provider-specific classifier, │
- * │ schemas — get pulled behind a narrow `PrProvider` interface:         │
- * │                                                                      │
- * │   interface PrProvider {                                             │
- * │     readonly kind: "gh" | "bkt";                                     │
- * │     resolve(repoRoot: string): Promise<PrResult>;                    │
- * │   }                                                                  │
- * │                                                                      │
- * │ Dispatch by forge detection (origin remote URL — same axis that      │
- * │ `/do`'s forge step uses). `PrResult` stays shared; each impl owns    │
- * │ its own classifier + pinned binary env var (`KOLU_GH_BIN`,           │
- * │ `KOLU_BKT_BIN`). Don't extract before the second impl exists —       │
- * │ the bkt stderr taxonomy is what will tell you where the seam goes.   │
+ * │ When Bitbucket (`bkt`) support lands (srid/agency#10), a sibling     │
+ * │ `kolu-bkt` will export the same `subscribeBitbucketPr` shape. This   │
+ * │ adapter dispatches by forge detection (origin remote URL — same      │
+ * │ axis `/do`'s forge step uses). `PrResult` stays shared; each impl    │
+ * │ owns its own classifier + pinned binary env var (`KOLU_GH_BIN`,      │
+ * │ `KOLU_BKT_BIN`). Don't extract a common `PrProvider` interface       │
+ * │ before bkt exists — its stderr taxonomy is what will tell you where  │
+ * │ the seam goes.                                                       │
  * └──────────────────────────────────────────────────────────────────────┘
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import {
-  GitHubPrStateSchema,
-  classifyGhError,
-  deriveCheckStatus,
-  prResultEqual,
-  type PrResult,
-} from "kolu-github";
-import type { GitInfo } from "kolu-common";
+import { subscribeGitHubPr } from "kolu-github";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal } from "../publisher.ts";
 import { updateServerMetadata } from "./index.ts";
 import { log } from "../log.ts";
 
-const execFileAsync = promisify(execFile);
-
-const POLL_INTERVAL_MS = 30_000;
-const GH_TIMEOUT_MS = 5_000;
-
-/** Pinned `gh` binary path. `KOLU_GH_BIN` is set by both the packaged
- *  wrapper and the dev shell via `nix/env.nix` → `shell.nix` / `default.nix`.
- *  Nix is the only supported runtime; fail fast if the env var is missing
- *  rather than silently falling through to PATH (which would resolve to a
- *  different `gh` than the one kolu ships with). */
-const GH_BIN = (() => {
-  const v = process.env.KOLU_GH_BIN;
-  if (!v) {
-    throw new Error(
-      "KOLU_GH_BIN is not set. Run kolu through the Nix wrapper or `nix develop`.",
-    );
-  }
-  return v;
-})();
-
-/** Shape returned by `gh pr view --json ...`. */
-interface GhPrViewResult {
-  number: number;
-  title: string;
-  url: string;
-  state: string;
-  statusCheckRollup?: Parameters<typeof deriveCheckStatus>[0];
-}
-
-/**
- * Look up the GitHub PR for the current branch.
- *
- * Uses `gh pr view` which resolves via git remote tracking — it finds the PR
- * opened from this repo (or fork) for the current branch, unlike `gh pr list
- * --head <name>` which matches by branch name alone and picks up unrelated
- * fork PRs.
- */
-async function resolveGitHubPr(repoRoot: string): Promise<PrResult> {
-  try {
-    const { stdout } = await execFileAsync(
-      GH_BIN,
-      ["pr", "view", "--json", "number,title,url,state,statusCheckRollup"],
-      { cwd: repoRoot, timeout: GH_TIMEOUT_MS },
-    );
-    const data = JSON.parse(stdout) as GhPrViewResult;
-    return {
-      kind: "ok",
-      value: {
-        number: data.number,
-        title: data.title,
-        url: data.url,
-        state: GitHubPrStateSchema.parse(data.state.toLowerCase()),
-        checks: deriveCheckStatus(data.statusCheckRollup),
-      },
-    };
-  } catch (err) {
-    const result = classifyGhError(err);
-    logGhResolveFailure(err, result);
-    return result;
-  }
-}
-
-/** Route a failed `gh pr view` result to the appropriate log level.
- *  absent = expected (branch has no PR) → debug.
- *  unavailable with code `unknown` = an actual unexpected error → error.
- *  unavailable with any other code = degraded-but-recoverable → warn. */
-function logGhResolveFailure(err: unknown, result: PrResult): void {
-  const ctx = { err: String(err), result: result.kind };
-  if (result.kind === "absent") {
-    log.debug(ctx, "gh pr view: no PR for branch");
-    return;
-  }
-  if (result.kind === "unavailable" && result.source.code === "unknown") {
-    log.error(ctx, "gh pr view: unknown error");
-    return;
-  }
-  log.warn(
-    result.kind === "unavailable" ? { ...ctx, code: result.source.code } : ctx,
-    "gh pr view: unavailable",
-  );
-}
-
-/**
- * Start the GitHub PR metadata provider for a terminal entry.
- *
- * Subscribes to the `git:` channel — the git provider publishes its
- * current state (including the initial resolve) on that channel, so there
- * is no need to peek at `entry.info.meta.git` at startup. Also polls
- * every 30s to pick up PRs created/updated externally.
- *
- * This provider owns the `pr` slot end-to-end: it clears `pr` immediately
- * on any branch change (so stale pr info doesn't linger while the async
- * `gh pr view` is in flight) and writes the new value when the resolve
- * completes.
- */
 export function startGitHubPrProvider(
   entry: TerminalProcess,
   terminalId: string,
 ): () => void {
   const plog = log.child({ provider: "github-pr", terminal: terminalId });
-  let lastBranch: string | undefined;
-  let lastRepoRoot: string | undefined;
-
   plog.debug("started");
 
-  function onGitChange(git: GitInfo | null) {
-    const branch = git?.branch;
-    const repoRoot = git?.repoRoot;
-    if (branch === lastBranch && repoRoot === lastRepoRoot) return;
-    plog.debug(
-      { from: lastBranch, to: branch },
-      "branch changed, re-resolving",
-    );
-    lastBranch = branch;
-    lastRepoRoot = repoRoot;
-    // Mark pr pending — the previous value is tied to the old branch and is
-    // now stale. If we still have a repo, the async resolve below will
-    // overwrite with the new branch's result. If we don't, pending is the
-    // final state until a new repo is attached.
-    if (entry.info.meta.pr.kind !== "pending") {
-      updateServerMetadata(entry, terminalId, (m) => {
-        m.pr = { kind: "pending" };
-      });
-    }
-    if (branch && repoRoot) {
-      void resolve(repoRoot);
-    }
-  }
-
-  async function resolve(repoRoot: string) {
-    const pr = await resolveGitHubPr(repoRoot);
-    if (prResultEqual(pr, entry.info.meta.pr)) return;
+  const watcher = subscribeGitHubPr((pr) => {
+    updateServerMetadata(entry, terminalId, (m) => {
+      m.pr = pr;
+    });
     plog.debug(
       pr.kind === "ok"
         ? {
@@ -181,25 +47,15 @@ export function startGitHubPrProvider(
         : { pr: pr.kind },
       "pr info updated",
     );
-    updateServerMetadata(entry, terminalId, (m) => {
-      m.pr = pr;
-    });
-  }
-
-  // Periodic poll — PRs can be created/updated externally
-  const pollTimer = setInterval(() => {
-    if (lastBranch && lastRepoRoot) {
-      plog.debug("poll tick");
-      void resolve(lastRepoRoot);
-    }
-  }, POLL_INTERVAL_MS);
+  }, plog);
 
   const abort = new AbortController();
-  subscribeForTerminal("git", terminalId, abort.signal, onGitChange);
+  subscribeForTerminal("git", terminalId, abort.signal, (git) => {
+    watcher.setGit(git?.repoRoot ?? null, git?.branch ?? null);
+  });
 
   return () => {
     abort.abort();
-    clearInterval(pollTimer);
-    plog.debug("stopped");
+    watcher.stop();
   };
 }

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -7,8 +7,8 @@
  *
  * ┌─ FUTURE: PrProvider extraction ──────────────────────────────────────┐
  * │ When Bitbucket (`bkt`) support lands (srid/agency#10), the forge-    │
- * │ specific bits here — `GH_BIN`, `gh pr view` invocation, gh-stderr    │
- * │ classifier — get pulled behind a narrow `PrProvider` interface:      │
+ * │ specific bits — the `gh`/`bkt` binary, provider-specific classifier, │
+ * │ schemas — get pulled behind a narrow `PrProvider` interface:         │
  * │                                                                      │
  * │   interface PrProvider {                                             │
  * │     readonly kind: "gh" | "bkt";                                     │
@@ -25,14 +25,14 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { match, P } from "ts-pattern";
 import {
   GitHubPrStateSchema,
-  type GitHubPrInfo,
-  type GitInfo,
+  classifyGhError,
+  deriveCheckStatus,
+  prResultEqual,
   type PrResult,
-  type PrUnavailableSource,
-} from "kolu-common";
+} from "kolu-github";
+import type { GitInfo } from "kolu-common";
 import type { TerminalProcess } from "../terminals.ts";
 import { subscribeForTerminal } from "../publisher.ts";
 import { updateServerMetadata } from "./index.ts";
@@ -58,81 +58,6 @@ const GH_BIN = (() => {
   return v;
 })();
 
-/**
- * Derive combined check status from statusCheckRollup entries.
- *
- * The rollup contains two GraphQL types, discriminated by __typename:
- *
- * CheckRun — GitHub Actions / Apps
- *   status:     QUEUED | IN_PROGRESS | COMPLETED | WAITING | PENDING | REQUESTED
- *   conclusion: SUCCESS | FAILURE | CANCELLED | NEUTRAL | SKIPPED | STALE
- *               | STARTUP_FAILURE | TIMED_OUT | ACTION_REQUIRED | null (not yet completed)
- *
- * StatusContext — commit statuses (set via REST status API)
- *   state: SUCCESS | PENDING | FAILURE | ERROR | EXPECTED
- *
- * See: https://docs.github.com/en/graphql/reference/unions#statuscheckrollupcontext
- */
-type CheckOutcome = "fail" | "pending" | "pass";
-
-/**
- * Classify a single rollup entry into fail / pending / pass.
- *
- * Two GitHub types share the rollup; `__typename` discriminates which enum to
- * dispatch on. Within each branch, `match` + `P.union` groups the failure-
- * and pending-class buckets so adding a new value (e.g. a future GitHub
- * conclusion) is a one-line edit.
- */
-function classifyCheck(check: {
-  __typename?: string;
-  status?: string;
-  conclusion?: string;
-  state?: string;
-}): CheckOutcome {
-  if (check.__typename === "StatusContext") {
-    return match(check.state?.toUpperCase())
-      .with(P.union("FAILURE", "ERROR"), () => "fail" as const)
-      .with(P.union("PENDING", "EXPECTED"), () => "pending" as const)
-      .otherwise(() => "pass" as const);
-  }
-  // CheckRun: anything not COMPLETED is still pending.
-  if (check.status?.toUpperCase() !== "COMPLETED") return "pending";
-  return match(check.conclusion?.toUpperCase())
-    .with(
-      P.union(
-        "FAILURE",
-        "CANCELLED",
-        "TIMED_OUT",
-        "STARTUP_FAILURE",
-        "ACTION_REQUIRED",
-        "STALE",
-      ),
-      () => "fail" as const,
-    )
-    .otherwise(() => "pass" as const);
-}
-
-export function deriveCheckStatus(
-  rollup:
-    | Array<{
-        __typename?: string;
-        status?: string;
-        conclusion?: string;
-        state?: string;
-      }>
-    | undefined,
-): GitHubPrInfo["checks"] {
-  if (!rollup || rollup.length === 0) return null;
-  // "fail" is terminal — short-circuit; "pending" is sticky until something fails.
-  let worst: CheckOutcome = "pass";
-  for (const check of rollup) {
-    const outcome = classifyCheck(check);
-    if (outcome === "fail") return "fail";
-    if (outcome === "pending") worst = "pending";
-  }
-  return worst;
-}
-
 /** Shape returned by `gh pr view --json ...`. */
 interface GhPrViewResult {
   number: number;
@@ -140,47 +65,6 @@ interface GhPrViewResult {
   url: string;
   state: string;
   statusCheckRollup?: Parameters<typeof deriveCheckStatus>[0];
-}
-
-/** Classify a `gh pr view` failure.
- *
- *  `gh pr view` exits non-zero for a genuine "no PR on this branch" (common,
- *  expected) AND for environmental failures (binary missing, not
- *  authenticated, hit timeout). The original code collapsed all of these into
- *  a single `null` — distinguish them here so the UI can surface the
- *  actionable ones. Only a positive match on gh's "no pull requests found"
- *  stderr counts as absent; anything else unrecognized is treated as
- *  unavailable rather than silently shown as "no PR." */
-export function classifyGhError(err: unknown): PrResult {
-  const e = err as {
-    code?: string | number;
-    killed?: boolean;
-    signal?: string;
-    stderr?: string;
-  };
-  const ghUnavailable = (
-    code: Extract<PrUnavailableSource, { provider: "gh" }>["code"],
-  ): PrResult => ({
-    kind: "unavailable",
-    source: { provider: "gh", code },
-  });
-  if (e.code === "ENOENT") return ghUnavailable("not-installed");
-  // execFile sets killed=true when the timeout fires and sends SIGTERM.
-  if (e.killed === true || e.signal === "SIGTERM") {
-    return ghUnavailable("timed-out");
-  }
-  const stderr = (e.stderr ?? "").toLowerCase();
-  if (
-    stderr.includes("not logged in") ||
-    stderr.includes("authentication") ||
-    stderr.includes("gh auth login")
-  ) {
-    return ghUnavailable("not-authenticated");
-  }
-  if (stderr.includes("no pull requests found")) {
-    return { kind: "absent" };
-  }
-  return ghUnavailable("unknown");
 }
 
 /**
@@ -234,31 +118,6 @@ function logGhResolveFailure(err: unknown, result: PrResult): void {
     result.kind === "unavailable" ? { ...ctx, code: result.source.code } : ctx,
     "gh pr view: unavailable",
   );
-}
-
-/** Compare two PR resolution states for equality. */
-export function prResultEqual(a: PrResult, b: PrResult): boolean {
-  if (a === b) return true;
-  if (a.kind !== b.kind) return false;
-  if (a.kind === "ok" && b.kind === "ok") {
-    return (
-      a.value.number === b.value.number &&
-      a.value.title === b.value.title &&
-      a.value.url === b.value.url &&
-      a.value.state === b.value.state &&
-      a.value.checks === b.value.checks
-    );
-  }
-  if (a.kind === "unavailable" && b.kind === "unavailable") {
-    // Compare the tagged source: provider + code. Both are the typed
-    // discriminators; the display reason derives from them via
-    // `reasonForSource` and doesn't need its own comparison.
-    return (
-      a.source.provider === b.source.provider && a.source.code === b.source.code
-    );
-  }
-  // "pending" and "absent" have no payload — kind equality is enough.
-  return true;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       kolu-git:
         specifier: workspace:*
         version: link:../integrations/git
+      kolu-github:
+        specifier: workspace:*
+        version: link:../integrations/github
       kolu-opencode:
         specifier: workspace:*
         version: link:../integrations/opencode
@@ -221,6 +224,25 @@ importers:
       simple-git:
         specifier: ^3.33.0
         version: 3.33.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/integrations/github:
+    dependencies:
+      ts-pattern:
+        specifier: ^5.9.0
+        version: 5.9.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -319,6 +341,9 @@ importers:
       kolu-git:
         specifier: workspace:*
         version: link:../integrations/git
+      kolu-github:
+        specifier: workspace:*
+        version: link:../integrations/github
       kolu-opencode:
         specifier: workspace:*
         version: link:../integrations/opencode

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
 
   packages/integrations/github:
     dependencies:
+      anyagent:
+        specifier: workspace:*
+        version: link:../anyagent
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0


### PR DESCRIPTION
**GitHub PR resolution now lives in its own leaf package**, `packages/integrations/github/`, and the server's `meta/github.ts` is a thin adapter. The extraction mirrors `kolu-git` exactly: schemas + pure helpers in `schemas.ts`/`github.ts`, the runtime resolver + branch-change + 30s polling loop in `resolve.ts`, and Zod schemas re-exported by `kolu-common` / `kolu-common/pr`. The server file drops from 346 lines to 61 — within shouting distance of `meta/git.ts`'s 53-line adapter — and keeps only what's actually server-coupled: channel subscription, `updateServerMetadata` publishing, logger injection.

The extraction went in two cuts. The first moved the pure helpers (`classifyGhError`, `deriveCheckStatus`, `prResultEqual`) and gh-specific schemas out (346→205). The second moved the `gh pr view` spawn, `KOLU_GH_BIN` lookup, failure-severity routing, and the branch-change/poll watcher out (205→61) — exported as `subscribeGitHubPr(onChange, log)`, whose shape mirrors `kolu-git`'s `subscribeGitInfo`. *`KOLU_GH_BIN` is now read lazily* (first resolve call, not at module load), so `resolve.ts` can sit behind the `kolu-common/pr` subpath without blowing up in browser bundles that never invoke it.

The non-obvious call is where the provider-*neutral* scaffolding ended up. `PrResult`, `PrUnavailableSourceSchema`, `reasonForSource`, and the extractors live in `kolu-github` alongside the gh-specific shapes. *Splitting them out the other way (neutrals in `kolu-common`, gh in `kolu-github`) would invert the package dep direction — `PrResult.ok.value` is `GitHubPrInfo`-shaped today, so `kolu-common` would need to both import from and be imported by `kolu-github`.* Promoting the neutrals to their own leaf is the right move once a second provider validates the seam; doing it speculatively would pick a boundary with no evidence behind it. The `kolu-common/pr` surface is narrowed to schemas + display helpers only — classifiers are not re-exported, so the neutrality promise of the subpath holds even inside the interim layout.

Follow-up to #638. Paves the way for [srid/agency#10](https://github.com/srid/agency/issues/10): when bkt lands, a sibling `kolu-bkt` exports the same `subscribeBitbucketPr` shape and the server's `meta/github.ts` becomes a 2-way forge dispatch.

### Try it locally

\`\`\`sh
nix run github:juspay/kolu/refactor/extract-kolu-github
\`\`\`