### PR TITLE
Code tab: resolve bare-filename file refs when basename is unique

### DIFF
--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -193,4 +193,60 @@ describe("resolveLineRefPath", () => {
       }),
     ).toBe("nested/src/app.ts");
   });
+
+  // ── Basename fallback (#898) ───────────────────────────────────────
+  // Compiler output frequently prints just `Foo.hs:42` without the
+  // `src/lib/` prefix; the path-first candidates miss, so the resolver
+  // falls back to the unique repo path that ends in that basename.
+  // Ambiguity (multiple files share the basename) stays null — opening
+  // the wrong file is worse than the toast.
+  it("resolves a bare filename whose basename is unique in the repo", () => {
+    expect(
+      resolveLineRefPath({
+        rawPath: "Main.hs",
+        repoRoot,
+        cwd: repoRoot,
+        repoPaths,
+      }),
+    ).toBe("packages/a/src/Main.hs");
+  });
+
+  it("returns null when the basename is ambiguous", () => {
+    // Both `src/app.ts` and `nested/src/app.ts` end in `app.ts` and
+    // neither path candidate hits when cwd is the repo root.
+    expect(
+      resolveLineRefPath({
+        rawPath: "app.ts",
+        repoRoot,
+        cwd: repoRoot,
+        repoPaths,
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to basename when a slash-containing path doesn't match", () => {
+    // User-printed `wrong/Main.hs` doesn't exist in the repo, but the
+    // basename `Main.hs` is unique — open it rather than toast.
+    expect(
+      resolveLineRefPath({
+        rawPath: "wrong/Main.hs",
+        repoRoot,
+        cwd: repoRoot,
+        repoPaths,
+      }),
+    ).toBe("packages/a/src/Main.hs");
+  });
+
+  it("prefers an exact path candidate over the basename fallback", () => {
+    // `src/app.ts` matches as a repo-relative candidate; the resolver
+    // must not fall through to basename ambiguity-checking and discard it.
+    expect(
+      resolveLineRefPath({
+        rawPath: "src/app.ts",
+        repoRoot,
+        cwd: repoRoot,
+        repoPaths,
+      }),
+    ).toBe("src/app.ts");
+  });
 });

--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -194,12 +194,6 @@ describe("resolveLineRefPath", () => {
     ).toBe("nested/src/app.ts");
   });
 
