### PR TITLE
Require a patched PostCSS release

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -47,7 +47,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-Klgo7A+q0VluW1gTtCZw0UhTf7HkZ0heVjj3Cpwb5kE=";
+    hash = "sha256-kvUBaRiuiTAVNhiMxuRjCgAOQw05EnCLwsUFD5MwuYg=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "picomatch": "^4.0.4",
       "yaml": "^2.8.3",
       "defu": "^6.1.5",
-      "postcss": "8.5.10",
+      "postcss": "^8.5.10",
       "@anthropic-ai/sdk": "^0.81.0",
       "@xterm/xterm": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built",
       "@xterm/addon-webgl": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "picomatch": "^4.0.4",
       "yaml": "^2.8.3",
       "defu": "^6.1.5",
+      "postcss": "8.5.10",
       "@anthropic-ai/sdk": "^0.81.0",
       "@xterm/xterm": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built",
       "@xterm/addon-webgl": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   picomatch: ^4.0.4
   yaml: ^2.8.3
   defu: ^6.1.5
-  postcss: 8.5.10
+  postcss: ^8.5.10
   '@anthropic-ai/sdk': ^0.81.0
   '@xterm/xterm': github:juspay/xterm.js#fix/kolu-xterm-fixes-built
   '@xterm/addon-webgl': github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   picomatch: ^4.0.4
   yaml: ^2.8.3
   defu: ^6.1.5
+  postcss: 8.5.10
   '@anthropic-ai/sdk': ^0.81.0
   '@xterm/xterm': github:juspay/xterm.js#fix/kolu-xterm-fixes-built
   '@xterm/addon-webgl': github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
@@ -3500,8 +3501,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact-render-to-string@6.6.5:
@@ -7518,7 +7519,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8291,7 +8292,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.10
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
**PostCSS now resolves to the patched release line for GHSA-qx2v-qp2m-jg93**. The root workspace was still pulling `postcss@8.5.8` through Vite, so this adds a root pnpm override for `^8.5.10` and refreshes the generated lockfile state to `8.5.10`.

The Nix dependency-store hash was updated with the lockfile after the security fix. Switching the override from an exact version to a caret range does not change the current store output, but it allows future compatible PostCSS 8 patch/minor refreshes.

### Validation

- `just check`
- `just fmt`
- `nix build .#pnpmDeps --no-link`
- `nix build --rebuild .#pnpmDeps --no-link`

### Try it locally

```sh
nix build 'github:juspay/kolu?ref=fix/dependabot-postcss-8-5-10#pnpmDeps'
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._