### PR TITLE
Update Pierre diff renderer to v1.1.20

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,7 +50,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-uefqzLSASr4++AGwC24LC+v8TW20bfqoTtk/4P4iUv8=";
+    hash = "sha256-1dtEXfSb53lltN510lhHEjFoGDQmm86Zok13lwPHS6M=";
     fetcherVersion = 3;
   };
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
     "@corvu/resizable": "^0.2.5",
     "@corvu/tooltip": "^0.2.2",
     "@orpc/client": "^1.13.13",
-    "@pierre/diffs": "^1.1.19",
+    "@pierre/diffs": "^1.1.20",
     "@pierre/trees": "^1.0.0-beta.3",
     "@orpc/contract": "^1.13.13",
     "@solid-primitives/event-listener": "^2.4.5",

--- a/packages/transcript-html/package.json
+++ b/packages/transcript-html/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@pierre/diffs": "^1.1.19",
+    "@pierre/diffs": "^1.1.20",
     "kolu-common": "workspace:*",
     "kolu-transcript-core": "workspace:*",
     "marked": "^18.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^1.13.13
         version: 1.13.13
       '@pierre/diffs':
-        specifier: ^1.1.19
-        version: 1.1.19(react@19.2.5)
+        specifier: ^1.1.20
+        version: 1.1.20(react@19.2.5)
       '@pierre/trees':
         specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(react@19.2.5)
@@ -548,8 +548,8 @@ importers:
   packages/transcript-html:
     dependencies:
       '@pierre/diffs':
-        specifier: ^1.1.19
-        version: 1.1.19(react@19.2.5)
+        specifier: ^1.1.20
+        version: 1.1.20(react@19.2.5)
       kolu-common:
         specifier: workspace:*
         version: link:../common
@@ -1918,8 +1918,8 @@ packages:
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
     engines: {node: '>=20.0.0'}
 
-  '@pierre/diffs@1.1.19':
-    resolution: {integrity: sha512-eYyDW69heXd7i9zdkWogGYosHzoYF2dstV6uDcmnQAf72uRChs3hrpf/7ym/ayTiwD8a+TQ7oZ5vNNb0tstJvA==}
+  '@pierre/diffs@1.1.20':
+    resolution: {integrity: sha512-lLi+3sLCm3QDd5/aLO9pw+WbF6UzhrkWm2oTZ5WZJTGemOyUNRJ4DDhcEKmVusu4C4bXx9Nssh6fF+wQcapb5w==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
@@ -6033,7 +6033,7 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
-  '@pierre/diffs@1.1.19(react@19.2.5)':
+  '@pierre/diffs@1.1.20(react@19.2.5)':
     dependencies:
       '@pierre/theme': 0.0.28
       '@shikijs/transformers': 3.23.0


### PR DESCRIPTION
**Kolu now consumes Pierre Diffs v1.1.20** in both the interactive Code tab and static transcript renderer. This picks up Pierre's latest empty-file deletion fix and CSS layering/minification work while leaving `@pierre/trees` on its current latest release, `1.0.0-beta.3`.

The pnpm lockfile is intentionally narrow: only the `@pierre/diffs` package resolution changes. The Nix `fetchPnpmDeps` hash was refreshed against that focused lockfile so `nix build` can populate the offline pnpm store reproducibly.

### Validation

- `nix develop -c pnpm install --frozen-lockfile`
- `nix develop -c just fmt`
- `nix build`
- `just ci` — all expected contexts green after retrying a flaky `ci/e2e@aarch64-darwin` mobile-scroll scenario; logged on #320

### Try it locally

```sh
nix build github:juspay/kolu/gay-thrust
```

_Generated by Codex (model `gpt-5`)._