### PR TITLE
[Kimi] refactor(git): share .git/HEAD watcher across terminals

### DIFF
--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -22,7 +22,8 @@ const DEBOUNCE_MS = 150;
 interface HeadWatcherEntry {
   watcher: fs.FSWatcher;
   listeners: Set<() => void>;
-  timer: ReturnType<typeof setTimeout> | undefined;
+  /** Cleanup function that clears any pending debounce timer and closes watcher. */
+  cleanup: () => void;
 }
 
 const sharedHeadWatchers = new Map<string, HeadWatcherEntry>();
@@ -187,7 +188,12 @@ export function watchGitHead(
       return () => {};
     }
 
-    entry = { watcher, listeners, timer };
+    const cleanup = (): void => {
+      if (timer) clearTimeout(timer);
+      watcher?.close();
+    };
+
+    entry = { watcher, listeners, cleanup };
     sharedHeadWatchers.set(gitDir, entry);
   }
 
@@ -197,10 +203,7 @@ export function watchGitHead(
     if (!entry) return;
     entry.listeners.delete(onChange);
     if (entry.listeners.size === 0) {
-      // Capture timer from closure before clearing entry reference
-      const activeTimer = entry.timer;
-      if (activeTimer) clearTimeout(activeTimer);
-      entry.watcher.close();
+      entry.cleanup();
       sharedHeadWatchers.delete(gitDir);
     }
   };

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -15,6 +15,18 @@ import type { GitInfo } from "./schemas.ts";
 
 const DEBOUNCE_MS = 150;
 
+/** Global registry of shared HEAD watchers keyed by absolute gitDir.
+ *  Mirrors the refcounted singleton pattern from createWalSubscription to
+ *  collapse N watchers on the same git dir to one fs.watch handle.
+ *  The cost per git operation scales with file watcher count, not terminal count. */
+interface HeadWatcherEntry {
+  watcher: fs.FSWatcher;
+  listeners: Set<() => void>;
+  timer: ReturnType<typeof setTimeout> | undefined;
+}
+
+const sharedHeadWatchers = new Map<string, HeadWatcherEntry>();
+
 /** Fast check: does a .git entry exist in this directory? (stat, not a git subprocess) */
 export function hasGitDir(cwd: string): boolean {
   try {
@@ -117,6 +129,10 @@ export async function resolveGitInfo(
 /**
  * Watch .git/HEAD for changes (branch switches, checkout, etc.).
  * Returns a cleanup function. Returns a no-op for non-git directories.
+ *
+ * Internally shares one `fs.watch` per git directory across all callers,
+ * collapsing N terminal subscriptions to the same repo into one handle.
+ * The debounce timer is also shared: all listeners fire after the same delay.
  */
 export function watchGitHead(
   cwd: string,
@@ -136,25 +152,57 @@ export function watchGitHead(
     return () => {};
   }
 
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let watcher: fs.FSWatcher | undefined;
-  try {
-    watcher = fs.watch(gitDir, (_, filename) => {
-      if (filename !== "HEAD") return;
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(onChange, DEBOUNCE_MS);
-    });
-  } catch (e) {
-    log?.debug(
-      { err: e instanceof Error ? e.message : String(e), gitDir },
-      "git: failed to watch git dir",
-    );
-    return () => {};
+  // Join an existing watcher or install a new one for this gitDir.
+  let entry = sharedHeadWatchers.get(gitDir);
+  if (!entry) {
+    const listeners = new Set<() => void>();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    let watcher: fs.FSWatcher | undefined;
+    try {
+      watcher = fs.watch(gitDir, (_, filename) => {
+        if (filename !== "HEAD") return;
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          // Snapshot before iteration so a listener that subscribes or
+          // unsubscribes synchronously can't skip a peer for this event.
+          for (const cb of [...listeners]) {
+            try {
+              cb();
+            } catch (err) {
+              // Fault isolation: one failing listener doesn't break others.
+              log?.error(
+                { err, gitDir },
+                "git: listener threw in watchGitHead",
+              );
+            }
+          }
+        }, DEBOUNCE_MS);
+      });
+    } catch (e) {
+      log?.debug(
+        { err: e instanceof Error ? e.message : String(e), gitDir },
+        "git: failed to watch git dir",
+      );
+      return () => {};
+    }
+
+    entry = { watcher, listeners, timer };
+    sharedHeadWatchers.set(gitDir, entry);
   }
 
+  entry.listeners.add(onChange);
+
   return () => {
-    if (timer) clearTimeout(timer);
-    watcher?.close();
+    if (!entry) return;
+    entry.listeners.delete(onChange);
+    if (entry.listeners.size === 0) {
+      // Capture timer from closure before clearing entry reference
+      const activeTimer = entry.timer;
+      if (activeTimer) clearTimeout(activeTimer);
+      entry.watcher.close();
+      sharedHeadWatchers.delete(gitDir);
+    }
   };
 }
 


### PR DESCRIPTION
**Multiple terminals in the same repository now share a single `fs.watch` handle on `.git/HEAD`.** Previously each terminal installed its own independent watcher, causing N duplicate callbacks and N-fold CPU burn per branch switch.

The implementation mirrors `createWalSubscription` in `anyagent`: a refcounted singleton keyed by resolved `gitDir`. First subscriber installs the watcher and debounce timer; subsequent callers join the listener set; last unsubscribe tears everything down.

After the change, the Watches diagnostic view shows one `git-head` row per unique repo with a collapsed subscription count — same pattern already used by `agent-external:*` watchers.

Closes #748.

> _Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `litellm/kimi-latest`)._