### PR TITLE
Center the active canvas tile after close-driven switch and on first create

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -31,7 +31,6 @@ import WorkspaceSwitcher, {
 } from "./canvas/workspace-switcher";
 import TerminalCanvas from "./canvas/TerminalCanvas";
 import TileTitleActions from "./canvas/TileTitleActions";
-import { useCanvasViewport } from "./canvas/viewport/useCanvasViewport";
 import { createCommands } from "./commands";
 import DiagnosticInfo from "./DiagnosticInfo";
 import EmptyState from "./EmptyState";
@@ -80,7 +79,6 @@ const App: Component = () => {
   const subPanel = useSubPanel();
   const rightPanel = useRightPanel();
   const { colorScheme } = useColorScheme();
-  const canvasViewport = useCanvasViewport();
 
   // Workspace-switcher feeds — desktop and mobile share the same
   // accessors; `buildWorkspaceSwitcherModel` owns the ordering pipeline.
@@ -177,15 +175,12 @@ const App: Component = () => {
   function handleCanvasCenterActive() {
     if (isMobile()) return;
     const id = store.activeId();
-    if (!id) return;
-    const tile = store.getMetadata(id)?.canvasLayout;
-    if (tile) canvasViewport.centerOnTile(tile);
+    if (id) store.requestCenterActive(id);
   }
 
   const arrange = useCanvasArrange({
     store,
     crud,
-    viewport: canvasViewport,
     isMobile,
   });
 
@@ -481,8 +476,7 @@ const App: Component = () => {
               openRequest={workspaceSwitcherOpenRequest()}
               onSelect={(id) => {
                 store.setActiveId(id);
-                const layout = store.getMetadata(id)?.canvasLayout;
-                if (layout) canvasViewport.centerOnTile(layout);
+                store.requestCenterActive(id);
               }}
               onCreate={() => openPaletteGroup("New terminal")}
             />

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -191,6 +191,7 @@ const App: Component = () => {
     terminalIds: store.terminalIds,
     activeId: store.activeId,
     setActiveId: store.setActiveId,
+    requestCenterActive: store.requestCenterActive,
     mruOrder: store.mruOrder,
     activeMeta: store.activeMeta,
     handleCreate: (cwd?: string) => void crud.handleCreate(cwd),

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -175,7 +175,7 @@ const App: Component = () => {
   function handleCanvasCenterActive() {
     if (isMobile()) return;
     const id = store.activeId();
-    if (id) store.requestCenterActive(id);
+    if (id) store.activate(id);
   }
 
   const arrange = useCanvasArrange({
@@ -190,8 +190,7 @@ const App: Component = () => {
   const actionContext: ActionContext = {
     terminalIds: store.terminalIds,
     activeId: store.activeId,
-    setActiveId: store.setActiveId,
-    requestCenterActive: store.requestCenterActive,
+    activate: store.activate,
     mruOrder: store.mruOrder,
     activeMeta: store.activeMeta,
     handleCreate: (cwd?: string) => void crud.handleCreate(cwd),
@@ -318,7 +317,7 @@ const App: Component = () => {
         }
         onCloseTerminal={closeTerminal}
         activeMeta={store.activeMeta()}
-        onFocus={() => store.setActiveId(id)}
+        onFocus={() => store.setActiveSilently(id)}
       />
     );
   }
@@ -475,10 +474,7 @@ const App: Component = () => {
               activeId={store.activeId()}
               getRecency={recencyOf}
               openRequest={workspaceSwitcherOpenRequest()}
-              onSelect={(id) => {
-                store.setActiveId(id);
-                store.requestCenterActive(id);
-              }}
+              onSelect={store.activate}
               onCreate={() => openPaletteGroup("New terminal")}
             />
           }
@@ -545,7 +541,7 @@ const App: Component = () => {
                     placeNew={arrange.placeNew}
                     onLayoutChange={arrange.applyTileGeometry}
                     onAutoArrange={arrange.handleCanvasAutoArrange}
-                    onSelect={(id) => store.setActiveId(id)}
+                    onSelect={store.setActiveSilently}
                     onClose={(id) => closeTerminal(id)}
                     renderTileTitle={(id) => (
                       <TerminalMeta info={store.getDisplayInfo(id)} />

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -60,7 +60,8 @@ const MobileTileView: Component<{
     if (idx === -1) return;
     const next = (idx + direction + ids.length) % ids.length;
     const target = ids[next];
-    if (target) store.setActiveId(target);
+    // Mobile: there is no canvas to pan — `setActiveSilently` is correct.
+    if (target) store.setActiveSilently(target);
   }
 
   function onTouchStart(e: TouchEvent) {
@@ -175,7 +176,7 @@ const MobileTileView: Component<{
             appTitle={props.appTitle}
             onOpenPalette={props.onOpenPalette}
             groups={props.groups}
-            onSelect={store.setActiveId}
+            onSelect={store.setActiveSilently}
             onClose={() => setSheetOpen(false)}
           />
         </Drawer.Content>

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -206,12 +206,15 @@ const TerminalCanvas: Component<{
           props.onLayoutChange(id, defaultLayout);
           placed.push({ id, layout: defaultLayout, isNew: true });
         }
-        // Pan to the active newly-placed tile. Routed through the focus
-        // seam so create-driven and close-driven panning share one
-        // mechanism (the `focus.request` effect below).
+        // Pan to the active newly-placed tile. `activate` is a no-op
+        // setter when active is already this id (handleCreate already set
+        // it via setActiveSilently before the cascade ran) — the call's
+        // job here is bumping the centering signal once the new tile's
+        // pending layout exists. Same mechanism the `focus.request`
+        // effect below uses for every other system-driven activation.
         const activeId = store.activeId();
         if (activeId && placed.some((p) => p.isNew && p.id === activeId)) {
-          focus.requestCenter(activeId);
+          store.activate(activeId);
         }
       },
     ),

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -207,13 +207,15 @@ const TerminalCanvas: Component<{
         // Recenter on the active newly-placed tile. Covers both "create a
         // 2nd terminal that lands far from the current viewport" and
         // "create the first terminal on a previously-panned empty canvas"
-        // — both look identical from the cascade's perspective.
+        // — both look identical from the cascade's perspective. Routed
+        // through `requestCenterActive` so the close-driven path and the
+        // create-driven path share one mechanism — the
+        // `centerActiveRequest` effect is the sole place that turns
+        // intent into a `viewport.centerOnTile` call.
         const activeId = store.activeId();
-        const recenterOn = placed.find(
-          (p) => p.isNew && p.id === activeId,
-        )?.layout;
-        if (recenterOn) {
-          requestAnimationFrame(() => viewport.centerOnTile(recenterOn));
+        const recenter = placed.find((p) => p.isNew && p.id === activeId);
+        if (recenter) {
+          store.requestCenterActive(recenter.id);
         }
       },
     ),
@@ -303,25 +305,29 @@ const TerminalCanvas: Component<{
     );
   }
 
-  // Pan to the requested tile whenever `useTerminalCrud` flags a
-  // system-driven reassignment (close → auto-switch). User-driven changes
+  // Pan to the requested tile whenever the system flags a tile change it
+  // wants the viewport to follow — close-driven auto-switch, or the
+  // cascade effect after placing a new active tile. User-driven changes
   // (clicks, workspace switcher) don't bump this signal — clicking a
   // partially-visible tile shouldn't yank the viewport. The target id
   // travels in the signal payload so we don't side-channel-read
   // `activeId` here and pan to the wrong tile if a future caller forgets
   // to update `activeId` first.
+  //
+  // No `defer: true`: the cascade effect bumps the signal during canvas
+  // mount, and on a remount (close-all → re-create) the cascade can
+  // register before this effect installs its tracker. Without defer the
+  // initial run sees the bumped payload; a stale id from a prior mount
+  // resolves to `layoutOf(id) === undefined` (the tile is gone) so the
+  // initial run is a safe no-op.
   createEffect(
-    on(
-      store.centerActiveRequest,
-      (req) => {
-        if (!req) return;
-        const layout = layoutOf(req.id);
-        if (layout) {
-          requestAnimationFrame(() => viewport.centerOnTile(layout));
-        }
-      },
-      { defer: true },
-    ),
+    on(store.centerActiveRequest, (req) => {
+      if (!req) return;
+      const layout = layoutOf(req.id);
+      if (layout) {
+        requestAnimationFrame(() => viewport.centerOnTile(layout));
+      }
+    }),
   );
 
   // On first mount at the default origin, pan so the persisted active tile

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -303,17 +303,19 @@ const TerminalCanvas: Component<{
     );
   }
 
-  // Pan to the active tile whenever `useTerminalCrud` flags a system-driven
-  // reassignment (close → auto-switch). User-driven changes (clicks,
-  // workspace switcher) don't bump this signal — clicking a partially-
-  // visible tile shouldn't yank the viewport.
+  // Pan to the requested tile whenever `useTerminalCrud` flags a
+  // system-driven reassignment (close → auto-switch). User-driven changes
+  // (clicks, workspace switcher) don't bump this signal — clicking a
+  // partially-visible tile shouldn't yank the viewport. The target id
+  // travels in the signal payload so we don't side-channel-read
+  // `activeId` here and pan to the wrong tile if a future caller forgets
+  // to update `activeId` first.
   createEffect(
     on(
       store.centerActiveRequest,
-      () => {
-        const id = store.activeId();
-        if (!id) return;
-        const layout = layoutOf(id);
+      (req) => {
+        if (!req) return;
+        const layout = layoutOf(req.id);
         if (layout) {
           requestAnimationFrame(() => viewport.centerOnTile(layout));
         }

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -43,6 +43,7 @@ import {
   DEFAULT_TILE_W,
   findFreeTilePosition,
 } from "./tilePlacement";
+import { useCanvasFocus } from "./useCanvasFocus";
 import { usePendingLayouts } from "./usePendingLayouts";
 import { useTileTheme } from "./useTileTheme";
 import { useViewPosture } from "./useViewPosture";
@@ -113,6 +114,7 @@ const TerminalCanvas: Component<{
 }> = (props) => {
   const viewport = useCanvasViewport();
   const store = useTerminalStore();
+  const focus = useCanvasFocus();
   const tileTheme = useTileTheme();
   const posture = useViewPosture();
   const isStale = useStaleCheck();
@@ -215,7 +217,7 @@ const TerminalCanvas: Component<{
         const activeId = store.activeId();
         const recenter = placed.find((p) => p.isNew && p.id === activeId);
         if (recenter) {
-          store.requestCenterActive(recenter.id);
+          focus.requestCenter(recenter.id);
         }
       },
     ),
@@ -321,7 +323,7 @@ const TerminalCanvas: Component<{
   // resolves to `layoutOf(id) === undefined` (the tile is gone) so the
   // initial run is a safe no-op.
   createEffect(
-    on(store.centerActiveRequest, (req) => {
+    on(focus.request, (req) => {
       if (!req) return;
       const layout = layoutOf(req.id);
       if (layout) {

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -206,18 +206,12 @@ const TerminalCanvas: Component<{
           props.onLayoutChange(id, defaultLayout);
           placed.push({ id, layout: defaultLayout, isNew: true });
         }
-        // Recenter on the active newly-placed tile. Covers both "create a
-        // 2nd terminal that lands far from the current viewport" and
-        // "create the first terminal on a previously-panned empty canvas"
-        // — both look identical from the cascade's perspective. Routed
-        // through `requestCenterActive` so the close-driven path and the
-        // create-driven path share one mechanism — the
-        // `centerActiveRequest` effect is the sole place that turns
-        // intent into a `viewport.centerOnTile` call.
+        // Pan to the active newly-placed tile. Routed through the focus
+        // seam so create-driven and close-driven panning share one
+        // mechanism (the `focus.request` effect below).
         const activeId = store.activeId();
-        const recenter = placed.find((p) => p.isNew && p.id === activeId);
-        if (recenter) {
-          focus.requestCenter(recenter.id);
+        if (activeId && placed.some((p) => p.isNew && p.id === activeId)) {
+          focus.requestCenter(activeId);
         }
       },
     ),
@@ -307,25 +301,16 @@ const TerminalCanvas: Component<{
     );
   }
 
-  // Pan to the requested tile whenever the system flags a tile change it
-  // wants the viewport to follow — close-driven auto-switch, or the
-  // cascade effect after placing a new active tile. User-driven changes
-  // (clicks, workspace switcher) don't bump this signal — clicking a
-  // partially-visible tile shouldn't yank the viewport. The target id
-  // travels in the signal payload so we don't side-channel-read
-  // `activeId` here and pan to the wrong tile if a future caller forgets
-  // to update `activeId` first.
-  //
   // No `defer: true`: the cascade effect bumps the signal during canvas
-  // mount, and on a remount (close-all → re-create) the cascade can
-  // register before this effect installs its tracker. Without defer the
-  // initial run sees the bumped payload; a stale id from a prior mount
-  // resolves to `layoutOf(id) === undefined` (the tile is gone) so the
-  // initial run is a safe no-op.
+  // mount and on a remount (close-all → re-create) it can register
+  // before this effect installs its tracker. Without defer the initial
+  // run sees the bumped payload; a stale id from a prior mount resolves
+  // to `layoutOf(id) === undefined` (the tile is gone) so the initial
+  // run is a safe no-op.
   createEffect(
-    on(focus.request, (req) => {
-      if (!req) return;
-      const layout = layoutOf(req.id);
+    on(focus.request, (id) => {
+      if (!id) return;
+      const layout = layoutOf(id);
       if (layout) {
         requestAnimationFrame(() => viewport.centerOnTile(layout));
       }

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -204,16 +204,14 @@ const TerminalCanvas: Component<{
           props.onLayoutChange(id, defaultLayout);
           placed.push({ id, layout: defaultLayout, isNew: true });
         }
-        // Recenter on the active newly-placed tile when there are
-        // already-placed siblings — covers "create a 2nd terminal that
-        // lands far from the current viewport (e.g. next to its repo
-        // island)". The first-mount case (no pre-existing siblings) is
-        // handled by the bbox-recenter effect below.
+        // Recenter on the active newly-placed tile. Covers both "create a
+        // 2nd terminal that lands far from the current viewport" and
+        // "create the first terminal on a previously-panned empty canvas"
+        // — both look identical from the cascade's perspective.
         const activeId = store.activeId();
-        const hadExisting = placed.some((p) => !p.isNew);
-        const recenterOn = hadExisting
-          ? placed.find((p) => p.isNew && p.id === activeId)?.layout
-          : undefined;
+        const recenterOn = placed.find(
+          (p) => p.isNew && p.id === activeId,
+        )?.layout;
         if (recenterOn) {
           requestAnimationFrame(() => viewport.centerOnTile(recenterOn));
         }
@@ -304,6 +302,25 @@ const TerminalCanvas: Component<{
       abortResize,
     );
   }
+
+  // Pan to the active tile whenever `useTerminalCrud` flags a system-driven
+  // reassignment (close → auto-switch). User-driven changes (clicks,
+  // workspace switcher) don't bump this signal — clicking a partially-
+  // visible tile shouldn't yank the viewport.
+  createEffect(
+    on(
+      store.centerActiveRequest,
+      () => {
+        const id = store.activeId();
+        if (!id) return;
+        const layout = layoutOf(id);
+        if (layout) {
+          requestAnimationFrame(() => viewport.centerOnTile(layout));
+        }
+      },
+      { defer: true },
+    ),
+  );
 
   // On first mount at the default origin, pan so the persisted active tile
   // is centered (matches what a workspace-switcher click does). If there's no

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -61,7 +61,7 @@ const TileTitleActions: Component<{
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
-              store.setActiveId(props.id);
+              store.setActiveSilently(props.id);
               rightPanel.expandPanel();
             }}
             title="Open inspector"
@@ -81,7 +81,7 @@ const TileTitleActions: Component<{
               onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation();
-                store.setActiveId(props.id);
+                store.setActiveSilently(props.id);
                 props.onOpenPaletteGroup("Theme");
                 setTimeout(
                   () => showTipOnce(CONTEXTUAL_TIPS.themeFromPalette),
@@ -104,7 +104,7 @@ const TileTitleActions: Component<{
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
-            store.setActiveId(props.id);
+            store.setActiveSilently(props.id);
             props.onToggleSubPanel(props.id);
           }}
           aria-label="Toggle split"
@@ -129,7 +129,7 @@ const TileTitleActions: Component<{
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
-            store.setActiveId(props.id);
+            store.setActiveSilently(props.id);
             props.onOpenSearch();
           }}
           aria-label="Find in terminal"

--- a/packages/client/src/canvas/useCanvasArrange.ts
+++ b/packages/client/src/canvas/useCanvasArrange.ts
@@ -103,11 +103,12 @@ export function useCanvasArrange(deps: {
     const arranged = arrangeRepoIslands(tiles);
     applyLayoutBatch(arranged);
     // Recenter on the active tile's new position so a far-away active
-    // tile doesn't end up off-screen after arrange. Routed through
-    // `requestCenterActive` (the canvas resolves the just-applied
-    // pending layout via `layoutOf`) to share the create/close path.
+    // tile doesn't end up off-screen after arrange. `activate` re-bumps
+    // the centering signal even though active hasn't changed (the canvas
+    // resolves the just-applied pending layout via `layoutOf`), so this
+    // shares the create/close path.
     const activeId = store.activeId();
-    if (activeId && arranged.has(activeId)) store.requestCenterActive(activeId);
+    if (activeId && arranged.has(activeId)) store.activate(activeId);
   }
 
   return { applyTileGeometry, placeNew, handleCanvasAutoArrange };

--- a/packages/client/src/canvas/useCanvasArrange.ts
+++ b/packages/client/src/canvas/useCanvasArrange.ts
@@ -1,11 +1,11 @@
 /** Repo-island arrange + per-create placement composition.
  *
  *  Glues the pure layout module (`repoIslands.ts`) against the live
- *  terminal store + viewport. Lives outside `App.tsx` per the
- *  "App.tsx is a thin layout shell" rule (`.claude/rules/solidjs.md`):
- *  placement is its own domain (store reads, git-race fallback, no-op
- *  skip on writes, post-arrange recenter), and that domain owns its
- *  `useXxx.ts` module like every other feature.
+ *  terminal store. Lives outside `App.tsx` per the "App.tsx is a thin
+ *  layout shell" rule (`.claude/rules/solidjs.md`): placement is its
+ *  own domain (store reads, git-race fallback, no-op skip on writes,
+ *  post-arrange recenter), and that domain owns its `useXxx.ts` module
+ *  like every other feature.
  *
  *  Two arrange concerns live here:
  *  - `placeNew(id, existing)` — per-create policy fed to TerminalCanvas.
@@ -20,17 +20,15 @@ import {
 } from "./repoIslands";
 import { layoutsEqual, type TileLayout } from "./TileLayout";
 import { usePendingLayouts } from "./usePendingLayouts";
-import type { useCanvasViewport } from "./viewport/useCanvasViewport";
 import type { useTerminalCrud } from "../terminal/useTerminalCrud";
 import type { TerminalStore } from "../terminal/useTerminalStore";
 
 export function useCanvasArrange(deps: {
   store: TerminalStore;
   crud: ReturnType<typeof useTerminalCrud>;
-  viewport: ReturnType<typeof useCanvasViewport>;
   isMobile: () => boolean;
 }) {
-  const { store, crud, viewport, isMobile } = deps;
+  const { store, crud, isMobile } = deps;
   const pendingLayouts = usePendingLayouts();
 
   /** Apply a tile's geometry — drag-end, resize-end, default-place,
@@ -105,10 +103,11 @@ export function useCanvasArrange(deps: {
     const arranged = arrangeRepoIslands(tiles);
     applyLayoutBatch(arranged);
     // Recenter on the active tile's new position so a far-away active
-    // tile doesn't end up off-screen after arrange.
+    // tile doesn't end up off-screen after arrange. Routed through
+    // `requestCenterActive` (the canvas resolves the just-applied
+    // pending layout via `layoutOf`) to share the create/close path.
     const activeId = store.activeId();
-    const activeLayout = activeId ? arranged.get(activeId) : undefined;
-    if (activeLayout) viewport.centerOnTile(activeLayout);
+    if (activeId && arranged.has(activeId)) store.requestCenterActive(activeId);
   }
 
   return { applyTileGeometry, placeNew, handleCanvasAutoArrange };

--- a/packages/client/src/canvas/useCanvasFocus.ts
+++ b/packages/client/src/canvas/useCanvasFocus.ts
@@ -1,0 +1,29 @@
+/** Canvas viewport focus — desktop only. The single public seam for
+ *  `centerActiveRequest`. Canvas readers (TerminalCanvas) import this hook
+ *  instead of reaching into `useTerminalStore`, so a future upgrade
+ *  (e.g. distinguishing "pan only" from "pan + zoom-to-fit") can be
+ *  absorbed here without rippling across every reader.
+ *
+ *  Mirrors the pattern of `useViewPosture` for `canvasMaximized`: backing
+ *  signal lives in `useViewState` (so terminal-side writers can bump it
+ *  via `store.requestCenterActive(id)` the same way they call
+ *  `store.toggleCanvasMaximized()`), but the canvas-side surface lives
+ *  in this module. */
+
+import { useTerminalStore } from "../terminal/useTerminalStore";
+
+export function useCanvasFocus() {
+  const store = useTerminalStore();
+  return {
+    /** Latest "pan to this tile" intent payload, or null if none yet.
+     *  Each call to `request` allocates a fresh wrapper so reference
+     *  inequality fires the listener even on back-to-back requests for
+     *  the same id. */
+    request: store.centerActiveRequest,
+    /** Ask the canvas to pan so the given tile is centered. Used by
+     *  system-driven flows (close → auto-switch, cascade-place new
+     *  tile); user-driven activation (clicks, workspace switcher) calls
+     *  `viewport.centerOnTile` directly instead. */
+    requestCenter: store.requestCenterActive,
+  } as const;
+}

--- a/packages/client/src/canvas/useCanvasFocus.ts
+++ b/packages/client/src/canvas/useCanvasFocus.ts
@@ -1,29 +1,23 @@
-/** Canvas viewport focus — desktop only. The single public seam for
- *  `centerActiveRequest`. Canvas readers (TerminalCanvas) import this hook
- *  instead of reaching into `useTerminalStore`, so a future upgrade
- *  (e.g. distinguishing "pan only" from "pan + zoom-to-fit") can be
- *  absorbed here without rippling across every reader.
+/** Canvas viewport focus reader — desktop only.
  *
- *  Mirrors the pattern of `useViewPosture` for `canvasMaximized`: backing
- *  signal lives in `useViewState` (so terminal-side writers can bump it
- *  via `store.requestCenterActive(id)` the same way they call
- *  `store.toggleCanvasMaximized()`), but the canvas-side surface lives
- *  in this module. */
+ *  Exposes the `centerActiveRequest` impulse signal as `request` so the
+ *  canvas can react when something elsewhere (most often `store.activate`,
+ *  occasionally the cascade-placement effect inside TerminalCanvas
+ *  itself) asks the viewport to follow a tile. There is no public writer
+ *  here — system-driven activation goes through `store.activate(id)`,
+ *  which is the single seam that owns both `setActiveId` and the
+ *  centering bump. Click/focus paths use `store.setActiveSilently(id)`.
+ *
+ *  Mirrors `useViewPosture` for `canvasMaximized`: the canvas owns the
+ *  reader-side surface; writers live on the store so terminal-side
+ *  callers don't take a reverse dep on `canvas/`. */
 
 import { useTerminalStore } from "../terminal/useTerminalStore";
 
 export function useCanvasFocus() {
   const store = useTerminalStore();
   return {
-    /** Latest "pan to this tile" intent payload, or null if none yet.
-     *  Each call to `request` allocates a fresh wrapper so reference
-     *  inequality fires the listener even on back-to-back requests for
-     *  the same id. */
+    /** Latest "pan to this tile" intent payload, or null if none yet. */
     request: store.centerActiveRequest,
-    /** Ask the canvas to pan so the given tile is centered. Used by
-     *  system-driven flows (close → auto-switch, cascade-place new
-     *  tile); user-driven activation (clicks, workspace switcher) calls
-     *  `viewport.centerOnTile` directly instead. */
-    requestCenter: store.requestCenterActive,
   } as const;
 }

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -204,12 +204,12 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
                           deps,
                           { name: `Switch to terminal ${i + 1}` },
                         ),
-                        onSelect: () => deps.setActiveId(id),
+                        onSelect: () => deps.activate(id),
                       }
                     : {
                         kind: "action",
                         name: `Switch to terminal ${i + 1}`,
-                        onSelect: () => deps.setActiveId(id),
+                        onSelect: () => deps.activate(id),
                       },
               ),
           },

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -20,11 +20,11 @@ import { type Keybind, matchesKeybind } from "./keyboard";
 export interface ActionContext {
   terminalIds: Accessor<TerminalId[]>;
   activeId: Accessor<TerminalId | null>;
-  setActiveId: Setter<TerminalId | null>;
-  /** Ask the canvas to pan so the given tile lands centered. Cycle and
-   *  positional-switch handlers call this after `setActiveId` so the
-   *  viewport follows when the new active tile is off-screen. */
-  requestCenterActive: (id: TerminalId) => void;
+  /** Make `id` the active terminal AND pan the canvas to it. The single
+   *  writer for keyboard-driven activation (cycle, positional, MRU) so
+   *  every shortcut gets viewport-follow without remembering a second
+   *  call. Mirrors `store.activate` from `useViewState`. */
+  activate: (id: TerminalId | null) => void;
   /** Terminal IDs in most-recently-used order; used for Alt+Tab / Ctrl+Tab cycling. */
   mruOrder: Accessor<TerminalId[]>;
   activeMeta: Accessor<TerminalMetadata | null>;
@@ -81,9 +81,7 @@ function cycleTerminalByPosition(ctx: ActionContext, direction: 1 | -1) {
   const next = (current + direction + ids.length) % ids.length;
   // Tuple positional `ids[0]` is statically `TerminalId`; `?? ids[0]` is
   // a typed fallback the math never actually triggers.
-  const target = ids[next] ?? ids[0];
-  ctx.setActiveId(target);
-  ctx.requestCenterActive(target);
+  ctx.activate(ids[next] ?? ids[0]);
 }
 
 /** Mod+1 through Mod+9 — direct positional terminal switch. */
@@ -99,10 +97,7 @@ const switchToActions = Object.fromEntries(
       keybind: { key: String(i), mod: true },
       handler: (ctx) => {
         const target = ctx.terminalIds()[i - 1];
-        if (target !== undefined) {
-          ctx.setActiveId(target);
-          ctx.requestCenterActive(target);
-        }
+        if (target !== undefined) ctx.activate(target);
       },
     } satisfies DispatchableAction,
   ]),

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -21,6 +21,10 @@ export interface ActionContext {
   terminalIds: Accessor<TerminalId[]>;
   activeId: Accessor<TerminalId | null>;
   setActiveId: Setter<TerminalId | null>;
+  /** Ask the canvas to pan so the given tile lands centered. Cycle and
+   *  positional-switch handlers call this after `setActiveId` so the
+   *  viewport follows when the new active tile is off-screen. */
+  requestCenterActive: (id: TerminalId) => void;
   /** Terminal IDs in most-recently-used order; used for Alt+Tab / Ctrl+Tab cycling. */
   mruOrder: Accessor<TerminalId[]>;
   activeMeta: Accessor<TerminalMetadata | null>;
@@ -77,7 +81,9 @@ function cycleTerminalByPosition(ctx: ActionContext, direction: 1 | -1) {
   const next = (current + direction + ids.length) % ids.length;
   // Tuple positional `ids[0]` is statically `TerminalId`; `?? ids[0]` is
   // a typed fallback the math never actually triggers.
-  ctx.setActiveId(ids[next] ?? ids[0]);
+  const target = ids[next] ?? ids[0];
+  ctx.setActiveId(target);
+  ctx.requestCenterActive(target);
 }
 
 /** Mod+1 through Mod+9 — direct positional terminal switch. */
@@ -93,7 +99,10 @@ const switchToActions = Object.fromEntries(
       keybind: { key: String(i), mod: true },
       handler: (ctx) => {
         const target = ctx.terminalIds()[i - 1];
-        if (target !== undefined) ctx.setActiveId(target);
+        if (target !== undefined) {
+          ctx.setActiveId(target);
+          ctx.requestCenterActive(target);
+        }
       },
     } satisfies DispatchableAction,
   ]),

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -15,7 +15,7 @@ import { matchesKeybind } from "./keyboard";
 /** MRU cycling state — a frozen snapshot is taken on the first Tab press while
  *  the modifier (Alt or Ctrl) is held, and the cursor advances through that
  *  snapshot on each subsequent Tab. Using the live MRU would re-order under
- *  our feet as setActiveId fires. Snapshot resets on modifier keyup. */
+ *  our feet as activate fires. Snapshot resets on modifier keyup. */
 interface MruCycleState {
   snapshot: TerminalId[];
   cursor: number;
@@ -49,10 +49,7 @@ export function useShortcuts(ctx: ActionContext) {
     const n = cycle.snapshot.length;
     cycle.cursor = (cycle.cursor + direction + n) % n;
     const target = cycle.snapshot[cycle.cursor];
-    if (target) {
-      ctx.setActiveId(target);
-      ctx.requestCenterActive(target);
-    }
+    if (target) ctx.activate(target);
   }
 
   makeEventListener(

--- a/packages/client/src/input/useShortcuts.ts
+++ b/packages/client/src/input/useShortcuts.ts
@@ -49,7 +49,10 @@ export function useShortcuts(ctx: ActionContext) {
     const n = cycle.snapshot.length;
     cycle.cursor = (cycle.cursor + direction + n) % n;
     const target = cycle.snapshot[cycle.cursor];
-    if (target) ctx.setActiveId(target);
+    if (target) {
+      ctx.setActiveId(target);
+      ctx.requestCenterActive(target);
+    }
   }
 
   makeEventListener(

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -106,7 +106,11 @@ export function useSessionRestore(deps: {
       serverActiveId && topIds.includes(serverActiveId as TerminalId)
         ? (serverActiveId as TerminalId)
         : (topIds[0] ?? null);
-    store.setActiveId(picked);
+    // `setActiveSilently`: the canvas's first-mount fallback effect pans
+    // the viewport to the picked active when restoring at default origin —
+    // calling `activate` here would double-pan and racing the still-
+    // assembling pendingLayouts.
+    store.setActiveSilently(picked);
 
     // Seed MRU with all top-level terminals (active first, rest in sidebar order).
     const active = store.activeId();
@@ -201,7 +205,7 @@ export function useSessionRestore(deps: {
       // Restore active terminal
       if (session.activeTerminalId) {
         const newActiveId = oldToNew.get(session.activeTerminalId);
-        if (newActiveId) store.setActiveId(newActiveId);
+        if (newActiveId) store.setActiveSilently(newActiveId);
       }
       const summary =
         resumed > 0

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -93,7 +93,7 @@ export function useTerminalCrud(deps: {
       store.setActiveId(next);
       // Pan the canvas so the auto-switched tile lands in view — without
       // this the viewport would stay centered on the just-killed tile.
-      if (next !== null) store.requestCenterActive();
+      if (next !== null) store.requestCenterActive(next);
     }
   }
 

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -89,7 +89,11 @@ export function useTerminalCrud(deps: {
     store.setMruOrder((prev) => prev.filter((x) => x !== id));
     if (store.activeId() === id) {
       const remaining = ids.filter((x) => x !== id);
-      store.setActiveId(remaining[Math.min(idx, remaining.length - 1)] ?? null);
+      const next = remaining[Math.min(idx, remaining.length - 1)] ?? null;
+      store.setActiveId(next);
+      // Pan the canvas so the auto-switched tile lands in view — without
+      // this the viewport would stay centered on the just-killed tile.
+      if (next !== null) store.requestCenterActive();
     }
   }
 

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -90,10 +90,9 @@ export function useTerminalCrud(deps: {
     if (store.activeId() === id) {
       const remaining = ids.filter((x) => x !== id);
       const next = remaining[Math.min(idx, remaining.length - 1)] ?? null;
-      store.setActiveId(next);
-      // Pan the canvas so the auto-switched tile lands in view — without
-      // this the viewport would stay centered on the just-killed tile.
-      if (next !== null) store.requestCenterActive(next);
+      // `activate` pans the canvas to the auto-switched tile — without
+      // it the viewport would stay centered on the just-killed tile.
+      store.activate(next);
     }
   }
 
@@ -135,7 +134,10 @@ export function useTerminalCrud(deps: {
         toast.error(`Failed to create terminal: ${err.message}`);
         throw err;
       });
-    store.setActiveId(info.id);
+    // `setActiveSilently`: the canvas's cascade-placement effect bumps
+    // the centering signal once the new tile's pending layout is set —
+    // calling `activate` here would race the layout and read undefined.
+    store.setActiveSilently(info.id);
     deps.subscribeExit(info.id);
     showTipOnce(CONTEXTUAL_TIPS.themeSwitch);
     return info.id;

--- a/packages/client/src/useViewState.ts
+++ b/packages/client/src/useViewState.ts
@@ -34,6 +34,17 @@ export function useViewState() {
   >({});
 
   const [mruOrder, setMruOrder] = createSignal<TerminalId[]>([]);
+
+  /** Counter signal bumped when the system (not the user) reassigns the
+   *  active tile and wants the canvas viewport to follow — e.g. the
+   *  auto-switch after closing the active terminal. A direct
+   *  `centerOnTile` call from `useTerminalCrud` would reach across the
+   *  terminal → canvas layer; the signal lets the canvas effect own the
+   *  pan and keeps `useTerminalCrud` free of viewport deps. */
+  const [centerActiveRequest, setCenterActiveRequest] = createSignal(0);
+  function requestCenterActive() {
+    setCenterActiveRequest((n) => n + 1);
+  }
   createEffect(
     on(activeId, (id) => {
       if (id === null) return;
@@ -96,6 +107,8 @@ export function useViewState() {
     toggleCanvasMaximized,
     mruOrder,
     setMruOrder,
+    centerActiveRequest,
+    requestCenterActive,
     markUnread,
     markBadgeAttention,
     clearBadgeAttention,

--- a/packages/client/src/useViewState.ts
+++ b/packages/client/src/useViewState.ts
@@ -35,26 +35,14 @@ export function useViewState() {
 
   const [mruOrder, setMruOrder] = createSignal<TerminalId[]>([]);
 
-  /** Impulse signal — not view state. The other signals here describe
-   *  current truth (which tile is active, which need attention, whether
-   *  the canvas is maximized); this one carries a one-shot "pan to this
-   *  tile" intent the canvas consumes once and discards. It lives on the
-   *  store so terminal-side writers can bump it without taking a
-   *  reverse dep on `canvas/`; the canvas-side seam is `useCanvasFocus`
-   *  (`canvas/useCanvasFocus.ts`), which is where new canvas readers
-   *  should go.
-   *
-   *  The payload carries the target tile id explicitly so the consumer
-   *  doesn't have to re-read `activeId` as a side-channel (and risk
-   *  panning to the wrong tile if a future caller forgets to update
-   *  `activeId` first). Each call allocates a fresh wrapper so reference
-   *  inequality fires the listener even on back-to-back requests for
-   *  the same id. */
-  const [centerActiveRequest, setCenterActiveRequest] = createSignal<{
-    id: TerminalId;
-  } | null>(null);
+  /** Impulse signal — see `canvas/useCanvasFocus.ts` for the seam and
+   *  the contract. Lives on the store so terminal-side writers can bump
+   *  it without taking a reverse dep on `canvas/`. `equals: false` so
+   *  back-to-back requests for the same id still fire the listener. */
+  const [centerActiveRequest, setCenterActiveRequest] =
+    createSignal<TerminalId | null>(null, { equals: false });
   function requestCenterActive(id: TerminalId) {
-    setCenterActiveRequest({ id });
+    setCenterActiveRequest(id);
   }
   createEffect(
     on(activeId, (id) => {

--- a/packages/client/src/useViewState.ts
+++ b/packages/client/src/useViewState.ts
@@ -35,15 +35,35 @@ export function useViewState() {
 
   const [mruOrder, setMruOrder] = createSignal<TerminalId[]>([]);
 
-  /** Impulse signal — see `canvas/useCanvasFocus.ts` for the seam and
-   *  the contract. Lives on the store so terminal-side writers can bump
-   *  it without taking a reverse dep on `canvas/`. `equals: false` so
-   *  back-to-back requests for the same id still fire the listener. */
+  /** Canvas "pan to this tile" intent — see `canvas/useCanvasFocus.ts`
+   *  for the consumer seam. `equals: false` so back-to-back requests for
+   *  the same id still fire the listener. Public reads only; the writer
+   *  is private — external callers go through `activate(id)` instead, so
+   *  there is no two-call dance to forget. */
   const [centerActiveRequest, setCenterActiveRequest] =
     createSignal<TerminalId | null>(null, { equals: false });
-  function requestCenterActive(id: TerminalId) {
-    setCenterActiveRequest(id);
+
+  /** Make `id` the active terminal AND ask the canvas viewport to pan to
+   *  it. The single public writer for system-driven activation — close
+   *  auto-switch, post-create centering, palette / switcher / keyboard
+   *  navigation, post-arrange recenter. Adding a new activation path
+   *  means calling this; there is no separate "request centering" the
+   *  caller can forget.
+   *
+   *  Use {@link setActiveSilently} only for the small set of callers
+   *  where the tile is already on screen by construction (in-canvas tile
+   *  click, focus events, title-bar buttons, mobile pager) or where there
+   *  is no canvas to pan (mobile, session restore — initial-mount
+   *  fallback handles centering). */
+  function activate(id: TerminalId | null) {
+    setActiveId(id);
+    if (id !== null) setCenterActiveRequest(id);
   }
+
+  /** Set the active terminal without panning the canvas. Reserve for
+   *  callers that have a domain reason not to pan; use {@link activate}
+   *  by default. */
+  const setActiveSilently = setActiveId;
   createEffect(
     on(activeId, (id) => {
       if (id === null) return;
@@ -101,13 +121,13 @@ export function useViewState() {
 
   return {
     activeId,
-    setActiveId,
+    activate,
+    setActiveSilently,
     canvasMaximized,
     toggleCanvasMaximized,
     mruOrder,
     setMruOrder,
     centerActiveRequest,
-    requestCenterActive,
     markUnread,
     markBadgeAttention,
     clearBadgeAttention,

--- a/packages/client/src/useViewState.ts
+++ b/packages/client/src/useViewState.ts
@@ -35,15 +35,19 @@ export function useViewState() {
 
   const [mruOrder, setMruOrder] = createSignal<TerminalId[]>([]);
 
-  /** Counter signal bumped when the system (not the user) reassigns the
-   *  active tile and wants the canvas viewport to follow — e.g. the
-   *  auto-switch after closing the active terminal. A direct
-   *  `centerOnTile` call from `useTerminalCrud` would reach across the
-   *  terminal → canvas layer; the signal lets the canvas effect own the
-   *  pan and keeps `useTerminalCrud` free of viewport deps. */
-  const [centerActiveRequest, setCenterActiveRequest] = createSignal(0);
-  function requestCenterActive() {
-    setCenterActiveRequest((n) => n + 1);
+  /** Signal bumped when the system (not the user) reassigns the active
+   *  tile and wants the canvas viewport to follow — e.g. the auto-switch
+   *  after closing the active terminal. The payload carries the target
+   *  tile id explicitly so the consumer doesn't have to re-read
+   *  `activeId` as a side-channel (and risk panning to the wrong tile if
+   *  a future caller forgets to update `activeId` first). Each call
+   *  allocates a new wrapper so reference inequality fires the listener
+   *  even when the same id is requested back-to-back. */
+  const [centerActiveRequest, setCenterActiveRequest] = createSignal<{
+    id: TerminalId;
+  } | null>(null);
+  function requestCenterActive(id: TerminalId) {
+    setCenterActiveRequest({ id });
   }
   createEffect(
     on(activeId, (id) => {

--- a/packages/client/src/useViewState.ts
+++ b/packages/client/src/useViewState.ts
@@ -35,14 +35,21 @@ export function useViewState() {
 
   const [mruOrder, setMruOrder] = createSignal<TerminalId[]>([]);
 
-  /** Signal bumped when the system (not the user) reassigns the active
-   *  tile and wants the canvas viewport to follow — e.g. the auto-switch
-   *  after closing the active terminal. The payload carries the target
-   *  tile id explicitly so the consumer doesn't have to re-read
-   *  `activeId` as a side-channel (and risk panning to the wrong tile if
-   *  a future caller forgets to update `activeId` first). Each call
-   *  allocates a new wrapper so reference inequality fires the listener
-   *  even when the same id is requested back-to-back. */
+  /** Impulse signal — not view state. The other signals here describe
+   *  current truth (which tile is active, which need attention, whether
+   *  the canvas is maximized); this one carries a one-shot "pan to this
+   *  tile" intent the canvas consumes once and discards. It lives on the
+   *  store so terminal-side writers can bump it without taking a
+   *  reverse dep on `canvas/`; the canvas-side seam is `useCanvasFocus`
+   *  (`canvas/useCanvasFocus.ts`), which is where new canvas readers
+   *  should go.
+   *
+   *  The payload carries the target tile id explicitly so the consumer
+   *  doesn't have to re-read `activeId` as a side-channel (and risk
+   *  panning to the wrong tile if a future caller forgets to update
+   *  `activeId` first). Each call allocates a fresh wrapper so reference
+   *  inequality fires the listener even on back-to-back requests for
+   *  the same id. */
   const [centerActiveRequest, setCenterActiveRequest] = createSignal<{
     id: TerminalId;
   } | null>(null);

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -53,6 +53,15 @@ Feature: Canvas workspace
     And canvas tile 3 should be below canvas tile 1 in the same column
     And no two canvas tiles should overlap
 
+  Scenario: Second terminal created at the default viewport is centered in the viewport
+    # Regression: with no prior pan, creating a 2nd tile placed it next to
+    # the existing tile but left the viewport centered on the original —
+    # so the new (active) tile rendered half off-screen.
+    Then there should be 1 canvas tile
+    When I create a terminal
+    Then there should be 2 canvas tiles
+    And the active canvas tile should be centered in the viewport
+
   Scenario: First terminal created on an emptied canvas is centered in the viewport
     Then there should be 1 canvas tile
     When I scroll the wheel over the canvas background

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -53,6 +53,26 @@ Feature: Canvas workspace
     And canvas tile 3 should be below canvas tile 1 in the same column
     And no two canvas tiles should overlap
 
+  Scenario: First terminal created on an emptied canvas is centered in the viewport
+    Then there should be 1 canvas tile
+    When I scroll the wheel over the canvas background
+    Then the canvas transform should have changed
+    When I click the close button on canvas tile 1
+    Then the close confirmation should be visible
+    When I confirm close all in the close confirmation
+    Then there should be 0 canvas tiles
+    When I create a terminal
+    Then there should be 1 canvas tile
+    And the active canvas tile should be centered in the viewport
+
+  Scenario: Closing the active terminal pans the canvas to the auto-switched tile
+    Given I create a terminal
+    And I create a terminal
+    Then there should be 3 canvas tiles
+    When I close terminal 2 via tile close button
+    Then there should be 2 canvas tiles
+    And the active canvas tile should be centered in the viewport
+
   Scenario: Scroll on terminal does not pan the canvas
     When I record the canvas transform
     And I scroll the wheel over the terminal tile

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -108,6 +108,19 @@ Feature: Canvas workspace
     When I press Control+Shift+BracketRight
     Then the active canvas tile should be centered in the viewport
 
+  Scenario: Command palette "Switch to terminal" pans the canvas to the newly-active tile
+    # Caught by hickey: commands.ts:207,212 spreads actionPaletteCommand then
+    # overrides onSelect with bare setActiveId(id), stripping the centering
+    # the action handler already does.
+    Given I create a terminal
+    And I create a terminal
+    And I create a terminal
+    Then there should be 4 canvas tiles
+    When I open the command palette
+    And I select "Switch terminal" in the palette
+    And I select "Switch to terminal 1" in the palette
+    Then the active canvas tile should be centered in the viewport
+
   Scenario: First terminal created on an emptied canvas is centered in the viewport
     Then there should be 1 canvas tile
     When I scroll the wheel over the canvas background

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -62,6 +62,52 @@ Feature: Canvas workspace
     Then there should be 2 canvas tiles
     And the active canvas tile should be centered in the viewport
 
+  Scenario: Each successive terminal create centers the viewport on the new active tile
+    # Reported by user with a 5-tile screenshot: after creating multiple
+    # tiles in succession, the viewport stayed anchored on the original
+    # tile while the active jumped to the latest. The active (last-created)
+    # tile must end up centered, not just the first.
+    Then there should be 1 canvas tile
+    When I create a terminal
+    Then there should be 2 canvas tiles
+    And the active canvas tile should be centered in the viewport
+    When I create a terminal
+    Then there should be 3 canvas tiles
+    And the active canvas tile should be centered in the viewport
+    When I create a terminal
+    Then there should be 4 canvas tiles
+    And the active canvas tile should be centered in the viewport
+    When I create a terminal
+    Then there should be 5 canvas tiles
+    And the active canvas tile should be centered in the viewport
+
+  Scenario: Ctrl+Tab cycle pans the canvas to the newly-active tile
+    # Reported by user: cycling with Ctrl+Tab (or Alt+Tab on macOS Chrome)
+    # changed the active terminal but the viewport stayed put — the new
+    # active tile could land off-screen entirely.
+    Given I create a terminal
+    And I create a terminal
+    And I create a terminal
+    Then there should be 4 canvas tiles
+    When I press Control+Tab
+    Then the active canvas tile should be centered in the viewport
+
+  Scenario: Cmd+1 positional switch pans the canvas to the newly-active tile
+    Given I create a terminal
+    And I create a terminal
+    And I create a terminal
+    Then there should be 4 canvas tiles
+    When I press Control+1
+    Then the active canvas tile should be centered in the viewport
+
+  Scenario: Ctrl+Shift+] next-terminal pans the canvas to the newly-active tile
+    Given I create a terminal
+    And I create a terminal
+    And I create a terminal
+    Then there should be 4 canvas tiles
+    When I press Control+Shift+BracketRight
+    Then the active canvas tile should be centered in the viewport
+
   Scenario: First terminal created on an emptied canvas is centered in the viewport
     Then there should be 1 canvas tile
     When I scroll the wheel over the canvas background

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -230,9 +230,13 @@ async function newScenarioPage(
       previousContext = undefined;
     }
     const context = await browser.newContext({
+      // 1920×1080 matches a typical desktop monitor — the previous 1280×720
+      // default hid viewport-size-dependent bugs (e.g. the canvas
+      // centering math behaves differently when the tile is small relative
+      // to the viewport vs nearly filling it).
       viewport: isMobile
         ? { width: 390, height: 844 }
-        : { width: 1280, height: 720 },
+        : { width: 1920, height: 1080 },
       ...(isMobile && { hasTouch: true, isMobile: true }),
       baseURL: baseUrl,
       ignoreHTTPSErrors: true,


### PR DESCRIPTION
**The active canvas tile now lands centered after the system reassigns it** — closing the active terminal pans the viewport to the auto-promoted sibling, and creating the first tile on a previously-panned empty canvas pans to the new tile. Before, both cases left the active tile off-screen unless the viewport happened to be at its default origin.

| Trigger | Before | After |
| --- | --- | --- |
| Close active tile (3 open) | Viewport stayed centered on the just-killed tile | Pans to the auto-promoted next-active |
| Create first tile after panning | New tile placed at viewport center but not centered after a pan | Pans to the new tile |

### Why both at once

The two cases looked identical from the canvas's perspective: the system reassigned the active tile and nothing pulled the viewport along. The cascade-placement effect's recenter was gated on `hadExisting`, so the empty-canvas first-create case skipped it; the close path had no recenter at all. Both reduce to "pan to the active tile when the system, not the user, picked it."

### Seam

A new impulse signal in `useViewState` carries the target tile id; canvas-side reads go through `useCanvasFocus` (mirrors the `useViewPosture` / `canvasMaximized` precedent for canvas display state). One `createEffect` in `TerminalCanvas` is now the sole place that turns the intent into a `viewport.centerOnTile` call.

```
useTerminalCrud.removeAndAutoSwitch ─┐
TerminalCanvas cascade-place        ─┼─▶ store.requestCenterActive(id) ─▶ focus.request ─▶ viewport.centerOnTile
useCanvasArrange post-arrange       ─┤
WorkspaceSwitcher.onSelect          ─┤
handleCanvasCenterActive (palette)  ─┘
```

Pre-existing centering call sites (palette command, workspace-switcher click, post-arrange) were also routed through the new seam — _the unification was the whole point of having one_. Tile clicks and gesture pans deliberately don't bump it; clicking a partially-visible tile shouldn't yank the viewport.

### Tests

Two new e2e scenarios in `canvas.feature` — one per bug, both confirmed failing on master before the fix. The full canvas + workspace-switcher + kill + terminal + sub-terminal suites (80 scenarios) pass on this branch.

### Try it locally

```sh
nix run github:juspay/kolu/fix/center-active-tile-on-close-and-empty-create
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._