### PR TITLE
fix(git): drop in-flight resolve after subscribeGitInfo.stop()

### DIFF
--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -16,6 +16,7 @@ import {
   worktreeCreate,
 } from "./index.ts";
 import { _sharedCwdGitWatcherCount } from "./cwd-git-watcher.ts";
+import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
 import { _sharedHeadWatcherCount } from "./head-watcher.ts";
 
 // --- getDiff: renames ---
@@ -1049,5 +1050,44 @@ describe("subscribeGitInfo watcher churn", () => {
     // Initial install on a + retire on transition + install on b + retire on stop.
     expect(counter.installs).toBe(2);
     expect(counter.retires).toBe(2);
+  });
+
+  // Regression: an fs watcher event fires after the test's last awaited
+  // update but before `stop()`. The debounced listener calls `resolve()`,
+  // which awaits git subprocesses. If `stop()` runs while that resolve is
+  // in flight, the resume path would hit `ensureMode("head")` with the
+  // watcher slot already null and install a fresh watcher that nobody
+  // retires — leaking past the subscription's lifetime. Manifested as a
+  // flaky `_sharedHeadWatcherCount() === 0` afterEach failure under CI
+  // load.
+  it("stop() during an in-flight resolve does not reinstall the watcher", async () => {
+    const { dir, git } = await initRepo("stop-race");
+
+    const counter = makeLog();
+    const updates: (GitInfo | null)[] = [];
+    const sub = subscribeGitInfo(
+      dir,
+      (info) => {
+        updates.push(info);
+      },
+      counter.log,
+    );
+
+    await waitFor(() => updates.length >= 1);
+
+    // Rewrite .git/HEAD to schedule a debounced watcher event. After the
+    // debounce window, the listener will call `resolve()`, which then
+    // awaits its git subprocesses — that's the window where stop() must
+    // make subsequent ensureMode calls into no-ops.
+    await git.checkoutLocalBranch("other");
+    await new Promise((r) => setTimeout(r, WATCHER_DEBOUNCE_MS + 20));
+    sub.stop();
+
+    // Drain any in-flight resolve so a reinstalled watcher (without the
+    // stopped gate) would be observable here.
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(_sharedHeadWatcherCount()).toBe(0);
+    expect(counter.installs).toBe(counter.retires);
   });
 });

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -155,6 +155,10 @@ export function subscribeGitInfo(
   // Head mode watches `.git/HEAD` (in-repo); cwd mode watches the parent
   // for `.git` appearing (out-of-repo). The two are mutually exclusive.
   let watcher: WatcherSlot | null = null;
+  // Set by `stop()` so an in-flight `resolve()` that resumes after teardown
+  // can't re-install a watcher via `ensureMode` — the resulting orphan
+  // would leak past the subscription's lifetime.
+  let stopped = false;
 
   function handleWatcherEvent(): void {
     void resolve();
@@ -180,6 +184,10 @@ export function subscribeGitInfo(
   async function resolve(): Promise<void> {
     const cwdAtStart = currentCwd;
     const result = await resolveGitInfo(cwdAtStart, log);
+    // Discard the result if the subscription was stopped during the await:
+    // `ensureMode` would otherwise install a fresh watcher with no path to
+    // retire it, and `onChange` would fire past the caller's stop barrier.
+    if (stopped) return;
     // Discard the result if cwd flipped during the await — a fresh resolve
     // is already in flight for the new cwd and will publish the right
     // state. Acting on a stale cwd here would re-swap watchers and emit a
@@ -205,6 +213,7 @@ export function subscribeGitInfo(
 
   return {
     setCwd(next: string): void {
+      if (stopped) return;
       if (next === currentCwd) {
         // Same cwd — the cwd watcher catches `.git` appearing. This is a
         // belt-and-braces re-resolve for platforms or filesystems where the
@@ -219,6 +228,7 @@ export function subscribeGitInfo(
       void resolve();
     },
     stop(): void {
+      stopped = true;
       tearDownWatchers();
     },
   };


### PR DESCRIPTION
## Summary

A debounced `fs.watch` event scheduled before `subscribeGitInfo`'s `stop()` could resume past the teardown, walk through `ensureMode`, and reinstall a fresh head/cwd watcher with no surviving handle to retire it. Under CI load this surfaced as a flaky `_sharedHeadWatcherCount() === 0` `afterEach` assertion in `packages/integrations/git` — the test in question was the messenger, not the bug.

The fix is a single `stopped` flag: `resolve()` returns immediately if set; `ensureMode`/`onChange` never run after stop; `setCwd` is gated symmetrically so a late caller can't reanimate a stopped subscription.

A regression test rewrites `.git/HEAD`, waits past the 150ms debounce window so the listener is mid-`resolve()`, then stops. Without the fix it deterministically leaks a watcher (verified by stashing the source change and re-running).

## Test plan

- [x] New `stop() during an in-flight resolve does not reinstall the watcher` test fails without the source fix
- [x] Full `packages/integrations/git` vitest suite passes (64/64) with the fix
- [ ] `just ci` green across linux + darwin

🤖 Generated with [Claude Code](https://claude.com/claude-code)