### PR TITLE
Log watcher install/retire across every long-lived fs.watch site

### DIFF
--- a/packages/integrations/anyagent/src/index.ts
+++ b/packages/integrations/anyagent/src/index.ts
@@ -19,6 +19,7 @@ export {
   TaskProgressSchema,
 } from "./schemas.ts";
 export { readTailLines, type TailReadConfig } from "./tail-lines.ts";
+export { logWatcherInstalled, logWatcherRetired } from "./watcher-events.ts";
 export {
   createWalSubscription,
   type WalSubscription,

--- a/packages/integrations/anyagent/src/wal-subscription.ts
+++ b/packages/integrations/anyagent/src/wal-subscription.ts
@@ -111,7 +111,6 @@ export function createWalSubscription(
       sharedWalWatcher = { cleanup, listeners };
       logWatcherInstalled(log, `${config.label}: wal`, {
         walPath: config.walPath,
-        label: config.label,
       });
     }
     const listener: WalListener = { cb: onChange, onError };
@@ -124,7 +123,6 @@ export function createWalSubscription(
         sharedWalWatcher = null;
         logWatcherRetired(log, `${config.label}: wal`, {
           walPath: config.walPath,
-          label: config.label,
         });
       }
     };

--- a/packages/integrations/anyagent/src/wal-subscription.ts
+++ b/packages/integrations/anyagent/src/wal-subscription.ts
@@ -108,6 +108,10 @@ export function createWalSubscription(
         log,
       );
       sharedWalWatcher = { cleanup, listeners };
+      log?.info(
+        { walPath: config.walPath, label: config.label },
+        `${config.label}: wal watcher installed`,
+      );
     }
     const listener: WalListener = { cb: onChange, onError };
     sharedWalWatcher.listeners.add(listener);
@@ -117,6 +121,10 @@ export function createWalSubscription(
       if (sharedWalWatcher.listeners.size === 0) {
         sharedWalWatcher.cleanup();
         sharedWalWatcher = null;
+        log?.info(
+          { walPath: config.walPath, label: config.label },
+          `${config.label}: wal watcher retired`,
+        );
       }
     };
   }

--- a/packages/integrations/anyagent/src/wal-subscription.ts
+++ b/packages/integrations/anyagent/src/wal-subscription.ts
@@ -31,6 +31,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { Logger } from "./index.ts";
+import { logWatcherInstalled, logWatcherRetired } from "./watcher-events.ts";
 
 /** Per-listener record tracked in the singleton's Set. */
 interface WalListener {
@@ -108,10 +109,10 @@ export function createWalSubscription(
         log,
       );
       sharedWalWatcher = { cleanup, listeners };
-      log?.info(
-        { walPath: config.walPath, label: config.label },
-        `${config.label}: wal watcher installed`,
-      );
+      logWatcherInstalled(log, `${config.label}: wal`, {
+        walPath: config.walPath,
+        label: config.label,
+      });
     }
     const listener: WalListener = { cb: onChange, onError };
     sharedWalWatcher.listeners.add(listener);
@@ -121,10 +122,10 @@ export function createWalSubscription(
       if (sharedWalWatcher.listeners.size === 0) {
         sharedWalWatcher.cleanup();
         sharedWalWatcher = null;
-        log?.info(
-          { walPath: config.walPath, label: config.label },
-          `${config.label}: wal watcher retired`,
-        );
+        logWatcherRetired(log, `${config.label}: wal`, {
+          walPath: config.walPath,
+          label: config.label,
+        });
       }
     };
   }

--- a/packages/integrations/anyagent/src/watcher-events.ts
+++ b/packages/integrations/anyagent/src/watcher-events.ts
@@ -1,0 +1,27 @@
+/**
+ * Lifecycle log helpers for long-lived `fs.watch` (or analogous)
+ * subscriptions. Centralizes the convention from PR #775 (the shared
+ * `.git/HEAD` watcher) so the format `<label> watcher installed/retired`
+ * lives in one place rather than being re-derived at each site.
+ *
+ * `label` names the specific watcher in operator log scans
+ * (e.g. `"git: head"`, `"claude-code: transcript"`, `"codex: wal"`).
+ */
+
+import type { Logger } from "./schemas.ts";
+
+export function logWatcherInstalled(
+  log: Logger | undefined,
+  label: string,
+  fields: Record<string, unknown>,
+): void {
+  log?.info(fields, `${label} watcher installed`);
+}
+
+export function logWatcherRetired(
+  log: Logger | undefined,
+  label: string,
+  fields: Record<string, unknown>,
+): void {
+  log?.info(fields, `${label} watcher retired`);
+}

