### PR TITLE
Teach Codex image paste to attach files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Detects [OpenCode](https://github.com/anomalyco/opencode) sessions and shows the
 
 ### Clipboard
 
-- <kbd>Ctrl+V</kbd> pastes images into Claude Code via server-side clipboard shims
+- <kbd>Ctrl+V</kbd> pastes images into Claude Code via server-side clipboard shims and into Codex via bracketed-paste file-path attachment
 
 ### Screen recording
 

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -659,7 +659,10 @@ const Terminal: Component<{
         touchAnchorY = null;
       });
 
-      // Bridge browser clipboard images → PTY for Claude Code's Ctrl+V image paste.
+      // Bridge browser clipboard images → PTY for agent image paste.
+      // The server resolves the PTY input per foreground agent (Claude Code
+      // reads the shimmed clipboard on raw Ctrl+V; Codex attaches a
+      // bracketed-pasted local path). See packages/server/src/clipboard.ts.
       // Capture phase fires before xterm's own paste handler on the textarea,
       // letting us intercept images while text paste falls through to xterm.
       // Uses the native paste event (not navigator.clipboard.read) so no explicit

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -674,11 +674,6 @@ const Terminal: Component<{
         } catch (err) {
           console.error("Failed to upload clipboard image:", err);
         }
-        // Forward Ctrl+V to PTY so Claude Code's xclip/wl-paste shim reads it
-        void client.terminal.sendInput({
-          id: props.terminalId,
-          data: "\x16",
-        });
       }
 
       makeEventListener(

--- a/packages/server/src/clipboard.test.ts
+++ b/packages/server/src/clipboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TerminalMetadata } from "kolu-common";
-import { dispatchPastedImage } from "./clipboard.ts";
+import { dispatchPastedImage, imagePasteMode } from "./clipboard.ts";
 
 function meta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
@@ -14,23 +14,20 @@ function meta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   };
 }
 
