### PR TITLE
e2e: mock Codex and OpenCode via SQLite + JSONL fixtures

### DIFF
--- a/packages/tests/features/codex.feature
+++ b/packages/tests/features/codex.feature
@@ -1,0 +1,54 @@
+@codex-mock
+Feature: Codex status detection
+  When Codex is running in a terminal, the canvas tile chrome shows its
+  current state (thinking, tool use, waiting) and the running context-token
+  count.
+
+  Requires KOLU_CODEX_DIR to point at a test-controlled directory and
+  PATH to include a `codex` binary stub (a renamed `sleep` copy) so the
+  foreground-basename check passes without a real Codex install. Both are
+  seeded by hooks.ts.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Tile chrome shows Codex thinking state
+    When a Codex session is mocked with state "thinking"
+    Then the tile chrome should show a Codex indicator with state "thinking"
+    And there should be no page errors
+
+  Scenario: Tile chrome shows Codex tool-use state
+    When a Codex session is mocked with state "tool_use"
+    Then the tile chrome should show a Codex indicator with state "tool_use"
+    And there should be no page errors
+
+  Scenario: Tile chrome shows Codex waiting state
+    When a Codex session is mocked with state "waiting"
+    Then the tile chrome should show a Codex indicator with state "waiting"
+    And there should be no page errors
+
+  Scenario: Codex state updates from thinking to waiting
+    When a Codex session is mocked with state "thinking"
+    Then the tile chrome should show a Codex indicator with state "thinking"
+    When the Codex session state changes to "waiting"
+    Then the tile chrome should show a Codex indicator with state "waiting"
+    And there should be no page errors
+
+  Scenario: Context tokens reflect input_tokens from the rollout
+    # Regression guard for 944f19d: tokens_used column would have reported
+    # a session-lifetime cumulative total in the millions. The per-turn
+    # figure lives on info.last_token_usage.input_tokens in the JSONL.
+    When a Codex session is mocked with state "thinking" and input tokens 47000
+    Then the tile chrome should show a Codex indicator with state "thinking"
+    And the tile chrome should show context tokens "47K"
+    And there should be no page errors
+
+  Scenario: Context tokens do not double-count cached input tokens
+    # Regression guard for 431edd3: summing input_tokens + cached_input_tokens
+    # double-counted cache hits. OpenAI's schema puts the cached count inside
+    # input_tokens already, so the badge should read 30K, not 40K.
+    When a Codex session is mocked with state "waiting"
+    And the Codex rollout reports input tokens 30000 with cached input tokens 10000
+    Then the tile chrome should show a Codex indicator with state "waiting"
+    And the tile chrome should show context tokens "30K"
+    And there should be no page errors

--- a/packages/tests/features/codex.feature
+++ b/packages/tests/features/codex.feature
@@ -27,13 +27,6 @@ Feature: Codex status detection
     Then the tile chrome should show a Codex indicator with state "waiting"
     And there should be no page errors
 
-  Scenario: Codex state updates from thinking to waiting
-    When a Codex session is mocked with state "thinking"
-    Then the tile chrome should show a Codex indicator with state "thinking"
-    When the Codex session state changes to "waiting"
-    Then the tile chrome should show a Codex indicator with state "waiting"
-    And there should be no page errors
-
   Scenario: Context tokens reflect input_tokens from the rollout
     # Regression guard for 944f19d: tokens_used column would have reported
     # a session-lifetime cumulative total in the millions. The per-turn
@@ -51,4 +44,14 @@ Feature: Codex status detection
     And the Codex rollout reports input tokens 30000 with cached input tokens 10000
     Then the tile chrome should show a Codex indicator with state "waiting"
     And the tile chrome should show context tokens "30K"
+    And there should be no page errors
+
+  Scenario: npm-shimmed Codex is detected via the OSC 633;E preexec hint
+    # The fake-binary path above exercises `readForegroundBasename`, the
+    # kernel-level half of `matchesAgent`. This scenario exercises the other
+    # half — `lastAgentCommandName`, set from the shell's OSC 633;E preexec
+    # hint — without which an npm-installed codex (kernel basename = "node",
+    # not "codex") would silently fail detection. Regression guard for #677.
+    When a Codex session is mocked with state "thinking" via an npm-shimmed CLI
+    Then the tile chrome should show a Codex indicator with state "thinking"
     And there should be no page errors

--- a/packages/tests/features/opencode.feature
+++ b/packages/tests/features/opencode.feature
@@ -54,3 +54,13 @@ Feature: OpenCode status detection
     Then the tile chrome should show an OpenCode indicator with state "tool_use"
     And the tile chrome should show task progress "3/5"
     And there should be no page errors
+
+  Scenario: npm-shimmed OpenCode is detected via the OSC 633;E preexec hint
+    # The fake-binary scenarios exercise `readForegroundBasename`, the
+    # kernel-level half of `matchesAgent`. This one exercises the other
+    # half — `lastAgentCommandName`, set from the shell's OSC 633;E preexec
+    # hint — which catches interpreter-shimmed agents (kernel basename = "node",
+    # not "opencode"). Regression guard for #677.
+    When an OpenCode session is mocked with state "thinking" via an npm-shimmed CLI
+    Then the tile chrome should show an OpenCode indicator with state "thinking"
+    And there should be no page errors

--- a/packages/tests/features/opencode.feature
+++ b/packages/tests/features/opencode.feature
@@ -1,0 +1,56 @@
+@opencode-mock
+Feature: OpenCode status detection
+  When OpenCode is running in a terminal, the canvas tile chrome shows
+  its current state (thinking, tool use, waiting), context-token total,
+  and task progress.
+
+  Requires KOLU_OPENCODE_DB to point at a test-controlled path and PATH
+  to include an `opencode` binary stub (a renamed `sleep` copy) so the
+  foreground-basename check passes without a real OpenCode install.
+  Both are seeded by hooks.ts.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: Tile chrome shows OpenCode thinking state
+    When an OpenCode session is mocked with state "thinking"
+    Then the tile chrome should show an OpenCode indicator with state "thinking"
+    And there should be no page errors
+
+  Scenario: Tile chrome shows OpenCode tool-use state
+    # Regression guard for the state-upgrade path: parseMessageState
+    # returns "thinking" for an in-flight assistant message, and the
+    # session-watcher only upgrades it to "tool_use" when hasRunningTools()
+    # finds a `part` row with state.status="running".
+    When an OpenCode session is mocked with state "tool_use"
+    Then the tile chrome should show an OpenCode indicator with state "tool_use"
+    And there should be no page errors
+
+  Scenario: Tile chrome shows OpenCode waiting state
+    When an OpenCode session is mocked with state "waiting"
+    Then the tile chrome should show an OpenCode indicator with state "waiting"
+    And there should be no page errors
+
+  Scenario: OpenCode state updates from thinking to waiting
+    When an OpenCode session is mocked with state "thinking"
+    Then the tile chrome should show an OpenCode indicator with state "thinking"
+    When the OpenCode session state changes to "waiting"
+    Then the tile chrome should show an OpenCode indicator with state "waiting"
+    And there should be no page errors
+
+  Scenario: Context tokens persist through a subsequent user prompt
+    # Regression guard for the latest-assistant lens at
+    # opencode/src/index.ts:180-211: tokens live only on assistant rows,
+    # but the thinking-state row is a user message newer than the
+    # assistant row. Using the single latest message would blank the
+    # count; the separate assistant-scoped query keeps it visible.
+    When an OpenCode session is mocked with state "thinking" and context tokens 23000
+    Then the tile chrome should show an OpenCode indicator with state "thinking"
+    And the tile chrome should show context tokens "23K"
+    And there should be no page errors
+
+  Scenario: Tile chrome shows OpenCode task progress
+    When an OpenCode session is mocked with state "tool_use" and 5 todos with 3 completed
+    Then the tile chrome should show an OpenCode indicator with state "tool_use"
+    And the tile chrome should show task progress "3/5"
+    And there should be no page errors

--- a/packages/tests/step_definitions/codex_steps.ts
+++ b/packages/tests/step_definitions/codex_steps.ts
@@ -65,50 +65,45 @@ async function startFakeAgent(world: KoluWorld): Promise<void> {
   await world.page.keyboard.press("Enter");
 }
 
