### PR TITLE
test(theme): update shuffle-theme shortcut step to Mod+Shift+J

### DIFF
--- a/packages/tests/step_definitions/theme_steps.ts
+++ b/packages/tests/step_definitions/theme_steps.ts
@@ -53,7 +53,7 @@ Then(
 );
 
 When("I press the shuffle theme shortcut", async function (this: KoluWorld) {
-  await this.page.keyboard.press(`${MOD_KEY}+j`);
+  await this.page.keyboard.press(`${MOD_KEY}+Shift+J`);
   await this.waitForFrame();
 });
 
@@ -70,7 +70,7 @@ When(
     this.shuffleHistory = [initial];
     for (let i = 0; i < count; i++) {
       const before = this.shuffleHistory.at(-1) ?? "";
-      await this.page.keyboard.press(`${MOD_KEY}+j`);
+      await this.page.keyboard.press(`${MOD_KEY}+Shift+J`);
       // Wait until the theme name actually changes — shuffle is async (RPC
       // round-trip + subscription tick), so reading immediately after the
       // keypress would race and capture the prior theme.


### PR DESCRIPTION
**Follow-up to #872, which slipped through the squash merge.** That PR rebound `shuffleTheme` from `Mod+J` to `Mod+Shift+J` (freeing Linux Ctrl+J for the PTY, closing #873), but the cucumber step that drives the shortcut still typed the old bare chord — so `theme.feature`'s shuffle scenarios time out on master waiting for a theme change that never happens.

One-line fix in `packages/tests/step_definitions/theme_steps.ts`: type `${MOD_KEY}+Shift+J` instead of `${MOD_KEY}+j`. Verified locally with `just test-quick features/theme.feature` — 12/12 scenarios pass.

_Generated by Claude Code (model \`claude-opus-4-7\`)._