### PR TITLE
Split theme into identity + render; OS scheme can flip variants

### DIFF
--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -13,7 +13,7 @@ import {
 } from "./minimapGestures";
 import type { TileLayout } from "./TileLayout";
 import { tileMinimapBorder } from "./tileChrome";
-import { useTileTheme } from "./useTileTheme";
+import { useTileIdentityTheme } from "./useTileIdentityTheme";
 import { useCanvasViewport } from "./viewport/useCanvasViewport";
 
 /** Minimap target dimensions in pixels. */
@@ -45,7 +45,7 @@ const CanvasMinimap: Component<{
 }> = (props) => {
   const viewport = useCanvasViewport();
   const store = useTerminalStore();
-  const tileTheme = useTileTheme();
+  const tileTheme = useTileIdentityTheme();
   const [hoveringViewport, setHoveringViewport] = createSignal(false);
   const [draggingViewport, setDraggingViewport] = createSignal(false);
 

--- a/packages/client/src/canvas/PillTree.tsx
+++ b/packages/client/src/canvas/PillTree.tsx
@@ -20,7 +20,7 @@ import {
   type PillRepoGroup,
   repoColor,
 } from "./pillTreeOrder";
-import { useTileTheme } from "./useTileTheme";
+import { useTileIdentityTheme } from "./useTileIdentityTheme";
 import { useViewPosture } from "./useViewPosture";
 
 const BRANCHES_PER_ROW = 3;
@@ -49,7 +49,7 @@ const PillTree: Component<{
   onCreate: () => void;
 }> = (props) => {
   const store = useTerminalStore();
-  const tileTheme = useTileTheme();
+  const tileTheme = useTileIdentityTheme();
   const posture = useViewPosture();
 
   return (
@@ -224,12 +224,14 @@ const PillTree: Component<{
                                         !active() && !agentState(),
                                     }}
                                     style={{
-                                      // Pill bg = terminal's BG color,
-                                      // text = its FG color. Each pill
-                                      // is a literal swatch of its
-                                      // terminal — clearest visual
-                                      // pill ↔ tile link without the
-                                      // brightness of full inversion.
+                                      // Pill bg = terminal's identity
+                                      // theme bg, text = its fg. Identity
+                                      // theme = stored pick (preview-
+                                      // aware), independent of OS-scheme
+                                      // resolution — so a terminal you've
+                                      // learned by color stays that color
+                                      // when the OS scheme flips and the
+                                      // rendered variant follows.
                                       "background-color": theme().bg,
                                       color: theme().fg,
                                       // --card-color drives the pseudo

--- a/packages/client/src/canvas/useTileIdentityTheme.ts
+++ b/packages/client/src/canvas/useTileIdentityTheme.ts
@@ -1,0 +1,20 @@
+/** Tile identity-theme accessor — the stable swatch that surfaces tied
+ *  to terminal identity (pill tree, minimap tile color) read so they
+ *  don't flicker when the OS scheme flips and the rendered terminal
+ *  variant follows. The render-side counterpart for tile chrome that
+ *  wraps the live terminal contents is `useTileTheme`. */
+
+import type { TerminalId } from "kolu-common";
+import { useThemeManager } from "../useThemeManager";
+import type { TileTheme } from "./tileChrome";
+
+export function useTileIdentityTheme(): (id: TerminalId) => TileTheme {
+  const themeManager = useThemeManager();
+  return (id) => {
+    const t = themeManager.getTerminalIdentityTheme(id);
+    return {
+      bg: t.background ?? "var(--color-surface-1)",
+      fg: t.foreground ?? "var(--color-fg)",
+    };
+  };
+}

--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -121,6 +121,20 @@ const SettingsPopover: Component<{
             />
           </SettingRow>
           <SettingRow
+            label="Match OS appearance"
+            hint={{
+              text: "Terminals on supported themes (Catppuccin, Gruvbox, Tokyo Night, …) flip to their light/dark sibling with your OS scheme. Pill colors stay stable.",
+            }}
+          >
+            <Toggle
+              testId="terminals-follow-os-toggle"
+              enabled={preferences().terminalsFollowOSScheme}
+              onChange={(on) =>
+                updatePreferences({ terminalsFollowOSScheme: on })
+              }
+            />
+          </SettingRow>
+          <SettingRow
             label="Scroll lock"
             hint={{
               text: "Hold new output while scrolled up; release at bottom.",

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -64,15 +64,20 @@ function init() {
     getThemeByName(toRenderName(activeThemeName())),
   );
 
-  function getTerminalTheme(id: TerminalId): ITheme {
+  /** Per-terminal stored name with the preview overlay applied (only on
+   *  the active terminal). The shared lookup that both identity and
+   *  render accessors compose over. */
+  function resolveStoredName(id: TerminalId): string {
     const preview = store.activeId() === id ? previewThemeName() : undefined;
-    const name = preview ?? getThemeName(id) ?? DEFAULT_THEME_NAME;
-    return getThemeByName(toRenderName(name));
+    return preview ?? getThemeName(id) ?? DEFAULT_THEME_NAME;
+  }
+
+  function getTerminalTheme(id: TerminalId): ITheme {
+    return getThemeByName(toRenderName(resolveStoredName(id)));
   }
 
   function getTerminalIdentityTheme(id: TerminalId): ITheme {
-    const preview = store.activeId() === id ? previewThemeName() : undefined;
-    return getThemeByName(preview ?? getThemeName(id));
+    return getThemeByName(resolveStoredName(id));
   }
 
   function setThemeName(id: TerminalId, name: string) {

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -2,8 +2,21 @@
  *
  *  Singleton: pulls live state from `useTerminalStore`, mutates server
  *  state via the typed RPC client directly. Callers (App.tsx, palette,
- *  pill swatches) just call `useThemeManager()` — no deps to wire. */
+ *  pill swatches) just call `useThemeManager()` — no deps to wire.
+ *
+ *  Two theme lenses live here so the OS-scheme auto-flip doesn't break
+ *  terminal identity:
+ *
+ *    - **Identity** (`getTerminalIdentityTheme`): always the stored
+ *      theme (preview-aware). Used by pill swatches and the minimap
+ *      tile color so a terminal you've learned by color stays that
+ *      color across OS scheme changes.
+ *    - **Render** (`getTerminalTheme` / `activeTheme`): identity, then
+ *      passed through `resolveThemeForVariant` when the user has
+ *      "Match OS appearance for terminals" on. Used by the terminal
+ *      contents and any chrome that wraps them. */
 
+import { usePrefersDark } from "@solid-primitives/media";
 import type { TerminalId } from "kolu-common";
 import { nonEmpty } from "nonempty";
 import { createMemo, createRoot, createSignal } from "solid-js";
@@ -15,12 +28,16 @@ import {
   type ITheme,
   pickTheme,
   resolveThemeBgs,
+  resolveThemeForVariant,
 } from "terminal-themes";
 import { client } from "./rpc/rpc";
+import { usePreferences } from "./settings/usePreferences";
 import { useTerminalStore } from "./terminal/useTerminalStore";
 
 function init() {
   const store = useTerminalStore();
+  const { preferences } = usePreferences();
+  const prefersDark = usePrefersDark();
   const getThemeName = (id: TerminalId) => store.getMetadata(id)?.themeName;
 
   const committedThemeName = createMemo(() => {
@@ -36,9 +53,24 @@ function init() {
     () => previewThemeName() ?? committedThemeName(),
   );
 
-  const activeTheme = createMemo(() => getThemeByName(activeThemeName()));
+  /** Apply OS-scheme variant resolution when the preference is on.
+   *  Themes outside any family pair pass through unchanged. */
+  function toRenderName(name: string): string {
+    if (!preferences().terminalsFollowOSScheme) return name;
+    return resolveThemeForVariant(name, prefersDark() ? "dark" : "light");
+  }
+
+  const activeTheme = createMemo(() =>
+    getThemeByName(toRenderName(activeThemeName())),
+  );
 
   function getTerminalTheme(id: TerminalId): ITheme {
+    const preview = store.activeId() === id ? previewThemeName() : undefined;
+    const name = preview ?? getThemeName(id) ?? DEFAULT_THEME_NAME;
+    return getThemeByName(toRenderName(name));
+  }
+
+  function getTerminalIdentityTheme(id: TerminalId): ITheme {
     const preview = store.activeId() === id ? previewThemeName() : undefined;
     return getThemeByName(preview ?? getThemeName(id));
   }
@@ -82,6 +114,7 @@ function init() {
     activeThemeName,
     activeTheme,
     getTerminalTheme,
+    getTerminalIdentityTheme,
     isPreviewingTheme: () => previewThemeName() !== undefined,
     handleSetTheme,
     handleShuffleTheme,

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -31,6 +31,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   scrollLock: true,
   activityAlerts: true,
   colorScheme: "dark",
+  terminalsFollowOSScheme: false,
   terminalRenderer: "auto",
   rightPanel: {
     collapsed: true,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -388,6 +388,12 @@ export const PreferencesSchema = z.object({
   scrollLock: z.boolean(),
   activityAlerts: z.boolean(),
   colorScheme: ColorSchemeSchema,
+  /** When on, terminals whose stored theme has a known light/dark family
+   *  sibling (see `FAMILY_PAIRS` in `terminal-themes`) render the variant
+   *  matching the OS `prefers-color-scheme`. Identity (pill swatch,
+   *  minimap tile color) stays anchored to the stored pick so a terminal
+   *  you've learned by color doesn't flip when the OS scheme changes. */
+  terminalsFollowOSScheme: z.boolean(),
   /** Renderer policy. `auto` lets the system choose (WebGL on the focused+
    *  visible tile, DOM elsewhere — Chrome's per-tab GL context budget makes
    *  WebGL-everywhere unsafe at scale). `webgl` forces WebGL on every tile

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -45,7 +45,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.18.0";
+const SCHEMA_VERSION = "1.19.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -316,6 +316,17 @@ export const store = new Conf<PersistedState>({
         ...session,
         terminals: terminals as typeof session.terminals,
       });
+    },
+    // terminalsFollowOSScheme added — default off so existing users keep
+    // their stored theme on OS scheme changes until they opt in.
+    "1.19.0": (store: Conf<PersistedState>) => {
+      const current = store.get("preferences") as Record<string, unknown>;
+      if (current.terminalsFollowOSScheme === undefined) {
+        store.set("preferences", {
+          ...current,
+          terminalsFollowOSScheme: DEFAULT_PREFERENCES.terminalsFollowOSScheme,
+        } as unknown as Preferences);
+      }
     },
   },
 });

--- a/packages/terminal-themes/src/families.test.ts
+++ b/packages/terminal-themes/src/families.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { FAMILY_PAIRS, resolveThemeForVariant } from "./families.ts";
+import { availableThemes } from "./theme.ts";
+
+describe("families", () => {
+  const names = new Set(availableThemes.map((t) => t.name));
+
+  it("every family-pair name exists in availableThemes", () => {
+    const missing: string[] = [];
+    for (const p of FAMILY_PAIRS) {
+      if (!names.has(p.light)) missing.push(p.light);
+      if (!names.has(p.dark)) missing.push(p.dark);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("resolveThemeForVariant returns the wanted sibling", () => {
+    expect(resolveThemeForVariant("Catppuccin Latte", "dark")).toBe(
+      "Catppuccin Mocha",
+    );
+    expect(resolveThemeForVariant("Catppuccin Mocha", "light")).toBe(
+      "Catppuccin Latte",
+    );
+  });
+
+  it("resolveThemeForVariant is a no-op when already in the right variant", () => {
+    expect(resolveThemeForVariant("Catppuccin Latte", "light")).toBe(
+      "Catppuccin Latte",
+    );
+    expect(resolveThemeForVariant("Catppuccin Mocha", "dark")).toBe(
+      "Catppuccin Mocha",
+    );
+  });
+
+  it("resolveThemeForVariant returns the input unchanged for unknown themes", () => {
+    expect(resolveThemeForVariant("Dracula", "light")).toBe("Dracula");
+    expect(resolveThemeForVariant("Dracula", "dark")).toBe("Dracula");
+    expect(resolveThemeForVariant("not-a-real-theme", "light")).toBe(
+      "not-a-real-theme",
+    );
+  });
+});

--- a/packages/terminal-themes/src/families.test.ts
+++ b/packages/terminal-themes/src/families.test.ts
@@ -14,6 +14,20 @@ describe("families", () => {
     expect(missing).toEqual([]);
   });
 
+  // Duplicate names would silently overwrite in the themeToPair Map and
+  // produce a wrong sibling resolution at runtime — pin it as a CI failure.
+  it("FAMILY_PAIRS has no duplicate theme names", () => {
+    const seen = new Set<string>();
+    const dups: string[] = [];
+    for (const p of FAMILY_PAIRS) {
+      for (const name of [p.light, p.dark]) {
+        if (seen.has(name)) dups.push(name);
+        seen.add(name);
+      }
+    }
+    expect(dups).toEqual([]);
+  });
+
   it("resolveThemeForVariant returns the wanted sibling", () => {
     expect(resolveThemeForVariant("Catppuccin Latte", "dark")).toBe(
       "Catppuccin Mocha",

--- a/packages/terminal-themes/src/families.ts
+++ b/packages/terminal-themes/src/families.ts
@@ -1,0 +1,55 @@
+/** Family-pair index for OS-driven light/dark variant swaps.
+ *
+ * Hand-curated set of light/dark sibling pairs drawn from
+ * {@link availableThemes}. When the user enables "Match OS appearance
+ * for terminals", a stored theme that belongs to a pair flips to its
+ * sibling on OS scheme change; themes outside the index keep their
+ * stored variant unchanged. Coverage is the popular tier — widening
+ * this list later is data-only, no schema change.
+ *
+ * Every name in {@link FAMILY_PAIRS} must exist in `availableThemes`.
+ * `families.test.ts` enforces this — a typo or a renamed upstream
+ * theme breaks the build, not a runtime user. */
+
+export interface FamilyPair {
+  /** Light-variant theme name. Must exist in availableThemes. */
+  light: string;
+  /** Dark-variant theme name. Must exist in availableThemes. */
+  dark: string;
+}
+
+export const FAMILY_PAIRS: readonly FamilyPair[] = [
+  { light: "Catppuccin Latte", dark: "Catppuccin Mocha" },
+  { light: "Gruvbox Light", dark: "Gruvbox Dark" },
+  { light: "Gruvbox Material Light", dark: "Gruvbox Material Dark" },
+  { light: "TokyoNight Day", dark: "TokyoNight Night" },
+  { light: "GitHub Light Default", dark: "GitHub Dark Default" },
+  { light: "One Half Light", dark: "One Half Dark" },
+  { light: "Atom One Light", dark: "Atom One Dark" },
+  { light: "One Double Light", dark: "One Double Dark" },
+  { light: "Rose Pine Dawn", dark: "Rose Pine Moon" },
+  { light: "Everforest Light Med", dark: "Everforest Dark Hard" },
+  { light: "Nord Light", dark: "Nord" },
+  { light: "Ayu Light", dark: "Ayu Mirage" },
+  { light: "Tomorrow", dark: "Tomorrow Night" },
+  { light: "Monokai Pro Light", dark: "Monokai Pro" },
+  { light: "Monospace Light", dark: "Monospace Dark" },
+];
+
+const themeToPair = new Map<string, FamilyPair>();
+for (const p of FAMILY_PAIRS) {
+  themeToPair.set(p.light, p);
+  themeToPair.set(p.dark, p);
+}
+
+/** Resolve a theme name to its family sibling for the wanted variant.
+ *  Returns the same name when it's already the right variant, or when
+ *  the theme isn't in any family pair (no auto-flip). */
+export function resolveThemeForVariant(
+  themeName: string,
+  wantVariant: "light" | "dark",
+): string {
+  const pair = themeToPair.get(themeName);
+  if (!pair) return themeName;
+  return wantVariant === "light" ? pair.light : pair.dark;
+}

--- a/packages/terminal-themes/src/index.ts
+++ b/packages/terminal-themes/src/index.ts
@@ -8,6 +8,12 @@
  */
 
 export type { ITheme } from "@xterm/xterm";
+// Family pairs (light/dark siblings for OS-driven variant swap)
+export {
+  FAMILY_PAIRS,
+  type FamilyPair,
+  resolveThemeForVariant,
+} from "./families.ts";
 // Theme picker
 export { hexToOkLab, okLabDistance, pickTheme } from "./picker.ts";
 // Theme catalog

--- a/packages/tests/features/settings.feature
+++ b/packages/tests/features/settings.feature
@@ -18,6 +18,12 @@ Feature: Settings Popover
     Then the shuffle theme toggle state should change
     And there should be no page errors
 
+  Scenario: Toggle match-OS-appearance setting
+    When I click the settings button
+    Then the settings popover should be visible
+    Then the match-OS-appearance toggle state should change
+    And there should be no page errors
+
   Scenario: Switch UI color scheme to light
     When I click the settings button
     Then the settings popover should be visible

--- a/packages/tests/features/theme.feature
+++ b/packages/tests/features/theme.feature
@@ -87,6 +87,26 @@ Feature: Theme switching
     And the palette search input should be focused
     And there should be no page errors
 
+  # When "Match OS appearance" is on, a terminal whose stored theme has
+  # a known light/dark family sibling renders the variant matching the
+  # OS prefers-color-scheme. Identity (the pill swatch) stays anchored
+  # to the stored pick so a terminal you've learned by color doesn't
+  # flip when the OS scheme changes.
+  Scenario: Terminal flips to family sibling when OS scheme changes
+    When I open the command palette
+    And I select "Theme" in the palette
+    And I type "Catppuccin Mocha" in the palette
+    And I press Enter
+    Then the header should show theme "Catppuccin Mocha"
+    And the terminal background should be "#1e1e2e"
+    When I click the settings button
+    Then the settings popover should be visible
+    When I click the match OS appearance toggle
+    And the OS color scheme is "light"
+    Then the terminal background should be "#eff1f5"
+    And the header should show theme "Catppuccin Mocha"
+    And there should be no page errors
+
   Scenario: Each terminal has independent theme
     When I open the command palette
     And I select "Theme" in the palette

--- a/packages/tests/step_definitions/settings_steps.ts
+++ b/packages/tests/step_definitions/settings_steps.ts
@@ -45,6 +45,42 @@ Then(
 );
 
 When(
+  "I click the match OS appearance toggle",
+  async function (this: KoluWorld) {
+    await this.page.click('[data-testid="terminals-follow-os-toggle"]');
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the match-OS-appearance toggle state should change",
+  async function (this: KoluWorld) {
+    const toggle = this.page.locator(
+      '[data-testid="terminals-follow-os-toggle"]',
+    );
+    const before = await toggle.getAttribute("data-enabled");
+    await this.page.click('[data-testid="terminals-follow-os-toggle"]');
+    await this.waitForFrame();
+    const after = await toggle.getAttribute("data-enabled");
+    assert.notStrictEqual(
+      before,
+      after,
+      "Expected match-OS-appearance toggle to change state on click",
+    );
+  },
+);
+
+When(
+  "the OS color scheme is {string}",
+  async function (this: KoluWorld, scheme: string) {
+    if (scheme !== "light" && scheme !== "dark") {
+      throw new Error(`Unsupported OS color scheme literal: ${scheme}`);
+    }
+    await this.page.emulateMedia({ colorScheme: scheme });
+  },
+);
+
+When(
   "I click the {string} color scheme button",
   async function (this: KoluWorld, scheme: string) {
     await this.page.click(`[data-testid="color-scheme-${scheme}"]`);

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -356,6 +356,7 @@ Before(async function (this: KoluWorld, scenario) {
         scrollLock: true,
         activityAlerts: true,
         colorScheme: "dark",
+        terminalsFollowOSScheme: false,
         terminalRenderer: "auto",
         rightPanel: {
           collapsed: true,


### PR DESCRIPTION
A coworker mentioned they live with their OS auto-flipping light/dark with the time of day, and asked Kolu to do the same for terminal themes — *neovim-style*, where you pick **Catppuccin** once and the right variant tracks your environment. **The naive implementation would break how Kolu has always used theme color: as the per-terminal identity in the pill tree and minimap.** If a terminal's background flips from purple to white at sunset, the "purple terminal" you'd learned by sight isn't purple anymore, and the spread picker's perceptual-distance computation is suddenly operating over a different color universe.

So before adding the toggle, this PR pulls apart what `themeName` was doing. *Identity* is what you picked, period — pill swatches and minimap tile color read from it and never move. *Render* is identity, then optionally swapped to its family sibling matching `prefers-color-scheme` when the new "Match OS appearance" toggle is on. Both lenses live in `useThemeManager`: `getTerminalIdentityTheme` feeds surfaces tied to identity, `getTerminalTheme` (now OS-aware) feeds surfaces that mirror live terminal contents. Pill tree and minimap moved to a parallel `useTileIdentityTheme` adapter; tile chrome stays on the original `useTileTheme`.

Family membership is data-driven via a curated 15-pair index in `terminal-themes/families.ts` covering the popular tier — *Catppuccin, Gruvbox, Tokyo Night, GitHub, One Half, Atom One, Rose Pine, Everforest, Nord, Ayu, Tomorrow, Monokai Pro, Monospace, and friends*. Themes outside the index simply don't auto-flip, which is the correct graceful degrade: a Dracula user keeps their stored Dracula across OS scheme changes. The toggle defaults off and ships with a 1.19.0 migration, so existing users see no behavior change until they opt in.

> **Deferred follow-up.** Lowy flagged that maintaining family pairs as a hand-curated table parallel to the regenerated `themes.json` is a small dual-maintenance gap. Closing it cleanly would mean teaching the regen pipeline (Python over Ghostty-format files) to derive family from filename conventions, which is brittle without upstream metadata. A unit test pins every entry to a real catalog name so typos break the build, and a sibling test pins no-duplicates — that holds the line until the regen story matures.

### Try it locally

```sh
nix run github:juspay/kolu/theme-family-variant
```

Open Settings → toggle **Match OS appearance**, pick a Catppuccin Mocha terminal, then flip your OS scheme to Light. The terminal repaints as Latte; the pill stays Mocha-purple.