### PR TITLE
Doc agent-state PR-evidence capture via opencode

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -60,3 +60,20 @@ gh release upload evidence-assets /tmp/kolu-evidence-<slug>.png --clobber
 ```
 
 URL pattern: `https://github.com/juspay/kolu/releases/download/evidence-assets/<filename>`. Use the single-quoted heredoc pattern (`<<'EOF'`) when posting so backticks and `$` survive unescaped.
+
+### Agent-state scenarios
+
+When the change touches the Dock, terminal, or any UI surface that reflects agent activity, the capture has to show real states — a blank Dock proves nothing. Kolu's opencode integration is first-class: run opencode inside a Kolu terminal and the preexec hook surfaces state in the Dock within ~300ms (states: `thinking`, `tool_use`, `awaiting_user`, `waiting`; bucketed in the Dock as `working ▸`, `awaiting ⏵`, `idle ☾`).
+
+```sh
+# Inside a Kolu terminal — no global install needed
+nix run github:juspay/AI#opencode
+```
+
+Drive distinct states by prompt:
+
+- **thinking / tool_use** (`working ▸`, pulsing border) — send a reasoning- or tool-heavy prompt (`explain the architecture of this repo`, `list every file in src/`); capture during the spinner.
+- **awaiting_user** (`awaiting ⏵`, breathing border) — request an action that needs confirmation (e.g. an edit opencode wants to apply).
+- **waiting / idle** (`idle ☾`) — let the reply finish; the row drops to the idle bucket.
+
+For PRs whose changes affect one state, a single representative capture is fine; capture each when the change spans multiple. The default evidence for any Dock-touching change is **a screenshot of the Dock showing an agent state with a visible opencode reply** — that single frame proves the pipeline (terminal → provider → Dock) is alive end-to-end.


### PR DESCRIPTION
**`.agency/do.md` now tells `/do` how to capture Dock agent-state screenshots** — `thinking`, `tool_use`, `awaiting_user`, `waiting` — by running opencode (`nix run github:juspay/AI#opencode`) inside a Kolu terminal. The Kolu↔opencode integration is first-class, so the Dock surfaces state automatically within ~300ms; the new sub-section just spells out which prompts drive which states and which glyph (`▸` working / `⏵` awaiting / `☾` idle) reviewers should expect to see.

Without this, screenshot-evidence sub-agents had no canonical recipe for exercising the activity column added in #897, and the easy failure mode — a screenshot of a blank Dock — proves nothing about the pipeline. The default for Dock-touching changes is now explicit: _one frame showing an agent state next to a visible opencode reply._

The PR itself ships such a frame under `## Evidence` as a smoke test of the new procedure.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._