### PR TITLE
Make pill tree pills taller

### DIFF
--- a/packages/client/src/canvas/PillTree.tsx
+++ b/packages/client/src/canvas/PillTree.tsx
@@ -88,7 +88,7 @@ const PillTree: Component<{
           <button
             type="button"
             data-testid="pill-tree-exit-maximize"
-            class="pointer-events-auto flex items-center justify-center w-6 h-6 rounded-lg shrink-0 cursor-pointer text-fg-2 hover:text-fg hover:bg-surface-2/80 transition-colors"
+            class="pointer-events-auto flex items-center justify-center w-7 h-7 rounded-lg shrink-0 cursor-pointer text-fg-2 hover:text-fg hover:bg-surface-2/80 transition-colors"
             onClick={posture.toggle}
             title="Show all on canvas"
           >
@@ -103,7 +103,7 @@ const PillTree: Component<{
         <button
           type="button"
           data-testid="pill-tree-new"
-          class="pointer-events-auto flex items-center justify-center w-6 h-6 mt-3 rounded-full shrink-0 cursor-pointer text-fg-3 hover:text-fg hover:bg-surface-2/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+          class="pointer-events-auto flex items-center justify-center w-7 h-7 mt-3 rounded-full shrink-0 cursor-pointer text-fg-3 hover:text-fg hover:bg-surface-2/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
           onClick={props.onCreate}
           aria-label="New terminal"
           title="New terminal"
@@ -202,7 +202,7 @@ const PillTree: Component<{
                                     data-active={active() ? "" : undefined}
                                     data-unread={unread() ? "" : undefined}
                                     data-agent-state={agentState()}
-                                    class={`pointer-events-auto flex items-center gap-1 px-2 h-6 rounded-full text-xs cursor-pointer transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 max-w-[20ch] whitespace-nowrap ${agentBorderClass()}`}
+                                    class={`pointer-events-auto flex items-center gap-1 px-2.5 h-8 rounded-full text-xs cursor-pointer transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50 max-w-[20ch] whitespace-nowrap ${agentBorderClass()}`}
                                     classList={{
                                       // Static repo-colored ring when
                                       // active and no agent animation


### PR DESCRIPTION
**Pill-tree branch buttons grow from `h-6` to `h-8`** so the row carries more visual weight in the chrome bar and the click target is easier to hit. The horizontal padding bumps `px-2` → `px-2.5` to keep the rounded shape balanced at the new height.

The "+" and exit-maximize icon buttons grow `w-6 h-6` → `w-7 h-7` in lockstep — *they stay visually subordinate to a branch pill, but track its size step-for-step so the row reads as a single horizontal band rather than mismatched chips.* `mt-3` on the "+" button is preserved: both it and the first pill row are anchored to `items-start` on the same flex parent, so the geometric offset between them is unchanged.

Pure className diff — no logic, no new dependencies, no test changes.

### Try it locally

```sh
nix run github:juspay/kolu/feat/pill-tree-taller
```

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._