### PR TITLE
Clear stale Code tab browse selections

### DIFF
--- a/.agents/skills/do/SKILL.md
+++ b/.agents/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: Do a task end-to-end — implement, PR, CI loop, ship
+description: Do a task end-to-end — implement, PR, CI loop, ship. ONLY invoke when the user explicitly types `/do` or `$do`; never auto-select from a natural-language request, even one that sounds like an end-to-end task.
 argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <step>] [--review-model=<opus|sonnet|haiku>]"
 ---
 
@@ -59,6 +59,8 @@ Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a 
 ```
 sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
 ```
+
+**Emit all `TaskCreate` calls as parallel `tool_use` blocks in a single assistant turn** — one model round-trip, not one per task. The seeded steps have no `addBlocks` / `addBlockedBy` dependencies, so there is nothing to serialize on. Sequential seeding (15 round-trips before any real work) is a regression: it adds latency to every `/do` invocation and clutters the transcript with 15 wrapper turns of "Task #N created successfully" before `sync` even starts.
 
 **Under `--minimal`, omit the four steps the flag skips** (`docs`, `hickey+lowy`, `police`, `evidence`) from the seeded list — the user explicitly opted out of them, so they shouldn't clutter the human-facing checklist. The seeded list becomes 11 items in `--minimal` runs. (Run-inherent skips like `--no-git` and forge skips stay in the list — see the Skipped steps rule below.)
 

--- a/.agents/skills/ralph/SKILL.md
+++ b/.agents/skills/ralph/SKILL.md
@@ -21,7 +21,7 @@ Use `AskUserQuestion` to collect:
 - Create a feature branch and **draft PR** early (load `forge-pr` skill for title/body). PR description includes a measurements table updated as cycles complete.
 - **Baseline**: measure at least 5 runs, report **median**. For time: distinguish cold (no cache) from hot (cached). Document methodology.
 - Create `docs/<target>-ralph-report.md` with baseline, methodology, optimization log table, and findings.
-- Seed `TaskCreate` list with N cycle tasks.
+- Seed `TaskCreate` list with N cycle tasks — emit all calls as parallel `tool_use` blocks in a single assistant turn so the seed is one model round-trip, not N.
 
 ## 2. The loop
 

--- a/.agents/skills/talk/SKILL.md
+++ b/.agents/skills/talk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: talk
-description: Enter talk mode — conversation and research, no repo changes
+description: Enter talk mode — conversation and research, no repo changes. ONLY invoke when the user explicitly types `/talk` or `$talk`; never auto-select from a natural-language question or design discussion.
 argument-hint: "[--no-laconic] [--review-model=<opus|sonnet|haiku>] <topic or question>"
 ---
 
@@ -78,15 +78,18 @@ This applies only to user-visible feature work. Refactors, internal scaffolding,
 
 Use `AskUserQuestion` to collaborate on the cut: propose your split, surface the trade-offs of each phase boundary (what does phase 1 alone give the user? what does deferring phase 3 cost?), and let the user adjust before they invoke `do`.
 
-## Auto-Lowy
+## Auto-review (Lowy + Hickey)
 
-Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `lowy` sub-agent on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold its findings into the recommendation (flag boundaries that track functionality instead of volatility, flag where a seam would cleanly encapsulate an axis of change) rather than dumping raw sub-agent output on top. Use `Agent(subagent_type="lowy")`, not the `Skill` tool — the sub-agent runs in an isolated context and keeps the main turn lean.
+Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke both the `lowy` and `hickey` sub-agents on that proposal in parallel before presenting your final recommendation** — do not wait for the user to ask. Use `Agent(subagent_type="lowy")` and `Agent(subagent_type="hickey")` (not the `Skill` tool) so each runs in an isolated context and keeps the main turn lean.
 
-Hickey's complecting critique deliberately does **not** run here. It needs a concrete diff to bite — running it on a sketch tends to surface generic concerns rather than the specific interleavings that matter. `do` runs hickey post-implement on the real diff. Talk mode sticks with Lowy because volatility-based decomposition is the design-level lens that's useful while the design is still a sketch.
+**Revise the recommendation in light of their findings before presenting it.** Invoking the reviewers is not the deliverable — the deliverable is a *post-review* proposal whose shape already reflects what landed. Concretely: when a finding lands (real complecting, fragmentation, or a missing volatility seam), change the design itself — don't tack the finding onto an unchanged sketch as a critique section the user has to reconcile. When a finding doesn't land, say briefly why. The headline the user reads should be the revised proposal, with the reviewer pass evident in what changed (and what was rejected), not the original sketch with raw sub-agent output appended.
 
