### PR TITLE
Add /workspace and /board routes

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,6 +23,7 @@
     "@solid-primitives/resize-observer": "^2.1.5",
     "@solid-primitives/storage": "^4.3.4",
     "@solidjs/meta": "^0.29.4",
+    "@solidjs/router": "^0.16.1",
     "@thisbeyond/solid-dnd": "^0.7.5",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.0",
+    "jsdom": "^29.0.2",
     "kolu-common": "workspace:*",
     "tailwindcss": "^4.1.0",
     "terminal-themes": "workspace:*",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -334,6 +334,7 @@ const App: Component = () => {
   const showEmpty = () =>
     !session.isLoading() && store.terminalIds().length === 0;
 
+  /** Workspace route leaf — preserves the existing Kolu terminal experience. */
   const WorkspacePage: Component = () => (
     <>
       {/* Desktop chrome — docked top bar carrying pill tree, identity,

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -44,6 +44,7 @@ import { useRecorder } from "./recorder/useRecorder";
 import type { TerminalId } from "kolu-common";
 import { client, wsStatus, serverProcessId } from "./rpc/rpc";
 import TransportOverlay from "./rpc/TransportOverlay";
+import AppRoutes from "./AppRoutes";
 import { useTerminals } from "./terminal/useTerminals";
 import { useThemeManager } from "./useThemeManager";
 import { useShortcuts } from "./input/useShortcuts";
@@ -333,6 +334,116 @@ const App: Component = () => {
   const showEmpty = () =>
     !session.isLoading() && store.terminalIds().length === 0;
 
+  const WorkspacePage: Component = () => (
+    <>
+      {/* Desktop chrome — docked top bar carrying pill tree, identity,
+       *  and global controls. Mobile has its own pull-down sheet (see
+       *  MobileTileView) and does not render this band. */}
+      <Show when={!isMobile()}>
+        <ChromeBar
+          status={wsStatus()}
+          onOpenPalette={() => openPalette()}
+          pillTree={
+            <PillTree
+              groups={pillGroups()}
+              onSelect={(id) => {
+                store.setActiveId(id);
+                if (!posture.maximized()) {
+                  const layout = store.getMetadata(id)?.canvasLayout;
+                  if (layout) canvasViewport.centerOnTile(layout);
+                }
+              }}
+              onCreate={() => openPaletteGroup("New terminal")}
+            />
+          }
+        />
+      </Show>
+      {/* relative: anchor for overlay panels.
+       *  --active-terminal-{bg,fg} published here so child components
+       *  can read them via CSS without prop drilling. The fg lets sub-
+       *  components re-tune text tiers against the terminal theme. */}
+      <div
+        class="relative flex flex-1 min-h-0"
+        style={{
+          "--active-terminal-bg":
+            activeTheme().background ?? "var(--color-surface-1)",
+          "--active-terminal-fg": activeTheme().foreground ?? "var(--color-fg)",
+        }}
+      >
+        <Show
+          when={!session.isLoading()}
+          fallback={
+            <div class="flex items-center justify-center flex-1 text-fg-3 text-sm">
+              Connecting...
+            </div>
+          }
+        >
+          <Show
+            when={!showEmpty()}
+            fallback={
+              <div
+                data-testid="canvas-container"
+                class="relative flex-1 min-h-0 canvas-grid-bg"
+              >
+                <CanvasWatermark text={appTitle()} />
+                <EmptyState
+                  savedSession={session.savedSession() ?? undefined}
+                  onRestore={() => void session.handleRestoreSession()}
+                />
+              </div>
+            }
+          >
+            <RightPanelLayout
+              meta={store.activeMeta()}
+              themeName={activeThemeName()}
+              onThemeClick={() => openPaletteGroup("Theme")}
+              contentClass={isMobile() ? "flex-col" : undefined}
+            >
+              {match(isMobile())
+                .with(true, () => (
+                  <MobileTileView
+                    orderedIds={orderedIds()}
+                    groups={pillGroups()}
+                    status={wsStatus()}
+                    appTitle={appTitle()}
+                    onOpenPalette={() => openPalette()}
+                    renderBody={renderMobileTileBody}
+                    bottomBar={<MobileKeyBar activeId={store.activeId} />}
+                  />
+                ))
+                .with(false, () => (
+                  <TerminalCanvas
+                    tileIds={store.terminalIds()}
+                    watermark={appTitle()}
+                    getLayout={(id) => store.getMetadata(id)?.canvasLayout}
+                    onLayoutChange={(id, layout) =>
+                      crud.setCanvasLayout(id, layout)
+                    }
+                    onSelect={(id) => store.setActiveId(id)}
+                    onClose={(id) => closeTerminal(id)}
+                    renderTileTitle={(id) => (
+                      <TerminalMeta info={store.getDisplayInfo(id)} />
+                    )}
+                    renderTileTitleActions={(id) => (
+                      <TileTitleActions
+                        id={id}
+                        onOpenPaletteGroup={openPaletteGroup}
+                        onToggleSubPanel={handleToggleSubPanel}
+                        onOpenSearch={() => setSearchOpen(true)}
+                        onScreenshot={handleScreenshotTerminal}
+                      />
+                    )}
+                    renderTileBody={renderCanvasTileBody}
+                  />
+                ))
+                .exhaustive()}
+            </RightPanelLayout>
+          </Show>
+        </Show>
+      </div>
+    </>
+  );
+
   return (
     <div
       class="relative flex flex-col h-dvh bg-surface-0 text-fg font-sans"
@@ -444,111 +555,7 @@ const App: Component = () => {
           if (target) void worktree.handleKillWorktree(target.id);
         }}
       />
-      {/* Desktop chrome — docked top bar carrying pill tree, identity,
-       *  and global controls. Mobile has its own pull-down sheet (see
-       *  MobileTileView) and does not render this band. */}
-      <Show when={!isMobile()}>
-        <ChromeBar
-          status={wsStatus()}
-          onOpenPalette={() => openPalette()}
-          pillTree={
-            <PillTree
-              groups={pillGroups()}
-              onSelect={(id) => {
-                store.setActiveId(id);
-                if (!posture.maximized()) {
-                  const layout = store.getMetadata(id)?.canvasLayout;
-                  if (layout) canvasViewport.centerOnTile(layout);
-                }
-              }}
-              onCreate={() => openPaletteGroup("New terminal")}
-            />
-          }
-        />
-      </Show>
-      {/* relative: anchor for overlay panels.
-       *  --active-terminal-{bg,fg} published here so child components
-       *  can read them via CSS without prop drilling. The fg lets sub-
-       *  components re-tune text tiers against the terminal theme. */}
-      <div
-        class="relative flex flex-1 min-h-0"
-        style={{
-          "--active-terminal-bg":
-            activeTheme().background ?? "var(--color-surface-1)",
-          "--active-terminal-fg": activeTheme().foreground ?? "var(--color-fg)",
-        }}
-      >
-        <Show
-          when={!session.isLoading()}
-          fallback={
-            <div class="flex items-center justify-center flex-1 text-fg-3 text-sm">
-              Connecting...
-            </div>
-          }
-        >
-          <Show
-            when={!showEmpty()}
-            fallback={
-              <div
-                data-testid="canvas-container"
-                class="relative flex-1 min-h-0 canvas-grid-bg"
-              >
-                <CanvasWatermark text={appTitle()} />
-                <EmptyState
-                  savedSession={session.savedSession() ?? undefined}
-                  onRestore={() => void session.handleRestoreSession()}
-                />
-              </div>
-            }
-          >
-            <RightPanelLayout
-              meta={store.activeMeta()}
-              themeName={activeThemeName()}
-              onThemeClick={() => openPaletteGroup("Theme")}
-              contentClass={isMobile() ? "flex-col" : undefined}
-            >
-              {match(isMobile())
-                .with(true, () => (
-                  <MobileTileView
-                    orderedIds={orderedIds()}
-                    groups={pillGroups()}
-                    status={wsStatus()}
-                    appTitle={appTitle()}
-                    onOpenPalette={() => openPalette()}
-                    renderBody={renderMobileTileBody}
-                    bottomBar={<MobileKeyBar activeId={store.activeId} />}
-                  />
-                ))
-                .with(false, () => (
-                  <TerminalCanvas
-                    tileIds={store.terminalIds()}
-                    watermark={appTitle()}
-                    getLayout={(id) => store.getMetadata(id)?.canvasLayout}
-                    onLayoutChange={(id, layout) =>
-                      crud.setCanvasLayout(id, layout)
-                    }
-                    onSelect={(id) => store.setActiveId(id)}
-                    onClose={(id) => closeTerminal(id)}
-                    renderTileTitle={(id) => (
-                      <TerminalMeta info={store.getDisplayInfo(id)} />
-                    )}
-                    renderTileTitleActions={(id) => (
-                      <TileTitleActions
-                        id={id}
-                        onOpenPaletteGroup={openPaletteGroup}
-                        onToggleSubPanel={handleToggleSubPanel}
-                        onOpenSearch={() => setSearchOpen(true)}
-                        onScreenshot={handleScreenshotTerminal}
-                      />
-                    )}
-                    renderTileBody={renderCanvasTileBody}
-                  />
-                ))
-                .exhaustive()}
-            </RightPanelLayout>
-          </Show>
-        </Show>
-      </div>
+      <AppRoutes workspacePage={WorkspacePage} />
     </div>
   );
 };

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -44,7 +44,6 @@ import { useRecorder } from "./recorder/useRecorder";
 import type { TerminalId } from "kolu-common";
 import { client, wsStatus, serverProcessId } from "./rpc/rpc";
 import TransportOverlay from "./rpc/TransportOverlay";
