### PR TITLE
Pin test git identity so e2e suite runs on pristine NixOS hosts

### DIFF
--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -23,6 +23,17 @@ import type { KoluWorld } from "./world.ts";
 
 const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0", 10);
 
+/** Fixtures scaffold real git repos in /tmp and run `git commit` against
+ *  them. On a pristine NixOS host with no `~/.gitconfig`, git aborts with
+ *  "Author identity unknown" and 31 scenarios fail (see #887). Pin a test
+ *  identity here so every fixture — current and future — inherits one.
+ *  `??=` lets a host with `git config --global` set still take precedence
+ *  when developers run locally. */
+process.env.GIT_AUTHOR_NAME ??= "kolu-test";
+process.env.GIT_AUTHOR_EMAIL ??= "test@kolu.dev";
+process.env.GIT_COMMITTER_NAME ??= "kolu-test";
+process.env.GIT_COMMITTER_EMAIL ??= "test@kolu.dev";
+
 /** One base $TMPDIR per worker holds everything this test run creates:
  *  the kolu server's state dir and the Claude Code mock harness's
  *  sessions/projects dirs. Nesting keeps /tmp tidy (one entry per run
@@ -280,11 +291,21 @@ BeforeAll(async () => {
     const port = await getPort();
     baseUrl = `http://localhost:${port}`;
     console.log(`[worker:${workerId}] Starting server on port ${port}...`);
+    // Extend the default nix-shell env whitelist (see shell.ts:31) with
+    // GIT_AUTHOR_*/GIT_COMMITTER_* so PTY shells in fixtures like
+    // `code-tab.feature` (which run `git init && git commit` inside the
+    // terminal under test) inherit the same identity set on process.env
+    // above. Without this, the whitelist filter strips them and those
+    // scenarios fail on pristine hosts.
+    const envWhitelist = [
+      "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM,TERM_PROGRAM",
+      "GIT_AUTHOR_NAME,GIT_AUTHOR_EMAIL,GIT_COMMITTER_NAME,GIT_COMMITTER_EMAIL",
+    ].join(",");
     serverProcess = spawn(
       koluServer,
       [
         "--allow-nix-shell-with-env-whitelist",
-        "default",
+        envWhitelist,
         "--port",
         String(port),
       ],


### PR DESCRIPTION
**Fixtures that scaffold real git repos in `/tmp` now inherit a test identity** the moment the Cucumber suite loads, so `just test` runs green on a pristine NixOS host with nothing more than `nix`, `git`, and a clone of the repo. Previously, any scenario that hit `git commit` against a freshly-init'd repo died with _Author identity unknown_ — an invisible precondition (`git config --global user.email/name`) that bit every new contributor, agent, and CI runner.

Closes #887.

### How it lands

`packages/tests/support/hooks.ts` does two things at module-load time:

| Layer | What | Covers |
|---|---|---|
| `process.env.GIT_AUTHOR_*` / `GIT_COMMITTER_*` | Pinned via `??=` so a developer's existing `gitconfig` still wins locally | Test-process `execFileSync("git", …)` in `worktree_steps.ts` and `git_context_steps.ts` |
| `--allow-nix-shell-with-env-whitelist` extension | Adds the four `GIT_*` vars to the default whitelist passed to the spawned server | PTY-shell `git init && git commit -m init` in `code_tab_steps.ts` (otherwise stripped by `cleanEnv` in `packages/server/src/shell.ts`) |

_Both layers are needed because the test fixtures run git through two different paths — the test process directly, and through the terminal-under-test's PTY shell. The whitelist filter in `shell.ts` deliberately keeps PTY env tight in production; we relax it only in the test harness._

### Verification

Reproduced the issue's recipe end-to-end via `devbox-run` to a pristine NixOS host (no `~/.gitconfig` for the active user):

| Run | Result |
|---|---|
| Before fix (issue #887) | 31 of 307 scenarios fail with _Author identity unknown_ |
| After fix, run 1 | 298/299 pass; 1 unrelated `opencode` indicator timeout |
| After fix, run 2 (retry) | **299/299 pass** in 58s — opencode failure was flaky |

> _Why `??=` and not a hard assignment: developers running `just test` locally have their own `git config --global user.email` set, and the fixture identity should not silently override it._

### Try it locally

```sh
nix run github:juspay/kolu/fix-887-cucumber-git-identity
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._