### PR TITLE
Clear stale Code tab selection when files disappear

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -128,6 +128,8 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     return status()?.files.map((f) => f.path) ?? [];
   });
 
+  // Track membership rather than the treePaths array identity: browse paths
+  // come from a reconciled store array whose contents can change in place.
   createEffect(
     on(
       () => {

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -99,7 +99,8 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
       const m = diffMode();
       if (!p || !s || !m) return null;
       const file = status()?.files.find((f) => f.path === s);
-      return { repoPath: p, filePath: s, mode: m, oldPath: file?.oldPath };
+      if (!file) return null;
+      return { repoPath: p, filePath: s, mode: m, oldPath: file.oldPath };
     },
     (input, signal) => stream.gitDiff(input, signal),
     {
@@ -126,6 +127,20 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     if (view() === "browse") return allPaths()?.paths ?? [];
     return status()?.files.map((f) => f.path) ?? [];
   });
+
+  createEffect(
+    on(
+      () => {
+        const s = selectedPath();
+        return [s, s ? treePaths().includes(s) : true] as const;
+      },
+      ([path, pathExists]) => {
+        if (path && !pathExists) setSelectedPath(null);
+      },
+      { defer: true },
+    ),
+  );
+
   const treeGitStatus = createMemo(() => {
     const s = status();
     return s ? toGitStatusEntries(s.files) : undefined;

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -218,3 +218,28 @@ Feature: Code tab (review + browse)
     When I click the terminal canvas
     And I run "printf 'second version\n' > letters.txt"
     Then the file content should contain "second version"
+
+  Scenario: Committing the selected local diff clears the stale content pane
+    When I run "rm -rf /tmp/kolu-clear-selected-local && git init /tmp/kolu-clear-selected-local && cd /tmp/kolu-clear-selected-local"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'before\n' > note.txt"
+    And I click the Code tab
+    And I click the changed file "note.txt" in the Code tab
+    Then the diff view should contain "before"
+    When I click the terminal canvas
+    And I run "git add note.txt && git commit -m 'save note'"
+    Then the Code tab should show the empty-changes message
+    And the Code tab content should show the select hint "Select a file to view its diff"
+
+  Scenario: Deleting the selected browse file clears the stale content pane
+    When I run "rm -rf /tmp/kolu-clear-selected-browse && git init /tmp/kolu-clear-selected-browse && cd /tmp/kolu-clear-selected-browse"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'old content\n' > obsolete.txt"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    And I click the file "obsolete.txt" in the file browser
+    Then the file content should contain "old content"
+    When I click the terminal canvas
+    And I run "rm obsolete.txt"
+    Then the file browser should not show a file "obsolete.txt"
+    And the Code tab content should show the select hint "Select a file to view its content"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -300,6 +300,28 @@ Then(
   },
 );
 
+Then(
+  "the file browser should not show a file {string}",
+  async function (this: KoluWorld, path: string) {
+    const item = this.page.locator(fileRow(path));
+    await item.waitFor({ state: "detached", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the Code tab content should show the select hint {string}",
+  async function (this: KoluWorld, expected: string) {
+    await this.page.waitForFunction(
+      (text) => {
+        const content = document.querySelector('[data-testid="diff-content"]');
+        return content?.textContent?.includes(text) ?? false;
+      },
+      expected,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // Pierre's File / FileDiff renderers mount highlighted code inside a
 // shadow root. `Element.textContent` does NOT cross shadow boundaries,
 // so we walk the tree (including each `shadowRoot`) and stitch the text.


### PR DESCRIPTION
**The Code tab now clears its selected file when that file leaves the current tree**, so the bottom pane no longer keeps showing stale diff or file content after local changes are committed or a browsed file is deleted. The diff subscription also refuses to call `gitDiff` unless the selected path still exists in the latest status snapshot.

### Details

- **Local and Branch diff modes** now guard the diff input against dangling selections before subscribing.
- **Browse and diff modes** share one selection-validity check against the current `treePaths()` domain.
- **Regression coverage** exercises both committing away a selected local diff and deleting a selected browse-mode file.

### Verification

- `just check`
- `just fmt`
- `just test-quick features/code-tab.feature` (19 scenarios, 214 steps)

Closes #797.

### Try it locally

```sh
nix run github:juspay/kolu/fix/code-tab-stale-diff-797
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `GPT-5`)._