### PR TITLE
Patch Anthropic SDK resolution

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,7 +50,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-6WDGaRDXr2hXtvXurr1BlEfM9u11C1Uhz0aDwGu7EQI=";
+    hash = "sha256-uefqzLSASr4++AGwC24LC+v8TW20bfqoTtk/4P4iUv8=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "yaml": "^2.8.3",
       "defu": "^6.1.5",
       "postcss": "^8.5.10",
-      "@anthropic-ai/sdk": "^0.81.0",
+      "@anthropic-ai/sdk": "^0.91.1",
       "@xterm/xterm": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built",
       "@xterm/addon-webgl": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   yaml: ^2.8.3
   defu: ^6.1.5
   postcss: ^8.5.10
-  '@anthropic-ai/sdk': ^0.81.0
+  '@anthropic-ai/sdk': ^0.91.1
   '@xterm/xterm': github:juspay/xterm.js#fix/kolu-xterm-fixes-built
   '@xterm/addon-webgl': github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
 
@@ -584,8 +584,8 @@ packages:
     peerDependencies:
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -4597,7 +4597,7 @@ snapshots:
 
   '@anthropic-ai/claude-agent-sdk@0.2.96(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -4614,7 +4614,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:


### PR DESCRIPTION
**The Claude Code integration now resolves `@anthropic-ai/sdk` to the patched `0.91.1` line**, addressing Dependabot alert 30 for CVE-2026-41686. The vulnerable SDK remains transitive through `@anthropic-ai/claude-agent-sdk`, so the fix stays at the existing root pnpm override boundary.

The lockfile now pins `@anthropic-ai/sdk@0.91.1`, and `default.nix` carries the refreshed `fetchPnpmDeps` hash for that dependency graph. `pnpm --filter kolu-claude-code test:unit`, `just check`, `just fmt`, and `nix build` all pass locally.

### Try it locally

```sh
nix build github:juspay/kolu/fix/dependabot-30-anthropic-sdk
```

_Addresses https://github.com/juspay/kolu/security/dependabot/30._

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._