### PR TITLE
Screenshot the viewport, not the scrollback

### DIFF
--- a/packages/client/src/screenshotTerminal.ts
+++ b/packages/client/src/screenshotTerminal.ts
@@ -1,10 +1,12 @@
-/** Copy a terminal's contents to the clipboard as a polished PNG.
+/** Copy the active terminal viewport to the clipboard as a polished PNG.
  *
- *  Reads `xterm.buffer.active` directly (scrollback + viewport), paints each
- *  cell onto an offscreen canvas with the theme's colors, and wraps the whole
- *  thing in a rounded-corner window chrome (border + title bar with traffic-
- *  light dots and the terminal's repo/branch label). Writes the PNG blob to
- *  the clipboard.
+ *  Reads the currently-visible slice of `xterm.buffer.active` — `xterm.rows`
+ *  lines starting at `buffer.viewportY` — and paints each cell onto an
+ *  offscreen canvas with the theme's colors, then wraps the whole thing in a
+ *  rounded-corner window chrome (border + title bar with traffic-light dots
+ *  and the terminal's repo/branch label). Writes the PNG blob to the
+ *  clipboard. Scrollback above the viewport is not captured; if the user has
+ *  scrolled up, the capture is WYSIWYG with what they're looking at.
  *
  *  Renderer-independent by construction — we never touch xterm's live canvas
  *  or DOM. An earlier attempt routed `SerializeAddon.serializeAsHTML` through
@@ -205,6 +207,7 @@ export async function screenshotTerminal(
   }
   const xterm = refs.xterm as unknown as {
     cols: number;
+    rows: number;
     options: {
       fontSize?: number;
       fontFamily?: string;
@@ -212,7 +215,7 @@ export async function screenshotTerminal(
     };
     buffer: {
       active: {
-        length: number;
+        viewportY: number;
         getLine: (
           y: number,
         ) =>
@@ -233,7 +236,8 @@ export async function screenshotTerminal(
   if (document.fonts?.ready) await document.fonts.ready;
   const buffer = xterm.buffer.active;
   const cols = xterm.cols;
-  const rows = buffer.length;
+  const rows = xterm.rows;
+  const yOffset = buffer.viewportY;
 
   // Measure a cell using a probe canvas. A fresh 2d context inherits the
   // browser's default font; we set it explicitly before measuring.
@@ -351,7 +355,7 @@ export async function screenshotTerminal(
 
   const tempCell = buffer.getNullCell();
   for (let y = 0; y < rows; y++) {
-    const line = buffer.getLine(y);
+    const line = buffer.getLine(yOffset + y);
     if (!line) continue;
     for (let x = 0; x < cols; x++) {
       const cell = line.getCell(x, tempCell);

--- a/packages/tests/features/terminal-screenshot.feature
+++ b/packages/tests/features/terminal-screenshot.feature
@@ -34,3 +34,11 @@ Feature: Terminal screenshot
     And I press Enter
     Then a toast should appear with text "Screenshot copied"
     And there should be no page errors
+
+  Scenario: Screenshot captures viewport only, not scrollback
+    When I run "for i in $(seq 1 200); do echo LINE-$i; done"
+    And the screen state should contain "LINE-200"
+    And I press the screenshot terminal shortcut
+    Then a toast should appear with text "Screenshot copied"
+    And the clipboard image should match the terminal viewport size
+    And there should be no page errors

--- a/packages/tests/step_definitions/keyboard_shortcut_steps.ts
+++ b/packages/tests/step_definitions/keyboard_shortcut_steps.ts
@@ -156,8 +156,6 @@ Then(
         return {
           rows,
           bufferLength,
-          dpr,
-          height: img.naturalHeight,
           logicalHeight: img.naturalHeight / dpr,
         };
       }

--- a/packages/tests/step_definitions/keyboard_shortcut_steps.ts
+++ b/packages/tests/step_definitions/keyboard_shortcut_steps.ts
@@ -1,5 +1,6 @@
 import { When, Then } from "@cucumber/cucumber";
 import { KoluWorld, MOD_KEY, POLL_TIMEOUT } from "../support/world.ts";
+import { ACTIVE_TERMINAL } from "../support/buffer.ts";
 const SHORTCUTS_HELP_SELECTOR = '[data-testid="shortcuts-help"]';
 
 When("I press the shortcuts help shortcut", async function (this: KoluWorld) {
@@ -113,6 +114,72 @@ Then(
     if (result.uniqueColors < 2) {
       throw new Error(
         `clipboard image appears blank: ${result.width}×${result.height} with ${result.uniqueColors} unique sampled color(s)`,
+      );
+    }
+  },
+);
+
+Then(
+  "the clipboard image should match the terminal viewport size",
+  async function (this: KoluWorld) {
+    // Regression guard: the screenshot must capture only the visible viewport
+    // (xterm.rows), not the entire scrollback buffer. A 200-line scrollback
+    // rendered at cellH ≈ 17 gives ~3400px of terminal body; a 24-row
+    // viewport gives ~408px. The threshold below catches that gap regardless
+    // of font size or dpr variations.
+    const result = await this.page.evaluate(async (sel) => {
+      const container = document.querySelector(sel) as
+        | (HTMLElement & {
+            __xterm?: { rows: number; buffer: { active: { length: number } } };
+          })
+        | null;
+      const xterm = container?.__xterm;
+      if (!xterm) return { error: "no __xterm on active terminal" };
+      const rows = xterm.rows;
+      const bufferLength = xterm.buffer.active.length;
+      const items = await navigator.clipboard.read();
+      for (const item of items) {
+        if (!item.types.includes("image/png")) continue;
+        const blob = await item.getType("image/png");
+        const dataUrl = await new Promise<string>((resolve) => {
+          const fr = new FileReader();
+          fr.onload = () => resolve(fr.result as string);
+          fr.readAsDataURL(blob);
+        });
+        const img = new Image();
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve();
+          img.onerror = () => reject(new Error("image decode failed"));
+          img.src = dataUrl;
+        });
+        const dpr = window.devicePixelRatio || 1;
+        return {
+          rows,
+          bufferLength,
+          dpr,
+          height: img.naturalHeight,
+          logicalHeight: img.naturalHeight / dpr,
+        };
+      }
+      return { error: "no image/png in clipboard" };
+    }, ACTIVE_TERMINAL);
+    if ("error" in result) throw new Error(result.error);
+    if (result.bufferLength <= result.rows * 2) {
+      throw new Error(
+        `test setup: buffer length ${result.bufferLength} not large enough ` +
+          `relative to ${result.rows} visible rows to distinguish viewport ` +
+          `capture from scrollback capture`,
+      );
+    }
+    // Per-row upper bound of 30 logical px covers any realistic font size
+    // (default cellH ≈ 17). Chrome is 66px (TITLE_H 34 + PAD*2 32); +100 gives
+    // additional slack.
+    const viewportMax = result.rows * 30 + 100;
+    if (result.logicalHeight > viewportMax) {
+      throw new Error(
+        `screenshot height ${Math.round(result.logicalHeight)}px (logical) ` +
+          `exceeds viewport bound ${viewportMax}px — rows=${result.rows}, ` +
+          `bufferLength=${result.bufferLength} suggests scrollback capture`,
       );
     }
   },


### PR DESCRIPTION
**Terminal screenshots now capture just what you can see** — the live viewport rows at `buffer.viewportY`, not hundreds of lines of scrollback history. Before this, a terminal with any real usage produced a towering PNG that was useless as an attachment and slow to encode; now the output is WYSIWYG with the live terminal (or with wherever the user has scrolled to).

The implementation swaps `rows = buffer.length` for `rows = xterm.rows` and offsets line reads by `buffer.viewportY` inside the cell-render loop in `screenshotTerminal.ts`. _The rendering pipeline, chrome, theming, and clipboard write are all unchanged_ — only the slice of buffer we paint shrinks.

A new e2e scenario fills 200 lines of scrollback, takes the screenshot, and asserts the captured PNG's logical height fits a viewport-rows bound rather than a buffer-length bound. That's the regression guard — if anyone ever points the render loop back at `buffer.length`, this test catches it.