### PR TITLE
Seed terminal metadata atomically to survive session restore

### DIFF
--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -139,6 +139,14 @@ const TerminalCanvas: Component<{
   // The pending seed makes the tile paint at the cascade position on its
   // first render — without it, there would be a (0,0) frame while waiting
   // for the server's metadata echo.
+  //
+  // Contract: the default-cascade runs only for tiles whose `getLayout(id)`
+  // is falsy on their first appearance in `tileIds`. Callers that intend
+  // to preserve a pre-existing layout (session restore, tile clone, …) are
+  // responsible for making `getLayout(id)` return it by then — e.g. by
+  // seeding server metadata before the list snapshot yields (#642). Any
+  // path that seeds AFTER the first `tileIds` fire will lose to this
+  // cascade and overwrite the intended layout.
   createEffect(
     on(
       () => props.tileIds,

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -4,14 +4,22 @@ import { createSignal, createEffect } from "solid-js";
 import { toast } from "solid-sonner";
 import { useSubPanel } from "./useSubPanel";
 import { useSavedSession } from "../settings/useSavedSession";
-import { client, lifecycle } from "../rpc/rpc";
-import type { TerminalId, TerminalInfo, SavedSession } from "kolu-common";
+import { lifecycle } from "../rpc/rpc";
+import type {
+  InitialTerminalMetadata,
+  TerminalId,
+  TerminalInfo,
+  SavedSession,
+} from "kolu-common";
 import type { TerminalStore } from "./useTerminalStore";
 
 export function useSessionRestore(deps: {
   store: TerminalStore;
   subscribeExit: (id: TerminalId) => void;
-  handleCreate: (cwd?: string, themeName?: string) => Promise<TerminalId>;
+  handleCreate: (
+    cwd?: string,
+    initial?: InitialTerminalMetadata,
+  ) => Promise<TerminalId>;
   handleCreateSubTerminal: (
     parentId: TerminalId,
     cwd?: string,
@@ -135,30 +143,26 @@ export function useSessionRestore(deps: {
       const subTerminals = session.terminals
         .filter((t) => t.parentId)
         .sort(bySortOrder);
+      // Seed each new terminal with its saved metadata atomically at create
+      // time — the server embeds it into the first `terminal.list` snapshot,
+      // so the canvas cascade effect sees the saved layout on its first run
+      // and skips the default-cascade branch (#642).
       for (const t of topLevel) {
-        const newId = await deps.handleCreate(t.cwd, t.themeName);
+        const newId = await deps.handleCreate(t.cwd, {
+          themeName: t.themeName,
+          canvasLayout: t.canvasLayout,
+          subPanel: t.subPanel,
+        });
         oldToNew.set(t.id, newId);
+        // Client-side sub-panel state (activeSubTab, focusTarget) isn't
+        // server-persisted — seed it locally so the restored panel reopens
+        // to the same tab. The server-persisted fields (collapsed, panelSize)
+        // ride along via handleCreate above.
+        if (t.subPanel) subPanel.seedPanel(newId, t.subPanel);
       }
       for (const t of subTerminals) {
         const newParentId = oldToNew.get(t.parentId!);
         if (newParentId) await deps.handleCreateSubTerminal(newParentId, t.cwd);
-      }
-      // Restore canvas layouts and sub-panel state under the new terminal IDs.
-      // Canvas layouts go straight to the server — the metadata subscription
-      // delivers them back to the canvas for rendering.
-      for (const t of session.terminals) {
-        const newId = oldToNew.get(t.id);
-        if (!newId) continue;
-        if (t.canvasLayout) {
-          void client.terminal
-            .setCanvasLayout({ id: newId, layout: t.canvasLayout })
-            .catch((err: Error) =>
-              toast.error(`Failed to restore canvas layout: ${err.message}`),
-            );
-        }
-        if (t.subPanel) {
-          subPanel.seedPanel(newId, t.subPanel);
-        }
       }
       // Restore active terminal
       if (session.activeTerminalId) {

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -11,7 +11,11 @@ import { writeTextToClipboard } from "./clipboard";
 import { useTips } from "../settings/useTips";
 import { usePreferences } from "../settings/usePreferences";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
-import type { TerminalId, CanvasLayout } from "kolu-common";
+import type {
+  CanvasLayout,
+  InitialTerminalMetadata,
+  TerminalId,
+} from "kolu-common";
 import type { TerminalStore } from "./useTerminalStore";
 
 export function useTerminalCrud(deps: {
@@ -102,11 +106,13 @@ export function useTerminalCrud(deps: {
 
   /** Create a new terminal on the server and make it active.
    *  Returns the new terminal ID (for session restore mapping).
-   *  When `themeName` is provided (e.g. session restore), it overrides
-   *  the shuffle-theme preference so only one setTheme RPC fires. */
+   *  `initial` carries client-owned metadata to seed atomically on the
+   *  server — used by session restore so the first `terminal.list`
+   *  yield already carries the saved theme / canvas layout / sub-panel
+   *  state, closing the race with the canvas cascade effect (#642). */
   async function handleCreate(
     cwd?: string,
-    themeName?: string,
+    initial?: InitialTerminalMetadata,
   ): Promise<TerminalId> {
     if (store.activeMeta()?.git) showTipOnce(CONTEXTUAL_TIPS.worktree);
 
@@ -119,18 +125,24 @@ export function useTerminalCrud(deps: {
           (id) => store.getMetadata(id)?.themeName,
         )
       : null;
-    const info = await client.terminal.create({ cwd }).catch((err: Error) => {
-      toast.error(`Failed to create terminal: ${err.message}`);
-      throw err;
-    });
     const theme =
-      themeName ??
+      initial?.themeName ??
       (peerBgs
         ? pickTheme(availableThemes, { spread: true, peerBgs })
         : undefined);
+    const info = await client.terminal
+      .create({
+        cwd,
+        themeName: theme,
+        canvasLayout: initial?.canvasLayout,
+        subPanel: initial?.subPanel,
+      })
+      .catch((err: Error) => {
+        toast.error(`Failed to create terminal: ${err.message}`);
+        throw err;
+      });
     store.setActiveId(info.id);
     deps.subscribeExit(info.id);
-    if (theme) setThemeName(info.id, theme);
     showTipOnce(CONTEXTUAL_TIPS.themeSwitch);
     return info.id;
   }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -226,10 +226,21 @@ export const SetActiveTerminalInputSchema = z.object({
   id: TerminalIdSchema.nullable(),
 });
 
-export const TerminalCreateInputSchema = z.object({
-  cwd: z.string().optional(),
-  parentId: TerminalIdSchema.optional(),
+/** Client-owned metadata supplied at create time. Seeded onto the new
+ *  terminal's `meta` before the first `terminal.list` yield, so session
+ *  restore can't race the canvas default-cascade effect (#642). */
+export const InitialTerminalMetadataSchema = z.object({
+  themeName: z.string().optional(),
+  canvasLayout: CanvasLayoutSchema.optional(),
+  subPanel: SubPanelStateSchema.optional(),
 });
+
+export const TerminalCreateInputSchema = z
+  .object({
+    cwd: z.string().optional(),
+    parentId: TerminalIdSchema.optional(),
+  })
+  .merge(InitialTerminalMetadataSchema);
 
 export const TerminalAttachInputSchema = z.object({ id: TerminalIdSchema });
 export const TerminalAttachOutputSchema = z.string();
@@ -399,6 +410,9 @@ export type TerminalClientMetadata = z.infer<
   typeof TerminalClientMetadataSchema
 >;
 export type TerminalMetadata = z.infer<typeof TerminalMetadataSchema>;
+export type InitialTerminalMetadata = z.infer<
+  typeof InitialTerminalMetadataSchema
+>;
 export type RecentRepo = z.infer<typeof RecentRepoSchema>;
 export type RecentAgent = z.infer<typeof RecentAgentSchema>;
 export type SavedTerminal = z.infer<typeof SavedTerminalSchema>;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -80,7 +80,11 @@ export const appRouter = t.router({
   },
   terminal: {
     create: t.terminal.create.handler(async ({ input }) =>
-      createTerminal(input.cwd, input.parentId),
+      createTerminal(input.cwd, input.parentId, {
+        themeName: input.themeName,
+        canvasLayout: input.canvasLayout,
+        subPanel: input.subPanel,
+      }),
     ),
     list: t.terminal.list.handler(async function* ({ signal }) {
       yield listTerminals();

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -3,7 +3,12 @@
  * Plain Map + exported functions. Each entry owns its PtyHandle.
  */
 import { spawnPty, type PtyHandle } from "./pty.ts";
-import type { TerminalId, TerminalInfo, TerminalMetadata } from "kolu-common";
+import type {
+  InitialTerminalMetadata,
+  TerminalId,
+  TerminalInfo,
+  TerminalMetadata,
+} from "kolu-common";
 import { log } from "./log.ts";
 import {
   CLIPBOARD_SHIM_DIR,
@@ -126,8 +131,16 @@ function publishSuffixChanges(): void {
   }
 }
 
-/** Create a new terminal, spawn a PTY process. Optionally set initial CWD and parent. */
-export function createTerminal(cwd?: string, parentId?: string): TerminalInfo {
+/** Create a new terminal, spawn a PTY process. `initial` seeds
+ *  client-owned metadata onto `meta` before the first `emitListChanged()`,
+ *  so the list snapshot already carries it — used by session restore
+ *  to avoid racing post-hoc `setCanvasLayout` / `setTheme` / `setSubPanel`
+ *  RPCs against the client's canvas-cascade effect (#642). */
+export function createTerminal(
+  cwd?: string,
+  parentId?: string,
+  initial?: InitialTerminalMetadata,
+): TerminalInfo {
   const id = crypto.randomUUID();
   const tlog = log.child({ terminal: id });
   const clipboardDir = createClipboardDir(id);
@@ -185,6 +198,11 @@ export function createTerminal(cwd?: string, parentId?: string): TerminalInfo {
 
   const meta = createMetadata(handle.cwd, nextSortOrder(parentId));
   if (parentId) meta.parentId = parentId;
+  // Seed client-owned initial metadata BEFORE emitListChanged so the
+  // first list snapshot carries these fields (see #642).
+  if (initial?.themeName) meta.themeName = initial.themeName;
+  if (initial?.canvasLayout) meta.canvasLayout = initial.canvasLayout;
+  if (initial?.subPanel) meta.subPanel = initial.subPanel;
   const entry: TerminalProcess = {
     info: {
       id,

--- a/packages/tests/features/session-restore.feature
+++ b/packages/tests/features/session-restore.feature
@@ -30,6 +30,19 @@ Feature: Session restore
     And the header should show theme "Dracula"
     And there should be no page errors
 
+  # Regression for #642: a saved canvas layout must survive session restore.
+  # The client used to race the canvas's cascade-default effect against a
+  # post-hoc setCanvasLayout RPC and lose — terminals ended up in the
+  # default cascade instead of their saved positions.
+  Scenario: Restored terminals preserve their canvas layout
+    Given a saved session with canvas layout at x=420 y=180 w=640 h=360
+    When I open the app
+    Then the session restore card should be visible
+    When I click the restore button
+    Then there should be 1 pill tree entries
+    And the canvas tile should be at x=420 y=180 w=640 h=360
+    And there should be no page errors
+
   Scenario: Active terminal persists across refresh
     When I open the app
     And I create a terminal

--- a/packages/tests/step_definitions/session_restore_steps.ts
+++ b/packages/tests/step_definitions/session_restore_steps.ts
@@ -181,6 +181,45 @@ Given(
   },
 );
 
+// --- Canvas layout restore scenario ---
+
+Given(
+  "a saved session with canvas layout at x={int} y={int} w={int} h={int}",
+  async function (this: KoluWorld, x: number, y: number, w: number, h: number) {
+    this.savedSessionTerminalCount = 1;
+    const terminals = [
+      { id: "0", cwd: os.homedir(), canvasLayout: { x, y, w, h } },
+    ];
+    this.savedSessionTerminals = terminals;
+    await postSavedSessionPayload(this.page, terminals);
+  },
+);
+
+Then(
+  "the canvas tile should be at x={int} y={int} w={int} h={int}",
+  async function (this: KoluWorld, x: number, y: number, w: number, h: number) {
+    // Poll — the tile's inline style may briefly reflect a pending layout
+    // while the server's metadata echo is in flight on first paint.
+    await this.page.waitForFunction(
+      (expected) => {
+        const tile = document.querySelector<HTMLElement>(
+          '[data-testid="canvas-tile"]',
+        );
+        if (!tile) return false;
+        const s = tile.style;
+        return (
+          s.left === `${expected.x}px` &&
+          s.top === `${expected.y}px` &&
+          s.width === `${expected.w}px` &&
+          s.height === `${expected.h}px`
+        );
+      },
+      { x, y, w, h },
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // --- Refresh preserves the active terminal ---
 
 /** The server debounces session auto-save by 500ms after the last change


### PR DESCRIPTION
**Session restore was losing canvas layouts**: the client created each terminal, _then_ fired a separate `setCanvasLayout` RPC — but the `terminal.list` subscription push could arrive in between, which kicked off the canvas's cascade-default effect and raced a default layout back to the server. Under FIFO ordering, the default write arrived second and wiped the saved one. Eight tiles ended up stacked in the cascade instead of where you left them.

The fix is to make terminal creation carry its full initial state in a single RPC. `TerminalCreateInputSchema` now accepts optional `themeName`, `canvasLayout`, and `subPanel`, and the server seeds them onto `meta` **before `emitListChanged` fires**. The first list snapshot already carries the saved layout, so the cascade-default effect's own guard (`if (layoutOf(id)) continue;`) skips the tile — no race to win.

_The cascade-default effect's JSDoc has been restated as a contract on when `getLayout(id)` must be populated, rather than as a note about session restore specifically._ Any future path that seeds layout (clone-with-layout, drag-duplicate, …) has to satisfy the same contract, and the comment now tells future editors what that contract is.

> **Net API change**: `terminal.create`'s input schema grows three optional fields. The post-hoc `setCanvasLayout` loop in session restore is gone. `handleCreate`'s second positional parameter changes from `themeName?: string` to `initial?: InitialTerminalMetadata` — all existing call sites pass only `cwd`, so they stay compatible.

Regression covered by a new e2e scenario that seeds a saved session at `{x:420, y:180, w:640, h:360}`, clicks restore, and asserts the tile's inline style matches — which would have failed pre-fix.

Closes #642