### PR TITLE
test(xterm): pre-#617 kolu + observer-nullify on latest xterm master

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-B+bX+aTMJScRbZC55ATPAnL8tJG5QAm6fkkABpTaljY=";
+    hash = "sha256-B5oxsfhyiX1xTf2RnXGgRsUwuIPa8d5YOV2YsdpGwDY=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
       "yaml": "^2.8.3",
       "defu": "^6.1.5",
       "@anthropic-ai/sdk": "^0.81.0",
-      "@xterm/xterm": "github:juspay/xterm.js#fix/dispose-leaks-built",
-      "@xterm/addon-webgl": "github:juspay/xterm.js#fix/dispose-leaks-built&path:/addons/addon-webgl"
+      "@xterm/xterm": "github:juspay/xterm.js#test/kolu-nullify-on-latest-master-built",
+      "@xterm/addon-webgl": "github:juspay/xterm.js#test/kolu-nullify-on-latest-master-built&path:/addons/addon-webgl"
     },
     "patchedDependencies": {
       "node-pty@1.1.0": "patches/node-pty@1.1.0.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ overrides:
   yaml: ^2.8.3
   defu: ^6.1.5
   '@anthropic-ai/sdk': ^0.81.0
-  '@xterm/xterm': github:juspay/xterm.js#fix/dispose-leaks-built
-  '@xterm/addon-webgl': github:juspay/xterm.js#fix/dispose-leaks-built&path:/addons/addon-webgl
+  '@xterm/xterm': github:juspay/xterm.js#test/kolu-nullify-on-latest-master-built
+  '@xterm/addon-webgl': github:juspay/xterm.js#test/kolu-nullify-on-latest-master-built&path:/addons/addon-webgl
 
 patchedDependencies:
   node-pty@1.1.0:
@@ -89,11 +89,11 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       '@xterm/addon-webgl':
-        specifier: github:juspay/xterm.js#fix/dispose-leaks-built&path:/addons/addon-webgl
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7#path:/addons/addon-webgl
+        specifier: github:juspay/xterm.js#test/kolu-nullify-on-latest-master-built&path:/addons/addon-webgl
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7#path:/addons/addon-webgl
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/dispose-leaks-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7
+        specifier: github:juspay/xterm.js#test/kolu-nullify-on-latest-master-built
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -357,8 +357,8 @@ importers:
   packages/terminal-themes:
     dependencies:
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/dispose-leaks-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7
+        specifier: github:juspay/xterm.js#test/kolu-nullify-on-latest-master-built
+        version: https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7
     devDependencies:
       typescript:
         specifier: ^5.8.0
@@ -2048,15 +2048,15 @@ packages:
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7#path:/addons/addon-webgl':
-    resolution: {path: /addons/addon-webgl, tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7}
+  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7#path:/addons/addon-webgl':
+    resolution: {path: /addons/addon-webgl, tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7}
     version: 0.19.0
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7':
-    resolution: {tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7}
+  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7':
+    resolution: {tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7}
     version: 6.0.0
 
   accepts@2.0.0:
@@ -5853,11 +5853,11 @@ snapshots:
 
   '@xterm/addon-web-links@0.12.0': {}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7#path:/addons/addon-webgl': {}
+  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7#path:/addons/addon-webgl': {}
 
   '@xterm/headless@6.0.0': {}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/f920f0c08e6fd1757d9304775ca41a1fc2f8dad7': {}
+  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/ca4541daca07054e50796035e92c7fd45cf49be7': {}
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
## Why this branch exists

The original [#617](https://github.com/juspay/kolu/pull/617) repro — 30× Focus↔Canvas **sidebar** mode toggle with 7 terminals, producing +367 MB / 30 toggles on pureintent — isn't reproducible on kolu master anymore because [#622](https://github.com/juspay/kolu/issues/622) made the workspace mode-less (no sidebar toggle, unified infinite canvas).

So to answer [jerch's question on xtermjs/xterm.js#5821](https://github.com/xtermjs/xterm.js/pull/5821#issuecomment-4294798017) — *does the observer-nullify variant defuse the retention as effectively as WeakRef?* — I need the **exact same kolu state** that #617 was measured against, only with the observer-nullify fork spliced in instead.

This branch does that:

- Base: `1b18af1^` (parent of #617's merge commit) → sidebar toggle still present
- `@xterm/xterm` override → [`juspay/xterm.js#test/kolu-nullify-on-latest-master-built`](https://github.com/juspay/xterm.js/tree/test/kolu-nullify-on-latest-master-built), which is **latest `xtermjs/xterm.js@master` (commit `32553b41`) + the nullify patch** (`lib/xterm.mjs` seeded from coordinated `@xterm/xterm@6.1.0-beta.200` + `@xterm/addon-webgl@0.20.0-beta.199`, both published from the same SHA).

No `WeakRef` anywhere in the IntersectionObserver callback lineage.

## Three-arm result

All three arms share the **same kolu UI** (pre-#622, sidebar toggle alive). The MCP Chrome measurement used fresh `just dev` runs, clean `.kolu-dev` where needed, 7 terminals created/restored through the UI, and 30 Focus↔Canvas round trips via the visible header toggle.

| Arm | kolu ref | xterm override | xterm buffer retention Δ / 30 toggles |
|---|---|---|---|
| **A** — unpatched baseline | `1b18af1^` | `juspay/xterm.js#fix/dispose-leaks-built` (pre-#5821) | `Uint32Array +339`, `JSArrayBufferData +339` |
| **B** — WeakRef (merged fix) | `1b18af1` | `juspay/xterm.js#fix/kolu-xterm-fixes-built` (dispose-leaks + WeakRef) | `Uint32Array +0`, `JSArrayBufferData +0` |
| **C** — observer-nullify (this PR) | this branch | `juspay/xterm.js#test/kolu-nullify-on-latest-master-built` (upstream master + nullify) | `Uint32Array +0`, `JSArrayBufferData +0` |

Heap snapshot self-size deltas were noisy because DevTools itself retained other frontend objects during the run, but the xterm buffer signature is the important signal here:

| Arm | Heap snapshot self Δ | `JSArrayBufferData` bytes Δ | `Uint32Array` count Δ |
|---|---:|---:|---:|
| **A** — unpatched baseline | +34.2 MB | +0.8 MB | +339 |
| **B** — WeakRef | +40.8 MB | +0.0 MB | +0 |
| **C** — observer-nullify | +40.7 MB | +0.0 MB | +0 |

Caveat: this MCP run reproduced the leak signature on A, but not the original +367 MB magnitude because the clean UI-created/restored terminals only had ~118 rows of scrollback rather than the large restored buffers from the pureintent measurement.

## Answering jerch

Observer-nullify defuses the same xterm buffer retention leak as the merged WeakRef fix. In the same Chrome DevTools MCP methodology, the unpatched baseline retained new xterm buffer arrays after 30 toggles, while both WeakRef and observer-nullify retained zero additional xterm buffer arrays.

That means the upstream PR can be simplified to the observer-nullify variant without relying on `WeakRef` in the IntersectionObserver callback lineage.

## Rollback

Not for merge. Close after data is collected. The real outcome lands as a change on #5821.

Refs xtermjs/xterm.js#5821, #617, #620, #652, #653
