### PR TITLE
Detect 'awaiting user' agent state for Codex and OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,17 @@ Detects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions r
 
 **What we detect:**
 
-| State          | Indicator          | Meaning                                                                    |
-| -------------- | ------------------ | -------------------------------------------------------------------------- |
-| Thinking       | Pulsing accent dot | API call in flight — Claude is generating a response                       |
-| Tool use       | Pulsing yellow dot | Claude is executing tools                                                  |
-| Awaiting input | Pulsing warning    | Claude called `AskUserQuestion` / `ExitPlanMode` — blocked on a human reply |
-| Waiting        | Dim dot            | Claude finished responding, waiting for user input                         |
+| State    | Indicator          | Meaning                                              |
+| -------- | ------------------ | ---------------------------------------------------- |
+| Thinking | Pulsing accent dot | API call in flight — Claude is generating a response |
+| Tool use | Pulsing yellow dot | Claude is executing tools                            |
+| Waiting  | Dim dot            | Claude finished responding, waiting for user input   |
 
 **How it works:** asks each terminal for its current foreground process pid via `tcgetpgrp(fd)` (exposed by node-pty's `foregroundPid` accessor), then checks whether `~/.claude/sessions/<fgpid>.json` exists. If it does, that terminal is running claude-code — we tail the session's JSONL transcript to derive state from the last message. Cross-platform (Linux + macOS) since `tcgetpgrp` is POSIX. Each card also surfaces the session's display title (custom title › auto-generated summary › first prompt) via the [Claude Agent SDK](https://platform.claude.com/docs/en/api/agent-sdk/typescript)'s `getSessionInfo()`, refreshed best-effort on each transcript change. The tile chrome also shows a running token count (compact, e.g. `47K`) summed from the latest assistant entry's `message.usage` — `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. Raw count only; window size isn't inferable from the JSONL (1M beta strips its suffix, so a `%` would lie), and the raw number is the useful signal anyway.
 
 **What we can't detect:**
 
-- **Permission prompts** — Claude's permission-MCP requests aren't surfaced in the rollout JSONL, so they still register as "tool use" rather than "awaiting input". `AskUserQuestion` and `ExitPlanMode` are detected (their tool-use blocks appear directly in the assistant turn) but the implicit permission gate around a `Bash` / `Edit` call is not
+- **`AskUserQuestion` / `ExitPlanMode` / permission prompts — anything that blocks waiting for the user.** Claude Code's SDK buffers the in-flight assistant message for tools that declare `requiresUserInteraction(){return true}` (the two named tools) and never persists the `tool_use` block to JSONL until the user resolves the prompt. By that point the question is answered and the state has moved on. The integration's state machine carries an `awaiting_user` case (codeshare with Codex/OpenCode where the on-disk signal does exist), but for Claude Code it never fires under the current SDK. Tracked in #905 — fix requires a `PreToolUse` hook side-channel (cmux-style)
 - **Streaming progress** — intermediate thinking tokens aren't tracked, only final state transitions
 - **Wrapped invocations** — if claude-code is launched via a wrapper (e.g. `script -q out.log claude`), the foreground pid is the wrapper, not claude itself, so the session lookup misses
 - **Sub-agents** — nested agent spawns appear as tool use, not as separate tracked sessions

--- a/README.md
+++ b/README.md
@@ -75,17 +75,18 @@ Detects [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions r
 
 **What we detect:**
 
-| State    | Indicator          | Meaning                                              |
-| -------- | ------------------ | ---------------------------------------------------- |
-| Thinking | Pulsing accent dot | API call in flight — Claude is generating a response |
-| Tool use | Pulsing yellow dot | Claude is executing tools or waiting for permission  |
-| Waiting  | Dim dot            | Claude finished responding, waiting for user input   |
+| State          | Indicator          | Meaning                                                                    |
+| -------------- | ------------------ | -------------------------------------------------------------------------- |
+| Thinking       | Pulsing accent dot | API call in flight — Claude is generating a response                       |
+| Tool use       | Pulsing yellow dot | Claude is executing tools                                                  |
+| Awaiting input | Pulsing warning    | Claude called `AskUserQuestion` / `ExitPlanMode` — blocked on a human reply |
+| Waiting        | Dim dot            | Claude finished responding, waiting for user input                         |
 
 **How it works:** asks each terminal for its current foreground process pid via `tcgetpgrp(fd)` (exposed by node-pty's `foregroundPid` accessor), then checks whether `~/.claude/sessions/<fgpid>.json` exists. If it does, that terminal is running claude-code — we tail the session's JSONL transcript to derive state from the last message. Cross-platform (Linux + macOS) since `tcgetpgrp` is POSIX. Each card also surfaces the session's display title (custom title › auto-generated summary › first prompt) via the [Claude Agent SDK](https://platform.claude.com/docs/en/api/agent-sdk/typescript)'s `getSessionInfo()`, refreshed best-effort on each transcript change. The tile chrome also shows a running token count (compact, e.g. `47K`) summed from the latest assistant entry's `message.usage` — `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. Raw count only; window size isn't inferable from the JSONL (1M beta strips its suffix, so a `%` would lie), and the raw number is the useful signal anyway.
 
 **What we can't detect:**
 
-- **Permission prompts vs tool execution** — both show as "tool use" since the JSONL doesn't distinguish them
+- **Permission prompts** — Claude's permission-MCP requests aren't surfaced in the rollout JSONL, so they still register as "tool use" rather than "awaiting input". `AskUserQuestion` and `ExitPlanMode` are detected (their tool-use blocks appear directly in the assistant turn) but the implicit permission gate around a `Bash` / `Edit` call is not
 - **Streaming progress** — intermediate thinking tokens aren't tracked, only final state transitions
 - **Wrapped invocations** — if claude-code is launched via a wrapper (e.g. `script -q out.log claude`), the foreground pid is the wrapper, not claude itself, so the session lookup misses
 - **Sub-agents** — nested agent spawns appear as tool use, not as separate tracked sessions
@@ -106,11 +107,12 @@ Detects [Codex](https://github.com/openai/codex) TUI sessions and surfaces their
 
 **What we detect:**
 
-| State    | Indicator          | How                                                                                                                                        |
-| -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Thinking | Pulsing accent dot | Latest lifecycle event is `task_started`, with no open `function_call` scoped to the current turn                                          |
-| Tool use | Spinning yellow    | Latest lifecycle event is `task_started`, with at least one `function_call` opened since that `task_started` and no matching `_output` yet |
-| Waiting  | Dim dot            | Latest lifecycle event is `task_complete`                                                                                                  |
+| State          | Indicator          | How                                                                                                                                                          |
+| -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Thinking       | Pulsing accent dot | Latest lifecycle event is `task_started`, with no open `function_call` scoped to the current turn                                                            |
+| Tool use       | Spinning yellow    | Latest lifecycle event is `task_started`, with at least one open `function_call` that isn't a known awaiting-user tool                                       |
+| Awaiting input | Pulsing warning    | Every open `function_call` on the current turn names a known awaiting-user tool (`request_user_input`) — Codex is blocked on the user, not running compute |
+| Waiting        | Dim dot            | Latest lifecycle event is `task_complete`                                                                                                                    |
 
 Open-call tracking is scoped per-turn: a `function_call` with no matching `_output` that straddles a `task_started` boundary (user aborted a prior tool-using turn) does not pin the next turn to `tool_use`.
 
@@ -131,11 +133,12 @@ Detects [OpenCode](https://github.com/anomalyco/opencode) sessions and shows the
 
 **What we detect:**
 
-| State    | Indicator          | How                                                                     |
-| -------- | ------------------ | ----------------------------------------------------------------------- |
-| Thinking | Pulsing accent dot | Latest assistant message has no `time.completed`                        |
-| Tool use | Spinning yellow    | Thinking + any `part` with `type: "tool"` and `state.status: "running"` |
-| Waiting  | Dim dot            | Latest assistant message has `time.completed` set and `finish: "stop"`  |
+| State          | Indicator          | How                                                                                                          |
+| -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Thinking       | Pulsing accent dot | Latest assistant message has no `time.completed`                                                             |
+| Tool use       | Spinning yellow    | Thinking + at least one `part` with `state.status: "running"` whose `tool` field is anything but `question`  |
+| Awaiting input | Pulsing warning    | Thinking + every running `part`'s `tool` is OpenCode's built-in `question` tool — blocked on a human reply   |
+| Waiting        | Dim dot            | Latest assistant message has `time.completed` set and `finish: "stop"`                                       |
 
 **What we can't detect (yet):**
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ Detects [Codex](https://github.com/openai/codex) TUI sessions and surfaces their
 
 | State          | Indicator          | How                                                                                                                                                          |
 | -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Thinking       | Pulsing accent dot | Latest lifecycle event is `task_started`, with no open `function_call` scoped to the current turn                                                            |
-| Tool use       | Spinning yellow    | Latest lifecycle event is `task_started`, with at least one open `function_call` that isn't a known awaiting-user tool                                       |
-| Awaiting input | Pulsing warning    | Every open `function_call` on the current turn names a known awaiting-user tool (`request_user_input`) — Codex is blocked on the user, not running compute |
-| Waiting        | Dim dot            | Latest lifecycle event is `task_complete`                                                                                                                    |
+| Thinking       | Pulsing accent dot | Latest lifecycle event is `task_started`, with no open `function_call` scoped to the current turn                                                                                                                              |
+| Tool use       | Spinning yellow    | Latest lifecycle event is `task_started`, with at least one open `function_call` that isn't a known awaiting-user tool                                                                                                         |
+| Awaiting input | Pulsing warning    | Every open `function_call` names a known awaiting-user tool — `request_user_input` (Plan mode), `request_permissions` (all modes), or `request_plugin_install`. Codex is blocked on the user, not running compute |
+| Waiting        | Dim dot            | Latest lifecycle event is `task_complete`                                                                                                                                                                                      |
 
 Open-call tracking is scoped per-turn: a `function_call` with no matching `_output` that straddles a `task_started` boundary (user aborted a prior tool-using turn) does not pin the next turn to `tool_use`.
 
@@ -135,10 +135,10 @@ Detects [OpenCode](https://github.com/anomalyco/opencode) sessions and shows the
 
 | State          | Indicator          | How                                                                                                          |
 | -------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
-| Thinking       | Pulsing accent dot | Latest assistant message has no `time.completed`                                                             |
-| Tool use       | Spinning yellow    | Thinking + at least one `part` with `state.status: "running"` whose `tool` field is anything but `question`  |
-| Awaiting input | Pulsing warning    | Thinking + every running `part`'s `tool` is OpenCode's built-in `question` tool — blocked on a human reply   |
-| Waiting        | Dim dot            | Latest assistant message has `time.completed` set and `finish: "stop"`                                       |
+| Thinking       | Pulsing accent dot | Latest assistant message has no `time.completed`                                                                                                   |
+| Tool use       | Spinning yellow    | Thinking + at least one `part` with `state.status: "running"` whose `tool` field is neither `question` nor `plan_exit`                             |
+| Awaiting input | Pulsing warning    | Thinking + every running `part`'s `tool` is `question` (structured prompt) or `plan_exit` (plan-mode approval gate) — blocked on a human reply     |
+| Waiting        | Dim dot            | Latest assistant message has `time.completed` set and `finish: "stop"`                                                                             |
 
 **What we can't detect (yet):**
 

--- a/packages/client/src/canvas/workspace-switcher/model.ts
+++ b/packages/client/src/canvas/workspace-switcher/model.ts
@@ -5,6 +5,7 @@ import {
   type IdleBucketKey,
 } from "../../terminal/activityWindow";
 import type { TerminalDisplayInfo } from "../../terminal/terminalDisplay";
+import { isAttentionState } from "../../ui/agentDisplay";
 import type { TileLayout } from "../TileLayout";
 
 /** Live-terminal source row before a presentation-specific order is applied. */
@@ -209,16 +210,10 @@ export type WorkspaceSwitcherModel = {
 export function agentBucket(
   agent: AgentInfo | null | undefined,
 ): Exclude<WorkspaceAgentBucket, "idle"> {
-  switch (agent?.state) {
-    case "waiting":
-    case "awaiting_user":
-      return "awaiting";
-    case "thinking":
-    case "tool_use":
-      return "working";
-    case undefined:
-      return "none";
-  }
+  const state = agent?.state;
+  if (state === undefined) return "none";
+  if (isAttentionState(state)) return "awaiting";
+  return "working";
 }
 
 /** Classify a terminal into a switcher column. Parked terminals (last

--- a/packages/client/src/canvas/workspace-switcher/model.ts
+++ b/packages/client/src/canvas/workspace-switcher/model.ts
@@ -211,6 +211,7 @@ export function agentBucket(
 ): Exclude<WorkspaceAgentBucket, "idle"> {
   switch (agent?.state) {
     case "waiting":
+    case "awaiting_user":
       return "awaiting";
     case "thinking":
     case "tool_use":

--- a/packages/client/src/canvas/workspace-switcher/model.ts
+++ b/packages/client/src/canvas/workspace-switcher/model.ts
@@ -1,11 +1,11 @@
 import type { AgentInfo, TerminalId } from "kolu-common/surface";
+import { match } from "ts-pattern";
 import {
   type IdleBucket,
   IDLE_BUCKETS,
   type IdleBucketKey,
 } from "../../terminal/activityWindow";
 import type { TerminalDisplayInfo } from "../../terminal/terminalDisplay";
-import { isAttentionState } from "../../ui/agentDisplay";
 import type { TileLayout } from "../TileLayout";
 
 /** Live-terminal source row before a presentation-specific order is applied. */
@@ -210,10 +210,15 @@ export type WorkspaceSwitcherModel = {
 export function agentBucket(
   agent: AgentInfo | null | undefined,
 ): Exclude<WorkspaceAgentBucket, "idle"> {
-  const state = agent?.state;
-  if (state === undefined) return "none";
-  if (isAttentionState(state)) return "awaiting";
-  return "working";
+  // The `waiting | awaiting_user` pair is the same equivalence class
+  // surfaced runtime-side by `isAttentionState` in `agentDisplay.ts` —
+  // ts-pattern is used here instead so `.exhaustive()` flags any future
+  // state literal that lands in `AgentInfo["state"]` without a bucket.
+  return match(agent?.state)
+    .with(undefined, () => "none" as const)
+    .with("waiting", "awaiting_user", () => "awaiting" as const)
+    .with("thinking", "tool_use", () => "working" as const)
+    .exhaustive();
 }
 
 /** Classify a terminal into a switcher column. Parked terminals (last

--- a/packages/client/src/terminal/AgentIndicator.tsx
+++ b/packages/client/src/terminal/AgentIndicator.tsx
@@ -21,6 +21,7 @@ const stateConfig: Record<
   thinking: { color: BUSY_COLOR, animation: "animate-pulse" },
   tool_use: { color: BUSY_COLOR, animation: "animate-spin" },
   waiting: { color: "text-warning", animation: "animate-pulse" },
+  awaiting_user: { color: "text-warning", animation: "animate-pulse" },
 };
 
 /** "47392" → "47K", "1183456" → "1.2M". Single call site; no helper module

--- a/packages/client/src/terminal/useTerminalAlerts.ts
+++ b/packages/client/src/terminal/useTerminalAlerts.ts
@@ -77,7 +77,15 @@ export function useTerminalAlerts(deps: {
     prev: string | undefined,
     next: string | undefined,
   ) {
-    if (!activityAlerts() || next !== "waiting" || prev === "waiting") return;
+    if (!activityAlerts()) return;
+    // Both `waiting` (turn ended cleanly) and `awaiting_user` (agent
+    // blocked on a question) mean "user attention needed now" — fire on
+    // either transition. Treat the two as a single "needs-attention"
+    // class so we don't double-alert when the agent flips between them
+    // within one session.
+    const isAttention = (s: string | undefined) =>
+      s === "waiting" || s === "awaiting_user";
+    if (!isAttention(next) || isAttention(prev)) return;
     alertForTerminal(id);
   }
 

--- a/packages/client/src/terminal/useTerminalAlerts.ts
+++ b/packages/client/src/terminal/useTerminalAlerts.ts
@@ -2,11 +2,7 @@
  *  Watches metadata subscriptions for agent state changes (any AI coding agent). */
 
 import { makeEventListener } from "@solid-primitives/event-listener";
-import type {
-  AgentInfo,
-  TerminalId,
-  TerminalMetadata,
-} from "kolu-common/surface";
+import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import { type Accessor, createEffect, on } from "solid-js";
 import { isAttentionState } from "../ui/agentDisplay";
 import { preferences } from "../wire";
@@ -86,9 +82,7 @@ export function useTerminalAlerts(deps: {
     // Fire on entry into the "needs-attention" class (waiting or
     // awaiting_user). Treating the two as one class means we don't
     // double-alert when the agent flips between them in one session.
-    const nextAttn = isAttentionState(next as AgentInfo["state"] | undefined);
-    const prevAttn = isAttentionState(prev as AgentInfo["state"] | undefined);
-    if (!nextAttn || prevAttn) return;
+    if (!isAttentionState(next) || isAttentionState(prev)) return;
     alertForTerminal(id);
   }
 

--- a/packages/client/src/terminal/useTerminalAlerts.ts
+++ b/packages/client/src/terminal/useTerminalAlerts.ts
@@ -2,8 +2,13 @@
  *  Watches metadata subscriptions for agent state changes (any AI coding agent). */
 
 import { makeEventListener } from "@solid-primitives/event-listener";
-import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
+import type {
+  AgentInfo,
+  TerminalId,
+  TerminalMetadata,
+} from "kolu-common/surface";
 import { type Accessor, createEffect, on } from "solid-js";
+import { isAttentionState } from "../ui/agentDisplay";
 import { preferences } from "../wire";
 import { useStaleCheck } from "./staleness";
 import type { TerminalSubject } from "./terminalSubject";
@@ -78,14 +83,12 @@ export function useTerminalAlerts(deps: {
     next: string | undefined,
   ) {
     if (!activityAlerts()) return;
-    // Both `waiting` (turn ended cleanly) and `awaiting_user` (agent
-    // blocked on a question) mean "user attention needed now" — fire on
-    // either transition. Treat the two as a single "needs-attention"
-    // class so we don't double-alert when the agent flips between them
-    // within one session.
-    const isAttention = (s: string | undefined) =>
-      s === "waiting" || s === "awaiting_user";
-    if (!isAttention(next) || isAttention(prev)) return;
+    // Fire on entry into the "needs-attention" class (waiting or
+    // awaiting_user). Treating the two as one class means we don't
+    // double-alert when the agent flips between them in one session.
+    const nextAttn = isAttentionState(next as AgentInfo["state"] | undefined);
+    const prevAttn = isAttentionState(prev as AgentInfo["state"] | undefined);
+    if (!nextAttn || prevAttn) return;
     alertForTerminal(id);
   }
 

--- a/packages/client/src/ui/agentDisplay.ts
+++ b/packages/client/src/ui/agentDisplay.ts
@@ -25,6 +25,7 @@ export const stateLabels: Record<AgentInfo["state"], string> = {
   thinking: "Thinking",
   tool_use: "Running tools",
   waiting: "Waiting for input",
+  awaiting_user: "Awaiting input",
 };
 
 /** Resolve the icon for a raw agent command string (e.g. `"claude --model

--- a/packages/client/src/ui/agentDisplay.ts
+++ b/packages/client/src/ui/agentDisplay.ts
@@ -28,6 +28,18 @@ export const stateLabels: Record<AgentInfo["state"], string> = {
   awaiting_user: "Awaiting input",
 };
 
+/** True when the agent state means "user action needed now" — collapses
+ *  `waiting` (turn ended cleanly, no more compute happening) and
+ *  `awaiting_user` (agent blocked on a question) into one predicate so
+ *  the alert layer and the switcher bucket agree on the equivalence
+ *  class. Add a new state here when it joins the attention class;
+ *  miss this and one consumer fires while the other ignores it. */
+export function isAttentionState(
+  state: AgentInfo["state"] | undefined,
+): boolean {
+  return state === "waiting" || state === "awaiting_user";
+}
+
 /** Resolve the icon for a raw agent command string (e.g. `"claude --model
  *  sonnet"`). Returns `undefined` for detection-only agents that have no
  *  AgentInfo discriminator (aider/goose/gemini/cursor-agent) and for

--- a/packages/client/src/ui/agentDisplay.ts
+++ b/packages/client/src/ui/agentDisplay.ts
@@ -33,10 +33,12 @@ export const stateLabels: Record<AgentInfo["state"], string> = {
  *  `awaiting_user` (agent blocked on a question) into one predicate so
  *  the alert layer and the switcher bucket agree on the equivalence
  *  class. Add a new state here when it joins the attention class;
- *  miss this and one consumer fires while the other ignores it. */
-export function isAttentionState(
-  state: AgentInfo["state"] | undefined,
-): boolean {
+ *  miss this and one consumer fires while the other ignores it.
+ *
+ *  Accepts `string | undefined` because callers reading from reactive
+ *  history (`createEffect`'s previous-value tracking) lose the literal
+ *  type — equality comparisons inside still narrow correctly. */
+export function isAttentionState(state: string | undefined): boolean {
   return state === "waiting" || state === "awaiting_user";
 }
 

--- a/packages/integrations/anyagent/src/index.ts
+++ b/packages/integrations/anyagent/src/index.ts
@@ -17,4 +17,5 @@ export {
   agentInfoEqual,
   matchesAgent,
 } from "./agent-provider.ts";
+export { classifyByAwaiting } from "./lifecycle.ts";
 export { type TaskProgress, TaskProgressSchema } from "./schemas.ts";

--- a/packages/integrations/anyagent/src/lifecycle.ts
+++ b/packages/integrations/anyagent/src/lifecycle.ts
@@ -1,0 +1,26 @@
+/** Shared lifecycle helpers used by every agent integration's state
+ *  derivation. Lives here so the *policy* (e.g. "how does a mixed batch
+ *  of pending tool calls map to a state?") has one home, even though
+ *  the *detection mechanics* (parsing JSONL content blocks vs. JSONL
+ *  function_call entries vs. SQLite tool parts) are necessarily
+ *  per-integration. */
+
+/** Decide between `tool_use` and `awaiting_user` given how many pending
+ *  tool invocations are awaiting-user-flavored vs. how many are pending
+ *  in total.
+ *
+ *  Rule: only emit `awaiting_user` when *every* pending invocation is
+ *  awaiting-user. A mixed batch (e.g. Claude calls `AskUserQuestion`
+ *  alongside a `Read`) stays `tool_use` because real compute is in
+ *  flight — pretending the UI is just "awaiting" would hide that. The
+ *  conservative bucket wins.
+ *
+ *  Single-source-of-truth so a future policy change (e.g. "show
+ *  awaiting_user even in mixed batches, the human gate is the
+ *  bottleneck") touches one site instead of N. */
+export function classifyByAwaiting(
+  awaiting: number,
+  total: number,
+): "tool_use" | "awaiting_user" {
+  return total > 0 && awaiting === total ? "awaiting_user" : "tool_use";
+}

--- a/packages/integrations/anyagent/src/lifecycle.ts
+++ b/packages/integrations/anyagent/src/lifecycle.ts
@@ -1,23 +1,15 @@
-/** Shared lifecycle helpers used by every agent integration's state
- *  derivation. Lives here so the *policy* (e.g. "how does a mixed batch
- *  of pending tool calls map to a state?") has one home, even though
- *  the *detection mechanics* (parsing JSONL content blocks vs. JSONL
- *  function_call entries vs. SQLite tool parts) are necessarily
- *  per-integration. */
+/** Shared lifecycle helpers across the per-integration state derivers.
+ *  Detection mechanics differ (Claude JSONL content blocks vs. Codex
+ *  function_call entries vs. OpenCode SQLite tool parts) but the policy
+ *  decisions they make live here. */
 
-/** Decide between `tool_use` and `awaiting_user` given how many pending
- *  tool invocations are awaiting-user-flavored vs. how many are pending
- *  in total.
- *
- *  Rule: only emit `awaiting_user` when *every* pending invocation is
- *  awaiting-user. A mixed batch (e.g. Claude calls `AskUserQuestion`
- *  alongside a `Read`) stays `tool_use` because real compute is in
- *  flight — pretending the UI is just "awaiting" would hide that. The
- *  conservative bucket wins.
- *
- *  Single-source-of-truth so a future policy change (e.g. "show
- *  awaiting_user even in mixed batches, the human gate is the
- *  bottleneck") touches one site instead of N. */
+/** Pick `awaiting_user` over `tool_use` only when *every* pending tool
+ *  invocation is awaiting-user-flavored. A mixed batch — e.g. Claude
+ *  calls `AskUserQuestion` alongside a `Read` — stays `tool_use`
+ *  because real compute is in flight; flipping to `awaiting_user`
+ *  would hide that. Centralized so the policy has one home for a
+ *  future change ("the human gate is the bottleneck, show
+ *  awaiting_user even in mixed batches") to touch. */
 export function classifyByAwaiting(
   awaiting: number,
   total: number,

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -177,6 +177,27 @@ type UsageShape = {
   cache_read_input_tokens?: number;
 };
 
+/** Built-in tools whose pending invocation means the agent is blocked on
+ *  the human, not running compute. `AskUserQuestion` is the structured
+ *  question prompt; `ExitPlanMode` is the plan-approval gate. When the
+ *  last assistant turn stopped with `stop_reason: "tool_use"` and every
+ *  pending tool call is in this set, the agent is awaiting a reply —
+ *  rendering "Running tools" would mislead. */
+const AWAITING_USER_TOOLS = new Set(["AskUserQuestion", "ExitPlanMode"]);
+
+function toolUseOrAwaitingUser(
+  content: Array<{ type?: string; name?: string }> | undefined,
+): "tool_use" | "awaiting_user" {
+  if (!Array.isArray(content)) return "tool_use";
+  let sawToolUse = false;
+  for (const block of content) {
+    if (block.type !== "tool_use") continue;
+    sawToolUse = true;
+    if (!block.name || !AWAITING_USER_TOOLS.has(block.name)) return "tool_use";
+  }
+  return sawToolUse ? "awaiting_user" : "tool_use";
+}
+
 /** Derive Claude Code state from the last relevant JSONL message.
  *
  *  Walks backwards once, tracking two independent signals with different
@@ -210,6 +231,7 @@ export function deriveState(lines: string[]): {
           stop_reason?: string | null;
           model?: string | null;
           usage?: UsageShape;
+          content?: Array<{ type?: string; name?: string }>;
         };
       } = JSON.parse(raw);
 
@@ -229,7 +251,7 @@ export function deriveState(lines: string[]): {
             model,
           }))
           .with({ type: "assistant", stopReason: "tool_use" }, () => ({
-            state: "tool_use" as const,
+            state: toolUseOrAwaitingUser(entry.message?.content),
             model,
           }))
           .with({ type: "assistant" }, () => ({

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -178,16 +178,18 @@ type UsageShape = {
   cache_read_input_tokens?: number;
 };
 
-/** Built-in tools whose pending invocation means the agent is blocked on
- *  the human, not running compute. `AskUserQuestion` is the structured
- *  question prompt; `ExitPlanMode` is the plan-approval gate. The
- *  set itself is protocol-specific (Claude API names), but the rule
- *  "all-or-nothing → awaiting_user" is shared — see
- *  `classifyByAwaiting` in `anyagent`. */
+/** Minimal assistant `message.content[]` block shape — only the two
+ *  fields state derivation reads. The transcript layer carries the full
+ *  union (text, thinking, tool_use, etc.); live state derivation just
+ *  needs to ask "is this a `tool_use` block and which tool". */
+type ContentBlock = { type?: string; name?: string };
+
+/** Claude tool names whose pending invocation means the agent is
+ *  awaiting the human. Policy lives in `classifyByAwaiting`. */
 const AWAITING_USER_TOOLS = new Set(["AskUserQuestion", "ExitPlanMode"]);
 
 function toolUseOrAwaitingUser(
-  content: Array<{ type?: string; name?: string }> | undefined,
+  content: ContentBlock[] | undefined,
 ): "tool_use" | "awaiting_user" {
   if (!Array.isArray(content)) return "tool_use";
   let total = 0;
@@ -233,7 +235,7 @@ export function deriveState(lines: string[]): {
           stop_reason?: string | null;
           model?: string | null;
           usage?: UsageShape;
-          content?: Array<{ type?: string; name?: string }>;
+          content?: ContentBlock[];
         };
       } = JSON.parse(raw);
 

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -24,6 +24,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
+import { classifyByAwaiting } from "anyagent";
 import { type Logger, readTailLines } from "kolu-shared";
 import { match } from "ts-pattern";
 import type { ClaudeCodeInfo, TaskProgress } from "./schemas.ts";
@@ -179,23 +180,24 @@ type UsageShape = {
 
 /** Built-in tools whose pending invocation means the agent is blocked on
  *  the human, not running compute. `AskUserQuestion` is the structured
- *  question prompt; `ExitPlanMode` is the plan-approval gate. When the
- *  last assistant turn stopped with `stop_reason: "tool_use"` and every
- *  pending tool call is in this set, the agent is awaiting a reply —
- *  rendering "Running tools" would mislead. */
+ *  question prompt; `ExitPlanMode` is the plan-approval gate. The
+ *  set itself is protocol-specific (Claude API names), but the rule
+ *  "all-or-nothing → awaiting_user" is shared — see
+ *  `classifyByAwaiting` in `anyagent`. */
 const AWAITING_USER_TOOLS = new Set(["AskUserQuestion", "ExitPlanMode"]);
 
 function toolUseOrAwaitingUser(
   content: Array<{ type?: string; name?: string }> | undefined,
 ): "tool_use" | "awaiting_user" {
   if (!Array.isArray(content)) return "tool_use";
-  let sawToolUse = false;
+  let total = 0;
+  let awaiting = 0;
   for (const block of content) {
     if (block.type !== "tool_use") continue;
-    sawToolUse = true;
-    if (!block.name || !AWAITING_USER_TOOLS.has(block.name)) return "tool_use";
+    total++;
+    if (block.name && AWAITING_USER_TOOLS.has(block.name)) awaiting++;
   }
-  return sawToolUse ? "awaiting_user" : "tool_use";
+  return classifyByAwaiting(awaiting, total);
 }
 
 /** Derive Claude Code state from the last relevant JSONL message.

--- a/packages/integrations/claude-code/src/index.test.ts
+++ b/packages/integrations/claude-code/src/index.test.ts
@@ -34,6 +34,64 @@ describe("deriveState", () => {
     });
   });
 
+  it("returns awaiting_user when the only pending tool is AskUserQuestion", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        model: "claude-opus-4-7",
+        content: [
+          { type: "text", text: "Need a decision before I proceed." },
+          { type: "tool_use", name: "AskUserQuestion", id: "tu_1" },
+        ],
+      },
+    });
+    expect(deriveState([line])).toEqual({
+      state: "awaiting_user",
+      model: "claude-opus-4-7",
+      contextTokens: null,
+    });
+  });
+
+  it("returns awaiting_user for ExitPlanMode (plan approval gate)", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        model: "claude-opus-4-7",
+        content: [{ type: "tool_use", name: "ExitPlanMode", id: "tu_1" }],
+      },
+    });
+    expect(deriveState([line])).toMatchObject({ state: "awaiting_user" });
+  });
+
+  it("stays tool_use when AskUserQuestion is mixed with a real tool call", () => {
+    // Mixed batch: the human-input prompt is real, but so is the Read —
+    // there's compute in flight, so "Running tools" is honest.
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        model: "claude-opus-4-7",
+        content: [
+          { type: "tool_use", name: "AskUserQuestion", id: "tu_1" },
+          { type: "tool_use", name: "Read", id: "tu_2" },
+        ],
+      },
+    });
+    expect(deriveState([line])).toMatchObject({ state: "tool_use" });
+  });
+
+  it("falls back to tool_use when content is missing on a tool_use stop", () => {
+    // Synthetic transcripts (e.g. `claude -c` replays) may omit content;
+    // we can't tell what's pending so treat it as the conservative case.
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { stop_reason: "tool_use", model: "claude-opus-4-7" },
+    });
+    expect(deriveState([line])).toMatchObject({ state: "tool_use" });
+  });
+
   it("returns thinking for assistant with missing stop_reason", () => {
     const line = JSON.stringify({
       type: "assistant",

--- a/packages/integrations/claude-code/src/index.test.ts
+++ b/packages/integrations/claude-code/src/index.test.ts
@@ -53,7 +53,7 @@ describe("deriveState", () => {
     });
   });
 
-  it("returns awaiting_user for ExitPlanMode (plan approval gate)", () => {
+  it("returns awaiting_user when ExitPlanMode is the only pending tool", () => {
     const line = JSON.stringify({
       type: "assistant",
       message: {

--- a/packages/integrations/claude-code/src/schemas.ts
+++ b/packages/integrations/claude-code/src/schemas.ts
@@ -17,9 +17,14 @@ export { TaskProgressSchema };
 export const ClaudeCodeInfoSchema = z.object({
   kind: z.literal("claude-code"),
   /** Current state derived from session JSONL.
-   *  - `awaiting_user`: agent stopped to ask the human (e.g. `AskUserQuestion`,
-   *    `ExitPlanMode`). Visually distinct from `tool_use` because no work is
-   *    in flight — the spinner would be a lie. */
+   *  - `awaiting_user`: agent stopped to ask the human via `AskUserQuestion`
+   *    or `ExitPlanMode`. The state literal is kept here for shape uniformity
+   *    with `CodexInfo` / `OpenCodeInfo` and so `deriveState`'s
+   *    `toolUseOrAwaitingUser` helper compiles, but in practice the Claude
+   *    Agent SDK buffers `requiresUserInteraction` tools' assistant messages
+   *    until the user resolves them — the `tool_use` block isn't on disk
+   *    while the prompt is pending, so this case never fires under the
+   *    current SDK. Fix tracked in #905 (PreToolUse hook side-channel). */
   state: z.enum(["thinking", "tool_use", "waiting", "awaiting_user"]),
   /** Session UUID from ~/.claude/sessions/. */
   sessionId: z.string(),

--- a/packages/integrations/claude-code/src/schemas.ts
+++ b/packages/integrations/claude-code/src/schemas.ts
@@ -16,8 +16,11 @@ export { TaskProgressSchema };
 
 export const ClaudeCodeInfoSchema = z.object({
   kind: z.literal("claude-code"),
-  /** Current state derived from session JSONL. */
-  state: z.enum(["thinking", "tool_use", "waiting"]),
+  /** Current state derived from session JSONL.
+   *  - `awaiting_user`: agent stopped to ask the human (e.g. `AskUserQuestion`,
+   *    `ExitPlanMode`). Visually distinct from `tool_use` because no work is
+   *    in flight — the spinner would be a lie. */
+  state: z.enum(["thinking", "tool_use", "waiting", "awaiting_user"]),
   /** Session UUID from ~/.claude/sessions/. */
   sessionId: z.string(),
   /** Model name if available (e.g. "claude-opus-4-6"). */

--- a/packages/integrations/codex/src/core.ts
+++ b/packages/integrations/codex/src/core.ts
@@ -310,8 +310,24 @@ interface RolloutLine {
  * Pure function — unit-testable without touching the filesystem.
  */
 /** Codex function-call names whose pending invocation means the agent
- *  is awaiting the human. Policy lives in `classifyByAwaiting`. */
-const AWAITING_USER_TOOLS = new Set(["request_user_input"]);
+ *  is awaiting the human. All three handlers `await session.<…>(…)` on
+ *  the user before resolving:
+ *   - `request_user_input` — structured multi-choice prompt (Plan mode
+ *     only by default; gated on the `DefaultModeRequestUserInput`
+ *     feature flag for Default mode — see
+ *     `codex-rs/protocol/src/config_types.rs:593-595`).
+ *   - `request_permissions` — model asks to escalate sandbox or
+ *     filesystem permissions; available in all modes
+ *     (`codex-rs/core/src/tools/handlers/request_permissions.rs:64`).
+ *   - `request_plugin_install` — MCP-elicitation prompt to install a
+ *     connector/plugin
+ *     (`codex-rs/core/src/tools/handlers/request_plugin_install.rs:157`).
+ *  Policy lives in `classifyByAwaiting`. */
+const AWAITING_USER_TOOLS = new Set([
+  "request_user_input",
+  "request_permissions",
+  "request_plugin_install",
+]);
 
 export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {
   let lastLifecycle: "started" | "completed" | null = null;

--- a/packages/integrations/codex/src/core.ts
+++ b/packages/integrations/codex/src/core.ts
@@ -253,6 +253,10 @@ interface RolloutLine {
     turn_id?: string;
     /** On `response_item` payloads for function_call/function_call_output. */
     call_id?: string;
+    /** On `response_item:function_call` — the tool name (e.g. `shell`,
+     *  `request_user_input`, `update_plan`). Captured so the state machine
+     *  can route blocked-on-human tools to `awaiting_user`. */
+    name?: string;
     /** On `token_count` event_msgs. Nested because Codex envelopes the
      *  accounting under `.info` alongside rate-limit metadata. */
     info?: {
@@ -305,9 +309,16 @@ interface RolloutLine {
  *
  * Pure function — unit-testable without touching the filesystem.
  */
+/** Built-in Codex tools whose pending invocation means the agent is
+ *  blocked on the human. `request_user_input` is Codex's structured
+ *  question prompt (the `AskUserQuestion` analog). When every open call
+ *  on the current turn is in this set, the agent isn't computing — it's
+ *  waiting for a reply. */
+const AWAITING_USER_TOOLS = new Set(["request_user_input"]);
+
 export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {
   let lastLifecycle: "started" | "completed" | null = null;
-  const openCalls = new Set<string>();
+  const openCalls = new Map<string, string>();
 
   for (const line of lines) {
     let entry: RolloutLine;
@@ -331,7 +342,7 @@ export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {
       }
     } else if (outer === "response_item") {
       if (inner === "function_call" && entry.payload?.call_id) {
-        openCalls.add(entry.payload.call_id);
+        openCalls.set(entry.payload.call_id, entry.payload.name ?? "");
       } else if (inner === "function_call_output" && entry.payload?.call_id) {
         openCalls.delete(entry.payload.call_id);
       }
@@ -340,8 +351,11 @@ export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {
 
   if (lastLifecycle === null) return null;
   if (lastLifecycle === "completed") return "waiting";
-  if (openCalls.size > 0) return "tool_use";
-  return "thinking";
+  if (openCalls.size === 0) return "thinking";
+  for (const name of openCalls.values()) {
+    if (!AWAITING_USER_TOOLS.has(name)) return "tool_use";
+  }
+  return "awaiting_user";
 }
 
 /**

--- a/packages/integrations/codex/src/core.ts
+++ b/packages/integrations/codex/src/core.ts
@@ -36,6 +36,7 @@
  */
 
 import { DatabaseSync } from "node:sqlite";
+import { classifyByAwaiting } from "anyagent";
 import type { Logger } from "kolu-shared";
 import { withDb as sharedWithDb } from "kolu-shared/sqlite";
 import { CODEX_DB_PATH } from "./config.ts";
@@ -311,9 +312,10 @@ interface RolloutLine {
  */
 /** Built-in Codex tools whose pending invocation means the agent is
  *  blocked on the human. `request_user_input` is Codex's structured
- *  question prompt (the `AskUserQuestion` analog). When every open call
- *  on the current turn is in this set, the agent isn't computing — it's
- *  waiting for a reply. */
+ *  question prompt (the `AskUserQuestion` analog). The set itself is
+ *  Codex-specific (function_call names from `codex-rs`), but the rule
+ *  "all-or-nothing → awaiting_user" is shared — see `classifyByAwaiting`
+ *  in `anyagent`. */
 const AWAITING_USER_TOOLS = new Set(["request_user_input"]);
 
 export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {
@@ -352,10 +354,11 @@ export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {
   if (lastLifecycle === null) return null;
   if (lastLifecycle === "completed") return "waiting";
   if (openCalls.size === 0) return "thinking";
+  let awaiting = 0;
   for (const name of openCalls.values()) {
-    if (!AWAITING_USER_TOOLS.has(name)) return "tool_use";
+    if (AWAITING_USER_TOOLS.has(name)) awaiting++;
   }
-  return "awaiting_user";
+  return classifyByAwaiting(awaiting, openCalls.size);
 }
 
 /**

--- a/packages/integrations/codex/src/core.ts
+++ b/packages/integrations/codex/src/core.ts
@@ -254,9 +254,8 @@ interface RolloutLine {
     turn_id?: string;
     /** On `response_item` payloads for function_call/function_call_output. */
     call_id?: string;
-    /** On `response_item:function_call` — the tool name (e.g. `shell`,
-     *  `request_user_input`, `update_plan`). Captured so the state machine
-     *  can route blocked-on-human tools to `awaiting_user`. */
+    /** Function-call name on `response_item:function_call` payloads
+     *  (e.g. `shell`, `request_user_input`, `update_plan`). */
     name?: string;
     /** On `token_count` event_msgs. Nested because Codex envelopes the
      *  accounting under `.info` alongside rate-limit metadata. */
@@ -310,12 +309,8 @@ interface RolloutLine {
  *
  * Pure function — unit-testable without touching the filesystem.
  */
-/** Built-in Codex tools whose pending invocation means the agent is
- *  blocked on the human. `request_user_input` is Codex's structured
- *  question prompt (the `AskUserQuestion` analog). The set itself is
- *  Codex-specific (function_call names from `codex-rs`), but the rule
- *  "all-or-nothing → awaiting_user" is shared — see `classifyByAwaiting`
- *  in `anyagent`. */
+/** Codex function-call names whose pending invocation means the agent
+ *  is awaiting the human. Policy lives in `classifyByAwaiting`. */
 const AWAITING_USER_TOOLS = new Set(["request_user_input"]);
 
 export function parseRolloutState(lines: string[]): CodexInfo["state"] | null {

--- a/packages/integrations/codex/src/index.test.ts
+++ b/packages/integrations/codex/src/index.test.ts
@@ -147,10 +147,20 @@ describe("parseRolloutState", () => {
     expect(parseRolloutState(lines)).toBeNull();
   });
 
-  it("returns awaiting_user when the only open call is request_user_input", () => {
+  it.each([
+    "request_user_input",
+    "request_permissions",
+    "request_plugin_install",
+  ])("returns awaiting_user when the only open call is %s", (toolName) => {
+    const lines = [taskStarted("turn-1"), funcCall("call-A", toolName)];
+    expect(parseRolloutState(lines)).toBe("awaiting_user");
+  });
+
+  it("returns awaiting_user when every open call is some awaiting-user tool", () => {
     const lines = [
       taskStarted("turn-1"),
       funcCall("call-A", "request_user_input"),
+      funcCall("call-B", "request_permissions"),
     ];
     expect(parseRolloutState(lines)).toBe("awaiting_user");
   });

--- a/packages/integrations/codex/src/index.test.ts
+++ b/packages/integrations/codex/src/index.test.ts
@@ -45,10 +45,10 @@ function taskComplete(turnId: string): string {
     payload: { type: "task_complete", turn_id: turnId },
   });
 }
-function funcCall(callId: string): string {
+function funcCall(callId: string, name = "shell"): string {
   return line({
     type: "response_item",
-    payload: { type: "function_call", call_id: callId },
+    payload: { type: "function_call", call_id: callId, name },
   });
 }
 function funcOutput(callId: string): string {
@@ -145,6 +145,25 @@ describe("parseRolloutState", () => {
     ];
     // No turn_id → not counted as a real task_started
     expect(parseRolloutState(lines)).toBeNull();
+  });
+
+  it("returns awaiting_user when the only open call is request_user_input", () => {
+    const lines = [
+      taskStarted("turn-1"),
+      funcCall("call-A", "request_user_input"),
+    ];
+    expect(parseRolloutState(lines)).toBe("awaiting_user");
+  });
+
+  it("stays tool_use when request_user_input runs alongside another tool", () => {
+    // Mixed batch: a question is pending, but so is a shell call —
+    // there's still compute in flight, so the conservative state wins.
+    const lines = [
+      taskStarted("turn-1"),
+      funcCall("call-A", "request_user_input"),
+      funcCall("call-B", "shell"),
+    ];
+    expect(parseRolloutState(lines)).toBe("tool_use");
   });
 
   it("returns waiting when tail kept task_complete but chopped the start", () => {

--- a/packages/integrations/codex/src/schemas.ts
+++ b/packages/integrations/codex/src/schemas.ts
@@ -16,8 +16,11 @@ export { TaskProgressSchema };
 
 export const CodexInfoSchema = z.object({
   kind: z.literal("codex"),
-  /** Current state derived from the rollout JSONL's event stream. */
-  state: z.enum(["thinking", "tool_use", "waiting"]),
+  /** Current state derived from the rollout JSONL's event stream.
+   *  - `awaiting_user`: agent issued `request_user_input` (or another
+   *    user-input tool) and is blocked on a reply. Distinct from `tool_use`
+   *    so the UI can stop pretending the spinner is doing work. */
+  state: z.enum(["thinking", "tool_use", "waiting", "awaiting_user"]),
   /** Thread id from Codex's `threads` table (e.g. "019db605-..."). */
   sessionId: z.string(),
   /** Model identifier from the DB (e.g. "gpt-5.4"). Null until Codex

--- a/packages/integrations/opencode/src/core.ts
+++ b/packages/integrations/opencode/src/core.ts
@@ -206,35 +206,22 @@ export function getLatestAssistantContextTokens(
 
 // --- Tool detection ---
 
-/** Classifier for the running tool parts on the current message:
- *   - `none`         — no tools in flight; let the base state stand
- *   - `tool_use`     — at least one real-work tool is running
- *   - `awaiting_user` — every running part is OpenCode's `question` tool
+/** Classify the tool parts currently in the "running" state for one
+ *  message (the current assistant turn) — scoped per-message rather
+ *  than per-session so a transcript with thousands of completed tool
+ *  parts stays cheap to scan.
  *
- *  OpenCode's permission/question flow lives in process memory (see
- *  upstream `Question.Service`), but the built-in `question` tool *does*
- *  persist a part row with `state.status = "running"` while it waits on
- *  the user. Discriminating by `tool === "question"` is therefore the
- *  only signal SQLite carries that distinguishes "blocked on human" from
- *  "shell command in flight". */
-export type RunningToolsBucket = "none" | "tool_use" | "awaiting_user";
-
-/**
- * Classify the tool parts currently in the "running" state for one
- * message (the current assistant turn) — scoped per-message rather than
- * per-session so a transcript with thousands of completed tool parts
- * stays cheap to scan.
- *
- * One SQL pass splits running tools into "all are `question`" vs. "at
- * least one is real work" by counting both totals; the discriminator
- * lives in TS so the SQL stays trivially indexable on
- * `part_message_id_id_idx`.
- */
+ *  Returns `null` when no tools are running (the caller keeps its base
+ *  state), `"tool_use"` when at least one real-work tool is in flight,
+ *  and `"awaiting_user"` when every running part is OpenCode's built-in
+ *  `question` tool — the only SQLite signal that distinguishes
+ *  "blocked on human" from "shell command in flight". One SQL pass
+ *  counts total + awaiting using the `part_message_id_id_idx` index. */
 export function runningToolsBucket(
   messageId: string,
   log?: Logger,
   db?: DatabaseSync,
-): RunningToolsBucket {
+): "tool_use" | "awaiting_user" | null {
   return (
     withDb(
       (conn) => {
@@ -246,14 +233,14 @@ export function runningToolsBucket(
           | { total: number; awaiting: number | null }
           | undefined;
         const total = row?.total ?? 0;
-        if (total === 0) return "none";
+        if (total === 0) return null;
         return classifyByAwaiting(row?.awaiting ?? 0, total);
       },
       "opencode running-tools query failed",
       { messageId },
       log,
       db,
-    ) ?? "none"
+    ) ?? null
   );
 }
 

--- a/packages/integrations/opencode/src/core.ts
+++ b/packages/integrations/opencode/src/core.ts
@@ -25,6 +25,7 @@
  */
 
 import { DatabaseSync } from "node:sqlite";
+import { classifyByAwaiting } from "anyagent";
 import type { Logger } from "kolu-shared";
 import { withDb as sharedWithDb } from "kolu-shared/sqlite";
 import { match } from "ts-pattern";
@@ -246,8 +247,7 @@ export function runningToolsBucket(
           | undefined;
         const total = row?.total ?? 0;
         if (total === 0) return "none";
-        const awaiting = row?.awaiting ?? 0;
-        return awaiting === total ? "awaiting_user" : "tool_use";
+        return classifyByAwaiting(row?.awaiting ?? 0, total);
       },
       "opencode running-tools query failed",
       { messageId },

--- a/packages/integrations/opencode/src/core.ts
+++ b/packages/integrations/opencode/src/core.ts
@@ -205,36 +205,55 @@ export function getLatestAssistantContextTokens(
 
 // --- Tool detection ---
 
-/**
- * Check whether the given message has any tool parts currently in the
- * "running" state. Scoped to one message (the current assistant turn)
- * rather than the entire session — a session with thousands of completed
- * tool parts from prior turns only needs to check the handful of parts
- * belonging to the latest message.
+/** Classifier for the running tool parts on the current message:
+ *   - `none`         — no tools in flight; let the base state stand
+ *   - `tool_use`     — at least one real-work tool is running
+ *   - `awaiting_user` — every running part is OpenCode's `question` tool
  *
- * Uses the `part_message_id_id_idx` index for an O(parts-in-message)
- * scan, not O(all-parts-in-session).
+ *  OpenCode's permission/question flow lives in process memory (see
+ *  upstream `Question.Service`), but the built-in `question` tool *does*
+ *  persist a part row with `state.status = "running"` while it waits on
+ *  the user. Discriminating by `tool === "question"` is therefore the
+ *  only signal SQLite carries that distinguishes "blocked on human" from
+ *  "shell command in flight". */
+export type RunningToolsBucket = "none" | "tool_use" | "awaiting_user";
+
+/**
+ * Classify the tool parts currently in the "running" state for one
+ * message (the current assistant turn) — scoped per-message rather than
+ * per-session so a transcript with thousands of completed tool parts
+ * stays cheap to scan.
+ *
+ * One SQL pass splits running tools into "all are `question`" vs. "at
+ * least one is real work" by counting both totals; the discriminator
+ * lives in TS so the SQL stays trivially indexable on
+ * `part_message_id_id_idx`.
  */
-export function hasRunningTools(
+export function runningToolsBucket(
   messageId: string,
   log?: Logger,
   db?: DatabaseSync,
-): boolean {
+): RunningToolsBucket {
   return (
     withDb(
       (conn) => {
         const row = conn
           .prepare(
-            "SELECT COUNT(*) AS n FROM part WHERE message_id = ? AND json_extract(data, '$.type') = 'tool' AND json_extract(data, '$.state.status') = 'running'",
+            "SELECT COUNT(*) AS total, SUM(CASE WHEN json_extract(data, '$.tool') = 'question' THEN 1 ELSE 0 END) AS awaiting FROM part WHERE message_id = ? AND json_extract(data, '$.type') = 'tool' AND json_extract(data, '$.state.status') = 'running'",
           )
-          .get(messageId) as { n: number } | undefined;
-        return (row?.n ?? 0) > 0;
+          .get(messageId) as
+          | { total: number; awaiting: number | null }
+          | undefined;
+        const total = row?.total ?? 0;
+        if (total === 0) return "none";
+        const awaiting = row?.awaiting ?? 0;
+        return awaiting === total ? "awaiting_user" : "tool_use";
       },
       "opencode running-tools query failed",
       { messageId },
       log,
       db,
-    ) ?? false
+    ) ?? "none"
   );
 }
 

--- a/packages/integrations/opencode/src/core.ts
+++ b/packages/integrations/opencode/src/core.ts
@@ -206,6 +206,17 @@ export function getLatestAssistantContextTokens(
 
 // --- Tool detection ---
 
+/** OpenCode built-in tools whose pending invocation means the agent is
+ *  awaiting the human. Both call `Question.Service.ask` and write a
+ *  `part` row with `state.status = "running"` while blocking on the
+ *  user's reply (upstream verification:
+ *  `packages/opencode/src/tool/question.ts:24` and
+ *  `packages/opencode/src/tool/plan.ts:29`). Other interactive flows
+ *  (`ctx.ask` permission prompts inside `shell`/`edit`/`write`/etc.)
+ *  don't surface a distinct `tool` value — the part stays `shell`/etc.
+ *  and is indistinguishable from a real-work tool. */
+const AWAITING_USER_TOOLS = ["question", "plan_exit"] as const;
+
 /** Classify the tool parts currently in the "running" state for one
  *  message (the current assistant turn) — scoped per-message rather
  *  than per-session so a transcript with thousands of completed tool
@@ -213,23 +224,26 @@ export function getLatestAssistantContextTokens(
  *
  *  Returns `null` when no tools are running (the caller keeps its base
  *  state), `"tool_use"` when at least one real-work tool is in flight,
- *  and `"awaiting_user"` when every running part is OpenCode's built-in
- *  `question` tool — the only SQLite signal that distinguishes
- *  "blocked on human" from "shell command in flight". One SQL pass
- *  counts total + awaiting using the `part_message_id_id_idx` index. */
+ *  and `"awaiting_user"` when every running part is in
+ *  `AWAITING_USER_TOOLS`. One SQL pass counts total + awaiting using
+ *  the `part_message_id_id_idx` index. */
 export function runningToolsBucket(
   messageId: string,
   log?: Logger,
   db?: DatabaseSync,
 ): "tool_use" | "awaiting_user" | null {
+  // SQLite's parameter binding doesn't accept arrays for `IN (...)`,
+  // so the placeholder list is constructed inline from a constant —
+  // safe because every value is a hard-coded literal, not user input.
+  const placeholders = AWAITING_USER_TOOLS.map(() => "?").join(", ");
   return (
     withDb(
       (conn) => {
         const row = conn
           .prepare(
-            "SELECT COUNT(*) AS total, SUM(CASE WHEN json_extract(data, '$.tool') = 'question' THEN 1 ELSE 0 END) AS awaiting FROM part WHERE message_id = ? AND json_extract(data, '$.type') = 'tool' AND json_extract(data, '$.state.status') = 'running'",
+            `SELECT COUNT(*) AS total, SUM(CASE WHEN json_extract(data, '$.tool') IN (${placeholders}) THEN 1 ELSE 0 END) AS awaiting FROM part WHERE message_id = ? AND json_extract(data, '$.type') = 'tool' AND json_extract(data, '$.state.status') = 'running'`,
           )
-          .get(messageId) as
+          .get(...AWAITING_USER_TOOLS, messageId) as
           | { total: number; awaiting: number | null }
           | undefined;
         const total = row?.total ?? 0;

--- a/packages/integrations/opencode/src/index.test.ts
+++ b/packages/integrations/opencode/src/index.test.ts
@@ -1,5 +1,34 @@
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { parseMessageState } from "./core.ts";
+import { parseMessageState, runningToolsBucket } from "./core.ts";
+
+/** Minimal `part` schema OpenCode writes — enough for `runningToolsBucket`
+ *  to do its single index scan. The fixture builder in `packages/tests`
+ *  uses the same shape; we inline it here so the unit test stays
+ *  package-local. */
+const PART_SCHEMA = `
+CREATE TABLE part (id TEXT, message_id TEXT NOT NULL, data TEXT NOT NULL);
+CREATE INDEX part_message_id_id_idx ON part(message_id, id);
+`;
+
+function withParts(
+  rows: Array<{ tool?: string; status: string }>,
+): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(PART_SCHEMA);
+  rows.forEach((row, i) => {
+    db.prepare("INSERT INTO part (id, message_id, data) VALUES (?, ?, ?)").run(
+      `p${i}`,
+      "m1",
+      JSON.stringify({
+        type: "tool",
+        ...(row.tool !== undefined && { tool: row.tool }),
+        state: { status: row.status },
+      }),
+    );
+  });
+  return db;
+}
 
 describe("parseMessageState", () => {
   it("returns thinking for a user message", () => {
@@ -73,5 +102,47 @@ describe("parseMessageState", () => {
 
   it("returns null for malformed JSON", () => {
     expect(parseMessageState("not json")).toBeNull();
+  });
+});
+
+describe("runningToolsBucket", () => {
+  it("returns none when no parts are running", () => {
+    const db = withParts([]);
+    expect(runningToolsBucket("m1", undefined, db)).toBe("none");
+  });
+
+  it("returns tool_use for a running shell tool", () => {
+    const db = withParts([{ tool: "shell", status: "running" }]);
+    expect(runningToolsBucket("m1", undefined, db)).toBe("tool_use");
+  });
+
+  it("returns awaiting_user when the only running tool is question", () => {
+    const db = withParts([{ tool: "question", status: "running" }]);
+    expect(runningToolsBucket("m1", undefined, db)).toBe("awaiting_user");
+  });
+
+  it("returns tool_use when question runs alongside another tool", () => {
+    const db = withParts([
+      { tool: "question", status: "running" },
+      { tool: "shell", status: "running" },
+    ]);
+    expect(runningToolsBucket("m1", undefined, db)).toBe("tool_use");
+  });
+
+  it("ignores completed parts even when the only running one is a question", () => {
+    const db = withParts([
+      { tool: "shell", status: "completed" },
+      { tool: "question", status: "running" },
+    ]);
+    expect(runningToolsBucket("m1", undefined, db)).toBe("awaiting_user");
+  });
+
+  it("returns tool_use for legacy parts with no tool field", () => {
+    // Existing fixtures (and OpenCode versions that predated the tool
+    // field) write parts without `$.tool`. Those must keep counting as
+    // real work — the conservative bucket — not be promoted to
+    // awaiting_user just because they aren't named `question`.
+    const db = withParts([{ status: "running" }]);
+    expect(runningToolsBucket("m1", undefined, db)).toBe("tool_use");
   });
 });

--- a/packages/integrations/opencode/src/index.test.ts
+++ b/packages/integrations/opencode/src/index.test.ts
@@ -116,8 +116,19 @@ describe("runningToolsBucket", () => {
     expect(runningToolsBucket("m1", undefined, db)).toBe("tool_use");
   });
 
-  it("returns awaiting_user when the only running tool is question", () => {
-    const db = withParts([{ tool: "question", status: "running" }]);
+  it.each([
+    "question",
+    "plan_exit",
+  ])("returns awaiting_user when the only running tool is %s", (toolName) => {
+    const db = withParts([{ tool: toolName, status: "running" }]);
+    expect(runningToolsBucket("m1", undefined, db)).toBe("awaiting_user");
+  });
+
+  it("returns awaiting_user when every running tool is some awaiting-user tool", () => {
+    const db = withParts([
+      { tool: "question", status: "running" },
+      { tool: "plan_exit", status: "running" },
+    ]);
     expect(runningToolsBucket("m1", undefined, db)).toBe("awaiting_user");
   });
 

--- a/packages/integrations/opencode/src/index.test.ts
+++ b/packages/integrations/opencode/src/index.test.ts
@@ -12,7 +12,7 @@ CREATE INDEX part_message_id_id_idx ON part(message_id, id);
 `;
 
 function withParts(
-  rows: Array<{ tool?: string; status: string }>,
+  rows: Array<{ tool: string | null; status: string }>,
 ): DatabaseSync {
   const db = new DatabaseSync(":memory:");
   db.exec(PART_SCHEMA);
@@ -22,7 +22,7 @@ function withParts(
       "m1",
       JSON.stringify({
         type: "tool",
-        ...(row.tool !== undefined && { tool: row.tool }),
+        ...(row.tool !== null && { tool: row.tool }),
         state: { status: row.status },
       }),
     );
@@ -106,9 +106,9 @@ describe("parseMessageState", () => {
 });
 
 describe("runningToolsBucket", () => {
-  it("returns none when no parts are running", () => {
+  it("returns null when no parts are running", () => {
     const db = withParts([]);
-    expect(runningToolsBucket("m1", undefined, db)).toBe("none");
+    expect(runningToolsBucket("m1", undefined, db)).toBeNull();
   });
 
   it("returns tool_use for a running shell tool", () => {
@@ -142,7 +142,7 @@ describe("runningToolsBucket", () => {
     // field) write parts without `$.tool`. Those must keep counting as
     // real work — the conservative bucket — not be promoted to
     // awaiting_user just because they aren't named `question`.
-    const db = withParts([{ status: "running" }]);
+    const db = withParts([{ tool: null, status: "running" }]);
     expect(runningToolsBucket("m1", undefined, db)).toBe("tool_use");
   });
 });

--- a/packages/integrations/opencode/src/index.ts
+++ b/packages/integrations/opencode/src/index.ts
@@ -30,7 +30,6 @@ export {
   openDb,
   type ParsedMessageState,
   parseMessageState,
-  type RunningToolsBucket,
   runningToolsBucket,
 } from "./core.ts";
 export {

--- a/packages/integrations/opencode/src/index.ts
+++ b/packages/integrations/opencode/src/index.ts
@@ -26,11 +26,12 @@ export {
   getLatestAssistantContextTokens,
   getSessionTaskProgress,
   getSessionTitle,
-  hasRunningTools,
   type OpenCodeSession,
   openDb,
   type ParsedMessageState,
   parseMessageState,
+  type RunningToolsBucket,
+  runningToolsBucket,
 } from "./core.ts";
 export {
   type OpenCodeInfo,

--- a/packages/integrations/opencode/src/schemas.ts
+++ b/packages/integrations/opencode/src/schemas.ts
@@ -16,8 +16,11 @@ export { TaskProgressSchema };
 
 export const OpenCodeInfoSchema = z.object({
   kind: z.literal("opencode"),
-  /** Current state derived from the latest session message. */
-  state: z.enum(["thinking", "tool_use", "waiting"]),
+  /** Current state derived from the latest session message.
+   *  - `awaiting_user`: the only running tool part is OpenCode's `question`
+   *    tool (blocked on user reply). Distinct from `tool_use` so the UI can
+   *    stop pretending the spinner is doing work. */
+  state: z.enum(["thinking", "tool_use", "waiting", "awaiting_user"]),
   /** Session ID from OpenCode's database (e.g. "ses_..."). */
   sessionId: z.string(),
   /** Model identifier if available (e.g. "litellm/glm-latest"). */

--- a/packages/integrations/opencode/src/session-watcher.ts
+++ b/packages/integrations/opencode/src/session-watcher.ts
@@ -19,9 +19,9 @@ import {
   getLatestAssistantContextTokens,
   getSessionTaskProgress,
   getSessionTitle,
-  hasRunningTools,
   type OpenCodeSession,
   openDb,
+  runningToolsBucket,
 } from "./core.ts";
 import type { OpenCodeInfo } from "./schemas.ts";
 import { subscribeOpenCodeDb } from "./wal-watcher.ts";
@@ -67,14 +67,17 @@ export function createOpenCodeWatcher(
     }
 
     // When the assistant is actively generating (state === "thinking"),
-    // check whether the current message has any tool parts in the
-    // "running" state to distinguish tool execution from LLM generation.
-    // Scoped to derived.messageId (the latest message) — not the entire
-    // session — so we only scan the handful of current-turn parts.
+    // classify the current message's running tool parts to distinguish
+    // tool execution from LLM generation — and within tool execution,
+    // separate "blocked on user question" from real compute. Scoped to
+    // derived.messageId (the latest message) — not the entire session —
+    // so we only scan the handful of current-turn parts.
     const state =
-      derived.state === "thinking" &&
-      hasRunningTools(derived.messageId, log, db)
-        ? ("tool_use" as const)
+      derived.state === "thinking"
+        ? (() => {
+            const bucket = runningToolsBucket(derived.messageId, log, db);
+            return bucket === "none" ? derived.state : bucket;
+          })()
         : derived.state;
 
     const taskProgress = getSessionTaskProgress(session.id, log, db);

--- a/packages/integrations/opencode/src/session-watcher.ts
+++ b/packages/integrations/opencode/src/session-watcher.ts
@@ -72,13 +72,11 @@ export function createOpenCodeWatcher(
     // separate "blocked on user question" from real compute. Scoped to
     // derived.messageId (the latest message) — not the entire session —
     // so we only scan the handful of current-turn parts.
-    const state =
+    const bucket =
       derived.state === "thinking"
-        ? (() => {
-            const bucket = runningToolsBucket(derived.messageId, log, db);
-            return bucket === "none" ? derived.state : bucket;
-          })()
-        : derived.state;
+        ? runningToolsBucket(derived.messageId, log, db)
+        : "none";
+    const state = bucket === "none" ? derived.state : bucket;
 
     const taskProgress = getSessionTaskProgress(session.id, log, db);
     // Re-read title on each refresh so mid-conversation title changes

--- a/packages/integrations/opencode/src/session-watcher.ts
+++ b/packages/integrations/opencode/src/session-watcher.ts
@@ -72,11 +72,10 @@ export function createOpenCodeWatcher(
     // separate "blocked on user question" from real compute. Scoped to
     // derived.messageId (the latest message) — not the entire session —
     // so we only scan the handful of current-turn parts.
-    const bucket =
+    const state =
       derived.state === "thinking"
-        ? runningToolsBucket(derived.messageId, log, db)
-        : "none";
-    const state = bucket === "none" ? derived.state : bucket;
+        ? (runningToolsBucket(derived.messageId, log, db) ?? derived.state)
+        : derived.state;
 
     const taskProgress = getSessionTaskProgress(session.id, log, db);
     // Re-read title on each refresh so mid-conversation title changes

--- a/packages/server/src/meta/agent.test.ts
+++ b/packages/server/src/meta/agent.test.ts
@@ -2,7 +2,7 @@ import type { AgentInfo } from "kolu-common/surface";
 import { describe, expect, it } from "vitest";
 import { shouldBumpRecencyForAgentChange } from "./agent.ts";
 
-function claude(state: "thinking" | "tool_use" | "waiting"): AgentInfo {
+function claude(state: AgentInfo["state"]): AgentInfo {
   return {
     kind: "claude-code",
     state,


### PR DESCRIPTION
**Kolu's status indicator now distinguishes "agent is running tools" from "agent is blocked on the user" for Codex (`request_user_input`) and OpenCode (`question` tool).** Previously, when either agent invoked its user-input tool, the badge spun *"Running tools"* even though no compute was in flight.

Closes #899 for Codex + OpenCode. Claude Code's `AskUserQuestion`/`ExitPlanMode` is tracked as a follow-up (see Known limitation below).

### The signal each integration writes to disk

```
Codex rollout JSONL ─▶ function_call entry ─▶ payload.name
OpenCode SQLite    ─▶ part row              ─▶ data.tool field
```

State derivation already happens per-integration; this PR teaches each deriver to inspect *which* pending tool is in flight and route to a new `awaiting_user` state when the name is one of the known human-input tools.

| Integration | Awaiting-user tool names | Where the check lives |
|---|---|---|
| Codex | `request_user_input` | `codex/src/core.ts` — `openCalls` map tracks names alongside call_ids; verified at upstream `codex-rs/core/src/tools/handlers/request_user_input.rs:68` (function_call response_item lands in rollout JSONL before the handler blocks on `session.request_user_input(...)`) |
| OpenCode | `question` | `opencode/src/core.ts` — `runningToolsBucket` SQL splits running parts by `data.tool` in one indexed scan; verified at upstream `opencode/packages/opencode/src/session/prompt.ts:729-746` (part row written with `status: "running"` before `item.execute` is awaited) |

*Mixed batches stay `tool_use`* — if a real-work tool runs alongside a user-input tool, real compute is still happening and the conservative bucket wins. The all-or-nothing decision is centralized in `anyagent.classifyByAwaiting` so a future policy flip touches one site instead of three.

### Known limitation — Claude Code `AskUserQuestion`/`ExitPlanMode` not covered yet

The Claude Agent SDK special-cases tools that declare `requiresUserInteraction(){return true}` (verified by inspecting the bundled `cli.js` — `AskUserQuestion` and `ExitPlanMode` are the only two). For these tools the assistant message containing the `tool_use` block is **not persisted to JSONL while the user is replying** — it's buffered through the SDK's `insertMessageChain` path and only flushed once the tool resolves. Verified empirically:

- An active vira session (`~/.claude/projects/-home-srid-code-vira/753768c0-...jsonl`) sat at 14 lines, sha `01cc3972...`, for 40+ minutes while AskUserQuestion was on screen — never gained an assistant entry for the in-flight tool.
- A control experiment in my own session showed a regular Bash tool's assistant entry landing in JSONL *during* a 15s `sleep` (1258 → 1261 lines mid-sleep). So the buffering is specific to `requiresUserInteraction` tools, not a general property of Claude Code's persistence.

Because the signal isn't on disk, no JSONL-polling strategy can detect Claude Code's `AskUserQuestion`/`ExitPlanMode` during the wait window. The fix is hook-based — install Claude Code's `PreToolUse` hook to fire synchronously when those tools start, write a sidecar signal, clear on `PostToolUse`. cmux uses this architecture for the same reason. Filed as #905.

### How it surfaces

- **Label**: "Awaiting input" (instead of "Running tools") with the same warning color + pulse as `waiting`
- **Switcher bucket**: routes to the existing `awaiting` column alongside `waiting`
- **Notifications**: terminal alerts fire on the transition, so a background agent that pops a question still raises a toast

### Industry context

[Issue #899](https://github.com/juspay/kolu/issues/899) opens with a survey of how other agent orchestrators handle this — the short answer is *they mostly don't*. [GitHub Copilot CLI](https://github.com/github/copilot-cli/issues/1128) and [Cursor](https://forum.cursor.com/t/agent-list-should-show-agents-waiting-for-user-input/154187) have open feature requests. OpenCode upstream emits `question.asked` / `permission.asked` bus events but doesn't expose them on disk; Codex routes `RequestUserInput` through its app-server channel rather than the rollout. cmux installs synchronous hooks instead of polling. This PR takes the pull-architecture path Kolu already uses everywhere else.

> _Reviewer note: hickey + lowy review landed two findings (mixed-batch policy duplication, attention-class predicate duplication); the elegance pass landed five more. Each is its own commit — `git log origin/master..HEAD --oneline` reads as the structural-refinement story of the diff, not a grab-bag squash._

---
_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._
