### PR TITLE
Wire Biome v2 alongside Prettier as a lint-only gate

### DIFF
--- a/.apm/instructions/workflow.instructions.md
+++ b/.apm/instructions/workflow.instructions.md
@@ -16,11 +16,11 @@ These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
 
 ### Check command
 
-`just check` — fast static-correctness gate (`pnpm typecheck` under the hood). Runs across the workspace. CI's `ci::typecheck` step uses the same recipe.
+`just check` — fast static-correctness gate. Runs `pnpm typecheck` plus `biome lint` across the workspace. CI's `ci::typecheck` runs the typecheck half and `ci::biome` runs the lint half. `just lint` is a standalone recipe that mirrors `ci::biome`.
 
 ### Format command
 
-`just fmt`
+`just fmt` — runs Prettier over the workspace plus `nixpkgs-fmt` over `.nix` files. Biome v2 is installed (see [#710](https://github.com/juspay/kolu/issues/710)) and used only for linting in this PR; a follow-up flips formatting from Prettier to Biome. Config lives in `biome.jsonc` at the repo root.
 
 ### Test command
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -16,11 +16,11 @@ These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
 
 ### Check command
 
-`just check` — fast static-correctness gate (`pnpm typecheck` under the hood). Runs across the workspace. CI's `ci::typecheck` step uses the same recipe.
+`just check` — fast static-correctness gate. Runs `pnpm typecheck` plus `biome lint` across the workspace. CI's `ci::typecheck` runs the typecheck half and `ci::biome` runs the lint half. `just lint` is a standalone recipe that mirrors `ci::biome`.
 
 ### Format command
 
-`just fmt`
+`just fmt` — runs Prettier over the workspace plus `nixpkgs-fmt` over `.nix` files. Biome v2 is installed (see [#710](https://github.com/juspay/kolu/issues/710)) and used only for linting in this PR; a follow-up flips formatting from Prettier to Biome. Config lives in `biome.jsonc` at the repo root.
 
 ### Test command
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,11 @@ These commands are used by the `/do` workflow's check, fmt, test, and ci steps.
 
 ### Check command
 
-`just check` — fast static-correctness gate (`pnpm typecheck` under the hood). Runs across the workspace. CI's `ci::typecheck` step uses the same recipe.
+`just check` — fast static-correctness gate. Runs `pnpm typecheck` plus `biome lint` across the workspace. CI's `ci::typecheck` runs the typecheck half and `ci::biome` runs the lint half. `just lint` is a standalone recipe that mirrors `ci::biome`.
 
 ### Format command
 
-`just fmt`
+`just fmt` — runs Prettier over the workspace plus `nixpkgs-fmt` over `.nix` files. Biome v2 is installed (see [#710](https://github.com/juspay/kolu/issues/710)) and used only for linting in this PR; a follow-up flips formatting from Prettier to Biome. Config lives in `biome.jsonc` at the repo root.
 
 ### Test command
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-24T20:49:36.407737+00:00'
+generated_at: '2026-04-25T01:17:48.658870+00:00'
 apm_version: 0.10.0
 dependencies:
 - repo_url: anthropics/skills
@@ -147,5 +147,5 @@ local_deployed_file_hashes:
   .claude/rules/state.md: sha256:749fbd3452a8182f29c26df5e2f5671cbe2a88ddc97aef162a36645efccc4ccf
   .claude/rules/streaming.md: sha256:f67ae607dd8c4baf97c656d639452d82027ac295bb551d3dd774386101c5d0ec
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
-  .claude/rules/workflow.md: sha256:9fd3625ba30f63cd5ec7543fcc71cd3dbd80cf12d6a88da046c7f11b03a83543
+  .claude/rules/workflow.md: sha256:e59ab2618ffbadf208114d751c79cf06971bdd22dee0703ad768e8b3ab46eba2
   .opencode/commands/whatchanged.md: sha256:283ce7bfddb6213172b2a89259c2b89b65d063c6f1d156dd6ee2b98760183f69

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,151 @@
+// Phase 1 of #710: install Biome v2, wire `just lint` + `ci::biome` as a
+// correctness gate alongside the existing Prettier formatter. Scope is
+// intentionally the **toolchain only** — no formatting churn, no mass
+// lint-fix rewrites. Follow-up PRs enable each rule class one at a time
+// (per the issue's own "one PR per rule class" guidance) so each
+// correctness bucket is reviewable on its own.
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!pnpm-lock.yaml",
+      "!apm.lock.yaml",
+      "!AGENTS.md",
+      "!CLAUDE.md",
+      "!.claude/agents",
+      "!.claude/commands",
+      "!.claude/rules",
+      "!.claude/skills",
+      "!.claude/hooks",
+      "!.claude/settings.json",
+      "!.agents",
+      "!.codex",
+      "!.opencode",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/.direnv",
+      "!**/.logs",
+      "!patches",
+      // Astro files: frontmatter imports/consts are resolved inside the template
+      // body, which Biome doesn't parse — lint + format would false-positive
+      // and corrupt files. Astro has its own formatter (future: astro fmt).
+      "!**/*.astro",
+      // One-off heap-snapshot analyzers; not part of the product surface.
+      "!docs/perf-investigations/scripts",
+    ],
+  },
+  // Prettier remains the formatter (see justfile `fmt`). Biome's formatter
+  // is explicitly disabled here so `biome lint`/`biome check` runs don't
+  // emit a formatting diff across 200+ files. Follow-up PR: flip formatter
+  // on and land the one-shot format churn.
+  "formatter": {
+    "enabled": false,
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      // Each disable below is a Phase-1 scoping decision. Re-enabling is the
+      // charter of a follow-up PR (one per rule class) — additive, not
+      // structural. The baseline stays `recommended: true` so rules
+      // promoted in future Biome releases surface on the next upgrade.
+      //
+      // Accessibility pass — 88 findings across useButtonType,
+      // noSvgWithoutTitle, noStaticElementInteractions, etc.
+      "a11y": "off",
+      "style": {
+        // 136 sites use `!` non-null assertions idiomatically. Migration
+        // to `?? throw`/narrowing is a dedicated cleanup pass.
+        "noNonNullAssertion": "off",
+        // 12 sites of plain `+` string concat; stylistic.
+        "useTemplate": "off",
+        // 40 sites of `import X` that could be `import type X`; reorders
+        // imports across many files and reads as formatting churn.
+        "useImportType": "off",
+        // 2 sites where `export { FooType }` could be `export type { FooType }`.
+        "useExportType": "off",
+        // 3 sites of `Math.pow(a, b)` that could be `a ** b`.
+        "useExponentiationOperator": "off",
+        // 2 sites of `let` that could be `const`.
+        "useConst": "off",
+      },
+      "suspicious": {
+        // 32 sites of gradual-typing debt on `any`. Dedicated cleanup.
+        "noExplicitAny": "off",
+        // Terminal code legitimately parses ANSI escape sequences —
+        // the rule is a false positive against xterm diagnostics.
+        "noControlCharactersInRegex": "off",
+        // `isNaN(x)` → `Number.isNaN(x)` (3) and `isFinite(x)` →
+        // `Number.isFinite(x)` (2). Real coercion-bug risk; follow-up.
+        "noGlobalIsNan": "off",
+        "noGlobalIsFinite": "off",
+        // 1 production site of `while ((x = next()))`. Addressed in the
+        // same follow-up that flips noAssignInExpressions on globally.
+        "noAssignInExpressions": "off",
+        // 1 unused string escape.
+        "noUselessEscapeInString": "off",
+      },
+      "complexity": {
+        // Tailwind `!important` overrides are intentional in kolu's
+        // rare CSS escape-hatches.
+        "noImportantStyles": "off",
+        // 8 sites where `a && a.b` could be `a?.b`. Small but a rewrite;
+        // a follow-up applies `biome check --write` once for all of them.
+        "useOptionalChain": "off",
+        // 5 sites of `function () {}` callbacks that could be arrows.
+        "useArrowFunction": "off",
+        // 1 site of `let x = undefined;`.
+        "noUselessUndefinedInitialization": "off",
+        // 1 auto-fixable regex escape.
+        "noUselessEscapeInRegex": "off",
+      },
+      "correctness": {
+        // 25 sites of unused locals (8 imports, 17 vars). Mix of real
+        // dead code, Solid signal destructures that drop fields, and a
+        // few that want underscore renames — each category deserves a
+        // focused review rather than a sweeping auto-rename.
+        "noUnusedVariables": "off",
+        "noUnusedImports": "off",
+        // 3 sites of `parseInt(x)` without radix; real bug potential but a
+        // focused follow-up.
+        "useParseIntRadix": "off",
+        // 2 inline <script> var declarations in index.html — `let` rewrite
+        // belongs with other pre-paint-bootstrap cleanup.
+        "noInnerDeclarations": "off",
+      },
+    },
+  },
+  "css": {
+    // Kolu uses Tailwind v4 (`@theme`, `@plugin`, `@apply`) in both the
+    // client and the website — without this flag the CSS parser rejects
+    // those directives even on lint-only runs.
+    "parser": {
+      "tailwindDirectives": true,
+    },
+  },
+  "overrides": [
+    {
+      // Test code uses idioms production code doesn't: async generators
+      // that throw before yielding (error-path tests) and assign-in-expr
+      // patterns (indexOf loops, Cucumber world-scratch fields).
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "packages/tests/**"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useYield": "off",
+          },
+          "suspicious": {
+            "noAssignInExpressions": "off",
+          },
+        },
+      },
+    },
+  ],
+}

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -26,7 +26,7 @@ _run-all: _local _linux _darwin
 # their own GitHub status — _summary reads those statuses to decide
 # the final pass/fail.
 _local:
