### PR TITLE
Turn on the real-bug Biome rules (coercion, scope, radix)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,10 +1,11 @@
-// Phase 3 of #710: turn on the lint rules whose fixes are mechanical
-// (Biome's safe `--write` applies them deterministically) so the bulk
-// of cheap correctness wins land in one auditable pass. Heavier rules
-// that require per-site judgment (noNonNullAssertion, noExplicitAny,
-// useTemplate, noUnusedVariables, the a11y group) remain off and get
-// dedicated PRs. Type-aware rules (noFloatingPromises etc.) require
-// Biome's Scanner/project domain — separate setup PR.
+// Phase 4 of #710: turn on the small "real-bug" rule class — coercion
+// hazards (noGlobalIsNan, noGlobalIsFinite, useParseIntRadix), inner
+// `var` declarations, and assign-in-expression — and fix every site by
+// hand, since these don't have safe auto-fixes. Heavier judgment-needed
+// rules (noNonNullAssertion, noExplicitAny, useTemplate, noUnused-
+// Variables, a11y) remain off and get dedicated PRs. Type-aware rules
+// (noFloatingPromises etc.) require Biome's Scanner/project domain —
+// separate setup PR.
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
@@ -89,14 +90,7 @@
         "noExplicitAny": "off",
         // Terminal code legitimately parses ANSI escape sequences —
         // the rule is a permanent false positive against xterm diagnostics.
-        "noControlCharactersInRegex": "off",
-        // `isNaN(x)` → `Number.isNaN(x)` (3) and `isFinite(x)` →
-        // `Number.isFinite(x)` (2). Real coercion-bug risk; follow-up.
-        "noGlobalIsNan": "off",
-        "noGlobalIsFinite": "off",
-        // 1 production site of `while ((x = next()))`. Addressed in the
-        // same follow-up that flips noAssignInExpressions on globally.
-        "noAssignInExpressions": "off"
+        "noControlCharactersInRegex": "off"
       },
       "complexity": {
         // Tailwind `!important` overrides are intentional in kolu's
@@ -107,13 +101,7 @@
         // 17 sites of unused locals — Solid signal destructures that drop
         // fields, a few that want underscore renames. Needs per-site review
         // rather than a sweeping auto-rename; deferred to its own PR.
-        "noUnusedVariables": "off",
-        // 3 sites of `parseInt(x)` without radix; real coercion-bug
-        // potential but no autofix — needs human pick of base.
-        "useParseIntRadix": "off",
-        // 2 inline <script> var declarations in index.html — `let` rewrite
-        // belongs with other pre-paint-bootstrap cleanup.
-        "noInnerDeclarations": "off"
+        "noUnusedVariables": "off"
       }
     }
   },

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -13,15 +13,17 @@
     <!-- Sync .dark class before first paint to prevent FOUC -->
     <script>
       try {
-        var s = JSON.parse(
+        const s = JSON.parse(
           localStorage.getItem("kolu-color-scheme") || '"dark"',
         );
-        var dark =
+        const dark =
           s === "dark" ||
           (s === "system" &&
             matchMedia("(prefers-color-scheme: dark)").matches);
         document.documentElement.classList.toggle("dark", dark);
-      } catch (e) {}
+      } catch {
+        // FOUC-sync must never throw — pre-paint runs before any error handler.
+      }
     </script>
   </head>
   <body>

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -63,7 +63,7 @@ const CanvasMinimap: Component<{
       maxX = Math.max(maxX, l.x + l.w);
       maxY = Math.max(maxY, l.y + l.h);
     }
-    if (!isFinite(minX))
+    if (!Number.isFinite(minX))
       return { minX: 0, minY: 0, maxX: 1, maxY: 1, w: 1, h: 1 };
     const padMinX = minX - MAP_PAD;
     const padMinY = minY - MAP_PAD;

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -292,7 +292,7 @@ const TerminalCanvas: Component<{
       maxX = Math.max(maxX, l.x + l.w);
       maxY = Math.max(maxY, l.y + l.h);
     }
