### PR TITLE
Morph parked minimap tiles instead of snapping

### DIFF
--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -358,6 +358,39 @@ const CanvasMinimap: Component<{
             // the staleness threshold over time.
             const parked = () => state().parked;
             const isActive = () => store.activeId() === id;
+            // Full styling for the morphing tile — geometry, background, and
+            // border in one place. When parked geometry or aesthetics change
+            // (e.g. a different ghost size, a new dim color), this helper is
+            // the only edit site. Background goes through inline style for
+            // both states (one mechanism), matching the `bg-fg-3/40` token via
+            // `color-mix` so the parked branch stays themable.
+            const tileStyle = (t: {
+              x: number;
+              y: number;
+              w: number;
+              h: number;
+              repoColor: string;
+            }): JSX.CSSProperties => {
+              if (parked()) {
+                return {
+                  left: `${t.x + t.w / 2 - GHOST_PX / 2}px`,
+                  top: `${t.y + t.h / 2 - GHOST_PX / 2}px`,
+                  width: `${GHOST_PX}px`,
+                  height: `${GHOST_PX}px`,
+                  "background-color":
+                    "color-mix(in oklab, var(--color-fg-3) 40%, transparent)",
+                  border: "1px solid transparent",
+                };
+              }
+              return {
+                left: `${t.x}px`,
+                top: `${t.y}px`,
+                width: `${t.w}px`,
+                height: `${t.h}px`,
+                "background-color": theme().bg,
+                border: `1px solid ${t.repoColor}`,
+              };
+            };
             return (
               <Show when={tile()}>
                 {(t) => (
@@ -372,7 +405,7 @@ const CanvasMinimap: Component<{
                     data-parked={parked() ? "" : undefined}
                     class={`absolute cursor-pointer transition-all ${MORPH_TRANSITION} hover:ring-1 hover:ring-accent/40`}
                     classList={{
-                      "rounded-full bg-fg-3/40 hover:bg-fg-3/80": parked(),
+                      "rounded-full": parked(),
                       "rounded-sm hover:opacity-100": !parked(),
                       "ring-1 ring-accent/60": isActive(),
                       // Active and parked tiles stay at full opacity so the
@@ -382,19 +415,7 @@ const CanvasMinimap: Component<{
                       "opacity-100": isActive() || parked(),
                       "opacity-70": !isActive() && !parked(),
                     }}
-                    style={{
-                      left: `${parked() ? t().x + t().w / 2 - GHOST_PX / 2 : t().x}px`,
-                      top: `${parked() ? t().y + t().h / 2 - GHOST_PX / 2 : t().y}px`,
-                      width: `${parked() ? GHOST_PX : t().w}px`,
-                      height: `${parked() ? GHOST_PX : t().h}px`,
-                      // When parked, leave background-color unset so the
-                      // `bg-fg-3/40` class wins; otherwise paint the themed
-                      // rect bg. Either way the value transitions smoothly.
-                      "background-color": parked() ? undefined : theme().bg,
-                      border: parked()
-                        ? "1px solid transparent"
-                        : `1px solid ${t().repoColor}`,
-                    }}
+                    style={tileStyle(t())}
                     title={tooltip()}
                     onPointerDown={handleTilePointerDown}
                     onClick={handleTileClick}

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -41,9 +41,17 @@ const MAP_PAD = 100;
  *  loud. */
 const GHOST_PX = 6;
 /** Duration + easing for the morph between full rect and ghost. Shared by
- *  the tile (transition-all) and the bucket badge (transition-opacity) so
- *  the geometry change and the badge fade always run on the same clock. */
+ *  the tile and the bucket badge so the geometry change and the badge fade
+ *  always run on the same clock. */
 const MORPH_TRANSITION = "duration-300 ease-out";
+/** Focused transition property list for the morphing tile. `transition-all`
+ *  would force the browser to watch every animatable property — including
+ *  hover-induced ring/shadow shifts and inherited color cascades — across
+ *  every minimap tile on every reactive tick (pan, zoom, staleness check).
+ *  Naming the four properties we actually animate lets the compositor
+ *  short-circuit the rest. */
+const TILE_TRANSITION_PROPS =
+  "transition-[left,top,width,height,background-color,border-color,border-radius]";
 
 /** Build the hover tooltip for a minimap tile. Closes #870: the previous
  *  `title={id}` showed the opaque terminal id; now it shows the same
@@ -412,7 +420,7 @@ const CanvasMinimap: Component<{
                     data-tile-id={id}
                     data-bucket={state().bucket}
                     data-parked={parked() ? "" : undefined}
-                    class={`absolute cursor-pointer transition-all ${MORPH_TRANSITION} hover:ring-1 hover:ring-accent/40`}
+                    class={`absolute cursor-pointer ${TILE_TRANSITION_PROPS} ${MORPH_TRANSITION} hover:ring-1 hover:ring-accent/40`}
                     classList={{
                       "rounded-full bg-fg-3/40": parked(),
                       "rounded-sm hover:opacity-100": !parked(),

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -366,6 +366,8 @@ const CanvasMinimap: Component<{
             // the staleness threshold over time.
             const parked = () => state().parked;
             const isActive = () => store.activeId() === id;
+            const hasBucket = () => state().bucket !== "none";
+            const badgeVisible = () => hasBucket() && !parked();
             // Geometry + repo-color border for the morphing tile. Parked tiles
             // get their dim background from the `bg-fg-3/40` Tailwind class
             // (see classList below) — keeping the design-system token as the
@@ -432,19 +434,17 @@ const CanvasMinimap: Component<{
                     {/* Bucket badge — color sourced from the bucket descriptor
                         in workspace-switcher/model so adding or recoloring a
                         bucket is a one-file edit. Parked tiles never paint a
-                        badge at steady state (attention can't outlive the
-                        attention it earned). The mount gate keeps the badge
-                        alive whenever it has something to show OR is fading
-                        out during a parking transition — without this, a
-                        bucket→none flip mid-park would unmount instantly and
-                        cut the opacity fade short. */}
-                    <Show when={state().bucket !== "none" || parked()}>
+                        badge at steady state; mount-gate keeps the badge
+                        alive whenever it might be visible OR mid-fade during
+                        a parking transition, so a bucket→none flip mid-park
+                        doesn't cut the opacity fade short. */}
+                    <Show when={hasBucket() || parked()}>
                       <span
                         data-testid={`minimap-${state().bucket}-dot`}
                         class={`absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full pointer-events-none transition-opacity ${MORPH_TRANSITION}`}
                         classList={{
-                          "opacity-0": parked() || state().bucket === "none",
-                          "opacity-100": !parked() && state().bucket !== "none",
+                          "opacity-0": !badgeVisible(),
+                          "opacity-100": badgeVisible(),
                         }}
                         style={{
                           "background-color": bucketDescriptor(state().bucket)

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -320,10 +320,6 @@ const CanvasMinimap: Component<{
               const i = info();
               return i ? tileTooltip(i, state().parked) : id;
             };
-            // Demoted to a ghost marker whenever the tile falls outside the
-            // user's activity window. With `windowSel() === "all"`, threshold
-            // is null → `isStale` returns false → nothing is ever ghosted.
-            const ghosted = () => state().parked;
             const handleTileClick = (e: MouseEvent) => {
               // Don't let this also trigger the background pan-to-point.
               e.stopPropagation();
@@ -349,76 +345,75 @@ const CanvasMinimap: Component<{
                 },
               });
             };
+            // A single morphing element handles both the full rect and the
+            // 6 px parked-ghost. The CSS `transition-all` then animates the
+            // geometry, color, and border-radius between the two states so a
+            // tile glides into / out of its ghost form (300 ms) instead of
+            // popping when `state().parked` flips — either because the user
+            // picked a stricter activity window or because a tile crossed
+            // the staleness threshold over time.
+            const parked = () => state().parked;
+            const isActive = () => store.activeId() === id;
             return (
               <Show when={tile()}>
                 {(t) => (
-                  <Show
-                    when={!ghosted()}
-                    fallback={
-                      <div
-                        data-testid="minimap-parked-ghost"
-                        data-tile-id={id}
-                        class="absolute rounded-full bg-fg-3/40 hover:bg-fg-3/80 transition-colors cursor-pointer"
+                  <div
+                    data-testid={
+                      parked() ? "minimap-parked-ghost" : "minimap-tile-rect"
+                    }
+                    data-tile-id={id}
+                    data-bucket={state().bucket}
+                    data-parked={parked() ? "" : undefined}
+                    class="absolute cursor-pointer transition-all duration-300 ease-out hover:ring-1 hover:ring-accent/40"
+                    classList={{
+                      "rounded-full bg-fg-3/40 hover:bg-fg-3/80": parked(),
+                      "rounded-sm hover:opacity-100": !parked(),
+                      "ring-1 ring-accent/60": isActive(),
+                      // Active and parked tiles stay at full opacity so the
+                      // active-ring stays legible (parked) and the chrome
+                      // stays crisp (active). Inactive non-parked rects fade
+                      // to 70 % so badges and the active tile pop visually.
+                      "opacity-100": isActive() || parked(),
+                      "opacity-70": !isActive() && !parked(),
+                    }}
+                    style={{
+                      left: `${parked() ? t().x + t().w / 2 - GHOST_PX / 2 : t().x}px`,
+                      top: `${parked() ? t().y + t().h / 2 - GHOST_PX / 2 : t().y}px`,
+                      width: `${parked() ? GHOST_PX : t().w}px`,
+                      height: `${parked() ? GHOST_PX : t().h}px`,
+                      // When parked, leave background-color unset so the
+                      // `bg-fg-3/40` class wins; otherwise paint the themed
+                      // rect bg. Either way the value transitions smoothly.
+                      "background-color": parked() ? undefined : theme().bg,
+                      border: parked()
+                        ? "1px solid transparent"
+                        : `1px solid ${t().repoColor}`,
+                    }}
+                    title={tooltip()}
+                    onPointerDown={handleTilePointerDown}
+                    onClick={handleTileClick}
+                  >
+                    {/* Bucket badge — color sourced from the bucket descriptor
+                        in workspace-switcher/model so adding or recoloring a
+                        bucket is a one-file edit. Parked tiles never paint a
+                        badge at steady state (attention can't outlive the
+                        attention it earned); the 300 ms opacity fade keeps the
+                        tile-morph coherent across the parking transition. */}
+                    <Show when={state().bucket !== "none"}>
+                      <span
+                        data-testid={`minimap-${state().bucket}-dot`}
+                        class="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full pointer-events-none transition-opacity duration-300"
                         classList={{
-                          "ring-1 ring-accent/60": store.activeId() === id,
+                          "opacity-0": parked(),
+                          "opacity-100": !parked(),
                         }}
                         style={{
-                          left: `${t().x + t().w / 2 - GHOST_PX / 2}px`,
-                          top: `${t().y + t().h / 2 - GHOST_PX / 2}px`,
-                          width: `${GHOST_PX}px`,
-                          height: `${GHOST_PX}px`,
+                          "background-color": bucketDescriptor(state().bucket)
+                            .accentVar,
                         }}
-                        title={tooltip()}
-                        onPointerDown={handleTilePointerDown}
-                        onClick={handleTileClick}
                       />
-                    }
-                  >
-                    <div
-                      data-testid="minimap-tile-rect"
-                      data-tile-id={id}
-                      data-bucket={state().bucket}
-                      data-parked={state().parked ? "" : undefined}
-                      class="absolute rounded-sm transition-opacity cursor-pointer hover:opacity-100 hover:ring-1 hover:ring-accent/40"
-                      classList={{
-                        "opacity-100 ring-1 ring-accent/60":
-                          store.activeId() === id,
-                        "opacity-70":
-                          store.activeId() !== id && !state().parked,
-                        // Parked-but-shown: fades into the background so
-                        // non-parked tiles still own the visual weight even
-                        // in show-all mode.
-                        "opacity-30": store.activeId() !== id && state().parked,
-                      }}
-                      style={{
-                        left: `${t().x}px`,
-                        top: `${t().y}px`,
-                        width: `${t().w}px`,
-                        height: `${t().h}px`,
-                        "background-color": theme().bg,
-                        border: `1px solid ${t().repoColor}`,
-                      }}
-                      title={tooltip()}
-                      onPointerDown={handleTilePointerDown}
-                      onClick={handleTileClick}
-                    >
-                      {/* Bucket badge — color sourced from the bucket
-                          descriptor in workspace-switcher/model so adding or
-                          recoloring a bucket is a one-file edit. Parked tiles
-                          never paint a badge: attention can't outlive the
-                          attention it earned. */}
-                      <Show when={!state().parked && state().bucket !== "none"}>
-                        <span
-                          data-testid={`minimap-${state().bucket}-dot`}
-                          class="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full pointer-events-none"
-                          style={{
-                            "background-color": bucketDescriptor(state().bucket)
-                              .accentVar,
-                          }}
-                        />
-                      </Show>
-                    </div>
-                  </Show>
+                    </Show>
+                  </div>
                 )}
               </Show>
             );

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -358,6 +358,15 @@ const CanvasMinimap: Component<{
             // the staleness threshold over time.
             const parked = () => state().parked;
             const isActive = () => store.activeId() === id;
+            // Tile opacity is governed by two independent reasons:
+            //   - Active → 100 %: the focused tile must read as the focused
+            //     tile (its ring needs solid chrome behind it).
+            //   - Parked → 100 %: the dim color already conveys low
+            //     attention, so dropping opacity on top would double-dim.
+            // Anything else (inactive, non-parked) fades to 70 % so the
+            // bucket badge and the active tile pop visually.
+            const tileOpacity = () =>
+              isActive() || parked() ? "opacity-100" : "opacity-70";
             // Full styling for the morphing tile — geometry, background, and
             // border in one place. When parked geometry or aesthetics change
             // (e.g. a different ghost size, a new dim color), this helper is
@@ -408,12 +417,7 @@ const CanvasMinimap: Component<{
                       "rounded-full": parked(),
                       "rounded-sm hover:opacity-100": !parked(),
                       "ring-1 ring-accent/60": isActive(),
-                      // Active and parked tiles stay at full opacity so the
-                      // active-ring stays legible (parked) and the chrome
-                      // stays crisp (active). Inactive non-parked rects fade
-                      // to 70 % so badges and the active tile pop visually.
-                      "opacity-100": isActive() || parked(),
-                      "opacity-70": !isActive() && !parked(),
+                      [tileOpacity()]: true,
                     }}
                     style={tileStyle(t())}
                     title={tooltip()}

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -366,15 +366,6 @@ const CanvasMinimap: Component<{
             // the staleness threshold over time.
             const parked = () => state().parked;
             const isActive = () => store.activeId() === id;
-            // Tile opacity is governed by two independent reasons:
-            //   - Active → 100 %: the focused tile must read as the focused
-            //     tile (its ring needs solid chrome behind it).
-            //   - Parked → 100 %: the dim color already conveys low
-            //     attention, so dropping opacity on top would double-dim.
-            // Anything else (inactive, non-parked) fades to 70 % so the
-            // bucket badge and the active tile pop visually.
-            const tileOpacity = () =>
-              isActive() || parked() ? "opacity-100" : "opacity-70";
             // Geometry + repo-color border for the morphing tile. Parked tiles
             // get their dim background from the `bg-fg-3/40` Tailwind class
             // (see classList below) — keeping the design-system token as the
@@ -425,7 +416,13 @@ const CanvasMinimap: Component<{
                       "rounded-full bg-fg-3/40": parked(),
                       "rounded-sm hover:opacity-100": !parked(),
                       "ring-1 ring-accent/60": isActive(),
-                      [tileOpacity()]: true,
+                      // Active and parked tiles stay at full opacity (active
+                      // needs solid chrome behind its ring; parked already
+                      // conveys low attention via dim color so dropping
+                      // opacity would double-dim). Inactive non-parked rects
+                      // fade to 70 % so badges + the active tile pop.
+                      "opacity-100": isActive() || parked(),
+                      "opacity-70": !isActive() && !parked(),
                     }}
                     style={tileStyle(t())}
                     title={tooltip()}

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -358,9 +358,11 @@ const CanvasMinimap: Component<{
               <Show when={tile()}>
                 {(t) => (
                   <div
-                    data-testid={
-                      parked() ? "minimap-parked-ghost" : "minimap-tile-rect"
-                    }
+                    // Stable across the parking morph — the element's identity
+                    // doesn't change just because its size and color do.
+                    // Consumers (e2e selectors, dev-tools inspection) that
+                    // care about parked-ness read `data-parked`.
+                    data-testid="minimap-tile-rect"
                     data-tile-id={id}
                     data-bucket={state().bucket}
                     data-parked={parked() ? "" : undefined}

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -367,12 +367,14 @@ const CanvasMinimap: Component<{
             // bucket badge and the active tile pop visually.
             const tileOpacity = () =>
               isActive() || parked() ? "opacity-100" : "opacity-70";
-            // Full styling for the morphing tile — geometry, background, and
-            // border in one place. When parked geometry or aesthetics change
-            // (e.g. a different ghost size, a new dim color), this helper is
-            // the only edit site. Background goes through inline style for
-            // both states (one mechanism), matching the `bg-fg-3/40` token via
-            // `color-mix` so the parked branch stays themable.
+            // Geometry + repo-color border for the morphing tile. Parked tiles
+            // get their dim background from the `bg-fg-3/40` Tailwind class
+            // (see classList below) — keeping the design-system token as the
+            // single source of truth for parked color so a theme change or a
+            // Tailwind colour-space upgrade flows through automatically. The
+            // inline `theme().bg` is for the non-parked branch only, where
+            // the bg is a dynamic per-repo color that can't be a Tailwind
+            // token.
             const tileStyle = (t: {
               x: number;
               y: number;
@@ -386,8 +388,6 @@ const CanvasMinimap: Component<{
                   top: `${t.y + t.h / 2 - GHOST_PX / 2}px`,
                   width: `${GHOST_PX}px`,
                   height: `${GHOST_PX}px`,
-                  "background-color":
-                    "color-mix(in oklab, var(--color-fg-3) 40%, transparent)",
                   border: "1px solid transparent",
                 };
               }
@@ -414,7 +414,7 @@ const CanvasMinimap: Component<{
                     data-parked={parked() ? "" : undefined}
                     class={`absolute cursor-pointer transition-all ${MORPH_TRANSITION} hover:ring-1 hover:ring-accent/40`}
                     classList={{
-                      "rounded-full": parked(),
+                      "rounded-full bg-fg-3/40": parked(),
                       "rounded-sm hover:opacity-100": !parked(),
                       "ring-1 ring-accent/60": isActive(),
                       [tileOpacity()]: true,

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -40,6 +40,10 @@ const MAP_PAD = 100;
  *  user has hidden them. Big enough to click/drag without being visually
  *  loud. */
 const GHOST_PX = 6;
+/** Duration + easing for the morph between full rect and ghost. Shared by
+ *  the tile (transition-all) and the bucket badge (transition-opacity) so
+ *  the geometry change and the badge fade always run on the same clock. */
+const MORPH_TRANSITION = "duration-300 ease-out";
 
 /** Build the hover tooltip for a minimap tile. Closes #870: the previous
  *  `title={id}` showed the opaque terminal id; now it shows the same
@@ -366,7 +370,7 @@ const CanvasMinimap: Component<{
                     data-tile-id={id}
                     data-bucket={state().bucket}
                     data-parked={parked() ? "" : undefined}
-                    class="absolute cursor-pointer transition-all duration-300 ease-out hover:ring-1 hover:ring-accent/40"
+                    class={`absolute cursor-pointer transition-all ${MORPH_TRANSITION} hover:ring-1 hover:ring-accent/40`}
                     classList={{
                       "rounded-full bg-fg-3/40 hover:bg-fg-3/80": parked(),
                       "rounded-sm hover:opacity-100": !parked(),
@@ -404,7 +408,7 @@ const CanvasMinimap: Component<{
                     <Show when={state().bucket !== "none"}>
                       <span
                         data-testid={`minimap-${state().bucket}-dot`}
-                        class="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full pointer-events-none transition-opacity duration-300"
+                        class={`absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full pointer-events-none transition-opacity ${MORPH_TRANSITION}`}
                         classList={{
                           "opacity-0": parked(),
                           "opacity-100": !parked(),

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -428,15 +428,18 @@ const CanvasMinimap: Component<{
                         in workspace-switcher/model so adding or recoloring a
                         bucket is a one-file edit. Parked tiles never paint a
                         badge at steady state (attention can't outlive the
-                        attention it earned); the 300 ms opacity fade keeps the
-                        tile-morph coherent across the parking transition. */}
-                    <Show when={state().bucket !== "none"}>
+                        attention it earned). The mount gate keeps the badge
+                        alive whenever it has something to show OR is fading
+                        out during a parking transition — without this, a
+                        bucket→none flip mid-park would unmount instantly and
+                        cut the opacity fade short. */}
+                    <Show when={state().bucket !== "none" || parked()}>
                       <span
                         data-testid={`minimap-${state().bucket}-dot`}
                         class={`absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full pointer-events-none transition-opacity ${MORPH_TRANSITION}`}
                         classList={{
-                          "opacity-0": parked(),
-                          "opacity-100": !parked(),
+                          "opacity-0": parked() || state().bucket === "none",
+                          "opacity-100": !parked() && state().bucket !== "none",
                         }}
                         style={{
                           "background-color": bucketDescriptor(state().bucket)

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -357,25 +357,17 @@ const CanvasMinimap: Component<{
                 },
               });
             };
-            // A single morphing element handles both the full rect and the
-            // 6 px parked-ghost. The CSS `transition-all` then animates the
-            // geometry, color, and border-radius between the two states so a
-            // tile glides into / out of its ghost form (300 ms) instead of
-            // popping when `state().parked` flips — either because the user
-            // picked a stricter activity window or because a tile crossed
-            // the staleness threshold over time.
+            // One morphing element covers both the full rect and the 6 px
+            // parked-ghost; CSS interpolates between them so the tile glides
+            // when `parked()` flips instead of popping.
             const parked = () => state().parked;
             const isActive = () => store.activeId() === id;
             const hasBucket = () => state().bucket !== "none";
             const badgeVisible = () => hasBucket() && !parked();
-            // Geometry + repo-color border for the morphing tile. Parked tiles
-            // get their dim background from the `bg-fg-3/40` Tailwind class
-            // (see classList below) — keeping the design-system token as the
-            // single source of truth for parked color so a theme change or a
-            // Tailwind colour-space upgrade flows through automatically. The
-            // inline `theme().bg` is for the non-parked branch only, where
-            // the bg is a dynamic per-repo color that can't be a Tailwind
-            // token.
+            // Parked-bg comes from the `bg-fg-3/40` class (see classList) so a
+            // theme or Tailwind-color-space change flows through. Inline bg
+            // is for non-parked only — `theme().bg` is a dynamic per-repo
+            // color that can't be a static Tailwind token.
             const tileStyle = (t: {
               x: number;
               y: number;
@@ -405,10 +397,8 @@ const CanvasMinimap: Component<{
               <Show when={tile()}>
                 {(t) => (
                   <div
-                    // Stable across the parking morph — the element's identity
-                    // doesn't change just because its size and color do.
-                    // Consumers (e2e selectors, dev-tools inspection) that
-                    // care about parked-ness read `data-parked`.
+                    // Identity stable across the morph; parked-ness queried
+                    // via `data-parked`, not by swapping the testid.
                     data-testid="minimap-tile-rect"
                     data-tile-id={id}
                     data-bucket={state().bucket}
@@ -418,11 +408,10 @@ const CanvasMinimap: Component<{
                       "rounded-full bg-fg-3/40": parked(),
                       "rounded-sm hover:opacity-100": !parked(),
                       "ring-1 ring-accent/60": isActive(),
-                      // Active and parked tiles stay at full opacity (active
-                      // needs solid chrome behind its ring; parked already
-                      // conveys low attention via dim color so dropping
-                      // opacity would double-dim). Inactive non-parked rects
-                      // fade to 70 % so badges + the active tile pop.
+                      // Active needs solid chrome behind its ring; parked is
+                      // already dim from bg-color so don't double-dim. Other
+                      // inactive tiles fade to 70 % so the badge + active
+                      // tile dominate.
                       "opacity-100": isActive() || parked(),
                       "opacity-70": !isActive() && !parked(),
                     }}
@@ -431,13 +420,8 @@ const CanvasMinimap: Component<{
                     onPointerDown={handleTilePointerDown}
                     onClick={handleTileClick}
                   >
-                    {/* Bucket badge — color sourced from the bucket descriptor
-                        in workspace-switcher/model so adding or recoloring a
-                        bucket is a one-file edit. Parked tiles never paint a
-                        badge at steady state; mount-gate keeps the badge
-                        alive whenever it might be visible OR mid-fade during
-                        a parking transition, so a bucket→none flip mid-park
-                        doesn't cut the opacity fade short. */}
+                    {/* Mount-gate stays open while parked so a bucket→none
+                        flip mid-park doesn't cut the opacity fade short. */}
                     <Show when={hasBucket() || parked()}>
                       <span
                         data-testid={`minimap-${state().bucket}-dot`}

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -362,8 +362,8 @@ const CanvasMinimap: Component<{
             // when `parked()` flips instead of popping.
             const parked = () => state().parked;
             const isActive = () => store.activeId() === id;
-            const hasBucket = () => state().bucket !== "none";
-            const badgeVisible = () => hasBucket() && !parked();
+            const hasAgent = () => state().bucket !== "none";
+            const badgeVisible = () => hasAgent() && !parked();
             // Parked-bg comes from the `bg-fg-3/40` class (see classList) so a
             // theme or Tailwind-color-space change flows through. Inline bg
             // is for non-parked only — `theme().bg` is a dynamic per-repo
@@ -422,7 +422,7 @@ const CanvasMinimap: Component<{
                   >
                     {/* Mount-gate stays open while parked so a bucket→none
                         flip mid-park doesn't cut the opacity fade short. */}
-                    <Show when={hasBucket() || parked()}>
+                    <Show when={hasAgent() || parked()}>
                       <span
                         data-testid={`minimap-${state().bucket}-dot`}
                         class={`absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full pointer-events-none transition-opacity ${MORPH_TRANSITION}`}


### PR DESCRIPTION
**Parked terminal tiles in the minimap now glide between their full rect and 6 px ghost-marker forms over 300 ms** instead of popping. A tile crossing the activity-window threshold — or one of many tiles flipping when the user picks a stricter window from the [#868](https://github.com/juspay/kolu/pull/868) selector — is now a soft transition that lets the eye follow what changed, not a jump-cut.

The visual seam from PR #868 — _"tiles outside the window collapse to small ghost markers so visual weight shifts onto what's still in play"_ — kept the right semantics but was abrupt. This PR adds the missing animation step.

### What animates

```
       parked() = false             parked() = true
       ┌──────────┐                    ·
       │  ▣       │   ── 300 ms ──▶   (6 px ghost)
       │ badge    │   transition-     centered on
       └──────────┘   all + opacity   original rect
```

Geometry, background-color, border-color, border-radius, and the bucket-badge opacity all interpolate together — the rect shrinks toward its center while the badge fades and the bg dims to `bg-fg-3/40`. _Both clocks share one `MORPH_TRANSITION` constant so geometry change and badge fade can never drift apart._

### How the diff lands

The old code branched two `<div>` subtrees through `<Show when={!ghosted()}>` / `fallback={ghost}`. CSS can't interpolate across that boundary — SolidJS destroys one element and creates the other on every parked-flip. **Collapsing into a single element that morphs via CSS is what unlocks the smooth transition.**

| Concern | Before | After |
|---|---|---|
| Rect ↔ ghost | Two `<Show>` branches, instant swap | One element, CSS `transition-[…]` morphs all 7 properties |
| Bucket badge mount | Unmounts when bucket → none | Mount-gate stays open while parked so the opacity fade can complete |
| Test selectors | `data-testid` switches on park (`minimap-tile-rect` ↔ `minimap-parked-ghost`) | Stable `minimap-tile-rect`; parked-ness queried via `data-parked` |
| Animation timing | Inline `duration-300` at two sites | One `MORPH_TRANSITION` constant shared by tile + badge |
| Transitioned properties | n/a | Explicit list — _not_ `transition-all`, which would force style-recalc on every animatable property across 30 tiles per pan |

### Refinements during review

The branch went through three audit layers — Hickey/Lowy structural review (parallel sub-agents) and then \`/code-police\` (rules + fact-check + elegance). Each finding landed as its own commit so the history reads as a refinement sequence.

| Lens | Refinement |
|---|---|
| Hickey + Lowy | Stable testid — element identity doesn't change just because its size and color do |
| Hickey + Lowy | Consolidated parked geometry/bg/border into one \`tileStyle\` helper (was 5 inline ternaries) |
| Hickey | Named the opacity policy with intent comments (active needs solid chrome; parked already dim) |
| Lowy | Hoisted \`MORPH_TRANSITION\` so geometry + badge fade stay on one clock |
| Lowy | Badge mount-gate kept open while parked so a bucket→none flip mid-park doesn't cut the fade short |
| Police | Reverted parked bg to \`bg-fg-3/40\` Tailwind class (was inline \`color-mix\`); design-token wins on \`styling-tailwind-only\` |
| Police | Focused \`transition-[left,top,width,height,…]\` instead of \`transition-all\` — avoids style-recalc on hover ring + inherited cascades |
| Police | Dedupe of the badge visibility matrix into \`hasBucket\` / \`badgeVisible\` |
| Police | Boolean classList keys instead of \`[tileOpacity()]: true\` computed-key |

### Try it locally

\`\`\`sh
nix run github:juspay/kolu/soft-steps
\`\`\`

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._