### PR TITLE
Fix three macOS CI failures: worktree e2e race, gitDir dedupe, session autosave clobber

### DIFF
--- a/packages/integrations/git/src/git-dir.ts
+++ b/packages/integrations/git/src/git-dir.ts
@@ -12,6 +12,7 @@
  *  retune touches one constant. */
 
 import { execSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 
 export const WATCHER_DEBOUNCE_MS = 150;
@@ -23,7 +24,13 @@ export function resolveGitDir(cwd: string): string | null {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
-    return path.resolve(cwd, result.trim());
+    // Canonicalize: macOS `/tmp` symlinks to `/private/tmp`, and `git
+    // rev-parse --git-dir` reports a relative path from the repo root but
+    // a realpath-resolved absolute path from a subdir. Without realpath
+    // here, two subscribers reaching the same .git via different paths
+    // would key the shared-watcher registry under two strings and fail
+    // to dedupe.
+    return fs.realpathSync(path.resolve(cwd, result.trim()));
   } catch {
     return null;
   }

--- a/packages/server/src/session.ts
+++ b/packages/server/src/session.ts
@@ -14,6 +14,10 @@ import { log } from "./log.ts";
 import { publisher, publishSystem } from "./publisher.ts";
 import { store } from "./state.ts";
 
+/** Pending autosave timer — declared at module top so `setSavedSession`
+ *  can cancel it (see comment on that function for the race). */
+let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
 /** Write the session blob (or clear it) and publish to subscribers. */
 function writeSession(next: SavedSession | null): void {
   store.set("session", next);
@@ -48,14 +52,26 @@ export function clearSavedSession(): void {
   writeSession(null);
 }
 
-/** Set the saved session directly (used by test harness and session tests). */
+/** Set the saved session directly (used by test harness and session tests).
+ *
+ *  Also cancels any pending autosave timer so a stale `terminals:dirty`
+ *  event scheduled before this call cannot fire after it and clobber the
+ *  manually-set session with an empty-snapshot null. The race surfaces in
+ *  e2e: the test scenario's Before hook drains terminals, then posts a
+ *  fresh saved session, then loads the page; in between, a lingering
+ *  provider event from a previous scenario's drained terminal fires
+ *  `terminals:dirty`, the autosave callback runs 500ms later with an empty
+ *  terminal snapshot, and `saveSession([])` rewrites the session to null —
+ *  the restore card disappears mid-scenario. */
 export function setSavedSession(session: SavedSession | null): void {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = undefined;
+  }
   writeSession(session);
 }
 
 // --- Auto-save: terminal lifecycle → session persistence (decoupled via publisher) ---
-
-let saveTimer: ReturnType<typeof setTimeout> | undefined;
 
 /** Wire up throttled session save from terminal change events. Called once at startup.
  *

--- a/packages/tests/features/worktree.feature
+++ b/packages/tests/features/worktree.feature
@@ -27,6 +27,7 @@ Feature: Git worktree management
     And I select "New terminal" in the palette
     And I select "kolu-wt-remove" in the palette
     Then the header CWD should show ".worktrees/"
+    And the pill tree should show a worktree indicator
     Given I note the pill tree entry count
     When I open the command palette
     And I select "Close terminal" in the palette
@@ -43,6 +44,7 @@ Feature: Git worktree management
     And I select "New terminal" in the palette
     And I select "kolu-wt-cancel" in the palette
     Then the header CWD should show ".worktrees/"
+    And the pill tree should show a worktree indicator
     Given I note the pill tree entry count
     When I open the command palette
     And I select "Close terminal" in the palette
@@ -59,6 +61,7 @@ Feature: Git worktree management
     And I select "New terminal" in the palette
     And I select "kolu-wt-close-only" in the palette
     Then the header CWD should show ".worktrees/"
+    And the pill tree should show a worktree indicator
     Given I note the pill tree entry count
     When I open the command palette
     And I select "Close terminal" in the palette


### PR DESCRIPTION
**Three independent macOS CI failures, each with a distinct root cause.** Locally each one repros at 10–25% under parallel load on darwin; on x86_64-linux they're either masked by faster timing or genuinely don't apply. Together they account for every red step the e2e + unit suites were posting on darwin.

| # | Symptom | Root cause | Fix |
| --- | --- | --- | --- |
| 1 | `Close terminal on worktree …` times out clicking the Remove button | `closeTerminal()` snapshots `meta.git?.isWorktree` once at dialog-open; the test only waited for CWD, not the async git-metadata stream | Wait for the worktree indicator before initiating close |
| 2 | 9 `watchGitHead` / `subscribeGitInfo` unit tests assert `_sharedHeadWatcherCount() = 0/1/2`, get 2/4/7… | `git rev-parse --git-dir` returns relative `.git` from the repo root but a realpath-resolved absolute path from a subdir; on macOS `/tmp` ↔ `/private/tmp` collides the registry | Pipe the resolved path through `fs.realpathSync` |
| 3 | `session-restore` scenarios — restore card flashes visible then disappears mid-scenario | Pending autosave timer scheduled by a stale `terminals:dirty` event fires 500ms later, runs `saveSession([])` and writes `null`, clobbering the test-set session | `setSavedSession` cancels the pending autosave timer before writing |

### #2 in detail

The shared-watcher registry is keyed by the resolved gitDir string. When two callers reach the same repo via different paths — one from the root, one from a subdir — `git rev-parse --git-dir` reports them differently:

```
cwd=/tmp/repo            → "git rev-parse --git-dir" → ".git"           → /tmp/repo/.git
cwd=/tmp/repo/src/deep   → "git rev-parse --git-dir" → "/private/...   → /private/tmp/repo/.git
                                                       tmp/repo/.git"
```

Different keys → two `fs.watch` handles for one `.git`. `fs.realpathSync` collapses both to `/private/tmp/repo/.git` and the singleton invariant holds.

### #3 in detail

The Before hook drains terminals and posts `session: null`; the Given step posts the test session; the page loads. _Between those_, a lingering provider event from a drained terminal in the previous scenario fires `terminals:dirty`, the leading-edge throttle (#767) schedules a save 500ms out, and the callback runs with an empty terminal snapshot. `saveSession([])` rewrites the session to `null`, the client's `session.get` subscription pushes `null`, and the `<Show when={savedSession}>` unmounts the restore card the test was about to assert on.

> _The fix is local to `setSavedSession`. Production callers (test-only path today) get a free upgrade: an explicit set always wins over a pending autosave._

### Verification

- `CUCUMBER_PARALLEL=1 just test-quick features/worktree.feature` — 5/5 (was 5/5; fix is for a parallel-only race in CI)
- `just test-quick features/session-restore.feature` ×5 with parallel=4 — 5/5 (was 1–2/5 failing on master and on this branch before the autosave fix)
- `pnpm -r test:unit` — all suites green, including the 9 previously-failing `watchGitHead` / `subscribeGitInfo` cases

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._