### PR TITLE
docs: reframe tagline as "terminal-native cockpit for coding agents"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # kolu
 
-A browser cockpit for coding agents. Bring your own CLI, run them anywhere.
+A terminal-native cockpit for coding agents. Bring your own CLI, run them anywhere.
 
 Unlike agent command centers that wrap a single model behind their own chat UI, kolu stays out of the agent's way: the terminal is the universal interface, so `claude`, `opencode`, or whatever ships next week works out of the box — and you can drop to a plain shell whenever you want. It's an [Agentic Development Environment](https://x.com/jdegoes/status/2036931874057314390) (ADE) that treats terminals as the thesis, not the substrate.
 

--- a/website/src/content/blog/xtermjs-perf.md
+++ b/website/src/content/blog/xtermjs-perf.md
@@ -8,7 +8,7 @@ author: "Sridhar Ratnakumar"
 _One afternoon, two xterm.js contributions, and a reminder that proxy
 metrics can be wrong by three orders of magnitude._
 
-[Kolu](https://github.com/juspay/kolu) is a browser cockpit for
+[Kolu](https://github.com/juspay/kolu) is a terminal-native cockpit for
 coding agents — `claude`, `opencode`, whatever ships next week.
 The terminal is the universal interface: every pane is a real
 [xterm.js](https://xtermjs.org/) in the browser, connected over

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -10,10 +10,10 @@ interface Props {
 
 const {
   title,
-  description = 'A browser cockpit for coding agents. Bring your own CLI, run them anywhere.',
+  description = 'A terminal-native cockpit for coding agents. Bring your own CLI, run them anywhere.',
 } = Astro.props;
 
-const fullTitle = title === 'kolu' ? 'kolu — a browser cockpit for coding agents' : `${title} · kolu`;
+const fullTitle = title === 'kolu' ? 'kolu — a terminal-native cockpit for coding agents' : `${title} · kolu`;
 
 const canonical = new URL(Astro.url.pathname, Astro.site);
 ---

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -81,7 +81,7 @@ const features = [
     <h1
       class="display reveal reveal-2 mt-5 text-[3.4rem] sm:text-[4.6rem] md:text-[6rem] max-w-4xl"
     >
-      A browser cockpit <span class="text-amber">for</span>
+      A terminal-native cockpit <span class="text-amber">for</span>
       <br class="hidden sm:block" />coding agents<span class="cursor" aria-hidden="true"></span>
     </h1>
 
@@ -89,8 +89,8 @@ const features = [
       class="reveal reveal-3 mt-10 max-w-xl text-lg leading-relaxed text-ink-dim"
       style="font-variation-settings: 'opsz' 14, 'SOFT' 60;"
     >
-      Bring your own CLI, run it anywhere. Kolu treats the terminal as the
-      universal interface — so <span class="mono text-ink">claude</span>, <span
+      Open source. Bring your own CLI, run it anywhere. Kolu treats the
+      terminal as the universal interface — so <span class="mono text-ink">claude</span>, <span
         class="mono text-ink">opencode</span
       >, or whatever ships next week all work the same way.
     </p>


### PR DESCRIPTION
## Summary

Swaps the headline framing from *"A browser cockpit for coding agents"* to **"A terminal-native cockpit for coding agents."** The old tagline sold the delivery mechanism (browser) instead of the thesis. Terminal-native is what the README has always claimed Kolu is — *"the terminal is the universal interface"*, *"terminals as the thesis, not the substrate"* — but the homepage H1 was still leading with the wrapper, not the idea.

The upgrade matters because **it changes who the tagline positions against**. "Browser cockpit" reads as *"not a native app"*, which is a delivery-layer distinction. "Terminal-native cockpit" reads as *"not a chat-UI wrapper"*, which is the actual competitive frame against Claude Desktop, Warp's agent mode, Cursor, and the rest of the proprietary-shell category. Same word count, same rhythm, sharper meaning.

To keep the open-source / run-anywhere signal that "browser" was doing part-time, the landing-page sub-paragraph picks it up explicitly — *"Open source. Bring your own CLI, run it anywhere."* — so the H1 stays clean with one qualifier doing one job. The eyebrow already announces the category (*an agentic development environment*), the H1 now announces the differentiator, and the sub carries the proofs. Three slots, three jobs, no overlap.

Touched surfaces: `README.md`, `website/src/layouts/BaseLayout.astro` (meta description + title template), `website/src/pages/index.astro` (hero H1 + sub), and the one in-post reference in `website/src/content/blog/xtermjs-perf.md`.

## Test plan

- [ ] `just website::dev` — confirm the H1 still fits its `max-w-4xl` container at `md:text-[6rem]` without awkward wrapping (terminal-native is longer than browser; worth eyeballing mobile + desktop)
- [ ] Check the rendered `<title>` and OG description on the homepage match the new copy
- [ ] Spot-check the xtermjs-perf blog post renders correctly