-Skip the Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
+- **Lowy** flags boundaries that track functionality instead of volatility and where a seam would cleanly encapsulate an axis of change.
+- **Hickey** flags structural complecting and fragmentation — concept multiplication, sum-types-as-parallel-fields, hidden coupling at OS or shared-state layers, and the rest of the Layer 3-4 catalog. Hickey on a sketch can drift toward generic critique; in your prompt, instruct it to either land specific complecting/fragmentation risks in *this* sketch or say explicitly that there's nothing yet to bite into. Generic principles are not findings. Layer 5 (entanglement counts) and the diff-shaped Actions table will be thin on a sketch — that's expected; the design-level layers are the ones that bite here.
 
-**Model override.** If `ARGUMENTS` contains `--review-model=<model>` (accept `opus`, `sonnet`, or `haiku`; strip the flag before treating the rest as the topic), pass `model: "<model>"` in the `Agent(subagent_type="lowy")` call. This overrides the `model: sonnet` in `lowy`'s agent frontmatter via the `Agent` tool's built-in `model` parameter. Without the flag, omit `model` so the default (sonnet) applies. Reject unknown values with a one-line error instead of silently falling back — a typo shouldn't quietly erase a budget decision.
+Skip both passes only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run them. `do` re-runs hickey + lowy post-implement on the real diff, so the talk-mode pass is the design-level rehearsal, not the final word.
+
+**Model override.** If `ARGUMENTS` contains `--review-model=<model>` (accept `opus`, `sonnet`, or `haiku`; strip the flag before treating the rest as the topic), pass `model: "<model>"` in **both** the `Agent(subagent_type="lowy")` and `Agent(subagent_type="hickey")` calls. This overrides the `model: sonnet` in each sub-agent's frontmatter via the `Agent` tool's built-in `model` parameter. Without the flag, omit `model` so the default (sonnet) applies. Reject unknown values with a one-line error instead of silently falling back — a typo shouldn't quietly erase a budget decision.
 
 ## Laconic mode (default)
 

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: Do a task end-to-end — implement, PR, CI loop, ship
+description: Do a task end-to-end — implement, PR, CI loop, ship. ONLY invoke when the user explicitly types `/do` or `$do`; never auto-select from a natural-language request, even one that sounds like an end-to-end task.
 argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <step>] [--review-model=<opus|sonnet|haiku>]"
 ---
 
@@ -59,6 +59,8 @@ Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a 
 ```
 sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
 ```
+
+**Emit all `TaskCreate` calls as parallel `tool_use` blocks in a single assistant turn** — one model round-trip, not one per task. The seeded steps have no `addBlocks` / `addBlockedBy` dependencies, so there is nothing to serialize on. Sequential seeding (15 round-trips before any real work) is a regression: it adds latency to every `/do` invocation and clutters the transcript with 15 wrapper turns of "Task #N created successfully" before `sync` even starts.
 
 **Under `--minimal`, omit the four steps the flag skips** (`docs`, `hickey+lowy`, `police`, `evidence`) from the seeded list — the user explicitly opted out of them, so they shouldn't clutter the human-facing checklist. The seeded list becomes 11 items in `--minimal` runs. (Run-inherent skips like `--no-git` and forge skips stay in the list — see the Skipped steps rule below.)
 

--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -21,7 +21,7 @@ Use `AskUserQuestion` to collect:
 - Create a feature branch and **draft PR** early (load `forge-pr` skill for title/body). PR description includes a measurements table updated as cycles complete.
 - **Baseline**: measure at least 5 runs, report **median**. For time: distinguish cold (no cache) from hot (cached). Document methodology.
 - Create `docs/<target>-ralph-report.md` with baseline, methodology, optimization log table, and findings.
-- Seed `TaskCreate` list with N cycle tasks.
+- Seed `TaskCreate` list with N cycle tasks — emit all calls as parallel `tool_use` blocks in a single assistant turn so the seed is one model round-trip, not N.
 
 ## 2. The loop
 

--- a/.claude/skills/talk/SKILL.md
+++ b/.claude/skills/talk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: talk
-description: Enter talk mode — conversation and research, no repo changes
+description: Enter talk mode — conversation and research, no repo changes. ONLY invoke when the user explicitly types `/talk` or `$talk`; never auto-select from a natural-language question or design discussion.
 argument-hint: "[--no-laconic] [--review-model=<opus|sonnet|haiku>] <topic or question>"
 ---
 
