### PR TITLE
Link terminal file references to code browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open http://127.0.0.1:7681 (or the address you chose above).
 - Create, switch, and kill terminals — every terminal renders as a draggable tile on the canvas, with a floating workspace switcher for at-a-glance navigation
 - Split terminals — <kbd>Ctrl+&#96;</kbd> splits a bottom pane per terminal; <kbd>Ctrl+Shift+&#96;</kbd> adds tabs, <kbd>Ctrl+PageDown</kbd> / <kbd>Ctrl+PageUp</kbd> cycles
 - Font zoom (<kbd>Cmd/Ctrl</kbd> <kbd>+</kbd>/<kbd>-</kbd>), persisted per terminal across sessions
-- WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
+- WebGL rendering with canvas fallback, clickable URLs and repo file references, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Lazy attach — late-joining clients receive serialized screen state (~4KB) instead of replaying raw buffer
 - Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap. Touch-swipe inside the terminal scrolls the scrollback buffer
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -42,6 +42,7 @@ import MobileKeyBar from "./MobileKeyBar";
 import MobileTileView from "./MobileTileView";
 import { useRecorder } from "./recorder/useRecorder";
 import WebcamOverlay from "./recorder/WebcamOverlay";
+import { openCodeReference } from "./right-panel/codeReferenceNavigation";
 import RightPanelLayout from "./right-panel/RightPanelLayout";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import { client } from "./wire";
@@ -55,6 +56,7 @@ import TerminalContent from "./terminal/TerminalContent";
 import TerminalMeta from "./terminal/TerminalMeta";
 import { useSubPanel } from "./terminal/useSubPanel";
 import { useTerminals } from "./terminal/useTerminals";
+import type { LineRef } from "./ui/lineRef";
 import ModalDialog, { refocusTerminal } from "./ui/ModalDialog";
 import { isMobile } from "./useMobile";
 import { useThemeManager } from "./useThemeManager";
