### PR TITLE
Fix launchd KeepAlive misses crashes; bad %h example

### DIFF
--- a/nix/home/example/flake.nix
+++ b/nix/home/example/flake.nix
@@ -112,13 +112,17 @@
       checks.${darwinSystem} = {
         home-activation = darwinHome.activationPackage;
 
-        launchd-log-paths =
+        launchd-config =
           let
             agentConfig = darwinHome.config.launchd.agents.kolu.config;
           in
           assert agentConfig.StandardOutPath == "/Users/alice/Library/Logs/kolu.out.log";
           assert agentConfig.StandardErrorPath == "/Users/alice/Library/Logs/kolu.err.log";
-          darwinPkgs.runCommand "kolu-launchd-log-paths" { } ''
+          # Restart on non-zero exit AND on crash signals — matches systemd's
+          # `Restart = "on-failure"`. `SuccessfulExit` alone misses SIGSEGV etc.
+          assert agentConfig.KeepAlive.SuccessfulExit == false;
+          assert agentConfig.KeepAlive.Crashed == true;
+          darwinPkgs.runCommand "kolu-launchd-config" { } ''
             touch $out
           '';
       };

--- a/nix/home/module.nix
+++ b/nix/home/module.nix
@@ -55,13 +55,14 @@ in
       dir = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
-        example = "%h/.kolu/diag";
+        example = lib.literalExpression ''"''${config.home.homeDirectory}/.kolu/diag"'';
         description = ''
           Enable memory/heap diagnostics. Value is the base directory under
           which kolu writes per-invocation subdirs containing heap snapshots
           (via --heapsnapshot-near-heap-limit + --heapsnapshot-signal=SIGUSR2)
           and periodic stats logs. `null` disables diagnostics entirely with
-          zero overhead. See the PR for the intended workflow.
+          zero overhead. Must be an absolute path — systemd `%h` specifiers
+          are not expanded here and would not work on launchd anyway.
         '';
       };
     };
@@ -117,7 +118,13 @@ in
         config = {
           ProgramArguments = args;
           RunAtLoad = true;
-          KeepAlive.SuccessfulExit = false;
+          # Match systemd's `Restart = "on-failure"`: restart on non-zero exit
+          # AND on crash signals (SIGSEGV, SIGILL, …). `SuccessfulExit` alone
+          # only covers clean exits with non-zero status.
+          KeepAlive = {
+            SuccessfulExit = false;
+            Crashed = true;
+          };
           # launchd drops stdout/stderr by default; keep service crashes visible.
           StandardOutPath = "${config.home.homeDirectory}/Library/Logs/kolu.out.log";
           StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/kolu.err.log";


### PR DESCRIPTION
**Two bugs in the launchd path of `nix/home/module.nix`** that snuck through the original macOS port (#799). One causes a kolu segfault to leave the service dead; the other makes a copy-pasted example silently misbehave. Both are local to the Darwin code path — Linux/systemd is unaffected.

| Bug | Symptom | Fix |
| --- | --- | --- |
| `KeepAlive.SuccessfulExit = false` alone | A SIGSEGV / SIGILL / `kill -9` exits via signal, not a non-zero status code, so launchd does **not** respawn. systemd's documented equivalent `Restart = "on-failure"` does. | Switch to a dict with both `SuccessfulExit = false` **and** `Crashed = true`. |
| `example = "%h/.kolu/diag"` on `services.kolu.diagnostics.dir` | `%h` is a *systemd unit specifier*. launchd never expands it, so kolu would receive the literal string `%h/.kolu/diag` and fail to write diagnostics. | Switch the example to `''${config.home.homeDirectory}/.kolu/diag` and call out the constraint in the option description. |

The Darwin example check now asserts the new `KeepAlive` shape (renamed `launchd-log-paths` → `launchd-config` since it covers more than log paths), so a future regression on the restart-on-crash behavior fails CI rather than silently lurking until someone's terminal multiplexer evaporates.

> _Surfaced from a re-review of #799 / #815 — neither original PR exercised the crash-restart path or the cross-platform example._

### Try it locally

```sh
nix build 'github:juspay/kolu?ref=fix/launchd-keepalive-and-diag-example&dir=nix/home/example#checks.aarch64-darwin.launchd-config'
```

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._