### PR TITLE
fix(terminal): unblock Linux Ctrl+Shift+C copy and Ctrl+J newline

### DIFF
--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -18,6 +18,7 @@ const HELP_ORDER: readonly { id: ActionId; label?: string }[] = [
   { id: "cycleTerminalMru" },
   { id: "switchTo1", label: "Switch to terminal 1–9" },
   { id: "findInTerminal" },
+  { id: "copySelection" },
   { id: "zoomIn" },
   { id: "zoomOut" },
   { id: "zoomReset" },

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -207,7 +207,12 @@ const _ACTIONS = {
   },
   shuffleTheme: {
     label: "Shuffle theme",
-    keybind: { key: "j", mod: true },
+    // Mod+Shift+J — bare Mod+J on Linux collided with Claude Code's
+    // in-PTY newline shortcut (Ctrl+J). The shifted chord stays
+    // memorable, frees Ctrl+J to reach the PTY, and matches the
+    // Mod+Shift+<letter> convention used by openWorkspaceSwitcher
+    // and screenshotTerminal. Closes #873.
+    keybind: { key: "J", code: "KeyJ", mod: true, shift: true },
     handler: (ctx) => ctx.handleShuffleTheme(),
   },
   screenshotTerminal: {

--- a/packages/client/src/input/actions.ts
+++ b/packages/client/src/input/actions.ts
@@ -215,6 +215,15 @@ const _ACTIONS = {
     keybind: { key: "S", code: "KeyS", mod: true, shift: true },
     handler: (ctx) => ctx.handleScreenshotTerminal(),
   },
+  copySelection: {
+    label: "Copy selection",
+    // Physical Ctrl (not platform mod) — Linux/Windows terminal chord.
+    // Dispatch is xterm-handler-local (Terminal.tsx) because xterm's
+    // selection lives outside the textarea, so the action only makes
+    // sense with a live xterm ref. Registered here for ShortcutsHelp
+    // visibility and so matchesAnyShortcut sees it.
+    keybind: { key: "C", code: "KeyC", ctrl: true, shift: true },
+  },
   toggleRightPanel: {
     label: "Toggle inspector panel",
     keybind: { key: "b", code: "KeyB", mod: true, alt: true },

--- a/packages/client/src/input/keyboard.test.ts
+++ b/packages/client/src/input/keyboard.test.ts
@@ -4,12 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("./platform", () => ({ isMac: false }));
 
 import { matchesAnyShortcut } from "./actions";
-import {
-  formatKeybind,
-  isCopySelectionChord,
-  type Keybind,
-  matchesKeybind,
-} from "./keyboard";
+import { formatKeybind, type Keybind, matchesKeybind } from "./keyboard";
 
 function makeEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
   return {
@@ -149,12 +144,15 @@ describe("matchesAnyShortcut", () => {
     ).toBe(true);
   });
 
-  it("does not match Ctrl/Cmd+Shift+C", () => {
+  it("matches Ctrl+Shift+C (copy selection — physical Ctrl)", () => {
     expect(
       matchesAnyShortcut(
         makeEvent({ key: "C", code: "KeyC", ctrlKey: true, shiftKey: true }),
       ),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("does not match Cmd+Shift+C (copy chord requires physical Ctrl)", () => {
     expect(
       matchesAnyShortcut(
         makeEvent({ key: "C", code: "KeyC", metaKey: true, shiftKey: true }),
@@ -164,39 +162,5 @@ describe("matchesAnyShortcut", () => {
 
   it("does not match random key", () => {
     expect(matchesAnyShortcut(makeEvent({ key: "z" }))).toBe(false);
-  });
-});
-
-describe("isCopySelectionChord (non-mac)", () => {
-  it("matches Ctrl+Shift+C", () => {
-    expect(
-      isCopySelectionChord(
-        makeEvent({ key: "C", code: "KeyC", ctrlKey: true, shiftKey: true }),
-      ),
-    ).toBe(true);
-  });
-
-  it("rejects Ctrl+C (no shift)", () => {
-    expect(
-      isCopySelectionChord(
-        makeEvent({ key: "c", code: "KeyC", ctrlKey: true }),
-      ),
-    ).toBe(false);
-  });
-
-  it("rejects Shift+C (no ctrl)", () => {
-    expect(
-      isCopySelectionChord(
-        makeEvent({ key: "C", code: "KeyC", shiftKey: true }),
-      ),
-    ).toBe(false);
-  });
-
-  it("rejects Ctrl+Shift+V", () => {
-    expect(
-      isCopySelectionChord(
-        makeEvent({ key: "V", code: "KeyV", ctrlKey: true, shiftKey: true }),
-      ),
-    ).toBe(false);
   });
 });

--- a/packages/client/src/input/keyboard.test.ts
+++ b/packages/client/src/input/keyboard.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("./platform", () => ({ isMac: false }));
 
 import { matchesAnyShortcut } from "./actions";
-import { formatKeybind, type Keybind, matchesKeybind } from "./keyboard";
+import {
+  formatKeybind,
+  isCopySelectionChord,
+  type Keybind,
+  matchesKeybind,
+} from "./keyboard";
 
 function makeEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
   return {
@@ -159,5 +164,39 @@ describe("matchesAnyShortcut", () => {
 
   it("does not match random key", () => {
     expect(matchesAnyShortcut(makeEvent({ key: "z" }))).toBe(false);
+  });
+});
+
+describe("isCopySelectionChord (non-mac)", () => {
+  it("matches Ctrl+Shift+C", () => {
+    expect(
+      isCopySelectionChord(
+        makeEvent({ key: "C", code: "KeyC", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects Ctrl+C (no shift)", () => {
+    expect(
+      isCopySelectionChord(
+        makeEvent({ key: "c", code: "KeyC", ctrlKey: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects Shift+C (no ctrl)", () => {
+    expect(
+      isCopySelectionChord(
+        makeEvent({ key: "C", code: "KeyC", shiftKey: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects Ctrl+Shift+V", () => {
+    expect(
+      isCopySelectionChord(
+        makeEvent({ key: "V", code: "KeyV", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -11,15 +11,6 @@ export function isPlatformModifier(e: KeyboardEvent): boolean {
   return isMac ? e.metaKey : e.ctrlKey;
 }
 
-/** Terminal-style copy chord (Ctrl+Shift+C) on Linux/Windows. Always false
- *  on macOS — Cmd+C is the platform copy chord there. Chromium binds this
- *  chord to DevTools' "Inspect Element" picker globally, so the page must
- *  call `preventDefault()` to keep it as a copy shortcut. */
-export function isCopySelectionChord(e: KeyboardEvent): boolean {
-  if (isMac) return false;
-  return e.ctrlKey && e.shiftKey && e.code === "KeyC";
-}
-
 /** Zoom key deltas: maps key to font-size change direction. */
 export const ZOOM_KEYS: Record<string, 1 | -1> = { "=": 1, "+": 1, "-": -1 };
 

--- a/packages/client/src/input/keyboard.ts
+++ b/packages/client/src/input/keyboard.ts
@@ -11,6 +11,15 @@ export function isPlatformModifier(e: KeyboardEvent): boolean {
   return isMac ? e.metaKey : e.ctrlKey;
 }
 
+/** Terminal-style copy chord (Ctrl+Shift+C) on Linux/Windows. Always false
+ *  on macOS — Cmd+C is the platform copy chord there. Chromium binds this
+ *  chord to DevTools' "Inspect Element" picker globally, so the page must
+ *  call `preventDefault()` to keep it as a copy shortcut. */
+export function isCopySelectionChord(e: KeyboardEvent): boolean {
+  if (isMac) return false;
+  return e.ctrlKey && e.shiftKey && e.code === "KeyC";
+}
+
 /** Zoom key deltas: maps key to font-size change direction. */
 export const ZOOM_KEYS: Record<string, 1 | -1> = { "=": 1, "+": 1, "-": -1 };
 

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -28,13 +28,13 @@ import {
   Show,
 } from "solid-js";
 import { match } from "ts-pattern";
-import { SafeClipboardProvider, writeTextToClipboard } from "./clipboard";
+import { copyTextWithToast, SafeClipboardProvider } from "./clipboard";
 import "@xterm/xterm/css/xterm.css";
 import type { TerminalId } from "kolu-common/surface";
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
 import { FONT_FAMILY } from "terminal-themes";
-import { matchesAnyShortcut } from "../input/actions";
-import { isCopySelectionChord } from "../input/keyboard";
+import { ACTIONS, matchesAnyShortcut } from "../input/actions";
+import { matchesKeybind } from "../input/keyboard";
 import { createZoom } from "../input/zoom";
 import { refitOnTabVisible } from "../refitOnTabVisible";
 import { streamCall } from "@kolu/surface/solid";
@@ -587,13 +587,17 @@ const Terminal: Component<{
             // preventDefault, Chromium hijacks the chord to open DevTools'
             // Inspect Element picker. xterm's selection isn't reflected in
             // the textarea either, so we copy via getSelection() ourselves.
-            if (isCopySelectionChord(e)) {
+            // Must come before the matchesAnyShortcut check below, since
+            // copySelection is registered there for ShortcutsHelp visibility
+            // but dispatched here.
+            if (matchesKeybind(e, ACTIONS.copySelection.keybind)) {
               e.preventDefault();
               const selection = term.getSelection();
               if (selection)
-                void writeTextToClipboard(selection).catch((err: Error) =>
-                  console.error("Failed to copy selection:", err),
-                );
+                void copyTextWithToast(selection, {
+                  success: "Copied selection to clipboard",
+                  failure: "Failed to copy selection",
+                });
               return false;
             }
 

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -28,12 +28,13 @@ import {
   Show,
 } from "solid-js";
 import { match } from "ts-pattern";
-import { SafeClipboardProvider } from "./clipboard";
+import { SafeClipboardProvider, writeTextToClipboard } from "./clipboard";
 import "@xterm/xterm/css/xterm.css";
 import type { TerminalId } from "kolu-common/surface";
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
 import { FONT_FAMILY } from "terminal-themes";
 import { matchesAnyShortcut } from "../input/actions";
+import { isCopySelectionChord } from "../input/keyboard";
 import { createZoom } from "../input/zoom";
 import { refitOnTabVisible } from "../refitOnTabVisible";
 import { streamCall } from "@kolu/surface/solid";
@@ -581,6 +582,20 @@ const Terminal: Component<{
             // Let browser handle Ctrl+V so it fires a paste event. Our capture-phase
             // paste listener uploads images; xterm's own paste handler covers text.
             if (e.ctrlKey && e.key === "v") return false;
+
+            // Ctrl+Shift+C — Linux/Windows terminal copy chord. Without
+            // preventDefault, Chromium hijacks the chord to open DevTools'
+            // Inspect Element picker. xterm's selection isn't reflected in
+            // the textarea either, so we copy via getSelection() ourselves.
+            if (isCopySelectionChord(e)) {
+              e.preventDefault();
+              const selection = term.getSelection();
+              if (selection)
+                void writeTextToClipboard(selection).catch((err: Error) =>
+                  console.error("Failed to copy selection:", err),
+                );
+              return false;
+            }
 
             // Let any registered app shortcut bubble through to the capture-phase dispatcher
             if (matchesAnyShortcut(e)) return false;


### PR DESCRIPTION
**Two Linux-terminal keyboard chords that should have just worked but didn't.** Ctrl+Shift+C — the universal terminal copy shortcut everywhere except Mac — opened Chrome DevTools' "Inspect Element" picker instead of copying the xterm selection. Ctrl+J — Claude Code's in-PTY newline — was eaten by the global shortcut dispatcher and routed to "Shuffle theme" before xterm could see it. Both are now fixed.

### What changed

| Chord | Before | After |
| --- | --- | --- |
| Ctrl+Shift+C (Linux/Windows) | Opens DevTools "Inspect Element"; nothing copied | Copies xterm selection via `copyTextWithToast`; toast confirms or surfaces error |
| Ctrl+J (Linux) / Cmd+J (Mac) | Shuffles theme — preempts Claude Code's newline | Reaches the PTY. Theme shuffle moved to Mod+Shift+J |

### How

For **Ctrl+Shift+C**: Chromium binds the chord to its DevTools accelerator, but the page can opt out via `preventDefault` on keydown. xterm's custom key handler now detects the chord (via the registry's `Keybind` — see below), calls `preventDefault` to block the accelerator, and copies `term.getSelection()` through the existing `writeTextToClipboard` / `copyTextWithToast` helpers. xterm's selection lives outside the textarea, so native Ctrl+C wouldn't work even if the accelerator were blocked. _Ctrl+Shift+V continues to work unchanged via the focused textarea's native paste path._

For **Ctrl+J**: rebind `shuffleTheme` to `{ key: "J", mod: true, shift: true }`. Same convention as `openWorkspaceSwitcher` and `screenshotTerminal`. The capture-phase dispatcher no longer claims the bare chord, so the global `keydown` listener doesn't `preventDefault` and the event bubbles to the focused xterm textarea, where the PTY receives `^J`.

### Structural notes

The PR went through hickey + lowy review mid-flight. Three findings landed as follow-up commits before the Ctrl+J work:

- The chord lives in `ACTIONS` as a `DisplayOnlyAction` (registry is the single source of truth), with dispatch staying in `Terminal.tsx` — same pattern as `zoomIn` / `cycleTerminalMru`. No bespoke `isCopySelectionChord` predicate; `matchesKeybind` does the work.
- Copy failures route through `copyTextWithToast` so users get a visible toast on permission denial or non-secure-context fallback failure, matching the other three clipboard sites and the `toast-conventions.md` rule.
- `copySelection` now appears in the Shortcuts-Help overlay, slotted next to `findInTerminal`.

Closes #873.

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._