### PR TITLE
Remove Ctrl/Cmd+Shift+C keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The desktop workspace is mode-less — every terminal renders as a draggable, re
 - **Floating pill tree** — a two-level overlay (repo → branches) sits at the top of the canvas, ghosted at rest and behind any tile that overlaps it; hover pops it to full opacity. Branches sort by **canvas x-position**, so the tree reads left-to-right exactly as the tiles sit. Click a branch pill to pan and center its tile
 - **Pill border encodes state** — each pill's border doubles as identity (repo color) and live status: a conic-gradient sweep while the agent is `thinking`/`tool_use`, a breathing pulse while `waiting`, a static ring when the terminal is just active, and an inset glow when the active tile also has a working agent
 - **Identity-collision suffix** — when two terminals share the same repo+branch (or cwd, for non-git), the server assigns each a stable 4-char id suffix (`#a3f2`) so the pill tree and tile chrome can disambiguate them at a glance
-- **Keyboard navigation** — <kbd>Cmd/Ctrl+Shift+2</kbd> centers on the active tile
+- **Canvas navigation** — the command palette can center the active tile when panning has moved it out of view
 - **Per-tile theming** — title bars and pill swatches derive their colors from each terminal's theme for guaranteed contrast
 - **Mobile** — the canvas, pan/zoom, and the floating pill tree are all disabled; the active tile fills the viewport and swipe-left/right cycles between terminals in pill-tree order. A pull-down chrome sheet at the top reveals the same logo + pill list + controls as a touch-sized drawer
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -200,7 +200,6 @@ const App: Component = () => {
     handleShuffleTheme,
     handleScreenshotTerminal: () => handleScreenshotTerminal(),
     toggleRightPanel: rightPanel.togglePanel,
-    canvasCenterActive: handleCanvasCenterActive,
     toggleRecordingPause: () => useRecorder().togglePause(),
   };
 
@@ -267,6 +266,7 @@ const App: Component = () => {
     handleCloseAll: () => void crud.handleCloseAll(),
     simulateAlert: alerts.simulateAlert,
     isMobile,
+    canvasCenterActive: handleCanvasCenterActive,
   });
 
   // Reset state on close and return focus to terminal

--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -25,7 +25,6 @@ const HELP_ORDER: readonly { id: ActionId; label?: string }[] = [
   { id: "nextSubTab" },
   { id: "prevSubTab" },
   { id: "toggleRightPanel" },
-  { id: "canvasCenterActive" },
   { id: "shortcutsHelp" },
 ];
 

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -53,6 +53,7 @@ export interface CommandDeps extends ActionContext {
   // Canvas — desktop only (always active there); hidden on mobile where
   // the canvas isn't mounted at all.
   isMobile: () => boolean;
+  canvasCenterActive: () => void;
   // Worktree
   handleCreateWorktree: (repoPath: string, initialCommand?: string) => void;
   handleClose: () => void;

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -145,7 +145,12 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       : []),
     actionPaletteCommand("toggleRightPanel", deps),
     ...(!deps.isMobile()
-      ? [actionPaletteCommand("canvasCenterActive", deps)]
+      ? [
+          {
+            name: "Center on active tile",
+            onSelect: () => deps.canvasCenterActive(),
+          },
+        ]
       : []),
     ...(deps.terminalIds().length > 0
       ? [

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -211,11 +211,6 @@ const _ACTIONS = {
     keybind: { key: "b", code: "KeyB", mod: true },
     handler: (ctx) => ctx.toggleRightPanel(),
   },
-  canvasCenterActive: {
-    label: "Center on active tile",
-    keybind: { key: "C", code: "KeyC", mod: true, shift: true },
-    handler: (ctx) => ctx.canvasCenterActive(),
-  },
   toggleRecordingPause: {
     label: "Pause / resume recording",
     keybind: { key: ".", code: "Period", mod: true, shift: true },

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -36,7 +36,6 @@ export interface ActionContext {
   handleShuffleTheme: () => void;
   handleScreenshotTerminal: () => void;
   toggleRightPanel: () => void;
-  canvasCenterActive: () => void;
   toggleRecordingPause: () => void;
 }
 

--- a/packages/client/src/input/keyboard.test.ts
+++ b/packages/client/src/input/keyboard.test.ts
@@ -129,6 +129,19 @@ describe("matchesAnyShortcut", () => {
     );
   });
 
+  it("does not match Ctrl/Cmd+Shift+C", () => {
+    expect(
+      matchesAnyShortcut(
+        makeEvent({ key: "C", code: "KeyC", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(false);
+    expect(
+      matchesAnyShortcut(
+        makeEvent({ key: "C", code: "KeyC", metaKey: true, shiftKey: true }),
+      ),
+    ).toBe(false);
+  });
+
   it("does not match random key", () => {
     expect(matchesAnyShortcut(makeEvent({ key: "z" }))).toBe(false);
   });

--- a/packages/tests/features/copy-pane-text.feature
+++ b/packages/tests/features/copy-pane-text.feature
@@ -1,5 +1,5 @@
 Feature: Copy terminal text
-  Copy the terminal buffer as plain text via keyboard shortcut or command palette.
+  Copy the terminal buffer as plain text via command palette.
 
   Background:
     Given the terminal is ready


### PR DESCRIPTION
**Kolu no longer intercepts Ctrl+Shift+C / Cmd+Shift+C as a global app shortcut.** That chord had been attached to “Center on active tile”; centering remains available from the command palette, while the shifted copy chord is no longer claimed by the app shortcut dispatcher.

### Details

- Removed `canvasCenterActive` from the global action registry and shortcut help.
- Kept “Center on active tile” as a palette-only desktop command.
- Added a shortcut-registry regression test for Ctrl/Cmd+Shift+C.
- Updated user-facing docs and copy-text feature wording so they no longer advertise a keyboard shortcut path.

### Verification

- `just check`
- `just fmt`
- `cd packages/client && pnpm test:unit src/input/keyboard.test.ts`
- `just test-quick features/copy-pane-text.feature features/keyboard-shortcuts.feature`

### Try it locally

```sh
nix run github:juspay/kolu/remove-copy-shift-c-keybinding
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._