### PR TITLE
Fix copy-path:line bleeding across Code tab files

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -264,60 +264,59 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
               />
             }
           >
-            <Switch>
-              <Match when={isDiffView()}>
-                <Switch
-                  fallback={
-                    <div class="px-2 py-1 text-fg-3/50">Loading diff…</div>
-                  }
-                >
-                  <Match when={diff.error}>
-                    <div class="px-2 py-1 text-danger">
-                      Error: {(diff.error as Error).message}
-                    </div>
-                  </Match>
-                  <Match when={renamedDiff()}>
-                    {(rename) => (
-                      <div class="flex items-center justify-center h-full text-fg-3/50">
-                        File renamed: {rename().oldFileName} →{" "}
-                        {rename().newFileName}
+            {(path) => (
+              // Keyed callback hands a reactive `Accessor<string>` down so
+              // the path tracks the live selection. A previous version
+              // captured `selectedPath()` to a `const` inside the diff
+              // <Match>, which Solid invokes once via `untrack` — leaving
+              // the "Copy path:line" menu pinned to the first file the
+              // user opened.
+              <Switch>
+                <Match when={isDiffView()}>
+                  <Switch
+                    fallback={
+                      <div class="px-2 py-1 text-fg-3/50">Loading diff…</div>
+                    }
+                  >
+                    <Match when={diff.error}>
+                      <div class="px-2 py-1 text-danger">
+                        Error: {(diff.error as Error).message}
                       </div>
-                    )}
-                  </Match>
-                  <Match when={diff()}>
-                    {(d) => (
-                      // `selectedPath()` must be read reactively so the
-                      // "Copy path:line" menu entry tracks the live file —
-                      // capturing it to a `const` here would freeze the
-                      // path at the moment this Match callback first ran.
-                      <Show when={selectedPath()}>
-                        {(path) => (
-                          <PierreDiffView
-                            path={path()}
-                            rawDiff={d().hunks[0] ?? ""}
-                            theme={diffTheme()}
-                          />
-                        )}
-                      </Show>
-                    )}
-                  </Match>
-                </Switch>
-              </Match>
-              <Match when={!isDiffView()}>
-                {(() => {
-                  const repo = repoPath();
-                  const path = selectedPath();
-                  if (repo === null || path === null) return null;
-                  return (
-                    <BrowseFileView
-                      repoPath={repo}
-                      filePath={path}
-                      theme={diffTheme()}
-                    />
-                  );
-                })()}
-              </Match>
-            </Switch>
+                    </Match>
+                    <Match when={renamedDiff()}>
+                      {(rename) => (
+                        <div class="flex items-center justify-center h-full text-fg-3/50">
+                          File renamed: {rename().oldFileName} →{" "}
+                          {rename().newFileName}
+                        </div>
+                      )}
+                    </Match>
+                    <Match when={diff()}>
+                      {(d) => (
+                        <PierreDiffView
+                          path={path()}
+                          rawDiff={d().hunks[0] ?? ""}
+                          theme={diffTheme()}
+                        />
+                      )}
+                    </Match>
+                  </Switch>
+                </Match>
+                <Match when={!isDiffView()}>
+                  {(() => {
+                    const repo = repoPath();
+                    if (repo === null) return null;
+                    return (
+                      <BrowseFileView
+                        repoPath={repo}
+                        filePath={path()}
+                        theme={diffTheme()}
+                      />
+                    );
+                  })()}
+                </Match>
+              </Switch>
+            )}
           </Show>
         </div>
       </div>

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -285,17 +285,21 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                     )}
                   </Match>
                   <Match when={diff()}>
