### PR TITLE
Fix Pierre skill frontmatter for YAML parsers

### DIFF
--- a/.agents/skills/pierre/SKILL.md
+++ b/.agents/skills/pierre/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: pierre
-description: Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla classes and wraps them in thin SolidJS components. Trigger when: wiring up a file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention of `@pierre/trees` / `@pierre/diffs` / "pierre library".
+description: >-
+  Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and
+  `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships
+  Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla
+  classes and wraps them in thin SolidJS components. Trigger when: wiring up a
+  file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention
+  of `@pierre/trees` / `@pierre/diffs` / "pierre library".
 ---
 
 # @pierre/trees + @pierre/diffs integration

--- a/.apm/skills/pierre/SKILL.md
+++ b/.apm/skills/pierre/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: pierre
-description: Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla classes and wraps them in thin SolidJS components. Trigger when: wiring up a file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention of `@pierre/trees` / `@pierre/diffs` / "pierre library".
+description: >-
+  Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and
+  `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships
+  Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla
+  classes and wraps them in thin SolidJS components. Trigger when: wiring up a
+  file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention
+  of `@pierre/trees` / `@pierre/diffs` / "pierre library".
 ---
 
 # @pierre/trees + @pierre/diffs integration

--- a/.claude/skills/pierre/SKILL.md
+++ b/.claude/skills/pierre/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: pierre
-description: Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla classes and wraps them in thin SolidJS components. Trigger when: wiring up a file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention of `@pierre/trees` / `@pierre/diffs` / "pierre library".
+description: >-
+  Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and
+  `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships
+  Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla
+  classes and wraps them in thin SolidJS components. Trigger when: wiring up a
+  file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention
+  of `@pierre/trees` / `@pierre/diffs` / "pierre library".
 ---
 
 # @pierre/trees + @pierre/diffs integration

--- a/.opencode/skills/pierre/SKILL.md
+++ b/.opencode/skills/pierre/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: pierre
-description: Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla classes and wraps them in thin SolidJS components. Trigger when: wiring up a file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention of `@pierre/trees` / `@pierre/diffs` / "pierre library".
+description: >-
+  Use Pierre Computer Company's `@pierre/trees` (path-first file tree) and
+  `@pierre/diffs` (shiki-based diff renderer) in Kolu. Pierre ships
+  Preact/vanilla cores with optional React wrappers — Kolu consumes the vanilla
+  classes and wraps them in thin SolidJS components. Trigger when: wiring up a
+  file tree, rendering unified diffs, replacing `@git-diff-view`, or any mention
+  of `@pierre/trees` / `@pierre/diffs` / "pierre library".
 ---
 
 # @pierre/trees + @pierre/diffs integration


### PR DESCRIPTION
**Pierre's skill metadata now loads as valid YAML** in opencode and the generated agent runtimes. The description keeps the same wording, but uses YAML's folded scalar form so `Trigger when:` is text instead of an invalid mapping marker.

Validation covered the parser-level failure and the repo gates: `just ai::apm-sync`, `just check`, `just fmt`, and a PyYAML smoke check over the `.apm`, `.agents`, `.claude`, and `.opencode` Pierre skill copies.

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._