### PR TITLE
Ignore generated OpenCode config in Biome

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -27,6 +27,7 @@
       "!.agents",
       "!.codex",
       "!.opencode",
+      "!opencode.json",
       "!**/dist",
       "!**/node_modules",
       "!**/.direnv",


### PR DESCRIPTION
**Biome no longer formats the generated `opencode.json` file**, which keeps fresh APM regenerations from tripping `just fmt-check` over a missing trailing newline. The generated OpenCode runtime directory was already outside Biome's file set; this applies the same treatment to the root config file that APM owns.

`opencode.json` remains verified by the APM sync workflow, so this only removes formatter ownership from an external generated artifact. Closes #738.