### PR TITLE
Keep @anthropic-ai SDK and node:sqlite out of the browser bundle

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.0",
+    "@types/node": "^22.0.0",
     "kolu-common": "workspace:*",
     "tailwindcss": "^4.1.0",
     "terminal-themes": "workspace:*",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.8.0"
   },
   "dependencies": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,9 +5,12 @@
 
 import { z } from "zod";
 import { TaskProgressSchema } from "anyagent";
-import { ClaudeCodeInfoSchema } from "kolu-claude-code";
-import { CodexInfoSchema } from "kolu-codex";
-import { OpenCodeInfoSchema } from "kolu-opencode";
+// Import from `/schemas` subpaths, not package roots — keeps the
+// client bundle free of `@anthropic-ai/claude-agent-sdk` and `node:sqlite`
+// (see juspay/kolu#682).
+import { ClaudeCodeInfoSchema } from "kolu-claude-code/schemas";
+import { CodexInfoSchema } from "kolu-codex/schemas";
+import { OpenCodeInfoSchema } from "kolu-opencode/schemas";
 import {
   GitInfoSchema,
   WorktreeCreateInputSchema,
@@ -73,8 +76,8 @@ const TerminalIdSchema = z.string().uuid();
 
 // --- GitHub PR context ---
 // Owned by kolu-github (mirrors the kolu-git re-export pattern above). The
-// `kolu-common/pr` subpath also re-exports these for browser clients that
-// want to avoid pulling kolu-claude-code → @anthropic-ai/claude-agent-sdk.
+// `kolu-common/pr` subpath re-exports the same zod schemas directly for
+// callers that only need the PR types without any other common imports.
 import {
   GitHubCheckStatusSchema,
   GitHubPrStateSchema,

--- a/packages/integrations/claude-code/package.json
+++ b/packages/integrations/claude-code/package.json
@@ -8,7 +8,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/integrations/claude-code/src/index.ts
+++ b/packages/integrations/claude-code/src/index.ts
@@ -16,39 +16,19 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { z } from "zod";
 import { match } from "ts-pattern";
 import { readTailLines } from "anyagent";
 import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
+import type { ClaudeCodeInfo, TaskProgress } from "./schemas.ts";
 
-// --- Claude Code schemas (single source of truth) ---
+// --- Claude Code schemas (browser-safe; re-exported from ./schemas) ---
 
-export { TaskProgressSchema, type TaskProgress } from "anyagent";
-import { TaskProgressSchema, type TaskProgress } from "anyagent";
-
-export const ClaudeCodeInfoSchema = z.object({
-  kind: z.literal("claude-code"),
-  /** Current state derived from session JSONL. */
-  state: z.enum(["thinking", "tool_use", "waiting"]),
-  /** Session UUID from ~/.claude/sessions/. */
-  sessionId: z.string(),
-  /** Model name if available (e.g. "claude-opus-4-6"). */
-  model: z.string().nullable(),
-  /** Display title from the Claude Agent SDK — custom title › auto-summary › first prompt.
-   *  Refreshed best-effort on each transcript change; null until the first lookup resolves. */
-  summary: z.string().nullable(),
-  /** Task checklist progress derived from TaskCreate/TaskUpdate tool calls in the transcript.
-   *  null when no tasks have been created in the session. */
-  taskProgress: TaskProgressSchema.nullable(),
-  /** Running context-window token count: sum of input + cache_creation +
-   *  cache_read on the latest assistant entry's `message.usage`. Null when
-   *  the transcript has no assistant entries yet, or the entry lacks usage
-   *  (e.g. synthetic entries from /compact). Window size is not encoded —
-   *  consumers render the raw count compact ("47k"). */
-  contextTokens: z.number().nullable(),
-});
-
-export type ClaudeCodeInfo = z.infer<typeof ClaudeCodeInfoSchema>;
+export {
+  TaskProgressSchema,
+  ClaudeCodeInfoSchema,
+  type TaskProgress,
+  type ClaudeCodeInfo,
+} from "./schemas.ts";
 
 // --- Configuration ---
 

--- a/packages/integrations/claude-code/src/schemas.ts
+++ b/packages/integrations/claude-code/src/schemas.ts
@@ -1,0 +1,39 @@
+/** Zod schemas for Claude Code session info — browser-safe.
+ *
+ *  Lives in its own module so `kolu-common` (and any client code) can import
+ *  the schema without pulling the package root, which transitively evaluates
+ *  `@anthropic-ai/claude-agent-sdk` and its `node:crypto` / `node:events`
+ *  imports. Mirrors the `kolu-github/schemas` precedent. See juspay/kolu#682.
+ *
+ *  Anything exported here MUST stay free of `node:*` imports, SDK imports,
+ *  and filesystem access — zod and `anyagent`'s schema re-exports only. */
+
+import { z } from "zod";
+import { TaskProgressSchema } from "anyagent";
+
+export { TaskProgressSchema };
+export type { TaskProgress } from "anyagent";
+
+export const ClaudeCodeInfoSchema = z.object({
+  kind: z.literal("claude-code"),
+  /** Current state derived from session JSONL. */
+  state: z.enum(["thinking", "tool_use", "waiting"]),
+  /** Session UUID from ~/.claude/sessions/. */
+  sessionId: z.string(),
+  /** Model name if available (e.g. "claude-opus-4-6"). */
+  model: z.string().nullable(),
+  /** Display title from the Claude Agent SDK — custom title › auto-summary › first prompt.
+   *  Refreshed best-effort on each transcript change; null until the first lookup resolves. */
+  summary: z.string().nullable(),
+  /** Task checklist progress derived from TaskCreate/TaskUpdate tool calls in the transcript.
+   *  null when no tasks have been created in the session. */
+  taskProgress: TaskProgressSchema.nullable(),
+  /** Running context-window token count: sum of input + cache_creation +
+   *  cache_read on the latest assistant entry's `message.usage`. Null when
+   *  the transcript has no assistant entries yet, or the entry lacks usage
+   *  (e.g. synthetic entries from /compact). Window size is not encoded —
+   *  consumers render the raw count compact ("47k"). */
+  contextTokens: z.number().nullable(),
+});
+
+export type ClaudeCodeInfo = z.infer<typeof ClaudeCodeInfoSchema>;

--- a/packages/integrations/codex/package.json
+++ b/packages/integrations/codex/package.json
@@ -8,7 +8,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/integrations/codex/src/index.ts
+++ b/packages/integrations/codex/src/index.ts
@@ -32,43 +32,22 @@
  */
 
 import { DatabaseSync } from "node:sqlite";
-import { z } from "zod";
-import { withDb as sharedWithDb } from "anyagent";
+import { withDb as sharedWithDb, type Logger } from "anyagent";
 import { CODEX_DB_PATH } from "./config.ts";
+import type { CodexInfo } from "./schemas.ts";
 
 // Re-export config so consumers can reference it (e.g. for env override docs).
 export { CODEX_DIR, CODEX_DB_PATH, CODEX_DB_WAL_PATH } from "./config.ts";
 
-// --- Codex schemas (single source of truth) ---
+// --- Codex schemas (browser-safe; re-exported from ./schemas) ---
 
-export { TaskProgressSchema, type TaskProgress, type Logger } from "anyagent";
-import { TaskProgressSchema, type TaskProgress, type Logger } from "anyagent";
-
-export const CodexInfoSchema = z.object({
-  kind: z.literal("codex"),
-  /** Current state derived from the rollout JSONL's event stream. */
-  state: z.enum(["thinking", "tool_use", "waiting"]),
-  /** Thread id from Codex's `threads` table (e.g. "019db605-..."). */
-  sessionId: z.string(),
-  /** Model identifier from the DB (e.g. "gpt-5.4"). Null until Codex
-   *  writes the first turn_context. */
-  model: z.string().nullable(),
-  /** Thread display title from the DB. Codex seeds this with the first
-   *  user message, then replaces with a short generated name after
-   *  the first exchange. */
-  summary: z.string().nullable(),
-  /** Codex has no TodoWrite equivalent — the `task_started`/`task_complete`
-   *  events are per-turn lifecycle, not user-facing checklists.
-   *  Permanently null; the field is kept for union shape uniformity. */
-  taskProgress: TaskProgressSchema.nullable(),
-  /** Running context-window token count from `threads.tokens_used` —
-   *  pre-summed by Codex from the latest `token_count` event's
-   *  `info.total_token_usage.total_tokens`. Null on a brand-new thread
-   *  before the first assistant turn accounts. */
-  contextTokens: z.number().nullable(),
-});
-
-export type CodexInfo = z.infer<typeof CodexInfoSchema>;
+export {
+  TaskProgressSchema,
+  CodexInfoSchema,
+  type TaskProgress,
+  type CodexInfo,
+} from "./schemas.ts";
+export { type Logger } from "anyagent";
 
 // --- Database helpers ---
 

--- a/packages/integrations/codex/src/schemas.ts
+++ b/packages/integrations/codex/src/schemas.ts
@@ -1,0 +1,41 @@
+/** Zod schemas for Codex session info — browser-safe.
+ *
+ *  Lives in its own module so `kolu-common` (and any client code) can import
+ *  the schema without pulling the package root, which imports `node:sqlite`
+ *  via `DatabaseSync`. Mirrors the `kolu-github/schemas` precedent. See
+ *  juspay/kolu#682.
+ *
+ *  Anything exported here MUST stay free of `node:*` imports and filesystem
+ *  access — zod and `anyagent`'s schema re-exports only. */
+
+import { z } from "zod";
+import { TaskProgressSchema } from "anyagent";
+
+export { TaskProgressSchema };
+export type { TaskProgress } from "anyagent";
+
+export const CodexInfoSchema = z.object({
+  kind: z.literal("codex"),
+  /** Current state derived from the rollout JSONL's event stream. */
+  state: z.enum(["thinking", "tool_use", "waiting"]),
+  /** Thread id from Codex's `threads` table (e.g. "019db605-..."). */
+  sessionId: z.string(),
+  /** Model identifier from the DB (e.g. "gpt-5.4"). Null until Codex
+   *  writes the first turn_context. */
+  model: z.string().nullable(),
+  /** Thread display title from the DB. Codex seeds this with the first
+   *  user message, then replaces with a short generated name after
+   *  the first exchange. */
+  summary: z.string().nullable(),
+  /** Codex has no TodoWrite equivalent — the `task_started`/`task_complete`
+   *  events are per-turn lifecycle, not user-facing checklists.
+   *  Permanently null; the field is kept for union shape uniformity. */
+  taskProgress: TaskProgressSchema.nullable(),
+  /** Running context-window token count from `threads.tokens_used` —
+   *  pre-summed by Codex from the latest `token_count` event's
+   *  `info.total_token_usage.total_tokens`. Null on a brand-new thread
+   *  before the first assistant turn accounts. */
+  contextTokens: z.number().nullable(),
+});
+
+export type CodexInfo = z.infer<typeof CodexInfoSchema>;

--- a/packages/integrations/opencode/package.json
+++ b/packages/integrations/opencode/package.json
@@ -8,7 +8,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/integrations/opencode/src/index.ts
+++ b/packages/integrations/opencode/src/index.ts
@@ -21,39 +21,23 @@
  */
 
 import { DatabaseSync } from "node:sqlite";
-import { z } from "zod";
 import { match } from "ts-pattern";
-import { withDb as sharedWithDb } from "anyagent";
+import { withDb as sharedWithDb, type Logger } from "anyagent";
 import { OPENCODE_DB_PATH } from "./config.ts";
+import type { OpenCodeInfo, TaskProgress } from "./schemas.ts";
 
 // Re-export config so consumers can reference it (e.g. for env override docs).
 export { OPENCODE_DB_PATH, OPENCODE_DB_WAL_PATH } from "./config.ts";
 
-// --- OpenCode schemas (single source of truth) ---
+// --- OpenCode schemas (browser-safe; re-exported from ./schemas) ---
 
-export { TaskProgressSchema, type TaskProgress, type Logger } from "anyagent";
-import { TaskProgressSchema, type TaskProgress, type Logger } from "anyagent";
-
-export const OpenCodeInfoSchema = z.object({
-  kind: z.literal("opencode"),
-  /** Current state derived from the latest session message. */
-  state: z.enum(["thinking", "tool_use", "waiting"]),
-  /** Session ID from OpenCode's database (e.g. "ses_..."). */
-  sessionId: z.string(),
-  /** Model identifier if available (e.g. "litellm/glm-latest"). */
-  model: z.string().nullable(),
-  /** Session title from OpenCode. */
-  summary: z.string().nullable(),
-  /** Todo progress from OpenCode's `todo` table. null when no todos. */
-  taskProgress: TaskProgressSchema.nullable(),
-  /** Running context-window token count from the latest assistant
-   *  message's `tokens.total` field (OpenCode emits it pre-summed).
-   *  Null when the latest message is a user turn or the agent has not
-   *  yet produced an assistant reply. */
-  contextTokens: z.number().nullable(),
-});
-
-export type OpenCodeInfo = z.infer<typeof OpenCodeInfoSchema>;
+export {
+  TaskProgressSchema,
+  OpenCodeInfoSchema,
+  type TaskProgress,
+  type OpenCodeInfo,
+} from "./schemas.ts";
+export { type Logger } from "anyagent";
 
 // --- Database helpers ---
 

--- a/packages/integrations/opencode/src/schemas.ts
+++ b/packages/integrations/opencode/src/schemas.ts
@@ -1,0 +1,36 @@
+/** Zod schemas for OpenCode session info — browser-safe.
+ *
+ *  Lives in its own module so `kolu-common` (and any client code) can import
+ *  the schema without pulling the package root, which imports `node:sqlite`
+ *  via `DatabaseSync`. Mirrors the `kolu-github/schemas` precedent. See
+ *  juspay/kolu#682.
+ *
+ *  Anything exported here MUST stay free of `node:*` imports and filesystem
+ *  access — zod and `anyagent`'s schema re-exports only. */
+
+import { z } from "zod";
+import { TaskProgressSchema } from "anyagent";
+
+export { TaskProgressSchema };
+export type { TaskProgress } from "anyagent";
+
+export const OpenCodeInfoSchema = z.object({
+  kind: z.literal("opencode"),
+  /** Current state derived from the latest session message. */
+  state: z.enum(["thinking", "tool_use", "waiting"]),
+  /** Session ID from OpenCode's database (e.g. "ses_..."). */
+  sessionId: z.string(),
+  /** Model identifier if available (e.g. "litellm/glm-latest"). */
+  model: z.string().nullable(),
+  /** Session title from OpenCode. */
+  summary: z.string().nullable(),
+  /** Todo progress from OpenCode's `todo` table. null when no todos. */
+  taskProgress: TaskProgressSchema.nullable(),
+  /** Running context-window token count from the latest assistant
+   *  message's `tokens.total` field (OpenCode emits it pre-summed).
+   *  Null when the latest message is a user turn or the agent has not
+   *  yet produced an assistant reply. */
+  contextTokens: z.number().nullable(),
+});
+
+export type OpenCodeInfo = z.infer<typeof OpenCodeInfoSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.0
         version: 4.2.2(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       kolu-common:
         specifier: workspace:*
         version: link:../common
@@ -171,6 +174,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       typescript:
         specifier: ^5.8.0
         version: 5.9.3


### PR DESCRIPTION
Closes #682.

**The browser bundle was pulling the Claude Agent SDK.** Importing anything from `kolu-claude-code` — even a pure zod schema — meant evaluating the package root, which `import`s `@anthropic-ai/claude-agent-sdk`. That SDK in turn touches `node:crypto` and `node:events`, so Vite's browser build either stubbed them out (`crypto.randomUUID is not a function` at runtime) or outright aborted in `vite-plugin-pwa` with *`"setMaxListeners" is not exported by "__vite-browser-external"`*. Same shape in `kolu-codex` and `kolu-opencode`: both import `DatabaseSync` from `node:sqlite` at module top-level and neither had shown up yet only because Vite was tree-shaking the sqlite import cleanly — it was a landmine, not a non-problem.

**The fix follows the precedent already established by `kolu-github/schemas`.** Each of `kolu-claude-code`, `kolu-codex`, `kolu-opencode` now exposes a `./schemas` subpath whose module imports only `zod` and `anyagent` — zero `node:*`, zero SDK, zero sqlite. The package root re-exports from the subpath, so server-side imports (`claudeCodeProvider`, `getSessionInfo`, the watchers) keep working unchanged. `kolu-common/src/index.ts` now pulls the three `*InfoSchema` symbols through the subpaths instead of the package roots, which is the single place the browser bundle branches.

*One small side effect of narrowing the import graph:* `kolu-common`'s TSC compile used to pick up `@types/node` via a `.d.ts` reference inside the Claude Agent SDK. Removing that import also removed the side-effect inclusion, so the transitively-included `.ts` files that legitimately use `node:*` (inside `anyagent`, `kolu-git`) stopped type-checking. Fixed by declaring `@types/node` explicitly in `kolu-common` and `kolu-client` devDeps — makes the implicit assumption explicit and doesn't touch the runtime bundle.

**Verified clean.** `pnpm build` completes end-to-end (previously aborted at `sdk.mjs:3710`), the emitted `dist/assets/*.js` contains **zero** occurrences of `claude-agent-sdk`, `anthropic-ai`, `DatabaseSync`, or `node:sqlite`, and `just check` passes across the workspace.

## Test plan

- [ ] `pnpm dev` — fresh browser tab, no `@anthropic-ai/claude-agent-sdk` evaluation, no `randomUUID` TypeError, no `__vite-browser-external` warnings.
- [ ] `pnpm build` — completes without the `setMaxListeners` abort.
- [ ] Server still detects Claude Code / Codex / OpenCode sessions end-to-end.
- [ ] e2e suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)