### PR TITLE
Let filtered code-browser folders collapse

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -350,14 +350,12 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                 }
               >
                 <FileTree
-                  paths={treeSearch().projectedPaths}
+                  pathInput={treeSearch()}
                   gitStatus={treeGitStatus()}
                   selectedPath={selectedPath()}
                   onSelect={handleSelect}
                   initialExpansion={isDiffView() ? "open" : "closed"}
-                  expandedPathsOnReset={treeSearch().expandedPathsOnReset}
                   search={false}
-                  searchQuery={treeSearch().pierreSearchQuery}
                   icons={pierreIconConfig}
                   contextMenu={{
                     enabled: true,

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -9,9 +9,11 @@
  * The toolbar combines two independent filter axes — mode picker
  * (`ModeChipPicker`) and filename input (`FileSearchInput`) — in one
  * row. Pierre's built-in tree-header search is disabled so the
- * `FileSearchInput` is the single source of filter state, forwarded
- * via `FileTree.searchQuery`. `@kolu/solid-pierre` owns the imperative
- * Pierre lifecycle; this component is just data flow + chrome. */
+ * `FileSearchInput` is the single source of filter state. Kolu projects
+ * the path list and opens matching ancestors only when that projection
+ * resets; this keeps results visible while preserving normal folder
+ * collapse after the user clicks. `@kolu/solid-pierre` owns the
+ * imperative Pierre lifecycle; this component is just data flow + chrome. */
 
 import { FileDiff, FileTree, Virtualizer } from "@kolu/solid-pierre";
 import type { GitDiffMode } from "kolu-git/schemas";
@@ -353,6 +355,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                   selectedPath={selectedPath()}
                   onSelect={handleSelect}
                   initialExpansion={isDiffView() ? "open" : "closed"}
+                  expandedPathsOnReset={treeSearch().expandedPathsOnReset}
                   search={false}
                   searchQuery={treeSearch().pierreSearchQuery}
                   icons={pierreIconConfig}

--- a/packages/client/src/right-panel/FileSearchInput.tsx
+++ b/packages/client/src/right-panel/FileSearchInput.tsx
@@ -1,8 +1,7 @@
 /** Free-text search input that filters the file tree by path. Hosts
- *  read the value back through `onChange` and forward it into the tree
- *  (e.g. via `PierreFileTree`'s `searchQuery` prop). The input is
- *  controlled so callers can clear or programmatically reset it
- *  (e.g. on view change). */
+ *  read the value back through `onChange` and apply the filter to their
+ *  path projection. The input is controlled so callers can clear or
+ *  programmatically reset it (e.g. on view change). */
 
 import { type Component, Show } from "solid-js";
 import { CloseIcon, SearchIcon } from "../ui/Icons";

--- a/packages/client/src/right-panel/fileSearch.test.ts
+++ b/packages/client/src/right-panel/fileSearch.test.ts
@@ -10,48 +10,42 @@ describe("projectFileTreeSearch", () => {
 
   it("leaves blank queries unfiltered", () => {
     expect(projectFileTreeSearch(paths, "")).toEqual({
-      projectedPaths: paths,
-      expandedPathsOnReset: null,
-      pierreSearchQuery: null,
+      paths,
     });
-    expect(projectFileTreeSearch(paths, "").projectedPaths).toBe(paths);
+    expect(projectFileTreeSearch(paths, "").paths).toBe(paths);
   });
 
   it("projects single-token queries", () => {
     expect(projectFileTreeSearch(paths, "index")).toEqual({
-      projectedPaths: ["common/src/index.tsx", "packages/client/src/index.tsx"],
-      expandedPathsOnReset: [
+      paths: ["common/src/index.tsx", "packages/client/src/index.tsx"],
+      initialExpandedPaths: [
         "common/",
         "common/src/",
         "packages/",
         "packages/client/",
         "packages/client/src/",
       ],
-      pierreSearchQuery: null,
     });
   });
 
   it("matches whitespace-separated path tokens in order", () => {
     expect(projectFileTreeSearch(paths, "common index.ts")).toEqual({
-      projectedPaths: ["common/src/index.tsx"],
-      expandedPathsOnReset: ["common/", "common/src/"],
-      pierreSearchQuery: null,
+      paths: ["common/src/index.tsx"],
+      initialExpandedPaths: ["common/", "common/src/"],
     });
   });
 
   it("normalizes backslashes and case", () => {
     expect(projectFileTreeSearch(paths, "COMMON\\src button")).toEqual({
-      projectedPaths: ["common/src/Button.tsx"],
-      expandedPathsOnReset: ["common/", "common/src/"],
-      pierreSearchQuery: null,
+      paths: ["common/src/Button.tsx"],
+      initialExpandedPaths: ["common/", "common/src/"],
     });
   });
 
   it("does not match tokens out of order", () => {
     expect(projectFileTreeSearch(paths, "index common")).toEqual({
-      projectedPaths: [],
-      expandedPathsOnReset: [],
-      pierreSearchQuery: null,
+      paths: [],
+      initialExpandedPaths: [],
     });
   });
 });

--- a/packages/client/src/right-panel/fileSearch.test.ts
+++ b/packages/client/src/right-panel/fileSearch.test.ts
@@ -8,32 +8,50 @@ describe("projectFileTreeSearch", () => {
     "packages/client/src/index.tsx",
   ];
 
-  it("leaves single-token queries to Pierre", () => {
-    expect(projectFileTreeSearch(paths, "index")).toEqual({
+  it("leaves blank queries unfiltered", () => {
+    expect(projectFileTreeSearch(paths, "")).toEqual({
       projectedPaths: paths,
-      pierreSearchQuery: "index",
+      expandedPathsOnReset: null,
+      pierreSearchQuery: null,
     });
-    expect(projectFileTreeSearch(paths, "index").projectedPaths).toBe(paths);
+    expect(projectFileTreeSearch(paths, "").projectedPaths).toBe(paths);
+  });
+
+  it("projects single-token queries", () => {
+    expect(projectFileTreeSearch(paths, "index")).toEqual({
+      projectedPaths: ["common/src/index.tsx", "packages/client/src/index.tsx"],
+      expandedPathsOnReset: [
+        "common/",
+        "common/src/",
+        "packages/",
+        "packages/client/",
+        "packages/client/src/",
+      ],
+      pierreSearchQuery: null,
+    });
   });
 
   it("matches whitespace-separated path tokens in order", () => {
     expect(projectFileTreeSearch(paths, "common index.ts")).toEqual({
       projectedPaths: ["common/src/index.tsx"],
-      pierreSearchQuery: "index.ts",
+      expandedPathsOnReset: ["common/", "common/src/"],
+      pierreSearchQuery: null,
     });
   });
 
   it("normalizes backslashes and case", () => {
     expect(projectFileTreeSearch(paths, "COMMON\\src button")).toEqual({
       projectedPaths: ["common/src/Button.tsx"],
-      pierreSearchQuery: "button",
+      expandedPathsOnReset: ["common/", "common/src/"],
+      pierreSearchQuery: null,
     });
   });
 
   it("does not match tokens out of order", () => {
     expect(projectFileTreeSearch(paths, "index common")).toEqual({
       projectedPaths: [],
-      pierreSearchQuery: "common",
+      expandedPathsOnReset: [],
+      pierreSearchQuery: null,
     });
   });
 });

--- a/packages/client/src/right-panel/fileSearch.ts
+++ b/packages/client/src/right-panel/fileSearch.ts
@@ -1,13 +1,12 @@
 /** Search projection for Pierre's current substring-only FileTree API.
  *
- *  `projectedPaths` is Kolu's visibility filter. Keeping Code-tab search as
- *  a path-list projection leaves Pierre's normal folder collapse semantics
- *  intact; Pierre's internal search expands matching ancestors after each
- *  row click, which makes filtered folders impossible to collapse. */
+ *  `paths` is Kolu's visibility filter. Keeping Code-tab search as a path
+ *  projection leaves Pierre's normal folder collapse semantics intact;
+ *  Pierre's internal search expands matching ancestors after each row click,
+ *  which makes filtered folders impossible to collapse. */
 type FileTreeSearchProjection = {
-  projectedPaths: string[];
-  expandedPathsOnReset: string[] | null;
-  pierreSearchQuery: string | null;
+  paths: string[];
+  initialExpandedPaths?: string[];
 };
 
 function normalizePathSearchText(value: string): string {
@@ -57,20 +56,15 @@ export function projectFileTreeSearch(
 ): FileTreeSearchProjection {
   const tokens = normalizePathSearchText(query).split(/\s+/).filter(Boolean);
   if (tokens.length === 0) {
-    return {
-      projectedPaths: paths,
-      expandedPathsOnReset: null,
-      pierreSearchQuery: null,
-    };
+    return { paths };
   }
 
-  const projectedPaths = paths.filter((path) =>
+  const matchingPaths = paths.filter((path) =>
     pathContainsTokensInOrder(path, tokens),
   );
 
   return {
-    projectedPaths,
-    expandedPathsOnReset: getExpandedPathsForMatches(projectedPaths),
-    pierreSearchQuery: null,
+    paths: matchingPaths,
+    initialExpandedPaths: getExpandedPathsForMatches(matchingPaths),
   };
 }

--- a/packages/client/src/right-panel/fileSearch.ts
+++ b/packages/client/src/right-panel/fileSearch.ts
@@ -1,11 +1,12 @@
 /** Search projection for Pierre's current substring-only FileTree API.
  *
- *  `projectedPaths` is the optional Kolu-side visibility filter; for native
- *  single-token searches it is the original path inventory by reference.
- *  `pierreSearchQuery` is the residual substring Pierre should own for
- *  expansion/focus after Kolu has handled multi-token path matching. */
+ *  `projectedPaths` is Kolu's visibility filter. Keeping Code-tab search as
+ *  a path-list projection leaves Pierre's normal folder collapse semantics
+ *  intact; Pierre's internal search expands matching ancestors after each
+ *  row click, which makes filtered folders impossible to collapse. */
 type FileTreeSearchProjection = {
   projectedPaths: string[];
+  expandedPathsOnReset: string[] | null;
   pierreSearchQuery: string | null;
 };
 
@@ -30,19 +31,46 @@ function pathContainsTokensInOrder(
   return true;
 }
 
+function getAncestorDirectoryPaths(path: string): string[] {
+  const normalizedPath = path.endsWith("/") ? path.slice(0, -1) : path;
+  if (normalizedPath.length === 0) return [];
+
+  const segments = normalizedPath.split("/");
+  return segments
+    .slice(0, -1)
+    .map((_, index) => `${segments.slice(0, index + 1).join("/")}/`);
+}
+
+function getExpandedPathsForMatches(paths: readonly string[]): string[] {
+  const expandedPaths = new Set<string>();
+  for (const path of paths) {
+    for (const ancestorPath of getAncestorDirectoryPaths(path)) {
+      expandedPaths.add(ancestorPath);
+    }
+  }
+  return [...expandedPaths];
+}
+
 export function projectFileTreeSearch(
   paths: string[],
   query: string,
 ): FileTreeSearchProjection {
   const tokens = normalizePathSearchText(query).split(/\s+/).filter(Boolean);
-  if (tokens.length <= 1) {
-    return { projectedPaths: paths, pierreSearchQuery: query };
+  if (tokens.length === 0) {
+    return {
+      projectedPaths: paths,
+      expandedPathsOnReset: null,
+      pierreSearchQuery: null,
+    };
   }
 
+  const projectedPaths = paths.filter((path) =>
+    pathContainsTokensInOrder(path, tokens),
+  );
+
   return {
-    projectedPaths: paths.filter((path) =>
-      pathContainsTokensInOrder(path, tokens),
-    ),
-    pierreSearchQuery: tokens.at(-1) ?? null,
+    projectedPaths,
+    expandedPathsOnReset: getExpandedPathsForMatches(projectedPaths),
+    pierreSearchQuery: null,
   };
 }

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -48,6 +48,11 @@ export type FileTreeProps = {
    *  toggling its parent `<Show when>`) to apply a new value. Defaults to
    *  `"closed"`. */
   initialExpansion?: FileTreeInitialExpansion;
+  /** Explicit directories to open when constructing or resetting `paths`.
+   *  Hosts that filter by projecting `paths` can pass matching ancestors
+   *  here so children are initially visible while normal folder collapse
+   *  remains under the user's control after reset. */
+  expandedPathsOnReset?: readonly string[] | null;
   /** Collapse single-child directory chains (e.g. `packages/client/src` →
    *  one row). Default `true`. */
   flattenEmptyDirectories?: boolean;
@@ -96,11 +101,19 @@ export const FileTree: Component<FileTreeProps> = (props) => {
     }
   };
 
+  const resetPathOptions = (
+    expandedPathsOnReset: readonly string[] | null | undefined,
+  ) =>
+    expandedPathsOnReset == null
+      ? undefined
+      : { initialExpandedPaths: expandedPathsOnReset };
+
   onMount(() => {
     try {
       tree = new FileTreeClass({
         paths: props.paths,
         initialExpansion: props.initialExpansion ?? "closed",
+        initialExpandedPaths: props.expandedPathsOnReset ?? undefined,
         flattenEmptyDirectories: props.flattenEmptyDirectories ?? true,
         stickyFolders: props.stickyFolders ?? true,
         icons: props.icons,
@@ -174,10 +187,10 @@ export const FileTree: Component<FileTreeProps> = (props) => {
 
   createEffect(
     on(
-      () => props.paths,
-      (paths) => {
+      [() => props.paths, () => props.expandedPathsOnReset],
+      ([paths, expandedPathsOnReset]) => {
         try {
-          tree?.resetPaths(paths);
+          tree?.resetPaths(paths, resetPathOptions(expandedPathsOnReset));
         } catch (e) {
           props.onError(toError(e));
         }

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -1,8 +1,8 @@
 /** SolidJS wrapper over `@pierre/trees`' vanilla `FileTree` class.
  *
  *  Pierre's `FileTree` owns its DOM (shadow-root rendered). Mount once,
- *  push updates via the class's setters (`resetPaths`, `setGitStatus`,
- *  `setSearch`) inside reactive effects, and call `cleanUp()` on disposal.
+ *  push updates via the class's setters (`resetPaths`, `setGitStatus`)
+ *  inside reactive effects, and call `cleanUp()` on disposal.
  *  Construction throws are routed to the `onError` prop so consumers can
  *  show a fallback panel instead of letting the exception escape Solid's
  *  `<ErrorBoundary>` (which only catches errors during *Solid* render). */
@@ -21,7 +21,6 @@ import {
   on,
   onCleanup,
   onMount,
-  untrack,
 } from "solid-js";
 import { toError } from "./toError";
 
@@ -29,30 +28,31 @@ type FileTreeOptions = ConstructorParameters<typeof FileTreeClass>[0];
 type Composition = NonNullable<FileTreeOptions["composition"]>;
 type FileTreeContextMenu = NonNullable<Composition["contextMenu"]>;
 
+/** Complete path-reset input for the Solid `FileTree` wrapper. */
+export type FileTreePathInput = {
+  paths: readonly string[];
+  /** Directories Pierre should open when constructing or resetting `paths`.
+   *  Use this with host-projected path filters so matching children start
+   *  visible while later user collapse stays authoritative. */
+  initialExpandedPaths?: readonly string[];
+};
+
+/** Props for the Solid wrapper around Pierre's imperative `FileTree`. */
 export type FileTreeProps = {
-  paths: string[];
+  pathInput: FileTreePathInput;
   gitStatus?: GitStatusEntry[];
   selectedPath?: string | null;
   onSelect?: (path: string | null) => void;
   /** Enable Pierre's built-in header search affordance. Default `true`.
-   *  Set to `false` when the host renders its own search input and drives
-   *  the tree externally via `searchQuery`. */
+   *  Set to `false` when the host renders its own filter and drives the
+   *  tree by updating `pathInput`. */
   search?: boolean;
-  /** External search query — when provided, forwarded to Pierre's
-   *  `setSearch()`. Useful when search lives in the caller's chrome
-   *  rather than the tree header. Pass empty string or `null` to clear. */
-  searchQuery?: string | null;
   /** Initial folder expansion — captured at construction and **not
    *  reactive**. Pierre takes this once in its constructor; later prop
    *  changes are silently ignored. Re-mount the component (e.g. by
    *  toggling its parent `<Show when>`) to apply a new value. Defaults to
    *  `"closed"`. */
   initialExpansion?: FileTreeInitialExpansion;
-  /** Explicit directories to open when constructing or resetting `paths`.
-   *  Hosts that filter by projecting `paths` can pass matching ancestors
-   *  here so children are initially visible while normal folder collapse
-   *  remains under the user's control after reset. */
-  expandedPathsOnReset?: readonly string[] | null;
   /** Collapse single-child directory chains (e.g. `packages/client/src` →
    *  one row). Default `true`. */
   flattenEmptyDirectories?: boolean;
@@ -74,6 +74,7 @@ export type FileTreeProps = {
   style?: JSX.CSSProperties;
 };
 
+/** Mounts and updates a Pierre `FileTree` instance from Solid props. */
 export const FileTree: Component<FileTreeProps> = (props) => {
   let container!: HTMLDivElement;
   let tree: FileTreeClass | undefined;
@@ -82,38 +83,19 @@ export const FileTree: Component<FileTreeProps> = (props) => {
   // produce an EISDIR if the consumer reads the path as a file. Directories
   // don't appear in `paths` (Pierre infers them from path prefixes), so
   // membership in this set is a reliable file-vs-folder discriminator.
-  const fileSet = createMemo(() => new Set(props.paths));
+  const fileSet = createMemo(() => new Set(props.pathInput.paths));
 
-  // Pierre rejects `""` for setSearch (empty string ≠ "no filter"); collapse
-  // empty/null/undefined to `null` so callers don't need to reproduce this.
-  const normalizeSearchQuery = (q: string | null | undefined) =>
-    q && q.length > 0 ? q : null;
-
-  // Single funnel for "tell Pierre to (re)set its filter". Three callers —
-  // initial mount, the deferred prop effect, and the row-click re-apply
-  // below — all need identical normalization and the same `onError` route,
-  // so they share one helper rather than three try/catch dances.
-  const applySearchQuery = (q: string | null | undefined) => {
-    try {
-      tree?.setSearch(normalizeSearchQuery(q));
-    } catch (e) {
-      props.onError(toError(e));
-    }
-  };
-
-  const resetPathOptions = (
-    expandedPathsOnReset: readonly string[] | null | undefined,
-  ) =>
-    expandedPathsOnReset == null
+  const resetPathOptions = (input: FileTreePathInput) =>
+    input.initialExpandedPaths == null
       ? undefined
-      : { initialExpandedPaths: expandedPathsOnReset };
+      : { initialExpandedPaths: input.initialExpandedPaths };
 
   onMount(() => {
     try {
       tree = new FileTreeClass({
-        paths: props.paths,
+        paths: props.pathInput.paths,
         initialExpansion: props.initialExpansion ?? "closed",
-        initialExpandedPaths: props.expandedPathsOnReset ?? undefined,
+        initialExpandedPaths: props.pathInput.initialExpandedPaths,
         flattenEmptyDirectories: props.flattenEmptyDirectories ?? true,
         stickyFolders: props.stickyFolders ?? true,
         icons: props.icons,
@@ -131,55 +113,6 @@ export const FileTree: Component<FileTreeProps> = (props) => {
         },
       });
       tree.render({ containerWrapper: container });
-
-      // Pierre's `handleRowClick` (in
-      // `node_modules/@pierre/trees/dist/render/FileTreeView.js`) clears its
-      // internal search via `controller.closeSearch()` after every row
-      // click — `closeSearch: isSearchOpen` is hardcoded in
-      // `fileTreeRowClickPlan.js` with no opt-out. When the host drives
-      // search externally via `searchQuery`, that prop is the source of
-      // truth, so we restore it after Pierre's click handler returns.
-      //
-      // We hook the DOM `click` event rather than Pierre's
-      // `onSelectionChange` callback because Pierre's selection-version
-      // gate (`FileTreeController.js` `#applySelection` short-circuits
-      // when the new selection equals the current one) suppresses the
-      // callback on re-clicks of the already-selected row — but
-      // `closeSearch()` still runs on every click, so an
-      // `onSelectionChange`-based hook would silently miss the re-click
-      // case while Pierre wipes the filter anyway.
-      //
-      // Detection uses the `data-item-path` attribute Pierre stamps on
-      // every row, found by walking `event.composedPath()` to pierce the
-      // shadow root. Invariants this depends on:
-      //   1. Pierre's row-click handler stays synchronous (so the
-      //      microtask runs *after* `closeSearch` has fired, not before).
-      //   2. Pierre keeps emitting `data-item-path` on row elements.
-      // Both are true today; both would silently break this re-apply if
-      // Pierre changes them, so they're worth the comment.
-      const reapplySearchAfterRowClick = (event: MouseEvent) => {
-        const clickedTreeRow = event
-          .composedPath()
-          .some(
-            (target) =>
-              target instanceof HTMLElement &&
-              target.dataset.itemPath !== undefined,
-          );
-        if (!clickedTreeRow) return;
-        queueMicrotask(() => {
-          const q = untrack(() => props.searchQuery);
-          if (normalizeSearchQuery(q) !== null) applySearchQuery(q);
-        });
-      };
-      container.addEventListener("click", reapplySearchAfterRowClick);
-      onCleanup(() =>
-        container.removeEventListener("click", reapplySearchAfterRowClick),
-      );
-
-      // Apply an initial searchQuery if it was already non-empty at mount —
-      // the deferred effect below only fires on subsequent changes, so a
-      // pre-mount value would otherwise be silently dropped.
-      applySearchQuery(untrack(() => props.searchQuery));
     } catch (e) {
       props.onError(toError(e));
     }
@@ -187,10 +120,10 @@ export const FileTree: Component<FileTreeProps> = (props) => {
 
   createEffect(
     on(
-      [() => props.paths, () => props.expandedPathsOnReset],
-      ([paths, expandedPathsOnReset]) => {
+      () => props.pathInput,
+      (pathInput) => {
         try {
-          tree?.resetPaths(paths, resetPathOptions(expandedPathsOnReset));
+          tree?.resetPaths(pathInput.paths, resetPathOptions(pathInput));
         } catch (e) {
           props.onError(toError(e));
         }
@@ -212,8 +145,6 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       { defer: true },
     ),
   );
-
-  createEffect(on(() => props.searchQuery, applySearchQuery, { defer: true }));
 
   onCleanup(() => tree?.cleanUp());
 

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -254,7 +254,7 @@ Feature: Code tab (review + browse)
     Then the file browser should show a file "lib/util.ts"
 
   Scenario: File browser can collapse a directory while filtered
-    When I run "git init /tmp/kolu-browse-filter-collapse && cd /tmp/kolu-browse-filter-collapse"
+    When I run "rm -rf /tmp/kolu-browse-filter-collapse && git init /tmp/kolu-browse-filter-collapse && cd /tmp/kolu-browse-filter-collapse"
     And I run "mkdir -p pkg && printf 'x\n' > pkg/alpha.ts && printf 'y\n' > pkg/beta.ts"
     And I run "git add . && git commit -m init"
     And I click the Code tab

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -117,14 +117,10 @@ Feature: Code tab (review + browse)
     When I click the changed file "note.txt" in the Code tab
     Then the Code tab should render a diff view
 
-  # Regression for #817: Pierre's row-click handler unconditionally calls
-  # `controller.closeSearch()` after firing selection (verified at
-  # @pierre/trees/dist/render/FileTreeView.js around the row-click plan,
-  # where `closeSearch: isSearchOpen` is hardcoded). The solid-pierre
-  # wrapper re-applies the host's `searchQuery` on the next microtask so
-  # the host-controlled filter survives clicks. Re-click step covers
-  # Pierre's selectionVersion gate that suppresses `onSelectionChange`
-  # but still runs `closeSearch()`.
+  # Regression for #817: clicking a filtered result must not clear the Code
+  # tab filter or reveal non-matching rows. The Code tab owns filtering as a
+  # Kolu-side path projection so the input value and visible tree stay stable
+  # across Pierre row clicks, including re-clicks of the already-selected row.
   Scenario Outline: Filter survives clicking a filtered result [<mode>]
     Given a Code tab in "<mode>" mode showing files:
       | path      | content |
@@ -256,6 +252,20 @@ Feature: Code tab (review + browse)
     Then the file browser should show a directory "lib"
     When I click the directory "lib" in the file browser
     Then the file browser should show a file "lib/util.ts"
+
+  Scenario: File browser can collapse a directory while filtered
+    When I run "git init /tmp/kolu-browse-filter-collapse && cd /tmp/kolu-browse-filter-collapse"
+    And I run "mkdir -p pkg && printf 'x\n' > pkg/alpha.ts && printf 'y\n' > pkg/beta.ts"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    When I type "alpha" into the Code tab filter
+    Then the file browser should show a directory "pkg"
+    And the file browser should show a file "pkg/alpha.ts"
+    And the file browser should not show a file "pkg/beta.ts"
+    When I click the directory "pkg" in the file browser
+    Then the Code tab filter input should contain "alpha"
+    And the file browser should not show a file "pkg/alpha.ts"
 
   # ── Pierre file/diff viewer right-click menu (Copy path:line) ──
 


### PR DESCRIPTION
**Filtered folders in the Code tab's All-files browser now stay user-collapsible.** Previously, searching the file tree delegated to Pierre's internal search state, which reopened matching ancestors after row clicks; a visible result could not stay collapsed.

The Code tab now treats the search box as a Kolu-side path projection. Matching paths and their initial expanded ancestors travel together into the Solid Pierre wrapper as one `pathInput`, so search results start visible while later folder clicks remain authoritative.

### Verification

- `nix develop --accept-flake-config -c pnpm --filter kolu-client test:unit -- src/right-panel/fileSearch.test.ts`
- `just check`
- `just fmt`
- `just test-quick features/code-tab.feature`

### Try it locally

```sh
nix run github:juspay/kolu/fix-code-browser-search-folder-collapse
```

_Generated by [`/do`](https://github.com/srid/agency) on Codex (model `gpt-5`)._