### PR TITLE
Recognize yolo agent launches

### DIFF
--- a/packages/integrations/anyagent/src/agent-cli.test.ts
+++ b/packages/integrations/anyagent/src/agent-cli.test.ts
@@ -95,6 +95,10 @@ describe("parseAgentCommand", () => {
     );
   });
 
+  it("preserves --yolo for opencode", () => {
+    expect(parseAgentCommand("opencode --yolo")).toBe("opencode --yolo");
+  });
+
   it("preserves --yolo for codex", () => {
     expect(parseAgentCommand("codex --yolo")).toBe("codex --yolo");
   });

--- a/packages/integrations/anyagent/src/agent-cli.test.ts
+++ b/packages/integrations/anyagent/src/agent-cli.test.ts
@@ -95,6 +95,10 @@ describe("parseAgentCommand", () => {
     );
   });
 
+  it("preserves --yolo for codex", () => {
+    expect(parseAgentCommand("codex --yolo")).toBe("codex --yolo");
+  });
+
   it("recognizes all known agents", () => {
     for (const agent of [
       "claude",

--- a/packages/integrations/anyagent/src/agent-cli.ts
+++ b/packages/integrations/anyagent/src/agent-cli.ts
@@ -52,7 +52,10 @@ const STABLE_FLAGS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
     "claude",
     new Set(["--model", "--dangerously-skip-permissions", "--allowedTools"]),
   ],
-  ["opencode", new Set(["--model", "--dangerously-skip-permissions"])],
+  [
+    "opencode",
+    new Set(["--model", "--dangerously-skip-permissions", "--yolo"]),
+  ],
   ["aider", new Set(["--model"])],
   ["codex", new Set(["--model", "--yolo"])],
   ["goose", new Set([])],

--- a/packages/integrations/anyagent/src/agent-cli.ts
+++ b/packages/integrations/anyagent/src/agent-cli.ts
@@ -54,7 +54,7 @@ const STABLE_FLAGS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ],
   ["opencode", new Set(["--model", "--dangerously-skip-permissions"])],
   ["aider", new Set(["--model"])],
-  ["codex", new Set(["--model"])],
+  ["codex", new Set(["--model", "--yolo"])],
   ["goose", new Set([])],
   ["gemini", new Set([])],
   ["cursor-agent", new Set([])],


### PR DESCRIPTION
**Codex and OpenCode launches that use `--yolo` now stay distinct in recent agents**, so the command palette can offer the same high-trust invocation after it has been run once. Previously the recent-agent normalizer dropped that flag and collapsed those commands to the bare agent binary.

**The fix extends the existing per-agent stable-flag policy** in the shared agent CLI parser and covers both CLIs with focused regression tests. _No UI or storage shape changes are needed; the MRU already stores the normalized command string._