### PR TITLE
Drop Cmd+P

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -36,7 +36,7 @@ import EmptyState from "./EmptyState";
 import RightPanelLayout from "./right-panel/RightPanelLayout";
 import CloseConfirm, { type CloseConfirmTarget } from "./CloseConfirm";
 import { createCommands } from "./commands";
-import { exportSessionAsPdf } from "./exportSessionAsPdf";
+import { exportScrollbackAsPdf } from "./exportScrollbackAsPdf";
 import { screenshotTerminal } from "./screenshotTerminal";
 import WebcamOverlay from "./recorder/WebcamOverlay";
 import { useRecorder } from "./recorder/useRecorder";
@@ -148,10 +148,10 @@ const App: Component = () => {
     }
   }
 
-  function handleExportSessionAsPdf() {
+  function handleExportScrollbackAsPdf() {
     const id = store.activeId();
     if (id === null) return;
-    exportSessionAsPdf(id, store.getMetadata(id));
+    exportScrollbackAsPdf(id, store.getMetadata(id));
   }
 
   function handleScreenshotTerminal(id?: TerminalId) {
@@ -195,7 +195,6 @@ const App: Component = () => {
         direction,
       ),
     handleShuffleTheme,
-    handleExportSessionAsPdf,
     handleScreenshotTerminal: () => handleScreenshotTerminal(),
     toggleRightPanel: rightPanel.togglePanel,
     canvasCenterActive: handleCanvasCenterActive,
@@ -245,7 +244,7 @@ const App: Component = () => {
       void crud.handleCreateSubTerminal(parentId, cwd),
     handleCopyTerminalText: () => void crud.handleCopyTerminalText(),
     handleRunInActiveTerminal: (cmd) => crud.handleRunInActiveTerminal(cmd),
-    handleExportSessionAsPdf,
+    handleExportScrollbackAsPdf,
     handleScreenshotTerminal: () => handleScreenshotTerminal(),
     toggleSubPanel: handleToggleSubPanel,
     committedThemeName,

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -45,7 +45,7 @@ export interface CommandDeps {
   handleCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
   handleCopyTerminalText: () => void;
   handleRunInActiveTerminal: (command: string) => void;
-  handleExportSessionAsPdf: () => void;
+  handleExportScrollbackAsPdf: () => void;
   handleScreenshotTerminal: () => void;
   /** Toggle sub-panel: creates first split if none exist, otherwise toggles visibility. */
   toggleSubPanel: (parentId: TerminalId) => void;
@@ -151,9 +151,8 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             onSelect: () => deps.handleCopyTerminalText(),
           },
           {
-            name: "Export session as PDF",
-            keybind: SHORTCUTS.exportSessionAsPdf.keybind,
-            onSelect: () => deps.handleExportSessionAsPdf(),
+            name: "Export scrollback as PDF",
+            onSelect: () => deps.handleExportScrollbackAsPdf(),
           },
           {
             name: "Screenshot terminal",

--- a/packages/client/src/exportScrollbackAsPdf.ts
+++ b/packages/client/src/exportScrollbackAsPdf.ts
@@ -1,9 +1,10 @@
-/** Export a terminal session as a printable PDF.
+/** Export the active terminal's available scrollback as a printable PDF.
  *
- *  Serializes the active terminal's buffer (scrollback + viewport) to themed
- *  HTML via xterm's SerializeAddon, opens it in a new window with the live
- *  theme and FiraCode Nerd Font applied, and triggers the browser print
- *  dialog. The user picks "Save as PDF" from there.
+ *  Serializes whatever the xterm ring buffer currently holds (scrollback +
+ *  viewport — NOT the full session, which may have scrolled past the buffer
+ *  cap) to themed HTML via xterm's SerializeAddon, opens it in a new window
+ *  with the live theme and FiraCode Nerd Font applied, and triggers the
+ *  browser print dialog. The user picks "Save as PDF" from there.
  *
  *  Client-side only — the server's headless xterm has no theme, so
  *  serializing there would produce unstyled HTML. */
@@ -14,7 +15,7 @@ import { FONT_FAMILY } from "terminal-themes";
 import { getTerminalRefs } from "./terminal/terminalRefs";
 import { terminalName } from "./terminal/terminalDisplay";
 
-export function exportSessionAsPdf(
+export function exportScrollbackAsPdf(
   id: TerminalId,
   meta: TerminalMetadata | undefined,
 ): void {

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -134,10 +134,6 @@ export const SHORTCUTS = {
     keybind: { key: "j", mod: true },
     label: "Shuffle theme",
   },
-  exportSessionAsPdf: {
-    keybind: { key: "p", code: "KeyP", mod: true },
-    label: "Export session as PDF",
-  },
   screenshotTerminal: {
     keybind: { key: "S", code: "KeyS", mod: true, shift: true },
     label: "Screenshot terminal",

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -22,7 +22,6 @@ interface ShortcutDeps {
   toggleSubPanel: (parentId: TerminalId) => void;
   cycleSubTab: (parentId: TerminalId, direction: 1 | -1) => void;
   handleShuffleTheme: () => void;
-  handleExportSessionAsPdf: () => void;
   handleScreenshotTerminal: () => void;
   toggleRightPanel: () => void;
   canvasCenterActive: () => void;
@@ -167,11 +166,6 @@ function dispatch(
 
   if (matchesKeybind(e, SHORTCUTS.shuffleTheme.keybind)) {
     deps.handleShuffleTheme();
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.exportSessionAsPdf.keybind)) {
-    deps.handleExportSessionAsPdf();
     return true;
   }
 

--- a/packages/client/src/settings/tips.ts
+++ b/packages/client/src/settings/tips.ts
@@ -59,10 +59,6 @@ export const AMBIENT_TIPS: readonly Tip[] = [
     text: `${formatKeybind(SHORTCUTS.shuffleTheme.keybind)} shuffles the terminal color theme`,
   },
   {
-    id: "amb-export-pdf",
-    text: `${formatKeybind(SHORTCUTS.exportSessionAsPdf.keybind)} exports the current session as a PDF`,
-  },
-  {
     id: "amb-screenshot",
     text: `${formatKeybind(SHORTCUTS.screenshotTerminal.keybind)} copies a PNG screenshot of the active terminal to your clipboard`,
   },

--- a/packages/client/src/terminal/terminalRefs.ts
+++ b/packages/client/src/terminal/terminalRefs.ts
@@ -1,7 +1,7 @@
 /** Per-terminal runtime refs (xterm instance + addons).
  *
  *  Handlers outside the Terminal component sometimes need the live xterm
- *  instance or one of its addons — e.g. "Export session as PDF" needs the
+ *  instance or one of its addons — e.g. "Export scrollback as PDF" needs the
  *  SerializeAddon to produce themed HTML. Rather than drill callbacks through
  *  CanvasTile or reach into the DOM, Terminal.tsx registers its refs here on
  *  mount and unregisters on cleanup. The `__xterm` DOM attachment on the

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -18,7 +18,7 @@ export const DEFAULT_PORT = 7681;
 export const DEFAULT_FONT_SIZE = 14;
 
 /** Scrollback buffer size in lines. Sized for multi-hour Claude sessions
- *  so PDF export (see `exportSessionAsPdf.ts`) captures a useful window —
+ *  so PDF export (see `exportScrollbackAsPdf.ts`) captures a useful window —
  *  the export reads from this same ring buffer. Per-line memory in xterm
  *  is small, so 50K is low tens of MB per terminal in the worst case. */
 export const DEFAULT_SCROLLBACK = 50_000;


### PR DESCRIPTION
## What changed

The "Export session as PDF" command has been renamed to **"Export scrollback as PDF"**, and its `Cmd+P` keyboard shortcut has been removed. The action is still reachable from the command palette (`Cmd+K`).

## Why

The old name *implies the full session is captured*, but the export only serializes whatever the xterm ring buffer currently holds — scrollback plus the viewport, capped at `DEFAULT_SCROLLBACK = 50_000` lines. Anything that scrolled past that cap is already gone when the export runs. The new name names what it actually does.

Dropping `Cmd+P` also frees up a very-high-frequency keybind that conflicts with muscle memory from other editors and the browser's own print dialog. The command remains palette-discoverable, which is the right surface for a low-frequency action.

## Mechanics

- `SHORTCUTS.exportSessionAsPdf` entry removed from `keyboard.ts` (the shortcut registry is the single source of truth — no keybind entry = no binding)
- Match arm dropped from `useShortcuts.ts`
- `amb-export-pdf` tip removed — it advertised the now-gone shortcut
- File + function + handler + label renamed: `exportSessionAsPdf` → `exportScrollbackAsPdf`
- Doc comments in `config.ts` (scrollback rationale) and `terminalRefs.ts` (serialize-addon rationale) updated to match

## Test plan

- [ ] `Cmd+P` no longer triggers PDF export (falls through to browser default)
- [ ] Command palette still lists "Export scrollback as PDF" and invokes it correctly
- [ ] Exported PDF still renders with live theme + FiraCode, identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)