### PR TITLE
Extract refcounted dir-watcher into kolu-io

### DIFF
--- a/.agents/skills/parcel/SKILL.md
+++ b/.agents/skills/parcel/SKILL.md
@@ -18,9 +18,9 @@ of `chokidar`, raw `fs.watch`, or hand-rolled polling whenever a feature
 needs to observe a directory subtree. Today's only consumer is the
 working-tree watcher (`packages/integrations/git/src/working-tree-watcher.ts`)
 — the git-dir watchers (`head-watcher`, `reflog-watcher`, `index-watcher`)
-use plain `fs.watch` via `shared-dir-filename-watcher.ts` because they target
-a single known file inside `.git/`, where parcel-watcher's recursive model
-would be overkill. New fs-monitoring code should default to parcel-watcher
+use plain `fs.watch` via `kolu-io`'s `refcounted-dir-watcher.ts` because they
+target a single known file inside `.git/`, where parcel-watcher's recursive
+model would be overkill. New fs-monitoring code should default to parcel-watcher
 unless it has a similarly narrow target.
 
 ## Backend dispatch

--- a/.apm/skills/parcel/SKILL.md
+++ b/.apm/skills/parcel/SKILL.md
@@ -18,9 +18,9 @@ of `chokidar`, raw `fs.watch`, or hand-rolled polling whenever a feature
 needs to observe a directory subtree. Today's only consumer is the
 working-tree watcher (`packages/integrations/git/src/working-tree-watcher.ts`)
 — the git-dir watchers (`head-watcher`, `reflog-watcher`, `index-watcher`)
-use plain `fs.watch` via `shared-dir-filename-watcher.ts` because they target
-a single known file inside `.git/`, where parcel-watcher's recursive model
-would be overkill. New fs-monitoring code should default to parcel-watcher
+use plain `fs.watch` via `kolu-io`'s `refcounted-dir-watcher.ts` because they
+target a single known file inside `.git/`, where parcel-watcher's recursive
+model would be overkill. New fs-monitoring code should default to parcel-watcher
 unless it has a similarly narrow target.
 
 ## Backend dispatch

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "**"
+---
+
+## Documentation
+Keep `README.md` in sync with user-facing changes.

--- a/.claude/skills/parcel/SKILL.md
+++ b/.claude/skills/parcel/SKILL.md
@@ -18,9 +18,9 @@ of `chokidar`, raw `fs.watch`, or hand-rolled polling whenever a feature
 needs to observe a directory subtree. Today's only consumer is the
 working-tree watcher (`packages/integrations/git/src/working-tree-watcher.ts`)
 — the git-dir watchers (`head-watcher`, `reflog-watcher`, `index-watcher`)
-use plain `fs.watch` via `shared-dir-filename-watcher.ts` because they target
-a single known file inside `.git/`, where parcel-watcher's recursive model
-would be overkill. New fs-monitoring code should default to parcel-watcher
+use plain `fs.watch` via `kolu-io`'s `refcounted-dir-watcher.ts` because they
+target a single known file inside `.git/`, where parcel-watcher's recursive
+model would be overkill. New fs-monitoring code should default to parcel-watcher
 unless it has a similarly narrow target.
 
 ## Backend dispatch

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ pnpm monorepo:
 | `packages/integrations/opencode/`    | OpenCode detection — reads OpenCode's SQLite database via Node's built-in `node:sqlite`; exports an `opencodeProvider` `AgentProvider`                                |
 | `packages/integrations/git/`         | Pure git operations — `simple-git` wrapper: repo resolution, worktree lifecycle, diff review, path security; schemas re-exported by `kolu-common`                     |
 | `packages/integrations/github/`      | GitHub PR schemas + pure helpers (`deriveCheckStatus`, `classifyGhError`, `prResultEqual`); server wraps with `gh pr view` spawn via `KOLU_GH_BIN`                    |
