### PR TITLE
Let folders collapse while the Code tab filter stays active

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -463,7 +463,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                   initialExpansion={isDiffView() ? "open" : "closed"}
                   search={false}
                   searchQuery={treeSearch().pierreSearchQuery}
-                  onSearchClearedByRowClick={() => setSearchQuery("")}
+                  onSearchCleared={() => setSearchQuery("")}
                   icons={pierreIconConfig}
                   contextMenu={{
                     enabled: true,

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -462,8 +462,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                   onSelect={handleSelect}
                   initialExpansion={isDiffView() ? "open" : "closed"}
                   search={false}
-                  searchQuery={treeSearch().pierreSearchQuery}
-                  onSearchCleared={() => setSearchQuery("")}
+                  expandPaths={treeSearch().expandedAncestors}
                   icons={pierreIconConfig}
                   contextMenu={{
                     enabled: true,

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -463,6 +463,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                   initialExpansion={isDiffView() ? "open" : "closed"}
                   search={false}
                   searchQuery={treeSearch().pierreSearchQuery}
+                  onSearchClearedByRowClick={() => setSearchQuery("")}
                   icons={pierreIconConfig}
                   contextMenu={{
                     enabled: true,

--- a/packages/client/src/right-panel/fileSearch.test.ts
+++ b/packages/client/src/right-panel/fileSearch.test.ts
@@ -18,10 +18,7 @@ describe("projectFileTreeSearch", () => {
 
   it("matches a single token against the path string", () => {
     expect(projectFileTreeSearch(paths, "index")).toEqual({
-      projectedPaths: [
-        "common/src/index.tsx",
-        "packages/client/src/index.tsx",
-      ],
+      projectedPaths: ["common/src/index.tsx", "packages/client/src/index.tsx"],
       expandedAncestors: [
         "common/",
         "common/src/",

--- a/packages/client/src/right-panel/fileSearch.test.ts
+++ b/packages/client/src/right-panel/fileSearch.test.ts
@@ -8,32 +8,48 @@ describe("projectFileTreeSearch", () => {
     "packages/client/src/index.tsx",
   ];
 
-  it("leaves single-token queries to Pierre", () => {
-    expect(projectFileTreeSearch(paths, "index")).toEqual({
+  it("returns the original path inventory and no expansions for an empty query", () => {
+    expect(projectFileTreeSearch(paths, "")).toEqual({
       projectedPaths: paths,
-      pierreSearchQuery: "index",
+      expandedAncestors: [],
     });
-    expect(projectFileTreeSearch(paths, "index").projectedPaths).toBe(paths);
+    expect(projectFileTreeSearch(paths, "").projectedPaths).toBe(paths);
+  });
+
+  it("matches a single token against the path string", () => {
+    expect(projectFileTreeSearch(paths, "index")).toEqual({
+      projectedPaths: [
+        "common/src/index.tsx",
+        "packages/client/src/index.tsx",
+      ],
+      expandedAncestors: [
+        "common/",
+        "common/src/",
+        "packages/",
+        "packages/client/",
+        "packages/client/src/",
+      ],
+    });
   });
 
   it("matches whitespace-separated path tokens in order", () => {
     expect(projectFileTreeSearch(paths, "common index.ts")).toEqual({
       projectedPaths: ["common/src/index.tsx"],
-      pierreSearchQuery: "index.ts",
+      expandedAncestors: ["common/", "common/src/"],
     });
   });
 
   it("normalizes backslashes and case", () => {
     expect(projectFileTreeSearch(paths, "COMMON\\src button")).toEqual({
       projectedPaths: ["common/src/Button.tsx"],
-      pierreSearchQuery: "button",
+      expandedAncestors: ["common/", "common/src/"],
     });
   });
 
   it("does not match tokens out of order", () => {
     expect(projectFileTreeSearch(paths, "index common")).toEqual({
       projectedPaths: [],
-      pierreSearchQuery: "common",
+      expandedAncestors: [],
     });
   });
 });

--- a/packages/client/src/right-panel/fileSearch.ts
+++ b/packages/client/src/right-panel/fileSearch.ts
@@ -1,12 +1,21 @@
-/** Search projection for Pierre's current substring-only FileTree API.
+/** Host-side filter projection for the Code-tab file tree.
  *
- *  `projectedPaths` is the optional Kolu-side visibility filter; for native
- *  single-token searches it is the original path inventory by reference.
- *  `pierreSearchQuery` is the residual substring Pierre should own for
- *  expansion/focus after Kolu has handled multi-token path matching. */
+ *  Kolu does **all** of the filtering — Pierre never sees the query.
+ *  Pierre's `hide-non-matches` mode forcibly re-expands every match
+ *  ancestor on each store event (`FileTreeController#refreshActiveSearchState`),
+ *  which makes a user-initiated folder collapse impossible to keep
+ *  while a query is live. By projecting the path set on Kolu's side and
+ *  driving Pierre purely through `paths` + a list of ancestors to
+ *  expand, the controller stays out of the collapse path entirely —
+ *  the user's collapse sticks, and the filter survives the click.
+ *
+ *  `projectedPaths` is the visible inventory. `expandedAncestors` is
+ *  the directories the wrapper should ensure are open so matches don't
+ *  hide behind a collapsed parent on first paint. */
+
 type FileTreeSearchProjection = {
   projectedPaths: string[];
-  pierreSearchQuery: string | null;
+  expandedAncestors: string[];
 };
 
 function normalizePathSearchText(value: string): string {
@@ -30,19 +39,37 @@ function pathContainsTokensInOrder(
   return true;
 }
 
+/** Pierre uses `getAncestorDirectoryPaths` internally to drive
+ *  expansion in `hide-non-matches` mode. Mirror that exact shape so
+ *  the wrapper's expansion request reaches every dir Pierre infers
+ *  from the projected paths. */
+function ancestorDirectoryPaths(path: string): string[] {
+  const normalized = path.endsWith("/") ? path.slice(0, -1) : path;
+  if (normalized.length === 0) return [];
+  const segments = normalized.split("/");
+  const out: string[] = [];
+  for (let i = 1; i < segments.length; i += 1) {
+    out.push(`${segments.slice(0, i).join("/")}/`);
+  }
+  return out;
+}
+
 export function projectFileTreeSearch(
   paths: string[],
   query: string,
 ): FileTreeSearchProjection {
   const tokens = normalizePathSearchText(query).split(/\s+/).filter(Boolean);
-  if (tokens.length <= 1) {
-    return { projectedPaths: paths, pierreSearchQuery: query };
+  if (tokens.length === 0) {
+    return { projectedPaths: paths, expandedAncestors: [] };
   }
-
-  return {
-    projectedPaths: paths.filter((path) =>
-      pathContainsTokensInOrder(path, tokens),
-    ),
-    pierreSearchQuery: tokens.at(-1) ?? null,
-  };
+  const matches = paths.filter((path) =>
+    pathContainsTokensInOrder(path, tokens),
+  );
+  const ancestors = new Set<string>();
+  for (const match of matches) {
+    for (const ancestor of ancestorDirectoryPaths(match)) {
+      ancestors.add(ancestor);
+    }
+  }
+  return { projectedPaths: matches, expandedAncestors: [...ancestors] };
 }

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -146,17 +146,19 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       // `onSelectionChange`-based hook would silently miss the re-click
       // case while Pierre wipes the filter anyway.
       //
-      // Detection uses the `data-item-path`, `data-item-type`, and
-      // `aria-expanded` attributes Pierre stamps on every row, read by
-      // walking `event.composedPath()` to pierce the shadow root. The
-      // listener runs in capture phase so reads happen *before* Pierre's
-      // bubble-phase row handler mutates state — folder rows need the
-      // pre-click expansion to reconstruct user intent. Invariants this
-      // depends on:
+      // Detection uses the `data-item-path` and `aria-expanded`
+      // attributes Pierre stamps on every row, read by walking
+      // `event.composedPath()` to pierce the shadow root. File-vs-folder
+      // discrimination reuses `fileSet` — the same Set that gates
+      // `onSelectionChange`, since directories never appear in
+      // `props.paths`. The listener runs in capture phase so reads happen
+      // *before* Pierre's bubble-phase row handler mutates state — folder
+      // rows need the pre-click expansion to reconstruct user intent.
+      // Invariants this depends on:
       //   1. Pierre's row-click handler stays synchronous (so the
       //      microtask runs *after* `closeSearch` has fired, not before).
-      //   2. Pierre keeps emitting `data-item-path`, `data-item-type`,
-      //      and `aria-expanded` on row elements.
+      //   2. Pierre keeps emitting `data-item-path` and `aria-expanded`
+      //      on row elements.
       // Both are true today; both would silently break this re-apply if
       // Pierre changes them, so they're worth the comment.
       //
@@ -175,7 +177,6 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       // search is null and `#refreshActiveSearchState` won't fire.
       const handleTreeRowClick = (event: MouseEvent) => {
         let rowPath: string | undefined;
-        let rowType: string | undefined;
         let rowWasExpanded = false;
         for (const target of event.composedPath()) {
           if (
@@ -183,22 +184,23 @@ export const FileTree: Component<FileTreeProps> = (props) => {
             target.dataset.itemPath !== undefined
           ) {
             rowPath = target.dataset.itemPath;
-            rowType = target.dataset.itemType;
             rowWasExpanded = target.getAttribute("aria-expanded") === "true";
             break;
           }
         }
         if (rowPath === undefined) return;
+        const clickedPath = rowPath;
+        const isFolder = !fileSet().has(clickedPath);
         queueMicrotask(() => {
           const q = untrack(() => props.searchQuery);
           if (normalizeSearchQuery(q) === null) return;
-          if (rowType !== "folder") {
+          if (!isFolder) {
             applySearchQuery(q);
             return;
           }
           props.onSearchClearedByRowClick?.();
           if (rowWasExpanded && tree != null) {
-            const item = tree.getItem(rowPath);
+            const item = tree.getItem(clickedPath);
             if (
               item != null &&
               "isExpanded" in item &&

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -147,53 +147,40 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       // `onSelectionChange`-based hook would silently miss the re-click
       // case while Pierre wipes the filter anyway.
       //
-      // Detection uses the `data-item-path` and `aria-expanded`
-      // attributes Pierre stamps on every row, read by walking
-      // `event.composedPath()` to pierce the shadow root. File-vs-folder
-      // discrimination reuses `fileSet` — the same Set that gates
-      // `onSelectionChange`, since directories never appear in
-      // `props.paths`. The listener runs in capture phase so reads happen
-      // *before* Pierre's bubble-phase row handler mutates state — folder
-      // rows need the pre-click expansion to reconstruct user intent.
-      // Invariants this depends on:
+      // Detection uses the `data-item-path` attribute Pierre stamps on
+      // every row, read by walking `event.composedPath()` to pierce the
+      // shadow root. File-vs-folder discrimination reuses `fileSet` —
+      // the same Set that gates `onSelectionChange`, since directories
+      // never appear in `props.paths`. Invariants this depends on:
       //   1. Pierre's row-click handler stays synchronous (so the
       //      microtask runs *after* `closeSearch` has fired, not before).
-      //   2. Pierre keeps emitting `data-item-path` and `aria-expanded`
-      //      on row elements.
+      //   2. Pierre keeps emitting `data-item-path` on row elements.
       // Both are true today; both would silently break this re-apply if
       // Pierre changes them, so they're worth the comment.
       //
-      // File rows: re-apply the host's search so the filter survives
-      // Pierre's `closeSearch()`.
-      //
-      // Folder rows: `hide-non-matches` mode auto-expands every match
+      // Folder branch: `hide-non-matches` mode auto-expands every match
       // ancestor on each store event (FileTreeController `#subscribe` ->
       // `#refreshActiveSearchState`), so a `setSearch` re-apply would
-      // immediately revert the user's collapse. Skip the re-apply and
-      // hand the host an `onSearchCleared` signal so its input
-      // clears to match the tree state. If the row was expanded
-      // pre-click but Pierre's `closeSearch` left it expanded (happens
-      // in `"open"` initial-expansion mode, where pre-search expanded
-      // paths include the folder), force a collapse — now safe because
-      // search is null and `#refreshActiveSearchState` won't fire.
-      const findClickedRow = (path: readonly EventTarget[]) => {
+      // immediately revert the user's collapse. Skip it and force-
+      // collapse if Pierre's `closeSearch` left the row expanded — only
+      // happens in `"open"` initial-expansion mode (pre-search expanded
+      // paths include the folder), and is now safe because search is
+      // null and the subscribe handler short-circuits.
+      const findClickedRowPath = (path: readonly EventTarget[]) => {
         for (const target of path) {
           if (
             target instanceof HTMLElement &&
             target.dataset.itemPath !== undefined
           ) {
-            return {
-              path: target.dataset.itemPath,
-              wasExpanded: target.getAttribute("aria-expanded") === "true",
-            } as const;
+            return target.dataset.itemPath;
           }
         }
         return null;
       };
       const handleTreeRowClick = (event: MouseEvent) => {
-        const row = findClickedRow(event.composedPath());
-        if (row === null) return;
-        const isFolder = !fileSet().has(row.path);
+        const rowPath = findClickedRowPath(event.composedPath());
+        if (rowPath === null) return;
+        const isFolder = !fileSet().has(rowPath);
         queueMicrotask(() => {
           const q = untrack(() => props.searchQuery);
           if (normalizeSearchQuery(q) === null) return;
@@ -202,30 +189,24 @@ export const FileTree: Component<FileTreeProps> = (props) => {
             return;
           }
           props.onSearchCleared?.();
-          if (row.wasExpanded && tree != null) {
-            const item = tree.getItem(row.path);
-            if (
-              item != null &&
-              "isExpanded" in item &&
-              "collapse" in item &&
-              item.isExpanded()
-            ) {
-              try {
-                item.collapse();
-              } catch (e) {
-                props.onError(toError(e));
-              }
+          const item = tree?.getItem(rowPath);
+          if (
+            item != null &&
+            "isExpanded" in item &&
+            "collapse" in item &&
+            item.isExpanded()
+          ) {
+            try {
+              item.collapse();
+            } catch (e) {
+              props.onError(toError(e));
             }
           }
         });
       };
-      container.addEventListener("click", handleTreeRowClick, {
-        capture: true,
-      });
+      container.addEventListener("click", handleTreeRowClick);
       onCleanup(() =>
-        container.removeEventListener("click", handleTreeRowClick, {
-          capture: true,
-        }),
+        container.removeEventListener("click", handleTreeRowClick),
       );
 
       // Apply an initial searchQuery if it was already non-empty at mount —

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -42,16 +42,17 @@ export type FileTreeProps = {
    *  `setSearch()`. Useful when search lives in the caller's chrome
    *  rather than the tree header. Pass empty string or `null` to clear. */
   searchQuery?: string | null;
-  /** Notified when a folder-row click implicitly ended the active
-   *  filter. Pierre's `hide-non-matches` mode auto-expands every
-   *  ancestor of a match on each store event, so a folder collapse
-   *  cannot stick while a query is in effect — the wrapper takes
-   *  Pierre's own `closeSearch()` as the user's exit cue and forwards
-   *  it here so the host can clear its search input to match. Without
-   *  it the tree clears, the input doesn't, and the next keystroke
-   *  re-filters against stale intent. Only fires when `searchQuery`
-   *  was non-empty at click time. */
-  onSearchClearedByRowClick?: () => void;
+  /** Notified when the wrapper's filter state has gone to null
+   *  independently of the host's `searchQuery` prop, leaving the host's
+   *  input out of sync with the tree. Today the only trigger is a
+   *  folder-row click during an active query — Pierre's
+   *  `hide-non-matches` mode auto-expands every ancestor of a match on
+   *  each store event, so a collapse can only stick after the filter is
+   *  released; the wrapper takes Pierre's own `closeSearch()` as the
+   *  user's exit cue. Hosts should resync their search input (typically
+   *  by clearing it) when this fires. Only invoked when `searchQuery`
+   *  was non-empty at the time of clearing. */
+  onSearchCleared?: () => void;
   /** Initial folder expansion — captured at construction and **not
    *  reactive**. Pierre takes this once in its constructor; later prop
    *  changes are silently ignored. Re-mount the component (e.g. by
@@ -169,7 +170,7 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       // ancestor on each store event (FileTreeController `#subscribe` ->
       // `#refreshActiveSearchState`), so a `setSearch` re-apply would
       // immediately revert the user's collapse. Skip the re-apply and
-      // hand the host an `onSearchClearedByRowClick` signal so its input
+      // hand the host an `onSearchCleared` signal so its input
       // clears to match the tree state. If the row was expanded
       // pre-click but Pierre's `closeSearch` left it expanded (happens
       // in `"open"` initial-expansion mode, where pre-search expanded
@@ -200,7 +201,7 @@ export const FileTree: Component<FileTreeProps> = (props) => {
             applySearchQuery(q);
             return;
           }
-          props.onSearchClearedByRowClick?.();
+          props.onSearchCleared?.();
           if (row.wasExpanded && tree != null) {
             const item = tree.getItem(row.path);
             if (

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -175,22 +175,24 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       // in `"open"` initial-expansion mode, where pre-search expanded
       // paths include the folder), force a collapse — now safe because
       // search is null and `#refreshActiveSearchState` won't fire.
-      const handleTreeRowClick = (event: MouseEvent) => {
-        let rowPath: string | undefined;
-        let rowWasExpanded = false;
-        for (const target of event.composedPath()) {
+      const findClickedRow = (path: readonly EventTarget[]) => {
+        for (const target of path) {
           if (
             target instanceof HTMLElement &&
             target.dataset.itemPath !== undefined
           ) {
-            rowPath = target.dataset.itemPath;
-            rowWasExpanded = target.getAttribute("aria-expanded") === "true";
-            break;
+            return {
+              path: target.dataset.itemPath,
+              wasExpanded: target.getAttribute("aria-expanded") === "true",
+            } as const;
           }
         }
-        if (rowPath === undefined) return;
-        const clickedPath = rowPath;
-        const isFolder = !fileSet().has(clickedPath);
+        return null;
+      };
+      const handleTreeRowClick = (event: MouseEvent) => {
+        const row = findClickedRow(event.composedPath());
+        if (row === null) return;
+        const isFolder = !fileSet().has(row.path);
         queueMicrotask(() => {
           const q = untrack(() => props.searchQuery);
           if (normalizeSearchQuery(q) === null) return;
@@ -199,8 +201,8 @@ export const FileTree: Component<FileTreeProps> = (props) => {
             return;
           }
           props.onSearchClearedByRowClick?.();
-          if (rowWasExpanded && tree != null) {
-            const item = tree.getItem(clickedPath);
+          if (row.wasExpanded && tree != null) {
+            const item = tree.getItem(row.path);
             if (
               item != null &&
               "isExpanded" in item &&

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -42,6 +42,16 @@ export type FileTreeProps = {
    *  `setSearch()`. Useful when search lives in the caller's chrome
    *  rather than the tree header. Pass empty string or `null` to clear. */
   searchQuery?: string | null;
+  /** Notified when a folder-row click implicitly ended the active
+   *  filter. Pierre's `hide-non-matches` mode auto-expands every
+   *  ancestor of a match on each store event, so a folder collapse
+   *  cannot stick while a query is in effect — the wrapper takes
+   *  Pierre's own `closeSearch()` as the user's exit cue and forwards
+   *  it here so the host can clear its search input to match. Without
+   *  it the tree clears, the input doesn't, and the next keystroke
+   *  re-filters against stale intent. Only fires when `searchQuery`
+   *  was non-empty at click time. */
+  onSearchClearedByRowClick?: () => void;
   /** Initial folder expansion — captured at construction and **not
    *  reactive**. Pierre takes this once in its constructor; later prop
    *  changes are silently ignored. Re-mount the component (e.g. by
@@ -136,31 +146,81 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       // `onSelectionChange`-based hook would silently miss the re-click
       // case while Pierre wipes the filter anyway.
       //
-      // Detection uses the `data-item-path` attribute Pierre stamps on
-      // every row, found by walking `event.composedPath()` to pierce the
-      // shadow root. Invariants this depends on:
+      // Detection uses the `data-item-path`, `data-item-type`, and
+      // `aria-expanded` attributes Pierre stamps on every row, read by
+      // walking `event.composedPath()` to pierce the shadow root. The
+      // listener runs in capture phase so reads happen *before* Pierre's
+      // bubble-phase row handler mutates state — folder rows need the
+      // pre-click expansion to reconstruct user intent. Invariants this
+      // depends on:
       //   1. Pierre's row-click handler stays synchronous (so the
       //      microtask runs *after* `closeSearch` has fired, not before).
-      //   2. Pierre keeps emitting `data-item-path` on row elements.
+      //   2. Pierre keeps emitting `data-item-path`, `data-item-type`,
+      //      and `aria-expanded` on row elements.
       // Both are true today; both would silently break this re-apply if
       // Pierre changes them, so they're worth the comment.
-      const reapplySearchAfterRowClick = (event: MouseEvent) => {
-        const clickedTreeRow = event
-          .composedPath()
-          .some(
-            (target) =>
-              target instanceof HTMLElement &&
-              target.dataset.itemPath !== undefined,
-          );
-        if (!clickedTreeRow) return;
+      //
+      // File rows: re-apply the host's search so the filter survives
+      // Pierre's `closeSearch()`.
+      //
+      // Folder rows: `hide-non-matches` mode auto-expands every match
+      // ancestor on each store event (FileTreeController `#subscribe` ->
+      // `#refreshActiveSearchState`), so a `setSearch` re-apply would
+      // immediately revert the user's collapse. Skip the re-apply and
+      // hand the host an `onSearchClearedByRowClick` signal so its input
+      // clears to match the tree state. If the row was expanded
+      // pre-click but Pierre's `closeSearch` left it expanded (happens
+      // in `"open"` initial-expansion mode, where pre-search expanded
+      // paths include the folder), force a collapse — now safe because
+      // search is null and `#refreshActiveSearchState` won't fire.
+      const handleTreeRowClick = (event: MouseEvent) => {
+        let rowPath: string | undefined;
+        let rowType: string | undefined;
+        let rowWasExpanded = false;
+        for (const target of event.composedPath()) {
+          if (
+            target instanceof HTMLElement &&
+            target.dataset.itemPath !== undefined
+          ) {
+            rowPath = target.dataset.itemPath;
+            rowType = target.dataset.itemType;
+            rowWasExpanded = target.getAttribute("aria-expanded") === "true";
+            break;
+          }
+        }
+        if (rowPath === undefined) return;
         queueMicrotask(() => {
           const q = untrack(() => props.searchQuery);
-          if (normalizeSearchQuery(q) !== null) applySearchQuery(q);
+          if (normalizeSearchQuery(q) === null) return;
+          if (rowType !== "folder") {
+            applySearchQuery(q);
+            return;
+          }
+          props.onSearchClearedByRowClick?.();
+          if (rowWasExpanded && tree != null) {
+            const item = tree.getItem(rowPath);
+            if (
+              item != null &&
+              "isExpanded" in item &&
+              "collapse" in item &&
+              item.isExpanded()
+            ) {
+              try {
+                item.collapse();
+              } catch (e) {
+                props.onError(toError(e));
+              }
+            }
+          }
         });
       };
-      container.addEventListener("click", reapplySearchAfterRowClick);
+      container.addEventListener("click", handleTreeRowClick, {
+        capture: true,
+      });
       onCleanup(() =>
-        container.removeEventListener("click", reapplySearchAfterRowClick),
+        container.removeEventListener("click", handleTreeRowClick, {
+          capture: true,
+        }),
       );
 
       // Apply an initial searchQuery if it was already non-empty at mount —

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -1,8 +1,8 @@
 /** SolidJS wrapper over `@pierre/trees`' vanilla `FileTree` class.
  *
  *  Pierre's `FileTree` owns its DOM (shadow-root rendered). Mount once,
- *  push updates via the class's setters (`resetPaths`, `setGitStatus`,
- *  `setSearch`) inside reactive effects, and call `cleanUp()` on disposal.
+ *  push updates via the class's setters (`resetPaths`, `setGitStatus`)
+ *  inside reactive effects, and call `cleanUp()` on disposal.
  *  Construction throws are routed to the `onError` prop so consumers can
  *  show a fallback panel instead of letting the exception escape Solid's
  *  `<ErrorBoundary>` (which only catches errors during *Solid* render). */
@@ -21,7 +21,6 @@ import {
   on,
   onCleanup,
   onMount,
-  untrack,
 } from "solid-js";
 import { toError } from "./toError";
 
@@ -35,18 +34,17 @@ export type FileTreeProps = {
   selectedPath?: string | null;
   onSelect?: (path: string | null) => void;
   /** Enable Pierre's built-in header search affordance. Default `true`.
-   *  Set to `false` when the host renders its own search input and drives
-   *  the tree externally via `searchQuery`. */
+   *  Set to `false` when the host renders its own search input and
+   *  drives the tree by projecting `paths` directly. */
   search?: boolean;
-  /** External search query — when provided, forwarded to Pierre's
-   *  `setSearch()`. Useful when search lives in the caller's chrome
-   *  rather than the tree header. Pass empty string or `null` to clear. */
-  searchQuery?: string | null;
-  /** Fired when the tree's filter has gone to null independently of
-   *  `searchQuery`, leaving the host's input out of sync. Hosts should
-   *  resync (typically by clearing the input). Only invoked when
-   *  `searchQuery` was non-empty at the time of clearing. */
-  onSearchCleared?: () => void;
+  /** Directories the wrapper should keep expanded on top of whatever
+   *  Pierre's own expansion logic decides. Re-applied whenever this
+   *  prop or `paths` changes; never *collapses* a path that's no
+   *  longer listed, so a user's manual collapse on an unrelated
+   *  directory survives. Pierre's controller does not fight these
+   *  expansions because there is no active `setSearch` to drive
+   *  `#refreshActiveSearchState`. */
+  expandPaths?: readonly string[];
   /** Initial folder expansion — captured at construction and **not
    *  reactive**. Pierre takes this once in its constructor; later prop
    *  changes are silently ignored. Re-mount the component (e.g. by
@@ -84,21 +82,28 @@ export const FileTree: Component<FileTreeProps> = (props) => {
   // membership in this set is a reliable file-vs-folder discriminator.
   const fileSet = createMemo(() => new Set(props.paths));
 
-  // Pierre rejects `""` for setSearch (empty string ≠ "no filter"); collapse
-  // empty/null/undefined to `null` so callers don't need to reproduce this.
-  const normalizeSearchQuery = (q: string | null | undefined) =>
-    q && q.length > 0 ? q : null;
-
-  // Single funnel for "tell Pierre to (re)set its filter". Three callers —
-  // initial mount, the deferred prop effect, and the row-click re-apply
-  // below — all need identical normalization and the same `onError` route,
-  // so they share one helper rather than three try/catch dances.
-  const applySearchQuery = (q: string | null | undefined) => {
-    try {
-      tree?.setSearch(normalizeSearchQuery(q));
-    } catch (e) {
-      props.onError(toError(e));
+  // Pierre's `getItem` returns a `FileHandle | FolderHandle | undefined`
+  // union; only folders expose `expand`/`isExpanded`. Structural narrowing
+  // here is the typed access path — there is no exported guard.
+  const expandIfFolder = (path: string) => {
+    const item = tree?.getItem(path);
+    if (
+      item != null &&
+      "expand" in item &&
+      "isExpanded" in item &&
+      !item.isExpanded()
+    ) {
+      try {
+        item.expand();
+      } catch (e) {
+        props.onError(toError(e));
+      }
     }
+  };
+
+  const applyExpansions = (paths: readonly string[] | undefined) => {
+    if (paths == null || tree == null) return;
+    for (const path of paths) expandIfFolder(path);
   };
 
   onMount(() => {
@@ -123,95 +128,17 @@ export const FileTree: Component<FileTreeProps> = (props) => {
         },
       });
       tree.render({ containerWrapper: container });
-
-      // Pierre's `handleRowClick` (in
-      // `node_modules/@pierre/trees/dist/render/FileTreeView.js`) clears its
-      // internal search via `controller.closeSearch()` after every row
-      // click — `closeSearch: isSearchOpen` is hardcoded in
-      // `fileTreeRowClickPlan.js` with no opt-out. When the host drives
-      // search externally via `searchQuery`, that prop is the source of
-      // truth, so we restore it after Pierre's click handler returns.
-      //
-      // We hook the DOM `click` event rather than Pierre's
-      // `onSelectionChange` callback because Pierre's selection-version
-      // gate (`FileTreeController.js` `#applySelection` short-circuits
-      // when the new selection equals the current one) suppresses the
-      // callback on re-clicks of the already-selected row — but
-      // `closeSearch()` still runs on every click, so an
-      // `onSelectionChange`-based hook would silently miss the re-click
-      // case while Pierre wipes the filter anyway.
-      //
-      // Detection uses the `data-item-path` attribute Pierre stamps on
-      // every row, read by walking `event.composedPath()` to pierce the
-      // shadow root. File-vs-folder discrimination reuses `fileSet` —
-      // the same Set that gates `onSelectionChange`, since directories
-      // never appear in `props.paths`. Invariants this depends on:
-      //   1. Pierre's row-click handler stays synchronous (so the
-      //      microtask runs *after* `closeSearch` has fired, not before).
-      //   2. Pierre keeps emitting `data-item-path` on row elements.
-      // Both are true today; both would silently break this re-apply if
-      // Pierre changes them, so they're worth the comment.
-      //
-      // Folder branch: `hide-non-matches` mode auto-expands every match
-      // ancestor on each store event (FileTreeController `#subscribe` ->
-      // `#refreshActiveSearchState`), so a `setSearch` re-apply would
-      // immediately revert the user's collapse. Skip it and force-
-      // collapse if Pierre's `closeSearch` left the row expanded — only
-      // happens in `"open"` initial-expansion mode (pre-search expanded
-      // paths include the folder), and is now safe because search is
-      // null and the subscribe handler short-circuits.
-      const findClickedRowPath = (path: readonly EventTarget[]) => {
-        for (const target of path) {
-          if (
-            target instanceof HTMLElement &&
-            target.dataset.itemPath !== undefined
-          ) {
-            return target.dataset.itemPath;
-          }
-        }
-        return null;
-      };
-      const handleTreeRowClick = (event: MouseEvent) => {
-        const rowPath = findClickedRowPath(event.composedPath());
-        if (rowPath === null) return;
-        const isFolder = !fileSet().has(rowPath);
-        queueMicrotask(() => {
-          const q = untrack(() => props.searchQuery);
-          if (normalizeSearchQuery(q) === null) return;
-          if (!isFolder) {
-            applySearchQuery(q);
-            return;
-          }
-          props.onSearchCleared?.();
-          const item = tree?.getItem(rowPath);
-          if (
-            item != null &&
-            "isExpanded" in item &&
-            "collapse" in item &&
-            item.isExpanded()
-          ) {
-            try {
-              item.collapse();
-            } catch (e) {
-              props.onError(toError(e));
-            }
-          }
-        });
-      };
-      container.addEventListener("click", handleTreeRowClick);
-      onCleanup(() =>
-        container.removeEventListener("click", handleTreeRowClick),
-      );
-
-      // Apply an initial searchQuery if it was already non-empty at mount —
-      // the deferred effect below only fires on subsequent changes, so a
-      // pre-mount value would otherwise be silently dropped.
-      applySearchQuery(untrack(() => props.searchQuery));
+      applyExpansions(props.expandPaths);
     } catch (e) {
       props.onError(toError(e));
     }
   });
 
+  // Pierre's `resetPaths` rebuilds the path projection; whether it
+  // preserves expansion for surviving paths is an implementation detail
+  // we don't depend on. The expansion effect below re-applies expansion
+  // requests after every paths change, which is idempotent (no-op when
+  // the dir is already open).
   createEffect(
     on(
       () => props.paths,
@@ -222,6 +149,17 @@ export const FileTree: Component<FileTreeProps> = (props) => {
           props.onError(toError(e));
         }
       },
+      { defer: true },
+    ),
+  );
+
+  // Registration order matters: the paths effect above runs first when
+  // both change in the same tick, so Pierre's tree is rebuilt before we
+  // ask it to expand ancestors of the freshly projected paths.
+  createEffect(
+    on(
+      [() => props.paths, () => props.expandPaths],
+      ([, expandPaths]) => applyExpansions(expandPaths),
       { defer: true },
     ),
   );
@@ -239,8 +177,6 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       { defer: true },
     ),
   );
-
-  createEffect(on(() => props.searchQuery, applySearchQuery, { defer: true }));
 
   onCleanup(() => tree?.cleanUp());
 

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -37,13 +37,11 @@ export type FileTreeProps = {
    *  Set to `false` when the host renders its own search input and
    *  drives the tree by projecting `paths` directly. */
   search?: boolean;
-  /** Directories the wrapper should keep expanded on top of whatever
-   *  Pierre's own expansion logic decides. Re-applied whenever this
-   *  prop or `paths` changes; never *collapses* a path that's no
-   *  longer listed, so a user's manual collapse on an unrelated
-   *  directory survives. Pierre's controller does not fight these
-   *  expansions because there is no active `setSearch` to drive
-   *  `#refreshActiveSearchState`. */
+  /** Directories Pierre should open whenever the path projection
+   *  resets — forwarded as `initialExpandedPaths` to the constructor
+   *  and to each `resetPaths` call. Pierre opens these atomically with
+   *  the rebuild; expansion never falls out of sync with a path swap,
+   *  and the wrapper holds no separate per-path expansion state. */
   expandPaths?: readonly string[];
   /** Initial folder expansion — captured at construction and **not
    *  reactive**. Pierre takes this once in its constructor; later prop
@@ -82,35 +80,12 @@ export const FileTree: Component<FileTreeProps> = (props) => {
   // membership in this set is a reliable file-vs-folder discriminator.
   const fileSet = createMemo(() => new Set(props.paths));
 
-  // Pierre's `getItem` returns a `FileHandle | FolderHandle | undefined`
-  // union; only folders expose `expand`/`isExpanded`. Structural narrowing
-  // here is the typed access path — there is no exported guard.
-  const expandIfFolder = (path: string) => {
-    const item = tree?.getItem(path);
-    if (
-      item != null &&
-      "expand" in item &&
-      "isExpanded" in item &&
-      !item.isExpanded()
-    ) {
-      try {
-        item.expand();
-      } catch (e) {
-        props.onError(toError(e));
-      }
-    }
-  };
-
-  const applyExpansions = (paths: readonly string[] | undefined) => {
-    if (paths == null || tree == null) return;
-    for (const path of paths) expandIfFolder(path);
-  };
-
   onMount(() => {
     try {
       tree = new FileTreeClass({
         paths: props.paths,
         initialExpansion: props.initialExpansion ?? "closed",
+        initialExpandedPaths: props.expandPaths,
         flattenEmptyDirectories: props.flattenEmptyDirectories ?? true,
         stickyFolders: props.stickyFolders ?? true,
         icons: props.icons,
@@ -128,38 +103,26 @@ export const FileTree: Component<FileTreeProps> = (props) => {
         },
       });
       tree.render({ containerWrapper: container });
-      applyExpansions(props.expandPaths);
     } catch (e) {
       props.onError(toError(e));
     }
   });
 
-  // Pierre's `resetPaths` rebuilds the path projection; whether it
-  // preserves expansion for surviving paths is an implementation detail
-  // we don't depend on. The expansion effect below re-applies expansion
-  // requests after every paths change, which is idempotent (no-op when
-  // the dir is already open).
+  // `resetPaths` takes the new path inventory and the directories to
+  // open in one call (Pierre's `FileTreeResetOptions.initialExpandedPaths`).
+  // Tracking both inputs in the same effect means a paths-and-ancestors
+  // swap lands atomically — no second effect, no ordering invariant
+  // between "rebuild tree" and "open ancestors".
   createEffect(
     on(
-      () => props.paths,
-      (paths) => {
+      [() => props.paths, () => props.expandPaths],
+      ([paths, expandPaths]) => {
         try {
-          tree?.resetPaths(paths);
+          tree?.resetPaths(paths, { initialExpandedPaths: expandPaths });
         } catch (e) {
           props.onError(toError(e));
         }
       },
-      { defer: true },
-    ),
-  );
-
-  // Registration order matters: the paths effect above runs first when
-  // both change in the same tick, so Pierre's tree is rebuilt before we
-  // ask it to expand ancestors of the freshly projected paths.
-  createEffect(
-    on(
-      [() => props.paths, () => props.expandPaths],
-      ([, expandPaths]) => applyExpansions(expandPaths),
       { defer: true },
     ),
   );

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -42,16 +42,10 @@ export type FileTreeProps = {
    *  `setSearch()`. Useful when search lives in the caller's chrome
    *  rather than the tree header. Pass empty string or `null` to clear. */
   searchQuery?: string | null;
-  /** Notified when the wrapper's filter state has gone to null
-   *  independently of the host's `searchQuery` prop, leaving the host's
-   *  input out of sync with the tree. Today the only trigger is a
-   *  folder-row click during an active query — Pierre's
-   *  `hide-non-matches` mode auto-expands every ancestor of a match on
-   *  each store event, so a collapse can only stick after the filter is
-   *  released; the wrapper takes Pierre's own `closeSearch()` as the
-   *  user's exit cue. Hosts should resync their search input (typically
-   *  by clearing it) when this fires. Only invoked when `searchQuery`
-   *  was non-empty at the time of clearing. */
+  /** Fired when the tree's filter has gone to null independently of
+   *  `searchQuery`, leaving the host's input out of sync. Hosts should
+   *  resync (typically by clearing the input). Only invoked when
+   *  `searchQuery` was non-empty at the time of clearing. */
   onSearchCleared?: () => void;
   /** Initial folder expansion — captured at construction and **not
    *  reactive**. Pierre takes this once in its constructor; later prop

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -165,8 +165,14 @@ Feature: Code tab (review + browse)
   # back to the host so the input and tree resync — the user's collapse
   # then sticks, with the filter cleared (matching Pierre's native
   # closeSearch-on-row-click semantics).
-  Scenario: Folder collapse during active filter takes effect (browse)
-    Given a Code tab in "browse" mode showing files:
+  #
+  # Runs across all three modes because `initialExpansion` differs:
+  # `"open"` for `local`/`branch` (Pierre's `closeSearch` leaves the
+  # folder expanded via `restoreSearchExpandedPaths`, so the wrapper
+  # force-collapses) vs `"closed"` for `browse` (the folder lands
+  # collapsed naturally). Both paths must behave identically.
+  Scenario Outline: Folder collapse during active filter takes effect [<mode>]
+    Given a Code tab in "<mode>" mode showing files:
       | path          | content |
       | src/alpha.txt | a       |
       | src/beta.txt  | b       |
@@ -178,6 +184,12 @@ Feature: Code tab (review + browse)
     Then the Code tab should not show file "src/alpha.txt"
     And the Code tab filter input should contain ""
     And the Code tab should show file "other.txt"
+
+    Examples:
+      | mode   |
+      | local  |
+      | branch |
+      | browse |
 
   Scenario Outline: Filter matches files by path tokens [<mode>]
     Given a Code tab in "<mode>" mode showing files:

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -155,6 +155,30 @@ Feature: Code tab (review + browse)
       | branch |
       | browse |
 
+  # Regression: with an active filter, Pierre's `hide-non-matches` mode
+  # auto-expands every ancestor of a match on each store event — meaning
+  # `item.toggle()` collapse is reverted by the controller's subscribe
+  # handler before the click finishes, and the wrapper's `setSearch`
+  # re-apply expands it again. Net effect: chevron clicks on folders did
+  # nothing while a filter was active. Fix: on folder-row clicks during
+  # search the wrapper skips the re-apply and hands a clear-search signal
+  # back to the host so the input and tree resync — the user's collapse
+  # then sticks, with the filter cleared (matching Pierre's native
+  # closeSearch-on-row-click semantics).
+  Scenario: Folder collapse during active filter takes effect (browse)
+    Given a Code tab in "browse" mode showing files:
+      | path          | content |
+      | src/alpha.txt | a       |
+      | src/beta.txt  | b       |
+      | other.txt     | o       |
+    When I type "alpha" into the Code tab filter
+    Then the Code tab should show file "src/alpha.txt"
+    And the Code tab should not show file "other.txt"
+    When I click the directory node "src" in the Code tab
+    Then the Code tab should not show file "src/alpha.txt"
+    And the Code tab filter input should contain ""
+    And the Code tab should show file "other.txt"
+
   Scenario Outline: Filter matches files by path tokens [<mode>]
     Given a Code tab in "<mode>" mode showing files:
       | path                          | content |

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -156,24 +156,27 @@ Feature: Code tab (review + browse)
       | browse |
 
   # Regression: folder-chevron clicks did nothing while a filter was
-  # active. Runs across all three modes because `initialExpansion`
-  # diverges (`"open"` for diff modes exercises the wrapper's force-
-  # collapse branch; `"closed"` for browse lands collapsed naturally),
-  # and both paths must produce the same user-visible result. Wrapper-
-  # side rationale lives in FileTree.tsx alongside the fix.
-  Scenario Outline: Folder collapse during active filter takes effect [<mode>]
+  # active because Pierre's `hide-non-matches` controller re-expands
+  # every match ancestor on each store event. Fix: filter on Kolu's side
+  # (`fileSearch.ts`) so Pierre never sees the query, and ask the
+  # wrapper to ensure match ancestors are expanded via `expandPaths`.
+  # The user can now collapse a folder freely, and the filter stays
+  # active until they explicitly change it.
+  Scenario Outline: Folder collapse during active filter persists the filter [<mode>]
     Given a Code tab in "<mode>" mode showing files:
-      | path          | content |
-      | src/alpha.txt | a       |
-      | src/beta.txt  | b       |
-      | other.txt     | o       |
+      | path              | content |
+      | src/alpha-one.txt | a1      |
+      | src/alpha-two.txt | a2      |
+      | other.txt         | o       |
     When I type "alpha" into the Code tab filter
-    Then the Code tab should show file "src/alpha.txt"
+    Then the Code tab should show file "src/alpha-one.txt"
+    And the Code tab should show file "src/alpha-two.txt"
     And the Code tab should not show file "other.txt"
     When I click the directory node "src" in the Code tab
-    Then the Code tab should not show file "src/alpha.txt"
-    And the Code tab filter input should contain ""
-    And the Code tab should show file "other.txt"
+    Then the Code tab should not show file "src/alpha-one.txt"
+    And the Code tab should not show file "src/alpha-two.txt"
+    And the Code tab filter input should contain "alpha"
+    And the Code tab should not show file "other.txt"
 
     Examples:
       | mode   |

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -155,22 +155,12 @@ Feature: Code tab (review + browse)
       | branch |
       | browse |
 
-  # Regression: with an active filter, Pierre's `hide-non-matches` mode
-  # auto-expands every ancestor of a match on each store event — meaning
-  # `item.toggle()` collapse is reverted by the controller's subscribe
-  # handler before the click finishes, and the wrapper's `setSearch`
-  # re-apply expands it again. Net effect: chevron clicks on folders did
-  # nothing while a filter was active. Fix: on folder-row clicks during
-  # search the wrapper skips the re-apply and hands a clear-search signal
-  # back to the host so the input and tree resync — the user's collapse
-  # then sticks, with the filter cleared (matching Pierre's native
-  # closeSearch-on-row-click semantics).
-  #
-  # Runs across all three modes because `initialExpansion` differs:
-  # `"open"` for `local`/`branch` (Pierre's `closeSearch` leaves the
-  # folder expanded via `restoreSearchExpandedPaths`, so the wrapper
-  # force-collapses) vs `"closed"` for `browse` (the folder lands
-  # collapsed naturally). Both paths must behave identically.
+  # Regression: folder-chevron clicks did nothing while a filter was
+  # active. Runs across all three modes because `initialExpansion`
+  # diverges (`"open"` for diff modes exercises the wrapper's force-
+  # collapse branch; `"closed"` for browse lands collapsed naturally),
+  # and both paths must produce the same user-visible result. Wrapper-
+  # side rationale lives in FileTree.tsx alongside the fix.
   Scenario Outline: Folder collapse during active filter takes effect [<mode>]
     Given a Code tab in "<mode>" mode showing files:
       | path          | content |


### PR DESCRIPTION
**Clicking a folder chevron while the Code tab filter is active now collapses the folder and keeps the filter intact.** Previously the click did nothing — Pierre's `hide-non-matches` controller force-expanded every match ancestor on each store event, so `item.toggle()` was reverted before the click finished.

The fix moves filtering up out of Pierre: `fileSearch.ts` projects the matching paths on Kolu's side, and the wrapper drives Pierre purely through `paths` plus a list of ancestors to keep expanded. With no active `setSearch`, the controller's `#refreshActiveSearchState` never runs, so a user-initiated collapse simply sticks.

### Before vs. after

| Step                                | Before                          | After                                |
| ----------------------------------- | ------------------------------- | ------------------------------------ |
| Type "alpha" in the filter          | tree shrinks to matches         | tree shrinks to matches              |
| Click a folder chevron to collapse  | nothing happens                 | folder collapses, descendants hide   |
| Filter input state after the click  | still "alpha"                   | still "alpha" — *filter persists*    |

### What changed

- **`fileSearch.ts`** — always filters host-side and returns the ancestor set the wrapper should expand. No longer hands a residual query to Pierre.
- **`solid-pierre/FileTree`** — drops `searchQuery` / `onSearchCleared`; adds `expandPaths`. The wrapper applies the expansions via `tree.getItem(path).expand()` after each `resetPaths`. The previous row-click microtask (the `#817` workaround) is gone — without an active Pierre search, `closeSearch` never fires and there's nothing to re-apply.
- **`CodeTab`** — swaps `searchQuery` / `onSearchCleared` for `expandPaths`.

### Coverage

A new `Scenario Outline` in `code-tab.feature` runs across `local`/`branch`/`browse` and asserts the input still contains `"alpha"` after the collapse. The existing "Filter survives clicking a filtered result" outline (file-row branch) stays green.

> *Trade-off*: Pierre's in-row match highlighting goes away since its search is no longer active. The tree shrinking to matches already conveys "what matched"; if highlighting is wanted back, it'd be a separate render-side concern rather than a controller-driven one.

---

*Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`).*