### PR TITLE
Wrap code browser file views by default

### DIFF
--- a/packages/client/src/right-panel/BrowseFileView.tsx
+++ b/packages/client/src/right-panel/BrowseFileView.tsx
@@ -55,6 +55,7 @@ const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
                     name={props.filePath}
                     contents={fc().content}
                     theme={props.theme}
+                    overflow="wrap"
                     enableLineSelection
                     onLineSelected={selection.handleSelect}
                     onError={(err) =>

--- a/packages/solid-pierre/src/FileView.tsx
+++ b/packages/solid-pierre/src/FileView.tsx
@@ -40,6 +40,9 @@ export type FileViewProps = {
   contents: string;
   /** Light vs dark syntax-highlight theme. */
   theme: "light" | "dark";
+  /** Horizontal overflow behavior. Default `"scroll"` matches Pierre's
+   *  file-view default; callers can opt into wrapped long lines. */
+  overflow?: FileOptions<undefined>["overflow"];
   /** When true, Pierre wires gutter selection. The consumer drives it via
    *  `onLineSelected`. Default `false`. */
   enableLineSelection?: boolean;
@@ -190,6 +193,7 @@ const FileView: Component<FileViewProps> = (props) => {
   const buildOptions = (): FileOptions<undefined> => ({
     theme: DEFAULT_THEMES,
     themeType: props.theme,
+    overflow: props.overflow ?? "scroll",
     enableLineSelection: props.enableLineSelection ?? false,
     onLineSelected: props.onLineSelected,
   });

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -237,6 +237,16 @@ Feature: Code tab (review + browse)
     When I click the file "greeting.txt" in the file browser
     Then the file content should contain "hello world"
 
+  Scenario: File browser wraps long lines by default
+    When I run "git init /tmp/kolu-browse-wrap && cd /tmp/kolu-browse-wrap"
+    And I run "printf 'prefix-' > long.txt && printf '%*s' 240 '' | tr ' ' x >> long.txt && printf '\n' >> long.txt"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    When I click the file "long.txt" in the file browser
+    Then the file content should contain "prefix-"
+    And the file content should wrap long lines
+
   Scenario: File browser expands directories lazily
     When I run "git init /tmp/kolu-browse-expand && cd /tmp/kolu-browse-expand"
     And I run "mkdir -p lib && printf 'x\n' > lib/util.ts"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1,4 +1,3 @@
-import * as assert from "node:assert";
 import { Given, Then, When } from "@cucumber/cucumber";
 import { pollFor } from "../support/poll.ts";
 import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
@@ -381,18 +380,29 @@ Then(
     const row = this.page.locator(`${FILE_VIEW} [data-line]`).first();
     await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 
-    const wraps = await row.evaluate((line) => {
-      const style = getComputedStyle(line);
-      const lineHeight = Number.parseFloat(style.lineHeight);
-      const singleLineHeight = Number.isFinite(lineHeight)
-        ? lineHeight
-        : Number.parseFloat(style.fontSize) * 1.2;
-      return line.getBoundingClientRect().height > singleLineHeight * 1.5;
-    });
-    assert.strictEqual(
-      wraps,
-      true,
-      "Expected browse-mode file content to render long lines in wrap mode",
+    await this.page.waitForFunction(
+      `(() => {
+        const root = document.querySelector('${FILE_VIEW}');
+        if (!root) return false;
+        const stack = [root];
+        while (stack.length) {
+          const node = stack.pop();
+          if (node.nodeType !== 1) continue;
+          if (node.matches?.('[data-line]')) {
+            const style = getComputedStyle(node);
+            const lineHeight = Number.parseFloat(style.lineHeight);
+            const singleLineHeight = Number.isFinite(lineHeight)
+              ? lineHeight
+              : Number.parseFloat(style.fontSize) * 1.2;
+            return node.getBoundingClientRect().height > singleLineHeight * 1.5;
+          }
+          if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
+          for (const ch of node.childNodes) stack.push(ch);
+        }
+        return false;
+      })()`,
+      undefined,
+      { timeout: POLL_TIMEOUT },
     );
   },
 );

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -379,29 +379,20 @@ Then(
   async function (this: KoluWorld) {
     const row = this.page.locator(`${FILE_VIEW} [data-line]`).first();
     await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const line = await row.elementHandle();
+    if (line === null) throw new Error("Expected a rendered file content line");
 
     await this.page.waitForFunction(
-      `(() => {
-        const root = document.querySelector('${FILE_VIEW}');
-        if (!root) return false;
-        const stack = [root];
-        while (stack.length) {
-          const node = stack.pop();
-          if (node.nodeType !== 1) continue;
-          if (node.matches?.('[data-line]')) {
-            const style = getComputedStyle(node);
-            const lineHeight = Number.parseFloat(style.lineHeight);
-            const singleLineHeight = Number.isFinite(lineHeight)
-              ? lineHeight
-              : Number.parseFloat(style.fontSize) * 1.2;
-            return node.getBoundingClientRect().height > singleLineHeight * 1.5;
-          }
-          if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
-          for (const ch of node.childNodes) stack.push(ch);
-        }
-        return false;
-      })()`,
-      undefined,
+      (node) => {
+        const line = node as Element;
+        const style = getComputedStyle(line);
+        const lineHeight = Number.parseFloat(style.lineHeight);
+        const singleLineHeight = Number.isFinite(lineHeight)
+          ? lineHeight
+          : Number.parseFloat(style.fontSize) * 1.2;
+        return line.getBoundingClientRect().height > singleLineHeight * 1.5;
+      },
+      line,
       { timeout: POLL_TIMEOUT },
     );
   },

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -382,21 +382,12 @@ Then(
     await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 
     const wraps = await row.evaluate((line) => {
-      const root = line.getRootNode();
-      const rootWrap =
-        root instanceof Document || root instanceof ShadowRoot
-          ? root.querySelector('[data-overflow="wrap"]')
-          : null;
-      const wrappedContainer =
-        line.closest('[data-overflow="wrap"]') ?? rootWrap;
-      if (wrappedContainer) return true;
-
       const style = getComputedStyle(line);
-      return (
-        style.whiteSpace === "pre-wrap" &&
-        (style.wordBreak === "break-word" ||
-          style.overflowWrap === "break-word")
-      );
+      const lineHeight = Number.parseFloat(style.lineHeight);
+      const singleLineHeight = Number.isFinite(lineHeight)
+        ? lineHeight
+        : Number.parseFloat(style.fontSize) * 1.2;
+      return line.getBoundingClientRect().height > singleLineHeight * 1.5;
     });
     assert.strictEqual(
       wraps,

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1,3 +1,4 @@
+import * as assert from "node:assert";
 import { Given, Then, When } from "@cucumber/cucumber";
 import { pollFor } from "../support/poll.ts";
 import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
@@ -371,6 +372,37 @@ Then(
   "the file content should contain {string}",
   async function (this: KoluWorld, expected: string) {
     await waitForViewText(this, "pierre-file-view", expected);
+  },
+);
+
+Then(
+  "the file content should wrap long lines",
+  async function (this: KoluWorld) {
+    const row = this.page.locator(`${FILE_VIEW} [data-line]`).first();
+    await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+
+    const wraps = await row.evaluate((line) => {
+      const root = line.getRootNode();
+      const rootWrap =
+        root instanceof Document || root instanceof ShadowRoot
+          ? root.querySelector('[data-overflow="wrap"]')
+          : null;
+      const wrappedContainer =
+        line.closest('[data-overflow="wrap"]') ?? rootWrap;
+      if (wrappedContainer) return true;
+
+      const style = getComputedStyle(line);
+      return (
+        style.whiteSpace === "pre-wrap" &&
+        (style.wordBreak === "break-word" ||
+          style.overflowWrap === "break-word")
+      );
+    });
+    assert.strictEqual(
+      wraps,
+      true,
+      "Expected browse-mode file content to render long lines in wrap mode",
+    );
   },
 );
 


### PR DESCRIPTION
**Code browser file views now wrap long lines by default**, so browsing source files in the right panel no longer forces horizontal scrolling for wide lines. Diff rendering already used Pierre's wrap mode; this brings the All files content view into the same readable default.

The change keeps the wrapping policy in the browse-mode caller while exposing Pierre's existing `overflow` option through Kolu's Solid `FileView` adapter. The regression test opens a long-line file in browse mode and waits for the rendered line geometry to show actual wrapping.

### Verification

- `just check`
- `just fmt`
- `just test-quick features/code-tab.feature --name "File browser wraps long lines by default"`

> An accidental full-suite `just test-quick features/code-tab.feature:240` run executed all features because the Cucumber config does not treat `feature:line` as a feature arg; the new code-tab scenario passed there too, while an unrelated OpenCode waiting-indicator scenario failed.

### Try it locally

```sh
nix run github:juspay/kolu/fix/file-view-word-wrap-default
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `unknown`)._