### PR TITLE
test(xterm): A/B observer-nullify variant vs WeakRef (upstream #5821)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-VXMh+I6dHB1/Dj8g9iw91dZsJWcnplswmpe4+abei7E=";
+    hash = "sha256-OTLK2f40ng1y1Sa/C3d0mVMRjiYFNs9r2mD70caO/FQ=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
       "yaml": "^2.8.3",
       "defu": "^6.1.5",
       "@anthropic-ai/sdk": "^0.81.0",
-      "@xterm/xterm": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built",
-      "@xterm/addon-webgl": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl"
+      "@xterm/xterm": "github:juspay/xterm.js#test/kolu-observer-nullify-built",
+      "@xterm/addon-webgl": "github:juspay/xterm.js#test/kolu-observer-nullify-built&path:/addons/addon-webgl"
     },
     "patchedDependencies": {
       "node-pty@1.1.0": "patches/node-pty@1.1.0.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ overrides:
   yaml: ^2.8.3
   defu: ^6.1.5
   '@anthropic-ai/sdk': ^0.81.0
-  '@xterm/xterm': github:juspay/xterm.js#fix/kolu-xterm-fixes-built
-  '@xterm/addon-webgl': github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
+  '@xterm/xterm': github:juspay/xterm.js#test/kolu-observer-nullify-built
+  '@xterm/addon-webgl': github:juspay/xterm.js#test/kolu-observer-nullify-built&path:/addons/addon-webgl
 
 patchedDependencies:
   node-pty@1.1.0:
@@ -89,11 +89,11 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       '@xterm/addon-webgl':
-        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl
+        specifier: github:juspay/xterm.js#test/kolu-observer-nullify-built&path:/addons/addon-webgl
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29#path:/addons/addon-webgl
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
+        specifier: github:juspay/xterm.js#test/kolu-observer-nullify-built
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29
       fix-webm-duration:
         specifier: ^1.0.6
         version: 1.0.6
@@ -391,8 +391,8 @@ importers:
   packages/terminal-themes:
     dependencies:
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
+        specifier: github:juspay/xterm.js#test/kolu-observer-nullify-built
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29
     devDependencies:
       typescript:
         specifier: ^5.8.0
@@ -2082,15 +2082,15 @@ packages:
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl':
-    resolution: {path: /addons/addon-webgl, tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c}
+  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29#path:/addons/addon-webgl':
+    resolution: {path: /addons/addon-webgl, tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29}
     version: 0.19.0
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c':
-    resolution: {tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c}
+  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29':
+    resolution: {tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29}
     version: 6.0.0
 
   accepts@2.0.0:
@@ -5890,11 +5890,11 @@ snapshots:
 
   '@xterm/addon-web-links@0.12.0': {}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl': {}
+  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29#path:/addons/addon-webgl': {}
 
   '@xterm/headless@6.0.0': {}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c': {}
+  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/7454e13f55148dc06c0eaa23e7395838be6d0c29': {}
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
## Purpose

Maintainers on [xtermjs/xterm.js#5821](https://github.com/xtermjs/xterm.js/pull/5821) (jerch, Tyriar) pushed back on the `WeakRef` wrap and suggested storing the `IntersectionObserver` on `this` and explicitly nulling it on dispose — *without* `WeakRef`. Per W3C spec, `disconnect()` does **not** release the callback (the observer retains it so `.observe()` can be re-armed), so their hypothesis is: the observer itself is the JS-reachable root, and dropping that ref lets the whole chain GC.

This **draft PR** points the xterm override at a stacked test branch that implements that variant, so we can run a prod Task Manager A/B on pureintent.

## Variant

[juspay/xterm.js@test/kolu-observer-nullify-built](https://github.com/juspay/xterm.js/tree/test/kolu-observer-nullify-built) stacks one commit on top of the existing `fix/kolu-xterm-fixes-built`. The diff (`src/browser/services/RenderService.ts`):

```ts
private _observer: IntersectionObserver | undefined;
...
this._observer = new w.IntersectionObserver(
  e => this._handleIntersectionChange(e[e.length - 1]),
  { threshold: 0 }
);
this._observer.observe(screenElement);
this._observerDisposable.value = toDisposable(() => {
  this._observer?.disconnect();
  this._observer = undefined;
});
```

No `WeakRef`. Strong `this` capture in the callback; observer ref hoisted onto the instance and nulled on dispose.

## Local test was inconclusive

Ran a 30-toggle canvas-maximize A/B under chrome-devtools MCP (headless). **All three variants — unpatched, WeakRef, observer-nullify — showed identical benign heap diffs**: no `JSArrayBufferData` / `Uint32Array` / `BufferLine` growth. The MCP Chrome lacks whatever instrumentation/extension caused the original retention in real-world Chrome, so local can't distinguish the variants. Prod Task Manager on pureintent is the actual arbiter.

## Repro recipe (updated for mode-less workspace)

The original #617 repro was `Focus ↔ Canvas` mode toggle, which no longer exists (#622 made the workspace mode-less — the canvas is always on). The modern equivalent that still cycles `Terminal` mount/unmount is the **canvas-maximize toggle** — the Maximize button on each tile's chrome.

Why it works: toggling `canvasMaximized` flips `TerminalCanvas.tsx:352-370` between `<For each={tileIds}>` and `<Show when={maximized && activeId} keyed>`. With 7 tiles, one toggle cycle produces 8 `Terminal` disposes + 8 `Terminal` mounts (7 tiled tiles → 1 maximized, then back). Over 30 cycles that's 240 `RenderService` create/dispose pairs — the same surface as the original repro. Confirmed locally via `window.__kolu.lifecycle()`: `mounts` increments from 15 → 255, `cleanups` from 8 → 248 across 30 cycles, with 7 live terminals throughout.

### Steps

1. Fresh tab on pureintent with 7 terminals restored (Task Manager: capture baseline `Memory Footprint`)
2. Paste in DevTools console:
   ```js
   (async () => {
     for (let i = 0; i < 30; i++) {
       document.querySelector('[data-testid=canvas-tile-maximize]').click();
       await new Promise(r => setTimeout(r, 250));
       document.querySelector('[data-testid=canvas-tile-maximize]').click();
       await new Promise(r => setTimeout(r, 250));
     }
   })();
   ```
3. Capture post `Memory Footprint`
4. Compute Δ / 30 toggles

### Interpreting the Δ

- **≈ 0 MB** → observer-nullify works. Reply to #5821 with prod evidence and simplify the upstream PR.
- **≈ +367 MB** (pre-#617 number) → observer-nullify doesn't defuse the retention. Reply to #5821 with that evidence and defend `WeakRef`.
- Anything in between — note the magnitude, still lands as data on #5821.

### Fallback if canvas-maximize doesn't stress the path

If the prod Δ with canvas-maximize is implausibly flat (possible — WebGL addon lifecycle could mask the IntersectionObserver path through some unrelated interaction), fall back to the close/recreate cycle: 30× `Ctrl+Enter` followed by `Ctrl+D` per terminal. That exercises the exact same `RenderService` lifecycle at 30× the rate of the maximize toggle, and was already a documented repro in the perf-diagnose skill.

## Rollback

Not for merge either way. Close draft after data is collected; the actual decision lands as a change to the upstream PR #5821 (either simplify to observer-nullify or keep `WeakRef`).

Refs xtermjs/xterm.js#5821, #617, #620