### PR TITLE
Keep Code browser filters after selecting files

### DIFF
--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -98,6 +98,12 @@ export const FileTree: Component<FileTreeProps> = (props) => {
           const p = paths[0] ?? null;
           if (p !== null && !fileSet().has(p)) return;
           props.onSelect?.(p);
+          // Pierre clears its internal search after row selection; when the
+          // host owns searchQuery, re-apply it after Pierre finishes the click.
+          queueMicrotask(() => {
+            const q = untrack(() => props.searchQuery);
+            if (q && q.length > 0) tree?.setSearch(q);
+          });
         },
       });
       tree.render({ containerWrapper: container });

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -78,6 +78,15 @@ export const FileTree: Component<FileTreeProps> = (props) => {
   // don't appear in `paths` (Pierre infers them from path prefixes), so
   // membership in this set is a reliable file-vs-folder discriminator.
   const fileSet = createMemo(() => new Set(props.paths));
+  const normalizeSearchQuery = (q: string | null | undefined) =>
+    q && q.length > 0 ? q : null;
+  const applySearchQuery = (q: string | null | undefined) => {
+    try {
+      tree?.setSearch(normalizeSearchQuery(q));
+    } catch (e) {
+      props.onError(toError(e));
+    }
+  };
 
   onMount(() => {
     try {
@@ -98,22 +107,35 @@ export const FileTree: Component<FileTreeProps> = (props) => {
           const p = paths[0] ?? null;
           if (p !== null && !fileSet().has(p)) return;
           props.onSelect?.(p);
-          // Pierre clears its internal search after row selection; when the
-          // host owns searchQuery, re-apply it after Pierre finishes the click.
-          queueMicrotask(() => {
-            const q = untrack(() => props.searchQuery);
-            if (q && q.length > 0) tree?.setSearch(q);
-          });
         },
       });
       tree.render({ containerWrapper: container });
+      const reapplySearchAfterRowClick = (event: MouseEvent) => {
+        const clickedTreeRow = event
+          .composedPath()
+          .some(
+            (target) =>
+              target instanceof HTMLElement &&
+              target.dataset.itemPath !== undefined,
+          );
+        if (!clickedTreeRow) return;
+        // Pierre clears its internal search after row clicks; when the host
+        // owns searchQuery, re-apply it after Pierre finishes the click.
+        queueMicrotask(() => {
+          const q = untrack(() => props.searchQuery);
+          if (normalizeSearchQuery(q) !== null) applySearchQuery(q);
+        });
+      };
+      container.addEventListener("click", reapplySearchAfterRowClick);
+      onCleanup(() =>
+        container.removeEventListener("click", reapplySearchAfterRowClick),
+      );
       // Apply an initial searchQuery if it was already non-empty at mount —
       // the deferred effect below only fires on subsequent changes, so a
       // pre-mount value would otherwise be silently dropped.
       const initialQuery = untrack(() => props.searchQuery);
-      if (initialQuery && initialQuery.length > 0) {
-        tree.setSearch(initialQuery);
-      }
+      if (normalizeSearchQuery(initialQuery) !== null)
+        applySearchQuery(initialQuery);
     } catch (e) {
       props.onError(toError(e));
     }
@@ -151,11 +173,7 @@ export const FileTree: Component<FileTreeProps> = (props) => {
     on(
       () => props.searchQuery,
       (q) => {
-        try {
-          tree?.setSearch(q && q.length > 0 ? q : null);
-        } catch (e) {
-          props.onError(toError(e));
-        }
+        applySearchQuery(q);
       },
       { defer: true },
     ),

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -61,6 +61,27 @@ Feature: Code tab (review + browse)
     When I click the changed file "note.txt" in the Code tab
     Then the Code tab should render a diff view
 
+  Scenario: Filter survives clicking a filtered result
+    When I run "git init /tmp/kolu-filter-survive && cd /tmp/kolu-filter-survive"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'a\n' > alpha.txt"
+    And I run "printf 'b\n' > beta.txt"
+    And I run "printf 'g\n' > gamma.txt"
+    And I click the Code tab
+    Then the Code tab should list a changed file "alpha.txt"
+    And the Code tab should list a changed file "beta.txt"
+    And the Code tab should list a changed file "gamma.txt"
+    When I type "alp" into the Code tab filter
+    Then the Code tab should list a changed file "alpha.txt"
+    And the Code tab should not list a changed file "beta.txt"
+    And the Code tab should not list a changed file "gamma.txt"
+    When I click the changed file "alpha.txt" in the Code tab
+    Then the Code tab should render a diff view
+    And the Code tab filter input should contain "alp"
+    And the Code tab should list a changed file "alpha.txt"
+    And the Code tab should not list a changed file "beta.txt"
+    And the Code tab should not list a changed file "gamma.txt"
+
   Scenario: Untracked files appear alongside modified tracked files
     When I run "git init /tmp/kolu-review-untracked && cd /tmp/kolu-review-untracked"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -81,6 +81,11 @@ Feature: Code tab (review + browse)
     And the Code tab should list a changed file "alpha.txt"
     And the Code tab should not list a changed file "beta.txt"
     And the Code tab should not list a changed file "gamma.txt"
+    When I click the changed file "alpha.txt" in the Code tab
+    Then the Code tab filter input should contain "alp"
+    And the Code tab should list a changed file "alpha.txt"
+    And the Code tab should not list a changed file "beta.txt"
+    And the Code tab should not list a changed file "gamma.txt"
 
   Scenario: Untracked files appear alongside modified tracked files
     When I run "git init /tmp/kolu-review-untracked && cd /tmp/kolu-review-untracked"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -22,6 +22,7 @@ import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 const TREE = '[data-testid="pierre-file-tree"]';
 const DIFF_VIEW = '[data-testid="pierre-diff-view"]';
 const FILE_VIEW = '[data-testid="pierre-file-view"]';
+const FILTER_SEARCH = '[data-testid="diff-filter-search"]';
 
 function fileRow(path: string): string {
   return `${TREE} [data-item-path="${path}"][data-item-type="file"]:not([data-file-tree-sticky-row])`;
@@ -71,6 +72,16 @@ When(
     const opt = this.page.locator(`[data-testid="diff-mode-${mode}"]`);
     await opt.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     await opt.click();
+    await this.waitForFrame();
+  },
+);
+
+When(
+  "I type {string} into the Code tab filter",
+  async function (this: KoluWorld, value: string) {
+    const input = this.page.locator(FILTER_SEARCH);
+    await input.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await input.fill(value);
     await this.waitForFrame();
   },
 );
@@ -244,6 +255,20 @@ Then(
     // `processLine` (see @pierre/diffs/utils/processLine).
     const row = this.page.locator(`${DIFF_VIEW} [data-line]`).first();
     await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the Code tab filter input should contain {string}",
+  async function (this: KoluWorld, value: string) {
+    const input = this.page.locator(FILTER_SEARCH);
+    await input.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const actual = await input.inputValue();
+    if (actual !== value) {
+      throw new Error(
+        `Expected Code tab filter to contain "${value}", got "${actual}"`,
+      );
+    }
   },
 );
 

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -263,12 +263,14 @@ Then(
   async function (this: KoluWorld, value: string) {
     const input = this.page.locator(FILTER_SEARCH);
     await input.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    const actual = await input.inputValue();
-    if (actual !== value) {
-      throw new Error(
-        `Expected Code tab filter to contain "${value}", got "${actual}"`,
-      );
-    }
+    await this.page.waitForFunction(
+      ({ expected, selector }) => {
+        const el = document.querySelector<HTMLInputElement>(selector);
+        return el?.value === expected;
+      },
+      { expected: value, selector: FILTER_SEARCH },
+      { timeout: POLL_TIMEOUT },
+    );
   },
 );
 


### PR DESCRIPTION
**The Code browser now keeps its active filename filter after file selection**, including repeated clicks on the already selected filtered result. Pierre closes its internal search after row clicks, so the Solid adapter restores Kolu's host-owned `searchQuery` after Pierre finishes handling the click.

The adapter keeps that workaround inside `@kolu/solid-pierre`: `CodeTab` still owns the search signal, while `FileTree` centralizes search forwarding through the same `onError` path used by the other Pierre setters. The regression scenario covers the original filtered click and the repeated-click case that does not emit a selection change.

### Verification

- `just check`
- `just fmt`
- `just test-quick features/code-tab.feature:64` (`223 scenarios`, `1544 steps`; Cucumber merged the configured feature glob with the line filter)

Closes #817

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._