### PR TITLE
Support path-token search in the Code browser

### DIFF
--- a/agents/ai.just
+++ b/agents/ai.just
@@ -34,9 +34,10 @@ apm-update *packages:
     {{ apm_cmd }} deps update --target {{ apm_targets }} {{ packages }}
     {{ just_executable() }} ai apm
 
-# Audit APM packages for security issues (Unicode, lockfile consistency)
+# Audit APM packages for security issues and lockfile consistency.
+# Drift is verified by apm-sync's repo-aware scratch diff below.
 apm-audit:
-    {{ apm_cmd }} audit --ci
+    {{ apm_cmd }} audit --ci --no-drift
 
 # Verify APM-managed outputs match sources + security audit
 #
@@ -81,11 +82,13 @@ apm-sync: apm-audit
     (cd "$scratch" && {{ apm_cmd }} install --target {{ apm_targets }})
     (cd "$scratch" && {{ apm_cmd }} compile --target {{ apm_compile_targets }})
     # Exclude files that apm doesn't manage: launch.json is user-owned,
-    # and `.claude/*` entries in .gitignore are runtime state written by
-    # Claude Code itself (worktree bookkeeping, local settings, session
-    # lockfiles). Keep this list in sync with .gitignore — if a new
-    # runtime file appears in .claude/, add it to .gitignore and here.
+    # `.apm-pin` is install metadata, and `.claude/*` entries in .gitignore
+    # are runtime state written by Claude Code itself (worktree bookkeeping,
+    # local settings, session lockfiles). Keep this list in sync with
+    # .gitignore — if a new runtime file appears in .claude/, add it to
+    # .gitignore and here.
     if ! diff -r \
+        -x .apm-pin \
         -x launch.json \
         -x worktrees \
         -x settings.local.json \
@@ -95,15 +98,17 @@ apm-sync: apm-audit
         exit 1
     fi
     if ! diff -r \
+        -x .apm-pin \
         .codex "$scratch/.codex"; then
         echo "ERROR: .codex/ out of sync with sources — run: just ai::apm" >&2
         exit 1
     fi
-    if ! diff -r .agents "$scratch/.agents"; then
+    if ! diff -r -x .apm-pin .agents "$scratch/.agents"; then
         echo "ERROR: .agents/ out of sync with sources — run: just ai::apm" >&2
         exit 1
     fi
     if ! diff -r \
+        -x .apm-pin \
         -x .gitignore \
         -x node_modules \
         -x package-lock.json \

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -329,13 +329,13 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                 }
               >
                 <FileTree
-                  paths={treeSearch().paths}
+                  paths={treeSearch().projectedPaths}
                   gitStatus={treeGitStatus()}
                   selectedPath={selectedPath()}
                   onSelect={handleSelect}
                   initialExpansion={isDiffView() ? "open" : "closed"}
                   search={false}
-                  searchQuery={treeSearch().treeSearchQuery}
+                  searchQuery={treeSearch().pierreSearchQuery}
                   icons={pierreIconConfig}
                   contextMenu={{
                     enabled: true,

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -15,7 +15,7 @@
 
 import { FileDiff, FileTree } from "@kolu/solid-pierre";
 import type { GitDiffMode } from "kolu-git/schemas";
-import type { CodeTabView, TerminalMetadata } from "kolu-common/surface";
+import type { TerminalMetadata } from "kolu-common/surface";
 import {
   type Component,
   createEffect,
@@ -41,6 +41,7 @@ import {
 } from "../ui/pierreTheme";
 import BrowseFileView from "./BrowseFileView";
 import CodeMenuFrame from "./CodeMenuFrame";
+import { projectFileTreeSearch } from "./fileSearch";
 import FileSearchInput from "./FileSearchInput";
 import ModeChipPicker, { type ModeOption } from "./ModeChipPicker";
 import { useRightPanel } from "./useRightPanel";
@@ -177,6 +178,10 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     if (view() === "browse") return allPaths()?.paths ?? [];
     return status()?.files.map((f) => f.path) ?? [];
   });
+
+  const treeSearch = createMemo(() =>
+    projectFileTreeSearch(treePaths(), searchQuery()),
+  );
 
   // Track membership rather than the treePaths array identity: browse paths
   // come from a reconciled store array whose contents can change in place.
@@ -324,13 +329,13 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                 }
               >
                 <FileTree
-                  paths={treePaths()}
+                  paths={treeSearch().paths}
                   gitStatus={treeGitStatus()}
                   selectedPath={selectedPath()}
                   onSelect={handleSelect}
                   initialExpansion={isDiffView() ? "open" : "closed"}
                   search={false}
