### PR TITLE
Drop redundant exit-maximize button from pill tree

### DIFF
--- a/packages/client/src/canvas/PillTree.tsx
+++ b/packages/client/src/canvas/PillTree.tsx
@@ -14,7 +14,7 @@ import type { TerminalId } from "kolu-common";
 import { type Component, createMemo, For, Show } from "solid-js";
 import { match, P } from "ts-pattern";
 import { useTerminalStore } from "../terminal/useTerminalStore";
-import { MinimapIcon, PlusIcon } from "../ui/Icons";
+import { PlusIcon } from "../ui/Icons";
 import {
   type PillBranch,
   type PillRepoGroup,
@@ -84,17 +84,6 @@ const PillTree: Component<{
           "opacity-50": posture.maximized(),
         }}
       >
-        <Show when={posture.maximized()}>
-          <button
-            type="button"
-            data-testid="pill-tree-exit-maximize"
-            class="pointer-events-auto flex items-center justify-center w-6 h-6 rounded-lg shrink-0 cursor-pointer text-fg-2 hover:text-fg hover:bg-surface-2/80 transition-colors"
-            onClick={posture.toggle}
-            title="Show all on canvas"
-          >
-            <MinimapIcon class="w-3.5 h-3.5" />
-          </button>
-        </Show>
         {/* "+" button — opens the new-terminal palette group (recent
          *  cwds + worktree create flow). Sits before the repo groups
          *  so it stays in a stable position regardless of how many

--- a/packages/client/src/ui/Icons.tsx
+++ b/packages/client/src/ui/Icons.tsx
@@ -417,26 +417,6 @@ export const TerminalIcon: Component<{ class?: string }> = (props) => (
   </svg>
 );
 
-/** Minimap toggle: grid/map icon. */
-export const MinimapIcon: Component<{ class?: string }> = (props) => (
-  <svg
-    class={props.class ?? "w-4 h-4"}
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    viewBox="0 0 24 24"
-    aria-hidden="true"
-  >
-    {/* 2×2 grid — spatial overview metaphor */}
-    <rect x="3" y="3" width="8" height="8" rx="1" />
-    <rect x="13" y="3" width="8" height="8" rx="1" />
-    <rect x="3" y="13" width="8" height="8" rx="1" />
-    <rect x="13" y="13" width="8" height="8" rx="1" />
-  </svg>
-);
-
 export const FileBrowseIcon: Component<{ class?: string }> = (props) => (
   <svg
     class={props.class ?? "w-3.5 h-3.5"}


### PR DESCRIPTION
**The pill tree's exit-maximize button was a third path to a toggle that already has two perfectly good ones**, used the wrong icon for the job, and bumped the centered pill row sideways every time it appeared. Removing it.

### Why it was redundant

Every tile's title bar already renders the canonical maximize/restore button (`CanvasTile.tsx:158-175`) — and double-clicking the title bar toggles the same state (`CanvasTile.tsx:149-152`). When a tile is maximized, that title-bar button (now showing `RestoreIcon`) is right there with a "Restore to canvas" tooltip. A separate exit affordance bolted onto the floating pill tree didn't add discoverability — it just multiplied paths to the same action.

### Why the icon was wrong

The button used `MinimapIcon` — a 2×2 grid of squares the codebase comments as a _spatial-overview metaphor_. The codebase already has the right pair (`MaximizeIcon` outline / `RestoreIcon` nested squares) and uses them correctly on the title bar. The pill-tree button reaching for the grid icon was the visual tell that something was off.

### Why the position was off

The button sat in a `justify-center` flex row, so the moment a tile was maximized the button appeared and shifted the entire centered pill cluster sideways. It was also missing the `mt-3` baseline-alignment offset the sibling `+` button carries, so it floated higher than everything else in the row.

`MinimapIcon` had no other consumers, so its definition is deleted along with the import.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._