### PR TITLE
Stop serving stale client assets after deploys

### DIFF
--- a/packages/client/src/pwa.ts
+++ b/packages/client/src/pwa.ts
@@ -25,7 +25,14 @@
  * chain short-circuits and the reload proceeds as a plain navigation.
  */
 export async function forceUpdateAndReload(): Promise<void> {
-  const reg = await navigator.serviceWorker?.getRegistration();
-  await reg?.update();
+  try {
+    const reg = await navigator.serviceWorker?.getRegistration();
+    await reg?.update();
+  } catch (err) {
+    // Best-effort: the user clicked Reload, honour that intent even if the
+    // SW update couldn't complete (network drop mid-click, script parse
+    // error, etc.). Log so a chronically-failing update doesn't hide.
+    console.warn("SW update before reload failed:", err);
+  }
   location.reload();
 }

--- a/packages/client/src/pwa.ts
+++ b/packages/client/src/pwa.ts
@@ -1,0 +1,31 @@
+/**
+ * PWA deploy-synchronization helpers. Owns "make sure the user's next
+ * navigation lands on the fresh build" — so callers (right now just the
+ * `TransportOverlay` restart button) don't have to know about
+ * `navigator.serviceWorker` at all.
+ *
+ * Extracting this boundary also means future additions (version-hash
+ * comparison, install-progress UI, analytics on reload) land here instead
+ * of growing a `TransportOverlay` whose declared role is transport-state
+ * display, not SW lifecycle.
+ */
+
+/**
+ * Install any pending service-worker update, then reload the page.
+ *
+ * Without the `update()` await, the reload serves the old Workbox precache
+ * while the new SW is still installing — the user sees stale UI until a
+ * *second* reload. Awaiting the Update algorithm (§3.2.8 of the SW spec)
+ * ensures the new SW has installed and (with `skipWaiting`+`clientsClaim`,
+ * which vite-plugin-pwa's autoUpdate mode enables by default) is controlling
+ * the page before navigation fires.
+ *
+ * Safe on HTTP: `navigator.serviceWorker` is `undefined` in insecure
+ * contexts per the `[SecureContext]` IDL annotation, so the optional
+ * chain short-circuits and the reload proceeds as a plain navigation.
+ */
+export async function forceUpdateAndReload(): Promise<void> {
+  const reg = await navigator.serviceWorker?.getRegistration();
+  await reg?.update();
+  location.reload();
+}

