### PR TITLE
Preserve kolu launchd logs on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ A home-manager module runs kolu as a systemd user service on Linux and as a laun
 
 See [`nix/home/example/`](nix/home/example/) for a full configuration — a NixOS VM test exercises the systemd path on Linux, and a standalone home-manager activation build exercises the launchd path on Darwin.
 
+On macOS, the LaunchAgent writes stdout to `~/Library/Logs/kolu.out.log` and stderr to `~/Library/Logs/kolu.err.log`, so crashes and startup failures leave service logs alongside other user logs.
+
 ### Diagnosing memory leaks
 
 If kolu grows unbounded (V8 heap climbing over hours), set `services.kolu.diagnostics.dir` to an absolute path. Each restart gets its own timestamped subdir there, with a baseline heap snapshot at T+5min, periodic `"diag"` stats lines (memory bands + `terminals`/`publisherSize`/`claudeSessions`/`pendingSummaryFetches`), and automatic near-OOM snapshots via V8's `--heapsnapshot-near-heap-limit`. `kill -USR2 <pid>` captures an on-demand snapshot into the same dir. Diff two snapshots offline with [memlab](https://facebook.github.io/memlab/docs/cli/CLI-commands/) to name the retainer. Unset = zero overhead; the code path is fully gated.

--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -31,6 +31,17 @@
         home.stateVersion = "24.11";
       };
 
+      darwinHome = home-manager.lib.homeManagerConfiguration {
+        pkgs = darwinPkgs;
+        modules = [
+          koluHmModule
+          {
+            home.username = "alice";
+            home.homeDirectory = "/Users/alice";
+          }
+        ];
+      };
+
       # NixOS module: minimal system + home-manager with kolu enabled.
       nixosModule = {
         boot.loader.grub.devices = [ "nodev" ];
@@ -98,15 +109,18 @@
       # Darwin: standalone home-manager activation package. Building this
       # exercises the launchd.agents.kolu path end-to-end (plist generation,
       # wait4path wrapping, etc.) without needing a live launchd session.
-      checks.${darwinSystem}.home-activation = (home-manager.lib.homeManagerConfiguration {
-        pkgs = darwinPkgs;
-        modules = [
-          koluHmModule
-          {
-            home.username = "alice";
-            home.homeDirectory = "/Users/alice";
-          }
-        ];
-      }).activationPackage;
+      checks.${darwinSystem} = {
+        home-activation = darwinHome.activationPackage;
+
+        launchd-log-paths =
+          let
+            agentConfig = darwinHome.config.launchd.agents.kolu.config;
+          in
+          assert agentConfig.StandardOutPath == "/Users/alice/Library/Logs/kolu.out.log";
+          assert agentConfig.StandardErrorPath == "/Users/alice/Library/Logs/kolu.err.log";
+          darwinPkgs.runCommand "kolu-launchd-log-paths" { } ''
+            touch $out
+          '';
+      };
     };
 }

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -118,6 +118,8 @@ in
           ProgramArguments = args;
           RunAtLoad = true;
           KeepAlive.SuccessfulExit = false;
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/kolu.out.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/kolu.err.log";
         } // lib.optionalAttrs (envAttrs != { }) {
           EnvironmentVariables = envAttrs;
         };

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -118,6 +118,7 @@ in
           ProgramArguments = args;
           RunAtLoad = true;
           KeepAlive.SuccessfulExit = false;
+          # launchd drops stdout/stderr by default; keep service crashes visible.
           StandardOutPath = "${config.home.homeDirectory}/Library/Logs/kolu.out.log";
           StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/kolu.err.log";
         } // lib.optionalAttrs (envAttrs != { }) {


### PR DESCRIPTION
**macOS Home Manager installs now keep kolu service output visible** by giving the launchd agent explicit stdout and stderr log files. Previously launchd sent both streams to `/dev/null`, so a crash left only low-level `.ips` reports with no JS stack trace or kolu logs.

The Darwin example check now evaluates the Home Manager launchd config and asserts the default log paths, while the README points users at the files they can inspect after startup failures or crashes.

Closes #814

### Try it locally

```sh
nix build 'github:juspay/kolu?ref=fix/814-launchd-logs&dir=nix/home/example#checks.aarch64-darwin.launchd-log-paths'
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._