--- a/packages/integrations/claude-code/src/agent-provider.ts
+++ b/packages/integrations/claude-code/src/agent-provider.ts
@@ -52,8 +52,8 @@ export const claudeCodeProvider: AgentProvider<SessionFile, ClaudeCodeInfo> = {
     isPresent(state) {
       return matchesAgent(state, "claude") || fs.existsSync(SESSIONS_DIR);
     },
-    install(onChange, onError) {
-      subscribeSessionsDir(onChange, onError);
+    install(onChange, onError, log) {
+      subscribeSessionsDir(onChange, onError, log);
     },
   },
 };

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -24,7 +24,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
-import { readTailLines } from "anyagent";
+import { type Logger, readTailLines } from "anyagent";
 import { match } from "ts-pattern";
 import type { ClaudeCodeInfo, TaskProgress } from "./schemas.ts";
 
@@ -380,15 +380,23 @@ export function deriveTaskProgress(
  * if watch failed. ENOENT (directory doesn't exist yet) is expected and
  * silent; other errors (EACCES, EMFILE, etc.) surface at debug so they're
  * discoverable without spamming the log.
+ *
+ * Mirrors `git: head watcher installed/retired` lifecycle logging so an
+ * operator can correlate watcher count against the events that opened
+ * each one.
  */
 export function tryWatchDir(
   dir: string,
   onChange: () => void,
-  log?: { debug: (obj: Record<string, unknown>, msg: string) => void },
+  log?: Logger,
 ): (() => void) | null {
   try {
     const w = fs.watch(dir, () => onChange());
-    return () => w.close();
+    log?.info({ dir }, "claude-code: dir watcher installed");
+    return () => {
+      w.close();
+      log?.info({ dir }, "claude-code: dir watcher retired");
+    };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
       log?.debug({ err, dir }, "fs.watch failed");
@@ -409,30 +417,36 @@ export function tryWatchDir(
 export function watchOrWaitForDir(
   dir: string,
   onChange: () => void,
-  log?: { debug: (obj: Record<string, unknown>, msg: string) => void },
+  log?: Logger,
 ): () => void {
   const direct = tryWatchDir(dir, onChange, log);
   if (direct) return direct;
 
   let child: (() => void) | null = null;
   let parentWatcher: fs.FSWatcher | null = null;
+  const parent = path.dirname(dir);
   try {
-    parentWatcher = fs.watch(path.dirname(dir), () => {
+    parentWatcher = fs.watch(parent, () => {
       if (child) return;
       const attached = tryWatchDir(dir, onChange, log);
       if (!attached) return;
       child = attached;
       parentWatcher?.close();
       parentWatcher = null;
+      log?.info({ dir, parent }, "claude-code: parent-dir watcher retired");
       // Kick — dir may already contain files (race: created between our
       // first attempt and the parent event).
       onChange();
     });
+    log?.info({ dir, parent }, "claude-code: parent-dir watcher installed");
   } catch (err) {
     log?.debug({ err, dir }, "fs.watch parent fallback failed");
   }
   return () => {
-    parentWatcher?.close();
+    if (parentWatcher) {
+      parentWatcher.close();
+      log?.info({ dir, parent }, "claude-code: parent-dir watcher retired");
+    }
     child?.();
   };
 }
@@ -479,20 +493,25 @@ let sharedSessionsDir: {
 export function subscribeSessionsDir(
   onChange: () => void,
   onError: (err: unknown) => void,
+  log?: Logger,
 ): () => void {
   if (!sharedSessionsDir) {
     const listeners = new Set<SessionsDirListener>();
-    const cleanup = watchOrWaitForDir(SESSIONS_DIR, () => {
-      // Snapshot before iteration so a listener that subscribes or
-      // unsubscribes synchronously can't skip a peer for this event.
-      for (const l of [...listeners]) {
-        try {
-          l.cb();
-        } catch (err) {
-          l.onError(err);
+    const cleanup = watchOrWaitForDir(
+      SESSIONS_DIR,
+      () => {
+        // Snapshot before iteration so a listener that subscribes or
+        // unsubscribes synchronously can't skip a peer for this event.
+        for (const l of [...listeners]) {
+          try {
+            l.cb();
+          } catch (err) {
+            l.onError(err);
+          }
         }
-      }
-    });
+      },
+      log,
+    );
     sharedSessionsDir = { cleanup, listeners };
   }
   const listener: SessionsDirListener = { cb: onChange, onError };

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -24,7 +24,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
-import { type Logger, readTailLines } from "anyagent";
+import {
+  type Logger,
+  logWatcherInstalled,
+  logWatcherRetired,
+  readTailLines,
+} from "anyagent";
 import { match } from "ts-pattern";
 import type { ClaudeCodeInfo, TaskProgress } from "./schemas.ts";
 
@@ -392,10 +397,10 @@ export function tryWatchDir(
 ): (() => void) | null {
   try {
     const w = fs.watch(dir, () => onChange());
-    log?.info({ dir }, "claude-code: dir watcher installed");
+    logWatcherInstalled(log, "claude-code: dir", { dir });
     return () => {
       w.close();
-      log?.info({ dir }, "claude-code: dir watcher retired");
+      logWatcherRetired(log, "claude-code: dir", { dir });
     };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -433,19 +438,19 @@ export function watchOrWaitForDir(
       child = attached;
       parentWatcher?.close();
       parentWatcher = null;
-      log?.info({ dir, parent }, "claude-code: parent-dir watcher retired");
+      logWatcherRetired(log, "claude-code: parent-dir", { dir, parent });
       // Kick — dir may already contain files (race: created between our
       // first attempt and the parent event).
       onChange();
     });
-    log?.info({ dir, parent }, "claude-code: parent-dir watcher installed");
+    logWatcherInstalled(log, "claude-code: parent-dir", { dir, parent });
   } catch (err) {
     log?.debug({ err, dir }, "fs.watch parent fallback failed");
   }
   return () => {
     if (parentWatcher) {
       parentWatcher.close();
-      log?.info({ dir, parent }, "claude-code: parent-dir watcher retired");
+      logWatcherRetired(log, "claude-code: parent-dir", { dir, parent });
     }
     child?.();
   };

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -116,7 +116,13 @@ export function createSessionWatcher(
     match(transcriptWatching)
       .with({ kind: "none" }, () => {})
       .with({ kind: "waiting" }, ({ dirWatcher }) => dirWatcher())
-      .with({ kind: "watching" }, ({ fileWatcher }) => fileWatcher.close())
+      .with({ kind: "watching" }, ({ path, fileWatcher }) => {
+        fileWatcher.close();
+        plog.info(
+          { path, session: session.sessionId },
+          "claude-code: transcript watcher retired",
+        );
+      })
       .exhaustive();
     transcriptWatching = { kind: "none" };
   }
@@ -139,6 +145,10 @@ export function createSessionWatcher(
     try {
       const fileWatcher = fs.watch(tp, () => scheduleTranscriptCheck());
       transcriptWatching = { kind: "watching", path: tp, fileWatcher };
+      plog.info(
+        { path: tp, session: session.sessionId },
+        "claude-code: transcript watcher installed",
+      );
     } catch (err) {
       plog.error({ err, path: tp }, "failed to watch transcript");
       transcriptWatching = { kind: "none" };
@@ -158,8 +168,10 @@ export function createSessionWatcher(
       "transcript not found yet (JSONL created after first message)",
     );
     const projectDir = `${PROJECTS_DIR}/${encodeProjectPath(session.cwd)}`;
-    const dirWatcher = watchOrWaitForDir(projectDir, () =>
-      onProjectDirChanged(),
+    const dirWatcher = watchOrWaitForDir(
+      projectDir,
+      () => onProjectDirChanged(),
+      plog,
     );
     transcriptWatching = { kind: "waiting", dirWatcher };
   }

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -10,7 +10,11 @@
  */
 
 import fs from "node:fs";
-import { agentInfoEqual } from "anyagent";
+import {
+  agentInfoEqual,
+  logWatcherInstalled,
+  logWatcherRetired,
+} from "anyagent";
 import { match } from "ts-pattern";
 import {
   deriveState,
@@ -118,10 +122,10 @@ export function createSessionWatcher(
       .with({ kind: "waiting" }, ({ dirWatcher }) => dirWatcher())
       .with({ kind: "watching" }, ({ path, fileWatcher }) => {
         fileWatcher.close();
-        plog.info(
-          { path, session: session.sessionId },
-          "claude-code: transcript watcher retired",
-        );
+        logWatcherRetired(plog, "claude-code: transcript", {
+          path,
+          session: session.sessionId,
+        });
       })
       .exhaustive();
     transcriptWatching = { kind: "none" };
@@ -145,10 +149,10 @@ export function createSessionWatcher(
     try {
       const fileWatcher = fs.watch(tp, () => scheduleTranscriptCheck());
       transcriptWatching = { kind: "watching", path: tp, fileWatcher };
-      plog.info(
-        { path: tp, session: session.sessionId },
-        "claude-code: transcript watcher installed",
-      );
+      logWatcherInstalled(plog, "claude-code: transcript", {
+        path: tp,
+        session: session.sessionId,
+      });
     } catch (err) {
       plog.error({ err, path: tp }, "failed to watch transcript");
       transcriptWatching = { kind: "none" };

--- a/packages/integrations/codex/src/session-watcher.ts
+++ b/packages/integrations/codex/src/session-watcher.ts
@@ -172,6 +172,7 @@ export function createCodexWatcher(
     (err) => log?.error({ err, session: session.id }, "wal listener threw"),
     log,
   );
+  log?.info({ session: session.id }, "codex: session watcher installed");
   refresh();
 
   return {
@@ -184,6 +185,7 @@ export function createCodexWatcher(
       }
       unsubscribe();
       db?.close();
+      log?.info({ session: session.id }, "codex: session watcher retired");
     },
   };
 }

--- a/packages/integrations/codex/src/session-watcher.ts
+++ b/packages/integrations/codex/src/session-watcher.ts
@@ -20,7 +20,12 @@
 import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import type { Logger } from "anyagent";
-import { agentInfoEqual, readTailLines } from "anyagent";
+import {
+  agentInfoEqual,
+  logWatcherInstalled,
+  logWatcherRetired,
+  readTailLines,
+} from "anyagent";
 import {
   type CodexSession,
   getThreadMetadata,
@@ -172,7 +177,7 @@ export function createCodexWatcher(
     (err) => log?.error({ err, session: session.id }, "wal listener threw"),
     log,
   );
-  log?.info({ session: session.id }, "codex: session watcher installed");
+  logWatcherInstalled(log, "codex: session", { session: session.id });
   refresh();
 
   return {
@@ -185,7 +190,7 @@ export function createCodexWatcher(
       }
       unsubscribe();
       db?.close();
-      log?.info({ session: session.id }, "codex: session watcher retired");
+      logWatcherRetired(log, "codex: session", { session: session.id });
     },
   };
 }

--- a/packages/integrations/git/src/head-watcher.ts
+++ b/packages/integrations/git/src/head-watcher.ts
@@ -16,7 +16,7 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import type { Logger } from "anyagent";
+import { type Logger, logWatcherInstalled, logWatcherRetired } from "anyagent";
 
 const DEBOUNCE_MS = 150;
 
@@ -68,7 +68,7 @@ function installSharedHeadWatcher(
     );
     return null;
   }
-  log?.info({ gitDir }, "git: head watcher installed");
+  logWatcherInstalled(log, "git: head", { gitDir });
 
   return {
     subscribe(onChange) {
@@ -85,7 +85,7 @@ function installSharedHeadWatcher(
           if (timer) clearTimeout(timer);
           watcher.close();
           onLast();
-          log?.info({ gitDir }, "git: head watcher retired");
+          logWatcherRetired(log, "git: head", { gitDir });
         }
       };
     },

--- a/packages/integrations/opencode/src/session-watcher.ts
+++ b/packages/integrations/opencode/src/session-watcher.ts
@@ -140,6 +140,7 @@ export function createOpenCodeWatcher(
     (err) => log?.error({ err, session: session.id }, "wal listener threw"),
     log,
   );
+  log?.info({ session: session.id }, "opencode: session watcher installed");
   refresh();
 
   return {
@@ -152,6 +153,7 @@ export function createOpenCodeWatcher(
       }
       unsubscribe();
       db?.close();
+      log?.info({ session: session.id }, "opencode: session watcher retired");
     },
   };
 }

--- a/packages/integrations/opencode/src/session-watcher.ts
+++ b/packages/integrations/opencode/src/session-watcher.ts
@@ -13,7 +13,11 @@
 
 import type { DatabaseSync } from "node:sqlite";
 import type { Logger } from "anyagent";
-import { agentInfoEqual } from "anyagent";
+import {
+  agentInfoEqual,
+  logWatcherInstalled,
+  logWatcherRetired,
+} from "anyagent";
 import {
   deriveSessionState,
   getLatestAssistantContextTokens,
@@ -140,7 +144,7 @@ export function createOpenCodeWatcher(
     (err) => log?.error({ err, session: session.id }, "wal listener threw"),
     log,
   );
-  log?.info({ session: session.id }, "opencode: session watcher installed");
+  logWatcherInstalled(log, "opencode: session", { session: session.id });
   refresh();
 
   return {
@@ -153,7 +157,7 @@ export function createOpenCodeWatcher(
       }
       unsubscribe();
       db?.close();
-      log?.info({ session: session.id }, "opencode: session watcher retired");
+      logWatcherRetired(log, "opencode: session", { session: session.id });
     },
   };
 }


### PR DESCRIPTION
**Every long-lived `fs.watch` in the codebase now emits info-level lifecycle logs**, mirroring the `git: head watcher installed/retired` convention from #775. Previously only the shared `.git/HEAD` watcher logged its install/retire boundary — five other watcher families fired silently, making it hard to correlate "watcher count climbed" against "what triggered it" in an operator log scan.

### Sites covered

| Watcher | Label in logs | Granularity |
| --- | --- | --- |
| `git/head-watcher.ts` | `git: head` | refcounted singleton (existing — migrated to helper) |
| `anyagent/wal-subscription.ts` | `<integration>: wal` | refcounted singleton (covers codex + opencode) |
| `claude-code/core.ts` `tryWatchDir` | `claude-code: dir` | one-shot dir watcher |
| `claude-code/core.ts` `watchOrWaitForDir` | `claude-code: parent-dir` | parent-dir fallback layer |
| `claude-code/session-watcher.ts` | `claude-code: transcript` | per-session JSONL |
| `codex/session-watcher.ts` | `codex: session` | per-session WAL+JSONL |
| `opencode/session-watcher.ts` | `opencode: session` | per-session WAL |

The format `<label> watcher installed/retired` is centralized in a new `logWatcherInstalled` / `logWatcherRetired` helper in `anyagent/src/watcher-events.ts` so a future format change is one edit instead of ten.

### Architectural ripples

Two small surface-area changes were needed to plumb a logger to sites that previously had none:

- `tryWatchDir` / `watchOrWaitForDir` had a narrow `{ debug: ... }` logger param; broadened to anyagent's `Logger` so `info` is callable.
- `subscribeSessionsDir` gained an optional `log?: Logger` argument. The `claudeCodeProvider`'s `install` callback (which already receives `log` from the orchestrator) forwards it through.

### Followups

> The hickey/lowy review surfaced two genuinely-out-of-scope refactors — extracting a shared debounce-watcher factory across codex+opencode session-watchers, and splitting "watch a dir" from "emit lifecycle events" in `tryWatchDir`. Tracked in #781 rather than coupled to this PR's logging-only scope.

Closes #778.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._