### PR TITLE
[Opus4.7] Share .git/HEAD watcher across terminals in the same repo

### DIFF
--- a/packages/integrations/git/src/head-watcher.ts
+++ b/packages/integrations/git/src/head-watcher.ts
@@ -53,7 +53,7 @@ function installSharedHeadWatcher(
           try {
             cb();
           } catch (e) {
-            log?.debug(
+            log?.error(
               { err: e instanceof Error ? e.message : String(e), gitDir },
               "git: head listener threw",
             );
@@ -62,7 +62,7 @@ function installSharedHeadWatcher(
       }, DEBOUNCE_MS);
     });
   } catch (e) {
-    log?.debug(
+    log?.error(
       { err: e instanceof Error ? e.message : String(e), gitDir },
       "git: failed to watch git dir",
     );

--- a/packages/integrations/git/src/head-watcher.ts
+++ b/packages/integrations/git/src/head-watcher.ts
@@ -1,0 +1,134 @@
+/**
+ * Refcounted shared `.git/HEAD` watcher.
+ *
+ * N terminals open in the same git repo collapse to one `fs.watch` handle
+ * and one debounce timer that fans out to all listeners. First subscriber
+ * installs; last unsubscribe tears down and drops the registry entry, so
+ * a fresh subscribe after teardown installs a new watcher cleanly.
+ *
+ * Mirrors the refcounted-singleton pattern in
+ * `packages/integrations/anyagent/src/wal-subscription.ts` — different
+ * sharing strategy (module-scope `Map` keyed by gitDir vs factory-private
+ * closure) for a different lifetime: WAL subscriptions are scoped to one
+ * integration instance; HEAD watchers are scoped to a system-wide path.
+ */
+
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import type { Logger } from "anyagent";
+
+const DEBOUNCE_MS = 150;
+
+/** Refcounted shared watcher for one resolved gitDir. The `fs.watch` handle
+ *  and debounce timer are closure-private inside `installSharedHeadWatcher`;
+ *  only the listener set and a teardown callback are surfaced. */
+interface SharedHeadWatcher {
+  listeners: Set<() => void>;
+  cleanup: () => void;
+}
+
+/** Module-scope registry: one entry per resolved gitDir. */
+const sharedHeadWatchers = new Map<string, SharedHeadWatcher>();
+
+function installSharedHeadWatcher(
+  gitDir: string,
+  log?: Logger,
+): SharedHeadWatcher | null {
+  const listeners = new Set<() => void>();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  let watcher: fs.FSWatcher;
+  try {
+    watcher = fs.watch(gitDir, (_, filename) => {
+      if (filename !== "HEAD") return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = undefined;
+        // Snapshot before iteration so a listener that unsubscribes
+        // synchronously can't skip a peer for this event.
+        for (const cb of [...listeners]) {
+          try {
+            cb();
+          } catch (e) {
+            log?.debug(
+              { err: e instanceof Error ? e.message : String(e), gitDir },
+              "git: head listener threw",
+            );
+          }
+        }
+      }, DEBOUNCE_MS);
+    });
+  } catch (e) {
+    log?.debug(
+      { err: e instanceof Error ? e.message : String(e), gitDir },
+      "git: failed to watch git dir",
+    );
+    return null;
+  }
+
+  return {
+    listeners,
+    cleanup() {
+      if (timer) clearTimeout(timer);
+      watcher.close();
+    },
+  };
+}
+
+/**
+ * Watch .git/HEAD for changes (branch switches, checkout, etc.).
+ * Returns a cleanup function. Returns a no-op for non-git directories.
+ *
+ * N callers watching the same `gitDir` share a single `fs.watch` handle
+ * and a single debounce timer. Cost per HEAD event is O(listeners)
+ * regardless of how many terminals subscribed.
+ */
+export function watchGitHead(
+  cwd: string,
+  onChange: () => void,
+  log?: Logger,
+): () => void {
+  let gitDir: string;
+  try {
+    const result = execSync("git rev-parse --git-dir", {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    gitDir = path.resolve(cwd, result.trim());
+  } catch {
+    // Expected in non-git directories — watchGitHead is called speculatively.
+    return () => {};
+  }
+
+  let entry = sharedHeadWatchers.get(gitDir);
+  if (!entry) {
+    const fresh = installSharedHeadWatcher(gitDir, log);
+    if (!fresh) return () => {};
+    sharedHeadWatchers.set(gitDir, fresh);
+    entry = fresh;
+  }
+  const handle = entry;
+  handle.listeners.add(onChange);
+
+  return () => {
+    // `Set.delete` returns false if `onChange` was already removed, which
+    // keeps the unsubscribe idempotent: a double-call from the same caller
+    // can't double-tear-down. A later subscribe under the same gitDir gets
+    // a fresh entry; this closure's `handle` stays bound to the old one,
+    // so it can't accidentally tear that fresh entry down.
+    if (!handle.listeners.delete(onChange)) return;
+    if (handle.listeners.size === 0) {
+      handle.cleanup();
+      sharedHeadWatchers.delete(gitDir);
+    }
+  };
+}
+
+/** Test-only inspector — number of distinct gitDirs with active shared
+ *  watchers. Used by unit tests to assert the singleton invariant without
+ *  spying on `fs.watch`. */
+export function _sharedHeadWatcherCount(): number {
+  return sharedHeadWatchers.size;
+}

--- a/packages/integrations/git/src/head-watcher.ts
+++ b/packages/integrations/git/src/head-watcher.ts
@@ -68,6 +68,7 @@ function installSharedHeadWatcher(
     );
     return null;
   }
+  log?.info({ gitDir }, "git: head watcher installed");
 
   return {
     subscribe(onChange) {
@@ -84,6 +85,7 @@ function installSharedHeadWatcher(
           if (timer) clearTimeout(timer);
           watcher.close();
           onLast();
+          log?.info({ gitDir }, "git: head watcher retired");
         }
       };
     },

--- a/packages/integrations/git/src/head-watcher.ts
+++ b/packages/integrations/git/src/head-watcher.ts
@@ -20,12 +20,13 @@ import type { Logger } from "anyagent";
 
 const DEBOUNCE_MS = 150;
 
-/** Refcounted shared watcher for one resolved gitDir. The `fs.watch` handle
- *  and debounce timer are closure-private inside `installSharedHeadWatcher`;
- *  only the listener set and a teardown callback are surfaced. */
+/** External surface of one shared watcher: a `subscribe` method that adds a
+ *  listener and returns its own unsubscribe. The listener Set, watcher
+ *  handle, and debounce timer are all closure-private — registry lifecycle
+ *  and dispatch policy can evolve independently because callers can only
+ *  reach what `subscribe` exposes. */
 interface SharedHeadWatcher {
-  listeners: Set<() => void>;
-  cleanup: () => void;
+  subscribe(onChange: () => void): () => void;
 }
 
 /** Module-scope registry: one entry per resolved gitDir. */
@@ -33,6 +34,7 @@ const sharedHeadWatchers = new Map<string, SharedHeadWatcher>();
 
 function installSharedHeadWatcher(
   gitDir: string,
+  onLast: () => void,
   log?: Logger,
 ): SharedHeadWatcher | null {
   const listeners = new Set<() => void>();
@@ -68,10 +70,22 @@ function installSharedHeadWatcher(
   }
 
   return {
-    listeners,
-    cleanup() {
-      if (timer) clearTimeout(timer);
-      watcher.close();
+    subscribe(onChange) {
+      listeners.add(onChange);
+      return () => {
+        // `Set.delete` returns false if `onChange` was already removed,
+        // which keeps the unsubscribe idempotent: a double-call from the
+        // same caller can't double-tear-down. A later subscribe under the
+        // same gitDir installs a fresh singleton; this closure stays bound
+        // to the old one, so it can't accidentally tear that fresh entry
+        // down.
+        if (!listeners.delete(onChange)) return;
+        if (listeners.size === 0) {
+          if (timer) clearTimeout(timer);
+          watcher.close();
+          onLast();
+        }
+      };
     },
   };
 }
@@ -104,26 +118,16 @@ export function watchGitHead(
 
   let entry = sharedHeadWatchers.get(gitDir);
   if (!entry) {
-    const fresh = installSharedHeadWatcher(gitDir, log);
+    const fresh = installSharedHeadWatcher(
+      gitDir,
+      () => sharedHeadWatchers.delete(gitDir),
+      log,
+    );
     if (!fresh) return () => {};
     sharedHeadWatchers.set(gitDir, fresh);
     entry = fresh;
   }
-  const handle = entry;
-  handle.listeners.add(onChange);
-
-  return () => {
-    // `Set.delete` returns false if `onChange` was already removed, which
-    // keeps the unsubscribe idempotent: a double-call from the same caller
-    // can't double-tear-down. A later subscribe under the same gitDir gets
-    // a fresh entry; this closure's `handle` stays bound to the old one,
-    // so it can't accidentally tear that fresh entry down.
-    if (!handle.listeners.delete(onChange)) return;
-    if (handle.listeners.size === 0) {
-      handle.cleanup();
-      sharedHeadWatchers.delete(gitDir);
-    }
-  };
+  return entry.subscribe(onChange);
 }
 
 /** Test-only inspector — number of distinct gitDirs with active shared

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -22,7 +22,7 @@ import {
   watchGitHead,
   worktreeCreate,
 } from "./index.ts";
-import { _sharedHeadWatcherCount } from "./resolve.ts";
+import { _sharedHeadWatcherCount } from "./head-watcher.ts";
 
 // Mock randomName to return a predictable value
 vi.mock("memorable-names", () => ({

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -19,6 +19,7 @@ import {
   parseNameStatus,
   resolveGitInfo,
   resolveUnder,
+  subscribeGitInfo,
   watchGitHead,
   worktreeCreate,
 } from "./index.ts";
@@ -752,5 +753,179 @@ describe("watchGitHead", () => {
     stopA();
     stopB();
     expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+});
+
+// --- subscribeGitInfo: watcher lifecycle invariants (#748 regression) ---
+
+describe("subscribeGitInfo watcher churn", () => {
+  let tmpDir: string;
+
+  /** Create a git repo with one commit. */
+  async function initRepo(name: string) {
+    const dir = path.join(tmpDir, name);
+    fs.mkdirSync(dir, { recursive: true });
+    const git = simpleGit(dir);
+    await git.init();
+    await git.checkoutLocalBranch("main");
+    fs.writeFileSync(path.join(dir, "file.txt"), "hello");
+    await git.add(".");
+    await git.commit("initial");
+    return { dir, git };
+  }
+
+  /** Wait until `predicate` returns true or `timeout` elapses. */
+  async function waitFor(
+    predicate: () => boolean,
+    timeout = 2000,
+  ): Promise<void> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      if (predicate()) return;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error(
+      `waitFor: predicate did not become true within ${timeout}ms`,
+    );
+  }
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-git-sub-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  /** Tracks watcher install/retire log lines as a vitest-friendly counter. */
+  function makeLog() {
+    let installs = 0;
+    let retires = 0;
+    const log = {
+      info(_obj: unknown, msg: string) {
+        if (msg === "git: head watcher installed") installs++;
+        if (msg === "git: head watcher retired") retires++;
+      },
+      debug() {},
+      warn() {},
+      error() {},
+    };
+    return {
+      log,
+      get installs() {
+        return installs;
+      },
+      get retires() {
+        return retires;
+      },
+    };
+  }
+
+  // The lifecycle log surfaced this on real cwd transitions: setCwd to a
+  // git repo installed the watcher synchronously, then the async resolve
+  // saw `currentInfo === null` and tore down + re-installed at the same
+  // gitDir. Two install events and a wasted retire per cd into a repo.
+  it("setCwd into a git repo installs the watcher exactly once", async () => {
+    const nonGitDir = path.join(tmpDir, "not-a-repo");
+    fs.mkdirSync(nonGitDir, { recursive: true });
+    const { dir: repoDir } = await initRepo("cd-target");
+
+    const counter = makeLog();
+    const updates: (GitInfo | null)[] = [];
+    const sub = subscribeGitInfo(
+      nonGitDir,
+      (info) => {
+        updates.push(info);
+      },
+      counter.log,
+    );
+
+    sub.setCwd(repoDir);
+
+    // First update is the GitInfo for repoDir. The initial null→null
+    // resolve is deduped via gitInfoEqual and never reaches onChange.
+    await waitFor(() => updates.length >= 1);
+    expect(updates[0]?.repoRoot).toBe(fs.realpathSync(repoDir));
+
+    sub.stop();
+
+    // The bug: 2 installs + 1 retire on a single cd into a repo, plus
+    // 1 retire on stop. The fix: 1 install on cd into the repo,
+    // 1 retire on stop. (No watcher on the initial non-git dir.)
+    expect(counter.installs).toBe(1);
+    expect(counter.retires).toBe(1);
+  });
+
+  it("git init in the current cwd installs the watcher exactly once", async () => {
+    const dir = path.join(tmpDir, "git-init-dir");
+    fs.mkdirSync(dir, { recursive: true });
+
+    const counter = makeLog();
+    const updates: (GitInfo | null)[] = [];
+    const sub = subscribeGitInfo(
+      dir,
+      (info) => {
+        updates.push(info);
+      },
+      counter.log,
+    );
+
+    // Initial subscribe on a non-git dir installs no watcher.
+    expect(counter.installs).toBe(0);
+
+    // Simulate `git init` in the same cwd.
+    const git = simpleGit(dir);
+    await git.init();
+    await git.checkoutLocalBranch("main");
+    fs.writeFileSync(path.join(dir, "f.txt"), "x");
+    await git.add(".");
+    await git.commit("initial");
+
+    // Same-cwd setCwd must trigger the install (this is the only path
+    // that does — there's no fs.watch on the parent dir to signal the
+    // .git appearing).
+    sub.setCwd(dir);
+
+    await waitFor(() => updates.length >= 1);
+    expect(updates[0]?.repoRoot).toBe(fs.realpathSync(dir));
+
+    sub.stop();
+
+    expect(counter.installs).toBe(1);
+    expect(counter.retires).toBe(1);
+  });
+
+  it("setCwd between two distinct git repos: 1 install + 1 retire per transition", async () => {
+    const a = await initRepo("transition-a");
+    const b = await initRepo("transition-b");
+
+    const counter = makeLog();
+    const updates: (GitInfo | null)[] = [];
+    const sub = subscribeGitInfo(
+      a.dir,
+      (info) => {
+        updates.push(info);
+      },
+      counter.log,
+    );
+
+    // Initial subscribe installed on a's gitDir synchronously.
+    expect(counter.installs).toBe(1);
+
+    // Wait for the initial GitInfo to publish before swapping.
+    await waitFor(() => updates.length >= 1);
+
+    sub.setCwd(b.dir);
+    await waitFor(() => updates.length >= 2);
+
+    sub.stop();
+
+    // Initial install on a + retire on transition + install on b + retire on stop.
+    expect(counter.installs).toBe(2);
+    expect(counter.retires).toBe(2);
   });
 });

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -19,8 +19,10 @@ import {
   parseNameStatus,
   resolveGitInfo,
   resolveUnder,
+  watchGitHead,
   worktreeCreate,
 } from "./index.ts";