--- a/packages/client/src/rpc/TransportOverlay.tsx
+++ b/packages/client/src/rpc/TransportOverlay.tsx
@@ -45,7 +45,18 @@ const TransportOverlay: Component = () => {
                 <button
                   type="button"
                   class="bg-accent text-surface-1 font-semibold rounded px-3 py-1.5 hover:opacity-90"
-                  onClick={() => location.reload()}
+                  onClick={async () => {
+                    // Force the SW update to install *before* reload, so the
+                    // single navigation below lands on the fresh SW. Without
+                    // this, `location.reload()` serves old precached assets
+                    // while the new SW is still installing — the user sees
+                    // stale UI until a second reload. No-op on HTTP
+                    // (serviceWorker is undefined in insecure contexts).
+                    const reg =
+                      await navigator.serviceWorker?.getRegistration();
+                    await reg?.update();
+                    location.reload();
+                  }}
                 >
                   Reload
                 </button>

--- a/packages/client/src/rpc/TransportOverlay.tsx
+++ b/packages/client/src/rpc/TransportOverlay.tsx
@@ -13,6 +13,7 @@
 import { type Component, Show } from "solid-js";
 import { match } from "ts-pattern";
 import { lifecycle } from "./rpc";
+import { forceUpdateAndReload } from "../pwa";
 
 const TransportOverlay: Component = () => {
   const visible = () => {
@@ -45,18 +46,7 @@ const TransportOverlay: Component = () => {
                 <button
                   type="button"
                   class="bg-accent text-surface-1 font-semibold rounded px-3 py-1.5 hover:opacity-90"
-                  onClick={async () => {
-                    // Force the SW update to install *before* reload, so the
-                    // single navigation below lands on the fresh SW. Without
-                    // this, `location.reload()` serves old precached assets
-                    // while the new SW is still installing — the user sees
-                    // stale UI until a second reload. No-op on HTTP
-                    // (serviceWorker is undefined in insecure contexts).
-                    const reg =
-                      await navigator.serviceWorker?.getRegistration();
-                    await reg?.update();
-                    location.reload();
-                  }}
+                  onClick={forceUpdateAndReload}
                 >
                   Reload
                 </button>

--- a/packages/server/src/cacheControl.ts
+++ b/packages/server/src/cacheControl.ts
@@ -1,0 +1,27 @@
+/**
+ * HTTP `Cache-Control` policy for static assets. Pure path→directive map so
+ * the server route file stays route-topology only.
+ *
+ * Three classes:
+ * - Vite-hashed `/assets/*` — content-addressed, pin forever.
+ * - SPA shell + service-worker scripts — must revalidate on every request so
+ *   deploys roll out on first reload (Workbox precache can otherwise serve
+ *   stale assets indefinitely; on HTTP deploys where SW is disabled by the
+ *   secure-context rule, browser heuristic caching does the same).
+ * - Everything else — no opinion, let the upstream default stand.
+ */
+export function getCacheControlHeader(path: string): string | null {
+  if (path.startsWith("/assets/")) {
+    return "public, max-age=31536000, immutable";
+  }
+  if (
+    path === "/" ||
+    path === "/index.html" ||
+    path === "/sw.js" ||
+    path === "/registerSW.js" ||
+    /^\/workbox-[^/]+\.js$/.test(path)
+  ) {
+    return "no-cache, must-revalidate";
+  }
+  return null;
+}

--- a/packages/server/src/cacheControl.ts
+++ b/packages/server/src/cacheControl.ts
@@ -10,17 +10,19 @@
  *   secure-context rule, browser heuristic caching does the same).
  * - Everything else — no opinion, let the upstream default stand.
  */
+const REVALIDATE_PATHS = new Set([
+  "/",
+  "/index.html",
+  "/sw.js",
+  "/registerSW.js",
+]);
+const WORKBOX_CHUNK = /^\/workbox-[^/]+\.js$/;
+
 export function getCacheControlHeader(path: string): string | null {
   if (path.startsWith("/assets/")) {
     return "public, max-age=31536000, immutable";
   }
-  if (
-    path === "/" ||
-    path === "/index.html" ||
-    path === "/sw.js" ||
-    path === "/registerSW.js" ||
-    /^\/workbox-[^/]+\.js$/.test(path)
-  ) {
+  if (REVALIDATE_PATHS.has(path) || WORKBOX_CHUNK.test(path)) {
     return "no-cache, must-revalidate";
   }
   return null;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -163,9 +163,28 @@ app.get("/manifest.webmanifest", (c) => {
 });
 
 // --- Static files (production) ---
+// Cache policy: Vite hashes files under /assets/ so they're safe to pin
+// forever; the SPA shell and SW scripts must revalidate so deploys roll
+// out on the first reload instead of sticking to stale Workbox precache
+// (or stale browser heuristic cache on HTTP deployments where SW is disabled).
 const clientDist = process.env.KOLU_CLIENT_DIST;
 if (clientDist) {
   const root = resolve(clientDist);
+  app.use("/*", async (c, next) => {
+    const path = c.req.path;
+    if (path.startsWith("/assets/")) {
+      c.header("Cache-Control", "public, max-age=31536000, immutable");
+    } else if (
+      path === "/" ||
+      path === "/index.html" ||
+      path === "/sw.js" ||
+      path === "/registerSW.js" ||
+      /^\/workbox-[^/]+\.js$/.test(path)
+    ) {
+      c.header("Cache-Control", "no-cache, must-revalidate");
+    }
+    return next();
+  });
   app.use("/*", serveStatic({ root }));
   app.get("/*", serveStatic({ root, path: "index.html" }));
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -19,6 +19,7 @@ import { configureNixShellEnv } from "./shell.ts";
 import { serverHostname } from "./hostname.ts";
 import { ensureKoluRoot, shutdownCleanup } from "./koluRoot.ts";
 import { startDiagnostics } from "./diagnostics.ts";
+import { getCacheControlHeader } from "./cacheControl.ts";
 import pkg from "../package.json" with { type: "json" };
 
 const argv = cli({
@@ -163,26 +164,12 @@ app.get("/manifest.webmanifest", (c) => {
 });
 
 // --- Static files (production) ---
-// Cache policy: Vite hashes files under /assets/ so they're safe to pin
-// forever; the SPA shell and SW scripts must revalidate so deploys roll
-// out on the first reload instead of sticking to stale Workbox precache
-// (or stale browser heuristic cache on HTTP deployments where SW is disabled).
 const clientDist = process.env.KOLU_CLIENT_DIST;
 if (clientDist) {
   const root = resolve(clientDist);
   app.use("/*", async (c, next) => {
-    const path = c.req.path;
-    if (path.startsWith("/assets/")) {
-      c.header("Cache-Control", "public, max-age=31536000, immutable");
-    } else if (
-      path === "/" ||
-      path === "/index.html" ||
-      path === "/sw.js" ||
-      path === "/registerSW.js" ||
-      /^\/workbox-[^/]+\.js$/.test(path)
-    ) {
-      c.header("Cache-Control", "no-cache, must-revalidate");
-    }
+    const directive = getCacheControlHeader(c.req.path);
+    if (directive) c.header("Cache-Control", directive);
     return next();
   });
   app.use("/*", serveStatic({ root }));


### PR DESCRIPTION
Restarting the Kolu PWA after a deploy would sometimes leave the app running on yesterday's JavaScript, CSS, or HTML — **the first page load after a deploy now reliably lands on the fresh build**. There were two independent causes, one that hit every user and one that hit only service-worker-capable deployments.

On the server side, Hono's `serveStatic` emits no `Cache-Control`, `ETag`, or `Last-Modified` headers, so browsers fell back to heuristic caching on every asset including `index.html`. A small middleware (`cacheControl.ts`) now pins hashed `/assets/*` as `immutable` forever and forces `no-cache, must-revalidate` on the SPA shell and service-worker scripts. _This is the only fix that helps users running Kolu over plain HTTP_, where service workers are disabled by the secure-context rule and there's no Workbox safety net to update independently.

On SW-capable deployments (`localhost` or HTTPS), the _"Server updated — Reload"_ modal called `location.reload()` synchronously. The old service worker would then serve the reloaded page from its Workbox precache while the new one was still installing in parallel, leaving the user on stale UI until a second reload. A new `forceUpdateAndReload` helper in `pwa.ts` awaits `registration.update()` first, so the new SW — already configured with `skipWaiting` + `clientsClaim` by vite-plugin-pwa's autoUpdate defaults — is controlling the page by the time navigation fires. _No-op on HTTP: `navigator.serviceWorker` is `undefined` in insecure contexts per the `[SecureContext]` IDL annotation, so the optional chain gracefully falls through to a plain reload._

> The commit history reads as a progression: primary fix, two Lowy-driven extractions that pull the cache-policy and SW-update concerns out of `index.ts` and `TransportOverlay.tsx`, a fact-check fix that catches `update()` rejection so the user's reload intent is honoured even when the update attempt fails, and an elegance pass naming the revalidate path set.