### PR TITLE
Drop TerminalInfo.meta — single channel for terminal metadata

### DIFF
--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -6,6 +6,7 @@ import type {
   SavedSession,
   TerminalId,
   TerminalInfo,
+  TerminalMetadata,
 } from "kolu-common/surface";
 import { createEffect, createSignal } from "solid-js";
 import { toast } from "solid-sonner";
@@ -48,30 +49,48 @@ export function useSessionRestore(deps: {
     // with a null before the server snapshot arrives and miss a restore prompt.
     if (existing === undefined || savedSessionSub.pending()) return;
     if (hydrated) return;
-    hydrated = true;
     if (existing.length === 0) {
+      hydrated = true;
       setSavedSession(fromServer);
       return;
     }
-    hydrateFromTerminals(existing, fromServer?.activeTerminalId ?? null);
+    // Wait for the `terminalMetadata` collection to yield a value for
+    // every terminal — hydration reads `parentId` and `subPanel` off it
+    // (since #806 the list snapshot no longer carries `meta`). The reads
+    // are reactive, so the effect re-runs as values arrive.
+    const metas = existing.map((t) => store.getMetadata(t.id));
+    if (metas.some((m) => m === undefined)) return;
+    hydrated = true;
+    hydrateFromTerminals(
+      existing,
+      metas as TerminalMetadata[],
+      fromServer?.activeTerminalId ?? null,
+    );
   });
 
   function hydrateFromTerminals(
     existing: TerminalInfo[],
+    metas: TerminalMetadata[],
     serverActiveId: string | null,
   ) {
     // Canvas layouts live on metadata — no client-side seeding needed.
     // Seed sub-panel state from server metadata.
-    for (const t of existing) {
-      if (t.meta.subPanel) {
-        subPanel.seedPanel(t.id, t.meta.subPanel);
+    for (let i = 0; i < existing.length; i++) {
+      const t = existing[i];
+      const m = metas[i];
+      if (!t || !m) continue;
+      if (m.subPanel) {
+        subPanel.seedPanel(t.id, m.subPanel);
       }
     }
 
     // Initialize sub-panel active tabs for parents with sub-terminals
     const subs: Record<TerminalId, TerminalId[]> = {};
-    for (const t of existing) {
-      const parentId = t.meta.parentId;
+    for (let i = 0; i < existing.length; i++) {
+      const t = existing[i];
+      const m = metas[i];
+      if (!t || !m) continue;
+      const parentId = m.parentId;
       if (!parentId) continue;
       const existingList = subs[parentId];
       if (existingList) {
@@ -92,8 +111,10 @@ export function useSessionRestore(deps: {
     // #554), so on refresh the server snapshot is the only source of truth
     // for "which terminal was active". `existing` arrives in the server's
     // Map insertion order, which is the canonical ordering.
-    const topLevel = existing.filter((t) => !t.meta.parentId);
-    const topIds = topLevel.map((t) => t.id);
+    const topIds = existing
+      .map((t, i) => ({ t, m: metas[i] }))
+      .filter(({ m }) => m && !m.parentId)
+      .map(({ t }) => t.id);
     const picked =
       serverActiveId && topIds.includes(serverActiveId as TerminalId)
         ? (serverActiveId as TerminalId)

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -19,6 +19,11 @@ import {
 import { useSubPanel } from "./useSubPanel";
 import type { TerminalStore } from "./useTerminalStore";
 
+/** A terminal paired with its (already-arrived) metadata. The hydration
+ *  effect builds these by gating on the `terminalMetadata` collection
+ *  having yielded for every entry, so `m` is always defined. */
+type HydrationEntry = { t: TerminalInfo; m: TerminalMetadata };
+
 export function useSessionRestore(deps: {
   store: TerminalStore;
   subscribeExit: (id: TerminalId) => void;
@@ -58,45 +63,35 @@ export function useSessionRestore(deps: {
     // every terminal — hydration reads `parentId` and `subPanel` off it
     // (since #806 the list snapshot no longer carries `meta`). The reads
     // are reactive, so the effect re-runs as values arrive.
-    const metas = existing.map((t) => store.getMetadata(t.id));
-    if (metas.some((m) => m === undefined)) return;
+    const entries: HydrationEntry[] = [];
+    for (const t of existing) {
+      const m = store.getMetadata(t.id);
+      if (m === undefined) return;
+      entries.push({ t, m });
+    }
     hydrated = true;
-    hydrateFromTerminals(
-      existing,
-      metas as TerminalMetadata[],
-      fromServer?.activeTerminalId ?? null,
-    );
+    hydrateFromTerminals(entries, fromServer?.activeTerminalId ?? null);
   });
 
   function hydrateFromTerminals(
-    existing: TerminalInfo[],
-    metas: TerminalMetadata[],
+    entries: HydrationEntry[],
     serverActiveId: string | null,
   ) {
     // Canvas layouts live on metadata — no client-side seeding needed.
     // Seed sub-panel state from server metadata.
-    for (let i = 0; i < existing.length; i++) {
-      const t = existing[i];
-      const m = metas[i];
-      if (!t || !m) continue;
-      if (m.subPanel) {
-        subPanel.seedPanel(t.id, m.subPanel);
-      }
+    for (const { t, m } of entries) {
+      if (m.subPanel) subPanel.seedPanel(t.id, m.subPanel);
     }
 
     // Initialize sub-panel active tabs for parents with sub-terminals
     const subs: Record<TerminalId, TerminalId[]> = {};
-    for (let i = 0; i < existing.length; i++) {
-      const t = existing[i];
-      const m = metas[i];
-      if (!t || !m) continue;
-      const parentId = m.parentId;
-      if (!parentId) continue;
-      const existingList = subs[parentId];
+    for (const { t, m } of entries) {
+      if (!m.parentId) continue;
+      const existingList = subs[m.parentId];
       if (existingList) {
         existingList.push(t.id);
       } else {
-        subs[parentId] = [t.id];
+        subs[m.parentId] = [t.id];
       }
     }
     for (const [parentId, subIds] of Object.entries(subs)) {
@@ -109,12 +104,9 @@ export function useSessionRestore(deps: {
     // Prefer the server-persisted active terminal; fall back to first in order.
     // `store.activeId()` starts as null after refresh (lost makePersisted in
     // #554), so on refresh the server snapshot is the only source of truth
-    // for "which terminal was active". `existing` arrives in the server's
+    // for "which terminal was active". `entries` arrives in the server's
     // Map insertion order, which is the canonical ordering.
-    const topIds = existing
-      .map((t, i) => ({ t, m: metas[i] }))
-      .filter(({ m }) => m && !m.parentId)
-      .map(({ t }) => t.id);
+    const topIds = entries.filter(({ m }) => !m.parentId).map(({ t }) => t.id);
     const picked =
       serverActiveId && topIds.includes(serverActiveId as TerminalId)
         ? (serverActiveId as TerminalId)
@@ -127,7 +119,7 @@ export function useSessionRestore(deps: {
       active ? [active, ...topIds.filter((x) => x !== active)] : topIds,
     );
 
-    for (const t of existing) deps.subscribeExit(t.id);
+    for (const { t } of entries) deps.subscribeExit(t.id);
   }
 
   // Re-fetch saved session when all terminals are killed mid-session,

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -84,17 +84,12 @@ export function useSessionRestore(deps: {
     }
 
     // Initialize sub-panel active tabs for parents with sub-terminals
-    const subs: Record<TerminalId, TerminalId[]> = {};
-    for (const { t, m } of entries) {
-      if (!m.parentId) continue;
-      const existingList = subs[m.parentId];
-      if (existingList) {
-        existingList.push(t.id);
-      } else {
-        subs[m.parentId] = [t.id];
-      }
-    }
-    for (const [parentId, subIds] of Object.entries(subs)) {
+    const subs = Object.groupBy(
+      entries.filter(({ m }) => m.parentId),
+      ({ m }) => m.parentId as string,
+    );
+    for (const [parentId, group] of Object.entries(subs)) {
+      const subIds = group?.map(({ t }) => t.id) ?? [];
       const panel = subPanel.getSubPanel(parentId);
       if (!panel.activeSubTab || !subIds.includes(panel.activeSubTab)) {
         subPanel.setActiveSubTab(parentId, subIds[0] ?? null);

--- a/packages/client/src/terminal/useTerminalMetadata.ts
+++ b/packages/client/src/terminal/useTerminalMetadata.ts
@@ -37,9 +37,7 @@ export function useTerminalMetadata(deps: {
   });
 
   function getMetadata(id: TerminalId): TerminalMetadata | undefined {
-    // Prefer live subscription value; fall back to list-embedded metadata
-    // so terminals appear in the sidebar immediately (before metadata sub connects).
-    return meta.byKey(id)?.() ?? deps.list()?.find((t) => t.id === id)?.meta;
+    return meta.byKey(id)?.();
   }
 
   // --- Order: server Map insertion order, filtered by parent relationship ---

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -181,13 +181,8 @@ export const InitialTerminalMetadataSchema = z.object({
 
 // ── Terminal cell value + raw-procedure shared schemas ────────────────
 
-/** Wire shape for the live `terminalList` cell snapshot. Carries only
- *  identity + process — terminal metadata reaches clients via the
- *  `terminalMetadata` collection (per-terminal subscription). Two parallel
- *  paths used to coexist (snapshot-embedded `meta` + live collection)
- *  with a fallback in `useTerminalMetadata`; #806 collapsed that to one
- *  source so the same fact doesn't live in two channels with different
- *  temporal semantics. */
+/** Wire shape for the `terminalList` cell. Identity only — metadata
+ *  flows through the `terminalMetadata` collection. */
 export const TerminalInfoSchema = z.object({
   id: TerminalIdSchema,
   pid: z.number(),

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -181,10 +181,16 @@ export const InitialTerminalMetadataSchema = z.object({
 
 // ── Terminal cell value + raw-procedure shared schemas ────────────────
 
+/** Wire shape for the live `terminalList` cell snapshot. Carries only
+ *  identity + process — terminal metadata reaches clients via the
+ *  `terminalMetadata` collection (per-terminal subscription). Two parallel
+ *  paths used to coexist (snapshot-embedded `meta` + live collection)
+ *  with a fallback in `useTerminalMetadata`; #806 collapsed that to one
+ *  source so the same fact doesn't live in two channels with different
+ *  temporal semantics. */
 export const TerminalInfoSchema = z.object({
   id: TerminalIdSchema,
   pid: z.number(),
-  meta: TerminalMetadataSchema,
 });
 
 /** Shared by both `terminal.attach` (raw oRPC streaming) and the

--- a/packages/server/src/meta/agent-command.ts
+++ b/packages/server/src/meta/agent-command.ts
@@ -58,7 +58,7 @@ export function startAgentCommandTracker(terminalId: TerminalId): () => void {
         // Gate on actual value change — otherwise re-invoking the same
         // agent (`claude --model sonnet` twice in a row) would refire
         // the metadata publish + session auto-save on every command.
-        if (entry && entry.info.meta.lastAgentCommand !== normalized) {
+        if (entry && entry.meta.lastAgentCommand !== normalized) {
           updateServerMetadata(entry, terminalId, (m) => {
             m.lastAgentCommand = normalized;
           });

--- a/packages/server/src/meta/agent.ts
+++ b/packages/server/src/meta/agent.ts
@@ -60,9 +60,9 @@ function setAgentMetadata(
   nextAgent: AgentInfo | null,
 ): void {
   const bump = shouldBumpRecencyForAgentChange(
-    entry.info.meta.agent,
+    entry.meta.agent,
     nextAgent,
-    entry.info.meta.lastActivityAt,
+    entry.meta.lastActivityAt,
   );
   updateServerMetadata(entry, terminalId, (m) => {
     m.agent = nextAgent;
@@ -114,7 +114,7 @@ function snapshotTerminalState(
     foregroundPid === undefined || foregroundPid === entry.handle.pid;
   return {
     foregroundPid,
-    cwd: entry.info.meta.cwd,
+    cwd: entry.meta.cwd,
     readForegroundBasename: () => {
       if (basename === undefined)
         basename = readForegroundBasenameOnce(entry, plog);
@@ -222,7 +222,7 @@ export function startAgentProvider<Session, Info extends AgentInfoShape>(
       if (hadCurrent) plog.debug("agent session ended");
       // Only clear metadata if the terminal's agent is ours to clear.
       // Other providers of different kinds share the same `m.agent` slot.
-      if (entry.info.meta.agent?.kind === provider.kind) {
+      if (entry.meta.agent?.kind === provider.kind) {
         setAgentMetadata(entry, terminalId, null);
       }
       return;

--- a/packages/server/src/meta/git.ts
+++ b/packages/server/src/meta/git.ts
@@ -22,10 +22,10 @@ export function startGitProvider(
   terminalId: string,
 ): () => void {
   const plog = log.child({ provider: "git", terminal: terminalId });
-  plog.debug({ cwd: entry.info.meta.cwd }, "started");
+  plog.debug({ cwd: entry.meta.cwd }, "started");
 
   const watcher = subscribeGitInfo(
-    entry.info.meta.cwd,
+    entry.meta.cwd,
     (git) => {
       if (git) trackRecentRepo(git.mainRepoRoot, git.repoName);
       updateServerMetadata(entry, terminalId, (m) => {

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -45,7 +45,7 @@ export function createMetadata(cwd: string): TerminalMetadata {
  *  `updateClientMetadata` so the publish/audit path is identical regardless
  *  of who wrote the fields. */
 function publishMetadata(entry: TerminalProcess, terminalId: string): void {
-  const m = entry.info.meta;
+  const m = entry.meta;
   const pr = prValue(m.pr);
   const prUnavailable = prUnavailableReason(m.pr);
   log.debug(
@@ -77,7 +77,7 @@ export function updateServerMetadata(
   terminalId: string,
   mutate: (meta: TerminalServerMetadata) => void,
 ): void {
-  mutate(entry.info.meta);
+  mutate(entry.meta);
   publishMetadata(entry, terminalId);
 }
 
@@ -90,6 +90,6 @@ export function updateClientMetadata(
   terminalId: string,
   mutate: (meta: TerminalClientMetadata) => void,
 ): void {
-  mutate(entry.info.meta);
+  mutate(entry.meta);
   publishMetadata(entry, terminalId);
 }

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -157,16 +157,16 @@ export const appRouter = t.router({
     exportTranscriptHtml: t.terminal.exportTranscriptHtml.handler(
       async ({ input }) => {
         const term = requireTerminal(input.id);
-        const agent = term.info.meta.agent;
+        const agent = term.meta.agent;
         if (!agent) {
           throw new ORPCError("PRECONDITION_FAILED", {
             message:
               "No active agent session in this terminal — start Claude Code, OpenCode, or Codex first",
           });
         }
-        const cwd = term.info.meta.cwd;
-        const repoName = term.info.meta.git?.repoName ?? null;
-        const prInfo = prValue(term.info.meta.pr);
+        const cwd = term.meta.cwd;
+        const repoName = term.meta.git?.repoName ?? null;
+        const prInfo = prValue(term.meta.pr);
         const pr: TranscriptPr | null = prInfo
           ? { number: prInfo.number, url: prInfo.url }
           : null;

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -34,6 +34,7 @@ import type {
   ActivityFeed,
   Preferences,
   SavedSession,
+  TerminalMetadata,
 } from "kolu-common/surface";
 import { contract } from "kolu-common/contract";
 import { TerminalNotFoundError } from "kolu-common/errors";
@@ -152,29 +153,21 @@ const { router: surfaceRouterFragment, ctx: surfaceCtxBuilt } =
     collections: {
       terminalMetadata: {
         readAll: () => {
-          const map = new Map<
-            string,
-            ReturnType<typeof getTerminal> extends infer T
-              ? T extends { info: { meta: infer M } }
-                ? M
-                : never
-              : never
-          >();
+          const map = new Map<string, TerminalMetadata>();
           for (const info of listTerminals()) {
             const term = getTerminal(info.id);
-            if (term)
-              (map as Map<string, unknown>).set(info.id, term.info.meta);
+            if (term) map.set(info.id, term.meta);
           }
           return map;
         },
         readOne: (key) => {
           const term = getTerminal(key as string);
-          return term ? term.info.meta : undefined;
+          return term ? term.meta : undefined;
         },
         // Server-internal collection: clients can't write. The `upsert`/
         // `remove` no-ops let `surfaceCtx.collections.terminalMetadata.upsert`
         // publish without re-mutating the registry (the registry is the
-        // store; meta/state.ts mutates entry.info.meta in place before
+        // store; meta/state.ts mutates entry.meta in place before
         // calling ctx.upsert).
         upsert: () => {},
         remove: () => {},

--- a/packages/server/src/terminal-registry.ts
+++ b/packages/server/src/terminal-registry.ts
@@ -14,13 +14,24 @@
  * keeps this file a leaf.
  */
 
-import type { TerminalId, TerminalInfo } from "kolu-common/surface";
+import type {
+  TerminalId,
+  TerminalInfo,
+  TerminalMetadata,
+} from "kolu-common/surface";
 import type { PtyHandle } from "./pty.ts";
 
-/** Server-side terminal state. Owns a PtyHandle and embeds the wire-type TerminalInfo. */
+/** Server-side terminal state. Owns a PtyHandle and the canonical
+ *  `TerminalMetadata` slot.
+ *
+ *  `info` is the wire shape (`id`, `pid`) sent in the `terminalList` cell
+ *  snapshot. `meta` is server-side state — providers mutate it in place
+ *  and `meta/state.ts` publishes via the `terminalMetadata` collection.
+ *  The split (#806) keeps a single channel for metadata: the snapshot
+ *  carries only identity, the collection carries the slow-changing state. */
 export interface TerminalProcess {
-  /** The wire-type snapshot — single source of truth for id, pid, meta. */
   info: TerminalInfo;
+  meta: TerminalMetadata;
   handle: PtyHandle;
   /** Cleanup function for all metadata providers. */
   stopProviders: () => void;
@@ -70,13 +81,13 @@ export function listTerminals(): TerminalInfo[] {
 export const terminalCount = (): number => terminals.size;
 
 /** Number of terminals currently hosting a Claude Code session. Derived
- *  from `entry.info.meta.agent` — the generic agent orchestrator
+ *  from `entry.meta.agent` — the generic agent orchestrator
  *  (`meta/agent.ts`, driven by `claudeCodeProvider` from `kolu-claude-code`)
  *  sets it on session match and clears it on teardown. Exported for diagnostics. */
 export function countActiveClaudeSessions(): number {
   let n = 0;
   for (const entry of terminals.values()) {
-    if (entry.info.meta.agent?.kind === "claude-code") n++;
+    if (entry.meta.agent?.kind === "claude-code") n++;
   }
   return n;
 }

--- a/packages/server/src/terminal-registry.ts
+++ b/packages/server/src/terminal-registry.ts
@@ -21,14 +21,10 @@ import type {
 } from "kolu-common/surface";
 import type { PtyHandle } from "./pty.ts";
 
-/** Server-side terminal state. Owns a PtyHandle and the canonical
- *  `TerminalMetadata` slot.
- *
- *  `info` is the wire shape (`id`, `pid`) sent in the `terminalList` cell
- *  snapshot. `meta` is server-side state — providers mutate it in place
- *  and `meta/state.ts` publishes via the `terminalMetadata` collection.
- *  The split (#806) keeps a single channel for metadata: the snapshot
- *  carries only identity, the collection carries the slow-changing state. */
+/** Server-side terminal state. `info` is the wire shape sent in the
+ *  `terminalList` cell snapshot; `meta` is mutated in place by providers
+ *  and published via the `terminalMetadata` collection from
+ *  `meta/state.ts`. */
 export interface TerminalProcess {
   info: TerminalInfo;
   meta: TerminalMetadata;

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -218,15 +218,18 @@ export function setCanvasLayout(
 }
 
 /** Store a terminal's sub-panel state (client-reported).
- *  Same approach: mutate metadata directly, session auto-save only. */
+ *  Publishes via metadata so other clients (and the same client after a
+ *  refresh, via the collection's snapshot read) pick up the change from
+ *  the same channel as every other client-owned metadata field. */
 export function setSubPanelState(
   id: TerminalId,
   state: { collapsed: boolean; panelSize: number },
 ): void {
   const entry = getTerminal(id);
   if (!entry) return;
-  entry.meta.subPanel = state;
-  emitChanged();
+  updateClientMetadata(entry, id, (m) => {
+    m.subPanel = state;
+  });
 }
 
 // Active terminal ID — client-reported, used only for session snapshots.

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -67,7 +67,7 @@ export function snapshotSession(): {
         agent: _agent,
         foreground: _foreground,
         ...persisted
-      } = entry.info.meta;
+      } = entry.meta;
       return { id, ...persisted };
     },
   );
@@ -89,10 +89,10 @@ function emitListChanged(): void {
 }
 
 /** Create a new terminal, spawn a PTY process. `initial` seeds
- *  client-owned metadata onto `meta` before the first `emitListChanged()`,
- *  so the list snapshot already carries it — used by session restore
- *  to avoid racing post-hoc `setCanvasLayout` / `setTheme` / `setSubPanel`
- *  RPCs against the client's canvas-cascade effect (#642). */
+ *  client-owned metadata before `startProviders` runs, so the first
+ *  `terminalMetadata` collection read carries it — used by session
+ *  restore to avoid racing post-hoc `setCanvasLayout` / `setTheme` /
+ *  `setSubPanel` RPCs against the client's canvas-cascade effect (#642). */
 export function createTerminal(
   cwd?: string,
   parentId?: string,
@@ -151,19 +151,16 @@ export function createTerminal(
 
   const meta = createMetadata(handle.cwd);
   if (parentId) meta.parentId = parentId;
-  // Seed client-owned initial metadata BEFORE emitListChanged so the
-  // first list snapshot carries these fields (see #642).
+  // Seed client-owned initial metadata BEFORE startProviders so the first
+  // `terminalMetadata` collection yield carries these fields (see #642).
   if (initial?.themeName) meta.themeName = initial.themeName;
   if (initial?.canvasLayout) meta.canvasLayout = initial.canvasLayout;
   if (initial?.subPanel) meta.subPanel = initial.subPanel;
   if (initial?.lastActivityAt !== undefined)
     meta.lastActivityAt = initial.lastActivityAt;
   const entry: TerminalProcess = {
-    info: {
-      id,
-      pid: handle.pid,
-      meta,
-    },
+    info: { id, pid: handle.pid },
+    meta,
     handle,
     stopProviders: () => {},
   };
@@ -228,7 +225,7 @@ export function setSubPanelState(
 ): void {
   const entry = getTerminal(id);
   if (!entry) return;
-  entry.info.meta.subPanel = state;
+  entry.meta.subPanel = state;
   emitChanged();
 }
 

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -220,13 +220,25 @@ export function setCanvasLayout(
 /** Store a terminal's sub-panel state (client-reported).
  *  Publishes via metadata so other clients (and the same client after a
  *  refresh, via the collection's snapshot read) pick up the change from
- *  the same channel as every other client-owned metadata field. */
+ *  the same channel as every other client-owned metadata field.
+ *
+ *  Equality-gated: the client RPCs this on every drag tick of the
+ *  resizable handle, so without a guard each mouse-move would fan a
+ *  full per-key metadata publish to every connected client. Same shape
+ *  as `meta/agent-command.ts`'s `lastAgentCommand` gate. */
 export function setSubPanelState(
   id: TerminalId,
   state: { collapsed: boolean; panelSize: number },
 ): void {
   const entry = getTerminal(id);
   if (!entry) return;
+  const cur = entry.meta.subPanel;
+  if (
+    cur &&
+    cur.collapsed === state.collapsed &&
+    cur.panelSize === state.panelSize
+  )
+    return;
   updateClientMetadata(entry, id, (m) => {
     m.subPanel = state;
   });


### PR DESCRIPTION
**Terminal metadata used to reach the client through two parallel paths** — embedded in the `terminalList` cell snapshot at publish time, _and_ live per-terminal via the `terminalMetadata` collection. A fallback in `useTerminalMetadata` (`meta.byKey(id)?.() ?? deps.list()?.find(t => t.id === id)?.meta`) hid the initial-subscription race. This PR collapses the dual path: the snapshot carries identity only, the collection carries metadata, and the fallback is gone.

### Before / after

```
                          BEFORE                              AFTER
terminalList cell  ──▶  TerminalInfo {id, pid, meta}    TerminalInfo {id, pid}
terminalMetadata   ──▶  TerminalMetadata                TerminalMetadata
useTerminalMetadata ──  meta.byKey(id) ?? snapshot.meta meta.byKey(id)
```

The two wire shapes now track genuinely independent volatility axes — identity (immutable for terminal lifetime) on the cell, live state (continuous provider updates) on the collection. Schema changes to metadata fields are localized to `TerminalMetadataSchema` only.

### Server split

`TerminalProcess` was carrying its own `TerminalMetadata` _inside_ the wire-typed `info`. Split into two siblings so the wire shape isn't smuggling server-only state:

```ts
interface TerminalProcess {
  info: TerminalInfo;       // {id, pid} — sent over the wire
  meta: TerminalMetadata;   // server-side, published via the collection
  handle: PtyHandle;
  stopProviders: () => void;
}
```

Every server-side `entry.info.meta.*` reference becomes `entry.meta.*` (8 files). Providers (git, agent, agent-command) and the `meta/state.ts` helpers continue to mutate-and-publish; only the access path renamed.

### Client hydration

`useSessionRestore` previously read `t.meta.subPanel` and `t.meta.parentId` straight off the snapshot. After the split there is no snapshot meta, so hydration now waits for the `terminalMetadata` collection to yield for every terminal in the list, then reads via `store.getMetadata`. The reads are reactive — the effect re-fires as values arrive, so the gate self-resolves without any extra plumbing.

### Refinements during review

| Pass | Finding | Fix |
| --- | --- | --- |
| Hickey | `setSubPanelState` mutated `entry.meta.subPanel` directly while every other client-owned mutator (`setCanvasLayout`, `setTerminalParent`, `setTerminalTheme`) published via `updateClientMetadata` — the snapshot fallback used to mask the asymmetry | Route through `updateClientMetadata` for parity |
| Hickey | `hydrateFromTerminals(existing, metas, ...)` took two parallel arrays with a "same length, same order" invariant the body defended against with dead `if (!t \|\| !m) continue` guards | Zip into a single `HydrationEntry[]` at the call site |
| Elegance (efficiency) | The new `setSubPanelState` publish path fired a full per-key metadata fan-out on every drag tick of the resizable handle | Equality-gate the publish — same shape as `meta/agent-command.ts`'s `lastAgentCommand` gate |
| Elegance (reuse) | Manual init-or-push idiom over `Record<TerminalId, TerminalId[]>` to bucket sub-terminals by parent | Native `Object.groupBy` (target is ESNext) |
| Elegance (quality) | `TerminalInfoSchema` and `TerminalProcess` JSDocs carried a paragraph of #806 history | Keep the directional pointer ("metadata flows through the collection"), drop the changelog narration |

> _No migration needed — `SavedTerminalSchema` is derived from `PersistedTerminalFieldsSchema` directly, never the wire `TerminalInfo`._

Closes #806.

### Try it locally

```sh
nix run github:juspay/kolu/speedy-rate
```

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._