-  // ── Basename fallback (#898) ───────────────────────────────────────
-  // Compiler output frequently prints just `Foo.hs:42` without the
-  // `src/lib/` prefix; the path-first candidates miss, so the resolver
-  // falls back to the unique repo path that ends in that basename.
-  // Ambiguity (multiple files share the basename) stays null — opening
-  // the wrong file is worse than the toast.
   it("resolves a bare filename whose basename is unique in the repo", () => {
     expect(
       resolveLineRefPath({
@@ -212,8 +206,6 @@ describe("resolveLineRefPath", () => {
   });
 
   it("returns null when the basename is ambiguous", () => {
-    // Both `src/app.ts` and `nested/src/app.ts` end in `app.ts` and
-    // neither path candidate hits when cwd is the repo root.
     expect(
       resolveLineRefPath({
         rawPath: "app.ts",
@@ -225,8 +217,6 @@ describe("resolveLineRefPath", () => {
   });
 
   it("falls back to basename when a slash-containing path doesn't match", () => {
-    // User-printed `wrong/Main.hs` doesn't exist in the repo, but the
-    // basename `Main.hs` is unique — open it rather than toast.
     expect(
       resolveLineRefPath({
         rawPath: "wrong/Main.hs",
@@ -238,8 +228,6 @@ describe("resolveLineRefPath", () => {
   });
 
   it("prefers an exact path candidate over the basename fallback", () => {
-    // `src/app.ts` matches as a repo-relative candidate; the resolver
-    // must not fall through to basename ambiguity-checking and discard it.
     expect(
       resolveLineRefPath({
         rawPath: "src/app.ts",

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -104,7 +104,13 @@ function hasRefBoundary(text: string, index: number): boolean {
  *    falls back to repo-relative interpretation only.
  *  - `repoPaths`: live `fsListAll` paths — repo-relative, no leading
  *    `/`. The resolver only returns a path that's actually in this
- *    set. */
+ *    set.
+ *
+ *  When path-based candidates miss, falls back to a basename match —
+ *  compiler output often prints just `Foo.hs:42` without the
+ *  `src/lib/` prefix (#898). The fallback only fires when the
+ *  basename is unique in the repo; ambiguous matches stay null since
+ *  opening the wrong file is worse than the toast. */
 export function resolveLineRefPath(args: {
   rawPath: string;
   repoRoot: string;
@@ -115,7 +121,27 @@ export function resolveLineRefPath(args: {
   for (const candidate of candidates(args)) {
     if (set.has(candidate)) return candidate;
   }
-  return null;
+  return resolveByBasename(args.rawPath, args.repoPaths);
+}
+
+function resolveByBasename(
+  rawPath: string,
+  repoPaths: readonly string[],
+): string | null {
+  const target = basename(rawPath);
+  if (target === "") return null;
+  let unique: string | null = null;
+  for (const p of repoPaths) {
+    if (basename(p) !== target) continue;
+    if (unique !== null) return null;
+    unique = p;
+  }
+  return unique;
+}
+
+function basename(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i < 0 ? path : path.slice(i + 1);
 }
 
 function* candidates(args: {

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -25,6 +25,21 @@ Feature: File-ref autolinking in terminal
     And I trigger the terminal file-ref link "range.txt:2-4"
     Then the selected file should show content "three"
 
+  # Compiler output frequently emits just `Foo.hs:42` without the
+  # `src/lib/` prefix. The path-based candidates miss, so the resolver
+  # falls back to the unique repo path that ends in that basename
+  # (#898). Ambiguous matches stay null and are covered by unit tests.
+  Scenario: Bare filename resolves when its basename is unique in the repo
+    When I run "git init /tmp/kolu-file-ref-898 && cd /tmp/kolu-file-ref-898"
+    And I run "git commit --allow-empty -m init"
+    And I run "mkdir -p src/lib && printf 'alpha\nbeta\ngamma\n' > src/lib/notes.txt"
+    And I run "echo 'see notes.txt:2 for the line'"
+    And I trigger the terminal file-ref link "notes.txt:2"
+    Then the right panel should be visible
+    And the Code tab should be active
+    And the Code tab mode should be "browse"
+    And the selected file should show content "beta"
+
   Scenario: Re-clicking the same file-ref after closing the panel re-selects the line
     When I run "git init /tmp/kolu-file-ref-861-reclick && cd /tmp/kolu-file-ref-861-reclick"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -25,10 +25,6 @@ Feature: File-ref autolinking in terminal
     And I trigger the terminal file-ref link "range.txt:2-4"
     Then the selected file should show content "three"
 
-  # Compiler output frequently emits just `Foo.hs:42` without the
-  # `src/lib/` prefix. The path-based candidates miss, so the resolver
-  # falls back to the unique repo path that ends in that basename
-  # (#898). Ambiguous matches stay null and are covered by unit tests.
   Scenario: Bare filename resolves when its basename is unique in the repo
     When I run "git init /tmp/kolu-file-ref-898 && cd /tmp/kolu-file-ref-898"
     And I run "git commit --allow-empty -m init"


### PR DESCRIPTION
**The Code tab now resolves a bare filename like `Foo.hs:42` to the unique repo file ending in that basename.** Compiler output frequently emits source locations without the full path prefix; previously those clicks fell through to a "File reference not found" toast even when exactly one file in the repo could match. Closes #898.

Resolution still tries the path-based candidates first (repo-relative, cwd-relative, absolute-stripped) — the basename scan only fires when all of them miss, and only commits to a result when there's exactly one match. _Ambiguous basenames keep returning `null`; opening the wrong file is worse than the toast._

```
repo:                       resolveLineRefPath("Foo.hs"):
  src/lib/Foo.hs              1. cwd-rel  → miss
  src/lib/Bar.hs              2. repo-rel → miss
  ...                         3. basename → src/lib/Foo.hs  ✓ (unique)
```

The fallback covers terminal-link clicks and right-click _Open path:N_ alike — both producers route through the single `openInCodeTab` resolver added in #891.

### Coverage

- **Unit** — `lineRef.test.ts`: unique basename, ambiguous basename → null, slash-with-bad-prefix falls back, exact path candidate still preferred over basename
- **E2E** — `file-ref-link.feature`: terminal emits `notes.txt:2` while the file lives at `src/lib/notes.txt`; click opens the file in browse mode at line 2

### Try it locally

\`\`\`sh
nix run github:juspay/kolu/fix-898-basename-fileref
\`\`\`

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._