@@ -176,6 +178,14 @@ const App: Component = () => {
     if (isMobile()) return;
     const id = store.activeId();
     if (id) store.activate(id);
+  }
+
+  function handleOpenCodeReference(terminalId: TerminalId, ref: LineRef) {
+    const meta = store.getMetadata(terminalId);
+    if (!meta) return;
+    if (openCodeReference({ terminalId, metadata: meta, ref })) {
+      store.setActiveSilently(meta.parentId ?? terminalId);
+    }
   }
 
   const arrange = useCanvasArrange({
@@ -318,6 +328,7 @@ const App: Component = () => {
         onCloseTerminal={closeTerminal}
         activeMeta={store.activeMeta()}
         onFocus={() => store.setActiveSilently(id)}
+        onOpenCodeReference={handleOpenCodeReference}
       />
     );
   }
@@ -340,6 +351,7 @@ const App: Component = () => {
         }
         onCloseTerminal={closeTerminal}
         activeMeta={store.activeMeta()}
+        onOpenCodeReference={handleOpenCodeReference}
       />
     );
   }

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -183,7 +183,7 @@ const App: Component = () => {
   function handleOpenCodeReference(terminalId: TerminalId, ref: LineRef) {
     const meta = store.getMetadata(terminalId);
     if (!meta) return;
-    if (openCodeReference({ terminalId, metadata: meta, ref })) {
+    if (openCodeReference({ metadata: meta, ref })) {
       store.setActiveSilently(meta.parentId ?? terminalId);
     }
   }

--- a/packages/client/src/right-panel/BrowseFileView.tsx
+++ b/packages/client/src/right-panel/BrowseFileView.tsx
@@ -6,6 +6,7 @@
  *  avoids stomping scroll position on no-op ticks. */
 
 import { FileView, Virtualizer } from "@kolu/solid-pierre";
+import type { SelectedLineRange } from "@pierre/diffs";
 import { type Component, Match, Show, Switch } from "solid-js";
 import { toast } from "solid-sonner";
 import { pierreDiffsStyle } from "../ui/pierreTheme";
@@ -16,6 +17,8 @@ export type BrowseFileViewProps = {
   repoPath: string;
   filePath: string;
   theme: "light" | "dark";
+  selectedLines?: SelectedLineRange | null;
+  onLineSelected?: (range: SelectedLineRange | null) => void;
 };
 
 const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
@@ -41,7 +44,11 @@ const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
                 File truncated (exceeds 1 MB)
               </div>
             </Show>
-            <CodeMenuFrame path={props.filePath}>
+            <CodeMenuFrame
+              path={props.filePath}
+              selectedLines={props.selectedLines}
+              onLineSelected={props.onLineSelected}
+            >
               {(selection) => (
                 // `<Virtualizer>` upgrades `<FileView>` to Pierre's
                 // `VirtualizedFile` for very large files
@@ -57,6 +64,7 @@ const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
                     theme={props.theme}
                     overflow="wrap"
                     enableLineSelection
+                    selectedLines={props.selectedLines}
                     onLineSelected={selection.handleSelect}
                     onError={(err) =>
                       toast.error(`File render failed: ${err.message}`)

--- a/packages/client/src/right-panel/BrowseFileView.tsx
+++ b/packages/client/src/right-panel/BrowseFileView.tsx
@@ -17,8 +17,7 @@ export type BrowseFileViewProps = {
   repoPath: string;
   filePath: string;
   theme: "light" | "dark";
-  selectedLines?: SelectedLineRange | null;
-  onLineSelected?: (range: SelectedLineRange | null) => void;
+  initialSelectedLines?: SelectedLineRange | null;
 };
 
 const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
@@ -46,8 +45,7 @@ const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
             </Show>
             <CodeMenuFrame
               path={props.filePath}
-              selectedLines={props.selectedLines}
-              onLineSelected={props.onLineSelected}
+              initialSelectedLines={props.initialSelectedLines}
             >
               {(selection) => (
                 // `<Virtualizer>` upgrades `<FileView>` to Pierre's
@@ -64,7 +62,7 @@ const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
                     theme={props.theme}
                     overflow="wrap"
                     enableLineSelection
-                    selectedLines={props.selectedLines}
+                    selectedLines={selection.range()}
                     onLineSelected={selection.handleSelect}
                     onError={(err) =>
                       toast.error(`File render failed: ${err.message}`)

--- a/packages/client/src/right-panel/CodeMenuFrame.tsx
+++ b/packages/client/src/right-panel/CodeMenuFrame.tsx
@@ -6,6 +6,7 @@
  *  selection range stays in sync with what the menu offers. */
 
 import type { Component, JSX } from "solid-js";
+import type { SelectedLineRange } from "@pierre/diffs";
 import {
   CodeContextMenu,
   type CodeContextMenuController,
@@ -20,11 +21,16 @@ export type CodeMenuFrameProps = {
   /** Render the inner Pierre viewer. Pass `selection.handleSelect` to its
    *  `onLineSelected` prop so range updates reach the menu. */
   children: (selection: LineSelection) => JSX.Element;
+  selectedLines?: SelectedLineRange | null;
+  onLineSelected?: (range: SelectedLineRange | null) => void;
 };
 
 export const CodeMenuFrame: Component<CodeMenuFrameProps> = (props) => {
   let menuCtrl: CodeContextMenuController | undefined;
-  const selection = useLineSelection(() => props.path);
+  const selection = useLineSelection(() => props.path, {
+    range: () => props.selectedLines,
+    onRangeChange: props.onLineSelected,
+  });
   return (
     <div
       // Attach contextmenu via addEventListener so the host div doesn't

--- a/packages/client/src/right-panel/CodeMenuFrame.tsx
+++ b/packages/client/src/right-panel/CodeMenuFrame.tsx
@@ -21,15 +21,13 @@ export type CodeMenuFrameProps = {
   /** Render the inner Pierre viewer. Pass `selection.handleSelect` to its
    *  `onLineSelected` prop so range updates reach the menu. */
   children: (selection: LineSelection) => JSX.Element;
-  selectedLines?: SelectedLineRange | null;
-  onLineSelected?: (range: SelectedLineRange | null) => void;
+  initialSelectedLines?: SelectedLineRange | null;
 };
 
 export const CodeMenuFrame: Component<CodeMenuFrameProps> = (props) => {
   let menuCtrl: CodeContextMenuController | undefined;
   const selection = useLineSelection(() => props.path, {
-    range: () => props.selectedLines,
-    onRangeChange: props.onLineSelected,
+    initialRange: () => props.initialSelectedLines,
   });
   return (
     <div

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -75,11 +75,6 @@ const BinaryFileHint: Component<{ fileName: string | null }> = (props) => (
   </div>
 );
 
-type SelectedFile = {
-  path: string;
-  selectedLines?: SelectedLineRange | null;
-};
-
 type PendingCodeRef = {
   id: number;
   ref: LineRef;
@@ -96,15 +91,14 @@ type CodeBrowseTarget = {
 const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
-  const [diffSelectedFile, setDiffSelectedFile] =
-    createSignal<SelectedFile | null>(null);
+  const [diffSelectedPath, setDiffSelectedPath] = createSignal<string | null>(
+    null,
+  );
   const [browseTarget, setBrowseTarget] = createSignal<CodeBrowseTarget | null>(
     null,
   );
   const selectedPath = () =>
-    isDiffView()
-      ? (diffSelectedFile()?.path ?? null)
-      : (browseTarget()?.selectedPath ?? null);
+    isDiffView() ? diffSelectedPath() : (browseTarget()?.selectedPath ?? null);
   const selectedLines = () =>
     isDiffView() ? null : (browseTarget()?.selectedLines ?? null);
 
@@ -227,7 +221,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     on(
       resetKey,
       () => {
-        setDiffSelectedFile(null);
+        setDiffSelectedPath(null);
         if (!codeReferenceRequest()) setBrowseTarget(null);
         setSearchQuery("");
       },
@@ -265,7 +259,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
       ([path, pathExists]) => {
         if (path && !pathExists) {
           if (isDiffView()) {
-            setDiffSelectedFile(null);
+            setDiffSelectedPath(null);
           } else {
             setBrowseTarget((current) =>
               current
@@ -294,7 +288,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     // selected file survive right-panel tab toggles (#818).
     if (path === null) return;
     if (isDiffView()) {
-      setDiffSelectedFile({ path });
+      setDiffSelectedPath(path);
       return;
     }
     const repo = repoPath();

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -14,6 +14,7 @@
  * Pierre lifecycle; this component is just data flow + chrome. */
 
 import { FileDiff, FileTree, Virtualizer } from "@kolu/solid-pierre";
+import type { SelectedLineRange } from "@pierre/diffs";
 import type { GitDiffMode } from "kolu-git/schemas";
 import type { TerminalMetadata } from "kolu-common/surface";
 import {
@@ -39,7 +40,12 @@ import {
   pierreIconConfig,
   pierreTreesStyle,
 } from "../ui/pierreTheme";
+import { resolveLineRefPath } from "../ui/lineRef";
 import BrowseFileView from "./BrowseFileView";
+import {
+  clearCodeReferenceRequest,
+  codeReferenceRequest,
+} from "./codeReferenceNavigation";
 import CodeMenuFrame from "./CodeMenuFrame";
 import { projectFileTreeSearch } from "./fileSearch";
 import FileSearchInput from "./FileSearchInput";
@@ -69,10 +75,20 @@ const BinaryFileHint: Component<{ fileName: string | null }> = (props) => (
   </div>
 );
 
+type SelectedFile = {
+  path: string;
+  selectedLines?: SelectedLineRange | null;
+};
+
 const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
-  const [selectedPath, setSelectedPath] = createSignal<string | null>(null);
+  const [selectedFile, setSelectedFile] = createSignal<SelectedFile | null>(
+    null,
+  );
+  const [browseRepoPath, setBrowseRepoPath] = createSignal<string | null>(null);
+  const selectedPath = () => selectedFile()?.path ?? null;
+  const selectedLines = () => selectedFile()?.selectedLines ?? null;
 
   // Read `codeMode` directly rather than projecting it from `activeTab`.
   // CodeTab now stays mounted across the Inspector tab toggle (#818); a
@@ -84,10 +100,24 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const view = rightPanel.codeMode;
   const setView = rightPanel.setCodeMode;
 
-  const repoPath = () => props.meta?.git?.repoRoot ?? null;
+  const activeRepoPath = () => props.meta?.git?.repoRoot ?? null;
+  const repoPath = () =>
+    view() === "browse"
+      ? (browseRepoPath() ?? activeRepoPath())
+      : activeRepoPath();
   const isDiffView = () => view() !== "browse";
   const diffMode = (): GitDiffMode | undefined =>
     view() === "browse" ? undefined : (view() as GitDiffMode);
+
+  createEffect(
+    on(
+      activeRepoPath,
+      () => {
+        if (!codeReferenceRequest()) setBrowseRepoPath(null);
+      },
+      { defer: true },
+    ),
+  );
 
   // Filename filter — drives Pierre's tree filter externally. Reset on
   // mode switch so a stale needle doesn't hide the wrong file set.
@@ -178,7 +208,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     on(
       resetKey,
       () => {
-        setSelectedPath(null);
+        setSelectedFile(null);
         setSearchQuery("");
       },
       { defer: true },
@@ -213,7 +243,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         return [s, !s || isPending || paths.includes(s)] as const;
       },
       ([path, pathExists]) => {
-        if (path && !pathExists) setSelectedPath(null);
+        if (path && !pathExists) setSelectedFile(null);
       },
       { defer: true },
     ),
@@ -232,8 +262,51 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     // ignore null and only honor explicit non-null selections. Keeping
     // the previous signal value through Pierre's internal churn lets the
     // selected file survive right-panel tab toggles (#818).
-    if (path !== null) setSelectedPath(path);
+    if (path !== null) setSelectedFile({ path });
   };
+
+  createEffect(
+    on(
+      () => {
+        const request = codeReferenceRequest();
+        return {
+          request,
+          view: view(),
+          repoPath: repoPath(),
+          paths: treePaths(),
+          pending: allPaths.pending(),
+        };
+      },
+      ({ request, view, repoPath, paths, pending }) => {
+        if (!request || view !== "browse") return;
+        if (browseRepoPath() !== request.repoRoot) {
+          setBrowseRepoPath(request.repoRoot);
+          return;
+        }
+        if (repoPath !== request.repoRoot || pending) return;
+
+        const path = resolveLineRefPath({
+          rawPath: request.ref.path,
+          repoRoot: request.repoRoot,
+          cwd: request.cwd,
+          repoPaths: paths,
+        });
+        if (!path) {
+          toast.error(`File reference not found: ${request.ref.path}`);
+          clearCodeReferenceRequest(request.id);
+          return;
+        }
+
+        setSearchQuery("");
+        setSelectedFile({
+          path,
+          selectedLines: { start: request.ref.start, end: request.ref.end },
+        });
+        clearCodeReferenceRequest(request.id);
+      },
+      { defer: true },
+    ),
+  );
 
   const treeError = (): Error | undefined =>
     isDiffView() ? status.error() : allPaths.error();
@@ -468,6 +541,14 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                         repoPath={repo}
                         filePath={path}
                         theme={diffTheme()}
+                        selectedLines={selectedLines()}
+                        onLineSelected={(range) =>
+                          setSelectedFile((current) =>
+                            current?.path === path
+                              ? { ...current, selectedLines: range }
+                              : current,
+                          )
+                        }
                       />
                     );
                   })()}

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -603,14 +603,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                         repoPath={repo}
                         filePath={path}
                         theme={diffTheme()}
-                        selectedLines={selectedLines()}
-                        onLineSelected={(range) =>
-                          setBrowseTarget((current) =>
-                            current?.selectedPath === path
-                              ? { ...current, selectedLines: range }
-                              : current,
-                          )
-                        }
+                        initialSelectedLines={selectedLines()}
                       />
                     );
                   })()}

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -40,7 +40,7 @@ import {
   pierreIconConfig,
   pierreTreesStyle,
 } from "../ui/pierreTheme";
-import { resolveLineRefPath } from "../ui/lineRef";
+import { type LineRef, resolveLineRefPath } from "../ui/lineRef";
 import BrowseFileView from "./BrowseFileView";
 import {
   clearCodeReferenceRequest,
@@ -80,15 +80,33 @@ type SelectedFile = {
   selectedLines?: SelectedLineRange | null;
 };
 
+type PendingCodeRef = {
+  id: number;
+  ref: LineRef;
+};
+
+type CodeBrowseTarget = {
+  repoRoot: string;
+  cwd: string | undefined;
+  selectedPath: string | null;
+  selectedLines?: SelectedLineRange | null;
+  pendingRef?: PendingCodeRef | null;
+};
+
 const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
-  const [selectedFile, setSelectedFile] = createSignal<SelectedFile | null>(
+  const [diffSelectedFile, setDiffSelectedFile] =
+    createSignal<SelectedFile | null>(null);
+  const [browseTarget, setBrowseTarget] = createSignal<CodeBrowseTarget | null>(
     null,
   );
-  const [browseRepoPath, setBrowseRepoPath] = createSignal<string | null>(null);
-  const selectedPath = () => selectedFile()?.path ?? null;
-  const selectedLines = () => selectedFile()?.selectedLines ?? null;
+  const selectedPath = () =>
+    isDiffView()
+      ? (diffSelectedFile()?.path ?? null)
+      : (browseTarget()?.selectedPath ?? null);
+  const selectedLines = () =>
+    isDiffView() ? null : (browseTarget()?.selectedLines ?? null);
 
   // Read `codeMode` directly rather than projecting it from `activeTab`.
   // CodeTab now stays mounted across the Inspector tab toggle (#818); a
@@ -103,7 +121,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const activeRepoPath = () => props.meta?.git?.repoRoot ?? null;
   const repoPath = () =>
     view() === "browse"
-      ? (browseRepoPath() ?? activeRepoPath())
+      ? (browseTarget()?.repoRoot ?? activeRepoPath())
       : activeRepoPath();
   const isDiffView = () => view() !== "browse";
   const diffMode = (): GitDiffMode | undefined =>
@@ -113,7 +131,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     on(
       activeRepoPath,
       () => {
-        if (!codeReferenceRequest()) setBrowseRepoPath(null);
+        if (!codeReferenceRequest()) setBrowseTarget(null);
       },
       { defer: true },
     ),
@@ -200,15 +218,17 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   //
   // `::` is collision-safe as the separator: `view()` is a typed enum
   // (`"browse" | "local" | "branch"`) so it can't contain `::`, and
-  // `repoPath()` is `props.meta?.git?.repoRoot ?? null` — a real
+  // `activeRepoPath()` is `props.meta?.git?.repoRoot ?? null` — a real
   // absolute path or `null`, never the empty string that would alias
-  // null.
-  const resetKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
+  // null. Browse-target repo switches are excluded from this reset key:
+  // they are explicit navigation commands and carry their own selection.
+  const resetKey = createMemo(() => `${activeRepoPath() ?? ""}::${view()}`);
   createEffect(
     on(
       resetKey,
       () => {
-        setSelectedFile(null);
+        setDiffSelectedFile(null);
+        if (!codeReferenceRequest()) setBrowseTarget(null);
         setSearchQuery("");
       },
       { defer: true },
@@ -243,7 +263,17 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         return [s, !s || isPending || paths.includes(s)] as const;
       },
       ([path, pathExists]) => {
-        if (path && !pathExists) setSelectedFile(null);
+        if (path && !pathExists) {
+          if (isDiffView()) {
+            setDiffSelectedFile(null);
+          } else {
+            setBrowseTarget((current) =>
+              current
+                ? { ...current, selectedPath: null, selectedLines: null }
+                : current,
+            );
+          }
+        }
       },
       { defer: true },
     ),
@@ -262,47 +292,79 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     // ignore null and only honor explicit non-null selections. Keeping
     // the previous signal value through Pierre's internal churn lets the
     // selected file survive right-panel tab toggles (#818).
-    if (path !== null) setSelectedFile({ path });
+    if (path === null) return;
+    if (isDiffView()) {
+      setDiffSelectedFile({ path });
+      return;
+    }
+    const repo = repoPath();
+    if (!repo) return;
+    setBrowseTarget((current) => ({
+      repoRoot: current?.repoRoot ?? repo,
+      cwd: current?.cwd ?? props.meta?.cwd,
+      selectedPath: path,
+      selectedLines: null,
+      pendingRef: null,
+    }));
   };
 
   createEffect(
     on(
       () => {
         const request = codeReferenceRequest();
+        const target = browseTarget();
         return {
           request,
+          target,
           view: view(),
           repoPath: repoPath(),
           paths: treePaths(),
           pending: allPaths.pending(),
         };
       },
-      ({ request, view, repoPath, paths, pending }) => {
-        if (!request || view !== "browse") return;
-        if (browseRepoPath() !== request.repoRoot) {
-          setBrowseRepoPath(request.repoRoot);
+      ({ request, target, view, repoPath, paths, pending }) => {
+        if (
+          request &&
+          (target?.pendingRef?.id !== request.id ||
+            target.repoRoot !== request.repoRoot)
+        ) {
+          setSearchQuery("");
+          setBrowseTarget({
+            repoRoot: request.repoRoot,
+            cwd: request.cwd,
+            selectedPath: null,
+            selectedLines: null,
+            pendingRef: { id: request.id, ref: request.ref },
+          });
           return;
         }
-        if (repoPath !== request.repoRoot || pending) return;
+        const pendingRef = target?.pendingRef;
+        if (!target || !pendingRef || view !== "browse") return;
+        if (repoPath !== target.repoRoot || pending) return;
 
         const path = resolveLineRefPath({
-          rawPath: request.ref.path,
-          repoRoot: request.repoRoot,
-          cwd: request.cwd,
+          rawPath: pendingRef.ref.path,
+          repoRoot: target.repoRoot,
+          cwd: target.cwd,
           repoPaths: paths,
         });
         if (!path) {
-          toast.error(`File reference not found: ${request.ref.path}`);
-          clearCodeReferenceRequest(request.id);
+          toast.error(`File reference not found: ${pendingRef.ref.path}`);
+          setBrowseTarget({ ...target, pendingRef: null });
+          clearCodeReferenceRequest(pendingRef.id);
           return;
         }
 
-        setSearchQuery("");
-        setSelectedFile({
-          path,
-          selectedLines: { start: request.ref.start, end: request.ref.end },
+        setBrowseTarget({
+          ...target,
+          selectedPath: path,
+          selectedLines: {
+            start: pendingRef.ref.start,
+            end: pendingRef.ref.end,
+          },
+          pendingRef: null,
         });
-        clearCodeReferenceRequest(request.id);
+        clearCodeReferenceRequest(pendingRef.id);
       },
       { defer: true },
     ),
@@ -543,8 +605,8 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                         theme={diffTheme()}
                         selectedLines={selectedLines()}
                         onLineSelected={(range) =>
-                          setSelectedFile((current) =>
-                            current?.path === path
+                          setBrowseTarget((current) =>
+                            current?.selectedPath === path
                               ? { ...current, selectedLines: range }
                               : current,
                           )

--- a/packages/client/src/right-panel/codeReferenceNavigation.ts
+++ b/packages/client/src/right-panel/codeReferenceNavigation.ts
@@ -1,7 +1,7 @@
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import { createSignal } from "solid-js";
 import type { LineRef } from "../ui/lineRef";
-import { updatePreferences } from "../wire";
+import { useRightPanel } from "./useRightPanel";
 
 export type CodeReferenceRequest = {
   id: number;
@@ -24,9 +24,7 @@ export function openCodeReference(input: {
   const repoRoot = input.metadata.git?.repoRoot;
   if (!repoRoot) return false;
 
-  updatePreferences({
-    rightPanel: { collapsed: false, activeTab: "code", codeMode: "browse" },
-  });
+  useRightPanel().showCodeExpanded("browse");
   setRequest({
     id: ++nextRequestId,
     terminalId: input.terminalId,

--- a/packages/client/src/right-panel/codeReferenceNavigation.ts
+++ b/packages/client/src/right-panel/codeReferenceNavigation.ts
@@ -3,6 +3,7 @@ import { createSignal } from "solid-js";
 import type { LineRef } from "../ui/lineRef";
 import { useRightPanel } from "./useRightPanel";
 
+/** Pending cross-component request to open a terminal file reference. */
 export type CodeReferenceRequest = {
   id: number;
   terminalId: TerminalId;
@@ -14,8 +15,10 @@ export type CodeReferenceRequest = {
 let nextRequestId = 0;
 const [request, setRequest] = createSignal<CodeReferenceRequest | null>(null);
 
+/** Latest terminal file-reference request waiting for CodeTab to consume it. */
 export const codeReferenceRequest = request;
 
+/** Open the Code tab in browse mode and publish a file-reference request. */
 export function openCodeReference(input: {
   terminalId: TerminalId;
   metadata: TerminalMetadata;
@@ -35,6 +38,7 @@ export function openCodeReference(input: {
   return true;
 }
 
+/** Clear a consumed request without racing newer requests. */
 export function clearCodeReferenceRequest(id: number): void {
   setRequest((current) => (current?.id === id ? null : current));
 }

--- a/packages/client/src/right-panel/codeReferenceNavigation.ts
+++ b/packages/client/src/right-panel/codeReferenceNavigation.ts
@@ -1,0 +1,42 @@
+import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
+import { createSignal } from "solid-js";
+import type { LineRef } from "../ui/lineRef";
+import { updatePreferences } from "../wire";
+
+export type CodeReferenceRequest = {
+  id: number;
+  terminalId: TerminalId;
+  repoRoot: string;
+  cwd: string | undefined;
+  ref: LineRef;
+};
+
+let nextRequestId = 0;
+const [request, setRequest] = createSignal<CodeReferenceRequest | null>(null);
+
+export const codeReferenceRequest = request;
+
+export function openCodeReference(input: {
+  terminalId: TerminalId;
+  metadata: TerminalMetadata;
+  ref: LineRef;
+}): boolean {
+  const repoRoot = input.metadata.git?.repoRoot;
+  if (!repoRoot) return false;
+
+  updatePreferences({
+    rightPanel: { collapsed: false, activeTab: "code", codeMode: "browse" },
+  });
+  setRequest({
+    id: ++nextRequestId,
+    terminalId: input.terminalId,
+    repoRoot,
+    cwd: input.metadata.cwd,
+    ref: input.ref,
+  });
+  return true;
+}
+
+export function clearCodeReferenceRequest(id: number): void {
+  setRequest((current) => (current?.id === id ? null : current));
+}

--- a/packages/client/src/right-panel/codeReferenceNavigation.ts
+++ b/packages/client/src/right-panel/codeReferenceNavigation.ts
@@ -1,4 +1,4 @@
-import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
+import type { TerminalMetadata } from "kolu-common/surface";
 import { createSignal } from "solid-js";
 import type { LineRef } from "../ui/lineRef";
 import { useRightPanel } from "./useRightPanel";
@@ -6,7 +6,6 @@ import { useRightPanel } from "./useRightPanel";
 /** Pending cross-component request to open a terminal file reference. */
 export type CodeReferenceRequest = {
   id: number;
-  terminalId: TerminalId;
   repoRoot: string;
   cwd: string | undefined;
   ref: LineRef;
@@ -20,7 +19,6 @@ export const codeReferenceRequest = request;
 
 /** Open the Code tab in browse mode and publish a file-reference request. */
 export function openCodeReference(input: {
-  terminalId: TerminalId;
   metadata: TerminalMetadata;
   ref: LineRef;
 }): boolean {
@@ -30,7 +28,6 @@ export function openCodeReference(input: {
   useRightPanel().showCodeExpanded("browse");
   setRequest({
     id: ++nextRequestId,
-    terminalId: input.terminalId,
     repoRoot,
     cwd: input.metadata.cwd,
     ref: input.ref,

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -42,6 +42,14 @@ export function useRightPanel() {
           ...(mode !== undefined && { codeMode: mode }),
         },
       }),
+    showCodeExpanded: (mode?: CodeTabView) =>
+      updatePreferences({
+        rightPanel: {
+          collapsed: false,
+          activeTab: "code",
+          ...(mode !== undefined && { codeMode: mode }),
+        },
+      }),
     /** Change the sub-mode within the Code tab. */
     setCodeMode: (mode: CodeTabView) =>
       updatePreferences({ rightPanel: { codeMode: mode } }),

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -15,7 +15,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
-import { type ITheme, Terminal as XTerm } from "@xterm/xterm";
+import { type IDisposable, type ITheme, Terminal as XTerm } from "@xterm/xterm";
 import {
   type Component,
   createEffect,
@@ -42,8 +42,10 @@ import { isExpectedCleanupError } from "../rpc/streamCleanup";
 import { createScrollLock } from "../scrollLock";
 import { preferences } from "../wire";
 import { isTouch } from "../useMobile";
+import type { LineRef } from "../ui/lineRef";
 import ScrollToBottom from "./ScrollToBottom";
 import SearchBar from "./SearchBar";
+import { registerFileReferenceLinks } from "./fileReferenceLinks";
 import { registerTerminalRefs, unregisterTerminalRefs } from "./terminalRefs";
 import { registerDiagnostics } from "./useTerminalDiagnostics";
 import {
@@ -145,6 +147,8 @@ const Terminal: Component<{
   onSearchOpenChange: (open: boolean) => void;
   /** Fired when the user interacts with this terminal (click/keyboard focus). */
   onFocus?: () => void;
+  /** Fired when terminal output contains a clicked `path:line` reference. */
+  onOpenCodeReference?: (terminalId: TerminalId, ref: LineRef) => void;
   /** When true, this terminal lives in a sub-panel — it owns its own grid
    *  (its container is independent of the main viewport) and stays out of
    *  the viewport signal. Also used for e2e test selectors. */
@@ -171,6 +175,7 @@ const Terminal: Component<{
   let webglCanvas: HTMLCanvasElement | null = null;
   let webglTrackerId: number | null = null;
   let disposeDiagnostics: (() => void) | null = null;
+  let fileReferenceLinks: IDisposable | null = null;
   /** True once this component's reactive owner has been disposed. Set by the
    *  synchronously-registered `onCleanup` below. The async `onMount` body
    *  checks this after each `await` and bails rather than creating xterm /
@@ -379,6 +384,8 @@ const Terminal: Component<{
     unregisterTerminalRefs(props.terminalId);
     disposeDiagnostics?.();
     disposeDiagnostics = null;
+    fileReferenceLinks?.dispose();
+    fileReferenceLinks = null;
     unloadWebgl();
     terminal?.dispose();
     terminal = null;
@@ -451,6 +458,11 @@ const Terminal: Component<{
           fitAddon = new FitAddon();
           term.loadAddon(fitAddon);
           term.loadAddon(new WebLinksAddon());
+          if (props.onOpenCodeReference) {
+            fileReferenceLinks = registerFileReferenceLinks(term, (ref) =>
+              props.onOpenCodeReference?.(props.terminalId, ref),
+            );
+          }
           const search = new SearchAddon();
           term.loadAddon(search);
           setSearchAddon(search);

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -8,6 +8,7 @@ import Resizable from "@corvu/resizable";
 import type { ITheme } from "@xterm/xterm";
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import { type Component, For, Show } from "solid-js";
+import type { LineRef } from "../ui/lineRef";
 import SubPanelTabBar from "./SubPanelTabBar";
 import Terminal from "./Terminal";
 import { useSubPanel } from "./useSubPanel";
@@ -32,6 +33,7 @@ const TerminalContent: Component<{
   /** Called when user focuses any terminal in this pane (click, keyboard).
    *  Canvas mode uses this to set the active tile. */
   onFocus?: () => void;
+  onOpenCodeReference?: (terminalId: TerminalId, ref: LineRef) => void;
 }> = (props) => {
   const subPanel = useSubPanel();
 
@@ -89,6 +91,7 @@ const TerminalContent: Component<{
           searchOpen={props.searchOpen}
           onSearchOpenChange={props.onSearchOpenChange}
           onFocus={handleMainFocus}
+          onOpenCodeReference={props.onOpenCodeReference}
         />
       </Resizable.Panel>
 
@@ -141,6 +144,7 @@ const TerminalContent: Component<{
                 searchOpen={false}
                 onSearchOpenChange={() => {}}
                 onFocus={handleSubFocus}
+                onOpenCodeReference={props.onOpenCodeReference}
                 isSub
               />
             )}

--- a/packages/client/src/terminal/fileReferenceLinks.ts
+++ b/packages/client/src/terminal/fileReferenceLinks.ts
@@ -1,0 +1,45 @@
+import type { IDisposable, ILink, ILinkProvider, Terminal } from "@xterm/xterm";
+import { findLineRefs, type LineRef } from "../ui/lineRef";
+
+export type FileReferenceLinkHandler = (ref: LineRef) => void;
+
+export function registerFileReferenceLinks(
+  terminal: Terminal,
+  onOpen: FileReferenceLinkHandler,
+): IDisposable {
+  return terminal.registerLinkProvider(
+    new FileReferenceLinkProvider(terminal, onOpen),
+  );
+}
+
+class FileReferenceLinkProvider implements ILinkProvider {
+  constructor(
+    private readonly terminal: Terminal,
+    private readonly onOpen: FileReferenceLinkHandler,
+  ) {}
+
+  provideLinks(
+    bufferLineNumber: number,
+    callback: (links: ILink[] | undefined) => void,
+  ): void {
+    const line = this.terminal.buffer.active.getLine(bufferLineNumber - 1);
+    const text = line?.translateToString(true);
+    if (!text) {
+      callback(undefined);
+      return;
+    }
+
+    const links = findLineRefs(text).map((ref): ILink => {
+      const { path, start, end } = ref;
+      return {
+        text: ref.text,
+        range: {
+          start: { x: ref.startIndex + 1, y: bufferLineNumber },
+          end: { x: ref.endIndex, y: bufferLineNumber },
+        },
+        activate: () => this.onOpen({ path, start, end }),
+      };
+    });
+    callback(links.length > 0 ? links : undefined);
+  }
+}

--- a/packages/client/src/terminal/fileReferenceLinks.ts
+++ b/packages/client/src/terminal/fileReferenceLinks.ts
@@ -1,8 +1,10 @@
 import type { IDisposable, ILink, ILinkProvider, Terminal } from "@xterm/xterm";
 import { findLineRefs, type LineRef } from "../ui/lineRef";
 
+/** Callback invoked when a terminal file-reference link is activated. */
 export type FileReferenceLinkHandler = (ref: LineRef) => void;
 
+/** Register an xterm link provider for repo file references like `src/app.ts:4`. */
 export function registerFileReferenceLinks(
   terminal: Terminal,
   onOpen: FileReferenceLinkHandler,

--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { findLineRefs, parseLineRef, resolveLineRefPath } from "./lineRef";
+
+describe("line refs", () => {
+  it("parses single-line and range references", () => {
+    expect(parseLineRef("packages/a/src/Main.hs:109")).toEqual({
+      path: "packages/a/src/Main.hs",
+      start: 109,
+      end: 109,
+    });
+    expect(parseLineRef("./src/app.ts:4-8")).toEqual({
+      path: "./src/app.ts",
+      start: 4,
+      end: 8,
+    });
+  });
+
+  it("finds references inside terminal text without trailing punctuation", () => {
+    expect(findLineRefs("see packages/a/src/Main.hs:109).")).toEqual([
+      {
+        path: "packages/a/src/Main.hs",
+        start: 109,
+        end: 109,
+        text: "packages/a/src/Main.hs:109",
+        startIndex: 4,
+        endIndex: 30,
+      },
+    ]);
+  });
+
+  it("ignores urls and non-path labels", () => {
+    expect(findLineRefs("http://example.com/src/app.ts:12")).toEqual([]);
+    expect(findLineRefs("error:12")).toEqual([]);
+  });
+});
+
+describe("resolveLineRefPath", () => {
+  const repoRoot = "/tmp/work";
+  const repoPaths = [
+    "packages/a/src/Main.hs",
+    "src/app.ts",
+    "nested/src/app.ts",
+  ];
+
+  it("resolves repo-relative paths", () => {
+    expect(
+      resolveLineRefPath({
+        rawPath: "packages/a/src/Main.hs",
+        repoRoot,
+        cwd: repoRoot,
+        repoPaths,
+      }),
+    ).toBe("packages/a/src/Main.hs");
+  });
+
+  it("resolves cwd-relative paths inside the repo", () => {
+    expect(
+      resolveLineRefPath({
+        rawPath: "src/app.ts",
+        repoRoot,
+        cwd: "/tmp/work/nested",
+        repoPaths,
+      }),
+    ).toBe("nested/src/app.ts");
+  });
+
+  it("resolves absolute paths under the repo", () => {
+    expect(
+      resolveLineRefPath({
+        rawPath: "/tmp/work/nested/src/app.ts",
+        repoRoot,
+        cwd: repoRoot,
+        repoPaths,
+      }),
+    ).toBe("nested/src/app.ts");
+  });
+
+  it("rejects paths outside the repo or not in git's file list", () => {
+    expect(
+      resolveLineRefPath({
+        rawPath: "/tmp/other/src/app.ts",
+        repoRoot,
+        cwd: repoRoot,
+        repoPaths,
+      }),
+    ).toBeNull();
+    expect(
+      resolveLineRefPath({
+        rawPath: "../outside.ts",
+        repoRoot,
+        cwd: "/tmp/work/nested",
+        repoPaths,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { findLineRefs, parseLineRef, resolveLineRefPath } from "./lineRef";
+import { findLineRefs, resolveLineRefPath } from "./lineRef";
 
 describe("line refs", () => {
   it("parses single-line and range references", () => {
-    expect(parseLineRef("packages/a/src/Main.hs:109")).toEqual({
-      path: "packages/a/src/Main.hs",
-      start: 109,
-      end: 109,
-    });
-    expect(parseLineRef("./src/app.ts:4-8")).toEqual({
-      path: "./src/app.ts",
-      start: 4,
-      end: 8,
-    });
+    expect(findLineRefs("packages/a/src/Main.hs:109")).toMatchObject([
+      { path: "packages/a/src/Main.hs", start: 109, end: 109 },
+    ]);
+    expect(findLineRefs("./src/app.ts:4-8")).toMatchObject([
+      { path: "./src/app.ts", start: 4, end: 8 },
+    ]);
   });
 
   it("finds references inside terminal text without trailing punctuation", () => {

--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -31,6 +31,7 @@ describe("line refs", () => {
   it("ignores urls and non-path labels", () => {
     expect(findLineRefs("http://example.com/src/app.ts:12")).toEqual([]);
     expect(findLineRefs("error:12")).toEqual([]);
+    expect(findLineRefs("~/src/app.ts:12")).toEqual([]);
   });
 });
 

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -1,10 +1,169 @@
 /** Format a `path:line` (single line) or `path:start-end` (range) reference
  *  the way most editors and code tools accept (VS Code, Vim's `:e file:N`,
  *  GitHub URL fragments, Linear-style snippets). */
+export type LineRef = {
+  path: string;
+  start: number;
+  end: number;
+};
+
+export type LineRefMatch = LineRef & {
+  text: string;
+  startIndex: number;
+  endIndex: number;
+};
+
+export type LineRefPathResolutionInput = {
+  rawPath: string;
+  repoRoot: string;
+  cwd: string | undefined;
+  repoPaths: readonly string[];
+};
+
+const LINE_REF_RE =
+  /((?:~\/|\.\.?\/|\/)?[A-Za-z0-9._@+-]+(?:\/[A-Za-z0-9._@+-]+)*):([1-9]\d*)(?:-([1-9]\d*))?/g;
+
+const PATH_CHAR_RE = /[A-Za-z0-9._@+/-]/;
+
 export function formatLineRef(
   path: string,
   start: number,
   end: number,
 ): string {
   return start === end ? `${path}:${start}` : `${path}:${start}-${end}`;
+}
+
+export function parseLineRef(text: string): LineRef | null {
+  const matches = findLineRefs(text.trim());
+  if (matches.length !== 1) return null;
+  const match = matches[0];
+  if (!match) return null;
+  return match.text === text.trim()
+    ? { path: match.path, start: match.start, end: match.end }
+    : null;
+}
+
+export function findLineRefs(text: string): LineRefMatch[] {
+  const refs: LineRefMatch[] = [];
+  for (const match of text.matchAll(LINE_REF_RE)) {
+    const rawPath = match[1];
+    const rawStart = match[2];
+    const rawEnd = match[3];
+    const startIndex = match.index;
+    if (
+      rawPath === undefined ||
+      rawStart === undefined ||
+      startIndex === undefined
+    ) {
+      continue;
+    }
+    if (!looksLikeFilePath(rawPath)) continue;
+    if (!hasReferenceBoundary(text, startIndex)) continue;
+    const start = Number(rawStart);
+    const end = rawEnd === undefined ? start : Number(rawEnd);
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end)) continue;
+    if (end < start) continue;
+    const refText = match[0];
+    refs.push({
+      path: rawPath,
+      start,
+      end,
+      text: refText,
+      startIndex,
+      endIndex: startIndex + refText.length,
+    });
+  }
+  return refs;
+}
+
+export function resolveLineRefPath({
+  rawPath,
+  repoRoot,
+  cwd,
+  repoPaths,
+}: LineRefPathResolutionInput): string | null {
+  const repoPathSet = new Set(repoPaths);
+  const candidates = candidateRepoPaths(rawPath, repoRoot, cwd);
+  for (const candidate of candidates) {
+    if (repoPathSet.has(candidate)) return candidate;
+  }
+  return null;
+}
+
+function looksLikeFilePath(path: string): boolean {
+  if (path.startsWith("//")) return false;
+  return (
+    path.includes("/") ||
+    path.includes(".") ||
+    path.startsWith("~/") ||
+    path.startsWith("./") ||
+    path.startsWith("../")
+  );
+}
+
+function hasReferenceBoundary(text: string, startIndex: number): boolean {
+  const prev = startIndex > 0 ? text[startIndex - 1] : undefined;
+  if (prev && PATH_CHAR_RE.test(prev)) return false;
+  return text.slice(Math.max(0, startIndex - 3), startIndex) !== "://";
+}
+
+function candidateRepoPaths(
+  rawPath: string,
+  repoRoot: string,
+  cwd: string | undefined,
+): string[] {
+  const candidates: string[] = [];
+  const add = (path: string | null) => {
+    if (path !== null && !candidates.includes(path)) candidates.push(path);
+  };
+
+  if (isAbsolutePath(rawPath)) {
+    add(repoRelativeFromAbsolute(rawPath, repoRoot));
+    return candidates;
+  }
+
+  const cwdRel = cwd ? repoRelativeFromAbsolute(cwd, repoRoot) : null;
+  if (cwdRel !== null) add(normalizeRelativePath(joinPath(cwdRel, rawPath)));
+  add(normalizeRelativePath(rawPath));
+  return candidates;
+}
+
+function isAbsolutePath(path: string): boolean {
+  return path.startsWith("/");
+}
+
+function repoRelativeFromAbsolute(
+  absolutePath: string,
+  repoRoot: string,
+): string | null {
+  const root = normalizeAbsolutePath(repoRoot);
+  const absolute = normalizeAbsolutePath(absolutePath);
+  if (absolute === root) return "";
+  if (!absolute.startsWith(`${root}/`)) return null;
+  return normalizeRelativePath(absolute.slice(root.length + 1));
+}
+
+function normalizeAbsolutePath(path: string): string {
+  const normalized = `/${path.split("/").filter(Boolean).join("/")}`;
+  return normalized.length > 1 && normalized.endsWith("/")
+    ? normalized.slice(0, -1)
+    : normalized;
+}
+
+function normalizeRelativePath(path: string): string | null {
+  const parts: string[] = [];
+  for (const part of path.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (parts.length === 0) return null;
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+  return parts.join("/");
+}
+
+function joinPath(base: string, path: string): string {
+  return base ? `${base}/${path}` : path;
 }

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -1,18 +1,18 @@
-/** Format a `path:line` (single line) or `path:start-end` (range) reference
- *  the way most editors and code tools accept (VS Code, Vim's `:e file:N`,
- *  GitHub URL fragments, Linear-style snippets). */
+/** Parsed source reference with a path and inclusive one-based line range. */
 export type LineRef = {
   path: string;
   start: number;
   end: number;
 };
 
+/** A `LineRef` plus source-string match metadata for xterm link ranges. */
 export type LineRefMatch = LineRef & {
   text: string;
   startIndex: number;
   endIndex: number;
 };
 
+/** Inputs needed to turn a terminal-visible path into a repo-relative path. */
 export type LineRefPathResolutionInput = {
   rawPath: string;
   repoRoot: string;
@@ -25,6 +25,9 @@ const LINE_REF_RE =
 
 const PATH_CHAR_RE = /[A-Za-z0-9._@+~/-]/;
 
+/** Format a `path:line` (single line) or `path:start-end` (range) reference
+ *  the way most editors and code tools accept (VS Code, Vim's `:e file:N`,
+ *  GitHub URL fragments, Linear-style snippets). */
 export function formatLineRef(
   path: string,
   start: number,
@@ -33,6 +36,7 @@ export function formatLineRef(
   return start === end ? `${path}:${start}` : `${path}:${start}-${end}`;
 }
 
+/** Parse a string that should contain exactly one complete line reference. */
 export function parseLineRef(text: string): LineRef | null {
   const matches = findLineRefs(text.trim());
   if (matches.length !== 1) return null;
@@ -43,6 +47,7 @@ export function parseLineRef(text: string): LineRef | null {
     : null;
 }
 
+/** Find file line references embedded in terminal output. */
 export function findLineRefs(text: string): LineRefMatch[] {
   const refs: LineRefMatch[] = [];
   for (const match of text.matchAll(LINE_REF_RE)) {
@@ -76,6 +81,7 @@ export function findLineRefs(text: string): LineRefMatch[] {
   return refs;
 }
 
+/** Resolve a parsed terminal path against git's repo file list. */
 export function resolveLineRefPath({
   rawPath,
   repoRoot,

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -36,17 +36,6 @@ export function formatLineRef(
   return start === end ? `${path}:${start}` : `${path}:${start}-${end}`;
 }
 
-/** Parse a string that should contain exactly one complete line reference. */
-export function parseLineRef(text: string): LineRef | null {
-  const matches = findLineRefs(text.trim());
-  if (matches.length !== 1) return null;
-  const match = matches[0];
-  if (!match) return null;
-  return match.text === text.trim()
-    ? { path: match.path, start: match.start, end: match.end }
-    : null;
-}
-
 /** Find file line references embedded in terminal output. */
 export function findLineRefs(text: string): LineRefMatch[] {
   const refs: LineRefMatch[] = [];

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -21,9 +21,9 @@ export type LineRefPathResolutionInput = {
 };
 
 const LINE_REF_RE =
-  /((?:~\/|\.\.?\/|\/)?[A-Za-z0-9._@+-]+(?:\/[A-Za-z0-9._@+-]+)*):([1-9]\d*)(?:-([1-9]\d*))?/g;
+  /((?:\.\.?\/|\/)?[A-Za-z0-9._@+-]+(?:\/[A-Za-z0-9._@+-]+)*):([1-9]\d*)(?:-([1-9]\d*))?/g;
 
-const PATH_CHAR_RE = /[A-Za-z0-9._@+/-]/;
+const PATH_CHAR_RE = /[A-Za-z0-9._@+~/-]/;
 
 export function formatLineRef(
   path: string,
@@ -95,7 +95,6 @@ function looksLikeFilePath(path: string): boolean {
   return (
     path.includes("/") ||
     path.includes(".") ||
-    path.startsWith("~/") ||
     path.startsWith("./") ||
     path.startsWith("../")
   );

--- a/packages/client/src/ui/useLineSelection.ts
+++ b/packages/client/src/ui/useLineSelection.ts
@@ -17,6 +17,7 @@ import type { CodeContextMenuItem } from "./CodeContextMenu";
 import { formatLineRef } from "./lineRef";
 
 export type LineSelection = {
+  range: Accessor<SelectedLineRange | null>;
   /** Bind to Pierre's `onLineSelected` — the renderer fires this on every
    *  selection commit (single-line click or drag end). */
   handleSelect: (range: SelectedLineRange | null) => void;
@@ -25,20 +26,42 @@ export type LineSelection = {
   buildItems: () => CodeContextMenuItem[];
 };
 
-export function useLineSelection(path: Accessor<string>): LineSelection {
+export type LineSelectionOptions = {
+  range?: Accessor<SelectedLineRange | null | undefined>;
+  onRangeChange?: (range: SelectedLineRange | null) => void;
+};
+
+export function useLineSelection(
+  path: Accessor<string>,
+  options: LineSelectionOptions = {},
+): LineSelection {
   const [range, setRange] = createSignal<SelectedLineRange | null>(null);
+  const currentRange = () => options.range?.() ?? range();
 
   // A new file replaces the old selection scope — drop it so a stale
   // "Copy path:N" menu entry from the previous file can't surface.
-  createEffect(on(path, () => setRange(null), { defer: true }));
+  createEffect(
+    on(
+      path,
+      () => {
+        setRange(null);
+        options.onRangeChange?.(null);
+      },
+      { defer: true },
+    ),
+  );
 
   return {
-    handleSelect: (r) => setRange(r),
+    range: currentRange,
+    handleSelect: (r) => {
+      setRange(r);
+      options.onRangeChange?.(r);
+    },
     buildItems: () => {
       const items: CodeContextMenuItem[] = [
         { label: "Copy path", textToCopy: path() },
       ];
-      const r = range();
+      const r = currentRange();
       if (r) {
         const ref = formatLineRef(path(), r.start, r.end);
         items.push({ label: `Copy ${ref}`, textToCopy: ref });

--- a/packages/client/src/ui/useLineSelection.ts
+++ b/packages/client/src/ui/useLineSelection.ts
@@ -34,7 +34,9 @@ export function useLineSelection(
   path: Accessor<string>,
   options: LineSelectionOptions = {},
 ): LineSelection {
-  const [range, setRange] = createSignal<SelectedLineRange | null>(null);
+  const [range, setRange] = createSignal<SelectedLineRange | null>(
+    options.initialRange?.() ?? null,
+  );
   const currentRange = () => range();
 
   // A new file replaces the old selection scope — drop it so a stale

--- a/packages/client/src/ui/useLineSelection.ts
+++ b/packages/client/src/ui/useLineSelection.ts
@@ -27,8 +27,7 @@ export type LineSelection = {
 };
 
 export type LineSelectionOptions = {
-  range?: Accessor<SelectedLineRange | null | undefined>;
-  onRangeChange?: (range: SelectedLineRange | null) => void;
+  initialRange?: Accessor<SelectedLineRange | null | undefined>;
 };
 
 export function useLineSelection(
@@ -36,27 +35,25 @@ export function useLineSelection(
   options: LineSelectionOptions = {},
 ): LineSelection {
   const [range, setRange] = createSignal<SelectedLineRange | null>(null);
-  const currentRange = () => options.range?.() ?? range();
+  const currentRange = () => range();
 
   // A new file replaces the old selection scope — drop it so a stale
   // "Copy path:N" menu entry from the previous file can't surface.
   createEffect(
+    on(path, () => setRange(options.initialRange?.() ?? null), { defer: true }),
+  );
+
+  createEffect(
     on(
-      path,
-      () => {
-        setRange(null);
-        options.onRangeChange?.(null);
-      },
+      () => options.initialRange?.() ?? null,
+      (initial) => setRange(initial),
       { defer: true },
     ),
   );
 
   return {
     range: currentRange,
-    handleSelect: (r) => {
-      setRange(r);
-      options.onRangeChange?.(r);
-    },
+    handleSelect: (r) => setRange(r),
     buildItems: () => {
       const items: CodeContextMenuItem[] = [
         { label: "Copy path", textToCopy: path() },

--- a/packages/solid-pierre/src/FileView.tsx
+++ b/packages/solid-pierre/src/FileView.tsx
@@ -49,6 +49,9 @@ export type FileViewProps = {
   /** Fires on every selection commit (single-line click or drag end);
    *  `null` on deselect. */
   onLineSelected?: (range: SelectedLineRange | null) => void;
+  /** Programmatically selected line/range. Used by callers that open a
+   *  `path:line` reference directly rather than via gutter interaction. */
+  selectedLines?: SelectedLineRange | null;
   /** Surface construction and render throws. Required because silent
    *  failures here produce a blank pane indistinguishable from "loading". */
   onError: (err: Error) => void;
@@ -67,6 +70,7 @@ export type FileViewProps = {
 type FileRenderer = {
   render(file: FileContents): void;
   setThemeType(theme: "light" | "dark"): void;
+  setSelectedLines(range: SelectedLineRange | null): void;
   cleanUp(): void;
 };
 
@@ -138,6 +142,7 @@ const createFileRenderer = (
         instance.render({ fileContainer, file });
       },
       setThemeType: (t) => instance?.setThemeType(t),
+      setSelectedLines: (range) => instance?.setSelectedLines(range),
       cleanUp: () => {
         instance?.cleanUp();
         fileContainer?.remove();
@@ -152,9 +157,57 @@ const createFileRenderer = (
   return {
     render: (file) => instance.render({ containerWrapper: container, file }),
     setThemeType: (t) => instance.setThemeType(t),
+    setSelectedLines: (range) => instance.setSelectedLines(range),
     cleanUp: () => instance.cleanUp(),
   };
 };
+
+function findDeep(root: ParentNode, selector: string): Element | null {
+  const direct = root.querySelector(selector);
+  if (direct) return direct;
+  const elements = root.querySelectorAll("*");
+  for (const el of elements) {
+    const shadow = (el as HTMLElement).shadowRoot;
+    if (!shadow) continue;
+    const found = findDeep(shadow, selector);
+    if (found) return found;
+  }
+  return null;
+}
+
+function scrollSelectedLineIntoView(
+  container: HTMLElement,
+  range: SelectedLineRange,
+  afterScroll: () => void,
+) {
+  requestAnimationFrame(() => {
+    const selector = `[data-column-number="${range.start}"]`;
+    const existing = findDeep(container, selector);
+    if (existing) {
+      existing.scrollIntoView({ block: "center" });
+      afterScroll();
+      return;
+    }
+
+    const scroller = container.closest(
+      '[data-testid="pierre-virtualizer"]',
+    ) as HTMLElement | null;
+    if (!scroller) return;
+
+    const lineHeight =
+      Number.parseFloat(getComputedStyle(scroller).lineHeight) ||
+      Number.parseFloat(getComputedStyle(scroller).fontSize) * 1.4 ||
+      18;
+    scroller.scrollTop = Math.max(
+      0,
+      (range.start - 1) * lineHeight - scroller.clientHeight / 2,
+    );
+    requestAnimationFrame(() => {
+      afterScroll();
+      findDeep(container, selector)?.scrollIntoView({ block: "center" });
+    });
+  });
+}
 
 const FileView: Component<FileViewProps> = (props) => {
   let container!: HTMLDivElement;
@@ -188,6 +241,21 @@ const FileView: Component<FileViewProps> = (props) => {
     }
   };
 
+  const applySelectedLines = (range: SelectedLineRange | null | undefined) => {
+    if (!renderer) return;
+    const selected = range ?? null;
+    try {
+      renderer.setSelectedLines(selected);
+      if (selected) {
+        scrollSelectedLineIntoView(container, selected, () =>
+          renderer?.setSelectedLines(selected),
+        );
+      }
+    } catch (e) {
+      props.onError(toError(e));
+    }
+  };
+
   // Closed over for the virtualized recreate path so each fresh
   // instance picks up the current `props.theme`.
   const buildOptions = (): FileOptions<undefined> => ({
@@ -202,12 +270,30 @@ const FileView: Component<FileViewProps> = (props) => {
     try {
       renderer = createFileRenderer(buildOptions, container, virtualizer);
       safeRender(fileContents());
+      applySelectedLines(props.selectedLines);
     } catch (e) {
       props.onError(toError(e));
     }
   });
 
-  createEffect(on(fileContents, (file) => safeRender(file), { defer: true }));
+  createEffect(
+    on(
+      fileContents,
+      (file) => {
+        safeRender(file);
+        applySelectedLines(props.selectedLines);
+      },
+      { defer: true },
+    ),
+  );
+
+  createEffect(
+    on(
+      () => props.selectedLines,
+      (range) => applySelectedLines(range),
+      { defer: true },
+    ),
+  );
 
   createEffect(
     on(

--- a/packages/solid-pierre/src/FileView.tsx
+++ b/packages/solid-pierre/src/FileView.tsx
@@ -70,7 +70,7 @@ export type FileViewProps = {
 type FileRenderer = {
   render(file: FileContents): void;
   setThemeType(theme: "light" | "dark"): void;
-  setSelectedLines(range: SelectedLineRange | null): void;
+  selectAndReveal(range: SelectedLineRange | null): void;
   cleanUp(): void;
 };
 
@@ -142,7 +142,14 @@ const createFileRenderer = (
         instance.render({ fileContainer, file });
       },
       setThemeType: (t) => instance?.setThemeType(t),
-      setSelectedLines: (range) => instance?.setSelectedLines(range),
+      selectAndReveal: (range) => {
+        instance?.setSelectedLines(range);
+        if (range) {
+          scrollSelectedLineIntoView(container, range, () =>
+            instance?.setSelectedLines(range),
+          );
+        }
+      },
       cleanUp: () => {
         instance?.cleanUp();
         fileContainer?.remove();
@@ -157,7 +164,14 @@ const createFileRenderer = (
   return {
     render: (file) => instance.render({ containerWrapper: container, file }),
     setThemeType: (t) => instance.setThemeType(t),
-    setSelectedLines: (range) => instance.setSelectedLines(range),
+    selectAndReveal: (range) => {
+      instance.setSelectedLines(range);
+      if (range) {
+        scrollSelectedLineIntoView(container, range, () =>
+          instance.setSelectedLines(range),
+        );
+      }
+    },
     cleanUp: () => instance.cleanUp(),
   };
 };
@@ -245,12 +259,7 @@ const FileView: Component<FileViewProps> = (props) => {
     if (!renderer) return;
     const selected = range ?? null;
     try {
-      renderer.setSelectedLines(selected);
-      if (selected) {
-        scrollSelectedLineIntoView(container, selected, () =>
-          renderer?.setSelectedLines(selected),
-        );
-      }
+      renderer.selectAndReveal(selected);
     } catch (e) {
       props.onError(toError(e));
     }

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -237,6 +237,17 @@ Feature: Code tab (review + browse)
     When I click the file "greeting.txt" in the file browser
     Then the file content should contain "hello world"
 
+  Scenario: Terminal file reference opens the file browser at the line
+    When I run "git init /tmp/kolu-terminal-code-ref && cd /tmp/kolu-terminal-code-ref"
+    And I run "mkdir -p src && printf 'alpha\nbeta\ngamma\n' > src/app.ts"
+    And I run "git add . && git commit -m init"
+    And I run "echo src/app.ts:2"
+    When I click the terminal file reference "src/app.ts:2"
+    Then the Code tab should be active
+    And the Code tab mode should be "browse"
+    And the file content should contain "beta"
+    And line 2 in the file content should be selected
+
   Scenario: File browser wraps long lines by default
     When I run "git init /tmp/kolu-browse-wrap && cd /tmp/kolu-browse-wrap"
     And I run "printf 'prefix-' > long.txt && printf '%*s' 240 '' | tr ' ' x >> long.txt && printf '\n' >> long.txt"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1,4 +1,5 @@
 import { Given, Then, When } from "@cucumber/cucumber";
+import { ACTIVE_TERMINAL, waitForBufferContains } from "../support/buffer.ts";
 import { pollFor } from "../support/poll.ts";
 import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
@@ -144,6 +145,81 @@ async function rightClickViewRoot(world: KoluWorld, root: string) {
   await view.click({ button: "right" });
   await world.waitForFrame();
 }
+
+type TerminalRefPoint = { x: number; y: number } | null;
+
+async function findTerminalRefPoint(
+  world: KoluWorld,
+  ref: string,
+): Promise<TerminalRefPoint> {
+  return world.page.evaluate(
+    ({ sel, refText }) => {
+      type BufferLine = { translateToString(trimRight?: boolean): string };
+      type XtermForClick = {
+        cols: number;
+        rows: number;
+        buffer: {
+          active: {
+            viewportY: number;
+            getLine(index: number): BufferLine | undefined;
+          };
+        };
+        _core?: {
+          _renderService?: {
+            dimensions?: { css?: { cell?: { width: number; height: number } } };
+          };
+        };
+      };
+      const container = document.querySelector(sel) as
+        | (HTMLElement & { __xterm?: XtermForClick })
+        | null;
+      const term = container?.__xterm;
+      const screen = container?.querySelector(".xterm-screen");
+      if (!container || !term || !screen) return null;
+
+      const { active } = term.buffer;
+      const viewportTop = active.viewportY;
+      for (let row = viewportTop; row < viewportTop + term.rows; row++) {
+        const line = active.getLine(row)?.translateToString(true) ?? "";
+        const col = line.indexOf(refText);
+        if (col < 0) continue;
+
+        const rect = screen.getBoundingClientRect();
+        const cell = term._core?._renderService?.dimensions?.css?.cell;
+        const cellWidth = cell?.width ?? rect.width / term.cols;
+        const cellHeight = cell?.height ?? rect.height / term.rows;
+        return {
+          x: rect.left + (col + 0.5) * cellWidth,
+          y: rect.top + (row - viewportTop + 0.5) * cellHeight,
+        };
+      }
+      return null;
+    },
+    { sel: ACTIVE_TERMINAL, refText: ref },
+  );
+}
+
+When(
+  "I click the terminal file reference {string}",
+  async function (this: KoluWorld, ref: string) {
+    await waitForBufferContains(this.page, ref);
+    const point = await pollFor({
+      observe: () => findTerminalRefPoint(this, ref),
+      isDone: (p) => p !== null,
+      onTimeout: (last, ms) =>
+        new Error(
+          `terminal reference ${ref} had no clickable point after ${ms}ms (last=${JSON.stringify(last)})`,
+        ),
+      timeoutMs: POLL_TIMEOUT,
+      intervalMs: 50,
+    });
+    if (point === null) throw new Error("unreachable: missing ref point");
+    await this.page.mouse.move(point.x, point.y);
+    await this.waitForFrame();
+    await this.page.mouse.click(point.x, point.y);
+    await this.waitForFrame();
+  },
+);
 
 When(
   "I click the line number {int} in the file content",
@@ -387,6 +463,42 @@ Then(
   "the file content should contain {string}",
   async function (this: KoluWorld, expected: string) {
     await waitForViewText(this, "pierre-file-view", expected);
+  },
+);
+
+Then(
+  "line {int} in the file content should be selected",
+  async function (this: KoluWorld, line: number) {
+    await this.page.waitForFunction(
+      (lineNumber) => {
+        const root = document.querySelector('[data-testid="pierre-file-view"]');
+        if (!root) return false;
+        const stack: Node[] = [root];
+        while (stack.length) {
+          const node = stack.pop();
+          if (!node || node.nodeType !== 1) continue;
+          const el = node as Element;
+          const shadow = (el as HTMLElement).shadowRoot;
+          if (shadow) for (const ch of shadow.childNodes) stack.push(ch);
+          for (const ch of el.childNodes) stack.push(ch);
+
+          if (el.getAttribute("data-column-number") !== String(lineNumber)) {
+            continue;
+          }
+          let parent: Element | null = el;
+          for (let depth = 0; parent && depth < 4; depth++) {
+            if (parent.hasAttribute("data-selected-line")) return true;
+            parent = parent.parentElement;
+          }
+          if (el.parentElement?.querySelector("[data-selected-line]")) {
+            return true;
+          }
+        }
+        return false;
+      },
+      line,
+      { timeout: POLL_TIMEOUT },
+    );
   },
 );
 

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -164,11 +164,6 @@ async function findTerminalRefPoint(
             getLine(index: number): BufferLine | undefined;
           };
         };
-        _core?: {
-          _renderService?: {
-            dimensions?: { css?: { cell?: { width: number; height: number } } };
-          };
-        };
       };
       const container = document.querySelector(sel) as
         | (HTMLElement & { __xterm?: XtermForClick })
@@ -185,9 +180,8 @@ async function findTerminalRefPoint(
         if (col < 0) continue;
 
         const rect = screen.getBoundingClientRect();
-        const cell = term._core?._renderService?.dimensions?.css?.cell;
-        const cellWidth = cell?.width ?? rect.width / term.cols;
-        const cellHeight = cell?.height ?? rect.height / term.rows;
+        const cellWidth = rect.width / term.cols;
+        const cellHeight = rect.height / term.rows;
         return {
           x: rect.left + (col + 0.5) * cellWidth,
           y: rect.top + (row - viewportTop + 0.5) * cellHeight,


### PR DESCRIPTION
**Terminal file paths are now clickable links into the code browser.** References like `packages/vira-ci-types/src/Vira/CI/Pipeline/Type.hs:109` printed in an agent terminal resolve against the active repo and terminal cwd, then open the right-panel Code tab in browse mode with the referenced line selected.

The flow stays narrow: terminal text is matched as a repo file reference, resolved against the git file list, routed through the right-panel Code API, and finally revealed by the Pierre file renderer. _Unsupported home-relative refs are ignored rather than guessing at a filesystem scope the terminal link resolver does not own._

### What reviewers should look at

- Custom xterm link provider for repo-relative, cwd-relative, and in-repo absolute file references.
- Code browse navigation that opens the right panel and selects the referenced line range.
- Line-selection ownership moved into the browse frame so menu text and file rendering share one source.
- E2E coverage for clicking a terminal file reference and landing on the selected line.

### Verification

- `nix develop -c pnpm --filter kolu-client test:unit -- lineRef`
- `nix develop -c pnpm --filter kolu-client typecheck`
- `nix develop -c pnpm --filter @kolu/solid-pierre typecheck`
- `just check`
- `just fmt`
- `just test-quick features/code-tab.feature`

Closes #861.

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `unknown`)._