-describe("dispatchPastedImage", () => {
-  it("keeps raw ctrl-v behavior for non-codex terminals", () => {
-    expect(dispatchPastedImage(meta(), "/tmp/image.png")).toBe("\x16");
+describe("imagePasteMode", () => {
+  it("defaults to raw ctrl-v", () => {
+    expect(imagePasteMode(meta())).toBe("raw-ctrl-v");
   });
 
-  it("uses bracketed-paste path input for codex foreground processes", () => {
+  it("selects bracketed-path for codex foreground processes", () => {
     expect(
-      dispatchPastedImage(
-        meta({ foreground: { name: "codex", title: "codex" } }),
-        "/tmp/image.png",
-      ),
-    ).toBe("\x1b[200~/tmp/image.png\x1b[201~");
+      imagePasteMode(meta({ foreground: { name: "codex", title: "codex" } })),
+    ).toBe("bracketed-path");
   });
 
   it("falls back to codex agent metadata if foreground lags", () => {
     expect(
-      dispatchPastedImage(
+      imagePasteMode(
         meta({
           agent: {
             kind: "codex",
@@ -42,8 +39,19 @@ describe("dispatchPastedImage", () => {
             contextTokens: null,
           },
         }),
-        "/tmp/image.png",
       ),
-    ).toBe("\x1b[200~/tmp/image.png\x1b[201~");
+    ).toBe("bracketed-path");
+  });
+});
+
+describe("dispatchPastedImage", () => {
+  it("keeps raw ctrl-v behavior for raw-ctrl-v mode", () => {
+    expect(dispatchPastedImage("raw-ctrl-v", "/tmp/image.png")).toBe("\x16");
+  });
+
+  it("uses bracketed-paste path input for bracketed-path mode", () => {
+    expect(dispatchPastedImage("bracketed-path", "/tmp/image.png")).toBe(
+      "\x1b[200~/tmp/image.png\x1b[201~",
+    );
   });
 });

--- a/packages/server/src/clipboard.test.ts
+++ b/packages/server/src/clipboard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { TerminalMetadata } from "kolu-common";
+import { dispatchPastedImage } from "./clipboard.ts";
+
+function meta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
+  return {
+    cwd: "/tmp",
+    git: null,
+    pr: { kind: "pending" },
+    agent: null,
+    foreground: null,
+    sortOrder: 1000,
+    ...overrides,
+  };
+}
+
+describe("dispatchPastedImage", () => {
+  it("keeps raw ctrl-v behavior for non-codex terminals", () => {
+    expect(dispatchPastedImage(meta(), "/tmp/image.png")).toBe("\x16");
+  });
+
+  it("uses bracketed-paste path input for codex foreground processes", () => {
+    expect(
+      dispatchPastedImage(
+        meta({ foreground: { name: "codex", title: "codex" } }),
+        "/tmp/image.png",
+      ),
+    ).toBe("\x1b[200~/tmp/image.png\x1b[201~");
+  });
+
+  it("falls back to codex agent metadata if foreground lags", () => {
+    expect(
+      dispatchPastedImage(
+        meta({
+          agent: {
+            kind: "codex",
+            state: "waiting",
+            sessionId: "session-1",
+            model: null,
+            summary: null,
+            taskProgress: null,
+            contextTokens: null,
+          },
+        }),
+        "/tmp/image.png",
+      ),
+    ).toBe("\x1b[200~/tmp/image.png\x1b[201~");
+  });
+});

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -53,6 +53,10 @@ export type ImagePasteMode = "raw-ctrl-v" | "bracketed-path";
 /** Collapse terminal metadata into one authoritative image-paste mode so
  *  routing decisions do not have to reconstruct policy from multiple fields. */
 export function imagePasteMode(meta: TerminalMetadata): ImagePasteMode {
+  // Two observations of the same fact at different latencies:
+  // `foreground` is the fast path (OSC 7 process name from the PTY);
+  // `agent` is the slower detection path that catches sessions where
+  // foreground has not yet resolved at paste time.
   if (meta.foreground?.name === "codex" || meta.agent?.kind === "codex") {
     return "bracketed-path";
   }

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -14,6 +14,7 @@
 
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { match } from "ts-pattern";
 import type { TerminalMetadata } from "kolu-common";
 import { koluClipboardDir } from "./koluRoot.ts";
 
@@ -65,10 +66,10 @@ export function dispatchPastedImage(
   mode: ImagePasteMode,
   imagePath: string,
 ): string {
-  if (mode === "bracketed-path") {
-    return `\x1b[200~${imagePath}\x1b[201~`;
-  }
-  return "\x16";
+  return match(mode)
+    .with("bracketed-path", () => `\x1b[200~${imagePath}\x1b[201~`)
+    .with("raw-ctrl-v", () => "\x16")
+    .exhaustive();
 }
 
 /** Remove a terminal's clipboard directory. */

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -46,6 +46,7 @@ export function saveClipboardImage(
   return imagePath;
 }
 
+/** The PTY input protocol a terminal expects for a pasted browser image. */
 export type ImagePasteMode = "raw-ctrl-v" | "bracketed-path";
 
 /** Collapse terminal metadata into one authoritative image-paste mode so

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -13,6 +13,7 @@
 
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import type { TerminalMetadata } from "kolu-common";
 import { koluClipboardDir } from "./koluRoot.ts";
 
 /** Clipboard shim bin directory — required, crashes on startup if missing. */
@@ -42,6 +43,19 @@ export function saveClipboardImage(
   const imagePath = join(clipboardDir, "image.png");
   writeFileSync(imagePath, Buffer.from(base64Data, "base64"));
   return imagePath;
+}
+
+/** Translate an uploaded browser image into the PTY input expected by the
+ *  foreground app. Claude reads the clipboard on raw Ctrl+V; Codex expects a
+ *  bracketed-paste path and attaches local images from that path. */
+export function dispatchPastedImage(
+  meta: TerminalMetadata,
+  imagePath: string,
+): string {
+  if (meta.foreground?.name === "codex" || meta.agent?.kind === "codex") {
+    return `\x1b[200~${imagePath}\x1b[201~`;
+  }
+  return "\x16";
 }
 
 /** Remove a terminal's clipboard directory. */

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -45,14 +45,25 @@ export function saveClipboardImage(
   return imagePath;
 }
 
+export type ImagePasteMode = "raw-ctrl-v" | "bracketed-path";
+
+/** Collapse terminal metadata into one authoritative image-paste mode so
+ *  routing decisions do not have to reconstruct policy from multiple fields. */
+export function imagePasteMode(meta: TerminalMetadata): ImagePasteMode {
+  if (meta.foreground?.name === "codex" || meta.agent?.kind === "codex") {
+    return "bracketed-path";
+  }
+  return "raw-ctrl-v";
+}
+
 /** Translate an uploaded browser image into the PTY input expected by the
- *  foreground app. Claude reads the clipboard on raw Ctrl+V; Codex expects a
- *  bracketed-paste path and attaches local images from that path. */
+ *  resolved terminal paste mode. Claude reads the clipboard on raw Ctrl+V;
+ *  Codex expects a bracketed-paste path and attaches local images from it. */
 export function dispatchPastedImage(
-  meta: TerminalMetadata,
+  mode: ImagePasteMode,
   imagePath: string,
 ): string {
-  if (meta.foreground?.name === "codex" || meta.agent?.kind === "codex") {
+  if (mode === "bracketed-path") {
     return `\x1b[200~${imagePath}\x1b[201~`;
   }
   return "\x16";

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -1,10 +1,11 @@
 /**
- * Clipboard bridge: browser clipboard → PTY via server-side shim scripts.
+ * Clipboard bridge: browser clipboard → PTY image-paste inputs.
  *
- * Claude Code reads images from the system clipboard via xclip/wl-paste
- * when the user presses Ctrl+V. In a web terminal, the server has no
- * access to the browser's clipboard. This module manages per-terminal
- * clipboard data directories that Nix-provided shim scripts read from.
+ * In a web terminal, the server has no access to the browser's clipboard.
+ * This module persists pasted browser images into a per-terminal directory,
+ * then translates that saved image into the PTY input expected by the
+ * foreground terminal app: Claude reads from xclip/wl-paste shims on raw
+ * Ctrl+V, while Codex attaches a bracketed-pasted local image path.
  *
  * The shim scripts themselves are packaged as Nix derivations
  * (writeShellScriptBin) and their bin directory is passed via the

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -22,7 +22,11 @@ import {
   reorderTerminals,
   type TerminalProcess,
 } from "./terminals.ts";
-import { dispatchPastedImage, saveClipboardImage } from "./clipboard.ts";
+import {
+  dispatchPastedImage,
+  imagePasteMode,
+  saveClipboardImage,
+} from "./clipboard.ts";
 import { subscribeForTerminal_, subscribeSystem_ } from "./publisher.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import {
@@ -165,7 +169,9 @@ export const appRouter = t.router({
           : 0;
       const bytes = Math.floor((input.data.length * 3) / 4) - padding;
       const path = saveClipboardImage(entry.clipboardDir, input.data);
-      entry.handle.write(dispatchPastedImage(entry.info.meta, path));
+      entry.handle.write(
+        dispatchPastedImage(imagePasteMode(entry.info.meta), path),
+      );
       log.info({ terminal: input.id, bytes, path }, "paste image");
     }),
 

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -22,7 +22,7 @@ import {
   reorderTerminals,
   type TerminalProcess,
 } from "./terminals.ts";
-import { saveClipboardImage } from "./clipboard.ts";
+import { dispatchPastedImage, saveClipboardImage } from "./clipboard.ts";
 import { subscribeForTerminal_, subscribeSystem_ } from "./publisher.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import {
@@ -165,6 +165,7 @@ export const appRouter = t.router({
           : 0;
       const bytes = Math.floor((input.data.length * 3) / 4) - padding;
       const path = saveClipboardImage(entry.clipboardDir, input.data);
+      entry.handle.write(dispatchPastedImage(entry.info.meta, path));
       log.info({ terminal: input.id, bytes, path }, "paste image");
     }),
 


### PR DESCRIPTION
**Codex image paste now works inside Kolu** instead of failing with a remote X11 clipboard timeout. Closes #672. Kolu still preserves the existing Claude flow, but Codex terminals now receive the kind of input Codex actually understands.

The key change is that image-paste dispatch moved to the server. *Claude still gets raw `Ctrl+V` backed by the clipboard shims, while Codex gets a bracketed-pasted local image path after the browser image is saved server-side.* That keeps browser clipboard handling in the client and terminal-specific paste semantics in one server boundary.

> Review the server clipboard dispatch path first: that is where the behavior split now lives, and the accompanying unit test locks the mode selection and emitted PTY input.