### PR TITLE
Enable useTemplate; rewrite 12 string concats

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,8 +1,6 @@
-// Phase 7 of #710: tiny sweep — flip on two small rules to clear them
-// off the follow-up list. `useExhaustiveSwitchCases` closes out the
-// type-aware trifecta from the original ticket (alongside
-// noFloatingPromises and noMisusedPromises). `noUndeclaredDependencies`
-// had a single finding when the project domain was wired in #719.
+// Phase 8 of #710: flip on `useTemplate` — 12 sites of `"foo " + bar`
+// across server + client get rewritten to template literals. Biome
+// applies the fix automatically with safe `--write`.
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
@@ -98,9 +96,7 @@
       "style": {
         // 136 sites use `!` non-null assertions idiomatically. Migration
         // to `?? throw`/narrowing is a dedicated cleanup pass.
-        "noNonNullAssertion": "off",
-        // 12 sites of plain `+` string concat; stylistic.
-        "useTemplate": "off"
+        "noNonNullAssertion": "off"
       },
       "suspicious": {
         // 32 sites of gradual-typing debt on `any`. Dedicated cleanup.

--- a/packages/integrations/claude-code/src/index.test.ts
+++ b/packages/integrations/claude-code/src/index.test.ts
@@ -219,7 +219,7 @@ describe("tailJsonlLines", () => {
         message: { stop_reason: "end_turn" },
       }),
     ];
-    fs.writeFileSync(filePath, lines.join("\n") + "\n");
+    fs.writeFileSync(filePath, `${lines.join("\n")}\n`);
     const result = tailJsonlLines(filePath, 16_384);
     expect(result).toEqual(lines);
   });
@@ -228,7 +228,7 @@ describe("tailJsonlLines", () => {
     const filePath = path.join(tmpDir, "large.jsonl");
     const longLine = JSON.stringify({ type: "system", data: "x".repeat(200) });
     const lastLine = JSON.stringify({ type: "user" });
-    fs.writeFileSync(filePath, longLine + "\n" + lastLine + "\n");
+    fs.writeFileSync(filePath, `${longLine}\n${lastLine}\n`);
     const result = tailJsonlLines(filePath, 50);
     expect(result).toEqual([lastLine]);
   });
