### PR TITLE
Stabilize flaky test harness waits

### DIFF
--- a/docs/flaky-tests-ralph-report.md
+++ b/docs/flaky-tests-ralph-report.md
@@ -1,0 +1,61 @@
+# Flaky Tests Ralph Report
+
+Issue: https://github.com/juspay/kolu/issues/320
+
+## Methodology
+
+Target metric: failures across repeated runs of known flaky test classes.
+
+Baseline commands:
+
+```sh
+for i in 1 2 3 4 5; do
+  nix develop . --accept-flake-config -c pnpm --filter kolu-server test:unit
+done
+
+for i in 1 2 3 4 5; do
+  CUCUMBER_PARALLEL=4 just test-quick \
+    features/code-tab.feature \
+    features/osc52-clipboard.feature \
+    features/session-restore.feature \
+    features/canvas.feature
+done
+```
+
+## Baseline
+
+| Target                   | Runs | Result             |
+| ------------------------ | ---: | ------------------ |
+| `kolu-server` unit tests |    5 | 5 passed, 0 failed |
+| Focused e2e flaky set    |    5 | 5 passed, 0 failed |
+
+The local Linux baseline did not reproduce the flakes. The mutation targets are therefore based on the repeated CI evidence in issue #320: darwin clipboard bleed, Code tab git-status waits, Before-hook socket resets, canvas wheel ownership timing, terminal readiness under darwin load, and the server unit shared-state race.
+
+## Optimization Log
+
+| Cycle | Target                 | Classification            | Change                                                                                                            | Measurement            |
+| ----- | ---------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| 1     | Harness setup          | transient connection race | Retry transient setup POST/page creation failures and preserve the root Before-hook error by guarding screenshots | 5/5 focused e2e passed |
+| 1     | E2E waits              | slow CI propagation       | Raise shared ready/poll budgets from 10s to 20s                                                                   | 5/5 focused e2e passed |
+| 1     | Clipboard tests        | shared external state     | Clear clipboard on app load to prevent cross-scenario bleed                                                       | 5/5 focused e2e passed |
+| 1     | Code tab               | stale/late git state      | Poll changed-file assertions and refresh the Code tab while waiting                                               | 5/5 focused e2e passed |
+| 1     | Canvas wheel ownership | step-boundary timing      | Wait for canvas/xterm and dispatch the ownership claim plus terminal wheel in one browser turn                    | 5/5 focused e2e passed |
+| 1     | Server unit tests      | shared state file         | Disable Vitest file parallelism for the server package                                                            | 5/5 server unit passed |
+
+## Re-measure
+
+Same commands as baseline, after the cycle-1 hardening changes:
+
+| Target                   | Runs | Result             |
+| ------------------------ | ---: | ------------------ |
+| `kolu-server` unit tests |    5 | 5 passed, 0 failed |
+| Focused e2e flaky set    |    5 | 5 passed, 0 failed |
+
+Local pass rate stayed at 100%, so this loop cannot claim a local failure-rate delta. The useful signal is the issue-log classification: each change removes or narrows a concrete race that has appeared in CI.
+
+## Findings
+
+- `ci/home-manager@x86_64-linux`'s `curl` readiness race was already fixed in this checkout by polling the HTTP listener.
+- The server unit flake has a small suite-level cost to eliminate: `kolu-server` now runs Vitest files serially, avoiding concurrent `Conf` reads/writes against one `KOLU_STATE_DIR`.
+- Several e2e failures were not product failures; they were harness races around setup, external clipboard state, and step-boundary timing.
+- The broad timeout increase is intentionally limited to test helpers. Cucumber's 30s step timeout remains the upper bound.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "KOLU_STATE_DIR=\"$(git rev-parse --show-toplevel)/.kolu-dev\" node --watch --import tsx src/index.ts --allow-nix-shell-with-env-whitelist default",
     "typecheck": "tsc --noEmit",
-    "test:unit": "KOLU_STATE_DIR=\"${TMPDIR:-/tmp}/kolu-unit-test-$$/state\" vitest run"
+    "test:unit": "KOLU_STATE_DIR=\"${TMPDIR:-/tmp}/kolu-unit-test-$$/state\" vitest run --fileParallelism=false"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.13",

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -10,6 +10,19 @@ const MINIMAP_VIEWPORT_RECT_SELECTOR = '[data-testid="minimap-viewport-rect"]';
 const TILE_SELECTOR = '[data-testid="canvas-tile"]';
 const TILE_TITLEBAR_SELECTOR = '[data-testid="canvas-tile-titlebar"]';
 
