### PR TITLE
Turn on noNonNullAssertion; replace 136 `!`s with narrowing

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -97,11 +97,6 @@
       // Accessibility pass — 88 findings across useButtonType,
       // noSvgWithoutTitle, noStaticElementInteractions, etc.
       "a11y": "off",
-      "style": {
-        // 136 sites use `!` non-null assertions idiomatically. Migration
-        // to `?? throw`/narrowing is a dedicated cleanup pass.
-        "noNonNullAssertion": "off"
-      },
       "suspicious": {
         // Terminal code legitimately parses ANSI escape sequences —
         // the rule is a permanent false positive against xterm diagnostics.

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -112,7 +112,8 @@ const CommandPalette: Component<{
    *  palette doesn't render an empty level mid-navigation. */
   const currentItems = createMemo((): PaletteItem[] => {
     const p = path();
-    if (p.length === 0) return props.commands();
+    const last = p.at(-1);
+    if (last === undefined) return props.commands();
     let level: PaletteItem[] = props.commands();
     for (const segment of p) {
       const match = level.find(
@@ -124,7 +125,7 @@ const CommandPalette: Component<{
         // the stale reference to keep the level rendered. Happens e.g.
         // when a visibility guard hides a parent group while the user
         // is still drilled into it.
-        return resolveChildren(p[p.length - 1]!);
+        return resolveChildren(last);
       }
       level = resolveChildren(match);
     }
@@ -383,17 +384,16 @@ const CommandPalette: Component<{
                       </span>
                     </Show>
                     <Show when={!isGroup(cmd) && cmd.keybind}>
-                      <span class="ml-auto shrink-0 pl-4 flex items-center gap-1.5">
-                        <For
-                          each={
-                            Array.isArray(cmd.keybind)
-                              ? cmd.keybind
-                              : [cmd.keybind!]
-                          }
-                        >
-                          {(kb) => <Kbd>{formatKeybind(kb)}</Kbd>}
-                        </For>
-                      </span>
+                      {(keybind) => {
+                        const kb = keybind();
+                        return (
+                          <span class="ml-auto shrink-0 pl-4 flex items-center gap-1.5">
+                            <For each={Array.isArray(kb) ? kb : [kb]}>
+                              {(k) => <Kbd>{formatKeybind(k)}</Kbd>}
+                            </For>
+                          </span>
+                        );
+                      }}
                     </Show>
                   </li>
                 )}

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -329,7 +329,7 @@ const TerminalCanvas: Component<{
               renderTitle={() => props.renderTileTitle(id)}
               renderTitleActions={
                 props.renderTileTitleActions
-                  ? () => props.renderTileTitleActions!(id)
+                  ? () => props.renderTileTitleActions?.(id)
                   : undefined
               }
               renderBody={() =>

--- a/packages/client/src/canvas/pillTreeOrder.ts
+++ b/packages/client/src/canvas/pillTreeOrder.ts
@@ -5,6 +5,7 @@
  *  handler so the two views never diverge. */
 
 import type { TerminalId } from "kolu-common";
+import { unwrap } from "kolu-common/unwrap";
 import {
   type TerminalDisplayInfo,
   terminalName,
@@ -83,7 +84,12 @@ export function groupByRepo(
   }
 
   if (!getLayout) {
-    return order.map((name) => groups.get(name)!);
+    return order.map((name) =>
+      unwrap(
+        groups.get(name),
+        `pill-tree group ${name} missing from groups map`,
+      ),
+    );
   }
 
   // Spatial sort. Tiles without a layout sort to the END of their
@@ -105,7 +111,12 @@ export function groupByRepo(
     .sort(
       (a, b) => (repoMinX.get(a) ?? Infinity) - (repoMinX.get(b) ?? Infinity),
     )
-    .map((name) => groups.get(name)!);
+    .map((name) =>
+      unwrap(
+        groups.get(name),
+        `pill-tree group ${name} missing from groups map`,
+      ),
+    );
 }
 
 /** Flat traversal of the grouped order — used by mobile swipe to cycle

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -135,16 +135,19 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
           {
             name: "Toggle terminal split",
             keybind: SHORTCUTS.toggleSubPanel.keybind,
-            onSelect: () => deps.toggleSubPanel(deps.activeId()!),
+            onSelect: () => {
+              const id = deps.activeId();
+              if (id !== null) deps.toggleSubPanel(id);
+            },
           },
           {
             name: "Split terminal",
             keybind: SHORTCUTS.createSubTerminal.keybind,
-            onSelect: () =>
-              deps.handleCreateSubTerminal(
-                deps.activeId()!,
-                deps.activeMeta()?.cwd,
-              ),
+            onSelect: () => {
+              const id = deps.activeId();
+              if (id !== null)
+                deps.handleCreateSubTerminal(id, deps.activeMeta()?.cwd);
+            },
           },
           {
             name: "Copy terminal text",

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -2,6 +2,7 @@
 
 import { makeEventListener } from "@solid-primitives/event-listener";
 import type { TerminalId, TerminalMetadata } from "kolu-common";
+import { unwrap } from "kolu-common/unwrap";
 import type { Accessor, Setter } from "solid-js";
 import { isPlatformModifier, matchesKeybind, SHORTCUTS } from "./keyboard";
 
@@ -90,7 +91,8 @@ function dispatch(
   const digit = parseInt(e.key, 10);
   if (isPlatformModifier(e) && !e.shiftKey && digit >= 1 && digit <= 9) {
     const ids = deps.terminalIds();
-    if (digit <= ids.length) deps.setActiveId(ids[digit - 1]!);
+    const target = ids[digit - 1];
+    if (target !== undefined) deps.setActiveId(target);
     return true;
   }
 
@@ -197,5 +199,9 @@ function cycleTerminal(deps: ShortcutDeps, direction: 1 | -1) {
   if (ids.length === 0) return;
   const current = ids.indexOf(deps.activeId() as TerminalId);
   const next = (current + direction + ids.length) % ids.length;
-  deps.setActiveId(ids[next]!);
+  // `next` is in `[0, ids.length)` by the modulus and the early return
+  // above; documenting that at the throw site.
+  deps.setActiveId(
+    unwrap(ids[next], `cycleTerminal: index ${next} out of bounds`),
+  );
 }

--- a/packages/client/src/recorder/mic.ts
+++ b/packages/client/src/recorder/mic.ts
@@ -62,8 +62,7 @@ export async function openMicPreview(deviceId: string): Promise<void> {
       if (!preview) return;
       preview.analyser.getFloatTimeDomainData(preview.buf);
       let sum = 0;
-      for (let i = 0; i < preview.buf.length; i++) {
-        const v = preview.buf[i]!;
+      for (const v of preview.buf) {
         sum += v * v;
       }
       // Light nonlinear shaping so talking registers visibly without

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -115,9 +115,10 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     if (view() === "browse") return allPaths() ?? [];
     return status()?.files.map((f) => f.path) ?? [];
   });
-  const treeGitStatus = createMemo(() =>
-    status() ? toGitStatusEntries(status()!.files) : undefined,
-  );
+  const treeGitStatus = createMemo(() => {
+    const s = status();
+    return s ? toGitStatusEntries(s.files) : undefined;
+  });
 
   const handleSelect = (path: string | null) => {
     // Pierre emits null on deselect; keep our single-select toggle semantics.
@@ -129,6 +130,20 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const treeReady = () => (isDiffView() ? status() : allPaths());
   const branchTooltip = () =>
     `Changes vs ${status()?.base?.ref ?? "branch base"}`;
+
+  /** Diff value narrowed to "this is a pure-rename" (no hunks, both old +
+   *  new file names present and different). Returning the full diff so the
+   *  rendering Match can read its names without re-narrowing. */
+  const renamedDiff = createMemo(() => {
+    const d = diff();
+    if (!d) return undefined;
+    if (d.hunks.length !== 0) return undefined;
+    const { oldFileName, newFileName } = d;
+    if (!oldFileName || !newFileName || oldFileName === newFileName) {
+      return undefined;
+    }
+    return { oldFileName, newFileName };
+  });
 
   return (
     <Show
@@ -203,9 +218,11 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         >
           <Switch fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}>
             <Match when={treeError()}>
-              <div class="px-2 py-1 text-danger" data-testid="diff-error">
-                Error: {treeError()!.message}
-              </div>
+              {(err) => (
+                <div class="px-2 py-1 text-danger" data-testid="diff-error">
+                  Error: {err().message}
+                </div>
+              )}
             </Match>
             <Match when={treeReady()}>
               <Show
@@ -215,9 +232,10 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                     class="px-2 py-4 text-fg-3/50 text-center"
                     data-testid="diff-empty"
                   >
-                    {isDiffView()
-                      ? EMPTY_STATE[diffMode()!]
-                      : "Empty repository"}
+                    {(() => {
+                      const m = diffMode();
+                      return m ? EMPTY_STATE[m] : "Empty repository";
+                    })()}
                   </div>
                 }
               >
@@ -258,37 +276,42 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                       Error: {(diff.error as Error).message}
                     </div>
                   </Match>
-                  <Match
-                    when={
-                      diff() &&
-                      diff()!.hunks.length === 0 &&
-                      diff()!.oldFileName &&
-                      diff()!.newFileName &&
-                      diff()!.oldFileName !== diff()!.newFileName
-                    }
-                  >
-                    <div class="flex items-center justify-center h-full text-fg-3/50">
-                      File renamed: {diff()!.oldFileName} →{" "}
-                      {diff()!.newFileName}
-                    </div>
+                  <Match when={renamedDiff()}>
+                    {(rename) => (
+                      <div class="flex items-center justify-center h-full text-fg-3/50">
+                        File renamed: {rename().oldFileName} →{" "}
+                        {rename().newFileName}
+                      </div>
+                    )}
                   </Match>
                   <Match when={diff()}>
-                    {(d) => (
-                      <PierreDiffView
-                        path={selectedPath()!}
-                        rawDiff={d().hunks[0] ?? ""}
-                        theme={diffTheme()}
-                      />
-                    )}
+                    {(d) => {
+                      const path = selectedPath();
+                      if (path === null) return null;
+                      return (
+                        <PierreDiffView
+                          path={path}
+                          rawDiff={d().hunks[0] ?? ""}
+                          theme={diffTheme()}
+                        />
+                      );
+                    }}
                   </Match>
                 </Switch>
               </Match>
               <Match when={!isDiffView()}>
-                <BrowseFileView
-                  repoPath={repoPath()!}
-                  filePath={selectedPath()!}
-                  theme={diffTheme()}
-                />
+                {(() => {
+                  const repo = repoPath();
+                  const path = selectedPath();
+                  if (repo === null || path === null) return null;
+                  return (
+                    <BrowseFileView
+                      repoPath={repo}
+                      filePath={path}
+                      theme={diffTheme()}
+                    />
+                  );
+                })()}
               </Match>
             </Switch>
           </Show>

--- a/packages/client/src/right-panel/MetadataInspector.tsx
+++ b/packages/client/src/right-panel/MetadataInspector.tsx
@@ -161,12 +161,14 @@ const MetadataInspector: Component<{
                       </Row>
                     )}
                   </Show>
-                  <Show when={agent().contextTokens != null}>
-                    <Row label="Context">
-                      <span class="font-mono text-fg">
-                        {agent().contextTokens!.toLocaleString()} tokens
-                      </span>
-                    </Row>
+                  <Show when={agent().contextTokens}>
+                    {(tokens) => (
+                      <Row label="Context">
+                        <span class="font-mono text-fg">
+                          {tokens().toLocaleString()} tokens
+                        </span>
+                      </Row>
+                    )}
                   </Show>
                 </div>
               </Section>

--- a/packages/client/src/rpc/createSubscription.test.ts
+++ b/packages/client/src/rpc/createSubscription.test.ts
@@ -1,6 +1,21 @@
+import { unwrap } from "kolu-common/unwrap";
 import { createEffect, createRoot } from "solid-js";
 import { describe, expect, it } from "vitest";
-import { createSubscription } from "./createSubscription";
+import { createSubscription, type Subscription } from "./createSubscription";
+
+/** Test-local: read the current value of a subscription, throwing with a
+ *  descriptive message if it hasn't yielded yet. Replaces inline non-null
+ *  assertions on `sub()` so the failure mode is "subscription expected a
+ *  value but had none" rather than "Cannot read property of undefined".
+ *  Only the `undefined` case (no value yet) throws — `null` is a legitimate
+ *  yielded value, exercised by the "handles null values" test. */
+function readSub<T>(sub: Subscription<T>): T {
+  const value = sub();
+  if (value === undefined) {
+    throw new Error("subscription has not yielded a value yet");
+  }
+  return value;
+}
 
 /** Create an async iterable from an array, yielding items with optional delay. */
 async function* fromArray<T>(items: T[], delayMs = 0): AsyncGenerator<T> {
@@ -28,8 +43,9 @@ function controllableStream<T>() {
 
   async function* iterate(): AsyncGenerator<T> {
     while (true) {
-      if (queue.length > 0) {
-        yield queue.shift()!;
+      const head = queue.shift();
+      if (head !== undefined) {
+        yield head;
         continue;
       }
       if (done) return;
@@ -76,7 +92,7 @@ describe("createSubscription", () => {
             stream.push(42);
             await flush();
 
-            resolve({ value: sub()!, pending: sub.pending() });
+            resolve({ value: readSub(sub), pending: sub.pending() });
             stream.close();
             dispose();
           });
@@ -98,15 +114,15 @@ describe("createSubscription", () => {
           const values: number[] = [];
           stream.push(1);
           await flush();
-          values.push(sub()!);
+          values.push(readSub(sub));
 
           stream.push(2);
           await flush();
-          values.push(sub()!);
+          values.push(readSub(sub));
 
           stream.push(3);
           await flush();
-          values.push(sub()!);
+          values.push(readSub(sub));
 
           resolve(values);
           stream.close();
@@ -126,7 +142,7 @@ describe("createSubscription", () => {
             Promise.resolve(fromArray(["hello"])),
           );
           await flush();
-          resolve(sub()!);
+          resolve(readSub(sub));
           dispose();
         });
       });
@@ -141,7 +157,7 @@ describe("createSubscription", () => {
             Promise.resolve(fromArray([true])),
           );
           await flush();
-          resolve(sub()!);
+          resolve(readSub(sub));
           dispose();
         });
       });
@@ -156,7 +172,7 @@ describe("createSubscription", () => {
             Promise.resolve(fromArray([null as unknown as string])),
           );
           await flush();
-          resolve(sub()! as unknown as null);
+          resolve(readSub(sub) as unknown as null);
           dispose();
         });
       });
@@ -176,7 +192,7 @@ describe("createSubscription", () => {
 
           stream.push({ a: 1, b: 2 });
           await flush();
-          resolve(sub()!);
+          resolve(readSub(sub));
           stream.close();
           dispose();
         });
@@ -224,7 +240,7 @@ describe("createSubscription", () => {
             Promise.resolve(fromArray([[1, 2, 3]])),
           );
           await flush();
-          resolve([...(sub()! as unknown as number[])]);
+          resolve([...(readSub(sub) as unknown as number[])]);
           dispose();
         });
       });
