### PR TITLE
refactor(palette): discriminated leaf modes (closes #834)

### DIFF
--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -357,21 +357,20 @@ const CommandPalette: Component<{
 
   // Track initialGroup reactively: a caller changing the prop (or opening
   // with a new value) re-targets the drilled level. Closing clears the path.
+  // Routes through `drillInto` rather than `setPath` directly so the
+  // value-input branch (prefill + auto-select) fires when initialGroup
+  // names a value-input leaf.
   createEffect(
     on([() => props.open, () => props.initialGroup], ([isOpen, initial]) => {
-      if (!isOpen) {
-        setPath([]);
-        return;
-      }
-      const group = initial
-        ? props
-            .commands()
-            .find(
-              (c): c is PaletteGroup | PaletteValueInput =>
-                isCommand(c) && c.name === initial && isGroup(c),
-            )
-        : undefined;
-      setPath(group ? [group] : []);
+      setPath([]);
+      if (!isOpen || !initial) return;
+      const group = props
+        .commands()
+        .find(
+          (c): c is PaletteGroup | PaletteValueInput =>
+            isCommand(c) && c.name === initial && isGroup(c),
+        );
+      if (group) drillInto(group);
     }),
   );
 

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -22,6 +22,7 @@ import {
   on,
   Show,
 } from "solid-js";
+import { match } from "ts-pattern";
 import { formatKeybind, type Keybind } from "./input/keyboard";
 import { useTips } from "./settings/useTips";
 import Kbd from "./ui/Kbd";
@@ -115,10 +116,6 @@ function isGroup(item: PaletteItem): item is PaletteGroup | PaletteValueInput {
  *  children fit the wider return type. */
 function resolveChildren(cmd: PaletteGroup | PaletteValueInput): PaletteItem[] {
   return typeof cmd.children === "function" ? cmd.children() : cmd.children;
-}
-
-function assertNever(x: never): never {
-  throw new Error(`unhandled palette command kind: ${JSON.stringify(x)}`);
 }
 
 /** Ctrl+key → normalized key for readline-style navigation. */
@@ -290,22 +287,18 @@ const CommandPalette: Component<{
     }
     // Filter mode — labels never appear at the top level (enforced by
     // PaletteValueChild only being reachable inside a value group).
-    switch (cmd.kind) {
-      case "group":
-      case "value":
-        drillInto(cmd);
-        return;
-      case "action":
+    // .exhaustive() forces a compile error if a future kind is added
+    // without an arm here.
+    match(cmd)
+      .with({ kind: "group" }, { kind: "value" }, (group) => drillInto(group))
+      .with({ kind: "action" }, (action) => {
         // Close first so the highlight effect stops tracking filtered(),
         // preventing onSelect's state changes from re-triggering a preview.
         closeForSelection();
-        cmd.onSelect();
-        return;
-      case "label":
-        return;
-      default:
-        assertNever(cmd);
-    }
+        action.onSelect();
+      })
+      .with({ kind: "label" }, () => {})
+      .exhaustive();
   }
 
   function handleKeyDown(e: KeyboardEvent) {

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -61,8 +61,13 @@ export interface PaletteGroup extends PaletteBase {
  *  value field — pre-filled with `prefill()` and auto-selected on focus.
  *  Children are passive label rows: their own `onSelect` (if any) is
  *  bypassed and Enter (or click) routes through this group's `onSubmit`
- *  with the typed value plus the highlighted child. Up/Down still moves
+ *  with the typed value plus the highlighted label. Up/Down still moves
  *  the highlight; Backspace on an empty value drills back out.
+ *
+ *  Children are typed as `PaletteValueChild` so the "labels live inside
+ *  value groups" invariant is enforced at compile time — no actions or
+ *  nested groups can appear here. `onSubmit` receives the highlighted
+ *  child narrowed to `PaletteLabel`.
  *
  *  `validate` runs on every keystroke; returning a non-null message
  *  paints the input red, renders the message under the input, and
@@ -72,9 +77,9 @@ export interface PaletteValueInput extends PaletteBase {
   prefill: () => string;
   placeholder?: string;
   validate?: (value: string) => string | null;
-  onSubmit: (value: string, selected: PaletteCommand) => void;
+  onSubmit: (value: string, selected: PaletteLabel) => void;
   /** Static array or accessor for dynamic lists. */
-  children: PaletteItem[] | (() => PaletteItem[]);
+  children: PaletteValueChild[] | (() => PaletteValueChild[]);
 }
 
 /** A passive selectable row inside a `PaletteValueInput`'s children —
@@ -90,26 +95,30 @@ export interface PaletteHint {
   text: string;
 }
 
-export type PaletteCommand =
-  | PaletteAction
-  | PaletteGroup
-  | PaletteValueInput
-  | PaletteLabel;
+/** Top-level commands — action, group, or value-input. Labels are not
+ *  permitted at the top level; they appear only as `PaletteValueInput`
+ *  children. */
+export type PaletteCommand = PaletteAction | PaletteGroup | PaletteValueInput;
 
-/** Anything renderable at a palette level — a command or a hint. */
-export type PaletteItem = PaletteCommand | PaletteHint;
+/** Children of a `PaletteValueInput`: passive labels plus optional hints. */
+export type PaletteValueChild = PaletteLabel | PaletteHint;
 
-function isCommand(item: PaletteItem): item is PaletteCommand {
-  return item.kind !== "hint";
+/** Anything renderable at a palette level. */
+export type PaletteItem = PaletteCommand | PaletteLabel | PaletteHint;
+
+function isGroup(item: PaletteItem): item is PaletteGroup | PaletteValueInput {
+  return item.kind === "group" || item.kind === "value";
 }
 
-function isGroup(cmd: PaletteCommand): cmd is PaletteGroup | PaletteValueInput {
-  return cmd.kind === "group" || cmd.kind === "value";
-}
-
-/** Resolve children, handling both static arrays and accessors. */
+/** Resolve children, handling both static arrays and accessors.
+ *  `PaletteValueChild` is a subset of `PaletteItem`, so a value-group's
+ *  children fit the wider return type. */
 function resolveChildren(cmd: PaletteGroup | PaletteValueInput): PaletteItem[] {
   return typeof cmd.children === "function" ? cmd.children() : cmd.children;
+}
+
+function assertNever(x: never): never {
+  throw new Error(`unhandled palette command kind: ${JSON.stringify(x)}`);
 }
 
 /** Ctrl+key → normalized key for readline-style navigation. */
@@ -162,7 +171,7 @@ const CommandPalette: Component<{
     for (const segment of p) {
       const match = level.find(
         (item): item is PaletteGroup | PaletteValueInput =>
-          isCommand(item) && item.name === segment.name && isGroup(item),
+          isGroup(item) && item.name === segment.name,
       );
       if (!match) return resolveChildren(last);
       level = resolveChildren(match);
@@ -170,17 +179,18 @@ const CommandPalette: Component<{
     return level;
   });
 
-  /** Single-pass partition of `currentItems()` into commands and hints —
-   *  one traversal feeds both consumers (the list and the hint footer). */
+  /** Single-pass partition of `currentItems()` into interactive rows
+   *  (commands or labels) and hints — one traversal feeds both consumers
+   *  (the list and the hint footer). */
   const partitioned = createMemo(() => {
     const items = currentItems();
-    const commands: PaletteCommand[] = [];
+    const interactive: (PaletteCommand | PaletteLabel)[] = [];
     const hints: PaletteHint[] = [];
     for (const item of items) {
       if (item.kind === "hint") hints.push(item);
-      else commands.push(item);
+      else interactive.push(item);
     }
-    return { commands, hints };
+    return { interactive, hints };
   });
 
   /** Discriminated UI mode driven by the deepest path segment.
@@ -212,9 +222,11 @@ const CommandPalette: Component<{
     return "Type a command...";
   });
 
-  /** Commands at the current level (filter is bypassed in value mode). */
-  const filtered = createMemo((): PaletteCommand[] => {
-    const items = partitioned().commands;
+  /** Interactive rows at the current level (filter is bypassed in value
+   *  mode). Filter mode produces `PaletteCommand[]`; value mode produces
+   *  `PaletteLabel[]` — the union covers both without dynamic typing. */
+  const filtered = createMemo((): (PaletteCommand | PaletteLabel)[] => {
+    const items = partitioned().interactive;
     if (mode().kind === "value") return items;
     const q = query().toLowerCase();
     return items.filter(
@@ -263,29 +275,37 @@ const CommandPalette: Component<{
     props.onOpenChange(open);
   }
 
-  function execute(cmd: PaletteCommand) {
+  function execute(cmd: PaletteCommand | PaletteLabel) {
     const m = mode();
     if (m.kind === "value") {
+      // Structural invariant: value-input children are PaletteLabel —
+      // anything else here is a caller bug.
+      if (cmd.kind !== "label") return;
       // Block submit while the typed value is invalid; the inline error
       // row already tells the user what to fix.
       if (valueError()) return;
-      // Children in value mode are passive — Enter routes through the
-      // leaf's onSubmit with the typed value + highlighted child.
       closeForSelection();
       m.leaf.onSubmit(query(), cmd);
       return;
     }
-    if (cmd.kind === "group" || cmd.kind === "value") {
-      drillInto(cmd);
-      return;
+    // Filter mode — labels never appear at the top level (enforced by
+    // PaletteValueChild only being reachable inside a value group).
+    switch (cmd.kind) {
+      case "group":
+      case "value":
+        drillInto(cmd);
+        return;
+      case "action":
+        // Close first so the highlight effect stops tracking filtered(),
+        // preventing onSelect's state changes from re-triggering a preview.
+        closeForSelection();
+        cmd.onSelect();
+        return;
+      case "label":
+        return;
+      default:
+        assertNever(cmd);
     }
-    if (cmd.kind === "action") {
-      // Close first so the highlight effect stops tracking filtered(),
-      // preventing onSelect's state changes from re-triggering a preview.
-      closeForSelection();
-      cmd.onSelect();
-    }
-    // PaletteLabel: not reachable in filter mode (labels live inside value groups).
   }
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -368,7 +388,7 @@ const CommandPalette: Component<{
         .commands()
         .find(
           (c): c is PaletteGroup | PaletteValueInput =>
-            isCommand(c) && c.name === initial && isGroup(c),
+            isGroup(c) && c.name === initial,
         );
       if (group) drillInto(group);
     }),

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -402,11 +402,11 @@ const CommandPalette: Component<{
 
   // Auto-scroll the highlighted row into view. One effect outside <For>:
   // the per-row JSX sets data-selected on the matching row; this effect
-  // queries it. Solid flushes JSX bindings before running effects in
-  // creation order, so the query finds the freshly-selected row.
+  // queries it. Filter changes already reset selectedIndex to 0 (see the
+  // selection-reset effect above), so the top item is structurally in
+  // view — no need to re-scroll on `filtered()` changes.
   createEffect(() => {
     selectedIndex();
-    filtered();
     if (!props.open) return;
     listEl
       ?.querySelector<HTMLElement>("[data-selected]")

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -255,21 +255,16 @@ const CommandPalette: Component<{
     setSelectedIndex(0);
   }
 
-  /** Internal close after a successful selection — bypasses cancel
-   *  propagation that `handleOpenChange` would otherwise run. */
-  function closeForSelection() {
-    props.onOpenChange(false);
-  }
+  // Selection-initiated close: signals the close-effect to skip
+  // path.onCancel propagation. External closes (Escape, backdrop click,
+  // parent toggle via setPaletteOpen) leave this false so onCancel fires.
+  // Three close paths converge on the close-effect; this signal is the
+  // single discriminator that distinguishes "completed" from "cancelled".
+  const [closingForSelection, setClosingForSelection] = createSignal(false);
 
-  /** External close (Escape, backdrop click, parent setting open=false
-   *  unprompted): fire onCancel handlers for the drilled-in path before
-   *  propagating. Internal selections call `closeForSelection` and skip
-   *  this path entirely. */
-  function handleOpenChange(open: boolean) {
-    if (!open) {
-      for (const g of path()) g.onCancel?.();
-    }
-    props.onOpenChange(open);
+  function closeForSelection() {
+    setClosingForSelection(true);
+    props.onOpenChange(false);
   }
 
   function execute(cmd: PaletteCommand | PaletteLabel) {
@@ -349,21 +344,29 @@ const CommandPalette: Component<{
   // Capture phase: intercept before terminal's keydown handler
   makeEventListener(window, "keydown", handleKeyDown, { capture: true });
 
-  // Reset transient state on open.
+  // Open: reset transient state. Close: fire onCancel for the drilled-in
+  // path unless the close was selection-initiated.
   createEffect(
     on(
       () => props.open,
       (isOpen) => {
-        if (!isOpen) return;
-        setQuery("");
-        setSelectedIndex(0);
-        setAmbientTip(randomAmbientTip());
-        setMouseActive(false);
-        // forceMount keeps the dialog in the DOM, so Corvu's initialFocusEl
-        // only fires on first mount. Re-focus explicitly on every open.
-        requestAnimationFrame(() =>
-          requestAnimationFrame(() => inputRef.focus()),
-        );
+        if (isOpen) {
+          setQuery("");
+          setSelectedIndex(0);
+          setAmbientTip(randomAmbientTip());
+          setMouseActive(false);
+          setClosingForSelection(false);
+          // forceMount keeps the dialog in the DOM, so Corvu's initialFocusEl
+          // only fires on first mount. Re-focus explicitly on every open.
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => inputRef.focus()),
+          );
+        } else {
+          if (!closingForSelection()) {
+            for (const g of path()) g.onCancel?.();
+          }
+          setClosingForSelection(false);
+        }
       },
     ),
   );
@@ -428,7 +431,7 @@ const CommandPalette: Component<{
   return (
     <ModalDialog
       open={props.open}
-      onOpenChange={handleOpenChange}
+      onOpenChange={props.onOpenChange}
       transparentOverlay={props.transparentOverlay}
       initialFocusEl={inputRef}
     >

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -65,10 +65,10 @@ export interface PaletteGroup extends PaletteBase {
  *  with the typed value plus the highlighted label. Up/Down still moves
  *  the highlight; Backspace on an empty value drills back out.
  *
- *  Children are typed as `PaletteValueChild` so the "labels live inside
- *  value groups" invariant is enforced at compile time — no actions or
- *  nested groups can appear here. `onSubmit` receives the highlighted
- *  child narrowed to `PaletteLabel`.
+ *  Children are restricted to labels and hints — the type rules out
+ *  actions or nested groups, so the "labels live inside value groups"
+ *  invariant is enforced at compile time. `onSubmit` receives the
+ *  highlighted child narrowed to `PaletteLabel`.
  *
  *  `validate` runs on every keystroke; returning a non-null message
  *  paints the input red, renders the message under the input, and
@@ -80,7 +80,9 @@ export interface PaletteValueInput extends PaletteBase {
   validate?: (value: string) => string | null;
   onSubmit: (value: string, selected: PaletteLabel) => void;
   /** Static array or accessor for dynamic lists. */
-  children: PaletteValueChild[] | (() => PaletteValueChild[]);
+  children:
+    | (PaletteLabel | PaletteHint)[]
+    | (() => (PaletteLabel | PaletteHint)[]);
 }
 
 /** A passive selectable row inside a `PaletteValueInput`'s children —
@@ -100,9 +102,6 @@ export interface PaletteHint {
  *  permitted at the top level; they appear only as `PaletteValueInput`
  *  children. */
 export type PaletteCommand = PaletteAction | PaletteGroup | PaletteValueInput;
-
-/** Children of a `PaletteValueInput`: passive labels plus optional hints. */
-export type PaletteValueChild = PaletteLabel | PaletteHint;
 
 /** Anything renderable at a palette level. */
 export type PaletteItem = PaletteCommand | PaletteLabel | PaletteHint;
@@ -140,7 +139,6 @@ const CommandPalette: Component<{
   const [selectedIndex, setSelectedIndex] = createSignal(0);
   // Ignore mouseEnter until a real mouse move after opening (prevents cursor-under-palette hijack).
   const [mouseActive, setMouseActive] = createSignal(false);
-  // Navigation path: list of group commands we've drilled into.
   const [path, setPath] = createSignal<(PaletteGroup | PaletteValueInput)[]>(
     [],
   );
@@ -212,12 +210,13 @@ const CommandPalette: Component<{
     return m.leaf.validate?.(query()) ?? null;
   });
 
-  /** Input placeholder, derived from mode. */
-  const placeholder = createMemo(() => {
+  /** Input placeholder, derived from mode. Plain function — single
+   *  consumer (the input element). */
+  function placeholder(): string {
     const m = mode();
     if (m.kind === "value") return m.leaf.placeholder ?? "Type a command...";
     return "Type a command...";
-  });
+  }
 
   /** Interactive rows at the current level (filter is bypassed in value
    *  mode). Filter mode produces `PaletteCommand[]`; value mode produces
@@ -319,7 +318,6 @@ const CommandPalette: Component<{
         );
         break;
       case "Backspace":
-        // Drill out when backspacing on empty query
         if (query() === "" && path().length > 0) {
           navigateTo(path().length - 1);
           break;

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -540,7 +540,7 @@ const CommandPalette: Component<{
                         →
                       </span>
                     </Show>
-                    <Show when={!isGroup(cmd) && cmd.keybind}>
+                    <Show when={cmd.kind === "action" && cmd.keybind}>
                       {(keybind) => {
                         const kb = keybind();
                         return (

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -27,42 +27,61 @@ import { useTips } from "./settings/useTips";
 import Kbd from "./ui/Kbd";
 import ModalDialog from "./ui/ModalDialog";
 
-/** A command that can be executed from the palette, or a group containing sub-commands. */
-export interface PaletteCommand {
-  kind?: "command";
+/** Fields shared by every interactive palette item. */
+interface PaletteBase {
   name: string;
   /** Secondary text shown after the name, de-emphasized. */
   description?: string;
-  /** Execute this command (leaf). Mutually exclusive with `children`. */
-  onSelect?: () => void;
-  /** Nested sub-commands (group). Static array or accessor for dynamic lists. */
-  children?: PaletteItem[] | (() => PaletteItem[]);
-  /** Opaque payload readable by `valueInput.onSubmit`. The palette never
-   *  interprets `data`; it just hands it back so callers can identify the
-   *  chosen option without string-matching on `name`. */
+  /** Opaque payload — palette never interprets `data`; it just hands it
+   *  back via `onSubmit` so callers can identify the chosen option
+   *  without string-matching on `name`. */
   data?: unknown;
-  /** When set on a group, drilling in switches the input from a filter to a
-   *  value field — pre-filled with `prefill()` and auto-selected on focus.
-   *  Children are passive label rows: their own `onSelect` is bypassed and
-   *  Enter (or click) routes through this group's `onSubmit` with the
-   *  typed value plus the highlighted child. Up/Down still moves the
-   *  highlight; Backspace on an empty value drills back out.
-   *
-   *  `validate` runs on every keystroke; returning a non-null message
-   *  paints the input red, renders the message under the input, and
-   *  blocks submit until the value passes again. */
-  valueInput?: {
-    prefill: () => string;
-    placeholder?: string;
-    validate?: (value: string) => string | null;
-    onSubmit: (value: string, selected: PaletteCommand) => void;
-  };
   /** Keyboard shortcut(s) to display alongside the command name. */
   keybind?: Keybind | Keybind[];
   /** Called when this item becomes the highlighted item during navigation. */
   onHighlight?: () => void;
-  /** Called when leaving this group without executing a child (Escape, Backspace, breadcrumb). */
+  /** Called when leaving this item without executing it (Escape, Backspace, breadcrumb). */
   onCancel?: () => void;
+}
+
+/** A leaf that runs an action when selected. */
+export interface PaletteAction extends PaletteBase {
+  kind: "action";
+  onSelect: () => void;
+}
+
+/** A nested level. Drilling in narrows navigation to its children. */
+export interface PaletteGroup extends PaletteBase {
+  kind: "group";
+  /** Static array or accessor for dynamic lists. */
+  children: PaletteItem[] | (() => PaletteItem[]);
+}
+
+/** A group whose drill-in switches the input from a filter to a free-text
+ *  value field — pre-filled with `prefill()` and auto-selected on focus.
+ *  Children are passive label rows: their own `onSelect` (if any) is
+ *  bypassed and Enter (or click) routes through this group's `onSubmit`
+ *  with the typed value plus the highlighted child. Up/Down still moves
+ *  the highlight; Backspace on an empty value drills back out.
+ *
+ *  `validate` runs on every keystroke; returning a non-null message
+ *  paints the input red, renders the message under the input, and
+ *  blocks submit until the value passes again. */
+export interface PaletteValueInput extends PaletteBase {
+  kind: "value";
+  prefill: () => string;
+  placeholder?: string;
+  validate?: (value: string) => string | null;
+  onSubmit: (value: string, selected: PaletteCommand) => void;
+  /** Static array or accessor for dynamic lists. */
+  children: PaletteItem[] | (() => PaletteItem[]);
+}
+
+/** A passive selectable row inside a `PaletteValueInput`'s children —
+ *  rendered like an action but has no `onSelect` of its own; the value
+ *  group's `onSubmit` receives it as the highlighted choice. */
+export interface PaletteLabel extends PaletteBase {
+  kind: "label";
 }
 
 /** A non-interactive informational row shown inside a palette group. */
@@ -71,6 +90,12 @@ export interface PaletteHint {
   text: string;
 }
 
+export type PaletteCommand =
+  | PaletteAction
+  | PaletteGroup
+  | PaletteValueInput
+  | PaletteLabel;
+
 /** Anything renderable at a palette level — a command or a hint. */
 export type PaletteItem = PaletteCommand | PaletteHint;
 
@@ -78,19 +103,13 @@ function isCommand(item: PaletteItem): item is PaletteCommand {
   return item.kind !== "hint";
 }
 
-function isHint(item: PaletteItem): item is PaletteHint {
-  return item.kind === "hint";
+function isGroup(cmd: PaletteCommand): cmd is PaletteGroup | PaletteValueInput {
+  return cmd.kind === "group" || cmd.kind === "value";
 }
 
 /** Resolve children, handling both static arrays and accessors. */
-function resolveChildren(cmd: PaletteCommand): PaletteItem[] {
-  if (!cmd.children) return [];
+function resolveChildren(cmd: PaletteGroup | PaletteValueInput): PaletteItem[] {
   return typeof cmd.children === "function" ? cmd.children() : cmd.children;
-}
-
-/** Whether a command is a group (has children rather than an action). */
-function isGroup(cmd: PaletteCommand): boolean {
-  return cmd.children !== undefined;
 }
 
 /** Ctrl+key → normalized key for readline-style navigation. */
@@ -100,20 +119,25 @@ const CommandPalette: Component<{
   commands: Accessor<PaletteItem[]>;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** If set, auto-drill into the group with this name on open. */
+  /** If set, auto-drill into the group with this name on open. Tracked
+   *  reactively — a caller updating the prop while open re-targets the
+   *  drilled level. */
   initialGroup?: string;
   /** When true, the backdrop is transparent so content behind is visible. */
   transparentOverlay?: boolean;
 }> = (props) => {
   const { randomAmbientTip } = useTips();
   let inputRef!: HTMLInputElement;
+  let listEl!: HTMLDivElement;
   const [query, setQuery] = createSignal("");
   const [ambientTip, setAmbientTip] = createSignal("");
   const [selectedIndex, setSelectedIndex] = createSignal(0);
-  // Ignore mouseEnter until a real mouse move after opening (prevents cursor-under-palette hijack)
-  let mouseActive = false;
-  // Navigation path: list of group commands we've drilled into
-  const [path, setPath] = createSignal<PaletteCommand[]>([]);
+  // Ignore mouseEnter until a real mouse move after opening (prevents cursor-under-palette hijack).
+  const [mouseActive, setMouseActive] = createSignal(false);
+  // Navigation path: list of group commands we've drilled into.
+  const [path, setPath] = createSignal<(PaletteGroup | PaletteValueInput)[]>(
+    [],
+  );
 
   /** Items at the current navigation level (may include hints).
    *
@@ -137,34 +161,61 @@ const CommandPalette: Component<{
     let level: PaletteItem[] = props.commands();
     for (const segment of p) {
       const match = level.find(
-        (item): item is PaletteCommand =>
-          isCommand(item) && item.name === segment.name,
+        (item): item is PaletteGroup | PaletteValueInput =>
+          isCommand(item) && item.name === segment.name && isGroup(item),
       );
-      if (!match || !isGroup(match)) {
-        // Segment no longer present in the current tree; fall back to
-        // the stale reference to keep the level rendered. Happens e.g.
-        // when a visibility guard hides a parent group while the user
-        // is still drilled into it.
-        return resolveChildren(last);
-      }
+      if (!match) return resolveChildren(last);
       level = resolveChildren(match);
     }
     return level;
   });
 
-  /** Active `valueInput` of the deepest path segment, if any. */
-  const valueLeaf = createMemo(() => path().at(-1)?.valueInput);
+  /** Single-pass partition of `currentItems()` into commands and hints —
+   *  one traversal feeds both consumers (the list and the hint footer). */
+  const partitioned = createMemo(() => {
+    const items = currentItems();
+    const commands: PaletteCommand[] = [];
+    const hints: PaletteHint[] = [];
+    for (const item of items) {
+      if (item.kind === "hint") hints.push(item);
+      else commands.push(item);
+    }
+    return { commands, hints };
+  });
 
-  /** Live validation error for the current value-input query. `null` when
-   *  the leaf has no validator, or the value passes; otherwise the
-   *  message to surface inline. Read by the input border, the error row,
-   *  and the submit guard in `execute`. */
-  const valueError = createMemo(() => valueLeaf()?.validate?.(query()) ?? null);
+  /** Discriminated UI mode driven by the deepest path segment.
+   *  Filter mode: input narrows the children list. Value mode: input is
+   *  a free-text field; children render as passive labels. The five
+   *  behavior swaps (filter bypass, validation, placeholder,
+   *  selection-reset suppression, submit dispatch) all switch on this. */
+  type Mode = { kind: "filter" } | { kind: "value"; leaf: PaletteValueInput };
 
-  /** Commands at the current level (filter is bypassed in value-input mode). */
+  const mode = createMemo<Mode>(() => {
+    const last = path().at(-1);
+    return last?.kind === "value"
+      ? { kind: "value", leaf: last }
+      : { kind: "filter" };
+  });
+
+  /** Validation error for the current value-input query. `null` outside
+   *  value mode or when the value passes. */
+  const valueError = createMemo<string | null>(() => {
+    const m = mode();
+    if (m.kind !== "value") return null;
+    return m.leaf.validate?.(query()) ?? null;
+  });
+
+  /** Input placeholder, derived from mode. */
+  const placeholder = createMemo(() => {
+    const m = mode();
+    if (m.kind === "value") return m.leaf.placeholder ?? "Type a command...";
+    return "Type a command...";
+  });
+
+  /** Commands at the current level (filter is bypassed in value mode). */
   const filtered = createMemo((): PaletteCommand[] => {
-    const items = currentItems().filter(isCommand);
-    if (valueLeaf()) return items;
+    const items = partitioned().commands;
+    if (mode().kind === "value") return items;
     const q = query().toLowerCase();
     return items.filter(
       (cmd) =>
@@ -174,29 +225,16 @@ const CommandPalette: Component<{
     );
   });
 
-  /** Hints at the current level — rendered as non-interactive rows below the list. */
-  const hintsAtLevel = createMemo((): PaletteHint[] =>
-    currentItems().filter(isHint),
-  );
-
-  function drillIn(cmd: PaletteCommand) {
+  function drillInto(cmd: PaletteGroup | PaletteValueInput) {
     setPath((p) => [...p, cmd]);
-    if (cmd.valueInput) {
-      setQuery(cmd.valueInput.prefill());
+    if (cmd.kind === "value") {
+      setQuery(cmd.prefill());
       // Defer select() to rAF so the input has rendered the new value
       // first — selecting before the render highlights nothing.
       requestAnimationFrame(() => inputRef.select());
     } else {
       setQuery("");
     }
-    setSelectedIndex(0);
-  }
-
-  function drillOut() {
-    const p = path();
-    p[p.length - 1]?.onCancel?.();
-    setPath(p.slice(0, -1));
-    setQuery("");
     setSelectedIndex(0);
   }
 
@@ -208,30 +246,46 @@ const CommandPalette: Component<{
     setSelectedIndex(0);
   }
 
-  // Track whether the palette is closing due to a selection (skip onCancel).
-  let didSelect = false;
+  /** Internal close after a successful selection — bypasses cancel
+   *  propagation that `handleOpenChange` would otherwise run. */
+  function closeForSelection() {
+    props.onOpenChange(false);
+  }
+
+  /** External close (Escape, backdrop click, parent setting open=false
+   *  unprompted): fire onCancel handlers for the drilled-in path before
+   *  propagating. Internal selections call `closeForSelection` and skip
+   *  this path entirely. */
+  function handleOpenChange(open: boolean) {
+    if (!open) {
+      for (const g of path()) g.onCancel?.();
+    }
+    props.onOpenChange(open);
+  }
 
   function execute(cmd: PaletteCommand) {
-    const leaf = valueLeaf();
-    if (leaf) {
+    const m = mode();
+    if (m.kind === "value") {
       // Block submit while the typed value is invalid; the inline error
       // row already tells the user what to fix.
       if (valueError()) return;
-      // Children in value-input mode are passive labels (see `valueInput` docs).
-      didSelect = true;
-      props.onOpenChange(false);
-      leaf.onSubmit(query(), cmd);
+      // Children in value mode are passive — Enter routes through the
+      // leaf's onSubmit with the typed value + highlighted child.
+      closeForSelection();
+      m.leaf.onSubmit(query(), cmd);
       return;
     }
-    if (isGroup(cmd)) {
-      drillIn(cmd);
-    } else {
+    if (cmd.kind === "group" || cmd.kind === "value") {
+      drillInto(cmd);
+      return;
+    }
+    if (cmd.kind === "action") {
       // Close first so the highlight effect stops tracking filtered(),
       // preventing onSelect's state changes from re-triggering a preview.
-      didSelect = true;
-      props.onOpenChange(false);
-      cmd.onSelect?.();
+      closeForSelection();
+      cmd.onSelect();
     }
+    // PaletteLabel: not reachable in filter mode (labels live inside value groups).
   }
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -259,7 +313,7 @@ const CommandPalette: Component<{
       case "Backspace":
         // Drill out when backspacing on empty query
         if (query() === "" && path().length > 0) {
-          drillOut();
+          navigateTo(path().length - 1);
           break;
         }
         return;
@@ -282,37 +336,43 @@ const CommandPalette: Component<{
   // Capture phase: intercept before terminal's keydown handler
   makeEventListener(window, "keydown", handleKeyDown, { capture: true });
 
-  // Reset all state when opening; cancel groups on close (unless a command was selected)
+  // Reset transient state on open.
   createEffect(
     on(
       () => props.open,
       (isOpen) => {
-        if (isOpen) {
-          setQuery("");
-          setSelectedIndex(0);
-          setAmbientTip(randomAmbientTip());
-          mouseActive = false;
-          const group = props.initialGroup
-            ? props
-                .commands()
-                .find(
-                  (c): c is PaletteCommand =>
-                    isCommand(c) && c.name === props.initialGroup,
-                )
-            : undefined;
-          setPath(group ? [group] : []);
-          didSelect = false;
-          // forceMount keeps the dialog in the DOM, so Corvu's initialFocusEl
-          // only fires on first mount. Re-focus explicitly on every open.
-          requestAnimationFrame(() =>
-            requestAnimationFrame(() => inputRef.focus()),
-          );
-        } else {
-          if (!didSelect) for (const g of path()) g.onCancel?.();
-          didSelect = false;
-        }
+        if (!isOpen) return;
+        setQuery("");
+        setSelectedIndex(0);
+        setAmbientTip(randomAmbientTip());
+        setMouseActive(false);
+        // forceMount keeps the dialog in the DOM, so Corvu's initialFocusEl
+        // only fires on first mount. Re-focus explicitly on every open.
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => inputRef.focus()),
+        );
       },
     ),
+  );
+
+  // Track initialGroup reactively: a caller changing the prop (or opening
+  // with a new value) re-targets the drilled level. Closing clears the path.
+  createEffect(
+    on([() => props.open, () => props.initialGroup], ([isOpen, initial]) => {
+      if (!isOpen) {
+        setPath([]);
+        return;
+      }
+      const group = initial
+        ? props
+            .commands()
+            .find(
+              (c): c is PaletteGroup | PaletteValueInput =>
+                isCommand(c) && c.name === initial && isGroup(c),
+            )
+        : undefined;
+      setPath(group ? [group] : []);
+    }),
   );
 
   // Reset selection when the user types (defer: skip initial run).
@@ -323,29 +383,40 @@ const CommandPalette: Component<{
     on(
       query,
       () => {
-        // Skip in value-input mode: query is a value, not a filter.
-        if (valueLeaf()) return;
+        // Skip in value mode: query is a value, not a filter.
+        if (mode().kind === "value") return;
         setSelectedIndex(0);
       },
       { defer: true },
     ),
   );
 
-  // Notify highlighted item when selection changes.
-  // Uses on() for stable dependency tracking — bare createEffect would drop
-  // filtered/selectedIndex tracking when props.open is false, creating
-  // flickering dependency sets across open/close cycles.
+  // Notify highlighted item when selection changes. Tracks props.open so
+  // the effect re-fires on reopen with the same selection.
   createEffect(
-    on([filtered, selectedIndex], ([items, idx]) => {
-      if (!props.open) return;
+    on([filtered, selectedIndex, () => props.open], ([items, idx, open]) => {
+      if (!open) return;
       items[idx]?.onHighlight?.();
     }),
   );
 
+  // Auto-scroll the highlighted row into view. One effect outside <For>:
+  // the per-row JSX sets data-selected on the matching row; this effect
+  // queries it. Solid flushes JSX bindings before running effects in
+  // creation order, so the query finds the freshly-selected row.
+  createEffect(() => {
+    selectedIndex();
+    filtered();
+    if (!props.open) return;
+    listEl
+      ?.querySelector<HTMLElement>("[data-selected]")
+      ?.scrollIntoView({ block: "nearest" });
+  });
+
   return (
     <ModalDialog
       open={props.open}
-      onOpenChange={props.onOpenChange}
+      onOpenChange={handleOpenChange}
       transparentOverlay={props.transparentOverlay}
       initialFocusEl={inputRef}
     >
@@ -390,9 +461,9 @@ const CommandPalette: Component<{
         <input
           ref={inputRef}
           type="text"
-          data-value-input={valueLeaf() ? "" : undefined}
+          data-value-input={mode().kind === "value" ? "" : undefined}
           data-value-invalid={valueError() ? "" : undefined}
-          placeholder={valueLeaf()?.placeholder ?? "Type a command..."}
+          placeholder={placeholder()}
           class="w-full px-4 py-3 bg-surface-1 text-fg text-sm border-b outline-none placeholder-fg-3"
           classList={{
             "border-edge": !valueError(),
@@ -413,16 +484,14 @@ const CommandPalette: Component<{
         </Show>
         <div
           ref={(el) => {
-            // Mouse activity tracker is incidental UI state, not a real
-            // interactive event on this scroll container — attach via
-            // addEventListener so the div stays a plain layout element.
-            el.addEventListener(
-              "mousemove",
-              () => {
-                mouseActive = true;
-              },
-              { passive: true },
-            );
+            listEl = el;
+            // mousemove is incidental UI state, not a real interactive event
+            // on this scroll container — attach via addEventListener so the
+            // div stays a plain layout element (Biome's
+            // noStaticElementInteractions would flag a JSX onMouseMove).
+            el.addEventListener("mousemove", () => setMouseActive(true), {
+              passive: true,
+            });
           }}
           class="flex-1 min-h-0 overflow-y-auto"
         >
@@ -438,13 +507,6 @@ const CommandPalette: Component<{
               <For each={filtered()}>
                 {(cmd, i) => (
                   <div
-                    ref={(el) => {
-                      // Auto-scroll selected item into view during keyboard navigation
-                      createEffect(() => {
-                        if (selectedIndex() === i())
-                          el.scrollIntoView({ block: "nearest" });
-                      });
-                    }}
                     role="option"
                     tabIndex={-1}
                     aria-selected={selectedIndex() === i()}
@@ -456,7 +518,7 @@ const CommandPalette: Component<{
                         selectedIndex() !== i(),
                     }}
                     data-selected={selectedIndex() === i() || undefined}
-                    onMouseEnter={() => mouseActive && setSelectedIndex(i())}
+                    onMouseEnter={() => mouseActive() && setSelectedIndex(i())}
                     onClick={() => execute(cmd)}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
@@ -495,9 +557,9 @@ const CommandPalette: Component<{
               </For>
             </div>
           </Show>
-          <Show when={hintsAtLevel().length > 0}>
+          <Show when={partitioned().hints.length > 0}>
             <ul class="py-1">
-              <For each={hintsAtLevel()}>
+              <For each={partitioned().hints}>
                 {(hint) => (
                   <li
                     data-testid="palette-hint"

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -6,10 +6,16 @@ import { randomName } from "memorable-names";
 import type { Accessor } from "solid-js";
 import { batch, createMemo } from "solid-js";
 import { availableThemes } from "terminal-themes";
-import type { PaletteCommand, PaletteItem } from "./CommandPalette";
+import type {
+  PaletteAction,
+  PaletteCommand,
+  PaletteItem,
+  PaletteLabel,
+  PaletteValueInput,
+} from "./CommandPalette";
 import { type ActionContext, actionPaletteCommand } from "./input/actions";
 import { client } from "./wire";
-import { recentRepos, recentAgents } from "./wire";
+import { recentAgents, recentRepos } from "./wire";
 
 /** Live worktree-name validator — reuses the server schema so the rule
  *  has one source of truth. Returns the first issue's message, or null
@@ -26,18 +32,29 @@ function agentItems(
   agents: RecentAgent[],
   onPick: (command: string) => void,
 ): PaletteItem[] {
-  return agents.map((a) => ({
-    name: a.command,
-    onSelect: () => onPick(a.command),
-  }));
+  return agents.map(
+    (a): PaletteAction => ({
+      kind: "action",
+      name: a.command,
+      onSelect: () => onPick(a.command),
+    }),
+  );
 }
 
 /** Children of the worktree-naming leaf. Each row's `data` is the agent
- *  CLI string to launch (or `undefined` for plain shell). */
+ *  CLI string to launch (or `undefined` for plain shell). They render as
+ *  passive labels — Enter/click routes through the value group's
+ *  `onSubmit`, not these rows' own (absent) handler. */
 function worktreeAgentOptions(agents: RecentAgent[]): PaletteItem[] {
   return [
-    { name: "Plain shell", data: undefined },
-    ...agents.map((a) => ({ name: a.command, data: a.command })),
+    { kind: "label", name: "Plain shell", data: undefined },
+    ...agents.map(
+      (a): PaletteLabel => ({
+        kind: "label",
+        name: a.command,
+        data: a.command,
+      }),
+    ),
   ];
 }
 
@@ -74,29 +91,28 @@ export interface CommandDeps extends ActionContext {
 export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
   return createMemo((): PaletteCommand[] => [
     {
+      kind: "group",
       name: "New terminal",
       children: (): PaletteItem[] => {
         const repos = recentRepos();
         return [
           {
+            kind: "action",
             name: "In current directory",
             onSelect: () => deps.handleCreate(deps.activeMeta()?.cwd),
           },
           ...repos.map(
-            (r): PaletteCommand => ({
+            (r): PaletteValueInput => ({
+              kind: "value",
               name: r.repoName,
               description: `New worktree in ${r.repoRoot}`,
-              valueInput: {
-                prefill: randomName,
-                placeholder: "Worktree name",
-                validate: validateWorktreeName,
-                onSubmit: (name, selected) => {
-                  const agentCmd =
-                    typeof selected.data === "string"
-                      ? selected.data
-                      : undefined;
-                  deps.handleCreateWorktree(r.repoRoot, name.trim(), agentCmd);
-                },
+              prefill: randomName,
+              placeholder: "Worktree name",
+              validate: validateWorktreeName,
+              onSubmit: (name, selected) => {
+                const agentCmd =
+                  typeof selected.data === "string" ? selected.data : undefined;
+                deps.handleCreateWorktree(r.repoRoot, name.trim(), agentCmd);
               },
               children: (): PaletteItem[] =>
                 worktreeAgentOptions(recentAgents()),
@@ -116,22 +132,26 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
     ...(deps.activeId() !== null
       ? [
           {
+            kind: "action" as const,
             name: "Close terminal",
             onSelect: () => deps.handleClose(),
           },
           actionPaletteCommand("toggleSubPanel", deps),
           actionPaletteCommand("createSubTerminal", deps),
           {
+            kind: "action" as const,
             name: "Copy terminal text",
             onSelect: () => deps.handleCopyTerminalText(),
           },
           {
+            kind: "action" as const,
             name: "Export scrollback as PDF",
             onSelect: () => deps.handleExportScrollbackAsPdf(),
           },
           ...(deps.activeMeta()?.agent
             ? [
                 {
+                  kind: "action" as const,
                   name: "Export agent session as HTML",
                   description:
                     "Open a self-contained transcript of the current Claude Code, OpenCode, or Codex session",
@@ -147,6 +167,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       ? [
           actionPaletteCommand("openWorkspaceSwitcher", deps),
           {
+            kind: "action" as const,
             name: "Center on active tile",
             onSelect: () => deps.canvasCenterActive(),
           },
@@ -155,36 +176,48 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
     ...(deps.terminalIds().length > 0
       ? [
           {
+            kind: "group" as const,
             name: "Switch terminal",
             children: () =>
-              deps.terminalIds().map((id, i) => ({
-                ...(i < 9
-                  ? actionPaletteCommand(
-                      `switchTo${(i + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`,
-                      deps,
-                      { name: `Switch to terminal ${i + 1}` },
-                    )
-                  : { name: `Switch to terminal ${i + 1}` }),
-                onSelect: () => deps.setActiveId(id),
-              })),
+              deps.terminalIds().map(
+                (id, i): PaletteAction =>
+                  i < 9
+                    ? {
+                        ...actionPaletteCommand(
+                          `switchTo${(i + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}`,
+                          deps,
+                          { name: `Switch to terminal ${i + 1}` },
+                        ),
+                        onSelect: () => deps.setActiveId(id),
+                      }
+                    : {
+                        kind: "action",
+                        name: `Switch to terminal ${i + 1}`,
+                        onSelect: () => deps.setActiveId(id),
+                      },
+              ),
           },
         ]
       : []),
     {
+      kind: "group",
       name: "Theme",
       onCancel: () => deps.setPreviewThemeName(undefined),
       children: () =>
         availableThemes
           .filter((t) => t.name !== deps.committedThemeName())
-          .map((t) => ({
-            name: t.name,
-            onHighlight: () => deps.setPreviewThemeName(t.name),
-            onSelect: () =>
-              batch(() => {
-                deps.setPreviewThemeName(undefined);
-                deps.handleSetTheme(t.name);
-              }),
-          })),
+          .map(
+            (t): PaletteAction => ({
+              kind: "action",
+              name: t.name,
+              onHighlight: () => deps.setPreviewThemeName(t.name),
+              onSelect: () =>
+                batch(() => {
+                  deps.setPreviewThemeName(undefined);
+                  deps.handleSetTheme(t.name);
+                }),
+            }),
+          ),
     },
     ...(deps.activeId() !== null
       ? [
@@ -196,18 +229,22 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       : []),
     actionPaletteCommand("shortcutsHelp", deps, { name: "Keyboard shortcuts" }),
     {
+      kind: "action",
       name: "About kolu",
       onSelect: () => deps.setAboutOpen(true),
     },
     {
+      kind: "group",
       name: "Debug",
       children: [
         {
+          kind: "action",
           name: "Diagnostic info",
           description: "Runtime state — renderer, WS, terminals",
           onSelect: () => deps.setDiagnosticInfoOpen(true),
         },
         {
+          kind: "action",
           name: "Simulate activity alert",
           onSelect: () => deps.simulateAlert(),
         },
@@ -219,6 +256,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
         ...(deps.activeId() !== null && recentAgents().length > 0
           ? [
               {
+                kind: "group" as const,
                 name: "Recent agents",
                 description: "Prefill an agent CLI into the active terminal",
                 children: (): PaletteItem[] =>
@@ -227,6 +265,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             ]
           : []),
         {
+          kind: "action",
           name: "Trigger server error",
           onSelect: () =>
             void client.terminal.resize({
@@ -236,10 +275,12 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
             }),
         },
         {
+          kind: "action",
           name: "Close all terminals",
           onSelect: () => deps.handleCloseAll(),
         },
         {
+          kind: "action",
           name: "Clear localStorage",
           onSelect: () => {
             localStorage.clear();

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -11,6 +11,7 @@ import type {
   PaletteCommand,
   PaletteItem,
   PaletteLabel,
+  PaletteValueChild,
   PaletteValueInput,
 } from "./CommandPalette";
 import { type ActionContext, actionPaletteCommand } from "./input/actions";
@@ -45,7 +46,7 @@ function agentItems(
  *  CLI string to launch (or `undefined` for plain shell). They render as
  *  passive labels — Enter/click routes through the value group's
  *  `onSubmit`, not these rows' own (absent) handler. */
-function worktreeAgentOptions(agents: RecentAgent[]): PaletteItem[] {
+function worktreeAgentOptions(agents: RecentAgent[]): PaletteValueChild[] {
   return [
     { kind: "label", name: "Plain shell", data: undefined },
     ...agents.map(
@@ -114,7 +115,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
                   typeof selected.data === "string" ? selected.data : undefined;
                 deps.handleCreateWorktree(r.repoRoot, name.trim(), agentCmd);
               },
-              children: (): PaletteItem[] =>
+              children: (): PaletteValueChild[] =>
                 worktreeAgentOptions(recentAgents()),
             }),
           ),

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -9,9 +9,9 @@ import { availableThemes } from "terminal-themes";
 import type {
   PaletteAction,
   PaletteCommand,
+  PaletteHint,
   PaletteItem,
   PaletteLabel,
-  PaletteValueChild,
   PaletteValueInput,
 } from "./CommandPalette";
 import { type ActionContext, actionPaletteCommand } from "./input/actions";
@@ -46,7 +46,9 @@ function agentItems(
  *  CLI string to launch (or `undefined` for plain shell). They render as
  *  passive labels — Enter/click routes through the value group's
  *  `onSubmit`, not these rows' own (absent) handler. */
-function worktreeAgentOptions(agents: RecentAgent[]): PaletteValueChild[] {
+function worktreeAgentOptions(
+  agents: RecentAgent[],
+): (PaletteLabel | PaletteHint)[] {
   return [
     { kind: "label", name: "Plain shell", data: undefined },
     ...agents.map(
@@ -115,7 +117,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
                   typeof selected.data === "string" ? selected.data : undefined;
                 deps.handleCreateWorktree(r.repoRoot, name.trim(), agentCmd);
               },
-              children: (): PaletteValueChild[] =>
+              children: (): (PaletteLabel | PaletteHint)[] =>
                 worktreeAgentOptions(recentAgents()),
             }),
           ),

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -13,7 +13,7 @@
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import { nonEmpty } from "nonempty";
 import type { Accessor, Setter } from "solid-js";
-import type { PaletteCommand } from "../CommandPalette";
+import type { PaletteAction } from "../CommandPalette";
 import { type Keybind, matchesKeybind } from "./keyboard";
 
 /** Shared handler context — every dispatched action receives this. */
@@ -255,10 +255,11 @@ export type DispatchableId = {
 export function actionPaletteCommand(
   id: DispatchableId,
   ctx: ActionContext,
-  overrides: Partial<Pick<PaletteCommand, "name" | "description">> = {},
-): PaletteCommand {
+  overrides: { name?: string; description?: string } = {},
+): PaletteAction {
   const a = ACTIONS[id] as DispatchableAction;
   return {
+    kind: "action",
     name: overrides.name ?? a.label,
     description: overrides.description,
     keybind: a.keybind,

--- a/packages/client/src/terminal/useWorktreeOps.ts
+++ b/packages/client/src/terminal/useWorktreeOps.ts
@@ -44,7 +44,7 @@ export function useWorktreeOps(deps: {
       }
     } catch (err) {
       // Toast surfaces the message; don't rethrow — the caller (palette
-      // valueInput.onSubmit) is fire-and-forget, and a rethrow leaks as
+      // value-mode onSubmit) is fire-and-forget, and a rethrow leaks as
       // an unhandled rejection now that user-typed names make
       // WORKTREE_NAME_COLLISION a normal-flow error.
       toast.error(`Failed to create worktree: ${(err as Error).message}`, {


### PR DESCRIPTION
**The palette's `valueInput?` flag-on-struct is replaced with a discriminated `kind`** — `action | group | value | label | hint`. The five sites that flipped behavior on a value-input leaf (filter bypass, validation, placeholder, selection-reset suppression, submit dispatch) now read off a typed mode signal. A future palette mode (number input, multi-select, confirm) plugs in by adding a kind, not by editing five sites.

Closes #834. _The issue framed this as a UI extraction (`<ValueInputMode>`); a whole-file Hickey/Lowy review surfaced that the real seam is in the data model — the sub-component is something that falls out for free once the type is right._

### Shape of the change

```ts
// before — flag-on-struct: every leaf can carry every field
interface PaletteCommand {
  onSelect?: () => void;
  children?: PaletteItem[] | (() => PaletteItem[]);
  valueInput?: { prefill, validate, onSubmit, placeholder };  // optional flag
}

// after — discriminated leaf modes: shape is the kind
type PaletteCommand = PaletteAction | PaletteGroup | PaletteValueInput;
type PaletteItem = PaletteCommand | PaletteLabel | PaletteHint;
```

`PaletteValueInput.children` is typed `(PaletteLabel | PaletteHint)[]` — labels can no longer leak to the top level, and `onSubmit` receives the highlighted child narrowed to `PaletteLabel`. Inside the component, `mode` is a typed memo `{ kind: \"filter\" } | { kind: \"value\", leaf }` that drives every behavior swap.

### Structural fixes the whole-file review caught (not in #834's brief)

| Site | Before | After |
| --- | --- | --- |
| `mouseActive` flag | plain `let` | signal |
| Close-intent flag (`didSelect`) | plain `let`, race-prone | `closingForSelection` signal |
| `currentItems` partition | two filter passes | one O(n) loop |
| `drillOut` | duplicates `navigateTo` body | inlined to `navigateTo(path.length - 1)` |
| `onHighlight` effect | dropped tracking when `props.open` flipped | `on()` tuple includes `props.open` |
| `initialGroup` | one-shot at open | reactive — caller can re-target while open |
| Auto-scroll into view | `createEffect` per `<For>` row | one effect querying `[data-selected]` |
| `execute` dispatch | `switch` + `assertNever` | `match(...).with(...).exhaustive()` |

### The regression caught during the police pass

> An earlier draft replaced `didSelect` with a `handleOpenChange` wrapper that fired `onCancel` handlers before propagating. The wrapper catches Corvu-initiated closes (Escape, backdrop) but **misses parent-initiated closes** — the Cmd+K toggle in `input/actions.ts:141` calls `setPaletteOpen(false)` directly, which Corvu treats as a controlled-prop change and skips the callback. With the wrapper, previewing a theme via drill-in and toggling the palette closed with Cmd+K would leave the preview live. Reverted to gating the close-effect on a signal so all three close paths converge in one place.

### Commits

The branch reads as a refinement progression — primary feature commit, then four Hickey/Lowy follow-ups (one per finding), then three police follow-ups (rules, fact-check, elegance). _Reviewing one commit at a time may be easier than reading the squashed diff._

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._