### PR TITLE
Throttle session auto-save so streaming agents don't starve it

### DIFF
--- a/packages/server/src/session.ts
+++ b/packages/server/src/session.ts
@@ -5,7 +5,7 @@
  * `session:changed` channel so the client's `session.get` live query stays
  * current. The autosave loop is driven by the `terminals:dirty` control-flow
  * channel (distinct from the `session:changed` *content* channel) — every
- * terminal/meta mutation fires `terminals:dirty`, this module debounces and
+ * terminal/meta mutation fires `terminals:dirty`, this module throttles and
  * then persists.
  */
 
@@ -57,7 +57,19 @@ export function setSavedSession(session: SavedSession | null): void {
 
 let saveTimer: ReturnType<typeof setTimeout> | undefined;
 
-/** Wire up debounced session save from terminal change events. Called once at startup. */
+/** Wire up throttled session save from terminal change events. Called once at startup.
+ *
+ *  Leading-edge throttle: the first dirty event in a quiet period schedules
+ *  a save 500ms later; subsequent events during that window are absorbed
+ *  into the same upcoming snapshot (because `snapshot()` runs inside the
+ *  callback, not at schedule time). A trailing-edge debounce — the obvious
+ *  alternative — starves under bursty inputs: the Claude transcript
+ *  watcher fires every 150ms while an agent is streaming, which would
+ *  reset the timer indefinitely and the save would never fire.
+ *
+ *  Assumes `saveSession` is synchronous (it is — `writeSession` does sync
+ *  `store.set` + sync publish). If anyone makes it async, add an in-flight
+ *  guard so a new schedule can't race an unfinished write. */
 export function initSessionAutoSave(
   snapshot: () => {
     terminals: SavedTerminal[];
@@ -67,8 +79,11 @@ export function initSessionAutoSave(
   void (async () => {
     try {
       for await (const _ of publisher.subscribe("terminals:dirty")) {
-        if (saveTimer) clearTimeout(saveTimer);
-        saveTimer = setTimeout(() => saveSession(snapshot()), 500);
+        if (saveTimer) continue;
+        saveTimer = setTimeout(() => {
+          saveTimer = undefined;
+          saveSession(snapshot());
+        }, 500);
       }
     } catch (err) {
       log.error({ err }, "session auto-save subscription failed");


### PR DESCRIPTION
**Session auto-save no longer stops firing while an agent is streaming.** The auto-save loop in `initSessionAutoSave` was a trailing-edge debounce — every `terminals:dirty` event cleared the pending 500ms timer and started a fresh one. While a Claude agent is running, its transcript watcher (`packages/integrations/claude-code/src/session-watcher.ts:38`, `TRANSCRIPT_DEBOUNCE_MS = 150`) fires faster than that 500ms window, so the timer was reset indefinitely and the save never fired.

Symptom: user picks "New worktree in *<repo>*" from the recent-agents palette to spin up agents in fresh worktrees, waits a few minutes, then a new Kolu version deploys and the server restarts. On "Restore session", *only the older idle terminals come back* — the agent-running ones are missing. They were stuck in a perpetually-reset debounce window when the SIGTERM hit; the older terminals had been saved earlier, when the system was quiescent.

The fix swaps the trailing-edge debounce for a **leading-edge throttle**: the first dirty event in a quiet period schedules a save 500ms later, and subsequent events during that window are absorbed into the same upcoming snapshot. `snapshot()` runs inside the timer callback, so whatever state mutations arrived during the window are captured at fire time — no events lost.

The throttle assumes `saveSession` is synchronous, which it is today (`writeSession` is a sync `store.set` + sync publish). A comment in the function documents the in-flight guard that would be needed if anyone makes it async.

### Follow-ups (separate PRs)

- **SIGTERM/SIGINT flush** — would close the abrupt-kill window even with the throttle in place. The throttle alone shrinks the lost-write window from indefinite to <500ms, which addresses the reported symptom.
- **Gate `terminals:dirty` on persisted-field mutations** — `publishMetadata` (`packages/server/src/meta/state.ts:62-63`) currently emits `dirty` on transient `agent`/`pr`/`foreground` churn that `snapshotSession` strips out, so most dirty events trigger no real disk-state change.
- **E2E that holds a streaming agent across a simulated restart** — the existing `session-restore.feature` scenarios all start quiescent, which is why this slipped through.

### Try it locally

```sh
nix run github:juspay/kolu/fix/session-autosave-throttle
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._