### PR TITLE
fix(comments): wire releaseTerminal to terminal-deletion lifecycle

### DIFF
--- a/packages/client/src/comments/useComments.ts
+++ b/packages/client/src/comments/useComments.ts
@@ -15,8 +15,15 @@
  *  function; the tray's "Copy to clipboard" calls it directly. */
 
 import { makePersisted } from "@solid-primitives/storage";
-import { createSignal } from "solid-js";
+import {
+  createComputed,
+  createRoot,
+  createSignal,
+  mapArray,
+  onCleanup,
+} from "solid-js";
 import { toast } from "solid-sonner";
+import { terminalListSub } from "../wire";
 import type { Comment, PersistedShape } from "./types";
 
 const STORAGE_PREFIX = "kolu:comments-by-terminal:";
@@ -87,17 +94,29 @@ function storeFor(terminalId: string) {
   return wrapped;
 }
 
-/** Drop the in-memory store wrapper for a terminal whose lifecycle has
- *  ended. The `makePersisted` storage entry stays — comments survive
- *  terminal recreation as long as the terminalId is reused (e.g. session
- *  restore).
- *
- *  Wired from `useTerminalMetadata` via `mapArray` + `onCleanup`: the
- *  per-key reactive owner is disposed when a terminalId leaves the
- *  live key set, which fires this release. */
-export function releaseTerminal(terminalId: string): void {
-  storesByKey.delete(terminalId);
-}
+// Lifecycle scope: data-scoped — fires when a terminalId leaves the
+// server's live terminal list (NOT on component unmount; xterm/WebGL
+// teardown lives in `Terminal.tsx`'s onCleanup, which is component-scoped).
+//
+// Bound `storesByKey` to live terminals by evicting an entry when its id
+// leaves `terminalListSub`. Owning the wiring here keeps the terminal
+// subsystem ignorant of per-feature cleanup APIs — features that key off
+// `terminalId` follow the same self-subscription pattern. createComputed
+// is load-bearing: it drives the mapArray accessor eagerly so per-key
+// reactive owners attach with their onCleanup hooks. Without it the
+// callback never runs and bound growth silently regresses. The
+// makePersisted storage entry stays — comments survive terminal
+// recreation as long as the terminalId is reused (session restore).
+createRoot(() => {
+  createComputed(
+    mapArray(
+      () => terminalListSub()?.map((t) => t.id) ?? [],
+      (id) => {
+        onCleanup(() => storesByKey.delete(id));
+      },
+    ),
+  );
+});
 
 /** API the rest of the client uses. Pass the active terminalId at the
  *  consumer site — there's no global ambient context (matches how

--- a/packages/client/src/comments/useComments.ts
+++ b/packages/client/src/comments/useComments.ts
@@ -90,16 +90,11 @@ function storeFor(terminalId: string) {
 /** Drop the in-memory store wrapper for a terminal whose lifecycle has
  *  ended. The `makePersisted` storage entry stays — comments survive
  *  terminal recreation as long as the terminalId is reused (e.g. session
- *  restore). Call this from the terminal-deletion path to bound the
- *  in-memory Map; without it, every `useComments(tid)` call leaves a
- *  Map entry that lives for the page session.
+ *  restore).
  *
- *  NOTE: not yet wired to terminal deletion — the comments feature
- *  doesn't own the terminal lifecycle. Filed as a follow-up because
- *  the Map entries are tiny (a few function closures each) and the
- *  realistic upper bound is the number of terminals opened in one
- *  session, which is small. The API exists so wiring it later is a
- *  one-line change in the terminal-management code. */
+ *  Wired from `useTerminalMetadata` via `mapArray` + `onCleanup`: the
+ *  per-key reactive owner is disposed when a terminalId leaves the
+ *  live key set, which fires this release. */
 export function releaseTerminal(terminalId: string): void {
   storesByKey.delete(terminalId);
 }

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -368,6 +368,12 @@ const Terminal: Component<{
     ),
   );
 
