### PR TITLE
feat(codex): resume with `--last` to skip the picker

### DIFF
--- a/packages/integrations/anyagent/src/agent-cli.test.ts
+++ b/packages/integrations/anyagent/src/agent-cli.test.ts
@@ -168,11 +168,11 @@ describe("resumeAgentCommand", () => {
       "claude --permission-mode plan --add-dir /tmp/foo",
       "claude -c --permission-mode plan --add-dir /tmp/foo",
     ],
-    ["codex", "codex resume"],
-    ["codex --yolo", "codex resume --yolo"],
+    ["codex", "codex resume --last"],
+    ["codex --yolo", "codex resume --last --yolo"],
     [
       `codex --yolo --model gpt-5.5 --config model_reasoning_effort="xhigh"`,
-      `codex resume --yolo --model gpt-5.5 --config model_reasoning_effort="xhigh"`,
+      `codex resume --last --yolo --model gpt-5.5 --config model_reasoning_effort="xhigh"`,
     ],
     ["opencode", "opencode --continue"],
     [

--- a/packages/integrations/anyagent/src/agent-cli.ts
+++ b/packages/integrations/anyagent/src/agent-cli.ts
@@ -115,9 +115,10 @@ function basename(s: string): string {
  * for them.
  *
  * The transforms splice a resume marker into the normalized argv:
- *   claude `-c`       → continue most-recent conversation in cwd
- *   codex `resume`    → subcommand form; last session in cwd
- *   opencode `--continue` → continue most-recent session in cwd
+ *   claude `-c`              → continue most-recent conversation in cwd
+ *   codex `resume --last`    → subcommand form; last session in cwd
+ *                              (`--last` skips the interactive picker)
+ *   opencode `--continue`    → continue most-recent session in cwd
  *
  * `parseAgentCommand` strips `-c`/`--continue`/`--resume`/`-r` during
  * normalization (per juspay/kolu#467), so the input to these transforms is
@@ -138,7 +139,7 @@ const AGENT_RESUME: Record<
   (argv: NonEmpty<string>) => string[]
 > = {
   claude: (argv) => withResumeFlags(argv, "-c"),
-  codex: (argv) => withResumeFlags(argv, "resume"),
+  codex: (argv) => withResumeFlags(argv, "resume", "--last"),
   opencode: (argv) => withResumeFlags(argv, "--continue"),
 };
 


### PR DESCRIPTION
Bare `codex resume` drops the user into an interactive session picker — every kolu-driven resume now requires an extra keystroke before the conversation actually appears. Codex's `--last` flag skips that picker and reattaches to the most recent session in `cwd`, lining the codex resume up with `claude -c` and `opencode --continue` (both already one-shot).

The transform now splices `resume --last` after the binary instead of just `resume`, so a normalized `codex --yolo` resumes as `codex resume --last --yolo`. Detection-only agents and the parser allowlist are untouched; only the resume table moves.

## Test plan
- [x] `vitest` table cases updated to match the new resume forms
- [ ] Manual: start a codex session in a kolu terminal, resume from the recent-agents UI, confirm it reattaches without the picker