### PR TITLE
Quarantine macOS-failing worktree e2e scenarios behind @platform-linux

### DIFF
--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -30,7 +30,7 @@ just test
 
 Scenarios tagged `@skip` are excluded by default (regression harnesses for known-broken behavior). Run them with `CUCUMBER_TAGS='@skip' just test-quick features/foo.feature`.
 
-Scenarios tagged `@platform-linux` run only on Linux; `@platform-darwin` run only on macOS. `cucumber.js` reads `process.platform` and excludes the other platform's tag. Use this for scenarios that consistently fail on one OS until the underlying bottleneck is diagnosed — the worktree e2e suite is currently `@platform-linux` per [#771](https://github.com/juspay/kolu/issues/771). Run a quarantined scenario on its non-default platform with `CUCUMBER_TAGS='@platform-linux'` (which fully replaces the default filter, so it includes them everywhere).
+Scenarios tagged `@platform-linux` run only on Linux; `@platform-darwin` run only on macOS. `cucumber.js` reads `process.platform` and excludes the other platform's tag. Use this for scenarios that consistently fail on one OS until the underlying bottleneck is diagnosed — the worktree e2e suite is currently `@platform-linux` per [#771](https://github.com/juspay/kolu/issues/771). Run a quarantined scenario on its non-default platform with `CUCUMBER_TAGS='@platform-linux and not @skip' just test-quick features/worktree.feature` — `CUCUMBER_TAGS` fully replaces the default filter, so the `not @skip` part has to be repeated explicitly when you don't want regression-harness scenarios mixed in.
 
 Set `HEADLESS=false` to see the browser:
 

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -30,6 +30,8 @@ just test
 
 Scenarios tagged `@skip` are excluded by default (regression harnesses for known-broken behavior). Run them with `CUCUMBER_TAGS='@skip' just test-quick features/foo.feature`.
 
