### PR TITLE
Identify kolu to PTY processes via TERM_PROGRAM env var

### DIFF
--- a/packages/server/src/pty.ts
+++ b/packages/server/src/pty.ts
@@ -15,7 +15,7 @@ import {
 import * as pty from "node-pty";
 import pkg from "../package.json" with { type: "json" };
 import type { Logger } from "./log.ts";
-import { cleanEnv, koluEnv, prepareShellInit } from "./shell.ts";
+import { cleanEnv, koluIdentityEnv, prepareShellInit } from "./shell.ts";
 
 // @xterm packages ship CJS only — use createRequire for clean ESM interop
 const require = createRequire(import.meta.url);
@@ -87,15 +87,16 @@ export function spawnPty(
   spawnCwd?: string,
 ): PtyHandle {
   // Env layering, ordered from least to most authoritative:
-  //   1. cleanEnv()      — parent env passthrough (Nix devshell filtering).
-  //   2. koluEnv()       — Kolu's identity (TERM_PROGRAM, version, VTE_VERSION);
-  //                        unconditionally stomps whatever the parent had.
-  //   3. shellInit.env   — per-PTY overrides (e.g. ZDOTDIR for zsh).
+  //   1. cleanEnv()         — parent env passthrough (Nix devshell filtering).
+  //   2. koluIdentityEnv()  — Kolu's identity (TERM_PROGRAM, version,
+  //                           VTE_VERSION); unconditionally stomps whatever
+  //                           the parent had.
+  //   3. shellInit.env      — per-PTY overrides (e.g. ZDOTDIR for zsh).
   const env = cleanEnv();
   const shell = env.SHELL ?? "/bin/sh";
   const cwd = spawnCwd || env.HOME || "/";
 
-  Object.assign(env, koluEnv(pkg.version));
+  Object.assign(env, koluIdentityEnv(pkg.version));
 
   const shellInit = prepareShellInit({
     shell,

--- a/packages/server/src/pty.ts
+++ b/packages/server/src/pty.ts
@@ -13,8 +13,9 @@ import {
   DEFAULT_SCROLLBACK,
 } from "kolu-common/config";
 import * as pty from "node-pty";
+import pkg from "../package.json" with { type: "json" };
 import type { Logger } from "./log.ts";
-import { cleanEnv, prepareShellInit } from "./shell.ts";
+import { cleanEnv, koluEnv, prepareShellInit } from "./shell.ts";
 
 // @xterm packages ship CJS only — use createRequire for clean ESM interop
 const require = createRequire(import.meta.url);
@@ -85,9 +86,16 @@ export function spawnPty(
   },
   spawnCwd?: string,
 ): PtyHandle {
+  // Env layering, ordered from least to most authoritative:
+  //   1. cleanEnv()      — parent env passthrough (Nix devshell filtering).
+  //   2. koluEnv()       — Kolu's identity (TERM_PROGRAM, version, VTE_VERSION);
+  //                        unconditionally stomps whatever the parent had.
+  //   3. shellInit.env   — per-PTY overrides (e.g. ZDOTDIR for zsh).
   const env = cleanEnv();
   const shell = env.SHELL ?? "/bin/sh";
   const cwd = spawnCwd || env.HOME || "/";
+
+  Object.assign(env, koluEnv(pkg.version));
 
   const shellInit = prepareShellInit({
     shell,

--- a/packages/server/src/shell.test.ts
+++ b/packages/server/src/shell.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  koluEnv,
+  koluIdentityEnv,
   OSC2_PRECMD_BASH,
   OSC2_PRECMD_ZSH,
   OSC2_PREEXEC_BASH_GUARD,
@@ -36,9 +36,9 @@ function runZsh(script: string, cwd = "/tmp"): string | null {
   }
 }
 
-describe("koluEnv", () => {
+describe("koluIdentityEnv", () => {
   it("returns Kolu's identity vars: TERM_PROGRAM, TERM_PROGRAM_VERSION, VTE_VERSION", () => {
-    const env = koluEnv("9.9.9");
+    const env = koluIdentityEnv("9.9.9");
     expect(env).toEqual({
       TERM_PROGRAM: "kolu",
       TERM_PROGRAM_VERSION: "9.9.9",

--- a/packages/server/src/shell.test.ts
+++ b/packages/server/src/shell.test.ts
@@ -45,6 +45,17 @@ describe("koluIdentityEnv", () => {
       VTE_VERSION: "7603",
     });
   });
+
+  it("VTE_VERSION stomps a parent value when layered via Object.assign", () => {
+    // Pins the intentional behavior change from `??=` in cleanEnv to
+    // unconditional assignment via koluIdentityEnv: kolu isn't a VTE
+    // terminal, so inheriting a stale parent VTE_VERSION would be a
+    // bigger lie than the hardcoded shim. Guards against a future
+    // refactor that quietly reintroduces inheritance.
+    const layered: Record<string, string> = { VTE_VERSION: "9999" };
+    Object.assign(layered, koluIdentityEnv("9.9.9"));
+    expect(layered.VTE_VERSION).toBe("7603");
+  });
 });
 
 describe("OSC7_FN", () => {

--- a/packages/server/src/shell.test.ts
+++ b/packages/server/src/shell.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  koluEnv,
   OSC2_PRECMD_BASH,
   OSC2_PRECMD_ZSH,
   OSC2_PREEXEC_BASH_GUARD,
@@ -34,6 +35,17 @@ function runZsh(script: string, cwd = "/tmp"): string | null {
     throw err;
   }
 }
+
+describe("koluEnv", () => {
+  it("returns Kolu's identity vars: TERM_PROGRAM, TERM_PROGRAM_VERSION, VTE_VERSION", () => {
+    const env = koluEnv("9.9.9");
+    expect(env).toEqual({
+      TERM_PROGRAM: "kolu",
+      TERM_PROGRAM_VERSION: "9.9.9",
+      VTE_VERSION: "7603",
+    });
+  });
+});
 
 describe("OSC7_FN", () => {
   it("emits OSC 7 with file:// URL containing hostname and cwd", () => {

--- a/packages/server/src/shell.ts
+++ b/packages/server/src/shell.ts
@@ -29,8 +29,9 @@ import { koluShellDir } from "./koluRoot.ts";
  * Exported so callers can pass it as the default whitelist value.
  *
  * Kolu's own identity vars (TERM_PROGRAM, TERM_PROGRAM_VERSION,
- * VTE_VERSION) live in `koluEnv()` and are layered on top of cleanEnv's
- * output by spawnPty — they don't belong in the parent-forward whitelist.
+ * VTE_VERSION) live in `koluIdentityEnv()` and are layered on top of
+ * cleanEnv's output by spawnPty — they don't belong in the parent-forward
+ * whitelist.
  */
 export const NIX_ENV_WHITELIST =
   "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM";
@@ -97,8 +98,12 @@ export function cleanEnv(): Record<string, string> {
  *
  * Separate function because the volatility axis is different: cleanEnv
  * decides what parent vars are safe to forward (driven by Nix devshell
- * pollution, OS conventions); koluEnv decides what Kolu asserts about
- * itself (driven by rebrand, version bumps, future capability vars).
+ * pollution, OS conventions); koluIdentityEnv decides what Kolu asserts
+ * about itself (driven by rebrand, version bumps, future capability vars).
+ *
+ * Distinct from the Nix `koluEnv` attribute in `nix/env.nix`, which holds
+ * build-time vars (KOLU_FONTS_DIR, KOLU_GH_BIN). Different namespace,
+ * different volatility axis — name shouldn't conflate them.
  *
  * `TERM_PROGRAM` follows the convention shared by VSCode, iTerm2,
  * Ghostty, WezTerm — set by the terminal emulator/host so tools like
@@ -111,7 +116,7 @@ export function cleanEnv(): Record<string, string> {
  * Per-PTY identity vars (anything that depends on terminalId) belong in
  * `SpawnInit.env` returned by `prepareShellInit`, not here.
  */
-export function koluEnv(version: string): Record<string, string> {
+export function koluIdentityEnv(version: string): Record<string, string> {
   return {
     TERM_PROGRAM: "kolu",
     TERM_PROGRAM_VERSION: version,

--- a/packages/server/src/shell.ts
+++ b/packages/server/src/shell.ts
@@ -27,9 +27,13 @@ import { koluShellDir } from "./koluRoot.ts";
  * Default env vars safe to forward from a nix devshell to PTY shells.
  * Everything else (NIX_*, DIRENV_*, derivation vars) is excluded.
  * Exported so callers can pass it as the default whitelist value.
+ *
+ * Kolu's own identity vars (TERM_PROGRAM, TERM_PROGRAM_VERSION,
+ * VTE_VERSION) live in `koluEnv()` and are layered on top of cleanEnv's
+ * output by spawnPty — they don't belong in the parent-forward whitelist.
  */
 export const NIX_ENV_WHITELIST =
-  "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM,TERM_PROGRAM";
+  "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM";
 
 /** Whitelist set once at startup; undefined means passthrough mode (production). */
 let envWhitelist: Set<string> | undefined;
@@ -85,9 +89,34 @@ export function cleanEnv(): Record<string, string> {
   // Ensure SHELL is set — systemd user services may not have it.
   // Fall back to the login shell from /etc/passwd.
   env.SHELL ??= userInfo().shell || "/bin/sh";
-  // Enable VTE integration in bash/zsh (some tools like direnv check this).
-  env.VTE_VERSION ??= "7603";
   return env;
+}
+
+/**
+ * Kolu's identity env vars, layered over `cleanEnv()` by spawnPty.
+ *
+ * Separate function because the volatility axis is different: cleanEnv
+ * decides what parent vars are safe to forward (driven by Nix devshell
+ * pollution, OS conventions); koluEnv decides what Kolu asserts about
+ * itself (driven by rebrand, version bumps, future capability vars).
+ *
+ * `TERM_PROGRAM` follows the convention shared by VSCode, iTerm2,
+ * Ghostty, WezTerm — set by the terminal emulator/host so tools like
+ * starship prompts and shell themes can detect their environment.
+ *
+ * `VTE_VERSION` is a compatibility shim some tools (e.g. direnv) check
+ * for VTE-style integration; it sits here, not in cleanEnv, because it's
+ * the same shape as the identity assertions.
+ *
+ * Per-PTY identity vars (anything that depends on terminalId) belong in
+ * `SpawnInit.env` returned by `prepareShellInit`, not here.
+ */
+export function koluEnv(version: string): Record<string, string> {
+  return {
+    TERM_PROGRAM: "kolu",
+    TERM_PROGRAM_VERSION: version,
+    VTE_VERSION: "7603",
+  };
 }
 
 /** Shell function that emits OSC 7 with the current working directory. */

--- a/packages/server/src/shell.ts
+++ b/packages/server/src/shell.ts
@@ -111,7 +111,8 @@ export function cleanEnv(): Record<string, string> {
  *
  * `VTE_VERSION` is a compatibility shim some tools (e.g. direnv) check
  * for VTE-style integration; it sits here, not in cleanEnv, because it's
- * the same shape as the identity assertions.
+ * the same shape as the identity assertions. The value `7603` encodes VTE
+ * 0.76.3 using VTE's scheme: major×10000 + minor×100 + micro.
  *
  * Per-PTY identity vars (anything that depends on terminalId) belong in
  * `SpawnInit.env` returned by `prepareShellInit`, not here.

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -19,6 +19,7 @@ import { After, AfterAll, Before, BeforeAll, Status } from "@cucumber/cucumber";
 import getPort from "get-port";
 import type { Browser, BrowserContext, Page } from "playwright";
 import { chromium } from "playwright";
+import { NIX_ENV_WHITELIST } from "../../server/src/shell.ts";
 import type { KoluWorld } from "./world.ts";
 
 const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || "0", 10);
@@ -291,14 +292,13 @@ BeforeAll(async () => {
     const port = await getPort();
     baseUrl = `http://localhost:${port}`;
     console.log(`[worker:${workerId}] Starting server on port ${port}...`);
-    // Extend the default nix-shell env whitelist (see NIX_ENV_WHITELIST in shell.ts) with
-    // GIT_AUTHOR_*/GIT_COMMITTER_* so PTY shells in fixtures like
-    // `code-tab.feature` (which run `git init && git commit` inside the
-    // terminal under test) inherit the same identity set on process.env
-    // above. Without this, the whitelist filter strips them and those
-    // scenarios fail on pristine hosts.
+    // Extend NIX_ENV_WHITELIST with GIT_AUTHOR_*/GIT_COMMITTER_* so PTY
+    // shells in fixtures like `code-tab.feature` (which run `git init &&
+    // git commit` inside the terminal under test) inherit the same
+    // identity set on process.env above. Without this, the whitelist
+    // filter strips them and those scenarios fail on pristine hosts.
     const envWhitelist = [
-      "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM",
+      NIX_ENV_WHITELIST,
       "GIT_AUTHOR_NAME,GIT_AUTHOR_EMAIL,GIT_COMMITTER_NAME,GIT_COMMITTER_EMAIL",
     ].join(",");
     serverProcess = spawn(

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -298,7 +298,7 @@ BeforeAll(async () => {
     // above. Without this, the whitelist filter strips them and those
     // scenarios fail on pristine hosts.
     const envWhitelist = [
-      "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM,TERM_PROGRAM",
+      "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM",
       "GIT_AUTHOR_NAME,GIT_AUTHOR_EMAIL,GIT_COMMITTER_NAME,GIT_COMMITTER_EMAIL",
     ].join(",");
     serverProcess = spawn(

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -291,7 +291,7 @@ BeforeAll(async () => {
     const port = await getPort();
     baseUrl = `http://localhost:${port}`;
     console.log(`[worker:${workerId}] Starting server on port ${port}...`);
-    // Extend the default nix-shell env whitelist (see shell.ts:31) with
+    // Extend the default nix-shell env whitelist (see NIX_ENV_WHITELIST in shell.ts) with
     // GIT_AUTHOR_*/GIT_COMMITTER_* so PTY shells in fixtures like
     // `code-tab.feature` (which run `git init && git commit` inside the
     // terminal under test) inherit the same identity set on process.env


### PR DESCRIPTION
**Kolu now identifies itself to every process running under a Kolu-spawned PTY** via the standard `TERM_PROGRAM=kolu` / `TERM_PROGRAM_VERSION=<pkg.version>` convention — the same one VSCode, iTerm2, Ghostty, and WezTerm set on their child shells. Prompt themes (starship, oh-my-zsh) pick it up automatically, and downstream agents (claude, opencode, codex…) can branch on it once a real consumer materializes (e.g. dropping an HTML plan file Kolu renders inline instead of streaming a wall of text).

This was the smallest change that earns the namespace. Deliberately deferred: `KOLU_TERMINAL_ID`, `KOLU_ARTIFACT_DIR`, `KOLU_CAPS` — they need a consumer before they earn an env slot.

### Env layering inside spawnPty

```
cleanEnv()         ──┐
                     ├─▶ koluIdentityEnv(pkg.version) ──┐
process.env         ─┘     {TERM_PROGRAM, _VERSION,     ├─▶ shellInit.env ──▶ node-pty
(filtered by             VTE_VERSION="7603"}            │   {ZDOTDIR, ...}
NIX_ENV_WHITELIST)        (unconditional stomp)         │   (per-PTY)
                                                        ▼
                                              final PTY env
```

The split tracks **volatility, not files**: `cleanEnv` answers _"what parent vars are safe to forward"_ (Nix devshell pollution, OS conventions); `koluIdentityEnv` answers _"what does Kolu assert about itself"_ (rebrand, version bumps, future capability vars). `VTE_VERSION` moved with the latter — it's a process-wide assertion, not a passthrough decision, and was previously misfiled inside `cleanEnv`. `TERM_PROGRAM` dropped out of `NIX_ENV_WHITELIST` because the unconditional stomp made passthrough dead behavior.

### Post-implement structural review

Hickey and Lowy ran in parallel on the primary commit, then cross-validated each other's findings.

| # | Lens | Finding | Disposition |
|---|--------|---------------------------------------------------------------|---------|
| 1 | Hickey | `buildPtyEnv` wrapper to convert "always pair cleanEnv with koluEnv" convention into structure | No-op (withdrew after Lowy cross-validation: would conflate two independent volatility axes for a single caller) |
| 2 | Hickey & Lowy | `koluEnv` name collides with the Nix `koluEnv` attribute in `nix/env.nix` (build-time vars) | **Fixed in this PR** — renamed to `koluIdentityEnv` |
| 3 | Hickey | `VTE_VERSION` behavioral flip (was `??=` inherit, now unconditional stomp) lacks an asserting test | **Fixed in this PR** — added Object.assign-layering test that seeds parent VTE_VERSION and asserts the override |
| 4 | Lowy | Three-call inline layering is correctly placed (sequence volatility is weak; wrapper would entangle with SpawnInit) | No-op |
| 5 | Lowy | `version` as parameter (not closure) keeps dependency visible and test stable | No-op |

Code-police caught a follow-on `dry-rule-of-three` violation introduced when `TERM_PROGRAM` was dropped from `NIX_ENV_WHITELIST`: the e2e test harness inlined a stale copy of the whitelist with a "see shell.ts" comment. The duplicate just drifted in this PR — fixed by importing `NIX_ENV_WHITELIST` from `shell.ts` so the two whitelists track each other.

> _Behavioral change worth flagging: a parent process's `VTE_VERSION` no longer leaks into PTY children — Kolu always asserts `7603` (VTE 0.76.3). Intentional, since Kolu isn't a VTE terminal and the value is a compatibility shim, not an inheritance question._

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._