@@ -78,15 +78,18 @@ This applies only to user-visible feature work. Refactors, internal scaffolding,
 
 Use `AskUserQuestion` to collaborate on the cut: propose your split, surface the trade-offs of each phase boundary (what does phase 1 alone give the user? what does deferring phase 3 cost?), and let the user adjust before they invoke `do`.
 
-## Auto-Lowy
+## Auto-review (Lowy + Hickey)
 
-Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `lowy` sub-agent on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold its findings into the recommendation (flag boundaries that track functionality instead of volatility, flag where a seam would cleanly encapsulate an axis of change) rather than dumping raw sub-agent output on top. Use `Agent(subagent_type="lowy")`, not the `Skill` tool — the sub-agent runs in an isolated context and keeps the main turn lean.
+Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke both the `lowy` and `hickey` sub-agents on that proposal in parallel before presenting your final recommendation** — do not wait for the user to ask. Use `Agent(subagent_type="lowy")` and `Agent(subagent_type="hickey")` (not the `Skill` tool) so each runs in an isolated context and keeps the main turn lean.
 
-Hickey's complecting critique deliberately does **not** run here. It needs a concrete diff to bite — running it on a sketch tends to surface generic concerns rather than the specific interleavings that matter. `do` runs hickey post-implement on the real diff. Talk mode sticks with Lowy because volatility-based decomposition is the design-level lens that's useful while the design is still a sketch.
+**Revise the recommendation in light of their findings before presenting it.** Invoking the reviewers is not the deliverable — the deliverable is a *post-review* proposal whose shape already reflects what landed. Concretely: when a finding lands (real complecting, fragmentation, or a missing volatility seam), change the design itself — don't tack the finding onto an unchanged sketch as a critique section the user has to reconcile. When a finding doesn't land, say briefly why. The headline the user reads should be the revised proposal, with the reviewer pass evident in what changed (and what was rejected), not the original sketch with raw sub-agent output appended.
 
-Skip the Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
+- **Lowy** flags boundaries that track functionality instead of volatility and where a seam would cleanly encapsulate an axis of change.
+- **Hickey** flags structural complecting and fragmentation — concept multiplication, sum-types-as-parallel-fields, hidden coupling at OS or shared-state layers, and the rest of the Layer 3-4 catalog. Hickey on a sketch can drift toward generic critique; in your prompt, instruct it to either land specific complecting/fragmentation risks in *this* sketch or say explicitly that there's nothing yet to bite into. Generic principles are not findings. Layer 5 (entanglement counts) and the diff-shaped Actions table will be thin on a sketch — that's expected; the design-level layers are the ones that bite here.
 
-**Model override.** If `ARGUMENTS` contains `--review-model=<model>` (accept `opus`, `sonnet`, or `haiku`; strip the flag before treating the rest as the topic), pass `model: "<model>"` in the `Agent(subagent_type="lowy")` call. This overrides the `model: sonnet` in `lowy`'s agent frontmatter via the `Agent` tool's built-in `model` parameter. Without the flag, omit `model` so the default (sonnet) applies. Reject unknown values with a one-line error instead of silently falling back — a typo shouldn't quietly erase a budget decision.
+Skip both passes only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run them. `do` re-runs hickey + lowy post-implement on the real diff, so the talk-mode pass is the design-level rehearsal, not the final word.
+
+**Model override.** If `ARGUMENTS` contains `--review-model=<model>` (accept `opus`, `sonnet`, or `haiku`; strip the flag before treating the rest as the topic), pass `model: "<model>"` in **both** the `Agent(subagent_type="lowy")` and `Agent(subagent_type="hickey")` calls. This overrides the `model: sonnet` in each sub-agent's frontmatter via the `Agent` tool's built-in `model` parameter. Without the flag, omit `model` so the default (sonnet) applies. Reject unknown values with a one-line error instead of silently falling back — a typo shouldn't quietly erase a budget decision.
 
 ## Laconic mode (default)
 

--- a/.opencode/skills/do/SKILL.md
+++ b/.opencode/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: Do a task end-to-end — implement, PR, CI loop, ship
+description: Do a task end-to-end — implement, PR, CI loop, ship. ONLY invoke when the user explicitly types `/do` or `$do`; never auto-select from a natural-language request, even one that sounds like an end-to-end task.
 argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <step>] [--review-model=<opus|sonnet|haiku>]"
 ---
 
@@ -59,6 +59,8 @@ Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a 
 ```
 sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
 ```
