### PR TITLE
fix(tests): detect feature:line args in cucumber profile

### DIFF
--- a/packages/tests/cucumber.js
+++ b/packages/tests/cucumber.js
@@ -3,9 +3,11 @@ const parallel = parseInt(process.env.CUCUMBER_PARALLEL || "1", 10);
 // Only set default paths if no feature files were passed as CLI args.
 // CLI positional args (e.g. features/worktree.feature) are ignored when
 // the profile hardcodes paths — so we omit paths to let CLI args win.
+// Match both `foo.feature` and `foo.feature:42[:56...]` line-targeted forms;
+// missing the line form would inject `paths` and silently broaden the run.
 const cliHasFeatureArgs = process.argv
   .slice(2)
-  .some((a) => a.endsWith(".feature"));
+  .some((a) => /\.feature(?::\d+)*$/.test(a));
 
 // Default tag filter: exclude @skip'd scenarios (regression harnesses for
 // known-broken behavior). `CUCUMBER_TAGS` fully replaces the default — e.g.


### PR DESCRIPTION
**`just test-quick features/foo.feature:42` no longer silently runs the entire suite.** The cucumber `ui` profile injects a default `paths: ["features/**/*.feature"]` only when no feature file is on the CLI — but the detector matched `.endsWith(".feature")`, so `feature:line` forms slipped through, the default `paths` got injected, and cucumber-js then ignores the CLI positional and runs everything.

Widen the predicate to `/\.feature(?::\d+)*$/` so line-targeted args are recognized as feature targets and keep `paths` empty.

| Arg | Pre-fix | Post-fix |
|-----|---------|----------|
| `features/smoke.feature` | targeted | targeted |
| `features/smoke.feature:4` | **runs entire suite** | targeted |
| `features/smoke.feature:4:8` | **runs entire suite** | targeted |
| _(no args)_ | runs all | runs all |

_Verified end-to-end: `just test-quick features/smoke.feature:4` reports `1 scenario (1 passed)` instead of fanning out across every `.feature` file._

Surfaced as an optimization suggestion in the [`/do` results comment on #840](https://github.com/juspay/kolu/pull/840#issuecomment-4397830257).

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._