### PR TITLE
Reveal programmatically-selected rows in the file tree

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-kEFpKzoY/9NhP+P8oTJurCBZqsn++q1hbkXJyiXsc9E=";
+    hash = "sha256-M6Tl1GYjQNaArka1sZLgKKbkOlir8MyShgCY5GvJeGc=";
     fetcherVersion = 3;
   };
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,7 +19,7 @@
     "@kolu/surface": "workspace:*",
     "@orpc/client": "^1.13.13",
     "@pierre/diffs": "^1.1.20",
-    "@pierre/trees": "^1.0.0-beta.3",
+    "@pierre/trees": "^1.0.0-beta.4",
     "@orpc/contract": "^1.13.13",
     "@solid-primitives/event-listener": "^2.4.5",
     "@solid-primitives/media": "^2.3.5",

--- a/packages/solid-pierre/package.json
+++ b/packages/solid-pierre/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@pierre/diffs": "^1.1.20",
-    "@pierre/trees": "^1.0.0-beta.3",
+    "@pierre/trees": "^1.0.0-beta.4",
     "solid-js": "^1.9.0"
   }
 }

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -97,16 +97,6 @@ export const FileTree: Component<FileTreeProps> = (props) => {
   // membership in this set is a reliable file-vs-folder discriminator.
   const fileSet = createMemo(() => new Set(props.paths));
 
-  // Known limitation: Pierre's vanilla `FileTree` doesn't expose a
-  // public `scrollToPath`. Its `scrollFocusedRowIntoView` (in
-  // `dist/render/FileTreeView.js`) is gated on `shouldOwnDomFocus`,
-  // which is set only by user-initiated handlers (row click, keyboard
-  // nav). Programmatic selection via `initialSelectedPaths` /
-  // `getItem(path)?.select()` marks the row `aria-selected="true"` but
-  // does NOT scroll the virtualizer to reveal it. For small trees the
-  // row happens to sit in the visible window; for large worktrees the
-  // selected row stays virtualized off-screen until the user scrolls.
-  // Filed upstream: https://github.com/pierrecomputer/pierre/issues/676
   onMount(() => {
     try {
       // Snapshot read of `props.selectedPath` for `initialExpandedPaths`.
@@ -217,6 +207,11 @@ export const FileTree: Component<FileTreeProps> = (props) => {
             }
           } else {
             tree?.getItem(path)?.select();
+            // `select()` marks aria-selected but doesn't move the
+            // virtualizer; deep paths in large worktrees would stay
+            // off-screen until the user scrolled. `scrollToPath`
+            // reveals the row.
+            tree?.scrollToPath(path);
           }
         } catch (e) {
           props.onError(toError(e));

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -131,6 +131,13 @@ export const FileTree: Component<FileTreeProps> = (props) => {
         },
       });
       tree.render({ containerWrapper: container });
+      // Mirror the reactive selection effect: pin the "selected row is
+      // visible" invariant to this wrapper at both write sites instead
+      // of relying on Pierre's mount-time auto-scroll
+      // (`initialFocusedScrollAppliedRef`) to cover the constructor
+      // path. Idempotent — Pierre's view processes the explicit scroll
+      // request in the same render tick as its own first-mount scroll.
+      if (props.selectedPath) tree.scrollToPath(props.selectedPath);
     } catch (e) {
       props.onError(toError(e));
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^1.1.20
         version: 1.1.20(react@19.2.5)
       '@pierre/trees':
-        specifier: ^1.0.0-beta.3
-        version: 1.0.0-beta.3(react@19.2.5)
+        specifier: ^1.0.0-beta.4
+        version: 1.0.0-beta.4(react@19.2.5)
       '@solid-primitives/event-listener':
         specifier: ^2.4.5
         version: 2.4.5(solid-js@1.9.11)
@@ -512,8 +512,8 @@ importers:
         specifier: ^1.1.20
         version: 1.1.20(react@19.2.5)
       '@pierre/trees':
-        specifier: ^1.0.0-beta.3
-        version: 1.0.0-beta.3(react@19.2.5)
+        specifier: ^1.0.0-beta.4
+        version: 1.0.0-beta.4(react@19.2.5)
       solid-js:
         specifier: ^1.9.0
         version: 1.9.11
@@ -2015,8 +2015,8 @@ packages:
     resolution: {integrity: sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw==}
     engines: {vscode: ^1.0.0}
 
-  '@pierre/trees@1.0.0-beta.3':
-    resolution: {integrity: sha512-gfV7V1AoceIwTSFwiiWl/89gNtJROyo2dFeYYuAkT4F3AbE+ajCIGZEICBw1ygmVxVetF9Kq1Xpjz8BhXXZwTQ==}
+  '@pierre/trees@1.0.0-beta.4':
+    resolution: {integrity: sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
@@ -6166,7 +6166,7 @@ snapshots:
 
   '@pierre/theme@0.0.28': {}
 
-  '@pierre/trees@1.0.0-beta.3(react@19.2.5)':
+  '@pierre/trees@1.0.0-beta.4(react@19.2.5)':
     dependencies:
       preact: 11.0.0-beta.0
       preact-render-to-string: 6.6.5(preact@11.0.0-beta.0)


### PR DESCRIPTION
**Selecting a file in the Code tab from outside the tree — terminal `path:line` clicks, `Open path:N` from a diff, session restore — now scrolls the row into view** instead of leaving it virtualized off-screen. Bumps [`@pierre/trees`](https://www.npmjs.com/package/@pierre/trees) to `1.0.0-beta.4`, which exposes `FileTree.scrollToPath(path, options?)` (pierrecomputer/pierre#699), the upstream resolution of the gap I filed at pierrecomputer/pierre#676.

The wrapper now owns the *"selected row is visible"* invariant explicitly at both write sites:

| Site | Mechanism (before) | Mechanism (after) |
| --- | --- | --- |
| `onMount` (initial) | `initialSelectedPaths` marks `aria-selected`; Pierre's view-layer `initialFocusedScrollAppliedRef` auto-scrolls on first render | Same, plus an explicit `tree.scrollToPath(props.selectedPath)` after `tree.render(...)` — idempotent, coalesces in the same render tick |
| Reactive `props.selectedPath` change | `getItem(path).select()` marks `aria-selected`; **virtualizer never moves** | `select()` plus `tree.scrollToPath(path)` |

*Pinning the invariant in the wrapper rather than relying on Pierre's mount-time auto-scroll means both paths read the same way and the rule is robust to future Pierre internals.*

The 10-line workaround comment block in `FileTree.tsx` that documented the old limitation (and linked pierrecomputer/pierre#676) is gone — replaced by a four-line inline note at the new call site explaining *why* `select()` alone isn't enough.

Closes the kolu-side dependency on pierrecomputer/pierre#676.

### Try it locally

```sh
nix run github:juspay/kolu/upgrade-pierre-trees-beta4
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._