### PR TITLE
Show tips in a top-center banner instead of bottom-right toast

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -48,6 +48,7 @@ import { serverProcessId, wsStatus } from "./rpc/rpc";
 import TransportOverlay from "./rpc/TransportOverlay";
 import ShortcutsHelp from "./ShortcutsHelp";
 import { screenshotTerminal } from "./screenshotTerminal";
+import TipBanner from "./settings/TipBanner";
 import { useColorScheme } from "./settings/useColorScheme";
 import { useTips } from "./settings/useTips";
 import { useStaleCheck } from "./terminal/staleness";
@@ -366,6 +367,7 @@ const App: Component = () => {
       </Show>
       <TransportOverlay />
       <WebcamOverlay />
+      <TipBanner />
       <Toaster
         position="bottom-right"
         theme={colorScheme()}

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -217,7 +217,7 @@ const CommandPalette: Component<{
   /** When true, the backdrop is transparent so content behind is visible. */
   transparentOverlay?: boolean;
 }> = (props) => {
-  const { randomAmbientTip } = useTips();
+  const { peekAmbientTipText } = useTips();
   let inputRef!: HTMLInputElement;
   let listEl!: HTMLDivElement;
   const [query, setQuery] = createSignal("");
@@ -512,7 +512,7 @@ const CommandPalette: Component<{
       if (isOpen) {
         setQuery("");
         setSelectedIndex(0);
-        setAmbientTip(randomAmbientTip());
+        setAmbientTip(peekAmbientTipText());
         setMouseActive(false);
         setClosingForSelection(false);
         setPath([]);

--- a/packages/client/src/settings/TipBanner.tsx
+++ b/packages/client/src/settings/TipBanner.tsx
@@ -1,0 +1,84 @@
+/** Top-center tip banner — a distinct surface for tips so they don't
+ *  blend into the bottom-right toast stream (success / error / warning
+ *  notifications). One tip is shown at a time; new tips replace the
+ *  current one. */
+
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  on,
+  onCleanup,
+  Show,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+import { CloseIcon } from "../ui/Icons";
+import { activeTip, dismissTip } from "./useTips";
+
+const VISIBLE_DURATION_MS = 8000;
+
+const TipBanner: Component = () => {
+  const [visible, setVisible] = createSignal(false);
+
+  createEffect(
+    on(activeTip, (tip) => {
+      if (!tip) {
+        setVisible(false);
+        return;
+      }
+      // Start off-screen, then flip on next frame so the CSS transition
+      // runs instead of snapping straight to the final position.
+      setVisible(false);
+      const raf = requestAnimationFrame(() => setVisible(true));
+      const timer = window.setTimeout(dismissTip, VISIBLE_DURATION_MS);
+      onCleanup(() => {
+        cancelAnimationFrame(raf);
+        window.clearTimeout(timer);
+      });
+    }),
+  );
+
+  return (
+    <Show when={activeTip()}>
+      {(tip) => (
+        <Portal>
+          <div
+            data-testid="tip-banner"
+            class="fixed top-3 left-1/2 z-50 -translate-x-1/2 pointer-events-none transition-all duration-300 ease-out"
+            classList={{
+              "opacity-0 -translate-y-6": !visible(),
+              "opacity-100 translate-y-0": visible(),
+            }}
+          >
+            <div
+              class="pointer-events-auto flex items-center gap-3 pl-4 pr-2 py-2 bg-surface-1 border border-accent/50 rounded-full max-w-[min(560px,calc(100vw-2rem))]"
+              style={{
+                "box-shadow":
+                  "0 10px 30px -10px rgba(0,0,0,0.5), 0 0 0 4px color-mix(in oklch, var(--color-accent) 12%, transparent)",
+              }}
+            >
+              <span
+                class="text-base leading-none select-none"
+                aria-hidden="true"
+              >
+                💡
+              </span>
+              <span class="text-sm text-fg">{tip().text}</span>
+              <button
+                type="button"
+                data-testid="tip-banner-dismiss"
+                onClick={dismissTip}
+                aria-label="Dismiss tip"
+                class="h-6 w-6 flex items-center justify-center text-fg-3 hover:text-fg hover:bg-surface-2 rounded-full transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+          </div>
+        </Portal>
+      )}
+    </Show>
+  );
+};
+
+export default TipBanner;

--- a/packages/client/src/settings/TipBanner.tsx
+++ b/packages/client/src/settings/TipBanner.tsx
@@ -20,10 +20,8 @@ const TipBanner: Component = () => {
 
   createEffect(
     on(activeTip, (tip) => {
-      if (!tip) {
-        setVisible(false);
-        return;
-      }
+      // <Show> unmounts the DOM when tip is null — nothing to animate out.
+      if (!tip) return;
       // Start off-screen, then flip on next frame so the CSS transition
       // runs instead of snapping straight to the final position.
       setVisible(false);

--- a/packages/client/src/settings/TipBanner.tsx
+++ b/packages/client/src/settings/TipBanner.tsx
@@ -1,7 +1,7 @@
 /** Top-center tip banner — a distinct surface for tips so they don't
  *  blend into the bottom-right toast stream (success / error / warning
- *  notifications). One tip is shown at a time; new tips replace the
- *  current one. */
+ *  notifications). Pure animation surface; `useTips` owns when a tip
+ *  becomes active and when it auto-dismisses. */
 
 import {
   type Component,
@@ -14,8 +14,6 @@ import {
 import { Portal } from "solid-js/web";
 import { CloseIcon } from "../ui/Icons";
 import { activeTip, dismissTip } from "./useTips";
-
-const VISIBLE_DURATION_MS = 8000;
 
 const TipBanner: Component = () => {
   const [visible, setVisible] = createSignal(false);
@@ -30,11 +28,7 @@ const TipBanner: Component = () => {
       // runs instead of snapping straight to the final position.
       setVisible(false);
       const raf = requestAnimationFrame(() => setVisible(true));
-      const timer = window.setTimeout(dismissTip, VISIBLE_DURATION_MS);
-      onCleanup(() => {
-        cancelAnimationFrame(raf);
-        window.clearTimeout(timer);
-      });
+      onCleanup(() => cancelAnimationFrame(raf));
     }),
   );
 

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TerminalId } from "kolu-common/surface";
-import { type Accessor, createEffect, createSignal } from "solid-js";
+import { type Accessor, createEffect, createSignal, onCleanup } from "solid-js";
 import { isMobile } from "../useMobile";
 import { AMBIENT_TIPS, type Tip, type TipId } from "./tips";
 import { preferences, updatePreferences } from "../wire";
@@ -78,7 +78,8 @@ function initTipTriggers(deps: { terminalIds: Accessor<TerminalId[]> }) {
   createEffect(() => {
     if (!startupFired && deps.terminalIds().length > 0) {
       startupFired = true;
-      setTimeout(showStartupTip, 1000);
+      const id = window.setTimeout(showStartupTip, 1000);
+      onCleanup(() => window.clearTimeout(id));
     }
   });
 }

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -42,30 +42,32 @@ function showTipOnce(tip: Tip) {
   setActiveTip(tip);
 }
 
-/** Pick a random ambient tip (prefers unseen, falls back to any).
- *  Returns the full tip so callers can show it in the banner; the
- *  palette consumer uses `.text` for its footer string. */
+/** Internal pure peek — picks a tip without marking it seen. */
 function pickAmbientTip(): Tip | null {
   if (isMobile()) return null;
   const unseen = ambientPool.filter((t) => !seen().has(t.id));
   const pool = unseen.length > 0 ? unseen : ambientPool;
-  const pick = pool[Math.floor(Math.random() * pool.length)];
-  if (!pick) return null;
-  if (!seen().has(pick.id)) markSeen(pick.id);
-  return pick;
+  return pool[Math.floor(Math.random() * pool.length)] ?? null;
 }
 
-/** Text-only variant for surfaces that just render a string (palette footer). */
-function randomAmbientTip(): string {
+/** Text-only peek for surfaces that render tip text without "consuming"
+ *  the tip (palette footer). Does not mark the tip seen so the banner's
+ *  unseen pool is not drained by incidental glances. */
+function peekAmbientTipText(): string {
   return pickAmbientTip()?.text ?? "";
 }
 
-/** Show a random tip in the banner (for startup). Respects the startup-tips setting. */
-function showStartupTip() {
-  if (isMobile()) return;
-  if (!preferences().startupTips) return;
+/** Atomic: pick an ambient tip, mark it seen, show it in the banner. */
+function showAmbientTip() {
   const tip = pickAmbientTip();
-  if (tip) setActiveTip(tip);
+  if (!tip) return;
+  if (!seen().has(tip.id)) markSeen(tip.id);
+  setActiveTip(tip);
+}
+
+/** Show a random tip in the banner on startup, if the setting is on. */
+function showStartupTip() {
+  if (preferences().startupTips) showAmbientTip();
 }
 
 /**
@@ -87,7 +89,7 @@ function initTipTriggers(deps: { terminalIds: Accessor<TerminalId[]> }) {
 export function useTips() {
   return {
     showTipOnce,
-    randomAmbientTip,
+    peekAmbientTipText,
     initTipTriggers,
     startupTips: () => preferences().startupTips,
     setStartupTips: (on: boolean) => updatePreferences({ startupTips: on }),

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -1,11 +1,12 @@
 /**
  * Tip state — singleton module. Persists seen tips in server state.
- * Owns all tip timing: state-driven triggers live here, not in consuming components.
+ * Tips render via `<TipBanner />` (top-center floating pill), kept
+ * separate from the bottom-right toast stream so they don't get lost
+ * among success / error notifications.
  */
 
 import type { TerminalId } from "kolu-common/surface";
-import { type Accessor, createEffect } from "solid-js";
-import { toast } from "solid-sonner";
+import { type Accessor, createEffect, createSignal } from "solid-js";
 import { isMobile } from "../useMobile";
 import { AMBIENT_TIPS, type Tip, type TipId } from "./tips";
 import { preferences, updatePreferences } from "../wire";
@@ -14,6 +15,14 @@ const isPWA = window.matchMedia("(display-mode: standalone)").matches;
 const ambientPool = AMBIENT_TIPS.filter(
   (t) => !(isPWA && t.id === "amb-pwa-install"),
 );
+
+const [activeTipSignal, setActiveTip] = createSignal<Tip | null>(null);
+
+/** Reactive accessor for the tip currently displayed by `<TipBanner />`. */
+export const activeTip: Accessor<Tip | null> = activeTipSignal;
+
+/** Hide the active tip (banner slides away). */
+export const dismissTip = () => setActiveTip(null);
 
 function seen(): Set<TipId> {
   return new Set(preferences().seenTips);
@@ -25,36 +34,38 @@ function markSeen(id: TipId) {
   updatePreferences({ seenTips: [...s] });
 }
 
-const TIP_PREFIX = "\u{1F4A1} ";
-
-/** Show a contextual tip toast if the user hasn't seen it yet. */
+/** Show a contextual tip once. Marks it seen so it never reappears. */
 function showTipOnce(tip: Tip) {
   if (isMobile()) return;
   if (seen().has(tip.id)) return;
   markSeen(tip.id);
-  toast(TIP_PREFIX + tip.text, { duration: 5000 });
+  setActiveTip(tip);
 }
 
-/** Pick a random ambient tip (prefers unseen, falls back to any). */
-function randomAmbientTip(): string {
-  if (isMobile()) return "";
+/** Pick a random ambient tip (prefers unseen, falls back to any).
+ *  Returns the full tip so callers can show it in the banner; the
+ *  palette consumer uses `.text` for its footer string. */
+function pickAmbientTip(): Tip | null {
+  if (isMobile()) return null;
   const unseen = ambientPool.filter((t) => !seen().has(t.id));
   const pool = unseen.length > 0 ? unseen : ambientPool;
   const pick = pool[Math.floor(Math.random() * pool.length)];
-  if (!pick) return "";
+  if (!pick) return null;
   if (!seen().has(pick.id)) markSeen(pick.id);
-  return pick.text;
+  return pick;
 }
 
-/** Show a random tip as a toast (for startup). Respects the startup-tips setting. */
+/** Text-only variant for surfaces that just render a string (palette footer). */
+function randomAmbientTip(): string {
+  return pickAmbientTip()?.text ?? "";
+}
+
+/** Show a random tip in the banner (for startup). Respects the startup-tips setting. */
 function showStartupTip() {
   if (isMobile()) return;
   if (!preferences().startupTips) return;
-  const text = randomAmbientTip();
-  toast(TIP_PREFIX + text, {
-    duration: 4000,
-    description: "Startup tip \u00B7 disable in Settings",
-  });
+  const tip = pickAmbientTip();
+  if (tip) setActiveTip(tip);
 }
 
 /**

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TerminalId } from "kolu-common/surface";
-import { type Accessor, createEffect, createSignal, onCleanup } from "solid-js";
+import { type Accessor, createEffect, createSignal } from "solid-js";
 import { isMobile } from "../useMobile";
 import { AMBIENT_TIPS, type Tip, type TipId } from "./tips";
 import { preferences, updatePreferences } from "../wire";
@@ -106,8 +106,10 @@ function initTipTriggers(deps: { terminalIds: Accessor<TerminalId[]> }) {
   createEffect(() => {
     if (!startupFired && deps.terminalIds().length > 0) {
       startupFired = true;
-      const id = window.setTimeout(showStartupTip, 1000);
-      onCleanup(() => window.clearTimeout(id));
+      // Fire-and-forget: the createEffect re-runs when terminalIds changes,
+      // and onCleanup would cancel the pending timeout before it fires.
+      // startupFired already guards against re-entry, so no cleanup needed.
+      window.setTimeout(showStartupTip, 1000);
     }
   });
 }

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -87,7 +87,7 @@ function peekAmbientTipText(): string {
 function showAmbientTip() {
   const tip = pickAmbientTip();
   if (!tip) return;
-  if (!seen().has(tip.id)) markSeen(tip.id);
+  markSeen(tip.id);
   present(tip);
 }
 

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -21,8 +21,34 @@ const [activeTipSignal, setActiveTip] = createSignal<Tip | null>(null);
 /** Reactive accessor for the tip currently displayed by `<TipBanner />`. */
 export const activeTip: Accessor<Tip | null> = activeTipSignal;
 
+/** How long a tip stays on screen before the banner auto-dismisses it.
+ *  Owned here (not in the banner) so the state module fully controls
+ *  "how a tip is displayed and for how long" — the banner is just the
+ *  rendering surface. */
+const TIP_DURATION_MS = 8000;
+let autoDismissTimer: number | null = null;
+
+function cancelAutoDismiss() {
+  if (autoDismissTimer !== null) {
+    window.clearTimeout(autoDismissTimer);
+    autoDismissTimer = null;
+  }
+}
+
+function present(tip: Tip) {
+  cancelAutoDismiss();
+  setActiveTip(tip);
+  autoDismissTimer = window.setTimeout(() => {
+    autoDismissTimer = null;
+    setActiveTip(null);
+  }, TIP_DURATION_MS);
+}
+
 /** Hide the active tip (banner slides away). */
-export const dismissTip = () => setActiveTip(null);
+export const dismissTip = () => {
+  cancelAutoDismiss();
+  setActiveTip(null);
+};
 
 function seen(): Set<TipId> {
   return new Set(preferences().seenTips);
@@ -39,7 +65,7 @@ function showTipOnce(tip: Tip) {
   if (isMobile()) return;
   if (seen().has(tip.id)) return;
   markSeen(tip.id);
-  setActiveTip(tip);
+  present(tip);
 }
 
 /** Internal pure peek — picks a tip without marking it seen. */
@@ -62,7 +88,7 @@ function showAmbientTip() {
   const tip = pickAmbientTip();
   if (!tip) return;
   if (!seen().has(tip.id)) markSeen(tip.id);
-  setActiveTip(tip);
+  present(tip);
 }
 
 /** Show a random tip in the banner on startup, if the setting is on. */


### PR DESCRIPTION
**Tips were getting lost in the toast stream** — same corner, same visual treatment as success/error/warning notifications. Move them to a dedicated top-center pill with a lightbulb icon, soft accent halo, and explicit dismiss button so they read as guidance, not noise. The existing bottom-right `<Toaster>` keeps handling outcome notifications; only tip rendering moves.

### What changed

| Layer | Before | After |
|---|---|---|
| Surface | `toast(TIP_PREFIX + text)` in the bottom-right stream | `<TipBanner />`, fixed top-center, slide-down, 8s auto-dismiss |
| State | `setActiveTip` called inline; timer lived in the component | `present(tip)` + `dismissTip()` in `useTips` own lifetime end-to-end |
| Ambient pool | One `randomAmbientTip()` adapter that marked-seen on every palette open | `showAmbientTip()` (atomic peek + mark + show) for startup, `peekAmbientTipText()` (read-only) for the palette footer |

### Structural cleanups landed alongside

The first commit is the feature; the rest are hickey/lowy + code-police follow-ups that refined the shape without changing user-visible behavior.

- **State owns timing, banner owns animation.** `TIP_DURATION_MS` and the dismiss `setTimeout` live in `useTips.ts`; `TipBanner.tsx` is just a slide-down surface that reads `activeTip()` and calls `dismissTip()` from its close button.
- **Atomic show vs read-only peek.** The palette footer no longer drains the unseen-tip pool by being incidentally rendered — `peekAmbientTipText()` does not mark seen. Only `showAmbientTip()` (the banner path) commits.
- **Fire-and-forget startup timer.** A `lowy` finding asked for `onCleanup(clearTimeout)` on the 1s startup-tip delay. _Code-police caught the regression_: `createEffect` re-runs whenever `terminalIds()` changes, and SolidJS invokes the prior cleanup first — so the pending timeout would be cancelled before it ever fired. `startupFired` already guards re-entry; an inline comment now explains why the bare `setTimeout` is correct.

### Try it locally

\`\`\`sh
nix run github:juspay/kolu/civil-fever
\`\`\`

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._