-    just ci::fmt ci::typecheck ci::unit ci::apm-sync || true
+    just ci::fmt ci::typecheck ci::biome ci::unit ci::apm-sync || true
 
 _linux:
     CI_SYSTEM=x86_64-linux just ci::pnpm-hash-fresh ci::nix ci::_linux-fanout || true
@@ -82,3 +82,8 @@ apm-sync:
 
 fmt:
     just ci::_run fmt just fmt-check
+
+# Biome lint — recommended preset with each currently-noisy rule explicitly
+# off in biome.jsonc. Each disabled rule has a follow-up PR slot (#710).
+biome:
+    just ci::_run biome "pnpm exec biome lint ."

--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-JcgFMcP48fOVxOPeUYncWdNTEkNS8Xggm2sP+I4iwOY=";
+    hash = "sha256-AQbDuMMjRultVzOqS/fLfR4a6E9smUxAQInsyWi8iZY=";
     fetcherVersion = 3;
   };
 
@@ -100,7 +100,7 @@ let
       # of 395MB, halving the I/O and Nix NAR hashing time.
       rm -rf packages/client/src packages/client/node_modules
       pushd node_modules/.pnpm
-      rm -rf typescript@* @esbuild* esbuild@* prettier@* \
+      rm -rf typescript@* @esbuild* esbuild@* prettier@* @biomejs* \
              lightningcss* rollup@* @rollup* \
              vitest@* @vitest* \
              vite@* vitefu@* vite-plugin-* @tailwindcss* tailwindcss@* \

