### PR TITLE
Render user messages as markdown in HTML transcript export

### DIFF
--- a/packages/transcript-html/src/components.tsx
+++ b/packages/transcript-html/src/components.tsx
@@ -579,21 +579,52 @@ const Eyebrow = (props: { transcript: Transcript }) => {
   );
 };
 
+/** Strip the most common markdown chrome from a single line so it
+ *  reads as prose: leading heading (`#`–`######`), list marker
+ *  (`-`/`*`/`+`/`1.`), or blockquote (`>`); inline emphasis pairs
+ *  (`**bold**`, `*em*`, `_em_`, `` `code` ``); and link syntax
+ *  (`[text](url)` → `text`). This is a heuristic, not a full
+ *  markdown parser — it covers the cases that surface in titles and
+ *  previews now that user prompts render as markdown. */
+export function plainFromMarkdownLine(line: string): string {
+  return line
+    .replace(/^\s*(?:#{1,6}\s+|[-*+]\s+|\d+\.\s+|>\s+)/, "")
+    .replace(/\*\*([^*\n]+)\*\*/g, "$1")
+    .replace(/\*([^*\n]+)\*/g, "$1")
+    .replace(/_([^_\n]+)_/g, "$1")
+    .replace(/`([^`\n]+)`/g, "$1")
+    .replace(/\[([^\]\n]+)\]\([^)\n]+\)/g, "$1")
+    .trim();
+}
+
+/** Find the first non-empty prose line in a markdown blob — walks
+ *  past blank lines, HR markers, and empty-after-strip lines so a
+ *  prompt that opens with `---` or `### ` still yields meaningful
+ *  preview text. */
+export function plainPreviewFromMarkdown(text: string): string {
+  for (const raw of text.split(/\r?\n/)) {
+    const cleaned = plainFromMarkdownLine(raw);
+    if (cleaned.length > 0) return cleaned;
+  }
+  return "";
+}
+
 /** Pick the displayed title for the document. Prefers the first user
- *  prompt (one-line, truncated). Claude Code's `summary` field comes
- *  from a rolling SDK summarizer that re-summarises on every turn, so
- *  on long sessions it drifts toward the LATEST prompt — exactly the
- *  opposite of what a session label should mean. The first prompt is
- *  the question that started the conversation and is the most useful
- *  one-line label across all three agents. */
+ *  prompt (one prose line, truncated). User prompts now render as
+ *  markdown, so the title walks past markdown chrome (heading marks,
+ *  list bullets, emphasis, link syntax) instead of pasting the raw
+ *  source into the document `<title>` and `<h1>`. Claude Code's
+ *  `summary` field is a rolling SDK summarizer that re-summarises on
+ *  every turn, so on long sessions it drifts toward the LATEST prompt
+ *  — exactly the opposite of what a session label should mean. The
+ *  first prompt is the question that started the conversation and is
+ *  the most useful one-line label across all three agents. */
 export function deriveDisplayTitle(transcript: Transcript): string {
   for (const ev of transcript.events) {
     if (ev.kind === "user") {
-      const firstLine = (ev.text.split(/\r?\n/)[0] ?? "").trim();
-      if (firstLine.length > 0) {
-        return firstLine.length > 120
-          ? `${firstLine.slice(0, 117)}…`
-          : firstLine;
+      const preview = plainPreviewFromMarkdown(ev.text);
+      if (preview.length > 0) {
+        return preview.length > 120 ? `${preview.slice(0, 117)}…` : preview;
       }
     }
   }

--- a/packages/transcript-html/src/index.tsx
+++ b/packages/transcript-html/src/index.tsx
@@ -35,7 +35,7 @@ import {
   isEditClass,
   type RenderedEvent,
 } from "./components.tsx";
-import { renderMarkdown } from "./markdown.ts";
+import { renderMarkdown, renderUserMarkdown } from "./markdown.ts";
 import {
   buildPierreBootstrap,
   renderEdit,
@@ -101,8 +101,8 @@ async function renderEditBody(input: ToolInput): Promise<string> {
 /** Pre-resolve the async body for one event. The output is a string
  *  of HTML that the SolidJS component splats via `innerHTML`. Per
  *  kind:
- *  - user → escaped text in a `<pre>`, optionally wrapped in a
- *    collapse shell when the prompt is long
+ *  - user → marked output with hard line breaks, optionally wrapped
+ *    in a collapse shell when the prompt is long
  *  - assistant → marked output, optionally collapsed
  *  - reasoning → marked output (already nested inside a `<details>`,
  *    so no outer collapse)
@@ -113,8 +113,8 @@ async function preRenderEvent(
   event: TranscriptEvent,
 ): Promise<string | undefined> {
   if (event.kind === "user") {
-    const pre = `<pre class="card-text card-text--user">${escapeHtml(event.text)}</pre>`;
-    return maybeCollapse(pre, event.text.split("\n").length);
+    const body = `<div class="card-text card-text--user md">${await renderUserMarkdown(event.text)}</div>`;
+    return maybeCollapse(body, event.text.split("\n").length);
   }
   if (event.kind === "assistant") {
     const body = `<div class="card-text card-text--assistant md">${await renderMarkdown(event.text)}</div>`;

--- a/packages/transcript-html/src/markdown.ts
+++ b/packages/transcript-html/src/markdown.ts
@@ -25,27 +25,34 @@ import { Marked, type Tokens } from "marked";
 
 import { renderCodeBlock } from "./pierre.ts";
 
-interface PierreCodeToken extends Tokens.Code {
-  pierreHtml?: string;
-}
-
 function makeMarked(options: { breaks: boolean }): Marked {
+  // Pierre's SSR is async, marked's `code` renderer is sync; we bridge
+  // the two by stashing the async result in a closure-captured WeakMap
+  // keyed by the code token. The async `walkTokens` pass writes;
+  // the sync `code` renderer reads on the same token instance.
+  // WeakMap keeps `marked`'s token objects untouched (no foreign-field
+  // mutation, no cast) and lets the cache GC alongside the parse AST.
+  const pierreCache = new WeakMap<Tokens.Code, string>();
   return new Marked({
     gfm: true,
     async: true,
     breaks: options.breaks,
     walkTokens: async (token) => {
       if (token.type === "code") {
-        const t = token as PierreCodeToken;
-        t.pierreHtml = await renderCodeBlock(t.text, t.lang);
+        // marked's `walkTokens` types `token` as the full token union,
+        // and the `type === "code"` guard doesn't narrow it to `Code`
+        // (the union includes `Generic` with an open `type` string).
+        // The cast is the same one the upstream marked types expect.
+        const code = token as Tokens.Code;
+        pierreCache.set(code, await renderCodeBlock(code.text, code.lang));
       }
     },
     renderer: {
       code(token) {
-        const t = token as PierreCodeToken;
-        if (typeof t.pierreHtml === "string") return t.pierreHtml;
+        const rendered = pierreCache.get(token);
+        if (rendered !== undefined) return rendered;
         // Fallback only fires if walkTokens was bypassed — keep it safe.
-        return `<pre class="md-code"><code>${escapeHtml(t.text)}</code></pre>`;
+        return `<pre class="md-code"><code>${escapeHtml(token.text)}</code></pre>`;
       },
       heading(token) {
         const text = this.parser.parseInline(token.tokens);

--- a/packages/transcript-html/src/markdown.ts
+++ b/packages/transcript-html/src/markdown.ts
@@ -3,12 +3,10 @@
  *  hand-tuned prose CSS in `styles.css` keeps working) and routes
  *  fenced code blocks through Pierre via `walkTokens`.
  *
- *  Marked's async mode lets `walkTokens` be async — we mutate the
- *  fenced-code token to carry a `pierreHtml` field, and the
- *  synchronous `code` renderer just returns that field verbatim.
- *  This is the canonical async-renderer pattern in marked v18; the
- *  alternative (returning a Promise from a renderer) is not
- *  supported.
+ *  Marked's async mode lets `walkTokens` be async; the synchronous
+ *  `code` renderer reads Pierre's result from a per-parse WeakMap
+ *  keyed on the code token — no foreign-field mutation, no cast.
+ *  (Returning a Promise from a renderer is not supported in marked.)
  *
  *  Headings shift down by two so a single `#` in agent prose becomes
  *  `h3` — `h1`/`h2` are reserved for the document chrome

--- a/packages/transcript-html/src/markdown.ts
+++ b/packages/transcript-html/src/markdown.ts
@@ -12,7 +12,13 @@
  *
  *  Headings shift down by two so a single `#` in agent prose becomes
  *  `h3` — `h1`/`h2` are reserved for the document chrome
- *  (transcript title + sectioning). */
+ *  (transcript title + sectioning).
+ *
+ *  Two instances share the same renderer config but differ on
+ *  `breaks`: assistant/reasoning prose follows the CommonMark default
+ *  (single newlines fold into a paragraph), while user prompts use
+ *  `breaks: true` so multi-line typing preserves its line breaks the
+ *  way a chat UI would. */
 
 import { escapeHtml } from "kolu-common/html";
 import { Marked, type Tokens } from "marked";
@@ -23,78 +29,92 @@ interface PierreCodeToken extends Tokens.Code {
   pierreHtml?: string;
 }
 
-const md = new Marked({
-  gfm: true,
-  async: true,
-  walkTokens: async (token) => {
-    if (token.type === "code") {
-      const t = token as PierreCodeToken;
-      t.pierreHtml = await renderCodeBlock(t.text, t.lang);
-    }
-  },
-  renderer: {
-    code(token) {
-      const t = token as PierreCodeToken;
-      if (typeof t.pierreHtml === "string") return t.pierreHtml;
-      // Fallback only fires if walkTokens was bypassed — keep it safe.
-      return `<pre class="md-code"><code>${escapeHtml(t.text)}</code></pre>`;
+function makeMarked(options: { breaks: boolean }): Marked {
+  return new Marked({
+    gfm: true,
+    async: true,
+    breaks: options.breaks,
+    walkTokens: async (token) => {
+      if (token.type === "code") {
+        const t = token as PierreCodeToken;
+        t.pierreHtml = await renderCodeBlock(t.text, t.lang);
+      }
     },
-    heading(token) {
-      const text = this.parser.parseInline(token.tokens);
-      const level = Math.min(token.depth + 2, 6);
-      return `<h${level} class="md-h">${text}</h${level}>`;
+    renderer: {
+      code(token) {
+        const t = token as PierreCodeToken;
+        if (typeof t.pierreHtml === "string") return t.pierreHtml;
+        // Fallback only fires if walkTokens was bypassed — keep it safe.
+        return `<pre class="md-code"><code>${escapeHtml(t.text)}</code></pre>`;
+      },
+      heading(token) {
+        const text = this.parser.parseInline(token.tokens);
+        const level = Math.min(token.depth + 2, 6);
+        return `<h${level} class="md-h">${text}</h${level}>`;
+      },
+      list(token) {
+        const tag = token.ordered ? "ol" : "ul";
+        const cls = token.ordered ? "md-list md-list--ordered" : "md-list";
+        const start =
+          token.ordered && token.start !== 1 ? ` start="${token.start}"` : "";
+        const body = token.items.map((item) => this.listitem(item)).join("");
+        return `<${tag} class="${cls}"${start}>${body}</${tag}>`;
+      },
+      blockquote(token) {
+        const body = this.parser.parse(token.tokens);
+        return `<blockquote class="md-quote">${body}</blockquote>`;
+      },
+      hr() {
+        return `<hr class="md-hr" />`;
+      },
+      table(token) {
+        const align = (idx: number): string => {
+          const a = token.align[idx];
+          return a ? ` style="text-align:${a}"` : "";
+        };
+        const head = token.header
+          .map(
+            (cell, idx) =>
+              `<th${align(idx)}>${this.parser.parseInline(cell.tokens)}</th>`,
+          )
+          .join("");
+        const body = token.rows
+          .map(
+            (row) =>
+              `<tr>${row
+                .map(
+                  (cell, idx) =>
+                    `<td${align(idx)}>${this.parser.parseInline(cell.tokens)}</td>`,
+                )
+                .join("")}</tr>`,
+          )
+          .join("");
+        return `<div class="md-table-wrap"><table class="md-table"><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
+      },
+      link(token) {
+        const text = this.parser.parseInline(token.tokens);
+        const titleAttr = token.title
+          ? ` title="${escapeHtml(token.title)}"`
+          : "";
+        return `<a href="${escapeHtml(token.href)}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+      },
     },
-    list(token) {
-      const tag = token.ordered ? "ol" : "ul";
-      const cls = token.ordered ? "md-list md-list--ordered" : "md-list";
-      const start =
-        token.ordered && token.start !== 1 ? ` start="${token.start}"` : "";
-      const body = token.items.map((item) => this.listitem(item)).join("");
-      return `<${tag} class="${cls}"${start}>${body}</${tag}>`;
-    },
-    blockquote(token) {
-      const body = this.parser.parse(token.tokens);
-      return `<blockquote class="md-quote">${body}</blockquote>`;
-    },
-    hr() {
-      return `<hr class="md-hr" />`;
-    },
-    table(token) {
-      const align = (idx: number): string => {
-        const a = token.align[idx];
-        return a ? ` style="text-align:${a}"` : "";
-      };
-      const head = token.header
-        .map(
-          (cell, idx) =>
-            `<th${align(idx)}>${this.parser.parseInline(cell.tokens)}</th>`,
-        )
-        .join("");
-      const body = token.rows
-        .map(
-          (row) =>
-            `<tr>${row
-              .map(
-                (cell, idx) =>
-                  `<td${align(idx)}>${this.parser.parseInline(cell.tokens)}</td>`,
-              )
-              .join("")}</tr>`,
-        )
-        .join("");
-      return `<div class="md-table-wrap"><table class="md-table"><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
-    },
-    link(token) {
-      const text = this.parser.parseInline(token.tokens);
-      const titleAttr = token.title
-        ? ` title="${escapeHtml(token.title)}"`
-        : "";
-      return `<a href="${escapeHtml(token.href)}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
-    },
-  },
-});
+  });
+}
 
-/** Render a markdown string to HTML. Async because fenced code blocks
- *  are routed through Pierre's SSR. */
+const mdProse = makeMarked({ breaks: false });
+const mdUser = makeMarked({ breaks: true });
+
+/** Render assistant / reasoning markdown. Async because fenced code
+ *  blocks are routed through Pierre's SSR. */
 export async function renderMarkdown(text: string): Promise<string> {
-  return await md.parse(text);
+  return await mdProse.parse(text);
+}
+
+/** Render a user prompt as markdown with hard line breaks — a typed
+ *  multi-line message preserves each newline as a `<br>` so the
+ *  prompt reads the way it was composed, not folded into a single
+ *  CommonMark paragraph. */
+export async function renderUserMarkdown(text: string): Promise<string> {
+  return await mdUser.parse(text);
 }

--- a/packages/transcript-html/src/styles.css
+++ b/packages/transcript-html/src/styles.css
@@ -891,12 +891,6 @@ body[data-hide-reasoning="true"] .event--reasoning {
   overflow-x: auto;
 }
 
-/* Generic plain pre (used for user / reasoning) */
-.card-text {
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
 /* Details/summary chrome */
 details summary {
   cursor: pointer;

--- a/packages/transcript-html/src/styles.css
+++ b/packages/transcript-html/src/styles.css
@@ -448,6 +448,11 @@ pre.text::-webkit-scrollbar-thumb:hover {
   background: color-mix(in srgb, var(--user) 7%, transparent);
   border-radius: 0 4px 4px 0;
 }
+/* User prompts render through the markdown pipeline (with `breaks:
+   true` so multi-line typed input keeps its line breaks), so the
+   container is a `<div>` with `.md` children — paragraphs, lists,
+   code, etc. The serif voice stays on the wrapper and inherits
+   into prose; `.md code` overrides it to monospace. */
 .event--user .card-text--user {
   font-family:
     ui-serif, "Iowan Old Style", "Charter", "Cambria", Georgia, serif;
@@ -456,11 +461,7 @@ pre.text::-webkit-scrollbar-thumb:hover {
   font-weight: 500;
   color: var(--ink);
   margin: 0;
-  white-space: pre-wrap;
   word-break: break-word;
-  background: none;
-  border: none;
-  padding: 0;
 }
 .event--user.is-current .card {
   background: color-mix(in srgb, var(--user) 14%, transparent);


### PR DESCRIPTION
**The HTML transcript exporter now renders user prompts as markdown** instead of dumping them through `escapeHtml` into a `<pre>` block. Lists, headings, links, code, blockquotes — everything a user typed with markdown intent shows up the way it was composed.

A typed multi-line prompt also keeps its line breaks: the user-side renderer uses `breaks: true` so each newline becomes a `<br>` (chat-UI convention), while assistant/reasoning prose keeps the CommonMark default where single newlines fold into a paragraph.

### Two renderers, one factory

```
                     ┌─ mdProse  (breaks: false) ─▶ renderMarkdown      ▶ assistant, reasoning
makeMarked({breaks})─┤
                     └─ mdUser   (breaks: true)  ─▶ renderUserMarkdown  ▶ user
```

Both instances share the renderer config (Pierre-routed fenced code, `.md-*` class hooks, heading shift, link targets) — only the `breaks` axis differs. _Two named exports preserve role-policy encapsulation: a future change to one policy doesn't ripple through the other's call sites._

### Refinements during review

| Lens | Finding | Fix |
| --- | --- | --- |
| Hickey | `.card-text { white-space: pre-wrap }` was a ghost after user moved off `<pre>` | Deleted the stale rule + comment |
| Hickey (cross-val) | `PierreCodeToken` interface mutated a foreign marked token via cast | Closure-captured `WeakMap<Tokens.Code, string>` inside `makeMarked` — cache GCs with the parse AST |
| Police elegance | Module doc described the old token-mutation pattern | Refreshed to describe the WeakMap bridge |
| Follow-up | `deriveDisplayTitle` pasted raw `###` / list markers into `<title>` and `<h1>` | New `plainPreviewFromMarkdown` helper walks past markdown chrome |

Lowy cross-validation flagged one proposed refinement as harmful — _collapsing_ `renderMarkdown` _and_ `renderUserMarkdown` _into a single parameterized function would braid two independent activity-volatility axes (user vs. assistant rendering policy) into one signature_ — so the two-export shape stands.

Addresses the "Markdown in user messages" task in #783. _#783 is a meta dumping ground for transcript improvements — this PR closes one item from that list, not the issue itself._

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._