### PR TITLE
Color installed Kolu windows by hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Detects [OpenCode](https://github.com/anomalyco/opencode) sessions and shows the
 - Live preview while browsing themes in the palette
 - Shuffle theme — new terminals (and the active one on <kbd>⌘J</kbd>) get a background perceptually distinct from every other open terminal (toggleable; on by default)
 - Dark / light / system UI theme
+- Installed PWA chrome color derives from the server hostname, so app windows from different machines are easier to distinguish
 
 ### Clipboard
 

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -8,7 +8,6 @@
     />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#161618" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <!-- Sync .dark class before first paint to prevent FOUC -->
     <script>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -101,8 +101,9 @@ const App: Component = () => {
   void client.server
     .info()
     .then((info) => setIdentity(info.identity))
-    .catch(() => {
+    .catch((err) => {
       // Server info is cosmetic — safe to ignore on failure.
+      console.warn("Server info fetch failed:", err);
     });
   const appTitle = () => identity()?.name ?? "kolu";
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -7,7 +7,7 @@
 
 import Dialog from "@corvu/dialog";
 import { Title } from "@solidjs/meta";
-import type { TerminalId } from "kolu-common";
+import type { ServerIdentity, TerminalId } from "kolu-common";
 import {
   type Component,
   createEffect,
@@ -96,18 +96,28 @@ const App: Component = () => {
   );
   const orderedIds = createMemo(() => flatPillOrder(pillGroups()));
 
-  // Fetch hostname from server; used in document title and header
-  const [hostname, setHostname] = createSignal<string>();
+  // Fetch server identity for document title, watermark, and PWA chrome color.
+  const [identity, setIdentity] = createSignal<ServerIdentity>();
   void client.server
     .info()
-    .then((info) => setHostname(info.hostname))
+    .then((info) => setIdentity(info.identity))
     .catch(() => {
-      // Server info is cosmetic (document title) — safe to ignore on failure
+      // Server info is cosmetic — safe to ignore on failure.
     });
-  const appTitle = () => {
-    const h = hostname();
-    return h ? `kolu@${h}` : "kolu";
-  };
+  createEffect(() => {
+    const color = identity()?.themeColor;
+    if (!color) return;
+    let meta = document.querySelector<HTMLMetaElement>(
+      'meta[name="theme-color"]',
+    );
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.name = "theme-color";
+      document.head.append(meta);
+    }
+    meta.content = color;
+  });
+  const appTitle = () => identity()?.name ?? "kolu";
 
   // Palette state
   const [paletteOpen, setPaletteOpen] = createSignal(false);

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -6,7 +6,7 @@
  *  bar via `canvas/TileTitleActions`. The header is intentionally minimal. */
 
 import Dialog from "@corvu/dialog";
-import { Title } from "@solidjs/meta";
+import { Meta, Title } from "@solidjs/meta";
 import type { ServerIdentity, TerminalId } from "kolu-common";
 import {
   type Component,
@@ -104,19 +104,6 @@ const App: Component = () => {
     .catch(() => {
       // Server info is cosmetic — safe to ignore on failure.
     });
-  createEffect(() => {
-    const color = identity()?.themeColor;
-    if (!color) return;
-    let meta = document.querySelector<HTMLMetaElement>(
-      'meta[name="theme-color"]',
-    );
-    if (!meta) {
-      meta = document.createElement("meta");
-      meta.name = "theme-color";
-      document.head.append(meta);
-    }
-    meta.content = color;
-  });
   const appTitle = () => identity()?.name ?? "kolu";
 
   // Palette state
@@ -354,6 +341,9 @@ const App: Component = () => {
       }}
     >
       <Title>{appTitle()}</Title>
+      <Show when={identity()?.themeColor}>
+        {(themeColor) => <Meta name="theme-color" content={themeColor()} />}
+      </Show>
       <TransportOverlay />
       <WebcamOverlay />
       <Toaster

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -306,9 +306,7 @@ export const TerminalSetParentInputSchema = z.object({
 export const ServerIdentitySchema = z.object({
   hostname: z.string(),
   name: z.string(),
-  shortName: z.string(),
   themeColor: z.string(),
-  backgroundColor: z.string(),
 });
 export type ServerIdentity = z.infer<typeof ServerIdentitySchema>;
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -303,8 +303,17 @@ export const TerminalSetParentInputSchema = z.object({
   parentId: TerminalIdSchema.nullable(),
 });
 
-export const ServerInfoSchema = z.object({
+export const ServerIdentitySchema = z.object({
   hostname: z.string(),
+  name: z.string(),
+  shortName: z.string(),
+  themeColor: z.string(),
+  backgroundColor: z.string(),
+});
+export type ServerIdentity = z.infer<typeof ServerIdentitySchema>;
+
+export const ServerInfoSchema = z.object({
+  identity: ServerIdentitySchema,
   /** Unique ID for this server process — changes on restart. */
   processId: z.string().uuid(),
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -64,6 +64,8 @@ const argv = cli({
   strictFlags: true,
 });
 
+const PWA_BACKGROUND_COLOR = "#0c0c0e";
+
 configureNixShellEnv(argv.flags.allowNixShellWithEnvWhitelist);
 ensureKoluRoot();
 initSessionAutoSave(snapshotSession);
@@ -149,10 +151,10 @@ app.get("/manifest.webmanifest", (c) => {
   return c.json(
     {
       name: identity.name,
-      short_name: identity.shortName,
+      short_name: identity.name,
       start_url: "/",
       display: "standalone",
-      background_color: identity.backgroundColor,
+      background_color: PWA_BACKGROUND_COLOR,
       theme_color: identity.themeColor,
       icons: [
         { src: "/icon-192.png", sizes: "192x192", type: "image/png" },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -16,6 +16,7 @@ import { startDiagnostics } from "./diagnostics.ts";
 import { serverHostname } from "./hostname.ts";
 import { ensureKoluRoot, shutdownCleanup } from "./koluRoot.ts";
 import { log } from "./log.ts";
+import { pwaIdentityForHostname } from "./pwaIdentity.ts";
 import { appRouter } from "./router.ts";
 import { initSessionAutoSave } from "./session.ts";
 import { configureNixShellEnv } from "./shell.ts";
@@ -143,17 +144,16 @@ process.on("unhandledRejection", (reason) => {
 app.get("/api/health", (c) => c.text("kolu"));
 
 // --- Dynamic PWA manifest (includes hostname) ---
-// theme_color must match <meta name="theme-color"> in client/index.html
 app.get("/manifest.webmanifest", (c) => {
-  const name = `kolu@${serverHostname}`;
+  const identity = pwaIdentityForHostname(serverHostname);
   return c.json(
     {
-      name,
-      short_name: name,
+      name: identity.name,
+      short_name: identity.shortName,
       start_url: "/",
       display: "standalone",
-      background_color: "#292c33",
-      theme_color: "#292c33",
+      background_color: identity.backgroundColor,
+      theme_color: identity.themeColor,
       icons: [
         { src: "/icon-192.png", sizes: "192x192", type: "image/png" },
         { src: "/icon-512.png", sizes: "512x512", type: "image/png" },

--- a/packages/server/src/pwaIdentity.test.ts
+++ b/packages/server/src/pwaIdentity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { pwaIdentityForHostname } from "./pwaIdentity";
+
+describe("pwaIdentityForHostname", () => {
+  it("derives stable PWA identity from hostname", () => {
+    expect(pwaIdentityForHostname("atlas")).toEqual({
+      hostname: "atlas",
+      name: "kolu@atlas",
+      shortName: "kolu@atlas",
+      themeColor: "#0f766e",
+      backgroundColor: "#0c0c0e",
+    });
+  });
+
+  it("varies theme color by hostname", () => {
+    const colors = new Set(
+      ["atlas", "boreal", "cygnus", "deneb"].map(
+        (hostname) => pwaIdentityForHostname(hostname).themeColor,
+      ),
+    );
+
+    expect(colors.size).toBeGreaterThan(1);
+  });
+
+  it("treats hostname case as the same color seed", () => {
+    expect(pwaIdentityForHostname("Atlas").themeColor).toBe(
+      pwaIdentityForHostname("atlas").themeColor,
+    );
+  });
+});

--- a/packages/server/src/pwaIdentity.test.ts
+++ b/packages/server/src/pwaIdentity.test.ts
@@ -6,7 +6,7 @@ describe("pwaIdentityForHostname", () => {
     expect(pwaIdentityForHostname("atlas")).toEqual({
       hostname: "atlas",
       name: "kolu@atlas",
-      themeColor: "#0f766e",
+      themeColor: "#a21caf",
     });
   });
 

--- a/packages/server/src/pwaIdentity.test.ts
+++ b/packages/server/src/pwaIdentity.test.ts
@@ -6,9 +6,7 @@ describe("pwaIdentityForHostname", () => {
     expect(pwaIdentityForHostname("atlas")).toEqual({
       hostname: "atlas",
       name: "kolu@atlas",
-      shortName: "kolu@atlas",
       themeColor: "#0f766e",
-      backgroundColor: "#0c0c0e",
     });
   });
 

--- a/packages/server/src/pwaIdentity.ts
+++ b/packages/server/src/pwaIdentity.ts
@@ -1,0 +1,44 @@
+import type { ServerIdentity } from "kolu-common";
+
+const BACKGROUND_COLOR = "#0c0c0e";
+const THEME_COLORS = [
+  "#0f766e",
+  "#1d4ed8",
+  "#7c3aed",
+  "#be185d",
+  "#b45309",
+  "#15803d",
+  "#be123c",
+  "#047857",
+  "#4338ca",
+  "#a21caf",
+  "#0369a1",
+  "#9a3412",
+] as const;
+
+export function pwaIdentityForHostname(hostname: string): ServerIdentity {
+  const name = `kolu@${hostname}`;
+  return {
+    hostname,
+    name,
+    shortName: name,
+    themeColor: themeColorForHostname(hostname),
+    backgroundColor: BACKGROUND_COLOR,
+  };
+}
+
+function themeColorForHostname(hostname: string): string {
+  const seed = hostname.toLowerCase();
+  return (
+    THEME_COLORS[hashHostname(seed) % THEME_COLORS.length] ?? THEME_COLORS[0]
+  );
+}
+
+function hashHostname(hostname: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < hostname.length; i++) {
+    hash ^= hostname.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}

--- a/packages/server/src/pwaIdentity.ts
+++ b/packages/server/src/pwaIdentity.ts
@@ -1,6 +1,5 @@
 import type { ServerIdentity } from "kolu-common";
 
-const BACKGROUND_COLOR = "#0c0c0e";
 const THEME_COLORS = [
   "#0f766e",
   "#1d4ed8",
@@ -21,9 +20,7 @@ export function pwaIdentityForHostname(hostname: string): ServerIdentity {
   return {
     hostname,
     name,
-    shortName: name,
     themeColor: themeColorForHostname(hostname),
-    backgroundColor: BACKGROUND_COLOR,
   };
 }
 

--- a/packages/server/src/pwaIdentity.ts
+++ b/packages/server/src/pwaIdentity.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { ServerIdentity } from "kolu-common";
 
 const THEME_COLORS = [
@@ -26,16 +27,10 @@ export function pwaIdentityForHostname(hostname: string): ServerIdentity {
 
 function themeColorForHostname(hostname: string): string {
   const seed = hostname.toLowerCase();
-  return (
-    THEME_COLORS[hashHostname(seed) % THEME_COLORS.length] ?? THEME_COLORS[0]
-  );
+  return THEME_COLORS[paletteIndex(seed)] ?? THEME_COLORS[0];
 }
 
-function hashHostname(hostname: string): number {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < hostname.length; i++) {
-    hash ^= hostname.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash >>> 0;
+function paletteIndex(hostname: string): number {
+  const digest = createHash("sha256").update(hostname).digest();
+  return digest.readUInt32BE(0) % THEME_COLORS.length;
 }

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -39,6 +39,7 @@ import {
   setPreferencesForTest,
   updatePreferences,
 } from "./preferences.ts";
+import { pwaIdentityForHostname } from "./pwaIdentity.ts";
 import { subscribeForTerminal_, subscribeSystem_ } from "./publisher.ts";
 import { getSavedSession, setSavedSession } from "./session.ts";
 import {
@@ -173,7 +174,7 @@ async function* repoEventStream(
 export const appRouter = t.router({
   server: {
     info: t.server.info.handler(async () => ({
-      hostname: serverHostname,
+      identity: pwaIdentityForHostname(serverHostname),
       processId: serverProcessId,
     })),
   },


### PR DESCRIPTION
**Installed Kolu windows now get a hostname-derived chrome color**, so multiple machine-backed PWAs are easier to tell apart where browsers expose PWA theming. The server owns a small display identity for each host, and both the web manifest and runtime `<meta name="theme-color">` project from that same source.

### What changed for reviewers

| Surface | Color source |
| --- | --- |
| Installed PWA manifest | Hostname-derived `theme_color` |
| Live browser metadata | `server.info.identity.themeColor` |
| Loading/background color | Static manifest-only fallback |

**The display identity stays deliberately narrow**: `hostname`, `name`, and `themeColor` travel over `server.info`, while `processId` remains lifecycle data. _Manifest-only loading color stays on the manifest route, so shell policy does not leak into the client contract._

### Verified

- `just check`
- `nix develop --accept-flake-config -c pnpm --filter kolu-server exec vitest run src/pwaIdentity.test.ts --fileParallelism=false`
- `just test-quick features/smoke.feature`

### Try it locally

```sh
nix run github:juspay/kolu/feat/pwa-host-theme-color
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._