--- a/justfile
+++ b/justfile
@@ -40,9 +40,13 @@ _dev: install _dev-parallel
 [parallel]
 _dev-parallel: server client
 
-# Run TypeScript type checking across all packages — fast static-correctness gate
+# Run TypeScript type checking + Biome lint across all packages — fast static-correctness gate
 check: install
-    {{ nix_shell }} pnpm typecheck
+    {{ nix_shell }} sh -c 'pnpm typecheck && pnpm exec biome lint .'
+
+# Biome lint only — mirrors ci::biome. Format stays on Prettier for now (see biome.jsonc).
+lint: install
+    {{ nix_shell }} pnpm exec biome lint .
 
 # Run server with auto-reload
 server:

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     }
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
     "prettier": "^3.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.13
+        version: 2.4.13
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -985,6 +988,63 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    resolution: {integrity: sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -5005,6 +5065,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-darwin-x64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    optional: true
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
**Biome v2 is installed and runs as a correctness gate** in `just check` and a new `ci::biome` status, but formatting still goes through Prettier. Shipping the toolchain and the formatter swap in one PR would have meant a two-hundred-file whitespace diff on top of real config changes — this PR is intentionally just the wiring, so follow-ups can land the formatter flip and per-rule-class cleanups in reviewable chunks. Phase 1 of #710.

The `biome.jsonc` baseline is `recommended: true` with each currently-noisy rule explicitly off and a one-line reason beside it — `noNonNullAssertion` fires at 136 sites, `useImportType` at 40, and so on. _Each disable is a follow-up PR's charter, not a permanent silencing: future Biome releases that promote new rules under `recommended` still fire on first run._ The Tailwind v4 directives parser is enabled so `@theme` and `@plugin` stop tripping the CSS lexer, and two surfaces — `*.astro` and `docs/perf-investigations/scripts` — are excluded because Biome can't safely reason about them (frontmatter refs in one, one-off heap-snapshot analyzers in the other).

The Nix side is a minor shuffle: `default.nix` adds `@biomejs*` to the installPhase dev-dep prune list so the runtime tarball doesn't balloon, and the `pnpmDeps` hash is bumped. `just lint` is a new standalone recipe that mirrors `ci::biome` so local and CI lint stay symmetric.

> **Deferred to follow-up PRs, each tracked under #710:** flip formatting from Prettier to Biome (lands the one-shot format churn); enable the three type-aware rules (`noFloatingPromises`, `noMisusedPromises`, `useExhaustiveSwitchCases`) once Scanner/project domain is wired; accessibility pass (88 findings); Solid-specific rules (`useSolidForComponent`, `noReactSpecificProps`); and one PR per remaining disabled rule class.

### Try it locally

```sh
nix develop github:juspay/kolu/feat/biome-v2-migration -c just lint
```