### PR TITLE
Keep node:child_process and anyagent node deps out of browser bundle

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,10 +4,10 @@
 // kolu-git); this module re-exports them and composes aggregate types.
 
 import { z } from "zod";
-import { TaskProgressSchema } from "anyagent";
 // Import from `/schemas` subpaths, not package roots — keeps the
-// client bundle free of `@anthropic-ai/claude-agent-sdk` and `node:sqlite`
-// (see juspay/kolu#682).
+// client bundle free of `@anthropic-ai/claude-agent-sdk`, `node:sqlite`,
+// `node:child_process`, etc. (see juspay/kolu#682).
+import { TaskProgressSchema } from "anyagent/schemas";
 import { ClaudeCodeInfoSchema } from "kolu-claude-code/schemas";
 import { CodexInfoSchema } from "kolu-codex/schemas";
 import { OpenCodeInfoSchema } from "kolu-opencode/schemas";
@@ -29,7 +29,7 @@ import {
   FsListDirOutputSchema,
   FsReadFileInputSchema,
   FsReadFileOutputSchema,
-} from "kolu-git";
+} from "kolu-git/schemas";
 
 // Re-export integration schemas so consumers import from kolu-common only.
 export {
@@ -68,7 +68,7 @@ export type {
   GitStatusOutput,
   GitDiffOutput,
   FsListDirOutput,
-} from "kolu-git";
+} from "kolu-git/schemas";
 
 // --- Zod schemas ---
 

--- a/packages/integrations/anyagent/package.json
+++ b/packages/integrations/anyagent/package.json
@@ -8,7 +8,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/integrations/anyagent/src/index.ts
+++ b/packages/integrations/anyagent/src/index.ts
@@ -24,24 +24,8 @@ export {
 
 export { readTailLines, type TailReadConfig } from "./tail-lines.ts";
 
-import { z } from "zod";
-
-/** Task/todo progress — total items and completed count.
- *  Used by both Claude Code (from TaskCreate/TaskUpdate tool calls)
- *  and OpenCode (from the `todo` SQLite table). */
-export const TaskProgressSchema = z.object({
-  total: z.number(),
-  completed: z.number(),
-});
-
-export type TaskProgress = z.infer<typeof TaskProgressSchema>;
-
-/** Logger interface accepted by integration library functions.
- *  Structurally compatible with pino child loggers — the server
- *  creates a `log.child(...)` and passes it through. */
-export type Logger = {
-  debug: (obj: Record<string, unknown>, msg: string) => void;
-  info: (obj: Record<string, unknown>, msg: string) => void;
-  warn: (obj: Record<string, unknown>, msg: string) => void;
-  error: (obj: Record<string, unknown>, msg: string) => void;
-};
+export {
+  TaskProgressSchema,
+  type TaskProgress,
+  type Logger,
+} from "./schemas.ts";

--- a/packages/integrations/anyagent/src/schemas.ts
+++ b/packages/integrations/anyagent/src/schemas.ts
@@ -1,0 +1,28 @@
+/** Browser-safe schemas and pure types from anyagent.
+ *
+ *  Split out from `index.ts` so kolu-common (and the client bundle) can
+ *  import zod schemas without dragging in `with-db.ts`/`wal-subscription.ts`/
+ *  `tail-lines.ts`, which transitively pull `node:fs`, `node:path`, and
+ *  `node:sqlite` (see juspay/kolu#682 for the same fix in the SDK packages). */
+
+import { z } from "zod";
+
+/** Task/todo progress — total items and completed count.
+ *  Used by both Claude Code (from TaskCreate/TaskUpdate tool calls)
+ *  and OpenCode (from the `todo` SQLite table). */
+export const TaskProgressSchema = z.object({
+  total: z.number(),
+  completed: z.number(),
+});
+
+export type TaskProgress = z.infer<typeof TaskProgressSchema>;
+
+/** Logger interface accepted by integration library functions.
+ *  Structurally compatible with pino child loggers — the server
+ *  creates a `log.child(...)` and passes it through. */
+export type Logger = {
+  debug: (obj: Record<string, unknown>, msg: string) => void;
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+};

--- a/packages/integrations/git/package.json
+++ b/packages/integrations/git/package.json
@@ -8,7 +8,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./schemas": "./src/schemas.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
**Continuation of #683.** That PR moved `@anthropic-ai/claude-agent-sdk` and `node:sqlite` behind `/schemas` subpaths for the SDK packages. Two more integration roots were still being pulled into the client bundle through `kolu-common`, and one of them was actively breaking dev mode.

The visible failure was `Uncaught Error: Module "node:child_process" has been externalized for browser compatibility. Cannot access "node:child_process.execSync" in client code.` traced to `git/resolve.ts:10`. Root cause is identical to #682: `kolu-common/src/index.ts` did `import { GitInfoSchema, ... } from "kolu-git"`, the package root re-exports `resolve.ts` (which calls `execSync`), and Vite dev mode doesn't tree-shake aggressively enough to drop the unused module — so `node:child_process` lands in the browser graph.

`anyagent` has the same shape: its index re-exports `with-db.ts` / `wal-subscription.ts` / `tail-lines.ts`, which transitively reach `node:fs`, `node:path`, `node:sqlite`. _Currently masked by tree-shaking, but one side-effecting import away from breaking the same way._ Fixed preventively in the same PR rather than waiting for it to bite.

Both packages now expose `/schemas` subpaths that re-export only zod schemas and pure types; `kolu-common` imports from those. Server-side consumers continue to import the package roots and behave identically.

> The deeper fix would be a lint rule that forbids importing integration package _roots_ from `kolu-common` — would have caught both #683 and this one at write time. Filing as a follow-up rather than scope-creeping the fix.