### PR TITLE
refactor(shell): per-shell init strategy, behavioral zshenv test

### DIFF
--- a/packages/server/src/pty.ts
+++ b/packages/server/src/pty.ts
@@ -14,7 +14,7 @@ import {
 } from "kolu-common/config";
 import * as pty from "node-pty";
 import type { Logger } from "./log.ts";
-import { cleanEnv, osc7Init } from "./shell.ts";
+import { cleanEnv, prepareShellInit } from "./shell.ts";
 
 // @xterm packages ship CJS only — use createRequire for clean ESM interop
 const require = createRequire(import.meta.url);
@@ -89,15 +89,15 @@ export function spawnPty(
   const shell = env.SHELL ?? "/bin/sh";
   const cwd = spawnCwd || env.HOME || "/";
 
-  const osc7 = osc7Init({
+  const shellInit = prepareShellInit({
     shell,
     home: env.HOME,
     terminalId,
   });
-  Object.assign(env, osc7.env);
+  Object.assign(env, shellInit.env);
 
   tlog.debug({ shell, cwd }, "spawning pty");
-  const proc = pty.spawn(shell, osc7.args, {
+  const proc = pty.spawn(shell, shellInit.args, {
     name: "xterm-256color",
     cols: DEFAULT_COLS,
     rows: DEFAULT_ROWS,
@@ -226,7 +226,7 @@ export function spawnPty(
       exitDisposable.dispose();
       proc.kill();
       headless.dispose();
-      osc7.cleanup();
+      shellInit.cleanup();
     },
   };
 }

--- a/packages/server/src/shell.test.ts
+++ b/packages/server/src/shell.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -15,7 +16,7 @@ import {
   OSC2_PREEXEC_BASH_GUARD,
   OSC2_PREEXEC_FN,
   OSC7_FN,
-  osc7Init,
+  prepareShellInit,
 } from "./shell.ts";
 
 /** Run a script in a clean bash subshell and return stdout. */
@@ -262,23 +263,36 @@ function execFileSyncBoth(script: string): string {
   }
 }
 
-describe("osc7Init zsh wrapper", () => {
-  it("sources ~/.zshenv (regression: ZDOTDIR override hides it from zsh)", () => {
-    // Without this line, any user env defined in ~/.zshenv (PATH, etc.) is
-    // lost in PTY shells when kolu's parent process has a stripped env —
-    // notably under macOS launchd. zsh's auto-lookup of ~/.zshenv goes
-    // through ZDOTDIR, which we override, so the wrapper must replay it.
-    const init = osc7Init({
-      shell: "/bin/zsh",
-      home: "/home/testuser",
-      terminalId: "test-zshenv-source",
-    });
+describe("prepareShellInit zsh wrapper", () => {
+  // Behavioral regression for #800: spawn zsh against the wrapper rcfile
+  // with a fake ~/.zshenv that exports a marker, then verify the marker
+  // survives. Stronger than a string-match on the generated rcfile —
+  // catches the case where the source line is present but unreachable
+  // (broken `if`, wrong path, accidentally inside a function, etc.).
+  it("loads user env from ~/.zshenv (regression: missing under macOS launchd)", () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "kolu-shell-"));
     try {
-      const rcPath = join(init.env.ZDOTDIR as string, ".zshrc");
-      const rc = readFileSync(rcPath, "utf8");
-      expect(rc).toContain('source "/home/testuser/.zshenv"');
+      writeFileSync(
+        join(fakeHome, ".zshenv"),
+        "export KOLU_TEST_MARKER=loaded\n",
+      );
+      const init = prepareShellInit({
+        shell: "/bin/zsh",
+        home: fakeHome,
+        terminalId: `test-zshenv-${process.pid}`,
+      });
+      try {
+        const rcPath = join(init.env.ZDOTDIR as string, ".zshrc");
+        const out = runZsh(
+          `source ${rcPath} >/dev/null 2>&1; printf '%s' "$KOLU_TEST_MARKER"`,
+        );
+        if (out === null) return; // zsh unavailable — skip
+        expect(out).toBe("loaded");
+      } finally {
+        init.cleanup();
+      }
     } finally {
-      init.cleanup();
+      rmSync(fakeHome, { recursive: true, force: true });
     }
   });
 });

--- a/packages/server/src/shell.ts
+++ b/packages/server/src/shell.ts
@@ -1,11 +1,21 @@
 /**
  * Shell environment preparation for PTY spawning.
  *
- * Passes the server's env straight through to PTY shells and injects
- * OSC 7 CWD reporting hooks.  Nix devshell pollution is handled at
- * startup: the server refuses to start inside a nix shell unless
- * --allow-nix-shell-with-env-whitelist is passed (used by `just dev` /
- * `just test`).
+ * Two cooperating layers reach the spawned PTY:
+ *   1. cleanEnv() — sanitizes the parent env passed to the PTY.
+ *   2. prepareShellInit() — writes a wrapper rcfile that replays the shell's
+ *      normal startup chain (which our --rcfile / ZDOTDIR override would
+ *      otherwise suppress) and injects kolu's OSC hooks.
+ *
+ * The split matters under macOS launchd user agents, where the parent env
+ * is near-empty and cleanEnv passthrough alone wouldn't carry a usable
+ * PATH — the wrapper's replay step compensates by sourcing user dotfiles
+ * directly. Linux/systemd masks this because PAM seeds the user-instance
+ * env from the login session.
+ *
+ * Nix devshell pollution is handled at startup: the server refuses to run
+ * inside a nix shell unless --allow-nix-shell-with-env-whitelist is passed
+ * (used by `just dev` / `just test`).
  */
 
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -47,11 +57,16 @@ export function configureNixShellEnv(whitelist: string | undefined): void {
 }
 
 /**
- * Build env for the PTY shell.
+ * Sanitize the parent env that will reach the PTY shell.
  *
  * Without a whitelist (production): pass process.env straight through.
  * With a whitelist (dev/test inside nix shell): pick only whitelisted vars
  * and override SHELL with the user's login shell from /etc/passwd.
+ *
+ * Scope note: this layer only filters what the parent process exposes.
+ * Restoring user env that the parent doesn't carry (e.g. PATH from
+ * ~/.zshenv under macOS launchd) is the wrapper rcfile's job — see
+ * prepareShellInit.
  */
 export function cleanEnv(): Record<string, string> {
   let env: Record<string, string>;
@@ -144,100 +159,133 @@ export const OSC2_PREEXEC_BASH_GUARD = [
 export const OSC2_PRECMD_BASH = `__kolu_title_precmd() { printf '\\033]2;%s\\033\\\\' "$(dirs +0)"; }`;
 export const OSC2_PRECMD_ZSH = `__kolu_title_precmd() { print -Pn '\\e]2;%(4~|…/%3~|%~)\\a'; }`;
 
+type SpawnInit = {
+  args: string[];
+  env: Record<string, string>;
+  cleanup: () => void;
+};
+
 /**
- * Prepare shell init that injects hooks *after* the user's login + rc files.
+ * Per-shell wrapper-rc strategy.
  *
- * The wrapper rc sources the login init chain (/etc/profile, ~/.bash_profile
- * or ~/.zprofile) followed by the interactive rc (~/.bashrc / ~/.zshrc), then
- * appends kolu's OSC hooks. This gives terminals the full PATH even when
- * the server runs as a systemd user service with a minimal environment.
+ * Two volatility axes are separated here so neither hides regressions in
+ * the other:
  *
- * We can't just set PROMPT_COMMAND in env — tools like starship overwrite it.
- * The wrapper approach lets us append after all user init completes.
+ *   - **replay**: the user dotfiles the shell would have auto-sourced if
+ *     our wrapper override didn't suppress the lookup. New entries land
+ *     here when shell startup semantics change (e.g. zsh's ~/.zshenv
+ *     gap, fixed in #800). Anything missing is silently stripped from
+ *     PTY shells whenever the parent env is empty.
  *
- * Returns extra spawn args, env overrides, and a cleanup function to remove
- * any temp files created.
+ *   - **hooks**: OSC injection script lines. Conceptually the same goal
+ *     across shells but expressed differently (bash DEBUG trap vs zsh
+ *     add-zsh-hook), so the lists aren't merge-able.
+ *
+ * The wrapper *mechanism* (--rcfile vs ZDOTDIR) is encapsulated in
+ * `spawn`, which writes the assembled rcContent and returns spawn args
+ * + env override + cleanup.
  */
-export function osc7Init(opts: {
-  shell: string;
-  home: string | undefined;
-  terminalId: string;
-}): { args: string[]; env: Record<string, string>; cleanup: () => void } {
-  const { shell, home, terminalId } = opts;
-  const noop = { args: [], env: {}, cleanup: () => {} };
-  if (!home) return noop;
+type ShellInit = {
+  replay: (home: string) => string[];
+  hooks: string[];
+  spawn: (rcContent: string, terminalId: string) => SpawnInit;
+};
 
-  const isBash = shell.endsWith("/bash") || shell.endsWith("/bash5");
-  const isZsh = shell.endsWith("/zsh");
-
-  if (isBash) {
+const BASH_INIT: ShellInit = {
+  replay: (home) => [
+    // /etc/profile pulls in distro-wide additions (e.g. NixOS sources
+    // /etc/profile.d/hm-session-vars.sh, which sets PATH).
+    `[ -f /etc/profile ] && . /etc/profile`,
+    // Bash login priority: first existing of these wins. Mirrors bash's
+    // own login-shell semantics — only one of the three is sourced.
+    `__kolu_login=0; for __f in "${home}/.bash_profile" "${home}/.bash_login" "${home}/.profile"; do [ -f "$__f" ] && { . "$__f"; __kolu_login=1; break; }; done`,
+    // Fallback to interactive rc if no login file matched.
+    `[ "$__kolu_login" = 0 ] && [ -f "${home}/.bashrc" ] && . "${home}/.bashrc"`,
+    `unset __kolu_login __f`,
+  ],
+  hooks: [
+    OSC7_FN,
+    OSC2_PREEXEC_FN,
+    OSC2_PREEXEC_BASH_GUARD,
+    OSC2_PRECMD_BASH,
+    // PROMPT_COMMAND order: our hooks first, user's after, arm last —
+    // so the DEBUG ready flag only goes "on" between prompt setup and
+    // the next user command (filters out PROMPT_COMMAND-internal hooks).
+    `PROMPT_COMMAND="__kolu_osc7;__kolu_title_precmd\${PROMPT_COMMAND:+;$PROMPT_COMMAND};__kolu_preexec_arm"`,
+    // DEBUG trap persists across commands, so install once at source time.
+    `trap '__kolu_preexec_dispatch' DEBUG`,
+  ],
+  spawn: (rcContent, terminalId) => {
     const rcFile = join(koluShellDir, `bashrc-${terminalId}`);
-    writeFileSync(
-      rcFile,
-      [
-        // Source login init chain so the shell inherits the full PATH
-        // (e.g., from /etc/profile.d/hm-session-vars.sh on NixOS).
-        // Mirrors bash login behavior: /etc/profile, then the first of
-        // ~/.bash_profile / ~/.bash_login / ~/.profile.
-        // If no login file exists, fall back to ~/.bashrc directly.
-        `[ -f /etc/profile ] && . /etc/profile`,
-        `__kolu_login=0; for __f in "${home}/.bash_profile" "${home}/.bash_login" "${home}/.profile"; do [ -f "$__f" ] && { . "$__f"; __kolu_login=1; break; }; done`,
-        `[ "$__kolu_login" = 0 ] && [ -f "${home}/.bashrc" ] && . "${home}/.bashrc"`,
-        `unset __kolu_login __f`,
-        OSC7_FN,
-        OSC2_PREEXEC_FN,
-        OSC2_PREEXEC_BASH_GUARD,
-        OSC2_PRECMD_BASH,
-        // PROMPT_COMMAND order matters:
-        //   1. Our own osc7 + title_precmd (title/CWD)
-        //   2. User's PROMPT_COMMAND (if any)
-        //   3. __kolu_preexec_arm — MUST be last, so the ready flag only goes
-        //      "on" between the end of prompt setup and the next user command.
-        //      Any DEBUG firing before arm (hooks, aliases, etc.) sees flag=""
-        //      and skips emitting OSC 2.
-        `PROMPT_COMMAND="__kolu_osc7;__kolu_title_precmd\${PROMPT_COMMAND:+;$PROMPT_COMMAND};__kolu_preexec_arm"`,
-        // Install the DEBUG trap at source time — reinstalling inside
-        // PROMPT_COMMAND is unnecessary since the trap persists across
-        // commands. If a user's .bashrc clears it, bash-preexec-compatible
-        // setups will still work if we're loaded first.
-        `trap '__kolu_preexec_dispatch' DEBUG`,
-      ].join("\n"),
-    );
+    writeFileSync(rcFile, rcContent);
     return {
       args: ["--rcfile", rcFile],
       env: {},
       cleanup: () => rmSync(rcFile, { force: true }),
     };
-  }
+  },
+};
 
-  if (isZsh) {
+const ZSH_INIT: ShellInit = {
+  replay: (home) => [
+    // Order matches zsh's natural startup order: zshenv → zprofile → zshrc.
+    // ZDOTDIR override (in spawn below) shadows zsh's auto-lookup of each
+    // of these, so we replay them by absolute path.
+    `[ -f "${home}/.zshenv" ] && source "${home}/.zshenv"`,
+    `[ -f /etc/zprofile ] && source /etc/zprofile`,
+    `[ -f "${home}/.zprofile" ] && source "${home}/.zprofile"`,
+    // Reset ZDOTDIR while sourcing the user's .zshrc so any internal
+    // ZDOTDIR-relative lookups (plugin managers, completion dirs) hit
+    // the real home rather than our wrapper temp dir.
+    `[ -f "${home}/.zshrc" ] && ZDOTDIR="${home}" source "${home}/.zshrc"`,
+  ],
+  hooks: [
+    OSC7_FN,
+    OSC2_PREEXEC_FN,
+    OSC2_PRECMD_ZSH,
+    `autoload -Uz add-zsh-hook`,
+    `add-zsh-hook precmd __kolu_osc7`,
+    `add-zsh-hook precmd __kolu_title_precmd`,
+    `add-zsh-hook preexec __kolu_preexec`,
+  ],
+  spawn: (rcContent, terminalId) => {
     const zdotdir = join(koluShellDir, `zdotdir-${terminalId}`);
     mkdirSync(zdotdir, { recursive: true });
-    writeFileSync(
-      join(zdotdir, ".zshrc"),
-      [
-        // ZDOTDIR override (below) suppresses zsh's auto-lookup of ~/.zshenv;
-        // replay it so the user's env (PATH etc.) loads even when the parent
-        // process has a stripped env — macOS launchd hands user agents one.
-        `[ -f "${home}/.zshenv" ] && source "${home}/.zshenv"`,
-        `[ -f /etc/zprofile ] && source /etc/zprofile`,
-        `[ -f "${home}/.zprofile" ] && source "${home}/.zprofile"`,
-        `[ -f "${home}/.zshrc" ] && ZDOTDIR="${home}" source "${home}/.zshrc"`,
-        OSC7_FN,
-        OSC2_PREEXEC_FN,
-        OSC2_PRECMD_ZSH,
-        `autoload -Uz add-zsh-hook`,
-        `add-zsh-hook precmd __kolu_osc7`,
-        `add-zsh-hook precmd __kolu_title_precmd`,
-        `add-zsh-hook preexec __kolu_preexec`,
-      ].join("\n"),
-    );
+    writeFileSync(join(zdotdir, ".zshrc"), rcContent);
     return {
       args: [],
       env: { ZDOTDIR: zdotdir },
       cleanup: () => rmSync(zdotdir, { recursive: true, force: true }),
     };
-  }
+  },
+};
 
-  return noop;
+function selectShellInit(shell: string): ShellInit | null {
+  if (shell.endsWith("/bash") || shell.endsWith("/bash5")) return BASH_INIT;
+  if (shell.endsWith("/zsh")) return ZSH_INIT;
+  return null;
+}
+
+/**
+ * Build the wrapper rcfile for the user's shell and return the spawn args
+ * + env override + cleanup that go alongside it.
+ *
+ * The wrapper layers two things in order: replay (user dotfiles the shell
+ * would have auto-sourced) → hooks (kolu's OSC injection). The layering is
+ * load-bearing — replay must precede hooks so user PROMPT_COMMAND / starship
+ * etc. can't clobber our hooks. PROMPT_COMMAND in env doesn't work because
+ * the user's rc would overwrite it.
+ */
+export function prepareShellInit(opts: {
+  shell: string;
+  home: string | undefined;
+  terminalId: string;
+}): SpawnInit {
+  const noop: SpawnInit = { args: [], env: {}, cleanup: () => {} };
+  const { shell, home, terminalId } = opts;
+  if (!home) return noop;
+  const init = selectShellInit(shell);
+  if (!init) return noop;
+  const rcContent = [...init.replay(home), ...init.hooks].join("\n");
+  return init.spawn(rcContent, terminalId);
 }


### PR DESCRIPTION
Follow-up to #800, applying the Hickey + Lowy review findings from that PR's reviewer pass. The bug is already fixed on master; this PR makes the *shape* of `shell.ts` resistant to the next bug in the same class.

**Why a refactor instead of leaving #800 as-is:** the original `shell.ts` interleaved three different volatility axes — which dotfiles to replay, which OSC hooks to inject, and how to invoke the wrapper — inside one big `if (isBash) ... if (isZsh) ...` block. That's exactly why the `~/.zshenv` omission slipped through review for so long: the replay list wasn't a thing you could audit on its own. After this PR, it is.

### What changes

| Concern | Before | After |
| --- | --- | --- |
| Function name | `osc7Init` (misleading — also handles OSC 2, OSC 633, ZDOTDIR rigging) | `prepareShellInit` |
| Replay list | Inline string array interleaved with OSC injection lines, two ad-hoc copies (bash + zsh) | Per-shell `replay(home) → string[]` field on a typed `ShellInit` table |
| OSC hooks | Inline | Per-shell `hooks: string[]` on the same table |
| Wrapper mechanism | Inline `--rcfile` / ZDOTDIR plumbing in each branch | Per-shell `spawn(rcContent, terminalId)` callback |
| Two-layer defense | Implicit — `cleanEnv` and the wrapper cooperated but neither named the other | Documented in the file header and at each layer's docstring |
| `ZDOTDIR="${home}" source ~/.zshrc` | Undocumented; flagged as "latent deletion risk" by Hickey | One-line comment naming why the reset is load-bearing |

### Test improvement

The regression guard for #800 was a string-match on the generated rcfile (`expect(rc).toContain('source "~/.zshenv"')`). Hickey's read: that test passes if the source line is _present but unreachable_ — wrapped in a broken `if`, accidentally inside a function, wrong path. Replaced with a behavioral test:

```ts
writeFileSync(join(fakeHome, ".zshenv"), "export KOLU_TEST_MARKER=loaded\n");
const init = prepareShellInit({ shell: "/bin/zsh", home: fakeHome, ... });
const out = runZsh(`source ${rcPath} >/dev/null 2>&1; printf '%s' "$KOLU_TEST_MARKER"`);
expect(out).toBe("loaded");
```

If the marker survives a real zsh invocation against the wrapper, the source line is reachable. If not, the test fails — regardless of whether the line _looks_ correct in the file.

### What's not changing

- No behavior change. The wrapper rcContent assembled at runtime is byte-identical to master's output for both bash and zsh.
- Existing OSC constants (`OSC7_FN`, `OSC2_PREEXEC_FN`, etc.) untouched — they were already at the right granularity.
- `cleanEnv()` body unchanged; only its docstring grew.

> _Reviewers' "defer until a third shell" note: the `ShellInit` shape now makes adding fish or tcsh a one-table-entry change, but no third shell is being added here._

_Generated by Claude Code (model `claude-opus-4-7`)._