### PR TITLE
Re-apply line range on repeat file-ref click in terminal

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -41,7 +41,7 @@ import {
 } from "../ui/pierreTheme";
 import { resolveLineRefPath } from "../ui/lineRef";
 import BrowseFileView from "./BrowseFileView";
-import { pendingCodeOpen } from "./codeNavigation";
+import { type CodeOpenRequest, pendingCodeOpen } from "./codeNavigation";
 import CodeMenuFrame from "./CodeMenuFrame";
 import { projectFileTreeSearch } from "./fileSearch";
 import FileSearchInput from "./FileSearchInput";
@@ -192,7 +192,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
           req &&
           req.repoRoot === repoPath() &&
           req.targetMode === view() &&
-          handled()?.token !== req.token
+          handled()?.request !== req
         ) {
           return;
         }
@@ -202,13 +202,16 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     ),
   );
 
-  // Consume-once record for the latest pendingCodeOpen tick.
-  // Storing the resolved path here lets `selectedRange` derive its
-  // value without re-running `resolveLineRefPath` (single resolution
-  // site per request) and lets `resetKey` know whether a pending
-  // request has already been applied.
+  // Consume-once record for the latest pendingCodeOpen tick. Holds
+  // the full request object (reference identity discriminates two
+  // structurally-identical clicks — `requestCodeOpen` mints a fresh
+  // object per call) alongside the resolved path. Storing the
+  // request here lets `selectedRange` derive its value without
+  // re-running `resolveLineRefPath` (single resolution site per
+  // request) and lets `resetKey` know whether a pending request
+  // has already been applied.
   const [handled, setHandled] = createSignal<{
-    token: number;
+    request: CodeOpenRequest;
     resolvedPath: string | null;
   } | null>(null);
 
@@ -230,7 +233,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
       },
       ({ req, repo, paths, isPending }) => {
         if (!req) return;
-        if (handled()?.token === req.token) return;
+        if (handled()?.request === req) return;
         if (repo === null || repo !== req.repoRoot) return;
         if (view() !== req.targetMode || isPending) return;
         const rel = resolveLineRefPath({
@@ -241,32 +244,33 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
         });
         if (rel === null) {
           toast.error(`File reference not found: ${req.ref.path}`);
-          setHandled({ token: req.token, resolvedPath: null });
+          setHandled({ request: req, resolvedPath: null });
           return;
         }
         setSelectedPath(rel);
-        setHandled({ token: req.token, resolvedPath: rel });
+        setHandled({ request: req, resolvedPath: rel });
       },
       { defer: true },
     ),
   );
 
   // Highlight range derives from the consume-once record: if the
-  // latest handled token matches the latest request AND its resolved
-  // path is still the rendered file, surface the line range. Any
-  // navigation away (user tree-click, mode switch) flips
+  // request we last handled matches the latest pending one AND its
+  // resolved path is still the rendered file, surface the line
+  // range. Any navigation away (user tree-click, mode switch) flips
   // `selectedPath` and naturally invalidates the memo — no second
   // resolution call.
   //
-  // No `equals` override: each click bumps `req.token`, but two clicks
-  // on the same `path:line` produce structurally identical
-  // `{start,end}`. Gating on content equality would suppress the
-  // second emit and leave the line-selection controller stuck on
-  // whatever range it last held (including `null`, if a Pierre
-  // tear-down between clicks cleared it). Pierre's
-  // `InteractionManager.setSelectedLines` dedups identical ranges
-  // internally, so re-emitting per click is a no-op when the
-  // selection is already correct, and a re-seed when it isn't.
+  // No `equals` override: two clicks on the same `path:line` produce
+  // structurally identical `{start, end}` but distinct request
+  // objects (`requestCodeOpen` mints a fresh one per call), so the
+  // memo emits a fresh value on every click. Pierre's
+  // `InteractionManager.setSelection` re-renders when the selection
+  // is "dirty" — and tearing down the gutter (panel collapse,
+  // virtualizer recreate) leaves `renderedSelectionRange === null`,
+  // which dirties it. Re-emitting per click is what re-paints the
+  // highlight in that case; the same content equality the old
+  // override gated on would silently drop the re-paint.
   const selectedRange = createMemo<{
     start: number;
     end: number;
@@ -274,7 +278,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     const req = pendingCodeOpen();
     if (!req) return null;
     const h = handled();
-    if (!h || h.token !== req.token || h.resolvedPath === null) return null;
+    if (!h || h.request !== req || h.resolvedPath === null) return null;
     if (h.resolvedPath !== selectedPath()) return null;
     return { start: req.ref.startLine, end: req.ref.endLine };
   });

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -257,28 +257,27 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // navigation away (user tree-click, mode switch) flips
   // `selectedPath` and naturally invalidates the memo — no second
   // resolution call.