+Scenarios tagged `@platform-linux` run only on Linux; `@platform-darwin` run only on macOS. `cucumber.js` reads `process.platform` and excludes the other platform's tag. Use this for scenarios that consistently fail on one OS until the underlying bottleneck is diagnosed — the worktree e2e suite is currently `@platform-linux` per [#771](https://github.com/juspay/kolu/issues/771). Run a quarantined scenario on its non-default platform with `CUCUMBER_TAGS='@platform-linux'` (which fully replaces the default filter, so it includes them everywhere).
+
 Set `HEADLESS=false` to see the browser:
 
 ```bash

--- a/packages/tests/cucumber.js
+++ b/packages/tests/cucumber.js
@@ -8,9 +8,16 @@ const cliHasFeatureArgs = process.argv
   .some((a) => a.endsWith(".feature"));
 
 // Default tag filter: exclude @skip'd scenarios (regression harnesses for
-// known-broken behavior). `CUCUMBER_TAGS` fully replaces the default — e.g.
-// `CUCUMBER_TAGS='@skip'` runs only skipped scenarios for local development.
-const tags = process.env.CUCUMBER_TAGS || "not @skip";
+// known-broken behavior) plus the platform-specific quarantine for the
+// other OS. `@platform-linux` scenarios run only on Linux; `@platform-darwin`
+// scenarios run only on macOS. `CUCUMBER_TAGS` fully replaces the default —
+// e.g. `CUCUMBER_TAGS='@skip'` runs only skipped scenarios for local
+// development, and `CUCUMBER_TAGS='@platform-linux'` runs only the
+// linux-quarantined scenarios (useful when investigating the macOS bug).
+const otherPlatformTag =
+  process.platform === "darwin" ? "@platform-linux" : "@platform-darwin";
+const tags =
+  process.env.CUCUMBER_TAGS || `not @skip and not ${otherPlatformTag}`;
 
 export const ui = {
   ...(!cliHasFeatureArgs && { paths: ["features/**/*.feature"] }),

--- a/packages/tests/cucumber.js
+++ b/packages/tests/cucumber.js
@@ -14,10 +14,10 @@ const cliHasFeatureArgs = process.argv
 // e.g. `CUCUMBER_TAGS='@skip'` runs only skipped scenarios for local
 // development, and `CUCUMBER_TAGS='@platform-linux'` runs only the
 // linux-quarantined scenarios (useful when investigating the macOS bug).
-const otherPlatformTag =
+const excludedPlatformTag =
   process.platform === "darwin" ? "@platform-linux" : "@platform-darwin";
 const tags =
-  process.env.CUCUMBER_TAGS || `not @skip and not ${otherPlatformTag}`;
+  process.env.CUCUMBER_TAGS || `not @skip and not ${excludedPlatformTag}`;
 
 export const ui = {
   ...(!cliHasFeatureArgs && { paths: ["features/**/*.feature"] }),

--- a/packages/tests/features/worktree-agent.feature
+++ b/packages/tests/features/worktree-agent.feature
@@ -14,6 +14,10 @@ Feature: Agent-aware worktree creation
     When I press the toggle inspector shortcut
     Then the right panel should be visible
 
+  # No @platform-linux tag — this scenario stops at palette visibility and
+  # never triggers worktree creation, so the macOS bottleneck (#771) doesn't
+  # apply. The next two scenarios go through the worktree-create flow and
+  # are tagged.
   Scenario: Agent sub-palette appears under a recent repo when agents exist
     # `claude` is not installed in the test env, but the preexec hook
     # fires BEFORE execution — the OSC 633;E mark is emitted regardless

--- a/packages/tests/features/worktree-agent.feature
+++ b/packages/tests/features/worktree-agent.feature
@@ -28,6 +28,9 @@ Feature: Agent-aware worktree creation
     And palette item "claude --dangerously-skip-permissions" should be visible
     And there should be no page errors
 
+  # Quarantined to Linux until the macOS waitForFunction timeout in the
+  # worktree-create flow is diagnosed — see issue #771.
+  @platform-linux
   Scenario: Picking an agent creates the worktree and writes the command
     When I set up a git repo at "/tmp/kolu-wt-agent-run"
     And I run "cd /tmp/kolu-wt-agent-run"
@@ -43,6 +46,8 @@ Feature: Agent-aware worktree creation
     And the screen state should contain "claude --dangerously-skip-permissions"
     And there should be no page errors
 
+  # Quarantined to Linux — see #771.
+  @platform-linux
   Scenario: Picking Plain shell creates a plain worktree terminal
     When I set up a git repo at "/tmp/kolu-wt-agent-plain"
     And I run "cd /tmp/kolu-wt-agent-plain"

--- a/packages/tests/features/worktree.feature
+++ b/packages/tests/features/worktree.feature
@@ -1,3 +1,9 @@
+# Quarantined to Linux until the macOS-only `waitForFunction` timeout in
+# `Then the header CWD should show ".worktrees/"` and `createTerminal` is
+# diagnosed — see issue #771. Every scenario in this file goes through the
+# worktree-create flow, which is the failing path. Tag is at feature level
+# so the @skip'd scenarios below stay skipped on both platforms.
+@platform-linux
 Feature: Git worktree management
   Users can create terminals in new git worktrees via "New terminal" in the
   command palette, and close terminals while optionally removing the worktree.


### PR DESCRIPTION
**The 7 worktree-create e2e scenarios consistently time out on macOS CI** — `page.waitForFunction: Timeout 20000ms exceeded` in `cwd_steps.ts:7` and `world.ts:109`. The failure reproduces across 12+ commits on unrelated branches (PR #744's `damn-booth`), so any PR that doesn't touch terminal/worktree/CWD code currently ships with a permanently-red `ci/e2e@aarch64-darwin` status. Linux is green on the same commits.

This PR takes the third option from #771: **tag the failing scenarios `@platform-linux` and have `cucumber.js` exclude the foreign platform's tag based on `process.platform`.** It's the cheapest unblocking move that keeps the bug visible — #771 stays open as the tracking issue for the actual macOS bottleneck.

### Mechanism

```
process.platform === "darwin"  ─▶  exclude "@platform-linux"
process.platform === "linux"   ─▶  exclude "@platform-darwin"
```

The default tag expression goes from `not @skip` to `not @skip and not <excludedTag>`. `CUCUMBER_TAGS` env var still fully overrides the default, so debugging quarantined scenarios on macOS is `CUCUMBER_TAGS='@platform-linux and not @skip' just test-quick features/worktree.feature`. _Symmetric `@platform-darwin` support is wired up at the same time so future quarantines in either direction don't need a config change._

### What's quarantined

| File | Granularity | Scenarios |
|---|---|---|
| `worktree.feature` | feature-level | 5 active + 2 already-`@skip` (all go through worktree-create) |
| `worktree-agent.feature` | scenario-level | 2 of 3 (line 17 stops at palette visibility — not on the failing list, untagged) |

### Verification

- 8/8 worktree scenarios pass on this Linux run (5 in `worktree.feature` + 3 in `worktree-agent.feature` including the untagged scenario at line 17). The quarantine doesn't regress current-platform behavior.
- Tag-filter resolution checked manually: on linux → `not @skip and not @platform-darwin`; on darwin → `not @skip and not @platform-linux`.

> The macOS bottleneck itself isn't fixed — `simple-git`'s `worktree add` may be slow under macOS sandbox, or `.worktrees/` path resolution has a Darwin-specific case that delays the OSC 7 → metadata path. _Diagnosing that is #771's remaining work; this PR just stops it blocking unrelated CI._

Refs #771

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._