### PR TITLE
docs(code-police): rename toast rule + add caught-error-must-not-collapse-to-empty

### DIFF
--- a/.agency/code-police.md
+++ b/.agency/code-police.md
@@ -26,12 +26,21 @@ Bad: `unwrap(arr[i], "out of bounds")` — type system can't see the throw
 Good: `arr[i] ?? arr[0]` on `NonEmpty<T>` — positional `arr[0]` is statically `T`, fallback is typed
 _Rationale_: Every "untyped throw" wrapper is an escape hatch the compiler can't reason about. The fix is structural — make the data model carry the invariant — not packaging the same assertion behind a nicer name.
 
-### catch-must-surface-error
+### toast-must-include-error-message
 
 When catching an error to show a toast, always include `err.message` in the toast text.
 Bad: `.catch(() => toast.error("Failed to set theme"))`
 Good: `.catch((err: Error) => toast.error(\`Failed to set theme: ${err.message}\`))`
 _Rationale_: Generic error toasts hide the server's actual error message, making debugging impossible. The server returns specific error details via oRPC — surface them.
+
+### caught-error-must-not-collapse-to-empty
+
+When a `try`/`catch` converts a thrown error into a "no data" return value (`undefined`, `null`, `[]`, `""`), the failure must be **distinguishable to the user from a legitimate empty result**. `console.warn` / `console.error` does not count — DevTools is not a user surface. Surface via toast, an error signal the caller renders, a `Result<T, E>` return, or an error boundary.
+
+Bad: `try { return parse(raw); } catch (e) { console.warn(e); return undefined; }` — caller can't tell malformed-input from no-input
+Good: `try { return ok(parse(raw)); } catch (e) { return err({ message: e.message }); }` — caller decides how to render the error
+
+_Rationale_: A silent fallback to empty state means a malformed input renders identically to a missing one. The bug stays invisible until someone notices and instruments DevTools — by which point the data path has been wrong for weeks. This rule covers the gap `toast-must-include-error-message` leaves: that one is about *how* to format a toast you've already decided to show; this one is about whether the failure surfaces at all.
 
 ### styling-tailwind-only
 


### PR DESCRIPTION
Two related tweaks to `.agency/code-police.md`. The trigger was a `/fact-check` pass on the Pierre wrappers (`PierreDiffView.tsx`, `PierreFileTree.tsx`, `PierreFileView.tsx`) that flagged a `try { return parse(raw); } catch (e) { console.warn(e); return undefined; }` pattern in `parseFirstFile`. None of the existing rules fired on it — the failure mode fell into a gap between the rule we had and the scope of `subscription-must-surface-errors`.

## What changed

### Rename `catch-must-surface-error` → `toast-must-include-error-message`

The old name overpromised. Read the rule body and it's specifically about toast message *formatting* (include `err.message` in the text). A toast that said `"Failed to set theme"` satisfied the literal name (the error did surface, as a toast) but violated the rule (the message was generic).

| | Old name | New name |
|---|---|---|
| What it sounds like | Any error in any catch must surface to the user | Toasts that report errors must include `err.message` |
| What it actually checks | Toasts that report errors must include `err.message` | Same |

No external references to the rule (grepped `*.md`, `*.ts`, `*.tsx` across the repo) — rename is safe.

### Add `caught-error-must-not-collapse-to-empty`

Covers the gap the rename leaves: a `try`/`catch` that returns `undefined` / `null` / `[]` / `""` to signal a parse or I/O failure is **indistinguishable to the user from a legitimate empty result**. `console.warn` / `console.error` doesn't count — DevTools is not a user surface.

```diff
- Bad: try { return parse(raw); } catch (e) { console.warn(e); return undefined; }
+ Good: try { return ok(parse(raw)); } catch (e) { return err({ message: e.message }); }
```

Surface via toast, an error signal the caller renders, a `Result<T, E>` return, or an error boundary — caller decides how to render the failure.

## Why two rules and not one consolidated rule

They check orthogonal aspects of error-surfacing and would compose cleanly when both apply (e.g., a future toast-on-parse-error site would trip both: collapse-to-empty fires on the silent path, toast-must-include-message fires once you add the toast).

| Rule | What it catches |
| --- | --- |
| `toast-must-include-error-message` | You **do** toast, but the toast says `"Failed to set theme"` instead of `"Failed to set theme: ${err.message}"` |
| `caught-error-must-not-collapse-to-empty` | You don't surface at all — `catch` returns `undefined` and the user sees a blank pane |
| `subscription-must-surface-errors` (existing) | `createSubscription(...)` is missing `onError`, so an oRPC stream death is invisible |

## Why no rule for the imperative-render case

The `/fact-check` also flagged `instance?.render(...)` calls inside `createEffect` with no try/catch — Pierre's render throws escape Solid's `<ErrorBoundary>` and crash the parent tree. A repo-wide rule for that has wrong locality: the problem only exists at four wrapper boundaries (`PierreFileTree.tsx`, `PierreDiffView.tsx`, `PierreFileView.tsx`, future Pierre wrappers). The structural fix is encapsulating Pierre behind a Solid-native package — tracked in #807.

## Try it locally

```sh
gh pr checkout code-police-error-surfacing
```

Then trigger `/code-police` on any branch and the new rule names show up in the rule checklist.