+
+**Emit all `TaskCreate` calls as parallel `tool_use` blocks in a single assistant turn** — one model round-trip, not one per task. The seeded steps have no `addBlocks` / `addBlockedBy` dependencies, so there is nothing to serialize on. Sequential seeding (15 round-trips before any real work) is a regression: it adds latency to every `/do` invocation and clutters the transcript with 15 wrapper turns of "Task #N created successfully" before `sync` even starts.
 
 **Under `--minimal`, omit the four steps the flag skips** (`docs`, `hickey+lowy`, `police`, `evidence`) from the seeded list — the user explicitly opted out of them, so they shouldn't clutter the human-facing checklist. The seeded list becomes 11 items in `--minimal` runs. (Run-inherent skips like `--no-git` and forge skips stay in the list — see the Skipped steps rule below.)
 

--- a/.opencode/skills/ralph/SKILL.md
+++ b/.opencode/skills/ralph/SKILL.md
@@ -21,7 +21,7 @@ Use `AskUserQuestion` to collect:
 - Create a feature branch and **draft PR** early (load `forge-pr` skill for title/body). PR description includes a measurements table updated as cycles complete.
 - **Baseline**: measure at least 5 runs, report **median**. For time: distinguish cold (no cache) from hot (cached). Document methodology.
 - Create `docs/<target>-ralph-report.md` with baseline, methodology, optimization log table, and findings.
-- Seed `TaskCreate` list with N cycle tasks.
+- Seed `TaskCreate` list with N cycle tasks — emit all calls as parallel `tool_use` blocks in a single assistant turn so the seed is one model round-trip, not N.
 
 ## 2. The loop
 

--- a/.opencode/skills/talk/SKILL.md
+++ b/.opencode/skills/talk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: talk
-description: Enter talk mode — conversation and research, no repo changes
+description: Enter talk mode — conversation and research, no repo changes. ONLY invoke when the user explicitly types `/talk` or `$talk`; never auto-select from a natural-language question or design discussion.
 argument-hint: "[--no-laconic] [--review-model=<opus|sonnet|haiku>] <topic or question>"
 ---
 
@@ -78,15 +78,18 @@ This applies only to user-visible feature work. Refactors, internal scaffolding,
 
 Use `AskUserQuestion` to collaborate on the cut: propose your split, surface the trade-offs of each phase boundary (what does phase 1 alone give the user? what does deferring phase 3 cost?), and let the user adjust before they invoke `do`.
 
-## Auto-Lowy
+## Auto-review (Lowy + Hickey)
 
-Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `lowy` sub-agent on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold its findings into the recommendation (flag boundaries that track functionality instead of volatility, flag where a seam would cleanly encapsulate an axis of change) rather than dumping raw sub-agent output on top. Use `Agent(subagent_type="lowy")`, not the `Skill` tool — the sub-agent runs in an isolated context and keeps the main turn lean.
+Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke both the `lowy` and `hickey` sub-agents on that proposal in parallel before presenting your final recommendation** — do not wait for the user to ask. Use `Agent(subagent_type="lowy")` and `Agent(subagent_type="hickey")` (not the `Skill` tool) so each runs in an isolated context and keeps the main turn lean.
 
-Hickey's complecting critique deliberately does **not** run here. It needs a concrete diff to bite — running it on a sketch tends to surface generic concerns rather than the specific interleavings that matter. `do` runs hickey post-implement on the real diff. Talk mode sticks with Lowy because volatility-based decomposition is the design-level lens that's useful while the design is still a sketch.
+**Revise the recommendation in light of their findings before presenting it.** Invoking the reviewers is not the deliverable — the deliverable is a *post-review* proposal whose shape already reflects what landed. Concretely: when a finding lands (real complecting, fragmentation, or a missing volatility seam), change the design itself — don't tack the finding onto an unchanged sketch as a critique section the user has to reconcile. When a finding doesn't land, say briefly why. The headline the user reads should be the revised proposal, with the reviewer pass evident in what changed (and what was rejected), not the original sketch with raw sub-agent output appended.
 
-Skip the Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
+- **Lowy** flags boundaries that track functionality instead of volatility and where a seam would cleanly encapsulate an axis of change.
+- **Hickey** flags structural complecting and fragmentation — concept multiplication, sum-types-as-parallel-fields, hidden coupling at OS or shared-state layers, and the rest of the Layer 3-4 catalog. Hickey on a sketch can drift toward generic critique; in your prompt, instruct it to either land specific complecting/fragmentation risks in *this* sketch or say explicitly that there's nothing yet to bite into. Generic principles are not findings. Layer 5 (entanglement counts) and the diff-shaped Actions table will be thin on a sketch — that's expected; the design-level layers are the ones that bite here.
 
