### PR TITLE
Stop capturing Ctrl+B for inspector toggle

### DIFF
--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -207,7 +207,7 @@ const _ACTIONS = {
   },
   toggleRightPanel: {
     label: "Toggle inspector panel",
-    keybind: { key: "b", code: "KeyB", mod: true },
+    keybind: { key: "b", code: "KeyB", mod: true, alt: true },
     handler: (ctx) => ctx.toggleRightPanel(),
   },
   toggleRecordingPause: {

--- a/packages/client/src/input/keyboard.test.ts
+++ b/packages/client/src/input/keyboard.test.ts
@@ -109,6 +109,7 @@ describe("formatKeybind (non-mac)", () => {
     { kb: { key: "t", mod: true }, expected: "Ctrl+T" },
     { kb: { key: "Tab", ctrl: true }, expected: "Ctrl+Tab" },
     { kb: { key: "]", mod: true, shift: true }, expected: "Ctrl+Shift+]" },
+    { kb: { key: "b", mod: true, alt: true }, expected: "Ctrl+Alt+B" },
     { kb: { key: "t" }, expected: "T" },
     { kb: { key: "k", mod: true }, expected: "Ctrl+K" },
   ] as const)("formatKeybind → $expected", ({ kb, expected }) => {
@@ -127,6 +128,20 @@ describe("matchesAnyShortcut", () => {
     expect(matchesAnyShortcut(makeEvent({ key: "t", ctrlKey: true }))).toBe(
       true,
     );
+  });
+
+  it("does not capture Ctrl+B", () => {
+    expect(
+      matchesAnyShortcut(makeEvent({ key: "b", code: "KeyB", ctrlKey: true })),
+    ).toBe(false);
+  });
+
+  it("matches Ctrl+Alt+B (toggle inspector)", () => {
+    expect(
+      matchesAnyShortcut(
+        makeEvent({ key: "b", code: "KeyB", ctrlKey: true, altKey: true }),
+      ),
+    ).toBe(true);
   });
 
   it("does not match Ctrl/Cmd+Shift+C", () => {

--- a/packages/tests/features/right-panel.feature
+++ b/packages/tests/features/right-panel.feature
@@ -1,5 +1,5 @@
 Feature: Right panel (inspector)
-  Collapsible right panel with metadata inspector, toggled via Cmd+B or header icon.
+  Collapsible right panel with metadata inspector, toggled via keyboard shortcut or header icon.
   Defaults to collapsed.
 
   Background:

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -5,7 +5,7 @@ import { type KoluWorld, MOD_KEY, POLL_TIMEOUT } from "../support/world.ts";
 // ── Actions ──
 
 When("I press the toggle inspector shortcut", async function (this: KoluWorld) {
-  await this.page.keyboard.press(`${MOD_KEY}+b`);
+  await this.page.keyboard.press(`${MOD_KEY}+Alt+b`);
   await this.waitForFrame();
 });
 


### PR DESCRIPTION
**Ctrl+B now reaches the terminal instead of toggling Kolu's inspector**, avoiding the Claude Code shortcut conflict reported on Linux. The inspector remains keyboard-accessible through a slightly more explicit `Mod+Alt+B` chord, and all visible shortcut hints still derive from the central action registry.

The change stays inside the existing shortcut system: `toggleRightPanel` owns the new chord, the e2e helper presses that semantic shortcut, and the unit coverage now pins both sides of the regression: plain `Ctrl+B` is not captured, while `Ctrl+Alt+B` still toggles the inspector on Linux.

Closes #820

### Try it locally

```sh
nix run github:juspay/kolu/fix-820-inspector-shortcut
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._