### PR TITLE
Fix titlebar click stealing focus from xterm

### DIFF
--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -140,6 +140,12 @@ const CanvasTile: Component<{
           "--color-fg-2": tileFgTier(props.theme, 2),
           "--color-fg-3": tileFgTier(props.theme, 3),
         }}
+        // Non-interactive chrome: prevent the browser's default
+        // mousedown focus shift so clicks on the title bar don't blur
+        // the xterm textarea. solid-dnd's drag uses pointerdown, not
+        // mousedown, so drag is unaffected; child buttons handle their
+        // own focus via stopPropagation on pointerdown.
+        onMouseDown={(e) => e.preventDefault()}
         onDblClick={(e) => {
           e.stopPropagation();
           props.onToggleMaximize();

--- a/packages/tests/features/terminal.feature
+++ b/packages/tests/features/terminal.feature
@@ -61,6 +61,18 @@ Feature: Terminal
     Then the terminal input should be focused
     And there should be no page errors
 
+  Scenario: Clicking the tile title bar keeps terminal input focused
+    # Regression guard: clicking the tile's title bar (or any chrome
+    # around the xterm canvas) must not steal focus from xterm — the
+    # user should keep typing after aiming at the title bar. Fixed by
+    # preventDefault on mousedown in CanvasTile (prevents browser's
+    # default focus shift without interfering with drag/double-click).
+    When I click the terminal canvas
+    Then the terminal input should be focused
+    When I click the terminal tile title bar
+    Then the terminal input should be focused
+    And there should be no page errors
+
   Scenario: Canvas refits its tile after tab visibility change
     # Tab-hidden xterms can lose their grid measurement. The post-visible
     # refit must re-fill the tile container regardless of viewport size.

--- a/packages/tests/step_definitions/terminal_steps.ts
+++ b/packages/tests/step_definitions/terminal_steps.ts
@@ -182,6 +182,19 @@ When("I click the terminal canvas", async function (this: KoluWorld) {
   await this.canvas.click();
 });
 
+When("I click the terminal tile title bar", async function (this: KoluWorld) {
+  // Scope to the active tile (`data-active="true"`) so the click lands on
+  // the same tile the user was just typing into, regardless of how many
+  // terminals are mounted.
+  await this.page
+    .locator(
+      '[data-testid="canvas-tile"][data-active="true"] [data-testid="canvas-tile-titlebar"]',
+    )
+    .first()
+    .click();
+  await this.waitForFrame();
+});
+
 Then("the terminal input should be focused", async function (this: KoluWorld) {
   const focused = await this.page.evaluate(
     () => !!document.activeElement?.closest("[data-visible]"),


### PR DESCRIPTION
## Summary

Clicking a tile's title bar used to blur the xterm textarea — the user would aim for a drag-handle or just _tap_ the titlebar, then find that their next keystroke went nowhere. Only a manual click back on the terminal canvas would restore typing.

The root cause is the browser's default `mousedown` behavior: on a non-focusable `<div>` with no focusable ancestor, focus falls through to `body`, blurring whichever textarea held it before. Calling `e.preventDefault()` on the titlebar's `mousedown` suppresses that default action. **solid-dnd's drag activators are pointer-event-based**, so drag is unaffected; the double-click-to-maximize handler still fires; and the tile root's `onSelect` still runs via event bubbling (`preventDefault` ≠ `stopPropagation`).

The regression harness is a new `terminal.feature` scenario that focuses the canvas, clicks the titlebar, then re-asserts focus. That scenario was originally added `@skip`-tagged to reproduce the bug; with the fix landed it runs unconditionally so the regression can't silently return.

## Test plan

- [x] `just check` — typecheck clean
- [x] `just fmt` — no diff
- [x] `just test-quick` — full e2e suite (205 scenarios) passes, including the new *Clicking the tile title bar keeps terminal input focused* scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)