-**Model override.** If `ARGUMENTS` contains `--review-model=<model>` (accept `opus`, `sonnet`, or `haiku`; strip the flag before treating the rest as the topic), pass `model: "<model>"` in the `Agent(subagent_type="lowy")` call. This overrides the `model: sonnet` in `lowy`'s agent frontmatter via the `Agent` tool's built-in `model` parameter. Without the flag, omit `model` so the default (sonnet) applies. Reject unknown values with a one-line error instead of silently falling back — a typo shouldn't quietly erase a budget decision.
+Skip both passes only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run them. `do` re-runs hickey + lowy post-implement on the real diff, so the talk-mode pass is the design-level rehearsal, not the final word.
+
+**Model override.** If `ARGUMENTS` contains `--review-model=<model>` (accept `opus`, `sonnet`, or `haiku`; strip the flag before treating the rest as the topic), pass `model: "<model>"` in **both** the `Agent(subagent_type="lowy")` and `Agent(subagent_type="hickey")` calls. This overrides the `model: sonnet` in each sub-agent's frontmatter via the `Agent` tool's built-in `model` parameter. Without the flag, omit `model` so the default (sonnet) applies. Reject unknown values with a one-line error instead of silently falling back — a typo shouldn't quietly erase a budget decision.
 
 ## Laconic mode (default)
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-04-29T21:56:01.081901+00:00'
+generated_at: '2026-04-30T00:10:17.844100+00:00'
 apm_version: 0.11.0
 dependencies:
 - repo_url: anthropics/skills
@@ -87,7 +87,7 @@ dependencies:
     .codex/hooks/agency/scripts/do-stop-guard.sh: sha256:cb033f86c15ffd3d09d8e4b74a61f55a70def4cc4131cc013b7368a2d23f3f33
     .opencode/agents/hickey.md: sha256:edde9b0d3b27b947b7372f662b2e8652d136e0bb9af7924892b00450a1e586bc
     .opencode/agents/lowy.md: sha256:a1c8e5ba115439bcfa0d7e331f96e71b2d690ff2e5fb9b824bb5f588eb43ac75
-  content_hash: sha256:10015c9a03d6d705f0c826c8b0867295650206b21583c72aad22ee3da82b55e5
+  content_hash: sha256:acc88f797bd541518d9f16bede5c71c47feb4e5a571f3756eb2b3b21b0f742d3
 mcp_servers:
 - chrome-devtools
 mcp_configs:

--- a/apm.yml
+++ b/apm.yml
@@ -3,6 +3,7 @@ version: 1.0.0
 description: Terminal multiplexer with AI-native development workflow
 type: hybrid
 target: [claude, codex, opencode]
+includes: auto
 
 # Generated AGENTS.md files are runtime outputs, not source inputs. Excluding
 # them keeps distributed compilation from treating stale generated files as

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -132,6 +132,17 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const branchTooltip = () =>
     `Changes vs ${status()?.base?.ref ?? "branch base"}`;
 
+  // Live updates can remove the selected path from the current tree (file
+  // delete, branch checkout, commit/stage cleanup). Drop the selection once
+  // the tree has a fresh snapshot so the body cannot keep rendering stale
+  // content for a path that no longer exists in this view.
+  createEffect(() => {
+    const selected = selectedPath();
+    if (!selected) return;
+    if (!treeReady()) return;
+    if (!treePaths().includes(selected)) setSelectedPath(null);
+  });
+
   /** Diff value narrowed to "this is a pure-rename" (no hunks, both old +
    *  new file names present and different). Returning the full diff so the
    *  rendering Match can read its names without re-narrowing. */

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -91,21 +91,6 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     },
   );
 
