### PR TITLE
Render placeholder for binary file diffs (closes #810)

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -391,6 +391,22 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                         </div>
                       )}
                     </Match>
+                    <Match when={diff()?.binary && diff()}>
+                      {(d) => (
+                        <div
+                          class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2"
+                          data-testid="diff-binary"
+                        >
+                          <FileDiffIcon class="w-8 h-8 opacity-40" />
+                          <span class="text-[11px]">
+                            Binary file — not displayable
+                          </span>
+                          <span class="text-[10px] text-fg-3/30">
+                            {d().newFileName ?? d().oldFileName}
+                          </span>
+                        </div>
+                      )}
+                    </Match>
                     <Match when={renamedDiff()}>
                       {(rename) => (
                         <div class="flex items-center justify-center h-full text-fg-3/50">

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -58,6 +58,17 @@ const FileSelectHint: Component<{ label: string }> = (props) => (
   </div>
 );
 
+const BinaryFileHint: Component<{ fileName: string | null }> = (props) => (
+  <div
+    class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2"
+    data-testid="diff-binary"
+  >
+    <FileDiffIcon class="w-8 h-8 opacity-40" />
+    <span class="text-[11px]">Binary file — not displayable</span>
+    <span class="text-[10px] text-fg-3/30">{props.fileName}</span>
+  </div>
+);
+
 const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
@@ -393,18 +404,9 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                     </Match>
                     <Match when={diff()?.binary && diff()}>
                       {(d) => (
-                        <div
-                          class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2"
-                          data-testid="diff-binary"
-                        >
-                          <FileDiffIcon class="w-8 h-8 opacity-40" />
-                          <span class="text-[11px]">
-                            Binary file — not displayable
-                          </span>
-                          <span class="text-[10px] text-fg-3/30">
-                            {d().newFileName ?? d().oldFileName}
-                          </span>
-                        </div>
+                        <BinaryFileHint
+                          fileName={d().newFileName ?? d().oldFileName}
+                        />
                       )}
                     </Match>
                     <Match when={renamedDiff()}>

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -274,10 +274,18 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
 
   /** Diff value narrowed to "this is a pure-rename" (no hunks, both old +
    *  new file names present and different). Returning the full diff so the
-   *  rendering Match can read its names without re-narrowing. */
+   *  rendering Match can read its names without re-narrowing.
+   *
+   *  Binary excluded from the rename predicate: a binary rename satisfies
+   *  hunks.length === 0 with distinct old/new names *and* `binary === true`.
+   *  Without this guard, dispatch between the binary placeholder and the
+   *  rename hint would depend on Switch arm ordering — load-bearing and
+   *  invisible. With this guard, the mutual exclusion lives in the data,
+   *  so a Switch refactor can't silently flip the rendering. */
   const renamedDiff = createMemo(() => {
     const d = diff();
     if (!d) return undefined;
+    if (d.binary) return undefined;
     if (d.hunks.length !== 0) return undefined;
     const { oldFileName, newFileName } = d;
     if (!oldFileName || !newFileName || oldFileName === newFileName) {

--- a/packages/integrations/git/src/equals.ts
+++ b/packages/integrations/git/src/equals.ts
@@ -56,6 +56,7 @@ export function gitDiffOutputEqual(
   return (
     a.oldFileName === b.oldFileName &&
     a.newFileName === b.newFileName &&
+    a.binary === b.binary &&
     arrayEqual(a.hunks, b.hunks, (x, y) => x === y)
   );
 }

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -108,12 +108,7 @@ describe("getDiff", () => {
     expect(diffLines).toEqual(["+export const b = 2;"]);
   });
 
-  // --- binary detection (#810) ---
-  // git emits `Binary files a/foo and b/foo differ` (no @@ hunks) when it
-  // detects NUL bytes. The flag lets the client render a placeholder
-  // instead of an empty pane — Pierre never sees the binary marker.
-
-  /** Bytes guaranteed to look binary to git: NUL in the first 8KB. */
+  /** Bytes guaranteed to trigger git's binary detection — NUL at byte 4. */
   const BINARY_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]);
 
   it("modified binary file: binary=true, hunks empty", async () => {

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -107,6 +107,69 @@ describe("getDiff", () => {
       );
     expect(diffLines).toEqual(["+export const b = 2;"]);
   });
+
+  // --- binary detection (#810) ---
+  // git emits `Binary files a/foo and b/foo differ` (no @@ hunks) when it
+  // detects NUL bytes. The flag lets the client render a placeholder
+  // instead of an empty pane — Pierre never sees the binary marker.
+
+  /** Bytes guaranteed to look binary to git: NUL in the first 8KB. */
+  const BINARY_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]);
+
+  it("modified binary file: binary=true, hunks empty", async () => {
+    const { dir, git } = await initRepo();
+
+    fs.writeFileSync(path.join(dir, "image.png"), BINARY_BYTES);
+    await git.add("image.png");
+    await git.commit("add binary");
+
+    fs.writeFileSync(
+      path.join(dir, "image.png"),
+      Buffer.concat([BINARY_BYTES, BINARY_BYTES]),
+    );
+
+    const result = await getDiff(dir, "image.png", "local");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.binary).toBe(true);
+    expect(result.value.hunks).toEqual([]);
+    expect(result.value.newFileName).toBe("image.png");
+  });
+
+  it("untracked binary file: binary=true via --no-index", async () => {
+    const { dir, git } = await initRepo();
+    // Need an initial commit so HEAD exists.
+    fs.writeFileSync(path.join(dir, "seed.txt"), "seed\n");
+    await git.add("seed.txt");
+    await git.commit("seed");
+
+    fs.writeFileSync(path.join(dir, "blob.bin"), BINARY_BYTES);
+
+    const result = await getDiff(dir, "blob.bin", "local");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.binary).toBe(true);
+    expect(result.value.hunks).toEqual([]);
+  });
+
+  it("text file: binary=false", async () => {
+    const { dir, git } = await initRepo();
+
+    fs.writeFileSync(path.join(dir, "readme.txt"), "hello\n");
+    await git.add("readme.txt");
+    await git.commit("add text");
+
+    fs.writeFileSync(path.join(dir, "readme.txt"), "hello\nworld\n");
+
+    const result = await getDiff(dir, "readme.txt", "local");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.binary).toBe(false);
+    expect(result.value.hunks.length).toBe(1);
+  });
 });
 
 // --- resolveUnder ---