-                  searchQuery={searchQuery()}
+                  searchQuery={treeSearch().treeSearchQuery}
                   icons={pierreIconConfig}
                   contextMenu={{
                     enabled: true,

--- a/packages/client/src/right-panel/fileSearch.test.ts
+++ b/packages/client/src/right-panel/fileSearch.test.ts
@@ -10,29 +10,30 @@ describe("projectFileTreeSearch", () => {
 
   it("leaves single-token queries to Pierre", () => {
     expect(projectFileTreeSearch(paths, "index")).toEqual({
-      paths,
-      treeSearchQuery: "index",
+      projectedPaths: paths,
+      pierreSearchQuery: "index",
     });
+    expect(projectFileTreeSearch(paths, "index").projectedPaths).toBe(paths);
   });
 
   it("matches whitespace-separated path tokens in order", () => {
     expect(projectFileTreeSearch(paths, "common index.ts")).toEqual({
-      paths: ["common/src/index.tsx"],
-      treeSearchQuery: "index.ts",
+      projectedPaths: ["common/src/index.tsx"],
+      pierreSearchQuery: "index.ts",
     });
   });
 
   it("normalizes backslashes and case", () => {
     expect(projectFileTreeSearch(paths, "COMMON\\src button")).toEqual({
-      paths: ["common/src/Button.tsx"],
-      treeSearchQuery: "button",
+      projectedPaths: ["common/src/Button.tsx"],
+      pierreSearchQuery: "button",
     });
   });
 
   it("does not match tokens out of order", () => {
     expect(projectFileTreeSearch(paths, "index common")).toEqual({
-      paths: [],
-      treeSearchQuery: "common",
+      projectedPaths: [],
+      pierreSearchQuery: "common",
     });
   });
 });

--- a/packages/client/src/right-panel/fileSearch.test.ts
+++ b/packages/client/src/right-panel/fileSearch.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { projectFileTreeSearch } from "./fileSearch";
+
+describe("projectFileTreeSearch", () => {
+  const paths = [
+    "common/src/index.tsx",
+    "common/src/Button.tsx",
+    "packages/client/src/index.tsx",
+  ];
+
+  it("leaves single-token queries to Pierre", () => {
+    expect(projectFileTreeSearch(paths, "index")).toEqual({
+      paths,
+      treeSearchQuery: "index",
+    });
+  });
+
+  it("matches whitespace-separated path tokens in order", () => {
+    expect(projectFileTreeSearch(paths, "common index.ts")).toEqual({
+      paths: ["common/src/index.tsx"],
+      treeSearchQuery: "index.ts",
+    });
+  });
+
+  it("normalizes backslashes and case", () => {
+    expect(projectFileTreeSearch(paths, "COMMON\\src button")).toEqual({
+      paths: ["common/src/Button.tsx"],
+      treeSearchQuery: "button",
+    });
+  });
+
+  it("does not match tokens out of order", () => {
+    expect(projectFileTreeSearch(paths, "index common")).toEqual({
+      paths: [],
+      treeSearchQuery: "common",
+    });
+  });
+});

--- a/packages/client/src/right-panel/fileSearch.ts
+++ b/packages/client/src/right-panel/fileSearch.ts
@@ -1,6 +1,6 @@
 export type FileTreeSearchProjection = {
-  paths: string[];
-  treeSearchQuery: string | null;
+  projectedPaths: string[];
+  pierreSearchQuery: string | null;
 };
 
 function normalizePathSearchText(value: string): string {
@@ -25,16 +25,18 @@ function pathContainsTokensInOrder(
 }
 
 export function projectFileTreeSearch(
-  paths: readonly string[],
+  paths: string[],
   query: string,
 ): FileTreeSearchProjection {
   const tokens = normalizePathSearchText(query).split(/\s+/).filter(Boolean);
   if (tokens.length <= 1) {
-    return { paths: [...paths], treeSearchQuery: query };
+    return { projectedPaths: paths, pierreSearchQuery: query };
   }
 
   return {
-    paths: paths.filter((path) => pathContainsTokensInOrder(path, tokens)),
-    treeSearchQuery: tokens.at(-1) ?? null,
+    projectedPaths: paths.filter((path) =>
+      pathContainsTokensInOrder(path, tokens),
+    ),
+    pierreSearchQuery: tokens.at(-1) ?? null,
   };
 }

--- a/packages/client/src/right-panel/fileSearch.ts
+++ b/packages/client/src/right-panel/fileSearch.ts
@@ -4,7 +4,7 @@
  *  single-token searches it is the original path inventory by reference.
  *  `pierreSearchQuery` is the residual substring Pierre should own for
  *  expansion/focus after Kolu has handled multi-token path matching. */
-export type FileTreeSearchProjection = {
+type FileTreeSearchProjection = {
   projectedPaths: string[];
   pierreSearchQuery: string | null;
 };

--- a/packages/client/src/right-panel/fileSearch.ts
+++ b/packages/client/src/right-panel/fileSearch.ts
@@ -1,3 +1,9 @@
+/** Search projection for Pierre's current substring-only FileTree API.
+ *
+ *  `projectedPaths` is the optional Kolu-side visibility filter; for native
+ *  single-token searches it is the original path inventory by reference.
+ *  `pierreSearchQuery` is the residual substring Pierre should own for
+ *  expansion/focus after Kolu has handled multi-token path matching. */
 export type FileTreeSearchProjection = {
   projectedPaths: string[];
   pierreSearchQuery: string | null;

--- a/packages/client/src/right-panel/fileSearch.ts
+++ b/packages/client/src/right-panel/fileSearch.ts
@@ -1,0 +1,40 @@
+export type FileTreeSearchProjection = {
+  paths: string[];
+  treeSearchQuery: string | null;
+};
+
+function normalizePathSearchText(value: string): string {
+  const trimmed = value.trim();
+  return (
+    trimmed.includes("\\") ? trimmed.replaceAll("\\", "/") : trimmed
+  ).toLowerCase();
+}
+
+function pathContainsTokensInOrder(
+  path: string,
+  tokens: readonly string[],
+): boolean {
+  const normalizedPath = normalizePathSearchText(path);
+  let offset = 0;
+  for (const token of tokens) {
+    const index = normalizedPath.indexOf(token, offset);
+    if (index < 0) return false;
+    offset = index + token.length;
+  }
+  return true;
+}
+
+export function projectFileTreeSearch(
+  paths: readonly string[],
+  query: string,
+): FileTreeSearchProjection {
+  const tokens = normalizePathSearchText(query).split(/\s+/).filter(Boolean);
+  if (tokens.length <= 1) {
+    return { paths: [...paths], treeSearchQuery: query };
+  }
+
+  return {
+    paths: paths.filter((path) => pathContainsTokensInOrder(path, tokens)),
+    treeSearchQuery: tokens.at(-1) ?? null,
+  };
+}

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -155,6 +155,23 @@ Feature: Code tab (review + browse)
       | branch |
       | browse |
 
+  Scenario Outline: Filter matches files by path tokens [<mode>]
+    Given a Code tab in "<mode>" mode showing files:
+      | path                          | content |
+      | common/src/index.tsx          | common  |
+      | common/src/components/App.tsx | app     |
+      | packages/client/src/index.tsx | client  |
+    When I type "common index.ts" into the Code tab filter
+    Then the Code tab should show file "common/src/index.tsx"
+    And the Code tab should not show file "common/src/components/App.tsx"
+    And the Code tab should not show file "packages/client/src/index.tsx"
+
+    Examples:
+      | mode   |
+      | local  |
+      | branch |
+      | browse |
+
   Scenario: Untracked files appear alongside modified tracked files
     When I run "git init /tmp/kolu-review-untracked && cd /tmp/kolu-review-untracked"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -508,11 +508,13 @@ async function waitForFixturePath(
   mode: CodeTabMode,
   path: string,
 ): Promise<void> {
-  const parentPath = path.slice(0, path.lastIndexOf("/"));
   const selector =
-    mode === "browse" && parentPath ? dirRow(parentPath) : fileRow(path);
+    mode === "browse"
+      ? `${TREE} [data-item-path][data-item-type]:not([data-file-tree-sticky-row])`
+      : fileRow(path);
   await world.page
     .locator(selector)
+    .first()
     .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 }
 

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -437,6 +437,16 @@ async function runShell(world: KoluWorld, cmd: string) {
   await world.waitForFrame();
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function writeFileCommand(path: string, content: string): string {
+  const parent = path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "";
+  const mkdir = parent ? `mkdir -p ${shellQuote(parent)} && ` : "";
+  return `${mkdir}printf '%s\\n' ${shellQuote(content)} > ${shellQuote(path)}`;
+}
+
 /** Per-mode shell sequence to land in a state where `<file>` is visible
  *  in the Code tab tree. Branch mode requires a real `origin` remote so
  *  Kolu's `gitStatus` stream can resolve `merge-base(origin/<default>)`
@@ -493,6 +503,19 @@ async function activateCodeTabMode(
   await world.waitForFrame();
 }
 
+async function waitForFixturePath(
+  world: KoluWorld,
+  mode: CodeTabMode,
+  path: string,
+): Promise<void> {
+  const parentPath = path.slice(0, path.lastIndexOf("/"));
+  const selector =
+    mode === "browse" && parentPath ? dirRow(parentPath) : fileRow(path);
+  await world.page
+    .locator(selector)
+    .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+}
+
 /** Set up the Code tab in `<mode>` showing one file. The shell sequence
  *  is mode-specific (see `setupCodeTabFixture`); post-conditions are
  *  uniform: file row visible, mode chip set. */
@@ -505,11 +528,9 @@ Given(
     content: string,
   ) {
     const m = mode as CodeTabMode;
-    await setupCodeTabFixture(this, m, `printf '${content}\\n' > ${path}`);
+    await setupCodeTabFixture(this, m, writeFileCommand(path, content));
     await activateCodeTabMode(this, m);
-    await this.page
-      .locator(fileRow(path))
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitForFixturePath(this, m, path);
   },
 );
 
@@ -523,14 +544,12 @@ Given(
   ) {
     const m = mode as CodeTabMode;
     const rows = table.rawTable.slice(1); // skip header
-    const writes = rows.map(([p, c]) => `printf '${c}\\n' > ${p}`).join(" && ");
+    const writes = rows.map(([p, c]) => writeFileCommand(p, c)).join(" && ");
     await setupCodeTabFixture(this, m, writes);
     await activateCodeTabMode(this, m);
     const firstPath = rows[0]?.[0];
     if (firstPath) {
-      await this.page
-        .locator(fileRow(firstPath))
-        .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+      await waitForFixturePath(this, m, firstPath);
     }
   },
 );

--- a/packages/tests/step_definitions/session_restore_steps.ts
+++ b/packages/tests/step_definitions/session_restore_steps.ts
@@ -93,18 +93,22 @@ Then(
   },
 );
 
-When("I click the restore button", async function (this: KoluWorld) {
-  const btn = this.page.locator('[data-testid="restore-session"]');
-  await btn.click();
-  // Wait for at least one terminal to appear — under load from 8 parallel
-  // workers, server can be slow to spawn terminals. Use waitForFunction
-  // for a reactive DOM check instead of locator.waitFor.
-  await this.page.waitForFunction(
-    (sel) => document.querySelectorAll(sel).length > 0,
-    PILL_TREE_ENTRY_SELECTOR,
-    { timeout: 20000 },
-  );
-});
+When(
+  "I click the restore button",
+  { timeout: 60_000 },
+  async function (this: KoluWorld) {
+    const btn = this.page.locator('[data-testid="restore-session"]');
+    await btn.click();
+    // Wait for at least one terminal to appear — under parallel macOS CI load,
+    // server can be slow to spawn restored PTYs. Use waitForFunction for a
+    // reactive DOM check instead of locator.waitFor.
+    await this.page.waitForFunction(
+      (sel) => document.querySelectorAll(sel).length > 0,
+      PILL_TREE_ENTRY_SELECTOR,
+      { timeout: 45_000 },
+    );
+  },
+);
 
 Then(
   "there should be {int} pill tree entries",


### PR DESCRIPTION
**The Code browser filter now treats multi-word searches as ordered path tokens**, so queries like `common index.ts` find `common/src/index.tsx` instead of depending on one contiguous substring. This closes the gap reported in #819 while preserving the existing single-token search behavior.

The search projection stays local to the Code tab wrapper around Pierre's file tree: single-token searches are passed through unchanged, and multi-token searches prefilter full paths before handing Pierre the final token for its normal tree expansion and focus behavior. *The regression is covered across Local, Branch, and Browse modes so the three Code tab surfaces keep matching behavior.*

### CI validation follow-ups

Two small validation fixes landed while getting the branch green:

- **APM sync now relies on the repo-aware scratch diff instead of APM audit's generic drift replay**, which avoids false failures from APM's install replay while keeping this repo's explicit `.claude` / `.codex` / `.agents` / `.opencode` / `AGENTS.md` checks.
- **Session restore e2e allows slower restored-PTY startup on macOS**, matching the existing test comment about parallel CI load and keeping the Darwin full-suite run stable.

Closes #819

Tests run:

- `nix develop . --accept-flake-config -c pnpm --filter kolu-client exec vitest run src/right-panel/fileSearch.test.ts`
- `just test-quick features/code-tab.feature`
- `just ai::apm-sync`
- `just test-quick features/session-restore.feature`
- `just ci`

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._