### PR TITLE
Enable Biome's Solid-specific lint rules

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,10 +1,8 @@
-// Phase 5 of #710: wire Biome's Scanner (project domain) and turn on
-// noFloatingPromises — the flagship rule from the original ticket.
-// Catches unawaited promises that silently swallow errors, which is
-// the kind of bug tsc's strict mode can't see. Future PRs enable the
-// other type-aware rules (noMisusedPromises, useExhaustiveSwitchCases)
-// one at a time. Still-off rules (noNonNullAssertion, noExplicitAny,
-// useTemplate, noUnusedVariables, a11y) keep their dedicated PR slots.
+// Phase 6 of #710: turn on the Solid-specific rules from the original
+// ticket — noReactSpecificProps (catch React-only prop names leaking
+// into Solid components) and useSolidForComponent (prefer `<For />`
+// over `.map()` for reactive lists). Both live in Biome's `solid`
+// domain which auto-activates from the solid dependency.
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
@@ -79,6 +77,12 @@
         // Unawaited promises that silently swallow errors — the
         // flagship motivation for adopting Biome (#710).
         "noFloatingPromises": "error"
+      },
+      "performance": {
+        // Solid domain: prefer `<For each={…}>` over `items.map(…)` so
+        // list reactivity is keyed properly instead of re-rendering on
+        // every signal change.
+        "useSolidForComponent": "error"
       },
       // Each disable below is a Phase-1 scoping decision. Re-enabling is the
       // charter of a follow-up PR (one per rule class) — additive, not

--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -1,7 +1,7 @@
 /** Modal overlay showing all keyboard shortcuts. */
 
 import Dialog from "@corvu/dialog";
-import type { Component } from "solid-js";
+import { type Component, For } from "solid-js";
 import { formatKeybind, type Keybind, SHORTCUTS } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
 import ModalDialog from "./ui/ModalDialog";
@@ -49,15 +49,17 @@ const ShortcutsHelp: Component<{
         Keyboard Shortcuts
       </Dialog.Label>
       <div class="px-4 py-2">
-        {DISPLAY_SHORTCUTS.map((s) => (
-          <div class="flex items-center justify-between py-1.5">
-            <span class="text-sm text-fg-2">{s.label}</span>
-            <span class="flex items-center gap-1.5">
-              <Kbd>{formatKeybind(s.keybind)}</Kbd>
-              {s.altKeybind && <Kbd>{formatKeybind(s.altKeybind)}</Kbd>}
-            </span>
-          </div>
-        ))}
+        <For each={DISPLAY_SHORTCUTS}>
+          {(s) => (
+            <div class="flex items-center justify-between py-1.5">
+              <span class="text-sm text-fg-2">{s.label}</span>
+              <span class="flex items-center gap-1.5">
+                <Kbd>{formatKeybind(s.keybind)}</Kbd>
+                {s.altKeybind && <Kbd>{formatKeybind(s.altKeybind)}</Kbd>}
+              </span>
+            </div>
+          )}
+        </For>
       </div>
     </Dialog.Content>
   </ModalDialog>


### PR DESCRIPTION
**Turn on `noReactSpecificProps` and `useSolidForComponent`** — both called out by name in the original #710 motivation as the Solid-specific correctness layer Biome adds on top of its core rules. The codebase was already clean on the first (no React prop names leaking into Solid JSX), and the second surfaced exactly one site worth fixing.

`ShortcutsHelp.tsx` was rendering the static shortcut list with `DISPLAY_SHORTCUTS.map(...)` instead of Solid's `<For />`. Rewrote to `<For each={DISPLAY_SHORTCUTS}>{(s) => ...}</For>`. _This particular list is static, so the keyed rendering isn't strictly necessary here — but the real value of the rule is catching the next `.map` over a reactive list, which is where `<For />` matters._ Phase 6 of #710.