+  // Lifecycle scope: component-scoped — fires on DOM disposal (e.g.
+  // `<Show>` tile swap, route change), NOT on server key-set departure.
+  // The data-scoped path (per-id eviction from `meta.keys`) lives in
+  // `useTerminalMetadata.ts`; the two scopes are intentionally separate
+  // and not synchronous.
+  //
   // Cleanup registered SYNCHRONOUSLY at component body top — NOT inside the
   // async `onMount` below. If the reactive owner disposes during `onMount`'s
   // `await document.fonts.load(...)` (e.g. an `<Show>` toggle swapping a tile

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -369,10 +369,11 @@ const Terminal: Component<{
   );
 
   // Lifecycle scope: component-scoped — fires on DOM disposal (e.g.
-  // `<Show>` tile swap, route change), NOT on server key-set departure.
-  // The data-scoped path (per-id eviction from `meta.keys`) lives in
-  // `useTerminalMetadata.ts`; the two scopes are intentionally separate
-  // and not synchronous.
+  // `<Show>` tile swap, route change), NOT on server-list departure.
+  // Per-feature data-scoped cleanup (e.g. comments-store eviction in
+  // `comments/useComments.ts`) lives at the feature site and subscribes
+  // to `terminalListSub` directly; the two scopes are intentionally
+  // separate and not synchronous.
   //
   // Cleanup registered SYNCHRONOUSLY at component body top — NOT inside the
   // async `onMount` below. If the reactive owner disposes during `onMount`'s

--- a/packages/client/src/terminal/useTerminalMetadata.ts
+++ b/packages/client/src/terminal/useTerminalMetadata.ts
@@ -19,15 +19,8 @@ import type {
   TerminalInfo,
   TerminalMetadata,
 } from "kolu-common/surface";
-import {
-  type Accessor,
-  createComputed,
-  createMemo,
-  mapArray,
-  onCleanup,
-} from "solid-js";
+import { type Accessor, createMemo } from "solid-js";
 import { toast } from "solid-sonner";