@@ -275,7 +275,7 @@ describe("findTranscriptPath", () => {
     const projectDir = path.join(tmpDir, encodeProjectPath(cwd));
     fs.mkdirSync(projectDir, { recursive: true });
     const transcriptPath = path.join(projectDir, `${sessionId}.jsonl`);
-    fs.writeFileSync(transcriptPath, JSON.stringify({ type: "user" }) + "\n");
+    fs.writeFileSync(transcriptPath, `${JSON.stringify({ type: "user" })}\n`);
 
     const result = findTranscriptPathFn({ pid: 1, sessionId, cwd });
     expect(result).toBe(transcriptPath);
@@ -287,7 +287,7 @@ describe("findTranscriptPath", () => {
     fs.mkdirSync(projectDir, { recursive: true });
 
     const otherPath = path.join(projectDir, "other-session.jsonl");
-    fs.writeFileSync(otherPath, JSON.stringify({ type: "user" }) + "\n");
+    fs.writeFileSync(otherPath, `${JSON.stringify({ type: "user" })}\n`);
 
     const result = findTranscriptPathFn({
       pid: 1,

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -157,7 +157,7 @@ export function createSessionWatcher(
       { session: session.sessionId, cwd: session.cwd },
       "transcript not found yet (JSONL created after first message)",
     );
-    const projectDir = PROJECTS_DIR + "/" + encodeProjectPath(session.cwd);
+    const projectDir = `${PROJECTS_DIR}/${encodeProjectPath(session.cwd)}`;
     const dirWatcher = watchOrWaitForDir(projectDir, () =>
       onProjectDirChanged(),
     );

--- a/packages/tests/step_definitions/claude_code_steps.ts
+++ b/packages/tests/step_definitions/claude_code_steps.ts
@@ -91,7 +91,7 @@ function buildTranscript(state: "thinking" | "tool_use" | "waiting"): string {
   if (state === "waiting") lines.push(assistantMsg("end_turn"));
   // "thinking" = user message only (no assistant response yet)
 
-  return lines.join("\n") + "\n";
+  return `${lines.join("\n")}\n`;
 }
 
 /** Unique CWD per scenario to avoid collisions in parallel workers. */
@@ -209,14 +209,14 @@ When(
     const stalePath = path.join(projectDir, "stale-previous-session.jsonl");
     fs.writeFileSync(
       stalePath,
-      JSON.stringify({
+      `${JSON.stringify({
         type: "assistant",
         message: {
           model: "claude-opus-4-6",
           stop_reason: "end_turn",
           content: [{ type: "text", text: "previous" }],
         },
-      }) + "\n",
+      })}\n`,
     );
     // Future mtime so an MRU fallback would always pick this over the
     // current-session JSONL.
@@ -359,7 +359,7 @@ function buildTaskLines(
       );
     }
   }
-  return lines.join("\n") + "\n";
+  return `${lines.join("\n")}\n`;
 }
 
 When(

--- a/packages/tests/step_definitions/mobile_terminal_scroll_steps.ts
+++ b/packages/tests/step_definitions/mobile_terminal_scroll_steps.ts
@@ -68,7 +68,7 @@ When(
     await this.page.evaluate(
       ({ sel, x, startY, endY, ys }) => {
         const target = document.querySelector(sel) as HTMLElement | null;
-        if (!target) throw new Error("No element matches " + sel);
+        if (!target) throw new Error(`No element matches ${sel}`);
         const startTouch = new Touch({
           identifier: 0,
           target,

--- a/packages/tests/step_definitions/scroll_lock_steps.ts
+++ b/packages/tests/step_definitions/scroll_lock_steps.ts
@@ -73,7 +73,7 @@ When("I fire the output trigger", async function (this: KoluWorld) {
   // Write to the FIFO from the test process — bypasses xterm keyboard input
   // entirely, so scrollOnUserInput doesn't interfere with scroll lock state.
   const lines = Array.from({ length: 10 }, (_, i) => `triggered-${i + 1}`);
-  await writeFile(scrollFifo(this), lines.join("\n") + "\n");
+  await writeFile(scrollFifo(this), `${lines.join("\n")}\n`);
   // When scroll-locked, data is buffered — wait for the activity indicator
   await this.page
     .locator('[data-testid="scroll-to-bottom"][data-active]')
@@ -84,7 +84,7 @@ When(
   "I fire the output trigger with {int} lines",
   async function (this: KoluWorld, count: number) {
     const lines = Array.from({ length: count }, (_, i) => `triggered-${i + 1}`);
-    await writeFile(scrollFifo(this), lines.join("\n") + "\n");
+    await writeFile(scrollFifo(this), `${lines.join("\n")}\n`);
     // When scroll-locked, data is buffered — wait for the activity indicator
     await this.page
       .locator('[data-testid="scroll-to-bottom"][data-active]')

--- a/packages/tests/support/agent-mock-codex.ts
+++ b/packages/tests/support/agent-mock-codex.ts
@@ -79,7 +79,7 @@ export function buildCodexRollout(opts: {
     );
   }
 
-  return lines.join("\n") + "\n";
+  return `${lines.join("\n")}\n`;
 }
 
 export interface CodexFixture {


### PR DESCRIPTION
**Flip on Biome's `useTemplate` and rewrite the 12 `"foo " + bar` sites** to template literals. Every site is string-to-string (`.join("\n") + "\n"` and friends, path-segment concatenation, error-message interpolation), and `tsc` confirms no non-string operands. Biome marks the fix "unsafe" only because it can't statically rule out numeric coercion in the general case.

One more row closed in #721 — the last of the mechanical / auto-fix category. What's left after this is the four judgment-heavy rules (`noNonNullAssertion`, `noExplicitAny`, `noUnusedVariables`, the a11y group), the three module-graph architectural decisions (`useImportExtensions`, `noUnresolvedImports`, `noImportCycles`), and `noMisusedPromises`.