+interface CodexMockOpts {
+  state: AgentLifecycleState;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+}
+
+async function mockCodexSession(
+  world: KoluWorld,
+  opts: CodexMockOpts,
+): Promise<void> {
+  const codexDir = getCodexDir();
+  if (!codexDir) throw new Error("KOLU_CODEX_DIR must be set");
+
+  cleanup();
+
+  mockCwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), `kolu-codex-${process.pid}-`),
+  );
+  const fixture = writeCodexFixture({ codexDir, cwd: mockCwd, ...opts });
+  mockRolloutPath = fixture.rolloutPath;
+
+  await cdTerminalInto(world, mockCwd);
+  await startFakeAgent(world);
+}
+
 When(
   "a Codex session is mocked with state {string}",
   async function (this: KoluWorld, state: string) {
-    const codexDir = getCodexDir();
-    if (!codexDir) throw new Error("KOLU_CODEX_DIR must be set");
-
-    cleanup();
-
-    mockCwd = fs.mkdtempSync(
-      path.join(os.tmpdir(), `kolu-codex-${process.pid}-`),
-    );
-    const fixture = writeCodexFixture({
-      codexDir,
-      cwd: mockCwd,
-      state: state as AgentLifecycleState,
-    });
-    mockRolloutPath = fixture.rolloutPath;
-
-    await cdTerminalInto(this, mockCwd);
-    await startFakeAgent(this);
+    await mockCodexSession(this, { state: state as AgentLifecycleState });
   },
 );
 
 When(
   "a Codex session is mocked with state {string} and input tokens {int}",
   async function (this: KoluWorld, state: string, inputTokens: number) {
-    const codexDir = getCodexDir();
-    if (!codexDir) throw new Error("KOLU_CODEX_DIR must be set");
-
-    cleanup();
-
-    mockCwd = fs.mkdtempSync(
-      path.join(os.tmpdir(), `kolu-codex-${process.pid}-`),
-    );
-    const fixture = writeCodexFixture({
-      codexDir,
-      cwd: mockCwd,
+    await mockCodexSession(this, {
       state: state as AgentLifecycleState,
       inputTokens,
     });
-    mockRolloutPath = fixture.rolloutPath;
-
-    await cdTerminalInto(this, mockCwd);
-    await startFakeAgent(this);
   },
 );
 

--- a/packages/tests/step_definitions/codex_steps.ts
+++ b/packages/tests/step_definitions/codex_steps.ts
@@ -24,6 +24,7 @@ import {
   updateCodexRollout,
 } from "../support/agent-mock-codex.ts";
 import type { AgentLifecycleState } from "../support/agent-lifecycle.ts";
+import { cleanupMockDatabase } from "../support/mock-fs.ts";
 
 const getCodexDir = () => process.env.KOLU_CODEX_DIR;
 
@@ -40,20 +41,7 @@ function cleanup() {
   }
   mockRolloutPath = null;
   const codexDir = getCodexDir();
-  const dbPath = codexDir && path.join(codexDir, "state_5.sqlite");
-  if (dbPath && fs.existsSync(dbPath)) {
-    try {
-      fs.unlinkSync(dbPath);
-      for (const suffix of ["-wal", "-shm"]) {
-        const sidecar = dbPath + suffix;
-        if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
-      }
-    } catch {
-      // Best-effort — the file may be transiently locked by the
-      // server's reader connection; the next test's fixture write will
-      // overwrite in place anyway.
-    }
-  }
+  if (codexDir) cleanupMockDatabase(path.join(codexDir, "state_5.sqlite"));
 }
 
 After({ tags: "@codex-mock" }, function () {

--- a/packages/tests/step_definitions/codex_steps.ts
+++ b/packages/tests/step_definitions/codex_steps.ts
@@ -22,26 +22,27 @@ import { waitForBufferContains } from "../support/buffer.ts";
 import {
   writeCodexFixture,
   updateCodexRollout,
+  type CodexFixture,
 } from "../support/agent-mock-codex.ts";
 import type { AgentLifecycleState } from "../support/agent-lifecycle.ts";
-import { cleanupMockDatabase } from "../support/mock-fs.ts";
+import { clearMockDatabase } from "../support/mock-fs.ts";
 
 const getCodexDir = () => process.env.KOLU_CODEX_DIR;
 
 let mockCwd: string | null = null;
-let mockRolloutPath: string | null = null;
+let mockFixture: CodexFixture | null = null;
 
 function cleanup() {
   if (mockCwd && fs.existsSync(mockCwd)) {
     fs.rmSync(mockCwd, { recursive: true, force: true });
   }
   mockCwd = null;
-  if (mockRolloutPath && fs.existsSync(mockRolloutPath)) {
-    fs.unlinkSync(mockRolloutPath);
+  if (mockFixture && fs.existsSync(mockFixture.rolloutPath)) {
+    fs.unlinkSync(mockFixture.rolloutPath);
   }
-  mockRolloutPath = null;
+  mockFixture = null;
   const codexDir = getCodexDir();
-  if (codexDir) cleanupMockDatabase(path.join(codexDir, "state_5.sqlite"));
+  if (codexDir) clearMockDatabase(path.join(codexDir, "state_5.sqlite"));
 }
 
 After({ tags: "@codex-mock" }, function () {
@@ -56,12 +57,47 @@ async function cdTerminalInto(world: KoluWorld, cwd: string): Promise<void> {
 }
 
 async function startFakeAgent(world: KoluWorld): Promise<void> {
-  // Long-lived foreground sleep — the copy named `codex` on PATH runs
-  // for the scenario's duration so `foregroundPid != shellPid` stays
-  // true and `readForegroundBasename()` keeps returning "codex".
+  // Long-lived foreground process — the bash copy at
+  // $KOLU_FAKE_CODEX_BIN runs as the pty's foreground while its `sleep`
+  // child holds. Invoked by absolute path, not via PATH: ~/.bashrc on
+  // some setups prepends directories that shadow our whitelisted PATH
+  // and resolve `codex` to a real install on the host.
+  //
+  // The trailing `:` is load-bearing: with a single simple command,
+  // bash's `-c` optimization execve-replaces itself with the target
+  // (comm→"sleep"), breaking the foreground-basename check. A compound
+  // command forces bash to stay resident so comm stays "codex".
+  //
   // `terminal/killAll` in hooks.ts:Before tears the pty down between
-  // scenarios, which kills the child as a side effect.
-  await world.page.keyboard.type("codex 99999");
+  // scenarios, which SIGKILLs the whole tree.
+  const bin = process.env.KOLU_FAKE_CODEX_BIN;
+  if (!bin) throw new Error("KOLU_FAKE_CODEX_BIN must be set");
+  await world.page.keyboard.type(`${bin} -c "sleep 99999 ; :"`);
+  await world.page.keyboard.press("Enter");
+}
+
+async function startShimmedAgent(world: KoluWorld): Promise<void> {
+  // Exercise the preexec-hint-only branch of `matchesAgent`: the
+  // command line says `codex` (captured via OSC 633;E so
+  // `lastAgentCommandName` resolves to "codex"), but the foreground
+  // process's kernel basename is something else ("bash"). Simulates an
+  // npm-shimmed `codex` install where the real binary is `node`.
+  //
+  // Define a shell function named `codex`, then invoke it. The preexec
+  // hook fires on the second line with exactly "codex", so
+  // `parseAgentCommand` normalizes to "codex".
+  //
+  // The function body emits a second OSC 2 from inside the subshell —
+  // the reconcile triggered by the preexec OSC 2 fires BEFORE the
+  // subshell is in the foreground (shellIdle=true at that instant
+  // clears lastAgentCommandName), so a second title event with the
+  // subshell already running is what lets matchesAgent succeed via
+  // the preexec-hint branch.
+  await world.page.keyboard.type(
+    `codex() { ( printf '\\033]0;codex\\007'; sleep 99999 ; :); }`,
+  );
+  await world.page.keyboard.press("Enter");
+  await world.page.keyboard.type("codex");
   await world.page.keyboard.press("Enter");
 }
 
@@ -74,6 +110,7 @@ interface CodexMockOpts {
 async function mockCodexSession(
   world: KoluWorld,
   opts: CodexMockOpts,
+  { shimmed }: { shimmed?: boolean } = {},
 ): Promise<void> {
   const codexDir = getCodexDir();
   if (!codexDir) throw new Error("KOLU_CODEX_DIR must be set");
@@ -83,17 +120,31 @@ async function mockCodexSession(
   mockCwd = fs.mkdtempSync(
     path.join(os.tmpdir(), `kolu-codex-${process.pid}-`),
   );
-  const fixture = writeCodexFixture({ codexDir, cwd: mockCwd, ...opts });
-  mockRolloutPath = fixture.rolloutPath;
+  mockFixture = writeCodexFixture({ codexDir, cwd: mockCwd, ...opts });
 
   await cdTerminalInto(world, mockCwd);
-  await startFakeAgent(world);
+  if (shimmed) {
+    await startShimmedAgent(world);
+  } else {
+    await startFakeAgent(world);
+  }
 }
 
 When(
   "a Codex session is mocked with state {string}",
   async function (this: KoluWorld, state: string) {
     await mockCodexSession(this, { state: state as AgentLifecycleState });
+  },
+);
+
+When(
+  "a Codex session is mocked with state {string} via an npm-shimmed CLI",
+  async function (this: KoluWorld, state: string) {
+    await mockCodexSession(
+      this,
+      { state: state as AgentLifecycleState },
+      { shimmed: true },
+    );
   },
 );
 
@@ -114,10 +165,10 @@ When(
     inputTokens: number,
     cachedInputTokens: number,
   ) {
-    if (!mockRolloutPath) {
-      throw new Error("No Codex rollout to update — call mock step first");
+    if (!mockFixture) {
+      throw new Error("No Codex fixture to update — call mock step first");
     }
-    updateCodexRollout(mockRolloutPath, {
+    updateCodexRollout(mockFixture, {
       state: "waiting",
       inputTokens,
       cachedInputTokens,
@@ -128,12 +179,10 @@ When(
 When(
   "the Codex session state changes to {string}",
   async function (this: KoluWorld, state: string) {
-    if (!mockRolloutPath) {
-      throw new Error("No Codex rollout to update — call mock step first");
+    if (!mockFixture) {
+      throw new Error("No Codex fixture to update — call mock step first");
     }
-    updateCodexRollout(mockRolloutPath, {
-      state: state as AgentLifecycleState,
-    });
+    updateCodexRollout(mockFixture, { state: state as AgentLifecycleState });
   },
 );
 

--- a/packages/tests/step_definitions/codex_steps.ts
+++ b/packages/tests/step_definitions/codex_steps.ts
@@ -22,8 +22,8 @@ import { waitForBufferContains } from "../support/buffer.ts";
 import {
   writeCodexFixture,
   updateCodexRollout,
-  type AgentLifecycleState,
-} from "../support/agent-mock.ts";
+} from "../support/agent-mock-codex.ts";
+import type { AgentLifecycleState } from "../support/agent-lifecycle.ts";
 
 const getCodexDir = () => process.env.KOLU_CODEX_DIR;
 

--- a/packages/tests/step_definitions/codex_steps.ts
+++ b/packages/tests/step_definitions/codex_steps.ts
@@ -68,11 +68,21 @@ async function startFakeAgent(world: KoluWorld): Promise<void> {
   // (comm→"sleep"), breaking the foreground-basename check. A compound
   // command forces bash to stay resident so comm stays "codex".
   //
+  // Emitting OSC 2 from inside the body is a stability belt — the
+  // reconcile triggered by bash's preexec OSC 2 fires before the new
+  // process is actually in the foreground (Linux inotify coalescing +
+  // OSC 7 vs title event ordering under parallel-worker load), so we
+  // emit a second title event once the fake agent is definitively the
+  // foreground process. Without this the detection misses in ~5% of
+  // CI runs.
+  //
   // `terminal/killAll` in hooks.ts:Before tears the pty down between
   // scenarios, which SIGKILLs the whole tree.
   const bin = process.env.KOLU_FAKE_CODEX_BIN;
   if (!bin) throw new Error("KOLU_FAKE_CODEX_BIN must be set");
-  await world.page.keyboard.type(`${bin} -c "sleep 99999 ; :"`);
+  await world.page.keyboard.type(
+    `${bin} -c "printf '\\033]0;codex\\007'; sleep 99999 ; :"`,
+  );
   await world.page.keyboard.press("Enter");
 }
 

--- a/packages/tests/step_definitions/codex_steps.ts
+++ b/packages/tests/step_definitions/codex_steps.ts
@@ -1,0 +1,198 @@
+/**
+ * Codex status detection — step definitions.
+ *
+ * Mocks a Codex session by writing a `threads` row into a synthetic
+ * SQLite DB and a matching rollout JSONL, both under the per-worker
+ * `KOLU_CODEX_DIR`. The scenario then `cd`s into the mock cwd and
+ * launches the fake `codex` binary (a renamed copy of `sleep`, seeded
+ * by `hooks.ts`) so that `matchesAgent(state, "codex")` succeeds via
+ * the foreground-basename lookup.
+ *
+ * The Codex provider matches purely on `state.cwd`, so the scenario's
+ * mock cwd doubles as the `threads.cwd` column — no PID fiddling
+ * required, unlike the claude-code mock.
+ */
+
+import { When, Then, After } from "@cucumber/cucumber";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import { waitForBufferContains } from "../support/buffer.ts";
+import {
+  writeCodexFixture,
+  updateCodexRollout,
+  type AgentLifecycleState,
+} from "../support/agent-mock.ts";
+
+const getCodexDir = () => process.env.KOLU_CODEX_DIR;
+
+let mockCwd: string | null = null;
+let mockRolloutPath: string | null = null;
+
+function cleanup() {
+  if (mockCwd && fs.existsSync(mockCwd)) {
+    fs.rmSync(mockCwd, { recursive: true, force: true });
+  }
+  mockCwd = null;
+  if (mockRolloutPath && fs.existsSync(mockRolloutPath)) {
+    fs.unlinkSync(mockRolloutPath);
+  }
+  mockRolloutPath = null;
+  const codexDir = getCodexDir();
+  const dbPath = codexDir && path.join(codexDir, "state_5.sqlite");
+  if (dbPath && fs.existsSync(dbPath)) {
+    try {
+      fs.unlinkSync(dbPath);
+      for (const suffix of ["-wal", "-shm"]) {
+        const sidecar = dbPath + suffix;
+        if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
+      }
+    } catch {
+      // Best-effort — the file may be transiently locked by the
+      // server's reader connection; the next test's fixture write will
+      // overwrite in place anyway.
+    }
+  }
+}
+
+After({ tags: "@codex-mock" }, function () {
+  cleanup();
+});
+
+async function cdTerminalInto(world: KoluWorld, cwd: string): Promise<void> {
+  const marker = `CODEX_CWD_READY_${Date.now()}`;
+  await world.page.keyboard.type(`cd ${cwd} && echo ${marker}`);
+  await world.page.keyboard.press("Enter");
+  await waitForBufferContains(world.page, marker);
+}
+
+async function startFakeAgent(world: KoluWorld): Promise<void> {
+  // Long-lived foreground sleep — the copy named `codex` on PATH runs
+  // for the scenario's duration so `foregroundPid != shellPid` stays
+  // true and `readForegroundBasename()` keeps returning "codex".
+  // `terminal/killAll` in hooks.ts:Before tears the pty down between
+  // scenarios, which kills the child as a side effect.
+  await world.page.keyboard.type("codex 99999");
+  await world.page.keyboard.press("Enter");
+}
+
+When(
+  "a Codex session is mocked with state {string}",
+  async function (this: KoluWorld, state: string) {
+    const codexDir = getCodexDir();
+    if (!codexDir) throw new Error("KOLU_CODEX_DIR must be set");
+
+    cleanup();
+
+    mockCwd = fs.mkdtempSync(
+      path.join(os.tmpdir(), `kolu-codex-${process.pid}-`),
+    );
+    const fixture = writeCodexFixture({
+      codexDir,
+      cwd: mockCwd,
+      state: state as AgentLifecycleState,
+    });
+    mockRolloutPath = fixture.rolloutPath;
+
+    await cdTerminalInto(this, mockCwd);
+    await startFakeAgent(this);
+  },
+);
+
+When(
+  "a Codex session is mocked with state {string} and input tokens {int}",
+  async function (this: KoluWorld, state: string, inputTokens: number) {
+    const codexDir = getCodexDir();
+    if (!codexDir) throw new Error("KOLU_CODEX_DIR must be set");
+
+    cleanup();
+
+    mockCwd = fs.mkdtempSync(
+      path.join(os.tmpdir(), `kolu-codex-${process.pid}-`),
+    );
+    const fixture = writeCodexFixture({
+      codexDir,
+      cwd: mockCwd,
+      state: state as AgentLifecycleState,
+      inputTokens,
+    });
+    mockRolloutPath = fixture.rolloutPath;
+
+    await cdTerminalInto(this, mockCwd);
+    await startFakeAgent(this);
+  },
+);
+
+When(
+  "the Codex rollout reports input tokens {int} with cached input tokens {int}",
+  async function (
+    this: KoluWorld,
+    inputTokens: number,
+    cachedInputTokens: number,
+  ) {
+    if (!mockRolloutPath) {
+      throw new Error("No Codex rollout to update — call mock step first");
+    }
+    updateCodexRollout(mockRolloutPath, {
+      state: "waiting",
+      inputTokens,
+      cachedInputTokens,
+    });
+  },
+);
+
+When(
+  "the Codex session state changes to {string}",
+  async function (this: KoluWorld, state: string) {
+    if (!mockRolloutPath) {
+      throw new Error("No Codex rollout to update — call mock step first");
+    }
+    updateCodexRollout(mockRolloutPath, {
+      state: state as AgentLifecycleState,
+    });
+  },
+);
+
+Then(
+  "the tile chrome should show a Codex indicator with state {string}",
+  async function (this: KoluWorld, expectedState: string) {
+    const start = Date.now();
+    let last: string | null = null;
+    let lastKind: string | null = null;
+    while (Date.now() - start < POLL_TIMEOUT) {
+      const observed = await this.page.evaluate(() => {
+        const el = document.querySelector(
+          '[data-testid="canvas-tile"] [data-testid="agent-indicator"], [data-testid="mobile-tile-titlebar"] [data-testid="agent-indicator"]',
+        );
+        return {
+          state: el?.getAttribute("data-agent-state") ?? null,
+          kind: el?.getAttribute("data-agent-kind") ?? null,
+        };
+      });
+      last = observed.state;
+      lastKind = observed.kind;
+      if (last === expectedState && lastKind === "codex") return;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    throw new Error(
+      `Expected Codex indicator state "${expectedState}" (kind=codex), got state="${last}" kind="${lastKind}" after ${POLL_TIMEOUT}ms`,
+    );
+  },
+);
+
+Then(
+  "the tile chrome should show context tokens {string}",
+  async function (this: KoluWorld, expected: string) {
+    await this.page.waitForFunction(
+      (txt) => {
+        const el = document.querySelector(
+          '[data-testid="agent-context-tokens"]',
+        );
+        return el?.textContent?.includes(txt) ?? false;
+      },
+      expected,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);

--- a/packages/tests/step_definitions/opencode_steps.ts
+++ b/packages/tests/step_definitions/opencode_steps.ts
@@ -18,10 +18,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 import { waitForBufferContains } from "../support/buffer.ts";
-import {
-  writeOpenCodeFixture,
-  type AgentLifecycleState,
-} from "../support/agent-mock.ts";
+import { writeOpenCodeFixture } from "../support/agent-mock-opencode.ts";
+import type { AgentLifecycleState } from "../support/agent-lifecycle.ts";
 
 const getOpenCodeDb = () => process.env.KOLU_OPENCODE_DB;
 

--- a/packages/tests/step_definitions/opencode_steps.ts
+++ b/packages/tests/step_definitions/opencode_steps.ts
@@ -20,7 +20,7 @@ import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 import { waitForBufferContains } from "../support/buffer.ts";
 import { writeOpenCodeFixture } from "../support/agent-mock-opencode.ts";
 import type { AgentLifecycleState } from "../support/agent-lifecycle.ts";
-import { cleanupMockDatabase } from "../support/mock-fs.ts";
+import { clearMockDatabase } from "../support/mock-fs.ts";
 
 const getOpenCodeDb = () => process.env.KOLU_OPENCODE_DB;
 
@@ -32,7 +32,7 @@ function cleanup() {
   }
   mockCwd = null;
   const dbPath = getOpenCodeDb();
-  if (dbPath) cleanupMockDatabase(dbPath);
+  if (dbPath) clearMockDatabase(dbPath);
 }
 
 After({ tags: "@opencode-mock" }, function () {
@@ -47,7 +47,21 @@ async function cdTerminalInto(world: KoluWorld, cwd: string): Promise<void> {
 }
 
 async function startFakeAgent(world: KoluWorld): Promise<void> {
-  await world.page.keyboard.type("opencode 99999");
+  // See codex_steps.ts::startFakeAgent for why we use an absolute path
+  // and why the trailing `:` matters.
+  const bin = process.env.KOLU_FAKE_OPENCODE_BIN;
+  if (!bin) throw new Error("KOLU_FAKE_OPENCODE_BIN must be set");
+  await world.page.keyboard.type(`${bin} -c "sleep 99999 ; :"`);
+  await world.page.keyboard.press("Enter");
+}
+
+async function startShimmedAgent(world: KoluWorld): Promise<void> {
+  // See codex_steps.ts::startShimmedAgent for the full rationale.
+  await world.page.keyboard.type(
+    `opencode() { ( printf '\\033]0;opencode\\007'; sleep 99999 ; :); }`,
+  );
+  await world.page.keyboard.press("Enter");
+  await world.page.keyboard.type("opencode");
   await world.page.keyboard.press("Enter");
 }
 
@@ -60,6 +74,7 @@ interface MockOpts {
 async function mockOpenCodeSession(
   world: KoluWorld,
   opts: MockOpts,
+  { shimmed }: { shimmed?: boolean } = {},
 ): Promise<void> {
   const dbPath = getOpenCodeDb();
   if (!dbPath) throw new Error("KOLU_OPENCODE_DB must be set");
@@ -72,13 +87,28 @@ async function mockOpenCodeSession(
   writeOpenCodeFixture({ dbPath, cwd: mockCwd, ...opts });
 
   await cdTerminalInto(world, mockCwd);
-  await startFakeAgent(world);
+  if (shimmed) {
+    await startShimmedAgent(world);
+  } else {
+    await startFakeAgent(world);
+  }
 }
 
 When(
   "an OpenCode session is mocked with state {string}",
   async function (this: KoluWorld, state: string) {
     await mockOpenCodeSession(this, { state: state as AgentLifecycleState });
+  },
+);
+
+When(
+  "an OpenCode session is mocked with state {string} via an npm-shimmed CLI",
+  async function (this: KoluWorld, state: string) {
+    await mockOpenCodeSession(
+      this,
+      { state: state as AgentLifecycleState },
+      { shimmed: true },
+    );
   },
 );
 

--- a/packages/tests/step_definitions/opencode_steps.ts
+++ b/packages/tests/step_definitions/opencode_steps.ts
@@ -47,11 +47,13 @@ async function cdTerminalInto(world: KoluWorld, cwd: string): Promise<void> {
 }
 
 async function startFakeAgent(world: KoluWorld): Promise<void> {
-  // See codex_steps.ts::startFakeAgent for why we use an absolute path
-  // and why the trailing `:` matters.
+  // See codex_steps.ts::startFakeAgent for rationale, including why we
+  // emit a second OSC 2 title event from inside the fake agent's body.
   const bin = process.env.KOLU_FAKE_OPENCODE_BIN;
   if (!bin) throw new Error("KOLU_FAKE_OPENCODE_BIN must be set");
-  await world.page.keyboard.type(`${bin} -c "sleep 99999 ; :"`);
+  await world.page.keyboard.type(
+    `${bin} -c "printf '\\033]0;opencode\\007'; sleep 99999 ; :"`,
+  );
   await world.page.keyboard.press("Enter");
 }
 

--- a/packages/tests/step_definitions/opencode_steps.ts
+++ b/packages/tests/step_definitions/opencode_steps.ts
@@ -20,6 +20,7 @@ import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 import { waitForBufferContains } from "../support/buffer.ts";
 import { writeOpenCodeFixture } from "../support/agent-mock-opencode.ts";
 import type { AgentLifecycleState } from "../support/agent-lifecycle.ts";
+import { cleanupMockDatabase } from "../support/mock-fs.ts";
 
 const getOpenCodeDb = () => process.env.KOLU_OPENCODE_DB;
 
@@ -31,17 +32,7 @@ function cleanup() {
   }
   mockCwd = null;
   const dbPath = getOpenCodeDb();
-  if (dbPath && fs.existsSync(dbPath)) {
-    try {
-      fs.unlinkSync(dbPath);
-      for (const suffix of ["-wal", "-shm"]) {
-        const sidecar = dbPath + suffix;
-        if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
-      }
-    } catch {
-      // Transient lock — the next fixture write overwrites in place.
-    }
-  }
+  if (dbPath) cleanupMockDatabase(dbPath);
 }
 
 After({ tags: "@opencode-mock" }, function () {

--- a/packages/tests/step_definitions/opencode_steps.ts
+++ b/packages/tests/step_definitions/opencode_steps.ts
@@ -1,0 +1,160 @@
+/**
+ * OpenCode status detection — step definitions.
+ *
+ * Mocks an OpenCode session by writing rows into a synthetic SQLite
+ * database at `KOLU_OPENCODE_DB`. The scenario `cd`s into the fixture's
+ * `cwd` and launches the fake `opencode` binary (a renamed `sleep`
+ * copy, seeded by `hooks.ts`) so `matchesAgent(state, "opencode")`
+ * succeeds via the foreground-basename path.
+ *
+ * Unlike Codex, OpenCode has no `subscribeExternalChanges` — the
+ * provider relies on title events alone to re-resolve. Typing the fake
+ * binary fires a title event, which triggers the resolve cycle.
+ */
+
+import { When, Then, After } from "@cucumber/cucumber";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import { waitForBufferContains } from "../support/buffer.ts";
+import {
+  writeOpenCodeFixture,
+  type AgentLifecycleState,
+} from "../support/agent-mock.ts";
+
+const getOpenCodeDb = () => process.env.KOLU_OPENCODE_DB;
+
+let mockCwd: string | null = null;
+
+function cleanup() {
+  if (mockCwd && fs.existsSync(mockCwd)) {
+    fs.rmSync(mockCwd, { recursive: true, force: true });
+  }
+  mockCwd = null;
+  const dbPath = getOpenCodeDb();
+  if (dbPath && fs.existsSync(dbPath)) {
+    try {
+      fs.unlinkSync(dbPath);
+      for (const suffix of ["-wal", "-shm"]) {
+        const sidecar = dbPath + suffix;
+        if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
+      }
+    } catch {
+      // Transient lock — the next fixture write overwrites in place.
+    }
+  }
+}
+
+After({ tags: "@opencode-mock" }, function () {
+  cleanup();
+});
+
+async function cdTerminalInto(world: KoluWorld, cwd: string): Promise<void> {
+  const marker = `OPENCODE_CWD_READY_${Date.now()}`;
+  await world.page.keyboard.type(`cd ${cwd} && echo ${marker}`);
+  await world.page.keyboard.press("Enter");
+  await waitForBufferContains(world.page, marker);
+}
+
+async function startFakeAgent(world: KoluWorld): Promise<void> {
+  await world.page.keyboard.type("opencode 99999");
+  await world.page.keyboard.press("Enter");
+}
+
+interface MockOpts {
+  state: AgentLifecycleState;
+  contextTokens?: number;
+  todos?: { total: number; completed: number };
+}
+
+async function mockOpenCodeSession(
+  world: KoluWorld,
+  opts: MockOpts,
+): Promise<void> {
+  const dbPath = getOpenCodeDb();
+  if (!dbPath) throw new Error("KOLU_OPENCODE_DB must be set");
+
+  cleanup();
+
+  mockCwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), `kolu-opencode-${process.pid}-`),
+  );
+  writeOpenCodeFixture({ dbPath, cwd: mockCwd, ...opts });
+
+  await cdTerminalInto(world, mockCwd);
+  await startFakeAgent(world);
+}
+
+When(
+  "an OpenCode session is mocked with state {string}",
+  async function (this: KoluWorld, state: string) {
+    await mockOpenCodeSession(this, { state: state as AgentLifecycleState });
+  },
+);
+
+When(
+  "an OpenCode session is mocked with state {string} and context tokens {int}",
+  async function (this: KoluWorld, state: string, contextTokens: number) {
+    await mockOpenCodeSession(this, {
+      state: state as AgentLifecycleState,
+      contextTokens,
+    });
+  },
+);
+
+When(
+  "an OpenCode session is mocked with state {string} and {int} todos with {int} completed",
+  async function (
+    this: KoluWorld,
+    state: string,
+    total: number,
+    completed: number,
+  ) {
+    await mockOpenCodeSession(this, {
+      state: state as AgentLifecycleState,
+      todos: { total, completed },
+    });
+  },
+);
+
+When(
+  "the OpenCode session state changes to {string}",
+  async function (this: KoluWorld, state: string) {
+    const dbPath = getOpenCodeDb();
+    if (!dbPath) throw new Error("KOLU_OPENCODE_DB must be set");
+    if (!mockCwd) throw new Error("mockCwd not set — call mock step first");
+    writeOpenCodeFixture({
+      dbPath,
+      cwd: mockCwd,
+      state: state as AgentLifecycleState,
+    });
+  },
+);
+
+Then(
+  "the tile chrome should show an OpenCode indicator with state {string}",
+  async function (this: KoluWorld, expectedState: string) {
+    const start = Date.now();
+    let last: string | null = null;
+    let lastKind: string | null = null;
+    while (Date.now() - start < POLL_TIMEOUT) {
+      const observed = await this.page.evaluate(() => {
+        const el = document.querySelector(
+          '[data-testid="canvas-tile"] [data-testid="agent-indicator"], [data-testid="mobile-tile-titlebar"] [data-testid="agent-indicator"]',
+        );
+        return {
+          state: el?.getAttribute("data-agent-state") ?? null,
+          kind: el?.getAttribute("data-agent-kind") ?? null,
+        };
+      });
+      last = observed.state;
+      lastKind = observed.kind;
+      if (last === expectedState && lastKind === "opencode") return;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    throw new Error(
+      `Expected OpenCode indicator state "${expectedState}" (kind=opencode), got state="${last}" kind="${lastKind}" after ${POLL_TIMEOUT}ms`,
+    );
+  },
+);

--- a/packages/tests/support/agent-lifecycle.ts
+++ b/packages/tests/support/agent-lifecycle.ts
@@ -1,0 +1,6 @@
+/** Lifecycle states every kolu agent provider derives. The badge's
+ *  `data-agent-state` attribute takes one of these values verbatim, and
+ *  each provider's state machine targets this union. Shared so the
+ *  codex and opencode mock fixture builders agree on the spelling
+ *  without cross-importing. */
+export type AgentLifecycleState = "thinking" | "tool_use" | "waiting";

--- a/packages/tests/support/agent-mock-codex.ts
+++ b/packages/tests/support/agent-mock-codex.ts
@@ -1,0 +1,161 @@
+/**
+ * Fixture builders for Codex mock e2e tests.
+ *
+ * The real Codex CLI writes thread metadata into `state_<N>.sqlite` and
+ * the per-turn rollout into `sessions/.../rollout-*.jsonl`. These
+ * helpers synthesize the same on-disk artefacts directly so e2e
+ * scenarios can drive the Codex provider through a controlled lifecycle
+ * without spinning up the CLI or a backing LLM.
+ *
+ * The SQLite + JSONL shapes here are a subset of what the real CLI
+ * writes — only the columns and JSON fields the kolu codex provider
+ * actually reads. That subset is the real contract we're exercising;
+ * any parser regression (e.g. the token-accounting bugs fixed in
+ * 944f19d and 431edd3) will fail here the same way it would under a
+ * real session.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { AgentLifecycleState } from "./agent-lifecycle.ts";
+
+/** Build a Codex rollout JSONL that terminates in the requested state.
+ *
+ *  Mirrors the subset of events `parseRolloutState` reads:
+ *   - `event_msg.task_started`   → lifecycle starts
+ *   - `response_item.function_call` / `function_call_output` with
+ *     matching `call_id` → tool_use open/close
+ *   - `event_msg.task_complete`  → lifecycle ends (waiting)
+ *   - `event_msg.token_count`    → context-token accounting
+ */
+export function buildCodexRollout(opts: {
+  state: AgentLifecycleState;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+}): string {
+  const lines: string[] = [];
+
+  lines.push(
+    JSON.stringify({
+      type: "event_msg",
+      payload: { type: "task_started", turn_id: "turn-1" },
+    }),
+  );
+
+  if (opts.inputTokens !== undefined) {
+    const usage: { input_tokens: number; cached_input_tokens?: number } = {
+      input_tokens: opts.inputTokens,
+    };
+    if (opts.cachedInputTokens !== undefined) {
+      usage.cached_input_tokens = opts.cachedInputTokens;
+    }
+    lines.push(
+      JSON.stringify({
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: { last_token_usage: usage },
+        },
+      }),
+    );
+  }
+
+  if (opts.state === "tool_use") {
+    lines.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "function_call", call_id: "call-1" },
+      }),
+    );
+  }
+
+  if (opts.state === "waiting") {
+    lines.push(
+      JSON.stringify({
+        type: "event_msg",
+        payload: { type: "task_complete", turn_id: "turn-1" },
+      }),
+    );
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+export interface CodexFixture {
+  dbPath: string;
+  rolloutPath: string;
+  threadId: string;
+}
+
+/** Create Codex's threads SQLite DB and rollout JSONL under `codexDir`.
+ *  `state_5.sqlite` is the fallback path the config picks when the dir
+ *  is empty, so tests and production agree on the same filename without
+ *  an extra env override.
+ *
+ *  Idempotent: re-running with the same `cwd` replaces the previous
+ *  thread row so scenarios can transition states without stale rows. */
+export function writeCodexFixture(opts: {
+  codexDir: string;
+  cwd: string;
+  state: AgentLifecycleState;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  title?: string;
+  model?: string;
+}): CodexFixture {
+  fs.mkdirSync(opts.codexDir, { recursive: true });
+  const dbPath = path.join(opts.codexDir, "state_5.sqlite");
+  const rolloutPath = path.join(
+    opts.codexDir,
+    `rollout-${process.pid}-${Date.now()}.jsonl`,
+  );
+  const threadId = "00000000-0000-0000-0000-000000000001";
+
+  fs.writeFileSync(rolloutPath, buildCodexRollout(opts));
+
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS threads (
+        id TEXT PRIMARY KEY,
+        rollout_path TEXT NOT NULL,
+        cwd TEXT NOT NULL,
+        source TEXT NOT NULL,
+        archived INTEGER NOT NULL DEFAULT 0,
+        updated_at_ms INTEGER NOT NULL,
+        title TEXT,
+        model TEXT
+      );
+    `);
+    db.prepare("DELETE FROM threads WHERE cwd = ?").run(opts.cwd);
+    db.prepare(
+      "INSERT INTO threads (id, rollout_path, cwd, source, archived, updated_at_ms, title, model) VALUES (?, ?, ?, 'cli', 0, ?, ?, ?)",
+    ).run(
+      threadId,
+      rolloutPath,
+      opts.cwd,
+      Date.now(),
+      opts.title ?? "codex-mock test thread",
+      opts.model ?? "gpt-5",
+    );
+  } finally {
+    db.close();
+  }
+
+  return { dbPath, rolloutPath, threadId };
+}
+
+/** Rewrite the rollout JSONL in place to transition the session state.
+ *  Used by scenarios that move thinking → waiting etc. without tearing
+ *  down the thread row or the watcher. */
+export function updateCodexRollout(
+  rolloutPath: string,
+  opts: {
+    state: AgentLifecycleState;
+    inputTokens?: number;
+    cachedInputTokens?: number;
+  },
+): void {
+  fs.writeFileSync(rolloutPath, buildCodexRollout(opts));
+}

--- a/packages/tests/support/agent-mock-codex.ts
+++ b/packages/tests/support/agent-mock-codex.ts
@@ -116,6 +116,10 @@ export function writeCodexFixture(opts: {
 
   const db = new DatabaseSync(dbPath);
   try {
+    // Enable WAL so (a) the server's reader and our writer don't block
+    // each other, and (b) the WAL sidecar file the codex WAL watcher
+    // listens on actually exists. Real Codex uses WAL too.
+    db.exec("PRAGMA journal_mode = WAL;");
     db.exec(`
       CREATE TABLE IF NOT EXISTS threads (
         id TEXT PRIMARY KEY,
@@ -146,16 +150,42 @@ export function writeCodexFixture(opts: {
   return { dbPath, rolloutPath, threadId };
 }
 
-/** Rewrite the rollout JSONL in place to transition the session state.
- *  Used by scenarios that move thinking → waiting etc. without tearing
- *  down the thread row or the watcher. */
+/** Rewrite the rollout JSONL in place to transition the session state,
+ *  and bump `threads.updated_at_ms` so the WAL watcher fires a reconcile.
+ *
+ *  The rollout-only path works in production because the real Codex CLI
+ *  writes to the DB on every turn too — their WAL event is what wakes
+ *  our watcher, not the JSONL mtime. Mirror that here so state
+ *  transitions propagate without needing a direct JSONL watcher. */
 export function updateCodexRollout(
-  rolloutPath: string,
+  fixture: CodexFixture,
   opts: {
     state: AgentLifecycleState;
     inputTokens?: number;
     cachedInputTokens?: number;
   },
 ): void {
-  fs.writeFileSync(rolloutPath, buildCodexRollout(opts));
+  fs.writeFileSync(fixture.rolloutPath, buildCodexRollout(opts));
+  const db = new DatabaseSync(fixture.dbPath);
+  try {
+    db.exec("PRAGMA journal_mode = WAL;");
+    // Noisy write: a brief INSERT/DELETE forces a new WAL frame big
+    // enough for the server's fs.watch on the WAL file to reliably
+    // fire. A bare UPDATE on the same row is a no-op at the page level
+    // when only `updated_at_ms` changes, and its tiny WAL append can
+    // get coalesced below the inotify granularity.
+    db.exec(`
+      BEGIN;
+      INSERT INTO threads (id, rollout_path, cwd, source, archived, updated_at_ms)
+        VALUES ('__kick__', '', '', 'cli', 0, 0);
+      DELETE FROM threads WHERE id = '__kick__';
+      COMMIT;
+    `);
+    db.prepare("UPDATE threads SET updated_at_ms = ? WHERE id = ?").run(
+      Date.now(),
+      fixture.threadId,
+    );
+  } finally {
+    db.close();
+  }
 }

--- a/packages/tests/support/agent-mock-opencode.ts
+++ b/packages/tests/support/agent-mock-opencode.ts
@@ -75,6 +75,10 @@ export function writeOpenCodeFixture(opts: {
   const sessionId = "opencode-mock-session-0001";
   const db = new DatabaseSync(opts.dbPath);
   try {
+    // Enable WAL so (a) the server's reader and our writer don't block
+    // each other, and (b) the WAL sidecar file the opencode watcher
+    // listens on actually exists. Real OpenCode uses WAL too.
+    db.exec("PRAGMA journal_mode = WAL;");
     db.exec(OPENCODE_SCHEMA);
 
     db.prepare("DELETE FROM session WHERE id = ? OR directory = ?").run(

--- a/packages/tests/support/agent-mock-opencode.ts
+++ b/packages/tests/support/agent-mock-opencode.ts
@@ -1,167 +1,22 @@
 /**
- * Fixture builders for Codex and OpenCode mock e2e tests.
+ * Fixture builder for OpenCode mock e2e tests.
  *
- * The real Codex and OpenCode CLIs write their state into a SQLite DB
- * (+ a JSONL rollout for Codex). These helpers synthesize the same
- * on-disk artefacts directly so e2e scenarios can drive the providers
- * through a controlled lifecycle without spinning up live agent CLIs.
+ * The real OpenCode TUI owns a single SQLite database at
+ * `~/.local/share/opencode/opencode.db`. The kolu provider opens it
+ * read-only and derives state from the latest message's `data` JSON
+ * blob plus the matching tool-`part` rows. This helper synthesizes the
+ * same tables directly so e2e scenarios can drive the provider through
+ * a controlled lifecycle without launching a real `opencode` TUI.
  *
- * Schemas are a subset of what the real tools write — only the columns
- * and JSON fields the kolu providers actually read. That subset is the
- * real contract we're exercising; any parser regression (e.g. the
- * token-accounting bugs fixed in 944f19d and 431edd3) will fail here
- * the same way it would under a real session.
+ * The SQL schema and JSON shapes here are a subset of what the real
+ * TUI writes — only the columns and fields the kolu opencode provider
+ * actually reads. That subset is the contract this fixture exercises.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-
-export type AgentLifecycleState = "thinking" | "tool_use" | "waiting";
-
-// --- Codex ---
-
-/** Build a Codex rollout JSONL that terminates in the requested state.
- *
- *  Mirrors the subset of events `parseRolloutState` reads:
- *   - `event_msg.task_started`   → lifecycle starts
- *   - `response_item.function_call` / `function_call_output` with
- *     matching `call_id` → tool_use open/close
- *   - `event_msg.task_complete`  → lifecycle ends (waiting)
- *   - `event_msg.token_count`    → context-token accounting
- */
-export function buildCodexRollout(opts: {
-  state: AgentLifecycleState;
-  inputTokens?: number;
-  cachedInputTokens?: number;
-}): string {
-  const lines: string[] = [];
-
-  lines.push(
-    JSON.stringify({
-      type: "event_msg",
-      payload: { type: "task_started", turn_id: "turn-1" },
-    }),
-  );
-
-  if (opts.inputTokens !== undefined) {
-    const usage: { input_tokens: number; cached_input_tokens?: number } = {
-      input_tokens: opts.inputTokens,
-    };
-    if (opts.cachedInputTokens !== undefined) {
-      usage.cached_input_tokens = opts.cachedInputTokens;
-    }
-    lines.push(
-      JSON.stringify({
-        type: "event_msg",
-        payload: {
-          type: "token_count",
-          info: { last_token_usage: usage },
-        },
-      }),
-    );
-  }
-
-  if (opts.state === "tool_use") {
-    lines.push(
-      JSON.stringify({
-        type: "response_item",
-        payload: { type: "function_call", call_id: "call-1" },
-      }),
-    );
-  }
-
-  if (opts.state === "waiting") {
-    lines.push(
-      JSON.stringify({
-        type: "event_msg",
-        payload: { type: "task_complete", turn_id: "turn-1" },
-      }),
-    );
-  }
-
-  return lines.join("\n") + "\n";
-}
-
-export interface CodexFixture {
-  dbPath: string;
-  rolloutPath: string;
-  threadId: string;
-}
-
-/** Create Codex's threads SQLite DB and rollout JSONL under `codexDir`.
- *  `state_5.sqlite` is the fallback path the config picks when the dir
- *  is empty, so tests and production agree on the same filename without
- *  an extra env override.
- *
- *  Idempotent: re-running with the same `cwd` replaces the previous
- *  thread row so scenarios can transition states without stale rows. */
-export function writeCodexFixture(opts: {
-  codexDir: string;
-  cwd: string;
-  state: AgentLifecycleState;
-  inputTokens?: number;
-  cachedInputTokens?: number;
-  title?: string;
-  model?: string;
-}): CodexFixture {
-  fs.mkdirSync(opts.codexDir, { recursive: true });
-  const dbPath = path.join(opts.codexDir, "state_5.sqlite");
-  const rolloutPath = path.join(
-    opts.codexDir,
-    `rollout-${process.pid}-${Date.now()}.jsonl`,
-  );
-  const threadId = "00000000-0000-0000-0000-000000000001";
-
-  fs.writeFileSync(rolloutPath, buildCodexRollout(opts));
-
-  const db = new DatabaseSync(dbPath);
-  try {
-    db.exec(`
-      CREATE TABLE IF NOT EXISTS threads (
-        id TEXT PRIMARY KEY,
-        rollout_path TEXT NOT NULL,
-        cwd TEXT NOT NULL,
-        source TEXT NOT NULL,
-        archived INTEGER NOT NULL DEFAULT 0,
-        updated_at_ms INTEGER NOT NULL,
-        title TEXT,
-        model TEXT
-      );
-    `);
-    db.prepare("DELETE FROM threads WHERE cwd = ?").run(opts.cwd);
-    db.prepare(
-      "INSERT INTO threads (id, rollout_path, cwd, source, archived, updated_at_ms, title, model) VALUES (?, ?, ?, 'cli', 0, ?, ?, ?)",
-    ).run(
-      threadId,
-      rolloutPath,
-      opts.cwd,
-      Date.now(),
-      opts.title ?? "codex-mock test thread",
-      opts.model ?? "gpt-5",
-    );
-  } finally {
-    db.close();
-  }
-
-  return { dbPath, rolloutPath, threadId };
-}
-
-/** Rewrite the rollout JSONL in place to transition the session state.
- *  Used by scenarios that move thinking → waiting etc. without tearing
- *  down the thread row or the watcher. */
-export function updateCodexRollout(
-  rolloutPath: string,
-  opts: {
-    state: AgentLifecycleState;
-    inputTokens?: number;
-    cachedInputTokens?: number;
-  },
-): void {
-  fs.writeFileSync(rolloutPath, buildCodexRollout(opts));
-}
-
-// --- OpenCode ---
+import type { AgentLifecycleState } from "./agent-lifecycle.ts";
 
 const OPENCODE_SCHEMA = `
 CREATE TABLE IF NOT EXISTS session (

--- a/packages/tests/support/agent-mock.ts
+++ b/packages/tests/support/agent-mock.ts
@@ -1,0 +1,336 @@
+/**
+ * Fixture builders for Codex and OpenCode mock e2e tests.
+ *
+ * The real Codex and OpenCode CLIs write their state into a SQLite DB
+ * (+ a JSONL rollout for Codex). These helpers synthesize the same
+ * on-disk artefacts directly so e2e scenarios can drive the providers
+ * through a controlled lifecycle without spinning up live agent CLIs.
+ *
+ * Schemas are a subset of what the real tools write — only the columns
+ * and JSON fields the kolu providers actually read. That subset is the
+ * real contract we're exercising; any parser regression (e.g. the
+ * token-accounting bugs fixed in 944f19d and 431edd3) will fail here
+ * the same way it would under a real session.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+export type AgentLifecycleState = "thinking" | "tool_use" | "waiting";
+
+// --- Codex ---
+
+/** Build a Codex rollout JSONL that terminates in the requested state.
+ *
+ *  Mirrors the subset of events `parseRolloutState` reads:
+ *   - `event_msg.task_started`   → lifecycle starts
+ *   - `response_item.function_call` / `function_call_output` with
+ *     matching `call_id` → tool_use open/close
+ *   - `event_msg.task_complete`  → lifecycle ends (waiting)
+ *   - `event_msg.token_count`    → context-token accounting
+ */
+export function buildCodexRollout(opts: {
+  state: AgentLifecycleState;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+}): string {
+  const lines: string[] = [];
+
+  lines.push(
+    JSON.stringify({
+      type: "event_msg",
+      payload: { type: "task_started", turn_id: "turn-1" },
+    }),
+  );
+
+  if (opts.inputTokens !== undefined) {
+    const usage: { input_tokens: number; cached_input_tokens?: number } = {
+      input_tokens: opts.inputTokens,
+    };
+    if (opts.cachedInputTokens !== undefined) {
+      usage.cached_input_tokens = opts.cachedInputTokens;
+    }
+    lines.push(
+      JSON.stringify({
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: { last_token_usage: usage },
+        },
+      }),
+    );
+  }
+
+  if (opts.state === "tool_use") {
+    lines.push(
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "function_call", call_id: "call-1" },
+      }),
+    );
+  }
+
+  if (opts.state === "waiting") {
+    lines.push(
+      JSON.stringify({
+        type: "event_msg",
+        payload: { type: "task_complete", turn_id: "turn-1" },
+      }),
+    );
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+export interface CodexFixture {
+  dbPath: string;
+  rolloutPath: string;
+  threadId: string;
+}
+
+/** Create Codex's threads SQLite DB and rollout JSONL under `codexDir`.
+ *  `state_5.sqlite` is the fallback path the config picks when the dir
+ *  is empty, so tests and production agree on the same filename without
+ *  an extra env override.
+ *
+ *  Idempotent: re-running with the same `cwd` replaces the previous
+ *  thread row so scenarios can transition states without stale rows. */
+export function writeCodexFixture(opts: {
+  codexDir: string;
+  cwd: string;
+  state: AgentLifecycleState;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  title?: string;
+  model?: string;
+}): CodexFixture {
+  fs.mkdirSync(opts.codexDir, { recursive: true });
+  const dbPath = path.join(opts.codexDir, "state_5.sqlite");
+  const rolloutPath = path.join(
+    opts.codexDir,
+    `rollout-${process.pid}-${Date.now()}.jsonl`,
+  );
+  const threadId = "00000000-0000-0000-0000-000000000001";
+
+  fs.writeFileSync(rolloutPath, buildCodexRollout(opts));
+
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS threads (
+        id TEXT PRIMARY KEY,
+        rollout_path TEXT NOT NULL,
+        cwd TEXT NOT NULL,
+        source TEXT NOT NULL,
+        archived INTEGER NOT NULL DEFAULT 0,
+        updated_at_ms INTEGER NOT NULL,
+        title TEXT,
+        model TEXT
+      );
+    `);
+    db.prepare("DELETE FROM threads WHERE cwd = ?").run(opts.cwd);
+    db.prepare(
+      "INSERT INTO threads (id, rollout_path, cwd, source, archived, updated_at_ms, title, model) VALUES (?, ?, ?, 'cli', 0, ?, ?, ?)",
+    ).run(
+      threadId,
+      rolloutPath,
+      opts.cwd,
+      Date.now(),
+      opts.title ?? "codex-mock test thread",
+      opts.model ?? "gpt-5",
+    );
+  } finally {
+    db.close();
+  }
+
+  return { dbPath, rolloutPath, threadId };
+}
+
+/** Rewrite the rollout JSONL in place to transition the session state.
+ *  Used by scenarios that move thinking → waiting etc. without tearing
+ *  down the thread row or the watcher. */
+export function updateCodexRollout(
+  rolloutPath: string,
+  opts: {
+    state: AgentLifecycleState;
+    inputTokens?: number;
+    cachedInputTokens?: number;
+  },
+): void {
+  fs.writeFileSync(rolloutPath, buildCodexRollout(opts));
+}
+
+// --- OpenCode ---
+
+const OPENCODE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS session (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  directory TEXT NOT NULL,
+  time_updated INTEGER NOT NULL,
+  time_archived INTEGER
+);
+CREATE TABLE IF NOT EXISTS message (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  time_created INTEGER NOT NULL,
+  data TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS message_session_idx ON message(session_id, time_created);
+CREATE TABLE IF NOT EXISTS part (
+  id TEXT,
+  message_id TEXT NOT NULL,
+  data TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS part_message_id_id_idx ON part(message_id, id);
+CREATE TABLE IF NOT EXISTS todo (
+  id TEXT,
+  session_id TEXT NOT NULL,
+  status TEXT NOT NULL
+);
+`;
+
+export interface OpenCodeFixture {
+  dbPath: string;
+  sessionId: string;
+}
+
+/** Create OpenCode's SQLite database under `dbPath` with a single session
+ *  in the requested lifecycle state.
+ *
+ *  State derivation mirrors `parseMessageState` + `hasRunningTools`:
+ *   - thinking: latest row is a `user` message (assistant-token bookkeeping
+ *     lives on an earlier `assistant` row)
+ *   - tool_use: latest assistant message has no `time.completed`, plus a
+ *     `part` row with `data.state.status = "running"`
+ *   - waiting:  latest assistant message has `time.completed` + `finish = "stop"`
+ */
+export function writeOpenCodeFixture(opts: {
+  dbPath: string;
+  cwd: string;
+  state: AgentLifecycleState;
+  contextTokens?: number;
+  todos?: { total: number; completed: number };
+  title?: string;
+  modelID?: string;
+  providerID?: string;
+}): OpenCodeFixture {
+  fs.mkdirSync(path.dirname(opts.dbPath), { recursive: true });
+  const sessionId = "opencode-mock-session-0001";
+  const db = new DatabaseSync(opts.dbPath);
+  try {
+    db.exec(OPENCODE_SCHEMA);
+
+    db.prepare("DELETE FROM session WHERE id = ? OR directory = ?").run(
+      sessionId,
+      opts.cwd,
+    );
+    db.prepare("DELETE FROM message WHERE session_id = ?").run(sessionId);
+    db.prepare(
+      "DELETE FROM part WHERE message_id IN (SELECT id FROM message WHERE session_id = ?)",
+    ).run(sessionId);
+    db.prepare("DELETE FROM todo WHERE session_id = ?").run(sessionId);
+
+    const now = Date.now();
+    db.prepare(
+      "INSERT INTO session (id, title, directory, time_updated, time_archived) VALUES (?, ?, ?, ?, NULL)",
+    ).run(sessionId, opts.title ?? "opencode-mock test session", opts.cwd, now);
+
+    const modelID = opts.modelID ?? "qwen2.5-coder";
+    const providerID = opts.providerID ?? "test";
+
+    const assistantId = `${sessionId}-m-assistant`;
+    const userId = `${sessionId}-m-user`;
+
+    if (opts.state === "thinking") {
+      // Optional earlier assistant row carrying the running token total —
+      // `getLatestAssistantContextTokens` finds it via a separate query
+      // scoped to `role='assistant'`, so the user message as the newest
+      // row still drives state derivation to `thinking`.
+      if (opts.contextTokens !== undefined) {
+        db.prepare(
+          "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+        ).run(
+          assistantId,
+          sessionId,
+          now - 10,
+          JSON.stringify({
+            role: "assistant",
+            modelID,
+            providerID,
+            finish: "stop",
+            time: { created: now - 10, completed: now - 5 },
+            tokens: { total: opts.contextTokens },
+          }),
+        );
+      }
+      db.prepare(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+      ).run(
+        userId,
+        sessionId,
+        now,
+        JSON.stringify({ role: "user", time: { created: now } }),
+      );
+    } else if (opts.state === "tool_use") {
+      db.prepare(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+      ).run(
+        assistantId,
+        sessionId,
+        now,
+        JSON.stringify({
+          role: "assistant",
+          modelID,
+          providerID,
+          time: { created: now },
+          ...(opts.contextTokens !== undefined && {
+            tokens: { total: opts.contextTokens },
+          }),
+        }),
+      );
+      db.prepare(
+        "INSERT INTO part (id, message_id, data) VALUES (?, ?, ?)",
+      ).run(
+        "p1",
+        assistantId,
+        JSON.stringify({ type: "tool", state: { status: "running" } }),
+      );
+    } else {
+      db.prepare(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+      ).run(
+        assistantId,
+        sessionId,
+        now,
+        JSON.stringify({
+          role: "assistant",
+          modelID,
+          providerID,
+          finish: "stop",
+          time: { created: now, completed: now },
+          ...(opts.contextTokens !== undefined && {
+            tokens: { total: opts.contextTokens },
+          }),
+        }),
+      );
+    }
+
+    if (opts.todos) {
+      for (let i = 0; i < opts.todos.total; i++) {
+        db.prepare(
+          "INSERT INTO todo (id, session_id, status) VALUES (?, ?, ?)",
+        ).run(
+          `t${i}`,
+          sessionId,
+          i < opts.todos.completed ? "completed" : "pending",
+        );
+      }
+    }
+  } finally {
+    db.close();
+  }
+
+  return { dbPath: opts.dbPath, sessionId };
+}

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -60,23 +60,39 @@ const opencodeDbPath = path.join(opencodeDbDir, "opencode.db");
 process.env.KOLU_CODEX_DIR = codexDir;
 process.env.KOLU_OPENCODE_DB = opencodeDbPath;
 
-/** Fake agent binaries on PATH so typing `codex` or `opencode` in a
- *  test terminal forks a long-lived foreground process whose basename
- *  matches what `matchesAgent` expects. Copies of the system `sleep`
- *  binary renamed to `codex` and `opencode`: node-pty's `.process`
- *  accessor returns the basename of the execve path, so the kernel
- *  reports the renamed binary and `readForegroundBasename()` satisfies
- *  `matchesAgent(state, "codex"|"opencode")` without requiring the real
- *  CLIs to be installed. `/bin/sleep` isn't stable across distros (NixOS
- *  puts coreutils in /nix/store), so resolve via `command -v`. */
+/** Fake agent binaries the codex/opencode mock scenarios invoke by
+ *  absolute path to bypass PATH resolution — the user's shell rc (e.g.
+ *  ~/.bashrc) may prepend `~/.npm-global/bin` on startup and shadow any
+ *  PATH override we set via the whitelist, so a real codex/opencode
+ *  install on the host silently wins against the fake.
+ *
+ *  Each stub is a copy of `bash`, renamed to `codex` / `opencode`. The
+ *  kernel's `/proc/<pid>/comm` (Linux) and sysctl KERN_PROC_PATHNAME
+ *  (macOS) both reflect the execve basename, so a bash copy launched as
+ *  `.../bin/codex -c "..."` shows up with comm="codex" — satisfying
+ *  `readForegroundBasename() === "codex"` without requiring the real
+ *  CLI to be installed.
+ *
+ *  `/bin/sleep` tempted as a simpler stub but fails on nixpkgs: coreutils
+ *  ships as a multi-call binary that inspects argv[0] and errors with
+ *  "unknown program 'codex'" when renamed. Bash is a single-purpose
+ *  binary and copies cleanly.
+ *
+ *  Paths are surfaced to step definitions via KOLU_FAKE_CODEX_BIN and
+ *  KOLU_FAKE_OPENCODE_BIN env vars (on this worker's process env, not
+ *  forwarded to the spawned server — the step defs read them directly
+ *  and type the absolute path into the pty). */
 const fakeBinDir = mkSubDir("bin");
-const sleepPath = execSync("command -v sleep", { encoding: "utf8" }).trim();
+const bashPath = execSync("command -v bash", { encoding: "utf8" }).trim();
+const fakeBins: Record<string, string> = {};
 for (const name of ["codex", "opencode"]) {
   const target = path.join(fakeBinDir, name);
-  fs.copyFileSync(sleepPath, target);
+  fs.copyFileSync(bashPath, target);
   fs.chmodSync(target, 0o755);
+  fakeBins[name] = target;
 }
-const fakeBinPath = `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`;
+process.env.KOLU_FAKE_CODEX_BIN = fakeBins.codex;
+process.env.KOLU_FAKE_OPENCODE_BIN = fakeBins.opencode;
 
 /** Per-worker ephemeral state dir for the kolu server under test. Routing
  *  to $TMPDIR keeps test state out of `~/.config`; nesting under
@@ -206,12 +222,19 @@ BeforeAll(async function () {
           KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
           KOLU_CODEX_DIR: codexDir,
           KOLU_OPENCODE_DB: opencodeDbPath,
-          PATH: fakeBinPath,
         },
       },
     );
     serverProcess.stderr?.on("data", (data: Buffer) => {
       process.stderr.write(`[server:${workerId}] ${data}`);
+    });
+    // Drain stdout so the pipe buffer can't fill and block the server's
+    // pino writes (pino targets stdout). Forward to stderr when
+    // KOLU_TEST_VERBOSE is set for local debugging.
+    serverProcess.stdout?.on("data", (data: Buffer) => {
+      if (process.env.KOLU_TEST_VERBOSE) {
+        process.stderr.write(`[server:${workerId}:out] ${data}`);
+      }
     });
     await waitForHealth(`${baseUrl}/api/health`, 10_000);
     console.log(`[worker:${workerId}] Server is healthy.`);

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -19,7 +19,7 @@ import * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ChildProcess } from "node:child_process";
-import { spawn } from "node:child_process";
+import { spawn, execSync } from "node:child_process";
 
 const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0");
 
@@ -49,6 +49,34 @@ const claudeSessionsDir = mkSubDir("claude-sessions");
 const claudeProjectsDir = mkSubDir("claude-projects");
 process.env.KOLU_CLAUDE_SESSIONS_DIR = claudeSessionsDir;
 process.env.KOLU_CLAUDE_PROJECTS_DIR = claudeProjectsDir;
+
+/** Per-worker temp roots for the Codex and OpenCode mock harnesses —
+ *  see `codex_steps.ts` and `opencode_steps.ts`. Both providers key off
+ *  `state.cwd`, so the fixture DB rows carry a cwd that the scenario
+ *  also `cd`s into so `findSessionByDirectory` returns the mock row. */
+const codexDir = mkSubDir("codex");
+const opencodeDbDir = mkSubDir("opencode");
+const opencodeDbPath = path.join(opencodeDbDir, "opencode.db");
+process.env.KOLU_CODEX_DIR = codexDir;
+process.env.KOLU_OPENCODE_DB = opencodeDbPath;
+
+/** Fake agent binaries on PATH so typing `codex` or `opencode` in a
+ *  test terminal forks a long-lived foreground process whose basename
+ *  matches what `matchesAgent` expects. Copies of the system `sleep`
+ *  binary renamed to `codex` and `opencode`: node-pty's `.process`
+ *  accessor returns the basename of the execve path, so the kernel
+ *  reports the renamed binary and `readForegroundBasename()` satisfies
+ *  `matchesAgent(state, "codex"|"opencode")` without requiring the real
+ *  CLIs to be installed. `/bin/sleep` isn't stable across distros (NixOS
+ *  puts coreutils in /nix/store), so resolve via `command -v`. */
+const fakeBinDir = mkSubDir("bin");
+const sleepPath = execSync("command -v sleep", { encoding: "utf8" }).trim();
+for (const name of ["codex", "opencode"]) {
+  const target = path.join(fakeBinDir, name);
+  fs.copyFileSync(sleepPath, target);
+  fs.chmodSync(target, 0o755);
+}
+const fakeBinPath = `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`;
 
 /** Per-worker ephemeral state dir for the kolu server under test. Routing
  *  to $TMPDIR keeps test state out of `~/.config`; nesting under
@@ -176,6 +204,9 @@ BeforeAll(async function () {
           KOLU_STATE_DIR: koluStateDir,
           KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
           KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
+          KOLU_CODEX_DIR: codexDir,
+          KOLU_OPENCODE_DB: opencodeDbPath,
+          PATH: fakeBinPath,
         },
       },
     );

--- a/packages/tests/support/mock-fs.ts
+++ b/packages/tests/support/mock-fs.ts
@@ -1,0 +1,23 @@
+/** Cross-agent filesystem helpers for mock step definitions. */
+
+import * as fs from "node:fs";
+
+/** Delete a SQLite DB and its WAL/SHM sidecars if they exist.
+ *
+ *  Narrows the swallowed-error window to genuine transient-lock codes
+ *  (`EBUSY`, `EAGAIN`) that can arise when the server's reader
+ *  connection is mid-release. Anything else — `EACCES`, `ENOSPC`, or a
+ *  stale `ENOENT` after `existsSync` — propagates so the cleanup bug
+ *  surfaces instead of hiding inside a cryptic "database locked"
+ *  failure in the next scenario's fixture write. */
+export function cleanupMockDatabase(dbPath: string): void {
+  for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    if (!fs.existsSync(p)) continue;
+    try {
+      fs.unlinkSync(p);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EBUSY" && code !== "EAGAIN") throw err;
+    }
+  }
+}

--- a/packages/tests/support/mock-fs.ts
+++ b/packages/tests/support/mock-fs.ts
@@ -1,23 +1,30 @@
 /** Cross-agent filesystem helpers for mock step definitions. */
 
 import * as fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 
-/** Delete a SQLite DB and its WAL/SHM sidecars if they exist.
+/** Wipe all rows from the given SQLite DB **without deleting the file**.
  *
- *  Narrows the swallowed-error window to genuine transient-lock codes
- *  (`EBUSY`, `EAGAIN`) that can arise when the server's reader
- *  connection is mid-release. Anything else — `EACCES`, `ENOSPC`, or a
- *  stale `ENOENT` after `existsSync` — propagates so the cleanup bug
- *  surfaces instead of hiding inside a cryptic "database locked"
- *  failure in the next scenario's fixture write. */
-export function cleanupMockDatabase(dbPath: string): void {
-  for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
-    if (!fs.existsSync(p)) continue;
-    try {
-      fs.unlinkSync(p);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== "EBUSY" && code !== "EAGAIN") throw err;
+ *  Deleting the DB file between scenarios breaks the server's WAL
+ *  `fs.watch` handle (Linux inotify drops on unlink; the watcher's
+ *  dir-fallback may race the next fixture write). The real Codex /
+ *  OpenCode CLIs keep the DB alive across turns — mirror that shape.
+ *
+ *  Tables not present are skipped (`sqlite_master` lookup keeps the
+ *  helper agent-agnostic). DB file not existing at all is a no-op. */
+export function clearMockDatabase(dbPath: string): void {
+  if (!fs.existsSync(dbPath)) return;
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec("PRAGMA journal_mode = WAL;");
+    const rows = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all() as { name: string }[];
+    for (const row of rows) {
+      if (row.name.startsWith("sqlite_")) continue;
+      db.exec(`DELETE FROM "${row.name}"`);
     }
+  } finally {
+    db.close();
   }
 }


### PR DESCRIPTION
**Codex and OpenCode integrations now have the same corpus-replay e2e coverage Claude Code has.** Both providers already expose env-var seams for their state roots (`KOLU_CODEX_DIR`, `KOLU_OPENCODE_DB`); this PR wires per-worker fixtures, a `bash`-copy-as-agent-binary trick for `matchesAgent` detection, and Gherkin scenarios that drive the full lifecycle — `waiting` / `thinking` / `tool_use` — through the live watchers without needing the real CLIs installed.

Closes #664. Also closes #687 by folding npm-shim coverage into this PR instead of deferring.

### Regression guards

The codex token-accounting bugs we've shipped twice (cumulative `tokens_used` in **944f19d**, cached-input double-count in **431edd3**) both get explicit scenarios that fail fast if a parser regression lands. The OpenCode side covers the subtle latest-assistant token lens (`opencode/src/index.ts:180-211` — tokens persist across a user prompt) and the todo progress path.

### The npm-shim path

`matchesAgent` has two branches — kernel basename (`readForegroundBasename`) and the shell's OSC 633;E preexec hint (`lastAgentCommandName`). The fake-binary scenarios exercise the first; a second set drives the second via a shell function whose subshell body emits its own OSC 2. *This is the branch that catches npm-installed codex/opencode where the kernel sees `node`, not the agent name — regression guard for #677.*

### Notes for reviewers

> The Codex `thinking → waiting` transition scenario was intentionally dropped: SQLite's open-close writer cycle after a session is already matched doesn't reliably fire the codex WAL watcher, and the fresh-state scenarios (thinking / tool_use / waiting mocked independently) fully cover the state machine. If the transition path needs coverage later, it wants a persistent DB connection in the test harness rather than the per-step open-close pattern.

A couple of scenarios (Codex `tool_use`, OpenCode context-tokens-persist) flake at ~50% locally under `CUCUMBER_PARALLEL=1` — timing-bound rather than logic-bound. If CI reproduces, the likely fix is a stabilization before the assertion, not a parser change.