### PR TITLE
Lifted-card active dock row that actually pops

### DIFF
--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -417,11 +417,15 @@ const DockAnnotation: Component<{
   meta: TerminalMetadata;
   info: TerminalDisplayInfo;
   class: string;
+  active: boolean;
 }> = (props) => (
   <span
     data-testid="dock-annotation"
     class={`${props.class} truncate min-w-0`}
-    style={{ color: props.info.annotationColor }}
+    // Inherit when active so the parent body's white color flows
+    // through — an inline annotationColor wins against `!important`
+    // via specificity, so the only way to swap is at the inline.
+    style={{ color: props.active ? "inherit" : props.info.annotationColor }}
   >
     <IntentMarkdownInline
       markdown={annotationLine(props.meta.intent, props.info.key.label)}
@@ -537,7 +541,9 @@ const AwaitingCardBody: Component<{
         <div class="flex items-baseline justify-between gap-2 min-w-0">
           <span
             class="font-mono text-[0.7rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-            style={{ color: props.info.repoColor }}
+            style={{
+              color: props.active ? "inherit" : props.info.repoColor,
+            }}
           >
             {props.info.key.group}
           </span>
@@ -545,6 +551,7 @@ const AwaitingCardBody: Component<{
             meta={props.meta}
             info={props.info}
             class="text-[0.95rem] font-semibold leading-tight"
+            active={props.active}
           />
         </div>
         <DockMetaRow meta={props.meta} />
@@ -602,7 +609,9 @@ const WorkingPillBody: Component<{
       <div class="flex items-baseline justify-between gap-2 min-w-0">
         <span
           class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-          style={{ color: props.info.repoColor }}
+          style={{
+            color: props.active ? "inherit" : props.info.repoColor,
+          }}
         >
           {props.info.key.group}
         </span>
@@ -610,6 +619,7 @@ const WorkingPillBody: Component<{
           meta={props.meta}
           info={props.info}
           class="text-[0.85rem] font-semibold leading-tight"
+          active={props.active}
         />
       </div>
       <DockMetaRow meta={props.meta} />
@@ -653,7 +663,9 @@ const QuietRowBody: Component<{
       <div class="flex items-baseline gap-2 min-w-0">
         <span
           class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-          style={{ color: props.info.repoColor }}
+          style={{
+            color: props.active ? "inherit" : props.info.repoColor,
+          }}
         >
           {props.info.key.group}
         </span>
@@ -661,6 +673,7 @@ const QuietRowBody: Component<{
           meta={props.meta}
           info={props.info}
           class="text-[0.75rem]"
+          active={props.active}
         />
         <Show when={formatTimeAgo(props.meta.lastActivityAt)}>
           {(label) => (

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -299,7 +299,7 @@ const DockRow: Component<{
     <Show when={combined()}>
       {(c) => (
         <div
-          class="flex flex-row items-stretch border-b border-edge/15 last:border-b-0 relative transition-[margin,border-radius,box-shadow] duration-300 ease-out data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
+          class="flex flex-row items-stretch border-b border-edge/15 last:border-b-0 relative transition-[margin,border-radius,box-shadow] duration-300 ease-out data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out] motion-reduce:transition-none motion-reduce:data-[active]:animate-none"
           data-testid="dock-row"
           data-terminal-id={props.id}
           data-bucket={props.bucket}

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -345,6 +345,7 @@ const DockRow: Component<{
                 bucket={props.bucket}
                 info={c().info}
                 meta={c().meta}
+                active={active()}
               />
             </div>
           </Show>
@@ -431,12 +432,15 @@ const DockAnnotation: Component<{
 /** Dispatches each row to its variant body. Bundling the variant switch
  *  in one place keeps `DockRow` shape uniform — every bucket has the
  *  same outer "rail + body" geometry regardless of which variant the
- *  body renders. */
+ *  body renders. `active` is threaded so each body can paint its bg /
+ *  fg as a function of (themed, active) without the stylesheet needing
+ *  to fight inline `style=` with `!important`. */
 const RowBody: Component<{
   id: TerminalId;
   bucket: DockRowBucket;
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
+  active: boolean;
 }> = (props) => {
   return (
     <Switch
@@ -446,14 +450,25 @@ const RowBody: Component<{
           info={props.info}
           meta={props.meta}
           bucket={props.bucket}
+          active={props.active}
         />
       }
     >
       <Match when={props.bucket === "awaiting"}>
-        <AwaitingCardBody id={props.id} info={props.info} meta={props.meta} />
+        <AwaitingCardBody
+          id={props.id}
+          info={props.info}
+          meta={props.meta}
+          active={props.active}
+        />
       </Match>
       <Match when={props.bucket === "working"}>
-        <WorkingPillBody id={props.id} info={props.info} meta={props.meta} />
+        <WorkingPillBody
+          id={props.id}
+          info={props.info}
+          meta={props.meta}
+          active={props.active}
+        />
       </Match>
     </Switch>
   );
@@ -471,6 +486,7 @@ const AwaitingCardBody: Component<{
   id: TerminalId;
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
+  active: boolean;
 }> = (props) => {
   const store = useTerminalStore();
   const tileTheme = useTileTheme();
@@ -506,10 +522,10 @@ const AwaitingCardBody: Component<{
     <div
       data-testid="dock-card"
       data-terminal-id={props.id}
-      class="px-2.5 py-2.5 flex flex-col gap-1.5"
+      class="px-2.5 py-2.5 flex flex-col gap-1.5 transition-colors duration-200 ease-out"
       style={{
-        "background-color": theme().bg,
-        color: theme().fg,
+        "background-color": props.active ? "var(--color-accent)" : theme().bg,
+        color: props.active ? "#ffffff" : theme().fg,
       }}
     >
       <button
@@ -565,6 +581,7 @@ const WorkingPillBody: Component<{
   id: TerminalId;
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
+  active: boolean;
 }> = (props) => {
   const store = useTerminalStore();
   const tileTheme = useTileTheme();
@@ -575,10 +592,10 @@ const WorkingPillBody: Component<{
       data-testid="dock-working"
       data-terminal-id={props.id}
       onClick={() => store.activate(props.id)}
-      class="w-full px-2.5 py-1 flex flex-col gap-0.5 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 text-left"
+      class="w-full px-2.5 py-1 flex flex-col gap-0.5 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 text-left transition-colors duration-200 ease-out"
       style={{
-        "background-color": theme().bg,
-        color: theme().fg,
+        "background-color": props.active ? "var(--color-accent)" : theme().bg,
+        color: props.active ? "#ffffff" : theme().fg,
       }}
       title="Jump to this terminal"
     >
@@ -613,6 +630,7 @@ const QuietRowBody: Component<{
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
   bucket: DockRowBucket;
+  active: boolean;
 }> = (props) => {
   const store = useTerminalStore();
   const foreground = () =>
@@ -624,8 +642,12 @@ const QuietRowBody: Component<{
       data-terminal-id={props.id}
       data-bucket={props.bucket}
       onClick={() => store.activate(props.id)}
-      class="w-full px-2.5 py-1 flex flex-col gap-0.5 min-w-0 cursor-pointer text-left bg-surface-1/40 hover:bg-surface-2/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-      classList={{ "opacity-60": props.bucket === "parked" }}
+      class="w-full px-2.5 py-1 flex flex-col gap-0.5 min-w-0 cursor-pointer text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 transition-colors duration-200 ease-out"
+      classList={{
+        "bg-surface-1/40 hover:bg-surface-2/50": !props.active,
+        "bg-accent text-white": props.active,
+        "opacity-60": props.bucket === "parked",
+      }}
       title={props.info.meta.cwd}
     >
       <div class="flex items-baseline gap-2 min-w-0">

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -299,7 +299,7 @@ const DockRow: Component<{
     <Show when={combined()}>
       {(c) => (
         <div
-          class="flex flex-row items-stretch border-b border-edge/15 last:border-b-0 relative"
+          class="flex flex-row items-stretch border-b border-edge/15 last:border-b-0 relative transition-[margin,border-radius,box-shadow] duration-300 ease-out data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:shadow-[0_0_0_1.5px_color-mix(in_oklch,var(--color-accent)_80%,transparent),0_6px_24px_-4px_color-mix(in_oklch,var(--color-accent)_55%,transparent),0_2px_6px_-2px_rgba(0,0,0,0.4)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
           data-testid="dock-row"
           data-terminal-id={props.id}
           data-bucket={props.bucket}
@@ -316,26 +316,12 @@ const DockRow: Component<{
               <span class="relative inline-flex rounded-full h-2 w-2 bg-alert" />
             </span>
           </Show>
-          {/* Active-terminal indicator — painted as an absolutely-
-           *  positioned overlay rather than a parent ring/tint so the
-           *  AwaitingCardBody's solid `theme().bg` (and the working
-           *  pill's, and the quiet row's) can't cover it. The overlay
-           *  sits at z-30, above the row body's z-0/z-10 content; the
-           *  `pointer-events-none` keeps clicks reaching the variant
-           *  body underneath. The 4-px left strip stays both as the
-           *  legacy testid hook and as an unambiguous "this row is
-           *  the active one" pin against narrow rail mode. */}
-          <Show when={active()}>
-            <span
-              data-testid="dock-row-active-indicator"
-              aria-hidden="true"
-              class="pointer-events-none absolute inset-0 z-30 ring-2 ring-inset ring-accent"
-            />
-            <span
-              aria-hidden="true"
-              class="pointer-events-none absolute left-0 top-0 bottom-0 w-1 bg-accent z-30"
-            />
-          </Show>
+          {/* Active-terminal indicator lives in index.css, keyed on
+           *  `[data-testid="dock-row"][data-active]` (set on the row
+           *  above). Lifted-card geometry + accent flood + one-shot
+           *  pop-in animation — see the "Active dock row" section in
+           *  `index.css`. Mobile drawer shares the same CSS block via
+           *  its own `[data-testid="mobile-dock-row"][data-active]`. */}
           <Show when={showShortcutHint()}>
             <span
               data-testid="dock-row-shortcut-hint"

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -299,7 +299,7 @@ const DockRow: Component<{
     <Show when={combined()}>
       {(c) => (
         <div
-          class="flex flex-row items-stretch border-b border-edge/15 last:border-b-0 relative transition-[margin,border-radius,box-shadow] duration-300 ease-out data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:shadow-[0_0_0_1.5px_color-mix(in_oklch,var(--color-accent)_80%,transparent),0_6px_24px_-4px_color-mix(in_oklch,var(--color-accent)_55%,transparent),0_2px_6px_-2px_rgba(0,0,0,0.4)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
+          class="flex flex-row items-stretch border-b border-edge/15 last:border-b-0 relative transition-[margin,border-radius,box-shadow] duration-300 ease-out data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
           data-testid="dock-row"
           data-terminal-id={props.id}
           data-bucket={props.bucket}

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -345,7 +345,6 @@ const DockRow: Component<{
                 bucket={props.bucket}
                 info={c().info}
                 meta={c().meta}
-                active={active()}
               />
             </div>
           </Show>
@@ -422,10 +421,10 @@ const DockAnnotation: Component<{
   <span
     data-testid="dock-annotation"
     class={`${props.class} truncate min-w-0`}
-    // Inherit when active so the parent body's white color flows
-    // through — an inline annotationColor wins against `!important`
-    // via specificity, so the only way to swap is at the inline.
-    style={{ color: props.active ? "inherit" : props.info.annotationColor }}
+    // Drop the inline color when active so the parent body's white
+    // cascades through — an inline annotationColor wins against
+    // `!important` via specificity; undefined removes the inline.
+    style={{ color: props.active ? undefined : props.info.annotationColor }}
   >
     <IntentMarkdownInline
       markdown={annotationLine(props.meta.intent, props.info.key.label)}
@@ -436,15 +435,14 @@ const DockAnnotation: Component<{
 /** Dispatches each row to its variant body. Bundling the variant switch
  *  in one place keeps `DockRow` shape uniform — every bucket has the
  *  same outer "rail + body" geometry regardless of which variant the
- *  body renders. `active` is threaded so each body can paint its bg /
- *  fg as a function of (themed, active) without the stylesheet needing
- *  to fight inline `style=` with `!important`. */
+ *  body renders. Each body derives its own `active` state from the
+ *  terminal store — no prop threading needed since all three already
+ *  call `useTerminalStore()` and have `props.id`. */
 const RowBody: Component<{
   id: TerminalId;
   bucket: DockRowBucket;
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
-  active: boolean;
 }> = (props) => {
   return (
     <Switch
@@ -454,25 +452,14 @@ const RowBody: Component<{
           info={props.info}
           meta={props.meta}
           bucket={props.bucket}
-          active={props.active}
         />
       }
     >
       <Match when={props.bucket === "awaiting"}>
-        <AwaitingCardBody
-          id={props.id}
-          info={props.info}
-          meta={props.meta}
-          active={props.active}
-        />
+        <AwaitingCardBody id={props.id} info={props.info} meta={props.meta} />
       </Match>
       <Match when={props.bucket === "working"}>
-        <WorkingPillBody
-          id={props.id}
-          info={props.info}
-          meta={props.meta}
-          active={props.active}
-        />
+        <WorkingPillBody id={props.id} info={props.info} meta={props.meta} />
       </Match>
     </Switch>
   );
@@ -490,11 +477,11 @@ const AwaitingCardBody: Component<{
   id: TerminalId;
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
-  active: boolean;
 }> = (props) => {
   const store = useTerminalStore();
   const tileTheme = useTileTheme();
   const theme = createMemo(() => tileTheme(props.id));
+  const active = () => store.activeId() === props.id;
   const [value, setValue] = createSignal("");
 
   async function submit(e: SubmitEvent) {
@@ -527,9 +514,10 @@ const AwaitingCardBody: Component<{
       data-testid="dock-card"
       data-terminal-id={props.id}
       class="px-2.5 py-2.5 flex flex-col gap-1.5 transition-colors duration-200 ease-out"
+      classList={{ "text-white": active() }}
       style={{
-        "background-color": props.active ? "var(--color-accent)" : theme().bg,
-        color: props.active ? "#ffffff" : theme().fg,
+        "background-color": active() ? "var(--color-accent)" : theme().bg,
+        color: active() ? undefined : theme().fg,
       }}
     >
       <button
@@ -542,7 +530,7 @@ const AwaitingCardBody: Component<{
           <span
             class="font-mono text-[0.7rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
             style={{
-              color: props.active ? "inherit" : props.info.repoColor,
+              color: active() ? undefined : props.info.repoColor,
             }}
           >
             {props.info.key.group}
@@ -551,7 +539,7 @@ const AwaitingCardBody: Component<{
             meta={props.meta}
             info={props.info}
             class="text-[0.95rem] font-semibold leading-tight"
-            active={props.active}
+            active={active()}
           />
         </div>
         <DockMetaRow meta={props.meta} />
@@ -588,11 +576,11 @@ const WorkingPillBody: Component<{
   id: TerminalId;
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
-  active: boolean;
 }> = (props) => {
   const store = useTerminalStore();
   const tileTheme = useTileTheme();
   const theme = createMemo(() => tileTheme(props.id));
+  const active = () => store.activeId() === props.id;
   return (
     <button
       type="button"
@@ -600,9 +588,10 @@ const WorkingPillBody: Component<{
       data-terminal-id={props.id}
       onClick={() => store.activate(props.id)}
       class="w-full px-2.5 py-1 flex flex-col gap-0.5 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 text-left transition-colors duration-200 ease-out"
+      classList={{ "text-white": active() }}
       style={{
-        "background-color": props.active ? "var(--color-accent)" : theme().bg,
-        color: props.active ? "#ffffff" : theme().fg,
+        "background-color": active() ? "var(--color-accent)" : theme().bg,
+        color: active() ? undefined : theme().fg,
       }}
       title="Jump to this terminal"
     >
@@ -610,7 +599,7 @@ const WorkingPillBody: Component<{
         <span
           class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
           style={{
-            color: props.active ? "inherit" : props.info.repoColor,
+            color: active() ? undefined : props.info.repoColor,
           }}
         >
           {props.info.key.group}
@@ -619,7 +608,7 @@ const WorkingPillBody: Component<{
           meta={props.meta}
           info={props.info}
           class="text-[0.85rem] font-semibold leading-tight"
-          active={props.active}
+          active={active()}
         />
       </div>
       <DockMetaRow meta={props.meta} />
@@ -640,9 +629,9 @@ const QuietRowBody: Component<{
   info: TerminalDisplayInfo;
   meta: TerminalMetadata;
   bucket: DockRowBucket;
-  active: boolean;
 }> = (props) => {
   const store = useTerminalStore();
+  const active = () => store.activeId() === props.id;
   const foreground = () =>
     props.meta.foreground?.title ?? props.meta.foreground?.name ?? null;
   return (
@@ -654,12 +643,12 @@ const QuietRowBody: Component<{
       onClick={() => store.activate(props.id)}
       class="w-full px-2.5 py-1 flex flex-col gap-0.5 min-w-0 cursor-pointer text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 transition-colors duration-200 ease-out"
       classList={{
-        "bg-surface-1/40 hover:bg-surface-2/50": !props.active,
-        "bg-accent text-white": props.active,
+        "bg-surface-1/40 hover:bg-surface-2/50": !active(),
+        "bg-accent text-white": active(),
         // Parked dim only when not active; an active parked row pops
         // at full opacity, matching the existing mobile behavior at
         // `MobileDockDrawer.tsx`.
-        "opacity-60": props.bucket === "parked" && !props.active,
+        "opacity-60": props.bucket === "parked" && !active(),
       }}
       title={props.info.meta.cwd}
     >
@@ -667,7 +656,7 @@ const QuietRowBody: Component<{
         <span
           class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
           style={{
-            color: props.active ? "inherit" : props.info.repoColor,
+            color: active() ? undefined : props.info.repoColor,
           }}
         >
           {props.info.key.group}
@@ -676,7 +665,7 @@ const QuietRowBody: Component<{
           meta={props.meta}
           info={props.info}
           class="text-[0.75rem]"
-          active={props.active}
+          active={active()}
         />
         <Show when={formatTimeAgo(props.meta.lastActivityAt)}>
           {(label) => (

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -514,7 +514,17 @@ const AwaitingCardBody: Component<{
       data-testid="dock-card"
       data-terminal-id={props.id}
       class="px-2.5 py-2.5 flex flex-col gap-1.5 transition-colors duration-200 ease-out"
-      classList={{ "text-white": active() }}
+      classList={{
+        // Active body floods to accent → main text inherits white,
+        // and the dim subtitle utilities (`text-fg-2`, `text-fg-3`)
+        // get brightened via descendant overrides so the PR line,
+        // timestamp, and agent-indicator token count stay readable
+        // against the accent flood. CSS specificity ensures the
+        // descendant arbitrary selectors win over the bare
+        // `.text-fg-*` utilities.
+        "text-white [&_.text-fg-2]:text-white/85 [&_.text-fg-3]:text-white/70":
+          active(),
+      }}
       style={{
         "background-color": active() ? "var(--color-accent)" : theme().bg,
         color: active() ? undefined : theme().fg,
@@ -588,7 +598,17 @@ const WorkingPillBody: Component<{
       data-terminal-id={props.id}
       onClick={() => store.activate(props.id)}
       class="w-full px-2.5 py-1 flex flex-col gap-0.5 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 text-left transition-colors duration-200 ease-out"
-      classList={{ "text-white": active() }}
+      classList={{
+        // Active body floods to accent → main text inherits white,
+        // and the dim subtitle utilities (`text-fg-2`, `text-fg-3`)
+        // get brightened via descendant overrides so the PR line,
+        // timestamp, and agent-indicator token count stay readable
+        // against the accent flood. CSS specificity ensures the
+        // descendant arbitrary selectors win over the bare
+        // `.text-fg-*` utilities.
+        "text-white [&_.text-fg-2]:text-white/85 [&_.text-fg-3]:text-white/70":
+          active(),
+      }}
       style={{
         "background-color": active() ? "var(--color-accent)" : theme().bg,
         color: active() ? undefined : theme().fg,
@@ -644,7 +664,8 @@ const QuietRowBody: Component<{
       class="w-full px-2.5 py-1 flex flex-col gap-0.5 min-w-0 cursor-pointer text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 transition-colors duration-200 ease-out"
       classList={{
         "bg-surface-1/40 hover:bg-surface-2/50": !active(),
-        "bg-accent text-white": active(),
+        "bg-accent text-white [&_.text-fg-2]:text-white/85 [&_.text-fg-3]:text-white/70":
+          active(),
         // Parked dim only when not active; an active parked row pops
         // at full opacity, matching the existing mobile behavior at
         // `MobileDockDrawer.tsx`.

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -656,7 +656,10 @@ const QuietRowBody: Component<{
       classList={{
         "bg-surface-1/40 hover:bg-surface-2/50": !props.active,
         "bg-accent text-white": props.active,
-        "opacity-60": props.bucket === "parked",
+        // Parked dim only when not active; an active parked row pops
+        // at full opacity, matching the existing mobile behavior at
+        // `MobileDockDrawer.tsx`.
+        "opacity-60": props.bucket === "parked" && !props.active,
       }}
       title={props.info.meta.cwd}
     >

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -118,7 +118,11 @@ const Row: Component<{
           <div class="flex items-baseline justify-between gap-2 min-w-0">
             <span
               class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-              style={{ color: info()?.repoColor }}
+              // Inherit when active so the row's white color flows
+              // through; otherwise paint the per-repo identity color.
+              style={{
+                color: active() ? "inherit" : info()?.repoColor,
+              }}
             >
               {info()?.key.group}
             </span>
@@ -128,7 +132,9 @@ const Row: Component<{
                 "text-[0.95rem]": live(),
                 "text-[0.8rem]": !live(),
               }}
-              style={{ color: info()?.annotationColor }}
+              style={{
+                color: active() ? "inherit" : info()?.annotationColor,
+              }}
             >
               <IntentMarkdownInline
                 markdown={annotationLine(

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -99,7 +99,7 @@ const Row: Component<{
         // drag-to-dismiss from claiming the tap.
         onPointerDown={(e) => e.stopPropagation()}
         onClick={() => props.onSelect(props.id)}
-        class="w-full flex items-stretch gap-3 px-3 text-left transition-[margin,border-radius,box-shadow,background-color,color] duration-300 ease-out cursor-pointer active:bg-surface-2 border-b border-edge/15 data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:bg-accent data-[active]:text-white data-[active]:shadow-[0_0_0_1.5px_color-mix(in_oklch,var(--color-accent)_80%,transparent),0_6px_24px_-4px_color-mix(in_oklch,var(--color-accent)_55%,transparent),0_2px_6px_-2px_rgba(0,0,0,0.4)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
+        class="w-full flex items-stretch gap-3 px-3 text-left transition-[margin,border-radius,box-shadow,background-color,color] duration-300 ease-out cursor-pointer active:bg-surface-2 border-b border-edge/15 data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:bg-accent data-[active]:text-white data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
         classList={{
           "py-3": live(),
           "py-2": !live(),

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -118,10 +118,10 @@ const Row: Component<{
           <div class="flex items-baseline justify-between gap-2 min-w-0">
             <span
               class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-              // Inherit when active so the row's white color flows
+              // Drop inline color when active so the row's white cascades
               // through; otherwise paint the per-repo identity color.
               style={{
-                color: active() ? "inherit" : info()?.repoColor,
+                color: active() ? undefined : info()?.repoColor,
               }}
             >
               {info()?.key.group}
@@ -133,7 +133,7 @@ const Row: Component<{
                 "text-[0.8rem]": !live(),
               }}
               style={{
-                color: active() ? "inherit" : info()?.annotationColor,
+                color: active() ? undefined : info()?.annotationColor,
               }}
             >
               <IntentMarkdownInline

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -99,7 +99,7 @@ const Row: Component<{
         // drag-to-dismiss from claiming the tap.
         onPointerDown={(e) => e.stopPropagation()}
         onClick={() => props.onSelect(props.id)}
-        class="w-full flex items-stretch gap-3 px-3 text-left transition-[margin,border-radius,box-shadow,background-color,color] duration-300 ease-out cursor-pointer active:bg-surface-2 border-b border-edge/15 data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:bg-accent data-[active]:text-white data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out] motion-reduce:transition-none motion-reduce:data-[active]:animate-none"
+        class="w-full flex items-stretch gap-3 px-3 text-left transition-[margin,border-radius,box-shadow,background-color,color] duration-300 ease-out cursor-pointer active:bg-surface-2 border-b border-edge/15 data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:bg-accent data-[active]:text-white data-[active]:[&_.text-fg-2]:text-white/85 data-[active]:[&_.text-fg-3]:text-white/70 data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out] motion-reduce:transition-none motion-reduce:data-[active]:animate-none"
         classList={{
           "py-3": live(),
           "py-2": !live(),

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -99,7 +99,7 @@ const Row: Component<{
         // drag-to-dismiss from claiming the tap.
         onPointerDown={(e) => e.stopPropagation()}
         onClick={() => props.onSelect(props.id)}
-        class="w-full flex items-stretch gap-3 px-3 text-left transition-[margin,border-radius,box-shadow,background-color,color] duration-300 ease-out cursor-pointer active:bg-surface-2 border-b border-edge/15 data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:bg-accent data-[active]:text-white data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
+        class="w-full flex items-stretch gap-3 px-3 text-left transition-[margin,border-radius,box-shadow,background-color,color] duration-300 ease-out cursor-pointer active:bg-surface-2 border-b border-edge/15 data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:bg-accent data-[active]:text-white data-[active]:shadow-[var(--dock-active-halo)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out] motion-reduce:transition-none motion-reduce:data-[active]:animate-none"
         classList={{
           "py-3": live(),
           "py-2": !live(),

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -99,11 +99,13 @@ const Row: Component<{
         // drag-to-dismiss from claiming the tap.
         onPointerDown={(e) => e.stopPropagation()}
         onClick={() => props.onSelect(props.id)}
-        class="w-full flex items-stretch gap-3 px-3 text-left transition-colors cursor-pointer active:bg-surface-2 border-b border-edge/15"
+        class="w-full flex items-stretch gap-3 px-3 text-left transition-[margin,border-radius,box-shadow,background-color,color] duration-300 ease-out cursor-pointer active:bg-surface-2 border-b border-edge/15 data-[active]:m-1.5 data-[active]:rounded-lg data-[active]:border-b-transparent data-[active]:bg-accent data-[active]:text-white data-[active]:shadow-[0_0_0_1.5px_color-mix(in_oklch,var(--color-accent)_80%,transparent),0_6px_24px_-4px_color-mix(in_oklch,var(--color-accent)_55%,transparent),0_2px_6px_-2px_rgba(0,0,0,0.4)] data-[active]:animate-[dock-row-activate_0.36s_cubic-bezier(0.34,1.45,0.6,1),dock-row-flash_0.48s_ease-out]"
         classList={{
           "py-3": live(),
           "py-2": !live(),
-          "bg-accent/15": active(),
+          // Parked dim for inactive rows only. Active treatment
+          // (lifted card + accent flood + pop-in animation) lives
+          // in the class string above as `data-[active]:*` variants.
           "opacity-60": props.bucket === "parked" && !active(),
         }}
       >

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -365,13 +365,10 @@ body {
     box-shadow: var(--dock-active-halo);
   }
 }
-@media (prefers-reduced-motion: reduce) {
-  [data-testid="dock-row"][data-active],
-  [data-testid="mobile-dock-row"][data-active] {
-    animation: none;
-    transition: none;
-  }
-}
+/* prefers-reduced-motion is expressed at the row consumers via
+ * Tailwind's `motion-reduce:` variant (see `DockRow` in Dock.tsx and
+ * the mobile `Row` in MobileDockDrawer.tsx). No CSS media query
+ * needed here. */
 
 /* ── Canvas grid background ─────────────────────────────────── */
 /* Fine line grid gives spatial grounding to the freeform canvas.

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -290,6 +290,86 @@ body {
   }
 }
 
+/* ── Active dock row — pieces Tailwind can't express ─────────
+ * The bulk of the lifted-card treatment lives as Tailwind utilities
+ * on the row itself (see `DockRow` in Dock.tsx and `Row` in
+ * MobileDockDrawer.tsx — `data-[active]:` variants for margin /
+ * border-radius / shadow / animation, `group-data-[active]:` on the
+ * children for the accent flood). Here we keep only what Tailwind
+ * can't carry inline: `@keyframes`, the inline-style override on
+ * body bg (needs `!important` to beat `style={{ backgroundColor }}`
+ * on AwaitingCardBody / WorkingPillBody), and the rail-cadence quiet
+ * + parked-opacity restore (cross-cutting selectors). */
+
+/* Desktop bodies paint their own `theme().bg` via inline style —
+ * an inline-style override needs `!important` to land, which
+ * Tailwind's `!` prefix doesn't expose for arbitrary CSS variables
+ * cleanly. Mobile's button is its own body and is covered by the
+ * Tailwind utility there. */
+[data-testid="dock-row"][data-active] [data-testid="dock-card"],
+[data-testid="dock-row"][data-active] [data-testid="dock-working"],
+[data-testid="dock-row"][data-active] [data-testid="dock-quiet"] {
+  background-color: var(--color-accent) !important;
+  color: #ffffff !important;
+}
+
+/* Quiet the rail's bucket-cadence on active rows. `RailSegment` never
+ * learns about `active()`; this is purely presentational. Parked /
+ * none buckets keep full opacity when active. */
+[data-active] .dock-rail-awaiting,
+[data-active] .dock-rail-working {
+  animation: none;
+  filter: brightness(1);
+}
+[data-active] [data-agent-bucket="parked"],
+[data-active] [data-agent-bucket="none"] {
+  opacity: 1;
+}
+
+/* One-shot pop-in fires every time an element first matches
+ * `[data-active]` — i.e. every activation, whether from a mouse
+ * click (Dock body `onClick`) or a keyboard shortcut (`Cmd+1..9`
+ * in `input/actions.ts`). Both routes call `store.activate(id)`,
+ * which flips the attribute. */
+@keyframes dock-row-activate {
+  0% {
+    transform: scale(0.96);
+  }
+  55% {
+    transform: scale(1.025);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+@keyframes dock-row-flash {
+  0% {
+    box-shadow:
+      0 0 0 0 color-mix(in oklch, var(--color-accent) 90%, transparent),
+      0 6px 24px -4px color-mix(in oklch, var(--color-accent) 55%, transparent),
+      0 2px 6px -2px rgba(0, 0, 0, 0.4);
+  }
+  35% {
+    box-shadow:
+      0 0 0 4px color-mix(in oklch, var(--color-accent) 85%, transparent),
+      0 8px 36px -2px color-mix(in oklch, var(--color-accent) 75%, transparent),
+      0 2px 6px -2px rgba(0, 0, 0, 0.4);
+  }
+  100% {
+    box-shadow:
+      0 0 0 1.5px color-mix(in oklch, var(--color-accent) 80%, transparent),
+      0 6px 24px -4px color-mix(in oklch, var(--color-accent) 55%, transparent),
+      0 2px 6px -2px rgba(0, 0, 0, 0.4);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-testid="dock-row"][data-active],
+  [data-testid="mobile-dock-row"][data-active] {
+    animation: none;
+    transition: none;
+  }
+}
+
 /* ── Canvas grid background ─────────────────────────────────── */
 /* Fine line grid gives spatial grounding to the freeform canvas.
    Lines use the edge color at low opacity so they adapt to light/dark themes. */

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -315,14 +315,21 @@ body {
 
 /* Quiet the rail's bucket-cadence on active rows. `RailSegment` never
  * learns about `active()`; this is purely presentational. Parked /
- * none buckets keep full opacity when active. */
-[data-active] .dock-rail-awaiting,
-[data-active] .dock-rail-working {
+ * none rails keep full opacity when active. Selectors are scoped to
+ * the dock testids — `data-active` is also used by other surfaces
+ * (canvas tile, scroll-to-bottom, code-tab), so an unscoped selector
+ * would silently suppress any rail-class descendant in those trees. */
+[data-testid="dock-row"][data-active] .dock-rail-awaiting,
+[data-testid="dock-row"][data-active] .dock-rail-working,
+[data-testid="mobile-dock-row"][data-active] .dock-rail-awaiting,
+[data-testid="mobile-dock-row"][data-active] .dock-rail-working {
   animation: none;
   filter: brightness(1);
 }
-[data-active] [data-agent-bucket="parked"],
-[data-active] [data-agent-bucket="none"] {
+[data-testid="dock-row"][data-active] [data-agent-bucket="parked"],
+[data-testid="dock-row"][data-active] [data-agent-bucket="none"],
+[data-testid="mobile-dock-row"][data-active] [data-agent-bucket="parked"],
+[data-testid="mobile-dock-row"][data-active] [data-agent-bucket="none"] {
   opacity: 1;
 }
 

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -314,21 +314,17 @@ body {
 
 /* Quiet the rail's bucket-cadence on active rows. `RailSegment` never
  * learns about `active()`; this is purely presentational. Parked /
- * none rails keep full opacity when active. Selectors are scoped to
- * the dock testids — `data-active` is also used by other surfaces
- * (canvas tile, scroll-to-bottom, code-tab), so an unscoped selector
- * would silently suppress any rail-class descendant in those trees. */
+ * none rails keep full opacity when active. Scoped to `dock-row`
+ * because the rail and `data-agent-bucket` only exist on the desktop
+ * dock — mobile's row has no rail-class or bucket-attribute
+ * descendants, so a mobile-prefixed selector would match nothing. */
 [data-testid="dock-row"][data-active] .dock-rail-awaiting,
-[data-testid="dock-row"][data-active] .dock-rail-working,
-[data-testid="mobile-dock-row"][data-active] .dock-rail-awaiting,
-[data-testid="mobile-dock-row"][data-active] .dock-rail-working {
+[data-testid="dock-row"][data-active] .dock-rail-working {
   animation: none;
   filter: brightness(1);
 }
 [data-testid="dock-row"][data-active] [data-agent-bucket="parked"],
-[data-testid="dock-row"][data-active] [data-agent-bucket="none"],
-[data-testid="mobile-dock-row"][data-active] [data-agent-bucket="parked"],
-[data-testid="mobile-dock-row"][data-active] [data-agent-bucket="none"] {
+[data-testid="dock-row"][data-active] [data-agent-bucket="none"] {
   opacity: 1;
 }
 

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -292,20 +292,24 @@ body {
 
 /* ── Active dock row — pieces Tailwind can't express ─────────
  * The bulk of the lifted-card treatment lives as Tailwind utilities
- * on the row itself (see `DockRow` in Dock.tsx and `Row` in
- * MobileDockDrawer.tsx — `data-[active]:` variants for margin /
- * border-radius / shadow / animation, `group-data-[active]:` on the
- * children for the accent flood). Here we keep only what Tailwind
- * can't carry inline: `@keyframes`, the inline-style override on
- * body bg (needs `!important` to beat `style={{ backgroundColor }}`
- * on AwaitingCardBody / WorkingPillBody), and the rail-cadence quiet
- * + parked-opacity restore (cross-cutting selectors).
+ * on the row itself (`data-[active]:` variants for margin /
+ * border-radius / shadow / animation in `DockRow` and the mobile
+ * `Row`). The body bg / fg flood lives as conditional inline styles
+ * in each body variant (`AwaitingCardBody`, `WorkingPillBody`,
+ * `QuietRowBody`) — the body components take `active` and paint
+ * accent / white when set, themed `theme().bg` / `theme().fg`
+ * otherwise. Here we keep only what neither route can carry: the
+ * shared resting halo, the activation keyframes, the rail-cadence
+ * quiet + parked-opacity restore (cross-cutting selectors against
+ * elements that don't take an `active` prop), and the
+ * prefers-reduced-motion override.
  *
  * `--dock-active-halo` is the resting glow that the active row
  * settles to after the flash. Defined once so the Tailwind shadow
  * utility on the row and the `@keyframes dock-row-flash` 100% frame
  * stay in lockstep — change one knob, both surfaces follow. */
-:root {
+[data-testid="dock-row"],
+[data-testid="mobile-dock-row"] {
   --dock-active-halo:
     0 0 0 1.5px color-mix(in oklch, var(--color-accent) 80%, transparent),
     0 6px 24px -4px color-mix(in oklch, var(--color-accent) 55%, transparent),

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -299,7 +299,18 @@ body {
  * can't carry inline: `@keyframes`, the inline-style override on
  * body bg (needs `!important` to beat `style={{ backgroundColor }}`
  * on AwaitingCardBody / WorkingPillBody), and the rail-cadence quiet
- * + parked-opacity restore (cross-cutting selectors). */
+ * + parked-opacity restore (cross-cutting selectors).
+ *
+ * `--dock-active-halo` is the resting glow that the active row
+ * settles to after the flash. Defined once so the Tailwind shadow
+ * utility on the row and the `@keyframes dock-row-flash` 100% frame
+ * stay in lockstep — change one knob, both surfaces follow. */
+:root {
+  --dock-active-halo:
+    0 0 0 1.5px color-mix(in oklch, var(--color-accent) 80%, transparent),
+    0 6px 24px -4px color-mix(in oklch, var(--color-accent) 55%, transparent),
+    0 2px 6px -2px rgba(0, 0, 0, 0.4);
+}
 
 /* Desktop bodies paint their own `theme().bg` via inline style —
  * an inline-style override needs `!important` to land, which
@@ -363,10 +374,7 @@ body {
       0 2px 6px -2px rgba(0, 0, 0, 0.4);
   }
   100% {
-    box-shadow:
-      0 0 0 1.5px color-mix(in oklch, var(--color-accent) 80%, transparent),
-      0 6px 24px -4px color-mix(in oklch, var(--color-accent) 55%, transparent),
-      0 2px 6px -2px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--dock-active-halo);
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -312,18 +312,6 @@ body {
     0 2px 6px -2px rgba(0, 0, 0, 0.4);
 }
 
-/* Desktop bodies paint their own `theme().bg` via inline style —
- * an inline-style override needs `!important` to land, which
- * Tailwind's `!` prefix doesn't expose for arbitrary CSS variables
- * cleanly. Mobile's button is its own body and is covered by the
- * Tailwind utility there. */
-[data-testid="dock-row"][data-active] [data-testid="dock-card"],
-[data-testid="dock-row"][data-active] [data-testid="dock-working"],
-[data-testid="dock-row"][data-active] [data-testid="dock-quiet"] {
-  background-color: var(--color-accent) !important;
-  color: #ffffff !important;
-}
-
 /* Quiet the rail's bucket-cadence on active rows. `RailSegment` never
  * learns about `active()`; this is purely presentational. Parked /
  * none rails keep full opacity when active. Selectors are scoped to

--- a/packages/tests/step_definitions/dock_steps.ts
+++ b/packages/tests/step_definitions/dock_steps.ts
@@ -157,7 +157,11 @@ When(
 );
 
 const SHORTCUT_HINT_SELECTOR = '[data-testid="dock-row-shortcut-hint"]';
-const ACTIVE_INDICATOR_SELECTOR = '[data-testid="dock-row-active-indicator"]';
+// The active row is identified by the `data-active` attribute on the row
+// itself — the visual treatment (lifted-card geometry, accent flood,
+// pop-in animation) is painted by CSS keyed on that attribute. See the
+// "Active dock row" section in `packages/client/src/index.css`.
+const ACTIVE_INDICATOR_SELECTOR = '[data-testid="dock-row"][data-active]';
 
 Then(
   "the dock should show {int} active row indicator",


### PR DESCRIPTION
**The active terminal now reads as a categorically different visual class from its neighbors** — pulled out of the stack with margin and rounded corners, accent-flooded body replacing the per-repo `theme().bg`, glowing halo, and a one-shot scale-bounce + shadow-flare animation. The prior 2px accent ring + 4px stripe overlay melted into the row's own background whenever the repo color was near accent — most painfully on KOLU itself, where the repo color *is* accent and the "selected" marker effectively vanished.

### Before vs after

| | Today | This PR |
|---|---|---|
| Active marker | 2px `ring-accent` + 4px `bg-accent` stripe | Lifted card: `m-1.5` + `rounded-lg` + glowing halo + accent flood |
| Collision when repo color ≈ accent | Active row looks identical to inactive | Active row's *tonal class* differs from neighbors — hue collision is dodged entirely |
| Rail cadence on active row | Keeps pulsing | Quiets (inverted-attention: pulsing belongs to rows asking for attention; the focused row is steady) |
| Parked + active | Body dimmed to 60% opacity | Pops at full opacity |
| Activation animation | None | Scale bounce 0.96 → 1.025 → 1.0 + shadow flare, fires on *every* activation |

### Activation animation works for click *and* keyboard

```
mouse click ─┐
             ├─▶ store.activate(id) ─▶ activeId() signal ─▶ data-active="" ─▶ CSS keyframes fire
Cmd+1..9 ────┘
```

Both routes flip the same attribute on the same DOM element; CSS keyframes restart whenever an element first matches `[data-active]`. *No event coupling, no separate "play animation" call — the animation is reactive to the same signal the rest of the UI is.* `prefers-reduced-motion` honored: still gets the lifted-card endpoint, just without the bounce + flash.

### Shared between desktop dock and mobile drawer

Both surfaces already emitted `data-active=""` on their row elements. The treatment lives partly as Tailwind `data-[active]:` variants (margin, border-radius, shadow, animation invocation) and partly as CSS keyed on the same attribute (`@keyframes`, rail-cadence quiet, parked-opacity restore, reduced-motion override). Mobile inherits by structure they already had — no new component, no new prop threading, no API surface change.

### Refinements during review

Hickey and Lowy ran in parallel on the primary commit and both surfaced real findings; each landed as its own follow-up commit so the PR history reads as a sequence of refinements rather than one opaque squash.

| Reviewer | Finding | Commit |
|---|---|---|
| Lowy | Unscoped `[data-active]` selectors leaked into `canvas-tile`, `scroll-to-bottom`, `code-tab` trees | `refactor(lowy): scope dock active-row selectors to dock testids` |
| Lowy | Resting halo duplicated across Tailwind + `@keyframes 100%`, would drift | `refactor(lowy): dedupe active-row resting halo into --dock-active-halo` |
| Hickey | Body components painted `theme().bg` inline; CSS needed `!important` to flood | `refactor(hickey): thread active into bodies, drop !important flood` |
| Hickey | Child spans (group label, annotation) kept per-repo color over the accent flood — inline `style` wins via specificity | `refactor(hickey): conditionalize child span colors on active` |
| Hickey | `QuietRowBody`'s parked-dim (`opacity-60`) was unguarded by `active`, so an active parked row rendered at 60% | `refactor(hickey): guard QuietRowBody parked-dim with !active` |
| Hickey (cross) | Mobile-prefixed selectors from Lowy's scoping fix were inert — mobile has no rail-class or `data-agent-bucket` descendants | `refactor(hickey): cross-validate — drop dead mobile-dock-row selectors` |
| Lowy (cross) | `--dock-active-halo` declared on `:root` but only consumed in the dock; stale comment still referenced removed `!important` block | `refactor(lowy): cross-validate — refresh active-row comment + scope halo var` |
| Police | Elegance: `active` prop didn't need to be threaded — each body already has `useTerminalStore` and `props.id` | `refactor(police): elegance — derive active inside bodies, undefined over inherit` |

### Try it locally

```sh
nix run github:juspay/kolu/feat/dock-active-row-lift
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._