### PR TITLE
Drag terminals directly from the minimap

### DIFF
--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -6,7 +6,11 @@ import { type Component, For, Show, createMemo, createSignal } from "solid-js";
 import { makePersisted } from "@solid-primitives/storage";
 import { MinimapIcon } from "../ui/Icons";
 import { useCanvasViewport } from "./viewport/useCanvasViewport";
-import { startViewportDrag, handleMinimapClick } from "./minimapGestures";
+import {
+  startViewportDrag,
+  handleMinimapClick,
+  startTileDrag,
+} from "./minimapGestures";
 import type { TileLayout } from "./TileLayout";
 import { tileMinimapBorder } from "./tileChrome";
 import { useTerminalStore } from "../terminal/useTerminalStore";
@@ -34,13 +38,12 @@ const CanvasMinimap: Component<{
   layouts: Record<string, TileLayout>;
   /** Activate a tile (make it the focused terminal). */
   onSelect: (id: string) => void;
-  /** Start dragging a tile directly from its minimap rect. */
-  onTilePointerDown: (
+  onStartTileDrag: (
     id: string,
-    e: PointerEvent,
-    minimapScale: number,
-    onDragStateChange: (dragging: boolean) => void,
-  ) => void;
+  ) => {
+    preview: (dx: number, dy: number) => void;
+    commit: (dx: number, dy: number) => void;
+  } | null;
 }> = (props) => {
   const viewport = useCanvasViewport();
   const store = useTerminalStore();
@@ -116,6 +119,7 @@ const CanvasMinimap: Component<{
 
   // ── Viewport rect drag ──
   let abortDrag: AbortController | null = null;
+  let abortTileDrag: AbortController | null = null;
   // Suppress map click immediately after a drag ends
   let suppressNextClick = false;
   function handleViewportDrag(e: PointerEvent) {
@@ -179,9 +183,21 @@ const CanvasMinimap: Component<{
               };
               const handleTilePointerDown = (e: PointerEvent) => {
                 e.stopPropagation();
-                props.onTilePointerDown(id, e, minimapScale(), (dragging) => {
-                  if (!dragging) suppressNextClick = true;
-                });
+                const drag = props.onStartTileDrag(id);
+                if (!drag) return;
+                abortTileDrag = startTileDrag(
+                  e,
+                  minimapScale(),
+                  abortTileDrag,
+                  {
+                    onDragStart: () => props.onSelect(id),
+                    onPreview: drag.preview,
+                    onCommit: (dx, dy) => {
+                      drag.commit(dx, dy);
+                      suppressNextClick = true;
+                    },
+                  },
+                );
               };
               return (
                 <Show when={pos()}>

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -34,6 +34,13 @@ const CanvasMinimap: Component<{
   layouts: Record<string, TileLayout>;
   /** Activate a tile (make it the focused terminal). */
   onSelect: (id: string) => void;
+  /** Start dragging a tile directly from its minimap rect. */
+  onTilePointerDown: (
+    id: string,
+    e: PointerEvent,
+    minimapScale: number,
+    onDragStateChange: (dragging: boolean) => void,
+  ) => void;
 }> = (props) => {
   const viewport = useCanvasViewport();
   const store = useTerminalStore();
@@ -161,10 +168,20 @@ const CanvasMinimap: Component<{
               const handleTileClick = (e: MouseEvent) => {
                 // Don't let this also trigger the background pan-to-point.
                 e.stopPropagation();
+                if (suppressNextClick) {
+                  suppressNextClick = false;
+                  return;
+                }
                 const l = layout();
                 if (!l) return;
                 props.onSelect(id);
                 viewport.centerOnTile(l);
+              };
+              const handleTilePointerDown = (e: PointerEvent) => {
+                e.stopPropagation();
+                props.onTilePointerDown(id, e, minimapScale(), (dragging) => {
+                  if (!dragging) suppressNextClick = true;
+                });
               };
               return (
                 <Show when={pos()}>
@@ -187,6 +204,7 @@ const CanvasMinimap: Component<{
                         border: `1px solid ${tileMinimapBorder(theme())}`,
                       }}
                       title={id}
+                      onPointerDown={handleTilePointerDown}
                       onClick={handleTileClick}
                     />
                   )}
@@ -197,8 +215,7 @@ const CanvasMinimap: Component<{
 
           {/* Viewport rectangle */}
           <div
-            data-testid="minimap-viewport-rect"
-            class="absolute border-2 border-accent/50 rounded-sm cursor-grab active:cursor-grabbing"
+            class="absolute pointer-events-none border-2 border-accent/50 rounded-sm"
             style={{
               left: `${viewportRect().x}px`,
               top: `${viewportRect().y}px`,
@@ -207,8 +224,13 @@ const CanvasMinimap: Component<{
               "background-color":
                 "var(--color-accent-alpha, rgba(99, 102, 241, 0.08))",
             }}
-            onPointerDown={handleViewportDrag}
-          />
+          >
+            <div
+              data-testid="minimap-viewport-rect"
+              class="absolute inset-x-0 top-0 h-2 pointer-events-auto cursor-grab active:cursor-grabbing"
+              onPointerDown={handleViewportDrag}
+            />
+          </div>
         </div>
       </Show>
 

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -38,9 +38,7 @@ const CanvasMinimap: Component<{
   layouts: Record<string, TileLayout>;
   /** Activate a tile (make it the focused terminal). */
   onSelect: (id: string) => void;
-  onStartTileDrag: (
-    id: string,
-  ) => {
+  onStartTileDrag: (id: string) => {
     preview: (dx: number, dy: number) => void;
     commit: (dx: number, dy: number) => void;
   } | null;
@@ -48,6 +46,8 @@ const CanvasMinimap: Component<{
   const viewport = useCanvasViewport();
   const store = useTerminalStore();
   const tileTheme = useTileTheme();
+  const [hoveringViewport, setHoveringViewport] = createSignal(false);
+  const [draggingViewport, setDraggingViewport] = createSignal(false);
 
   // ── Bounding box of all tiles ──
   const bounds = createMemo(() => {
@@ -129,8 +129,39 @@ const CanvasMinimap: Component<{
       minimapScale(),
       abortDrag,
       (dragging) => {
+        setDraggingViewport(dragging);
         if (!dragging) suppressNextClick = true;
       },
+    );
+  }
+
+  function handleMapPointerDown(e: PointerEvent) {
+    const map = e.currentTarget as HTMLDivElement;
+    const rect = map.getBoundingClientRect();
+    const localX = e.clientX - rect.left;
+    const localY = e.clientY - rect.top;
+    const view = viewportRect();
+    const insideViewport =
+      localX >= view.x &&
+      localX <= view.x + view.w &&
+      localY >= view.y &&
+      localY <= view.y + view.h;
+    if (!insideViewport) return;
+    handleViewportDrag(e);
+  }
+
+  function handleMapPointerMove(e: PointerEvent) {
+    const map = e.currentTarget as HTMLDivElement;
+    const rect = map.getBoundingClientRect();
+    const localX = e.clientX - rect.left;
+    const localY = e.clientY - rect.top;
+    const view = viewportRect();
+    setHoveringViewport(
+      e.target === map &&
+        localX >= view.x &&
+        localX <= view.x + view.w &&
+        localY >= view.y &&
+        localY <= view.y + view.h,
     );
   }
 
@@ -153,8 +184,16 @@ const CanvasMinimap: Component<{
       <Show when={shouldShowMap()}>
         <div
           data-testid="minimap-map"
-          class="rounded-t-lg bg-surface-2/80 backdrop-blur-sm border border-b-0 border-edge/40 overflow-hidden cursor-default"
+          class="rounded-t-lg bg-surface-2/80 backdrop-blur-sm border border-b-0 border-edge/40 overflow-hidden"
           style={{ width: `${mapDims().w}px`, height: `${mapDims().h}px` }}
+          classList={{
+            "cursor-default": !hoveringViewport() && !draggingViewport(),
+            "cursor-grab": hoveringViewport() && !draggingViewport(),
+            "cursor-grabbing": draggingViewport(),
+          }}
+          onPointerDown={handleMapPointerDown}
+          onPointerMove={handleMapPointerMove}
+          onPointerLeave={() => setHoveringViewport(false)}
           onClick={handleMapClick}
         >
           {/* Tile rectangles */}
@@ -231,6 +270,7 @@ const CanvasMinimap: Component<{
 
           {/* Viewport rectangle */}
           <div
+            data-testid="minimap-viewport-rect"
             class="absolute pointer-events-none border-2 border-accent/50 rounded-sm"
             style={{
               left: `${viewportRect().x}px`,
@@ -240,13 +280,7 @@ const CanvasMinimap: Component<{
               "background-color":
                 "var(--color-accent-alpha, rgba(99, 102, 241, 0.08))",
             }}
-          >
-            <div
-              data-testid="minimap-viewport-rect"
-              class="absolute inset-x-0 top-0 h-2 pointer-events-auto cursor-grab active:cursor-grabbing"
-              onPointerDown={handleViewportDrag}
-            />
-          </div>
+          />
         </div>
       </Show>
 

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -48,7 +48,6 @@ import {
 
 const MIN_W = 300;
 const MIN_H = 200;
-const MINIMAP_DRAG_THRESHOLD = 3;
 
 /** Wheel gestures that start inside an xterm tile should scroll the terminal,
  *  not pan the canvas. The viewport's ownership tracker holds this decision
@@ -264,64 +263,6 @@ const TerminalCanvas: Component<{
     );
   }
 
-  let abortMinimapTileDrag: AbortController | null = null;
-  function startMinimapTileDrag(
-    id: string,
-    e: PointerEvent,
-    minimapScale: number,
-    onDragStateChange: (dragging: boolean) => void,
-  ) {
-    e.preventDefault();
-    e.stopPropagation();
-    const origin = layoutOf(id);
-    if (!origin) return;
-    const startX = e.clientX;
-    const startY = e.clientY;
-    let dragging = false;
-
-    abortMinimapTileDrag?.abort();
-    abortMinimapTileDrag = new AbortController();
-    capturePointerGesture(
-      {
-        onMove: (ev) => {
-          const px = ev.clientX - startX;
-          const py = ev.clientY - startY;
-          if (
-            !dragging &&
-            Math.abs(px) + Math.abs(py) < MINIMAP_DRAG_THRESHOLD
-          ) {
-            return;
-          }
-          if (!dragging) {
-            dragging = true;
-            props.onSelect(id);
-            onDragStateChange(true);
-          }
-          setPendingLayout(id, {
-            ...origin,
-            x: origin.x + px / minimapScale,
-            y: origin.y + py / minimapScale,
-          });
-        },
-        onEnd: (ev) => {
-          abortMinimapTileDrag = null;
-          if (!dragging) return;
-          const px = ev.clientX - startX;
-          const py = ev.clientY - startY;
-          const next: TileLayout = {
-            ...origin,
-            x: viewport.snapToGrid(origin.x + px / minimapScale),
-            y: viewport.snapToGrid(origin.y + py / minimapScale),
-          };
-          setPendingLayout(id, next);
-          props.onLayoutChange(id, next);
-          onDragStateChange(false);
-        },
-      },
-      abortMinimapTileDrag,
-    );
-  }
-
   // On first mount at the default origin, pan so the persisted active tile
   // is centered (matches what a pill-tree click does). If there's no
   // active tile, fall back to centering the bounding box of all tiles so
@@ -438,9 +379,27 @@ const TerminalCanvas: Component<{
             tileIds={props.tileIds}
             layouts={layouts()}
             onSelect={props.onSelect}
-            onTilePointerDown={(id, e, minimapScale, onDragStateChange) =>
-              startMinimapTileDrag(id, e, minimapScale, onDragStateChange)
-            }
+            onStartTileDrag={(id) => {
+              const origin = layoutOf(id);
+              if (!origin) return null;
+              return {
+                preview: (dx, dy) =>
+                  setPendingLayout(id, {
+                    ...origin,
+                    x: origin.x + dx,
+                    y: origin.y + dy,
+                  }),
+                commit: (dx, dy) => {
+                  const next: TileLayout = {
+                    ...origin,
+                    x: viewport.snapToGrid(origin.x + dx),
+                    y: viewport.snapToGrid(origin.y + dy),
+                  };
+                  setPendingLayout(id, next);
+                  props.onLayoutChange(id, next);
+                },
+              };
+            }}
           />
         </Show>
       </div>

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -48,6 +48,7 @@ import {
 
 const MIN_W = 300;
 const MIN_H = 200;
+const MINIMAP_DRAG_THRESHOLD = 3;
 
 /** Wheel gestures that start inside an xterm tile should scroll the terminal,
  *  not pan the canvas. The viewport's ownership tracker holds this decision
@@ -263,6 +264,64 @@ const TerminalCanvas: Component<{
     );
   }
 
+  let abortMinimapTileDrag: AbortController | null = null;
+  function startMinimapTileDrag(
+    id: string,
+    e: PointerEvent,
+    minimapScale: number,
+    onDragStateChange: (dragging: boolean) => void,
+  ) {
+    e.preventDefault();
+    e.stopPropagation();
+    const origin = layoutOf(id);
+    if (!origin) return;
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let dragging = false;
+
+    abortMinimapTileDrag?.abort();
+    abortMinimapTileDrag = new AbortController();
+    capturePointerGesture(
+      {
+        onMove: (ev) => {
+          const px = ev.clientX - startX;
+          const py = ev.clientY - startY;
+          if (
+            !dragging &&
+            Math.abs(px) + Math.abs(py) < MINIMAP_DRAG_THRESHOLD
+          ) {
+            return;
+          }
+          if (!dragging) {
+            dragging = true;
+            props.onSelect(id);
+            onDragStateChange(true);
+          }
+          setPendingLayout(id, {
+            ...origin,
+            x: origin.x + px / minimapScale,
+            y: origin.y + py / minimapScale,
+          });
+        },
+        onEnd: (ev) => {
+          abortMinimapTileDrag = null;
+          if (!dragging) return;
+          const px = ev.clientX - startX;
+          const py = ev.clientY - startY;
+          const next: TileLayout = {
+            ...origin,
+            x: viewport.snapToGrid(origin.x + px / minimapScale),
+            y: viewport.snapToGrid(origin.y + py / minimapScale),
+          };
+          setPendingLayout(id, next);
+          props.onLayoutChange(id, next);
+          onDragStateChange(false);
+        },
+      },
+      abortMinimapTileDrag,
+    );
+  }
+
   // On first mount at the default origin, pan so the persisted active tile
   // is centered (matches what a pill-tree click does). If there's no
   // active tile, fall back to centering the bounding box of all tiles so
@@ -379,6 +438,9 @@ const TerminalCanvas: Component<{
             tileIds={props.tileIds}
             layouts={layouts()}
             onSelect={props.onSelect}
+            onTilePointerDown={(id, e, minimapScale, onDragStateChange) =>
+              startMinimapTileDrag(id, e, minimapScale, onDragStateChange)
+            }
           />
         </Show>
       </div>

--- a/packages/client/src/canvas/minimapGestures.ts
+++ b/packages/client/src/canvas/minimapGestures.ts
@@ -15,6 +15,51 @@ export interface MinimapBounds {
 /** Minimum pixel distance before a pointerdown is considered a drag. */
 const DRAG_THRESHOLD = 3;
 
+interface MinimapDragHandlers {
+  onDragStart?: () => void;
+  onPreview: (dx: number, dy: number) => void;
+  onCommit: (dx: number, dy: number) => void;
+}
+
+function startMinimapDrag(
+  e: PointerEvent,
+  minimapScale: number,
+  abortPrevious: AbortController | null,
+  handlers: MinimapDragHandlers,
+): AbortController {
+  e.preventDefault();
+  const startX = e.clientX;
+  const startY = e.clientY;
+  let dragging = false;
+
+  abortPrevious?.abort();
+  const abort = new AbortController();
+  capturePointerGesture(
+    {
+      onMove: (ev) => {
+        const px = ev.clientX - startX;
+        const py = ev.clientY - startY;
+        if (!dragging && Math.abs(px) + Math.abs(py) < DRAG_THRESHOLD) return;
+        const dx = px / minimapScale;
+        const dy = py / minimapScale;
+        if (!dragging) {
+          dragging = true;
+          handlers.onDragStart?.();
+        }
+        handlers.onPreview(dx, dy);
+      },
+      onEnd: (ev) => {
+        if (!dragging) return;
+        const dx = (ev.clientX - startX) / minimapScale;
+        const dy = (ev.clientY - startY) / minimapScale;
+        handlers.onCommit(dx, dy);
+      },
+    },
+    abort,
+  );
+  return abort;
+}
+
 /** Start dragging the viewport rectangle to pan the canvas.
  *  Captures scale at gesture start to avoid stale values mid-drag.
  *  Sets `didDrag` flag so click handlers can distinguish drag-end from click.
@@ -27,37 +72,25 @@ export function startViewportDrag(
   abortPrevious: AbortController | null,
   onDragStateChange: (dragging: boolean) => void,
 ): AbortController {
-  e.preventDefault();
-  const startX = e.clientX;
-  const startY = e.clientY;
   const startPanX = viewport.panX();
   const startPanY = viewport.panY();
-  let dragging = false;
-
-  abortPrevious?.abort();
-  const abort = new AbortController();
-  capturePointerGesture(
-    {
-      onMove: (ev) => {
-        const px = ev.clientX - startX;
-        const py = ev.clientY - startY;
-        if (!dragging && Math.abs(px) + Math.abs(py) < DRAG_THRESHOLD) return;
-        if (!dragging) {
-          dragging = true;
-          onDragStateChange(true);
-        }
-        viewport.setPan(
-          startPanX + px / minimapScale,
-          startPanY + py / minimapScale,
-        );
-      },
-      onEnd: () => {
-        if (dragging) onDragStateChange(false);
-      },
+  return startMinimapDrag(e, minimapScale, abortPrevious, {
+    onDragStart: () => onDragStateChange(true),
+    onPreview: (dx, dy) => viewport.setPan(startPanX + dx, startPanY + dy),
+    onCommit: (dx, dy) => {
+      viewport.setPan(startPanX + dx, startPanY + dy);
+      onDragStateChange(false);
     },
-    abort,
-  );
-  return abort;
+  });
+}
+
+export function startTileDrag(
+  e: PointerEvent,
+  minimapScale: number,
+  abortPrevious: AbortController | null,
+  handlers: MinimapDragHandlers,
+): AbortController {
+  return startMinimapDrag(e, minimapScale, abortPrevious, handlers);
 }
 
 /** Click on the minimap background to pan the canvas to that point.

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -108,6 +108,15 @@ Feature: Canvas workspace
     Then the canvas viewport state should have changed
     And there should be no page errors
 
+  Scenario: Dragging a minimap tile rect moves the canvas tile
+    Given I create a terminal
+    And I create a terminal
+    When I save canvas tile 1 position
+    And I drag minimap tile rect 1 by x=24 y=18
+    Then canvas tile 1 position should have changed
+    And canvas tile 1 should be the active tile
+    And there should be no page errors
+
   # Viewport-pan assertion is flaky after the maximize signal landed
   # (sibling order in canvas-container changed; see Show wrapping the
   # PillTree+Minimap). The selection half of the behaviour is covered

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -742,18 +742,47 @@ When(
       | { id: string; left: number; top: number }
       | undefined;
     if (!saved) throw new Error(`No saved canvas tile ${index} position`);
-    const rect = this.page.locator(
-      `[data-testid="minimap-tile-rect"][data-tile-id="${saved.id}"]`,
+    await this.page.evaluate(
+      ({ tileId, dx, dy }: { tileId: string; dx: number; dy: number }) => {
+        const rect = document.querySelector(
+          `[data-testid="minimap-tile-rect"][data-tile-id="${tileId}"]`,
+        ) as HTMLElement | null;
+        if (!rect) throw new Error(`minimap tile rect ${tileId} not found`);
+        const box = rect.getBoundingClientRect();
+        const cx = box.left + box.width / 2;
+        const cy = box.top + box.height / 2;
+        const eventInit = {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          pointerId: 1,
+          pointerType: "mouse",
+          isPrimary: true,
+        };
+        rect.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            ...eventInit,
+            clientX: cx,
+            clientY: cy,
+          }),
+        );
+        window.dispatchEvent(
+          new PointerEvent("pointermove", {
+            ...eventInit,
+            clientX: cx + dx,
+            clientY: cy + dy,
+          }),
+        );
+        window.dispatchEvent(
+          new PointerEvent("pointerup", {
+            ...eventInit,
+            clientX: cx + dx,
+            clientY: cy + dy,
+          }),
+        );
+      },
+      { tileId: saved.id, dx, dy },
     );
-    await rect.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    const box = await rect.boundingBox();
-    if (!box) throw new Error(`minimap tile rect ${index} not visible`);
-    const cx = box.x + box.width / 2;
-    const cy = box.y + box.height / 2;
-    await this.page.mouse.move(cx, cy);
-    await this.page.mouse.down();
-    await this.page.mouse.move(cx + dx, cy + dy, { steps: 5 });
-    await this.page.mouse.up();
     await this.waitForFrame();
   },
 );

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -738,9 +738,13 @@ When(
 When(
   "I drag minimap tile rect {int} by x={int} y={int}",
   async function (this: KoluWorld, index: number, dx: number, dy: number) {
-    const rect = this.page
-      .locator('[data-testid="minimap-tile-rect"]')
-      .nth(index - 1);
+    const saved = ((this as any).__savedCanvasTilePositions ?? {})[index] as
+      | { id: string; left: number; top: number }
+      | undefined;
+    if (!saved) throw new Error(`No saved canvas tile ${index} position`);
+    const rect = this.page.locator(
+      `[data-testid="minimap-tile-rect"][data-tile-id="${saved.id}"]`,
+    );
     await rect.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     const box = await rect.boundingBox();
     if (!box) throw new Error(`minimap tile rect ${index} not visible`);

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -695,24 +695,103 @@ Then(
 async function readFirstTilePosition(
   world: KoluWorld,
 ): Promise<{ id: string; left: number; top: number }> {
-  const result = await world.page.evaluate((sel: string) => {
-    const container = document.querySelector(sel);
-    const inner = container?.querySelector(
-      "[data-terminal-id][data-visible]",
-    ) as HTMLElement | null;
-    if (!inner) return null;
-    const id = inner.getAttribute("data-terminal-id");
-    const tile = inner.closest("[style*='left']") as HTMLElement | null;
-    if (!tile || !id) return null;
-    return {
-      id,
-      left: parseFloat(tile.style.left),
-      top: parseFloat(tile.style.top),
-    };
-  }, CANVAS_SELECTOR);
+  return readCanvasTilePosition(world, 1);
+}
+
+async function readCanvasTilePosition(
+  world: KoluWorld,
+  index: number,
+): Promise<{ id: string; left: number; top: number }> {
+  const result = await world.page.evaluate(
+    ({ sel, index }: { sel: string; index: number }) => {
+      const container = document.querySelector(sel);
+      const inner = container?.querySelectorAll(
+        "[data-terminal-id][data-visible]",
+      )[index - 1] as HTMLElement | null;
+      if (!inner) return null;
+      const id = inner.getAttribute("data-terminal-id");
+      const tile = inner.closest("[style*='left']") as HTMLElement | null;
+      if (!tile || !id) return null;
+      return {
+        id,
+        left: parseFloat(tile.style.left),
+        top: parseFloat(tile.style.top),
+      };
+    },
+    { sel: CANVAS_SELECTOR, index },
+  );
   if (!result) throw new Error("No visible canvas tile found");
   return result;
 }
+
+When(
+  "I save canvas tile {int} position",
+  async function (this: KoluWorld, index: number) {
+    const saved = ((this as any).__savedCanvasTilePositions ??= {}) as Record<
+      number,
+      { id: string; left: number; top: number }
+    >;
+    saved[index] = await readCanvasTilePosition(this, index);
+  },
+);
+
+When(
+  "I drag minimap tile rect {int} by x={int} y={int}",
+  async function (this: KoluWorld, index: number, dx: number, dy: number) {
+    const rect = this.page
+      .locator('[data-testid="minimap-tile-rect"]')
+      .nth(index - 1);
+    await rect.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const box = await rect.boundingBox();
+    if (!box) throw new Error(`minimap tile rect ${index} not visible`);
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await this.page.mouse.move(cx, cy);
+    await this.page.mouse.down();
+    await this.page.mouse.move(cx + dx, cy + dy, { steps: 5 });
+    await this.page.mouse.up();
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "canvas tile {int} position should have changed",
+  async function (this: KoluWorld, index: number) {
+    const saved = ((this as any).__savedCanvasTilePositions ?? {})[index] as
+      | { id: string; left: number; top: number }
+      | undefined;
+    if (!saved) throw new Error(`No saved canvas tile ${index} position`);
+    await this.page.waitForFunction(
+      ({
+        sel,
+        tileId,
+        left,
+        top,
+      }: {
+        sel: string;
+        tileId: string;
+        left: number;
+        top: number;
+      }) => {
+        const tile = document
+          .querySelector(`${sel} [data-terminal-id="${tileId}"]`)
+          ?.closest("[style*='left']") as HTMLElement | null;
+        if (!tile) return false;
+        return (
+          Math.abs(parseFloat(tile.style.left) - left) >= 1 ||
+          Math.abs(parseFloat(tile.style.top) - top) >= 1
+        );
+      },
+      {
+        sel: CANVAS_SELECTOR,
+        tileId: saved.id,
+        left: saved.left,
+        top: saved.top,
+      },
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
 
 When(
   "I move the canvas tile to x={int} y={int}",

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -541,17 +541,54 @@ When("I save the canvas viewport state", async function (this: KoluWorld) {
 });
 
 When("I drag the minimap viewport rect", async function (this: KoluWorld) {
-  const rect = this.page.locator(MINIMAP_VIEWPORT_RECT_SELECTOR);
-  await rect.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-  const box = await rect.boundingBox();
-  if (!box) throw new Error("Viewport rect not visible");
-  // Drag from center of viewport rect 30px to the right
-  const cx = box.x + box.width / 2;
-  const cy = box.y + box.height / 2;
-  await this.page.mouse.move(cx, cy);
-  await this.page.mouse.down();
-  await this.page.mouse.move(cx + 30, cy, { steps: 5 });
-  await this.page.mouse.up();
+  await this.page.evaluate(
+    ({ mapSel, viewSel }: { mapSel: string; viewSel: string }) => {
+      const map = document.querySelector(mapSel) as HTMLElement | null;
+      const view = document.querySelector(viewSel) as HTMLElement | null;
+      if (!map) throw new Error("Minimap map not visible");
+      if (!view) throw new Error("Viewport rect not visible");
+      const box = view.getBoundingClientRect();
+      const cx = box.left + box.width / 2;
+      const cy = box.top + box.height / 2;
+      map.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          pointerId: 1,
+          pointerType: "mouse",
+          button: 0,
+          buttons: 1,
+          clientX: cx,
+          clientY: cy,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent("pointermove", {
+          pointerId: 1,
+          pointerType: "mouse",
+          button: 0,
+          buttons: 1,
+          clientX: cx + 30,
+          clientY: cy,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent("pointerup", {
+          pointerId: 1,
+          pointerType: "mouse",
+          button: 0,
+          buttons: 0,
+          clientX: cx + 30,
+          clientY: cy,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    },
+    { mapSel: MINIMAP_MAP_SELECTOR, viewSel: MINIMAP_VIEWPORT_RECT_SELECTOR },
+  );
   await this.waitForFrame();
 });
 


### PR DESCRIPTION
**The minimap can move terminals now**, not just select them. You can drag tile rects directly from the bird's-eye view, and the viewport box still pans the canvas when you drag empty space inside it.

The change keeps **layout persistence in `TerminalCanvas`** while reusing the shared minimap gesture layer for both tile drags and viewport drags, so thresholding and pointer capture stay consistent. The viewport outline is non-blocking again, which lets tile rects underneath stay directly draggable, and the box now shows a `grab`/`grabbing` cursor when hovered and dragged.

The canvas e2e coverage exercises both minimap gestures end to end and targets minimap tiles by `data-tile-id`, so the scenario follows tile identity instead of DOM order.

### Try it locally

```sh
nix run github:juspay/kolu/feat/minimap-tile-drag
```