-import AppRoutes from "./AppRoutes";
 import { useTerminals } from "./terminal/useTerminals";
 import { useThemeManager } from "./useThemeManager";
 import { useShortcuts } from "./input/useShortcuts";
@@ -556,7 +555,7 @@ const App: Component = () => {
           if (target) void worktree.handleKillWorktree(target.id);
         }}
       />
-      <AppRoutes workspacePage={WorkspacePage} />
+      <WorkspacePage />
     </div>
   );
 };

--- a/packages/client/src/AppRoutes.test.tsx
+++ b/packages/client/src/AppRoutes.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect } from "vitest";
+import { afterAll, beforeAll, describe, it, expect, vi } from "vitest";
 import { render } from "solid-js/web";
 import { Router } from "@solidjs/router";
 import AppRoutes from "./AppRoutes";
@@ -25,6 +25,14 @@ function renderAt(path: string) {
     },
   };
 }
+
+beforeAll(() => {
+  vi.stubGlobal("scrollTo", vi.fn());
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("AppRoutes", () => {
   it("renders the workspace page at /workspace", () => {

--- a/packages/client/src/AppRoutes.test.tsx
+++ b/packages/client/src/AppRoutes.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from "vitest";
+import { render } from "solid-js/web";
+import { Router } from "@solidjs/router";
+import AppRoutes from "./AppRoutes";
+
+function renderAt(path: string) {
+  window.history.replaceState({}, "", path);
+  const container = document.createElement("div");
+  document.body.append(container);
+  const dispose = render(
+    () => (
+      <Router>
+        <AppRoutes workspacePage={() => <div>Workspace sentinel</div>} />
+      </Router>
+    ),
+    container,
+  );
+  return {
+    container,
+    dispose: () => {
+      dispose();
+      container.remove();
+    },
+  };
+}
+
+describe("AppRoutes", () => {
+  it("renders the workspace page at /workspace", () => {
+    const view = renderAt("/workspace");
+    expect(view.container.textContent).toContain("Workspace sentinel");
+    view.dispose();
+  });
+
+  it("renders the board placeholder at /board with a workspace link", () => {
+    const view = renderAt("/board");
+    expect(view.container.textContent).toContain("Board coming soon");
+    const link = view.container.querySelector("a[href='/workspace']");
+    expect(link).not.toBeNull();
+    view.dispose();
+  });
+
+  it("redirects / to /workspace", async () => {
+    const view = renderAt("/");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(window.location.pathname).toBe("/workspace");
+    expect(view.container.textContent).toContain("Workspace sentinel");
+    view.dispose();
+  });
+});

--- a/packages/client/src/AppRoutes.tsx
+++ b/packages/client/src/AppRoutes.tsx
@@ -2,6 +2,7 @@ import type { Component } from "solid-js";
 import { Navigate, Route } from "@solidjs/router";
 import BoardPlaceholder from "./BoardPlaceholder";
 
+/** Top-level app routes for the minimal Mani OS navigation slice. */
 const AppRoutes: Component<{
   workspacePage: Component;
 }> = (props) => (

--- a/packages/client/src/AppRoutes.tsx
+++ b/packages/client/src/AppRoutes.tsx
@@ -1,0 +1,31 @@
+import type { Component } from "solid-js";
+import { A, Navigate, Route } from "@solidjs/router";
+
+const BoardPlaceholder: Component = () => (
+  <main class="flex flex-1 items-center justify-center px-6 py-10">
+    <div class="max-w-md rounded-2xl border border-edge bg-surface-1 p-6 text-center shadow-lg">
+      <h1 class="text-xl font-semibold text-fg">Board coming soon</h1>
+      <p class="mt-2 text-sm text-fg-3">
+        The board route is wired up, but the board UI is not implemented yet.
+      </p>
+      <A
+        href="/workspace"
+        class="mt-5 inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-surface-1 hover:opacity-90"
+      >
+        Go to workspace
+      </A>
+    </div>
+  </main>
+);
+
+const AppRoutes: Component<{
+  workspacePage: Component;
+}> = (props) => (
+  <>
+    <Route path="/" component={() => <Navigate href="/workspace" />} />
+    <Route path="/workspace" component={props.workspacePage} />
+    <Route path="/board" component={BoardPlaceholder} />
+  </>
+);
+
+export default AppRoutes;

--- a/packages/client/src/AppRoutes.tsx
+++ b/packages/client/src/AppRoutes.tsx
@@ -1,22 +1,6 @@
 import type { Component } from "solid-js";
-import { A, Navigate, Route } from "@solidjs/router";
-
-const BoardPlaceholder: Component = () => (
-  <main class="flex flex-1 items-center justify-center px-6 py-10">
-    <div class="max-w-md rounded-2xl border border-edge bg-surface-1 p-6 text-center shadow-lg">
-      <h1 class="text-xl font-semibold text-fg">Board coming soon</h1>
-      <p class="mt-2 text-sm text-fg-3">
-        The board route is wired up, but the board UI is not implemented yet.
-      </p>
-      <A
-        href="/workspace"
-        class="mt-5 inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-surface-1 hover:opacity-90"
-      >
-        Go to workspace
-      </A>
-    </div>
-  </main>
-);
+import { Navigate, Route } from "@solidjs/router";
+import BoardPlaceholder from "./BoardPlaceholder";
 
 const AppRoutes: Component<{
   workspacePage: Component;

--- a/packages/client/src/BoardPlaceholder.tsx
+++ b/packages/client/src/BoardPlaceholder.tsx
@@ -1,0 +1,21 @@
+import type { Component } from "solid-js";
+import { A } from "@solidjs/router";
+
+const BoardPlaceholder: Component = () => (
+  <main class="flex flex-1 items-center justify-center px-6 py-10">
+    <div class="max-w-md rounded-2xl border border-edge bg-surface-1 p-6 text-center shadow-lg">
+      <h1 class="text-xl font-semibold text-fg">Board coming soon</h1>
+      <p class="mt-2 text-sm text-fg-3">
+        The board route is wired up, but the board UI is not implemented yet.
+      </p>
+      <A
+        href="/workspace"
+        class="mt-5 inline-flex items-center justify-center rounded-lg bg-accent px-4 py-2 text-sm font-medium text-surface-1 hover:opacity-90"
+      >
+        Go to workspace
+      </A>
+    </div>
+  </main>
+);
+
+export default BoardPlaceholder;

--- a/packages/client/src/BoardPlaceholder.tsx
+++ b/packages/client/src/BoardPlaceholder.tsx
@@ -1,6 +1,7 @@
 import type { Component } from "solid-js";
 import { A } from "@solidjs/router";
 
+/** Temporary board route until the real board UI lands. */
 const BoardPlaceholder: Component = () => (
   <main class="flex flex-1 items-center justify-center px-6 py-10">
     <div class="max-w-md rounded-2xl border border-edge bg-surface-1 p-6 text-center shadow-lg">

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 import { render } from "solid-js/web";
 import { MetaProvider } from "@solidjs/meta";
+import { Router } from "@solidjs/router";
 import App from "./App";
 import "./index.css";
 
@@ -21,7 +22,9 @@ if (import.meta.env.DEV) {
 render(
   () => (
     <MetaProvider>
-      <App />
+      <Router>
+        <App />
+      </Router>
     </MetaProvider>
   ),
   document.body,

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -3,6 +3,7 @@ import { render } from "solid-js/web";
 import { MetaProvider } from "@solidjs/meta";
 import { Router } from "@solidjs/router";
 import App from "./App";
+import AppRoutes from "./AppRoutes";
 import "./index.css";
 
 // Unregister any stale service worker in dev mode — production SW from a previous
@@ -23,7 +24,7 @@ render(
   () => (
     <MetaProvider>
       <Router>
-        <App />
+        <AppRoutes workspacePage={App} />
       </Router>
     </MetaProvider>
   ),

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vitest/config";
+import solid from "vite-plugin-solid";
 
 export default defineConfig({
+  plugins: [solid()],
   test: {
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });

--- a/packages/tests/features/smoke.feature
+++ b/packages/tests/features/smoke.feature
@@ -1,9 +1,15 @@
 Feature: Smoke
   Basic checks that the app loads and responds.
 
-  Scenario: Page loads with branding
+  Scenario: Root route redirects to the workspace
     When I open the app
-    Then the canvas watermark should contain "kolu"
+    Then the current URL path should be "/workspace"
+    And the canvas watermark should contain "kolu"
+
+  Scenario: Board route shows the placeholder page
+    When I open "/board"
+    Then the page should contain "Board coming soon"
+    And the page should have a link to "/workspace"
 
   Scenario: Health endpoint responds
     When I request "/api/health"

--- a/packages/tests/step_definitions/smoke_steps.ts
+++ b/packages/tests/step_definitions/smoke_steps.ts
@@ -6,11 +6,23 @@ When("I open the app", async function (this: KoluWorld) {
   await this.page.goto("/");
 });
 
+When("I open {string}", async function (this: KoluWorld, path: string) {
+  await this.page.goto(path);
+});
+
 When("I request {string}", async function (this: KoluWorld, path: string) {
   const resp = await this.page.request.get(path);
   this.lastResponseOk = resp.ok();
   this.lastResponseText = await resp.text();
 });
+
+Then(
+  "the current URL path should be {string}",
+  async function (this: KoluWorld, expected: string) {
+    await this.page.waitForURL(`**${expected}`);
+    assert.strictEqual(new URL(this.page.url()).pathname, expected);
+  },
+);
 
 Then(
   "the canvas watermark should contain {string}",
@@ -22,6 +34,29 @@ Then(
       content?.includes(text),
       `Watermark "${content}" does not contain "${text}"`,
     );
+  },
+);
+
+Then(
+  "the page should contain {string}",
+  async function (this: KoluWorld, text: string) {
+    await this.page.waitForFunction(
+      (expected) => document.body.textContent?.includes(expected) ?? false,
+      text,
+    );
+    const content = await this.page.locator("body").textContent();
+    assert.ok(
+      content?.includes(text),
+      `Page content "${content}" does not contain "${text}"`,
+    );
+  },
+);
+
+Then(
+  "the page should have a link to {string}",
+  async function (this: KoluWorld, href: string) {
+    const link = this.page.locator(`a[href="${href}"]`);
+    await link.waitFor({ state: "visible" });
   },
 );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       '@solidjs/meta':
         specifier: ^0.29.4
         version: 0.29.4(solid-js@1.9.11)
+      '@solidjs/router':
+        specifier: ^0.16.1
+        version: 0.16.1(solid-js@1.9.11)
       '@thisbeyond/solid-dnd':
         specifier: ^0.7.5
         version: 0.7.5(solid-js@1.9.11)
@@ -116,6 +119,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.0
         version: 4.2.2(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       kolu-common:
         specifier: workspace:*
         version: link:../common
@@ -139,7 +145,7 @@ importers:
         version: 2.11.11(solid-js@1.9.11)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/common:
     dependencies:
@@ -192,7 +198,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/integrations/claude-code:
     dependencies:
@@ -217,7 +223,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/integrations/codex:
     dependencies:
@@ -239,7 +245,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/integrations/git:
     dependencies:
@@ -264,7 +270,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/integrations/github:
     dependencies:
@@ -286,7 +292,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/integrations/opencode:
     dependencies:
@@ -308,7 +314,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/memorable-names:
     devDependencies:
@@ -317,7 +323,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/server:
     dependencies:
@@ -417,7 +423,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/terminal-themes:
     dependencies:
@@ -430,7 +436,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/tests:
     devDependencies:
@@ -469,6 +475,21 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -975,6 +996,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1008,6 +1033,42 @@ packages:
     resolution: {integrity: sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA==}
     peerDependencies:
       solid-js: ^1.8
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@cucumber/ci-environment@13.0.0':
     resolution: {integrity: sha512-cs+3NzfNkGbcmHPddjEv4TKFiBpZRQ6WJEEufB9mw+ExS22V/4R/zpDSEG+fsJ/iSNCd6A2sATdY8PFOyY3YnA==}
@@ -1378,6 +1439,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1902,6 +1972,11 @@ packages:
     peerDependencies:
       solid-js: '>=1.8.4'
 
+  '@solidjs/router@0.16.1':
+    resolution: {integrity: sha512-IhyjedgC6LRpw/8CPGGI89FrV+r0xTHzOl2c4CRyzYQ1bLepJxbVI1LLKvsavMWY5TRBRacV7hAeOhuTXkjiqg==}
+    peerDependencies:
+      solid-js: ^1.8.6
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2245,6 +2320,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -2379,8 +2457,16 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2409,6 +2495,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -2480,6 +2569,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -2771,6 +2864,10 @@ packages:
     resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
 
@@ -2883,6 +2980,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2965,6 +3065,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3116,6 +3225,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -3246,6 +3358,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -3488,6 +3603,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
@@ -3739,6 +3858,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -3795,6 +3917,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -3802,8 +3931,16 @@ packages:
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -3884,6 +4021,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -4050,8 +4191,24 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -4149,9 +4306,16 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -4204,6 +4368,26 @@ snapshots:
       ajv: 8.18.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4868,6 +5052,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -4910,6 +5098,30 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.7.6
       solid-js: 1.9.11
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@cucumber/ci-environment@13.0.0': {}
 
@@ -5173,6 +5385,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.4':
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -5723,6 +5937,10 @@ snapshots:
     dependencies:
       solid-js: 1.9.11
 
+  '@solidjs/router@0.16.1(solid-js@1.9.11)':
+    dependencies:
+      solid-js: 1.9.11
+
   '@standard-schema/spec@1.1.0': {}
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
@@ -6049,6 +6267,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.16: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -6189,7 +6411,19 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -6220,6 +6454,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+
+  decimal.js@10.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -6281,6 +6517,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@3.0.0: {}
 
@@ -6676,6 +6914,12 @@ snapshots:
     dependencies:
       lru-cache: 11.2.7
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-entities@2.3.3: {}
 
   http-errors@2.0.1:
@@ -6784,6 +7028,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -6854,6 +7100,32 @@ snapshots:
   js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -6969,6 +7241,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.27.1: {}
+
   media-typer@1.1.0: {}
 
   merge-anything@5.1.7:
@@ -7082,6 +7356,10 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   parseurl@1.3.3: {}
 
@@ -7373,6 +7651,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   secure-json-parse@4.1.0: {}
 
   seed-random@2.2.0: {}
@@ -7662,6 +7944,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tagged-tag@1.0.0: {}
 
   tailwindcss@4.2.2: {}
@@ -7711,11 +7995,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   toidentifier@1.0.1: {}
 
   toposort@2.0.2: {}
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
   tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -7803,6 +8101,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -7895,7 +8195,7 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@22.19.15)(jsdom@29.0.2)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -7919,10 +8219,27 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@4.0.2: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@7.1.0:
     dependencies:
@@ -8099,7 +8416,11 @@ snapshots:
 
   ws@8.19.0: {}
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
**Kolu now has navigation URLs** : `/` redirects to `/workspace`, the existing terminal canvas lives at `/workspace`, and `/board` is reserved as a temporary placeholder instead of being folded into the workspace view. That gives us a clean place to start layering navigation without disturbing the current terminal experience.

The important detail is *where the routing boundary sits*. The workspace stays intact as the current Kolu app, while the route table lives separately and smoke coverage now exercises both the redirect and the placeholder path. *This keeps the change intentionally small*: no board domain work yet, no task/project model yet, just enough structure to start building the shell one route at a time.