+| `packages/integrations/io/`          | Filesystem & I/O primitives — refcounted shared `fs.watch` keyed by directory (`createDirFilenameWatcher`); zero `kolu-*` deps so any package can adopt without coupling |
 | `packages/transcript-core/`          | Vendor-neutral transcript IR (`Transcript`, `TranscriptEvent`, typed `ToolInput` union) + structural transforms; per-agent loaders normalize into this shape          |
 | `packages/transcript-html/`          | Static-export renderer — `marked` for prose, [`@pierre/diffs`](https://www.npmjs.com/package/@pierre/diffs) SSR for shiki-tokenized code/diffs, [Preact](https://preactjs.com/) JSX for chrome; emits one self-contained `.html` |
 | `packages/terminal-themes/`          | Terminal color scheme catalog + perceptual-distance picker — themes checked-in as JSON                                                                                |

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-05-19T19:27:18.616070+00:00'
+generated_at: '2026-05-20T13:08:09.883929+00:00'
 apm_version: 0.14.0
 dependencies:
 - repo_url: anthropics/skills
@@ -20,6 +20,8 @@ dependencies:
   - .agents/skills/ci
   - .claude/rules/workflow.md
   - .claude/skills/ci
+  deployed_file_hashes:
+    .claude/rules/workflow.md: sha256:babf61cdd29cfc8f03b3d20f17b4bf13ef5f173dc05640bc83c505dca4b42010
   content_hash: sha256:22765d5f63a5d06a9bc60ea0cb2afb212291eaef767d1476389e441e44245e29
 - repo_url: juspay/nix-chrome-devtools-mcp
   host: github.com

--- a/packages/integrations/git/src/cwd-git-watcher.ts
+++ b/packages/integrations/git/src/cwd-git-watcher.ts
@@ -14,7 +14,7 @@
  */
 
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
-import { createDirFilenameWatcher } from "./shared-dir-filename-watcher.ts";
+import { createDirFilenameWatcher } from "kolu-io";
 
 const cwdGitWatcher = createDirFilenameWatcher({
   resolveDir: (cwd) => cwd,

--- a/packages/integrations/git/src/head-watcher.ts
+++ b/packages/integrations/git/src/head-watcher.ts
@@ -13,7 +13,7 @@
  */
 
 import { resolveGitDir, WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
-import { createDirFilenameWatcher } from "./shared-dir-filename-watcher.ts";
+import { createDirFilenameWatcher } from "kolu-io";
 
 const headWatcher = createDirFilenameWatcher({
   resolveDir: resolveGitDir,

--- a/packages/integrations/git/src/index-watcher.ts
+++ b/packages/integrations/git/src/index-watcher.ts
@@ -13,7 +13,7 @@
  */
 
 import { resolveGitDir, WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
-import { createDirFilenameWatcher } from "./shared-dir-filename-watcher.ts";
+import { createDirFilenameWatcher } from "kolu-io";
 
 const indexWatcher = createDirFilenameWatcher({
   resolveDir: resolveGitDir,

--- a/packages/integrations/git/src/reflog-watcher.ts
+++ b/packages/integrations/git/src/reflog-watcher.ts
@@ -14,7 +14,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveGitDir, WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
-import { createDirFilenameWatcher } from "./shared-dir-filename-watcher.ts";
+import { createDirFilenameWatcher } from "kolu-io";
 
 const reflogWatcher = createDirFilenameWatcher({
   resolveDir: (cwd) => {

--- a/packages/integrations/io/package.json
+++ b/packages/integrations/io/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kolu-git",
+  "name": "kolu-io",
   "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
@@ -8,20 +8,11 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./schemas": "./src/schemas.ts"
+    ".": "./src/index.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test:unit": "vitest run"
-  },
-  "dependencies": {
-    "@parcel/watcher": "^2.5.1",
-    "kolu-io": "workspace:*",
-    "kolu-shared": "workspace:*",
-    "memorable-names": "workspace:*",
-    "simple-git": "^3.36.0",
-    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/integrations/io/package.json
+++ b/packages/integrations/io/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run --passWithNoTests"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/integrations/io/src/index.ts
+++ b/packages/integrations/io/src/index.ts
@@ -8,5 +8,4 @@ export {
   createDirFilenameWatcher,
   type DirFilenameWatcher,
   type DirFilenameWatcherConfig,
-  type Logger,
 } from "./refcounted-dir-watcher.ts";

--- a/packages/integrations/io/src/index.ts
+++ b/packages/integrations/io/src/index.ts
@@ -1,0 +1,12 @@
+/** kolu-io — filesystem and I/O primitives for Kolu.
+ *
+ *  Standalone integration package with no `kolu-*` dependencies — only
+ *  third-party packages and the Node stdlib. Consumers across the workspace
+ *  can adopt these primitives without taking a feature-package dependency. */
+
+export {
+  createDirFilenameWatcher,
+  type DirFilenameWatcher,
+  type DirFilenameWatcherConfig,
+  type Logger,
+} from "./refcounted-dir-watcher.ts";

--- a/packages/integrations/io/src/refcounted-dir-watcher.ts
+++ b/packages/integrations/io/src/refcounted-dir-watcher.ts
@@ -14,11 +14,14 @@
 
 import fs from "node:fs";
 
-/** Minimal structured-logging contract. Structurally compatible with
- *  [pino](https://getpino.io)'s child loggers — pass `pinoLogger.child({...})`
- *  directly anywhere a `Logger` is expected. Inlined here so this package
- *  carries zero `kolu-*` dependencies. */
-export type Logger = {
+/** Minimal structured-logging contract for the optional `log?` parameter.
+ *  Structurally compatible with [pino](https://getpino.io)'s child loggers
+ *  and with `kolu-shared`'s `Logger` — callers pass either without an
+ *  adapter. Kept private (no re-export from the barrel) so `kolu-shared/log`
+ *  remains the workspace's single authoritative public `Logger` contract;
+ *  this declaration exists only to keep `kolu-io` a zero-`kolu-*`-deps
+ *  leaf. */
+type Logger = {
   debug: (obj: Record<string, unknown>, msg: string) => void;
   info: (obj: Record<string, unknown>, msg: string) => void;
   warn: (obj: Record<string, unknown>, msg: string) => void;

--- a/packages/integrations/io/src/refcounted-dir-watcher.ts
+++ b/packages/integrations/io/src/refcounted-dir-watcher.ts
@@ -1,10 +1,10 @@
 /**
  * Generic refcounted shared `fs.watch` watcher keyed by directory.
  *
- * The directory is the watch target, not the file: most editors and git
- * itself rewrite files via temp+rename, which destroys an `fs.watch` handle
- * pointed at the original file. A parent-directory watcher catches the
- * rename event cleanly on both Linux inotify and macOS FSEvents.
+ * The directory is the watch target, not the file: most editors and tools
+ * rewrite files via temp+rename, which destroys an `fs.watch` handle pointed
+ * at the original file. A parent-directory watcher catches the rename event
+ * cleanly on both Linux inotify and macOS FSEvents.
  *
  * Refcounted singleton per resolved dir: first subscribe installs, last
  * unsubscribe tears down and drops the registry entry. Idempotent
@@ -13,7 +13,17 @@
  */
 
 import fs from "node:fs";
-import type { Logger } from "kolu-shared";
+
+/** Minimal structured-logging contract. Structurally compatible with
+ *  [pino](https://getpino.io)'s child loggers — pass `pinoLogger.child({...})`
+ *  directly anywhere a `Logger` is expected. Inlined here so this package
+ *  carries zero `kolu-*` dependencies. */
+export type Logger = {
+  debug: (obj: Record<string, unknown>, msg: string) => void;
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+};
 
 interface SharedFilenameWatcher {
   subscribe(onChange: () => void): () => void;

--- a/packages/integrations/io/tsconfig.json
+++ b/packages/integrations/io/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/transcript-core/src/fetcher.ts
+++ b/packages/transcript-core/src/fetcher.ts
@@ -7,12 +7,13 @@
 
 import type { Transcript, TranscriptPr } from "./schemas.ts";
 
-/** Logger interface accepted by integration library functions.
- *  Structurally compatible with pino child loggers — the server creates
- *  a `log.child(...)` and passes it through. Re-declared here (instead
- *  of imported from `anyagent`) so transcript-core has zero deps on
- *  integration-side packages. */
-export type Logger = {
+/** Logger interface for the optional `log?` parameter on fetchers.
+ *  Structurally compatible with pino child loggers and with `kolu-shared`'s
+ *  `Logger` — callers pass either without an adapter. Kept private (no
+ *  re-export from the barrel) so `kolu-shared/log` remains the workspace's
+ *  single authoritative public `Logger` contract; this declaration exists
+ *  only to keep `transcript-core` a zero-`kolu-*`-deps leaf. */
+type Logger = {
   debug: (obj: Record<string, unknown>, msg: string) => void;
   info: (obj: Record<string, unknown>, msg: string) => void;
   warn: (obj: Record<string, unknown>, msg: string) => void;

--- a/packages/transcript-core/src/index.ts
+++ b/packages/transcript-core/src/index.ts
@@ -6,7 +6,7 @@
  *  the other side of `Fetcher`. Renderers (kolu-transcript-html today,
  *  others later) consume IR; they don't redefine it. */
 
-export type { Fetcher, FetcherInput, Logger } from "./fetcher.ts";
+export type { Fetcher, FetcherInput } from "./fetcher.ts";
 export {
   AGENT_KINDS,
   type AgentKindLiteral,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@parcel/watcher':
         specifier: ^2.5.1
         version: 2.5.6
+      kolu-io:
+        specifier: workspace:*
+        version: link:../io
       kolu-shared:
         specifier: workspace:*
         version: link:../../shared
@@ -358,6 +361,18 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/integrations/io:
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1864,56 +1879,66 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
@@ -2066,36 +2091,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2265,66 +2296,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2487,24 +2531,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3675,24 +3723,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
**`createDirFilenameWatcher` no longer lives under kolu-git.** The watcher's own docstring called itself "generic" — it caught file changes on a parent directory to survive temp+rename, refcounted N subscribers onto one OS handle, debounced fanout, all of it git-agnostic. This PR moves it to a new `packages/integrations/io/` package so a future Host abstraction (and anything else needing refcounted dir-watching) can adopt the primitive without a `kolu-git` dependency. Closes #942.

Pure relocation + rename — no behavior change. The four git-side consumers (`head-watcher`, `index-watcher`, `reflog-watcher`, `cwd-git-watcher`) now import from `kolu-io`. All 67 existing `kolu-git` unit tests pass unmodified.

### `kolu-io` shape

| Property | Value |
|---|---|
| Workspace name | `kolu-io` |
| `kolu-*` deps | **zero** (true library shape) |
| External deps | `node:fs` only |
| Public exports | `createDirFilenameWatcher`, `DirFilenameWatcher`, `DirFilenameWatcherConfig` |

The watcher's old file took a `kolu-shared` `Logger` import — replaced with an inline structural `Logger` type per the issue's "prefer inline" guidance. Pino child loggers and `kolu-shared`'s `Logger` both satisfy it structurally with no adapter.

### Follow-on refinements from review

Hickey and Lowy ran post-implement; the structural reviews are in the PR comment below. Two findings landed as their own commits:

| Commit | Lens | Finding |
|---|---|---|
| `52bd9449` | Hickey + Lowy (convergent) | `kolu-io`'s barrel re-exported `Logger` byte-identical to `kolu-shared/log` — two public authoritative sources of the same contract. Dropped the re-export; the inline declaration is now private to `refcounted-dir-watcher.ts`. |
| `f3e9401b` | Hickey (cross-validation) | `transcript-core/fetcher.ts` had the same fragmentation pattern — same fix applied: drop the public re-export, keep inline private. `kolu-shared/log` is now the workspace's single authoritative public `Logger`. |

One Hickey finding (extract `createSharedSubscription` to dedupe the listener-set/debounce/fanout machinery shared with `repo-change.ts`'s `compose()`) was flipped to **No-op** by Lowy's cross-validation: the two factories share *mechanical shape* but encapsulate *distinct volatility axes* (OS-handle management vs. composed-upstream sequencing), so a shared factory would complect them and dilute `kolu-io`'s I/O-primitives boundary.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._