### PR TITLE
Stop terminals:dirty firehose; route live writes via updateServerLiveMetadata

### DIFF
--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -77,11 +77,33 @@ export const SubPanelStateSchema = z.object({
 });
 
 // ── Terminal metadata fields, organized by write-authority + persistence ──
+//
+// Invariant: every terminal-metadata field appears in EXACTLY ONE of
+// `ServerPersistedTerminalFieldsSchema`, `ClientPersistedTerminalFieldsSchema`,
+// or `LiveTerminalFieldsSchema`. The three schemas partition the
+// `TerminalMetadata` field set; their merge (in `TerminalMetadataSchema`
+// below) is the wire shape.
+//
+// Adding a field misclassifies in one of two failure modes:
+//   - Persisted base, but written through the live update helper →
+//     compile error (the live mutator type excludes it).
+//   - Live base, but written through the persisting update helper →
+//     compile error (the persisting mutator types exclude it).
+//
+// Misclassifying a NEW field (declaring it on the wrong base) is the
+// only silent failure mode — choose the base on the first axis: "must
+// this survive a process restart?" If yes → one of the persisted
+// schemas; if no → `LiveTerminalFieldsSchema`. Then on the second
+// axis: "is this written by a server-side provider or by a client RPC
+// handler?" That picks server-persisted vs client-persisted.
 
 /**
  * Server-persisted fields — written by server-side metadata providers
  * (via `updateServerMetadata`) and round-tripped through disk. The
  * "server-writes + persisted" intersection, declared structurally.
+ *
+ * Disjoint from `ClientPersistedTerminalFieldsSchema` and
+ * `LiveTerminalFieldsSchema`. See the partition comment above.
  */
 export const ServerPersistedTerminalFieldsSchema = z.object({
   cwd: z.string(),
@@ -102,6 +124,9 @@ export const ServerPersistedTerminalFieldsSchema = z.object({
  * `updateClientMetadata`, or direct mutation for paths that intentionally
  * skip the publish like sub-panel state) and round-tripped through disk.
  * The "client-writes + persisted" intersection, declared structurally.
+ *
+ * Disjoint from `ServerPersistedTerminalFieldsSchema` and
+ * `LiveTerminalFieldsSchema`. See the partition comment above.
  */
 export const ClientPersistedTerminalFieldsSchema = z.object({
   themeName: z.string().optional(),
@@ -118,6 +143,12 @@ export const ClientPersistedTerminalFieldsSchema = z.object({
  * external state and never persisted. If a field is here, a session
  * restore must re-derive it; if a field is on one of the persisted
  * schemas, it round-trips through disk as-is.
+ *
+ * Disjoint from `ServerPersistedTerminalFieldsSchema` and
+ * `ClientPersistedTerminalFieldsSchema`. See the partition comment
+ * above. Writes go through `updateServerLiveMetadata`, which does NOT
+ * fire `terminals:dirty` — that's how the agent-stream firehose is
+ * kept off the autosave channel.
  */
 export const LiveTerminalFieldsSchema = z.object({
   /** GitHub PR resolution — discriminated union (see PrResultSchema). */
@@ -129,9 +160,11 @@ export const LiveTerminalFieldsSchema = z.object({
 });
 
 /**
- * Every field that rides to disk. Union of the two write-authority
- * bases — `SavedTerminal` just adds `id` to this shape. Adding a
- * persisted field is a one-place change on whichever base owns it.
+ * Every field that rides to disk. Disjoint union of the two
+ * write-authority persisted bases — `SavedTerminal` just adds `id` to
+ * this shape. Adding a persisted field is a one-place change on
+ * whichever base owns it (server vs client). Live fields don't
+ * participate.
  */
 export const PersistedTerminalFieldsSchema =
   ServerPersistedTerminalFieldsSchema.merge(

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -328,6 +328,9 @@ export type PersistedTerminalFields = z.infer<
   typeof PersistedTerminalFieldsSchema
 >;
 export type LiveTerminalFields = z.infer<typeof LiveTerminalFieldsSchema>;
+export type ServerPersistedTerminalFields = z.infer<
+  typeof ServerPersistedTerminalFieldsSchema
+>;
 export type RecentRepo = z.infer<typeof RecentRepoSchema>;
 export type RecentAgent = z.infer<typeof RecentAgentSchema>;
 export type SavedTerminal = z.infer<typeof SavedTerminalSchema>;

--- a/packages/server/src/meta/agent.ts
+++ b/packages/server/src/meta/agent.ts
@@ -53,16 +53,18 @@ export function shouldBumpRecencyForAgentChange(
   return !isReDetectionAfterRestore;
 }
 
-/** Single write-site for `m.agent`. The provider's watcher emits at ~150ms
- *  cadence while an agent is streaming; only a small fraction of those
- *  emits cross the recency-bump threshold (transitions on
+/** Single write-site for `m.agent`. The provider's watcher emits at
+ *  ~150ms cadence while an agent is streaming; only a small fraction
+ *  of those emits cross the recency-bump threshold (transitions on
  *  `kind`/`sessionId`/`state`). Sub-info refreshes — `contextTokens`,
  *  `summary`, `taskProgress` — share the live `agent` slot but don't
  *  bump.
  *
- *  We split the write per-tick so the firehose stays live-only:
- *  bump → persist (`updateServerMetadata` fires `terminals:dirty`),
- *  no-bump → live (`updateServerLiveMetadata` skips the channel). */
+ *  Every tick writes `m.agent` via the live variant (no dirty signal,
+ *  no autosave). On a bump, a second call writes `m.lastActivityAt`
+ *  via the persisting variant. The two-call shape is forced by the
+ *  bidirectional type fence in `state.ts`; the second publish is
+ *  cheap and only happens on transitions. */
 function setAgentMetadata(
   entry: TerminalProcess,
   terminalId: string,
@@ -73,14 +75,17 @@ function setAgentMetadata(
     nextAgent,
     entry.meta.lastActivityAt,
   );
+  // Live first so the dirty-fire snapshot already includes `nextAgent`.
+  // The bidirectional fence on `updateServerMetadata` (mutator typed
+  // to ServerPersistedTerminalFields) means the bump path can't write
+  // `m.agent` and `m.lastActivityAt` in one closure — that's the price
+  // of the structural fence, paid only on transitions (sparse).
+  updateServerLiveMetadata(entry, terminalId, (m) => {
+    m.agent = nextAgent;
+  });
   if (bump) {
     updateServerMetadata(entry, terminalId, (m) => {
-      m.agent = nextAgent;
       m.lastActivityAt = Date.now();
-    });
-  } else {
-    updateServerLiveMetadata(entry, terminalId, (m) => {
-      m.agent = nextAgent;
     });
   }
 }

--- a/packages/server/src/meta/agent.ts
+++ b/packages/server/src/meta/agent.ts
@@ -23,7 +23,7 @@ import { log } from "../log.ts";
 import { terminalChannels } from "../publisher.ts";
 import type { TerminalProcess } from "../terminal-registry.ts";
 import { getLastAgentCommandName } from "./agent-command.ts";
-import { updateServerMetadata } from "./state.ts";
+import { updateServerLiveMetadata, updateServerMetadata } from "./state.ts";
 
 /** Pure decision: does this agent transition warrant a recency bump?
  *
@@ -53,7 +53,16 @@ export function shouldBumpRecencyForAgentChange(
   return !isReDetectionAfterRestore;
 }
 
-/** Single write-site for `m.agent`. */
+/** Single write-site for `m.agent`. The provider's watcher emits at ~150ms
+ *  cadence while an agent is streaming; only a small fraction of those
+ *  emits cross the recency-bump threshold (transitions on
+ *  `kind`/`sessionId`/`state`). Sub-info refreshes — `contextTokens`,
+ *  `summary`, `taskProgress` — share the live `agent` slot but don't
+ *  bump.
+ *
+ *  We split the write per-tick so the firehose stays live-only:
+ *  bump → persist (`updateServerMetadata` fires `terminals:dirty`),
+ *  no-bump → live (`updateServerLiveMetadata` skips the channel). */
 function setAgentMetadata(
   entry: TerminalProcess,
   terminalId: string,
@@ -64,10 +73,16 @@ function setAgentMetadata(
     nextAgent,
     entry.meta.lastActivityAt,
   );
-  updateServerMetadata(entry, terminalId, (m) => {
-    m.agent = nextAgent;
-    if (bump) m.lastActivityAt = Date.now();
-  });
+  if (bump) {
+    updateServerMetadata(entry, terminalId, (m) => {
+      m.agent = nextAgent;
+      m.lastActivityAt = Date.now();
+    });
+  } else {
+    updateServerLiveMetadata(entry, terminalId, (m) => {
+      m.agent = nextAgent;
+    });
+  }
 }
 
 /** node-pty may return a full path (e.g. `/nix/store/.../bin/opencode` on

--- a/packages/server/src/meta/github.ts
+++ b/packages/server/src/meta/github.ts
@@ -5,7 +5,8 @@
  * `gh pr view` spawn, branch-change dedup, the 30s polling loop, failure
  * classification and routing. This file just wires the watcher to the
  * server's `git:` channel and pushes resolved `PrResult` values into
- * terminal metadata via `updateServerMetadata`.
+ * terminal metadata via `updateServerLiveMetadata` — `pr` is a live
+ * field, so PR-poll churn doesn't trigger session autosaves.
  *
  * ┌─ FUTURE: PrProvider extraction ──────────────────────────────────────┐
  * │ When Bitbucket (`bkt`) support lands (srid/agency#10), a sibling     │
@@ -23,7 +24,7 @@ import { subscribeGitHubPr } from "kolu-github";
 import { log } from "../log.ts";
 import { terminalChannels } from "../publisher.ts";
 import type { TerminalProcess } from "../terminal-registry.ts";
-import { updateServerMetadata } from "./state.ts";
+import { updateServerLiveMetadata } from "./state.ts";
 
 export function startGitHubPrProvider(
   entry: TerminalProcess,
@@ -33,7 +34,7 @@ export function startGitHubPrProvider(
   plog.debug("started");
 
   const watcher = subscribeGitHubPr((pr) => {
-    updateServerMetadata(entry, terminalId, (m) => {
+    updateServerLiveMetadata(entry, terminalId, (m) => {
       m.pr = pr;
     });
     plog.debug(

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -10,12 +10,25 @@
  *                                                 + metadata:<id> (lastAgentCommand)
  *                                                 + activity:changed
  *
- * Providers publish server-derived fields via `updateServerMetadata`; client
- * RPC handlers persist client-owned fields via `updateClientMetadata` (or
- * direct mutation for paths that skip the metadata publish). Both functions
- * share the same publish/auto-save path — the type difference is a
- * compile-time fence so a provider cannot accidentally write canvasLayout
- * and an RPC handler cannot accidentally write git.
+ * Providers route writes through one of three helpers in `./state.ts`:
+ *
+ *   - `updateServerMetadata` — server-persisted fields (cwd, git,
+ *     lastAgentCommand, lastActivityAt). Mutator is narrowed to
+ *     `ServerPersistedTerminalFields` so the live-field firehose can't
+ *     grow back through this path. Fires `terminals:dirty`.
+ *   - `updateServerLiveMetadata` — live-only fields (pr, agent,
+ *     foreground). Mutator is narrowed to `LiveTerminalFields`. Does
+ *     NOT fire `terminals:dirty` — that's the whole point: the agent
+ *     stream watcher publishes ~150ms during streaming, and most of
+ *     those publishes touch only live state.
+ *   - `updateClientMetadata` — client-persisted fields (themeName,
+ *     parentId, canvasLayout, subPanel). Fires `terminals:dirty`.
+ *
+ * The mutator-type narrowing is a bidirectional compile-time fence:
+ * each helper can only write the fields it owns, so a provider cannot
+ * accidentally write canvasLayout, an RPC handler cannot accidentally
+ * write git, and a live-field write cannot accidentally re-trigger
+ * the autosave firehose.
  *
  * No provider subscribes to the aggregated "metadata" channel — that's client-facing only.
  *
@@ -51,6 +64,7 @@ import { startProcessProvider } from "./process.ts";
 export {
   createMetadata,
   updateClientMetadata,
+  updateServerLiveMetadata,
   updateServerMetadata,
 } from "./state.ts";
 

--- a/packages/server/src/meta/process.ts
+++ b/packages/server/src/meta/process.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 import { log } from "../log.ts";
 import { terminalChannels } from "../publisher.ts";
 import type { TerminalProcess } from "../terminal-registry.ts";
-import { updateServerMetadata } from "./state.ts";
+import { updateServerLiveMetadata } from "./state.ts";
 
 /** node-pty may return a full path (e.g. `/nix/store/.../bin/opencode` on NixOS).
  *  Always normalize to the basename. */
@@ -41,7 +41,7 @@ export function startProcessProvider(
     );
     lastName = name;
     lastTitle = newTitle;
-    updateServerMetadata(entry, terminalId, (m) => {
+    updateServerLiveMetadata(entry, terminalId, (m) => {
       m.foreground = { name, title: newTitle };
     });
   }

--- a/packages/server/src/meta/state.test.ts
+++ b/packages/server/src/meta/state.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Publish-routing tests for the metadata update helpers.
+ *
+ * Guards against the firehose regressing: persisted-field writers MUST
+ * fire `terminals:dirty`; live-field writers MUST NOT. Without this,
+ * a future contributor who routes a new persisted field through
+ * `updateServerLiveMetadata` (or vice versa) silently breaks autosave
+ * cadence — either over-saving or losing data on restart.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { terminalsDirtyChannel } from "../publisher.ts";
+import type { TerminalProcess } from "../terminal-registry.ts";
+import {
+  updateClientMetadata,
+  updateServerLiveMetadata,
+  updateServerMetadata,
+} from "./state.ts";
+
+function fakeTerminal(): TerminalProcess {
+  return {
+    info: { id: "term-pub-test", pid: 0 },
+    meta: {
+      cwd: "/tmp",
+      git: null,
+      pr: { kind: "pending" },
+      agent: null,
+      foreground: null,
+      lastActivityAt: 0,
+    },
+    // Tests never touch the PTY handle; the publish path doesn't read it.
+    handle: {} as TerminalProcess["handle"],
+    stopProviders: () => {},
+  };
+}
+
+let dirtyCount: number;
+let stopWatch: () => void;
+
+beforeEach(() => {
+  dirtyCount = 0;
+  stopWatch = terminalsDirtyChannel.consume({
+    onEvent: () => {
+      dirtyCount += 1;
+    },
+    onError: () => {},
+  });
+});
+
+afterAll(() => {
+  stopWatch?.();
+});
+
+describe("metadata publish routing", () => {
+  it("updateServerMetadata fires terminals:dirty (cwd is persisted)", () => {
+    const entry = fakeTerminal();
+    updateServerMetadata(entry, "term-pub-test", (m) => {
+      m.cwd = "/new/cwd";
+    });
+    expect(dirtyCount).toBe(1);
+  });
+
+  it("updateClientMetadata fires terminals:dirty (every client field is persisted)", () => {
+    const entry = fakeTerminal();
+    updateClientMetadata(entry, "term-pub-test", (m) => {
+      m.themeName = "dracula";
+    });
+    expect(dirtyCount).toBe(1);
+  });
+
+  it("updateServerLiveMetadata does NOT fire terminals:dirty (agent stream is live)", () => {
+    const entry = fakeTerminal();
+    updateServerLiveMetadata(entry, "term-pub-test", (m) => {
+      m.agent = {
+        kind: "claude-code",
+        state: "thinking",
+        sessionId: "sess-A",
+        model: null,
+        summary: "tick",
+        taskProgress: null,
+        contextTokens: null,
+      };
+    });
+    expect(dirtyCount).toBe(0);
+  });
+
+  it("updateServerLiveMetadata called repeatedly stays silent (the firehose case)", () => {
+    const entry = fakeTerminal();
+    for (let i = 0; i < 50; i += 1) {
+      updateServerLiveMetadata(entry, "term-pub-test", (m) => {
+        m.foreground = { name: "claude", title: `tick ${i}` };
+      });
+    }
+    expect(dirtyCount).toBe(0);
+  });
+});

--- a/packages/server/src/meta/state.test.ts
+++ b/packages/server/src/meta/state.test.ts
@@ -8,7 +8,7 @@
  * cadence — either over-saving or losing data on restart.
  */
 
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { terminalsDirtyChannel } from "../publisher.ts";
 import type { TerminalProcess } from "../terminal-registry.ts";
 import {
@@ -37,7 +37,18 @@ function fakeTerminal(): TerminalProcess {
 let dirtyCount: number;
 let stopWatch: () => void;
 
-beforeEach(() => {
+/** Yield to the event loop so the channel's async iterator (started by
+ *  `consume`) can receive any queued publishes. The publisher pipeline
+ *  is async end-to-end (`publish` returns a Promise; the consume IIFE
+ *  awaits via `for await`), so a synchronous read of `dirtyCount`
+ *  immediately after `updateServerMetadata` will see the pre-event
+ *  count. Two `setImmediate` ticks cover both legs of the pipe. */
+async function settle(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+beforeEach(async () => {
   dirtyCount = 0;
   stopWatch = terminalsDirtyChannel.consume({
     onEvent: () => {
@@ -45,30 +56,38 @@ beforeEach(() => {
     },
     onError: () => {},
   });
+  // Let `consume`'s async IIFE reach its first `for await` before any
+  // test publishes; otherwise the first publish races the subscribe.
+  await settle();
 });
 
-afterAll(() => {
+afterEach(() => {
+  // Each test gets a fresh subscriber; without this, prior subscribers
+  // keep firing into the shared `dirtyCount` and bystander tests see
+  // inflated counts.
   stopWatch?.();
 });
 
 describe("metadata publish routing", () => {
-  it("updateServerMetadata fires terminals:dirty (cwd is persisted)", () => {
+  it("updateServerMetadata fires terminals:dirty (cwd is persisted)", async () => {
     const entry = fakeTerminal();
     updateServerMetadata(entry, "term-pub-test", (m) => {
       m.cwd = "/new/cwd";
     });
+    await settle();
     expect(dirtyCount).toBe(1);
   });
 
-  it("updateClientMetadata fires terminals:dirty (every client field is persisted)", () => {
+  it("updateClientMetadata fires terminals:dirty (every client field is persisted)", async () => {
     const entry = fakeTerminal();
     updateClientMetadata(entry, "term-pub-test", (m) => {
       m.themeName = "dracula";
     });
+    await settle();
     expect(dirtyCount).toBe(1);
   });
 
-  it("updateServerLiveMetadata does NOT fire terminals:dirty (agent stream is live)", () => {
+  it("updateServerLiveMetadata does NOT fire terminals:dirty (agent stream is live)", async () => {
     const entry = fakeTerminal();
     updateServerLiveMetadata(entry, "term-pub-test", (m) => {
       m.agent = {
@@ -81,16 +100,18 @@ describe("metadata publish routing", () => {
         contextTokens: null,
       };
     });
+    await settle();
     expect(dirtyCount).toBe(0);
   });
 
-  it("updateServerLiveMetadata called repeatedly stays silent (the firehose case)", () => {
+  it("updateServerLiveMetadata called repeatedly stays silent (the firehose case)", async () => {
     const entry = fakeTerminal();
     for (let i = 0; i < 50; i += 1) {
       updateServerLiveMetadata(entry, "term-pub-test", (m) => {
         m.foreground = { name: "claude", title: `tick ${i}` };
       });
     }
+    await settle();
     expect(dirtyCount).toBe(0);
   });
 

--- a/packages/server/src/meta/state.test.ts
+++ b/packages/server/src/meta/state.test.ts
@@ -93,4 +93,32 @@ describe("metadata publish routing", () => {
     }
     expect(dirtyCount).toBe(0);
   });
+
+  // Type-fence assertions — these are the structural guarantee that the
+  // firehose can't grow back. If any of these `@ts-expect-error` lines
+  // start compiling, the fence is broken and a future write site can
+  // silently re-firehose live writes through the persisting path (or
+  // vice versa). Test runtime is irrelevant; the assertion is at type
+  // check.
+  it("type fence: live fields cannot be written through updateServerMetadata", () => {
+    const entry = fakeTerminal();
+    updateServerMetadata(entry, "term-pub-test", (m) => {
+      // @ts-expect-error — `agent` is live, not persisted.
+      m.agent = null;
+      // @ts-expect-error — `pr` is live, not persisted.
+      m.pr = { kind: "pending" };
+      // @ts-expect-error — `foreground` is live, not persisted.
+      m.foreground = null;
+    });
+  });
+
+  it("type fence: persisted fields cannot be written through updateServerLiveMetadata", () => {
+    const entry = fakeTerminal();
+    updateServerLiveMetadata(entry, "term-pub-test", (m) => {
+      // @ts-expect-error — `cwd` is persisted, not live.
+      m.cwd = "/tmp";
+      // @ts-expect-error — `lastActivityAt` is persisted, not live.
+      m.lastActivityAt = 0;
+    });
+  });
 });

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -41,14 +41,18 @@ export function createMetadata(cwd: string): TerminalMetadata {
   };
 }
 
-/** Log + publish the current metadata snapshot. Shared tail for every
- *  update variant — the publish/audit path is identical regardless of who
- *  wrote the fields. Distinct from `publishMetadataAndPersist` (below):
- *  this one does NOT fire `terminals:dirty`, so live-only writes (agent
- *  stream sub-info, pr poll results, foreground process churn) don't
- *  schedule autosaves whose persisted bytes would be byte-identical to
- *  the previous snapshot. */
-function publishMetadata(entry: TerminalProcess, terminalId: string): void {
+/** Log + emit the current metadata snapshot to the surface collection.
+ *  Shared tail for every update variant — the publish/audit path is
+ *  identical regardless of who wrote the fields. Distinct from
+ *  `publishSnapshotAndDirty` (below): this one does NOT fire
+ *  `terminals:dirty`, so live-only writes (agent stream sub-info, pr poll
+ *  results, foreground process churn) don't schedule autosaves whose
+ *  persisted bytes would be byte-identical to the previous snapshot.
+ *
+ *  The name is "snapshot", not "persist": no I/O happens here. The
+ *  `terminals:dirty` channel is the *signal* that downstream
+ *  `session.ts` listens for and translates into a write to disk. */
+function publishSnapshot(entry: TerminalProcess, terminalId: string): void {
   const m = entry.meta;
   const pr = prValue(m.pr);
   const prUnavailable = prUnavailableReason(m.pr);
@@ -71,13 +75,16 @@ function publishMetadata(entry: TerminalProcess, terminalId: string): void {
   surfaceCtx.collections.terminalMetadata.upsert(terminalId, { ...m });
 }
 
-/** `publishMetadata` + fire `terminals:dirty`. Use this from any path that
- *  wrote a persisted field — the channel tells `session.ts` to flush. */
-function publishMetadataAndPersist(
+/** `publishSnapshot` + fire `terminals:dirty`. Use this from any path
+ *  that wrote a persisted field — the dirty signal tells `session.ts`'s
+ *  autosave loop to debounce-save the snapshot. The actual disk write
+ *  is downstream; this function is named for what it *does* (signal
+ *  dirty), not what eventually happens (a write). */
+function publishSnapshotAndDirty(
   entry: TerminalProcess,
   terminalId: string,
 ): void {
-  publishMetadata(entry, terminalId);
+  publishSnapshot(entry, terminalId);
   terminalsDirtyChannel.publish({});
 }
 
@@ -93,7 +100,7 @@ export function updateServerMetadata(
   mutate: (meta: TerminalServerMetadata) => void,
 ): void {
   mutate(entry.meta);
-  publishMetadataAndPersist(entry, terminalId);
+  publishSnapshotAndDirty(entry, terminalId);
 }
 
 /** Atomically mutate live-only server metadata (`pr`, `agent`,
@@ -107,7 +114,7 @@ export function updateServerLiveMetadata(
   mutate: (meta: LiveTerminalFields) => void,
 ): void {
   mutate(entry.meta);
-  publishMetadata(entry, terminalId);
+  publishSnapshot(entry, terminalId);
 }
 
 /** Atomically mutate client-owned metadata (themeName, parentId,
@@ -121,5 +128,5 @@ export function updateClientMetadata(
   mutate: (meta: TerminalClientMetadata) => void,
 ): void {
   mutate(entry.meta);
-  publishMetadataAndPersist(entry, terminalId);
+  publishSnapshotAndDirty(entry, terminalId);
 }

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -16,9 +16,9 @@
 
 import type {
   LiveTerminalFields,
+  ServerPersistedTerminalFields,
   TerminalClientMetadata,
   TerminalMetadata,
-  TerminalServerMetadata,
 } from "kolu-common/surface";
 import { prUnavailableReason, prValue } from "kolu-github/schemas";
 import { log } from "../log.ts";
@@ -88,16 +88,18 @@ function publishSnapshotAndDirty(
   terminalsDirtyChannel.publish({});
 }
 
-/** Atomically mutate server-derived metadata (cwd, git, lastAgentCommand,
- *  lastActivityAt, pr, agent, foreground) and publish. The mutator is
- *  narrowed to `TerminalServerMetadata` so providers cannot accidentally
- *  write client-owned fields. Fires `terminals:dirty` — use the `Live`
- *  variant when you know only live fields (`pr`, `agent`, `foreground`)
- *  are touched. */
+/** Atomically mutate server-persisted metadata (`cwd`, `git`,
+ *  `lastAgentCommand`, `lastActivityAt`) and publish. The mutator is
+ *  narrowed to `ServerPersistedTerminalFields` — bidirectional fence: a
+ *  provider cannot write client-owned fields (themeName, parentId, …)
+ *  AND cannot write live-only fields (pr, agent, foreground) through
+ *  this function. The latter half is the structural guarantee that the
+ *  terminals:dirty firehose can't grow back: every live-field write
+ *  must go through `updateServerLiveMetadata`. Fires `terminals:dirty`. */
 export function updateServerMetadata(
   entry: TerminalProcess,
   terminalId: string,
-  mutate: (meta: TerminalServerMetadata) => void,
+  mutate: (meta: ServerPersistedTerminalFields) => void,
 ): void {
   mutate(entry.meta);
   publishSnapshotAndDirty(entry, terminalId);
@@ -106,8 +108,10 @@ export function updateServerMetadata(
 /** Atomically mutate live-only server metadata (`pr`, `agent`,
  *  `foreground`) and publish — without firing `terminals:dirty`. The
  *  mutator type is `LiveTerminalFields`, a compile-time fence: writing
- *  any persisted field through this function is a type error, which is
- *  the structural guarantee that the firehose can't grow back. */
+ *  any persisted field through this function is a type error.
+ *  Together with the matching narrowing on `updateServerMetadata`,
+ *  this is the structural guarantee that the firehose can't grow
+ *  back. */
 export function updateServerLiveMetadata(
   entry: TerminalProcess,
   terminalId: string,

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -15,6 +15,7 @@
  */
 
 import type {
+  LiveTerminalFields,
   TerminalClientMetadata,
   TerminalMetadata,
   TerminalServerMetadata,
@@ -40,10 +41,13 @@ export function createMetadata(cwd: string): TerminalMetadata {
   };
 }
 
-/** Log + publish the current metadata snapshot and trigger debounced
- *  session auto-save. Shared tail for both `updateServerMetadata` and
- *  `updateClientMetadata` so the publish/audit path is identical regardless
- *  of who wrote the fields. */
+/** Log + publish the current metadata snapshot. Shared tail for every
+ *  update variant — the publish/audit path is identical regardless of who
+ *  wrote the fields. Distinct from `publishMetadataAndPersist` (below):
+ *  this one does NOT fire `terminals:dirty`, so live-only writes (agent
+ *  stream sub-info, pr poll results, foreground process churn) don't
+ *  schedule autosaves whose persisted bytes would be byte-identical to
+ *  the previous snapshot. */
 function publishMetadata(entry: TerminalProcess, terminalId: string): void {
   const m = entry.meta;
   const pr = prValue(m.pr);
@@ -65,17 +69,42 @@ function publishMetadata(entry: TerminalProcess, terminalId: string): void {
     "metadata publish",
   );
   surfaceCtx.collections.terminalMetadata.upsert(terminalId, { ...m });
+}
+
+/** `publishMetadata` + fire `terminals:dirty`. Use this from any path that
+ *  wrote a persisted field — the channel tells `session.ts` to flush. */
+function publishMetadataAndPersist(
+  entry: TerminalProcess,
+  terminalId: string,
+): void {
+  publishMetadata(entry, terminalId);
   terminalsDirtyChannel.publish({});
 }
 
-/** Atomically mutate server-derived metadata (cwd, git, pr, agent,
- *  foreground) and publish. The mutator is narrowed to
- *  `TerminalServerMetadata` so providers cannot accidentally write
- *  client-owned fields. */
+/** Atomically mutate server-derived metadata (cwd, git, lastAgentCommand,
+ *  lastActivityAt, pr, agent, foreground) and publish. The mutator is
+ *  narrowed to `TerminalServerMetadata` so providers cannot accidentally
+ *  write client-owned fields. Fires `terminals:dirty` — use the `Live`
+ *  variant when you know only live fields (`pr`, `agent`, `foreground`)
+ *  are touched. */
 export function updateServerMetadata(
   entry: TerminalProcess,
   terminalId: string,
   mutate: (meta: TerminalServerMetadata) => void,
+): void {
+  mutate(entry.meta);
+  publishMetadataAndPersist(entry, terminalId);
+}
+
+/** Atomically mutate live-only server metadata (`pr`, `agent`,
+ *  `foreground`) and publish — without firing `terminals:dirty`. The
+ *  mutator type is `LiveTerminalFields`, a compile-time fence: writing
+ *  any persisted field through this function is a type error, which is
+ *  the structural guarantee that the firehose can't grow back. */
+export function updateServerLiveMetadata(
+  entry: TerminalProcess,
+  terminalId: string,
+  mutate: (meta: LiveTerminalFields) => void,
 ): void {
   mutate(entry.meta);
   publishMetadata(entry, terminalId);
@@ -84,12 +113,13 @@ export function updateServerMetadata(
 /** Atomically mutate client-owned metadata (themeName, parentId,
  *  canvasLayout, subPanel) and publish. The mutator is narrowed to
  *  `TerminalClientMetadata` so RPC handlers cannot accidentally overwrite
- *  provider-owned state. */
+ *  provider-owned state. Every client field is persisted, so this always
+ *  fires `terminals:dirty`. */
 export function updateClientMetadata(
   entry: TerminalProcess,
   terminalId: string,
   mutate: (meta: TerminalClientMetadata) => void,
 ): void {
   mutate(entry.meta);
-  publishMetadata(entry, terminalId);
+  publishMetadataAndPersist(entry, terminalId);
 }

--- a/packages/surface/README.md
+++ b/packages/surface/README.md
@@ -352,7 +352,7 @@ Concrete inventory — what every server-pushed reactive surface in Kolu maps to
 
 | Descriptor | Backs | Mutation |
 |---|---|---|
-| `terminalMetadataCollection` | Per-terminal metadata (cwd, git, PR, agent state, foreground process, last-activity timestamp for switcher recency) — each terminal's tile chrome and inspector reads its own key | _server-only_ (providers under `meta/*.ts` write via `updateServerMetadata`; the agent provider stamps `lastActivityAt` on every semantic-key transition) |
+| `terminalMetadataCollection` | Per-terminal metadata (cwd, git, PR, agent state, foreground process, last-activity timestamp for switcher recency) — each terminal's tile chrome and inspector reads its own key | _server-only_ (providers under `meta/*.ts` route writes through `updateServerMetadata` for persisted fields and `updateServerLiveMetadata` for live-only fields — `pr`, `agent`, `foreground` — so the high-frequency agent-stream watcher doesn't fire `terminals:dirty` and trigger no-op session autosaves; the agent provider switches to the persisting variant on each semantic-key transition that bumps `lastActivityAt`) |
 
 ### Streams
 


### PR DESCRIPTION
**Closes #803.** The agent stream watcher fires every 150ms while an agent is streaming, and every fire used to publish `terminals:dirty` — which scheduled a session autosave whose persisted bytes were _byte-identical_ to the previous snapshot. The channel was over-eager; the fix is bus-native.

### The shape of the fix

`publishMetadata` co-published `terminals:dirty` for every metadata write — both persisted (`cwd`, `git`, `lastAgentCommand`, `lastActivityAt`) and live (`pr`, `agent`, `foreground`). Split the publish path and add a third update helper for live writes.

```
                           ┌──▶ surface collection upsert  (always)
publishSnapshot         ───┤
                           └──▶ (no dirty signal)

                           ┌──▶ publishSnapshot
publishSnapshotAndDirty ───┤
                           └──▶ terminalsDirtyChannel.publish({})
```

Three update helpers, each with a narrowed mutator type:

| Helper | Mutator type | Fires `terminals:dirty`? |
| --- | --- | --- |
| `updateServerMetadata` | `ServerPersistedTerminalFields` | Yes |
| `updateServerLiveMetadata` | `LiveTerminalFields` | **No** |
| `updateClientMetadata` | `TerminalClientMetadata` | Yes |

The mutator-type narrowing is a **bidirectional compile-time fence**: a live-field write through the persisting path is a type error, and a persisted-field write through the live path is also a type error. The firehose can't grow back without first defeating the type system.

### Per call site

| Site | Field | Routing |
| --- | --- | --- |
| `terminals.ts` `cwd`/`parentId`/`canvasLayout`/`subPanel`/`themeName` | persisted | `updateServer/ClientMetadata` (unchanged) |
| `meta/git.ts` `git` | persisted | `updateServerMetadata` (unchanged) |
| `meta/agent-command.ts` `lastAgentCommand` | persisted | `updateServerMetadata` (unchanged) |
| `meta/agent.ts` `agent` (every tick) | live | `updateServerLiveMetadata` _(new)_ |
| `meta/agent.ts` `lastActivityAt` (on bump) | persisted | `updateServerMetadata` _(second call)_ |
| `meta/github.ts` `pr` | live | `updateServerLiveMetadata` _(was persisted)_ |
| `meta/process.ts` `foreground` | live | `updateServerLiveMetadata` _(was persisted)_ |

The agent provider's bump branch used to write `m.agent` and `m.lastActivityAt` in one closure. The bidirectional fence forces a split: live writer for `m.agent` (every tick), persisting writer for `m.lastActivityAt` (only on transitions). _Two publishes per transition; transitions are sparse._

### Hickey/Lowy findings landed in-PR

The structural review caught five things, each addressed in its own commit so the PR's `git log` reads as a progression. See the commit list and the [Hickey/Lowy Analysis](https://kolu.dev/blog/hickey-lowy/) comment posted alongside this PR for the full reasoning.

### Test coverage

- **Unit** — `packages/server/src/meta/state.test.ts` adds five assertions: persisted writes fire dirty, live writes don't, the firehose case (50× `updateServerLiveMetadata`) stays silent, and two `@ts-expect-error` blocks pin both halves of the type fence.
- **E2e** — `session-restore.feature` (8 scenarios) all green, confirming the autosave round-trip survives the channel-fire change.

> _The `setSavedSession` race documented at `session.ts:55-65` is real even with sparse events. The throttle + cancel-on-`setSavedSession` mechanism is what stops a lingering provider event between e2e scenarios from clobbering a manually-set session — kept as-is. Drop-the-throttle is a separate refactor._

### Try it locally

```sh
nix run github:juspay/kolu/fix/803-terminals-dirty-firehose
```

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._