### PR TITLE
feat: add per-terminal light/dark terminal themes

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -64,6 +64,10 @@ const App: Component = () => {
 
   const {
     committedThemeName,
+    committedThemeNameForMode,
+    themePickerMode,
+    setThemePickerMode,
+    resetThemePickerMode,
     setPreviewThemeName,
     activeThemeName,
     activeTheme,
@@ -249,6 +253,10 @@ const App: Component = () => {
     handleScreenshotTerminal: () => handleScreenshotTerminal(),
     toggleSubPanel: handleToggleSubPanel,
     committedThemeName,
+    committedThemeNameForMode,
+    themePickerMode,
+    setThemePickerMode,
+    resetThemePickerMode,
     setPreviewThemeName,
     handleSetTheme,
     handleShuffleTheme,

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -63,12 +63,9 @@ const App: Component = () => {
   (window as any).__koluSimulateAlert = alerts.simulateAlert;
 
   const {
-    committedThemeName,
     committedThemeNameForMode,
-    themePickerMode,
-    setThemePickerMode,
-    resetThemePickerMode,
     setPreviewThemeName,
+    clearPreviewTheme,
     activeThemeName,
     activeTheme,
     getTerminalTheme,
@@ -79,7 +76,7 @@ const App: Component = () => {
 
   const subPanel = useSubPanel();
   const rightPanel = useRightPanel();
-  const { colorScheme, setColorScheme } = useColorScheme();
+  const { colorScheme, resolvedColorScheme, setColorScheme } = useColorScheme();
   const canvasViewport = useCanvasViewport();
   const posture = useViewPosture();
   const { showTipOnce } = useTips();
@@ -252,12 +249,10 @@ const App: Component = () => {
     handleExportSessionAsPdf,
     handleScreenshotTerminal: () => handleScreenshotTerminal(),
     toggleSubPanel: handleToggleSubPanel,
-    committedThemeName,
     committedThemeNameForMode,
-    themePickerMode,
-    setThemePickerMode,
-    resetThemePickerMode,
+    resolvedColorScheme,
     setPreviewThemeName,
+    clearPreviewTheme,
     handleSetTheme,
     handleShuffleTheme,
     setShortcutsHelpOpen,

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -63,7 +63,6 @@ const App: Component = () => {
   (window as any).__koluSimulateAlert = alerts.simulateAlert;
 
   const {
-    committedThemeNameForMode,
     setPreviewThemeName,
     clearPreviewTheme,
     activeThemeName,
@@ -249,7 +248,6 @@ const App: Component = () => {
     handleExportSessionAsPdf,
     handleScreenshotTerminal: () => handleScreenshotTerminal(),
     toggleSubPanel: handleToggleSubPanel,
-    committedThemeNameForMode,
     resolvedColorScheme,
     setPreviewThemeName,
     clearPreviewTheme,

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -13,6 +13,7 @@
 import {
   type Component,
   type Accessor,
+  type JSX,
   createSignal,
   createMemo,
   createEffect,
@@ -37,6 +38,10 @@ export interface PaletteCommand {
   onSelect?: () => void;
   /** Nested sub-commands (group). Static array or accessor for dynamic lists. */
   children?: PaletteItem[] | (() => PaletteItem[]);
+  /** Optional inline toolbar rendered under the search input while this group is open. */
+  toolbar?: JSX.Element | (() => JSX.Element);
+  /** Called when drilling into this group. */
+  onEnter?: () => void;
   /** Keyboard shortcut(s) to display alongside the command name. */
   keybind?: Keybind | Keybind[];
   /** Called when this item becomes the highlighted item during navigation. */
@@ -66,6 +71,11 @@ function isHint(item: PaletteItem): item is PaletteHint {
 function resolveChildren(cmd: PaletteCommand): PaletteItem[] {
   if (!cmd.children) return [];
   return typeof cmd.children === "function" ? cmd.children() : cmd.children;
+}
+
+function resolveToolbar(cmd: PaletteCommand): JSX.Element | undefined {
+  if (!cmd.toolbar) return undefined;
+  return typeof cmd.toolbar === "function" ? cmd.toolbar() : cmd.toolbar;
 }
 
 /** Whether a command is a group (has children rather than an action). */
@@ -131,6 +141,23 @@ const CommandPalette: Component<{
     return level;
   });
 
+  const currentGroup = createMemo((): PaletteCommand | undefined => {
+    const p = path();
+    if (p.length === 0) return undefined;
+    let level: PaletteItem[] = props.commands();
+    let current: PaletteCommand | undefined;
+    for (const segment of p) {
+      const match = level.find(
+        (item): item is PaletteCommand =>
+          isCommand(item) && item.name === segment.name,
+      );
+      if (!match || !isGroup(match)) return current ?? segment;
+      current = match;
+      level = resolveChildren(match);
+    }
+    return current;
+  });
+
   /** Commands at the current level, filtered by the search query. Hints are excluded. */
   const filtered = createMemo((): PaletteCommand[] => {
     const q = query().toLowerCase();
@@ -150,6 +177,7 @@ const CommandPalette: Component<{
   );
 
   function drillIn(cmd: PaletteCommand) {
+    cmd.onEnter?.();
     setPath((p) => [...p, cmd]);
     setQuery("");
     setSelectedIndex(0);
@@ -252,6 +280,7 @@ const CommandPalette: Component<{
                     isCommand(c) && c.name === props.initialGroup,
                 )
             : undefined;
+          group?.onEnter?.();
           setPath(group ? [group] : []);
           didSelect = false;
           // forceMount keeps the dialog in the DOM, so Corvu's initialFocusEl
@@ -335,6 +364,17 @@ const CommandPalette: Component<{
           value={query()}
           onInput={(e) => setQuery(e.currentTarget.value)}
         />
+        <Show when={currentGroup()}>
+          {(group) => (
+            <Show when={resolveToolbar(group())}>
+              {(toolbar) => (
+                <div class="px-4 py-2 border-b border-edge bg-surface-1">
+                  {toolbar()}
+                </div>
+              )}
+            </Show>
+          )}
+        </Show>
         <div
           class="flex-1 min-h-0 overflow-y-auto"
           onMouseMove={() => (mouseActive = true)}

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -41,12 +41,11 @@ const TileTitleActions: Component<{
   const store = useTerminalStore();
   const rightPanel = useRightPanel();
   const subPanel = useSubPanel();
-  const { activeThemeName } = useThemeManager();
+  const { getEffectiveThemeName } = useThemeManager();
   const { showTipOnce } = useTips();
 
   const meta = () => store.getMetadata(props.id);
-  const themeName = () =>
-    store.activeId() === props.id ? activeThemeName() : meta()?.themeName;
+  const themeName = () => getEffectiveThemeName(props.id);
   const subCount = () => store.getSubTerminalIds(props.id).length;
   const splitExpanded = () =>
     subCount() > 0 && !subPanel.getSubPanel(props.id).collapsed;

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -58,9 +58,17 @@ export interface CommandDeps {
   toggleSubPanel: (parentId: TerminalId) => void;
   // Theme
   resolvedColorScheme: Accessor<ThemeMode>;
-  setPreviewThemeName: (mode: ThemeMode, name: string) => void;
+  setPreviewThemeName: (
+    terminalId: TerminalId | null,
+    mode: ThemeMode,
+    name: string,
+  ) => void;
   clearPreviewTheme: () => void;
-  handleSetTheme: (mode: ThemeMode, name: string) => void;
+  handleSetTheme: (
+    terminalId: TerminalId | null,
+    mode: ThemeMode,
+    name: string,
+  ) => void;
   handleShuffleTheme: () => void;
   // Dialogs
   setShortcutsHelpOpen: (open: boolean) => void;
@@ -86,9 +94,12 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
   const [themePickerMode, setThemePickerMode] = createSignal<ThemeMode>(
     deps.resolvedColorScheme(),
   );
+  const [themePickerTerminalId, setThemePickerTerminalId] =
+    createSignal<TerminalId | null>(deps.activeId());
   const resetThemePickerMode = () => {
     deps.clearPreviewTheme();
     setThemePickerMode(deps.resolvedColorScheme());
+    setThemePickerTerminalId(deps.activeId());
   };
 
   return createMemo((): PaletteCommand[] => [
@@ -243,11 +254,19 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
           .map((t) => ({
             name: t.name,
             onHighlight: () =>
-              deps.setPreviewThemeName(themePickerMode(), t.name),
+              deps.setPreviewThemeName(
+                themePickerTerminalId(),
+                themePickerMode(),
+                t.name,
+              ),
             onSelect: () =>
               batch(() => {
                 deps.clearPreviewTheme();
-                deps.handleSetTheme(themePickerMode(), t.name);
+                deps.handleSetTheme(
+                  themePickerTerminalId(),
+                  themePickerMode(),
+                  t.name,
+                );
               }),
           })),
     },

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -5,7 +5,13 @@ import type { Accessor } from "solid-js";
 import type { PaletteCommand, PaletteItem } from "./CommandPalette";
 import { SHORTCUTS } from "./input/keyboard";
 import { availableThemes } from "terminal-themes";
-import type { TerminalId, TerminalMetadata, RecentAgent } from "kolu-common";
+import type {
+  TerminalId,
+  TerminalMetadata,
+  RecentAgent,
+  ThemeMode,
+} from "kolu-common";
+import SegmentedControl from "./ui/SegmentedControl";
 import { useActivityFeed } from "./settings/useActivityFeed";
 import { client } from "./rpc/rpc";
 
@@ -51,6 +57,10 @@ export interface CommandDeps {
   toggleSubPanel: (parentId: TerminalId) => void;
   // Theme
   committedThemeName: Accessor<string>;
+  committedThemeNameForMode: (mode: ThemeMode) => string;
+  themePickerMode: Accessor<ThemeMode>;
+  setThemePickerMode: (mode: ThemeMode) => void;
+  resetThemePickerMode: () => void;
   setPreviewThemeName: (name: string | undefined) => void;
   handleSetTheme: (name: string) => void;
   handleShuffleTheme: () => void;
@@ -200,10 +210,24 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       : []),
     {
       name: "Theme",
+      onEnter: () => deps.resetThemePickerMode(),
       onCancel: () => deps.setPreviewThemeName(undefined),
+      toolbar: () =>
+        SegmentedControl({
+          options: [
+            { value: "light", label: "Light" },
+            { value: "dark", label: "Dark" },
+          ],
+          value: deps.themePickerMode(),
+          onChange: deps.setThemePickerMode,
+          testIdPrefix: "theme-slot",
+        }),
       children: () =>
         availableThemes
-          .filter((t) => t.name !== deps.committedThemeName())
+          .filter(
+            (t) =>
+              t.name !== deps.committedThemeNameForMode(deps.themePickerMode()),
+          )
           .map((t) => ({
             name: t.name,
             onHighlight: () => deps.setPreviewThemeName(t.name),

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -13,6 +13,7 @@ import type {
 } from "kolu-common";
 import SegmentedControl from "./ui/SegmentedControl";
 import { useActivityFeed } from "./settings/useActivityFeed";
+import { storedThemeNameForMode } from "./themeSlots";
 import { client } from "./rpc/rpc";
 
 /** PaletteItems listing each recent agent command. Used by the Debug →
@@ -56,7 +57,6 @@ export interface CommandDeps {
   /** Toggle sub-panel: creates first split if none exist, otherwise toggles visibility. */
   toggleSubPanel: (parentId: TerminalId) => void;
   // Theme
-  committedThemeNameForMode: (mode: ThemeMode) => string;
   resolvedColorScheme: Accessor<ThemeMode>;
   setPreviewThemeName: (mode: ThemeMode, name: string) => void;
   clearPreviewTheme: () => void;
@@ -233,7 +233,12 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       children: () =>
         availableThemes
           .filter(
-            (t) => t.name !== deps.committedThemeNameForMode(themePickerMode()),
+            (t) =>
+              t.name !==
+              storedThemeNameForMode(
+                deps.activeMeta()?.themeSlots,
+                themePickerMode(),
+              ),
           )
           .map((t) => ({
             name: t.name,

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -1,6 +1,6 @@
 /** Command palette registry — declarative list of all app-level actions. */
 
-import { createMemo, batch } from "solid-js";
+import { createMemo, createSignal, batch } from "solid-js";
 import type { Accessor } from "solid-js";
 import type { PaletteCommand, PaletteItem } from "./CommandPalette";
 import { SHORTCUTS } from "./input/keyboard";
@@ -56,13 +56,11 @@ export interface CommandDeps {
   /** Toggle sub-panel: creates first split if none exist, otherwise toggles visibility. */
   toggleSubPanel: (parentId: TerminalId) => void;
   // Theme
-  committedThemeName: Accessor<string>;
   committedThemeNameForMode: (mode: ThemeMode) => string;
-  themePickerMode: Accessor<ThemeMode>;
-  setThemePickerMode: (mode: ThemeMode) => void;
-  resetThemePickerMode: () => void;
-  setPreviewThemeName: (name: string | undefined) => void;
-  handleSetTheme: (name: string) => void;
+  resolvedColorScheme: Accessor<ThemeMode>;
+  setPreviewThemeName: (mode: ThemeMode, name: string) => void;
+  clearPreviewTheme: () => void;
+  handleSetTheme: (mode: ThemeMode, name: string) => void;
   handleShuffleTheme: () => void;
   // Dialogs
   setShortcutsHelpOpen: (open: boolean) => void;
@@ -85,6 +83,13 @@ export interface CommandDeps {
 
 export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
   const { recentRepos, recentAgents } = useActivityFeed();
+  const [themePickerMode, setThemePickerMode] = createSignal<ThemeMode>(
+    deps.resolvedColorScheme(),
+  );
+  const resetThemePickerMode = () => {
+    deps.clearPreviewTheme();
+    setThemePickerMode(deps.resolvedColorScheme());
+  };
 
   return createMemo((): PaletteCommand[] => [
     {
@@ -210,31 +215,34 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       : []),
     {
       name: "Theme",
-      onEnter: () => deps.resetThemePickerMode(),
-      onCancel: () => deps.setPreviewThemeName(undefined),
+      onEnter: resetThemePickerMode,
+      onCancel: () => deps.clearPreviewTheme(),
       toolbar: () =>
         SegmentedControl({
           options: [
             { value: "light", label: "Light" },
             { value: "dark", label: "Dark" },
           ],
-          value: deps.themePickerMode(),
-          onChange: deps.setThemePickerMode,
+          value: themePickerMode(),
+          onChange: (mode) => {
+            deps.clearPreviewTheme();
+            setThemePickerMode(mode);
+          },
           testIdPrefix: "theme-slot",
         }),
       children: () =>
         availableThemes
           .filter(
-            (t) =>
-              t.name !== deps.committedThemeNameForMode(deps.themePickerMode()),
+            (t) => t.name !== deps.committedThemeNameForMode(themePickerMode()),
           )
           .map((t) => ({
             name: t.name,
-            onHighlight: () => deps.setPreviewThemeName(t.name),
+            onHighlight: () =>
+              deps.setPreviewThemeName(themePickerMode(), t.name),
             onSelect: () =>
               batch(() => {
-                deps.setPreviewThemeName(undefined);
-                deps.handleSetTheme(t.name);
+                deps.clearPreviewTheme();
+                deps.handleSetTheme(themePickerMode(), t.name);
               }),
           })),
     },

--- a/packages/client/src/settings/useColorScheme.ts
+++ b/packages/client/src/settings/useColorScheme.ts
@@ -5,9 +5,9 @@
  * Defaults to "dark" (the app's original palette).
  */
 
-import { createEffect } from "solid-js";
+import { createEffect, createMemo } from "solid-js";
 import { usePrefersDark } from "@solid-primitives/media";
-import type { ColorScheme } from "kolu-common";
+import type { ColorScheme, ThemeMode } from "kolu-common";
 import { usePreferences } from "./usePreferences";
 
 export type { ColorScheme };
@@ -16,20 +16,27 @@ let effectInitialized = false;
 
 export function useColorScheme() {
   const { preferences, updatePreferences } = usePreferences();
+  const prefersDark = usePrefersDark();
   const colorScheme = () => preferences().colorScheme;
   const setColorScheme = (scheme: ColorScheme) =>
     updatePreferences({ colorScheme: scheme });
+  const resolvedColorScheme = createMemo<ThemeMode>(() => {
+    const scheme = colorScheme();
+    return scheme === "dark" || (scheme === "system" && prefersDark())
+      ? "dark"
+      : "light";
+  });
 
   // Toggle .dark class — only set up once (first consumer wins)
   if (!effectInitialized) {
     effectInitialized = true;
-    const prefersDark = usePrefersDark();
     createEffect(() => {
-      const scheme = colorScheme();
-      const dark = scheme === "dark" || (scheme === "system" && prefersDark());
-      document.documentElement.classList.toggle("dark", dark);
+      document.documentElement.classList.toggle(
+        "dark",
+        resolvedColorScheme() === "dark",
+      );
     });
   }
 
-  return { colorScheme, setColorScheme } as const;
+  return { colorScheme, resolvedColorScheme, setColorScheme } as const;
 }

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -150,8 +150,7 @@ export function useSessionRestore(deps: {
       // and skips the default-cascade branch (#642).
       for (const t of topLevel) {
         const newId = await deps.handleCreate(t.cwd, {
-          lightThemeName: t.lightThemeName,
-          darkThemeName: t.darkThemeName,
+          themeSlots: t.themeSlots,
           canvasLayout: t.canvasLayout,
           subPanel: t.subPanel,
         });
@@ -166,8 +165,7 @@ export function useSessionRestore(deps: {
         const newParentId = oldToNew.get(t.parentId!);
         if (newParentId) {
           await deps.handleCreateSubTerminal(newParentId, t.cwd, {
-            lightThemeName: t.lightThemeName,
-            darkThemeName: t.darkThemeName,
+            themeSlots: t.themeSlots,
             subPanel: t.subPanel,
           });
         }

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -23,6 +23,7 @@ export function useSessionRestore(deps: {
   handleCreateSubTerminal: (
     parentId: TerminalId,
     cwd?: string,
+    initial?: InitialTerminalMetadata,
   ) => Promise<void>;
 }) {
   const { store } = deps;
@@ -149,7 +150,8 @@ export function useSessionRestore(deps: {
       // and skips the default-cascade branch (#642).
       for (const t of topLevel) {
         const newId = await deps.handleCreate(t.cwd, {
-          themeName: t.themeName,
+          lightThemeName: t.lightThemeName,
+          darkThemeName: t.darkThemeName,
           canvasLayout: t.canvasLayout,
           subPanel: t.subPanel,
         });
@@ -162,7 +164,13 @@ export function useSessionRestore(deps: {
       }
       for (const t of subTerminals) {
         const newParentId = oldToNew.get(t.parentId!);
-        if (newParentId) await deps.handleCreateSubTerminal(newParentId, t.cwd);
+        if (newParentId) {
+          await deps.handleCreateSubTerminal(newParentId, t.cwd, {
+            lightThemeName: t.lightThemeName,
+            darkThemeName: t.darkThemeName,
+            subPanel: t.subPanel,
+          });
+        }
       }
       // Restore active terminal
       if (session.activeTerminalId) {

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -12,7 +12,7 @@ import { useTips } from "../settings/useTips";
 import { usePreferences } from "../settings/usePreferences";
 import { useColorScheme } from "../settings/useColorScheme";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
-import { effectiveThemeNameForMode } from "../useThemeManager";
+import { effectiveThemeNameForMode, seedThemeSlots } from "../themeSlots";
 import type {
   CanvasLayout,
   InitialTerminalMetadata,
@@ -138,13 +138,7 @@ export function useTerminalCrud(deps: {
     const info = await client.terminal
       .create({
         cwd,
-        themeSlots:
-          initial?.themeSlots || theme
-            ? {
-                light: initial?.themeSlots?.light ?? theme,
-                dark: initial?.themeSlots?.dark ?? theme,
-              }
-            : undefined,
+        themeSlots: seedThemeSlots(initial?.themeSlots, theme),
         canvasLayout: initial?.canvasLayout,
         subPanel: initial?.subPanel,
       })

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -126,20 +126,25 @@ export function useTerminalCrud(deps: {
     const mode = resolvedColorScheme();
     const peerBgs = preferences().shuffleTheme
       ? resolveThemeBgs(store.terminalIds(), (id) =>
-          effectiveThemeNameForMode(store.getMetadata(id), mode),
+          effectiveThemeNameForMode(store.getMetadata(id)?.themeSlots, mode),
         )
       : null;
     const theme =
-      initial?.lightThemeName ??
-      initial?.darkThemeName ??
+      initial?.themeSlots?.light ??
+      initial?.themeSlots?.dark ??
       (peerBgs
         ? pickTheme(availableThemes, { spread: true, peerBgs })
         : undefined);
     const info = await client.terminal
       .create({
         cwd,
-        lightThemeName: initial?.lightThemeName ?? theme,
-        darkThemeName: initial?.darkThemeName ?? theme,
+        themeSlots:
+          initial?.themeSlots || theme
+            ? {
+                light: initial?.themeSlots?.light ?? theme,
+                dark: initial?.themeSlots?.dark ?? theme,
+              }
+            : undefined,
         canvasLayout: initial?.canvasLayout,
         subPanel: initial?.subPanel,
       })
@@ -162,8 +167,7 @@ export function useTerminalCrud(deps: {
       .create({
         cwd,
         parentId,
-        lightThemeName: initial?.lightThemeName,
-        darkThemeName: initial?.darkThemeName,
+        themeSlots: initial?.themeSlots,
         canvasLayout: initial?.canvasLayout,
         subPanel: initial?.subPanel,
       })

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -10,11 +10,14 @@ import { useSubPanel } from "./useSubPanel";
 import { writeTextToClipboard } from "./clipboard";
 import { useTips } from "../settings/useTips";
 import { usePreferences } from "../settings/usePreferences";
+import { useColorScheme } from "../settings/useColorScheme";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
+import { effectiveThemeNameForMode } from "../useThemeManager";
 import type {
   CanvasLayout,
   InitialTerminalMetadata,
   TerminalId,
+  ThemeMode,
 } from "kolu-common";
 import type { TerminalStore } from "./useTerminalStore";
 
@@ -26,6 +29,7 @@ export function useTerminalCrud(deps: {
   const subPanel = useSubPanel();
   const { showTipOnce } = useTips();
   const { preferences } = usePreferences();
+  const { resolvedColorScheme } = useColorScheme();
 
   /** The terminal the user is currently interacting with —
    *  the active sub-tab when a split has focus, otherwise the workspace root. */
@@ -40,10 +44,10 @@ export function useTerminalCrud(deps: {
 
   // --- Handlers ---
 
-  /** Set a terminal's theme name on the server. */
-  function setThemeName(id: TerminalId, name: string) {
+  /** Set one appearance slot's theme name on the server. */
+  function setThemeName(id: TerminalId, mode: ThemeMode, name: string) {
     void client.terminal
-      .setTheme({ id, themeName: name })
+      .setTheme({ id, mode, themeName: name })
       .catch((err: Error) =>
         toast.error(`Failed to set theme: ${err.message}`),
       );
@@ -119,21 +123,23 @@ export function useTerminalCrud(deps: {
     // Snapshot peer backgrounds BEFORE creating — the new terminal gets the
     // server's default theme for a frame, which we don't want scored as a
     // peer against itself.
+    const mode = resolvedColorScheme();
     const peerBgs = preferences().shuffleTheme
-      ? resolveThemeBgs(
-          store.terminalIds(),
-          (id) => store.getMetadata(id)?.themeName,
+      ? resolveThemeBgs(store.terminalIds(), (id) =>
+          effectiveThemeNameForMode(store.getMetadata(id), mode),
         )
       : null;
     const theme =
-      initial?.themeName ??
+      initial?.lightThemeName ??
+      initial?.darkThemeName ??
       (peerBgs
         ? pickTheme(availableThemes, { spread: true, peerBgs })
         : undefined);
     const info = await client.terminal
       .create({
         cwd,
-        themeName: theme,
+        lightThemeName: initial?.lightThemeName ?? theme,
+        darkThemeName: initial?.darkThemeName ?? theme,
         canvasLayout: initial?.canvasLayout,
         subPanel: initial?.subPanel,
       })
@@ -147,9 +153,20 @@ export function useTerminalCrud(deps: {
     return info.id;
   }
 
-  async function handleCreateSubTerminal(parentId: TerminalId, cwd?: string) {
+  async function handleCreateSubTerminal(
+    parentId: TerminalId,
+    cwd?: string,
+    initial?: InitialTerminalMetadata,
+  ) {
     const info = await client.terminal
-      .create({ cwd, parentId })
+      .create({
+        cwd,
+        parentId,
+        lightThemeName: initial?.lightThemeName,
+        darkThemeName: initial?.darkThemeName,
+        canvasLayout: initial?.canvasLayout,
+        subPanel: initial?.subPanel,
+      })
       .catch((err: Error) => {
         toast.error(`Failed to create terminal: ${err.message}`);
         throw err;

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -17,7 +17,6 @@ import type {
   CanvasLayout,
   InitialTerminalMetadata,
   TerminalId,
-  ThemeMode,
 } from "kolu-common";
 import type { TerminalStore } from "./useTerminalStore";
 
@@ -43,15 +42,6 @@ export function useTerminalCrud(deps: {
   }
 
   // --- Handlers ---
-
-  /** Set one appearance slot's theme name on the server. */
-  function setThemeName(id: TerminalId, mode: ThemeMode, name: string) {
-    void client.terminal
-      .setTheme({ id, mode, themeName: name })
-      .catch((err: Error) =>
-        toast.error(`Failed to set theme: ${err.message}`),
-      );
-  }
 
   /** Reorder terminals on the server. */
   function reorderTerminals(ids: TerminalId[]) {
@@ -227,7 +217,6 @@ export function useTerminalCrud(deps: {
   }
 
   return {
-    setThemeName,
     reorderTerminals,
     setCanvasLayout,
     removeAndAutoSwitch,

--- a/packages/client/src/themeSlots.test.ts
+++ b/packages/client/src/themeSlots.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { effectiveThemeNameForMode, seedThemeSlots } from "./themeSlots";
+import {
+  effectiveThemeNameForMode,
+  previewAppliesToMode,
+  seedThemeSlots,
+  storedThemeNameForMode,
+} from "./themeSlots";
 
 describe("effectiveThemeNameForMode", () => {
   it("prefers the requested slot", () => {
@@ -21,6 +26,23 @@ describe("effectiveThemeNameForMode", () => {
     expect(effectiveThemeNameForMode({ light: "3024 Day" }, "dark")).toBe(
       "3024 Day",
     );
+  });
+});
+
+describe("storedThemeNameForMode", () => {
+  it("returns the exact stored slot without applying fallback", () => {
+    expect(
+      storedThemeNameForMode({ dark: "Dracula" }, "light"),
+    ).toBeUndefined();
+    expect(storedThemeNameForMode({ dark: "Dracula" }, "dark")).toBe("Dracula");
+  });
+});
+
+describe("previewAppliesToMode", () => {
+  it("only applies a preview when it targets the visible mode", () => {
+    expect(previewAppliesToMode("dark", "dark")).toBe(true);
+    expect(previewAppliesToMode("light", "dark")).toBe(false);
+    expect(previewAppliesToMode(undefined, "dark")).toBe(false);
   });
 });
 

--- a/packages/client/src/themeSlots.test.ts
+++ b/packages/client/src/themeSlots.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { effectiveThemeNameForMode, seedThemeSlots } from "./themeSlots";
+
+describe("effectiveThemeNameForMode", () => {
+  it("prefers the requested slot", () => {
+    expect(
+      effectiveThemeNameForMode(
+        { light: "3024 Day", dark: "Dracula" },
+        "light",
+      ),
+    ).toBe("3024 Day");
+    expect(
+      effectiveThemeNameForMode({ light: "3024 Day", dark: "Dracula" }, "dark"),
+    ).toBe("Dracula");
+  });
+
+  it("falls back to the other slot when the requested slot is unset", () => {
+    expect(effectiveThemeNameForMode({ dark: "Dracula" }, "light")).toBe(
+      "Dracula",
+    );
+    expect(effectiveThemeNameForMode({ light: "3024 Day" }, "dark")).toBe(
+      "3024 Day",
+    );
+  });
+});
+
+describe("seedThemeSlots", () => {
+  it("preserves explicit partial slots during restore", () => {
+    expect(seedThemeSlots({ dark: "Dracula" }, "3024 Day")).toEqual({
+      dark: "Dracula",
+    });
+  });
+
+  it("seeds both slots for brand new terminals when only a fallback theme exists", () => {
+    expect(seedThemeSlots(undefined, "Tomorrow Night")).toEqual({
+      light: "Tomorrow Night",
+      dark: "Tomorrow Night",
+    });
+  });
+
+  it("returns undefined when neither slots nor fallback exist", () => {
+    expect(seedThemeSlots(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/packages/client/src/themeSlots.ts
+++ b/packages/client/src/themeSlots.ts
@@ -1,6 +1,22 @@
 import { DEFAULT_THEME_NAME } from "terminal-themes";
 import type { ThemeMode, ThemeSlots } from "kolu-common";
 
+/** Return the exact stored value for a slot without applying fallback. */
+export function storedThemeNameForMode(
+  themeSlots: ThemeSlots,
+  mode: ThemeMode,
+): string | undefined {
+  return mode === "light" ? themeSlots?.light : themeSlots?.dark;
+}
+
+/** Whether a preview for one slot is actually visible under the current mode. */
+export function previewAppliesToMode(
+  previewMode: ThemeMode | undefined,
+  resolvedMode: ThemeMode,
+): boolean {
+  return previewMode !== undefined && previewMode === resolvedMode;
+}
+
 /** Resolve the theme name for the requested appearance, falling back to the
  *  other slot before the global default. */
 export function effectiveThemeNameForMode(

--- a/packages/client/src/themeSlots.ts
+++ b/packages/client/src/themeSlots.ts
@@ -1,0 +1,29 @@
+import { DEFAULT_THEME_NAME } from "terminal-themes";
+import type { ThemeMode, ThemeSlots } from "kolu-common";
+
+/** Resolve the theme name for the requested appearance, falling back to the
+ *  other slot before the global default. */
+export function effectiveThemeNameForMode(
+  themeSlots: ThemeSlots,
+  mode: ThemeMode,
+): string {
+  if (mode === "light") {
+    return themeSlots?.light ?? themeSlots?.dark ?? DEFAULT_THEME_NAME;
+  }
+  return themeSlots?.dark ?? themeSlots?.light ?? DEFAULT_THEME_NAME;
+}
+
+/** Build theme slots for terminal creation.
+ *
+ *  - If explicit slots are provided (including a partial one), preserve them
+ *    exactly — used by session restore.
+ *  - Otherwise seed both slots from the chosen fallback theme so brand-new
+ *    terminals keep one visual identity across light/dark until customized. */
+export function seedThemeSlots(
+  themeSlots: ThemeSlots,
+  fallbackTheme: string | undefined,
+): ThemeSlots {
+  if (themeSlots) return themeSlots;
+  if (!fallbackTheme) return undefined;
+  return { light: fallbackTheme, dark: fallbackTheme };
+}

--- a/packages/client/src/ui/SegmentedControl.tsx
+++ b/packages/client/src/ui/SegmentedControl.tsx
@@ -26,6 +26,7 @@ export default function SegmentedControl<T extends string>(props: {
         {(opt) => (
           <button
             data-testid={`${props.testIdPrefix}-${opt.value}`}
+            data-selected={props.value === opt.value || undefined}
             class="px-2 py-0.5 text-xs transition-colors cursor-pointer"
             classList={{
               "bg-accent text-surface-0": props.value === opt.value,

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -14,39 +14,33 @@ import {
   pickTheme,
   type ITheme,
 } from "terminal-themes";
-import type { TerminalId, TerminalMetadata, ThemeMode } from "kolu-common";
+import type { TerminalId, ThemeMode, ThemeSlots } from "kolu-common";
 import { client } from "./rpc/rpc";
 import { useColorScheme } from "./settings/useColorScheme";
 import { useTerminalStore } from "./terminal/useTerminalStore";
 
 export function effectiveThemeNameForMode(
-  meta:
-    | Pick<TerminalMetadata, "lightThemeName" | "darkThemeName">
-    | null
-    | undefined,
+  themeSlots: ThemeSlots,
   mode: ThemeMode,
 ): string {
   if (mode === "light") {
-    return meta?.lightThemeName ?? meta?.darkThemeName ?? DEFAULT_THEME_NAME;
+    return themeSlots?.light ?? themeSlots?.dark ?? DEFAULT_THEME_NAME;
   }
-  return meta?.darkThemeName ?? meta?.lightThemeName ?? DEFAULT_THEME_NAME;
+  return themeSlots?.dark ?? themeSlots?.light ?? DEFAULT_THEME_NAME;
 }
 
 function init() {
   const store = useTerminalStore();
   const { resolvedColorScheme } = useColorScheme();
-  const getMeta = (id: TerminalId) => store.getMetadata(id);
+  const getThemeSlots = (id: TerminalId) => store.getMetadata(id)?.themeSlots;
 
   const committedThemeName = createMemo(() => {
     const id = store.activeId();
     return id !== null
-      ? effectiveThemeNameForMode(getMeta(id), resolvedColorScheme())
+      ? effectiveThemeNameForMode(getThemeSlots(id), resolvedColorScheme())
       : DEFAULT_THEME_NAME;
   });
 
-  const [themePickerMode, setThemePickerModeState] = createSignal<ThemeMode>(
-    resolvedColorScheme(),
-  );
   const [previewTheme, setPreviewTheme] = createSignal<
     { mode: ThemeMode; name: string } | undefined
   >(undefined);
@@ -63,16 +57,15 @@ function init() {
   function committedThemeNameForMode(mode: ThemeMode): string {
     const id = store.activeId();
     return id !== null
-      ? effectiveThemeNameForMode(getMeta(id), mode)
+      ? effectiveThemeNameForMode(getThemeSlots(id), mode)
       : DEFAULT_THEME_NAME;
   }
 
   function getEffectiveThemeName(id: TerminalId): string {
-    const meta = getMeta(id);
     const preview = store.activeId() === id ? previewTheme() : undefined;
     return preview && preview.mode === resolvedColorScheme()
       ? preview.name
-      : effectiveThemeNameForMode(meta, resolvedColorScheme());
+      : effectiveThemeNameForMode(getThemeSlots(id), resolvedColorScheme());
   }
 
   function getTerminalTheme(id: TerminalId): ITheme {
@@ -87,27 +80,18 @@ function init() {
       );
   }
 
-  function handleSetTheme(themeName: string) {
+  function handleSetTheme(mode: ThemeMode, themeName: string) {
     const id = store.activeId();
     if (id === null) return;
-    setThemeName(id, themePickerMode(), themeName);
+    setThemeName(id, mode, themeName);
   }
 
-  function setPreviewThemeName(name: string | undefined) {
-    if (!name) {
-      setPreviewTheme(undefined);
-      return;
-    }
-    setPreviewTheme({ mode: themePickerMode(), name });
+  function setPreviewThemeName(mode: ThemeMode, name: string) {
+    setPreviewTheme({ mode, name });
   }
 
-  function setThemePickerMode(mode: ThemeMode) {
+  function clearPreviewTheme() {
     setPreviewTheme(undefined);
-    setThemePickerModeState(mode);
-  }
-
-  function resetThemePickerMode() {
-    setThemePickerMode(resolvedColorScheme());
   }
 
   /** Shuffle the active terminal's current appearance slot to a random theme.
@@ -121,22 +105,19 @@ function init() {
     const id = store.activeId();
     if (id === null) return;
     const mode = resolvedColorScheme();
-    const current = effectiveThemeNameForMode(getMeta(id), mode);
+    const current = effectiveThemeNameForMode(getThemeSlots(id), mode);
     const candidates = availableThemes.filter((t) => t.name !== current);
     if (candidates.length === 0) return;
     const excludeBgs = resolveThemeBgs(store.terminalIds(), (terminalId) =>
-      effectiveThemeNameForMode(getMeta(terminalId), mode),
+      effectiveThemeNameForMode(getThemeSlots(terminalId), mode),
     );
     setThemeName(id, mode, pickTheme(candidates, { excludeBgs }));
   }
 
   return {
-    committedThemeName,
     committedThemeNameForMode,
-    themePickerMode,
-    setThemePickerMode,
-    resetThemePickerMode,
     setPreviewThemeName,
+    clearPreviewTheme,
     activeThemeName,
     activeTheme,
     getEffectiveThemeName,

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -17,7 +17,7 @@ import {
 import type { TerminalId, ThemeMode } from "kolu-common";
 import { client } from "./rpc/rpc";
 import { useColorScheme } from "./settings/useColorScheme";
-import { effectiveThemeNameForMode } from "./themeSlots";
+import { effectiveThemeNameForMode, previewAppliesToMode } from "./themeSlots";
 import { useTerminalStore } from "./terminal/useTerminalStore";
 
 function init() {
@@ -38,24 +38,17 @@ function init() {
 
   const activeThemeName = createMemo(() => {
     const preview = previewTheme();
-    return preview && preview.mode === resolvedColorScheme()
-      ? preview.name
+    return previewAppliesToMode(preview?.mode, resolvedColorScheme())
+      ? preview!.name
       : committedThemeName();
   });
 
   const activeTheme = createMemo(() => getThemeByName(activeThemeName()));
 
-  function committedThemeNameForMode(mode: ThemeMode): string {
-    const id = store.activeId();
-    return id !== null
-      ? effectiveThemeNameForMode(getThemeSlots(id), mode)
-      : DEFAULT_THEME_NAME;
-  }
-
   function getEffectiveThemeName(id: TerminalId): string {
     const preview = store.activeId() === id ? previewTheme() : undefined;
-    return preview && preview.mode === resolvedColorScheme()
-      ? preview.name
+    return previewAppliesToMode(preview?.mode, resolvedColorScheme())
+      ? preview!.name
       : effectiveThemeNameForMode(getThemeSlots(id), resolvedColorScheme());
   }
 
@@ -106,14 +99,14 @@ function init() {
   }
 
   return {
-    committedThemeNameForMode,
     setPreviewThemeName,
     clearPreviewTheme,
     activeThemeName,
     activeTheme,
     getEffectiveThemeName,
     getTerminalTheme,
-    isPreviewingTheme: () => previewTheme() !== undefined,
+    isPreviewingTheme: () =>
+      previewAppliesToMode(previewTheme()?.mode, resolvedColorScheme()),
     handleSetTheme,
     handleShuffleTheme,
     setThemeName,

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -19,16 +19,6 @@ import { client } from "./rpc/rpc";
 import { useColorScheme } from "./settings/useColorScheme";
 import { useTerminalStore } from "./terminal/useTerminalStore";
 
-export function themeNameForMode(
-  meta:
-    | Pick<TerminalMetadata, "lightThemeName" | "darkThemeName">
-    | null
-    | undefined,
-  mode: ThemeMode,
-): string | undefined {
-  return mode === "light" ? meta?.lightThemeName : meta?.darkThemeName;
-}
-
 export function effectiveThemeNameForMode(
   meta:
     | Pick<TerminalMetadata, "lightThemeName" | "darkThemeName">

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -33,22 +33,23 @@ function init() {
   });
 
   const [previewTheme, setPreviewTheme] = createSignal<
-    { mode: ThemeMode; name: string } | undefined
+    { terminalId: TerminalId; mode: ThemeMode; name: string } | undefined
   >(undefined);
 
   const activeThemeName = createMemo(() => {
-    const preview = previewTheme();
-    return previewAppliesToMode(preview?.mode, resolvedColorScheme())
-      ? preview!.name
-      : committedThemeName();
+    const activeId = store.activeId();
+    return activeId !== null
+      ? getEffectiveThemeName(activeId)
+      : DEFAULT_THEME_NAME;
   });
 
   const activeTheme = createMemo(() => getThemeByName(activeThemeName()));
 
   function getEffectiveThemeName(id: TerminalId): string {
-    const preview = store.activeId() === id ? previewTheme() : undefined;
-    return previewAppliesToMode(preview?.mode, resolvedColorScheme())
-      ? preview!.name
+    const preview = previewTheme();
+    return preview?.terminalId === id &&
+      previewAppliesToMode(preview.mode, resolvedColorScheme())
+      ? preview.name
       : effectiveThemeNameForMode(getThemeSlots(id), resolvedColorScheme());
   }
 
@@ -64,14 +65,25 @@ function init() {
       );
   }
 
-  function handleSetTheme(mode: ThemeMode, themeName: string) {
-    const id = store.activeId();
-    if (id === null) return;
-    setThemeName(id, mode, themeName);
+  function handleSetTheme(
+    terminalId: TerminalId | null,
+    mode: ThemeMode,
+    themeName: string,
+  ) {
+    if (terminalId === null) return;
+    setThemeName(terminalId, mode, themeName);
   }
 
-  function setPreviewThemeName(mode: ThemeMode, name: string) {
-    setPreviewTheme({ mode, name });
+  function setPreviewThemeName(
+    terminalId: TerminalId | null,
+    mode: ThemeMode,
+    name: string,
+  ) {
+    if (terminalId === null) {
+      setPreviewTheme(undefined);
+      return;
+    }
+    setPreviewTheme({ terminalId, mode, name });
   }
 
   function clearPreviewTheme() {
@@ -105,8 +117,13 @@ function init() {
     activeTheme,
     getEffectiveThemeName,
     getTerminalTheme,
-    isPreviewingTheme: () =>
-      previewAppliesToMode(previewTheme()?.mode, resolvedColorScheme()),
+    isPreviewingTheme: () => {
+      const preview = previewTheme();
+      return (
+        preview?.terminalId === store.activeId() &&
+        previewAppliesToMode(preview?.mode, resolvedColorScheme())
+      );
+    },
     handleSetTheme,
     handleShuffleTheme,
     setThemeName,

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -14,37 +14,84 @@ import {
   pickTheme,
   type ITheme,
 } from "terminal-themes";
-import type { TerminalId } from "kolu-common";
+import type { TerminalId, TerminalMetadata, ThemeMode } from "kolu-common";
 import { client } from "./rpc/rpc";
+import { useColorScheme } from "./settings/useColorScheme";
 import { useTerminalStore } from "./terminal/useTerminalStore";
+
+export function themeNameForMode(
+  meta:
+    | Pick<TerminalMetadata, "lightThemeName" | "darkThemeName">
+    | null
+    | undefined,
+  mode: ThemeMode,
+): string | undefined {
+  return mode === "light" ? meta?.lightThemeName : meta?.darkThemeName;
+}
+
+export function effectiveThemeNameForMode(
+  meta:
+    | Pick<TerminalMetadata, "lightThemeName" | "darkThemeName">
+    | null
+    | undefined,
+  mode: ThemeMode,
+): string {
+  if (mode === "light") {
+    return meta?.lightThemeName ?? meta?.darkThemeName ?? DEFAULT_THEME_NAME;
+  }
+  return meta?.darkThemeName ?? meta?.lightThemeName ?? DEFAULT_THEME_NAME;
+}
 
 function init() {
   const store = useTerminalStore();
-  const getThemeName = (id: TerminalId) => store.getMetadata(id)?.themeName;
+  const { resolvedColorScheme } = useColorScheme();
+  const getMeta = (id: TerminalId) => store.getMetadata(id);
 
   const committedThemeName = createMemo(() => {
     const id = store.activeId();
-    return (id !== null && getThemeName(id)) || DEFAULT_THEME_NAME;
+    return id !== null
+      ? effectiveThemeNameForMode(getMeta(id), resolvedColorScheme())
+      : DEFAULT_THEME_NAME;
   });
 
-  const [previewThemeName, setPreviewThemeName] = createSignal<
-    string | undefined
+  const [themePickerMode, setThemePickerModeState] = createSignal<ThemeMode>(
+    resolvedColorScheme(),
+  );
+  const [previewTheme, setPreviewTheme] = createSignal<
+    { mode: ThemeMode; name: string } | undefined
   >(undefined);
 
-  const activeThemeName = createMemo(
-    () => previewThemeName() ?? committedThemeName(),
-  );
+  const activeThemeName = createMemo(() => {
+    const preview = previewTheme();
+    return preview && preview.mode === resolvedColorScheme()
+      ? preview.name
+      : committedThemeName();
+  });
 
   const activeTheme = createMemo(() => getThemeByName(activeThemeName()));
 
-  function getTerminalTheme(id: TerminalId): ITheme {
-    const preview = store.activeId() === id ? previewThemeName() : undefined;
-    return getThemeByName(preview ?? getThemeName(id));
+  function committedThemeNameForMode(mode: ThemeMode): string {
+    const id = store.activeId();
+    return id !== null
+      ? effectiveThemeNameForMode(getMeta(id), mode)
+      : DEFAULT_THEME_NAME;
   }
 
-  function setThemeName(id: TerminalId, name: string) {
+  function getEffectiveThemeName(id: TerminalId): string {
+    const meta = getMeta(id);
+    const preview = store.activeId() === id ? previewTheme() : undefined;
+    return preview && preview.mode === resolvedColorScheme()
+      ? preview.name
+      : effectiveThemeNameForMode(meta, resolvedColorScheme());
+  }
+
+  function getTerminalTheme(id: TerminalId): ITheme {
+    return getThemeByName(getEffectiveThemeName(id));
+  }
+
+  function setThemeName(id: TerminalId, mode: ThemeMode, name: string) {
     void client.terminal
-      .setTheme({ id, themeName: name })
+      .setTheme({ id, mode, themeName: name })
       .catch((err: Error) =>
         toast.error(`Failed to set theme: ${err.message}`),
       );
@@ -53,33 +100,58 @@ function init() {
   function handleSetTheme(themeName: string) {
     const id = store.activeId();
     if (id === null) return;
-    setThemeName(id, themeName);
+    setThemeName(id, themePickerMode(), themeName);
   }
 
-  /** Shuffle the active terminal to a random theme. Random — not argmax —
-   *  because argmax ping-pongs (theme A's farthest neighbour is theme B,
-   *  and B's farthest is A, so repeated ⌘J just bounces between two).
-   *  Excludes every live terminal's bg so we don't land on a duplicate of
-   *  a sibling, and stays under the chroma cap so we don't surface neon
-   *  yellow. New-terminal creation uses spread mode instead —
-   *  see {@link pickTheme} for the rationale. */
+  function setPreviewThemeName(name: string | undefined) {
+    if (!name) {
+      setPreviewTheme(undefined);
+      return;
+    }
+    setPreviewTheme({ mode: themePickerMode(), name });
+  }
+
+  function setThemePickerMode(mode: ThemeMode) {
+    setPreviewTheme(undefined);
+    setThemePickerModeState(mode);
+  }
+
+  function resetThemePickerMode() {
+    setThemePickerMode(resolvedColorScheme());
+  }
+
+  /** Shuffle the active terminal's current appearance slot to a random theme.
+   *  Random — not argmax — because argmax ping-pongs (theme A's farthest
+   *  neighbour is theme B, and B's farthest is A, so repeated ⌘J just bounces
+   *  between two). Excludes every live terminal's effective bg so we don't land
+   *  on a duplicate of a sibling, and stays under the chroma cap so we don't
+   *  surface neon yellow. New-terminal creation uses spread mode instead — see
+   *  {@link pickTheme} for the rationale. */
   function handleShuffleTheme() {
     const id = store.activeId();
     if (id === null) return;
-    const current = getThemeName(id);
+    const mode = resolvedColorScheme();
+    const current = effectiveThemeNameForMode(getMeta(id), mode);
     const candidates = availableThemes.filter((t) => t.name !== current);
     if (candidates.length === 0) return;
-    const excludeBgs = resolveThemeBgs(store.terminalIds(), getThemeName);
-    handleSetTheme(pickTheme(candidates, { excludeBgs }));
+    const excludeBgs = resolveThemeBgs(store.terminalIds(), (terminalId) =>
+      effectiveThemeNameForMode(getMeta(terminalId), mode),
+    );
+    setThemeName(id, mode, pickTheme(candidates, { excludeBgs }));
   }
 
   return {
     committedThemeName,
+    committedThemeNameForMode,
+    themePickerMode,
+    setThemePickerMode,
+    resetThemePickerMode,
     setPreviewThemeName,
     activeThemeName,
     activeTheme,
+    getEffectiveThemeName,
     getTerminalTheme,
-    isPreviewingTheme: () => previewThemeName() !== undefined,
+    isPreviewingTheme: () => previewTheme() !== undefined,
     handleSetTheme,
     handleShuffleTheme,
     setThemeName,

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -14,20 +14,11 @@ import {
   pickTheme,
   type ITheme,
 } from "terminal-themes";
-import type { TerminalId, ThemeMode, ThemeSlots } from "kolu-common";
+import type { TerminalId, ThemeMode } from "kolu-common";
 import { client } from "./rpc/rpc";
 import { useColorScheme } from "./settings/useColorScheme";
+import { effectiveThemeNameForMode } from "./themeSlots";
 import { useTerminalStore } from "./terminal/useTerminalStore";
-
-export function effectiveThemeNameForMode(
-  themeSlots: ThemeSlots,
-  mode: ThemeMode,
-): string {
-  if (mode === "light") {
-    return themeSlots?.light ?? themeSlots?.dark ?? DEFAULT_THEME_NAME;
-  }
-  return themeSlots?.dark ?? themeSlots?.light ?? DEFAULT_THEME_NAME;
-}
 
 function init() {
   const store = useTerminalStore();

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -175,9 +175,17 @@ export const TerminalServerMetadataSchema = z.object({
  */
 export const ThemeModeSchema = z.enum(["light", "dark"]);
 
+/** Theme names keyed by app appearance. When one side is unset, resolution
+ *  falls back to the other before using the global default. */
+export const ThemeSlotsSchema = z
+  .object({
+    light: z.string().optional(),
+    dark: z.string().optional(),
+  })
+  .optional();
+
 export const TerminalClientMetadataSchema = z.object({
-  lightThemeName: z.string().optional(),
-  darkThemeName: z.string().optional(),
+  themeSlots: ThemeSlotsSchema,
   /** If set, this terminal is a sub-terminal of the given parent. */
   parentId: z.string().optional(),
   /** Numeric ordering within the terminal's group (top-level or same parent). Higher = later. */
@@ -190,8 +198,9 @@ export const TerminalClientMetadataSchema = z.object({
 
 /**
  * Unified wire shape — merge of the server-derived and client-owned halves.
- * Flat for backwards-compat with existing consumers; code that only needs
- * one half should import the sub-schema so the dependency is explicit.
+ * Terminal metadata stays mostly flat so existing consumers can keep reading
+ * fields directly, with `themeSlots` grouped because the paired values are
+ * one logical concern.
  */
 export const TerminalMetadataSchema = TerminalServerMetadataSchema.merge(
   TerminalClientMetadataSchema,
@@ -241,8 +250,7 @@ export const SetActiveTerminalInputSchema = z.object({
  *  terminal's `meta` before the first `terminal.list` yield, so session
  *  restore can't race the canvas default-cascade effect (#642). */
 export const InitialTerminalMetadataSchema = z.object({
-  lightThemeName: z.string().optional(),
-  darkThemeName: z.string().optional(),
+  themeSlots: ThemeSlotsSchema,
   canvasLayout: CanvasLayoutSchema.optional(),
   subPanel: SubPanelStateSchema.optional(),
 });
@@ -324,8 +332,7 @@ export const SavedTerminalSchema = z.object({
   /** Ordering within group at save time. */
   sortOrder: z.number().optional(),
   /** Theme names per app appearance; unset slots symmetrically reuse the other. */
-  lightThemeName: z.string().optional(),
-  darkThemeName: z.string().optional(),
+  themeSlots: ThemeSlotsSchema,
   /** Canvas tile position and size at save time. */
   canvasLayout: CanvasLayoutSchema.optional(),
   /** Sub-panel state at save time (collapsed, size). */
@@ -429,6 +436,7 @@ export type RecentRepo = z.infer<typeof RecentRepoSchema>;
 export type RecentAgent = z.infer<typeof RecentAgentSchema>;
 export type SavedTerminal = z.infer<typeof SavedTerminalSchema>;
 export type SavedSession = z.infer<typeof SavedSessionSchema>;
+export type ThemeSlots = z.infer<typeof ThemeSlotsSchema>;
 export type ThemeMode = z.infer<typeof ThemeModeSchema>;
 export type ColorScheme = z.infer<typeof ColorSchemeSchema>;
 export type Preferences = z.infer<typeof PreferencesSchema>;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -173,8 +173,11 @@ export const TerminalServerMetadataSchema = z.object({
  * via `updateClientMetadata` (or direct mutation for paths that intentionally
  * skip the metadata publish, like sub-panel state).
  */
+export const ThemeModeSchema = z.enum(["light", "dark"]);
+
 export const TerminalClientMetadataSchema = z.object({
-  themeName: z.string().optional(),
+  lightThemeName: z.string().optional(),
+  darkThemeName: z.string().optional(),
   /** If set, this terminal is a sub-terminal of the given parent. */
   parentId: z.string().optional(),
   /** Numeric ordering within the terminal's group (top-level or same parent). Higher = later. */
@@ -215,6 +218,7 @@ export const TerminalSendInputSchema = z.object({
 
 export const TerminalSetThemeInputSchema = z.object({
   id: TerminalIdSchema,
+  mode: ThemeModeSchema,
   themeName: z.string(),
 });
 
@@ -237,7 +241,8 @@ export const SetActiveTerminalInputSchema = z.object({
  *  terminal's `meta` before the first `terminal.list` yield, so session
  *  restore can't race the canvas default-cascade effect (#642). */
 export const InitialTerminalMetadataSchema = z.object({
-  themeName: z.string().optional(),
+  lightThemeName: z.string().optional(),
+  darkThemeName: z.string().optional(),
   canvasLayout: CanvasLayoutSchema.optional(),
   subPanel: SubPanelStateSchema.optional(),
 });
@@ -318,8 +323,9 @@ export const SavedTerminalSchema = z.object({
   branch: z.string().optional(),
   /** Ordering within group at save time. */
   sortOrder: z.number().optional(),
-  /** Theme name at save time. */
-  themeName: z.string().optional(),
+  /** Theme names per app appearance; unset slots symmetrically reuse the other. */
+  lightThemeName: z.string().optional(),
+  darkThemeName: z.string().optional(),
   /** Canvas tile position and size at save time. */
   canvasLayout: CanvasLayoutSchema.optional(),
   /** Sub-panel state at save time (collapsed, size). */
@@ -423,6 +429,7 @@ export type RecentRepo = z.infer<typeof RecentRepoSchema>;
 export type RecentAgent = z.infer<typeof RecentAgentSchema>;
 export type SavedTerminal = z.infer<typeof SavedTerminalSchema>;
 export type SavedSession = z.infer<typeof SavedSessionSchema>;
+export type ThemeMode = z.infer<typeof ThemeModeSchema>;
 export type ColorScheme = z.infer<typeof ColorSchemeSchema>;
 export type Preferences = z.infer<typeof PreferencesSchema>;
 export type PreferencesPatch = z.infer<typeof PreferencesPatchSchema>;

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -113,8 +113,8 @@ export function updateServerMetadata(
   publishMetadata(entry, terminalId);
 }
 
-/** Atomically mutate client-owned metadata (lightThemeName, darkThemeName,
- *  parentId, sortOrder, canvasLayout, subPanel) and publish. The mutator is narrowed to
+/** Atomically mutate client-owned metadata (themeSlots, parentId,
+ *  sortOrder, canvasLayout, subPanel) and publish. The mutator is narrowed to
  *  `TerminalClientMetadata` so RPC handlers cannot accidentally overwrite
  *  provider-owned state. */
 export function updateClientMetadata(

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -113,8 +113,8 @@ export function updateServerMetadata(
   publishMetadata(entry, terminalId);
 }
 
-/** Atomically mutate client-owned metadata (themeName, parentId, sortOrder,
- *  canvasLayout, subPanel) and publish. The mutator is narrowed to
+/** Atomically mutate client-owned metadata (lightThemeName, darkThemeName,
+ *  parentId, sortOrder, canvasLayout, subPanel) and publish. The mutator is narrowed to
  *  `TerminalClientMetadata` so RPC handlers cannot accidentally overwrite
  *  provider-owned state. */
 export function updateClientMetadata(

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -81,7 +81,8 @@ export const appRouter = t.router({
   terminal: {
     create: t.terminal.create.handler(async ({ input }) =>
       createTerminal(input.cwd, input.parentId, {
-        themeName: input.themeName,
+        lightThemeName: input.lightThemeName,
+        darkThemeName: input.darkThemeName,
         canvasLayout: input.canvasLayout,
         subPanel: input.subPanel,
       }),
@@ -103,8 +104,11 @@ export const appRouter = t.router({
 
     setTheme: t.terminal.setTheme.handler(async ({ input }) => {
       requireTerminal(input.id);
-      log.info({ terminal: input.id, theme: input.themeName }, "set theme");
-      setTerminalTheme(input.id, input.themeName);
+      log.info(
+        { terminal: input.id, mode: input.mode, theme: input.themeName },
+        "set theme",
+      );
+      setTerminalTheme(input.id, input.mode, input.themeName);
     }),
 
     setCanvasLayout: t.terminal.setCanvasLayout.handler(async ({ input }) => {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -81,8 +81,7 @@ export const appRouter = t.router({
   terminal: {
     create: t.terminal.create.handler(async ({ input }) =>
       createTerminal(input.cwd, input.parentId, {
-        lightThemeName: input.lightThemeName,
-        darkThemeName: input.darkThemeName,
+        themeSlots: input.themeSlots,
         canvasLayout: input.canvasLayout,
         subPanel: input.subPanel,
       }),

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -78,15 +78,23 @@ describe("session persistence", () => {
     expect(session!.terminals[2]!.parentId).toBe("a");
   });
 
-  it("preserves themeName on round-trip", () => {
+  it("preserves light/dark theme names on round-trip", () => {
     const terminals: SavedTerminal[] = [
-      { id: "a", cwd: "/a", sortOrder: 0, themeName: "Dracula" },
+      {
+        id: "a",
+        cwd: "/a",
+        sortOrder: 0,
+        lightThemeName: "3024 Day",
+        darkThemeName: "Dracula",
+      },
       { id: "b", cwd: "/b", sortOrder: 1 },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();
-    expect(session!.terminals[0]!.themeName).toBe("Dracula");
-    expect(session!.terminals[1]!.themeName).toBeUndefined();
+    expect(session!.terminals[0]!.lightThemeName).toBe("3024 Day");
+    expect(session!.terminals[0]!.darkThemeName).toBe("Dracula");
+    expect(session!.terminals[1]!.lightThemeName).toBeUndefined();
+    expect(session!.terminals[1]!.darkThemeName).toBeUndefined();
   });
 
   it("clearSavedSession removes the session", () => {

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -78,23 +78,23 @@ describe("session persistence", () => {
     expect(session!.terminals[2]!.parentId).toBe("a");
   });
 
-  it("preserves light/dark theme names on round-trip", () => {
+  it("preserves themeSlots on round-trip", () => {
     const terminals: SavedTerminal[] = [
       {
         id: "a",
         cwd: "/a",
         sortOrder: 0,
-        lightThemeName: "3024 Day",
-        darkThemeName: "Dracula",
+        themeSlots: { light: "3024 Day", dark: "Dracula" },
       },
       { id: "b", cwd: "/b", sortOrder: 1 },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();
-    expect(session!.terminals[0]!.lightThemeName).toBe("3024 Day");
-    expect(session!.terminals[0]!.darkThemeName).toBe("Dracula");
-    expect(session!.terminals[1]!.lightThemeName).toBeUndefined();
-    expect(session!.terminals[1]!.darkThemeName).toBeUndefined();
+    expect(session!.terminals[0]!.themeSlots).toEqual({
+      light: "3024 Day",
+      dark: "Dracula",
+    });
+    expect(session!.terminals[1]!.themeSlots).toBeUndefined();
   });
 
   it("clearSavedSession removes the session", () => {

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -45,7 +45,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.18.0";
+const SCHEMA_VERSION = "1.19.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -290,9 +290,9 @@ export const store = new Conf<PersistedState>({
       }
     },
     // Terminal themes moved from a single `themeName` to per-appearance
-    // `lightThemeName`/`darkThemeName` slots. Existing saved-session entries
-    // inherit the old theme into both slots so terminals keep the same look
-    // until the user explicitly customizes one appearance.
+    // flat slots. Existing saved-session entries inherit the old theme into
+    // both sides so terminals keep the same look until the user explicitly
+    // customizes one appearance.
     "1.18.0": (store: Conf<PersistedState>) => {
       const session = store.get("session") as
         | ({ terminals?: Array<Record<string, unknown>> } & Record<
@@ -310,6 +310,41 @@ export const store = new Conf<PersistedState>({
           ...rest,
           lightThemeName: terminal.lightThemeName ?? themeName,
           darkThemeName: terminal.darkThemeName ?? themeName,
+        };
+      });
+      if (changed) {
+        store.set("session", {
+          ...session,
+          terminals,
+        } as PersistedState["session"]);
+      }
+    },
+    // Theme slot fields are grouped under one `themeSlots` object so paired
+    // theme data travels through the wire/persistence layers as a single
+    // concept. Existing saved-session entries with flat slots are rewritten.
+    "1.19.0": (store: Conf<PersistedState>) => {
+      const session = store.get("session") as
+        | ({ terminals?: Array<Record<string, unknown>> } & Record<
+            string,
+            unknown
+          >)
+        | null;
+      if (!session?.terminals) return;
+      let changed = false;
+      const terminals = session.terminals.map((terminal) => {
+        const hasFlatSlots =
+          typeof terminal.lightThemeName === "string" ||
+          typeof terminal.darkThemeName === "string";
+        if (!hasFlatSlots) return terminal;
+        changed = true;
+        const { lightThemeName, darkThemeName, ...rest } = terminal;
+        return {
+          ...rest,
+          themeSlots: {
+            light:
+              typeof lightThemeName === "string" ? lightThemeName : undefined,
+            dark: typeof darkThemeName === "string" ? darkThemeName : undefined,
+          },
         };
       });
       if (changed) {

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -45,7 +45,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.17.0";
+const SCHEMA_VERSION = "1.18.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -287,6 +287,36 @@ export const store = new Conf<PersistedState>({
           ...current,
           rightPanel: rest as typeof current.rightPanel,
         });
+      }
+    },
+    // Terminal themes moved from a single `themeName` to per-appearance
+    // `lightThemeName`/`darkThemeName` slots. Existing saved-session entries
+    // inherit the old theme into both slots so terminals keep the same look
+    // until the user explicitly customizes one appearance.
+    "1.18.0": (store: Conf<PersistedState>) => {
+      const session = store.get("session") as
+        | ({ terminals?: Array<Record<string, unknown>> } & Record<
+            string,
+            unknown
+          >)
+        | null;
+      if (!session?.terminals) return;
+      let changed = false;
+      const terminals = session.terminals.map((terminal) => {
+        if (typeof terminal.themeName !== "string") return terminal;
+        changed = true;
+        const { themeName, ...rest } = terminal;
+        return {
+          ...rest,
+          lightThemeName: terminal.lightThemeName ?? themeName,
+          darkThemeName: terminal.darkThemeName ?? themeName,
+        };
+      });
+      if (changed) {
+        store.set("session", {
+          ...session,
+          terminals,
+        } as PersistedState["session"]);
       }
     },
   },

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -66,8 +66,7 @@ export function snapshotSession(): {
       ...(m.parentId && { parentId: m.parentId }),
       ...(m.git && { repoName: m.git.repoName, branch: m.git.branch }),
       sortOrder: m.sortOrder,
-      ...(m.lightThemeName && { lightThemeName: m.lightThemeName }),
-      ...(m.darkThemeName && { darkThemeName: m.darkThemeName }),
+      ...(m.themeSlots && { themeSlots: m.themeSlots }),
       ...(m.canvasLayout && { canvasLayout: m.canvasLayout }),
       ...(m.subPanel && { subPanel: m.subPanel }),
     };
@@ -198,8 +197,7 @@ export function createTerminal(
   if (parentId) meta.parentId = parentId;
   // Seed client-owned initial metadata BEFORE emitListChanged so the
   // first list snapshot carries these fields (see #642).
-  if (initial?.lightThemeName) meta.lightThemeName = initial.lightThemeName;
-  if (initial?.darkThemeName) meta.darkThemeName = initial.darkThemeName;
+  if (initial?.themeSlots) meta.themeSlots = { ...initial.themeSlots };
   if (initial?.canvasLayout) meta.canvasLayout = initial.canvasLayout;
   if (initial?.subPanel) meta.subPanel = initial.subPanel;
   const entry: TerminalProcess = {
@@ -333,8 +331,10 @@ export function setTerminalTheme(
   const entry = terminals.get(id);
   if (entry) {
     updateClientMetadata(entry, id, (m) => {
-      if (mode === "light") m.lightThemeName = themeName;
-      else m.darkThemeName = themeName;
+      m.themeSlots = {
+        ...m.themeSlots,
+        [mode]: themeName,
+      };
     });
   }
 }

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -66,7 +66,8 @@ export function snapshotSession(): {
       ...(m.parentId && { parentId: m.parentId }),
       ...(m.git && { repoName: m.git.repoName, branch: m.git.branch }),
       sortOrder: m.sortOrder,
-      ...(m.themeName && { themeName: m.themeName }),
+      ...(m.lightThemeName && { lightThemeName: m.lightThemeName }),
+      ...(m.darkThemeName && { darkThemeName: m.darkThemeName }),
       ...(m.canvasLayout && { canvasLayout: m.canvasLayout }),
       ...(m.subPanel && { subPanel: m.subPanel }),
     };
@@ -197,7 +198,8 @@ export function createTerminal(
   if (parentId) meta.parentId = parentId;
   // Seed client-owned initial metadata BEFORE emitListChanged so the
   // first list snapshot carries these fields (see #642).
-  if (initial?.themeName) meta.themeName = initial.themeName;
+  if (initial?.lightThemeName) meta.lightThemeName = initial.lightThemeName;
+  if (initial?.darkThemeName) meta.darkThemeName = initial.darkThemeName;
   if (initial?.canvasLayout) meta.canvasLayout = initial.canvasLayout;
   if (initial?.subPanel) meta.subPanel = initial.subPanel;
   const entry: TerminalProcess = {
@@ -322,12 +324,17 @@ export function setActiveTerminalId(id: TerminalId | null): void {
   if (id !== null) emitChanged();
 }
 
-/** Set the theme name for a terminal (stored in metadata, published to clients). */
-export function setTerminalTheme(id: TerminalId, themeName: string): void {
+/** Set one appearance slot's theme name for a terminal (stored in metadata, published to clients). */
+export function setTerminalTheme(
+  id: TerminalId,
+  mode: "light" | "dark",
+  themeName: string,
+): void {
   const entry = terminals.get(id);
   if (entry) {
     updateClientMetadata(entry, id, (m) => {
-      m.themeName = themeName;
+      if (mode === "light") m.lightThemeName = themeName;
+      else m.darkThemeName = themeName;
     });
   }
 }

--- a/packages/tests/features/theme.feature
+++ b/packages/tests/features/theme.feature
@@ -119,6 +119,18 @@ Feature: Theme switching
     And the palette search input should be focused
     And there should be no page errors
 
+  Scenario: Theme selection stays on the terminal that opened the picker
+    When I create a terminal
+    And I select pill tree entry 1
+    And I click the theme name in the header
+    And I type "Dracula" in the palette
+    And I press the switch to terminal 2 shortcut
+    And I press Enter
+    Then the header should show theme "Tomorrow Night"
+    When I press the switch to terminal 1 shortcut
+    Then the header should show theme "Dracula"
+    And there should be no page errors
+
   Scenario: Each terminal has independent theme
     When I open the command palette
     And I select "Theme" in the palette

--- a/packages/tests/features/theme.feature
+++ b/packages/tests/features/theme.feature
@@ -29,6 +29,38 @@ Feature: Theme switching
     Then the command palette should be visible
     And the palette breadcrumb should show "Theme"
     And the palette search input should be focused
+    And the "dark" theme slot should be selected in the palette
+    And there should be no page errors
+
+  Scenario: Terminal theme slots can be edited separately
+    When I click the settings button
+    And I click the "light" color scheme button
+    And I click the theme name in the header
+    Then the "light" theme slot should be selected in the palette
+    When I type "3024 Day" in the palette
+    And I press Enter
+    Then the header should show theme "3024 Day"
+    And the terminal background should be "#f7f7f7"
+    When I click the theme name in the header
+    And I click the "dark" theme slot in the palette
+    And I type "Dracula" in the palette
+    And I press Enter
+    When I click the settings button
+    And I click the "dark" color scheme button
+    Then the header should show theme "Dracula"
+    And the terminal background should be "#282a36"
+    And there should be no page errors
+
+  Scenario: Unset theme slot reuses the other slot
+    When I click the settings button
+    And I click the "light" color scheme button
+    And I click the theme name in the header
+    And I type "3024 Day" in the palette
+    And I press Enter
+    When I click the settings button
+    And I click the "dark" color scheme button
+    Then the header should show theme "3024 Day"
+    And the terminal background should be "#f7f7f7"
     And there should be no page errors
 
   Scenario: Theme preview while navigating palette

--- a/packages/tests/step_definitions/session_restore_steps.ts
+++ b/packages/tests/step_definitions/session_restore_steps.ts
@@ -179,8 +179,7 @@ Given(
       {
         id: "0",
         cwd: os.homedir(),
-        lightThemeName: themeName,
-        darkThemeName: themeName,
+        themeSlots: { light: themeName, dark: themeName },
       },
     ];
     this.savedSessionTerminals = terminals;

--- a/packages/tests/step_definitions/session_restore_steps.ts
+++ b/packages/tests/step_definitions/session_restore_steps.ts
@@ -175,7 +175,14 @@ Given(
   "a saved session with theme {string}",
   async function (this: KoluWorld, themeName: string) {
     this.savedSessionTerminalCount = 1;
-    const terminals = [{ id: "0", cwd: os.homedir(), themeName }];
+    const terminals = [
+      {
+        id: "0",
+        cwd: os.homedir(),
+        lightThemeName: themeName,
+        darkThemeName: themeName,
+      },
+    ];
     this.savedSessionTerminals = terminals;
     await postSavedSessionPayload(this.page, terminals);
   },

--- a/packages/tests/step_definitions/theme_steps.ts
+++ b/packages/tests/step_definitions/theme_steps.ts
@@ -125,6 +125,24 @@ When("I click the theme name in the header", async function (this: KoluWorld) {
   await this.waitForFrame();
 });
 
+When(
+  "I click the {string} theme slot in the palette",
+  async function (this: KoluWorld, slot: string) {
+    await this.page.click(`[data-testid="theme-slot-${slot}"]`);
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the {string} theme slot should be selected in the palette",
+  async function (this: KoluWorld, slot: string) {
+    const selected = this.page.locator(
+      `[data-testid="theme-slot-${slot}"][data-selected="true"]`,
+    );
+    await selected.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
 Then(
   "the header should show theme {string}",
   async function (this: KoluWorld, expectedTheme: string) {


### PR DESCRIPTION
This PR teaches each terminal to keep independent light and dark theme slots instead of a single theme name. The active terminal theme now resolves against the current UI appearance with symmetric fallback, so a terminal keeps its visual identity across light and dark mode until the user explicitly customizes one side.

On the UI side, the terminal theme picker stays terminal-scoped and gains an inline Light/Dark tab bar that defaults to the current appearance while still letting the user edit the other slot. The title-bar theme pill continues to show only the currently effective theme, and session persistence/migration now carry the paired theme data through refresh and restore.

A follow-up review pass also grouped the paired values under `themeSlots`, moved the picker-mode state out of `useThemeManager`, extracted a pure `themeSlots` helper module, and fixed a bug where switching terminals while the theme picker was open could recolor the wrong terminal.

> **Deferred:** #695
