### PR TITLE
Drop the minimap hide toggle

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -22,7 +22,6 @@ import ChromeBar from "./ChromeBar";
 import CloseConfirm, { type CloseConfirmTarget } from "./CloseConfirm";
 import CommandPalette from "./CommandPalette";
 import "kolu-common/test-hooks";
-import { toggleMinimap } from "./canvas/CanvasMinimap";
 import CanvasWatermark from "./canvas/CanvasWatermark";
 import PillTree from "./canvas/PillTree";
 import { flatPillOrder, groupByRepo } from "./canvas/pillTreeOrder";
@@ -265,7 +264,6 @@ const App: Component = () => {
     simulateAlert: alerts.simulateAlert,
     toggleRightPanel: rightPanel.togglePanel,
     canvasCenterActive: handleCanvasCenterActive,
-    toggleMinimap,
     isMobile,
   });
 

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -1,11 +1,8 @@
 /** Canvas minimap — spatial overview of all tiles + integrated zoom controls.
- *  Two states: expanded (minimap visualization + zoom bar) and minimized
- *  (zoom bar only). Auto-hides the map when ≤2 tiles. */
+ *  Auto-hides the map when ≤2 tiles. */
 
-import { makePersisted } from "@solid-primitives/storage";
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { useTerminalStore } from "../terminal/useTerminalStore";
-import { MinimapIcon } from "../ui/Icons";
 import {
   handleMinimapClick,
   startTileDrag,
@@ -23,15 +20,6 @@ const MAP_H = 120;
 const MAP_PAD = 100;
 /** Show full minimap only when tile count exceeds this. */
 const AUTO_SHOW_THRESHOLD = 2;
-
-/** Singleton expanded state — persisted across reloads. */
-const [expanded, setExpanded] = makePersisted(createSignal(true), {
-  name: "kolu-minimap-expanded",
-});
-
-export function toggleMinimap() {
-  setExpanded((v) => !v);
-}
 
 const CanvasMinimap: Component<{
   tileIds: string[];
@@ -114,7 +102,7 @@ const CanvasMinimap: Component<{
 
   // ── Whether to show the full minimap or just the zoom bar ──
   const shouldShowMap = createMemo(
-    () => expanded() && props.tileIds.length > AUTO_SHOW_THRESHOLD,
+    () => props.tileIds.length > AUTO_SHOW_THRESHOLD,
   );
 
   // ── Viewport rect drag ──
@@ -177,7 +165,6 @@ const CanvasMinimap: Component<{
   return (
     <div
       data-testid="canvas-minimap"
-      data-expanded={shouldShowMap() ? "" : undefined}
       class="absolute bottom-4 left-4 z-20 flex flex-col items-start gap-px"
     >
       {/* Minimap visualization */}
@@ -293,18 +280,6 @@ const CanvasMinimap: Component<{
         }}
         style={shouldShowMap() ? { width: `${mapDims().w}px` } : undefined}
       >
-        {/* Minimap toggle */}
-        <button
-          type="button"
-          data-testid="minimap-toggle"
-          class="flex items-center justify-center w-8 h-8 text-fg-3 hover:text-fg hover:bg-surface-3/60 transition-colors cursor-pointer"
-          classList={{ "text-accent": expanded() }}
-          title="Toggle minimap"
-          onClick={() => toggleMinimap()}
-        >
-          <MinimapIcon class="w-3.5 h-3.5" />
-        </button>
-        <div class="w-px h-5 bg-edge/30" />
         <button
           type="button"
           class="flex items-center justify-center w-7 h-8 text-fg-3 hover:text-fg hover:bg-surface-3/60 transition-colors cursor-pointer text-sm font-medium"

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -63,7 +63,6 @@ export interface CommandDeps {
   // Canvas — desktop only (always active there); hidden on mobile where
   // the canvas isn't mounted at all.
   canvasCenterActive: () => void;
-  toggleMinimap: () => void;
   isMobile: () => boolean;
   // Worktree
   handleCreateWorktree: (repoPath: string, initialCommand?: string) => void;
@@ -175,10 +174,6 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             name: "Center on active tile",
             keybind: SHORTCUTS.canvasCenterActive.keybind,
             onSelect: () => deps.canvasCenterActive(),
-          },
-          {
-            name: "Toggle minimap",
-            onSelect: () => deps.toggleMinimap(),
           },
         ]
       : []),

--- a/packages/client/src/settings/tips.ts
+++ b/packages/client/src/settings/tips.ts
@@ -79,10 +79,6 @@ export const AMBIENT_TIPS: readonly Tip[] = [
     text: "Hold Shift and drag (or scroll) to pan the canvas — even over a terminal tile",
   },
   {
-    id: "amb-canvas-minimap",
-    text: "Toggle the minimap via its grid icon (bottom-left) for a bird's-eye view of every tile",
-  },
-  {
     id: "amb-tile-maximize",
     text: "Double-click a tile's title bar to maximize it to the viewport. Double-click again to restore.",
   },

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -81,22 +81,11 @@ Feature: Canvas workspace
 
   Scenario: Minimap shows zoom bar on the canvas
     Then the minimap should be visible
-    And the minimap toggle button should be visible
     And there should be no page errors
 
   Scenario: Minimap expands with multiple terminals
     Given I create a terminal
     And I create a terminal
-    Then the minimap map should be visible
-    And there should be no page errors
-
-  Scenario: Minimap toggle collapses and expands the map
-    Given I create a terminal
-    And I create a terminal
-    Then the minimap map should be visible
-    When I click the minimap toggle
-    Then the minimap map should not be visible
-    When I click the minimap toggle
     Then the minimap map should be visible
     And there should be no page errors
 

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -5,7 +5,6 @@ import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 const CANVAS_SELECTOR = '[data-testid="canvas-container"]';
 const MINIMAP_SELECTOR = '[data-testid="canvas-minimap"]';
 const MINIMAP_MAP_SELECTOR = '[data-testid="minimap-map"]';
-const MINIMAP_TOGGLE_SELECTOR = '[data-testid="minimap-toggle"]';
 const MINIMAP_VIEWPORT_RECT_SELECTOR = '[data-testid="minimap-viewport-rect"]';
 const TILE_SELECTOR = '[data-testid="canvas-tile"]';
 
@@ -522,38 +521,12 @@ Then("the minimap should be visible", async function (this: KoluWorld) {
   );
 });
 
-Then(
-  "the minimap toggle button should be visible",
-  async function (this: KoluWorld) {
-    await this.page.waitForFunction(
-      (sel: string) => document.querySelector(sel) !== null,
-      MINIMAP_TOGGLE_SELECTOR,
-      { timeout: POLL_TIMEOUT },
-    );
-  },
-);
-
 Then("the minimap map should be visible", async function (this: KoluWorld) {
   await this.page.waitForFunction(
     (sel: string) => document.querySelector(sel) !== null,
     MINIMAP_MAP_SELECTOR,
     { timeout: POLL_TIMEOUT },
   );
-});
-
-Then("the minimap map should not be visible", async function (this: KoluWorld) {
-  await this.page.waitForFunction(
-    (sel: string) => document.querySelector(sel) === null,
-    MINIMAP_MAP_SELECTOR,
-    { timeout: POLL_TIMEOUT },
-  );
-});
-
-When("I click the minimap toggle", async function (this: KoluWorld) {
-  const toggle = this.page.locator(MINIMAP_TOGGLE_SELECTOR);
-  await toggle.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-  await toggle.click();
-  await this.waitForFrame();
 });
 
 When("I save the canvas viewport state", async function (this: KoluWorld) {


### PR DESCRIPTION
**The canvas minimap can no longer be hidden** — past the 2-tile threshold it's always on. The persisted toggle (a grid-icon button in the zoom bar, a `kolu-minimap-expanded` localStorage flag, a *Toggle minimap* command, and an ambient discoverability tip) is gone, along with the e2e scenario that exercised it.

The behaviour rule that survives is the auto-show threshold: with ≤2 tiles the map collapses to just the zoom bar; with more, the map appears. *Same rule as before, minus the user override.* Net effect on `CanvasMinimap.tsx` is the loss of a `makePersisted` signal, a singleton setter exported across module boundaries to `App.tsx` + `commands.ts`, and one branch of a `createMemo` — the component now reads as plain rendering with no preference state of its own.

> Diff is **76 deletions, 2 insertions** across six files; based off `simplify-extensions`, not `master`.

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._