### PR TITLE
Badge active alerts when Kolu is hidden

### DIFF
--- a/packages/client/src/terminal/useTerminalAlerts.ts
+++ b/packages/client/src/terminal/useTerminalAlerts.ts
@@ -1,7 +1,8 @@
 /** Terminal alerts — reactively detect agent state transitions and fire notifications.
  *  Watches metadata subscriptions for agent state changes (any AI coding agent). */
 
-import { type Accessor, createEffect, on } from "solid-js";
+import { type Accessor, createEffect, createSignal, on } from "solid-js";
+import { makeEventListener } from "@solid-primitives/event-listener";
 import type { TerminalId, TerminalMetadata } from "kolu-common";
 import { usePreferences } from "../settings/usePreferences";
 import {
@@ -19,6 +20,9 @@ export function useTerminalAlerts(deps: {
 }) {
   const { preferences } = usePreferences();
   const activityAlerts = () => preferences().activityAlerts;
+  const [hiddenAttentionIds, setHiddenAttentionIds] = createSignal<
+    ReadonlySet<TerminalId>
+  >(new Set<TerminalId>());
 
   // Request browser notification permission eagerly when alerts are enabled
   if (activityAlerts()) requestNotificationPermission();
@@ -27,11 +31,19 @@ export function useTerminalAlerts(deps: {
   // Clears automatically when the user visits all unread terminals.
   createEffect(() => {
     if (!("setAppBadge" in navigator)) return;
-    const count = deps.terminalIds().filter((id) => deps.isUnread(id)).length;
+    const count = deps
+      .terminalIds()
+      .filter((id) => deps.isUnread(id) || hiddenAttentionIds().has(id)).length;
     if (count > 0) {
       void navigator.setAppBadge(count);
     } else {
       void navigator.clearAppBadge();
+    }
+  });
+
+  makeEventListener(document, "visibilitychange", () => {
+    if (!document.hidden && hiddenAttentionIds().size > 0) {
+      setHiddenAttentionIds(new Set<TerminalId>());
     }
   });
 
@@ -57,19 +69,32 @@ export function useTerminalAlerts(deps: {
     next: string | undefined,
   ) {
     if (!activityAlerts() || next !== "waiting" || prev === "waiting") return;
+    alertForTerminal(id);
+  }
+
+  function markHiddenAttention(id: TerminalId) {
+    setHiddenAttentionIds((prev) => new Set(prev).add(id));
+  }
+
+  function alertForTerminal(id: TerminalId) {
     const isBackground = id !== deps.activeId();
-    if (isBackground) deps.markUnread(id);
+    if (isBackground) {
+      deps.markUnread(id);
+    } else if (document.hidden) {
+      markHiddenAttention(id);
+    }
     if (isBackground || document.hidden)
       fireActivityAlert(deps.terminalLabel(id));
   }
 
-  function simulateAlert() {
+  function simulateAlert(options?: { target?: "active" | "inactive" }) {
     if (!activityAlerts()) return;
-    const inactive = deps.terminalIds().filter((id) => id !== deps.activeId());
-    if (inactive.length === 0) return;
-    const id = inactive[Math.floor(Math.random() * inactive.length)]!;
-    deps.markUnread(id);
-    fireActivityAlert(deps.terminalLabel(id));
+    const ids =
+      options?.target === "active"
+        ? deps.terminalIds().filter((id) => id === deps.activeId())
+        : deps.terminalIds().filter((id) => id !== deps.activeId());
+    if (ids.length === 0) return;
+    alertForTerminal(ids[Math.floor(Math.random() * ids.length)]!);
   }
 
   return { simulateAlert };

--- a/packages/client/src/terminal/useTerminalAlerts.ts
+++ b/packages/client/src/terminal/useTerminalAlerts.ts
@@ -1,7 +1,7 @@
 /** Terminal alerts — reactively detect agent state transitions and fire notifications.
  *  Watches metadata subscriptions for agent state changes (any AI coding agent). */
 
-import { type Accessor, createEffect, createSignal, on } from "solid-js";
+import { type Accessor, createEffect, on } from "solid-js";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import type { TerminalId, TerminalMetadata } from "kolu-common";
 import { usePreferences } from "../settings/usePreferences";
@@ -13,27 +13,23 @@ import {
 export function useTerminalAlerts(deps: {
   activeId: Accessor<TerminalId | null>;
   getMetadata: (id: TerminalId) => TerminalMetadata | undefined;
-  isUnread: (id: TerminalId) => boolean;
+  hasBadgeAttention: (id: TerminalId) => boolean;
+  clearBadgeAttention: () => void;
   markUnread: (id: TerminalId) => void;
+  markBadgeAttention: (id: TerminalId) => void;
   terminalIds: Accessor<TerminalId[]>;
   terminalLabel: (id: TerminalId) => string;
 }) {
   const { preferences } = usePreferences();
   const activityAlerts = () => preferences().activityAlerts;
-  const [hiddenAttentionIds, setHiddenAttentionIds] = createSignal<
-    ReadonlySet<TerminalId>
-  >(new Set<TerminalId>());
 
   // Request browser notification permission eagerly when alerts are enabled
   if (activityAlerts()) requestNotificationPermission();
 
-  // Badge the PWA dock icon with the unread agent count (Badging API).
-  // Clears automatically when the user visits all unread terminals.
+  // Badge the PWA dock icon with terminals that need attention.
   createEffect(() => {
     if (!("setAppBadge" in navigator)) return;
-    const count = deps
-      .terminalIds()
-      .filter((id) => deps.isUnread(id) || hiddenAttentionIds().has(id)).length;
+    const count = deps.terminalIds().filter(deps.hasBadgeAttention).length;
     if (count > 0) {
       void navigator.setAppBadge(count);
     } else {
@@ -42,9 +38,7 @@ export function useTerminalAlerts(deps: {
   });
 
   makeEventListener(document, "visibilitychange", () => {
-    if (!document.hidden && hiddenAttentionIds().size > 0) {
-      setHiddenAttentionIds(new Set<TerminalId>());
-    }
+    if (!document.hidden) deps.clearBadgeAttention();
   });
 
   // Reactively watch agent state for all terminals.
@@ -72,16 +66,12 @@ export function useTerminalAlerts(deps: {
     alertForTerminal(id);
   }
 
-  function markHiddenAttention(id: TerminalId) {
-    setHiddenAttentionIds((prev) => new Set(prev).add(id));
-  }
-
   function alertForTerminal(id: TerminalId) {
     const isBackground = id !== deps.activeId();
     if (isBackground) {
       deps.markUnread(id);
     } else if (document.hidden) {
-      markHiddenAttention(id);
+      deps.markBadgeAttention(id);
     }
     if (isBackground || document.hidden)
       fireActivityAlert(deps.terminalLabel(id));

--- a/packages/client/src/terminal/useTerminals.ts
+++ b/packages/client/src/terminal/useTerminals.ts
@@ -25,8 +25,10 @@ export function useTerminals() {
   const alerts = useTerminalAlerts({
     activeId: store.activeId,
     getMetadata: store.getMetadata,
-    isUnread: store.isUnread,
+    hasBadgeAttention: store.hasBadgeAttention,
+    clearBadgeAttention: store.clearBadgeAttention,
     markUnread: store.markUnread,
+    markBadgeAttention: store.markBadgeAttention,
     terminalIds: store.terminalIds,
     terminalLabel: store.terminalLabel,
   });

--- a/packages/client/src/useViewState.ts
+++ b/packages/client/src/useViewState.ts
@@ -11,6 +11,8 @@ import { makePersisted } from "@solid-primitives/storage";
 import type { TerminalId } from "kolu-common";
 import { client } from "./rpc/rpc";
 
+type TerminalAttention = "unread" | "badge-only";
+
 export function useViewState() {
   const [activeId, setActiveId] = createSignal<TerminalId | null>(null);
 
@@ -25,15 +27,19 @@ export function useViewState() {
     { name: "kolu-canvas-maximized" },
   );
 
-  /** Terminals with unseen Claude completions (cleared when user visits). */
-  const [unread, setUnread] = createStore<Record<TerminalId, true>>({});
+  /** Terminals needing attention. `unread` drives in-app dots and badges;
+   *  `badge-only` is for OS/PWA attention that should not show an in-app dot. */
+  const [attention, setAttention] = createStore<
+    Record<TerminalId, TerminalAttention>
+  >({});
 
   const [mruOrder, setMruOrder] = createSignal<TerminalId[]>([]);
   createEffect(
     on(activeId, (id) => {
       if (id === null) return;
       setMruOrder((prev) => [id, ...prev.filter((x) => x !== id)]);
-      if (unread[id]) setUnread(produce((s) => delete s[id]));
+      if (attention[id] === "unread")
+        setAttention(produce((s) => delete s[id]));
       // Report active terminal to server for session snapshots
       void client.terminal.setActive({ id }).catch(() => {});
     }),
@@ -51,18 +57,36 @@ export function useViewState() {
   }
 
   function markUnread(id: TerminalId) {
-    setUnread(id, true);
+    setAttention(id, "unread");
+  }
+
+  function markBadgeAttention(id: TerminalId) {
+    if (attention[id] !== "unread") setAttention(id, "badge-only");
+  }
+
+  function clearBadgeAttention() {
+    setAttention(
+      produce((s) => {
+        for (const id of Object.keys(s) as TerminalId[]) {
+          if (s[id] === "badge-only") delete s[id];
+        }
+      }),
+    );
   }
 
   function isUnread(id: TerminalId): boolean {
-    return !!unread[id];
+    return attention[id] === "unread";
+  }
+
+  function hasBadgeAttention(id: TerminalId): boolean {
+    return attention[id] !== undefined;
   }
 
   function reset() {
     setActiveId(null);
     setCanvasMaximizedSignal(false);
     setMruOrder([]);
-    setUnread(reconcile({}));
+    setAttention(reconcile({}));
   }
 
   return {
@@ -73,7 +97,10 @@ export function useViewState() {
     mruOrder,
     setMruOrder,
     markUnread,
+    markBadgeAttention,
+    clearBadgeAttention,
     isUnread,
+    hasBadgeAttention,
     reset,
   };
 }

--- a/packages/tests/features/activity-alerts.feature
+++ b/packages/tests/features/activity-alerts.feature
@@ -35,3 +35,13 @@ Feature: Activity Alerts
     And I simulate an activity alert
     Then no pill tree branch should be notified
     And there should be no page errors
+
+  Scenario: Hidden active terminal badges the PWA dock icon
+    When I stub the Badging API
+    And I simulate the Kolu tab being hidden
+    And I simulate an activity alert for the active terminal
+    Then the app badge should show 1
+    When I simulate the Kolu tab becoming visible
+    Then the app badge should be cleared
+    And no pill tree branch should be notified
+    And there should be no page errors

--- a/packages/tests/step_definitions/activity_alert_steps.ts
+++ b/packages/tests/step_definitions/activity_alert_steps.ts
@@ -16,6 +16,49 @@ When("I simulate an activity alert", async function (this: KoluWorld) {
   await this.waitForFrame();
 });
 
+When(
+  "I simulate an activity alert for the active terminal",
+  async function (this: KoluWorld) {
+    await this.page.evaluate(() => {
+      (window as any).__koluSimulateAlert?.({ target: "active" });
+    });
+    await this.waitForFrame();
+  },
+);
+
+When("I simulate the Kolu tab being hidden", async function (this: KoluWorld) {
+  await this.page.evaluate(() => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+  await this.waitForFrame();
+});
+
+When(
+  "I simulate the Kolu tab becoming visible",
+  async function (this: KoluWorld) {
+    await this.page.evaluate(() => {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      });
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await this.waitForFrame();
+  },
+);
+
 Then("a pill tree branch should be notified", async function (this: KoluWorld) {
   const notified = this.page.locator(
     '[data-testid="pill-tree-branch"][data-unread]',


### PR DESCRIPTION
**Kolu now badges the app icon when the selected terminal finishes while the Kolu tab or window is hidden.** Previously that path could play the activity alert but leave the PWA dock badge at zero because badge state only counted unread background terminals.

**Terminal attention is now explicit enough to separate the two surfaces.** Background completions still show the in-app unread dot and badge; hidden active-terminal completions create badge-only attention that clears when Kolu becomes visible again, so returning to the already-selected terminal does not leave a stale pill-tree dot.

**Covered by e2e:** `activity-alerts.feature` now exercises the hidden-active terminal path, including badge set, visibility-return clear, and no in-app unread dot.

### Try it locally

```sh
nix run github:juspay/kolu/fix/activity-alert-hidden-active
```