### PR TITLE
fix(nix): use linux-produced website pnpmDeps hash

### DIFF
--- a/website/default.nix
+++ b/website/default.nix
@@ -29,7 +29,7 @@ let
     pname = "kolu-website";
     version = "0.1.0";
     inherit src;
-    hash = "sha256-EgCvlKgSv86ecZR7aL1J2uGFWnaCMyQjkvUlpqXjaTo=";
+    hash = "sha256-UKIHmWIr5s0RkpDOB8RMDvLL779dugiBDoVOWqQgYrQ=";
     fetcherVersion = 3;
   };
 


### PR DESCRIPTION
## Summary

`ci::pnpm-hash-fresh` only runs on `x86_64-linux` (see `ci/mod.just:32`), but the declared hash in `website/default.nix:32` was the one `fetchPnpmDeps` produces on `aarch64-darwin`. Linux produces a different byte layout for the same lockfile, so CI has been failing with:

\`\`\`
specified: sha256-EgCvlKgSv86ecZR7aL1J2uGFWnaCMyQjkvUlpqXjaTo=
     got: sha256-UKIHmWIr5s0RkpDOB8RMDvLL779dugiBDoVOWqQgYrQ=
\`\`\`

Swap in the linux hash to unstick CI. Fixes #937.

The "hashes are platform-independent" assumption (per the comment in `ci/mod.just`) no longer holds for this lockfile — likely an optional binary in the website tree (e.g. `@img/sharp-*`) that `pnpm install --force` doesn't normalize the same way on both platforms. Worth investigating root cause separately; this PR is the quick unblock.

## Test plan

- [ ] `just ci::pnpm-hash-fresh` passes on `x86_64-linux`
- [ ] Website still builds (`nix build .#website`)