### PR TITLE
Copy branch names from terminal titles

### DIFF
--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -11,11 +11,13 @@
  *  exported below for reuse. */
 
 import { type Component, Show } from "solid-js";
+import { toast } from "solid-sonner";
 import { prValue, prUnavailableSource } from "kolu-common/pr";
 import ChecksIndicator from "./ChecksIndicator";
 import Tip from "../ui/Tip";
 import { PrStateIcon, WorktreeIcon } from "../ui/Icons";
 import { PrUnavailableButton } from "./PrUnavailablePopover";
+import { writeTextToClipboard } from "./clipboard";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 
 const TerminalMeta: Component<{
@@ -92,9 +94,24 @@ const TerminalMeta: Component<{
                 <Tip label={git().branch}>
                   <span
                     data-testid="terminal-meta-branch"
-                    class="truncate shrink-0 max-w-[16ch]"
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Copy branch ${git().branch} to clipboard`}
+                    class="truncate shrink-0 max-w-[16ch] cursor-copy hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded-sm"
                     style={{ color: info().branchColor }}
                     classList={{ "text-fg-2": !info().branchColor }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void copyBranchName(git().branch);
+                    }}
+                    onDblClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => {
+                      if (e.key !== "Enter" && e.key !== " ") return;
+                      e.preventDefault();
+                      e.stopPropagation();
+                      void copyBranchName(git().branch);
+                    }}
                   >
                     {git().branch}
                   </span>
@@ -139,6 +156,16 @@ const TerminalMeta: Component<{
     </Show>
   );
 };
+
+async function copyBranchName(branch: string): Promise<void> {
+  try {
+    await writeTextToClipboard(branch);
+    toast.success("Copied branch name to clipboard");
+  } catch (err) {
+    console.error("Failed to copy branch name:", err);
+    toast.error(`Failed to copy branch name: ${(err as Error).message}`);
+  }
+}
 
 /** Mobile pull-handle one-row variant — repo + branch + #PR inline.
  *  Mirrors what the pill tree shows for a focused terminal; the full

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -11,13 +11,12 @@
  *  exported below for reuse. */
 
 import { type Component, Show } from "solid-js";
-import { toast } from "solid-sonner";
 import { prValue, prUnavailableSource } from "kolu-common/pr";
 import ChecksIndicator from "./ChecksIndicator";
 import Tip from "../ui/Tip";
 import { PrStateIcon, WorktreeIcon } from "../ui/Icons";
 import { PrUnavailableButton } from "./PrUnavailablePopover";
-import { writeTextToClipboard } from "./clipboard";
+import { copyTextWithToast } from "./clipboard";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 
 const TerminalMeta: Component<{
@@ -102,7 +101,10 @@ const TerminalMeta: Component<{
                     onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => {
                       e.stopPropagation();
-                      void copyBranchName(git().branch);
+                      void copyTextWithToast(git().branch, {
+                        success: "Copied branch name to clipboard",
+                        failure: "Failed to copy branch name",
+                      });
                     }}
                     onDblClick={(e) => e.stopPropagation()}
                   >
@@ -149,16 +151,6 @@ const TerminalMeta: Component<{
     </Show>
   );
 };
-
-async function copyBranchName(branch: string): Promise<void> {
-  try {
-    await writeTextToClipboard(branch);
-    toast.success("Copied branch name to clipboard");
-  } catch (err) {
-    console.error("Failed to copy branch name:", err);
-    toast.error(`Failed to copy branch name: ${(err as Error).message}`);
-  }
-}
 
 /** Mobile pull-handle one-row variant — repo + branch + #PR inline.
  *  Mirrors what the pill tree shows for a focused terminal; the full

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -92,12 +92,11 @@ const TerminalMeta: Component<{
             {(git) => (
               <div class="flex items-center gap-1.5 min-w-0 text-xs">
                 <Tip label={git().branch}>
-                  <span
+                  <button
+                    type="button"
                     data-testid="terminal-meta-branch"
-                    role="button"
-                    tabIndex={0}
                     aria-label={`Copy branch ${git().branch} to clipboard`}
-                    class="truncate shrink-0 max-w-[16ch] cursor-copy hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded-sm"
+                    class="appearance-none bg-transparent border-0 p-0 text-left [font:inherit] truncate shrink-0 max-w-[16ch] cursor-copy hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded-sm"
                     style={{ color: info().branchColor }}
                     classList={{ "text-fg-2": !info().branchColor }}
                     onPointerDown={(e) => e.stopPropagation()}
@@ -106,15 +105,9 @@ const TerminalMeta: Component<{
                       void copyBranchName(git().branch);
                     }}
                     onDblClick={(e) => e.stopPropagation()}
-                    onKeyDown={(e) => {
-                      if (e.key !== "Enter" && e.key !== " ") return;
-                      e.preventDefault();
-                      e.stopPropagation();
-                      void copyBranchName(git().branch);
-                    }}
                   >
                     {git().branch}
-                  </span>
+                  </button>
                 </Tip>
                 <Show when={prValue(info().meta.pr)}>
                   {(pr) => (

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -95,7 +95,7 @@ const TerminalMeta: Component<{
                     type="button"
                     data-testid="terminal-meta-branch"
                     aria-label={`Copy branch ${git().branch} to clipboard`}
-                    class="appearance-none bg-transparent border-0 p-0 text-left [font:inherit] truncate shrink-0 max-w-[16ch] cursor-copy hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded-sm"
+                    class="appearance-none bg-transparent border-0 p-0 text-left [font:inherit] truncate shrink-0 max-w-[16ch] cursor-pointer hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 rounded-sm"
                     style={{ color: info().branchColor }}
                     classList={{ "text-fg-2": !info().branchColor }}
                     onPointerDown={(e) => e.stopPropagation()}

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -77,8 +77,7 @@ const TerminalMeta: Component<{
             </Show>
           </div>
 
-          {/* Branch + PR — combined row. Tooltip on branch shows full
-           *  name when truncated. PR (if present) follows inline:
+          {/* Branch + PR — combined row. PR (if present) follows inline:
            *  state icon, checks indicator, linked #N, truncated title. */}
           <Show
             when={info().meta.git}
@@ -90,7 +89,7 @@ const TerminalMeta: Component<{
           >
             {(git) => (
               <div class="flex items-center gap-1.5 min-w-0 text-xs">
-                <Tip label={git().branch}>
+                <Tip label="Copy branch name">
                   <button
                     type="button"
                     data-testid="terminal-meta-branch"
@@ -170,16 +169,14 @@ export const TerminalMetaCompact: Component<{
           </Show>
           <Show when={info().meta.git}>
             {(git) => (
-              <Tip label={git().branch}>
-                <span
-                  data-testid="terminal-meta-branch"
-                  class="text-xs truncate min-w-0"
-                  style={{ color: info().branchColor }}
-                  classList={{ "text-fg-2": !info().branchColor }}
-                >
-                  {git().branch}
-                </span>
-              </Tip>
+              <span
+                data-testid="terminal-meta-branch"
+                class="text-xs truncate min-w-0"
+                style={{ color: info().branchColor }}
+                classList={{ "text-fg-2": !info().branchColor }}
+              >
+                {git().branch}
+              </span>
             )}
           </Show>
           {/* Anchor stops propagation so a tap on the PR doesn't toggle

--- a/packages/client/src/terminal/clipboard.ts
+++ b/packages/client/src/terminal/clipboard.ts
@@ -14,6 +14,7 @@ import type {
   IClipboardProvider,
   ClipboardSelectionType,
 } from "@xterm/addon-clipboard";
+import { toast } from "solid-sonner";
 
 /** Write `text` to the system clipboard, falling back to execCommand when
  *  navigator.clipboard is unavailable or throws. Throws if both paths fail. */
@@ -38,6 +39,19 @@ export async function writeTextToClipboard(text: string): Promise<void> {
     if (!ok) throw new Error("clipboard access blocked");
   } finally {
     document.body.removeChild(textarea);
+  }
+}
+
+export async function copyTextWithToast(
+  text: string,
+  messages: { success: string; failure: string },
+): Promise<void> {
+  try {
+    await writeTextToClipboard(text);
+    toast.success(messages.success);
+  } catch (err) {
+    console.error(`${messages.failure}:`, err);
+    toast.error(`${messages.failure}: ${(err as Error).message}`);
   }
 }
 

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -7,7 +7,7 @@ import { toast } from "solid-sonner";
 import { availableThemes, resolveThemeBgs, pickTheme } from "terminal-themes";
 import { client } from "../rpc/rpc";
 import { useSubPanel } from "./useSubPanel";
-import { writeTextToClipboard } from "./clipboard";
+import { copyTextWithToast } from "./clipboard";
 import { useTips } from "../settings/useTips";
 import { usePreferences } from "../settings/usePreferences";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
@@ -180,8 +180,10 @@ export function useTerminalCrud(deps: {
     if (id === null) return;
     try {
       const text = await client.terminal.screenText({ id });
-      await writeTextToClipboard(text);
-      toast.success("Copied terminal text to clipboard");
+      await copyTextWithToast(text, {
+        success: "Copied terminal text to clipboard",
+        failure: "Failed to copy terminal text",
+      });
     } catch (err) {
       console.error("Failed to copy terminal text:", err);
       toast.error(`Failed to copy terminal text: ${(err as Error).message}`);

--- a/packages/tests/features/git-context.feature
+++ b/packages/tests/features/git-context.feature
@@ -56,6 +56,14 @@ Feature: Git context in header and pill tree
     And the pill tree branch should contain "test-branch"
     And there should be no page errors
 
+  Scenario: Clicking the terminal title branch copies the branch name
+    When I run "rm -rf /tmp/kolu-git-copy && git init /tmp/kolu-git-copy && cd /tmp/kolu-git-copy && git checkout -b copy-branch"
+    Then the pill tree branch should contain "copy-branch"
+    When I click the terminal title branch
+    Then a toast should appear with text "Copied branch name to clipboard"
+    And the clipboard should contain "copy-branch"
+    And there should be no page errors
+
   Scenario: Pill tree does not show PR info on default branch
     When I run "git init /tmp/kolu-pr-default && cd /tmp/kolu-pr-default"
     Then the header should show a branch name

--- a/packages/tests/features/git-context.feature
+++ b/packages/tests/features/git-context.feature
@@ -62,6 +62,8 @@ Feature: Git context in header and pill tree
     When I click the terminal title branch
     Then a toast should appear with text "Copied branch name to clipboard"
     And the clipboard should contain "copy-branch"
+    When I double-click the terminal title branch
+    Then no canvas tile should be maximized
     And there should be no page errors
 
   Scenario: Pill tree does not show PR info on default branch

--- a/packages/tests/step_definitions/git_context_steps.ts
+++ b/packages/tests/step_definitions/git_context_steps.ts
@@ -56,6 +56,20 @@ When("I click the terminal title branch", async function (this: KoluWorld) {
   await branch.click();
 });
 
+When(
+  "I double-click the terminal title branch",
+  async function (this: KoluWorld) {
+    const branch = this.page.locator(ACTIVE_TITLE_BRANCH_SELECTOR);
+    await branch.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await branch.evaluate((el) => {
+      el.dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+    await this.waitForFrame();
+  },
+);
+
 Then(
   "the pill tree should show a branch name",
   async function (this: KoluWorld) {

--- a/packages/tests/step_definitions/git_context_steps.ts
+++ b/packages/tests/step_definitions/git_context_steps.ts
@@ -47,6 +47,12 @@ Then(
   },
 );
 
+When("I click the terminal title branch", async function (this: KoluWorld) {
+  const branch = this.page.locator('[data-testid="terminal-meta-branch"]');
+  await branch.first().waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await branch.first().click();
+});
+
 Then(
   "the pill tree should show a branch name",
   async function (this: KoluWorld) {

--- a/packages/tests/step_definitions/git_context_steps.ts
+++ b/packages/tests/step_definitions/git_context_steps.ts
@@ -3,6 +3,9 @@ import { execFileSync } from "node:child_process";
 import { KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 import * as assert from "node:assert";
 
+const ACTIVE_TITLE_BRANCH_SELECTOR =
+  '[data-testid="canvas-tile"][data-active="true"] [data-testid="terminal-meta-branch"]';
+
 /** Wait for a data-testid element's text to include the given substring. */
 async function waitForTestIdText(
   world: KoluWorld,
@@ -48,9 +51,9 @@ Then(
 );
 
 When("I click the terminal title branch", async function (this: KoluWorld) {
-  const branch = this.page.locator('[data-testid="terminal-meta-branch"]');
-  await branch.first().waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-  await branch.first().click();
+  const branch = this.page.locator(ACTIVE_TITLE_BRANCH_SELECTOR);
+  await branch.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await branch.click();
 });
 
 Then(


### PR DESCRIPTION
**Terminal title branch labels now copy the branch name** with a click, matching the small copy affordances users expect in git-heavy workflows. The interaction uses the existing clipboard fallback path, so it works in the same secure and non-secure contexts as terminal text copy.

**The branch label is a native titlebar control** that absorbs the titlebar drag/maximize gestures around it. The e2e coverage checks both the clipboard/toast path and the double-click containment contract, with pane-text copy covered as a guard for the shared copy feedback helper.

Verified with `just check`, `just fmt`, and `just test-quick features/git-context.feature features/copy-pane-text.feature`.