### PR TITLE
Biome tiny sweep: exhaustive switch + undeclared deps

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,8 +1,8 @@
-// Phase 6 of #710: turn on the Solid-specific rules from the original
-// ticket — noReactSpecificProps (catch React-only prop names leaking
-// into Solid components) and useSolidForComponent (prefer `<For />`
-// over `.map()` for reactive lists). Both live in Biome's `solid`
-// domain which auto-activates from the solid dependency.
+// Phase 7 of #710: tiny sweep — flip on two small rules to clear them
+// off the follow-up list. `useExhaustiveSwitchCases` closes out the
+// type-aware trifecta from the original ticket (alongside
+// noFloatingPromises and noMisusedPromises). `noUndeclaredDependencies`
+// had a single finding when the project domain was wired in #719.
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
@@ -76,7 +76,10 @@
       "nursery": {
         // Unawaited promises that silently swallow errors — the
         // flagship motivation for adopting Biome (#710).
-        "noFloatingPromises": "error"
+        "noFloatingPromises": "error",
+        // Type-aware exhaustiveness on discriminated unions — adding a
+        // new variant forces every `switch` site to handle it.
+        "useExhaustiveSwitchCases": "error"
       },
       "performance": {
         // Solid domain: prefer `<For each={…}>` over `items.map(…)` so
@@ -127,9 +130,7 @@
         // Project-domain rule: 39 findings. Triggers on path-aliased
         // imports Biome's resolver doesn't understand the same way tsc
         // does; dedicated follow-up needed to align them.
-        "noUnresolvedImports": "off",
-        // Project-domain rule: 1 finding. Own PR to audit.
-        "noUndeclaredDependencies": "off"
+        "noUnresolvedImports": "off"
       }
     }
   },

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@cucumber/cucumber": "^12.8.1",
     "get-port": "^7.2.0",
+    "kolu-common": "workspace:*",
     "playwright": "1.57.0",
     "tsx": "^4.19.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,9 @@ importers:
       get-port:
         specifier: ^7.2.0
         version: 7.2.0
+      kolu-common:
+        specifier: workspace:*
+        version: link:../common
       playwright:
         specifier: 1.57.0
         version: 1.57.0


### PR DESCRIPTION
**Two small Biome rules flipped on in one pass** to knock them off the #721 follow-up backlog. `useExhaustiveSwitchCases` closes the type-aware trifecta the original #710 pitch was built around (joining `noFloatingPromises` from #719), and `noUndeclaredDependencies` cleans up one workspace-link declaration the auto-unlocked project domain surfaced in #719.

The type-aware rule found **zero** findings — the one `switch` in the codebase already handles every discriminated-union variant, which is the boring-but-good outcome the Vercel stress-test framed as the expected case. Keeping the rule on catches the next `switch` that grows a missing case.

`noUndeclaredDependencies` found exactly **one** hit: `packages/tests/step_definitions/session_restore_steps.ts` imports a type from `kolu-common`, but `packages/tests/package.json` didn't list it. Added `"kolu-common": "workspace:*"` to devDependencies — matches how `packages/server` and `packages/client` declare the same workspace link. _The `pnpmDeps` hash is unchanged because workspace links don't fetch artifacts._

Closes 2 of 11 rows in #721.