### PR TITLE
Cascade canvas tiles so sequential opens don't stack

### DIFF
--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -15,6 +15,7 @@ import { createDraggable } from "@thisbeyond/solid-dnd";
 import type { TileLayout } from "./TileLayout";
 import { RESIZE_HANDLES, type ResizeDirection } from "./resizeGeometry";
 import { MaximizeIcon, RestoreIcon } from "../ui/Icons";
+import { DEFAULT_TILE_W, DEFAULT_TILE_H } from "./tilePlacement";
 import {
   type TileTheme,
   tileTitleBarBg,
@@ -24,12 +25,6 @@ import {
 } from "./tileChrome";
 
 export type { TileTheme };
-
-// 800×540 fits ~88 cols × 27 rows at the default font (~9px × 20px cell),
-// safely above the legacy 80×24 baseline that downstream tools (`stty`,
-// `$COLUMNS`, less, vim) treat as the floor.
-const DEFAULT_W = 800;
-const DEFAULT_H = 540;
 
 const CanvasTile: Component<{
   id: string;
@@ -60,7 +55,7 @@ const CanvasTile: Component<{
   const { id } = props;
   const draggable = createDraggable(id);
   const layout = () =>
-    props.layouts[id] ?? { x: 0, y: 0, w: DEFAULT_W, h: DEFAULT_H };
+    props.layouts[id] ?? { x: 0, y: 0, w: DEFAULT_TILE_W, h: DEFAULT_TILE_H };
 
   const bg = () => props.theme.bg;
 

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -40,10 +40,12 @@ import CanvasWatermark from "./CanvasWatermark";
 import { useTerminalStore } from "../terminal/useTerminalStore";
 import { useTileTheme } from "./useTileTheme";
 import { useViewPosture } from "./useViewPosture";
+import {
+  DEFAULT_TILE_W,
+  DEFAULT_TILE_H,
+  findFreeTilePosition,
+} from "./tilePlacement";
 
-const DEFAULT_W = 800;
-const DEFAULT_H = 540;
-const CASCADE_OFFSET = 30;
 const MIN_W = 300;
 const MIN_H = 200;
 
@@ -140,35 +142,38 @@ const TerminalCanvas: Component<{
   // first render — without it, there would be a (0,0) frame while waiting
   // for the server's metadata echo.
   //
-  // Contract: the default-cascade runs only for tiles whose `getLayout(id)`
+  // Contract: the default-placement runs only for tiles whose `getLayout(id)`
   // is falsy on their first appearance in `tileIds`. Callers that intend
   // to preserve a pre-existing layout (session restore, tile clone, …) are
   // responsible for making `getLayout(id)` return it by then — e.g. by
   // seeding server metadata before the list snapshot yields (#642). Any
   // path that seeds AFTER the first `tileIds` fire will lose to this
-  // cascade and overwrite the intended layout.
+  // effect and overwrite the intended layout.
   createEffect(
     on(
       () => props.tileIds,
       (ids) => {
-        // Viewport center in canvas-space — stable within this batch
-        const cx =
-          viewport.panX() + containerRef.clientWidth / (2 * viewport.zoom());
-        const cy =
-          viewport.panY() + containerRef.clientHeight / (2 * viewport.zoom());
-        let newIndex = 0;
+        const { width, height } = viewport.viewportSize();
+        const zoom = viewport.zoom();
+        const cx = viewport.panX() + width / (2 * zoom);
+        const cy = viewport.panY() + height / (2 * zoom);
+        const placed: TileLayout[] = [];
         for (const id of ids) {
-          if (layoutOf(id)) continue;
-          const offset = newIndex * CASCADE_OFFSET;
+          const existing = layoutOf(id);
+          if (existing) {
+            placed.push(existing);
+            continue;
+          }
+          const { x, y } = findFreeTilePosition(cx, cy, placed);
           const defaultLayout: TileLayout = {
-            x: viewport.snapToGrid(cx - DEFAULT_W / 2 + offset),
-            y: viewport.snapToGrid(cy - DEFAULT_H / 2 + offset),
-            w: DEFAULT_W,
-            h: DEFAULT_H,
+            x,
+            y,
+            w: DEFAULT_TILE_W,
+            h: DEFAULT_TILE_H,
           };
           setPendingLayout(id, defaultLayout);
           props.onLayoutChange(id, defaultLayout);
-          newIndex++;
+          placed.push(defaultLayout);
         }
       },
     ),

--- a/packages/client/src/canvas/tilePlacement.ts
+++ b/packages/client/src/canvas/tilePlacement.ts
@@ -1,0 +1,39 @@
+/** Default placement policy for newly created canvas tiles.
+ *
+ *  A tile opens at the viewport center. If that snapped position already
+ *  hosts another tile, it cascades diagonally until a free spot is found —
+ *  opening two terminals without panning produces a staircase, not a stack.
+ *
+ *  `CASCADE_STEP` is a multiple of `GRID_SIZE` so `snapToGrid` can't collapse
+ *  successive cascade steps onto the same coordinate. */
+
+import { GRID_SIZE, snapToGrid } from "./viewport/transforms";
+
+/** Default tile dimensions — 800×540 fits ~88 cols × 27 rows at the default
+ *  font, safely above the legacy 80×24 baseline. */
+export const DEFAULT_TILE_W = 800;
+export const DEFAULT_TILE_H = 540;
+
+const CASCADE_STEP = GRID_SIZE * 2;
+const MAX_CASCADE_ITERATIONS = 50;
+
+/** Find a free top-left for a new default-sized tile, starting at the viewport
+ *  center and cascading diagonally if the spot is already taken. `existing`
+ *  is the set of already-positioned tiles (saved + pending); only their
+ *  top-left is compared, so callers must pass tiles of the same default
+ *  dimensions for collision detection to be accurate. */
+export function findFreeTilePosition(
+  viewportCenterX: number,
+  viewportCenterY: number,
+  existing: ReadonlyArray<{ x: number; y: number }>,
+): { x: number; y: number } {
+  const occupied = new Set(existing.map((l) => `${l.x},${l.y}`));
+  const baseX = viewportCenterX - DEFAULT_TILE_W / 2;
+  const baseY = viewportCenterY - DEFAULT_TILE_H / 2;
+  for (let i = 0; i < MAX_CASCADE_ITERATIONS; i++) {
+    const x = snapToGrid(baseX + i * CASCADE_STEP);
+    const y = snapToGrid(baseY + i * CASCADE_STEP);
+    if (!occupied.has(`${x},${y}`)) return { x, y };
+  }
+  return { x: snapToGrid(baseX), y: snapToGrid(baseY) };
+}

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -36,7 +36,15 @@ Feature: Canvas workspace
     And the canvas tiles should be visible in the viewport
     And there should be no page errors
 
-  Scenario: New terminal opens at viewport center
+  Scenario: New terminal shifts when an existing tile occupies the viewport center
+    When I create a terminal with keyboard shortcut
+    Then there should be 2 canvas tiles
+    And canvas tile 2 should be offset from canvas tile 1
+
+  Scenario: Creating a terminal after panning opens at the new viewport center
+    When I record the canvas transform
+    And I scroll the wheel over the canvas background
+    Then the canvas transform should have changed
     When I create a terminal with keyboard shortcut
     Then there should be 2 canvas tiles
     And the newest canvas tile should be centered in the viewport

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -222,6 +222,28 @@ When(
   },
 );
 
+Then(
+  "canvas tile {int} should be offset from canvas tile {int}",
+  async function (this: KoluWorld, a: number, b: number) {
+    await this.page.waitForFunction(
+      ({ sel, i, j }: { sel: string; i: number; j: number }) => {
+        const tiles = document.querySelectorAll(
+          `${sel} [data-terminal-id][data-visible]`,
+        );
+        const tileA = tiles.item(i) as HTMLElement | null;
+        const tileB = tiles.item(j) as HTMLElement | null;
+        if (!tileA || !tileB) return false;
+        const rA = tileA.getBoundingClientRect();
+        const rB = tileB.getBoundingClientRect();
+        // Snapped top-left must differ on both axes (cascade is diagonal).
+        return Math.abs(rA.left - rB.left) > 1 && Math.abs(rA.top - rB.top) > 1;
+      },
+      { sel: CANVAS_SELECTOR, i: a - 1, j: b - 1 },
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // ── Gesture ownership: two-finger scroll on terminal must not pan the canvas ──
 
 /** Read the inner canvas transform div's transform (scale(z) translate(x, y)).


### PR DESCRIPTION
**Opening a second terminal without panning now produces a staircase, not a stack.** Before this, every new tile opened exactly on top of the previous one at the viewport center — the existing `newIndex * CASCADE_OFFSET` offset only incremented within a single reactive batch, and in practice batches never carry more than one unplaced tile (session restore pre-seeds layouts before the list snapshot yields, and user-driven creates fire one at a time).

The replacement is a collision-aware placer: start at the viewport center, cascade diagonally by `2 × GRID_SIZE` until the snapped top-left is free. _The cascade step is a multiple of `GRID_SIZE` on purpose — otherwise `snapToGrid` can collapse successive iterations onto the same coordinate and burn several loop iterations producing no visual shift._ If the user pans first, the new viewport center is unoccupied and the tile lands cleanly there with no cascade, matching intuition.

Along the way: extract `DEFAULT_TILE_W/H` into a new `tilePlacement.ts` module instead of duplicating them across `TerminalCanvas` and `CanvasTile`, and route the viewport-center read through `viewport.viewportSize()` instead of reaching through `containerRef`.

> The existing `New terminal opens at viewport center` scenario in `canvas.feature` asserted the old stacking behavior. It's replaced with two scenarios — one for the new cascade-on-collision path, one for the pan-then-create path where no cascade fires.

### Try it locally

```sh
nix run github:juspay/kolu/cascade-placement
```