### PR TITLE
Turn on noExplicitAny; replace 32 sites with proper types

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -103,8 +103,6 @@
         "noNonNullAssertion": "off"
       },
       "suspicious": {
-        // 32 sites of gradual-typing debt on `any`. Dedicated cleanup.
-        "noExplicitAny": "off",
         // Terminal code legitimately parses ANSI escape sequences —
         // the rule is a permanent false positive against xterm diagnostics.
         "noControlCharactersInRegex": "off"

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -21,6 +21,7 @@ import { match } from "ts-pattern";
 import ChromeBar from "./ChromeBar";
 import CloseConfirm, { type CloseConfirmTarget } from "./CloseConfirm";
 import CommandPalette from "./CommandPalette";
+import "kolu-common/test-hooks";
 import { toggleMinimap } from "./canvas/CanvasMinimap";
 import CanvasWatermark from "./canvas/CanvasWatermark";
 import PillTree from "./canvas/PillTree";
@@ -58,8 +59,8 @@ import { useThemeManager } from "./useThemeManager";
 const App: Component = () => {
   const { store, crud, session, worktree, alerts } = useTerminals();
 
-  // Expose for e2e test access
-  (window as any).__koluSimulateAlert = alerts.simulateAlert;
+  // Expose for e2e test access — type comes from "kolu-common/test-hooks"
+  window.__koluSimulateAlert = alerts.simulateAlert;
 
   const {
     committedThemeName,

--- a/packages/client/src/rpc/createSubscription.test.ts
+++ b/packages/client/src/rpc/createSubscription.test.ts
@@ -268,9 +268,11 @@ describe("createSubscription", () => {
     it("throws if reduce is provided without initial", () => {
       expect(() => {
         createRoot((dispose) => {
+          // @ts-expect-error testing the runtime guard fires when
+          // `initial` is omitted (the type system would normally require it).
           createSubscription(() => Promise.resolve(fromArray([1])), {
             reduce: (acc: number, item: number) => acc + item,
-          } as any);
+          });
           dispose();
         });
       }).toThrow("'initial' is required when using 'reduce'");

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,7 +12,8 @@
     "./contract": "./src/contract.ts",
     "./errors": "./src/errors.ts",
     "./config": "./src/config.ts",
-    "./pr": "./src/pr.ts"
+    "./pr": "./src/pr.ts",
+    "./test-hooks": "./src/test-hooks.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/common/src/test-hooks.ts
+++ b/packages/common/src/test-hooks.ts
@@ -1,0 +1,81 @@
+/**
+ * Test-only hooks installed on `window` by the client at app startup and
+ * read by Cucumber e2e step definitions. Plus the Badging API surface
+ * the alert tests stub out. Declared here in `kolu-common` so both sides
+ * (client setter, test reader) type-check against the same shape —
+ * without this, `(window as any).__koluFoo` and `(navigator as any)`
+ * casts proliferate at every call site (the noExplicitAny migration
+ * in #710 / #721).
+ *
+ * Usage: `import "kolu-common/test-hooks"` for side-effect (loads the
+ * `Window` / `Navigator` augmentations). They're module-scoped — TS
+ * only sees these properties in files that transitively import this
+ * module.
+ */
+
+export {};
+
+declare global {
+  interface Window {
+    /** Triggers the activity-alert codepath. Set by `App.tsx` from
+     *  `useTerminalAlerts.simulateAlert` so e2e tests can fire alerts
+     *  without driving the underlying server-pushed event. */
+    __koluSimulateAlert?: (opts?: { target?: "active" | "inactive" }) => void;
+
+    /** Stash for `setAppBadge` / `clearAppBadge` calls captured by the
+     *  alert e2e suite's `I stub the Badging API` step. Test-only. */
+    __badgeCalls?: Array<
+      { method: "set"; count?: number } | { method: "clear" }
+    >;
+
+    /** Reads the live xterm buffer for the `idx`-th element matching `sel`,
+     *  installed once per scenario by the e2e harness in `hooks.ts` via
+     *  `page.addInitScript`. Returns the joined visible-buffer text, or
+     *  `""` if the selector matches nothing or the element has no
+     *  `__xterm` attached. Used by the shared `support/buffer.ts` helpers. */
+    __readXtermBuffer?: (sel: string, idx: number) => string;
+
+    /** Stash of stringified `WebSocket.send` payloads captured by
+     *  `Given I intercept oRPC sendInput calls`. The interceptor monkey-
+     *  patches `WebSocket.prototype.send` once per scenario; subsequent
+     *  steps `evaluate` and read this array. */
+    __wsSent?: string[];
+  }
+
+  /** Structural subset of `xterm.Terminal` that e2e steps read off the
+   *  `__xterm` DOM attachment below — kept narrow on purpose so adding
+   *  this augmentation here doesn't pull `@xterm/xterm` into
+   *  `kolu-common`'s dependency surface. `Terminal.tsx` assigns the full
+   *  `XTerm` instance, which is structurally assignable to this shape. */
+  interface KoluXtermProbe {
+    cols: number;
+    rows: number;
+    buffer: {
+      active: {
+        length: number;
+        baseY: number;
+        viewportY: number;
+        getLine(
+          i: number,
+        ): { translateToString(trim: boolean): string } | undefined;
+      };
+    };
+  }
+
+  /** xterm's per-container reference. `Terminal.tsx` attaches the xterm
+   *  instance to the canvas tile's wrapping `<div>` so e2e tests can
+   *  reach the terminal API without going through the SolidJS reactivity
+   *  layer. `__xterm` is `undefined` until the component's `onMount`
+   *  body runs and is cleared on cleanup (#591 leak fix). */
+  interface HTMLDivElement {
+    __xterm?: KoluXtermProbe;
+  }
+
+  /** Badging API (Chrome/Edge PWAs) — not yet in TypeScript's lib.dom.
+   *  Used in production by `useTerminalAlerts.ts`; the e2e suite
+   *  reassigns these stubs in `I stub the Badging API`. */
+  interface Navigator {
+    setAppBadge(count?: number): Promise<void>;
+    clearAppBadge(): Promise<void>;
+  }
+}

--- a/packages/server/src/publisher.ts
+++ b/packages/server/src/publisher.ts
@@ -58,7 +58,17 @@ type SystemChannels = {
 
 // The publisher accepts any string channel at runtime.
 // Terminal channels are namespaced as "channel:terminalId"; system channels are used as-is.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+//
+// `MemoryPublisher` constrains its generic to `Record<string, object>`,
+// which excludes the primitive payloads kolu actually publishes (strings
+// like terminal data + cwd + title, numbers like exit codes). The
+// generic itself is dead weight here: type safety on actual publish/
+// subscribe calls is enforced by the typed wrappers below
+// (`publishForTerminal` / `publishSystem` / `subscribeForTerminal` /
+// `subscribeSystem`) using Kolu's own `TerminalChannels` and
+// `SystemChannels`. So this `any` widens *only* the unused library
+// generic; every real call site is still strictly typed.
+// biome-ignore lint/suspicious/noExplicitAny: library's Record<string, object> generic is too strict for our primitive payloads (data: string, exit: number, …); call-site types come from the typed wrappers below, not from this generic.
 export const publisher = new MemoryPublisher<Record<string, any>>();
 
 /** Total pending events + active listeners across all channels. Exposed for

--- a/packages/tests/step_definitions/activity_alert_steps.ts
+++ b/packages/tests/step_definitions/activity_alert_steps.ts
@@ -113,7 +113,9 @@ Then(
     const lastSet = await this.page.evaluate(() => {
       const calls = window.__badgeCalls ?? [];
       return calls
-        .filter((c): c is { method: "set"; count?: number } => c.method === "set")
+        .filter(
+          (c): c is { method: "set"; count?: number } => c.method === "set",
+        )
         .pop();
     });
     assert.ok(lastSet, "Expected setAppBadge to have been called");

--- a/packages/tests/step_definitions/activity_alert_steps.ts
+++ b/packages/tests/step_definitions/activity_alert_steps.ts
@@ -11,7 +11,7 @@ When("I simulate an activity alert", async function (this: KoluWorld) {
   // Use page.evaluate to call the simulate function directly,
   // avoiding command palette navigation complexity.
   await this.page.evaluate(() => {
-    (window as any).__koluSimulateAlert?.();
+    window.__koluSimulateAlert?.();
   });
   await this.waitForFrame();
 });
@@ -20,7 +20,7 @@ When(
   "I simulate an activity alert for the active terminal",
   async function (this: KoluWorld) {
     await this.page.evaluate(() => {
-      (window as any).__koluSimulateAlert?.({ target: "active" });
+      window.__koluSimulateAlert?.({ target: "active" });
     });
     await this.waitForFrame();
   },
@@ -94,15 +94,13 @@ When("I click the notified pill tree branch", async function (this: KoluWorld) {
 
 When("I stub the Badging API", async function (this: KoluWorld) {
   await this.page.evaluate(() => {
-    (window as any).__badgeCalls = [] as Array<
-      { method: "set"; count?: number } | { method: "clear" }
-    >;
-    (navigator as any).setAppBadge = (count?: number) => {
-      (window as any).__badgeCalls.push({ method: "set", count });
+    window.__badgeCalls = [];
+    navigator.setAppBadge = (count?: number) => {
+      window.__badgeCalls?.push({ method: "set", count });
       return Promise.resolve();
     };
-    (navigator as any).clearAppBadge = () => {
-      (window as any).__badgeCalls.push({ method: "clear" });
+    navigator.clearAppBadge = () => {
+      window.__badgeCalls?.push({ method: "clear" });
       return Promise.resolve();
     };
   });
@@ -113,8 +111,10 @@ Then(
   async function (this: KoluWorld, expected: number) {
     await this.waitForFrame();
     const lastSet = await this.page.evaluate(() => {
-      const calls: any[] = (window as any).__badgeCalls ?? [];
-      return calls.filter((c: any) => c.method === "set").pop();
+      const calls = window.__badgeCalls ?? [];
+      return calls
+        .filter((c): c is { method: "set"; count?: number } => c.method === "set")
+        .pop();
     });
     assert.ok(lastSet, "Expected setAppBadge to have been called");
     assert.strictEqual(lastSet.count, expected);
@@ -124,7 +124,7 @@ Then(
 Then("the app badge should be cleared", async function (this: KoluWorld) {
   await this.waitForFrame();
   const lastCall = await this.page.evaluate(() => {
-    const calls: any[] = (window as any).__badgeCalls ?? [];
+    const calls = window.__badgeCalls ?? [];
     return calls[calls.length - 1];
   });
   assert.ok(lastCall, "Expected a badge API call");

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -150,7 +150,7 @@ When("I zoom the canvas in", async function (this: KoluWorld) {
     const el = document.querySelector(sel);
     return parseFloat(el?.getAttribute("data-zoom") ?? "1");
   }, CANVAS_SELECTOR);
-  (this as any).__zoomBefore = before;
+  this.zoomBefore = before;
   const container = this.page.locator(CANVAS_SELECTOR);
   await container.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   // Dispatch a ctrl+wheel event to trigger zoom (negative deltaY = zoom in).
@@ -179,7 +179,7 @@ When("I zoom the canvas in", async function (this: KoluWorld) {
 Then(
   "the canvas zoom level should have changed",
   async function (this: KoluWorld) {
-    const before = (this as any).__zoomBefore as number | undefined;
+    const before = this.zoomBefore;
     await this.page.waitForFunction(
       ({ sel, prev }: { sel: string; prev: number }) => {
         const el = document.querySelector(sel);
@@ -569,7 +569,7 @@ When("I save the canvas viewport state", async function (this: KoluWorld) {
       transform: inner?.style.transform,
     };
   }, CANVAS_SELECTOR);
-  (this as any).__savedViewportState = state;
+  this.savedViewportState = state;
 });
 
 When("I drag the minimap viewport rect", async function (this: KoluWorld) {
@@ -627,10 +627,7 @@ When("I drag the minimap viewport rect", async function (this: KoluWorld) {
 Then(
   "the canvas viewport state should have changed",
   async function (this: KoluWorld) {
-    const saved = (this as any).__savedViewportState as {
-      zoom: string | null;
-      transform: string | null;
-    } | null;
+    const saved = this.savedViewportState;
     await this.page.waitForFunction(
       (prev: { transform: string | null }) => {
         const inner = document.querySelector(
@@ -796,20 +793,18 @@ async function readCanvasTilePosition(
 When(
   "I save canvas tile {int} position",
   async function (this: KoluWorld, index: number) {
-    const saved = ((this as any).__savedCanvasTilePositions ??= {}) as Record<
-      number,
-      { id: string; left: number; top: number }
-    >;
-    saved[index] = await readCanvasTilePosition(this, index);
+    this.savedCanvasTilePositions ??= {};
+    this.savedCanvasTilePositions[index] = await readCanvasTilePosition(
+      this,
+      index,
+    );
   },
 );
 
 When(
   "I drag minimap tile rect {int} by x={int} y={int}",
   async function (this: KoluWorld, index: number, dx: number, dy: number) {
-    const saved = (this as any).__savedCanvasTilePositions?.[index] as
-      | { id: string; left: number; top: number }
-      | undefined;
+    const saved = this.savedCanvasTilePositions?.[index];
     if (!saved) throw new Error(`No saved canvas tile ${index} position`);
     await this.page.evaluate(
       ({ tileId, dx, dy }: { tileId: string; dx: number; dy: number }) => {
@@ -859,9 +854,7 @@ When(
 Then(
   "canvas tile {int} position should have changed",
   async function (this: KoluWorld, index: number) {
-    const saved = (this as any).__savedCanvasTilePositions?.[index] as
-      | { id: string; left: number; top: number }
-      | undefined;
+    const saved = this.savedCanvasTilePositions?.[index];
     if (!saved) throw new Error(`No saved canvas tile ${index} position`);
     await this.page.waitForFunction(
       ({

--- a/packages/tests/step_definitions/claude_code_steps.ts
+++ b/packages/tests/step_definitions/claude_code_steps.ts
@@ -35,7 +35,7 @@ async function getTerminalPid(world: KoluWorld): Promise<number> {
   // Uses the shared __readXtermBuffer helper (injected by hooks.ts).
   const handle = await world.page.waitForFunction(
     ({ marker, sel }) => {
-      const text = (window as any).__readXtermBuffer(sel, 0) as string;
+      const text = window.__readXtermBuffer?.(sel, 0) ?? "";
       if (!text) return null;
       const lines = text.split("\n").map((l: string) => l.trim());
       // Find the marker on a line that's NOT the typed echo command.

--- a/packages/tests/step_definitions/command_palette_steps.ts
+++ b/packages/tests/step_definitions/command_palette_steps.ts
@@ -240,7 +240,7 @@ Then(
   "no sendInput call should contain {string}",
   async function (this: KoluWorld, key: string) {
     const messages: string[] = await this.page.evaluate(
-      () => (window as any).__wsSent ?? [],
+      () => window.__wsSent ?? [],
     );
     for (const msg of messages) {
       if (!msg.includes("sendInput")) continue;

--- a/packages/tests/step_definitions/scroll_lock_steps.ts
+++ b/packages/tests/step_definitions/scroll_lock_steps.ts
@@ -95,10 +95,10 @@ When(
 /** Read the first visible row from the xterm buffer at the current viewport position. */
 function readFirstVisibleLine(world: KoluWorld) {
   return world.page.evaluate(() => {
-    const container = document.querySelector(
+    const container = document.querySelector<HTMLDivElement>(
       "[data-visible][data-terminal-id]",
     );
-    const term = (container as any)?.__xterm;
+    const term = container?.__xterm;
     if (!term) return "";
     const buf = term.buffer.active;
     return buf.getLine(buf.viewportY)?.translateToString(true) ?? "";
@@ -176,10 +176,10 @@ Then(
   async function (this: KoluWorld) {
     await this.page.waitForFunction(
       () => {
-        const container = document.querySelector(
+        const container = document.querySelector<HTMLDivElement>(
           "[data-visible][data-terminal-id]",
         );
-        const term = (container as any)?.__xterm;
+        const term = container?.__xterm;
         if (!term) return false;
         const buf = term.buffer.active;
         return buf.baseY <= buf.viewportY;

--- a/packages/tests/step_definitions/terminal_steps.ts
+++ b/packages/tests/step_definitions/terminal_steps.ts
@@ -216,10 +216,10 @@ Given("I intercept oRPC sendInput calls", async function (this: KoluWorld) {
   // oRPC sends JSON-encoded messages over WS.
   await this.page.evaluate(() => {
     const origSend = WebSocket.prototype.send;
-    (window as any).__wsSent = [];
-    WebSocket.prototype.send = function (data: any) {
+    window.__wsSent = [];
+    WebSocket.prototype.send = function (data) {
       if (typeof data === "string") {
-        (window as any).__wsSent.push(data);
+        window.__wsSent?.push(data);
       }
       return origSend.call(this, data);
     };
@@ -230,7 +230,7 @@ Then(
   "no sendInput call should contain {string} {string} {string}",
   async function (this: KoluWorld, k1: string, k2: string, k3: string) {
     const messages: string[] = await this.page.evaluate(
-      () => (window as any).__wsSent ?? [],
+      () => window.__wsSent ?? [],
     );
     // Look for sendInput calls whose data field contains zoom key chars
     for (const msg of messages) {

--- a/packages/tests/support/buffer.ts
+++ b/packages/tests/support/buffer.ts
@@ -25,7 +25,7 @@ export function readBufferText(
   index = 0,
 ): Promise<string> {
   return page.evaluate(
-    ({ sel, idx }) => (window as any).__readXtermBuffer(sel, idx),
+    ({ sel, idx }) => window.__readXtermBuffer?.(sel, idx) ?? "",
     { sel: selector, idx: index },
   );
 }
@@ -42,7 +42,7 @@ export async function waitForBufferContains(
 ): Promise<string> {
   const handle = await page.waitForFunction(
     ({ sel, idx, exp }) => {
-      const content = (window as any).__readXtermBuffer(sel, idx);
+      const content = window.__readXtermBuffer?.(sel, idx) ?? "";
       return content.includes(exp) ? content : null;
     },
     { sel: selector, idx: index, exp: expected },

--- a/packages/tests/support/world.ts
+++ b/packages/tests/support/world.ts
@@ -9,6 +9,11 @@ import {
   World,
 } from "@cucumber/cucumber";
 import type { Browser, BrowserContext, Locator, Page } from "playwright";
+// Side-effect import: pulls in the `Window`/`HTMLDivElement`/`Navigator`
+// augmentations every step definition needs (window.__readXtermBuffer,
+// `__xterm` on tile divs, the Badging API stubs, …) so tests can read
+// them without `(window as any)` / `(this as any)` casts.
+import "kolu-common/test-hooks";
 
 setDefaultTimeout(30_000);
 
@@ -47,6 +52,23 @@ export class KoluWorld extends World {
   savedScrollTop?: number;
   savedVisibleText?: string;
   snapshotCols?: Record<string, number>;
+  /** Snapshot of `data-zoom` from `before I zoom the canvas in` so the
+   *  follow-up `Then the canvas zoom level should have changed` step can
+   *  compare. */
+  zoomBefore?: number;
+  /** Snapshot of zoom + transform attributes captured by the
+   *  `When I save the canvas viewport state` step. */
+  savedViewportState?: {
+    zoom: string | null;
+    transform: string | null;
+  } | null;
+  /** Map of tile-index → tile geometry captured by `When I save canvas
+   *  tile {int} position`, read back by minimap-drag and position-changed
+   *  steps. */
+  savedCanvasTilePositions?: Record<
+    number,
+    { id: string; left: number; top: number }
+  >;
   _scrollFifo?: string;
   createdTerminalIds: string[] = [];
   shuffleHistory: string[] = [];


### PR DESCRIPTION
**Most of the 32 `noExplicitAny` findings were e2e-test boundary casts** — `(window as any).__koluFoo` for hooks the client installs and tests read, `(this as any).__scratch` for ad-hoc per-scenario stash fields, and `(container as any)?.__xterm` for the xterm reference `Terminal.tsx` attaches to canvas tiles. The pattern is fixable structurally, not by suppression: declare each shape once and let TS check both ends.

New module **`kolu-common/test-hooks`** declares the cross-side augmentations: `Window.__koluSimulateAlert` / `__badgeCalls` / `__readXtermBuffer` / `__wsSent`, the `Navigator.setAppBadge`/`clearAppBadge` Badging API surface, and `HTMLDivElement.__xterm: KoluXtermProbe`. `KoluXtermProbe` is a structural subset of `xterm.Terminal` — exactly the fields tests read (`cols`, `rows`, `buffer.active.{length, baseY, viewportY, getLine}`) — kept narrow so adding this augmentation doesn't drag `@xterm/xterm` into `kolu-common`'s dependency surface. `packages/tests/support/world.ts` does a single side-effect import so every step file inherits the augmentations transitively; `App.tsx` does the same for the assignment side.

Per-test scratch fields move from `(this as any).__zoomBefore` onto typed members of `KoluWorld` — `zoomBefore?: number`, `savedViewportState?`, `savedCanvasTilePositions?`. The world class already had a long list of typed scratch fields (`savedCanvas`, `savedFontSize`, …); these slot in alongside.

> **Two `any`s remain, both with explicit justifications:** `publisher.ts` keeps an `any` because `MemoryPublisher<T extends Record<string, object>>`'s constraint excludes the primitive payloads kolu publishes (string data, number exit codes); the previous `eslint-disable` becomes a `biome-ignore` with the same rationale. `createSubscription.test.ts` swaps `as any` for `@ts-expect-error` — the precise tool for "this line is intentionally a type error to verify the runtime guard fires." _No `as any` remains in production code._