### PR TITLE
Linkify terminal file paths without a `:line` suffix

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -295,6 +295,9 @@ const CodeTab: Component<{
     const h = handled();
     if (!h || h.request !== req || h.resolvedPath === null) return null;
     if (h.resolvedPath !== selectedPath()) return null;
+    // No-line refs (`src/Main.hs` with no `:N`) open the file with no
+    // highlight — the user asked for the file, not a specific line.
+    if (req.ref.startLine === null || req.ref.endLine === null) return null;
     return { start: req.ref.startLine, end: req.ref.endLine };
   });
 

--- a/packages/client/src/terminal/fileRefLinkProvider.ts
+++ b/packages/client/src/terminal/fileRefLinkProvider.ts
@@ -24,10 +24,12 @@ export function createFileRefLinkProvider(
         return;
       }
       const text = lineObj.translateToString(true);
-      // `:` is the cheapest necessary condition for the pattern;
-      // skipping the regex on plain prompts / output is a meaningful
-      // win on a hot-path that fires per hover-cell.
-      if (text.indexOf(":") < 0) {
+      // Cheap necessary condition: every match requires at least one
+      // `/` (slash-containing branch) or one `.` (bare extension
+      // branch). Skipping the regex on plain prompts is a meaningful
+      // win on a hot-path that fires per hover-cell. `:` alone is no
+      // longer sufficient since `:N` became optional.
+      if (text.indexOf("/") < 0 && text.indexOf(".") < 0) {
         callback(undefined);
         return;
       }

--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -6,6 +6,10 @@ describe("formatLineRef", () => {
     expect(formatLineRef("src/a.ts", 5, 5)).toBe("src/a.ts:5");
     expect(formatLineRef("src/a.ts", 5, 9)).toBe("src/a.ts:5-9");
   });
+
+  it("returns the bare path when start is null", () => {
+    expect(formatLineRef("src/a.ts", null, null)).toBe("src/a.ts");
+  });
 });
 
 describe("parseLineRefs", () => {
@@ -109,6 +113,35 @@ describe("parseLineRefs", () => {
     expect(refs).toHaveLength(1);
     expect(refs[0]?.index).toBe(line.indexOf("packages/"));
     expect(refs[0]?.text).toBe("packages/foo.ts:7");
+  });
+
+  it("matches a bare slash-containing path without a line number", () => {
+    const refs = parseLineRefs("see src/Main.hs for details");
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      path: "src/Main.hs",
+      startLine: null,
+      endLine: null,
+      text: "src/Main.hs",
+    });
+  });
+
+  it("matches a bare filename with an extension and no line number", () => {
+    const refs = parseLineRefs("open Main.hs to start");
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      path: "Main.hs",
+      startLine: null,
+      endLine: null,
+    });
+  });
+
+  it("does not linkify plain words without a `/` or `.ext`", () => {
+    // `react`, `init`, `Makefile` etc. — common terminal output that
+    // would be noisy if every word became hover-decorated.
+    expect(parseLineRefs("npm i react")).toEqual([]);
+    expect(parseLineRefs("git init")).toEqual([]);
+    expect(parseLineRefs("run Makefile")).toEqual([]);
   });
 });
 

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -3,11 +3,14 @@
  *  excerpts, and editor messages all share this shape; this module is
  *  the single place that knows how to read and resolve it. */
 
-/** Parsed line reference with an inclusive 1-based range. */
+/** Parsed line reference with an inclusive 1-based range. `startLine`
+ *  and `endLine` are null when the source had no `:N` suffix — `path`
+ *  alone is enough to navigate, and the consumer should open the file
+ *  without selecting any line. */
 export interface LineRef {
   path: string;
-  startLine: number;
-  endLine: number;
+  startLine: number | null;
+  endLine: number | null;
 }
 
 /** Parsed match including source positions — what an xterm link
@@ -19,14 +22,16 @@ export interface LineRefMatch extends LineRef {
   index: number;
 }
 
-/** Format a `path:line` (single line) or `path:start-end` (range)
- *  reference the way most editors and code tools accept (VS Code,
- *  Vim's `:e file:N`, GitHub URL fragments, Linear-style snippets). */
+/** Format a `path`, `path:line`, or `path:start-end` reference the way
+ *  most editors and code tools accept (VS Code, Vim's `:e file:N`,
+ *  GitHub URL fragments, Linear-style snippets). When `start` is null
+ *  the bare path is returned. */
 export function formatLineRef(
   path: string,
-  start: number,
-  end: number,
+  start: number | null,
+  end: number | null,
 ): string {
+  if (start === null) return path;
   return start === end ? `${path}:${start}` : `${path}:${start}-${end}`;
 }
 
