### PR TITLE
refactor(input): unify keyboard layer into one action registry

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -33,6 +33,7 @@ import { createCommands } from "./commands";
 import DiagnosticInfo from "./DiagnosticInfo";
 import EmptyState from "./EmptyState";
 import { exportScrollbackAsPdf } from "./exportScrollbackAsPdf";
+import type { ActionContext } from "./input/actions";
 import { useShortcuts } from "./input/useShortcuts";
 import MobileKeyBar from "./MobileKeyBar";
 import MobileTileView from "./MobileTileView";
@@ -166,16 +167,19 @@ const App: Component = () => {
     if (tile) canvasViewport.centerOnTile(tile);
   }
 
-  useShortcuts({
+  // Shared between the keyboard dispatcher and the command palette so a single
+  // wiring keeps both surfaces in sync. Palette-only deps (theme management,
+  // dialog setters, debug, etc.) are added below in the createCommands call.
+  const actionContext: ActionContext = {
     terminalIds: store.terminalIds,
     activeId: store.activeId,
     setActiveId: store.setActiveId,
     mruOrder: store.mruOrder,
+    activeMeta: store.activeMeta,
     handleCreate: (cwd?: string) => void crud.handleCreate(cwd),
     handleCreateSubTerminal: (parentId, cwd) =>
       void crud.handleCreateSubTerminal(parentId, cwd),
     openNewTerminalMenu: () => openPaletteGroup("New terminal"),
-    activeMeta: store.activeMeta,
     setPaletteOpen,
     setShortcutsHelpOpen,
     setSearchOpen,
@@ -191,7 +195,9 @@ const App: Component = () => {
     toggleRightPanel: rightPanel.togglePanel,
     canvasCenterActive: handleCanvasCenterActive,
     toggleRecordingPause: () => useRecorder().togglePause(),
-  });
+  };
+
+  useShortcuts(actionContext);
 
   function openPalette() {
     setPaletteInitialGroup(undefined);
@@ -235,23 +241,13 @@ const App: Component = () => {
   }
 
   const commands = createCommands({
-    terminalIds: store.terminalIds,
-    activeId: store.activeId,
-    setActiveId: store.setActiveId,
-    activeMeta: store.activeMeta,
-    handleCreate: (cwd) => void crud.handleCreate(cwd),
-    handleCreateSubTerminal: (parentId, cwd) =>
-      void crud.handleCreateSubTerminal(parentId, cwd),
+    ...actionContext,
     handleCopyTerminalText: () => void crud.handleCopyTerminalText(),
     handleRunInActiveTerminal: (cmd) => crud.handleRunInActiveTerminal(cmd),
     handleExportScrollbackAsPdf,
-    handleScreenshotTerminal: () => handleScreenshotTerminal(),
-    toggleSubPanel: handleToggleSubPanel,
     committedThemeName,
     setPreviewThemeName,
     handleSetTheme,
-    handleShuffleTheme,
-    setShortcutsHelpOpen,
     setAboutOpen,
     setDiagnosticInfoOpen,
     handleCreateWorktree: (repoPath, initialCommand) =>
@@ -262,8 +258,6 @@ const App: Component = () => {
     },
     handleCloseAll: () => void crud.handleCloseAll(),
     simulateAlert: alerts.simulateAlert,
-    toggleRightPanel: rightPanel.togglePanel,
-    canvasCenterActive: handleCanvasCenterActive,
     isMobile,
   });
 

--- a/packages/client/src/ChromeBar.tsx
+++ b/packages/client/src/ChromeBar.tsx
@@ -21,7 +21,8 @@
 
 import { type Component, createSignal, type JSX } from "solid-js";
 import { useViewPosture } from "./canvas/useViewPosture";
-import { formatKeybind, SHORTCUTS } from "./input/keyboard";
+import { ACTIONS } from "./input/actions";
+import { formatKeybind } from "./input/keyboard";
 import RecordButton from "./recorder/RecordButton";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import type { WsStatus } from "./rpc/rpc";
@@ -117,7 +118,7 @@ const ChromeBar: Component<{
       <div class="flex items-center gap-2 shrink-0">
         <RecordButton />
         <Tip
-          label={`Toggle inspector (${formatKeybind(SHORTCUTS.toggleRightPanel.keybind)})`}
+          label={`Toggle inspector (${formatKeybind(ACTIONS.toggleRightPanel.keybind)})`}
         >
           <button
             type="button"
@@ -160,7 +161,7 @@ const ChromeBar: Component<{
             class="pointer-events-auto h-7 flex items-center gap-1.5 px-2 text-xs text-fg-2 hover:text-fg bg-surface-2 hover:bg-surface-3 rounded-lg border border-edge transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
             onClick={() => props.onOpenPalette()}
           >
-            <Kbd>{formatKeybind(SHORTCUTS.commandPalette.keybind)}</Kbd>
+            <Kbd>{formatKeybind(ACTIONS.commandPalette.keybind)}</Kbd>
           </button>
         </Tip>
       </div>

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -6,15 +6,22 @@ import {
   terminalKey,
 } from "kolu-common";
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
-import { formatKeybind, SHORTCUTS } from "./input/keyboard";
+import { ACTIONS } from "./input/actions";
+import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
 import Toggle from "./ui/Toggle";
 
 const features = [
-  { label: "New terminal", shortcut: SHORTCUTS.createTerminalAlt.keybind },
-  { label: "New terminal menu", shortcut: SHORTCUTS.newTerminalMenu.keybind },
-  { label: "Command palette", shortcut: SHORTCUTS.commandPalette.keybind },
-  { label: "Cycle terminals", shortcut: SHORTCUTS.cycleTerminalMru.keybind },
+  // Show the alt chord (Cmd+Enter): Cmd+T is intercepted by browsers outside
+  // PWA-installed mode, so the alt is the more universally-functional advert.
+  {
+    label: "New terminal",
+    shortcut:
+      ACTIONS.createTerminal.altKeybind ?? ACTIONS.createTerminal.keybind,
+  },
+  { label: "New terminal menu", shortcut: ACTIONS.newTerminalMenu.keybind },
+  { label: "Command palette", shortcut: ACTIONS.commandPalette.keybind },
+  { label: "Cycle terminals", shortcut: ACTIONS.cycleTerminalMru.keybind },
 ];
 
 interface RepoGroup {

--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -15,7 +15,8 @@
 import type { TerminalId } from "kolu-common";
 import { type Component, createSignal, For, Show } from "solid-js";
 import { type PillRepoGroup, repoColor } from "./canvas/pillTreeOrder";
-import { formatKeybind, SHORTCUTS } from "./input/keyboard";
+import { ACTIONS } from "./input/actions";
+import { formatKeybind } from "./input/keyboard";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import type { WsStatus } from "./rpc/rpc";
 import SettingsPopover from "./settings/SettingsPopover";
@@ -140,7 +141,7 @@ const MobileChromeSheet: Component<{
             props.onClose();
           }}
         >
-          <Kbd>{formatKeybind(SHORTCUTS.commandPalette.keybind)}</Kbd>
+          <Kbd>{formatKeybind(ACTIONS.commandPalette.keybind)}</Kbd>
           <span>Palette</span>
         </button>
         <div>

--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -2,37 +2,31 @@
 
 import Dialog from "@corvu/dialog";
 import { type Component, For } from "solid-js";
-import { formatKeybind, type Keybind, SHORTCUTS } from "./input/keyboard";
+import { ACTIONS, type ActionId } from "./input/actions";
+import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
 import ModalDialog from "./ui/ModalDialog";
 
-interface DisplayEntry {
-  label: string;
-  keybind: Keybind;
-  altKeybind?: Keybind;
-}
-
-/** Shortcuts to display — curated order, Mod+1-9 collapsed into one row. */
-const DISPLAY_SHORTCUTS: DisplayEntry[] = [
-  SHORTCUTS.commandPalette,
-  {
-    ...SHORTCUTS.createTerminal,
-    altKeybind: SHORTCUTS.createTerminalAlt.keybind,
-  },
-  SHORTCUTS.newTerminalMenu,
-  SHORTCUTS.cycleTerminalMru,
-  { ...SHORTCUTS.switchTo1, label: "Switch to terminal 1–9" },
-  SHORTCUTS.findInTerminal,
-  SHORTCUTS.zoomIn,
-  SHORTCUTS.zoomOut,
-  SHORTCUTS.zoomReset,
-  SHORTCUTS.toggleSubPanel,
-  SHORTCUTS.createSubTerminal,
-  SHORTCUTS.nextSubTab,
-  SHORTCUTS.prevSubTab,
-  SHORTCUTS.toggleRightPanel,
-  SHORTCUTS.canvasCenterActive,
-  SHORTCUTS.shortcutsHelp,
+/** Curated display order for the shortcuts help overlay. Referencing actions
+ *  by id (instead of restating label/keybind) keeps the overlay in sync with
+ *  any chord reassignment in the registry. */
+const HELP_ORDER: readonly { id: ActionId; label?: string }[] = [
+  { id: "commandPalette" },
+  { id: "createTerminal" },
+  { id: "newTerminalMenu" },
+  { id: "cycleTerminalMru" },
+  { id: "switchTo1", label: "Switch to terminal 1–9" },
+  { id: "findInTerminal" },
+  { id: "zoomIn" },
+  { id: "zoomOut" },
+  { id: "zoomReset" },
+  { id: "toggleSubPanel" },
+  { id: "createSubTerminal" },
+  { id: "nextSubTab" },
+  { id: "prevSubTab" },
+  { id: "toggleRightPanel" },
+  { id: "canvasCenterActive" },
+  { id: "shortcutsHelp" },
 ];
 
 const ShortcutsHelp: Component<{
@@ -49,16 +43,23 @@ const ShortcutsHelp: Component<{
         Keyboard Shortcuts
       </Dialog.Label>
       <div class="px-4 py-2">
-        <For each={DISPLAY_SHORTCUTS}>
-          {(s) => (
-            <div class="flex items-center justify-between py-1.5">
-              <span class="text-sm text-fg-2">{s.label}</span>
-              <span class="flex items-center gap-1.5">
-                <Kbd>{formatKeybind(s.keybind)}</Kbd>
-                {s.altKeybind && <Kbd>{formatKeybind(s.altKeybind)}</Kbd>}
-              </span>
-            </div>
-          )}
+        <For each={HELP_ORDER}>
+          {(entry) => {
+            const action = ACTIONS[entry.id];
+            return (
+              <div class="flex items-center justify-between py-1.5">
+                <span class="text-sm text-fg-2">
+                  {entry.label ?? action.label}
+                </span>
+                <span class="flex items-center gap-1.5">
+                  <Kbd>{formatKeybind(action.keybind)}</Kbd>
+                  {action.altKeybind && (
+                    <Kbd>{formatKeybind(action.altKeybind)}</Kbd>
+                  )}
+                </span>
+              </div>
+            );
+          }}
         </For>
       </div>
     </Dialog.Content>

--- a/packages/client/src/SplitStrip.tsx
+++ b/packages/client/src/SplitStrip.tsx
@@ -2,7 +2,8 @@
  *  "prompt" when no splits exist yet, "collapsed" when splits are hidden. */
 
 import type { Component } from "solid-js";
-import { formatKeybind, SHORTCUTS } from "./input/keyboard";
+import { ACTIONS } from "./input/actions";
+import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
 
 type SplitStripProps =
@@ -35,7 +36,7 @@ const SplitStrip: Component<SplitStripProps> = (props) => {
       <span class="text-fg-3">
         {isCollapsed() ? `${count()} split${count() > 1 ? "s" : ""}` : "Split"}
       </span>
-      <Kbd>{formatKeybind(SHORTCUTS.toggleSubPanel.keybind)}</Kbd>
+      <Kbd>{formatKeybind(ACTIONS.toggleSubPanel.keybind)}</Kbd>
     </button>
   );
 };

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -1,11 +1,11 @@
 /** Command palette registry — declarative list of all app-level actions. */
 
-import type { RecentAgent, TerminalId, TerminalMetadata } from "kolu-common";
+import type { RecentAgent } from "kolu-common";
 import type { Accessor } from "solid-js";
 import { batch, createMemo } from "solid-js";
 import { availableThemes } from "terminal-themes";
 import type { PaletteCommand, PaletteItem } from "./CommandPalette";
-import { SHORTCUTS } from "./input/keyboard";
+import { type ActionContext, actionPaletteCommand } from "./input/actions";
 import { client } from "./rpc/rpc";
 import { useActivityFeed } from "./settings/useActivityFeed";
 
@@ -36,33 +36,21 @@ function agentItemsWithPlainShell(
   ];
 }
 
-export interface CommandDeps {
-  terminalIds: Accessor<TerminalId[]>;
-  activeId: Accessor<TerminalId | null>;
-  setActiveId: (id: TerminalId) => void;
-  activeMeta: Accessor<TerminalMetadata | null>;
-  handleCreate: (cwd?: string) => void;
-  handleCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
+/** Palette-only dependencies — anything `ActionContext` doesn't already
+ *  provide for the keyboard dispatcher. */
+export interface CommandDeps extends ActionContext {
   handleCopyTerminalText: () => void;
   handleRunInActiveTerminal: (command: string) => void;
   handleExportScrollbackAsPdf: () => void;
-  handleScreenshotTerminal: () => void;
-  /** Toggle sub-panel: creates first split if none exist, otherwise toggles visibility. */
-  toggleSubPanel: (parentId: TerminalId) => void;
   // Theme
   committedThemeName: Accessor<string>;
   setPreviewThemeName: (name: string | undefined) => void;
   handleSetTheme: (name: string) => void;
-  handleShuffleTheme: () => void;
   // Dialogs
-  setShortcutsHelpOpen: (open: boolean) => void;
   setAboutOpen: (open: boolean) => void;
   setDiagnosticInfoOpen: (open: boolean) => void;
-  // Right panel
-  toggleRightPanel: () => void;
   // Canvas — desktop only (always active there); hidden on mobile where
   // the canvas isn't mounted at all.
-  canvasCenterActive: () => void;
   isMobile: () => boolean;
   // Worktree
   handleCreateWorktree: (repoPath: string, initialCommand?: string) => void;
@@ -131,23 +119,8 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             name: "Close terminal",
             onSelect: () => deps.handleClose(),
           },
-          {
-            name: "Toggle terminal split",
-            keybind: SHORTCUTS.toggleSubPanel.keybind,
-            onSelect: () => {
-              const id = deps.activeId();
-              if (id !== null) deps.toggleSubPanel(id);
-            },
-          },
-          {
-            name: "Split terminal",
-            keybind: SHORTCUTS.createSubTerminal.keybind,
-            onSelect: () => {
-              const id = deps.activeId();
-              if (id !== null)
-                deps.handleCreateSubTerminal(id, deps.activeMeta()?.cwd);
-            },
-          },
+          actionPaletteCommand("toggleSubPanel", deps),
+          actionPaletteCommand("createSubTerminal", deps),
           {
             name: "Copy terminal text",
             onSelect: () => deps.handleCopyTerminalText(),
@@ -156,26 +129,12 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             name: "Export scrollback as PDF",
             onSelect: () => deps.handleExportScrollbackAsPdf(),
           },
-          {
-            name: "Screenshot terminal",
-            keybind: SHORTCUTS.screenshotTerminal.keybind,
-            onSelect: () => deps.handleScreenshotTerminal(),
-          },
+          actionPaletteCommand("screenshotTerminal", deps),
         ]
       : []),
-    {
-      name: "Toggle inspector panel",
-      keybind: SHORTCUTS.toggleRightPanel.keybind,
-      onSelect: () => deps.toggleRightPanel(),
-    },
+    actionPaletteCommand("toggleRightPanel", deps),
     ...(!deps.isMobile()
-      ? [
-          {
-            name: "Center on active tile",
-            keybind: SHORTCUTS.canvasCenterActive.keybind,
-            onSelect: () => deps.canvasCenterActive(),
-          },
-        ]
+      ? [actionPaletteCommand("canvasCenterActive", deps)]
       : []),
     ...(deps.terminalIds().length > 0
       ? [
@@ -183,13 +142,13 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             name: "Switch terminal",
             children: () =>
               deps.terminalIds().map((id, i) => ({
-                name: `Switch to terminal ${i + 1}`,
-                keybind:
-                  i < 9
-                    ? SHORTCUTS[
-                        `switchTo${(i + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`
-                      ].keybind
-                    : undefined,
+                ...(i < 9
+                  ? actionPaletteCommand(
+                      `switchTo${(i + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`,
+                      deps,
+                      { name: `Switch to terminal ${i + 1}` },
+                    )
+                  : { name: `Switch to terminal ${i + 1}` }),
                 onSelect: () => deps.setActiveId(id),
               })),
           },
@@ -213,20 +172,13 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
     },
     ...(deps.activeId() !== null
       ? [
-          {
-            name: "Shuffle theme",
+          actionPaletteCommand("shuffleTheme", deps, {
             description:
               "Pick a theme whose background is perceptually distinct from every live terminal",
-            keybind: SHORTCUTS.shuffleTheme.keybind,
-            onSelect: () => deps.handleShuffleTheme(),
-          },
+          }),
         ]
       : []),
-    {
-      name: "Keyboard shortcuts",
-      keybind: SHORTCUTS.shortcutsHelp.keybind,
-      onSelect: () => deps.setShortcutsHelpOpen(true),
-    },
+    actionPaletteCommand("shortcutsHelp", deps, { name: "Keyboard shortcuts" }),
     {
       name: "About kolu",
       onSelect: () => deps.setAboutOpen(true),

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -1,7 +1,8 @@
 /**
  * Unified action registry — single source of truth for keyboard shortcuts,
- * the help overlay, and shared palette command metadata. Each entry binds an
- * id to its label, keybind, handler, and surface flags.
+ * the help overlay, and shared palette command metadata. The registry key is
+ * the action's id; each entry carries label, keybind, optional altKeybind,
+ * and optional handler.
  *
  * Adding or rebinding a global action touches this one file. The dispatcher
  * in `useShortcuts.ts` loops over `ACTIONS`; `ShortcutsHelp.tsx` walks
@@ -40,7 +41,6 @@ export interface ActionContext {
 }
 
 export interface AppAction {
-  id: string;
   label: string;
   keybind: Keybind;
   /** Optional alternate keybind that triggers the same handler (e.g. Cmd+Enter for "New terminal"). */
@@ -73,7 +73,6 @@ const switchToActions = Object.fromEntries(
   SWITCH_KEYS.map((i) => [
     `switchTo${i}`,
     {
-      id: `switchTo${i}`,
       label: `Switch to terminal ${i}`,
       keybind: { key: String(i), mod: true },
       handler: (ctx) => {
@@ -92,72 +91,60 @@ const switchToActions = Object.fromEntries(
 const _ACTIONS = {
   ...switchToActions,
   createTerminal: {
-    id: "createTerminal",
     label: "New terminal",
     keybind: { key: "t", mod: true },
     altKeybind: { key: "Enter", mod: true },
     handler: (ctx) => ctx.handleCreate(ctx.activeMeta()?.cwd ?? undefined),
   },
   newTerminalMenu: {
-    id: "newTerminalMenu",
     label: "New terminal menu",
     keybind: { key: "Enter", mod: true, shift: true },
     handler: (ctx) => ctx.openNewTerminalMenu(),
   },
   nextTerminal: {
-    id: "nextTerminal",
     label: "Next terminal",
     keybind: { key: "]", code: "BracketRight", mod: true, shift: true },
     handler: (ctx) => cycleTerminalByPosition(ctx, 1),
   },
   prevTerminal: {
-    id: "prevTerminal",
     label: "Previous terminal",
     keybind: { key: "[", code: "BracketLeft", mod: true, shift: true },
     handler: (ctx) => cycleTerminalByPosition(ctx, -1),
   },
   cycleTerminalMru: {
-    id: "cycleTerminalMru",
     label: "Cycle terminals by most recent use",
     keybind: { key: "Tab", code: "Tab", ctrl: true },
     // Dispatched by the stateful Alt+Tab/Ctrl+Tab cycle in useShortcuts.
   },
   commandPalette: {
-    id: "commandPalette",
     label: "Command palette",
     keybind: { key: "k", mod: true },
     handler: (ctx) => ctx.setPaletteOpen((v) => !v),
   },
   shortcutsHelp: {
-    id: "shortcutsHelp",
     label: "Shortcuts help",
     keybind: { key: "/", mod: true },
     handler: (ctx) => ctx.setShortcutsHelpOpen((v) => !v),
   },
   findInTerminal: {
-    id: "findInTerminal",
     label: "Find in terminal",
     keybind: { key: "f", mod: true },
     handler: (ctx) => ctx.setSearchOpen((v) => !v),
   },
   zoomIn: {
-    id: "zoomIn",
     label: "Zoom in",
     keybind: { key: "+", mod: true },
     // Dispatched by per-terminal createZoom listener.
   },
   zoomOut: {
-    id: "zoomOut",
     label: "Zoom out",
     keybind: { key: "-", mod: true },
   },
   zoomReset: {
-    id: "zoomReset",
     label: "Reset zoom",
     keybind: { key: "0", mod: true },
   },
   toggleSubPanel: {
-    id: "toggleSubPanel",
     label: "Toggle terminal split",
     keybind: { key: "`", code: "Backquote", ctrl: true },
     handler: (ctx) => {
@@ -166,7 +153,6 @@ const _ACTIONS = {
     },
   },
   createSubTerminal: {
-    id: "createSubTerminal",
     label: "Split terminal",
     keybind: { key: "`", code: "Backquote", ctrl: true, shift: true },
     handler: (ctx) => {
@@ -176,7 +162,6 @@ const _ACTIONS = {
     },
   },
   nextSubTab: {
-    id: "nextSubTab",
     label: "Next split tab",
     keybind: { key: "PageDown", code: "PageDown", ctrl: true },
     handler: (ctx) => {
@@ -185,7 +170,6 @@ const _ACTIONS = {
     },
   },
   prevSubTab: {
-    id: "prevSubTab",
     label: "Previous split tab",
     keybind: { key: "PageUp", code: "PageUp", ctrl: true },
     handler: (ctx) => {
@@ -194,31 +178,26 @@ const _ACTIONS = {
     },
   },
   shuffleTheme: {
-    id: "shuffleTheme",
     label: "Shuffle theme",
     keybind: { key: "j", mod: true },
     handler: (ctx) => ctx.handleShuffleTheme(),
   },
   screenshotTerminal: {
-    id: "screenshotTerminal",
     label: "Screenshot terminal",
     keybind: { key: "S", code: "KeyS", mod: true, shift: true },
     handler: (ctx) => ctx.handleScreenshotTerminal(),
   },
   toggleRightPanel: {
-    id: "toggleRightPanel",
     label: "Toggle inspector panel",
     keybind: { key: "b", code: "KeyB", mod: true },
     handler: (ctx) => ctx.toggleRightPanel(),
   },
   canvasCenterActive: {
-    id: "canvasCenterActive",
     label: "Center on active tile",
     keybind: { key: "C", code: "KeyC", mod: true, shift: true },
     handler: (ctx) => ctx.canvasCenterActive(),
   },
   toggleRecordingPause: {
-    id: "toggleRecordingPause",
     label: "Pause / resume recording",
     keybind: { key: ".", code: "Period", mod: true, shift: true },
     handler: (ctx) => ctx.toggleRecordingPause(),

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -1,0 +1,265 @@
+/**
+ * Unified action registry — single source of truth for keyboard shortcuts,
+ * the help overlay, and shared palette command metadata. Each entry binds an
+ * id to its label, keybind, handler, and surface flags.
+ *
+ * Adding or rebinding a global action touches this one file. The dispatcher
+ * in `useShortcuts.ts` loops over `ACTIONS`; `ShortcutsHelp.tsx` walks
+ * `HELP_ORDER` against the registry; `commands.ts` derives palette entries
+ * via `actionPaletteCommand`.
+ */
+
+import type { TerminalId, TerminalMetadata } from "kolu-common";
+import { nonEmpty } from "nonempty";
+import type { Accessor, Setter } from "solid-js";
+import type { PaletteCommand } from "../CommandPalette";
+import { type Keybind, matchesKeybind } from "./keyboard";
+
+/** Shared handler context — every dispatched action receives this. */
+export interface ActionContext {
+  terminalIds: Accessor<TerminalId[]>;
+  activeId: Accessor<TerminalId | null>;
+  setActiveId: Setter<TerminalId | null>;
+  /** Terminal IDs in most-recently-used order; used for Alt+Tab / Ctrl+Tab cycling. */
+  mruOrder: Accessor<TerminalId[]>;
+  activeMeta: Accessor<TerminalMetadata | null>;
+  handleCreate: (cwd?: string) => void;
+  handleCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
+  openNewTerminalMenu: () => void;
+  setPaletteOpen: Setter<boolean>;
+  setShortcutsHelpOpen: Setter<boolean>;
+  setSearchOpen: Setter<boolean>;
+  /** Toggle sub-panel: creates first split if none exist, otherwise toggles visibility. */
+  toggleSubPanel: (parentId: TerminalId) => void;
+  cycleSubTab: (parentId: TerminalId, direction: 1 | -1) => void;
+  handleShuffleTheme: () => void;
+  handleScreenshotTerminal: () => void;
+  toggleRightPanel: () => void;
+  canvasCenterActive: () => void;
+  toggleRecordingPause: () => void;
+}
+
+export interface AppAction {
+  id: string;
+  label: string;
+  keybind: Keybind;
+  /** Optional alternate keybind that triggers the same handler (e.g. Cmd+Enter for "New terminal"). */
+  altKeybind?: Keybind;
+  /** Handler invoked by the keyboard dispatcher and by palette entries derived
+   *  via `actionPaletteCommand`. Absent for entries whose dispatch is
+   *  inherently stateful or owned by another listener (e.g. `cycleTerminalMru`
+   *  is committed on modifier keyup; `zoom*` is handled per-terminal in
+   *  `createZoom`). The entry remains registered for help/palette display. */
+  handler?: (ctx: ActionContext) => void;
+}
+
+/** Cycle to the next/previous terminal by position. */
+function cycleTerminalByPosition(ctx: ActionContext, direction: 1 | -1) {
+  const ids = nonEmpty(ctx.terminalIds());
+  if (!ids) return;
+  const current = ids.indexOf(ctx.activeId() as TerminalId);
+  const next = (current + direction + ids.length) % ids.length;
+  // Tuple positional `ids[0]` is statically `TerminalId`; `?? ids[0]` is
+  // a typed fallback the math never actually triggers.
+  ctx.setActiveId(ids[next] ?? ids[0]);
+}
+
+/** Mod+1 through Mod+9 — direct positional terminal switch. */
+const SWITCH_KEYS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+type SwitchKey = (typeof SWITCH_KEYS)[number];
+type SwitchId = `switchTo${SwitchKey}`;
+
+const switchToActions = Object.fromEntries(
+  SWITCH_KEYS.map((i) => [
+    `switchTo${i}`,
+    {
+      id: `switchTo${i}`,
+      label: `Switch to terminal ${i}`,
+      keybind: { key: String(i), mod: true },
+      handler: (ctx) => {
+        const target = ctx.terminalIds()[i - 1];
+        if (target !== undefined) ctx.setActiveId(target);
+      },
+    } satisfies AppAction,
+  ]),
+) as { [K in SwitchId]: AppAction };
+
+// `_ACTIONS` keeps each entry's literal shape so `keyof typeof _ACTIONS`
+// produces the precise `ActionId` union. `ACTIONS` re-types it through
+// `Record<ActionId, AppAction>` so consumers see a uniform `AppAction` at
+// every access site (optional `handler`/`altKeybind` properly typed),
+// instead of a discriminated union where some variants lack those fields.
+const _ACTIONS = {
+  ...switchToActions,
+  createTerminal: {
+    id: "createTerminal",
+    label: "New terminal",
+    keybind: { key: "t", mod: true },
+    altKeybind: { key: "Enter", mod: true },
+    handler: (ctx) => ctx.handleCreate(ctx.activeMeta()?.cwd ?? undefined),
+  },
+  newTerminalMenu: {
+    id: "newTerminalMenu",
+    label: "New terminal menu",
+    keybind: { key: "Enter", mod: true, shift: true },
+    handler: (ctx) => ctx.openNewTerminalMenu(),
+  },
+  nextTerminal: {
+    id: "nextTerminal",
+    label: "Next terminal",
+    keybind: { key: "]", code: "BracketRight", mod: true, shift: true },
+    handler: (ctx) => cycleTerminalByPosition(ctx, 1),
+  },
+  prevTerminal: {
+    id: "prevTerminal",
+    label: "Previous terminal",
+    keybind: { key: "[", code: "BracketLeft", mod: true, shift: true },
+    handler: (ctx) => cycleTerminalByPosition(ctx, -1),
+  },
+  cycleTerminalMru: {
+    id: "cycleTerminalMru",
+    label: "Cycle terminals by most recent use",
+    keybind: { key: "Tab", code: "Tab", ctrl: true },
+    // Dispatched by the stateful Alt+Tab/Ctrl+Tab cycle in useShortcuts.
+  },
+  commandPalette: {
+    id: "commandPalette",
+    label: "Command palette",
+    keybind: { key: "k", mod: true },
+    handler: (ctx) => ctx.setPaletteOpen((v) => !v),
+  },
+  shortcutsHelp: {
+    id: "shortcutsHelp",
+    label: "Shortcuts help",
+    keybind: { key: "/", mod: true },
+    handler: (ctx) => ctx.setShortcutsHelpOpen((v) => !v),
+  },
+  findInTerminal: {
+    id: "findInTerminal",
+    label: "Find in terminal",
+    keybind: { key: "f", mod: true },
+    handler: (ctx) => ctx.setSearchOpen((v) => !v),
+  },
+  zoomIn: {
+    id: "zoomIn",
+    label: "Zoom in",
+    keybind: { key: "+", mod: true },
+    // Dispatched by per-terminal createZoom listener.
+  },
+  zoomOut: {
+    id: "zoomOut",
+    label: "Zoom out",
+    keybind: { key: "-", mod: true },
+  },
+  zoomReset: {
+    id: "zoomReset",
+    label: "Reset zoom",
+    keybind: { key: "0", mod: true },
+  },
+  toggleSubPanel: {
+    id: "toggleSubPanel",
+    label: "Toggle terminal split",
+    keybind: { key: "`", code: "Backquote", ctrl: true },
+    handler: (ctx) => {
+      const id = ctx.activeId();
+      if (id) ctx.toggleSubPanel(id);
+    },
+  },
+  createSubTerminal: {
+    id: "createSubTerminal",
+    label: "Split terminal",
+    keybind: { key: "`", code: "Backquote", ctrl: true, shift: true },
+    handler: (ctx) => {
+      const id = ctx.activeId();
+      if (id)
+        ctx.handleCreateSubTerminal(id, ctx.activeMeta()?.cwd ?? undefined);
+    },
+  },
+  nextSubTab: {
+    id: "nextSubTab",
+    label: "Next split tab",
+    keybind: { key: "PageDown", code: "PageDown", ctrl: true },
+    handler: (ctx) => {
+      const id = ctx.activeId();
+      if (id) ctx.cycleSubTab(id, 1);
+    },
+  },
+  prevSubTab: {
+    id: "prevSubTab",
+    label: "Previous split tab",
+    keybind: { key: "PageUp", code: "PageUp", ctrl: true },
+    handler: (ctx) => {
+      const id = ctx.activeId();
+      if (id) ctx.cycleSubTab(id, -1);
+    },
+  },
+  shuffleTheme: {
+    id: "shuffleTheme",
+    label: "Shuffle theme",
+    keybind: { key: "j", mod: true },
+    handler: (ctx) => ctx.handleShuffleTheme(),
+  },
+  screenshotTerminal: {
+    id: "screenshotTerminal",
+    label: "Screenshot terminal",
+    keybind: { key: "S", code: "KeyS", mod: true, shift: true },
+    handler: (ctx) => ctx.handleScreenshotTerminal(),
+  },
+  toggleRightPanel: {
+    id: "toggleRightPanel",
+    label: "Toggle inspector panel",
+    keybind: { key: "b", code: "KeyB", mod: true },
+    handler: (ctx) => ctx.toggleRightPanel(),
+  },
+  canvasCenterActive: {
+    id: "canvasCenterActive",
+    label: "Center on active tile",
+    keybind: { key: "C", code: "KeyC", mod: true, shift: true },
+    handler: (ctx) => ctx.canvasCenterActive(),
+  },
+  toggleRecordingPause: {
+    id: "toggleRecordingPause",
+    label: "Pause / resume recording",
+    keybind: { key: ".", code: "Period", mod: true, shift: true },
+    handler: (ctx) => ctx.toggleRecordingPause(),
+  },
+} satisfies Record<string, AppAction>;
+
+export type ActionId = keyof typeof _ACTIONS;
+export const ACTIONS: Record<ActionId, AppAction> = _ACTIONS;
+
+/**
+ * Check if a KeyboardEvent matches any registered action's keybind.
+ * Used by xterm's key handler to let app shortcuts bubble through
+ * instead of being consumed by the terminal.
+ */
+export function matchesAnyShortcut(e: KeyboardEvent): boolean {
+  // Alt+Tab is not a registry keybind (Ctrl+Tab is, via cycleTerminalMru) but
+  // it triggers the same MRU cycle and must not leak to the terminal.
+  if (e.altKey && e.key === "Tab") return true;
+  for (const a of Object.values(ACTIONS)) {
+    if (matchesKeybind(e, a.keybind)) return true;
+    if (a.altKeybind !== undefined && matchesKeybind(e, a.altKeybind))
+      return true;
+  }
+  return false;
+}
+
+/**
+ * Build a palette command from a registered action — same label, same keybind,
+ * same handler. Lets palette code reference an action by id and inherit its
+ * metadata, instead of restating label/keybind/handler at the call site.
+ */
+export function actionPaletteCommand(
+  id: ActionId,
+  ctx: ActionContext,
+  overrides: Partial<Pick<PaletteCommand, "name" | "description">> = {},
+): PaletteCommand {
+  const a = ACTIONS[id];
+  return {
+    name: overrides.name ?? a.label,
+    description: overrides.description,
+    keybind: a.keybind,
+    onSelect: () => a.handler?.(ctx),
+  };
+}

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -40,17 +40,33 @@ export interface ActionContext {
   toggleRecordingPause: () => void;
 }
 
-export interface AppAction {
+interface AppActionBase {
   label: string;
   keybind: Keybind;
   /** Optional alternate keybind that triggers the same handler (e.g. Cmd+Enter for "New terminal"). */
   altKeybind?: Keybind;
-  /** Handler invoked by the keyboard dispatcher and by palette entries derived
-   *  via `actionPaletteCommand`. Absent for entries whose dispatch is
-   *  inherently stateful or owned by another listener (e.g. `cycleTerminalMru`
-   *  is committed on modifier keyup; `zoom*` is handled per-terminal in
-   *  `createZoom`). The entry remains registered for help/palette display. */
-  handler?: (ctx: ActionContext) => void;
+}
+
+/** An action whose dispatch flows through the registry's generic loop —
+ *  every palette-callable action, the position-switch group, and every
+ *  toggle/open chord. */
+export type DispatchableAction = AppActionBase & {
+  handler: (ctx: ActionContext) => void;
+};
+
+/** An action that's registered only for help/palette/passthrough display.
+ *  Dispatch lives elsewhere because it needs state the registry can't
+ *  carry: `cycleTerminalMru` snapshots MRU order in a closure inside
+ *  `useShortcuts` and commits on modifier keyup; `zoom*` is owned by the
+ *  per-terminal `createZoom` listener. They still appear in
+ *  `matchesAnyShortcut` so xterm doesn't consume their chords. */
+export type DisplayOnlyAction = AppActionBase;
+
+export type AppAction = DispatchableAction | DisplayOnlyAction;
+
+/** Type guard: does this action carry a registry-dispatched handler? */
+export function isDispatchable(a: AppAction): a is DispatchableAction {
+  return "handler" in a;
 }
 
 /** Cycle to the next/previous terminal by position. */
@@ -79,9 +95,9 @@ const switchToActions = Object.fromEntries(
         const target = ctx.terminalIds()[i - 1];
         if (target !== undefined) ctx.setActiveId(target);
       },
-    } satisfies AppAction,
+    } satisfies DispatchableAction,
   ]),
-) as { [K in SwitchId]: AppAction };
+) as { [K in SwitchId]: DispatchableAction };
 
 // `_ACTIONS` keeps each entry's literal shape so `keyof typeof _ACTIONS`
 // produces the precise `ActionId` union. `ACTIONS` re-types it through
@@ -113,8 +129,11 @@ const _ACTIONS = {
   },
   cycleTerminalMru: {
     label: "Cycle terminals by most recent use",
-    keybind: { key: "Tab", code: "Tab", ctrl: true },
-    // Dispatched by the stateful Alt+Tab/Ctrl+Tab cycle in useShortcuts.
+    // shiftOptional: shift modulates direction (forward/back) rather than
+    // selecting a different chord. alt covers macOS Chrome, which captures
+    // Ctrl+Tab. Dispatch is stateful (snapshot/cursor in useShortcuts).
+    keybind: { key: "Tab", code: "Tab", ctrl: true, shiftOptional: true },
+    altKeybind: { key: "Tab", code: "Tab", alt: true, shiftOptional: true },
   },
   commandPalette: {
     label: "Command palette",
@@ -213,9 +232,6 @@ export const ACTIONS: Record<ActionId, AppAction> = _ACTIONS;
  * instead of being consumed by the terminal.
  */
 export function matchesAnyShortcut(e: KeyboardEvent): boolean {
-  // Alt+Tab is not a registry keybind (Ctrl+Tab is, via cycleTerminalMru) but
-  // it triggers the same MRU cycle and must not leak to the terminal.
-  if (e.altKey && e.key === "Tab") return true;
   for (const a of Object.values(ACTIONS)) {
     if (matchesKeybind(e, a.keybind)) return true;
     if (a.altKeybind !== undefined && matchesKeybind(e, a.altKeybind))
@@ -224,21 +240,28 @@ export function matchesAnyShortcut(e: KeyboardEvent): boolean {
   return false;
 }
 
+/** Action ids whose registry entry is a `DispatchableAction` — i.e. has a
+ *  handler that the keyboard dispatcher and palette can both invoke. */
+export type DispatchableId = {
+  [K in ActionId]: (typeof _ACTIONS)[K] extends DispatchableAction ? K : never;
+}[ActionId];
+
 /**
  * Build a palette command from a registered action — same label, same keybind,
- * same handler. Lets palette code reference an action by id and inherit its
- * metadata, instead of restating label/keybind/handler at the call site.
+ * same handler. The id is constrained to `DispatchableId` so palette callers
+ * can't accidentally mount a display-only action (which would render a
+ * clickable entry that silently does nothing).
  */
 export function actionPaletteCommand(
-  id: ActionId,
+  id: DispatchableId,
   ctx: ActionContext,
   overrides: Partial<Pick<PaletteCommand, "name" | "description">> = {},
 ): PaletteCommand {
-  const a = ACTIONS[id];
+  const a = ACTIONS[id] as DispatchableAction;
   return {
     name: overrides.name ?? a.label,
     description: overrides.description,
     keybind: a.keybind,
-    onSelect: () => a.handler?.(ctx),
+    onSelect: () => a.handler(ctx),
   };
 }

--- a/packages/client/src/input/keyboard.test.ts
+++ b/packages/client/src/input/keyboard.test.ts
@@ -3,12 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 // Mock the platform module before importing keyboard
 vi.mock("./platform", () => ({ isMac: false }));
 
-import {
-  formatKeybind,
-  type Keybind,
-  matchesAnyShortcut,
-  matchesKeybind,
-} from "./keyboard";
+import { matchesAnyShortcut } from "./actions";
+import { formatKeybind, type Keybind, matchesKeybind } from "./keyboard";
 
 function makeEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
   return {

--- a/packages/client/src/input/keyboard.test.ts
+++ b/packages/client/src/input/keyboard.test.ts
@@ -118,9 +118,9 @@ describe("formatKeybind (non-mac)", () => {
 
 describe("matchesAnyShortcut", () => {
   it("matches Alt+Tab", () => {
-    expect(matchesAnyShortcut(makeEvent({ altKey: true, key: "Tab" }))).toBe(
-      true,
-    );
+    expect(
+      matchesAnyShortcut(makeEvent({ altKey: true, key: "Tab", code: "Tab" })),
+    ).toBe(true);
   });
 
   it("matches Ctrl+T (create terminal)", () => {

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -28,7 +28,13 @@ export interface Keybind {
   mod?: boolean;
   /** Always the physical Ctrl key, regardless of platform. Use for shortcuts where Cmd is captured by macOS (e.g. Cmd+`). */
   ctrl?: boolean;
+  /** Physical Alt/Option key. Used for chords macOS Chrome intercepts (e.g. Alt+Tab as an alternate to Ctrl+Tab). */
+  alt?: boolean;
   shift?: boolean;
+  /** Match whether shift is pressed or not. Used by stateful actions
+   *  (e.g. MRU cycling) where shift modulates direction rather than
+   *  participating in the chord identity. */
+  shiftOptional?: boolean;
 }
 
 /** Check if a KeyboardEvent matches a keybind definition. */
@@ -36,15 +42,22 @@ export function matchesKeybind(e: KeyboardEvent, kb: Keybind): boolean {
   // Prefer physical key code when specified (Shift changes e.key but not e.code)
   const keyMatch = kb.code ? e.code === kb.code : e.key === kb.key;
   if (!keyMatch) return false;
+  if (kb.alt) {
+    if (!e.altKey) return false;
+  } else if (e.altKey) {
+    return false;
+  }
   if (kb.ctrl) {
     // ctrl: always the physical Ctrl key
     if (!e.ctrlKey) return false;
   } else {
     if (kb.mod && !isPlatformModifier(e)) return false;
-    if (!kb.mod && isPlatformModifier(e)) return false;
+    if (!kb.mod && !kb.alt && isPlatformModifier(e)) return false;
   }
-  if (kb.shift && !e.shiftKey) return false;
-  if (!kb.shift && e.shiftKey) return false;
+  if (!kb.shiftOptional) {
+    if (kb.shift && !e.shiftKey) return false;
+    if (!kb.shift && e.shiftKey) return false;
+  }
   return true;
 }
 
@@ -53,6 +66,7 @@ export function formatKeybind(kb: Keybind): string {
   const parts: string[] = [];
   if (kb.ctrl) parts.push(isMac ? "⌃" : "Ctrl");
   else if (kb.mod) parts.push(isMac ? "⌘" : "Ctrl");
+  if (kb.alt) parts.push(isMac ? "⌥" : "Alt");
   if (kb.shift) parts.push(isMac ? "⇧" : "Shift");
   const displayKey = kb.key.length === 1 ? kb.key.toUpperCase() : kb.key;
   parts.push(displayKey);

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -1,6 +1,7 @@
 /**
- * Keyboard shortcut helpers — keybind types, matching, formatting, and
- * the global shortcut registry consumed by useShortcuts and ShortcutsHelp.
+ * Keyboard shortcut primitives — keybind types, matching, and platform-aware
+ * formatting. The application-level action registry (label + handler + chord)
+ * lives in `./actions.ts`.
  */
 
 import { isMac } from "./platform";
@@ -30,12 +31,6 @@ export interface Keybind {
   shift?: boolean;
 }
 
-/** A shortcut definition: keybind + human-readable label. */
-export interface Shortcut {
-  keybind: Keybind;
-  label: string;
-}
-
 /** Check if a KeyboardEvent matches a keybind definition. */
 export function matchesKeybind(e: KeyboardEvent, kb: Keybind): boolean {
   // Prefer physical key code when specified (Shift changes e.key but not e.code)
@@ -62,103 +57,4 @@ export function formatKeybind(kb: Keybind): string {
   const displayKey = kb.key.length === 1 ? kb.key.toUpperCase() : kb.key;
   parts.push(displayKey);
   return isMac ? parts.join("") : parts.join("+");
-}
-
-/** Mod+1 through Mod+9 for direct terminal switching. */
-const SWITCH_SHORTCUTS = Object.fromEntries(
-  Array.from({ length: 9 }, (_, i) => [
-    `switchTo${i + 1}`,
-    {
-      keybind: { key: String(i + 1), mod: true },
-      label: `Switch to terminal ${i + 1}`,
-    },
-  ]),
-) as { [K in `switchTo${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`]: Shortcut };
-
-/** All global keyboard shortcuts with their keybinds and display labels. */
-export const SHORTCUTS = {
-  ...SWITCH_SHORTCUTS,
-  createTerminal: {
-    keybind: { key: "t", mod: true },
-    label: "New terminal",
-  },
-  createTerminalAlt: {
-    keybind: { key: "Enter", mod: true },
-    label: "New terminal",
-  },
-  newTerminalMenu: {
-    keybind: { key: "Enter", mod: true, shift: true },
-    label: "New terminal menu",
-  },
-  nextTerminal: {
-    keybind: { key: "]", code: "BracketRight", mod: true, shift: true },
-    label: "Next terminal",
-  },
-  prevTerminal: {
-    keybind: { key: "[", code: "BracketLeft", mod: true, shift: true },
-    label: "Previous terminal",
-  },
-  cycleTerminalMru: {
-    keybind: { key: "Tab", code: "Tab", ctrl: true },
-    label: "Cycle terminals by most recent use",
-  },
-  commandPalette: {
-    keybind: { key: "k", mod: true },
-    label: "Command palette",
-  },
-  shortcutsHelp: { keybind: { key: "/", mod: true }, label: "Shortcuts help" },
-  findInTerminal: {
-    keybind: { key: "f", mod: true },
-    label: "Find in terminal",
-  },
-  zoomIn: { keybind: { key: "+", mod: true }, label: "Zoom in" },
-  zoomOut: { keybind: { key: "-", mod: true }, label: "Zoom out" },
-  zoomReset: { keybind: { key: "0", mod: true }, label: "Reset zoom" },
-  toggleSubPanel: {
-    keybind: { key: "`", code: "Backquote", ctrl: true },
-    label: "Toggle terminal split",
-  },
-  createSubTerminal: {
-    keybind: { key: "`", code: "Backquote", ctrl: true, shift: true },
-    label: "Split terminal",
-  },
-  nextSubTab: {
-    keybind: { key: "PageDown", code: "PageDown", ctrl: true },
-    label: "Next split tab",
-  },
-  prevSubTab: {
-    keybind: { key: "PageUp", code: "PageUp", ctrl: true },
-    label: "Previous split tab",
-  },
-  shuffleTheme: {
-    keybind: { key: "j", mod: true },
-    label: "Shuffle theme",
-  },
-  screenshotTerminal: {
-    keybind: { key: "S", code: "KeyS", mod: true, shift: true },
-    label: "Screenshot terminal",
-  },
-  toggleRightPanel: {
-    keybind: { key: "b", code: "KeyB", mod: true },
-    label: "Toggle inspector panel",
-  },
-  canvasCenterActive: {
-    keybind: { key: "C", code: "KeyC", mod: true, shift: true },
-    label: "Center on active tile",
-  },
-  toggleRecordingPause: {
-    keybind: { key: ".", code: "Period", mod: true, shift: true },
-    label: "Pause / resume recording",
-  },
-} as const satisfies Record<string, Shortcut>;
-
-/**
- * Check if a KeyboardEvent matches any registered app shortcut.
- * Used by xterm's key handler to let app shortcuts bubble through
- * instead of being consumed by the terminal.
- */
-export function matchesAnyShortcut(e: KeyboardEvent): boolean {
-  // Alt+Tab: not in SHORTCUTS (handled specially in useShortcuts) but must not leak to terminal
-  if (e.altKey && e.key === "Tab") return true;
-  return Object.values(SHORTCUTS).some((s) => matchesKeybind(e, s.keybind));
 }

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -3,7 +3,13 @@
 
 import { makeEventListener } from "@solid-primitives/event-listener";
 import type { TerminalId } from "kolu-common";
-import { ACTIONS, type ActionContext } from "./actions";
+import {
+  ACTIONS,
+  type ActionContext,
+  type ActionId,
+  type AppAction,
+  isDispatchable,
+} from "./actions";
 import { matchesKeybind } from "./keyboard";
 
 /** MRU cycling state — a frozen snapshot is taken on the first Tab press while
@@ -13,6 +19,13 @@ import { matchesKeybind } from "./keyboard";
 interface MruCycleState {
   snapshot: TerminalId[];
   cursor: number;
+}
+
+/** Match the event against an action's primary or alt keybind. */
+function actionMatches(action: AppAction, e: KeyboardEvent): boolean {
+  if (matchesKeybind(e, action.keybind)) return true;
+  if (action.altKeybind && matchesKeybind(e, action.altKeybind)) return true;
+  return false;
 }
 
 /** Wire up all global keyboard shortcuts. Call once from the app root. */
@@ -64,26 +77,27 @@ function dispatch(
   ctx: ActionContext,
   advanceCycle: (direction: 1 | -1) => void,
 ): boolean {
-  // Alt+Tab / Ctrl+Tab: stateful MRU cycling, committed on modifier release.
-  // Alt+Tab covers macOS Chrome, which intercepts Ctrl+Tab. Must come before
-  // the registry loop so Ctrl+Tab doesn't fall through to cycleTerminalMru
-  // (which has no handler — it's display-only and dispatched here).
-  if (e.key === "Tab" && (e.altKey || e.ctrlKey)) {
-    advanceCycle(e.shiftKey ? -1 : 1);
-    return true;
-  }
+  for (const [id, action] of Object.entries(ACTIONS) as [
+    ActionId,
+    AppAction,
+  ][]) {
+    if (!actionMatches(action, e)) continue;
 
-  // Generic dispatch over the action registry.
-  for (const action of Object.values(ACTIONS)) {
-    if (!action.handler) continue;
-    if (
-      matchesKeybind(e, action.keybind) ||
-      (action.altKeybind !== undefined && matchesKeybind(e, action.altKeybind))
-    ) {
+    // cycleTerminalMru is stateful — the closure-bound snapshot/cursor pattern
+    // can't fit the registry's plain `(ctx) => void` handler shape, so it's
+    // the one display-only action the dispatcher consults by id.
+    if (id === "cycleTerminalMru") {
+      advanceCycle(e.shiftKey ? -1 : 1);
+      return true;
+    }
+
+    if (isDispatchable(action)) {
       action.handler(ctx);
       return true;
     }
-  }
 
+    // Display-only (zoom*) — don't claim the event; the per-terminal
+    // `createZoom` listener owns the dispatch.
+  }
   return false;
 }

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -1,33 +1,10 @@
-/** Global keyboard shortcuts — single capture-phase listener dispatching to handlers. */
+/** Global keyboard shortcuts — single capture-phase listener that dispatches
+ *  through the unified action registry in `./actions.ts`. */
 
 import { makeEventListener } from "@solid-primitives/event-listener";
-import type { TerminalId, TerminalMetadata } from "kolu-common";
-import { nonEmpty } from "nonempty";
-import type { Accessor, Setter } from "solid-js";
-import { isPlatformModifier, matchesKeybind, SHORTCUTS } from "./keyboard";
-
-interface ShortcutDeps {
-  terminalIds: Accessor<TerminalId[]>;
-  activeId: Accessor<TerminalId | null>;
-  setActiveId: Setter<TerminalId | null>;
-  /** Terminal IDs in most-recently-used order; used for Alt+Tab / Ctrl+Tab cycling. */
-  mruOrder: Accessor<TerminalId[]>;
-  handleCreate: (cwd?: string) => void;
-  handleCreateSubTerminal: (parentId: TerminalId, cwd?: string) => void;
-  openNewTerminalMenu: () => void;
-  activeMeta: Accessor<TerminalMetadata | null>;
-  setPaletteOpen: Setter<boolean>;
-  setShortcutsHelpOpen: Setter<boolean>;
-  setSearchOpen: Setter<boolean>;
-  /** Toggle sub-panel: creates first split if none exist, otherwise toggles visibility. */
-  toggleSubPanel: (parentId: TerminalId) => void;
-  cycleSubTab: (parentId: TerminalId, direction: 1 | -1) => void;
-  handleShuffleTheme: () => void;
-  handleScreenshotTerminal: () => void;
-  toggleRightPanel: () => void;
-  canvasCenterActive: () => void;
-  toggleRecordingPause: () => void;
-}
+import type { TerminalId } from "kolu-common";
+import { ACTIONS, type ActionContext } from "./actions";
+import { matchesKeybind } from "./keyboard";
 
 /** MRU cycling state — a frozen snapshot is taken on the first Tab press while
  *  the modifier (Alt or Ctrl) is held, and the cursor advances through that
@@ -39,7 +16,7 @@ interface MruCycleState {
 }
 
 /** Wire up all global keyboard shortcuts. Call once from the app root. */
-export function useShortcuts(deps: ShortcutDeps) {
+export function useShortcuts(ctx: ActionContext) {
   let cycle: MruCycleState | null = null;
 
   function resetCycle() {
@@ -49,8 +26,8 @@ export function useShortcuts(deps: ShortcutDeps) {
   function advanceCycle(direction: 1 | -1) {
     if (cycle === null) {
       // First press: snapshot current MRU, include active id at head if missing.
-      const live = deps.mruOrder();
-      const active = deps.activeId();
+      const live = ctx.mruOrder();
+      const active = ctx.activeId();
       const snap =
         active && !live.includes(active) ? [active, ...live] : live.slice();
       if (snap.length < 2) return; // nothing to cycle between
@@ -59,14 +36,14 @@ export function useShortcuts(deps: ShortcutDeps) {
     const n = cycle.snapshot.length;
     cycle.cursor = (cycle.cursor + direction + n) % n;
     const target = cycle.snapshot[cycle.cursor];
-    if (target) deps.setActiveId(target);
+    if (target) ctx.setActiveId(target);
   }
 
   makeEventListener(
     window,
     "keydown",
     (e: KeyboardEvent) => {
-      const handled = dispatch(e, deps, advanceCycle);
+      const handled = dispatch(e, ctx, advanceCycle);
       if (handled) {
         e.preventDefault();
         e.stopPropagation();
@@ -84,122 +61,29 @@ export function useShortcuts(deps: ShortcutDeps) {
 /** Try to handle the event. Returns true if a shortcut matched. */
 function dispatch(
   e: KeyboardEvent,
-  deps: ShortcutDeps,
+  ctx: ActionContext,
   advanceCycle: (direction: 1 | -1) => void,
 ): boolean {
-  // Mod+1-9: switch to terminal by position
-  const digit = parseInt(e.key, 10);
-  if (isPlatformModifier(e) && !e.shiftKey && digit >= 1 && digit <= 9) {
-    const ids = deps.terminalIds();
-    const target = ids[digit - 1];
-    if (target !== undefined) deps.setActiveId(target);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.newTerminalMenu.keybind)) {
-    deps.openNewTerminalMenu();
-    return true;
-  }
-
-  if (
-    matchesKeybind(e, SHORTCUTS.createTerminal.keybind) ||
-    matchesKeybind(e, SHORTCUTS.createTerminalAlt.keybind)
-  ) {
-    deps.handleCreate(deps.activeMeta()?.cwd ?? undefined);
-    return true;
-  }
-
-  // Alt+Tab / Ctrl+Tab: cycle through terminals in MRU order, committing on
-  // modifier release. Alt+Tab covers macOS Chrome, which intercepts Ctrl+Tab.
+  // Alt+Tab / Ctrl+Tab: stateful MRU cycling, committed on modifier release.
+  // Alt+Tab covers macOS Chrome, which intercepts Ctrl+Tab. Must come before
+  // the registry loop so Ctrl+Tab doesn't fall through to cycleTerminalMru
+  // (which has no handler — it's display-only and dispatched here).
   if (e.key === "Tab" && (e.altKey || e.ctrlKey)) {
     advanceCycle(e.shiftKey ? -1 : 1);
     return true;
   }
 
-  if (matchesKeybind(e, SHORTCUTS.nextTerminal.keybind)) {
-    cycleTerminal(deps, 1);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.prevTerminal.keybind)) {
-    cycleTerminal(deps, -1);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.commandPalette.keybind)) {
-    deps.setPaletteOpen((v) => !v);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.shortcutsHelp.keybind)) {
-    deps.setShortcutsHelpOpen((v) => !v);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.findInTerminal.keybind)) {
-    deps.setSearchOpen((v) => !v);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.createSubTerminal.keybind)) {
-    const id = deps.activeId();
-    if (id)
-      deps.handleCreateSubTerminal(id, deps.activeMeta()?.cwd ?? undefined);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.toggleSubPanel.keybind)) {
-    const id = deps.activeId();
-    if (id) deps.toggleSubPanel(id);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.nextSubTab.keybind)) {
-    const id = deps.activeId();
-    if (id) deps.cycleSubTab(id, 1);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.prevSubTab.keybind)) {
-    const id = deps.activeId();
-    if (id) deps.cycleSubTab(id, -1);
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.shuffleTheme.keybind)) {
-    deps.handleShuffleTheme();
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.screenshotTerminal.keybind)) {
-    deps.handleScreenshotTerminal();
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.toggleRightPanel.keybind)) {
-    deps.toggleRightPanel();
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.canvasCenterActive.keybind)) {
-    deps.canvasCenterActive();
-    return true;
-  }
-
-  if (matchesKeybind(e, SHORTCUTS.toggleRecordingPause.keybind)) {
-    deps.toggleRecordingPause();
-    return true;
+  // Generic dispatch over the action registry.
+  for (const action of Object.values(ACTIONS)) {
+    if (!action.handler) continue;
+    if (
+      matchesKeybind(e, action.keybind) ||
+      (action.altKeybind !== undefined && matchesKeybind(e, action.altKeybind))
+    ) {
+      action.handler(ctx);
+      return true;
+    }
   }
 
   return false;
-}
-
-function cycleTerminal(deps: ShortcutDeps, direction: 1 | -1) {
-  const ids = nonEmpty(deps.terminalIds());
-  if (!ids) return;
-  const current = ids.indexOf(deps.activeId() as TerminalId);
-  const next = (current + direction + ids.length) % ids.length;
-  // Tuple positional `ids[0]` is statically `TerminalId`; `?? ids[0]` is
-  // a typed fallback the math never actually triggers.
-  deps.setActiveId(ids[next] ?? ids[0]);
 }

--- a/packages/client/src/recorder/RecordButton.tsx
+++ b/packages/client/src/recorder/RecordButton.tsx
@@ -18,7 +18,8 @@
 
 import { type Component, createSignal, Match, Show, Switch } from "solid-js";
 import { match } from "ts-pattern";
-import { formatKeybind, SHORTCUTS } from "../input/keyboard";
+import { ACTIONS } from "../input/actions";
+import { formatKeybind } from "../input/keyboard";
 import { PauseIcon, RecordIcon, ResumeIcon, WebcamIcon } from "../ui/Icons";
 import Tip from "../ui/Tip";
 import RecordPopover from "./RecordPopover";
@@ -52,8 +53,8 @@ const RecordButton: Component = () => {
 
   const pauseLabel = () =>
     isPaused()
-      ? `Resume (${formatKeybind(SHORTCUTS.toggleRecordingPause.keybind)})`
-      : `Pause (${formatKeybind(SHORTCUTS.toggleRecordingPause.keybind)})`;
+      ? `Resume (${formatKeybind(ACTIONS.toggleRecordingPause.keybind)})`
+      : `Pause (${formatKeybind(ACTIONS.toggleRecordingPause.keybind)})`;
 
   const webcamLabel = () =>
     recorder.webcamEnabled() ? "Hide webcam" : "Show webcam";

--- a/packages/client/src/settings/tips.ts
+++ b/packages/client/src/settings/tips.ts
@@ -3,7 +3,8 @@
  * All tip IDs and text builders live here for easy maintenance.
  */
 
-import { formatKeybind, SHORTCUTS } from "../input/keyboard";
+import { ACTIONS } from "../input/actions";
+import { formatKeybind } from "../input/keyboard";
 
 export type TipId = string;
 
@@ -18,29 +19,29 @@ export function pillTreeSwitchTip(index: number): Tip {
   const key = (index + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
   return {
     id: "pill-tree-switch",
-    text: `Tip: ${formatKeybind(SHORTCUTS[`switchTo${key}`].keybind)} switches directly`,
+    text: `Tip: ${formatKeybind(ACTIONS[`switchTo${key}`].keybind)} switches directly`,
   };
 }
 
 export const CONTEXTUAL_TIPS = {
   themeFromPalette: {
     id: "theme-palette",
-    text: `Tip: ${formatKeybind(SHORTCUTS.commandPalette.keybind)} → Theme for quick switching`,
+    text: `Tip: ${formatKeybind(ACTIONS.commandPalette.keybind)} → Theme for quick switching`,
   },
   worktree: {
     id: "worktree",
-    text: `${formatKeybind(SHORTCUTS.commandPalette.keybind)} → New terminal → worktree for parallel sessions`,
+    text: `${formatKeybind(ACTIONS.commandPalette.keybind)} → New terminal → worktree for parallel sessions`,
   },
   themeSwitch: {
     id: "theme-switch",
-    text: `Tip: ${formatKeybind(SHORTCUTS.shuffleTheme.keybind)} cycles through terminal themes`,
+    text: `Tip: ${formatKeybind(ACTIONS.shuffleTheme.keybind)} cycles through terminal themes`,
   },
 } as const satisfies Record<string, Tip>;
 
 export const AMBIENT_TIPS: readonly Tip[] = [
   {
     id: "amb-sub",
-    text: `${formatKeybind(SHORTCUTS.toggleSubPanel.keybind)} splits your terminal into a bottom pane`,
+    text: `${formatKeybind(ACTIONS.toggleSubPanel.keybind)} splits your terminal into a bottom pane`,
   },
   {
     id: "amb-pill-tree",
@@ -48,23 +49,23 @@ export const AMBIENT_TIPS: readonly Tip[] = [
   },
   {
     id: "amb-mru",
-    text: `${formatKeybind(SHORTCUTS.cycleTerminalMru.keybind)} cycles terminals in most-recently-used order`,
+    text: `${formatKeybind(ACTIONS.cycleTerminalMru.keybind)} cycles terminals in most-recently-used order`,
   },
   {
     id: "amb-search",
-    text: `${formatKeybind(SHORTCUTS.findInTerminal.keybind)} searches terminal output`,
+    text: `${formatKeybind(ACTIONS.findInTerminal.keybind)} searches terminal output`,
   },
   {
     id: "amb-shuffle-theme",
-    text: `${formatKeybind(SHORTCUTS.shuffleTheme.keybind)} shuffles the terminal color theme`,
+    text: `${formatKeybind(ACTIONS.shuffleTheme.keybind)} shuffles the terminal color theme`,
   },
   {
     id: "amb-screenshot",
-    text: `${formatKeybind(SHORTCUTS.screenshotTerminal.keybind)} copies a PNG screenshot of the active terminal to your clipboard`,
+    text: `${formatKeybind(ACTIONS.screenshotTerminal.keybind)} copies a PNG screenshot of the active terminal to your clipboard`,
   },
   {
     id: "amb-inspector",
-    text: `${formatKeybind(SHORTCUTS.toggleRightPanel.keybind)} toggles the inspector panel with full terminal context`,
+    text: `${formatKeybind(ACTIONS.toggleRightPanel.keybind)} toggles the inspector panel with full terminal context`,
   },
   {
     id: "amb-canvas-zoom",

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -33,7 +33,7 @@ import "@xterm/xterm/css/xterm.css";
 import type { TerminalId } from "kolu-common";
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
 import { FONT_FAMILY } from "terminal-themes";
-import { matchesAnyShortcut } from "../input/keyboard";
+import { matchesAnyShortcut } from "../input/actions";
 import { createZoom } from "../input/zoom";
 import { refitOnTabVisible } from "../refitOnTabVisible";
 import { client, stream } from "../rpc/rpc";


### PR DESCRIPTION
**Reassigning a single chord no longer spiders across five files.** The keyboard layer carried each app action as four cooperating pieces — keybind+label, dispatcher signature, palette signature, help-overlay membership — that all had to agree by hand. PR #755 (moving Ctrl+Shift+C from `canvasCenterActive` to `copyText`) is the reference example: one logical change, five edited files. This PR collapses those four structures into one registered `ACTIONS` record so the same change touches one file going forward.

Closes #759.

### Before / after

| | Before | After |
| --- | --- | --- |
| Keybind + label | `SHORTCUTS` (`input/keyboard.ts`) | `ACTIONS[id].keybind` / `.label` |
| Dispatcher handler shape | `ShortcutDeps` (`input/useShortcuts.ts`) | `ActionContext` (shared) |
| Palette handler shape | `CommandDeps` (`commands.ts`) | `CommandDeps extends ActionContext` |
| Help overlay membership | `DISPLAY_SHORTCUTS` (`ShortcutsHelp.tsx`) | `HELP_ORDER: ActionId[]` |

`packages/client/src/input/actions.ts` is the new single source of truth. Each entry carries `{ label, keybind, altKeybind?, handler? }`, and consumers derive what they need:

- The dispatcher in `useShortcuts.ts` becomes a four-line `for of Object.values(ACTIONS)` loop.
- `commands.ts` derives shared palette entries via a new `actionPaletteCommand(id, ctx)` helper — bespoke palette items (Theme group, New terminal subtree, Debug, dynamic Switch terminal) keep their literal forms.
- `ShortcutsHelp.tsx` walks a typed `HELP_ORDER: ActionId[]` against the registry — typo-resistant id references replace object spreads.
- App.tsx threads one `actionContext` object into both `useShortcuts` and `createCommands`.

`handler?` is **optional** so display-only entries can stay registered without a dispatch path: `cycleTerminalMru` (the Alt+Tab/Ctrl+Tab cycle is stateful and lives in `useShortcuts`), and `zoomIn`/`zoomOut`/`zoomReset` (per-terminal `createZoom` listener). They still surface in help, palette tooltips, and `matchesAnyShortcut` for xterm passthrough.

### Notable

> No user-visible behavior change. Every chord, palette entry, and help-overlay row is identical to before; the consolidation is internal.

> Hickey review (forked) flagged a dead `AppAction.id` field — every entry set `id` equal to its registry key, no consumer read it, and the invariant `entry.id === key` was enforced only by convention. Removed in a follow-up commit.

> **Deferred:** #769 (replace optional `handler` with discriminated union), #770 (add `alt?` to `Keybind` so Alt+Tab can be a registry entry — pre-existing).

### Try it locally

```sh
nix run github:juspay/kolu/brisk-stamp
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._