### PR TITLE
[kimi-latest] feat: Codex agent status in terminal tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ Detects [OpenCode](https://github.com/anomalyco/opencode) sessions and shows the
 - **Same-directory disambiguation** — if multiple OpenCode sessions share a working directory, we pick the most recently updated one
 - **Non-default DB location** — set `KOLU_OPENCODE_DB` to override the path
 
+### Codex Status
+
+Detects [Codex](https://github.com/openai/codex) sessions and shows their state alongside Claude Code and OpenCode on the tile chrome.
+
+**How it works:** when the foreground process is `codex`, the provider queries Codex's SQLite database directly at `~/.codex/state_5.sqlite` to find the most recently updated thread whose `cwd` matches the terminal's CWD. State is derived from the thread's `updated_at` timestamp and `approval_mode`: recent activity with `approval_mode: "on-request"` suggests _tool_use_; recent updates without completion indicators suggest _thinking_; idle sessions with user events indicate _waiting_. The tile chrome also shows the running token count from the thread's `tokens_used` field. Live updates come from `fs.watch` on the SQLite WAL file (`state_5.sqlite-wal`), which Codex writes to on every database mutation.
+
+**Why SQLite, not REST?** Like OpenCode, the Codex TUI doesn't expose an HTTP server by default. Reading the SQLite DB directly works against the actual TUI users run, with no port discovery and no extra processes. SQLite WAL mode allows concurrent readers while Codex is writing.
+
+**What we detect:**
+
+| State    | Indicator          | How                                               |
+| -------- | ------------------ | ------------------------------------------------- |
+| Thinking | Pulsing accent dot | Thread recently updated, actively processing      |
+| Tool use | Spinning yellow    | Approval mode suggests tool execution in progress |
+| Waiting  | Dim dot            | Thread idle with prior user interaction           |
+
+**What we can't detect (yet):**
+
+- **Granular tool state** — Codex doesn't expose running tool parts like OpenCode does; we infer tool use from approval mode heuristics
+- **Same-directory disambiguation** — if multiple Codex threads share a working directory, we pick the most recently updated one
+- **Non-default DB location** — set `KOLU_CODEX_STATE` to override the path
+
 ### Theming
 
 - 200+ color schemes from [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes), switchable at runtime

--- a/opencode.json
+++ b/opencode.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://opencode.ai/config.json",
   "mcp": {
     "chrome-devtools": {
       "type": "local",

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -76,6 +76,24 @@ export const OpenCodeIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
+/** Codex logo — stylized angled brackets suggesting code/text.
+ *  Simple geometric design distinct from Claude Code and OpenCode. */
+export const CodexIcon: Component<{ class?: string }> = (props) => (
+  <svg
+    class={props.class ?? "w-3 h-3"}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M8 6L3 12L8 18" />
+    <path d="M16 6L21 12L16 18" />
+    <line x1="12" y1="4" x2="12" y2="20" stroke-dasharray="2 2" opacity="0.5" />
+  </svg>
+);
+
 /** Local diff: pencil icon — uncommitted working-tree edits. */
 export const DiffLocalIcon: Component<{ class?: string }> = (props) => (
   <svg

--- a/packages/client/src/ui/agentDisplay.ts
+++ b/packages/client/src/ui/agentDisplay.ts
@@ -3,7 +3,7 @@
 
 import type { Component } from "solid-js";
 import type { AgentInfo } from "kolu-common";
-import { ClaudeCodeIcon, OpenCodeIcon } from "../ui/Icons";
+import { ClaudeCodeIcon, OpenCodeIcon, CodexIcon } from "../ui/Icons";
 
 export const agentIcons: Record<
   AgentInfo["kind"],
@@ -11,11 +11,13 @@ export const agentIcons: Record<
 > = {
   "claude-code": ClaudeCodeIcon,
   opencode: OpenCodeIcon,
+  codex: CodexIcon,
 };
 
 export const agentNames: Record<AgentInfo["kind"], string> = {
   "claude-code": "Claude Code",
   opencode: "OpenCode",
+  codex: "Codex",
 };
 
 export const stateLabels: Record<AgentInfo["state"], string> = {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@orpc/contract": "^1.13.13",
     "kolu-claude-code": "workspace:*",
+    "kolu-codex": "workspace:*",
     "kolu-git": "workspace:*",
     "kolu-github": "workspace:*",
     "anyagent": "workspace:*",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { TaskProgressSchema } from "anyagent";
 import { ClaudeCodeInfoSchema } from "kolu-claude-code";
 import { OpenCodeInfoSchema } from "kolu-opencode";
+import { CodexInfoSchema } from "kolu-codex";
 import {
   GitInfoSchema,
   WorktreeCreateInputSchema,
@@ -28,7 +29,12 @@ import {
 } from "kolu-git";
 
 // Re-export integration schemas so consumers import from kolu-common only.
-export { TaskProgressSchema, ClaudeCodeInfoSchema, OpenCodeInfoSchema };
+export {
+  TaskProgressSchema,
+  ClaudeCodeInfoSchema,
+  OpenCodeInfoSchema,
+  CodexInfoSchema,
+};
 
 // Re-export git schemas from kolu-git.
 export {
@@ -106,11 +112,12 @@ export type {
 
 // --- AI coding agent context ---
 
-export const AgentKindSchema = z.enum(["claude-code", "opencode"]);
+export const AgentKindSchema = z.enum(["claude-code", "opencode", "codex"]);
 
 export const AgentInfoSchema = z.discriminatedUnion("kind", [
   ClaudeCodeInfoSchema,
   OpenCodeInfoSchema,
+  CodexInfoSchema,
 ]);
 
 // --- Foreground process context ---
@@ -400,6 +407,7 @@ export type AgentKind = z.infer<typeof AgentKindSchema>;
 export type AgentInfo = z.infer<typeof AgentInfoSchema>;
 export type ClaudeCodeInfo = z.infer<typeof ClaudeCodeInfoSchema>;
 export type OpenCodeInfo = z.infer<typeof OpenCodeInfoSchema>;
+export type CodexInfo = z.infer<typeof CodexInfoSchema>;
 export type Foreground = z.infer<typeof ForegroundSchema>;
 export type TerminalServerMetadata = z.infer<
   typeof TerminalServerMetadataSchema

--- a/packages/integrations/codex/package.json
+++ b/packages/integrations/codex/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "kolu-codex",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "anyagent": "workspace:*",
+    "ts-pattern": "^5.9.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/integrations/codex/src/agent-provider.ts
+++ b/packages/integrations/codex/src/agent-provider.ts
@@ -1,0 +1,36 @@
+/**
+ * Codex's AgentProvider — wires the package's existing helpers
+ * (`findSessionByDirectory`, `createCodexWatcher`) into the shared
+ * `AgentProvider<Session, Info>` contract from anyagent.
+ *
+ * `subscribeExternalChanges` is intentionally omitted: Codex's TUI
+ * process owns its session throughout its lifetime, and the session only
+ * appears in the database *after* the first user exchange — but by then
+ * a title event has already fired, so re-resolving on title covers the
+ * appearance case. WAL changes are per-session state, owned by
+ * `createCodexWatcher`, not session-identity changes.
+ */
+
+import type { AgentProvider } from "anyagent";
+import { findSessionByDirectory } from "./index.ts";
+import { createCodexWatcher } from "./session-watcher.ts";
+import type { CodexSession, CodexInfo } from "./index.ts";
+
+export const codexProvider: AgentProvider<CodexSession, CodexInfo> = {
+  kind: "codex",
+
+  resolveSession(state, log) {
+    if (state.readForegroundBasename() !== "codex") return null;
+    return findSessionByDirectory(state.cwd, log);
+  },
+
+  sessionKey(session) {
+    return session.id;
+  },
+
+  createWatcher(session, onChange, log) {
+    return createCodexWatcher(session, onChange, log);
+  },
+
+  // subscribeExternalChanges: intentionally omitted.
+};

--- a/packages/integrations/codex/src/config.ts
+++ b/packages/integrations/codex/src/config.ts
@@ -1,0 +1,13 @@
+/** Configuration constants for the Codex integration.
+ *  Leaf module — no imports from other package files. */
+
+import path from "node:path";
+import os from "node:os";
+
+/** Path to Codex's SQLite database. Configurable via env for testing. */
+export const CODEX_STATE_PATH =
+  process.env.KOLU_CODEX_STATE ??
+  path.join(os.homedir(), ".codex", "state_5.sqlite");
+
+/** Path to the SQLite WAL file — fs.watch this to detect writes. */
+export const CODEX_STATE_WAL_PATH = `${CODEX_STATE_PATH}-wal`;

--- a/packages/integrations/codex/src/index.test.ts
+++ b/packages/integrations/codex/src/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { parseThreadState } from "./index.ts";
+
+describe("parseThreadState", () => {
+  it("returns waiting state for idle session with user events", () => {
+    const now = Date.now();
+    const row = {
+      id: "test-1",
+      title: "Test",
+      model: "gpt-5.4",
+      tokens_used: 1000,
+      created_at: Math.floor((now - 60000) / 1000),
+      // Updated >30s ago (not recently active) and exists >5s
+      updated_at: Math.floor((now - 40000) / 1000),
+      approval_mode: "off",
+      has_user_event: 1,
+    };
+
+    const result = parseThreadState(row);
+    expect(result).not.toBeNull();
+    expect(result!.state).toBe("waiting");
+    expect(result!.model).toBe("gpt-5.4");
+  });
+
+  it("returns thinking state for recently active session", () => {
+    const now = Date.now();
+    const row = {
+      id: "test-2",
+      title: "Test",
+      model: "gpt-5.4",
+      tokens_used: 5000,
+      created_at: Math.floor((now - 60000) / 1000),
+      updated_at: Math.floor(now / 1000),
+      approval_mode: "off",
+      has_user_event: 1,
+    };
+
+    const result = parseThreadState(row);
+    expect(result).not.toBeNull();
+    expect(result!.state).toBe("thinking");
+  });
+
+  it("returns tool_use state for recently active with approval mode", () => {
+    const now = Date.now();
+    const row = {
+      id: "test-3",
+      title: "Test",
+      model: "gpt-5.4",
+      tokens_used: 3000,
+      created_at: Math.floor((now - 60000) / 1000),
+      updated_at: Math.floor(now / 1000),
+      approval_mode: "on-request",
+      has_user_event: 1,
+    };
+
+    const result = parseThreadState(row);
+    expect(result).not.toBeNull();
+    expect(result!.state).toBe("tool_use");
+  });
+
+  it("handles null model gracefully", () => {
+    const now = Date.now();
+    const row = {
+      id: "test-4",
+      title: "Test",
+      model: "",
+      tokens_used: 0,
+      created_at: Math.floor((now - 60000) / 1000),
+      updated_at: Math.floor((now - 10000) / 1000),
+      approval_mode: "off",
+      has_user_event: 1,
+    };
+
+    const result = parseThreadState(row);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBeNull();
+  });
+});

--- a/packages/integrations/codex/src/index.ts
+++ b/packages/integrations/codex/src/index.ts
@@ -1,0 +1,280 @@
+/**
+ * Codex integration — pure functions and IO helpers for detecting
+ * Codex sessions and deriving state from its SQLite database.
+ *
+ * No dependency on server internals (no updateServerMetadata, no TerminalProcess).
+ * The server's provider imports these and wires them into the metadata system.
+ *
+ * Architecture: Codex TUI mode owns `~/.codex/state_5.sqlite` directly via
+ * SQLite WAL mode. Sessions are tracked in the `threads` table, with the
+ * current working directory stored in the `cwd` column.
+ *
+ * Read concurrency is safe because Codex uses WAL mode — readers don't
+ * block writers and vice versa. We open the DB read-only.
+ *
+ * State derivation from the `threads` table:
+ *   - `updated_at` advancing without completion state → "thinking"
+ *   - `approval_mode` and internal state imply tool execution → "tool_use"
+ *   - Session idle with completion indicators → "waiting"
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { z } from "zod";
+import { match } from "ts-pattern";
+import { CODEX_STATE_PATH } from "./config.ts";
+
+// Re-export config so consumers can reference it (e.g. for env override docs).
+export { CODEX_STATE_PATH, CODEX_STATE_WAL_PATH } from "./config.ts";
+
+// --- Codex schemas (single source of truth) ---
+
+export { TaskProgressSchema, type TaskProgress, type Logger } from "anyagent";
+import { TaskProgressSchema, type TaskProgress, type Logger } from "anyagent";
+
+export const CodexInfoSchema = z.object({
+  kind: z.literal("codex"),
+  /** Current state derived from thread activity. */
+  state: z.enum(["thinking", "tool_use", "waiting"]),
+  /** Session ID from Codex's database (UUID format). */
+  sessionId: z.string(),
+  /** Model identifier if available (e.g. "gpt-5.4"). */
+  model: z.string().nullable(),
+  /** Session title from Codex (user prompt or auto-generated). */
+  summary: z.string().nullable(),
+  /** Always null — Codex doesn't have a todo/task system yet. */
+  taskProgress: TaskProgressSchema.nullable(),
+  /** Running context-window token count from `tokens_used`. */
+  contextTokens: z.number().nullable(),
+});
+
+export type CodexInfo = z.infer<typeof CodexInfoSchema>;
+
+// --- Database helpers ---
+
+/** Run `fn` with a DatabaseSync connection. If `db` is provided, uses it
+ *  without owning it (caller manages lifecycle). If absent, opens a fresh
+ *  connection and closes it after `fn` returns. Returns null if the DB
+ *  can't be opened or if `fn` throws (logged at error via `errorMsg`). */
+function withDb<T>(
+  fn: (db: DatabaseSync) => T,
+  errorMsg: string,
+  errorCtx: Record<string, unknown>,
+  log?: Logger,
+  db?: DatabaseSync,
+): T | null {
+  const ownsDb = db === undefined;
+  const conn = db ?? openDb(log);
+  if (!conn) return null;
+  try {
+    return fn(conn);
+  } catch (err) {
+    log?.error({ err, ...errorCtx }, errorMsg);
+    return null;
+  } finally {
+    if (ownsDb) conn.close();
+  }
+}
+
+// --- Database session lookup ---
+
+export interface CodexSession {
+  id: string;
+  title: string | null;
+  directory: string;
+}
+
+/** Open a read-only connection to Codex's database. Returns null if absent.
+ *  Caller MUST close the returned database when done. */
+export function openDb(log?: Logger): DatabaseSync | null {
+  try {
+    return new DatabaseSync(CODEX_STATE_PATH, { readOnly: true });
+  } catch (err) {
+    log?.debug({ err, path: CODEX_STATE_PATH }, "codex db unavailable");
+    return null;
+  }
+}
+
+/**
+ * Find the most recently updated thread for a given directory.
+ * Returns null if no threads exist for that directory or the DB is absent.
+ *
+ * Heuristic: pick the thread with the largest `updated_at` — the one
+ * the user most recently interacted with. If multiple threads share a
+ * directory, this picks the active one in practice.
+ */
+export function findSessionByDirectory(
+  directory: string,
+  log?: Logger,
+): CodexSession | null {
+  return withDb(
+    (conn) => {
+      const row = conn
+        .prepare(
+          "SELECT id, title, cwd FROM threads WHERE cwd = ? AND archived = 0 ORDER BY updated_at DESC LIMIT 1",
+        )
+        .get(directory) as
+        | { id: string; title: string; cwd: string }
+        | undefined;
+      if (!row) return null;
+      return {
+        id: row.id,
+        title: row.title || null,
+        directory: row.cwd,
+      };
+    },
+    "codex session query failed",
+    { directory },
+    log,
+  );
+}
+
+// --- Session title refresh ---
+
+/** Re-read the current session title from the DB. Returns null if absent. */
+export function getSessionTitle(
+  sessionId: string,
+  log?: Logger,
+  db?: DatabaseSync,
+): string | null {
+  return withDb(
+    (conn) => {
+      const row = conn
+        .prepare("SELECT title FROM threads WHERE id = ?")
+        .get(sessionId) as { title: string } | undefined;
+      return row?.title || null;
+    },
+    "codex session title query failed",
+    { sessionId },
+    log,
+    db,
+  );
+}
+
+// --- Context-token lookup ---
+
+/**
+ * Read the thread's running token total from `tokens_used`.
+ * Returns null if unavailable.
+ */
+export function getSessionContextTokens(
+  sessionId: string,
+  log?: Logger,
+  db?: DatabaseSync,
+): number | null {
+  return withDb(
+    (conn) => {
+      const row = conn
+        .prepare("SELECT tokens_used FROM threads WHERE id = ?")
+        .get(sessionId) as { tokens_used: number } | undefined;
+      return row?.tokens_used ?? null;
+    },
+    "codex tokens query failed",
+    { sessionId },
+    log,
+    db,
+  );
+}
+
+// --- State derivation ---
+
+/** Shape of relevant thread columns. */
+interface ThreadRow {
+  id: string;
+  title: string;
+  model: string;
+  tokens_used: number;
+  created_at: number;
+  updated_at: number;
+  approval_mode: string;
+  has_user_event: number;
+}
+
+/** State derived from thread row. */
+export type DerivedState = {
+  state: CodexInfo["state"];
+  model: string | null;
+};
+
+/**
+ * Read the thread row and derive Kolu state from it.
+ * Returns null if the thread doesn't exist or the DB is absent.
+ *
+ * Pass an existing `db` to share a connection with the caller — used by
+ * `createCodexWatcher` to avoid opening/closing on every WAL event.
+ * If `db` is omitted, opens and closes its own connection.
+ */
+export function deriveSessionState(
+  sessionId: string,
+  log?: Logger,
+  db?: DatabaseSync,
+): DerivedState | null {
+  return withDb(
+    (conn) => {
+      const row = conn
+        .prepare(
+          "SELECT id, title, model, tokens_used, created_at, updated_at, approval_mode, has_user_event FROM threads WHERE id = ?",
+        )
+        .get(sessionId) as ThreadRow | undefined;
+      if (!row) return null;
+      return parseThreadState(row);
+    },
+    "codex thread query failed",
+    { sessionId },
+    log,
+    db,
+  );
+}
+
+/** Parse thread row into derived state.
+ *  Exported for unit testing. */
+export function parseThreadState(row: ThreadRow): DerivedState | null {
+  // Codex state inference is heuristic-based:
+  // - If updated_at is recent relative to created_at, session is active
+  // - approval_mode hints at tool use ("on-request" means tools need approval)
+  // - has_user_event indicates user interaction happened
+
+  const now = Date.now();
+  const updatedAtMs = row.updated_at * 1000;
+  const createdAtMs = row.created_at * 1000;
+
+  // Determine if session is recently active (within last 30 seconds)
+  const isRecentlyActive = now - updatedAtMs < 30000;
+
+  // Determine if session has been idle (no updates for 5+ seconds after creation)
+  const isIdle = !isRecentlyActive && updatedAtMs - createdAtMs > 5000;
+
+  return match({
+    isRecentlyActive,
+    isIdle,
+    hasUserEvent: row.has_user_event === 1,
+    approvalMode: row.approval_mode,
+  })
+    .with({ isIdle: true, hasUserEvent: true }, () => ({
+      state: "waiting" as const,
+      model: row.model || null,
+    }))
+    .with({ approvalMode: "on-request", isRecentlyActive: true }, () => ({
+      state: "tool_use" as const,
+      model: row.model || null,
+    }))
+    .with({ isRecentlyActive: true }, () => ({
+      state: "thinking" as const,
+      model: row.model || null,
+    }))
+    .otherwise(() => ({
+      state: "waiting" as const,
+      model: row.model || null,
+    }));
+}
+
+// --- Session watcher (encapsulates per-session lifecycle) ---
+
+export { createCodexWatcher, type CodexWatcher } from "./session-watcher.ts";
+
+// --- Shared WAL watcher ---
+
+export { subscribeCodexDb } from "./wal-watcher.ts";
+
+// --- AgentProvider instance ---
+
+export { codexProvider } from "./agent-provider.ts";

--- a/packages/integrations/codex/src/session-watcher.ts
+++ b/packages/integrations/codex/src/session-watcher.ts
@@ -1,0 +1,143 @@
+/**
+ * CodexWatcher — encapsulates all per-session lifecycle state.
+ *
+ * Creating a CodexWatcher subscribes to the shared WAL watcher and
+ * emits state via the onChange callback. Destroying it unsubscribes and
+ * closes the held DB connection. No "remember to reset N variables"
+ * invariant — the lifetime IS the object.
+ *
+ * The server's codex provider creates one of these per matched session
+ * and replaces it on session change. Mirrors the SessionWatcher pattern
+ * from `kolu-claude-code` and `kolu-opencode`.
+ */
+
+import type { DatabaseSync } from "node:sqlite";
+import { agentInfoEqual } from "anyagent";
+import {
+  type CodexInfo,
+  type CodexSession,
+  deriveSessionState,
+  getSessionContextTokens,
+  getSessionTitle,
+  openDb,
+  subscribeCodexDb,
+} from "./index.ts";
+import type { Logger } from "anyagent";
+
+// --- Tuning constants ---
+
+/** Trailing-edge debounce for WAL fs.watch callbacks. Codex streams
+ *  tokens during generation, and Linux fs.watch fires multiple events per
+ *  write — without debouncing, `refresh` runs dozens of times per second
+ *  during active use, each call running SQL queries. 150 ms coalesces
+ *  bursts into one handler run while keeping user-perceptible lag
+ *  imperceptible. Matches WAL_DEBOUNCE_MS in kolu-opencode. */
+const WAL_DEBOUNCE_MS = 150;
+
+// --- Watcher ---
+
+export interface CodexWatcher {
+  readonly session: CodexSession;
+  destroy(): void;
+}
+
+/**
+ * Start watching a Codex session. Reads the thread immediately
+ * and emits an initial state, then re-reads on every WAL file change
+ * (debounced) and emits a new state if it differs from the last one.
+ *
+ * `onChange` is called with the full CodexInfo each time state changes.
+ * The caller is responsible for forwarding it to the metadata system.
+ */
+export function createCodexWatcher(
+  session: CodexSession,
+  onChange: (info: CodexInfo) => void,
+  log?: Logger,
+): CodexWatcher {
+  let lastInfo: CodexInfo | null = null;
+  let destroyed = false;
+  // Trailing-edge debounce timer for WAL fs.watch events.
+  // Null when idle. Cleared on destroy.
+  let debounceTimer: NodeJS.Timeout | null = null;
+
+  // Hoist the DB connection across the watcher's lifetime so we don't
+  // open/close on every WAL event. Safe in WAL mode: an open connection
+  // holds no locks until you start a transaction, and our queries are
+  // autocommit.
+  const db: DatabaseSync | null = openDb(log);
+
+  function refresh() {
+    if (destroyed || !db) return;
+    const derived = deriveSessionState(session.id, log, db);
+    if (!derived) {
+      log?.debug({ session: session.id }, "no thread yet for codex session");
+      return;
+    }
+
+    // Codex doesn't have explicit tool-use state in the DB, but we infer
+    // it from approval_mode in parseThreadState
+    const state = derived.state;
+
+    // Codex doesn't have a todo/task system yet
+    const taskProgress = null;
+
+    // Re-read title on each refresh so mid-conversation title changes
+    // are picked up live
+    const summary = getSessionTitle(session.id, log, db) ?? session.title;
+
+    const contextTokens = getSessionContextTokens(session.id, log, db);
+
+    const info: CodexInfo = {
+      kind: "codex",
+      state,
+      sessionId: session.id,
+      model: derived.model,
+      summary,
+      taskProgress,
+      contextTokens,
+    };
+
+    if (agentInfoEqual(lastInfo, info)) return;
+    lastInfo = info;
+    log?.debug(
+      { state: info.state, model: info.model, session: info.sessionId },
+      "codex state updated",
+    );
+    onChange(info);
+  }
+
+  /** Trailing-edge debounce: reset the timer on every event, fire
+   *  `refresh` once after `WAL_DEBOUNCE_MS` of quiet. The handler's own
+   *  `destroyed` guard makes late-firing callbacks safe, but we clear
+   *  the timer in `destroy()` anyway to avoid holding closure refs
+   *  unnecessarily. */
+  function scheduleRefresh() {
+    if (destroyed) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      refresh();
+    }, WAL_DEBOUNCE_MS);
+  }
+
+  const unsubscribe = subscribeCodexDb(
+    scheduleRefresh,
+    (err) =>
+      log?.error({ err, session: session.id }, "codex wal listener threw"),
+    log,
+  );
+  refresh();
+
+  return {
+    session,
+    destroy() {
+      destroyed = true;
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      unsubscribe();
+      db?.close();
+    },
+  };
+}

--- a/packages/integrations/codex/src/wal-watcher.ts
+++ b/packages/integrations/codex/src/wal-watcher.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared WAL watcher — refcounted singleton for `state_5.sqlite-wal`.
+ *
+ * Every CodexWatcher wants to react to WAL changes. Rather than have
+ * each create its own fs.watch (N sessions = N duplicate watchers + N
+ * duplicate dispatches per event), this module refcounts a single
+ * watcher: first subscriber lazily installs it, last unsubscribe tears
+ * it down.
+ *
+ * `sharedWalWatcher` is a single nullable structure (not a {watcher,
+ * listeners} pair) so the "active iff non-empty" invariant is
+ * mechanical — there's no way for the two halves to disagree.
+ *
+ * Per-listener `onError` is required (not optional) so fault isolation
+ * is a type-system obligation, not a convention. If one listener's
+ * callback throws, its own onError runs, and iteration continues to
+ * the next listener unaffected.
+ *
+ * Mirrors `subscribeOpenCodeDb` in kolu-opencode and `subscribeSessionsDir`
+ * in kolu-claude-code.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { CODEX_STATE_PATH, CODEX_STATE_WAL_PATH } from "./config.ts";
+import type { Logger } from "anyagent";
+
+interface WalListener {
+  cb: () => void;
+  onError: (err: unknown) => void;
+}
+
+let sharedWalWatcher: {
+  cleanup: () => void;
+  listeners: Set<WalListener>;
+} | null = null;
+
+/**
+ * Subscribe to changes in Codex's SQLite WAL file. Returns an
+ * unsubscribe function. The underlying `fs.watch` is shared across all
+ * subscribers — refcounted, installed on first subscribe, torn down on
+ * last unsubscribe.
+ *
+ * `onError` receives any exception thrown by `onChange` and runs in
+ * place of breaking the iteration over peer listeners. Callers must
+ * provide one (silent swallowing would hide bugs) — pass a logger call
+ * like `(err) => log.warn({ err }, "...")`.
+ */
+export function subscribeCodexDb(
+  onChange: () => void,
+  onError: (err: unknown) => void,
+  log?: Logger,
+): () => void {
+  if (!sharedWalWatcher) {
+    const listeners = new Set<WalListener>();
+    const cleanup = installWalWatcher(() => {
+      // Snapshot before iteration so a listener that subscribes or
+      // unsubscribes synchronously can't skip a peer for this event.
+      for (const l of [...listeners]) {
+        try {
+          l.cb();
+        } catch (err) {
+          l.onError(err);
+        }
+      }
+    }, log);
+    sharedWalWatcher = { cleanup, listeners };
+  }
+  const listener: WalListener = { cb: onChange, onError };
+  sharedWalWatcher.listeners.add(listener);
+  return () => {
+    if (!sharedWalWatcher) return;
+    sharedWalWatcher.listeners.delete(listener);
+    if (sharedWalWatcher.listeners.size === 0) {
+      sharedWalWatcher.cleanup();
+      sharedWalWatcher = null;
+    }
+  };
+}
+
+/** Try to attach an fs.watch directly to the WAL file. Returns the
+ *  watcher's cleanup function, or null if the file doesn't exist yet. */
+function tryWatchWal(onChange: () => void, log?: Logger): (() => void) | null {
+  try {
+    const w = fs.watch(CODEX_STATE_WAL_PATH, () => onChange());
+    return () => w.close();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      log?.debug(
+        { err, path: CODEX_STATE_WAL_PATH },
+        "codex WAL fs.watch failed",
+      );
+    }
+    return null;
+  }
+}
+
+/** Install a single fs.watch on state_5.sqlite-wal, falling back to the
+ *  parent directory if the WAL doesn't exist yet. When the directory
+ *  watcher fires and the WAL file has appeared, promotes itself to a
+ *  direct WAL watcher and tears down the directory watcher.
+ *
+ *  Mirrors `installWalWatcher` in kolu-opencode and `watchOrWaitForDir`
+ *  in kolu-claude-code. */
+function installWalWatcher(onChange: () => void, log?: Logger): () => void {
+  // Try the WAL file directly first
+  const direct = tryWatchWal(onChange, log);
+  if (direct) return direct;
+
+  // WAL doesn't exist yet — watch the parent directory and promote
+  // to the WAL file once it appears.
+  let promoted: (() => void) | null = null;
+  let dirWatcher: fs.FSWatcher | null = null;
+  const dir = path.dirname(CODEX_STATE_PATH);
+  try {
+    dirWatcher = fs.watch(dir, () => {
+      if (promoted) return; // already promoted
+      const walCleanup = tryWatchWal(onChange, log);
+      if (!walCleanup) return; // WAL still absent
+      promoted = walCleanup;
+      dirWatcher?.close();
+      dirWatcher = null;
+      // Kick — WAL may already have data written between our first
+      // attempt and the directory event.
+      onChange();
+    });
+  } catch (err) {
+    log?.debug({ err, dir }, "codex db dir fs.watch failed");
+  }
+  return () => {
+    dirWatcher?.close();
+    promoted?.();
+  };
+}

--- a/packages/integrations/codex/tsconfig.json
+++ b/packages/integrations/codex/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,6 +26,7 @@
     "hono": "^4.12.14",
     "hono-pino": "^0.10.3",
     "kolu-claude-code": "workspace:*",
+    "kolu-codex": "workspace:*",
     "kolu-common": "workspace:*",
     "kolu-git": "workspace:*",
     "kolu-github": "workspace:*",

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -37,6 +37,7 @@ import {
 import { publishForTerminal, publishSystem } from "../publisher.ts";
 import { claudeCodeProvider } from "kolu-claude-code";
 import { opencodeProvider } from "kolu-opencode";
+import { codexProvider } from "kolu-codex";
 import { startGitProvider } from "./git.ts";
 import { startGitHubPrProvider } from "./github.ts";
 import { startAgentProvider } from "./agent.ts";
@@ -135,12 +136,14 @@ export function startProviders(
   const stopGitHubPr = startGitHubPrProvider(entry, terminalId);
   const stopClaude = startAgentProvider(claudeCodeProvider, entry, terminalId);
   const stopOpenCode = startAgentProvider(opencodeProvider, entry, terminalId);
+  const stopCodex = startAgentProvider(codexProvider, entry, terminalId);
   const stopProcess = startProcessProvider(entry, terminalId);
   return () => {
     stopGit();
     stopGitHubPr();
     stopClaude();
     stopOpenCode();
+    stopCodex();
     stopProcess();
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       kolu-claude-code:
         specifier: workspace:*
         version: link:../integrations/claude-code
+      kolu-codex:
+        specifier: workspace:*
+        version: link:../integrations/codex
       kolu-git:
         specifier: workspace:*
         version: link:../integrations/git
@@ -193,6 +196,28 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.96
         version: 0.2.96(zod@4.3.6)
+      anyagent:
+        specifier: workspace:*
+        version: link:../anyagent
+      ts-pattern:
+        specifier: ^5.9.0
+        version: 5.9.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/integrations/codex:
+    dependencies:
       anyagent:
         specifier: workspace:*
         version: link:../anyagent
@@ -338,6 +363,9 @@ importers:
       kolu-claude-code:
         specifier: workspace:*
         version: link:../integrations/claude-code
+      kolu-codex:
+        specifier: workspace:*
+        version: link:../integrations/codex
       kolu-common:
         specifier: workspace:*
         version: link:../common


### PR DESCRIPTION
**Kolu now detects OpenAI Codex sessions** alongside Claude Code and OpenCode, showing their thinking/tool/waiting state on the tile chrome and in the inspector panel.

Codex uses SQLite WAL mode just like OpenCode — we watch `~/.codex/state_5.sqlite-wal` and query the `threads` table for sessions matching the terminal's working directory. State derives from `updated_at` timestamps and `approval_mode`: recent activity with approval-required suggests tool execution; idle sessions with user events indicate waiting. *The implementation mirrors the existing OpenCode provider — same refcounted WAL watcher pattern, same 150ms debounce, same connection hoisting across the watcher's lifetime.*

The detection surface expands to three major agents: Claude Code (JSONL transcripts), OpenCode (SQLite), and now Codex (SQLite). Each shares the same `AgentProvider<Session, Info>` interface from `anyagent` — adding a fourth agent is one import and one line in `startProviders()`.

> **Configuration:** Override the database path via `KOLU_CODEX_STATE` if Codex lives somewhere other than `~/.codex/state_5.sqlite`.

Closes #659