### PR TITLE
feat(home-manager): support macOS launchd

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,9 @@ just ci::protect     # set branch protection
 just ci::_summary    # check current status
 ```
 
-## Deployment (NixOS + home-manager)
+## Deployment (home-manager)
 
-A home-manager module runs kolu as a systemd user service:
+A home-manager module runs kolu as a systemd user service on Linux and as a launchd LaunchAgent on macOS:
 
 ```nix
 {
@@ -313,7 +313,7 @@ A home-manager module runs kolu as a systemd user service:
 }
 ```
 
-See [`nix/home/example/`](nix/home/example/) for a full configuration with a VM test.
+See [`nix/home/example/`](nix/home/example/) for a full configuration — a NixOS VM test exercises the systemd path on Linux, and a standalone home-manager activation build exercises the launchd path on Darwin.
 
 ### Diagnosing memory leaks
 

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -37,7 +37,7 @@ _linux:
 _linux-fanout: home-manager e2e smoke
 
 [parallel]
-_darwin-fanout: e2e smoke
+_darwin-fanout: home-manager e2e smoke
 
 _darwin:
     CI_SYSTEM=aarch64-darwin just ci::nix ci::_darwin-fanout || true

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -1,6 +1,9 @@
-# Example NixOS configuration using kolu's home-manager module.
+# Example configuration using kolu's home-manager module.
 # Built in CI to ensure the module evaluates correctly.
-# Also provides a VM test that verifies the service actually starts.
+# Linux: NixOS VM test that boots the config and verifies the systemd
+# service actually starts. Darwin: standalone home-manager eval-build that
+# verifies the launchd path produces a valid plist (no runtime test —
+# CI builders don't have a launchd session).
 {
   inputs = {
     # In CI, localci builds this with --override-input kolu pointing to the repo root.
@@ -12,11 +15,24 @@
 
   outputs = { nixpkgs, home-manager, kolu, ... }:
     let
-      system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system};
+      linuxSystem = "x86_64-linux";
+      darwinSystem = "aarch64-darwin";
+      linuxPkgs = nixpkgs.legacyPackages.${linuxSystem};
+      darwinPkgs = nixpkgs.legacyPackages.${darwinSystem};
 
-      # Shared NixOS module: minimal system + home-manager with kolu enabled
-      koluModule = {
+      # Pure home-manager module — used both inside the NixOS VM (Linux
+      # systemd path) and standalone on Darwin (launchd path).
+      koluHmModule = { pkgs, ... }: {
+        imports = [ kolu.homeManagerModules.default ];
+        services.kolu = {
+          enable = true;
+          package = kolu.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+        home.stateVersion = "24.11";
+      };
+
+      # NixOS module: minimal system + home-manager with kolu enabled.
+      nixosModule = {
         boot.loader.grub.devices = [ "nodev" ];
         fileSystems."/" = { device = "none"; fsType = "tmpfs"; };
         system.stateVersion = "24.11";
@@ -27,33 +43,26 @@
           initialPassword = "pass";
         };
 
-        home-manager.users.alice = {
-          imports = [ kolu.homeManagerModules.default ];
-          services.kolu = {
-            enable = true;
-            package = kolu.packages.${system}.default;
-          };
-          home.stateVersion = "24.11";
-        };
+        home-manager.users.alice = koluHmModule;
       };
     in
     {
       nixosConfigurations.example = nixpkgs.lib.nixosSystem {
-        inherit system;
+        system = linuxSystem;
         modules = [
           home-manager.nixosModules.home-manager
-          koluModule
+          nixosModule
         ];
       };
 
-      # VM test: boots the config and verifies kolu listens on its port
-      checks.${system}.vm-test = pkgs.testers.nixosTest {
+      # Linux: VM test boots the config and verifies kolu listens on its port.
+      checks.${linuxSystem}.vm-test = linuxPkgs.testers.nixosTest {
         name = "kolu-service";
 
         nodes.machine = { ... }: {
           imports = [
             home-manager.nixosModules.home-manager
-            koluModule
+            nixosModule
           ];
 
           # Auto-login alice so her user session starts
@@ -85,5 +94,19 @@
           )
         '';
       };
+
+      # Darwin: standalone home-manager activation package. Building this
+      # exercises the launchd.agents.kolu path end-to-end (plist generation,
+      # wait4path wrapping, etc.) without needing a live launchd session.
+      checks.${darwinSystem}.home-activation = (home-manager.lib.homeManagerConfiguration {
+        pkgs = darwinPkgs;
+        modules = [
+          koluHmModule
+          {
+            home.username = "alice";
+            home.homeDirectory = "/Users/alice";
+          }
+        ];
+      }).activationPackage;
     };
 }

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -1,6 +1,32 @@
 { config, lib, pkgs, ... }:
 let
   cfg = config.services.kolu;
+
+  # Three-state TLS: explicit cert+key pair, auto-signed self-signed, or off.
+  # The certFile/keyFile pairing is enforced by an assertion below.
+  tlsArgs =
+    if cfg.tls.certFile != null then
+      [ "--tls-cert" (toString cfg.tls.certFile) "--tls-key" (toString cfg.tls.keyFile) ]
+    else if cfg.tls.enable then
+      [ "--tls" ]
+    else
+      [ ];
+
+  args = [
+    (lib.getExe cfg.package)
+    "--host"
+    cfg.host
+    "--port"
+    (toString cfg.port)
+  ]
+  ++ tlsArgs
+  ++ lib.optionals cfg.verbose [ "--verbose" ];
+
+  # Shared by both supervisors. systemd wants `[ "KEY=val" ]`; launchd wants
+  # the attrset as a plist dict — converted at each call site.
+  envAttrs = lib.optionalAttrs (cfg.diagnostics.dir != null) {
+    KOLU_DIAG_DIR = cfg.diagnostics.dir;
+  };
 in
 {
   options.services.kolu = {
@@ -65,28 +91,36 @@ in
       }
     ];
 
-    systemd.user.services.kolu = {
-      Unit = {
-        Description = "kolu web terminal multiplexer";
-        After = [ "network.target" ];
+    systemd.user.services = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+      kolu = {
+        Unit = {
+          Description = "kolu web terminal multiplexer";
+          After = [ "network.target" ];
+        };
+        Service = {
+          ExecStart = toString args;
+          Restart = "on-failure";
+        } // lib.optionalAttrs (envAttrs != { }) {
+          Environment = lib.mapAttrsToList (k: v: "${k}=${v}") envAttrs;
+        };
+        Install = {
+          WantedBy = [ "default.target" ];
+        };
       };
-      Service = {
-        ExecStart = toString ([
-          (lib.getExe cfg.package)
-          "--host"
-          cfg.host
-          "--port"
-          (toString cfg.port)
-        ]
-        ++ lib.optionals (cfg.tls.certFile != null) [ "--tls-cert" (toString cfg.tls.certFile) "--tls-key" (toString cfg.tls.keyFile) ]
-        ++ lib.optionals (cfg.tls.certFile == null && cfg.tls.enable) [ "--tls" ]
-        ++ lib.optionals cfg.verbose [ "--verbose" ]);
-        Restart = "on-failure";
-      } // lib.optionalAttrs (cfg.diagnostics.dir != null) {
-        Environment = [ "KOLU_DIAG_DIR=${cfg.diagnostics.dir}" ];
-      };
-      Install = {
-        WantedBy = [ "default.target" ];
+    };
+
+    # home-manager activation reloads the LaunchAgent only when the plist
+    # bytes change, which means args/env changes drop active terminal sessions.
+    launchd.agents = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+      kolu = {
+        enable = true;
+        config = {
+          ProgramArguments = args;
+          RunAtLoad = true;
+          KeepAlive.SuccessfulExit = false;
+        } // lib.optionalAttrs (envAttrs != { }) {
+          EnvironmentVariables = envAttrs;
+        };
       };
     };
   };

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -191,9 +191,9 @@ const features = [
           > (with flakes enabled), and you're one command away.
         </p>
         <p class="text-ink-muted text-sm">
-          Or wire it into a NixOS/home-manager module to run as a long-lived
-          systemd user service — see the <a
-            href="https://github.com/juspay/kolu#deployment-nixos--home-manager"
+          Or wire it into a home-manager module to run as a long-lived user
+          service — systemd on Linux, launchd on macOS — see the <a
+            href="https://github.com/juspay/kolu#deployment-home-manager"
             rel="noopener"
             class="border-b border-ink-faint hover:border-amber hover:text-ink transition-colors"
             >deployment guide</a


### PR DESCRIPTION
**The home-manager module now works on macOS.** Previously, `services.kolu.enable = true` failed eval on Darwin because the module only emitted a `systemd.user.services.kolu` block, and home-manager's systemd module hard-asserts `isLinux`. This adds a parallel launchd path so the same `imports = [ kolu.homeManagerModules.default ]` works unchanged on both platforms.

The argv/env computation is hoisted into shared `let` bindings so each supervisor stanza is just plumbing — kolu CLI changes touch one place, not two.

### Supervisor mapping

| Concept | systemd (Linux) | launchd (macOS) |
| --- | --- | --- |
| Autostart on login | `WantedBy = [ "default.target" ]` | `RunAtLoad = true` |
| Restart on crash | `Restart = "on-failure"` | `KeepAlive.SuccessfulExit = false` |
| Environment | `Environment = [ "K=v" ]` _(list)_ | `EnvironmentVariables = { K = "v"; }` _(plist dict)_ |
| Network ordering | `After = [ "network.target" ]` | _(no analog — irrelevant for localhost)_ |

A small TLS refactor falls out of the hoist: the three-state cert/auto/off decision now lives in one `tlsArgs` binding instead of being scattered across two `lib.optionals` in the argv list.

### CI coverage

The example flake gains `checks.aarch64-darwin.home-activation` — a standalone `home-manager.lib.homeManagerConfiguration` whose `activationPackage` is built end-to-end on a real Darwin runner. This exercises plist generation, the `wait4path /nix/store` wrapping home-manager applies, and the `~/Library/LaunchAgents` symlink — without needing a live launchd session. The `home-manager` step is added to `_darwin-fanout` in `ci/mod.just` so the Darwin lane actually picks it up; the Linux NixOS VM test is unchanged and still verifies the systemd path boots and binds the port.

> _Caveat worth knowing: home-manager reloads the LaunchAgent whenever the rendered plist's bytes change. Since the resolved kolu store path is embedded in `ProgramArguments` (`/bin/sh -c "wait4path /nix/store && exec /nix/store/<hash>-kolu/bin/kolu …"`), **a kolu package upgrade also drops active terminal sessions** — not just option changes. Only switches that touch neither kolu nor its config leave the agent untouched. There's no "reload if changed" primitive in launchd. Called out in a comment above `launchd.agents`._

Docs synced too: README's deployment section now covers both supervisors, and the website's install panel links to the renamed anchor.

### Try it locally

```sh
nix build github:juspay/kolu/back-stoic#default
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._