### PR TITLE
Boot packaged Kolu in CI and assert /api/health (#761)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Bug fixes, build/CI fixes, doc tweaks, and behavior-preserving refactors are wel
 
 ## CI
 
-`just ci` builds all flake outputs on x86_64-linux and aarch64-darwin in parallel, runs e2e tests, and posts GitHub commit statuses. See [`ci/`](ci/) for details and reuse instructions.
+`just ci` builds all flake outputs on x86_64-linux and aarch64-darwin in parallel, runs e2e tests, boots the packaged binary against `/api/health` as a runtime smoke, and posts GitHub commit statuses. See [`ci/`](ci/) for details and reuse instructions.
 
 ```sh
 just ci              # full CI run

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -34,10 +34,10 @@ _linux:
 # Runs post-nix steps in parallel. Within the same just process, their
 # `: nix` deps are already satisfied, so nix is not rebuilt.
 [parallel]
-_linux-fanout: home-manager e2e
+_linux-fanout: home-manager e2e smoke
 
 [parallel]
-_darwin-fanout: e2e
+_darwin-fanout: e2e smoke
 
 _darwin:
     CI_SYSTEM=aarch64-darwin just ci::nix ci::_darwin-fanout || true
@@ -71,6 +71,12 @@ typecheck:
 
 e2e: nix
     just ci::_run e2e just test
+
+# Boot the packaged Kolu and verify /api/health — runtime smoke that catches
+# packaging regressions where `nix build` passes but the binary crashes at
+# boot (e.g. missing workspace dep — see #761).
+smoke: nix
+    just ci::_run smoke just smoke
 
 # Run vitest unit tests (server + client)
 unit:

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -7,6 +7,10 @@
 
 set -euo pipefail
 
+readonly LISTEN_TIMEOUT_SEC=10
+readonly POLL_INTERVAL_SEC=0.1
+readonly HEALTH_TIMEOUT_MS=5000
+
 KOLU=$(nix build .#default --no-link --print-out-paths)/bin/kolu
 
 tmp=$(mktemp -d)
@@ -28,12 +32,13 @@ trap cleanup EXIT
 env -i HOME="$tmp" "$KOLU" --host 127.0.0.1 --port 0 >"$log" 2>&1 &
 pid=$!
 
-# Wait up to 10s for the "kolu listening" event in the log, then extract the
-# address from that line. The message text is the semantic anchor — it's what
-# the server logs from the listen callback (packages/server/src/index.ts:204)
-# and is stable across pino transports (pino-pretty and JSON both preserve it).
+# Wait for the "kolu listening" event in the log, then extract the address
+# from that line. The message text is the semantic anchor — it's what the
+# server logs from the listen callback (packages/server/src/index.ts:204) and
+# is stable across pino transports (pino-pretty and JSON both preserve it).
 addr=""
-for _ in $(seq 1 100); do
+ticks=$(awk "BEGIN { print int($LISTEN_TIMEOUT_SEC / $POLL_INTERVAL_SEC) }")
+for _ in $(seq 1 "$ticks"); do
     if grep -q "kolu listening" "$log" 2>/dev/null; then
         addr=$(grep -oE '"address":"http[^"]*"' "$log" | head -1 | sed -E 's/^"address":"(.*)"$/\1/')
         break
@@ -43,11 +48,11 @@ for _ in $(seq 1 100); do
         cat "$log" >&2
         exit 1
     fi
-    sleep 0.1
+    sleep "$POLL_INTERVAL_SEC"
 done
 
 if [[ -z "$addr" ]]; then
-    echo "kolu did not log a listen address within 10s" >&2
+    echo "kolu did not log a listen address within ${LISTEN_TIMEOUT_SEC}s" >&2
     cat "$log" >&2
     exit 1
 fi
@@ -57,11 +62,11 @@ echo "kolu listening at $addr (pid=$pid)"
 # HTTP 200 — the response body is an implementation detail of index.ts:143
 # that the smoke shouldn't couple to.
 node -e '
-  const url = process.argv[1] + "/api/health";
-  fetch(url, { signal: AbortSignal.timeout(5000) })
+  const [url, timeoutMs] = [process.argv[1] + "/api/health", Number(process.argv[2])];
+  fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
     .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); })
     .catch(e => { console.error(e.message || e); process.exit(1); });
-' "$addr"
+' "$addr" "$HEALTH_TIMEOUT_MS"
 echo "/api/health returned 200"
 
 # Graceful shutdown: SIGTERM, expect exit 0.

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -40,7 +40,9 @@ addr=""
 ticks=$(awk "BEGIN { print int($LISTEN_TIMEOUT_SEC / $POLL_INTERVAL_SEC) }")
 for _ in $(seq 1 "$ticks"); do
     if grep -q "kolu listening" "$log" 2>/dev/null; then
-        addr=$(grep -oE '"address":"http[^"]*"' "$log" | head -1 | sed -E 's/^"address":"(.*)"$/\1/')
+        # `|| true` keeps an empty match from tripping pipefail+set-e silently;
+        # the [[ -z "$addr" ]] check below produces a clear diagnostic.
+        addr=$(grep -oE '"address":"http[^"]*"' "$log" | head -1 | sed -E 's/^"address":"(.*)"$/\1/' || true)
         break
     fi
     if ! kill -0 "$pid" 2>/dev/null; then
@@ -52,7 +54,11 @@ for _ in $(seq 1 "$ticks"); do
 done
 
 if [[ -z "$addr" ]]; then
-    echo "kolu did not log a listen address within ${LISTEN_TIMEOUT_SEC}s" >&2
+    if grep -q "kolu listening" "$log" 2>/dev/null; then
+        echo "kolu logged 'listening' but no address could be parsed from the line" >&2
+    else
+        echo "kolu did not log a listen address within ${LISTEN_TIMEOUT_SEC}s" >&2
+    fi
     cat "$log" >&2
     exit 1
 fi

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -72,7 +72,7 @@ echo "/api/health returned 'kolu'"
 kill -TERM "$pid"
 ec=0
 wait "$pid" || ec=$?
-pid=""
+pid=""  # disarm cleanup trap — we've already waited
 if [[ $ec -ne 0 ]]; then
     echo "kolu exited with code $ec after SIGTERM" >&2
     cat "$log" >&2

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -67,12 +67,16 @@ echo "kolu listening at $addr (pid=$pid)"
 # Health check via Node's built-in fetch (no curl in dev shell). Asserts only
 # HTTP 200 — the response body is an implementation detail of index.ts:143
 # that the smoke shouldn't couple to.
-node -e '
+if ! node -e '
   const [url, timeoutMs] = [process.argv[1] + "/api/health", Number(process.argv[2])];
   fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
     .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); })
     .catch(e => { console.error(e.message || e); process.exit(1); });
-' "$addr" "$HEALTH_TIMEOUT_MS"
+' "$addr" "$HEALTH_TIMEOUT_MS"; then
+    echo "/api/health request failed" >&2
+    cat "$log" >&2
+    exit 1
+fi
 echo "/api/health returned 200"
 
 # Graceful shutdown: SIGTERM, expect exit 0.

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -53,20 +53,16 @@ if [[ -z "$addr" ]]; then
 fi
 echo "kolu listening at $addr (pid=$pid)"
 
-# Health check via Node's built-in fetch (no curl in dev shell).
-resp=$(node -e '
+# Health check via Node's built-in fetch (no curl in dev shell). Asserts only
+# HTTP 200 — the response body is an implementation detail of index.ts:143
+# that the smoke shouldn't couple to.
+node -e '
   const url = process.argv[1] + "/api/health";
   fetch(url, { signal: AbortSignal.timeout(5000) })
-    .then(r => r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`)))
-    .then(t => process.stdout.write(t))
+    .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); })
     .catch(e => { console.error(e.message || e); process.exit(1); });
