### PR TITLE
Fix Code tab preview loss on terminal switch (slotKey race)

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -317,16 +317,26 @@ const CodeTab: Component<{
   // resubscribe and lose the selection across tab toggles. Once the stream
   // has delivered (`!pending()`), an empty paths set IS authoritative —
   // the file truly went away (commit cleared local diff, rm deleted it).
+  //
+  // Bail on the tick where `slotKey` itself just changed: the shared
+  // `treePaths()` / `pending()` signals can momentarily expose the
+  // previous slot's snapshot before `createReactiveSubscription` resets
+  // them for the new input, so the new slot's selection would be checked
+  // against the previous slot's tree and falsely cleared. The next tick
+  // (after the reset effect runs) re-evaluates with the authoritative
+  // values for the new slot.
   createEffect(
     on(
       () => {
         const s = selectedPath();
+        const sk = slotKey();
         const isPending = isDiffView() ? status.pending() : allPaths.pending();
         const paths = treePaths();
-        return [s, !s || isPending || paths.includes(s)] as const;
+        return { s, sk, pathExists: !s || isPending || paths.includes(s) };
       },
-      ([path, pathExists]) => {
-        if (path && !pathExists) setSelectedPath(null);
+      (cur, prev) => {
+        if (prev && prev.sk !== cur.sk) return;
+        if (cur.s && !cur.pathExists) setSelectedPath(null);
       },
       { defer: true },
     ),

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -146,6 +146,36 @@ Feature: Code tab (review + browse)
     When I select workspace switcher entry 2
     Then the selected file should show content "from-B"
 
+  # Regression: with two terminals in different repos and DIFFERENT
+  # filenames selected in browse mode, switching back and forth used to
+  # silently delete the original slot from `selectedFilesByKey`
+  # mid-transition. Root cause: the "selected file no longer in tree"
+  # effect read `treePaths()` from the shared `fsListAll` store before
+  # the slot change had propagated through `createReactiveSubscription`'s
+  # reset, so the new slot's selection was checked against the previous
+  # slot's paths. Same-filename selections accidentally masked the bug
+  # because the membership check still succeeded against the stale tree.
+  # The bug is a reactive race so the round-trip is exercised three times
+  # to make the test consistently red without the fix.
+  Scenario: Browse preview survives terminal switch when filenames differ across repos
+    Given a Code tab in "browse" mode showing file "file-a.txt" with content "AAAA"
+    When I open file "file-a.txt" in the Code tab
+    Then the selected file should show content "AAAA"
+    When I create a terminal
+    Given a Code tab in "browse" mode showing file "file-b.txt" with content "BBBB"
+    When I open file "file-b.txt" in the Code tab
+    Then the selected file should show content "BBBB"
+    When I select workspace switcher entry 1
+    Then the selected file should show content "AAAA"
+    When I select workspace switcher entry 2
+    Then the selected file should show content "BBBB"
+    When I select workspace switcher entry 1
+    Then the selected file should show content "AAAA"
+    When I select workspace switcher entry 2
+    Then the selected file should show content "BBBB"
+    When I select workspace switcher entry 1
+    Then the selected file should show content "AAAA"
+
   # Regression: opening a file in the Code tab and refreshing the browser
   # used to lose the preview because `selectedPath` lived in a local
   # `createSignal` that died with the component. Selection is now backed

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -106,6 +106,46 @@ Feature: Code tab (review + browse)
       | branch |
       | browse |
 
+  # Regression for #919's per-slot design under multi-terminal switching.
+  # Each terminal carries its own `repoRoot` via `props.meta?.git`; the
+  # `selectedFilesByKey` record is keyed by (repoRoot, view) and shared
+  # across terminals through localStorage, so switching the active
+  # terminal reactively rebinds `slotKey` and surfaces the right slot's
+  # pick without one terminal clobbering the other.
+  Scenario Outline: Selected file survives switching to another terminal and back [<mode>]
+    Given a Code tab in "<mode>" mode showing file "a.txt" with content "aaa"
+    When I open file "a.txt" in the Code tab
+    Then the selected file should show content "aaa"
+    When I create a terminal
+    And I run "rm -rf /tmp/kolu-codetab-otherdir && mkdir -p /tmp/kolu-codetab-otherdir && cd /tmp/kolu-codetab-otherdir"
+    And I select workspace switcher entry 1
+    Then the selected file should show content "aaa"
+
+    Examples:
+      | mode   |
+      | local  |
+      | branch |
+      | browse |
+
+  # Same-filename variant: both terminals are in valid git repos, and both
+  # have a file at the same relative path selected. The outer
+  # `<Show when={repoPath()}>` therefore stays in the truthy branch and
+  # cannot mask staleness via remount — the preview must follow
+  # `props.meta` reactively, so the displayed content has to flip between
+  # "from-A" and "from-B" as the active terminal changes.
+  Scenario: Browse preview follows the active terminal when two repos pick the same filename
+    Given a Code tab in "browse" mode showing file "shared.txt" with content "from-A"
+    When I open file "shared.txt" in the Code tab
+    Then the selected file should show content "from-A"
+    When I create a terminal
+    And a Code tab in "browse" mode showing file "shared.txt" with content "from-B"
+    And I open file "shared.txt" in the Code tab
+    Then the selected file should show content "from-B"
+    When I select workspace switcher entry 1
+    Then the selected file should show content "from-A"
+    When I select workspace switcher entry 2
+    Then the selected file should show content "from-B"
+
   # Regression: opening a file in the Code tab and refreshing the browser
   # used to lose the preview because `selectedPath` lived in a local
   # `createSignal` that died with the component. Selection is now backed

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -138,8 +138,8 @@ Feature: Code tab (review + browse)
     When I open file "shared.txt" in the Code tab
     Then the selected file should show content "from-A"
     When I create a terminal
-    And a Code tab in "browse" mode showing file "shared.txt" with content "from-B"
-    And I open file "shared.txt" in the Code tab
+    Given a Code tab in "browse" mode showing file "shared.txt" with content "from-B"
+    When I open file "shared.txt" in the Code tab
     Then the selected file should show content "from-B"
     When I select workspace switcher entry 1
     Then the selected file should show content "from-A"

--- a/packages/tests/step_definitions/terminal_lifecycle_steps.ts
+++ b/packages/tests/step_definitions/terminal_lifecycle_steps.ts
@@ -6,8 +6,8 @@ import { Given, Then, When } from "@cucumber/cucumber";
 import { waitForBufferContains } from "../support/buffer.ts";
 import {
   type KoluWorld,
-  WORKSPACE_SWITCHER_ENTRY_SELECTOR,
   POLL_TIMEOUT,
+  WORKSPACE_SWITCHER_ENTRY_SELECTOR,
 } from "../support/world.ts";
 
 When("I create a terminal", async function (this: KoluWorld) {
@@ -49,6 +49,28 @@ When(
       .locator(`[data-terminal-id="${id}"][data-focused]`)
       .waitFor({ state: "attached", timeout: POLL_TIMEOUT });
     await this.waitForFrame();
+  },
+);
+
+/** Select a terminal by its position in the workspace switcher (1-based),
+ *  regardless of `createdTerminalIds`. Complements
+ *  `I select terminal {int} in the workspace switcher` (ID-based, waits on
+ *  `data-focused`): this variant addresses entries by DOM position and
+ *  waits on `data-visible`, which is what scenarios that don't track
+ *  created IDs (or want to address pre-existing background terminals)
+ *  need. */
+When(
+  "I select workspace switcher entry {int}",
+  async function (this: KoluWorld, position: number) {
+    const entry = this.page
+      .locator(WORKSPACE_SWITCHER_ENTRY_SELECTOR)
+      .nth(position - 1);
+    await entry.click();
+    const id = await entry.getAttribute("data-terminal-id");
+    assert.ok(id, `Workspace switcher entry ${position} has no terminal ID`);
+    await this.page
+      .locator(`[data-terminal-id="${id}"][data-visible]`)
+      .waitFor({ state: "attached", timeout: POLL_TIMEOUT });
   },
 );
 

--- a/packages/tests/step_definitions/terminal_lifecycle_steps.ts
+++ b/packages/tests/step_definitions/terminal_lifecycle_steps.ts
@@ -71,6 +71,7 @@ When(
     await this.page
       .locator(`[data-terminal-id="${id}"][data-visible]`)
       .waitFor({ state: "attached", timeout: POLL_TIMEOUT });
+    await this.waitForFrame();
   },
 );
 

--- a/packages/tests/step_definitions/terminal_lifecycle_steps.ts
+++ b/packages/tests/step_definitions/terminal_lifecycle_steps.ts
@@ -58,7 +58,15 @@ When(
  *  `data-focused`): this variant addresses entries by DOM position and
  *  waits on `data-visible`, which is what scenarios that don't track
  *  created IDs (or want to address pre-existing background terminals)
- *  need. */
+ *  need.
+ *
+ *  Positional order matches terminal-creation order only for plain-shell
+ *  terminals — they all have `lastActivityAt === 0`, tie in
+ *  `rankDockRows()`'s `b.ts - a.ts` sort, and the stable sort then
+ *  preserves the `Map`'s insertion order. Agent-backed terminals carry
+ *  real activity timestamps and may reshuffle the dock, so position-based
+ *  addressing isn't safe for them; reach for the ID-based sibling step
+ *  instead. */
 When(
   "I select workspace switcher entry {int}",
   async function (this: KoluWorld, position: number) {

--- a/packages/tests/step_definitions/theme_steps.ts
+++ b/packages/tests/step_definitions/theme_steps.ts
@@ -1,33 +1,12 @@
 import * as assert from "node:assert";
 import { Then, When } from "@cucumber/cucumber";
-import {
-  type KoluWorld,
-  MOD_KEY,
-  WORKSPACE_SWITCHER_ENTRY_SELECTOR,
-  POLL_TIMEOUT,
-} from "../support/world.ts";
+import { type KoluWorld, MOD_KEY, POLL_TIMEOUT } from "../support/world.ts";
 
 /** Convert "#rrggbb" to "rgb(r, g, b)" for comparison with getComputedStyle. */
 function hexToRgb(hex: string): string {
   const n = parseInt(hex.slice(1), 16);
   return `rgb(${(n >> 16) & 0xff}, ${(n >> 8) & 0xff}, ${n & 0xff})`;
 }
-
-/** Select a terminal by its position in the workspace switcher (1-based), regardless of createdTerminalIds. */
-When(
-  "I select workspace switcher entry {int}",
-  async function (this: KoluWorld, position: number) {
-    const entry = this.page
-      .locator(WORKSPACE_SWITCHER_ENTRY_SELECTOR)
-      .nth(position - 1);
-    await entry.click();
-    const id = await entry.getAttribute("data-terminal-id");
-    assert.ok(id, `Workspace switcher entry ${position} has no terminal ID`);
-    await this.page
-      .locator(`[data-terminal-id="${id}"][data-visible]`)
-      .waitFor({ state: "attached", timeout: POLL_TIMEOUT });
-  },
-);
 
 Then(
   "the terminal background should be {string}",


### PR DESCRIPTION
**Switching between two terminals in different repos used to silently lose the file preview in the Code tab's browse mode.** The selection slot for the original terminal was being deleted mid-transition by a reactive race in the "selected file no longer in tree" guard.

### What was happening

```
Terminal A (/repo-a)        Terminal B (/repo-b)
  selectedPath = "file-a.txt"   selectedPath = "file-b.txt"

selectedFilesByKey (localStorage)
  "/repo-a::browse" → "file-a.txt"
  "/repo-b::browse" → "file-b.txt"

         B → A switch happens
            │
            ▼
slotKey memo flips to "/repo-a::browse" first
selectedPath() now reads A's slot → "file-a.txt"
BUT treePaths() still has B's stale paths → ["file-b.txt"]
AND pending() still false (B's stream was settled)

      ▼  membership effect fires before reset propagates  ▼
"file-a.txt" not in ["file-b.txt"], not pending → CLEAR /repo-a slot
```

The "selected file is missing" guard at `CodeTab.tsx:320` was correct in spirit — when a commit or `rm` removes a file, the selection should clear — but it relied on `treePaths()` / `pending()` being authoritative for the current slot. Those are shared signals; `createReactiveSubscription` doesn't reset them atomically with the input change, so the *new* slot's `selectedPath` was checked against the *previous* slot's tree on the transition tick.

Same-filename selections accidentally masked the bug — when both repos had a `shared.txt` selected, the membership check happened to succeed against the stale tree, hiding the false-clear.

### Fix

Guard the membership effect with the previous `slotKey`: skip the clear on the exact tick `slotKey` changed. The next tick (after the reset effect propagates) re-evaluates with authoritative values for the new slot.

### Test coverage

Two new browse-mode scenarios in `code-tab.feature`:

| Scenario | What it pins down |
| --- | --- |
| _Browse preview follows the active terminal when two repos pick the same filename_ | Reactivity follows `props.meta` when the outer `<Show when={repoPath()}>` stays mounted (same filename masks staleness via membership check) |
| _Browse preview survives terminal switch when filenames differ across repos_ | The actual race — different filenames in two repos, multi-switch round-trip surfaces the slotKey transition race deterministically |

The Scenario Outline at the top (`Selected file survives switching to another terminal and back`) covers the non-git-second-terminal variant for all three modes (local / branch / browse) where the outer `<Show>` flip masks the race.

### Refinements during review

| Lens | Finding | Action |
| --- | --- | --- |
| Lowy | `I select workspace switcher entry {int}` lived in `theme_steps.ts` by accident — its volatility axis is terminal selection, not theme | Relocated to `terminal_lifecycle_steps.ts` alongside the ID-based sibling |
| Hickey (cross-validate) | Middle step under the same-filename scenario used `And` after `When` for fixture setup | Switched to `Given` for keyword honesty |
| Police (elegance) | The relocated step dropped the sibling step's `await this.waitForFrame()` after the visibility wait | Restored the call for SolidJS rAF symmetry |
| Police (fact-check) | Position-based addressing relies on `lastActivityAt === 0` ties + stable sort — only safe for plain-shell terminals | Added a doc comment warning agent-backed terminals off the positional step |

### Try it locally

\`\`\`sh
nix run github:juspay/kolu/fix/code-tab-preview-multi-terminal
\`\`\`

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._