### PR TITLE
Stop pill-tree overflow rows from collapsing under the cursor

### DIFF
--- a/packages/client/src/canvas/PillTree.tsx
+++ b/packages/client/src/canvas/PillTree.tsx
@@ -112,7 +112,18 @@ const PillTree: Component<{
           {(group) => {
             const rows = createMemo(() => chunkBranches(group.branches));
             return (
-              <div class="flex flex-col items-start gap-1 min-w-0">
+              // pointer-events-auto on the column so the 4 px row-gap
+              // (and the between-pill gaps inside a row) stay part of
+              // the hover target. Without this, a cursor travelling
+              // from a row-1 pill toward a hover-revealed row-2 pill
+              // crosses a transparent band that inherits `none` from
+              // the outer wrapper — `:hover` on `group/pill-tree`
+              // drops, the revealed row collapses before it can be
+              // clicked. Also promotes the `▾ +N` hint below to a
+              // real hover target. The outer wrapper stays
+              // `pointer-events-none` so the empty chrome between
+              // repo groups still passes clicks through to the canvas.
+              <div class="pointer-events-auto flex flex-col items-start gap-1 min-w-0">
                 <div
                   data-testid="pill-tree-repo"
                   class="text-[0.65rem] font-semibold uppercase tracking-wide truncate max-w-[16ch]"


### PR DESCRIPTION
**Hovering a repo with more than 3 terminals now keeps the revealed row-2 pills clickable.** Before this, moving the cursor from a visible pill toward one of the `▾ +N` hover-revealed pills made the whole row vanish mid-travel — the click landed on the canvas behind instead of the pill.

Root cause: the tree wrapper sets `pointer-events: none` so the empty chrome between repo groups passes clicks through to the canvas (for panning). *`pointer-events` inherits*, so the 4 px gap between rows — and the gaps between pills within a row — inherited `none` too, meaning cursor travel through a gap landed on `canvas-container`, dropped `:hover` on `group/pill-tree`, and collapsed the revealed row before it could be clicked.

The fix re-enables pointer events on the per-repo column so its descendants (row divs, pill grid, gaps, and the `▾ +N` hint itself) stay a single continuous hover target. *The outer wrapper is untouched*, so canvas panning through the empty chrome between repo groups is preserved.

Closes #659

### Try it locally

```sh
nix run github:juspay/kolu/civil-garden
```