-                    {(d) => {
-                      const path = selectedPath();
-                      if (path === null) return null;
-                      return (
-                        <PierreDiffView
-                          path={path}
-                          rawDiff={d().hunks[0] ?? ""}
-                          theme={diffTheme()}
-                        />
-                      );
-                    }}
+                    {(d) => (
+                      // `selectedPath()` must be read reactively so the
+                      // "Copy path:line" menu entry tracks the live file —
+                      // capturing it to a `const` here would freeze the
+                      // path at the moment this Match callback first ran.
+                      <Show when={selectedPath()}>
+                        {(path) => (
+                          <PierreDiffView
+                            path={path()}
+                            rawDiff={d().hunks[0] ?? ""}
+                            theme={diffTheme()}
+                          />
+                        )}
+                      </Show>
+                    )}
                   </Match>
                 </Switch>
               </Match>

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -254,6 +254,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         <div class="flex-1 min-h-0 overflow-auto" data-testid="diff-content">
           <Show
             when={selectedPath()}
+            keyed
             fallback={
               <FileSelectHint
                 label={
@@ -265,12 +266,15 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
             }
           >
             {(path) => (
-              // Keyed callback hands a reactive `Accessor<string>` down so
-              // the path tracks the live selection. A previous version
-              // captured `selectedPath()` to a `const` inside the diff
-              // <Match>, which Solid invokes once via `untrack` — leaving
-              // the "Copy path:line" menu pinned to the first file the
-              // user opened.
+              // `keyed` remounts this subtree whenever the selected file
+              // changes. Pierre's `FileDiff.render(newFileDiff)` reuses
+              // the same instance — its line-selection handlers don't
+              // re-bind to the new gutter elements, so right-clicking on
+              // a line in the second file would yield a "Copy path" menu
+              // with no "Copy path:line" entry. Per-file remount gives
+              // each file a fresh `FileDiff` and a clean
+              // `useLineSelection` range, which is also the right
+              // semantic — line refs don't survive across files.
               <Switch>
                 <Match when={isDiffView()}>
                   <Switch
@@ -294,7 +298,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                     <Match when={diff()}>
                       {(d) => (
                         <PierreDiffView
-                          path={path()}
+                          path={path}
                           rawDiff={d().hunks[0] ?? ""}
                           theme={diffTheme()}
                         />
@@ -309,7 +313,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                     return (
                       <BrowseFileView
                         repoPath={repo}
-                        filePath={path()}
+                        filePath={path}
                         theme={diffTheme()}
                       />
                     );

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -155,3 +155,31 @@ Feature: Code tab (review + browse)
     And I right-click the file content
     And I click the context menu item "Copy letters.txt:2"
     Then the clipboard should contain "letters.txt:2"
+
+  # Regression: switching diff files used to leave the previous file's path
+  # in the "Copy path:line" context-menu entry. The line number tracked the
+  # new file but the path stayed stale, so users copying refs after switching
+  # files got `<old-file>:<new-line>` — wrong filename, plausible-looking
+  # line, no error. Root cause: the `<Match when={diff()}>{(d) => …}` callback
+  # captured `selectedPath()` to a `const`, which is non-reactive (Solid runs
+  # the callback once when the match becomes active).
+  Scenario: Switching diff files keeps the "Copy path:line" entry in sync
+    When I run "git init /tmp/kolu-diff-multifile && cd /tmp/kolu-diff-multifile"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'a-one\na-two\na-three\n' > file-a.txt"
+    And I run "printf 'b-one\nb-two\nb-three\n' > file-b.txt"
+    And I click the Code tab
+    And I click the refresh button in the Code tab
+    Then the Code tab should list a changed file "file-a.txt"
+    And the Code tab should list a changed file "file-b.txt"
+    When I click the changed file "file-a.txt" in the Code tab
+    And I click the line number 1 in the diff view
+    And I right-click the diff view
+    And I click the context menu item "Copy file-a.txt:1"
+    Then the clipboard should contain "file-a.txt:1"
+    When I click the changed file "file-b.txt" in the Code tab
+    And I click the line number 1 in the diff view
+    And I right-click the diff view
+    And I click the context menu item "Copy file-b.txt:1"
+    Then the clipboard should contain "file-b.txt:1"
+    And the clipboard should not contain "file-a.txt"

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -156,13 +156,17 @@ Feature: Code tab (review + browse)
     And I click the context menu item "Copy letters.txt:2"
     Then the clipboard should contain "letters.txt:2"
 
-  # Regression: switching diff files used to leave the previous file's path
-  # in the "Copy path:line" context-menu entry. The line number tracked the
-  # new file but the path stayed stale, so users copying refs after switching
-  # files got `<old-file>:<new-line>` — wrong filename, plausible-looking
-  # line, no error. Root cause: the `<Match when={diff()}>{(d) => …}` callback
-  # captured `selectedPath()` to a `const`, which is non-reactive (Solid runs
-  # the callback once when the match becomes active).
+  # Regression: switching diff files used to break the "Copy path:line"
+  # context-menu entry. Two interleaved causes — first, a `<Match>` callback
+  # in CodeTab captured `selectedPath()` to a `const`, freezing the path
+  # prop fed into `<PierreDiffView>`. Second, even after the path was made
+  # reactive, Pierre's `FileDiff.render(newFileDiff)` reuses the same
+  # instance and its line-selection handlers don't re-bind to the fresh
+  # gutter elements — so right-clicks on the second file's lines yielded a
+  # menu with no "Copy path:line" entry at all (range stayed null because
+  # no `onLineSelected` ever fired). Fix: key the diff/browse subtree on
+  # path so each file gets a fresh `FileDiff` and a clean
+  # `useLineSelection` range.
   Scenario: Switching diff files keeps the "Copy path:line" entry in sync
     When I run "git init /tmp/kolu-diff-multifile && cd /tmp/kolu-diff-multifile"
     And I run "git commit --allow-empty -m init"
@@ -173,13 +177,16 @@ Feature: Code tab (review + browse)
     Then the Code tab should list a changed file "file-a.txt"
     And the Code tab should list a changed file "file-b.txt"
     When I click the changed file "file-a.txt" in the Code tab
-    And I click the line number 1 in the diff view
+    Then the diff view should contain "a-one"
+    When I click the line number 1 in the diff view
     And I right-click the diff view
     And I click the context menu item "Copy file-a.txt:1"
     Then the clipboard should contain "file-a.txt:1"
     When I click the changed file "file-b.txt" in the Code tab
-    And I click the line number 1 in the diff view
+    Then the diff view should contain "b-one"
+    When I click the line number 1 in the diff view
     And I right-click the diff view
-    And I click the context menu item "Copy file-b.txt:1"
+    Then the context menu items should be "Copy path | Copy file-b.txt:1"
+    When I click the context menu item "Copy file-b.txt:1"
     Then the clipboard should contain "file-b.txt:1"
     And the clipboard should not contain "file-a.txt"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -153,6 +153,32 @@ When("I right-click the file content", async function (this: KoluWorld) {
   await this.waitForFrame();
 });
 
+// Diff-view counterparts. Pierre's `FileDiff` shares `enableLineSelection`
+// with the file viewer, so the gutter selector and pointerdown/up dance
+// are the same — only the host element changes.
+When(
+  "I click the line number {int} in the diff view",
+  async function (this: KoluWorld, line: number) {
+    const lineEl = this.page.locator(
+      `${DIFF_VIEW} [data-column-number="${line}"]`,
+    );
+    await lineEl.first().waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const box = await lineEl.first().boundingBox();
+    if (!box) throw new Error("diff line gutter has no bounding box");
+    await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await this.page.mouse.down();
+    await this.page.mouse.up();
+    await this.waitForFrame();
+  },
+);
+
+When("I right-click the diff view", async function (this: KoluWorld) {
+  const view = this.page.locator(DIFF_VIEW);
+  await view.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await view.click({ button: "right" });
+  await this.waitForFrame();
+});
+
 // ── Assertions ──
 
 Then("the Code tab should be active", async function (this: KoluWorld) {

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -174,6 +174,29 @@ When("I right-click the diff view", async function (this: KoluWorld) {
   await rightClickViewRoot(this, DIFF_VIEW);
 });
 
+// Asserts the exact set of items in the Pierre diff/file context menu,
+// in order, joined with " | ". Stronger than `I click the context menu
+// item {string}` because it catches "wrong items present" regressions
+// (e.g. a stale path:line entry persisting across file switches) that a
+// targeted click would only surface as an opaque locator timeout.
+Then(
+  "the context menu items should be {string}",
+  async function (this: KoluWorld, expected: string) {
+    await this.page.waitForFunction(
+      (exp) => {
+        const menu = document.querySelector("#code-context-menu");
+        if (!menu) return false;
+        const got = Array.from(menu.querySelectorAll('[role="menuitem"]'))
+          .map((b) => b.textContent || "")
+          .join(" | ");
+        return got === exp;
+      },
+      expected,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // ── Assertions ──
 
 Then("the Code tab should be active", async function (this: KoluWorld) {
@@ -295,32 +318,47 @@ Then(
   },
 );
 
+// Pierre's File / FileDiff renderers mount highlighted code inside a
+// shadow root. `Element.textContent` does NOT cross shadow boundaries,
+// so we walk the tree (including each `shadowRoot`) and stitch the text.
+// Inlined as a string-evaluate to dodge tsx's `__name` injection, which
+// crashes inside `page.evaluate` arg functions.
+async function waitForViewText(
+  world: KoluWorld,
+  testid: string,
+  expected: string,
+) {
+  await world.page.waitForFunction(
+    `(() => {
+      const root = document.querySelector('[data-testid="${testid}"]');
+      if (!root) return false;
+      const stack = [root];
+      let text = '';
+      while (stack.length) {
+        const node = stack.pop();
+        if (node.nodeType === 3) text += node.nodeValue || '';
+        if (node.nodeType === 1) {
+          if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
+          for (const ch of node.childNodes) stack.push(ch);
+        }
+      }
+      return text.includes(${JSON.stringify(expected)});
+    })()`,
+    undefined,
+    { timeout: POLL_TIMEOUT },
+  );
+}
+
 Then(
   "the file content should contain {string}",
   async function (this: KoluWorld, expected: string) {
-    // Pierre's File renderer mounts highlighted code inside its shadow
-    // root. `Element.textContent` does NOT cross shadow boundaries, so
-    // we walk the tree (including each `shadowRoot`) and stitch the text.
-    // Inlined as a string-evaluate to dodge tsx's `__name` injection,
-    // which crashes inside `page.evaluate` arg functions.
-    await this.page.waitForFunction(
-      `(() => {
-        const root = document.querySelector('[data-testid="pierre-file-view"]');
-        if (!root) return false;
-        const stack = [root];
-        let text = '';
-        while (stack.length) {
-          const node = stack.pop();
-          if (node.nodeType === 3) text += node.nodeValue || '';
-          if (node.nodeType === 1) {
-            if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
-            for (const ch of node.childNodes) stack.push(ch);
-          }
-        }
-        return text.includes(${JSON.stringify(expected)});
-      })()`,
-      undefined,
-      { timeout: POLL_TIMEOUT },
-    );
+    await waitForViewText(this, "pierre-file-view", expected);
+  },
+);
+
+Then(
+  "the diff view should contain {string}",
+  async function (this: KoluWorld, expected: string) {
+    await waitForViewText(this, "pierre-diff-view", expected);
   },
 );

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -126,57 +126,52 @@ When(
 // `enableLineSelection` only fires for clicks on gutter line numbers,
 // not on the line content. Target the `[data-column-number]` element
 // (Pierre's `getSelectionPointerInfo` requires `numberColumn=true`).
+//
+// Pierre's `enableLineSelection` commits on `document` pointerup, not
+// element-level click — drive the gutter via Playwright's mouse API so
+// pointerdown / pointerup bubble through the document listener Pierre
+// attached on pointerdown. Both the file viewer (`FILE_VIEW`) and the
+// diff viewer (`DIFF_VIEW`) wrap the same Pierre primitive, so the
+// gutter selector and mouse dance are identical — only the host
+// element's CSS root changes.
+async function clickLineGutterIn(world: KoluWorld, root: string, line: number) {
+  const lineEl = world.page.locator(`${root} [data-column-number="${line}"]`);
+  await lineEl.first().waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  const box = await lineEl.first().boundingBox();
+  if (!box) throw new Error("line gutter has no bounding box");
+  await world.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await world.page.mouse.down();
+  await world.page.mouse.up();
+  await world.waitForFrame();
+}
+
+async function rightClickViewRoot(world: KoluWorld, root: string) {
+  const view = world.page.locator(root);
+  await view.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await view.click({ button: "right" });
+  await world.waitForFrame();
+}
+
 When(
   "I click the line number {int} in the file content",
   async function (this: KoluWorld, line: number) {
-    const lineEl = this.page.locator(
-      `${FILE_VIEW} [data-column-number="${line}"]`,
-    );
-    await lineEl.first().waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    // Pierre's `enableLineSelection` commits on `document` pointerup —
-    // not the element-level click. Drive the gutter via Playwright's
-    // mouse API so pointerdown / pointerup bubble through the
-    // document listener Pierre attached on pointerdown.
-    const box = await lineEl.first().boundingBox();
-    if (!box) throw new Error("line gutter has no bounding box");
-    await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    await this.page.mouse.down();
-    await this.page.mouse.up();
-    await this.waitForFrame();
+    await clickLineGutterIn(this, FILE_VIEW, line);
   },
 );
 
 When("I right-click the file content", async function (this: KoluWorld) {
-  const view = this.page.locator(FILE_VIEW);
-  await view.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-  await view.click({ button: "right" });
-  await this.waitForFrame();
+  await rightClickViewRoot(this, FILE_VIEW);
 });
 
-// Diff-view counterparts. Pierre's `FileDiff` shares `enableLineSelection`
-// with the file viewer, so the gutter selector and pointerdown/up dance
-// are the same — only the host element changes.
 When(
   "I click the line number {int} in the diff view",
   async function (this: KoluWorld, line: number) {
-    const lineEl = this.page.locator(
-      `${DIFF_VIEW} [data-column-number="${line}"]`,
-    );
-    await lineEl.first().waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    const box = await lineEl.first().boundingBox();
-    if (!box) throw new Error("diff line gutter has no bounding box");
-    await this.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    await this.page.mouse.down();
-    await this.page.mouse.up();
-    await this.waitForFrame();
+    await clickLineGutterIn(this, DIFF_VIEW, line);
   },
 );
 
 When("I right-click the diff view", async function (this: KoluWorld) {
-  const view = this.page.locator(DIFF_VIEW);
-  await view.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-  await view.click({ button: "right" });
-  await this.waitForFrame();
+  await rightClickViewRoot(this, DIFF_VIEW);
 });
 
 // ── Assertions ──


### PR DESCRIPTION
**Right-clicking a line in the Code tab's diff view, copying the ref, then opening a different file and doing the same** produced a clipboard string that combined the *previous* file's path with the *new* file's line — `<old-file>:<new-line>`. Wrong filename, plausible-looking line, no error. The visible label in the context menu told the same lie before the click ever happened.

The root cause turned out to be two issues interleaved. First, the `<Match when={diff()}>{(d) => …}` callback in `CodeTab.tsx` captured `selectedPath()` to a `const` — Solid invokes Match callbacks once via `untrack`, so the path prop fed into `<PierreDiffView>` froze at whatever the user opened first. *Making the read reactive surfaced the second issue: Pierre's `FileDiff.render(newFileDiff)` reuses the same instance and doesn't re-bind its line-selection pointer handlers to the fresh gutter elements.* So even with the path tracking correctly, clicking a line on the second file produced no `onLineSelected` call — `useLineSelection`'s range stayed null and the "Copy path:line" entry vanished from the menu entirely.

Fix: add `keyed` to the outer `<Show when={selectedPath()}>` in CodeTab so the diff/browse subtree remounts whenever the selected file changes. Each file gets a fresh `FileDiff` and a clean `useLineSelection` range, which is also the right semantic — a line ref doesn't survive across files.

> Regression test asserts the **exact set** of menu items present after right-clicking on the second file (`Copy path | Copy file-b.txt:1`), so a future regression where a stale entry persists or the line-ref entry vanishes will fail with a precise diff in the error message rather than an opaque locator timeout.