### PR TITLE
fix: gate canvas first-mount centring on session.get yield

### DIFF
--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -33,6 +33,7 @@ import {
 } from "solid-js";
 import { useStaleCheck } from "../terminal/staleness";
 import { useTerminalStore } from "../terminal/useTerminalStore";
+import { savedSessionSub } from "../wire";
 import ActivityDock from "./ActivityDock";
 import CanvasMinimap from "./CanvasMinimap";
 import CanvasTile from "./CanvasTile";
@@ -331,6 +332,16 @@ const TerminalCanvas: Component<{
   createEffect(() => {
     const ids = props.tileIds;
     if (ids.length === 0 || !isDefaultViewport()) return;
+    // Wait for `session.get` to yield before deciding between "centre on
+    // saved active" and "bbox fallback". `terminalList.get` (which feeds
+    // `tileIds`) can win the race against `session.get` on cold load —
+    // running the bbox fallback now would pan the viewport off-default,
+    // and the `isDefaultViewport()` guard above would then block any
+    // re-centre once `useSessionRestore` calls `setActiveSilently` with
+    // the persisted id. Once `pending()` flips false, `useSessionRestore`'s
+    // hydration effect runs synchronously (registered earlier) and assigns
+    // the active id, so this effect re-runs and observes it.
+    if (savedSessionSub.pending() && store.activeId() === null) return;
     const active = store.activeId();
     const activeLayout = active ? layoutOf(active) : undefined;
     if (activeLayout) {

--- a/packages/tests/features/session-restore.feature
+++ b/packages/tests/features/session-restore.feature
@@ -72,6 +72,39 @@ Feature: Session restore
     Then workspace switcher entry 2 should be active
     And there should be no page errors
 
+  # Regression guard for the centering side of refresh persistence. The
+  # production bug is a race: on cold load the canvas first-mount centring
+  # effect (`TerminalCanvas.tsx:331`) fires on the initial `terminalList`
+  # snapshot; if `session.get` (carries `activeTerminalId`) hasn't yielded
+  # yet, the effect sees a null `activeId`, takes the bbox-of-tiles fallback
+  # branch, pans the viewport, and the `isDefaultViewport()` guard latches
+  # the wrong centre for the rest of the session.
+  #
+  # The race winner shifts run to run, so we make the check deterministic
+  # by installing a WebSocket init script that holds `session.get`'s first
+  # yield for 500 ms — long enough that `terminalList.get` always wins the
+  # race. One reload then surfaces the bug 100 % of the time. Tiles are
+  # placed at far corners so the bbox midpoint sits ~2.8k px from the
+  # active tile, making the failure geometrically unambiguous rather than
+  # a tolerance-level call.
+  Scenario: Active terminal stays active AND centered across refresh
+    When I open the app
+    And I create a terminal
+    And I create a terminal
+    And I create a terminal
+    And I move canvas tile 1 to x=-2400 y=-1500
+    And I move canvas tile 2 to x=2400 y=1500
+    And I move canvas tile 3 to x=-2400 y=1500
+    And I select terminal 2 in the workspace switcher
+    And I save the active canvas tile id
+    Then the active canvas tile should be centered in the viewport
+    When I wait for the session auto-save
+    Given session.get's first yield is delayed by 500 ms to force the active-id race
+    When I reload the page and wait for ready
+    Then the saved active canvas tile should still be active
+    And the active canvas tile should be centered in the viewport
+    And there should be no page errors
+
   # Captured agent commands (persisted on each SavedTerminal's `lastAgentCommand`)
   # surface as a "resume M agents" suffix on the restore button, with each
   # command shown beneath its terminal. A single "Resume agent sessions" toggle

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -1,5 +1,5 @@
 import * as assert from "node:assert";
-import { Then, When } from "@cucumber/cucumber";
+import { Given, Then, When } from "@cucumber/cucumber";
 import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
 const CANVAS_SELECTOR = '[data-testid="canvas-container"]';
@@ -476,31 +476,116 @@ When("I save the active canvas tile id", async function (this: KoluWorld) {
   this.savedActiveTerminalId = id;
 });
 
+async function waitForSavedActiveTileStillActive(world: KoluWorld) {
+  const saved = world.savedActiveTerminalId;
+  if (!saved) throw new Error("No saved active canvas tile id");
+  await world.page.waitForFunction(
+    ({ sel, savedId }: { sel: string; savedId: string }) => {
+      // The active tile's CanvasTile wrapper carries data-active="true".
+      // Its inner Terminal element carries data-terminal-id. Walk down
+      // from the active wrapper rather than checking every tile —
+      // that makes "did active flip to a different tile" the failure
+      // mode, not "is savedId still in the DOM" (it always is).
+      const activeWrapper = document
+        .querySelector(sel)
+        ?.querySelector('[data-active="true"]');
+      if (!activeWrapper) return false;
+      const inner = activeWrapper.querySelector("[data-terminal-id]");
+      const activeId =
+        inner?.getAttribute("data-terminal-id") ??
+        activeWrapper.getAttribute("data-terminal-id");
+      return activeId === savedId;
+    },
+    { sel: CANVAS_SELECTOR, savedId: saved },
+    { timeout: POLL_TIMEOUT },
+  );
+}
+
 Then(
   "the saved active canvas tile should still be active",
   async function (this: KoluWorld) {
-    const saved = this.savedActiveTerminalId;
-    if (!saved) throw new Error("No saved active canvas tile id");
-    await this.page.waitForFunction(
-      ({ sel, savedId }: { sel: string; savedId: string }) => {
-        // The active tile's CanvasTile wrapper carries data-active="true".
-        // Its inner Terminal element carries data-terminal-id. Walk down
-        // from the active wrapper rather than checking every tile —
-        // that makes "did active flip to a different tile" the failure
-        // mode, not "is savedId still in the DOM" (it always is).
-        const activeWrapper = document
-          .querySelector(sel)
-          ?.querySelector('[data-active="true"]');
-        if (!activeWrapper) return false;
-        const inner = activeWrapper.querySelector("[data-terminal-id]");
-        const activeId =
-          inner?.getAttribute("data-terminal-id") ??
-          activeWrapper.getAttribute("data-terminal-id");
-        return activeId === savedId;
-      },
-      { sel: CANVAS_SELECTOR, savedId: saved },
-      { timeout: POLL_TIMEOUT },
-    );
+    await waitForSavedActiveTileStillActive(this);
+  },
+);
+
+// Deterministic race-forcer. Installs a Playwright init script that runs
+// before every subsequent navigation and patches `window.WebSocket` so the
+// first EVENT_ITERATOR yield for `/surface/session/get` is held for `ms`
+// before being dispatched. `terminalList.get`'s first yield reaches the
+// surface client unblocked, so the canvas first-mount centering effect
+// (`TerminalCanvas.tsx:331`) always observes a null `activeId`, takes the
+// bbox-fallback branch, pans the viewport, and the `isDefaultViewport()`
+// guard latches the bug for the rest of the session — exactly the
+// production race described in `useSessionRestore.ts:178-182`, made
+// deterministic. 500ms is overkill for the race window but cheap.
+Given(
+  "session.get's first yield is delayed by {int} ms to force the active-id race",
+  async function (this: KoluWorld, ms: number) {
+    // Plain-string init script: Playwright pipes function-form scripts
+    // through esbuild, which inserts `__name(fn, "…")` for name-preservation
+    // and crashes in the page context with `__name is not defined`. The
+    // hook itself isn't TypeScript-heavy enough to need transpilation, so
+    // a hand-written IIFE sidesteps the toolchain entirely.
+    await this.page.addInitScript(`(() => {
+      const Original = globalThis.WebSocket;
+      const SESSION_PATH = "/surface/session/get";
+      const DELAY_MS = ${ms};
+      function readJsonHeader(bytes) {
+        const delim = bytes.indexOf(255);
+        const jsonBytes = delim >= 0 ? bytes.subarray(0, delim) : bytes;
+        return JSON.parse(new TextDecoder().decode(jsonBytes));
+      }
+      function PatchedWebSocket(url, protocols) {
+        const ws = new Original(url, protocols);
+        if (!String(url).includes("/rpc/ws")) return ws;
+        const sessionIds = new Set();
+        const seenFirstYield = new Set();
+        const origSend = ws.send.bind(ws);
+        ws.send = (data) => {
+          try {
+            let msg = null;
+            if (data instanceof Uint8Array) msg = readJsonHeader(data);
+            else if (data instanceof ArrayBuffer) msg = readJsonHeader(new Uint8Array(data));
+            else if (typeof data === "string") msg = JSON.parse(data);
+            if (msg && typeof msg.p?.u === "string" && msg.p.u.includes(SESSION_PATH)) {
+              sessionIds.add(msg.i);
+            }
+          } catch {}
+          return origSend(data);
+        };
+        const origAdd = ws.addEventListener.bind(ws);
+        ws.addEventListener = (type, listener, options) => {
+          if (type !== "message" || typeof listener !== "function") {
+            return origAdd(type, listener, options);
+          }
+          const wrapped = async (event) => {
+            try {
+              const data = event.data;
+              let bytes = null;
+              if (data instanceof Blob) bytes = new Uint8Array(await data.arrayBuffer());
+              else if (data instanceof ArrayBuffer) bytes = new Uint8Array(data);
+              else if (typeof data === "string") bytes = new TextEncoder().encode(data);
+              if (bytes) {
+                const msg = readJsonHeader(bytes);
+                // EVENT_ITERATOR=3 (server pushing yields). Only delay the
+                // first one per session id — subsequent updates (session
+                // auto-save echoes) shouldn't be slowed.
+                if (msg && msg.t === 3 && sessionIds.has(msg.i) && !seenFirstYield.has(msg.i)) {
+                  seenFirstYield.add(msg.i);
+                  await new Promise((r) => setTimeout(r, DELAY_MS));
+                }
+              }
+            } catch {}
+            listener.call(ws, event);
+          };
+          return origAdd(type, wrapped, options);
+        };
+        return ws;
+      }
+      PatchedWebSocket.prototype = Original.prototype;
+      Object.setPrototypeOf(PatchedWebSocket, Original);
+      globalThis.WebSocket = PatchedWebSocket;
+    })();`);
   },
 );
 
@@ -1103,46 +1188,61 @@ Then(
   },
 );
 
+async function setCanvasLayoutById(
+  world: KoluWorld,
+  id: string,
+  x: number,
+  y: number,
+): Promise<void> {
+  const layout = { x, y, w: 700, h: 500 };
+  const resp = await world.page.request.fetch("/rpc/terminal/setCanvasLayout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    data: JSON.stringify({ json: { id, layout } }),
+  });
+  assert.ok(resp.ok(), `terminal/setCanvasLayout failed: ${resp.status()}`);
+  // Wait for the tile to render at the new position — proves the metadata
+  // subscription delivered the update (the mechanism that must survive refresh).
+  await world.page.waitForFunction(
+    ({
+      sel,
+      tileId,
+      wantX,
+      wantY,
+    }: {
+      sel: string;
+      tileId: string;
+      wantX: number;
+      wantY: number;
+    }) => {
+      const tile = document
+        .querySelector(`${sel} [data-terminal-id="${tileId}"]`)
+        ?.closest("[style*='left']") as HTMLElement | null;
+      if (!tile) return false;
+      return (
+        Math.abs(parseFloat(tile.style.left) - wantX) < 1 &&
+        Math.abs(parseFloat(tile.style.top) - wantY) < 1
+      );
+    },
+    { sel: CANVAS_SELECTOR, tileId: id, wantX: x, wantY: y },
+    { timeout: POLL_TIMEOUT },
+  );
+}
+
 When(
   "I move the canvas tile to x={int} y={int}",
   async function (this: KoluWorld, x: number, y: number) {
     const { id } = await readFirstTilePosition(this);
-    const layout = { x, y, w: 700, h: 500 };
-    const resp = await this.page.request.fetch(
-      "/rpc/terminal/setCanvasLayout",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        data: JSON.stringify({ json: { id, layout } }),
-      },
-    );
-    assert.ok(resp.ok(), `terminal/setCanvasLayout failed: ${resp.status()}`);
-    // Wait for the tile to render at the new position — proves the metadata
-    // subscription delivered the update (the mechanism that must survive refresh).
-    await this.page.waitForFunction(
-      ({
-        sel,
-        tileId,
-        wantX,
-        wantY,
-      }: {
-        sel: string;
-        tileId: string;
-        wantX: number;
-        wantY: number;
-      }) => {
-        const tile = document
-          .querySelector(`${sel} [data-terminal-id="${tileId}"]`)
-          ?.closest("[style*='left']") as HTMLElement | null;
-        if (!tile) return false;
-        return (
-          Math.abs(parseFloat(tile.style.left) - wantX) < 1 &&
-          Math.abs(parseFloat(tile.style.top) - wantY) < 1
-        );
-      },
-      { sel: CANVAS_SELECTOR, tileId: id, wantX: x, wantY: y },
-      { timeout: POLL_TIMEOUT },
-    );
+    await setCanvasLayoutById(this, id, x, y);
+  },
+);
+
+When(
+  "I move canvas tile {int} to x={int} y={int}",
+  async function (this: KoluWorld, index: number, x: number, y: number) {
+    const id = this.createdTerminalIds[index - 1];
+    assert.ok(id, `No terminal created at index ${index} in this scenario`);
+    await setCanvasLayoutById(this, id, x, y);
   },
 );
 


### PR DESCRIPTION
On a cold refresh **`terminalList.get` can win the race against `session.get`**, and when it does the canvas opens centred on the bounding-box midpoint of all tiles instead of the one the user had selected. The viewport then latches the wrong centre for the rest of the session.

### Where the race lived

```
session.get   ─┐
                  ├─▶ if terminalList wins ─▶ activeId=null  ─▶ bbox fallback ─▶ pan ─▶ guard latches
terminalList.get ─┘   if session  wins    ─▶ activeId set    ─▶ centre on active ✓
```

The first-mount centring effect in `TerminalCanvas.tsx` fires on the first `terminalList` snapshot. If `session.get` hasn't yielded yet, `store.activeId()` is still `null`, the effect takes the bbox-fallback branch, pans the viewport, and the `isDefaultViewport()` guard then **blocks any later re-centre** once `useSessionRestore` finally calls `setActiveSilently`.

### The fix

One reactive read: wait for `savedSessionSub.pending()` to flip false before deciding between *centre on active* and *bbox fallback*. `useSessionRestore`'s hydration effect is registered earlier and runs synchronously on the same pending-flip, so by the time this effect re-fires the active id is already assigned and the saved-active path wins.

### Making the test deterministic

The race winner shifts run to run, so a vanilla refresh-and-assert scenario catches the bug only sometimes (measured ~33 % on this machine at 50 reloads). To turn this into a real CI guard, the scenario installs a **Playwright init script that monkey-patches `window.WebSocket`** and holds `session.get`'s first `EVENT_ITERATOR` yield for 500 ms — long enough that `terminalList.get` always wins. *One reload then surfaces the bug 100 % of the time.* Tiles are placed at far corners so the bbox midpoint sits ~2.8k px from the active tile, making the failure geometrically unambiguous.

| Before | After |
| --- | --- |
| Bbox fallback fires on the first tile snapshot with `activeId=null` | Effect waits for `session.get` to yield before deciding |
| `isDefaultViewport()` guard then blocks re-centre after `setActiveSilently` | Hydration assigns active id first; effect re-runs and centres correctly |
| Reproducible only via repeated reloads (~1-in-3 on this box) | Deterministic via the WebSocket delay init script |

_Generated by Claude Code (model \`claude-opus-4-7\`)._