-  const diff = createReactiveSubscription(
-    () => {
-      const p = repoPath();
-      const s = selectedPath();
-      const m = diffMode();
-      if (!p || !s || !m) return null;
-      const file = status()?.files.find((f) => f.path === s);
-      return { repoPath: p, filePath: s, mode: m, oldPath: file?.oldPath };
-    },
-    (input, signal) => stream.gitDiff(input, signal),
-    {
-      onError: (err) => toast.error(`Git diff stream: ${err.message}`),
-    },
-  );
-
   // Reset selection when the repo or view changes so a stale path doesn't
   // bleed across modes (e.g. a browse-mode pick showing up in diff mode).
   createEffect(
@@ -132,16 +117,27 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const branchTooltip = () =>
     `Changes vs ${status()?.base?.ref ?? "branch base"}`;
 
-  // Live updates can remove the selected path from the current tree (file
-  // delete, branch checkout, commit/stage cleanup). Drop the selection once
-  // the tree has a fresh snapshot so the body cannot keep rendering stale
-  // content for a path that no longer exists in this view.
-  createEffect(() => {
+  const selectedVisiblePath = createMemo(() => {
     const selected = selectedPath();
-    if (!selected) return;
-    if (!treeReady()) return;
-    if (!treePaths().includes(selected)) setSelectedPath(null);
+    if (!selected) return null;
+    if (!treeReady()) return null;
+    return treePaths().includes(selected) ? selected : null;
   });
+
+  const diff = createReactiveSubscription(
+    () => {
+      const p = repoPath();
+      const s = selectedVisiblePath();
+      const m = diffMode();
+      if (!p || !s || !m) return null;
+      const file = status()?.files.find((f) => f.path === s);
+      return { repoPath: p, filePath: s, mode: m, oldPath: file?.oldPath };
+    },
+    (input, signal) => stream.gitDiff(input, signal),
+    {
+      onError: (err) => toast.error(`Git diff stream: ${err.message}`),
+    },
+  );
 
   /** Diff value narrowed to "this is a pure-rename" (no hunks, both old +
    *  new file names present and different). Returning the full diff so the
@@ -245,7 +241,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                 <PierreFileTree
                   paths={treePaths()}
                   gitStatus={treeGitStatus()}
-                  selectedPath={selectedPath()}
+                  selectedPath={selectedVisiblePath()}
                   onSelect={handleSelect}
                   initialExpansion={isDiffView() ? "open" : "closed"}
                 />
@@ -256,7 +252,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
 
         <div class="flex-1 min-h-0 overflow-auto" data-testid="diff-content">
           <Show
-            when={selectedPath()}
+            when={selectedVisiblePath()}
             keyed
             fallback={
               <FileSelectHint

--- a/packages/integrations/git/src/browse.test.ts
+++ b/packages/integrations/git/src/browse.test.ts
@@ -1,8 +1,13 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { readFile } from "./browse.ts";
+import { listAll, readFile } from "./browse.ts";
+
+function git(cwd: string, args: string[]) {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
 
 describe("readFile", () => {
   let tmpDir: string;
@@ -38,5 +43,42 @@ describe("readFile", () => {
     if (!result.ok) {
       expect(result.error.code).toBe("GIT_FAILED");
     }
+  });
+});
+
+describe("listAll", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-listall-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("omits tracked files deleted from the worktree", async () => {
+    const repo = fs.mkdtempSync(path.join(tmpDir, "repo-"));
+    git(repo, ["init"]);
+    fs.writeFileSync(path.join(repo, "tracked.txt"), "stale\n");
+    git(repo, ["add", "tracked.txt"]);
+    git(repo, [
+      "-c",
+      "user.name=Kolu Test",
+      "-c",
+      "user.email=kolu@example.test",
+      "commit",
+      "-m",
+      "init",
+    ]);
+
+    fs.unlinkSync(path.join(repo, "tracked.txt"));
+    fs.writeFileSync(path.join(repo, "loose.txt"), "live\n");
+
+    const result = await listAll(repo);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toContain("loose.txt");
+    expect(result.value).not.toContain("tracked.txt");
   });
 });

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -3,7 +3,7 @@
  *  Uses `git ls-files` to enumerate tracked + untracked-but-not-ignored
  *  paths, then removes tracked paths deleted from the worktree. This avoids
  *  listing `node_modules/`, `.git/`, build artifacts, etc., while keeping the
- *  browse tree aligned with files that can actually be opened. */
+ *  browse tree aligned with files present in the working tree. */
 
 import { execFile } from "node:child_process";
 import { readFile as fsReadFile } from "node:fs/promises";
@@ -14,7 +14,7 @@ import { resolveUnder } from "./safe-path.ts";
 
 const execFileAsync = promisify(execFile);
 
-/** Flat list of every readable repo-relative path (tracked +
+/** Flat list of every present repo-relative path (tracked +
  *  untracked-but-not-ignored, excluding tracked files deleted from the
  *  worktree).
  *

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -1,8 +1,9 @@
 /** File tree browsing — git-filtered file listing and file reading.
  *
- *  Uses `git ls-files --cached --others --exclude-standard` to enumerate
- *  tracked + untracked-but-not-ignored paths in one shot. This avoids
- *  listing `node_modules/`, `.git/`, build artifacts, etc. */
+ *  Uses `git ls-files` to enumerate tracked + untracked-but-not-ignored
+ *  paths, then removes tracked paths deleted from the worktree. This avoids
+ *  listing `node_modules/`, `.git/`, build artifacts, etc., while keeping the
+ *  browse tree aligned with files that can actually be opened. */
 
 import { execFile } from "node:child_process";
 import { readFile as fsReadFile } from "node:fs/promises";
@@ -13,7 +14,10 @@ import { resolveUnder } from "./safe-path.ts";
 
 const execFileAsync = promisify(execFile);
 
-/** Flat list of every repo-relative path (tracked + untracked-but-not-ignored).
+/** Flat list of every readable repo-relative path (tracked +
+ *  untracked-but-not-ignored, excluding tracked files deleted from the
+ *  worktree).
+ *
  *  One-shot snapshot for Pierre's `@pierre/trees`, which builds the tree
  *  hierarchy itself from a flat path list.
  *
@@ -24,12 +28,23 @@ export async function listAll(
   log?: Logger,
 ): Promise<GitResult<string[]>> {
   try {
-    const { stdout } = await execFileAsync(
-      "git",
-      ["ls-files", "--cached", "--others", "--exclude-standard"],
-      { cwd: repoPath, maxBuffer: 64 * 1024 * 1024 },
+    const [{ stdout }, { stdout: deletedStdout }] = await Promise.all([
+      execFileAsync(
+        "git",
+        ["ls-files", "--cached", "--others", "--exclude-standard"],
+        { cwd: repoPath, maxBuffer: 64 * 1024 * 1024 },
+      ),
+      execFileAsync("git", ["ls-files", "--deleted"], {
+        cwd: repoPath,
+        maxBuffer: 64 * 1024 * 1024,
+      }),
+    ]);
+    const deletedPaths = new Set(
+      deletedStdout.split("\n").filter((l) => l.length > 0),
     );
-    const paths = stdout.split("\n").filter((l) => l.length > 0);
+    const paths = stdout
+      .split("\n")
+      .filter((l) => l.length > 0 && !deletedPaths.has(l));
     return ok(paths);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -218,3 +218,16 @@ Feature: Code tab (review + browse)
     When I click the terminal canvas
     And I run "printf 'second version\n' > letters.txt"
     Then the file content should contain "second version"
+
+  Scenario: Deleting the selected browse-mode file clears stale content
+    When I run "git init /tmp/kolu-live-browse-delete && cd /tmp/kolu-live-browse-delete"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'stale content\n' > scratch.txt"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    And I click the file "scratch.txt" in the file browser
+    Then the file content should contain "stale content"
+    When I click the terminal canvas
+    And I run "rm scratch.txt"
+    Then the file browser should not show a file "scratch.txt"
+    And the file content should not contain "stale content"

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -220,9 +220,9 @@ Feature: Code tab (review + browse)
     Then the file content should contain "second version"
 
   Scenario: Deleting the selected browse-mode file clears stale content
-    When I run "git init /tmp/kolu-live-browse-delete && cd /tmp/kolu-live-browse-delete"
-    And I run "git commit --allow-empty -m init"
+    When I run "rm -rf /tmp/kolu-live-browse-delete && git init /tmp/kolu-live-browse-delete && cd /tmp/kolu-live-browse-delete"
     And I run "printf 'stale content\n' > scratch.txt"
+    And I run "git add scratch.txt && git commit -m init"
     And I click the Code tab
     And I click the Code tab mode "browse"
     And I click the file "scratch.txt" in the file browser

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -292,6 +292,14 @@ Then(
   },
 );
 
+Then(
+  "the file browser should not show a file {string}",
+  async function (this: KoluWorld, path: string) {
+    const item = this.page.locator(fileRow(path));
+    await item.waitFor({ state: "detached", timeout: POLL_TIMEOUT });
+  },
+);
+
 // Pierre's File / FileDiff renderers mount highlighted code inside a
 // shadow root. `Element.textContent` does NOT cross shadow boundaries,
 // so we walk the tree (including each `shadowRoot`) and stitch the text.
@@ -323,10 +331,43 @@ async function waitForViewText(
   );
 }
 
+async function waitForViewTextAbsent(
+  world: KoluWorld,
+  testid: string,
+  unexpected: string,
+) {
+  await world.page.waitForFunction(
+    `(() => {
+      const root = document.querySelector('[data-testid="${testid}"]');
+      if (!root) return true;
+      const stack = [root];
+      let text = '';
+      while (stack.length) {
+        const node = stack.pop();
+        if (node.nodeType === 3) text += node.nodeValue || '';
+        if (node.nodeType === 1) {
+          if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
+          for (const ch of node.childNodes) stack.push(ch);
+        }
+      }
+      return !text.includes(${JSON.stringify(unexpected)});
+    })()`,
+    undefined,
+    { timeout: POLL_TIMEOUT },
+  );
+}
+
 Then(
   "the file content should contain {string}",
   async function (this: KoluWorld, expected: string) {
     await waitForViewText(this, "pierre-file-view", expected);
+  },
+);
+
+Then(
+  "the file content should not contain {string}",
+  async function (this: KoluWorld, unexpected: string) {
+    await waitForViewTextAbsent(this, "pierre-file-view", unexpected);
   },
 );
 

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -305,15 +305,20 @@ Then(
 // so we walk the tree (including each `shadowRoot`) and stitch the text.
 // Inlined as a string-evaluate to dodge tsx's `__name` injection, which
 // crashes inside `page.evaluate` arg functions.
-async function waitForViewText(
+async function waitForViewTextPresence(
   world: KoluWorld,
   testid: string,
-  expected: string,
+  needle: string,
+  shouldContain: boolean,
 ) {
+  const missingRootResult = shouldContain ? "false" : "true";
+  const textPredicate = shouldContain
+    ? `text.includes(${JSON.stringify(needle)})`
+    : `!text.includes(${JSON.stringify(needle)})`;
   await world.page.waitForFunction(
     `(() => {
       const root = document.querySelector('[data-testid="${testid}"]');
-      if (!root) return false;
+      if (!root) return ${missingRootResult};
       const stack = [root];
       let text = '';
       while (stack.length) {
@@ -324,11 +329,19 @@ async function waitForViewText(
           for (const ch of node.childNodes) stack.push(ch);
         }
       }
-      return text.includes(${JSON.stringify(expected)});
+      return ${textPredicate};
     })()`,
     undefined,
     { timeout: POLL_TIMEOUT },
   );
+}
+
+async function waitForViewText(
+  world: KoluWorld,
+  testid: string,
+  expected: string,
+) {
+  await waitForViewTextPresence(world, testid, expected, true);
 }
 
 async function waitForViewTextAbsent(
@@ -336,25 +349,7 @@ async function waitForViewTextAbsent(
   testid: string,
   unexpected: string,
 ) {
-  await world.page.waitForFunction(
-    `(() => {
-      const root = document.querySelector('[data-testid="${testid}"]');
-      if (!root) return true;
-      const stack = [root];
-      let text = '';
-      while (stack.length) {
-        const node = stack.pop();
-        if (node.nodeType === 3) text += node.nodeValue || '';
-        if (node.nodeType === 1) {
-          if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
-          for (const ch of node.childNodes) stack.push(ch);
-        }
-      }
-      return !text.includes(${JSON.stringify(unexpected)});
-    })()`,
-    undefined,
-    { timeout: POLL_TIMEOUT },
-  );
+  await waitForViewTextPresence(world, testid, unexpected, false);
 }
 
 Then(


### PR DESCRIPTION
**Browse mode now drops selected-file content when the live file tree no longer has that path.** After #786, the Code tab auto-refreshed its tree, but a selected browse file could keep rendering stale content after deletion because the file-content stream retained its last successful snapshot.

The fix makes the renderable selection derive from the current tree and keeps the browse listing aligned with files present in the working tree. *Tracked files deleted from disk are removed from All mode, so the body cannot keep showing their old contents.*

### Details

- `selectedVisiblePath` gates tree selection, diff subscription input, and the content body.
- Browse listing subtracts `git ls-files --deleted` from the tracked/untracked path list.
- The e2e scenario deletes a committed selected file, and `kolu-git` has a unit test for the tracked-delete listing case.
- Pierre shadow-DOM content assertions now share one polling helper for contains/not-contains checks.
- CI required refreshing the `srid/agency` APM lock and declaring `includes: auto`; that is isolated in the final commit.

### Verification

```sh
nix develop --accept-flake-config -c pnpm --filter kolu-git test:unit -- browse.test.ts
nix develop --accept-flake-config -c pnpm --filter kolu-client typecheck
nix develop --accept-flake-config -c pnpm --filter kolu-git typecheck
CUCUMBER_PARALLEL=1 just test-quick features/code-tab.feature
just ai::apm-sync
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._