-import { releaseTerminal } from "../comments/useComments";
 import { app } from "../wire";
 import {
   buildTerminalDisplayInfos,
@@ -42,24 +35,6 @@ export function useTerminalMetadata(deps: {
     keys: () => deps.list()?.map((t) => t.id) ?? [],
     onError: (err) => toast.error(`Metadata error: ${err.message}`),
   });
-
-  // Lifecycle scope: data-scoped — fires on server key-set departure
-  // (an id leaves `meta.keys`), NOT on component unmount. The component
-  // path uses `Terminal.tsx`'s onCleanup for xterm/WebGL teardown; the
-  // two scopes are intentionally separate and not synchronous.
-  //
-  // Free per-terminal comment-store entries when a terminal leaves the
-  // live key set. createComputed is load-bearing: it drives the mapArray
-  // accessor eagerly so per-key reactive owners attach with their
-  // onCleanup hooks. Without it the callback never runs, onCleanup never
-  // registers, and storesByKey resumes unbounded growth — with no
-  // compilation or test failure. Each per-key owner is disposed when its
-  // id leaves the set, firing onCleanup → releaseTerminal.
-  createComputed(
-    mapArray(meta.keys, (id) => {
-      onCleanup(() => releaseTerminal(id));
-    }),
-  );
 
   function getMetadata(id: TerminalId): TerminalMetadata | undefined {
     return meta.byKey(id)?.();

--- a/packages/client/src/terminal/useTerminalMetadata.ts
+++ b/packages/client/src/terminal/useTerminalMetadata.ts
@@ -43,6 +43,11 @@ export function useTerminalMetadata(deps: {
     onError: (err) => toast.error(`Metadata error: ${err.message}`),
   });
 
+  // Lifecycle scope: data-scoped — fires on server key-set departure
+  // (an id leaves `meta.keys`), NOT on component unmount. The component
+  // path uses `Terminal.tsx`'s onCleanup for xterm/WebGL teardown; the
+  // two scopes are intentionally separate and not synchronous.
+  //
   // Free per-terminal comment-store entries when a terminal leaves the
   // live key set. createComputed is load-bearing: it drives the mapArray
   // accessor eagerly so per-key reactive owners attach with their

--- a/packages/client/src/terminal/useTerminalMetadata.ts
+++ b/packages/client/src/terminal/useTerminalMetadata.ts
@@ -44,9 +44,12 @@ export function useTerminalMetadata(deps: {
   });
 
   // Free per-terminal comment-store entries when a terminal leaves the
-  // live key set. mapArray's per-key reactive owner is disposed on
-  // removal, firing onCleanup — bounds storesByKey to the active set
-  // without a separate diff effect.
+  // live key set. createComputed is load-bearing: it drives the mapArray
+  // accessor eagerly so per-key reactive owners attach with their
+  // onCleanup hooks. Without it the callback never runs, onCleanup never
+  // registers, and storesByKey resumes unbounded growth — with no
+  // compilation or test failure. Each per-key owner is disposed when its
+  // id leaves the set, firing onCleanup → releaseTerminal.
   createComputed(
     mapArray(meta.keys, (id) => {
       onCleanup(() => releaseTerminal(id));

--- a/packages/client/src/terminal/useTerminalMetadata.ts
+++ b/packages/client/src/terminal/useTerminalMetadata.ts
@@ -19,8 +19,15 @@ import type {
   TerminalInfo,
   TerminalMetadata,
 } from "kolu-common/surface";
-import { type Accessor, createMemo } from "solid-js";
+import {
+  type Accessor,
+  createComputed,
+  createMemo,
+  mapArray,
+  onCleanup,
+} from "solid-js";
 import { toast } from "solid-sonner";
+import { releaseTerminal } from "../comments/useComments";
 import { app } from "../wire";
 import {
   buildTerminalDisplayInfos,
@@ -35,6 +42,16 @@ export function useTerminalMetadata(deps: {
     keys: () => deps.list()?.map((t) => t.id) ?? [],
     onError: (err) => toast.error(`Metadata error: ${err.message}`),
   });
+
+  // Free per-terminal comment-store entries when a terminal leaves the
+  // live key set. mapArray's per-key reactive owner is disposed on
+  // removal, firing onCleanup — bounds storesByKey to the active set
+  // without a separate diff effect.
+  createComputed(
+    mapArray(meta.keys, (id) => {
+      onCleanup(() => releaseTerminal(id));
+    }),
+  );
 
   function getMetadata(id: TerminalId): TerminalMetadata | undefined {
     return meta.byKey(id)?.();


### PR DESCRIPTION
**Per-terminal comment-store entries now free themselves when a terminal leaves the live key set.** PR #922 added a `releaseTerminal(terminalId)` API to bound the `storesByKey` Map but left it unwired — the police `no-unbounded-growth` finding was acknowledged, not closed. This PR closes it.

The cleanup lives in `useComments.ts` itself: a module-level `createRoot(createComputed(mapArray(...)))` subscribes to `terminalListSub` and registers a per-key `onCleanup` that drops the entry from `storesByKey` when its id leaves the live list. The terminal subsystem stays ignorant of who's listening; future features keyed off `terminalId` follow the same self-subscription pattern.

```ts
createRoot(() => {
  createComputed(
    mapArray(
      () => terminalListSub()?.map((t) => t.id) ?? [],
      (id) => {
        onCleanup(() => storesByKey.delete(id));
      },
    ),
  );
});
```

_`createComputed` is load-bearing — without it `mapArray`'s callback never runs and the cleanup hooks never attach. The exported `releaseTerminal` API is no longer needed and was removed; the eviction is fully internal to `useComments` now._

### Lifecycle scope is intentionally split

The codebase has two cleanup paths for "terminal removed," anchored to different lifecycle signals:

| Site | Scope | Fires on |
| --- | --- | --- |
| `comments/useComments.ts` (this PR) | **Data-scoped** | id leaves `terminalListSub` (server list update) |
| `terminal/Terminal.tsx` `onCleanup` | **Component-scoped** | DOM disposal (`<Show>` tile swap, route change) |

Both sites carry a short "Lifecycle scope:" comment so the separation is structural documentation, not tribal memory. Per-feature in-memory stores belong on the data path (they outlive any single component instance); xterm / WebGL teardown belongs on the component path.

### How we got here

Initial implementation parked the `mapArray` block in `useTerminalMetadata.ts` (closest to `meta.keys`). Hickey + Lowy + cross-validation all signed off on that placement — and they were wrong: it complected the terminal subsystem with a feature's cleanup API. Reviewer feedback caught the smell. The commit history shows the iterative refinement: original wiring → two doc commits → relocate to the feature side and drop the cross-domain coupling.

Closes #939.

### Try it locally

```sh
nix run github:juspay/kolu/golden-share
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._