@@ -255,7 +271,7 @@ describe("createSubscription", () => {
           stream.push(3);
           await flush();
 
-          resolve([...(sub()! as number[])]);
+          resolve([...(readSub(sub) as number[])]);
           stream.close();
           dispose();
         });
@@ -312,7 +328,7 @@ describe("createSubscription", () => {
             await flush();
 
             resolve({
-              error: sub.error()!.message,
+              error: unwrap(sub.error(), "expected sub.error()").message,
               pending: sub.pending(),
             });
             dispose();
@@ -336,7 +352,7 @@ describe("createSubscription", () => {
           );
 
           await flush();
-          resolve(sub.error()!.message);
+          resolve(unwrap(sub.error(), "expected sub.error()").message);
           dispose();
         });
       });
@@ -433,8 +449,7 @@ describe("createSubscription", () => {
           stream.push(3); // should not be received
           await flush();
 
-          const values = sub();
-          resolve([values!]);
+          resolve([readSub(sub)]);
           stream.close();
           dispose();
         });
@@ -455,7 +470,7 @@ describe("createSubscription", () => {
           stream.push(1);
           await flush();
 
-          resolve({ valueBefore: sub()! });
+          resolve({ valueBefore: readSub(sub) });
           dispose(); // triggers onCleanup → abort
         });
 