+  //
+  // No `equals` override: each click bumps `req.token`, but two clicks
+  // on the same `path:line` produce structurally identical
+  // `{start,end}`. Gating on content equality would suppress the
+  // second emit and leave the line-selection controller stuck on
+  // whatever range it last held (including `null`, if a Pierre
+  // tear-down between clicks cleared it). Pierre's
+  // `InteractionManager.setSelectedLines` dedups identical ranges
+  // internally, so re-emitting per click is a no-op when the
+  // selection is already correct, and a re-seed when it isn't.
   const selectedRange = createMemo<{
     start: number;
     end: number;
-  } | null>(
-    () => {
-      const req = pendingCodeOpen();
-      if (!req) return null;
-      const h = handled();
-      if (!h || h.token !== req.token || h.resolvedPath === null) return null;
-      if (h.resolvedPath !== selectedPath()) return null;
-      return { start: req.ref.startLine, end: req.ref.endLine };
-    },
-    null,
-    {
-      // Same-value re-emits cause the line-selection controller to
-      // re-fire its initial-range effect with an identical object.
-      // Equality-gating here keeps the controller stable when the
-      // request hasn't actually changed.
-      equals: (a, b) =>
-        a === b || (!!a && !!b && a.start === b.start && a.end === b.end),
-    },
-  );
+  } | null>(() => {
+    const req = pendingCodeOpen();
+    if (!req) return null;
+    const h = handled();
+    if (!h || h.token !== req.token || h.resolvedPath === null) return null;
+    if (h.resolvedPath !== selectedPath()) return null;
+    return { start: req.ref.startLine, end: req.ref.endLine };
+  });
 
   const treePaths = createMemo(() => {
     if (view() === "browse") return allPaths()?.paths ?? [];

--- a/packages/client/src/right-panel/codeNavigation.ts
+++ b/packages/client/src/right-panel/codeNavigation.ts
@@ -3,7 +3,10 @@
  *  Terminal link-click handlers (and any future caller that needs to
  *  open a file from outside the right panel) publish a request here;
  *  `CodeTab` observes the signal and reacts. Latest request wins;
- *  callers don't need to clear it. */
+ *  callers don't need to clear it. Each call mints a fresh request
+ *  object, so two clicks on the same `path:line` are distinct by
+ *  reference — that's what lets `CodeTab` tell them apart even when
+ *  their `ref` content matches. */
 
 import { createSignal } from "solid-js";
 import type { LineRef } from "../ui/lineRef";
@@ -25,21 +28,13 @@ export interface CodeOpenRequest {
    *  consumer guard explicitly instead of relying on the click
    *  handler having pre-called `openCodeBrowser` in the right order. */
   targetMode: "browse";
-  /** Token incremented on every request so two clicks on the same
-   *  `path:line` re-trigger the effect (signals dedupe by reference;
-   *  identical content with a new token compares unequal). */
-  token: number;
 }
 
-let nextToken = 1;
 const [pending, setPending] = createSignal<CodeOpenRequest | null>(null);
 
 export const pendingCodeOpen = pending;
 
-export function requestCodeOpen(
-  req: Omit<CodeOpenRequest, "token">,
-): CodeOpenRequest {
-  const full: CodeOpenRequest = { ...req, token: nextToken++ };
-  setPending(full);
-  return full;
+export function requestCodeOpen(req: CodeOpenRequest): CodeOpenRequest {
+  setPending(req);
+  return req;
 }

--- a/packages/client/src/right-panel/codeNavigation.ts
+++ b/packages/client/src/right-panel/codeNavigation.ts
@@ -34,7 +34,6 @@ const [pending, setPending] = createSignal<CodeOpenRequest | null>(null);
 
 export const pendingCodeOpen = pending;
 
-export function requestCodeOpen(req: CodeOpenRequest): CodeOpenRequest {
+export function requestCodeOpen(req: CodeOpenRequest): void {
   setPending(req);
-  return req;
 }

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -24,3 +24,17 @@ Feature: File-ref autolinking in terminal
     And I run "echo 'block at range.txt:2-4 needs attention'"
     And I trigger the terminal file-ref link "range.txt:2-4"
     Then the selected file should show content "three"
+
+  Scenario: Re-clicking the same file-ref after closing the panel re-selects the line
+    When I run "git init /tmp/kolu-file-ref-861-reclick && cd /tmp/kolu-file-ref-861-reclick"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'one\ntwo\nthree\nfour\nfive\nsix\n' > recheck.txt"
+    And I run "echo 'see recheck.txt:3 again'"
+    And I trigger the terminal file-ref link "recheck.txt:3"
+    Then the selected file should show content "three"
+    And line 3 should be selected in the file content
+    When I collapse the right panel
+    Then the right panel should not be visible
+    When I trigger the terminal file-ref link "recheck.txt:3"
+    Then the right panel should be visible
+    And line 3 should be selected in the file content

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -689,31 +689,20 @@ Then(
   "the selected file should show content {string}",
   async function (this: KoluWorld, expected: string) {
     await this.page.waitForFunction(
-      (exp) => {
-        for (const sel of [
-          '[data-testid="pierre-diff-view"]',
-          '[data-testid="pierre-file-view"]',
-        ]) {
+      `(() => {
+        ${SHADOW_DFS_FN_SRC}
+        for (const sel of ['${DIFF_VIEW}', '${FILE_VIEW}']) {
           const root = document.querySelector(sel);
           if (!root) continue;
-          const stack: Node[] = [root];
-          let text = "";
-          while (stack.length) {
-            const n = stack.pop() as Node;
-            if (n.nodeType === 3) text += (n as Text).nodeValue || "";
-            if (n.nodeType === 1) {
-              const el = n as Element;
-              const sh = (el as unknown as { shadowRoot?: ShadowRoot })
-                .shadowRoot;
-              if (sh) for (const ch of sh.childNodes) stack.push(ch);
-              for (const ch of el.childNodes) stack.push(ch);
-            }
-          }
-          if (text.includes(exp)) return true;
+          let text = '';
+          shadowDfs(root, (node) => {
+            if (node.nodeType === 3) text += node.nodeValue || '';
+          });
+          if (text.includes(${JSON.stringify(expected)})) return true;
         }
         return false;
-      },
-      expected,
+      })()`,
+      undefined,
       { timeout: POLL_TIMEOUT },
     );
   },

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -170,34 +170,30 @@ When("I right-click the diff view", async function (this: KoluWorld) {
 // Pierre marks selected gutter + content rows with `data-selected-line`
 // (see @pierre/diffs InteractionManager.renderSelectedLines). The gutter
 // element also carries `data-column-number`, so we can pinpoint the line
-// number from outside Pierre's shadow root via a combined attribute
-// selector. Walks open shadow roots because Pierre mounts the gutter
-// inside its `<pre>` shadow tree.
+// number via a combined attribute selector. The traversal goes through
+// Pierre's open shadow tree — see `SHADOW_DFS_FN_SRC` below.
 Then(
   "line {int} should be selected in the file content",
   async function (this: KoluWorld, line: number) {
     await this.page.waitForFunction(
-      ({ sel, ln }) => {
-        const root = document.querySelector(sel);
+      `(() => {
+        ${SHADOW_DFS_FN_SRC}
+        const root = document.querySelector('${FILE_VIEW}');
         if (!root) return false;
-        const stack: Node[] = [root];
-        while (stack.length) {
-          const n = stack.pop() as Node;
-          if (n.nodeType !== 1) continue;
-          const el = n as Element;
-          const sh = (el as unknown as { shadowRoot?: ShadowRoot }).shadowRoot;
-          if (sh) for (const ch of sh.childNodes) stack.push(ch);
-          for (const ch of el.childNodes) stack.push(ch);
+        let found = false;
+        shadowDfs(root, (node) => {
           if (
-            el.hasAttribute("data-selected-line") &&
-            el.getAttribute("data-column-number") === String(ln)
+            node.nodeType === 1 &&
+            node.hasAttribute('data-selected-line') &&
+            node.getAttribute('data-column-number') === '${line}'
           ) {
+            found = true;
             return true;
           }
-        }
-        return false;
-      },
-      { sel: FILE_VIEW, ln: line },
+        });
+        return found;
+      })()`,
+      undefined,
       { timeout: POLL_TIMEOUT },
     );
   },
@@ -388,11 +384,28 @@ Then(
   },
 );
 
-// Pierre's File / FileDiff renderers mount highlighted code inside a
-// shadow root. `Element.textContent` does NOT cross shadow boundaries,
-// so we walk the tree (including each `shadowRoot`) and stitch the text.
-// Inlined as a string-evaluate to dodge tsx's `__name` injection, which
-// crashes inside `page.evaluate` arg functions.
+// Browser-side shadow-aware DFS, shared by every Pierre-DOM assertion in
+// this file. Pierre mounts its rendered content inside an open shadow
+// root; ordinary descendant CSS queries pierce it, but `textContent` and
+// attribute walks need an explicit traversal that descends through each
+// `shadowRoot.childNodes`. Defined as a string so callers can splice it
+// into `page.waitForFunction` evaluators — `page.evaluate` arg functions
+// crash on tsx's `__name` injection. `visit(node)` returns `true` to
+// short-circuit (predicate walks); accumulator walks mutate closure
+// state and return `undefined`.
+const SHADOW_DFS_FN_SRC = `
+function shadowDfs(root, visit) {
+  const stack = [root];
+  while (stack.length) {
+    const node = stack.pop();
+    if (visit(node) === true) return;
+    if (node.nodeType === 1) {
+      if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
+      for (const ch of node.childNodes) stack.push(ch);
+    }
+  }
+}`;
+
 async function waitForViewText(
   world: KoluWorld,
   testid: string,
@@ -400,18 +413,13 @@ async function waitForViewText(
 ) {
   await world.page.waitForFunction(
     `(() => {
+      ${SHADOW_DFS_FN_SRC}
       const root = document.querySelector('[data-testid="${testid}"]');
       if (!root) return false;
-      const stack = [root];
       let text = '';
-      while (stack.length) {
-        const node = stack.pop();
+      shadowDfs(root, (node) => {
         if (node.nodeType === 3) text += node.nodeValue || '';
-        if (node.nodeType === 1) {
-          if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
-          for (const ch of node.childNodes) stack.push(ch);
-        }
-      }
+      });
       return text.includes(${JSON.stringify(expected)});
     })()`,
     undefined,

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -180,18 +180,11 @@ Then(
         ${SHADOW_DFS_FN_SRC}
         const root = document.querySelector('${FILE_VIEW}');
         if (!root) return false;
-        let found = false;
-        shadowDfs(root, (node) => {
-          if (
-            node.nodeType === 1 &&
-            node.hasAttribute('data-selected-line') &&
-            node.getAttribute('data-column-number') === '${line}'
-          ) {
-            found = true;
-            return true;
-          }
-        });
-        return found;
+        return shadowDfs(root, (node) =>
+          node.nodeType === 1 &&
+          node.hasAttribute('data-selected-line') &&
+          node.getAttribute('data-column-number') === '${line}'
+        ) === true;
       })()`,
       undefined,
       { timeout: POLL_TIMEOUT },
@@ -390,15 +383,16 @@ Then(
 // attribute walks need an explicit traversal that descends through each
 // `shadowRoot.childNodes`. Defined as a string so callers can splice it
 // into `page.waitForFunction` evaluators — `page.evaluate` arg functions
-// crash on tsx's `__name` injection. `visit(node)` returns `true` to
-// short-circuit (predicate walks); accumulator walks mutate closure
-// state and return `undefined`.
+// crash on tsx's `__name` injection. A truthy return from `visit(node)`
+// short-circuits the walk and bubbles back as the helper's return value;
+// accumulator walks mutate closure state and return `undefined`.
 const SHADOW_DFS_FN_SRC = `
 function shadowDfs(root, visit) {
   const stack = [root];
   while (stack.length) {
     const node = stack.pop();
-    if (visit(node) === true) return;
+    const r = visit(node);
+    if (r) return r;
     if (node.nodeType === 1) {
       if (node.shadowRoot) for (const ch of node.shadowRoot.childNodes) stack.push(ch);
       for (const ch of node.childNodes) stack.push(ch);

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -167,6 +167,42 @@ When("I right-click the diff view", async function (this: KoluWorld) {
   await rightClickViewRoot(this, DIFF_VIEW);
 });
 
+// Pierre marks selected gutter + content rows with `data-selected-line`
+// (see @pierre/diffs InteractionManager.renderSelectedLines). The gutter
+// element also carries `data-column-number`, so we can pinpoint the line
+// number from outside Pierre's shadow root via a combined attribute
+// selector. Walks open shadow roots because Pierre mounts the gutter
+// inside its `<pre>` shadow tree.
+Then(
+  "line {int} should be selected in the file content",
+  async function (this: KoluWorld, line: number) {
+    await this.page.waitForFunction(
+      ({ sel, ln }) => {
+        const root = document.querySelector(sel);
+        if (!root) return false;
+        const stack: Node[] = [root];
+        while (stack.length) {
+          const n = stack.pop() as Node;
+          if (n.nodeType !== 1) continue;
+          const el = n as Element;
+          const sh = (el as unknown as { shadowRoot?: ShadowRoot }).shadowRoot;
+          if (sh) for (const ch of sh.childNodes) stack.push(ch);
+          for (const ch of el.childNodes) stack.push(ch);
+          if (
+            el.hasAttribute("data-selected-line") &&
+            el.getAttribute("data-column-number") === String(ln)
+          ) {
+            return true;
+          }
+        }
+        return false;
+      },
+      { sel: FILE_VIEW, ln: line },
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // Asserts the exact set of items in the Pierre diff/file context menu,
 // in order, joined with " | ". Stronger than `I click the context menu
 // item {string}` because it catches "wrong items present" regressions

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -9,6 +9,16 @@ When("I press the toggle inspector shortcut", async function (this: KoluWorld) {
   await this.waitForFrame();
 });
 
+When("I collapse the right panel", async function (this: KoluWorld) {
+  // RightPanel's chrome-bar collapse button — clicking it from the
+  // expanded state toggles `rightPanel.collapsed` to true (Resizable
+  // shrinks the panel to ~0 width while the DOM stays mounted).
+  const btn = this.page.locator('button[aria-label="Collapse panel"]');
+  await btn.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await btn.click();
+  await this.waitForFrame();
+});
+
 When(
   "I click the inspector toggle icon in the header",
   async function (this: KoluWorld) {


### PR DESCRIPTION
**Clicking the same `path:line` reference in the terminal twice now consistently selects the line on each click — even after collapsing and re-opening the right panel between clicks.** The previous build silently dropped the second click's selection when its `{start, end}` content happened to match the first.

### Why the bug existed

`CodeTab`'s `selectedRange` memo carried an `equals` override that gated emit on `{start, end}` content equality. Two clicks on the same `path:line` produce structurally identical ranges, so the second click was suppressed at the memo boundary. Downstream, `useLineSelection`'s deferred initial-range effect never re-fired and the controller stayed on whatever range it last held — including `null`, if a Pierre tear-down (panel collapse, virtualizer recreate) had cleared `renderedSelectionRange` in the meantime. Pierre's `InteractionManager.setSelection` already dedups identical ranges internally _when the selection isn't dirty_; the consumer-side gate was double-dipping on dedup and losing the dirty-selection re-paint.

### What changed

The fix drops the `equals` override. Each click flows through the memo as a fresh emission and Pierre decides whether to actually re-paint. While here, two structural follow-ons surfaced cleanly:

| Commit | What | Why |
|---|---|---|
| `fix(code-tab)` | Drop `selectedRange` `equals` override | Primary fix |
| `refactor(hickey)` | Use request reference identity instead of `token` counter | `nextToken` was the fossil of the equals workaround — each `requestCodeOpen` call already mints a fresh object, so `pendingCodeOpen` ticks on reference identity alone |
| `refactor(lowy)` | Extract `SHADOW_DFS_FN_SRC` for Pierre-shadow assertions | The new line-selection step would have been the second hand-rolled DFS in the file |
| `refactor(police)` × 3 | `shadowDfs` propagates visitor return; third walker uses the helper; `requestCodeOpen` returns `void` | Elegance pass cleanup |

### Test coverage

A new scenario in `file-ref-link.feature` exercises the exact bug path: click → assert line selected → collapse panel → re-click same ref → assert line still selected. The assertion uses a new `Then "line {int} should be selected in the file content"` step that probes Pierre's `data-selected-line` attribute through the shared shadow-DFS helper.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._