-    if (!isFinite(minX)) return;
+    if (!Number.isFinite(minX)) return;
     requestAnimationFrame(() => {
       viewport.panTo((minX + maxX) / 2, (minY + maxY) / 2);
     });

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -87,7 +87,7 @@ function dispatch(
   advanceCycle: (direction: 1 | -1) => void,
 ): boolean {
   // Mod+1-9: switch to terminal by position
-  const digit = parseInt(e.key);
+  const digit = parseInt(e.key, 10);
   if (isPlatformModifier(e) && !e.shiftKey && digit >= 1 && digit <= 9) {
     const ids = deps.terminalIds();
     if (digit <= ids.length) deps.setActiveId(ids[digit - 1]!);

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -69,7 +69,8 @@ export function useSessionRestore(deps: {
     const subs: Record<TerminalId, TerminalId[]> = {};
     for (const t of existing) {
       if (t.meta.parentId) {
-        (subs[t.meta.parentId] ??= []).push(t.id);
+        subs[t.meta.parentId] ??= [];
+        subs[t.meta.parentId]!.push(t.id);
       }
     }
     for (const [parentId, subIds] of Object.entries(subs)) {

--- a/packages/tests/cucumber.js
+++ b/packages/tests/cucumber.js
@@ -1,4 +1,4 @@
-const parallel = parseInt(process.env.CUCUMBER_PARALLEL || "1");
+const parallel = parseInt(process.env.CUCUMBER_PARALLEL || "1", 10);
 
 // Only set default paths if no feature files were passed as CLI args.
 // CLI positional args (e.g. features/worktree.feature) are ignored when

--- a/packages/tests/step_definitions/claude_code_steps.ts
+++ b/packages/tests/step_definitions/claude_code_steps.ts
@@ -46,7 +46,8 @@ async function getTerminalPid(world: KoluWorld): Promise<number> {
       // Walk backwards from marker to find the PID (first purely numeric line).
       for (let i = markerIdx - 1; i >= 0; i--) {
         const num = parseInt(lines[i]!, 10);
-        if (!isNaN(num) && num > 0 && String(num) === lines[i]) return num;
+        if (!Number.isNaN(num) && num > 0 && String(num) === lines[i])
+          return num;
       }
       return null;
     },

--- a/packages/tests/step_definitions/terminal_steps.ts
+++ b/packages/tests/step_definitions/terminal_steps.ts
@@ -261,11 +261,11 @@ Then(
           return NaN;
         }
       },
-      (n) => !isNaN(n) && n > min,
+      (n) => !Number.isNaN(n) && n > min,
       { attempts: 30 },
     );
     assert.ok(
-      !isNaN(cols) && cols > min,
+      !Number.isNaN(cols) && cols > min,
       `Expected ${filePath} to contain a number > ${min}, got: "${cols}"`,
     );
   },

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -21,7 +21,7 @@ import type { Browser, BrowserContext, Page } from "playwright";
 import { chromium } from "playwright";
 import type { KoluWorld } from "./world.ts";
 
-const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0");
+const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0", 10);
 
 /** One base $TMPDIR per worker holds everything this test run creates:
  *  the kolu server's state dir and the Claude Code mock harness's


### PR DESCRIPTION
**Five Biome rules that catch actual bugs**, not stylistic ones, get flipped on and the eleven sites are fixed by hand. None of these have safe auto-fixes — that's why they sit in their own pass after the mechanical wave in #717. Phase 4 of #710.

The three coercion rules (`noGlobalIsNan`, `noGlobalIsFinite`, `useParseIntRadix`) fix real footguns: `isNaN("foo")` is `true` because the global form coerces, while `Number.isNaN("foo")` is `false`; `parseInt("010")` parses as octal on engines that still honor the legacy heuristic. The two scope rules (`noInnerDeclarations`, `noAssignInExpressions`) clean up a `var`-inside-`try` in the FOUC pre-paint hook (where var-hoisting was hiding the catch-block's intent) and a `(subs[k] ??= []).push(...)` map-default that splits cleanly into two lines.

_The test-file `overrides` block keeps `noAssignInExpressions` off for cucumber step definitions_ — those use `(idx = buf.indexOf(...)) !== -1` and similar idioms canonically, and rewriting them just to satisfy a rule disabled for tests would be circular. Production code passes the rule everywhere.

> Each fix is independently verifiable: every replacement preserves observable behavior, and the call sites that fed `isNaN` already had `parseInt`/`Number` inputs that produce real `NaN` values, so the stricter `Number.isNaN` keeps doing the right thing on those paths.