--- a/packages/integrations/git/src/review.ts
+++ b/packages/integrations/git/src/review.ts
@@ -155,14 +155,9 @@ export async function getStatus(
   }
 }
 
-/**
- * Classify a raw `git diff` blob along the axes the wire schema cares
- * about: hunk presence (`hasHunks`), per-side existence (`oldAbsent` /
- * `newAbsent` from `--- /dev/null` / `+++ /dev/null` headers), and git's
- * binary marker. Co-located with `getDiff` so the next axis (submodule,
- * skipped, large-file) has one named home to extend rather than another
- * inline regex sprinkled into the result builder.
- */
+/** Single home for raw-diff parsing — every classification flag the wire
+ *  schema gates rendering on lives here, not split across the result
+ *  builder. */
 function parseRawDiffFlags(rawDiff: string): {
   hasHunks: boolean;
   oldAbsent: boolean;

--- a/packages/integrations/git/src/review.ts
+++ b/packages/integrations/git/src/review.ts
@@ -156,6 +156,38 @@ export async function getStatus(
 }
 
 /**
+ * Classify a raw `git diff` blob along the axes the wire schema cares
+ * about: hunk presence (`hasHunks`), per-side existence (`oldAbsent` /
+ * `newAbsent` from `--- /dev/null` / `+++ /dev/null` headers), and git's
+ * binary marker. Co-located with `getDiff` so the next axis (submodule,
+ * skipped, large-file) has one named home to extend rather than another
+ * inline regex sprinkled into the result builder.
+ */
+function parseRawDiffFlags(rawDiff: string): {
+  hasHunks: boolean;
+  oldAbsent: boolean;
+  newAbsent: boolean;
+  binary: boolean;
+} {
+  return {
+    // A pure rename produces a header (similarity index, rename from/to)
+    // but no @@ hunks. The client renders renames via the
+    // oldFileName/newFileName pair, so only emit hunks when the diff
+    // actually contains hunk markers.
+    hasHunks: rawDiff.includes("\n@@"),
+    // Existence on each side from the unified-diff headers: added emits
+    // `--- /dev/null`, deleted emits `+++ /dev/null`. Cheaper than a
+    // separate `git cat-file -e` round-trip per side.
+    oldAbsent: /^--- \/dev\/null/m.test(rawDiff),
+    newAbsent: /^\+\+\+ \/dev\/null/m.test(rawDiff),
+    // Binary files: git emits `Binary files a/foo and b/foo differ` with
+    // no @@ hunks. Same marker for added (`Binary files /dev/null and
+    // b/foo differ`) and deleted, so one regex covers all cases.
+    binary: /^Binary files .* differ$/m.test(rawDiff),
+  };
+}
+
+/**
  * Run git and return stdout, surviving the `--no-index` exit-1 convention.
  *
  * `git diff --no-index` exits 1 when the two paths differ — that's its
@@ -247,30 +279,13 @@ export async function getDiff(
       );
     }
 
-    // A pure rename produces a header (similarity index, rename from/to)
-    // but no @@ hunks. The client (PierreDiffView) renders renames via
-    // the oldFileName/newFileName pair, so only emit hunks when the diff
-    // actually contains hunk markers.
-    const hasHunks = rawDiff.includes("\n@@");
-
-    // Existence on each side, derived from the unified-diff headers:
-    // added files emit `--- /dev/null`, deleted files emit `+++ /dev/null`.
-    // Cheaper than a separate `git cat-file -e` round-trip per side.
-    const oldAbsent = /^--- \/dev\/null/m.test(rawDiff);
-    const newAbsent = /^\+\+\+ \/dev\/null/m.test(rawDiff);
-
-    // Binary files: git emits `Binary files a/foo and b/foo differ` with
-    // no @@ hunks. Same marker for added (`Binary files /dev/null and
-    // b/foo differ`) and deleted, so one regex covers all cases. The
-    // client uses this flag to render a placeholder; the marker itself
-    // stays out of `hunks` since `hasHunks` is already false.
-    const binary = /^Binary files .* differ$/m.test(rawDiff);
+    const flags = parseRawDiffFlags(rawDiff);
 
     return ok({
-      oldFileName: oldAbsent ? null : oldRel,
-      newFileName: newAbsent ? null : rel,
-      hunks: rawDiff && hasHunks ? [rawDiff] : [],
-      binary,
+      oldFileName: flags.oldAbsent ? null : oldRel,
+      newFileName: flags.newAbsent ? null : rel,
+      hunks: rawDiff && flags.hasHunks ? [rawDiff] : [],
+      binary: flags.binary,
     });
   } catch (e) {
     return err({

--- a/packages/integrations/git/src/review.ts
+++ b/packages/integrations/git/src/review.ts
@@ -259,10 +259,18 @@ export async function getDiff(
     const oldAbsent = /^--- \/dev\/null/m.test(rawDiff);
     const newAbsent = /^\+\+\+ \/dev\/null/m.test(rawDiff);
 
+    // Binary files: git emits `Binary files a/foo and b/foo differ` with
+    // no @@ hunks. Same marker for added (`Binary files /dev/null and
+    // b/foo differ`) and deleted, so one regex covers all cases. The
+    // client uses this flag to render a placeholder; the marker itself
+    // stays out of `hunks` since `hasHunks` is already false.
+    const binary = /^Binary files .* differ$/m.test(rawDiff);
+
     return ok({
       oldFileName: oldAbsent ? null : oldRel,
       newFileName: newAbsent ? null : rel,
       hunks: rawDiff && hasHunks ? [rawDiff] : [],
+      binary,
     });
   } catch (e) {
     return err({

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -120,15 +120,9 @@ export const GitDiffInputSchema = z.object({
  *  newFileName null). The renderer uses the pair to spot pure renames
  *  (no hunks but both names set and different).
  *
- *  Two field categories live here:
- *    - **Structural** (`oldFileName`, `newFileName`, `hunks`) — what the
- *      renderer paints when it has displayable content.
- *    - **Classification flags** (`binary`, …) — what dispatches to a
- *      placeholder panel instead. Detection lives in one site:
- *      `parseRawDiffFlags` in `review.ts`. Adding a new flag (submodule,
- *      skipped, large-file) means a field here, a branch in
- *      `parseRawDiffFlags`, and a `<Match>` in the client — in that
- *      order. Don't put detection in the client. */
+ *  Classification flags (`binary`, …) gate the client to a placeholder
+ *  instead of the renderer. Detection lives in `parseRawDiffFlags`
+ *  (`review.ts`) — not in the client. */
 export const GitDiffOutputSchema = z.object({
   oldFileName: z.string().nullable(),
   newFileName: z.string().nullable(),

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -118,7 +118,17 @@ export const GitDiffInputSchema = z.object({
  *  `oldFileName` / `newFileName` are null when the file doesn't exist on
  *  that side of the diff (added file → oldFileName null; deleted file →
  *  newFileName null). The renderer uses the pair to spot pure renames
- *  (no hunks but both names set and different). */
+ *  (no hunks but both names set and different).
+ *
+ *  Two field categories live here:
+ *    - **Structural** (`oldFileName`, `newFileName`, `hunks`) — what the
+ *      renderer paints when it has displayable content.
+ *    - **Classification flags** (`binary`, …) — what dispatches to a
+ *      placeholder panel instead. Detection lives in one site:
+ *      `parseRawDiffFlags` in `review.ts`. Adding a new flag (submodule,
+ *      skipped, large-file) means a field here, a branch in
+ *      `parseRawDiffFlags`, and a `<Match>` in the client — in that
+ *      order. Don't put detection in the client. */
 export const GitDiffOutputSchema = z.object({
   oldFileName: z.string().nullable(),
   newFileName: z.string().nullable(),

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -126,6 +126,11 @@ export const GitDiffOutputSchema = z.object({
    *  header block (i.e. passthrough of `git diff` output), not a bare hunk
    *  body. Currently always zero or one element — a single per-file patch. */
   hunks: z.array(z.string()),
+  /** True when git classified the file as binary (NUL bytes in the first
+   *  8KB). Binary files yield no `@@` hunks — git emits a single
+   *  `Binary files a/x and b/x differ` line — so the client renders a
+   *  "Binary file — not displayable" placeholder instead of an empty pane. */
+  binary: z.boolean(),
 });
 export type GitDiffOutput = z.infer<typeof GitDiffOutputSchema>;
 

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -317,6 +317,51 @@ Feature: Code tab (review + browse)
   # right-panel tab moves focus off the terminal, so subsequent keystrokes
   # would land in the panel instead of the PTY.
 
+  # ── Binary file diffs (#810) ──
+  # git classifies a file as binary when it sees NUL bytes in the first
+  # ~8KB and emits `Binary files a/x and b/x differ` instead of @@ hunks.
+  # Without a placeholder the diff pane is empty and indistinguishable
+  # from "no file selected". The server now sets `binary: true` on the
+  # diff response so the client renders a "Binary file — not displayable"
+  # panel. Scenarios cover three distinct user-visible paths: binary
+  # file selected, text file selected, and the binary→text streaming
+  # flip from #786.
+
+  Scenario: Binary file shows the "not displayable" placeholder
+    When I run "rm -rf /tmp/kolu-binary-diff && git init /tmp/kolu-binary-diff && cd /tmp/kolu-binary-diff"
+    And I run "git commit --allow-empty -m init"
+    And I run "head -c 64 /dev/urandom > image.png"
+    And I click the Code tab
+    Then the Code tab should list a changed file "image.png"
+    When I click the changed file "image.png" in the Code tab
+    Then the Code tab should show the binary placeholder
+
+  Scenario: Text file does not show the binary placeholder
+    When I run "rm -rf /tmp/kolu-text-diff && git init /tmp/kolu-text-diff && cd /tmp/kolu-text-diff"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'hello\nworld\n' > note.txt"
+    And I click the Code tab
+    Then the Code tab should list a changed file "note.txt"
+    When I click the changed file "note.txt" in the Code tab
+    Then the Code tab should render a diff view
+    And the Code tab should not show the binary placeholder
+
+  # Regression for #810 + #786: a file transitioning from binary to text
+  # via live updates must flip the placeholder off (and vice versa). The
+  # streaming endpoint re-emits `binary` on every diff change; without it
+  # in `gitDiffOutputEqual`, the snapshot dedupe would suppress the flip.
+  Scenario: Binary placeholder flips off when the file becomes text
+    When I run "rm -rf /tmp/kolu-binary-flip && git init /tmp/kolu-binary-flip && cd /tmp/kolu-binary-flip"
+    And I run "git commit --allow-empty -m init"
+    And I run "head -c 64 /dev/urandom > note.txt"
+    And I click the Code tab
+    And I click the changed file "note.txt" in the Code tab
+    Then the Code tab should show the binary placeholder
+    When I click the terminal canvas
+    And I run "printf 'now text\n' > note.txt"
+    Then the diff view should contain "now text"
+    And the Code tab should not show the binary placeholder
+
   Scenario: Editing a file updates the diff view live
     When I run "git init /tmp/kolu-live-diff && cd /tmp/kolu-live-diff"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -330,7 +330,7 @@ Feature: Code tab (review + browse)
   Scenario: Binary file shows the "not displayable" placeholder
     When I run "rm -rf /tmp/kolu-binary-diff && git init /tmp/kolu-binary-diff && cd /tmp/kolu-binary-diff"
     And I run "git commit --allow-empty -m init"
-    And I run "head -c 64 /dev/urandom > image.png"
+    And I run "printf 'PNG\0fake\1\2' > image.png"
     And I click the Code tab
     Then the Code tab should list a changed file "image.png"
     When I click the changed file "image.png" in the Code tab
@@ -346,15 +346,11 @@ Feature: Code tab (review + browse)
     Then the Code tab should render a diff view
     And the Code tab should not show the binary placeholder
 
-  # A binary rename satisfies both the pure-rename predicate (no @@ hunks,
-  # distinct old/new names) and the binary predicate. The intersection has
-  # one correct answer — show the binary placeholder, not the rename hint
-  # — and the data-level guard (`renamedDiff` excludes `binary`) is what
-  # enforces it. Without that guard, dispatch would depend on Switch arm
-  # ordering, which a refactor could silently flip.
+  # Regression: binary + rename satisfies both predicates. Rationale for
+  # picking binary over rename lives at the `renamedDiff` memo guard.
   Scenario: Binary rename shows the binary placeholder, not the rename hint
     When I run "rm -rf /tmp/kolu-binary-rename && git init /tmp/kolu-binary-rename && cd /tmp/kolu-binary-rename"
-    And I run "head -c 64 /dev/urandom > old.png"
+    And I run "printf 'PNG\0fake\1\2' > old.png"
     And I run "git add old.png && git commit -m 'add binary'"
     And I run "git mv old.png new.png"
     And I click the Code tab
@@ -369,7 +365,7 @@ Feature: Code tab (review + browse)
   Scenario: Binary placeholder flips off when the file becomes text
     When I run "rm -rf /tmp/kolu-binary-flip && git init /tmp/kolu-binary-flip && cd /tmp/kolu-binary-flip"
     And I run "git commit --allow-empty -m init"
-    And I run "head -c 64 /dev/urandom > note.txt"
+    And I run "printf 'PNG\0fake\1\2' > note.txt"
     And I click the Code tab
     And I click the changed file "note.txt" in the Code tab
     Then the Code tab should show the binary placeholder

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -348,11 +348,16 @@ Feature: Code tab (review + browse)
 
   # Regression: binary + rename satisfies both predicates. Rationale for
   # picking binary over rename lives at the `renamedDiff` memo guard.
-  Scenario: Binary rename shows the binary placeholder, not the rename hint
+  # Needs an actual content edit on the renamed file — git only emits the
+  # `Binary files ... differ` marker when there's a content delta; a pure
+  # rename of binary content (similarity 100%) emits only the rename
+  # header, with nothing for the regex to match against.
+  Scenario: Binary rename with content change shows the binary placeholder
     When I run "rm -rf /tmp/kolu-binary-rename && git init /tmp/kolu-binary-rename && cd /tmp/kolu-binary-rename"
-    And I run "printf 'PNG\0fake\1\2' > old.png"
+    And I run "printf 'PNG\0fake\1\2\3\4\5\6\7\10\11\12\13\14\15\16\17' > old.png"
     And I run "git add old.png && git commit -m 'add binary'"
     And I run "git mv old.png new.png"
+    And I run "printf 'PNG\0fake\1\2\3\4\5\6\7\10\11\12\13\14\15\16\17modified' > new.png"
     And I click the Code tab
     Then the Code tab should list a changed file "new.png"
     When I click the changed file "new.png" in the Code tab

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -346,6 +346,22 @@ Feature: Code tab (review + browse)
     Then the Code tab should render a diff view
     And the Code tab should not show the binary placeholder
 
+  # A binary rename satisfies both the pure-rename predicate (no @@ hunks,
+  # distinct old/new names) and the binary predicate. The intersection has
+  # one correct answer — show the binary placeholder, not the rename hint
+  # — and the data-level guard (`renamedDiff` excludes `binary`) is what
+  # enforces it. Without that guard, dispatch would depend on Switch arm
+  # ordering, which a refactor could silently flip.
+  Scenario: Binary rename shows the binary placeholder, not the rename hint
+    When I run "rm -rf /tmp/kolu-binary-rename && git init /tmp/kolu-binary-rename && cd /tmp/kolu-binary-rename"
+    And I run "head -c 64 /dev/urandom > old.png"
+    And I run "git add old.png && git commit -m 'add binary'"
+    And I run "git mv old.png new.png"
+    And I click the Code tab
+    Then the Code tab should list a changed file "new.png"
+    When I click the changed file "new.png" in the Code tab
+    Then the Code tab should show the binary placeholder
+
   # Regression for #810 + #786: a file transitioning from binary to text
   # via live updates must flip the placeholder off (and vice versa). The
   # streaming endpoint re-emits `binary` on every diff change; without it

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -262,6 +262,22 @@ Then(
 );
 
 Then(
+  "the Code tab should show the binary placeholder",
+  async function (this: KoluWorld) {
+    const placeholder = this.page.locator('[data-testid="diff-binary"]');
+    await placeholder.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the Code tab should not show the binary placeholder",
+  async function (this: KoluWorld) {
+    const placeholder = this.page.locator('[data-testid="diff-binary"]');
+    await placeholder.waitFor({ state: "detached", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
   "the Code tab mode should be {string}",
   async function (this: KoluWorld, mode: string) {
     // The chip carries `data-mode` reflecting the current view, so the


### PR DESCRIPTION
**Binary files used to render as an empty diff pane** — indistinguishable from "no file selected." `git diff` emits `Binary files a/x and b/x differ` with no `@@` hunks, the server returned `{ hunks: [] }`, and Pierre painted an empty pane. The Code tab now flags binary diffs at the wire and the client renders a "Binary file — not displayable" panel ahead of the rename and main-diff matches.

```
git diff output ─▶ parseRawDiffFlags ─▶ GitDiffOutput { binary, … } ─▶ <Match> dispatch
                   (review.ts)          (wire schema)                    (CodeTab.tsx)
```

`parseRawDiffFlags` is the single home for raw-diff classification. Today it surfaces hunk presence, per-side existence, and binary; future axes (submodule, skipped, large-file) extend in one place. The detection itself is a regex against the existing `git diff` output — no extra subprocess.

### Detection across modes

| Mode | git invocation | Binary marker source |
| --- | --- | --- |
| Local, tracked | `git diff HEAD -- <path>` | `Binary files a/x and b/x differ` |
| Local, untracked | `git diff --no-index /dev/null <path>` | Same marker, `/dev/null` on left |
| Branch | `git diff <merge-base> -- <path>` | Same marker |
| Rename + edit | `git diff -M <rev> -- <old> <new>` | Marker emitted alongside rename header |

### What's covered

- Binary file → placeholder
- Text file → normal Pierre diff (placeholder absent)
- Binary rename + content change → placeholder wins over the rename hint (data-level guard in the `renamedDiff` memo, so Switch arm ordering isn't load-bearing)
- Binary→text streaming flip (live updates from #786) → placeholder flips off; `gitDiffOutputEqual` includes `binary` so snapshot dedupe doesn't suppress the transition

### Out of scope

- _Inline image preview for binary image diffs_ — separate scope decision (security model, size cap)
- _Rich `+12 −7` numstat summaries for non-binary files_ — schema is unblocked but UX is a different feature
- _Virtualization for large diffs_ — tracked in #809

Closes #810. Phase 8 of #514.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._