### PR TITLE
fix(shell): source ~/.zshenv in zsh PTY wrapper

### DIFF
--- a/packages/server/src/shell.test.ts
+++ b/packages/server/src/shell.test.ts
@@ -6,6 +6,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   OSC2_PRECMD_BASH,
@@ -13,6 +15,7 @@ import {
   OSC2_PREEXEC_BASH_GUARD,
   OSC2_PREEXEC_FN,
   OSC7_FN,
+  osc7Init,
 } from "./shell.ts";
 
 /** Run a script in a clean bash subshell and return stdout. */
@@ -258,6 +261,27 @@ function execFileSyncBoth(script: string): string {
     return "";
   }
 }
+
+describe("osc7Init zsh wrapper", () => {
+  it("sources ~/.zshenv (regression: ZDOTDIR override hides it from zsh)", () => {
+    // Without this line, any user env defined in ~/.zshenv (PATH, etc.) is
+    // lost in PTY shells when kolu's parent process has a stripped env —
+    // notably under macOS launchd. zsh's auto-lookup of ~/.zshenv goes
+    // through ZDOTDIR, which we override, so the wrapper must replay it.
+    const init = osc7Init({
+      shell: "/bin/zsh",
+      home: "/home/testuser",
+      terminalId: "test-zshenv-source",
+    });
+    try {
+      const rcPath = join(init.env.ZDOTDIR as string, ".zshrc");
+      const rc = readFileSync(rcPath, "utf8");
+      expect(rc).toContain('source "/home/testuser/.zshenv"');
+    } finally {
+      init.cleanup();
+    }
+  });
+});
 
 describe("OSC2_PRECMD_ZSH", () => {
   it("emits OSC 2 with compact zsh prompt path", () => {

--- a/packages/server/src/shell.ts
+++ b/packages/server/src/shell.ts
@@ -216,6 +216,10 @@ export function osc7Init(opts: {
     writeFileSync(
       join(zdotdir, ".zshrc"),
       [
+        // ZDOTDIR override (below) suppresses zsh's auto-lookup of ~/.zshenv;
+        // replay it so home-manager's hm-session-vars.sh (PATH) loads under
+        // macOS launchd, which hands kolu a near-empty parent env.
+        `[ -f "${home}/.zshenv" ] && source "${home}/.zshenv"`,
         `[ -f /etc/zprofile ] && source /etc/zprofile`,
         `[ -f "${home}/.zprofile" ] && source "${home}/.zprofile"`,
         `[ -f "${home}/.zshrc" ] && ZDOTDIR="${home}" source "${home}/.zshrc"`,

--- a/packages/server/src/shell.ts
+++ b/packages/server/src/shell.ts
@@ -217,8 +217,8 @@ export function osc7Init(opts: {
       join(zdotdir, ".zshrc"),
       [
         // ZDOTDIR override (below) suppresses zsh's auto-lookup of ~/.zshenv;
-        // replay it so home-manager's hm-session-vars.sh (PATH) loads under
-        // macOS launchd, which hands kolu a near-empty parent env.
+        // replay it so the user's env (PATH etc.) loads even when the parent
+        // process has a stripped env — macOS launchd hands user agents one.
         `[ -f "${home}/.zshenv" ] && source "${home}/.zshenv"`,
         `[ -f /etc/zprofile ] && source /etc/zprofile`,
         `[ -f "${home}/.zprofile" ] && source "${home}/.zprofile"`,


### PR DESCRIPTION
## Summary

PTY shells spawned by Kolu running as a macOS launchd user agent (#799) inherited a near-empty PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) — none of the user's home-manager / nix paths. On Linux the same setup worked fine. The cause is in `packages/server/src/shell.ts`'s zsh init wrapper.

The wrapper sets `ZDOTDIR` to a temp dir so it can layer Kolu's OSC hooks on top of the user's existing zsh init without modifying their dotfiles (zsh's analog of bash's `--rcfile`). The cost: `ZDOTDIR` redirects zsh's auto-lookup of `~/.zshenv`, `~/.zprofile`, `~/.zlogin` to the temp dir, where they don't exist. The wrapper used to compensate by manually sourcing `/etc/zprofile`, `~/.zprofile`, `~/.zshrc` — but **not** `~/.zshenv`.

`~/.zshenv` is exactly where home-manager's zsh module places the `hm-session-vars.sh` source line that sets up `PATH`, `NIX_PATH`, `XDG_*`, etc. (verified at [`home-manager/modules/programs/zsh/default.nix:483-485`](https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh/default.nix#L483-L485)). With `ZDOTDIR` overridden and no manual replay, those vars never load.

## Why Linux didn't surface it

Under `systemd --user`, kolu's `process.env` already carries `PATH` from the PAM session, so `cleanEnv()`'s passthrough at `shell.ts:67-68` masked the missing `~/.zshenv` source. macOS launchd seeds user agents with a stripped env, so the wrapper has to do the work itself.

This means the fix is a correctness fix on **all** platforms, not just macOS — the same defect would surface on Linux in any stripped-env launch context (minimal `Environment=`, container, `sudo -i` without `--preserve-env`).

## Fix

One line, plus a comment naming the invariant so the next person editing this block sees the trap: anything `ZDOTDIR` would have redirected must be replayed manually.

```ts
// ZDOTDIR override (below) suppresses zsh's auto-lookup of ~/.zshenv;
// replay it so home-manager's hm-session-vars.sh (PATH) loads under
// macOS launchd, which hands kolu a near-empty parent env.
\`[ -f "${home}/.zshenv" ] && source "${home}/.zshenv"\`,
```

Bash is unaffected: bash has no `~/.zshenv` analog, and the `--rcfile`-suppressed login chain is already replayed in full at `shell.ts:183-186` (`/etc/profile` → `~/.bash_profile` / `~/.bash_login` / `~/.profile` → `~/.bashrc`), which on home-manager's bash module pulls in `hm-session-vars.sh` via `~/.profile`.

## Test plan

- [ ] Local `just ci` (in particular the nix lane via `/ci nix`)
- [ ] Manual: deploy via home-manager launchd on macOS, open a PTY in Kolu, confirm `echo \$PATH` shows nix + home-manager profile entries