@@ -525,7 +540,7 @@ describe("createSubscription", () => {
 
             await flush();
             resolve({
-              error: sub.error()!.message,
+              error: unwrap(sub.error(), "expected sub.error()").message,
               pending: sub.pending(),
             });
             dispose();

--- a/packages/client/src/screenshotTerminal.ts
+++ b/packages/client/src/screenshotTerminal.ts
@@ -16,6 +16,7 @@
  *  sidesteps that entire surface. */
 
 import type { TerminalId, TerminalMetadata } from "kolu-common";
+import { unwrap } from "kolu-common/unwrap";
 import { toast } from "solid-sonner";
 import { FONT_FAMILY } from "terminal-themes";
 import { terminalName } from "./terminal/terminalDisplay";
@@ -23,7 +24,7 @@ import { getTerminalRefs } from "./terminal/terminalRefs";
 
 /** Standard xterm 256-color palette. First 16 come from the theme; 16-231
  *  form a 6×6×6 RGB cube; 232-255 are grayscale. */
-const CUBE_STEPS = [0, 95, 135, 175, 215, 255];
+const CUBE_STEPS: readonly number[] = [0, 95, 135, 175, 215, 255];
 
 /** Window chrome geometry (logical pixels). */
 const PAD = 16;
@@ -48,11 +49,20 @@ const BRAND_STEPS: ReadonlyArray<
   [16, 2, 10, 5, "#3b82f6"],
 ] as const;
 
+/** Indexed read into the 6-step palette. The math at the call sites
+ *  (`% 6`) is statically in-range, but TypeScript's
+ *  `noUncheckedIndexedAccess` widens the access to `number | undefined`
+ *  regardless — `unwrap` documents the static-bounds invariant at the
+ *  throw site. */
+function cubeStep(idx: number): number {
+  return unwrap(CUBE_STEPS[idx], `cubeStep idx ${idx} out of [0, 6)`);
+}
+
 function cubeColor(i: number): string {
   const n = i - 16;
-  const r = CUBE_STEPS[Math.floor(n / 36) % 6]!;
-  const g = CUBE_STEPS[Math.floor(n / 6) % 6]!;
-  const b = CUBE_STEPS[n % 6]!;
+  const r = cubeStep(Math.floor(n / 36) % 6);
+  const g = cubeStep(Math.floor(n / 6) % 6);
+  const b = cubeStep(n % 6);
   return `rgb(${r},${g},${b})`;
 }
 
@@ -164,12 +174,16 @@ function mix(a: string, b: string, ratio: number): string {
 function parseHex(c: string): { r: number; g: number; b: number } {
   const m = /^#([0-9a-f]{6})$/i.exec(c);
   if (m) {
-    const n = parseInt(m[1]!, 16);
+    const n = parseInt(unwrap(m[1], "hex regex shape changed"), 16);
     return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff };
   }
   const rgb = /^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/.exec(c);
   if (rgb) {
-    return { r: +rgb[1]!, g: +rgb[2]!, b: +rgb[3]! };
+    return {
+      r: +unwrap(rgb[1], "rgb regex shape changed"),
+      g: +unwrap(rgb[2], "rgb regex shape changed"),
+      b: +unwrap(rgb[3], "rgb regex shape changed"),
+    };
   }
   // Unknown color string — return black; the mix result will just be `b`.
   return { r: 0, g: 0, b: 0 };
@@ -295,7 +309,7 @@ export async function screenshotTerminal(
 
   // Traffic-light dots.
   const dotY = TITLE_H / 2;
-  for (let i = 0; i < DOT_MACOS.length; i++) {
+  for (const [i, color] of DOT_MACOS.entries()) {
     ctx.beginPath();
     ctx.arc(
       DOT_MARGIN_LEFT + i * (DOT_R * 2 + DOT_GAP),
@@ -304,7 +318,7 @@ export async function screenshotTerminal(
       0,
       Math.PI * 2,
     );
-    ctx.fillStyle = DOT_MACOS[i]!;
+    ctx.fillStyle = color;
     ctx.fill();
   }
 

--- a/packages/client/src/settings/useColorScheme.ts
+++ b/packages/client/src/settings/useColorScheme.ts
@@ -15,7 +15,9 @@ import { usePreferences } from "./usePreferences";
 
 export type { ColorScheme };
 
-let effectInitialized = false;
+// Lazily-initialised on first `useColorScheme()` call. Module-level so the
+// .dark class effect runs once across all consumers (singleton — see
+// solidjs.md "State per domain"). Once non-null it stays non-null.
 let sharedIsDark: (() => boolean) | null = null;
 
 export function useColorScheme() {
@@ -24,25 +26,29 @@ export function useColorScheme() {
   const setColorScheme = (scheme: ColorScheme) =>
     updatePreferences({ colorScheme: scheme });
 
-  // Toggle .dark class — only set up once (first consumer wins)
-  if (!effectInitialized) {
-    effectInitialized = true;
-    const prefersDark = usePrefersDark();
-    sharedIsDark = createMemo(() => {
-      const scheme = colorScheme();
-      return scheme === "dark" || (scheme === "system" && prefersDark());
-    });
-    createEffect(() => {
-      const dark = sharedIsDark!();
-      document.documentElement.classList.toggle("dark", dark);
-      document.documentElement.style.colorScheme = dark ? "dark" : "light";
-    });
-  }
+  // First consumer initialises the shared memo + side-effect; subsequent
+  // consumers reuse them.
+  const isDarkMemo = sharedIsDark ?? initSharedIsDark(colorScheme);
 
-  const isDark = () => sharedIsDark!();
+  const isDark = () => isDarkMemo();
   /** Resolved scheme as a string literal, for libraries that accept
    *  `"dark" | "light"` (e.g. Pierre's `themeType`). */
   const themeTypeLiteral = (): "light" | "dark" =>
-    sharedIsDark!() ? "dark" : "light";
+    isDarkMemo() ? "dark" : "light";
   return { colorScheme, setColorScheme, isDark, themeTypeLiteral } as const;
+}
+
+function initSharedIsDark(colorScheme: () => ColorScheme): () => boolean {
+  const prefersDark = usePrefersDark();
+  const memo = createMemo(() => {
+    const scheme = colorScheme();
+    return scheme === "dark" || (scheme === "system" && prefersDark());
+  });
+  createEffect(() => {
+    const dark = memo();
+    document.documentElement.classList.toggle("dark", dark);
+    document.documentElement.style.colorScheme = dark ? "dark" : "light";
+  });
+  sharedIsDark = memo;
+  return memo;
 }

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -51,7 +51,8 @@ function randomAmbientTip(): string {
   if (isMobile()) return "";
   const unseen = ambientPool.filter((t) => !seen().has(t.id));
   const pool = unseen.length > 0 ? unseen : ambientPool;
-  const pick = pool[Math.floor(Math.random() * pool.length)]!;
+  const pick = pool[Math.floor(Math.random() * pool.length)];
+  if (!pick) return "";
   if (!seen().has(pick.id)) markSeen(pick.id);
   return pick.text;
 }

--- a/packages/client/src/terminal/AgentIndicator.tsx
+++ b/packages/client/src/terminal/AgentIndicator.tsx
@@ -57,22 +57,27 @@ const AgentIndicator: Component<{ agent: AgentInfo }> = (props) => {
         <Dynamic component={Icon()} class="w-3 h-3" />
       </span>
       <span class="hidden sm:inline">{label()}</span>
-      {/* `!= null` (not truthy) so a legitimate `0` — e.g. a synthetic
-       *  assistant entry with a zeroed usage block — still renders. We
-       *  only want to hide when telemetry is *absent*, not when it's
-       *  zero. The `!` is safe inside the Show body (SolidJS re-runs
-       *  this subtree when contextTokens flips to null). */}
-      <Show when={props.agent.contextTokens != null}>
-        <span
-          data-testid="agent-context-tokens"
-          class="tabular-nums text-fg-3"
-          title={contextTokensTooltip(
-            props.agent.contextTokens!,
-            props.agent.model,
-          )}
-        >
-          {tokenFormat.format(props.agent.contextTokens!)}
-        </span>
+      {/* Wrap the value in an object so `<Show>`'s truthy check fires
+       *  even when `contextTokens` is `0` — a legitimate value for a
+       *  synthetic assistant entry with a zeroed usage block. Show's
+       *  callback then sees `box()` typed as `{ value: number }`,
+       *  dropping the `null | undefined` widening. */}
+      <Show
+        when={
+          props.agent.contextTokens != null
+            ? { value: props.agent.contextTokens }
+            : null
+        }
+      >
+        {(box) => (
+          <span
+            data-testid="agent-context-tokens"
+            class="tabular-nums text-fg-3"
+            title={contextTokensTooltip(box().value, props.agent.model)}
+          >
+            {tokenFormat.format(box().value)}
+          </span>
+        )}
       </Show>
     </span>
   );

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -637,8 +637,9 @@ const Terminal: Component<{
           let touchAnchorY: number | null = null;
           makeEventListener(containerRef, "touchstart", (e: TouchEvent) => {
             // Multi-touch (pinch-zoom) passes through to the browser
-            if (e.touches.length !== 1) return;
-            touchAnchorY = e.touches[0]!.clientY;
+            const first = e.touches[0];
+            if (e.touches.length !== 1 || first === undefined) return;
+            touchAnchorY = first.clientY;
           });
           makeEventListener(containerRef, "touchmove", (e: TouchEvent) => {
             // Multi-touch interrupts a swipe — drop the anchor so the next
@@ -657,8 +658,11 @@ const Terminal: Component<{
             // Number.isFinite catches NaN (0/0 if rows is transiently 0) which
             // a bare `<= 0` check would miss — NaN poisons the anchor.
             if (!Number.isFinite(cellHeight) || cellHeight <= 0) return;
-            const currentY = e.touches[0]!.clientY;
-            const lines = Math.trunc((currentY - touchAnchorY) / cellHeight);
+            const first = e.touches[0];
+            if (first === undefined) return;
+            const lines = Math.trunc(
+              (first.clientY - touchAnchorY) / cellHeight,
+            );
             if (lines === 0) return;
             // Down-swipe (positive delta) shows earlier scrollback → scrollLines(-N)
             terminal.scrollLines(-lines);

--- a/packages/client/src/terminal/terminalDisplay.test.ts
+++ b/packages/client/src/terminal/terminalDisplay.test.ts
@@ -93,11 +93,10 @@ describe("buildTerminalDisplayInfos", () => {
       () => [],
     );
     expect(result.size).toBe(1);
-    const info = result.get("id-1")!;
-    expect(info.name).toBe("repo");
-    expect(info.repoColor).toMatch(/^oklch\(/);
-    expect(info.branchColor).toMatch(/^oklch\(/);
-    expect(info.subCount).toBe(0);
+    expect(result.get("id-1")?.name).toBe("repo");
+    expect(result.get("id-1")?.repoColor).toMatch(/^oklch\(/);
+    expect(result.get("id-1")?.branchColor).toMatch(/^oklch\(/);
+    expect(result.get("id-1")?.subCount).toBe(0);
   });
 
   it("counts sub-terminals", () => {
@@ -106,7 +105,7 @@ describe("buildTerminalDisplayInfos", () => {
       () => makeMeta(),
       () => ["sub-1", "sub-2"],
     );
-    expect(result.get("id-1")!.subCount).toBe(2);
+    expect(result.get("id-1")?.subCount).toBe(2);
   });
 
   it("skips terminals with no metadata", () => {
@@ -129,8 +128,8 @@ describe("buildTerminalDisplayInfos", () => {
           : makeMeta({ git: makeGit({ branch: "feature" }) }),
       () => [],
     );
-    expect(result.get("aaaa-1")!.key.suffix).toBeUndefined();
-    expect(result.get("bbbb-2")!.key.suffix).toBeUndefined();
+    expect(result.get("aaaa-1")?.key.suffix).toBeUndefined();
+    expect(result.get("bbbb-2")?.key.suffix).toBeUndefined();
   });
 
   it("stamps collision suffixes on terminals sharing (group, label)", () => {
@@ -142,8 +141,8 @@ describe("buildTerminalDisplayInfos", () => {
           : makeMeta({ git: makeGit({ branch: "main" }) }),
       () => [],
     );
-    expect(result.get("aaaa-1")!.key.suffix).toBe("#aaaa");
-    expect(result.get("bbbb-2")!.key.suffix).toBe("#bbbb");
-    expect(result.get("cccc-3")!.key.suffix).toBeUndefined();
+    expect(result.get("aaaa-1")?.key.suffix).toBe("#aaaa");
+    expect(result.get("bbbb-2")?.key.suffix).toBe("#bbbb");
+    expect(result.get("cccc-3")?.key.suffix).toBeUndefined();
   });
 });

--- a/packages/client/src/terminal/terminalDisplay.ts
+++ b/packages/client/src/terminal/terminalDisplay.ts
@@ -8,6 +8,7 @@ import {
   type TerminalKey,
   type TerminalMetadata,
 } from "kolu-common";
+import { unwrap } from "kolu-common/unwrap";
 import { cwdBasename } from "../path";
 
 export type TerminalDisplayInfo = {
@@ -80,7 +81,10 @@ export function buildTerminalDisplayInfos(
       repoColor: repoKey ? unified.get(repoKey) : undefined,
       branchColor: branchKey ? unified.get(branchKey) : undefined,
       subCount: getSubTerminalIds(id).length,
-      key: keys.get(id)!,
+      // `computeTerminalKeys` keys its map by the ids we just passed in,
+      // so every id in `entries` has an entry. Documented at the throw
+      // site instead of hidden behind `!`.
+      key: unwrap(keys.get(id), `computeTerminalKeys missed id ${id}`),
     });
   }
   return result;

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -68,9 +68,13 @@ export function useSessionRestore(deps: {
     // Initialize sub-panel active tabs for parents with sub-terminals
     const subs: Record<TerminalId, TerminalId[]> = {};
     for (const t of existing) {
-      if (t.meta.parentId) {
-        subs[t.meta.parentId] ??= [];
-        subs[t.meta.parentId]!.push(t.id);
+      const parentId = t.meta.parentId;
+      if (!parentId) continue;
+      const existingList = subs[parentId];
+      if (existingList) {
+        existingList.push(t.id);
+      } else {
+        subs[parentId] = [t.id];
       }
     }
     for (const [parentId, subIds] of Object.entries(subs)) {
@@ -140,7 +144,11 @@ export function useSessionRestore(deps: {
       // Array order is the ordering — the server wrote terminals in Map
       // insertion order, and that order round-trips verbatim through disk.
       const topLevel = session.terminals.filter((t) => !t.parentId);
-      const subTerminals = session.terminals.filter((t) => t.parentId);
+      // Type predicate so the body of the loop below sees `parentId`
+      // narrowed to `string` instead of `string | undefined`.
+      const subTerminals = session.terminals.filter(
+        (t): t is typeof t & { parentId: string } => t.parentId !== undefined,
+      );
       let resumed = 0;
       // Seed each new terminal with its saved metadata atomically at create
       // time — the server embeds it into the first `terminal.list` snapshot,
@@ -175,7 +183,7 @@ export function useSessionRestore(deps: {
         }
       }
       for (const t of subTerminals) {
-        const newParentId = oldToNew.get(t.parentId!);
+        const newParentId = oldToNew.get(t.parentId);
         if (newParentId) await deps.handleCreateSubTerminal(newParentId, t.cwd);
       }
       // Restore active terminal

--- a/packages/client/src/terminal/useSubPanel.ts
+++ b/packages/client/src/terminal/useSubPanel.ts
@@ -2,6 +2,7 @@
  *  Reported to server for session snapshots; seeded from server on restore. */
 
 import type { TerminalId } from "kolu-common";
+import { unwrap } from "kolu-common/unwrap";
 import { createStore, produce } from "solid-js/store";
 import { client } from "../rpc/rpc";
 
@@ -19,15 +20,16 @@ const DEFAULT_PANEL_SIZE = 0.3;
 const [state, setState] = createStore<Record<TerminalId, SubPanelState>>({});
 
 function ensureState(parentId: TerminalId): SubPanelState {
-  if (!state[parentId]) {
-    setState(parentId, {
-      collapsed: false,
-      panelSize: DEFAULT_PANEL_SIZE,
-      activeSubTab: null,
-      focusTarget: "sub",
-    });
-  }
-  return state[parentId]!;
+  const existing = state[parentId];
+  if (existing) return existing;
+  const seeded: SubPanelState = {
+    collapsed: false,
+    panelSize: DEFAULT_PANEL_SIZE,
+    activeSubTab: null,
+    focusTarget: "sub",
+  };
+  setState(parentId, seeded);
+  return seeded;
 }
 
 /** Report sub-panel state to server for session persistence. */
@@ -86,7 +88,13 @@ export function useSubPanel() {
       const panel = ensureState(parentId);
       const current = subIds.indexOf(panel.activeSubTab as string);
       const next = (current + direction + subIds.length) % subIds.length;
-      setState(parentId, "activeSubTab", subIds[next]!);
+      // `next` is in `[0, subIds.length)` by the modulus and the early
+      // return above; documenting that at the throw site.
+      setState(
+        parentId,
+        "activeSubTab",
+        unwrap(subIds[next], `cycleSubTab: index ${next} out of bounds`),
+      );
     },
 
     setFocusTarget(parentId: TerminalId, target: "main" | "sub") {

--- a/packages/client/src/terminal/useTerminalAlerts.ts
+++ b/packages/client/src/terminal/useTerminalAlerts.ts
@@ -48,10 +48,10 @@ export function useTerminalAlerts(deps: {
       () => deps.terminalIds().map((id) => deps.getMetadata(id)?.agent?.state),
       (states, prevStates) => {
         const ids = deps.terminalIds();
-        for (let i = 0; i < ids.length; i++) {
-          if (prevStates && prevStates[i] !== undefined) {
-            checkAgentFinished(ids[i]!, prevStates[i], states[i]);
-          }
+        if (!prevStates) return;
+        for (const [i, id] of ids.entries()) {
+          const prev = prevStates[i];
+          if (prev !== undefined) checkAgentFinished(id, prev, states[i]);
         }
       },
     ),
@@ -83,8 +83,9 @@ export function useTerminalAlerts(deps: {
       options?.target === "active"
         ? deps.terminalIds().filter((id) => id === deps.activeId())
         : deps.terminalIds().filter((id) => id !== deps.activeId());
-    if (ids.length === 0) return;
-    alertForTerminal(ids[Math.floor(Math.random() * ids.length)]!);
+    const pick = ids[Math.floor(Math.random() * ids.length)];
+    if (pick === undefined) return;
+    alertForTerminal(pick);
   }
 
   return { simulateAlert };

--- a/packages/client/src/ui/PierreDiffView.tsx
+++ b/packages/client/src/ui/PierreDiffView.tsx
@@ -88,12 +88,12 @@ const PierreDiffView: Component<PierreDiffViewProps> = (props) => {
 
   return (
     <div
-      ref={host!}
+      ref={host}
       class="h-full w-full"
       onContextMenu={(e) => menuCtrl?.open(e)}
     >
       <div
-        ref={container!}
+        ref={container}
         class="h-full w-full overflow-auto"
         style={pierreDiffsStyle}
         data-testid="pierre-diff-view"

--- a/packages/client/src/ui/PierreFileTree.tsx
+++ b/packages/client/src/ui/PierreFileTree.tsx
@@ -191,7 +191,7 @@ const PierreFileTree: Component<PierreFileTreeProps> = (props) => {
 
   return (
     <div
-      ref={container!}
+      ref={container}
       class="h-full w-full"
       style={pierreTreesStyle}
       data-testid="pierre-file-tree"

--- a/packages/client/src/ui/PierreFileView.tsx
+++ b/packages/client/src/ui/PierreFileView.tsx
@@ -65,12 +65,12 @@ const PierreFileView: Component<PierreFileViewProps> = (props) => {
 
   return (
     <div
-      ref={host!}
+      ref={host}
       class="h-full w-full"
       onContextMenu={(e) => menuCtrl?.open(e)}
     >
       <div
-        ref={container!}
+        ref={container}
         class="h-full w-full overflow-auto"
         style={pierreDiffsStyle}
         data-testid="pierre-file-view"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,7 +13,8 @@
     "./errors": "./src/errors.ts",
     "./config": "./src/config.ts",
     "./pr": "./src/pr.ts",
-    "./test-hooks": "./src/test-hooks.ts"
+    "./test-hooks": "./src/test-hooks.ts",
+    "./unwrap": "./src/unwrap.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/common/src/unwrap.ts
+++ b/packages/common/src/unwrap.ts
@@ -1,0 +1,9 @@
+/**
+ * Re-export of `unwrap` from `anyagent` so higher-level kolu code
+ * (client, server, common itself) can import it through the same
+ * `kolu-common/*` namespace they use for the rest of the shared
+ * surface. The implementation lives in `anyagent` because integration
+ * packages need it too and `kolu-common` sits above them in the
+ * workspace dep graph.
+ */
+export { unwrap } from "anyagent/unwrap";

--- a/packages/integrations/anyagent/package.json
+++ b/packages/integrations/anyagent/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./schemas": "./src/schemas.ts",
-    "./cli": "./src/agent-cli.ts"
+    "./cli": "./src/agent-cli.ts",
+    "./unwrap": "./src/unwrap.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/integrations/anyagent/src/agent-cli.ts
+++ b/packages/integrations/anyagent/src/agent-cli.ts
@@ -30,6 +30,7 @@
  */
 
 import { parseArgsStringToArgv } from "string-argv";
+import { unwrap } from "./unwrap.ts";
 
 /** Flags that cause the CLI to print info and exit immediately.
  *  Commands containing any of these are not agent sessions. */
@@ -124,13 +125,30 @@ function basename(s: string): string {
  */
 type ResumableAgent = "claude" | "codex" | "opencode";
 
+/** Insert one or more "resume" tokens after the agent binary in a
+ *  normalized argv. The argv is non-empty by `resumeAgentCommand`'s
+ *  precondition (callers `parseArgsStringToArgv` and check `length`),
+ *  but TypeScript's `noUncheckedIndexedAccess` widens `argv[0]` to
+ *  `string | undefined` regardless — `unwrap` documents the
+ *  precondition at the throw site. */
+function withResumeFlags(
+  argv: readonly string[],
+  ...flags: string[]
+): string[] {
+  return [
+    unwrap(argv[0], "resume transform invoked on empty argv"),
+    ...flags,
+    ...argv.slice(1),
+  ];
+}
+
 const AGENT_RESUME: Record<
   ResumableAgent,
   (argv: readonly string[]) => string[]
 > = {
-  claude: (argv) => [argv[0]!, "-c", ...argv.slice(1)],
-  codex: (argv) => [argv[0]!, "resume", ...argv.slice(1)],
-  opencode: (argv) => [argv[0]!, "--continue", ...argv.slice(1)],
+  claude: (argv) => withResumeFlags(argv, "-c"),
+  codex: (argv) => withResumeFlags(argv, "resume"),
+  opencode: (argv) => withResumeFlags(argv, "--continue"),
 };
 
 /**
@@ -139,37 +157,37 @@ const AGENT_RESUME: Record<
  * to a known agent binary, or `null` otherwise.
  */
 export function parseAgentCommand(raw: string): string | null {
-  const tokens = parseArgsStringToArgv(raw.trim());
-  if (tokens.length === 0) return null;
+  const [head, ...args] = parseArgsStringToArgv(raw.trim());
+  if (head === undefined) return null;
 
-  const agent = basename(tokens[0]!);
-  if (!STABLE_FLAGS.has(agent)) return null;
-
-  const args = tokens.slice(1);
+  const agent = basename(head);
+  const allowed = STABLE_FLAGS.get(agent);
+  if (allowed === undefined) return null;
 
   // Exit-immediately flags → not an agent session.
   if (args.some((t) => EXIT_FLAGS.has(t))) return null;
-
-  const allowed = STABLE_FLAGS.get(agent)!;
 
   // Keep only allowlisted flags + their values.
   // Anything else (unknown flags, positional args) is dropped.
   const kept: string[] = [agent];
   for (let i = 0; i < args.length; i++) {
-    const t = args[i]!;
+    const t = args[i];
+    if (t === undefined) break;
     if (t === "--") break; // stop at explicit end-of-flags
     if (!t.startsWith("-")) continue; // drop positional
+    const next = args[i + 1];
     if (!allowed.has(t)) {
       // Unknown flag — skip it and its value (if present)
-      if (i + 1 < args.length && !args[i + 1]!.startsWith("-")) i++;
+      if (next !== undefined && !next.startsWith("-")) i++;
       continue;
     }
     // Stable flag — keep verbatim
     kept.push(t);
     // If the next token is a non-flag value (e.g. `--model sonnet`),
     // attach it to the flag as-is.
-    if (i + 1 < args.length && !args[i + 1]!.startsWith("-")) {
-      kept.push(args[++i]!);
+    if (next !== undefined && !next.startsWith("-")) {
+      kept.push(next);
+      i++;
     }
   }
   return kept.join(" ");
@@ -183,8 +201,7 @@ export function parseAgentCommand(raw: string): string | null {
  */
 export function resumeAgentCommand(normalized: string): string | null {
   const argv = parseArgsStringToArgv(normalized.trim());
-  if (argv.length === 0) return null;
-  const agent = argv[0]!;
-  if (!(agent in AGENT_RESUME)) return null;
+  const agent = argv[0];
+  if (agent === undefined || !(agent in AGENT_RESUME)) return null;
   return AGENT_RESUME[agent as ResumableAgent](argv).join(" ");
 }

--- a/packages/integrations/anyagent/src/unwrap.ts
+++ b/packages/integrations/anyagent/src/unwrap.ts
@@ -1,0 +1,27 @@
+/**
+ * `unwrap` — narrow a `T | undefined | null` to `T` or throw with a
+ * descriptive message. The Haskell `fromJust` analogue, but forced to
+ * carry a `message` so the throw site is debuggable instead of giving
+ * the bare "Cannot read properties of undefined".
+ *
+ * Use at boundaries where TypeScript can't see the invariant:
+ *   - `Map.get(key)` when the caller has externally established that
+ *     `key` is in the map (`unwrap(map.get(k), \`no entry for ${k}\`)`)
+ *   - regex match groups that the pattern guarantees but TS types as
+ *     `string | undefined` (`unwrap(match[1], "regex shape changed")`)
+ *   - DOM lookups where the consumer has just verified existence
+ *
+ * Don't use it as a quieter `!`. If the value's non-nullness is provable
+ * by control flow (a preceding `if (x === undefined) return`), narrow
+ * locally instead — TypeScript will track that and the call is gone.
+ *
+ * Introduced in #710 / #721 alongside the `noNonNullAssertion` rule
+ * flip: every load-bearing `!` either narrowed via control flow or
+ * routed through this helper, so the throw site is the documentation.
+ */
+export function unwrap<T>(value: T | undefined | null, message: string): T {
+  if (value === undefined || value === null) {
+    throw new Error(`unwrap: ${message}`);
+  }
+  return value;
+}

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -201,6 +201,8 @@ export function deriveState(lines: string[]): {
   let contextTokens: number | null = null;
 
   for (let i = lines.length - 1; i >= 0; i--) {
+    const raw = lines[i];
+    if (raw === undefined) continue;
     try {
       const entry: {
         type?: string;
@@ -209,7 +211,7 @@ export function deriveState(lines: string[]): {
           model?: string | null;
           usage?: UsageShape;
         };
-      } = JSON.parse(lines[i]!);
+      } = JSON.parse(raw);
 
       if (contextTokens === null) {
         const tokens = sumUsageTokens(entry.message?.usage);
@@ -319,10 +321,11 @@ export function extractTasks(
     }
 
     // TaskUpdate calls come on "assistant" type messages as tool_use content blocks
-    if (entry.type !== "assistant" || !Array.isArray(entry.message?.content))
-      continue;
+    if (entry.type !== "assistant") continue;
+    const content = entry.message?.content;
+    if (!Array.isArray(content)) continue;
 
-    for (const block of entry.message!.content!) {
+    for (const block of content) {
       if (block.type !== "tool_use" || block.name !== "TaskUpdate") continue;
       const input = block.input;
       if (!input || typeof input !== "object") {

--- a/packages/integrations/codex/src/config.ts
+++ b/packages/integrations/codex/src/config.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { unwrap } from "anyagent/unwrap";
 
 /** Root of Codex's per-user state directory. Contains the threads
  *  SQLite DB, session JSONL rollouts, auth, and config. */
@@ -34,7 +35,12 @@ export function findCodexStateDbPath(dir: string = CODEX_DIR): string | null {
   for (const name of entries) {
     const match = /^state_(\d+)\.sqlite$/.exec(name);
     if (!match) continue;
-    const version = Number.parseInt(match[1]!, 10);
+    // Group 1 is required by the pattern itself — `unwrap` documents that
+    // invariant at the throw site rather than papering over it with `!`.
+    const version = Number.parseInt(
+      unwrap(match[1], `state_(\\d+).sqlite regex shape changed for ${name}`),
+      10,
+    );
     if (version > bestVersion) {
       bestVersion = version;
       bestFile = name;

--- a/packages/integrations/codex/src/core.ts
+++ b/packages/integrations/codex/src/core.ts
@@ -366,9 +366,11 @@ export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {
  */
 export function parseRolloutContextTokens(lines: string[]): number | null {
   for (let i = lines.length - 1; i >= 0; i--) {
+    const raw = lines[i];
+    if (raw === undefined) continue;
     let entry: RolloutLine;
     try {
-      entry = JSON.parse(lines[i]!) as RolloutLine;
+      entry = JSON.parse(raw) as RolloutLine;
     } catch {
       continue;
     }

--- a/packages/memorable-names/package.json
+++ b/packages/memorable-names/package.json
@@ -14,6 +14,9 @@
     "typecheck": "tsc --noEmit",
     "test:unit": "vitest run"
   },
+  "dependencies": {
+    "anyagent": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "^5.8.0",
     "vitest": "^4.1.2"

--- a/packages/memorable-names/src/index.ts
+++ b/packages/memorable-names/src/index.ts
@@ -6,10 +6,17 @@
  *   just regenerate  (from packages/memorable-names/)
  */
 
+import { unwrap } from "anyagent/unwrap";
 import words from "../words.json" with { type: "json" };
 
 function pick(list: string[]): string {
-  return list[Math.floor(Math.random() * list.length)]!;
+  // The math (uniform random × length, floored) is in-range for any
+  // non-empty list — `unwrap` documents the precondition at the throw
+  // site instead of the bare `!`.
+  return unwrap(
+    list[Math.floor(Math.random() * list.length)],
+    "memorable-names pick: word list is empty",
+  );
 }
 
 /** Generate a random ADJ-NOUN name (e.g. "bright-falcon"). */

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from "kolu-common/unwrap";
 import type { SavedTerminal } from "kolu-common";
 import { afterAll, describe, expect, it } from "vitest";
 import {
@@ -39,15 +40,17 @@ describe("session persistence", () => {
       terminals: [terminal],
       activeTerminalId: null,
     });
-    const session = getSavedSession();
-    expect(session).not.toBeNull();
-    expect(session!.terminals).toHaveLength(1);
-    expect(session!.terminals[0]).toMatchObject({
+    const session = unwrap(
+      getSavedSession(),
+      "session round-trip lost the saved value",
+    );
+    expect(session.terminals).toHaveLength(1);
+    expect(session.terminals[0]).toMatchObject({
       id: "term-1",
       cwd: "/home/user/project",
       git: { repoName: "project", branch: "main" },
     });
-    expect(session!.savedAt).toBeTypeOf("number");
+    expect(session.savedAt).toBeTypeOf("number");
   });
 
   it("clears session when saving empty terminals", () => {
@@ -76,10 +79,13 @@ describe("session persistence", () => {
       { id: "c", cwd: "/c", git: null, parentId: "a" },
     ];
     saveSession({ terminals, activeTerminalId: null });
-    const session = getSavedSession();
-    expect(session!.terminals).toHaveLength(3);
-    expect(session!.terminals.map((t) => t.id)).toEqual(["a", "b", "c"]);
-    expect(session!.terminals[2]!.parentId).toBe("a");
+    const session = unwrap(
+      getSavedSession(),
+      "session round-trip lost the saved value",
+    );
+    expect(session.terminals).toHaveLength(3);
+    expect(session.terminals.map((t) => t.id)).toEqual(["a", "b", "c"]);
+    expect(session.terminals[2]?.parentId).toBe("a");
   });
 
   it("preserves themeName on round-trip", () => {
@@ -88,9 +94,12 @@ describe("session persistence", () => {
       { id: "b", cwd: "/b", git: null },
     ];
     saveSession({ terminals, activeTerminalId: null });
-    const session = getSavedSession();
-    expect(session!.terminals[0]!.themeName).toBe("Dracula");
-    expect(session!.terminals[1]!.themeName).toBeUndefined();
+    const session = unwrap(
+      getSavedSession(),
+      "session round-trip lost the saved value",
+    );
+    expect(session.terminals[0]?.themeName).toBe("Dracula");
+    expect(session.terminals[1]?.themeName).toBeUndefined();
   });
 
   it("clearSavedSession removes the session", () => {

--- a/packages/server/src/shell.test.ts
+++ b/packages/server/src/shell.test.ts
@@ -49,8 +49,8 @@ describe("OSC7_FN", () => {
     // First emission ends with /, second ends with /tmp
     const matches = [...out.matchAll(/file:\/\/[^/]+([^\x1b]*)/g)];
     expect(matches).toHaveLength(2);
-    expect(matches[0]![1]).toBe("/");
-    expect(matches[1]![1]).toBe("/tmp");
+    expect(matches[0]?.[1]).toBe("/");
+    expect(matches[1]?.[1]).toBe("/tmp");
   });
 });
 

--- a/packages/server/src/shell.ts
+++ b/packages/server/src/shell.ts
@@ -58,7 +58,8 @@ export function cleanEnv(): Record<string, string> {
   if (envWhitelist) {
     env = {};
     for (const key of envWhitelist) {
-      if (process.env[key] != null) env[key] = process.env[key]!;
+      const value = process.env[key];
+      if (value != null) env[key] = value;
     }
     // Nix sets SHELL to /nix/store/.../bash which lacks features like progcomp
     // that user bashrc files expect. Use the real login shell from /etc/passwd.

--- a/packages/terminal-themes/package.json
+++ b/packages/terminal-themes/package.json
@@ -15,7 +15,8 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
-    "@xterm/xterm": "^6.0.0"
+    "@xterm/xterm": "^6.0.0",
+    "anyagent": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.8.0",

--- a/packages/terminal-themes/src/picker.test.ts
+++ b/packages/terminal-themes/src/picker.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from "anyagent/unwrap";
 import { describe, expect, it } from "vitest";
 import { hexToOkLab, okLabDistance, pickTheme } from "./picker";
 import type { NamedTheme } from "./theme";
@@ -14,9 +15,8 @@ function seqRand(...values: number[]): () => number {
 
 describe("hexToOkLab", () => {
   it("parses #rrggbb", () => {
-    const lab = hexToOkLab("#000000");
-    expect(lab).toBeDefined();
-    expect(lab!.L).toBeCloseTo(0, 5);
+    const lab = unwrap(hexToOkLab("#000000"), "#000000 should parse");
+    expect(lab.L).toBeCloseTo(0, 5);
   });
 
   it("parses #rgb shorthand same as full form", () => {
@@ -33,8 +33,8 @@ describe("hexToOkLab", () => {
   });
 
   it("white has max L", () => {
-    const white = hexToOkLab("#ffffff")!;
-    const black = hexToOkLab("#000000")!;
+    const white = unwrap(hexToOkLab("#ffffff"), "#ffffff should parse");
+    const black = unwrap(hexToOkLab("#000000"), "#000000 should parse");
     expect(white.L).toBeGreaterThan(black.L);
     expect(white.L).toBeCloseTo(1, 2);
   });
@@ -42,7 +42,7 @@ describe("hexToOkLab", () => {
 
 describe("okLabDistance", () => {
   it("is zero for identical colours", () => {
-    const a = hexToOkLab("#282a36")!;
+    const a = unwrap(hexToOkLab("#282a36"), "#282a36 should parse");
     expect(okLabDistance(a, a)).toBe(0);
   });
 
@@ -167,8 +167,14 @@ describe("pickTheme – shuffle mode", () => {
     const rand = seqRand(0.0, 0.34, 0.67, 0.99, 0.5);
     for (let i = 0; i < 4; i++) {
       const candidates = themes.filter((t) => t.name !== current);
-      const currentBg = themes.find((t) => t.name === current)!.theme
-        .background!;
+      const currentTheme = unwrap(
+        themes.find((t) => t.name === current),
+        `theme ${current} not in fixture`,
+      );
+      const currentBg = unwrap(
+        currentTheme.theme.background,
+        `theme ${current} has no background`,
+      );
       current = pickTheme(candidates, { excludeBgs: [currentBg], rand });
       visited.push(current);
     }

--- a/packages/terminal-themes/src/picker.ts
+++ b/packages/terminal-themes/src/picker.ts
@@ -14,6 +14,8 @@ interface OkLab {
   b: number;
 }
 
+import { unwrap } from "anyagent/unwrap";
+
 /** sRGB gamma → linear light. */
 function srgbToLinear(c: number): number {
   return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
@@ -25,9 +27,13 @@ function srgbToLinear(c: number): number {
 export function hexToOkLab(hex: string): OkLab | undefined {
   const m = hex.trim().match(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
   if (!m) return undefined;
-  const s = m[1]!;
-  const full =
-    s.length === 3 ? s[0]! + s[0]! + s[1]! + s[1]! + s[2]! + s[2]! : s;
+  // Group 1 is required by the alternation; the throw documents that
+  // contract instead of papering over it with `!`.
+  const s = unwrap(m[1], "hex regex shape changed");
+  // Expand `#rgb` → `#rrggbb` by doubling each character. `Array.from`
+  // ensures TS sees `c` as `string` (not `string | undefined`) without
+  // any per-index nullability dance.
+  const full = s.length === 3 ? [...s].map((c) => c + c).join("") : s;
   const r = parseInt(full.slice(0, 2), 16) / 255;
   const g = parseInt(full.slice(2, 4), 16) / 255;
   const b = parseInt(full.slice(4, 6), 16) / 255;
@@ -127,7 +133,10 @@ function pickSpread(
     if (lab) peerLabs.push(lab);
   }
   if (peerLabs.length === 0) {
-    return pool[Math.floor(rand() * pool.length)]!.name;
+    return unwrap(
+      pool[Math.floor(rand() * pool.length)],
+      "filterEligible falls back to candidates, which the public entry asserts non-empty",
+    ).name;
   }
   const scores: number[] = [];
   let bestScore = Number.NEGATIVE_INFINITY;
@@ -150,11 +159,12 @@ function pickSpread(
   }
   const threshold = bestScore - SCORE_TOLERANCE;
   const band: number[] = [];
-  for (let i = 0; i < scores.length; i++) {
-    if (scores[i]! >= threshold) band.push(i);
+  for (const [i, score] of scores.entries()) {
+    if (score >= threshold) band.push(i);
   }
   const pickIdx = band[Math.floor(rand() * band.length)] ?? 0;
-  return pool[pickIdx]!.name;
+  return unwrap(pool[pickIdx], "pickIdx came from band-of-valid-pool-indices")
+    .name;
 }
 
 /** Pick uniformly at random, excluding `excludeBgs`. */
@@ -164,7 +174,10 @@ function pickShuffle(
   rand: () => number,
 ): string {
   const pool = filterEligible(candidates, new Set(excludeBgs));
-  return pool[Math.floor(rand() * pool.length)]!.name;
+  return unwrap(
+    pool[Math.floor(rand() * pool.length)],
+    "filterEligible falls back to candidates, which the public entry asserts non-empty",
+  ).name;
 }
 
 /**

--- a/packages/terminal-themes/src/theme.ts
+++ b/packages/terminal-themes/src/theme.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ITheme } from "@xterm/xterm";
+import { unwrap } from "anyagent/unwrap";
 import availableThemesJson from "../themes.json" with { type: "json" };
 
 export interface NamedTheme {
@@ -21,7 +22,9 @@ export const availableThemes: NamedTheme[] =
 export const DEFAULT_THEME_NAME = "Tomorrow Night";
 export const DEFAULT_THEME: ITheme =
   availableThemes.find((t) => t.name === DEFAULT_THEME_NAME)?.theme ??
-  availableThemes[0]!.theme;
+  // themes.json ships non-empty (built from iTerm2-Color-Schemes); the
+  // empty-fallback throw documents the contract explicitly.
+  unwrap(availableThemes[0], "themes.json is empty").theme;
 
 // O(1) lookup by name, built once at module load
 const themesByName = new Map(availableThemes.map((t) => [t.name, t.theme]));

--- a/packages/tests/step_definitions/claude_code_steps.ts
+++ b/packages/tests/step_definitions/claude_code_steps.ts
@@ -45,9 +45,10 @@ async function getTerminalPid(world: KoluWorld): Promise<number> {
       if (markerIdx <= 0) return null;
       // Walk backwards from marker to find the PID (first purely numeric line).
       for (let i = markerIdx - 1; i >= 0; i--) {
-        const num = parseInt(lines[i]!, 10);
-        if (!Number.isNaN(num) && num > 0 && String(num) === lines[i])
-          return num;
+        const line = lines[i];
+        if (line === undefined) continue;
+        const num = parseInt(line, 10);
+        if (!Number.isNaN(num) && num > 0 && String(num) === line) return num;
       }
       return null;
     },

--- a/packages/tests/step_definitions/clipboard_steps.ts
+++ b/packages/tests/step_definitions/clipboard_steps.ts
@@ -16,7 +16,8 @@ When("I paste an image into the terminal", async function (this: KoluWorld) {
   // Write a 1×1 PNG to the system clipboard
   await this.page.evaluate(async () => {
     const canvas = new OffscreenCanvas(1, 1);
-    const ctx = canvas.getContext("2d")!;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("OffscreenCanvas getContext('2d') unavailable");
     ctx.fillStyle = "red";
     ctx.fillRect(0, 0, 1, 1);
     const blob = await canvas.convertToBlob({ type: "image/png" });

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -34,11 +34,7 @@ Then(
     // from 2 to 4. Asserting >= N tolerates extra renders.
     await this.page.waitForFunction(
       ([sel, exp, n]) => {
-        const buf: string = (
-          window as Window & {
-            __readXtermBuffer?: (s: string, i: number) => string;
-          }
-        ).__readXtermBuffer!(sel, 0);
+        const buf = window.__readXtermBuffer?.(sel, 0) ?? "";
         let occurrences = 0;
         let idx = 0;
         while ((idx = buf.indexOf(exp, idx)) !== -1) {

--- a/packages/tests/step_definitions/scroll_lock_steps.ts
+++ b/packages/tests/step_definitions/scroll_lock_steps.ts
@@ -192,8 +192,9 @@ Then(
 Then(
   "the scroll position should be unchanged",
   async function (this: KoluWorld) {
+    const saved = this.savedScrollTop;
     assert.ok(
-      this.savedScrollTop !== undefined,
+      saved !== undefined,
       "No saved scroll position — was 'I note the scroll position' called first?",
     );
     const current = await this.page
@@ -201,8 +202,8 @@ Then(
       .evaluate((el) => el.scrollTop);
     // Allow small tolerance (1px) for rounding
     assert.ok(
-      Math.abs(current - this.savedScrollTop!) <= 1,
-      `Scroll position changed: was ${this.savedScrollTop}, now ${current}`,
+      Math.abs(current - saved) <= 1,
+      `Scroll position changed: was ${saved}, now ${current}`,
     );
   },
 );

--- a/packages/tests/step_definitions/sub_terminal_steps.ts
+++ b/packages/tests/step_definitions/sub_terminal_steps.ts
@@ -26,10 +26,16 @@ async function paletteCommand(world: KoluWorld, query: string) {
     ({ sel, q }) => {
       const input = document.querySelector(`${sel} input`) as HTMLInputElement;
       if (!input) throw new Error("Palette input not found");
-      const nativeSet = Object.getOwnPropertyDescriptor(
+      // Bypass Solid's reactivity by calling the native HTMLInputElement.value
+      // setter directly. Both lookups should always succeed in a real browser
+      // — the explicit guards turn an environmental misconfiguration into a
+      // descriptive throw rather than `Cannot read properties of undefined`.
+      const descriptor = Object.getOwnPropertyDescriptor(
         HTMLInputElement.prototype,
         "value",
-      )!.set!;
+      );
+      const nativeSet = descriptor?.set;
+      if (!nativeSet) throw new Error("HTMLInputElement.value setter missing");
       nativeSet.call(input, q);
       input.dispatchEvent(new Event("input", { bubbles: true }));
     },

--- a/packages/tests/step_definitions/terminal_steps.ts
+++ b/packages/tests/step_definitions/terminal_steps.ts
@@ -277,11 +277,9 @@ Then(
   "the font size should be larger than before",
   async function (this: KoluWorld) {
     const current = await this.fontSize();
-    assert.ok(this.savedFontSize !== undefined, "No saved font size");
-    assert.ok(
-      current > this.savedFontSize!,
-      `Font size ${current} not larger than ${this.savedFontSize}`,
-    );
+    const saved = this.savedFontSize;
+    assert.ok(saved !== undefined, "No saved font size");
+    assert.ok(current > saved, `Font size ${current} not larger than ${saved}`);
   },
 );
 
@@ -289,10 +287,11 @@ Then(
   "the font size should be smaller than the original",
   async function (this: KoluWorld) {
     const current = await this.fontSize();
-    assert.ok(this.savedFontSize !== undefined, "No saved font size");
+    const saved = this.savedFontSize;
+    assert.ok(saved !== undefined, "No saved font size");
     assert.ok(
-      current < this.savedFontSize!,
-      `Font size ${current} not smaller than ${this.savedFontSize}`,
+      current < saved,
+      `Font size ${current} not smaller than ${saved}`,
     );
   },
 );

--- a/packages/tests/step_definitions/theme_steps.ts
+++ b/packages/tests/step_definitions/theme_steps.ts
@@ -67,7 +67,7 @@ When(
     const initial = (await themeName.textContent()) ?? "";
     this.shuffleHistory = [initial];
     for (let i = 0; i < count; i++) {
-      const before = this.shuffleHistory[this.shuffleHistory.length - 1]!;
+      const before = this.shuffleHistory.at(-1) ?? "";
       await this.page.keyboard.press(`${MOD_KEY}+j`);
       // Wait until the theme name actually changes — shuffle is async (RPC
       // round-trip + subscription tick), so reading immediately after the

--- a/packages/tests/step_definitions/worktree_steps.ts
+++ b/packages/tests/step_definitions/worktree_steps.ts
@@ -159,11 +159,9 @@ Then(
 Then(
   "the pill tree should have {int} fewer terminal entry/entries",
   async function (this: KoluWorld, fewer: number) {
-    assert.ok(
-      this.savedPillTreeCount !== undefined,
-      "Must note pill tree count first",
-    );
-    const expected = this.savedPillTreeCount! - fewer;
+    const saved = this.savedPillTreeCount;
+    assert.ok(saved !== undefined, "Must note pill tree count first");
+    const expected = saved - fewer;
     const sel = PILL_TREE_ENTRY_SELECTOR;
     await this.page.waitForFunction(
       ({ sel, exp }) => document.querySelectorAll(sel).length === exp,

--- a/packages/tests/support/buffer.ts
+++ b/packages/tests/support/buffer.ts
@@ -48,5 +48,9 @@ export async function waitForBufferContains(
     { sel: selector, idx: index, exp: expected },
     { timeout },
   );
-  return (await handle.jsonValue())!;
+  // The handle's predicate above returns either a non-null string (match)
+  // or `null`, and `waitForFunction` only resolves on a truthy value — so
+  // `jsonValue()` is structurally always a string by the time we read it.
+  // The `?? ""` fallback satisfies the type checker without a `!`.
+  return (await handle.jsonValue()) ?? "";
 }

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -187,9 +187,14 @@ function httpGet(url: string): Promise<{ ok: boolean }> {
       },
       (res) => {
         res.resume();
-        res.on("end", () =>
-          resolve({ ok: res.statusCode! >= 200 && res.statusCode! < 300 }),
-        );
+        res.on("end", () => {
+          // `res.statusCode` is typed `number | undefined` because the parser
+          // can technically receive a malformed first line; in practice
+          // node's `http` always supplies it once `end` fires, but treat
+          // an absent code as a non-2xx response rather than asserting.
+          const code = res.statusCode ?? 0;
+          resolve({ ok: code >= 200 && code < 300 });
+        });
         res.on("error", reject);
       },
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,10 @@ importers:
         version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/memorable-names:
+    dependencies:
+      anyagent:
+        specifier: workspace:*
+        version: link:../integrations/anyagent
     devDependencies:
       typescript:
         specifier: ^5.8.0
@@ -435,6 +439,9 @@ importers:
       '@xterm/xterm':
         specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
         version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
+      anyagent:
+        specifier: workspace:*
+        version: link:../integrations/anyagent
     devDependencies:
       typescript:
         specifier: ^5.8.0


### PR DESCRIPTION
**The biggest single-rule migration in #710's tail.** Every `!` is a runtime promise the compiler doesn't audit — the Haskell `fromJust` everyone-secretly-uses. Replacing them comes in three flavours, and not a single site was suppressed with `biome-ignore`.

**The helper.** `unwrap<T>(value: T | undefined | null, message: string): T` lives in `anyagent/unwrap` (workspace leaf so integration packages can use it; `kolu-common/unwrap` re-exports). Used only at boundaries TypeScript genuinely can't see — `Map.get(key)` against an externally-established key, regex match groups required by the pattern itself, modular-arithmetic indices into a fixed palette, library-imposed optionality on values the API contract guarantees. Each call carries a one-line message so the throw is self-documenting.

**Narrowing.** The bulk: stash + check. `signal()!` becomes `const v = signal(); if (!v) return;` and the rest of the function sees `v: T`. Solid's `<Show>` callback form (`{(t) => ...}`) does this automatically — converted about ten sites to that shape. For `<Show>` cases where `0` is a legitimate value (e.g. `AgentIndicator`'s context-token zero), the standard "wrap to bypass falsy" pattern: `when={x != null ? { value: x } : null}`, and `box().value` is typed `number`.

**Test helpers.** `createSubscription.test.ts` had 16 `sub()!` sites; introduced a local `readSub<T>(sub)` that throws on `undefined` but lets `null` through, since one test exercises `null` as a legitimate yielded value. `picker.test.ts` and `session.test.ts` use `unwrap` inline alongside vitest expectations.

**Idiomatic replacements.**
- `for (let i = 0; i < arr.length; i++) { arr[i]! }` → `for (const x of arr)` (or `arr.entries()` when both index and value matter).
- `arr[arr.length - 1]!` → `arr.at(-1)` consumed with a stash + check.
- `match[1]!` → `unwrap(match[1], "regex shape changed")`.
- `<div ref={el!}>` → `<div ref={el}>`. The `!` was always meaningless: Solid types `ref` as a setter, not a value.

**Architectural cleanups along the way.**
- `useSessionRestore` filtered `subTerminals` on truthy `parentId` then read `t.parentId!`. The filter is now a type predicate (`(t): t is typeof t & { parentId: string }`), so the array's element type carries the narrowing and the loop body has no `!`.
- `useColorScheme` had `sharedIsDark: () => boolean | null` set on first call, asserted non-null on every subsequent call. Restructured around `isDarkMemo = sharedIsDark ?? initSharedIsDark(...)` so the type system tracks initialisation locally.

**Two genuine library exceptions stay**, both with explicit one-line justifications and no `!`: `terminal-themes` `themes.json` is non-empty by build invariant (uses `unwrap` with that message), and `MemoryPublisher`'s `Record<string, object>` generic excludes the primitive payloads kolu publishes (kept the prior `biome-ignore` comment from #726).

> **For reviewers:** the 51-file count is the migration surface, not the semantic delta. Most edits are 1–2 lines per site. The new `unwrap.ts` files in `anyagent/` and `kolu-common/` are 30 lines combined; the rest is small, focused changes per pattern.