### PR TITLE
Wire Biome Scanner; turn on noFloatingPromises

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,11 +1,10 @@
-// Phase 4 of #710: turn on the small "real-bug" rule class — coercion
-// hazards (noGlobalIsNan, noGlobalIsFinite, useParseIntRadix), inner
-// `var` declarations, and assign-in-expression — and fix every site by
-// hand, since these don't have safe auto-fixes. Heavier judgment-needed
-// rules (noNonNullAssertion, noExplicitAny, useTemplate, noUnused-
-// Variables, a11y) remain off and get dedicated PRs. Type-aware rules
-// (noFloatingPromises etc.) require Biome's Scanner/project domain —
-// separate setup PR.
+// Phase 5 of #710: wire Biome's Scanner (project domain) and turn on
+// noFloatingPromises — the flagship rule from the original ticket.
+// Catches unawaited promises that silently swallow errors, which is
+// the kind of bug tsc's strict mode can't see. Future PRs enable the
+// other type-aware rules (noMisusedPromises, useExhaustiveSwitchCases)
+// one at a time. Still-off rules (noNonNullAssertion, noExplicitAny,
+// useTemplate, noUnusedVariables, a11y) keep their dedicated PR slots.
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
@@ -68,8 +67,19 @@
   },
   "linter": {
     "enabled": true,
+    // `project` domain unlocks Biome's type-aware rules (Scanner-backed).
+    // Per-rule opt-in: only the rules explicitly turned on below fire;
+    // Scanner runs lazily for files touched by those rules.
+    "domains": {
+      "project": "all"
+    },
     "rules": {
       "recommended": true,
+      "nursery": {
+        // Unawaited promises that silently swallow errors — the
+        // flagship motivation for adopting Biome (#710).
+        "noFloatingPromises": "error"
+      },
       // Each disable below is a Phase-1 scoping decision. Re-enabling is the
       // charter of a follow-up PR (one per rule class) — additive, not
       // structural. The baseline stays `recommended: true` so rules
@@ -90,7 +100,10 @@
         "noExplicitAny": "off",
         // Terminal code legitimately parses ANSI escape sequences —
         // the rule is a permanent false positive against xterm diagnostics.
-        "noControlCharactersInRegex": "off"
+        "noControlCharactersInRegex": "off",
+        // Project-domain rule: 31 cycles. Real architecture risk but
+        // each cycle needs judgment; own PR.
+        "noImportCycles": "off"
       },
       "complexity": {
         // Tailwind `!important` overrides are intentional in kolu's
@@ -101,7 +114,18 @@
         // 17 sites of unused locals — Solid signal destructures that drop
         // fields, a few that want underscore renames. Needs per-site review
         // rather than a sweeping auto-rename; deferred to its own PR.
-        "noUnusedVariables": "off"
+        "noUnusedVariables": "off",
+        // Project-domain rule: 293 sites of bare relative imports that
+        // would need `.ts`/`.tsx` extensions. Kolu uses TS's
+        // `moduleResolution: bundler` which resolves without extensions;
+        // flipping this on is an independent migration.
+        "useImportExtensions": "off",
+        // Project-domain rule: 39 findings. Triggers on path-aliased
+        // imports Biome's resolver doesn't understand the same way tsc
+        // does; dedicated follow-up needed to align them.
+        "noUnresolvedImports": "off",
+        // Project-domain rule: 1 finding. Own PR to audit.
+        "noUndeclaredDependencies": "off"
       }
     }
   },

--- a/packages/client/src/terminal/useTerminals.ts
+++ b/packages/client/src/terminal/useTerminals.ts
@@ -41,7 +41,10 @@ export function useTerminals() {
    *  itself is still removed via the list subscription in useTerminalStore,
    *  so correctness is preserved even if the toast is lost. */
   function subscribeExit(id: TerminalId) {
-    (async () => {
+    // Fire-and-forget: the IIFE owns its try/catch so the floating
+    // promise never rejects out into the caller. `void` makes the
+    // discard explicit for noFloatingPromises.
+    void (async () => {
       try {
         const iter = await stream.exit(id);
         for await (const code of iter) {

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -210,7 +210,10 @@ export function createSessionWatcher(
       onUpdate(info);
     }
 
-    refreshSummary();
+    // Fire-and-forget: refreshSummary owns its try/catch/finally and
+    // the pendingSummaryFetches counter. Not awaited so the caller
+    // (transcript-change handler) doesn't block on the network fetch.
+    void refreshSummary();
   }
 
   /** Incrementally scan the transcript for TaskCreate/TaskUpdate entries.


### PR DESCRIPTION
**Biome's type-aware lint is now live** — enabling the `project` domain in `biome.jsonc` lets the Scanner run, which unlocks the correctness rules that `tsc` structurally can't see. This PR flips on `noFloatingPromises`, the flagship rule quoted directly in the original motivation for #710 ("unawaited promises that swallow errors silently"). Phase 5 of #710.

Only two sites in the entire codebase fire the rule — both genuine fire-and-forget async patterns that already own their `try/catch`. A `void` prefix at each call site makes the discard explicit without changing behavior: `useTerminals.subscribeExit`'s async IIFE, and `session-watcher`'s `refreshSummary()` call from the transcript-change handler. _The small number of hits validates the codebase's existing promise hygiene — we didn't discover a pile of latent bugs, which is the boring-but-good outcome._

Enabling the `project` domain under `"all"` auto-enables several other project-aware rules beyond `noFloatingPromises`. Each sits at its own PR boundary now: `useImportExtensions` (293 sites — TS `bundler` resolution doesn't need the extensions), `noUnresolvedImports` (39 — path-alias resolver mismatch), `noImportCycles` (31 cycles), and `noUndeclaredDependencies` (1). Every disable has a one-line reason in `biome.jsonc` so re-enabling is the charter of a follow-up.

> **For reviewers:** the `void` prefix is Biome's idiomatic suppression for "I know this is a floating promise and it's fine." If you'd rather see `.catch(…)` or `toast.error(…)` at these sites, the inner try/catch already handles it — the rejection path is structurally unreachable.