@@ -42,13 +47,17 @@ const LINE_REF_RE = new RegExp(
   //   2. bare filename with a letter-led extension (`Type.hs`,
   //      `package.json`) — letter-led extension rejects IPv4-style
   //      `192.168.1.1:8080` and version strings like `1.2.3:5`.
+  // Both branches require either a `/` or a `.ext`, which keeps plain
+  // words (`react`, `init`) from getting linkified when the `:N`
+  // suffix is absent.
   `((?:\\.\\.?\\/|\\/)?(?:${PATH_CHARS}+\\/)+${PATH_CHARS}+|${PATH_CHARS}+\\.[A-Za-z]\\w*)` +
-    // Line + optional `:col` (consumed but ignored) or `-end`.
-    `:(\\d+)(?::\\d+|-(\\d+))?`,
+    // Optional `:line[:col|-end]`. When absent the bare path links to
+    // the file with no line selected.
+    `(?::(\\d+)(?::\\d+|-(\\d+))?)?`,
   "g",
 );
 
-/** Find every `path:line[-end]` reference in `text`. URL embeds
+/** Find every `path[:line[-end]]` reference in `text`. URL embeds
  *  (`://...`) and mid-token matches (immediately preceded by another
  *  path char) are rejected. */
 export function parseLineRefs(text: string): LineRefMatch[] {
@@ -57,13 +66,13 @@ export function parseLineRefs(text: string): LineRefMatch[] {
   let m = LINE_REF_RE.exec(text);
   while (m !== null) {
     const path = m[1];
-    const start = Number(m[2]);
+    const hasLine = m[2] !== undefined;
+    const start = hasLine ? Number(m[2]) : null;
     const end = m[3] !== undefined ? Number(m[3]) : start;
-    const ok =
-      path !== undefined &&
-      start >= 1 &&
-      end >= start &&
-      hasRefBoundary(text, m.index);
+    const lineOk =
+      !hasLine ||
+      (start !== null && start >= 1 && end !== null && end >= start);
+    const ok = path !== undefined && lineOk && hasRefBoundary(text, m.index);
     if (ok && path !== undefined) {
       out.push({
         path,

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -36,6 +36,53 @@ Feature: File-ref autolinking in terminal
     And the Code tab mode should be "browse"
     And the selected file should show content "beta"
 
+  Scenario: Clicking a slash-containing path opens the file at the line
+    When I run "git init /tmp/kolu-file-ref-slash && cd /tmp/kolu-file-ref-slash"
+    And I run "git commit --allow-empty -m init"
+    And I run "mkdir -p src && printf 'module Main\nimport Data\nmain = pure ()\n' > src/Main.hs"
+    And I run "echo 'error in src/Main.hs:2 — bad import'"
+    And I trigger the terminal file-ref link "src/Main.hs:2"
+    Then the right panel should be visible
+    And the Code tab should be active
+    And the Code tab mode should be "browse"
+    And the selected file should show content "import Data"
+    And line 2 should be selected in the file content
+
+  Scenario: Clicking a bare path (no line number) opens the file with no selection
+    When I run "git init /tmp/kolu-file-ref-noline && cd /tmp/kolu-file-ref-noline"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'alpha\nbeta\ngamma\n' > plain.txt"
+    And I run "echo 'see plain.txt for context'"
+    And I trigger the terminal file-ref link "plain.txt"
+    Then the right panel should be visible
+    And the Code tab should be active
+    And the Code tab mode should be "browse"
+    And the selected file should show content "alpha"
+    And no line should be selected in the file content
+
+  Scenario: Clicking a slash-containing path with no line opens the file with no selection
+    When I run "git init /tmp/kolu-file-ref-slash-noline && cd /tmp/kolu-file-ref-slash-noline"
+    And I run "git commit --allow-empty -m init"
+    And I run "mkdir -p src && printf 'module Main\nimport Data\nmain = pure ()\n' > src/Main.hs"
+    And I run "echo 'see src/Main.hs for the entrypoint'"
+    And I trigger the terminal file-ref link "src/Main.hs"
+    Then the right panel should be visible
+    And the Code tab should be active
+    And the Code tab mode should be "browse"
+    And the selected file should show content "module Main"
+    And no line should be selected in the file content
+
+  Scenario: Bare basename without a line number resolves via unique-basename fallback
+    When I run "git init /tmp/kolu-file-ref-noline-basename && cd /tmp/kolu-file-ref-noline-basename"
+    And I run "git commit --allow-empty -m init"
+    And I run "mkdir -p src/lib && printf 'alpha\nbeta\ngamma\n' > src/lib/unique.txt"
+    And I run "echo 'open unique.txt for details'"
+    And I trigger the terminal file-ref link "unique.txt"
+    Then the right panel should be visible
+    And the Code tab should be active
+    And the selected file should show content "alpha"
+    And no line should be selected in the file content
+
   Scenario: Re-clicking the same file-ref after closing the panel re-selects the line
     When I run "git init /tmp/kolu-file-ref-861-reclick && cd /tmp/kolu-file-ref-861-reclick"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -39,13 +39,13 @@ Feature: File-ref autolinking in terminal
   Scenario: Clicking a slash-containing path opens the file at the line
     When I run "git init /tmp/kolu-file-ref-slash && cd /tmp/kolu-file-ref-slash"
     And I run "git commit --allow-empty -m init"
-    And I run "mkdir -p src && printf 'module Main\nimport Data\nmain = pure ()\n' > src/Main.hs"
-    And I run "echo 'error in src/Main.hs:2 — bad import'"
-    And I trigger the terminal file-ref link "src/Main.hs:2"
+    And I run "mkdir -p src && printf 'alpha\nbeta\ngamma\n' > src/notes.txt"
+    And I run "echo 'error in src/notes.txt:2 — context'"
+    And I trigger the terminal file-ref link "src/notes.txt:2"
     Then the right panel should be visible
     And the Code tab should be active
     And the Code tab mode should be "browse"
-    And the selected file should show content "import Data"
+    And the selected file should show content "beta"
     And line 2 should be selected in the file content
 
   Scenario: Clicking a bare path (no line number) opens the file with no selection
@@ -63,13 +63,13 @@ Feature: File-ref autolinking in terminal
   Scenario: Clicking a slash-containing path with no line opens the file with no selection
     When I run "git init /tmp/kolu-file-ref-slash-noline && cd /tmp/kolu-file-ref-slash-noline"
     And I run "git commit --allow-empty -m init"
-    And I run "mkdir -p src && printf 'module Main\nimport Data\nmain = pure ()\n' > src/Main.hs"
-    And I run "echo 'see src/Main.hs for the entrypoint'"
-    And I trigger the terminal file-ref link "src/Main.hs"
+    And I run "mkdir -p src && printf 'alpha\nbeta\ngamma\n' > src/notes.txt"
+    And I run "echo 'see src/notes.txt for context'"
+    And I trigger the terminal file-ref link "src/notes.txt"
     Then the right panel should be visible
     And the Code tab should be active
     And the Code tab mode should be "browse"
-    And the selected file should show content "module Main"
+    And the selected file should show content "alpha"
     And no line should be selected in the file content
 
   Scenario: Bare basename without a line number resolves via unique-basename fallback

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -201,6 +201,30 @@ Then(
   },
 );
 
+// Negative variant: file is rendered but no line is highlighted. Used
+// for bare-path refs (`src/Main.hs` with no `:N`) — the file should
+// open, but no selection appears. Callers should first assert the file
+// has loaded (e.g. `the selected file should show content "..."`) so
+// this check doesn't pass trivially against a blank view.
+Then(
+  "no line should be selected in the file content",
+  async function (this: KoluWorld) {
+    const hasSelection = await this.page.evaluate(
+      `(() => {
+        ${SHADOW_DFS_FN_SRC}
+        const root = document.querySelector('${FILE_VIEW}');
+        if (!root) return false;
+        return shadowDfs(root, (node) =>
+          node.nodeType === 1 && node.hasAttribute('data-selected-line')
+        ) === true;
+      })()`,
+    );
+    if (hasSelection) {
+      throw new Error("expected no selected line, but one was found");
+    }
+  },
+);
+
 // Asserts the exact set of items in the Pierre diff/file context menu,
 // in order, joined with " | ". Stronger than `I click the context menu
 // item {string}` because it catches "wrong items present" regressions


### PR DESCRIPTION
**The terminal file-ref linkifier now matches paths without a `:N` suffix** — `src/Main.hs` and `Main.hs` are clickable links, not just `src/Main.hs:42`. Clicking a bare path opens the file in the Code tab with no line highlighted; clicking a path with a line still selects that line as before.

The regex's two path branches already required either a `/` or a letter-led `.ext`, so plain words (`react`, `init`, `Makefile`) stay unlinked even with `:N` made optional. Tokens that look like paths but resolve to nothing (`cd src/foo`, `git log src/`) get a harmless hover decoration — the resolver returns `null` and the click is a no-op.

### E2E coverage was thinner than expected

The slash-containing path branch — the regex's primary shape — wasn't exercised end-to-end at all. _Every existing scenario used a bare basename like `notes.txt:3`._ This PR adds the missing slash-path scenario plus three no-line variants:

| Scenario | Reference | What it verifies |
| --- | --- | --- |
| Slash path with line | `src/Main.hs:2` | Multi-segment relative path opens at the line |
| Bare basename, no line | `plain.txt` | File opens, no selection |
| Slash path, no line | `src/Main.hs` | Slash path resolves with no `:N` |
| Unique basename, no line | `unique.txt` (at `src/lib/unique.txt`) | Basename fallback works without a line |

Unit coverage in `lineRef.test.ts` mirrors the new shapes plus a negative for plain words (`npm i react`, `git init`, `run Makefile`).

> _The behavior change is permissive: every path-shaped token in terminal output now gets a hover underline. Resolution still gates the click, so misses are silent no-ops, but the visual density of decorations in noisy output goes up._

### Try it locally

```sh
nix run github:juspay/kolu/brief-flag
```

_Generated by Claude Code (model `claude-opus-4-7`)._