### PR TITLE
Preview .html/.svg/.pdf artifacts inline in the Code tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The desktop workspace is mode-less — every terminal renders as a draggable, re
 - Auto-detected repo name, branch, and working directory (via OSC 7 + `.git/HEAD` watcher)
 - GitHub PR detection — shows PR number, title, and CI check status (pass/pending/fail) on the tile chrome and inspector
 - Per-repo color coding on the dock, tile chrome, canvas tile border, and minimap via golden-angle hue spacing — the same hue echoes across every surface so a repo reads as one identity at a glance
+- Inline preview of agent-generated `.html` / `.svg` / `.pdf` artifacts — selecting one in the Code tab's browse mode renders it in a sandboxed iframe (`sandbox="allow-scripts"`, no `allow-same-origin` — page scripts run in an opaque origin and can't touch Kolu's cookies/localStorage; cross-origin `fetch()` from inside is blocked, which is fine for static artifacts) served from a per-terminal route under the terminal's repo root. The iframe live-reloads when the file changes (mtime bump on the URL) via the same `fsReadFile` subscription path as text
 
 ### Claude Code Status
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -516,6 +516,7 @@ const App: Component = () => {
             }
           >
             <RightPanelLayout
+              terminalId={store.activeId()}
               meta={store.activeMeta()}
               themeName={activeThemeName()}
               onThemeClick={() => openPaletteGroup("Theme")}

--- a/packages/client/src/right-panel/BrowseFileDispatcher.tsx
+++ b/packages/client/src/right-panel/BrowseFileDispatcher.tsx
@@ -6,11 +6,11 @@
  *  Loading and error surfaces stay here so the two presenters underneath
  *  remain pure — each handles its own variant of a successful read and
  *  nothing else. The server picks the variant by file extension via
- *  `isIframePreviewable` (see `kolu-git/schemas`). */
+ *  `isIframePreviewable` (see `packages/server/src/iframePreviewRoute.ts`). */
 
 import type { SelectedLineRange } from "@kolu/solid-pierre";
 import type { TerminalId } from "kolu-common/surface";
-import { type Component, Match, Switch } from "solid-js";
+import { type Component, createMemo, Match, Switch } from "solid-js";
 import { toast } from "solid-sonner";
 import { app } from "../wire";
 import BrowseFileView from "./BrowseFileView";
@@ -36,6 +36,17 @@ const BrowseFileDispatcher: Component<BrowseFileDispatcherProps> = (props) => {
     },
   );
 
+  // Pre-narrow to each variant so the Match arms receive a typed accessor
+  // without needing a runtime re-check inside the callback.
+  const textContent = createMemo(() => {
+    const fc = fileContent();
+    return fc?.kind === "text" ? fc : null;
+  });
+  const binaryContent = createMemo(() => {
+    const fc = fileContent();
+    return fc?.kind === "binary" ? fc : null;
+  });
+
   return (
     <Switch fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}>
       <Match when={fileContent.error()}>
@@ -43,27 +54,19 @@ const BrowseFileDispatcher: Component<BrowseFileDispatcherProps> = (props) => {
           <div class="px-2 py-1 text-danger">Error: {err().message}</div>
         )}
       </Match>
-      <Match when={fileContent()?.kind === "text" && fileContent()}>
-        {(fc) => {
-          const v = fc();
-          if (v.kind !== "text") return null;
-          return (
-            <BrowseFileView
-              filePath={props.filePath}
-              content={v.content}
-              truncated={v.truncated}
-              theme={props.theme}
-              initialSelectedLines={props.initialSelectedLines}
-            />
-          );
-        }}
+      <Match when={textContent()}>
+        {(fc) => (
+          <BrowseFileView
+            filePath={props.filePath}
+            content={fc().content}
+            truncated={fc().truncated}
+            theme={props.theme}
+            initialSelectedLines={props.initialSelectedLines}
+          />
+        )}
       </Match>
-      <Match when={fileContent()?.kind === "binary" && fileContent()}>
-        {(fc) => {
-          const v = fc();
-          if (v.kind !== "binary") return null;
-          return <BrowsePreviewView filePath={props.filePath} url={v.url} />;
-        }}
+      <Match when={binaryContent()}>
+        {(fc) => <BrowsePreviewView filePath={props.filePath} url={fc().url} />}
       </Match>
     </Switch>
   );

--- a/packages/client/src/right-panel/BrowseFileDispatcher.tsx
+++ b/packages/client/src/right-panel/BrowseFileDispatcher.tsx
@@ -1,0 +1,72 @@
+/** Owns the `fsReadFile` subscription for the Code tab's browse mode and
+ *  routes by the wire-level `kind` discriminator:
+ *    - `text`   → `BrowseFileView`   (Pierre's syntax-highlighted FileView)
+ *    - `binary` → `BrowsePreviewView` (iframe at server-built URL)
+ *
+ *  Loading and error surfaces stay here so the two presenters underneath
+ *  remain pure — each handles its own variant of a successful read and
+ *  nothing else. The server picks the variant by file extension via
+ *  `isIframePreviewable` (see `kolu-git/schemas`). */
+
+import type { SelectedLineRange } from "@kolu/solid-pierre";
+import type { TerminalId } from "kolu-common/surface";
+import { type Component, Match, Switch } from "solid-js";
+import { toast } from "solid-sonner";
+import { app } from "../wire";
+import BrowseFileView from "./BrowseFileView";
+import BrowsePreviewView from "./BrowsePreviewView";
+
+export type BrowseFileDispatcherProps = {
+  terminalId: TerminalId;
+  repoPath: string;
+  filePath: string;
+  theme: "light" | "dark";
+  initialSelectedLines?: SelectedLineRange | null;
+};
+
+const BrowseFileDispatcher: Component<BrowseFileDispatcherProps> = (props) => {
+  const fileContent = app.streams.fsReadFile.use(
+    () => ({
+      terminalId: props.terminalId,
+      repoPath: props.repoPath,
+      filePath: props.filePath,
+    }),
+    {
+      onError: (err) => toast.error(`File content stream: ${err.message}`),
+    },
+  );
+
+  return (
+    <Switch fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}>
+      <Match when={fileContent.error()}>
+        {(err) => (
+          <div class="px-2 py-1 text-danger">Error: {err().message}</div>
+        )}
+      </Match>
+      <Match when={fileContent()?.kind === "text" && fileContent()}>
+        {(fc) => {
+          const v = fc();
+          if (v.kind !== "text") return null;
+          return (
+            <BrowseFileView
+              filePath={props.filePath}
+              content={v.content}
+              truncated={v.truncated}
+              theme={props.theme}
+              initialSelectedLines={props.initialSelectedLines}
+            />
+          );
+        }}
+      </Match>
+      <Match when={fileContent()?.kind === "binary" && fileContent()}>
+        {(fc) => {
+          const v = fc();
+          if (v.kind !== "binary") return null;
+          return <BrowsePreviewView filePath={props.filePath} url={v.url} />;
+        }}
+      </Match>
+    </Switch>
+  );
+};
+
+export default BrowseFileDispatcher;

--- a/packages/client/src/right-panel/BrowseFileView.tsx
+++ b/packages/client/src/right-panel/BrowseFileView.tsx
@@ -1,24 +1,24 @@
-/** File content viewer for the Code tab's browse mode. Subscribes to the
- *  server's live file-content stream so editor saves and branch checkouts
- *  reflect without a manual refresh. The wrapper around `@kolu/solid-pierre`'s
- *  `FileView` provides shiki-powered syntax highlighting; equality-gating
- *  the snapshot via `reconcile` (inside `useStream`'s underlying primitive)
- *  avoids stomping scroll position on no-op ticks. */
+/** Pure presenter for a text file in the Code tab's browse mode. Receives
+ *  the file body as props and renders Pierre's syntax-highlighted `FileView`.
+ *  Subscription, loading, error, and kind-dispatch live one level up in
+ *  `BrowseFileDispatcher` so the views stay single-strategy — `BrowseFileView`
+ *  for `kind: "text"`, `BrowsePreviewView` for `kind: "binary"`. */
 
 import {
   FileView,
   type SelectedLineRange,
   Virtualizer,
 } from "@kolu/solid-pierre";
-import { type Component, Match, Show, Switch } from "solid-js";
+import { type Component, Show } from "solid-js";
 import { toast } from "solid-sonner";
 import { pierreDiffsStyle } from "../ui/pierreTheme";
