### PR TITLE
Boot packaged Kolu during CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Bug fixes, build/CI fixes, doc tweaks, and behavior-preserving refactors are wel
 
 ## CI
 
-`just ci` builds all flake outputs on x86_64-linux and aarch64-darwin in parallel, runs e2e tests, and posts GitHub commit statuses. See [`ci/`](ci/) for details and reuse instructions.
+`just ci` builds all flake outputs on x86_64-linux and aarch64-darwin in parallel, smoke-runs the packaged Kolu server, runs e2e tests, and posts GitHub commit statuses. See [`ci/`](ci/) for details and reuse instructions.
 
 ```sh
 just ci              # full CI run

--- a/ci/README.md
+++ b/ci/README.md
@@ -31,6 +31,8 @@ If `CI_SYSTEM` matches the local system, commands run directly (prefixed with `~
 
 Systems run in parallel via just's `[parallel]` attribute. Within each system, steps run sequentially respecting recipe dependencies.
 
+Kolu's project configuration runs the packaged production wrapper on each target system and waits for `/api/health`, so missing runtime dependencies fail CI even when the Nix build itself succeeds.
+
 ## Usage in your project
 
 ### 1. Create `ci/lib.just`

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -74,7 +74,7 @@ e2e: nix
 
 # Smoke-test the production wrapper can start and serve health.
 run: nix
-    just ci::_run run bash ci/smoke-run.sh
+    just ci::_run run "nix develop . --accept-flake-config -c bash ci/smoke-run.sh"
 
 # Run vitest unit tests (server + client)
 unit:

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -34,10 +34,10 @@ _linux:
 # Runs post-nix steps in parallel. Within the same just process, their
 # `: nix` deps are already satisfied, so nix is not rebuilt.
 [parallel]
-_linux-fanout: home-manager e2e
+_linux-fanout: home-manager e2e run
 
 [parallel]
-_darwin-fanout: e2e
+_darwin-fanout: e2e run
 
 _darwin:
     CI_SYSTEM=aarch64-darwin just ci::nix ci::_darwin-fanout || true
@@ -71,6 +71,10 @@ typecheck:
 
 e2e: nix
     just ci::_run e2e just test
+
+# Smoke-test the production wrapper can start and serve health.
+run: nix
+    just ci::_run run bash ci/smoke-run.sh
 
 # Run vitest unit tests (server + client)
 unit:

--- a/ci/smoke-run.sh
+++ b/ci/smoke-run.sh
@@ -10,6 +10,7 @@ kolu_pid=""
 
 cleanup() {
   if [[ -n "$kolu_pid" ]] && kill -0 "$kolu_pid" 2>/dev/null; then
+    # The process may exit between the liveness check and cleanup commands.
     kill "$kolu_pid" 2>/dev/null || true
     wait "$kolu_pid" 2>/dev/null || true
   fi

--- a/ci/smoke-run.sh
+++ b/ci/smoke-run.sh
@@ -59,6 +59,7 @@ try {
   const body = await response.text();
   process.exit(response.ok && body === "kolu" ? 0 : 1);
 } catch {
+  // The server may not be accepting connections yet; the outer loop retries.
   process.exit(1);
 }
 NODE

--- a/ci/smoke-run.sh
+++ b/ci/smoke-run.sh
@@ -3,19 +3,6 @@ set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
 kolu_bin="$(nix build "$root#default" --print-out-paths --no-link)/bin/kolu"
-port="$(
-  node --input-type=module <<'NODE'
-import { createServer } from "node:net";
-
-const server = createServer();
-server.listen(0, "127.0.0.1", () => {
-  const address = server.address();
-  if (!address || typeof address === "string") process.exit(1);
-  console.log(address.port);
-  server.close();
-});
-NODE
-)"
 
 scratch="$(mktemp -d)"
 log="$scratch/kolu.log"
@@ -39,12 +26,31 @@ env -i \
   NODE_ENV=production \
   "$kolu_bin" \
   --host 127.0.0.1 \
-  --port "$port" \
+  --port 0 \
   >"$log" 2>&1 &
 kolu_pid="$!"
 
 for _ in {1..80}; do