+async function waitForCanvas(world: KoluWorld) {
+  await world.page
+    .locator(CANVAS_SELECTOR)
+    .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+}
+
+async function waitForXterm(world: KoluWorld) {
+  await world.page
+    .locator("[data-visible] .xterm-screen")
+    .first()
+    .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+}
+
 Then(
   "the canvas grid background should be visible",
   async function (this: KoluWorld) {
@@ -268,6 +281,7 @@ When("I record the canvas transform", async function (this: KoluWorld) {
 When(
   "I scroll the wheel over the terminal tile",
   async function (this: KoluWorld) {
+    await waitForXterm(this);
     await this.page.evaluate(() => {
       const xterm = document.querySelector(
         "[data-visible] .xterm-screen",
@@ -292,6 +306,7 @@ When(
 When(
   "I scroll the wheel over the canvas background",
   async function (this: KoluWorld) {
+    await waitForCanvas(this);
     await this.page.evaluate((sel: string) => {
       const container = document.querySelector(sel) as HTMLElement | null;
       if (!container) throw new Error("canvas-container not found");
@@ -315,14 +330,18 @@ When(
 When(
   "I scroll the wheel over the terminal tile within the idle window",
   async function (this: KoluWorld) {
+    await waitForCanvas(this);
+    await waitForXterm(this);
     // Install a one-shot probe on the xterm element before dispatching. Canvas
     // owns the gesture from the previous background scroll; stopPropagation at
     // the canvas's capture-phase listener should prevent this event from ever
     // reaching the xterm probe.
-    await this.page.evaluate(() => {
+    await this.page.evaluate((sel: string) => {
+      const container = document.querySelector(sel) as HTMLElement | null;
       const xterm = document.querySelector(
         "[data-visible] .xterm-screen",
       ) as HTMLElement | null;
+      if (!container) throw new Error("canvas-container not found");
       if (!xterm) throw new Error("xterm-screen not found");
       (
         window as unknown as { __xtermWheelReceived?: boolean }
@@ -336,6 +355,17 @@ When(
         },
         { once: true },
       );
+      const containerRect = container.getBoundingClientRect();
+      container.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaX: 0,
+          deltaY: 120,
+          clientX: containerRect.left + 8,
+          clientY: containerRect.top + 8,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
       const rect = xterm.getBoundingClientRect();
       xterm.dispatchEvent(
         new WheelEvent("wheel", {
@@ -347,7 +377,7 @@ When(
           cancelable: true,
         }),
       );
-    });
+    }, CANVAS_SELECTOR);
     await this.waitForFrame();
   },
 );
@@ -357,6 +387,7 @@ When(
 When(
   "I Shift+scroll the wheel over the terminal tile",
   async function (this: KoluWorld) {
+    await waitForXterm(this);
     await this.page.evaluate(() => {
       const xterm = document.querySelector(
         "[data-visible] .xterm-screen",
@@ -382,6 +413,7 @@ When(
 When(
   "I Shift+drag from inside the terminal tile",
   async function (this: KoluWorld) {
+    await waitForXterm(this);
     await this.page.evaluate(() => {
       const xterm = document.querySelector(
         "[data-visible] .xterm-screen",

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1,6 +1,30 @@
 import { When, Then } from "@cucumber/cucumber";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
+function changedFileSelector(path: string): string {
+  return `[data-testid="diff-file-item"][data-path="${path}"]`;
+}
+
+async function waitForChangedFile(world: KoluWorld, path: string) {
+  const item = world.page.locator(changedFileSelector(path));
+  const refresh = world.page.locator('[data-testid="diff-refresh"]');
+  const deadline = Date.now() + POLL_TIMEOUT;
+  let nextRefresh = Date.now();
+
+  while (Date.now() < deadline) {
+    if (await item.isVisible().catch(() => false)) return;
+
+    if (Date.now() >= nextRefresh && (await refresh.isVisible())) {
+      await refresh.click().catch(() => undefined);
+      nextRefresh = Date.now() + 1000;
+    }
+
+    await world.page.waitForTimeout(100);
+  }
+
+  await item.waitFor({ state: "visible", timeout: 1 });
+}
+
 // ── Actions ──
 
 When("I click the Code tab", async function (this: KoluWorld) {
@@ -23,9 +47,7 @@ When(
 When(
   "I click the changed file {string} in the Code tab",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(
-      `[data-testid="diff-file-item"][data-path="${path}"]`,
-    );
+    const item = this.page.locator(changedFileSelector(path));
     await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     await item.click();
     await this.waitForFrame();
@@ -72,10 +94,7 @@ Then(
 Then(
   "the Code tab should list a changed file {string}",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(
-      `[data-testid="diff-file-item"][data-path="${path}"]`,
-    );
-    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitForChangedFile(this, path);
   },
 );
 
@@ -104,9 +123,7 @@ When(
 Then(
   "the Code tab should not list a changed file {string}",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(
-      `[data-testid="diff-file-item"][data-path="${path}"]`,
-    );
+    const item = this.page.locator(changedFileSelector(path));
     await item.waitFor({ state: "detached", timeout: POLL_TIMEOUT });
   },
 );

--- a/packages/tests/step_definitions/smoke_steps.ts
+++ b/packages/tests/step_definitions/smoke_steps.ts
@@ -4,6 +4,9 @@ import * as assert from "node:assert";
 
 When("I open the app", async function (this: KoluWorld) {
   await this.page.goto("/");
+  await this.page
+    .evaluate(() => navigator.clipboard?.writeText?.(""))
+    .catch(() => undefined);
 });
 
 When("I request {string}", async function (this: KoluWorld, path: string) {

--- a/packages/tests/step_definitions/terminal_steps.ts
+++ b/packages/tests/step_definitions/terminal_steps.ts
@@ -4,6 +4,12 @@ import { readBufferText, waitForBufferContains } from "../support/buffer.ts";
 import { pollUntil } from "../support/poll.ts";
 import * as assert from "node:assert";
 
+async function clearClipboard(world: KoluWorld) {
+  await world.page
+    .evaluate(() => navigator.clipboard?.writeText?.(""))
+    .catch(() => undefined);
+}
+
 /** Count terminals by reading canvas tile entries from the DOM. */
 async function countTerminals(world: KoluWorld) {
   return world.page
@@ -15,6 +21,7 @@ async function countTerminals(world: KoluWorld) {
 
 Given("the terminal is ready", async function (this: KoluWorld) {
   await this.page.goto("/");
+  await clearClipboard(this);
   await this.waitForReady();
 });
 

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -11,7 +11,7 @@
 
 import { Before, After, BeforeAll, AfterAll, Status } from "@cucumber/cucumber";
 import { chromium } from "playwright";
-import type { Browser } from "playwright";
+import type { Browser, BrowserContext, Page } from "playwright";
 import getPort from "get-port";
 import { KoluWorld } from "./world.ts";
 import * as fs from "node:fs";
@@ -107,8 +107,46 @@ let serverProcess: ChildProcess | undefined;
 // accumulation on macOS (see #334).
 const keepAliveAgent = new http.Agent({ keepAlive: true });
 
+const TRANSIENT_SETUP_ERRORS = [
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EPIPE",
+  "socket hang up",
+  "read ECONNRESET",
+];
+
+function isTransientSetupError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return TRANSIENT_SETUP_ERRORS.some((needle) => msg.includes(needle));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function retryTransient<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  let last: unknown;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      last = err;
+      if (!isTransientSetupError(err) || attempt === 3) break;
+      await sleep(100 * attempt);
+    }
+  }
+  throw last instanceof Error
+    ? new Error(`${label} failed after retries: ${last.message}`, {
+        cause: last,
+      })
+    : new Error(`${label} failed after retries: ${String(last)}`);
+}
+
 /** POST JSON to a local URL, reusing TCP connections via keepAlive. */
-function postJSON(url: string, body: object): Promise<void> {
+function postJSONOnce(url: string, body: object): Promise<void> {
   return new Promise((resolve, reject) => {
     const u = new URL(url);
     const req = http.request(
@@ -129,6 +167,10 @@ function postJSON(url: string, body: object): Promise<void> {
     req.on("error", reject);
     req.end(JSON.stringify(body));
   });
+}
+
+function postJSON(url: string, body: object): Promise<void> {
+  return retryTransient(`POST ${url}`, () => postJSONOnce(url, body));
 }
 
 /** GET a URL, reusing TCP connections via keepAlive. */
@@ -172,6 +214,34 @@ const ciArgs = [
   "--disable-dev-shm-usage",
   "--headless=new",
 ];
+
+async function newScenarioPage(
+  isMobile: boolean,
+): Promise<{ context: BrowserContext; page: Page }> {
+  let previousContext: BrowserContext | undefined;
+  return retryTransient("create Playwright page", async () => {
+    if (previousContext) {
+      await previousContext.close().catch(() => undefined);
+      previousContext = undefined;
+    }
+    const context = await browser.newContext({
+      viewport: isMobile
+        ? { width: 390, height: 844 }
+        : { width: 1280, height: 720 },
+      ...(isMobile && { hasTouch: true, isMobile: true }),
+      baseURL: baseUrl,
+      ignoreHTTPSErrors: true,
+      // clipboard-write: lets tests place images in the clipboard for paste testing.
+      // clipboard-read: lets tests verify clipboard contents after copy operations.
+      // Production code never calls clipboard.read — these are test-only permissions.
+      permissions: ["clipboard-write", "clipboard-read"],
+    });
+    previousContext = context;
+    const page = await context.newPage();
+    previousContext = undefined;
+    return { context, page };
+  });
+}
 
 async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
   const start = Date.now();
@@ -301,19 +371,9 @@ Before(async function (this: KoluWorld, scenario) {
   const isMobile = scenario.pickle.tags.some((t) => t.name === "@mobile");
 
   this.browser = browser;
-  this.context = await browser.newContext({
-    viewport: isMobile
-      ? { width: 390, height: 844 }
-      : { width: 1280, height: 720 },
-    ...(isMobile && { hasTouch: true, isMobile: true }),
-    baseURL: baseUrl,
-    ignoreHTTPSErrors: true,
-    // clipboard-write: lets tests place images in the clipboard for paste testing.
-    // clipboard-read: lets tests verify clipboard contents after copy operations.
-    // Production code never calls clipboard.read — these are test-only permissions.
-    permissions: ["clipboard-write", "clipboard-read"],
-  });
-  this.page = await this.context.newPage();
+  const created = await newScenarioPage(isMobile);
+  this.context = created.context;
+  this.page = created.page;
   // Disable CSS transitions/animations so Corvu dialogs open/close instantly.
   // prefers-reduced-motion tells well-behaved libraries to skip animations.
   // The style override catches anything that doesn't respect the media query.
@@ -348,7 +408,7 @@ Before(async function (this: KoluWorld, scenario) {
 
 After(async function (this: KoluWorld, scenario) {
   // Screenshot on failure
-  if (scenario.result?.status === Status.FAILED) {
+  if (scenario.result?.status === Status.FAILED && this.page) {
     const dir = path.resolve(
       import.meta.dirname,
       "..",
@@ -357,10 +417,17 @@ After(async function (this: KoluWorld, scenario) {
     );
     fs.mkdirSync(dir, { recursive: true });
     const name = scenario.pickle.name.replace(/\s+/g, "-").toLowerCase();
-    await this.page.screenshot({
-      path: path.join(dir, `${name}.png`),
-      fullPage: true,
-    });
+    await this.page
+      .screenshot({
+        path: path.join(dir, `${name}.png`),
+        fullPage: true,
+      })
+      .catch((err) => {
+        console.error(
+          `[worker:${workerId}] Failed to capture failure screenshot:`,
+          err,
+        );
+      });
   }
   if (this.context) await this.context.close();
 });

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -12,9 +12,9 @@ import type { Browser, BrowserContext, Page, Locator } from "playwright";
 
 setDefaultTimeout(30_000);
 
-const READY_TIMEOUT = 10_000;
+const READY_TIMEOUT = 20_000;
 /** Shared timeout for element polling (waitFor / waitForFunction). Generous for darwin CI under load. */
-export const POLL_TIMEOUT = 10_000;
+export const POLL_TIMEOUT = 20_000;
 export const MOD_KEY = process.platform === "darwin" ? "Meta" : "Control";
 
 /** Locator for the app's settled state: either a visible terminal screen or the empty state tip. */


### PR DESCRIPTION
**Known flakes in #320 now have stronger harness guardrails** around the places that kept failing under CI load: setup sockets, clipboard state, delayed git metadata, canvas wheel ownership, and server unit state. The local Linux baseline stayed green before and after, so the Ralph report records the repeated CI evidence driving each change instead of pretending there was a local failure-rate delta.

**The patch keeps behavior changes inside tests.** E2E readiness budgets move from 10s to 20s, server unit files run serially to avoid one shared Conf state file, Code tab assertions poll with explicit refreshes, and the canvas idle-window check now performs the ownership claim and terminal wheel in one browser turn.

| Measurement | Before | After |
| --- | ---: | ---: |
| `kolu-server` unit tests, 5 hot runs | 5/5 passed | 5/5 passed |
| Focused flaky e2e set, 5 hot runs | 5/5 passed | 5/5 passed |
| `just ci` expected contexts | not run | 10/10 success |

**Local CI is fully green on `e1784de`**, with no missing status contexts and no non-success statuses. Details are in `docs/flaky-tests-ralph-report.md`.

Refs #320