### PR TITLE
fix: silence GitHub PR warning for repos with no remote

### DIFF
--- a/packages/integrations/github/src/github.test.ts
+++ b/packages/integrations/github/src/github.test.ts
@@ -174,6 +174,15 @@ describe("classifyGhError", () => {
     ).toEqual({ kind: "absent" });
   });
 
+  it("classifies gh's 'no git remotes found' as absent", () => {
+    expect(
+      classifyGhError({
+        code: 1,
+        stderr: "no git remotes found\n",
+      }),
+    ).toEqual({ kind: "absent" });
+  });
+
   it.each([
     { input: new Error("JSON parse boom"), label: "Error instance" },
     { input: "raw string", label: "raw string" },

--- a/packages/integrations/github/src/github.ts
+++ b/packages/integrations/github/src/github.ts
@@ -116,6 +116,11 @@ export function classifyGhError(err: unknown): PrResult {
   if (stderr.includes("no pull requests found")) {
     return { kind: "absent" };
   }
+  // A repo with no remote can't have a PR — same UI outcome as "no PR on
+  // this branch" (silent), not a warning the user needs to act on.
+  if (stderr.includes("no git remotes found")) {
+    return { kind: "absent" };
+  }
   return ghUnavailable("unknown");
 }
 


### PR DESCRIPTION
**Repos with no Git remote no longer trigger a "GitHub lookup failed" warning** in the terminal title bar. `gh pr view` exits with stderr `no git remotes found` for these repos — `classifyGhError()` didn't recognize that string, so it fell through to `code: "unknown"` (server `ERROR` log + a scary popover pointing the user at server logs).

A repo without a remote *cannot* have a PR, so the right UI outcome is the same as "no PR on this branch": silent. One new stderr arm in `classifyGhError` maps it to `{ kind: "absent" }` alongside the existing `"no pull requests found"` match. _No new `GhUnavailableCode`, no UI changes._

A test arm pins the stderr string — the existing tripwire for gh wording drift (see the `FRAGILE` comment in `github.ts`).

Closes #780.

### Try it locally

```sh
nix run github:juspay/kolu/stormy-creed
```

Then `cd` into a git repo with no remote — the title bar should stay quiet.

_Generated by Claude Code (model `claude-opus-4-7`)._