-  if node --input-type=module - "http://127.0.0.1:$port/api/health" <<'NODE'
+  url="$(node --input-type=module - "$log" <<'NODE'
+import { readFileSync } from "node:fs";
+
+const logPath = process.argv.at(-1);
+for (const line of readFileSync(logPath, "utf8").trim().split("\n")) {
+  if (!line) continue;
+  try {
+    const entry = JSON.parse(line);
+    if (entry.msg === "kolu listening" && typeof entry.address === "string") {
+      console.log(entry.address);
+      process.exit(0);
+    }
+  } catch {
+    // Ignore non-JSON lines so startup errors are still printed below.
+  }
+}
+NODE
+)"
+
+  if [[ -n "$url" ]] && node --input-type=module - "$url/api/health" <<'NODE'
 const url = process.argv.at(-1);
 try {
   const response = await fetch(url);
@@ -55,7 +61,7 @@ try {
 }
 NODE
   then
-    echo "kolu health check passed on 127.0.0.1:$port"
+    echo "kolu health check passed at $url"
     exit 0
   fi
 
@@ -68,5 +74,5 @@ NODE
 done
 
 cat "$log" >&2
-echo "kolu did not become healthy on 127.0.0.1:$port" >&2
+echo "kolu did not become healthy" >&2
 exit 1

--- a/ci/smoke-run.sh
+++ b/ci/smoke-run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+kolu_bin="$(nix build "$root#default" --print-out-paths --no-link)/bin/kolu"
+port="$(
+  node --input-type=module <<'NODE'
+import { createServer } from "node:net";
+
+const server = createServer();
+server.listen(0, "127.0.0.1", () => {
+  const address = server.address();
+  if (!address || typeof address === "string") process.exit(1);
+  console.log(address.port);
+  server.close();
+});
+NODE
+)"
+
+scratch="$(mktemp -d)"
+log="$scratch/kolu.log"
+kolu_pid=""
+
+cleanup() {
+  if [[ -n "$kolu_pid" ]] && kill -0 "$kolu_pid" 2>/dev/null; then
+    kill "$kolu_pid" 2>/dev/null || true
+    wait "$kolu_pid" 2>/dev/null || true
+  fi
+  rm -rf "$scratch"
+}
+trap cleanup EXIT
+
+XDG_CONFIG_HOME="$scratch/config" "$kolu_bin" \
+  --host 127.0.0.1 \
+  --port "$port" \
+  >"$log" 2>&1 &
+kolu_pid="$!"
+
+for _ in {1..80}; do
+  if node --input-type=module - "http://127.0.0.1:$port/api/health" <<'NODE'
+const url = process.argv.at(-1);
+try {
+  const response = await fetch(url);
+  const body = await response.text();
+  process.exit(response.ok && body === "kolu" ? 0 : 1);
+} catch {
+  process.exit(1);
+}
+NODE
+  then
+    echo "kolu health check passed on 127.0.0.1:$port"
+    exit 0
+  fi
+
+  if ! kill -0 "$kolu_pid" 2>/dev/null; then
+    cat "$log" >&2
+    wait "$kolu_pid"
+  fi
+
+  sleep 0.25
+done
+
+cat "$log" >&2
+echo "kolu did not become healthy on 127.0.0.1:$port" >&2
+exit 1

--- a/ci/smoke-run.sh
+++ b/ci/smoke-run.sh
@@ -30,7 +30,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-XDG_CONFIG_HOME="$scratch/config" "$kolu_bin" \
+env -i \
+  HOME="$HOME" \
+  USER="${USER:-}" \
+  LOGNAME="${LOGNAME:-}" \
+  PATH="/usr/bin:/bin" \
+  XDG_CONFIG_HOME="$scratch/config" \
+  NODE_ENV=production \
+  "$kolu_bin" \
   --host 127.0.0.1 \
   --port "$port" \
   >"$log" 2>&1 &

--- a/ci/smoke-run.sh
+++ b/ci/smoke-run.sh
@@ -17,6 +17,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# The helper runs under nix develop for Node, but the packaged server should
+# start with a production-like env so devshell variables do not leak into PTYs.
 env -i \
   HOME="$HOME" \
   USER="${USER:-}" \


### PR DESCRIPTION
**CI now starts the same packaged Kolu wrapper that production uses** before reporting success. The missing-package crash from #761 happened after the Nix build had already passed, so the CI matrix now includes a runtime smoke that boots Kolu and waits for `/api/health` on both target systems.

The new `ci::run` step depends on the existing Nix build, enters the dev shell only for helper tooling, and launches the packaged server under a production-like sanitized environment. Kolu owns the listen port with `--port 0`; the smoke reads the actual address from the JSON startup log and polls that URL.

Closes #761.

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `GPT-5`)._