### PR TITLE
Code tab: chip + popover picker with inline file-name filter

### DIFF
--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -2,16 +2,10 @@
  *  meter, webcam preview, "Start recording" commit button. Appears when
  *  the chrome-bar record button is clicked from idle. */
 
-import { makeEventListener } from "@solid-primitives/event-listener";
-import {
-  type Component,
-  createEffect,
-  createSignal,
-  For,
-  Show,
-} from "solid-js";
+import { type Component, createEffect, For, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import Toggle from "../ui/Toggle";
+import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import LevelMeter from "./LevelMeter";
 import { useRecorder } from "./useRecorder";
 
@@ -47,45 +41,19 @@ const RecordPopover: Component<{
   const recorder = useRecorder();
   const open = () => recorder.phase() === "setup";
 
-  let panelRef: HTMLDivElement | undefined;
   let webcamVideoRef: HTMLVideoElement | undefined;
-  const [pos, setPos] = createSignal({ top: 0, right: 0 });
 
-  const updatePos = () => {
-    if (!props.triggerRef) return;
-    const rect = props.triggerRef.getBoundingClientRect();
-    setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-  };
-
-  // Reposition whenever the popover opens OR the trigger element
-  // reference changes. With signal-backed trigger ref from RecordButton,
-  // remounts of the idle button (after record↔idle cycles) flow through
-  // here so the popover doesn't end up anchored to a detached element.
-  createEffect(() => {
-    if (open() && props.triggerRef) updatePos();
+  const { panelRef, panelStyle } = useAnchoredPopover({
+    triggerRef: () => props.triggerRef,
+    open,
+    onDismiss: () => recorder.cancelSetup(),
+    anchor: "bottom-end",
   });
 
   // Keep the preview `<video>` in sync with the webcam stream signal.
   createEffect(() => {
     const s = recorder.webcamStream();
     if (webcamVideoRef) webcamVideoRef.srcObject = s;
-  });
-
-  // Click outside → cancel setup. Ignore clicks on the trigger itself
-  // so toggling-via-trigger doesn't double-dispatch.
-  makeEventListener(document, "mousedown", (e) => {
-    if (!open()) return;
-    if (
-      panelRef &&
-      !panelRef.contains(e.target as Node) &&
-      !props.triggerRef?.contains(e.target as Node)
-    ) {
-      recorder.cancelSetup();
-    }
-  });
-
-  makeEventListener(document, "keydown", (e) => {
-    if (open() && e.key === "Escape") recorder.cancelSetup();
   });
 
   const showMicSelector = () => recorder.micDevices().length > 1;
@@ -101,15 +69,11 @@ const RecordPopover: Component<{
     <Show when={open()}>
       <Portal>
         <div
-          ref={(el) => {
-            panelRef = el;
-            updatePos();
-          }}
+          ref={panelRef}
           data-testid="record-popover"
           class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[280px] space-y-3"
           style={{
-            top: `${pos().top}px`,
-            right: `${pos().right}px`,
+            ...panelStyle(),
             "background-color": "var(--color-surface-1)",
           }}
         >

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -92,6 +92,7 @@ const CodeFilterBar: Component<{
         class="flex items-center gap-1.5 px-2 h-5 rounded text-[10px] font-mono cursor-pointer transition-colors bg-surface-2/40 hover:bg-surface-2/80 text-fg-2 hover:text-fg data-[active=true]:bg-surface-0 data-[active=true]:text-fg data-[active=true]:shadow-sm"
         data-testid="diff-filter-chip"
         data-active={open()}
+        data-mode={props.view}
         aria-expanded={open()}
         aria-haspopup="menu"
         title="Change view"

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -17,14 +17,8 @@
 import { makeEventListener } from "@solid-primitives/event-listener";
 import type { CodeTabView } from "kolu-common";
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
-import { Portal } from "solid-js/web";
-import {
-  ChevronDownIcon,
-  CloseIcon,
-  FileBrowseIcon,
-  GitBranchIcon,
-  SearchIcon,
-} from "../ui/Icons";
+import { Dynamic, Portal } from "solid-js/web";
+import { ChevronDownIcon, CloseIcon, SearchIcon } from "../ui/Icons";
 
 export type ModeOption = {
   view: CodeTabView;
@@ -34,10 +28,9 @@ export type ModeOption = {
   label: string;
   hint: string;
   testId: string;
-  /** When `true`, renders the git-branch icon in the chip; otherwise the
-   *  file-browse icon. Drives the chip's leading glyph without leaking
-   *  view-string knowledge into this component. */
-  iconKind?: "git" | "file";
+  /** Leading glyph for the chip. Host owns icon registry so the picker
+   *  doesn't import every possible icon. */
+  icon: Component<{ class?: string }>;
 };
 
 const CodeFilterBar: Component<{
@@ -88,7 +81,6 @@ const CodeFilterBar: Component<{
   );
   const chipLabel = (m: ModeOption) =>
     m.group ? `${m.group}: ${m.label}` : m.label;
-  const activeIsGit = () => activeMode()?.iconKind === "git";
 
   return (
     <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-2">
@@ -106,17 +98,14 @@ const CodeFilterBar: Component<{
         aria-haspopup="menu"
         title="Change view"
       >
-        <Show
-          when={activeIsGit()}
-          fallback={<FileBrowseIcon class="w-3 h-3 opacity-70" />}
-        >
-          <GitBranchIcon class="w-3 h-3 opacity-70" />
+        <Show when={activeMode()}>
+          {(m) => (
+            <>
+              <Dynamic component={m().icon} class="w-3 h-3 opacity-70" />
+              <span>{chipLabel(m())}</span>
+            </>
+          )}
         </Show>
-        <span>
-          <Show when={activeMode()} fallback={props.view}>
-            {(m) => chipLabel(m())}
-          </Show>
-        </span>
         <ChevronDownIcon
           class={`w-3 h-3 opacity-50 transition-transform ${
             open() ? "rotate-180" : ""

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -52,10 +52,18 @@ const CodeFilterBar: Component<{
   let panelRef: HTMLDivElement | undefined;
   const [pos, setPos] = createSignal({ top: 0, left: 0 });
 
+  // Popover panel min-width — kept in sync with the `min-w-[240px]`
+  // class on the panel below. Used for viewport clamping so the popover
+  // doesn't slip off the right edge when the trigger is near it.
+  const PANEL_MIN_WIDTH = 240;
+  const VIEWPORT_PAD = 8;
+
   const updatePos = () => {
     if (!triggerRef) return;
     const r = triggerRef.getBoundingClientRect();
-    setPos({ top: r.bottom + 6, left: r.left });
+    const maxLeft = window.innerWidth - PANEL_MIN_WIDTH - VIEWPORT_PAD;
+    const left = Math.max(VIEWPORT_PAD, Math.min(r.left, maxLeft));
+    setPos({ top: r.bottom + 6, left });
   };
 
   // Close on outside click — ignore clicks on the trigger itself so the

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -6,11 +6,17 @@
  *  one chip element holds the current mode label, a popover reveals the
  *  full set of options with their semantic hints. The search input
  *  shares the bar so file-set narrowing and file-name filtering live in
- *  one place — the only filter chrome the user has to scan. */
+ *  one place — the only filter chrome the user has to scan.
+ *
+ *  Mode metadata is *not* defined in this file — the host (CodeTab)
+ *  owns the list of `ModeOption`s and passes them in. That keeps
+ *  mode-identity volatility (adding a new view, changing a hint, wiring
+ *  a new data source) localized to a single module instead of split
+ *  across the picker and the host. */
 
 import { makeEventListener } from "@solid-primitives/event-listener";
 import type { CodeTabView } from "kolu-common";
-import { type Component, createSignal, For, Show } from "solid-js";
+import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import {
   ChevronDownIcon,
@@ -20,41 +26,18 @@ import {
   SearchIcon,
 } from "../ui/Icons";
 
-type ModeOption = {
+export type ModeOption = {
   view: CodeTabView;
-  group?: "Git";
+  /** Optional grouping label rendered as a `<group>:` prefix in the chip
+   *  and popover (e.g. `Git: Local`). */
+  group?: string;
   label: string;
   hint: string;
   testId: string;
-};
-
-const OPTIONS: readonly ModeOption[] = [
-  {
-    view: "browse",
-    label: "All files",
-    hint: "Browse the whole repo",
-    testId: "diff-mode-browse",
-  },
-  {
-    view: "local",
-    group: "Git",
-    label: "Local",
-    hint: "Working tree vs HEAD",
-    testId: "diff-mode-local",
-  },
-  {
-    view: "branch",
-    group: "Git",
-    label: "Branch",
-    hint: "Working tree vs branch base",
-    testId: "diff-mode-branch",
-  },
-];
-
-const VIEW_CHIP_LABEL: Record<CodeTabView, string> = {
-  browse: "All files",
-  local: "Git: Local",
-  branch: "Git: Branch",
+  /** When `true`, renders the git-branch icon in the chip; otherwise the
+   *  file-browse icon. Drives the chip's leading glyph without leaking
+   *  view-string knowledge into this component. */
+  iconKind?: "git" | "file";
 };
 
 const CodeFilterBar: Component<{
@@ -62,9 +45,7 @@ const CodeFilterBar: Component<{
   onViewChange: (v: CodeTabView) => void;
   searchQuery: string;
   onSearchChange: (q: string) => void;
-  /** When known, replaces the generic "Branch" hint in the popover with
-   *  `vs <ref>` (e.g. "vs origin/master"). */
-  branchRef?: string | null;
+  modes: readonly ModeOption[];
 }> = (props) => {
   const [open, setOpen] = createSignal(false);
   let triggerRef: HTMLButtonElement | undefined;
@@ -94,10 +75,11 @@ const CodeFilterBar: Component<{
     setOpen(false);
   };
 
-  const optionHint = (opt: ModeOption) =>
-    opt.view === "branch" && props.branchRef
-      ? `vs ${props.branchRef}`
-      : opt.hint;
+  const activeMode = createMemo(() =>
+    props.modes.find((m) => m.view === props.view),
+  );
+  const chipLabel = (m: ModeOption) =>
+    m.group ? `${m.group}: ${m.label}` : m.label;
 
   return (
     <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-2">
@@ -116,12 +98,12 @@ const CodeFilterBar: Component<{
         title="Change view"
       >
         <Show
-          when={props.view !== "browse"}
+          when={activeMode()?.iconKind === "git"}
           fallback={<FileBrowseIcon class="w-3 h-3 opacity-70" />}
         >
           <GitBranchIcon class="w-3 h-3 opacity-70" />
         </Show>
-        <span>{VIEW_CHIP_LABEL[props.view]}</span>
+        <span>{activeMode() ? chipLabel(activeMode()!) : props.view}</span>
         <ChevronDownIcon
           class={`w-3 h-3 opacity-50 transition-transform ${
             open() ? "rotate-180" : ""
@@ -166,10 +148,14 @@ const CodeFilterBar: Component<{
             role="menu"
             data-testid="diff-filter-popover"
           >
-            <For each={OPTIONS}>
+            <For each={props.modes}>
               {(opt, idx) => (
                 <>
-                  <Show when={idx() === 1}>
+                  <Show
+                    when={
+                      idx() > 0 && opt.group !== props.modes[idx() - 1]?.group
+                    }
+                  >
                     <div class="my-1 border-t border-edge/60" />
                   </Show>
                   <button
@@ -201,9 +187,7 @@ const CodeFilterBar: Component<{
                         </Show>
                         {opt.label}
                       </span>
-                      <span class="text-fg-3 text-[10px]">
-                        {optionHint(opt)}
-                      </span>
+                      <span class="text-fg-3 text-[10px]">{opt.hint}</span>
                     </div>
                   </button>
                 </>

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -165,25 +165,16 @@ const CodeFilterBar: Component<{
                     onClick={() => select(opt.view)}
                     role="menuitemradio"
                     aria-checked={props.view === opt.view}
-                    class="w-full flex items-center gap-2.5 px-2.5 py-1.5 text-left hover:bg-surface-2/60 cursor-pointer"
+                    class="group w-full flex items-center gap-2.5 px-2.5 py-1.5 text-left hover:bg-surface-2/60 cursor-pointer"
                     data-testid={opt.testId}
                     data-active={props.view === opt.view}
                   >
                     <span
-                      class="w-1.5 h-1.5 rounded-full shrink-0 transition-colors"
-                      classList={{
-                        "bg-accent": props.view === opt.view,
-                        "bg-edge-bright": props.view !== opt.view,
-                      }}
+                      class="w-1.5 h-1.5 rounded-full shrink-0 transition-colors bg-edge-bright group-data-[active=true]:bg-accent"
                       aria-hidden="true"
                     />
                     <div class="flex flex-col items-start min-w-0 gap-0.5">
-                      <span
-                        classList={{
-                          "text-fg": props.view === opt.view,
-                          "text-fg-2": props.view !== opt.view,
-                        }}
-                      >
+                      <span class="text-fg-2 group-data-[active=true]:text-fg">
                         <Show when={opt.group}>
                           <span class="text-fg-3">{opt.group}: </span>
                         </Show>

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -88,6 +88,7 @@ const CodeFilterBar: Component<{
   );
   const chipLabel = (m: ModeOption) =>
     m.group ? `${m.group}: ${m.label}` : m.label;
+  const activeIsGit = () => activeMode()?.iconKind === "git";
 
   return (
     <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-2">
@@ -106,12 +107,16 @@ const CodeFilterBar: Component<{
         title="Change view"
       >
         <Show
-          when={activeMode()?.iconKind === "git"}
+          when={activeIsGit()}
           fallback={<FileBrowseIcon class="w-3 h-3 opacity-70" />}
         >
           <GitBranchIcon class="w-3 h-3 opacity-70" />
         </Show>
-        <span>{activeMode() ? chipLabel(activeMode()!) : props.view}</span>
+        <span>
+          <Show when={activeMode()} fallback={props.view}>
+            {(m) => chipLabel(m())}
+          </Show>
+        </span>
         <ChevronDownIcon
           class={`w-3 h-3 opacity-50 transition-transform ${
             open() ? "rotate-180" : ""

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -14,7 +14,7 @@
  *  a new data source) localized to a single module instead of split
  *  across the picker and the host. */
 
-import { makeEventListener } from "@solid-primitives/event-listener";
+import { createEventListener } from "@solid-primitives/event-listener";
 import type { CodeTabView } from "kolu-common";
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { Dynamic, Portal } from "solid-js/web";
@@ -59,16 +59,17 @@ const CodeFilterBar: Component<{
     setPos({ top: r.bottom + 6, left });
   };
 
-  // Close on outside click — ignore clicks on the trigger itself so the
-  // toggle button drives open/close cleanly.
-  makeEventListener(document, "mousedown", (e) => {
-    if (!open()) return;
+  // Document listeners exist only while the popover is open — passing
+  // `undefined` as the target detaches them. Outside-click ignores the
+  // trigger so the chip toggle drives open/close cleanly.
+  const popoverTarget = () => (open() ? document : undefined);
+  createEventListener(popoverTarget, "mousedown", (e) => {
     const t = e.target as Node;
     if (panelRef?.contains(t) || triggerRef?.contains(t)) return;
     setOpen(false);
   });
-  makeEventListener(document, "keydown", (e) => {
-    if (open() && e.key === "Escape") setOpen(false);
+  createEventListener(popoverTarget, "keydown", (e) => {
+    if (e.key === "Escape") setOpen(false);
   });
 
   const select = (v: CodeTabView) => {
@@ -87,10 +88,7 @@ const CodeFilterBar: Component<{
       <button
         ref={triggerRef}
         type="button"
-        onClick={() => {
-          updatePos();
-          setOpen(!open());
-        }}
+        onClick={() => setOpen(!open())}
         class="flex items-center gap-1.5 px-2 h-5 rounded text-[10px] font-mono cursor-pointer transition-colors bg-surface-2/40 hover:bg-surface-2/80 text-fg-2 hover:text-fg data-[active=true]:bg-surface-0 data-[active=true]:text-fg data-[active=true]:shadow-sm"
         data-testid="diff-filter-chip"
         data-active={open()}

--- a/packages/client/src/right-panel/CodeFilterBar.tsx
+++ b/packages/client/src/right-panel/CodeFilterBar.tsx
@@ -1,0 +1,219 @@
+/** Filter chrome for the Code tab — a single horizontal strip combining
+ *  the mode picker (chip + popover) and a free-text search input that
+ *  drives Pierre's tree filter externally.
+ *
+ *  Visual register intentionally avoids a tab/segmented-control look:
+ *  one chip element holds the current mode label, a popover reveals the
+ *  full set of options with their semantic hints. The search input
+ *  shares the bar so file-set narrowing and file-name filtering live in
+ *  one place — the only filter chrome the user has to scan. */
+
+import { makeEventListener } from "@solid-primitives/event-listener";
+import type { CodeTabView } from "kolu-common";
+import { type Component, createSignal, For, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import {
+  ChevronDownIcon,
+  CloseIcon,
+  FileBrowseIcon,
+  GitBranchIcon,
+  SearchIcon,
+} from "../ui/Icons";
+
+type ModeOption = {
+  view: CodeTabView;
+  group?: "Git";
+  label: string;
+  hint: string;
+  testId: string;
+};
+
+const OPTIONS: readonly ModeOption[] = [
+  {
+    view: "browse",
+    label: "All files",
+    hint: "Browse the whole repo",
+    testId: "diff-mode-browse",
+  },
+  {
+    view: "local",
+    group: "Git",
+    label: "Local",
+    hint: "Working tree vs HEAD",
+    testId: "diff-mode-local",
+  },
+  {
+    view: "branch",
+    group: "Git",
+    label: "Branch",
+    hint: "Working tree vs branch base",
+    testId: "diff-mode-branch",
+  },
+];
+
+const VIEW_CHIP_LABEL: Record<CodeTabView, string> = {
+  browse: "All files",
+  local: "Git: Local",
+  branch: "Git: Branch",
+};
+
+const CodeFilterBar: Component<{
+  view: CodeTabView;
+  onViewChange: (v: CodeTabView) => void;
+  searchQuery: string;
+  onSearchChange: (q: string) => void;
+  /** When known, replaces the generic "Branch" hint in the popover with
+   *  `vs <ref>` (e.g. "vs origin/master"). */
+  branchRef?: string | null;
+}> = (props) => {
+  const [open, setOpen] = createSignal(false);
+  let triggerRef: HTMLButtonElement | undefined;
+  let panelRef: HTMLDivElement | undefined;
+  const [pos, setPos] = createSignal({ top: 0, left: 0 });
+
+  const updatePos = () => {
+    if (!triggerRef) return;
+    const r = triggerRef.getBoundingClientRect();
+    setPos({ top: r.bottom + 6, left: r.left });
+  };
+
+  // Close on outside click — ignore clicks on the trigger itself so the
+  // toggle button drives open/close cleanly.
+  makeEventListener(document, "mousedown", (e) => {
+    if (!open()) return;
+    const t = e.target as Node;
+    if (panelRef?.contains(t) || triggerRef?.contains(t)) return;
+    setOpen(false);
+  });
+  makeEventListener(document, "keydown", (e) => {
+    if (open() && e.key === "Escape") setOpen(false);
+  });
+
+  const select = (v: CodeTabView) => {
+    props.onViewChange(v);
+    setOpen(false);
+  };
+
+  const optionHint = (opt: ModeOption) =>
+    opt.view === "branch" && props.branchRef
+      ? `vs ${props.branchRef}`
+      : opt.hint;
+
+  return (
+    <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-2">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => {
+          updatePos();
+          setOpen(!open());
+        }}
+        class="flex items-center gap-1.5 px-2 h-5 rounded text-[10px] font-mono cursor-pointer transition-colors bg-surface-2/40 hover:bg-surface-2/80 text-fg-2 hover:text-fg data-[active=true]:bg-surface-0 data-[active=true]:text-fg data-[active=true]:shadow-sm"
+        data-testid="diff-filter-chip"
+        data-active={open()}
+        aria-expanded={open()}
+        aria-haspopup="menu"
+        title="Change view"
+      >
+        <Show
+          when={props.view !== "browse"}
+          fallback={<FileBrowseIcon class="w-3 h-3 opacity-70" />}
+        >
+          <GitBranchIcon class="w-3 h-3 opacity-70" />
+        </Show>
+        <span>{VIEW_CHIP_LABEL[props.view]}</span>
+        <ChevronDownIcon
+          class={`w-3 h-3 opacity-50 transition-transform ${
+            open() ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+
+      <label class="flex items-center gap-1.5 flex-1 min-w-0 text-[10px] font-mono text-fg-3 focus-within:text-fg-2">
+        <SearchIcon class="w-3 h-3 opacity-50 shrink-0" />
+        <input
+          type="text"
+          value={props.searchQuery}
+          onInput={(e) => props.onSearchChange(e.currentTarget.value)}
+          placeholder="filter files…"
+          class="flex-1 min-w-0 bg-transparent outline-none border-0 placeholder:text-fg-3/40 text-fg"
+          data-testid="diff-filter-search"
+          spellcheck={false}
+          autocomplete="off"
+        />
+        <Show when={props.searchQuery.length > 0}>
+          <button
+            type="button"
+            onClick={() => props.onSearchChange("")}
+            title="Clear filter"
+            class="shrink-0 text-fg-3 hover:text-fg cursor-pointer p-0.5 -mr-0.5"
+            data-testid="diff-filter-clear"
+          >
+            <CloseIcon class="w-3 h-3" />
+          </button>
+        </Show>
+      </label>
+
+      <Show when={open()}>
+        <Portal>
+          <div
+            ref={(el) => {
+              panelRef = el;
+              updatePos();
+            }}
+            class="fixed z-50 bg-surface-1 border border-edge rounded-md shadow-2xl shadow-black/40 py-1 min-w-[240px] text-[11px] font-mono"
+            style={{ top: `${pos().top}px`, left: `${pos().left}px` }}
+            role="menu"
+            data-testid="diff-filter-popover"
+          >
+            <For each={OPTIONS}>
+              {(opt, idx) => (
+                <>
+                  <Show when={idx() === 1}>
+                    <div class="my-1 border-t border-edge/60" />
+                  </Show>
+                  <button
+                    type="button"
+                    onClick={() => select(opt.view)}
+                    role="menuitemradio"
+                    aria-checked={props.view === opt.view}
+                    class="w-full flex items-center gap-2.5 px-2.5 py-1.5 text-left hover:bg-surface-2/60 cursor-pointer"
+                    data-testid={opt.testId}
+                    data-active={props.view === opt.view}
+                  >
+                    <span
+                      class="w-1.5 h-1.5 rounded-full shrink-0 transition-colors"
+                      classList={{
+                        "bg-accent": props.view === opt.view,
+                        "bg-edge-bright": props.view !== opt.view,
+                      }}
+                      aria-hidden="true"
+                    />
+                    <div class="flex flex-col items-start min-w-0 gap-0.5">
+                      <span
+                        classList={{
+                          "text-fg": props.view === opt.view,
+                          "text-fg-2": props.view !== opt.view,
+                        }}
+                      >
+                        <Show when={opt.group}>
+                          <span class="text-fg-3">{opt.group}: </span>
+                        </Show>
+                        {opt.label}
+                      </span>
+                      <span class="text-fg-3 text-[10px]">
+                        {optionHint(opt)}
+                      </span>
+                    </div>
+                  </button>
+                </>
+              )}
+            </For>
+          </div>
+        </Portal>
+      </Show>
+    </div>
+  );
+};
+
+export default CodeFilterBar;

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -29,7 +29,7 @@ import { toast } from "solid-sonner";
 import { createReactiveSubscription } from "../rpc/createReactiveSubscription";
 import { stream } from "../rpc/rpc";
 import { useColorScheme } from "../settings/useColorScheme";
-import { FileDiffIcon, GitBranchIcon } from "../ui/Icons";
+import { FileBrowseIcon, FileDiffIcon, GitBranchIcon } from "../ui/Icons";
 import PierreDiffView from "../ui/PierreDiffView";
 import PierreFileTree, { toGitStatusEntries } from "../ui/PierreFileTree";
 import BrowseFileView from "./BrowseFileView";
@@ -143,31 +143,34 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // Mode catalog — owns the list of views, their labels, hints, and
   // test IDs. Adding a new mode (e.g. "stash") happens here, plus the
   // data-source switch above. CodeFilterBar is purely a presenter.
-  const modeOptions = createMemo<ModeOption[]>(() => [
-    {
-      view: "browse",
-      label: "All files",
-      hint: "Browse the whole repo",
-      testId: "diff-mode-browse",
-      iconKind: "file",
-    },
-    {
-      view: "local",
-      group: "Git",
-      label: "Local",
-      hint: "Working tree vs HEAD",
-      testId: "diff-mode-local",
-      iconKind: "git",
-    },
-    {
-      view: "branch",
-      group: "Git",
-      label: "Branch",
-      hint: branchRef() ? `vs ${branchRef()}` : "Working tree vs branch base",
-      testId: "diff-mode-branch",
-      iconKind: "git",
-    },
-  ]);
+  const modeOptions = createMemo<ModeOption[]>(() => {
+    const ref = branchRef();
+    return [
+      {
+        view: "browse",
+        label: "All files",
+        hint: "Browse the whole repo",
+        testId: "diff-mode-browse",
+        icon: FileBrowseIcon,
+      },
+      {
+        view: "local",
+        group: "Git",
+        label: "Local",
+        hint: "Working tree vs HEAD",
+        testId: "diff-mode-local",
+        icon: GitBranchIcon,
+      },
+      {
+        view: "branch",
+        group: "Git",
+        label: "Branch",
+        hint: ref ? `vs ${ref}` : "Working tree vs branch base",
+        testId: "diff-mode-branch",
+        icon: GitBranchIcon,
+      },
+    ];
+  });
 
   /** Diff value narrowed to "this is a pure-rename" (no hunks, both old +
    *  new file names present and different). Returning the full diff so the

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -6,10 +6,12 @@
  *   - Branch: working tree vs `merge-base(origin/<default>)` — same, with a
  *     branch base. Forge-agnostic "what this branch will ship".
  *
- * The mode trio is structured as a nested segmented control: All sits
- * apart from the Local/Branch pair because Local and Branch are siblings
- * (both filter to changed files; only the diff base differs), while All
- * is the unfiltered base view. Pierre's `@pierre/trees` owns the tree
+ * The mode trio is surfaced as a two-level toggle: a primary `{All, Git}`
+ * picker chooses between the unfiltered fs-listing view and the git-diff
+ * view; when Git is active, a sub-toggle picks the diff base
+ * `{Local, Branch}`. `lastGitMode` remembers which diff base to restore
+ * when the user toggles All → Git, so the secondary choice survives the
+ * round-trip. Pierre's `@pierre/trees` owns the tree
  * layout/search/virtualization; `@pierre/diffs` owns diff parsing and
  * shiki highlighting. This component is just data flow + chrome. */
 
@@ -67,6 +69,16 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const isDiffView = () => view() !== "browse";
   const diffMode = (): GitDiffMode | undefined =>
     view() === "browse" ? undefined : (view() as GitDiffMode);
+
+  // Remember which diff base the user last chose so toggling All → Git
+  // restores it instead of always landing on "local".
+  const [lastGitMode, setLastGitMode] = createSignal<GitDiffMode>(
+    diffMode() ?? "local",
+  );
+  createEffect(() => {
+    const m = diffMode();
+    if (m) setLastGitMode(m);
+  });
 
   const status = createReactiveSubscription(
     () => {
@@ -164,7 +176,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         data-testid="diff-tab"
       >
         <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-1.5">
-          <div class="flex items-center bg-surface-2/40 rounded p-0.5">
+          <div class="flex items-center bg-surface-2/40 rounded p-0.5 gap-0.5">
             <button
               type="button"
               onClick={() => setView("browse")}
@@ -176,31 +188,44 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
             >
               All
             </button>
-          </div>
-          <div class="flex items-center bg-surface-2/40 rounded p-0.5 gap-0.5">
             <button
               type="button"
-              onClick={() => setView("local")}
-              title="Changes vs HEAD"
+              onClick={() => setView(lastGitMode())}
+              title="Git changes"
               class={PILL_BUTTON_CLASS}
-              data-testid="diff-mode-local"
-              data-active={view() === "local"}
-              aria-pressed={view() === "local"}
+              data-testid="diff-mode-git"
+              data-active={isDiffView()}
+              aria-pressed={isDiffView()}
             >
-              Local
-            </button>
-            <button
-              type="button"
-              onClick={() => setView("branch")}
-              title={branchTooltip()}
-              class={PILL_BUTTON_CLASS}
-              data-testid="diff-mode-branch"
-              data-active={view() === "branch"}
-              aria-pressed={view() === "branch"}
-            >
-              Branch
+              Git
             </button>
           </div>
+          <Show when={isDiffView()}>
+            <div class="flex items-center bg-surface-2/40 rounded p-0.5 gap-0.5">
+              <button
+                type="button"
+                onClick={() => setView("local")}
+                title="Changes vs HEAD"
+                class={PILL_BUTTON_CLASS}
+                data-testid="diff-mode-local"
+                data-active={view() === "local"}
+                aria-pressed={view() === "local"}
+              >
+                Local
+              </button>
+              <button
+                type="button"
+                onClick={() => setView("branch")}
+                title={branchTooltip()}
+                class={PILL_BUTTON_CLASS}
+                data-testid="diff-mode-branch"
+                data-active={view() === "branch"}
+                aria-pressed={view() === "branch"}
+              >
+                Branch
+              </button>
+            </div>
+          </Show>
           <div class="flex-1" />
         </div>
 

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -33,7 +33,7 @@ import { FileDiffIcon, GitBranchIcon } from "../ui/Icons";
 import PierreDiffView from "../ui/PierreDiffView";
 import PierreFileTree, { toGitStatusEntries } from "../ui/PierreFileTree";
 import BrowseFileView from "./BrowseFileView";
-import CodeFilterBar from "./CodeFilterBar";
+import CodeFilterBar, { type ModeOption } from "./CodeFilterBar";
 import { useRightPanel } from "./useRightPanel";
 
 const EMPTY_STATE: Record<GitDiffMode, string> = {
@@ -140,6 +140,35 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const treeReady = () => (isDiffView() ? status() : allPaths());
   const branchRef = (): string | null => status()?.base?.ref ?? null;
 
+  // Mode catalog — owns the list of views, their labels, hints, and
+  // test IDs. Adding a new mode (e.g. "stash") happens here, plus the
+  // data-source switch above. CodeFilterBar is purely a presenter.
+  const modeOptions = createMemo<ModeOption[]>(() => [
+    {
+      view: "browse",
+      label: "All files",
+      hint: "Browse the whole repo",
+      testId: "diff-mode-browse",
+      iconKind: "file",
+    },
+    {
+      view: "local",
+      group: "Git",
+      label: "Local",
+      hint: "Working tree vs HEAD",
+      testId: "diff-mode-local",
+      iconKind: "git",
+    },
+    {
+      view: "branch",
+      group: "Git",
+      label: "Branch",
+      hint: branchRef() ? `vs ${branchRef()}` : "Working tree vs branch base",
+      testId: "diff-mode-branch",
+      iconKind: "git",
+    },
+  ]);
+
   /** Diff value narrowed to "this is a pure-rename" (no hunks, both old +
    *  new file names present and different). Returning the full diff so the
    *  rendering Match can read its names without re-narrowing. */
@@ -176,7 +205,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
           onViewChange={setView}
           searchQuery={searchQuery()}
           onSearchChange={setSearchQuery}
-          branchRef={branchRef()}
+          modes={modeOptions()}
         />
 
         <div

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -6,14 +6,13 @@
  *   - Branch: working tree vs `merge-base(origin/<default>)` — same, with a
  *     branch base. Forge-agnostic "what this branch will ship".
  *
- * The mode trio is surfaced as a two-level toggle: a primary `{All, Git}`
- * picker chooses between the unfiltered fs-listing view and the git-diff
- * view; when Git is active, a sub-toggle picks the diff base
- * `{Local, Branch}`. `lastGitMode` remembers which diff base to restore
- * when the user toggles All → Git, so the secondary choice survives the
- * round-trip. Pierre's `@pierre/trees` owns the tree
- * layout/search/virtualization; `@pierre/diffs` owns diff parsing and
- * shiki highlighting. This component is just data flow + chrome. */
+ * Mode + filename filtering live side-by-side in `CodeFilterBar`: a chip +
+ * popover picks the mode, a free-text input drives Pierre's tree filter
+ * via `searchQuery`. Pierre's built-in header search is disabled so the
+ * caller-rendered input is the single source of filter state. Pierre's
+ * `@pierre/trees` owns the tree layout/virtualization; `@pierre/diffs`
+ * owns diff parsing and shiki highlighting. This component is just data
+ * flow + chrome. */
 
 import type { CodeTabView, GitDiffMode, TerminalMetadata } from "kolu-common";
 import {
@@ -34,18 +33,13 @@ import { FileDiffIcon, GitBranchIcon } from "../ui/Icons";
 import PierreDiffView from "../ui/PierreDiffView";
 import PierreFileTree, { toGitStatusEntries } from "../ui/PierreFileTree";
 import BrowseFileView from "./BrowseFileView";
+import CodeFilterBar from "./CodeFilterBar";
 import { useRightPanel } from "./useRightPanel";
 
 const EMPTY_STATE: Record<GitDiffMode, string> = {
   local: "No local changes",
   branch: "No changes vs base",
 };
-
-/** Pill button shared by both segment groups. Inherits the same active-state
- *  chrome the canvas tile chrome uses (lifted surface-0 + soft shadow), so
- *  the mode picker reads as a continuation of kolu's existing tab language. */
-const PILL_BUTTON_CLASS =
-  "px-2 h-5 rounded text-[10px] font-mono cursor-pointer transition-colors text-fg-3/50 hover:text-fg-2 data-[active=true]:text-fg data-[active=true]:bg-surface-0 data-[active=true]:shadow-sm";
 
 const FileSelectHint: Component<{ label: string }> = (props) => (
   <div class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2">
@@ -70,15 +64,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const diffMode = (): GitDiffMode | undefined =>
     view() === "browse" ? undefined : (view() as GitDiffMode);
 
-  // Remember which diff base the user last chose so toggling All → Git
-  // restores it instead of always landing on "local".
-  const [lastGitMode, setLastGitMode] = createSignal<GitDiffMode>(
-    diffMode() ?? "local",
-  );
-  createEffect(() => {
-    const m = diffMode();
-    if (m) setLastGitMode(m);
-  });
+  // Filename filter — drives Pierre's tree filter externally. Reset on
+  // mode switch so a stale needle doesn't hide the wrong file set.
+  const [searchQuery, setSearchQuery] = createSignal("");
 
   const status = createReactiveSubscription(
     () => {
@@ -120,8 +108,17 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
 
   // Reset selection when the repo or view changes so a stale path doesn't
   // bleed across modes (e.g. a browse-mode pick showing up in diff mode).
+  // Same reset clears the filename filter — the search needle was scoped
+  // to the previous file set and rarely makes sense post-switch.
   createEffect(
-    on([repoPath, view], () => setSelectedPath(null), { defer: true }),
+    on(
+      [repoPath, view],
+      () => {
+        setSelectedPath(null);
+        setSearchQuery("");
+      },
+      { defer: true },
+    ),
   );
 
   const treePaths = createMemo(() => {
@@ -141,8 +138,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const treeError = (): Error | undefined =>
     isDiffView() ? status.error() : allPaths.error();
   const treeReady = () => (isDiffView() ? status() : allPaths());
-  const branchTooltip = () =>
-    `Changes vs ${status()?.base?.ref ?? "branch base"}`;
+  const branchRef = (): string | null => status()?.base?.ref ?? null;
 
   /** Diff value narrowed to "this is a pure-rename" (no hunks, both old +
    *  new file names present and different). Returning the full diff so the
@@ -175,59 +171,13 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         class="flex flex-col h-full min-h-0 text-[11px]"
         data-testid="diff-tab"
       >
-        <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-1.5">
-          <div class="flex items-center bg-surface-2/40 rounded p-0.5 gap-0.5">
-            <button
-              type="button"
-              onClick={() => setView("browse")}
-              title="Browse all files"
-              class={PILL_BUTTON_CLASS}
-              data-testid="diff-mode-browse"
-              data-active={view() === "browse"}
-              aria-pressed={view() === "browse"}
-            >
-              All
-            </button>
-            <button
-              type="button"
-              onClick={() => setView(lastGitMode())}
-              title="Git changes"
-              class={PILL_BUTTON_CLASS}
-              data-testid="diff-mode-git"
-              data-active={isDiffView()}
-              aria-pressed={isDiffView()}
-            >
-              Git
-            </button>
-          </div>
-          <Show when={isDiffView()}>
-            <div class="flex items-center bg-surface-2/40 rounded p-0.5 gap-0.5">
-              <button
-                type="button"
-                onClick={() => setView("local")}
-                title="Changes vs HEAD"
-                class={PILL_BUTTON_CLASS}
-                data-testid="diff-mode-local"
-                data-active={view() === "local"}
-                aria-pressed={view() === "local"}
-              >
-                Local
-              </button>
-              <button
-                type="button"
-                onClick={() => setView("branch")}
-                title={branchTooltip()}
-                class={PILL_BUTTON_CLASS}
-                data-testid="diff-mode-branch"
-                data-active={view() === "branch"}
-                aria-pressed={view() === "branch"}
-              >
-                Branch
-              </button>
-            </div>
-          </Show>
-          <div class="flex-1" />
-        </div>
+        <CodeFilterBar
+          view={view()}
+          onViewChange={setView}
+          searchQuery={searchQuery()}
+          onSearchChange={setSearchQuery}
+          branchRef={branchRef()}
+        />
 
         <div
           class="shrink-0 h-[35%] min-h-0 border-b border-edge"
@@ -262,6 +212,8 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                   selectedPath={selectedPath()}
                   onSelect={handleSelect}
                   initialExpansion={isDiffView() ? "open" : "closed"}
+                  search={false}
+                  searchQuery={searchQuery()}
                 />
               </Show>
             </Match>

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -6,13 +6,13 @@
  *   - Branch: working tree vs `merge-base(origin/<default>)` — same, with a
  *     branch base. Forge-agnostic "what this branch will ship".
  *
- * Mode + filename filtering live side-by-side in `CodeFilterBar`: a chip +
- * popover picks the mode, a free-text input drives Pierre's tree filter
- * via `searchQuery`. Pierre's built-in header search is disabled so the
- * caller-rendered input is the single source of filter state. Pierre's
- * `@pierre/trees` owns the tree layout/virtualization; `@pierre/diffs`
- * owns diff parsing and shiki highlighting. This component is just data
- * flow + chrome. */
+ * The toolbar combines two independent filter axes — mode picker
+ * (`ModeChipPicker`) and filename input (`FileSearchInput`) — in one
+ * row. Pierre's built-in tree-header search is disabled so the
+ * `FileSearchInput` is the single source of filter state, forwarded
+ * via `PierreFileTree.searchQuery`. Pierre's `@pierre/trees` owns the
+ * tree layout/virtualization; `@pierre/diffs` owns diff parsing and
+ * shiki highlighting. This component is just data flow + chrome. */
 
 import type { CodeTabView, GitDiffMode, TerminalMetadata } from "kolu-common";
 import {
@@ -33,7 +33,8 @@ import { FileBrowseIcon, FileDiffIcon, GitBranchIcon } from "../ui/Icons";
 import PierreDiffView from "../ui/PierreDiffView";
 import PierreFileTree, { toGitStatusEntries } from "../ui/PierreFileTree";
 import BrowseFileView from "./BrowseFileView";
-import CodeFilterBar, { type ModeOption } from "./CodeFilterBar";
+import FileSearchInput from "./FileSearchInput";
+import ModeChipPicker, { type ModeOption } from "./ModeChipPicker";
 import { useRightPanel } from "./useRightPanel";
 
 const EMPTY_STATE: Record<GitDiffMode, string> = {
@@ -142,7 +143,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
 
   // Mode catalog — owns the list of views, their labels, hints, and
   // test IDs. Adding a new mode (e.g. "stash") happens here, plus the
-  // data-source switch above. CodeFilterBar is purely a presenter.
+  // data-source switch above. ModeChipPicker is purely a presenter.
   const modeOptions = createMemo<ModeOption[]>(() => {
     const ref = branchRef();
     return [
@@ -203,13 +204,14 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         class="flex flex-col h-full min-h-0 text-[11px]"
         data-testid="diff-tab"
       >
-        <CodeFilterBar
-          view={view()}
-          onViewChange={setView}
-          searchQuery={searchQuery()}
-          onSearchChange={setSearchQuery}
-          modes={modeOptions()}
-        />
+        <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-2">
+          <ModeChipPicker
+            view={view()}
+            onViewChange={setView}
+            modes={modeOptions()}
+          />
+          <FileSearchInput value={searchQuery()} onChange={setSearchQuery} />
+        </div>
 
         <div
           class="shrink-0 h-[35%] min-h-0 border-b border-edge"

--- a/packages/client/src/right-panel/FileSearchInput.tsx
+++ b/packages/client/src/right-panel/FileSearchInput.tsx
@@ -1,0 +1,40 @@
+/** Free-text search input that filters the file tree by path. Hosts
+ *  read the value back through `onChange` and forward it into the tree
+ *  (e.g. via `PierreFileTree`'s `searchQuery` prop). The input is
+ *  controlled so callers can clear or programmatically reset it
+ *  (e.g. on view change). */
+
+import { type Component, Show } from "solid-js";
+import { CloseIcon, SearchIcon } from "../ui/Icons";
+
+const FileSearchInput: Component<{
+  value: string;
+  onChange: (q: string) => void;
+}> = (props) => (
+  <label class="flex items-center gap-1.5 flex-1 min-w-0 text-[10px] font-mono text-fg-3 focus-within:text-fg-2">
+    <SearchIcon class="w-3 h-3 opacity-50 shrink-0" />
+    <input
+      type="text"
+      value={props.value}
+      onInput={(e) => props.onChange(e.currentTarget.value)}
+      placeholder="filter files…"
+      class="flex-1 min-w-0 bg-transparent outline-none border-0 placeholder:text-fg-3/40 text-fg"
+      data-testid="diff-filter-search"
+      spellcheck={false}
+      autocomplete="off"
+    />
+    <Show when={props.value.length > 0}>
+      <button
+        type="button"
+        onClick={() => props.onChange("")}
+        title="Clear filter"
+        class="shrink-0 text-fg-3 hover:text-fg cursor-pointer p-0.5 -mr-0.5"
+        data-testid="diff-filter-clear"
+      >
+        <CloseIcon class="w-3 h-3" />
+      </button>
+    </Show>
+  </label>
+);
+
+export default FileSearchInput;

--- a/packages/client/src/right-panel/ModeChipPicker.tsx
+++ b/packages/client/src/right-panel/ModeChipPicker.tsx
@@ -1,24 +1,22 @@
-/** Filter chrome for the Code tab — a single horizontal strip combining
- *  the mode picker (chip + popover) and a free-text search input that
- *  drives Pierre's tree filter externally.
+/** Compact chip + popover mode picker. The chip displays the active
+ *  `ModeOption`'s icon and label; clicking opens a Portal'd popover with
+ *  the full set of options grouped by their optional `group` field.
  *
- *  Visual register intentionally avoids a tab/segmented-control look:
- *  one chip element holds the current mode label, a popover reveals the
- *  full set of options with their semantic hints. The search input
- *  shares the bar so file-set narrowing and file-name filtering live in
- *  one place — the only filter chrome the user has to scan.
+ *  The picker is purely presentational — mode metadata (label, hint,
+ *  testId, icon, group) is passed in by the host. Group dividers are
+ *  inferred at render time when consecutive options have different
+ *  `group` values.
  *
- *  Mode metadata is *not* defined in this file — the host (CodeTab)
- *  owns the list of `ModeOption`s and passes them in. That keeps
- *  mode-identity volatility (adding a new view, changing a hint, wiring
- *  a new data source) localized to a single module instead of split
- *  across the picker and the host. */
+ *  Popover positioning is hand-rolled (Portal + viewport clamp +
+ *  outside-click + Escape). The same scaffold is duplicated across
+ *  Settings/Record/PrUnavailable popovers in this codebase — extraction
+ *  is tracked in #795. */
 
 import { createEventListener } from "@solid-primitives/event-listener";
 import type { CodeTabView } from "kolu-common";
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { Dynamic, Portal } from "solid-js/web";
-import { ChevronDownIcon, CloseIcon, SearchIcon } from "../ui/Icons";
+import { ChevronDownIcon } from "../ui/Icons";
 
 export type ModeOption = {
   view: CodeTabView;
@@ -33,11 +31,9 @@ export type ModeOption = {
   icon: Component<{ class?: string }>;
 };
 
-const CodeFilterBar: Component<{
+const ModeChipPicker: Component<{
   view: CodeTabView;
   onViewChange: (v: CodeTabView) => void;
-  searchQuery: string;
-  onSearchChange: (q: string) => void;
   modes: readonly ModeOption[];
 }> = (props) => {
   const [open, setOpen] = createSignal(false);
@@ -84,7 +80,7 @@ const CodeFilterBar: Component<{
     m.group ? `${m.group}: ${m.label}` : m.label;
 
   return (
-    <div class="flex items-center h-7 px-1.5 bg-surface-1/30 border-b border-edge shrink-0 gap-2">
+    <>
       <button
         ref={triggerRef}
         type="button"
@@ -111,31 +107,6 @@ const CodeFilterBar: Component<{
           }`}
         />
       </button>
-
-      <label class="flex items-center gap-1.5 flex-1 min-w-0 text-[10px] font-mono text-fg-3 focus-within:text-fg-2">
-        <SearchIcon class="w-3 h-3 opacity-50 shrink-0" />
-        <input
-          type="text"
-          value={props.searchQuery}
-          onInput={(e) => props.onSearchChange(e.currentTarget.value)}
-          placeholder="filter files…"
-          class="flex-1 min-w-0 bg-transparent outline-none border-0 placeholder:text-fg-3/40 text-fg"
-          data-testid="diff-filter-search"
-          spellcheck={false}
-          autocomplete="off"
-        />
-        <Show when={props.searchQuery.length > 0}>
-          <button
-            type="button"
-            onClick={() => props.onSearchChange("")}
-            title="Clear filter"
-            class="shrink-0 text-fg-3 hover:text-fg cursor-pointer p-0.5 -mr-0.5"
-            data-testid="diff-filter-clear"
-          >
-            <CloseIcon class="w-3 h-3" />
-          </button>
-        </Show>
-      </label>
 
       <Show when={open()}>
         <Portal>
@@ -188,8 +159,8 @@ const CodeFilterBar: Component<{
           </div>
         </Portal>
       </Show>
-    </div>
+    </>
   );
 };
 
-export default CodeFilterBar;
+export default ModeChipPicker;

--- a/packages/client/src/right-panel/ModeChipPicker.tsx
+++ b/packages/client/src/right-panel/ModeChipPicker.tsx
@@ -7,16 +7,15 @@
  *  inferred at render time when consecutive options have different
  *  `group` values.
  *
- *  Popover positioning is hand-rolled (Portal + viewport clamp +
- *  outside-click + Escape). The same scaffold is duplicated across
- *  Settings/Record/PrUnavailable popovers in this codebase — extraction
- *  is tracked in #795. */
+ *  Popover positioning, outside-click, and Escape come from
+ *  `useAnchoredPopover` — same scaffold is shared with the
+ *  Settings/Record/PrUnavailable popovers. */
 
-import { createEventListener } from "@solid-primitives/event-listener";
 import type { CodeTabView } from "kolu-common";
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { Dynamic, Portal } from "solid-js/web";
 import { ChevronDownIcon } from "../ui/Icons";
+import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 
 export type ModeOption = {
   view: CodeTabView;
@@ -37,35 +36,15 @@ const ModeChipPicker: Component<{
   modes: readonly ModeOption[];
 }> = (props) => {
   const [open, setOpen] = createSignal(false);
-  let triggerRef: HTMLButtonElement | undefined;
-  let panelRef: HTMLDivElement | undefined;
-  const [pos, setPos] = createSignal({ top: 0, left: 0 });
+  let triggerEl: HTMLButtonElement | undefined;
 
-  // Popover panel min-width — kept in sync with the `min-w-[240px]`
-  // class on the panel below. Used for viewport clamping so the popover
-  // doesn't slip off the right edge when the trigger is near it.
-  const PANEL_MIN_WIDTH = 240;
-  const VIEWPORT_PAD = 8;
-
-  const updatePos = () => {
-    if (!triggerRef) return;
-    const r = triggerRef.getBoundingClientRect();
-    const maxLeft = window.innerWidth - PANEL_MIN_WIDTH - VIEWPORT_PAD;
-    const left = Math.max(VIEWPORT_PAD, Math.min(r.left, maxLeft));
-    setPos({ top: r.bottom + 6, left });
-  };
-
-  // Document listeners exist only while the popover is open — passing
-  // `undefined` as the target detaches them. Outside-click ignores the
-  // trigger so the chip toggle drives open/close cleanly.
-  const popoverTarget = () => (open() ? document : undefined);
-  createEventListener(popoverTarget, "mousedown", (e) => {
-    const t = e.target as Node;
-    if (panelRef?.contains(t) || triggerRef?.contains(t)) return;
-    setOpen(false);
-  });
-  createEventListener(popoverTarget, "keydown", (e) => {
-    if (e.key === "Escape") setOpen(false);
+  const { panelRef, panelStyle } = useAnchoredPopover({
+    triggerRef: () => triggerEl,
+    open,
+    onDismiss: () => setOpen(false),
+    anchor: "bottom-start",
+    panelMinWidth: 240,
+    offset: 6,
   });
 
   const select = (v: CodeTabView) => {
@@ -82,7 +61,7 @@ const ModeChipPicker: Component<{
   return (
     <>
       <button
-        ref={triggerRef}
+        ref={triggerEl}
         type="button"
         onClick={() => setOpen(!open())}
         class="flex items-center gap-1.5 px-2 h-5 rounded text-[10px] font-mono cursor-pointer transition-colors bg-surface-2/40 hover:bg-surface-2/80 text-fg-2 hover:text-fg data-[active=true]:bg-surface-0 data-[active=true]:text-fg data-[active=true]:shadow-sm"
@@ -111,12 +90,9 @@ const ModeChipPicker: Component<{
       <Show when={open()}>
         <Portal>
           <div
-            ref={(el) => {
-              panelRef = el;
-              updatePos();
-            }}
+            ref={panelRef}
             class="fixed z-50 bg-surface-1 border border-edge rounded-md shadow-2xl shadow-black/40 py-1 min-w-[240px] text-[11px] font-mono"
-            style={{ top: `${pos().top}px`, left: `${pos().left}px` }}
+            style={panelStyle()}
             role="menu"
             data-testid="diff-filter-popover"
           >

--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -1,14 +1,14 @@
 /** Settings popover — reads and writes preferences via usePreferences directly.
  *  Only needs open/close state and trigger ref from the parent. */
 
-import { makeEventListener } from "@solid-primitives/event-listener";
 import type { Preferences } from "kolu-common";
-import { type Component, createSignal, Show } from "solid-js";
+import { type Component, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import SegmentedControl, {
   type SegmentedControlOption,
 } from "../ui/SegmentedControl";
 import Toggle from "../ui/Toggle";
+import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import SettingRow, { type Hint } from "./SettingRow";
 import { type ColorScheme, useColorScheme } from "./useColorScheme";
 import { usePreferences } from "./usePreferences";
@@ -57,48 +57,22 @@ const SettingsPopover: Component<{
   const { preferences, updatePreferences } = usePreferences();
   const { colorScheme, setColorScheme } = useColorScheme();
 
-  let panelRef: HTMLDivElement | undefined;
-  const [pos, setPos] = createSignal({ top: 0, right: 0 });
-
-  // Recompute position each time popover opens
-  const updatePos = () => {
-    if (!props.triggerRef) return;
-    const rect = props.triggerRef.getBoundingClientRect();
-    setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-  };
-
-  // Close on click outside (ignore clicks on the trigger itself)
-  makeEventListener(document, "mousedown", (e) => {
-    if (
-      props.open &&
-      panelRef &&
-      !panelRef.contains(e.target as Node) &&
-      !props.triggerRef?.contains(e.target as Node)
-    ) {
-      props.onOpenChange(false);
-    }
-  });
-
-  // Close on Escape
-  makeEventListener(document, "keydown", (e) => {
-    if (props.open && e.key === "Escape") {
-      props.onOpenChange(false);
-    }
+  const { panelRef, panelStyle } = useAnchoredPopover({
+    triggerRef: () => props.triggerRef,
+    open: () => props.open,
+    onDismiss: () => props.onOpenChange(false),
+    anchor: "bottom-end",
   });
 
   return (
     <Show when={props.open}>
       <Portal>
         <div
-          ref={(el) => {
-            panelRef = el;
-            updatePos();
-          }}
+          ref={panelRef}
           data-testid="settings-popover"
           class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-4 min-w-[280px] space-y-4"
           style={{
-            top: `${pos().top}px`,
-            right: `${pos().right}px`,
+            ...panelStyle(),
             "background-color": "var(--color-surface-1)",
           }}
         >

--- a/packages/client/src/terminal/PrUnavailablePopover.tsx
+++ b/packages/client/src/terminal/PrUnavailablePopover.tsx
@@ -2,17 +2,16 @@
  *  `PrResult.kind === "unavailable"`. Dispatch happens in two layers:
  *  `ProviderUnavailableContent` matches on `source.provider` (today only
  *  `"gh"`), delegating to a per-provider content component so bkt's future
- *  recovery UX doesn't need to fit a shared mold. Portal + click-outside +
- *  Escape mirror `settings/SettingsPopover.tsx` — no Corvu Popover in the
- *  repo, and the settings panel is the canonical anchored-floating pattern. */
+ *  recovery UX doesn't need to fit a shared mold. Anchored positioning
+ *  comes from `useAnchoredPopover`. */
 
-import { makeEventListener } from "@solid-primitives/event-listener";
 import type { GhUnavailableCode, PrUnavailableSource } from "kolu-common";
 import { reasonForSource } from "kolu-common/pr";
 import { type Component, createSignal, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 import { toast } from "solid-sonner";
 import { match } from "ts-pattern";
+import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import { WarningIcon } from "../ui/Icons";
 import { writeTextToClipboard } from "./clipboard";
 
@@ -111,49 +110,25 @@ const PrUnavailablePopover: Component<{
   triggerRef?: HTMLElement;
   source: PrUnavailableSource;
 }> = (props) => {
-  let panelRef: HTMLDivElement | undefined;
-  const [pos, setPos] = createSignal({ top: 0, left: 0 });
-
-  const updatePos = () => {
-    if (!props.triggerRef) return;
-    const rect = props.triggerRef.getBoundingClientRect();
-    // Anchor below the trigger, aligned to its left edge, with viewport clamp
-    // so narrow tiles near the right edge don't clip the panel.
-    const panelWidth = 280;
-    const left = Math.min(rect.left, window.innerWidth - panelWidth - 8);
-    setPos({ top: rect.bottom + 4, left: Math.max(8, left) });
-  };
-
-  makeEventListener(document, "mousedown", (e) => {
-    if (
-      props.open &&
-      panelRef &&
-      !panelRef.contains(e.target as Node) &&
-      !props.triggerRef?.contains(e.target as Node)
-    ) {
-      props.onOpenChange(false);
-    }
-  });
-
-  makeEventListener(document, "keydown", (e) => {
-    if (props.open && e.key === "Escape") props.onOpenChange(false);
+  const { panelRef, panelStyle } = useAnchoredPopover({
+    triggerRef: () => props.triggerRef,
+    open: () => props.open,
+    onDismiss: () => props.onOpenChange(false),
+    anchor: "bottom-start",
+    panelMinWidth: 280,
   });
 
   return (
     <Show when={props.open}>
       <Portal>
         <div
-          ref={(el) => {
-            panelRef = el;
-            updatePos();
-          }}
+          ref={panelRef}
           data-testid="pr-unavailable-popover"
           role="dialog"
           aria-label={reasonForSource(props.source)}
           class="fixed z-50 bg-surface-1 border border-edge rounded-xl shadow-2xl shadow-black/50 p-3 w-[280px] space-y-2 text-xs"
           style={{
-            top: `${pos().top}px`,
-            left: `${pos().left}px`,
+            ...panelStyle(),
             "background-color": "var(--color-surface-1)",
           }}
         >

--- a/packages/client/src/ui/PierreFileTree.tsx
+++ b/packages/client/src/ui/PierreFileTree.tsx
@@ -50,8 +50,15 @@ export type PierreFileTreeProps = {
   gitStatus?: GitStatusEntry[];
   selectedPath?: string | null;
   onSelect?: (path: string | null) => void;
-  /** Enable the search affordance inside the tree header. */
+  /** Enable Pierre's built-in header search affordance. Default `true`.
+   *  Set to `false` when the host renders its own search input and drives
+   *  the tree externally via `searchQuery`. */
   search?: boolean;
+  /** External search query — when provided, forwarded to Pierre's
+   *  `setSearch()` on every change. Useful when search lives in the
+   *  caller's chrome (e.g. a sibling toolbar) rather than the tree
+   *  header. Pass empty string to clear. */
+  searchQuery?: string;
   /** Initial folder expansion — captured at construction and **not
    *  reactive**. Pierre takes this once in the `FileTree` constructor;
    *  later prop changes are silently ignored. Re-mount the component
@@ -183,6 +190,17 @@ const PierreFileTree: Component<PierreFileTreeProps> = (props) => {
     on(
       () => props.gitStatus,
       (g) => tree?.setGitStatus(g),
+      { defer: true },
+    ),
+  );
+
+  // Forward external search query into Pierre's filter session so a
+  // host-rendered search input can drive the tree without Pierre's
+  // built-in header. `null` clears the filter; "" is treated the same.
+  createEffect(
+    on(
+      () => props.searchQuery,
+      (q) => tree?.setSearch(q && q.length > 0 ? q : null),
       { defer: true },
     ),
   );

--- a/packages/client/src/ui/useAnchoredPopover.ts
+++ b/packages/client/src/ui/useAnchoredPopover.ts
@@ -1,0 +1,105 @@
+/** Shared scaffold for "popover anchored beneath a trigger element."
+ *
+ *  Returns a `panelRef` callback and a reactive `panelStyle` accessor;
+ *  the caller renders the panel via `<Portal>` and binds both. The hook
+ *  owns:
+ *    - viewport-clamped positioning (`bottom-start` left-anchored or
+ *      `bottom-end` right-anchored, recomputed on open/trigger change),
+ *    - document-level outside-click dismiss (active only while open),
+ *    - Escape-key dismiss (same).
+ *
+ *  Dismiss is delivered via `onDismiss`, never inside the hook — callers
+ *  with controlled open state, derived open state, or internal open
+ *  state all wire the same way. */
+
+import { createEventListener } from "@solid-primitives/event-listener";
+import { createEffect, createSignal, type JSX } from "solid-js";
+
+export type AnchorSide = "bottom-start" | "bottom-end";
+
+export type UseAnchoredPopoverOpts = {
+  /** Accessor for the trigger element. Allows signal-backed refs that
+   *  change identity (e.g. a button that remounts) to reposition the
+   *  popover automatically. */
+  triggerRef: () => HTMLElement | undefined;
+  /** Accessor for current open state. Document listeners are attached
+   *  only while this returns `true`. */
+  open: () => boolean;
+  /** Called when the user clicks outside the panel/trigger or presses
+   *  Escape. The hook never mutates state itself. */
+  onDismiss: () => void;
+  /** Defaults to `"bottom-start"` (left-anchored, viewport-clamped).
+   *  `"bottom-end"` right-anchors to the trigger. */
+  anchor?: AnchorSide;
+  /** Min panel width — used for viewport clamping when
+   *  `anchor === "bottom-start"`. Defaults to 0 (no clamp). */
+  panelMinWidth?: number;
+  /** Vertical offset below the trigger's bottom edge. Defaults to 4px. */
+  offset?: number;
+};
+
+export type UseAnchoredPopover = {
+  panelRef: (el: HTMLElement) => void;
+  panelStyle: () => JSX.CSSProperties;
+};
+
+const VIEWPORT_PAD = 8;
+
+export function useAnchoredPopover(
+  opts: UseAnchoredPopoverOpts,
+): UseAnchoredPopover {
+  let panelEl: HTMLElement | undefined;
+  const [pos, setPos] = createSignal<{
+    top: number;
+    left?: number;
+    right?: number;
+  }>({ top: 0 });
+
+  const updatePos = () => {
+    const t = opts.triggerRef();
+    if (!t) return;
+    const r = t.getBoundingClientRect();
+    const top = r.bottom + (opts.offset ?? 4);
+    if (opts.anchor === "bottom-end") {
+      setPos({ top, right: window.innerWidth - r.right });
+      return;
+    }
+    const minW = opts.panelMinWidth ?? 0;
+    const maxLeft = window.innerWidth - minW - VIEWPORT_PAD;
+    const left = Math.max(VIEWPORT_PAD, Math.min(r.left, maxLeft));
+    setPos({ top, left });
+  };
+
+  // Document listeners exist only while the popover is open — passing
+  // `undefined` as the target detaches them.
+  const docTarget = () => (opts.open() ? document : undefined);
+  createEventListener(docTarget, "mousedown", (e) => {
+    const node = e.target as Node;
+    const t = opts.triggerRef();
+    if (panelEl?.contains(node) || t?.contains(node)) return;
+    opts.onDismiss();
+  });
+  createEventListener(docTarget, "keydown", (e) => {
+    if (e.key === "Escape") opts.onDismiss();
+  });
+
+  // Reposition when the trigger ref or open state changes — covers both
+  // first open and trigger remounts (e.g. a button that re-renders).
+  createEffect(() => {
+    if (opts.open() && opts.triggerRef()) updatePos();
+  });
+
+  const panelRef = (el: HTMLElement) => {
+    panelEl = el;
+    updatePos();
+  };
+
+  const panelStyle = (): JSX.CSSProperties => {
+    const p = pos();
+    return p.right !== undefined
+      ? { top: `${p.top}px`, right: `${p.right}px` }
+      : { top: `${p.top}px`, left: `${p.left}px` };
+  };
+
+  return { panelRef, panelStyle };
+}

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -63,9 +63,14 @@ When(
 When(
   "I click the Code tab mode {string}",
   async function (this: KoluWorld, mode: string) {
-    const btn = this.page.locator(`[data-testid="diff-mode-${mode}"]`);
-    await btn.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await btn.click();
+    // The mode picker is a chip + popover: open the chip, then pick
+    // the option. The chip closes itself after a selection.
+    const chip = this.page.locator(`[data-testid="diff-filter-chip"]`);
+    await chip.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await chip.click();
+    const opt = this.page.locator(`[data-testid="diff-mode-${mode}"]`);
+    await opt.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await opt.click();
     await this.waitForFrame();
   },
 );
@@ -245,10 +250,13 @@ Then(
 Then(
   "the Code tab mode should be {string}",
   async function (this: KoluWorld, mode: string) {
-    const btn = this.page.locator(
-      `[data-testid="diff-mode-${mode}"][data-active="true"]`,
+    // The chip carries `data-mode` reflecting the current view, so the
+    // assertion doesn't need to open the popover (where the per-mode
+    // testids live).
+    const chip = this.page.locator(
+      `[data-testid="diff-filter-chip"][data-mode="${mode}"]`,
     );
-    await btn.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await chip.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   },
 );
 


### PR DESCRIPTION
The Code browser's mode picker had three flat tabs — **All**, **Local**, **Branch** — that read as tabs and wasted horizontal space the file-name filter could have used. Pierre's `FileTree` rendered its own search header inside the tree, so the panel had _two_ filter affordances stacked on top of each other.

This PR replaces the trio with **a single chip + popover on the left and a free-text filter input on the right**, all inside one toolbar row. State is unchanged — `CodeTabView` is still `"local" | "branch" | "browse"`, the persisted preference shape is untouched, and the existing per-mode `data-testid`s still resolve (now inside the popover).

```
┌──────────────────────────────────────────────┐
│ [⎇ Git: Local ▾]   🔍 filter files…    ×    │
├──────────────────────────────────────────────┤
│ <file tree, filtered live by the input>      │
├──────────────────────────────────────────────┤
│ <selected file's diff or content>            │
└──────────────────────────────────────────────┘
```

### Two presenters, one toolbar

The two filter axes live in two focused components, arranged inline in `CodeTab`'s toolbar:

- **`ModeChipPicker`** — chip + popover. Pure presenter parameterized by `modes: ModeOption[]`.
- **`FileSearchInput`** — input + clear button. Just `value` + `onChange`.

Visual co-location is preserved by `CodeTab`'s flex row; the components don't share state or know about each other.

### How mode metadata flows

The host owns mode identity so adding a new mode (stash, vs-commit, etc.) touches one file:

```ts
// CodeTab.tsx
const modeOptions = createMemo<ModeOption[]>(() => {
  const ref = branchRef();
  return [
    { view: "browse", label: "All files", icon: FileBrowseIcon, ... },
    { view: "local",  group: "Git", label: "Local",  icon: GitBranchIcon, ... },
    { view: "branch", group: "Git", label: "Branch",
      hint: ref ? `vs ${ref}` : "Working tree vs branch base", ... },
  ];
});
```

`ModeChipPicker` renders this list verbatim — no per-mode knowledge bakes in.

### Search ownership change

`PierreFileTree` accepts a `searchQuery?: string` prop forwarded to Pierre's `setSearch()` reactively. `CodeTab` passes `search={false}` to disable the built-in tree-header search and renders `FileSearchInput` itself in the toolbar. _Result: one filter input, not two._

### Shared popover scaffold

Reaching for a chip + popover surfaced that the same Portal + outside-click + Escape + viewport-clamp scaffold already lived in three other components. This PR extracts it into a single `useAnchoredPopover` hook (`ui/useAnchoredPopover.ts`) and migrates all four sites:

```ts
const { panelRef, panelStyle } = useAnchoredPopover({
  triggerRef: () => triggerEl,
  open,
  onDismiss: () => setOpen(false),
  anchor: "bottom-start",     // or "bottom-end" for right-anchored
  panelMinWidth: 240,         // viewport clamp pad
});
```

Migrated: `SettingsPopover`, `RecordPopover`, `PrUnavailablePopover`, `ModeChipPicker`. ~110 lines of duplicated scaffolding removed.

### Refinements during review

| What was off | Fix |
| --- | --- |
| Mode trio read as tabs | Replaced with chip + popover |
| Two filter inputs stacked (toolbar + tree header) | Externalized search into `PierreFileTree.searchQuery` |
| Mode metadata split between picker and host (Lowy) | Moved `OPTIONS` to `CodeTab`; picker parameterized by `modes` prop |
| Filter chrome conflated mode + search volatilities (Lowy [#794](https://github.com/juspay/kolu/issues/794)) | Split into `ModeChipPicker` + `FileSearchInput` |
| Popover scaffold duplicated 4 times ([#795](https://github.com/juspay/kolu/issues/795)) | Extracted `useAnchoredPopover`, migrated all 4 sites |
| Popover slipped off-screen near right edge (Hickey) | Clamped `pos.left` to viewport with 8px pad — now part of the hook |
| Stringly-typed `iconKind` discriminator | Pass the icon component directly via `Dynamic` |
| Two `classList` blocks encoding active-state | Collapsed to `group-data-[active=true]` Tailwind variants |
| Document listeners attached for component lifetime | Gated via reactive `createEventListener` target |
| `activeMode()!` non-null assertion | `<Show when={…}>{(m) => …}` callback narrowing |

### Try it locally

```sh
nix run github:juspay/kolu/code-tab-toggle-ui
```

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._