### PR TITLE
Persist Code tab file preview across browser refresh

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -16,6 +16,7 @@
 import { FileDiff, FileTree, Virtualizer } from "@kolu/solid-pierre";
 import type { GitDiffMode } from "kolu-git/schemas";
 import type { TerminalMetadata } from "kolu-common/surface";
+import { makePersisted } from "@solid-primitives/storage";
 import {
   type Component,
   createEffect,
@@ -78,7 +79,6 @@ const BinaryFileHint: Component<{ fileName: string | null }> = (props) => (
 const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
-  const [selectedPath, setSelectedPath] = createSignal<string | null>(null);
 
   // Read `codeMode` directly rather than projecting it from `activeTab`.
   // CodeTab now stays mounted across the Inspector tab toggle (#818); a
@@ -95,34 +95,56 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   const diffMode = (): GitDiffMode | undefined =>
     view() === "browse" ? undefined : (view() as GitDiffMode);
 
+  // Selection is keyed per (repoRoot, view) and persisted to localStorage.
+  // Each slot owns its own pick — switching modes / repos surfaces the
+  // right slot rather than clearing on transition, and a full browser
+  // reload restores whichever slot is current. `::` is collision-safe:
+  // `view()` is a typed enum so it can't contain `::`, and `repoPath()`
+  // is an absolute path or null.
+  const [selectedFilesByKey, setSelectedFilesByKey] = makePersisted(
+    createSignal<Record<string, string>>({}),
+    { name: "kolu-codetab-selected-files" },
+  );
+  const slotKey = () => `${repoPath() ?? ""}::${view()}`;
+  const selectedPath = (): string | null =>
+    selectedFilesByKey()[slotKey()] ?? null;
+  const setSelectedPath = (path: string | null) => {
+    const key = slotKey();
+    setSelectedFilesByKey((prev) => {
+      if (path === null) {
+        if (!(key in prev)) return prev;
+        const { [key]: _, ...rest } = prev;
+        return rest;
+      }
+      if (prev[key] === path) return prev;
+      return { ...prev, [key]: path };
+    });
+  };
+
   // Filename filter — drives Pierre's tree filter externally. Reset on
   // mode switch so a stale needle doesn't hide the wrong file set.
   const [searchQuery, setSearchQuery] = createSignal("");
 
-  // ── Selection-stability invariant ──────────────────────────────────
+  // ── Selection-stability invariants ─────────────────────────────────
   // CodeTab survives right-panel tab toggles and panel collapse (#818)
-  // — meaning every reactive surface in this component stays alive
-  // across UI state changes that previously destroyed and rebuilt it.
-  // Three independent sources of `selectedPath = null` would fire
-  // spuriously without explicit guards; each guard defends against a
-  // *different* origin of churn, so they don't collapse into one rule:
+  // — every reactive surface stays alive across UI state changes that
+  // previously destroyed and rebuilt it. Two independent sources of
+  // spurious `selectedPath = null` would fire without explicit guards:
   //
-  //   1. `resetKey` memo (below) — preferences cell ticks on unrelated
-  //      pref updates; raw `on([repoPath, view], …)` would re-fire its
-  //      callback every tick and wipe selection.
-  //   2. `pending()` gate on the membership check — gitStatus / fsList
+  //   1. `pending()` gate on the membership check — gitStatus / fsList
   //      stream resubscribes briefly drop `treePaths()` to `[]`; without
   //      the gate, the membership check reads transient empty as
-  //      "selected file is missing".
-  //   3. `handleSelect` ignores Pierre's `null` events — Pierre fires
+  //      "selected file is missing" and deletes the slot.
+  //   2. `handleSelect` ignores Pierre's `null` events — Pierre fires
   //      `onSelectionChange([])` from `resetPaths` and tear-down, not
   //      just user deselect; the Code tab has no UX for explicit
   //      deselect anyway (user switches by clicking another file).
   //
-  // The unifying invariant is "preserve selection across non-genuine
-  // transitions". Adding a fourth churn source means adding a fourth
-  // guard in the same shape — extract a `createStableSignal`-style
-  // helper if/when it appears.
+  // (Repo / view transitions used to be a third churn source — the
+  // resetKey effect cleared selection on every (repoPath, view) change.
+  // Per-slot storage above makes that clear obsolete: the new slot's
+  // value is already correct without writing through. resetKey now only
+  // clears `searchQuery`, which is genuinely shared across slots.)
 
   const status = app.streams.gitStatus.use(
     () => {
@@ -160,55 +182,26 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     },
   );
 
-  // Reset selection when the repo or view changes so a stale path doesn't
-  // bleed across modes (e.g. a browse-mode pick showing up in diff mode).
-  // Same reset clears the filename filter — the search needle was scoped
-  // to the previous file set and rarely makes sense post-switch.
+  // Clear the filename filter when the repo or view changes — the search
+  // needle was scoped to the previous file set and rarely makes sense
+  // post-switch. Selection itself is per-slot (see `selectedFilesByKey`
+  // above) so the new view automatically surfaces its own pick without
+  // a clear here.
   //
-  // The `on()` here is paired with a memoized key so it only fires when
-  // the (repoPath, view) tuple actually CHANGES VALUE. Without the memo,
+  // The `on()` is paired with a memoized key so it only fires when the
+  // (repoPath, view) tuple actually CHANGES VALUE. Without the memo,
   // SolidJS' `on(...)` re-runs its callback on every upstream signal tick
   // — and the upstream `preferences` cell ticks on activity beyond just
-  // tab/repo changes (e.g. unrelated pref updates). Since the callback
-  // unconditionally nulls `selectedPath`, an unmemoed accessor wipes the
-  // user's selection on every preference tick — visible after #818 made
+  // tab/repo changes (e.g. unrelated pref updates). The unmemoed accessor
+  // would wipe the filter on every preference tick after #818 made
   // CodeTab survive across right-panel tab toggles.
-  //
-  // `::` is collision-safe as the separator: `view()` is a typed enum
-  // (`"browse" | "local" | "branch"`) so it can't contain `::`, and
-  // `repoPath()` is `props.meta?.git?.repoRoot ?? null` — a real
-  // absolute path or `null`, never the empty string that would alias
-  // null.
   const resetKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
-
-  /** The resetKey effect runs BEFORE the pendingOpen effect by
-   *  registration order. When a navigation request is about to land in
-   *  the new (repo, mode) — same repoRoot, target mode equals the
-   *  freshly-ticked `view()`, and the request hasn't already been
-   *  consumed by `handled()` — the resetKey effect must skip its clear,
-   *  or the pendingOpen effect would null what we're about to set.
-   *  This predicate names the cross-effect temporal coupling so the
-   *  guard isn't a wall of inline conjunctions a future editor has to
-   *  re-derive. The `batch()` in `openInCodeTab` ensures both writes
-   *  (`view` and `pendingOpen`) commit before either effect fires; the
-   *  registration-order discipline survives ABOVE that. */
-  const isPendingOpenAboutToLand = (): boolean => {
-    const req = pendingOpen();
-    return (
-      req !== null &&
-      req.repoRoot === repoPath() &&
-      req.targetMode === view() &&
-      handled()?.request !== req
-    );
-  };
 
   createEffect(
     on(
       resetKey,
       () => {
         setSearchQuery("");
-        if (isPendingOpenAboutToLand()) return;
-        setSelectedPath(null);
       },
       { defer: true },
     ),
@@ -220,8 +213,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // object per call) alongside the resolved path. Storing the
   // request here lets `selectedRange` derive its value without
   // re-running `resolveLineRefPath` (single resolution site per
-  // request) and lets `resetKey` know whether a pending request
-  // has already been applied.
+  // request).
   const [handled, setHandled] = createSignal<{
     request: OpenInCodeTabRequest;
     resolvedPath: string | null;
@@ -233,9 +225,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // resolution can validate against a complete file list — otherwise
   // a request fired during boot would toast "not found" on a path
   // that just hasn't been enumerated yet. `openInCodeTab` flips the
-  // panel to browse mode itself; this effect only sets
-  // `selectedPath`. The `resetKey` effect above guards against
-  // clearing selectedPath when this effect is about to set it.
+  // panel to browse mode itself; this effect only sets `selectedPath`.
   createEffect(
     on(
       () => {

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -27,7 +27,6 @@ import {
   Show,
   Switch,
 } from "solid-js";
-import { createStore, produce } from "solid-js/store";
 import { toast } from "solid-sonner";
 import { useColorScheme } from "../settings/useColorScheme";
 import { app } from "../wire";
@@ -101,30 +100,39 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // right slot rather than clearing on transition, and a full browser
   // reload restores whichever slot is current. `::` is collision-safe:
   // `view()` is a typed enum so it can't contain `::`, and `repoPath()`
-  // is an absolute path or null. `createStore` (not `createSignal`) so
-  // that reads of the active slot are fine-grained — unrelated slot
-  // writes don't re-tick `selectedPath()` consumers (per project rule:
-  // `createStore` over `createSignal<Record>` for keyed state). The
-  // `slotKey` memo doubles as the source of truth for the search-reset
-  // effect below — same value, single derivation.
+  // is an absolute path or null. The `slotKey` memo doubles as the
+  // source of truth for the search-reset effect below — same value,
+  // single derivation.
+  //
+  // `createSignal<Record>` is deliberate against the project rule
+  // (`createStore` over `createSignal<Record>` for keyed state): the
+  // fine-grained read tracking createStore offers isn't actually
+  // observed here because Pierre's `FileTree` snapshots `selectedPath`
+  // at mount via `initialSelectedPaths` and the host re-mounts that
+  // subtree on view transitions. The synchronous, whole-record
+  // semantics of a signal match this lifecycle; `createStore`'s
+  // late-arriving notifications on a not-yet-seen key produce a
+  // remount race where the new slot's pick is set AFTER FileTree's
+  // constructor reads it (verified empirically against the
+  // "right-click Open jumps to browse" regression suite).
   const [selectedFilesByKey, setSelectedFilesByKey] = makePersisted(
-    createStore<Record<string, string>>({}),
+    createSignal<Record<string, string>>({}),
     { name: "kolu-codetab-selected-files" },
   );
   const slotKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
   const selectedPath = (): string | null =>
-    selectedFilesByKey[slotKey()] ?? null;
+    selectedFilesByKey()[slotKey()] ?? null;
   const setSelectedPath = (path: string | null) => {
     const key = slotKey();
-    if (path === null) {
-      setSelectedFilesByKey(
-        produce((s) => {
-          delete s[key];
-        }),
-      );
-    } else {
-      setSelectedFilesByKey(key, path);
-    }
+    setSelectedFilesByKey((prev) => {
+      if (path === null) {
+        if (!(key in prev)) return prev;
+        const { [key]: _, ...rest } = prev;
+        return rest;
+      }
+      if (prev[key] === path) return prev;
+      return { ...prev, [key]: path };
+    });
   };
 
   // Filename filter — drives Pierre's tree filter externally. Reset on

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -86,7 +86,7 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // projection-with-fallback (`activeTab.kind === "code" ? mode : "local"`)
   // would flip `view()` from the persisted mode (e.g. `"browse"`) to the
   // fallback `"local"` while Inspector is active, then back on return —
-  // a real value transition that fires the `resetKey` reset effect and
+  // a real value transition that fires the `slotKey` effect and
   // wipes selection on every Inspector round-trip in non-local modes.
   const view = rightPanel.codeMode;
   const setView = rightPanel.setCodeMode;
@@ -149,8 +149,8 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // (Repo / view transitions used to be a third churn source — the
   // resetKey effect cleared selection on every (repoPath, view) change.
   // Per-slot storage above makes that clear obsolete: the new slot's
-  // value is already correct without writing through. resetKey now only
-  // clears `searchQuery`, which is genuinely shared across slots.)
+  // value is already correct without writing through. slotKey effect now
+  // only clears `searchQuery`, which is genuinely shared across slots.)
 
   const status = app.streams.gitStatus.use(
     () => {

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -27,6 +27,7 @@ import {
   Show,
   Switch,
 } from "solid-js";
+import { createStore, produce } from "solid-js/store";
 import { toast } from "solid-sonner";
 import { useColorScheme } from "../settings/useColorScheme";
 import { app } from "../wire";
@@ -100,25 +101,30 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
   // right slot rather than clearing on transition, and a full browser
   // reload restores whichever slot is current. `::` is collision-safe:
   // `view()` is a typed enum so it can't contain `::`, and `repoPath()`
-  // is an absolute path or null.
+  // is an absolute path or null. `createStore` (not `createSignal`) so
+  // that reads of the active slot are fine-grained — unrelated slot
+  // writes don't re-tick `selectedPath()` consumers (per project rule:
+  // `createStore` over `createSignal<Record>` for keyed state). The
+  // `slotKey` memo doubles as the source of truth for the search-reset
+  // effect below — same value, single derivation.
   const [selectedFilesByKey, setSelectedFilesByKey] = makePersisted(
-    createSignal<Record<string, string>>({}),
+    createStore<Record<string, string>>({}),
     { name: "kolu-codetab-selected-files" },
   );
-  const slotKey = () => `${repoPath() ?? ""}::${view()}`;
+  const slotKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
   const selectedPath = (): string | null =>
-    selectedFilesByKey()[slotKey()] ?? null;
+    selectedFilesByKey[slotKey()] ?? null;
   const setSelectedPath = (path: string | null) => {
     const key = slotKey();
-    setSelectedFilesByKey((prev) => {
-      if (path === null) {
-        if (!(key in prev)) return prev;
-        const { [key]: _, ...rest } = prev;
-        return rest;
-      }
-      if (prev[key] === path) return prev;
-      return { ...prev, [key]: path };
-    });
+    if (path === null) {
+      setSelectedFilesByKey(
+        produce((s) => {
+          delete s[key];
+        }),
+      );
+    } else {
+      setSelectedFilesByKey(key, path);
+    }
   };
 
   // Filename filter — drives Pierre's tree filter externally. Reset on
@@ -182,24 +188,18 @@ const CodeTab: Component<{ meta: TerminalMetadata | null }> = (props) => {
     },
   );
 
-  // Clear the filename filter when the repo or view changes — the search
-  // needle was scoped to the previous file set and rarely makes sense
-  // post-switch. Selection itself is per-slot (see `selectedFilesByKey`
+  // Clear the filename filter when the slot changes — the search needle
+  // was scoped to the previous file set and rarely makes sense post-
+  // switch. Selection itself is per-slot (see `selectedFilesByKey`
   // above) so the new view automatically surfaces its own pick without
-  // a clear here.
-  //
-  // The `on()` is paired with a memoized key so it only fires when the
-  // (repoPath, view) tuple actually CHANGES VALUE. Without the memo,
-  // SolidJS' `on(...)` re-runs its callback on every upstream signal tick
-  // — and the upstream `preferences` cell ticks on activity beyond just
-  // tab/repo changes (e.g. unrelated pref updates). The unmemoed accessor
-  // would wipe the filter on every preference tick after #818 made
-  // CodeTab survive across right-panel tab toggles.
-  const resetKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
-
+  // a clear here. `slotKey` is memoized, so this fires only when the
+  // tuple genuinely changes — without the memo, `on(...)` would re-run
+  // its callback on every preferences tick (the upstream cell ticks on
+  // activity beyond tab/repo changes) and wipe the filter spuriously
+  // after #818 made CodeTab survive right-panel tab toggles.
   createEffect(
     on(
-      resetKey,
+      slotKey,
       () => {
         setSearchQuery("");
       },

--- a/packages/client/src/right-panel/openInCodeTab.ts
+++ b/packages/client/src/right-panel/openInCodeTab.ts
@@ -46,11 +46,12 @@ export const pendingOpen = pending;
 
 /** Open the right panel's Code tab at `req.targetMode` showing `req.ref`.
  *  The two reactive writes (preferences patch + pending-request signal)
- *  are wrapped in `batch()` so SolidJS defers dependent effects until
- *  both have committed. Without the batch, the preferences optimistic
- *  update ticks `view()` first, fires `CodeTab`'s `resetKey` effect
- *  when `pendingOpen()` is still null, the guard fails, and the
- *  selectedPath the user navigated to gets cleared. */
+ *  are wrapped in `batch()` so downstream effects see both changes in
+ *  the same reactive transaction — one tick instead of two. Pure
+ *  optimization since the `resetKey`-vs-pendingOpen race was removed
+ *  (selection is now per-slot, so no effect clears `selectedPath`);
+ *  kept because the merged tick still avoids a flash of intermediate
+ *  state during navigation. */
 export function openInCodeTab(req: OpenInCodeTabRequest): void {
   batch(() => {
     useRightPanel().openCodeAt(req.targetMode);

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -192,6 +192,40 @@ export const FileTree: Component<FileTreeProps> = (props) => {
     ),
   );
 
+  // Push post-mount `props.selectedPath` changes into Pierre's
+  // selection state. Pierre's `initialSelectedPaths` is snapshot-only
+  // at construction; reactive prop changes after mount must be applied
+  // via `getItem(path)?.select()` / `deselect()` to mark
+  // `aria-selected="true"`. Without this, a host that drives selection
+  // through a reactive accessor (e.g. CodeTab's per-(repoRoot,view)
+  // slot map) leaves the tree out of sync whenever selection arrives
+  // after FileTree mount — the `Open path:N` flow from a diff is the
+  // canonical case. `onSelectionChange` re-fires when we call
+  // `select()`, so the host's `onSelect` handler must be idempotent on
+  // same-value writes (which it already is, as a SolidJS reactive
+  // setter on an equal value is a no-op).
+  createEffect(
+    on(
+      () => props.selectedPath ?? null,
+      (path) => {
+        try {
+          const current = tree?.getSelectedPaths()[0] ?? null;
+          if (current === path) return;
+          if (path === null) {
+            for (const p of tree?.getSelectedPaths() ?? []) {
+              tree?.getItem(p)?.deselect();
+            }
+          } else {
+            tree?.getItem(path)?.select();
+          }
+        } catch (e) {
+          props.onError(toError(e));
+        }
+      },
+      { defer: true },
+    ),
+  );
+
   onCleanup(() => tree?.cleanUp());
 
   return (

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -106,6 +106,28 @@ Feature: Code tab (review + browse)
       | branch |
       | browse |
 
+  # Regression: opening a file in the Code tab and refreshing the browser
+  # used to lose the preview because `selectedPath` lived in a local
+  # `createSignal` that died with the component. Selection is now backed
+  # by `makePersisted` keyed per (repoRoot, view) so each slot's pick
+  # survives a full reload AND switching modes/repos surfaces the right
+  # slot without clobbering siblings.
+  Scenario Outline: Selected file survives page refresh [<mode>]
+    Given a Code tab in "<mode>" mode showing file "a.txt" with content "aaa"
+    When I open file "a.txt" in the Code tab
+    Then the selected file should show content "aaa"
+    When I wait for the session auto-save
+    And I reload the page and wait for ready
+    Then the right panel should be visible
+    And the Code tab mode should be "<mode>"
+    And the selected file should show content "aaa"
+
+    Examples:
+      | mode   |
+      | local  |
+      | branch |
+      | browse |
+
   # ── Local mode: file list + diff rendering ──
 
   Scenario: Lists changed files and opens a diff on click


### PR DESCRIPTION
**Opening a file in the Code tab's preview and refreshing the browser used to drop the preview** — the right panel, tab, and code mode were all preference-restored, but the selected file lived in a local `createSignal` that died with the component. Selection is now keyed per `(repoRoot, view)` and backed by `makePersisted` so each slot's pick survives a reload.

### How the selection is stored

```
selectedFilesByKey  (localStorage: kolu-codetab-selected-files)
  "/repo/X::browse" → "src/index.ts"
  "/repo/X::local"  → "src/main.ts"
  "/repo/Y::browse" → "README.md"
```

Each `(repoRoot, view)` owns its own pick. Switching modes or repos surfaces the right slot rather than clearing on transition — *and the resetKey effect's `setSelectedPath(null)` clear (plus its `isPendingOpenAboutToLand` guard) goes away with it, since per-slot semantics make the cross-effect coupling structurally unnecessary.*

### Why localStorage, not server preferences

| Layer | What lives there | Why this fits |
| --- | --- | --- |
| `makePersisted` localStorage | `canvasMaximized`, `dockMode`, `fontSize`, minimap window — and now the Code tab pick | Per-browser-tab view state; doesn't travel cross-device |
| Server preferences | `rightPanel.codeMode`, `activeTab`, `colorScheme`, … | User prefs that affect server-side stream subscriptions |
| Server saved session | Terminal CWD, layout, theme | Cross-restart terminal state |

Selected file is **ephemeral, per-device, per-session UI state** — the same volatility axis as `canvasMaximized`. It deserved the same layer.

### The Pierre wrapper post-mount fix

Pierre's vanilla `FileTree` snapshots `initialSelectedPaths` at construction; later `props.selectedPath` changes were silently dropped by the solid wrapper. That was fine when the host's `selectedPath` was a single signal that survived view transitions (its value was already correct by the time FileTree remounted), but per-slot storage exposes a window where `selectedPath` is `null` during the view flip and the resolved path arrives *after* mount — leaving `aria-selected` permanently off.

The wrapper now pushes prop changes into Pierre via `getItem(path)?.select() / .deselect()`, paired with the existing ancestor-expand effect. `onSelectionChange` re-fires when we call `select()`, but the host's `onSelect` handler is already idempotent on same-value writes.

### Test coverage

- Three new `Scenario Outline: Selected file survives page refresh` examples (`local`, `branch`, `browse`) in `code-tab.feature` — all pass.
- The existing `Right-click 'Open path:N' in diff view jumps to browse` regression suite caught the post-mount-update bug and now passes after the Pierre wrapper fix.

### Try it locally

\`\`\`sh
nix run github:juspay/kolu/sure-rut
\`\`\`

> *Cross-validated by hickey + lowy structural review. Findings actioned: duplicate `slotKey`/`resetKey` collapsed; stale `batch()` comment in `openInCodeTab.ts` refreshed. Lowy's LRU-cap proposal rejected as no-op (N=20 arbitrary, working set bounded by repos × modes, explicit Clear-localStorage command already exists).*

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._