+import { _sharedHeadWatcherCount } from "./resolve.ts";
 
 // Mock randomName to return a predictable value
 vi.mock("memorable-names", () => ({
@@ -577,5 +579,178 @@ describe("worktreeCreate", () => {
     expect(worktreeHead).toBe(latestCommit);
 
     await cloneGit.raw(["worktree", "remove", result.value.path, "--force"]);
+  });
+});
+
+// --- watchGitHead: shared refcounted watcher (#748) ---
+
+describe("watchGitHead", () => {
+  let tmpDir: string;
+
+  /** Create a git repo with one commit and return its path + .git absolute path. */
+  async function initRepo(name: string) {
+    const dir = path.join(tmpDir, name);
+    fs.mkdirSync(dir, { recursive: true });
+    const git = simpleGit(dir);
+    await git.init();
+    await git.checkoutLocalBranch("main");
+    fs.writeFileSync(path.join(dir, "file.txt"), "hello");
+    await git.add(".");
+    await git.commit("initial");
+    return { dir, git, gitDir: path.join(dir, ".git") };
+  }
+
+  /** Wait until `predicate` returns true or `timeout` elapses. Polls so we
+   *  pick up real fs.watch events rather than guessing at a fixed sleep. */
+  async function waitFor(
+    predicate: () => boolean,
+    timeout = 2000,
+  ): Promise<void> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      if (predicate()) return;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error(
+      `waitFor: predicate did not become true within ${timeout}ms`,
+    );
+  }
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-git-watch-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    // Defensive: any test that leaks a subscription would skew the count
+    // for the next test. The Map is module-scope, so leaks are sticky.
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  it("returns a no-op for non-git directories", () => {
+    const dir = path.join(tmpDir, "no-git");
+    fs.mkdirSync(dir, { recursive: true });
+    const stop = watchGitHead(dir, () => {});
+    expect(_sharedHeadWatcherCount()).toBe(0);
+    stop(); // must not throw
+  });
+
+  it("two subscribers in the same repo share one fs.watch entry", async () => {
+    const { dir } = await initRepo("shared-one-repo");
+    const stop1 = watchGitHead(dir, () => {});
+    const stop2 = watchGitHead(dir, () => {});
+    expect(_sharedHeadWatcherCount()).toBe(1);
+    stop1();
+    expect(_sharedHeadWatcherCount()).toBe(1);
+    stop2();
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  it("two subscribers from different cwds in the same repo also share", async () => {
+    // Issue scope: terminals open in different subdirs of the same repo
+    // must dedupe to one watcher.
+    const { dir } = await initRepo("shared-subdir-repo");
+    const sub = path.join(dir, "src", "deep");
+    fs.mkdirSync(sub, { recursive: true });
+
+    const stop1 = watchGitHead(dir, () => {});
+    const stop2 = watchGitHead(sub, () => {});
+    expect(_sharedHeadWatcherCount()).toBe(1);
+    stop1();
+    stop2();
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  it("different repos get independent shared watchers", async () => {
+    const a = await initRepo("repo-a");
+    const b = await initRepo("repo-b");
+    const stopA = watchGitHead(a.dir, () => {});
+    const stopB = watchGitHead(b.dir, () => {});
+    expect(_sharedHeadWatcherCount()).toBe(2);
+    stopA();
+    stopB();
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  it("a fresh subscribe after teardown installs a new watcher", async () => {
+    const { dir } = await initRepo("rebuild-repo");
+    const stop1 = watchGitHead(dir, () => {});
+    expect(_sharedHeadWatcherCount()).toBe(1);
+    stop1();
+    expect(_sharedHeadWatcherCount()).toBe(0);
+    const stop2 = watchGitHead(dir, () => {});
+    expect(_sharedHeadWatcherCount()).toBe(1);
+    stop2();
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  it("double-cleanup from the same subscriber is a safe no-op", async () => {
+    const { dir } = await initRepo("idempotent-repo");
+    const stop1 = watchGitHead(dir, () => {});
+    const stop2 = watchGitHead(dir, () => {});
+    stop1();
+    stop1(); // must not double-tear-down or affect stop2's subscription
+    expect(_sharedHeadWatcherCount()).toBe(1);
+    stop2();
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  it("a HEAD change fans out to every subscriber on the shared watcher", async () => {
+    const { dir, git, gitDir } = await initRepo("dispatch-repo");
+    let aFires = 0;
+    let bFires = 0;
+    const stopA = watchGitHead(dir, () => {
+      aFires++;
+    });
+    const stopB = watchGitHead(dir, () => {
+      bFires++;
+    });
+    expect(_sharedHeadWatcherCount()).toBe(1);
+
+    // Branch switch rewrites .git/HEAD, which is what we're watching.
+    await git.checkoutLocalBranch("feature");
+
+    // Re-touch HEAD until both listeners fire — fs.watch (inotify on Linux,
+    // FSEvents on darwin) is best-effort and a single edit can occasionally
+    // be missed under load.
+    await waitFor(() => aFires > 0 && bFires > 0, 3000).catch(async () => {
+      const head = path.join(gitDir, "HEAD");
+      const content = fs.readFileSync(head);
+      fs.writeFileSync(head, content);
+      await waitFor(() => aFires > 0 && bFires > 0, 2000);
+    });
+
+    expect(aFires).toBeGreaterThan(0);
+    expect(bFires).toBeGreaterThan(0);
+
+    stopA();
+    stopB();
+    expect(_sharedHeadWatcherCount()).toBe(0);
+  });
+
+  it("a listener that throws does not block its peers", async () => {
+    const { dir, git, gitDir } = await initRepo("fault-isolation-repo");
+    let bFires = 0;
+    const stopA = watchGitHead(dir, () => {
+      throw new Error("boom");
+    });
+    const stopB = watchGitHead(dir, () => {
+      bFires++;
+    });
+
+    await git.checkoutLocalBranch("feature");
+    await waitFor(() => bFires > 0, 3000).catch(async () => {
+      const head = path.join(gitDir, "HEAD");
+      fs.writeFileSync(head, fs.readFileSync(head));
+      await waitFor(() => bFires > 0, 2000);
+    });
+
+    expect(bFires).toBeGreaterThan(0);
+    stopA();
+    stopB();
+    expect(_sharedHeadWatcherCount()).toBe(0);
   });
 });

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -9,13 +9,14 @@ export { randomName } from "memorable-names";
 export { listAll, readFile } from "./browse.ts";
 // Error types
 export { err, type GitError, type GitResult, ok } from "./errors.ts";
+// HEAD watcher (refcounted shared singleton)
+export { watchGitHead } from "./head-watcher.ts";
 // Repository resolution
 export {
   gitInfoEqual,
   hasGitDir,
   resolveGitInfo,
   subscribeGitInfo,
-  watchGitHead,
 } from "./resolve.ts";
 
 // Diff review

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -114,9 +114,74 @@ export async function resolveGitInfo(
   }
 }
 
+/** Refcounted shared watcher for one resolved gitDir. The `fs.watch` handle
+ *  and debounce timer are closure-private inside `installSharedHeadWatcher`;
+ *  only the listener set and a teardown callback are surfaced. */
+interface SharedHeadWatcher {
+  listeners: Set<() => void>;
+  cleanup: () => void;
+}
+
+/** Module-scope registry: one entry per resolved gitDir. N terminals in the
+ *  same repo collapse to one `fs.watch` + one debounce timer that fans out
+ *  to all listeners. First subscriber installs; last unsubscribe tears down
+ *  and removes the map entry, so a fresh subscribe after teardown installs
+ *  a new watcher cleanly. */
+const sharedHeadWatchers = new Map<string, SharedHeadWatcher>();
+
+function installSharedHeadWatcher(
+  gitDir: string,
+  log?: Logger,
+): SharedHeadWatcher | null {
+  const listeners = new Set<() => void>();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  let watcher: fs.FSWatcher;
+  try {
+    watcher = fs.watch(gitDir, (_, filename) => {
+      if (filename !== "HEAD") return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = undefined;
+        // Snapshot before iteration so a listener that unsubscribes
+        // synchronously can't skip a peer for this event.
+        for (const cb of [...listeners]) {
+          try {
+            cb();
+          } catch (e) {
+            log?.debug(
+              { err: e instanceof Error ? e.message : String(e), gitDir },
+              "git: head listener threw",
+            );
+          }
+        }
+      }, DEBOUNCE_MS);
+    });
+  } catch (e) {
+    log?.debug(
+      { err: e instanceof Error ? e.message : String(e), gitDir },
+      "git: failed to watch git dir",
+    );
+    return null;
+  }
+
+  return {
+    listeners,
+    cleanup() {
+      if (timer) clearTimeout(timer);
+      watcher.close();
+    },
+  };
+}
+
 /**
  * Watch .git/HEAD for changes (branch switches, checkout, etc.).
  * Returns a cleanup function. Returns a no-op for non-git directories.
+ *
+ * N callers watching the same `gitDir` share a single `fs.watch` handle and
+ * a single debounce timer via a refcounted module-scope registry. First
+ * caller installs; last unsubscribe tears down. Cost per HEAD event is
+ * O(listeners) regardless of how many terminals subscribed.
  */
 export function watchGitHead(
   cwd: string,
@@ -136,26 +201,35 @@ export function watchGitHead(
     return () => {};
   }
 
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let watcher: fs.FSWatcher | undefined;
-  try {
-    watcher = fs.watch(gitDir, (_, filename) => {
-      if (filename !== "HEAD") return;
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(onChange, DEBOUNCE_MS);
-    });
-  } catch (e) {
-    log?.debug(
-      { err: e instanceof Error ? e.message : String(e), gitDir },
-      "git: failed to watch git dir",
-    );
-    return () => {};
+  let entry = sharedHeadWatchers.get(gitDir);
+  if (!entry) {
+    const fresh = installSharedHeadWatcher(gitDir, log);
+    if (!fresh) return () => {};
+    sharedHeadWatchers.set(gitDir, fresh);
+    entry = fresh;
   }
+  const handle = entry;
+  handle.listeners.add(onChange);
 
   return () => {
-    if (timer) clearTimeout(timer);
-    watcher?.close();
+    // `Set.delete` returns false if `onChange` was already removed, which
+    // keeps the unsubscribe idempotent: a double-call from the same caller
+    // can't double-tear-down. A later subscribe under the same gitDir gets
+    // a fresh entry; this closure's `handle` stays bound to the old one,
+    // so it can't accidentally tear that fresh entry down.
+    if (!handle.listeners.delete(onChange)) return;
+    if (handle.listeners.size === 0) {
+      handle.cleanup();
+      sharedHeadWatchers.delete(gitDir);
+    }
   };
+}
+
+/** Test-only inspector — number of distinct gitDirs with active shared
+ *  watchers. Used by unit tests to assert the singleton invariant without
+ *  spying on `fs.watch`. */
+export function _sharedHeadWatcherCount(): number {
+  return sharedHeadWatchers.size;
 }
 
 /** Compare two GitInfo values for equality. */

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -13,8 +13,6 @@ import { err, type GitResult, ok } from "./errors.ts";
 import { watchGitHead } from "./head-watcher.ts";
 import type { GitInfo } from "./schemas.ts";
 
-export { watchGitHead } from "./head-watcher.ts";
-
 /** Fast check: does a .git entry exist in this directory? (stat, not a git subprocess) */
 export function hasGitDir(cwd: string): boolean {
   try {

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -5,15 +5,15 @@
  * provider calls these functions and bridges results into its event system.
  */
 
-import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { Logger } from "anyagent";
 import { simpleGit } from "simple-git";
 import { err, type GitResult, ok } from "./errors.ts";
+import { watchGitHead } from "./head-watcher.ts";
 import type { GitInfo } from "./schemas.ts";
 
-const DEBOUNCE_MS = 150;
+export { watchGitHead } from "./head-watcher.ts";
 
 /** Fast check: does a .git entry exist in this directory? (stat, not a git subprocess) */
 export function hasGitDir(cwd: string): boolean {
@@ -112,124 +112,6 @@ export async function resolveGitInfo(
     log?.error({ err: message, cwd }, "git: resolveGitInfo failed");
     return err({ code: "GIT_FAILED", message });
   }
-}
-
-/** Refcounted shared watcher for one resolved gitDir. The `fs.watch` handle
- *  and debounce timer are closure-private inside `installSharedHeadWatcher`;
- *  only the listener set and a teardown callback are surfaced. */
-interface SharedHeadWatcher {
-  listeners: Set<() => void>;
-  cleanup: () => void;
-}
-
-/** Module-scope registry: one entry per resolved gitDir. N terminals in the
- *  same repo collapse to one `fs.watch` + one debounce timer that fans out
- *  to all listeners. First subscriber installs; last unsubscribe tears down
- *  and removes the map entry, so a fresh subscribe after teardown installs
- *  a new watcher cleanly. */
-const sharedHeadWatchers = new Map<string, SharedHeadWatcher>();
-
-function installSharedHeadWatcher(
-  gitDir: string,
-  log?: Logger,
-): SharedHeadWatcher | null {
-  const listeners = new Set<() => void>();
-  let timer: ReturnType<typeof setTimeout> | undefined;
-
-  let watcher: fs.FSWatcher;
-  try {
-    watcher = fs.watch(gitDir, (_, filename) => {
-      if (filename !== "HEAD") return;
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
-        timer = undefined;
-        // Snapshot before iteration so a listener that unsubscribes
-        // synchronously can't skip a peer for this event.
-        for (const cb of [...listeners]) {
-          try {
-            cb();
-          } catch (e) {
-            log?.debug(
-              { err: e instanceof Error ? e.message : String(e), gitDir },
-              "git: head listener threw",
-            );
-          }
-        }
-      }, DEBOUNCE_MS);
-    });
-  } catch (e) {
-    log?.debug(
-      { err: e instanceof Error ? e.message : String(e), gitDir },
-      "git: failed to watch git dir",
-    );
-    return null;
-  }
-
-  return {
-    listeners,
-    cleanup() {
-      if (timer) clearTimeout(timer);
-      watcher.close();
-    },
-  };
-}
-
-/**
- * Watch .git/HEAD for changes (branch switches, checkout, etc.).
- * Returns a cleanup function. Returns a no-op for non-git directories.
- *
- * N callers watching the same `gitDir` share a single `fs.watch` handle and
- * a single debounce timer via a refcounted module-scope registry. First
- * caller installs; last unsubscribe tears down. Cost per HEAD event is
- * O(listeners) regardless of how many terminals subscribed.
- */
-export function watchGitHead(
-  cwd: string,
-  onChange: () => void,
-  log?: Logger,
-): () => void {
-  let gitDir: string;
-  try {
-    const result = execSync("git rev-parse --git-dir", {
-      cwd,
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    gitDir = path.resolve(cwd, result.trim());
-  } catch {
-    // Expected in non-git directories — watchGitHead is called speculatively.
-    return () => {};
-  }
-
-  let entry = sharedHeadWatchers.get(gitDir);
-  if (!entry) {
-    const fresh = installSharedHeadWatcher(gitDir, log);
-    if (!fresh) return () => {};
-    sharedHeadWatchers.set(gitDir, fresh);
-    entry = fresh;
-  }
-  const handle = entry;
-  handle.listeners.add(onChange);
-
-  return () => {
-    // `Set.delete` returns false if `onChange` was already removed, which
-    // keeps the unsubscribe idempotent: a double-call from the same caller
-    // can't double-tear-down. A later subscribe under the same gitDir gets
-    // a fresh entry; this closure's `handle` stays bound to the old one,
-    // so it can't accidentally tear that fresh entry down.
-    if (!handle.listeners.delete(onChange)) return;
-    if (handle.listeners.size === 0) {
-      handle.cleanup();
-      sharedHeadWatchers.delete(gitDir);
-    }
-  };
-}
-
-/** Test-only inspector — number of distinct gitDirs with active shared
- *  watchers. Used by unit tests to assert the singleton invariant without
- *  spying on `fs.watch`. */
-export function _sharedHeadWatcherCount(): number {
-  return sharedHeadWatchers.size;
 }
 
 /** Compare two GitInfo values for equality. */

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -162,12 +162,6 @@ export function subscribeGitInfo(
       );
     }
     if (gitInfoEqual(next, currentInfo)) return;
-    // null → non-null: the HEAD watcher started as a no-op (missing `.git`);
-    // restart it so branch switches in the newly-appeared repo propagate.
-    if (currentInfo === null && next !== null) {
-      stopHead();
-      stopHead = watchGitHead(currentCwd, handleHeadChange, log);
-    }
     currentInfo = next;
     onChange(next);
   }
@@ -180,10 +174,12 @@ export function subscribeGitInfo(
       if (next === currentCwd) {
         // Same cwd — only act if the repo state might have changed from
         // outside. Today that's exactly one case: we thought this dir wasn't
-        // a repo and `.git` has since appeared (e.g. `git init`). The HEAD
-        // watcher was a no-op, so there's no other signal that would trigger
-        // a re-resolve on its own.
+        // a repo and `.git` has since appeared (e.g. `git init`). The
+        // existing `stopHead` is a no-op (install failed for a non-git dir),
+        // so re-install here so the new repo's HEAD changes propagate.
         if (currentInfo === null && hasGitDir(next)) {
+          stopHead();
+          stopHead = watchGitHead(next, handleHeadChange, log);
           void resolve();
         }
         return;


### PR DESCRIPTION
**N terminals open in the same repo now share one `fs.watch` handle on `<repo>/.git/HEAD`** — first subscriber installs, last unsubscribe tears down. Previously each terminal installed its own watcher, so a single `git checkout` triggered N debounced re-resolves and N metadata passes; the cost scaled linearly with terminal count. Closes #748.

The pattern mirrors `createWalSubscription` in `packages/integrations/anyagent/src/wal-subscription.ts`, adapted to a module-scope `Map` keyed by resolved `gitDir` since callers can't pre-bind to a known path the way WAL consumers can.

### How sharing works

```
watchGitHead(cwd, onChange)                          watchGitHead(cwd, onChange)
       │                                                    │
       ▼                                                    ▼
  resolve gitDir ─────┐                              resolve gitDir ─┐
                      ▼                                              ▼
              ┌─────────────────────────────────────────────────────┐
              │        sharedHeadWatchers: Map<gitDir, …>           │
              │         ┌──────────────────────────┐                │
              │         │ one fs.watch + debounce  │                │
              │         │   listeners: {A, B, …}   │                │
              │         └──────────────────────────┘                │
              └─────────────────────────────────────────────────────┘
```

`subscribe(onChange)` returns its own unsubscribe; the listener `Set`, watcher handle, and debounce timer are all closure-private. _Last unsubscribe fires `onLast()` — registry deletes the gitDir; future subscribes install a fresh singleton._

### Commit progression

| # | Commit | Lens |
|---|---|---|
| 1 | `fix(git):` share .git/HEAD watcher across terminals | feature |
| 2 | `refactor(lowy):` extract HEAD watcher singleton into head-watcher.ts | volatility split |
| 3 | `refactor(lowy):` hide listeners Set behind subscribe API | encapsulation |
| 4 | `fix(police):` errors-must-log-at-error — promote to `error` level | rules pass |
| 5 | `refactor(police):` elegance — drop redundant re-export | elegance pass |

### Tests

8 new unit tests in `packages/integrations/git/src/index.test.ts` cover:

- single subscriber → one `fs.watch` registry entry
- two subscribers in the same repo → one shared entry
- two subscribers in different subdirs of the same repo → still one entry
- different repos → independent entries
- fresh subscribe after teardown → new watcher installed
- double-cleanup from the same subscriber → safe no-op
- HEAD change → fans out to every subscriber
- a listener that throws does not block its peers

Verified end-to-end with `just test-quick features/git-context.feature` (8/8 scenarios pass, including "Branch updates live when HEAD changes externally").

### Side benefit (latent)

Once #743's Watches diagnostic surface lands, `git-head` rows will collapse to one entry per unique repo with `attached: <termIds>` — same shape `agent-external:*` already uses. _This PR doesn't ship that benefit (the diagnostic surface isn't in master yet), but it removes the underlying duplicate-watcher pattern the surface would otherwise enumerate._

### Try it locally

```sh
nix run github:juspay/kolu/fix/share-git-head-watcher
```

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._