-' "$addr")
-if [[ "$resp" != "kolu" ]]; then
-    echo "unexpected /api/health response: ${resp:-<empty>}" >&2
-    cat "$log" >&2
-    exit 1
-fi
-echo "/api/health returned 'kolu'"
+' "$addr"
+echo "/api/health returned 200"
 
 # Graceful shutdown: SIGTERM, expect exit 0.
 kill -TERM "$pid"

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Boot the packaged Kolu (production wrapper) and verify it serves /api/health.
+#
+# Catches packaging regressions where `nix build` succeeds but the binary
+# crashes at runtime — e.g. a missing workspace dep slipping past the build
+# (the production crash that motivated #761).
+
+set -euo pipefail
+
+KOLU=$(nix build .#default --no-link --print-out-paths)/bin/kolu
+
+tmp=$(mktemp -d)
+log="$tmp/kolu.log"
+pid=""
+
+cleanup() {
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        kill -TERM "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    fi
+    rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+# Sanitize env so we mirror production: clear IN_NIX_SHELL and devshell
+# pollution. HOME→tmp so the wrapper's KOLU_STATE_DIR lands there instead of
+# the runner's real ~/.config.
+env -i HOME="$tmp" "$KOLU" --host 127.0.0.1 --port 0 >"$log" 2>&1 &
+pid=$!
+
+# Wait up to 10s for the listening line. The log is pino-pretty (the production
+# default — kolu doesn't set NODE_ENV=production), so match the address field
+# directly rather than the JSON `msg` key. Bail early if the process dies.
+found=0
+for _ in $(seq 1 100); do
+    if grep -q '"address":"http' "$log" 2>/dev/null; then
+        found=1
+        break
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+        echo "kolu exited before listening" >&2
+        cat "$log" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+
+if [[ $found -eq 0 ]]; then
+    echo "kolu did not log a listen address within 10s" >&2
+    cat "$log" >&2
+    exit 1
+fi
+
+addr=$(grep -oE '"address":"http[^"]*"' "$log" | head -1 | sed -E 's/^"address":"(.*)"$/\1/')
+echo "kolu listening at $addr (pid=$pid)"
+
+# Health check via Node's built-in fetch (no curl in dev shell).
+resp=$(node -e '
+  const url = process.argv[1] + "/api/health";
+  fetch(url, { signal: AbortSignal.timeout(5000) })
+    .then(r => r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`)))
+    .then(t => process.stdout.write(t))
+    .catch(e => { console.error(e.message || e); process.exit(1); });
+' "$addr")
+if [[ "$resp" != "kolu" ]]; then
+    echo "unexpected /api/health response: ${resp:-<empty>}" >&2
+    cat "$log" >&2
+    exit 1
+fi
+echo "/api/health returned 'kolu'"
+
+# Graceful shutdown: SIGTERM, expect exit 0.
+kill -TERM "$pid"
+ec=0
+wait "$pid" || ec=$?
+pid=""
+if [[ $ec -ne 0 ]]; then
+    echo "kolu exited with code $ec after SIGTERM" >&2
+    cat "$log" >&2
+    exit 1
+fi
+echo "shutdown clean"

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -28,13 +28,13 @@ trap cleanup EXIT
 env -i HOME="$tmp" "$KOLU" --host 127.0.0.1 --port 0 >"$log" 2>&1 &
 pid=$!
 
-# Wait up to 10s for the address to appear in the log, extracting it as we go.
-# The log is pino-pretty (the production default — kolu doesn't set
-# NODE_ENV=production), so match the address field directly rather than the
-# JSON `msg` key. Bail early if the process dies.
+# Wait up to 10s for the "kolu listening" event in the log, then extract the
+# address from that line. The message text is the semantic anchor — it's what
+# the server logs from the listen callback (packages/server/src/index.ts:204)
+# and is stable across pino transports (pino-pretty and JSON both preserve it).
 addr=""
 for _ in $(seq 1 100); do
-    if grep -q '"address":"http' "$log" 2>/dev/null; then
+    if grep -q "kolu listening" "$log" 2>/dev/null; then
         addr=$(grep -oE '"address":"http[^"]*"' "$log" | head -1 | sed -E 's/^"address":"(.*)"$/\1/')
         break
     fi

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -18,6 +18,9 @@ log="$tmp/kolu.log"
 pid=""
 
 cleanup() {
+    # Best-effort teardown on EXIT — `|| true` because the trap can race with
+    # the process's own exit, and we don't want a stale-PID kill to mask the
+    # real error that triggered the trap.
     if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
         kill -TERM "$pid" 2>/dev/null || true
         wait "$pid" 2>/dev/null || true

--- a/ci/smoke.sh
+++ b/ci/smoke.sh
@@ -28,13 +28,14 @@ trap cleanup EXIT
 env -i HOME="$tmp" "$KOLU" --host 127.0.0.1 --port 0 >"$log" 2>&1 &
 pid=$!
 
-# Wait up to 10s for the listening line. The log is pino-pretty (the production
-# default — kolu doesn't set NODE_ENV=production), so match the address field
-# directly rather than the JSON `msg` key. Bail early if the process dies.
-found=0
+# Wait up to 10s for the address to appear in the log, extracting it as we go.
+# The log is pino-pretty (the production default — kolu doesn't set
+# NODE_ENV=production), so match the address field directly rather than the
+# JSON `msg` key. Bail early if the process dies.
+addr=""
 for _ in $(seq 1 100); do
     if grep -q '"address":"http' "$log" 2>/dev/null; then
-        found=1
+        addr=$(grep -oE '"address":"http[^"]*"' "$log" | head -1 | sed -E 's/^"address":"(.*)"$/\1/')
         break
     fi
     if ! kill -0 "$pid" 2>/dev/null; then
@@ -45,13 +46,11 @@ for _ in $(seq 1 100); do
     sleep 0.1
 done
 
-if [[ $found -eq 0 ]]; then
+if [[ -z "$addr" ]]; then
     echo "kolu did not log a listen address within 10s" >&2
     cat "$log" >&2
     exit 1
 fi
-
-addr=$(grep -oE '"address":"http[^"]*"' "$log" | head -1 | sed -E 's/^"address":"(.*)"$/\1/')
 echo "kolu listening at $addr (pid=$pid)"
 
 # Health check via Node's built-in fetch (no curl in dev shell).

--- a/justfile
+++ b/justfile
@@ -96,6 +96,10 @@ test-quick *args: install
         ./node_modules/@cucumber/cucumber/bin/cucumber-js \
         --profile ui {{ args }}
 
+# Boot the packaged Kolu and verify /api/health — production-like runtime smoke
+smoke:
+    {{ nix_shell }} bash ci/smoke.sh
+
 # Remove all gitignored files (node_modules, build artifacts, etc.)
 clean:
     git clean -fdX


### PR DESCRIPTION
**`just ci` now runs Kolu, not just builds it.** Each system's CI lane boots `.#default` — the production wrapper — under a sanitized environment, asserts `/api/health` returns 200, sends SIGTERM and confirms a clean exit. The Nix build is no longer a stand-in for "the binary actually works."

The motivating regression: a missing workspace dep slipped past `nix build` and only surfaced when production booted the artifact (`Cannot find package 'kolu-transcript-html' imported from .../kolu-stamped/packages/server/src/router.ts`, see #761). Build success was telling us nothing about runtime success.

### How the smoke runs

```
nix build .#default ─▶ env -i HOME=$tmp $KOLU --port 0
                                │
                                ▼
                       wait for "kolu listening" in log
                                │
                                ▼
                       parse address, fetch /api/health
                                │
                                ▼
                       SIGTERM, assert exit 0
```

`env -i HOME=$tmp` mirrors the production launch: no `IN_NIX_SHELL`, no devshell pollution, state dir lands in a tmp. `--port 0` means the OS picks a free port; the smoke reads the actual address from the pino startup log line. _The wait predicate is the message text `"kolu listening"`, not a JSON-shape match — stable across pino transports._

`smoke` plugs into `_linux-fanout` and `_darwin-fanout` parallel to `e2e` and `home-manager`, both depending on the existing `nix` step so the build is shared. Top-level `just smoke` reproduces the same check locally without `gh` status plumbing.

### Refinements landed during review

| Review pass | Finding | Fix |
| --- | --- | --- |
| Hickey | Two-pass log scan duplicated the format predicate | Single extraction inside the polling loop |
| Hickey | `pid=""` disarmed the cleanup trap by unwritten convention | Inline comment encodes the rule |
| Lowy | Wait anchor `"address":"http"` coupled to JSON shape | Switch to semantic `"kolu listening"` message text |
| Lowy | Health body equality (`resp == "kolu"`) coupled to a route detail | Assert HTTP 200 only |
| Police (rules) | `cleanup`'s `\|\| true` lacked a "why best-effort" comment | Documented |
| Police (fact-check) | Address-parse failure exited script silently under pipefail | `\|\| true` + explicit "logged listening but no address" diagnostic |
| Police (fact-check) | Health-check failure didn't dump the server log | Wrap `node -e` in if/else, `cat "$log" >&2` on failure |
| Police (elegance) | 10s budget duplicated as `100 × 0.1s` and "within 10s" | Extract `LISTEN_TIMEOUT_SEC` / `POLL_INTERVAL_SEC` / `HEALTH_TIMEOUT_MS` constants |

> _Lowy's NODE_ENV=production proposal was rejected — production doesn't set `NODE_ENV` either, so that would diverge from prod rather than match it. The semantic-anchor switch addresses the underlying volatility concern._

Closes #761.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._