-import { app } from "../wire";
 import CodeMenuFrame from "./CodeMenuFrame";
 
 export type BrowseFileViewProps = {
-  repoPath: string;
   filePath: string;
+  content: string;
+  /** True if the file exceeded the server's size limit and was truncated. */
+  truncated: boolean;
   theme: "light" | "dark";
   /** Initial line range to highlight (and scroll to). Set when the
    *  caller opens the file at a specific range — e.g. a terminal
@@ -28,61 +28,43 @@ export type BrowseFileViewProps = {
 };
 
 const BrowseFileView: Component<BrowseFileViewProps> = (props) => {
-  const fileContent = app.streams.fsReadFile.use(
-    () => ({ repoPath: props.repoPath, filePath: props.filePath }),
-    {
-      onError: (err) => toast.error(`File content stream: ${err.message}`),
-    },
-  );
-
   return (
-    <Switch fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}>
-      <Match when={fileContent.error()}>
-        {(err) => (
-          <div class="px-2 py-1 text-danger">Error: {err().message}</div>
+    <>
+      <Show when={props.truncated}>
+        <div class="px-2 py-1 text-warning text-[10px] border-b border-edge bg-surface-1/30">
+          File truncated (exceeds 1 MB)
+        </div>
+      </Show>
+      <CodeMenuFrame
+        path={props.filePath}
+        initialSelectedLines={props.initialSelectedLines}
+      >
+        {(selection) => (
+          // `<Virtualizer>` upgrades `<FileView>` to Pierre's
+          // `VirtualizedFile` for very large files
+          // (#809 / #514 Phase 8). Without it, `<FileView>` uses
+          // the vanilla `File` class — same behavior as before.
+          <Virtualizer
+            class="h-full w-full overflow-auto"
+            style={pierreDiffsStyle}
+          >
+            <FileView
+              name={props.filePath}
+              contents={props.content}
+              theme={props.theme}
+              overflow="wrap"
+              enableLineSelection
+              onLineSelected={selection.handleSelect}
+              selectedLines={selection.range()}
+              onError={(err) =>
+                toast.error(`File render failed: ${err.message}`)
+              }
+              class="w-full"
+            />
+          </Virtualizer>
         )}
-      </Match>
-      <Match when={fileContent()}>
-        {(fc) => (
-          <>
-            <Show when={fc().truncated}>
-              <div class="px-2 py-1 text-warning text-[10px] border-b border-edge bg-surface-1/30">
-                File truncated (exceeds 1 MB)
-              </div>
-            </Show>
-            <CodeMenuFrame
-              path={props.filePath}
-              initialSelectedLines={props.initialSelectedLines}
-            >
-              {(selection) => (
-                // `<Virtualizer>` upgrades `<FileView>` to Pierre's
-                // `VirtualizedFile` for very large files
-                // (#809 / #514 Phase 8). Without it, `<FileView>` uses
-                // the vanilla `File` class — same behavior as before.
-                <Virtualizer
-                  class="h-full w-full overflow-auto"
-                  style={pierreDiffsStyle}
-                >
-                  <FileView
-                    name={props.filePath}
-                    contents={fc().content}
-                    theme={props.theme}
-                    overflow="wrap"
-                    enableLineSelection
-                    onLineSelected={selection.handleSelect}
-                    selectedLines={selection.range()}
-                    onError={(err) =>
-                      toast.error(`File render failed: ${err.message}`)
-                    }
-                    class="w-full"
-                  />
-                </Virtualizer>
-              )}
-            </CodeMenuFrame>
-          </>
-        )}
-      </Match>
-    </Switch>
+      </CodeMenuFrame>
+    </>
   );
 };
 

--- a/packages/client/src/right-panel/BrowsePreviewView.tsx
+++ b/packages/client/src/right-panel/BrowsePreviewView.tsx
@@ -1,0 +1,30 @@
+/** Iframe presenter for binary previewable files (`.html`, `.svg`, `.pdf`).
+ *  Receives a server-built URL the iframe `src`-binds to; URL re-binds when
+ *  the file changes (server bumps the `?v=<mtime>` query on save), so the
+ *  iframe reloads via the same `fsReadFile` subscription path as text. No
+ *  state, no subscription — `BrowseFileDispatcher` owns both. */
+
+import type { Component } from "solid-js";
+
+export type BrowsePreviewViewProps = {
+  filePath: string;
+  url: string;
+};
+
+const BrowsePreviewView: Component<BrowsePreviewViewProps> = (props) => {
+  return (
+    <iframe
+      data-testid="browse-preview-iframe"
+      src={props.url}
+      title={props.filePath}
+      // `allow-scripts` runs the page's JS in an opaque origin (no
+      // `allow-same-origin`), so the iframe can't read Kolu's cookies or
+      // localStorage. Cross-origin `fetch()` from inside is blocked —
+      // acceptable for static-artifact previews; documented in the PR.
+      sandbox="allow-scripts"
+      class="w-full h-full border-0 bg-white"
+    />
+  );
+};
+
+export default BrowsePreviewView;

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -15,7 +15,7 @@
 
 import { FileDiff, FileTree, Virtualizer } from "@kolu/solid-pierre";
 import type { GitDiffMode } from "kolu-git/schemas";
-import type { TerminalMetadata } from "kolu-common/surface";
+import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import {
   type Component,
   createEffect,
@@ -40,7 +40,7 @@ import {
   pierreTreesStyle,
 } from "../ui/pierreTheme";
 import { resolveLineRefPath } from "../ui/lineRef";
-import BrowseFileView from "./BrowseFileView";
+import BrowseFileDispatcher from "./BrowseFileDispatcher";
 import CodeMenuFrame from "./CodeMenuFrame";
 import {
   openInCodeTab,
@@ -75,7 +75,10 @@ const BinaryFileHint: Component<{ fileName: string | null }> = (props) => (
   </div>
 );
 
-const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
+const CodeTab: Component<{
+  terminalId: TerminalId | null;
+  meta: TerminalMetadata | null;
+}> = (props) => {
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
   const [selectedPath, setSelectedPath] = createSignal<string | null>(null);
@@ -598,9 +601,11 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
                 <Match when={!isDiffView()}>
                   {(() => {
                     const repo = repoPath();
-                    if (repo === null) return null;
+                    const tid = props.terminalId;
+                    if (repo === null || tid === null) return null;
                     return (
-                      <BrowseFileView
+                      <BrowseFileDispatcher
+                        terminalId={tid}
                         repoPath={repo}
                         filePath={path}
                         theme={diffTheme()}

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -533,7 +533,15 @@ const CodeTab: Component<{
             // outer panel-resize handle hit-targetable along its full
             // height.
             startIntersection={false}
-            class="shrink-0 h-0 relative before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors"
+            // `z-10` raises the ::before pseudo-element above Pierre's tree
+            // (which is the previous flex sibling). Without it, the tree's
+            // bottom 4px shadow the upper half of the handle's hit area —
+            // Pierre's row hit-targets paint above the handle's absolute
+            // ::before because both use auto z-index and the tree comes
+            // first in document order with positioned descendants. Setting
+            // `z-10` on the handle creates a stacking context that lifts
+            // the ::before in front of the tree's interior.
+            class="shrink-0 h-0 relative z-10 before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors"
           />
 
           <Resizable.Panel

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -13,6 +13,7 @@
  * via `FileTree.searchQuery`. `@kolu/solid-pierre` owns the imperative
  * Pierre lifecycle; this component is just data flow + chrome. */
 
+import Resizable from "@corvu/resizable";
 import { FileDiff, FileTree, Virtualizer } from "@kolu/solid-pierre";
 import type { GitDiffMode } from "kolu-git/schemas";
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
@@ -447,177 +448,219 @@ const CodeTab: Component<{
           <FileSearchInput value={searchQuery()} onChange={setSearchQuery} />
         </div>
 
-        <div
-          class="shrink-0 h-[35%] min-h-0 border-b border-edge"
-          data-testid="diff-file-list"
+        {/* Vertical split between tree and content. Mirrors the horizontal
+         *  split in `RightPanelLayout` — same `@corvu/resizable` shell,
+         *  vertical orientation. Split fraction persists via
+         *  `rightPanel.codeTabTreeSize` so reload restores the user's layout. */}
+        <Resizable
+          orientation="vertical"
+          sizes={[
+            rightPanel.codeTabTreeSize(),
+            1 - rightPanel.codeTabTreeSize(),
+          ]}
+          onSizesChange={(sizes) => {
+            if (sizes[0] !== undefined) rightPanel.setCodeTabTreeSize(sizes[0]);
+          }}
+          class="flex-1 min-h-0 overflow-hidden"
         >
-          <Switch fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}>
-            <Match when={treeError()}>
-              {(err) => (
-                <div class="px-2 py-1 text-danger" data-testid="diff-error">
-                  Error: {err().message}
-                </div>
-              )}
-            </Match>
-            <Match when={treeReady()}>
-              <Show
-                when={treePaths().length > 0}
-                fallback={
-                  <div
-                    class="px-2 py-4 text-fg-3/50 text-center"
-                    data-testid="diff-empty"
-                  >
-                    {(() => {
-                      const m = diffMode();
-                      return m ? EMPTY_STATE[m] : "Empty repository";
-                    })()}
-                  </div>
-                }
-              >
-                <FileTree
-                  paths={treeSearch().projectedPaths}
-                  gitStatus={treeGitStatus()}
-                  selectedPath={selectedPath()}
-                  onSelect={handleSelect}
-                  initialExpansion={isDiffView() ? "open" : "closed"}
-                  search={false}
-                  expandPaths={treeSearch().expandedAncestors}
-                  icons={pierreIconConfig}
-                  contextMenu={{
-                    enabled: true,
-                    triggerMode: "both",
-                    render: renderTreeContextMenu,
-                  }}
-                  onError={(err) =>
-                    toast.error(`File tree render failed: ${err.message}`)
-                  }
-                  class="h-full w-full"
-                  style={pierreTreesStyle}
-                />
-              </Show>
-            </Match>
-          </Switch>
-        </div>
-
-        <div class="flex-1 min-h-0 overflow-auto" data-testid="diff-content">
-          <Show
-            when={selectedPath()}
-            keyed
-            fallback={
-              <FileSelectHint
-                label={
-                  isDiffView()
-                    ? "Select a file to view its diff"
-                    : "Select a file to view its content"
-                }
-              />
-            }
+          <Resizable.Panel
+            as="div"
+            data-testid="diff-file-list"
+            class="min-h-0 border-b border-edge"
+            minSize={0.1}
           >
-            {(path) => (
-              // `keyed` remounts this subtree whenever the selected file
-              // changes. Pierre's `FileDiff.render(newFileDiff)` reuses
-              // the same instance — its line-selection handlers don't
-              // re-bind to the new gutter elements, so right-clicking on
-              // a line in the second file would yield a "Copy path" menu
-              // with no "Copy path:line" entry. Per-file remount gives
-              // each file a fresh `FileDiff` and a clean
-              // `useLineSelection` range, which is also the right
-              // semantic — line refs don't survive across files.
-              <Switch>
-                <Match when={isDiffView()}>
-                  <Switch
-                    fallback={
-                      <div class="px-2 py-1 text-fg-3/50">Loading diff…</div>
+            <Switch
+              fallback={<div class="px-2 py-1 text-fg-3/50">Loading…</div>}
+            >
+              <Match when={treeError()}>
+                {(err) => (
+                  <div class="px-2 py-1 text-danger" data-testid="diff-error">
+                    Error: {err().message}
+                  </div>
+                )}
+              </Match>
+              <Match when={treeReady()}>
+                <Show
+                  when={treePaths().length > 0}
+                  fallback={
+                    <div
+                      class="px-2 py-4 text-fg-3/50 text-center"
+                      data-testid="diff-empty"
+                    >
+                      {(() => {
+                        const m = diffMode();
+                        return m ? EMPTY_STATE[m] : "Empty repository";
+                      })()}
+                    </div>
+                  }
+                >
+                  <FileTree
+                    paths={treeSearch().projectedPaths}
+                    gitStatus={treeGitStatus()}
+                    selectedPath={selectedPath()}
+                    onSelect={handleSelect}
+                    initialExpansion={isDiffView() ? "open" : "closed"}
+                    search={false}
+                    expandPaths={treeSearch().expandedAncestors}
+                    icons={pierreIconConfig}
+                    contextMenu={{
+                      enabled: true,
+                      triggerMode: "both",
+                      render: renderTreeContextMenu,
+                    }}
+                    onError={(err) =>
+                      toast.error(`File tree render failed: ${err.message}`)
                     }
-                  >
-                    <Match when={diff.error()}>
-                      {(err) => (
-                        <div class="px-2 py-1 text-danger">
-                          Error: {err().message}
-                        </div>
-                      )}
-                    </Match>
-                    <Match when={diff()?.binary && diff()}>
-                      {(d) => (
-                        <BinaryFileHint
-                          fileName={d().newFileName ?? d().oldFileName}
+                    class="h-full w-full"
+                    style={pierreTreesStyle}
+                  />
+                </Show>
+              </Match>
+            </Switch>
+          </Resizable.Panel>
+
+          <Resizable.Handle
+            data-testid="diff-tree-content-handle"
+            aria-label="Resize tree pane"
+            // Disable startIntersection (the handle's left edge): Corvu's
+            // registerHandle keeps a *module-level* handles[] and pairs
+            // handles whose orientations differ and rects touch at the
+            // corner (see @corvu/resizable/dist/index.js:201–222). Without
+            // this opt-out, our left edge equals `RightPanelLayout`'s
+            // outer horizontal handle's right edge → the two are coupled,
+            // and clicks on the outer handle near the file-tree row land
+            // on the inner handle instead. Explicit opt-out keeps the
+            // outer panel-resize handle hit-targetable along its full
+            // height.
+            startIntersection={false}
+            class="shrink-0 h-0 relative before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors"
+          />
+
+          <Resizable.Panel
+            as="div"
+            data-testid="diff-content"
+            class="min-h-0 overflow-auto"
+            minSize={0.1}
+          >
+            <Show
+              when={selectedPath()}
+              keyed
+              fallback={
+                <FileSelectHint
+                  label={
+                    isDiffView()
+                      ? "Select a file to view its diff"
+                      : "Select a file to view its content"
+                  }
+                />
+              }
+            >
+              {(path) => (
+                // `keyed` remounts this subtree whenever the selected file
+                // changes. Pierre's `FileDiff.render(newFileDiff)` reuses
+                // the same instance — its line-selection handlers don't
+                // re-bind to the new gutter elements, so right-clicking on
+                // a line in the second file would yield a "Copy path" menu
+                // with no "Copy path:line" entry. Per-file remount gives
+                // each file a fresh `FileDiff` and a clean
+                // `useLineSelection` range, which is also the right
+                // semantic — line refs don't survive across files.
+                <Switch>
+                  <Match when={isDiffView()}>
+                    <Switch
+                      fallback={
+                        <div class="px-2 py-1 text-fg-3/50">Loading diff…</div>
+                      }
+                    >
+                      <Match when={diff.error()}>
+                        {(err) => (
+                          <div class="px-2 py-1 text-danger">
+                            Error: {err().message}
+                          </div>
+                        )}
+                      </Match>
+                      <Match when={diff()?.binary && diff()}>
+                        {(d) => (
+                          <BinaryFileHint
+                            fileName={d().newFileName ?? d().oldFileName}
+                          />
+                        )}
+                      </Match>
+                      <Match when={renamedDiff()}>
+                        {(rename) => (
+                          <div class="flex items-center justify-center h-full text-fg-3/50">
+                            File renamed: {rename().oldFileName} →{" "}
+                            {rename().newFileName}
+                          </div>
+                        )}
+                      </Match>
+                      <Match when={diff()}>
+                        {(d) => (
+                          <CodeMenuFrame
+                            path={path}
+                            onOpen={(ref) => {
+                              // Diff paths are repo-relative; cwd is irrelevant.
+                              const repo = repoPath();
+                              if (repo === null) return;
+                              openInCodeTab({
+                                ref,
+                                repoRoot: repo,
+                                targetMode: "browse",
+                              });
+                            }}
+                          >
+                            {(selection) => (
+                              // `<Virtualizer>` is the scroll container —
+                              // `<FileDiff>` consumes its context and
+                              // upgrades to Pierre's `VirtualizedFileDiff`,
+                              // windowing huge diffs (50k-line lockfile,
+                              // #809 / #514 Phase 8). Without this wrapper
+                              // `<FileDiff>` falls back to the vanilla
+                              // class — same as before.
+                              <Virtualizer
+                                class="h-full w-full overflow-auto"
+                                style={pierreDiffsStyle}
+                              >
+                                <FileDiff
+                                  rawDiff={d().hunks[0] ?? ""}
+                                  theme={diffTheme()}
+                                  enableLineSelection
+                                  onLineSelected={selection.handleSelect}
+                                  onError={(err) =>
+                                    toast.error(
+                                      `Diff render failed: ${err.message}`,
+                                    )
+                                  }
+                                  class="w-full"
+                                />
+                              </Virtualizer>
+                            )}
+                          </CodeMenuFrame>
+                        )}
+                      </Match>
+                    </Switch>
+                  </Match>
+                  <Match when={!isDiffView()}>
+                    {(() => {
+                      const repo = repoPath();
+                      const tid = props.terminalId;
+                      if (repo === null || tid === null) return null;
+                      return (
+                        <BrowseFileDispatcher
+                          terminalId={tid}
+                          repoPath={repo}
+                          filePath={path}
+                          theme={diffTheme()}
+                          initialSelectedLines={selectedRange()}
                         />
-                      )}
-                    </Match>
-                    <Match when={renamedDiff()}>
-                      {(rename) => (
-                        <div class="flex items-center justify-center h-full text-fg-3/50">
-                          File renamed: {rename().oldFileName} →{" "}
-                          {rename().newFileName}
-                        </div>
-                      )}
-                    </Match>
-                    <Match when={diff()}>
-                      {(d) => (
-                        <CodeMenuFrame
-                          path={path}
-                          onOpen={(ref) => {
-                            // Diff paths are repo-relative; cwd is irrelevant.
-                            const repo = repoPath();
-                            if (repo === null) return;
-                            openInCodeTab({
-                              ref,
-                              repoRoot: repo,
-                              targetMode: "browse",
-                            });
-                          }}
-                        >
-                          {(selection) => (
-                            // `<Virtualizer>` is the scroll container —
-                            // `<FileDiff>` consumes its context and
-                            // upgrades to Pierre's `VirtualizedFileDiff`,
-                            // windowing huge diffs (50k-line lockfile,
-                            // #809 / #514 Phase 8). Without this wrapper
-                            // `<FileDiff>` falls back to the vanilla
-                            // class — same as before.
-                            <Virtualizer
-                              class="h-full w-full overflow-auto"
-                              style={pierreDiffsStyle}
-                            >
-                              <FileDiff
-                                rawDiff={d().hunks[0] ?? ""}
-                                theme={diffTheme()}
-                                enableLineSelection
-                                onLineSelected={selection.handleSelect}
-                                onError={(err) =>
-                                  toast.error(
-                                    `Diff render failed: ${err.message}`,
-                                  )
-                                }
-                                class="w-full"
-                              />
-                            </Virtualizer>
-                          )}
-                        </CodeMenuFrame>
-                      )}
-                    </Match>
-                  </Switch>
-                </Match>
-                <Match when={!isDiffView()}>
-                  {(() => {
-                    const repo = repoPath();
-                    const tid = props.terminalId;
-                    if (repo === null || tid === null) return null;
-                    return (
-                      <BrowseFileDispatcher
-                        terminalId={tid}
-                        repoPath={repo}
-                        filePath={path}
-                        theme={diffTheme()}
-                        initialSelectedLines={selectedRange()}
-                      />
-                    );
-                  })()}
-                </Match>
-              </Switch>
-            )}
-          </Show>
-        </div>
+                      );
+                    })()}
+                  </Match>
+                </Switch>
+              )}
+            </Show>
+          </Resizable.Panel>
+        </Resizable>
       </div>
     </Show>
   );

--- a/packages/client/src/right-panel/RightPanel.tsx
+++ b/packages/client/src/right-panel/RightPanel.tsx
@@ -2,7 +2,11 @@
  *  Routes between Inspector and Code tabs via the DU view exposed by
  *  `useRightPanel().activeTab()`. */
 
-import type { RightPanelTabKind, TerminalMetadata } from "kolu-common/surface";
+import type {
+  RightPanelTabKind,
+  TerminalId,
+  TerminalMetadata,
+} from "kolu-common/surface";
 import { type Component, For } from "solid-js";
 import { CHROME_ICON_BUTTON_CLASS } from "../ui/chromeSpacing";
 import { ChevronRightIcon } from "../ui/Icons";
@@ -24,6 +28,7 @@ const TAB_LABEL: Record<RightPanelTabKind, string> = {
 };
 
 const RightPanel: Component<{
+  terminalId: TerminalId | null;
   meta: TerminalMetadata | null;
   onToggle: () => void;
   themeName?: string;
@@ -107,7 +112,7 @@ const RightPanel: Component<{
           class={rightPanel.activeTab().kind === "code" ? "h-full" : "hidden"}
           aria-hidden={rightPanel.activeTab().kind !== "code"}
         >
-          <CodeTab meta={props.meta} />
+          <CodeTab terminalId={props.terminalId} meta={props.meta} />
         </div>
       </div>
     </div>

--- a/packages/client/src/right-panel/RightPanelLayout.tsx
+++ b/packages/client/src/right-panel/RightPanelLayout.tsx
@@ -4,7 +4,7 @@
  *  too narrow for a useful side panel. */
 
 import Resizable from "@corvu/resizable";
-import type { TerminalMetadata } from "kolu-common/surface";
+import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import { type Component, type JSX, Show } from "solid-js";
 import { isMobile } from "../useMobile";
 import RightPanel from "./RightPanel";
@@ -12,6 +12,9 @@ import { useRightPanel } from "./useRightPanel";
 
 const RightPanelLayout: Component<{
   children: JSX.Element;
+  /** Active terminal id. Used by the Code tab's iframe-preview path to
+   *  build the per-terminal file-serving URL. */
+  terminalId: TerminalId | null;
   meta: TerminalMetadata | null;
   themeName?: string;
   onThemeClick?: () => void;
@@ -71,6 +74,7 @@ const RightPanelLayout: Component<{
              *  shrinks this panel to zero width via sizes=[1,0] above. An
              *  inner <Show> would unmount and discard that state. */}
             <RightPanel
+              terminalId={props.terminalId}
               meta={props.meta}
               onToggle={rightPanel.togglePanel}
               themeName={props.themeName}

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -11,6 +11,11 @@ import {
 import { preferences, updatePreferences } from "../wire";
 
 const MIN_PANEL_SIZE = 0.05;
+/** Lower bound for the Code-tab vertical split — keep the tree and content
+ *  panes from collapsing to invisible via drag. Mirrors `MIN_PANEL_SIZE`'s
+ *  role for the horizontal split. */
+const MIN_TREE_SIZE = 0.1;
+const MAX_TREE_SIZE = 0.9;
 
 export function useRightPanel() {
   const rp = () => preferences().rightPanel;
@@ -71,6 +76,14 @@ export function useRightPanel() {
     expandPanel: () => updatePreferences({ rightPanel: { collapsed: false } }),
     setPanelSize: (size: number) => {
       if (size > MIN_PANEL_SIZE) updatePreferences({ rightPanel: { size } });
+    },
+    /** Vertical split fraction inside the Code tab — tree pane occupies
+     *  this share, content pane gets the rest. Persisted across reload. */
+    codeTabTreeSize: () => rp().codeTabTreeSize,
+    setCodeTabTreeSize: (size: number) => {
+      if (size >= MIN_TREE_SIZE && size <= MAX_TREE_SIZE) {
+        updatePreferences({ rightPanel: { codeTabTreeSize: size } });
+      }
     },
   } as const;
 }

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -301,6 +301,10 @@ export const RightPanelPrefsSchema = z.object({
   size: z.number(),
   activeTab: RightPanelTabKindSchema,
   codeMode: CodeTabViewSchema,
+  /** Vertical split fraction (0–1) inside the Code tab: tree pane occupies
+   *  this share, content pane gets the rest. Persisted so layout survives
+   *  reload, mirroring the horizontal `size` field's behavior. */
+  codeTabTreeSize: z.number(),
 });
 
 export const PreferencesSchema = z.object({
@@ -395,6 +399,7 @@ export const DEFAULT_PREFERENCES: z.infer<typeof PreferencesSchema> = {
     size: 0.25,
     activeTab: "inspector",
     codeMode: "local",
+    codeTabTreeSize: 0.35,
   },
 };
 

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -5,7 +5,7 @@
  *  listing `node_modules/`, `.git/`, build artifacts, etc. */
 
 import { execFile } from "node:child_process";
-import { readFile as fsReadFile } from "node:fs/promises";
+import { readFile as fsReadFile, stat as fsStat } from "node:fs/promises";
 import { promisify } from "node:util";
 import type { Logger } from "kolu-shared";
 import { err, type GitResult, ok } from "./errors.ts";
@@ -69,5 +69,23 @@ export async function readFile(
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     return err({ code: "GIT_FAILED", message: `Failed to read file: ${msg}` });
+  }
+}
+
+/** Stat a file's mtime in ms-since-epoch, used to cache-bust the iframe URL
+ *  for binary previewable kinds. Same path-traversal guard as `readFile`. */
+export async function statFileMtimeMs(
+  repoPath: string,
+  filePath: string,
+  log?: Logger,
+): Promise<GitResult<number>> {
+  const resolved = resolveUnder(repoPath, filePath, log);
+  if (!resolved.ok) return resolved as GitResult<number>;
+  try {
+    const s = await fsStat(resolved.value.abs);
+    return ok(s.mtimeMs);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return err({ code: "GIT_FAILED", message: `Failed to stat file: ${msg}` });
   }
 }

--- a/packages/integrations/git/src/equals.ts
+++ b/packages/integrations/git/src/equals.ts
@@ -72,5 +72,12 @@ export function fsReadFileOutputEqual(
   a: FsReadFileOutput,
   b: FsReadFileOutput,
 ): boolean {
-  return a.content === b.content && a.truncated === b.truncated;
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "text" && b.kind === "text") {
+    return a.content === b.content && a.truncated === b.truncated;
+  }
+  if (a.kind === "binary" && b.kind === "binary") {
+    return a.url === b.url;
+  }
+  return false;
 }

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -6,7 +6,7 @@
 // Name generation
 export { randomName } from "memorable-names";
 // File tree browsing
-export { listAll, readFile } from "./browse.ts";
+export { listAll, readFile, statFileMtimeMs } from "./browse.ts";
 // Equality predicates for streamed snapshot dedup
 export {
   fsListAllOutputEqual,
@@ -38,11 +38,15 @@ export { getDiff, getStatus, parseNameStatus } from "./review.ts";
 export { resolveUnder } from "./safe-path.ts";
 // Schemas
 export {
+  buildIframePreviewUrl,
   FsListAllInputSchema,
   type FsListAllOutput,
   FsListAllOutputSchema,
   FsReadFileInputSchema,
+  type FsReadFileOutput,
   FsReadFileOutputSchema,
+  IFRAME_PREVIEWABLE_EXTENSIONS,
+  isIframePreviewable,
   type GitBaseRef,
   GitBaseRefSchema,
   type GitChangedFile,

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -38,7 +38,6 @@ export { getDiff, getStatus, parseNameStatus } from "./review.ts";
 export { resolveUnder } from "./safe-path.ts";
 // Schemas
 export {
-  buildIframePreviewUrl,
   FsListAllInputSchema,
   type FsListAllOutput,
   FsListAllOutputSchema,

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -45,8 +45,6 @@ export {
   FsReadFileInputSchema,
   type FsReadFileOutput,
   FsReadFileOutputSchema,
-  IFRAME_PREVIEWABLE_EXTENSIONS,
-  isIframePreviewable,
   type GitBaseRef,
   GitBaseRefSchema,
   type GitChangedFile,

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -165,8 +165,8 @@ export const FsReadFileInputSchema = z.object({
 
 /** Discriminated by `kind`. Text files yield their content; iframe-
  *  previewable binaries yield a cache-busted URL the client points
- *  an `<iframe>` at. Server picks the variant per file extension via
- *  `isIframePreviewable` below. */
+ *  an `<iframe>` at. The variant-picker (`isIframePreviewable`) and
+ *  URL builder live server-side in `iframePreviewRoute.ts`. */
 export const FsReadFileOutputSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("text"),

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -152,18 +152,66 @@ export const FsListAllOutputSchema = z.object({
 export type FsListAllOutput = z.infer<typeof FsListAllOutputSchema>;
 
 export const FsReadFileInputSchema = z.object({
+  /** Terminal that owns the URL handle for `kind: "binary"` outputs.
+   *  Text reads ignore this — the field is on the input because the URL
+   *  shape (`/api/terminals/<id>/file/...`) is constructed server-side
+   *  from this id, so the client doesn't have to know the route layout. */
+  terminalId: z.string().uuid(),
   /** Absolute path to the repo root. */
   repoPath: z.string(),
   /** Path relative to repo root. */
   filePath: z.string(),
 });
 
-export const FsReadFileOutputSchema = z.object({
-  content: z.string(),
-  /** True if the file exceeded the size limit and was truncated. */
-  truncated: z.boolean(),
-});
+/** Discriminated by `kind`. Text files yield their content; iframe-
+ *  previewable binaries yield a cache-busted URL the client points
+ *  an `<iframe>` at. Server picks the variant per file extension via
+ *  `isIframePreviewable` below. */
+export const FsReadFileOutputSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("text"),
+    content: z.string(),
+    /** True if the file exceeded the size limit and was truncated. */
+    truncated: z.boolean(),
+  }),
+  z.object({
+    kind: z.literal("binary"),
+    /** Server-constructed URL for the iframe `src`. Includes a `?v=<mtime>`
+     *  query so the stream re-yield on file change produces a new URL and
+     *  the iframe reloads via the same subscription path. */
+    url: z.string(),
+  }),
+]);
 export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
+
+/** Extensions whose contents the browser renders natively in an iframe.
+ *  `.html` and `.htm` are the primary use case (agent-generated artifacts);
+ *  `.svg` and `.pdf` come along for free because every browser handles them. */
+export const IFRAME_PREVIEWABLE_EXTENSIONS = [
+  ".html",
+  ".htm",
+  ".svg",
+  ".pdf",
+] as const;
+
+export function isIframePreviewable(filePath: string): boolean {
+  const lower = filePath.toLowerCase();
+  return IFRAME_PREVIEWABLE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+/** Canonical URL shape for the iframe-served file route, used in
+ *  `FsReadFileOutput.kind === "binary"` and matched by a Hono route in the
+ *  server's `index.ts`. Single source of truth so the two sides can't drift.
+ *  `mtimeMs` is rounded down so a stable file always produces the same URL
+ *  (browser caches the iframe content per URL). */
+export function buildIframePreviewUrl(
+  terminalId: string,
+  filePath: string,
+  mtimeMs: number,
+): string {
+  const encodedPath = filePath.split("/").map(encodeURIComponent).join("/");
+  return `/api/terminals/${terminalId}/file/${encodedPath}?v=${Math.floor(mtimeMs)}`;
+}
 
 // --- Derived types ---
 

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -184,20 +184,6 @@ export const FsReadFileOutputSchema = z.discriminatedUnion("kind", [
 ]);
 export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
 
-/** Canonical URL shape for the iframe-served file route, used in
- *  `FsReadFileOutput.kind === "binary"` and matched by a Hono route in the
- *  server's `index.ts`. Single source of truth so the two sides can't drift.
- *  `mtimeMs` is rounded down so a stable file always produces the same URL
- *  (browser caches the iframe content per URL). */
-export function buildIframePreviewUrl(
-  terminalId: string,
-  filePath: string,
-  mtimeMs: number,
-): string {
-  const encodedPath = filePath.split("/").map(encodeURIComponent).join("/");
-  return `/api/terminals/${terminalId}/file/${encodedPath}?v=${Math.floor(mtimeMs)}`;
-}
-
 // --- Derived types ---
 
 export type GitInfo = z.infer<typeof GitInfoSchema>;

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -184,21 +184,6 @@ export const FsReadFileOutputSchema = z.discriminatedUnion("kind", [
 ]);
 export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
 
-/** Extensions whose contents the browser renders natively in an iframe.
- *  `.html` and `.htm` are the primary use case (agent-generated artifacts);
- *  `.svg` and `.pdf` come along for free because every browser handles them. */
-export const IFRAME_PREVIEWABLE_EXTENSIONS = [
-  ".html",
-  ".htm",
-  ".svg",
-  ".pdf",
-] as const;
-
-export function isIframePreviewable(filePath: string): boolean {
-  const lower = filePath.toLowerCase();
-  return IFRAME_PREVIEWABLE_EXTENSIONS.some((ext) => lower.endsWith(ext));
-}
-
 /** Canonical URL shape for the iframe-served file route, used in
  *  `FsReadFileOutput.kind === "binary"` and matched by a Hono route in the
  *  server's `index.ts`. Single source of truth so the two sides can't drift.

--- a/packages/server/src/iframePreviewRoute.test.ts
+++ b/packages/server/src/iframePreviewRoute.test.ts
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  contentTypeForPath,
+  resolvePreviewPath,
+  serveResolvedFile,
+} from "./iframePreviewRoute";
+
+describe("contentTypeForPath", () => {
+  it("maps the iframe-previewable extensions", () => {
+    expect(contentTypeForPath("a.html")).toBe("text/html; charset=utf-8");
+    expect(contentTypeForPath("a.HTM")).toBe("text/html; charset=utf-8");
+    expect(contentTypeForPath("logo.svg")).toBe("image/svg+xml");
+    expect(contentTypeForPath("doc.pdf")).toBe("application/pdf");
+  });
+
+  it("maps common HTML-asset siblings so relative <link>/<script> resolve", () => {
+    expect(contentTypeForPath("style.css")).toBe("text/css; charset=utf-8");
+    expect(contentTypeForPath("app.js")).toBe(
+      "application/javascript; charset=utf-8",
+    );
+    expect(contentTypeForPath("icon.png")).toBe("image/png");
+  });
+
+  it("falls back to octet-stream for unknown types", () => {
+    expect(contentTypeForPath("mystery.xyz")).toBe("application/octet-stream");
+    expect(contentTypeForPath("noext")).toBe("application/octet-stream");
+  });
+});
+
+describe("resolvePreviewPath", () => {
+  const repoRoot = "/tmp/some-repo";
+
+  it("accepts a simple relative path", () => {
+    const res = resolvePreviewPath(repoRoot, "docs/output.html");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.abs).toBe(path.join(repoRoot, "docs/output.html"));
+    expect(res.mime).toBe("text/html; charset=utf-8");
+  });
+
+  it("rejects plaintext .. segments", () => {
+    const res = resolvePreviewPath(repoRoot, "../etc/passwd");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects URL-encoded .. (%2e%2e)", () => {
+    const res = resolvePreviewPath(repoRoot, "%2e%2e/etc/passwd");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects encoded-slash smuggling (foo%2f..%2fpasswd)", () => {
+    // splitting BEFORE decoding would let this through as one segment.
+    const res = resolvePreviewPath(repoRoot, "foo%2f..%2fpasswd");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty middle segments (double slash)", () => {
+    const res = resolvePreviewPath(repoRoot, "foo//bar.html");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects trailing slash (directory-listing intent)", () => {
+    const res = resolvePreviewPath(repoRoot, "docs/");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty tail", () => {
+    const res = resolvePreviewPath(repoRoot, "");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a malformed encoding (invalid percent sequence)", () => {
+    const res = resolvePreviewPath(repoRoot, "%zz");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an absolute child path", () => {
+    const res = resolvePreviewPath(repoRoot, "/etc/passwd");
+    // Leading slash → empty first segment, caught by the empty-segment check.
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects `.` segment", () => {
+    const res = resolvePreviewPath(repoRoot, "docs/./output.html");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("serveResolvedFile", () => {
+  let tmpRoot: string;
+
+  beforeAll(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-iframe-route-test-"));
+    fs.writeFileSync(
+      path.join(tmpRoot, "page.html"),
+      "<!doctype html><h1>hi</h1>",
+    );
+    fs.mkdirSync(path.join(tmpRoot, "sub"));
+    fs.writeFileSync(path.join(tmpRoot, "sub", "child.svg"), "<svg/>");
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("serves an existing HTML file with the right Content-Type", async () => {
+    const res = await serveResolvedFile(
+      resolvePreviewPath(tmpRoot, "page.html"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers["Content-Type"]).toBe("text/html; charset=utf-8");
+    expect(res.headers["X-Content-Type-Options"]).toBe("nosniff");
+    expect(res.body.toString()).toBe("<!doctype html><h1>hi</h1>");
+  });
+
+  it("serves a nested asset", async () => {
+    const res = await serveResolvedFile(
+      resolvePreviewPath(tmpRoot, "sub/child.svg"),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers["Content-Type"]).toBe("image/svg+xml");
+  });
+
+  it("404s for missing files (with valid path)", async () => {
+    const res = await serveResolvedFile(resolvePreviewPath(tmpRoot, "no.html"));
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for a directory (not a file)", async () => {
+    const res = await serveResolvedFile(resolvePreviewPath(tmpRoot, "sub"));
+    expect(res.status).toBe(404);
+  });
+
+  it("propagates the resolver's 400 verbatim", async () => {
+    const res = await serveResolvedFile(
+      resolvePreviewPath(tmpRoot, "../escape"),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/iframePreviewRoute.ts
+++ b/packages/server/src/iframePreviewRoute.ts
@@ -18,6 +18,29 @@ import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { resolveUnder } from "kolu-git";
 
+/** Base URL for the iframe-preview file route. Used by both
+ *  `buildIframePreviewUrl` (server emits URLs in this shape) and the Hono
+ *  route registration in `index.ts` (matches incoming requests against the
+ *  same shape). One constant → renames touch one place. */
+export const TERMINAL_FILE_ROUTE_BASE = "/api/terminals";
+
+/** Path suffix relative to `TERMINAL_FILE_ROUTE_BASE` for per-terminal file
+ *  serving. Concatenated as `${BASE}/${terminalId}/file/${path}`. */
+export const TERMINAL_FILE_ROUTE_FILE_SEGMENT = "file";
+
+/** Canonical URL shape for the iframe-served file route, used in
+ *  `FsReadFileOutput.kind === "binary"` and matched by the Hono route in
+ *  `index.ts`. `mtimeMs` is rounded down so a stable file always produces
+ *  the same URL (browser caches the iframe content per URL). */
+export function buildIframePreviewUrl(
+  terminalId: string,
+  filePath: string,
+  mtimeMs: number,
+): string {
+  const encodedPath = filePath.split("/").map(encodeURIComponent).join("/");
+  return `${TERMINAL_FILE_ROUTE_BASE}/${terminalId}/${TERMINAL_FILE_ROUTE_FILE_SEGMENT}/${encodedPath}?v=${Math.floor(mtimeMs)}`;
+}
+
 /** Extensions whose contents the browser renders natively in an iframe.
  *  Lives here (next to `CONTENT_TYPES`) because both lists are facets of
  *  the same iframe-rendering decision — adding a new previewable extension

--- a/packages/server/src/iframePreviewRoute.ts
+++ b/packages/server/src/iframePreviewRoute.ts
@@ -180,11 +180,21 @@ export async function serveResolvedFile(
       },
       body: buf,
     };
-  } catch {
+  } catch (e: unknown) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        status: 404,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+        body: "not found",
+      };
+    }
+    // Unexpected I/O error (EACCES, EIO, …) — surface as 500 so it doesn't
+    // masquerade as a missing file.
     return {
-      status: 404,
+      status: 500,
       headers: { "Content-Type": "text/plain; charset=utf-8" },
-      body: "not found",
+      body: e instanceof Error ? e.message : "internal error",
     };
   }
 }

--- a/packages/server/src/iframePreviewRoute.ts
+++ b/packages/server/src/iframePreviewRoute.ts
@@ -1,0 +1,147 @@
+/** HTTP route serving repo files for the iframe-preview surface
+ *  (`FsReadFileOutput.kind === "binary"`). URL contract lives in
+ *  `kolu-git/schemas`'s `buildIframePreviewUrl` — keep the two in sync.
+ *
+ *  Two-stage path-traversal guard:
+ *    1. Inspect raw URL-decoded segments and reject `..` or empty parts
+ *       *before* path.join — defense in depth against URL-encoded `..`
+ *       and double-slash collapsing tricks.
+ *    2. `resolveUnder` canonicalizes and re-verifies via `path.relative`
+ *       (the established kolu-git guard pattern).
+ *
+ *  Content-Type is set explicitly per extension; `X-Content-Type-Options:
+ *  nosniff` blocks the browser from second-guessing. Sandbox restrictions
+ *  (`allow-scripts` only, no `allow-same-origin`) are the iframe element's
+ *  responsibility — the route is plain HTTP. */
+
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { resolveUnder } from "kolu-git";
+
+const CONTENT_TYPES: Record<string, string> = {
+  // Iframe-previewable kinds (must match IFRAME_PREVIEWABLE_EXTENSIONS).
+  ".html": "text/html; charset=utf-8",
+  ".htm": "text/html; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".pdf": "application/pdf",
+  // Assets a previewable HTML page can reference via relative <link>/<script>/<img>.
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+};
+
+export function contentTypeForPath(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return CONTENT_TYPES[ext] ?? "application/octet-stream";
+}
+
+export type PathResolution =
+  | { ok: true; abs: string; mime: string }
+  | { ok: false; status: 400 | 403 | 404; reason: string };
+
+/** Parse the URL tail, run both guard stages, return the absolute file path
+ *  or the HTTP status to respond with. Pure function — no I/O — so the
+ *  Hono route stays a thin adapter and the guard is unit-testable. */
+export function resolvePreviewPath(
+  repoRoot: string,
+  rawTail: string,
+): PathResolution {
+  if (rawTail.length === 0) return { ok: false, status: 404, reason: "empty" };
+
+  // Stage 1: decode the whole tail FIRST, then split. Order matters:
+  // splitting before decode would treat `foo%2f..%2fpasswd` as one segment
+  // (slipping a `..` past the per-segment check). Decode-then-split turns
+  // any URL-encoded slash into a real boundary so every component the
+  // resolver will see gets validated. Catches `%2e%2e`, `%2f`, double
+  // slashes, `.`, `..`, absolute segments — all rejected before path.join.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawTail);
+  } catch {
+    return { ok: false, status: 400, reason: "malformed encoding" };
+  }
+  const segments = decoded.split("/");
+  for (const seg of segments) {
+    if (seg === "" || seg === "." || seg === "..") {
+      return { ok: false, status: 400, reason: "illegal segment" };
+    }
+    if (path.isAbsolute(seg)) {
+      return { ok: false, status: 400, reason: "absolute segment" };
+    }
+  }
+  const relPath = segments.join("/");
+
+  // Stage 2: canonical resolve + relative-prefix check (kolu-git's guard).
+  const resolved = resolveUnder(repoRoot, relPath);
+  if (!resolved.ok) return { ok: false, status: 403, reason: "escapes root" };
+
+  return {
+    ok: true,
+    abs: resolved.value.abs,
+    mime: contentTypeForPath(relPath),
+  };
+}
+
+export interface ServeResult {
+  status: number;
+  headers: Record<string, string>;
+  /** `Uint8Array` covers `Buffer` (subclass) and satisfies `Response`'s
+   *  `BodyInit` directly — `Buffer` alone confuses TS in the DOM-typed
+   *  Response constructor. Strings come back for error responses. */
+  body: Uint8Array | string;
+}
+
+/** Read the resolved file and assemble the HTTP response. Separated from
+ *  `resolvePreviewPath` so the guard logic is testable without filesystem
+ *  fixtures, and the I/O failure modes are testable without crafting URLs. */
+export async function serveResolvedFile(
+  res: PathResolution,
+): Promise<ServeResult> {
+  if (!res.ok) {
+    return {
+      status: res.status,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      body: res.reason,
+    };
+  }
+  try {
+    const s = await stat(res.abs);
+    if (!s.isFile()) {
+      return {
+        status: 404,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+        body: "not a file",
+      };
+    }
+    const buf = await readFile(res.abs);
+    return {
+      status: 200,
+      headers: {
+        "Content-Type": res.mime,
+        "X-Content-Type-Options": "nosniff",
+        // Browsers cache aggressively — the URL's `?v=<mtime>` query is the
+        // cache key on our side, so a same-URL request can safely hit the
+        // browser cache. mtime change → new URL → fresh fetch.
+        "Cache-Control": "private, max-age=60",
+      },
+      body: buf,
+    };
+  } catch {
+    return {
+      status: 404,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      body: "not found",
+    };
+  }
+}

--- a/packages/server/src/iframePreviewRoute.ts
+++ b/packages/server/src/iframePreviewRoute.ts
@@ -18,8 +18,27 @@ import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { resolveUnder } from "kolu-git";
 
+/** Extensions whose contents the browser renders natively in an iframe.
+ *  Lives here (next to `CONTENT_TYPES`) because both lists are facets of
+ *  the same iframe-rendering decision — adding a new previewable extension
+ *  means adding its Content-Type below, and they can no longer drift
+ *  across packages. `.html`/`.htm` are the primary use case (agent-
+ *  generated artifacts); `.svg`/`.pdf` come along for free. */
+export const IFRAME_PREVIEWABLE_EXTENSIONS = [
+  ".html",
+  ".htm",
+  ".svg",
+  ".pdf",
+] as const;
+
+export function isIframePreviewable(filePath: string): boolean {
+  const lower = filePath.toLowerCase();
+  return IFRAME_PREVIEWABLE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
 const CONTENT_TYPES: Record<string, string> = {
-  // Iframe-previewable kinds (must match IFRAME_PREVIEWABLE_EXTENSIONS).
+  // Iframe-previewable kinds — co-located with
+  // `IFRAME_PREVIEWABLE_EXTENSIONS` above. Drift impossible.
   ".html": "text/html; charset=utf-8",
   ".htm": "text/html; charset=utf-8",
   ".svg": "image/svg+xml",

--- a/packages/server/src/iframePreviewRoute.ts
+++ b/packages/server/src/iframePreviewRoute.ts
@@ -1,6 +1,7 @@
 /** HTTP route serving repo files for the iframe-preview surface
- *  (`FsReadFileOutput.kind === "binary"`). URL contract lives in
- *  `kolu-git/schemas`'s `buildIframePreviewUrl` — keep the two in sync.
+ *  (`FsReadFileOutput.kind === "binary"`). URL contract (`buildIframePreviewUrl`,
+ *  `TERMINAL_FILE_ROUTE_BASE`, `TERMINAL_FILE_ROUTE_FILE_SEGMENT`) lives in
+ *  this module — `kolu-git/schemas` holds only the wire shape (`FsReadFileOutputSchema`).
  *
  *  Two-stage path-traversal guard:
  *    1. Inspect raw URL-decoded segments and reject `..` or empty parts

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,12 +14,14 @@ import pkg from "../package.json" with { type: "json" };
 import { getCacheControlHeader } from "./cacheControl.ts";
 import { startDiagnostics } from "./diagnostics.ts";
 import { serverHostname } from "./hostname.ts";
+import { resolvePreviewPath, serveResolvedFile } from "./iframePreviewRoute.ts";
 import { ensureKoluRoot, shutdownCleanup } from "./koluRoot.ts";
 import { log } from "./log.ts";
 import { pwaIdentityForHostname } from "./pwaIdentity.ts";
 import { appRouter } from "./router.ts";
 import { initSessionAutoSave } from "./session.ts";
 import { configureNixShellEnv } from "./shell.ts";
+import { getTerminal } from "./terminal-registry.ts";
 import { snapshotSession } from "./terminals.ts";
 import { resolveTlsOptions } from "./tls.ts";
 
@@ -147,6 +149,36 @@ process.on("unhandledRejection", (reason) => {
 
 // --- Health endpoint ---
 app.get("/api/health", (c) => c.text("kolu"));
+
+// --- Iframe preview file route ---
+// Serves repo files referenced by `FsReadFileOutput.kind === "binary"`.
+// URL contract lives in `kolu-git/schemas`'s `buildIframePreviewUrl`.
+// Registered before the static-serve catch-all so production builds don't
+// shadow this route with `serveStatic`'s `/*` matcher.
+app.get("/api/terminals/:terminalId/file/*", async (c) => {
+  const terminalId = c.req.param("terminalId");
+  const prefix = `/api/terminals/${terminalId}/file/`;
+  // Use the raw decoded path from req.url to keep our own URL-decoding
+  // pipeline (see `resolvePreviewPath`) in charge of segment parsing —
+  // anything Hono pre-decodes here would bypass the guard.
+  const rawTail = c.req.path.startsWith(prefix)
+    ? c.req.path.slice(prefix.length)
+    : "";
+
+  const term = getTerminal(terminalId);
+  const repoRoot = term?.meta.git?.repoRoot;
+  if (!repoRoot) return c.text("terminal has no repo", 404);
+
+  const res = await serveResolvedFile(resolvePreviewPath(repoRoot, rawTail));
+  // `Buffer` (subclass of `Uint8Array<ArrayBufferLike>`) is a runtime-valid
+  // `BodyInit` but the DOM-typed lib.dom.d.ts narrows `BodyInit` to
+  // `Uint8Array<ArrayBuffer>` — the unions don't align in TS even though
+  // node-server forwards the buffer unchanged. Cast at the boundary.
+  return new Response(res.body as BodyInit, {
+    status: res.status,
+    headers: res.headers,
+  });
+});
 
 // --- Dynamic PWA manifest (includes hostname) ---
 app.get("/manifest.webmanifest", (c) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,7 +14,12 @@ import pkg from "../package.json" with { type: "json" };
 import { getCacheControlHeader } from "./cacheControl.ts";
 import { startDiagnostics } from "./diagnostics.ts";
 import { serverHostname } from "./hostname.ts";
-import { resolvePreviewPath, serveResolvedFile } from "./iframePreviewRoute.ts";
+import {
+  resolvePreviewPath,
+  serveResolvedFile,
+  TERMINAL_FILE_ROUTE_BASE,
+  TERMINAL_FILE_ROUTE_FILE_SEGMENT,
+} from "./iframePreviewRoute.ts";
 import { ensureKoluRoot, shutdownCleanup } from "./koluRoot.ts";
 import { log } from "./log.ts";
 import { pwaIdentityForHostname } from "./pwaIdentity.ts";
@@ -152,33 +157,36 @@ app.get("/api/health", (c) => c.text("kolu"));
 
 // --- Iframe preview file route ---
 // Serves repo files referenced by `FsReadFileOutput.kind === "binary"`.
-// URL contract lives in `kolu-git/schemas`'s `buildIframePreviewUrl`.
+// URL contract (base + builder + parser) all lives in `iframePreviewRoute.ts`.
 // Registered before the static-serve catch-all so production builds don't
 // shadow this route with `serveStatic`'s `/*` matcher.
-app.get("/api/terminals/:terminalId/file/*", async (c) => {
-  const terminalId = c.req.param("terminalId");
-  const prefix = `/api/terminals/${terminalId}/file/`;
-  // Use the raw decoded path from req.url to keep our own URL-decoding
-  // pipeline (see `resolvePreviewPath`) in charge of segment parsing —
-  // anything Hono pre-decodes here would bypass the guard.
-  const rawTail = c.req.path.startsWith(prefix)
-    ? c.req.path.slice(prefix.length)
-    : "";
+app.get(
+  `${TERMINAL_FILE_ROUTE_BASE}/:terminalId/${TERMINAL_FILE_ROUTE_FILE_SEGMENT}/*`,
+  async (c) => {
+    const terminalId = c.req.param("terminalId");
+    const prefix = `${TERMINAL_FILE_ROUTE_BASE}/${terminalId}/${TERMINAL_FILE_ROUTE_FILE_SEGMENT}/`;
+    // Use the raw decoded path from req.url to keep our own URL-decoding
+    // pipeline (see `resolvePreviewPath`) in charge of segment parsing —
+    // anything Hono pre-decodes here would bypass the guard.
+    const rawTail = c.req.path.startsWith(prefix)
+      ? c.req.path.slice(prefix.length)
+      : "";
 
-  const term = getTerminal(terminalId);
-  const repoRoot = term?.meta.git?.repoRoot;
-  if (!repoRoot) return c.text("terminal has no repo", 404);
+    const term = getTerminal(terminalId);
+    const repoRoot = term?.meta.git?.repoRoot;
+    if (!repoRoot) return c.text("terminal has no repo", 404);
 
-  const res = await serveResolvedFile(resolvePreviewPath(repoRoot, rawTail));
-  // `Buffer` (subclass of `Uint8Array<ArrayBufferLike>`) is a runtime-valid
-  // `BodyInit` but the DOM-typed lib.dom.d.ts narrows `BodyInit` to
-  // `Uint8Array<ArrayBuffer>` — the unions don't align in TS even though
-  // node-server forwards the buffer unchanged. Cast at the boundary.
-  return new Response(res.body as BodyInit, {
-    status: res.status,
-    headers: res.headers,
-  });
-});
+    const res = await serveResolvedFile(resolvePreviewPath(repoRoot, rawTail));
+    // `Buffer` (subclass of `Uint8Array<ArrayBufferLike>`) is a runtime-valid
+    // `BodyInit` but the DOM-typed lib.dom.d.ts narrows `BodyInit` to
+    // `Uint8Array<ArrayBuffer>` — the unions don't align in TS even though
+    // node-server forwards the buffer unchanged. Cast at the boundary.
+    return new Response(res.body as BodyInit, {
+      status: res.status,
+      headers: res.headers,
+    });
+  },
+);
 
 // --- Dynamic PWA manifest (includes hostname) ---
 app.get("/manifest.webmanifest", (c) => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -165,9 +165,11 @@ app.get(
   async (c) => {
     const terminalId = c.req.param("terminalId");
     const prefix = `${TERMINAL_FILE_ROUTE_BASE}/${terminalId}/${TERMINAL_FILE_ROUTE_FILE_SEGMENT}/`;
-    // Use the raw decoded path from req.url to keep our own URL-decoding
-    // pipeline (see `resolvePreviewPath`) in charge of segment parsing —
-    // anything Hono pre-decodes here would bypass the guard.
+    // Slice the tail off `c.req.path` (Hono applies `decodeURI` here, so
+    // `%2f` stays encoded) rather than read `c.req.param("*")` (which
+    // applies `decodeURIComponent` — that would decode `%2f` → `/` and
+    // destroy segment boundaries before `resolvePreviewPath`'s split
+    // could see them, letting `foo%2f..%2fpasswd` through the guard).
     const rawTail = c.req.path.startsWith(prefix)
       ? c.req.path.slice(prefix.length)
       : "";

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -40,15 +40,19 @@ import { contract } from "kolu-common/contract";
 import { TerminalNotFoundError } from "kolu-common/errors";
 import { surface } from "kolu-common/surface";
 import {
+  buildIframePreviewUrl,
   fsListAllOutputEqual,
+  type FsReadFileOutput,
   fsReadFileOutputEqual,
   type GitResult,
   getDiff,
   getStatus,
   gitDiffOutputEqual,
   gitStatusOutputEqual,
+  isIframePreviewable,
   listAll,
   readFile,
+  statFileMtimeMs,
   subscribeFileChange,
   subscribeRepoChange,
 } from "kolu-git";
@@ -224,8 +228,25 @@ const { router: surfaceRouterFragment, ctx: surfaceCtxBuilt } =
         isEqual: fsListAllOutputEqual,
       },
       fsReadFile: {
-        read: async (input) =>
-          unwrapGit(await readFile(input.repoPath, input.filePath, log)),
+        read: async (input): Promise<FsReadFileOutput> => {
+          if (isIframePreviewable(input.filePath)) {
+            const mtimeMs = unwrapGit(
+              await statFileMtimeMs(input.repoPath, input.filePath, log),
+            );
+            return {
+              kind: "binary",
+              url: buildIframePreviewUrl(
+                input.terminalId,
+                input.filePath,
+                mtimeMs,
+              ),
+            };
+          }
+          const { content, truncated } = unwrapGit(
+            await readFile(input.repoPath, input.filePath, log),
+          );
+          return { kind: "text", content, truncated };
+        },
         install: (input, cb) =>
           subscribeFileChange(input.repoPath, input.filePath, cb, log),
         isEqual: fsReadFileOutputEqual,

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -40,7 +40,6 @@ import { contract } from "kolu-common/contract";
 import { TerminalNotFoundError } from "kolu-common/errors";
 import { surface } from "kolu-common/surface";
 import {
-  buildIframePreviewUrl,
   fsListAllOutputEqual,
   type FsReadFileOutput,
   fsReadFileOutputEqual,
@@ -55,7 +54,10 @@ import {
   subscribeFileChange,
   subscribeRepoChange,
 } from "kolu-git";
-import { isIframePreviewable } from "./iframePreviewRoute.ts";
+import {
+  buildIframePreviewUrl,
+  isIframePreviewable,
+} from "./iframePreviewRoute.ts";
 import { log } from "./log.ts";
 import { publisher } from "./publisher.ts";
 import { cancelPendingAutosave, getSavedSession } from "./session.ts";

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -49,13 +49,13 @@ import {
   getStatus,
   gitDiffOutputEqual,
   gitStatusOutputEqual,
-  isIframePreviewable,
   listAll,
   readFile,
   statFileMtimeMs,
   subscribeFileChange,
   subscribeRepoChange,
 } from "kolu-git";
+import { isIframePreviewable } from "./iframePreviewRoute.ts";
 import { log } from "./log.ts";
 import { publisher } from "./publisher.ts";
 import { cancelPendingAutosave, getSavedSession } from "./session.ts";

--- a/packages/surface/README.md
+++ b/packages/surface/README.md
@@ -361,7 +361,7 @@ Concrete inventory — what every server-pushed reactive surface in Kolu maps to
 | `gitStatusStream` | Code-view's Local/Branch mode file list (changed files) |
 | `gitDiffStream` | Code-view's unified diff for the selected file |
 | `fsListAllStream` | Code-view's All mode tree (full repo path list) |
-| `fsReadFileStream` | Code-view's All mode body (file content) |
+| `fsReadFileStream` | Code-view's All mode body — discriminated by `kind`: `text` yields the file content for Pierre's syntax-highlighted viewer; `binary` yields a cache-busted URL pointing at `/api/terminals/<id>/file/<path>?v=<mtime>` for the iframe-preview viewer (`.html`/`.svg`/`.pdf`). One subscription path; mtime bump on save re-yields a fresh URL so the iframe reloads. |
 
 ### Events
 

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -311,6 +311,21 @@ Feature: Code tab (review + browse)
     Then the file content should contain "hello"
     And the file preview iframe should not be visible
 
+  # ── Tree/content vertical split is draggable ──
+  # The tree pane used to be a fixed `h-[35%]`; it's now a Corvu Resizable
+  # panel keyed off `preferences.rightPanel.codeTabTreeSize`. The handle
+  # presence is the wiring proof — persistence rides on the same
+  # `updatePreferences` infra the horizontal split already covers in
+  # `right-panel.feature`.
+
+  Scenario: Tree/content split has a draggable handle
+    When I run "rm -rf /tmp/kolu-tree-resize && git init /tmp/kolu-tree-resize && cd /tmp/kolu-tree-resize"
+    And I run "printf 'hello\n' > note.txt"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    Then the Code tab tree pane split handle should be visible
+
   Scenario: File browser expands directories lazily
     When I run "git init /tmp/kolu-browse-expand && cd /tmp/kolu-browse-expand"
     And I run "mkdir -p lib && printf 'x\n' > lib/util.ts"

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -276,6 +276,41 @@ Feature: Code tab (review + browse)
     Then the file content should contain "prefix-"
     And the file content should wrap long lines
 
+  # ── Browse mode: iframe preview for .html / .svg / .pdf ──
+  # Files whose extension matches `isIframePreviewable` (see
+  # `kolu-git/schemas`) render in `BrowsePreviewView` (an `<iframe>` pointed
+  # at the per-terminal file route) instead of Pierre's syntax-highlighted
+  # `FileView`. The discriminator lives on the wire (`FsReadFileOutput.kind`)
+  # so the client never sees the extension list.
+
+  Scenario: HTML file renders in an iframe instead of as code
+    When I run "rm -rf /tmp/kolu-iframe-html && git init /tmp/kolu-iframe-html && cd /tmp/kolu-iframe-html"
+    And I run "printf '<!doctype html><h1>preview</h1>\n' > page.html"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    When I click the file "page.html" in the file browser
+    Then the file preview iframe should be visible
+
+  Scenario: SVG file renders in the iframe preview
+    When I run "rm -rf /tmp/kolu-iframe-svg && git init /tmp/kolu-iframe-svg && cd /tmp/kolu-iframe-svg"
+    And I run "printf '<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"/>\n' > logo.svg"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    When I click the file "logo.svg" in the file browser
+    Then the file preview iframe should be visible
+
+  Scenario: Plain text file still renders as syntax-highlighted code (no iframe)
+    When I run "rm -rf /tmp/kolu-iframe-text && git init /tmp/kolu-iframe-text && cd /tmp/kolu-iframe-text"
+    And I run "printf 'hello\n' > note.txt"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    When I click the file "note.txt" in the file browser
+    Then the file content should contain "hello"
+    And the file preview iframe should not be visible
+
   Scenario: File browser expands directories lazily
     When I run "git init /tmp/kolu-browse-expand && cd /tmp/kolu-browse-expand"
     And I run "mkdir -p lib && printf 'x\n' > lib/util.ts"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -495,6 +495,22 @@ Then(
 );
 
 Then(
+  "the Code tab tree pane split handle should be visible",
+  async function (this: KoluWorld) {
+    // The handle's own bounding box is intentionally zero-height (`h-0`);
+    // a `::before` pseudo-element draws the actual hit area. Playwright's
+    // `visible` check rejects zero-dimension elements, so assert
+    // `attached` (in DOM) + a non-empty `data-corvu-resizable-handle`
+    // attribute — proof the Corvu primitive is wired up, not just a stray
+    // div carrying the testid.
+    const handle = this.page.locator(
+      '[data-testid="diff-tree-content-handle"][data-corvu-resizable-handle]',
+    );
+    await handle.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
   "the file preview iframe should not be visible",
   async function (this: KoluWorld) {
     // `display:none` parents (inactive tabs, collapsed panel) still leave

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -484,6 +484,32 @@ Then(
   },
 );
 
+// ── Iframe preview (.html / .svg / .pdf in browse mode) ──
+
+Then(
+  "the file preview iframe should be visible",
+  async function (this: KoluWorld) {
+    const iframe = this.page.locator('[data-testid="browse-preview-iframe"]');
+    await iframe.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the file preview iframe should not be visible",
+  async function (this: KoluWorld) {
+    // `display:none` parents (inactive tabs, collapsed panel) still leave
+    // the iframe in the DOM. The text path is "not rendered at all" — assert
+    // count, not visibility, so the absence is read literally.
+    await this.page.waitForFunction(
+      () =>
+        document.querySelectorAll('[data-testid="browse-preview-iframe"]')
+          .length === 0,
+      undefined,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // ── Right-panel tab switching + filter input ──
 
 When(

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -387,6 +387,7 @@ Before(async function (this: KoluWorld, scenario) {
           size: 0.25,
           activeTab: "inspector",
           codeMode: "local",
+          codeTabTreeSize: 0.35,
         },
       },
     }),


### PR DESCRIPTION
Kolu's Code tab now renders agent-generated `.html`, `.svg`, and `.pdf` files inline in a sandboxed iframe instead of as syntax-highlighted source. **Selecting one of those files in the existing browse-mode tree swaps to the iframe**; text files still render through Pierre's `FileView` exactly as before.

Sets up #881 phase 2 (HTML annotator via lavish-axi's `artifact-sdk.js`) — this PR establishes the iframe rendering surface that phase will inject the annotation SDK into. _Comments and selection are deliberately not part of this PR; it's the render primitive only._

### How the variant is picked

```text
fsReadFile(repo, file) ──▶ isIframePreviewable(ext)?
                                    │
              ┌─────────────────────┴────────────────────┐
              ▼                                          ▼
        kind: "text"                              kind: "binary"
        { content, truncated }                    { url: /api/terminals/<id>/file/<path>?v=<mtime> }
              │                                          │
              ▼                                          ▼
       BrowseFileView                            BrowsePreviewView
       (Pierre's FileView)                       (<iframe sandbox="allow-scripts">)
```

The `kind` discriminator lives on the wire (`FsReadFileOutputSchema`). The client never sees a file-extension list — it dispatches on `kind` in `BrowseFileDispatcher`. _Server's `fsReadFile` re-yields the binary variant with a bumped `?v=<mtime>` on every save, so the iframe live-reloads through the same subscription path as text — no parallel notification channel._

### Security

- **Sandbox**: `sandbox="allow-scripts"` only — no `allow-same-origin`. Page JS runs in an opaque origin and can't touch Kolu cookies/localStorage. _Cross-origin `fetch()` from inside is blocked; acceptable for static artifacts._
- **Path traversal**: two-stage guard in `iframePreviewRoute.ts`. Stage 1 URL-decodes-then-splits and rejects `..`, `.`, empty, and absolute segments _before_ `path.join` (defends against `%2e%2e`, `foo%2f..%2fpasswd`, double-slash collapsing). Stage 2 calls the existing `resolveUnder` from `kolu-git` for the canonical `path.relative` re-check.
- **Content-Type**: explicit per extension; `X-Content-Type-Options: nosniff` blocks MIME sniffing.

### Refinements during review

Seven follow-up commits from `/hickey`, `/lowy`, and `/code-police` reshaped the boundaries:

| Finding                                                                                          | Fix                                                                                                                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
| `isIframePreviewable` lived in `kolu-git/schemas.ts` — rendering concern in git layer            | Moved to `server/src/iframePreviewRoute.ts` alongside `CONTENT_TYPES` (both lists co-located; drift impossible)                       |
| `buildIframePreviewUrl` similarly server-internal — client never builds the URL, just renders it | Moved to the same module                                                                                                              |
| Route base `/api/terminals/.../file/...` repeated 3×                                             | Extracted `TERMINAL_FILE_ROUTE_BASE` + `TERMINAL_FILE_ROUTE_FILE_SEGMENT`; route registration, builder, and prefix all derive from it |
| Bare `catch {}` mapped every I/O failure to 404                                                  | Branch on `ENOENT` for true 404; surface other errors (`EACCES`, `EIO`) as 500 with the message                                       |
| Stale comment claimed `c.req.path` was "raw" — Hono actually applies `decodeURI`                 | Replaced with the actual rationale: `c.req.param("*")` would `decodeURIComponent` and destroy segment boundaries                      |
| Dead-code `if (v.kind !== "text") return null` inside Match callback (TS couldn't narrow `&&`)   | Pre-narrow each variant via `createMemo`; Match arms receive typed accessors                                                          |

### Coverage

- **16 unit tests** in `iframePreviewRoute.test.ts` — MIME mapping; path-resolver corner cases (`..`, `%2e%2e`, `foo%2f..%2fpasswd`, `//`, trailing `/`, `%zz` malformed, absolute, `.`, empty); serve happy path + 404 + directory-rejection.
- **3 e2e scenarios** in `code-tab.feature` — HTML→iframe, SVG→iframe, `.txt`→no iframe (regression that text path still renders Pierre's FileView).

### Out of scope

- _Dev-server URL browser_ — dropped during design; `ssh -L` + real browser is fine for that.
- _Per-terminal browser tab_ — dropped; feature shrunk to "render the selected file as an iframe when its extension matches."
- _Annotation/comments_ — deferred to #881 phase 2 (HTML annotator).

### Related

Prerequisite for [#881 phase 2](https://github.com/juspay/kolu/issues/881) — the HTML annotator will inject lavish-axi's `artifact-sdk.js` into the iframe surface this PR sets up. This PR is not itself a phase of #881.

### Try it locally

```sh
nix run github:juspay/kolu/feat/iframe-preview
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._