### PR TITLE
Make the right panel follow the terminal, not the workspace

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -201,13 +201,15 @@ const CodeTab: Component<{
 
   // Clear the filename filter when the slot changes — the search needle
   // was scoped to the previous file set and rarely makes sense post-
-  // switch. Selection itself is per-slot (see `selectedFilesByKey`
-  // above) so the new view automatically surfaces its own pick without
-  // a clear here. `slotKey` is memoized, so this fires only when the
-  // tuple genuinely changes — without the memo, `on(...)` would re-run
-  // its callback on every preferences tick (the upstream cell ticks on
-  // activity beyond tab/repo changes) and wipe the filter spuriously
-  // after #818 made CodeTab survive right-panel tab toggles.
+  // switch. Selection itself is per-slot (read/written via
+  // `rightPanel.selectedFile(mode)` → `selectedFileByMode` on the
+  // per-terminal record) so the new view automatically surfaces its own
+  // pick without a clear here. `slotKey` is memoized, so this fires
+  // only when the tuple genuinely changes — without the memo, `on(...)`
+  // would re-run its callback on every incidental tick of `repoPath()`
+  // (metadata cell) or `view()` (per-terminal in-memory store) and wipe
+  // the filter spuriously after #818 made CodeTab survive right-panel
+  // tab toggles.
   createEffect(
     on(
       slotKey,

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -22,7 +22,6 @@ import {
   useCodeViewSelection,
 } from "@kolu/solid-pierre";
 import type { GitDiffMode } from "kolu-git/schemas";
-import { makePersisted } from "@solid-primitives/storage";
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import {
   type Component,
@@ -124,45 +123,20 @@ const CodeTab: Component<{
   const diffMode = (): GitDiffMode | undefined =>
     view() === "browse" ? undefined : (view() as GitDiffMode);
 
-  // Selection is keyed per (repoRoot, view) and persisted to localStorage.
-  // Each slot owns its own pick — switching modes / repos surfaces the
-  // right slot rather than clearing on transition, and a full browser
-  // reload restores whichever slot is current. `::` is collision-safe:
-  // `view()` is a typed enum so it can't contain `::`, and `repoPath()`
-  // is an absolute path or null. The `slotKey` memo doubles as the
-  // source of truth for the search-reset effect below — same value,
-  // single derivation.
+  // Selection is per-terminal, keyed by mode, stored in
+  // `TerminalMetadata.rightPanel.selectedFileByMode` via `useRightPanel`.
+  // Each (terminal, mode) slot owns its own pick — switching modes within
+  // a terminal restores that mode's last file; switching terminals
+  // restores that terminal's last (file, mode) pair.
   //
-  // `createSignal<Record>` is deliberate against the project rule
-  // (`createStore` over `createSignal<Record>` for keyed state): the
-  // fine-grained read tracking createStore offers isn't actually
-  // observed here because Pierre's `FileTree` snapshots `selectedPath`
-  // at mount via `initialSelectedPaths` and the host re-mounts that
-  // subtree on view transitions. The synchronous, whole-record
-  // semantics of a signal match this lifecycle; `createStore`'s
-  // late-arriving notifications on a not-yet-seen key produce a
-  // remount race where the new slot's pick is set AFTER FileTree's
-  // constructor reads it (verified empirically against the
-  // "right-click Open jumps to browse" regression suite).
-  const [selectedFilesByKey, setSelectedFilesByKey] = makePersisted(
-    createSignal<Record<string, string>>({}),
-    { name: "kolu-codetab-selected-files" },
-  );
-  const slotKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
-  const selectedPath = (): string | null =>
-    selectedFilesByKey()[slotKey()] ?? null;
+  // The `slotKey` memo doubles as the source of truth for the
+  // search-reset effect below; collision-safe by construction since
+  // `view()` is a typed enum and `repoPath()` is absolute-or-null.
+  const selectedPath = (): string | null => rightPanel.selectedFile(view());
   const setSelectedPath = (path: string | null) => {
-    const key = slotKey();
-    setSelectedFilesByKey((prev) => {
-      if (path === null) {
-        if (!(key in prev)) return prev;
-        const { [key]: _, ...rest } = prev;
-        return rest;
-      }
-      if (prev[key] === path) return prev;
-      return { ...prev, [key]: path };
-    });
+    rightPanel.setSelectedFile(view(), path);
   };
+  const slotKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
 
   // Filename filter — drives Pierre's tree filter externally. Reset on
   // mode switch so a stale needle doesn't hide the wrong file set.

--- a/packages/client/src/right-panel/RightPanel.tsx
+++ b/packages/client/src/right-panel/RightPanel.tsx
@@ -8,6 +8,7 @@ import type {
   TerminalMetadata,
 } from "kolu-common/surface";
 import { type Component, For } from "solid-js";
+import { match } from "ts-pattern";
 import { CHROME_ICON_BUTTON_CLASS } from "../ui/chromeSpacing";
 import { ChevronRightIcon } from "../ui/Icons";
 import { ACTIVE_TERMINAL_ACCENT } from "./activeTerminalAccent";
@@ -18,8 +19,10 @@ import { useRightPanel } from "./useRightPanel";
 /** Ordered tab kinds shown in the tab bar. Adding a new kind to the
  *  discriminated union requires a corresponding entry here AND in
  *  `TAB_LABEL` below — both are typed `Record<RightPanelTabKind, …>` and
- *  fail-compile on missing keys. The body renderer further down takes a
- *  matching wrapper div per kind; that part is checked at review time. */
+ *  fail-compile on missing keys. The body renderer further down dispatches
+ *  via `match(kind).exhaustive()`, which also fails-compile on a missing
+ *  variant — so adding a new kind is a three-place change that the
+ *  compiler enforces end-to-end. */
 const TAB_KINDS: readonly RightPanelTabKind[] = ["inspector", "code"] as const;
 
 const TAB_LABEL: Record<RightPanelTabKind, string> = {
@@ -91,29 +94,37 @@ const RightPanel: Component<{
       {/* Both tabs are always rendered; the inactive one is display:none.
        *  Mounting both keeps each tab's local state (CodeTab's selected file,
        *  Pierre's tree expansion, scroll position) alive across tab switches
-       *  — a `match()` swap would unmount the inactive sibling and discard
-       *  it. TAB_KINDS / TAB_LABEL above already give compile-time
-       *  exhaustiveness over RightPanelTabKind, so adding a new tab kind
-       *  fails to compile there before reaching this renderer. */}
+       *  — wrapping a single `match(...).exhaustive()` over `activeTab()`
+       *  would unmount the inactive sibling and discard that state. The
+       *  shape below iterates `TAB_KINDS` (already compile-exhaustive over
+       *  RightPanelTabKind via the `Record<RightPanelTabKind, …>` typings
+       *  on TAB_LABEL) so both bodies mount once, then `match(kind)` picks
+       *  which component to render per slot — exhaustive *and* both-mounted. */}
       <div class="flex-1 min-h-0 overflow-hidden">
-        <div
-          class={
-            rightPanel.activeTab().kind === "inspector" ? "h-full" : "hidden"
-          }
-          aria-hidden={rightPanel.activeTab().kind !== "inspector"}
-        >
-          <MetadataInspector
-            meta={props.meta}
-            themeName={props.themeName}
-            onThemeClick={props.onThemeClick}
-          />
-        </div>
-        <div
-          class={rightPanel.activeTab().kind === "code" ? "h-full" : "hidden"}
-          aria-hidden={rightPanel.activeTab().kind !== "code"}
-        >
-          <CodeTab terminalId={props.terminalId} meta={props.meta} />
-        </div>
+        <For each={TAB_KINDS}>
+          {(kind) => {
+            const isActive = () => rightPanel.activeTab().kind === kind;
+            return (
+              <div
+                class={isActive() ? "h-full" : "hidden"}
+                aria-hidden={!isActive()}
+              >
+                {match(kind)
+                  .with("inspector", () => (
+                    <MetadataInspector
+                      meta={props.meta}
+                      themeName={props.themeName}
+                      onThemeClick={props.onThemeClick}
+                    />
+                  ))
+                  .with("code", () => (
+                    <CodeTab terminalId={props.terminalId} meta={props.meta} />
+                  ))
+                  .exhaustive()}
+              </div>
+            );
+          }}
+        </For>
       </div>
     </div>
   );

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -36,12 +36,9 @@ const [perTerminal, setPerTerminal] = createStore<
   Record<TerminalId, RightPanelPerTerminalState>
 >({});
 
-function ensureState(id: TerminalId): RightPanelPerTerminalState {
-  const existing = perTerminal[id];
-  if (existing) return existing;
+function ensureState(id: TerminalId): void {
+  if (perTerminal[id]) return;
   setPerTerminal(id, { ...DEFAULT_RIGHT_PANEL_PER_TERMINAL });
-  // Re-read so the returned reference points at the store-tracked object.
-  return perTerminal[id] as RightPanelPerTerminalState;
 }
 
 function reportToServer(id: TerminalId): void {

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -1,14 +1,29 @@
-/** Right panel state — singleton module. Tracks collapsed, size, active tab
- *  (`"inspector" | "code"`), and the last-used code-mode (restored on
- *  Inspector→Code toggle). Persisted via server preferences under
- *  `preferences.rightPanel`. Defaults to collapsed with the Inspector tab. */
+/** Right panel state — singleton module.
+ *
+ *  Two storage layers because the right panel has two volatilities:
+ *
+ *  - **Workspace chrome** (collapsed, size, codeTabTreeSize) lives on
+ *    `preferences.rightPanel` — global to the user, set once and forgotten.
+ *  - **Per-terminal task state** (activeTab, codeMode, per-mode selected
+ *    file) lives in an in-memory store keyed by terminal id; mutations
+ *    push to the server via `client.terminal.setRightPanel`, which writes
+ *    `TerminalMetadata.rightPanel` for session restore. Pattern mirrors
+ *    `useSubPanel.ts` exactly.
+ *
+ *  Callers read/write for the *active* terminal — the API is parameterless,
+ *  resolving the current terminal id from `useTerminalStore` internally. */
 
 import {
   type CodeTabView,
+  DEFAULT_RIGHT_PANEL_PER_TERMINAL,
+  type RightPanelPerTerminalState,
   type RightPanelTab,
+  type TerminalId,
   rightPanelView,
 } from "kolu-common/surface";
-import { preferences, updatePreferences } from "../wire";
+import { createStore, produce } from "solid-js/store";
+import { useTerminalStore } from "../terminal/useTerminalStore";
+import { client, preferences, updatePreferences } from "../wire";
 
 const MIN_PANEL_SIZE = 0.05;
 /** Lower bound for the Code-tab vertical split — keep the tree and content
@@ -17,59 +32,59 @@ const MIN_PANEL_SIZE = 0.05;
 const MIN_TREE_SIZE = 0.1;
 const MAX_TREE_SIZE = 0.9;
 
+const [perTerminal, setPerTerminal] = createStore<
+  Record<TerminalId, RightPanelPerTerminalState>
+>({});
+
+function ensureState(id: TerminalId): RightPanelPerTerminalState {
+  const existing = perTerminal[id];
+  if (existing) return existing;
+  setPerTerminal(id, { ...DEFAULT_RIGHT_PANEL_PER_TERMINAL });
+  // Re-read so the returned reference points at the store-tracked object.
+  return perTerminal[id] as RightPanelPerTerminalState;
+}
+
+function reportToServer(id: TerminalId): void {
+  const s = perTerminal[id];
+  if (!s) return;
+  void client.terminal
+    .setRightPanel({
+      id,
+      activeTab: s.activeTab,
+      codeMode: s.codeMode,
+      selectedFileByMode: s.selectedFileByMode,
+    })
+    .catch(() => {});
+}
+
 export function useRightPanel() {
+  const store = useTerminalStore();
   const rp = () => preferences().rightPanel;
 
+  /** Read the per-terminal record for the active terminal, falling back
+   *  to defaults when no terminal is active or the terminal has no record
+   *  yet. The returned object is read-only — write through the mutators. */
+  function activeState(): RightPanelPerTerminalState {
+    const id = store.activeId();
+    if (id === null) return DEFAULT_RIGHT_PANEL_PER_TERMINAL;
+    return perTerminal[id] ?? DEFAULT_RIGHT_PANEL_PER_TERMINAL;
+  }
+
+  /** Mutate the active terminal's per-terminal record. No-op when no
+   *  terminal is active — clicks on the panel before a terminal exists
+   *  are dropped silently. */
+  function mutateActive(patch: Partial<RightPanelPerTerminalState>): void {
+    const id = store.activeId();
+    if (id === null) return;
+    ensureState(id);
+    setPerTerminal(id, patch);
+    reportToServer(id);
+  }
+
   return {
+    // ── Workspace chrome (global) ────────────────────────────────────
     collapsed: () => rp().collapsed,
     panelSize: () => rp().size,
-    /** DU view of the active tab — `{ kind: "inspector" }` or
-     *  `{ kind: "code", mode }`. Matches `match(...).with(...).exhaustive()`. */
-    activeTab: (): RightPanelTab => rightPanelView(rp()),
-    /** Persisted Code-tab sub-mode regardless of which tab is active.
-     *  CodeTab needs the mode even when the user has flipped over to
-     *  Inspector — selection / filter state is keyed by it, and the
-     *  fallback behaviour of reading `activeTab` would mask a "browse"
-     *  selection as "local" while Inspector is active and trigger a
-     *  spurious reset on the round-trip back. */
-    codeMode: (): CodeTabView => rp().codeMode,
-    /** Switch to Inspector. `codeMode` is preserved so toggling back to Code
-     *  restores the user's last sub-mode. */
-    showInspector: () =>
-      updatePreferences({ rightPanel: { activeTab: "inspector" } }),
-    /** Switch to Code tab. When `mode` is omitted, the persisted `codeMode`
-     *  is used — this is the round-trip case (Inspector→Code restores the
-     *  last view). Pass `mode` explicitly to override. */
-    showCode: (mode?: CodeTabView) =>
-      updatePreferences({
-        rightPanel: {
-          activeTab: "code",
-          ...(mode !== undefined && { codeMode: mode }),
-        },
-      }),
-    /** Atomic "open the Code tab at `mode`" — uncollapse the panel,
-     *  switch to Code, set the requested sub-mode. Single preferences
-     *  patch so the UI ticks once instead of three times when callers
-     *  need all three transitions together. Skips the patch when the
-     *  panel is already in the target state (every diff→browse and
-     *  browse→browse `openInCodeTab` would otherwise round-trip a
-     *  three-field preferences write to the server). */
-    openCodeAt: (mode: CodeTabView) => {
-      const cur = rp();
-      if (!cur.collapsed && cur.activeTab === "code" && cur.codeMode === mode) {
-        return;
-      }
-      updatePreferences({
-        rightPanel: {
-          collapsed: false,
-          activeTab: "code",
-          codeMode: mode,
-        },
-      });
-    },
-    /** Change the sub-mode within the Code tab. */
-    setCodeMode: (mode: CodeTabView) =>
-      updatePreferences({ rightPanel: { codeMode: mode } }),
     togglePanel: () =>
       updatePreferences({ rightPanel: { collapsed: !rp().collapsed } }),
     collapsePanel: () => updatePreferences({ rightPanel: { collapsed: true } }),
@@ -84,6 +99,88 @@ export function useRightPanel() {
       if (size >= MIN_TREE_SIZE && size <= MAX_TREE_SIZE) {
         updatePreferences({ rightPanel: { codeTabTreeSize: size } });
       }
+    },
+
+    // ── Per-terminal task state ──────────────────────────────────────
+    /** DU view of the active tab — `{ kind: "inspector" }` or
+     *  `{ kind: "code", mode }`. Matches `match(...).with(...).exhaustive()`. */
+    activeTab: (): RightPanelTab => rightPanelView(activeState()),
+    /** Persisted Code-tab sub-mode regardless of which tab is active.
+     *  CodeTab needs the mode even when the user has flipped over to
+     *  Inspector — selection / filter state is keyed by it, and the
+     *  fallback behaviour of reading `activeTab` would mask a "browse"
+     *  selection as "local" while Inspector is active and trigger a
+     *  spurious reset on the round-trip back. */
+    codeMode: (): CodeTabView => activeState().codeMode,
+    /** Switch to Inspector. `codeMode` is preserved so toggling back to Code
+     *  restores the user's last sub-mode. */
+    showInspector: () => mutateActive({ activeTab: "inspector" }),
+    /** Switch to Code tab. When `mode` is omitted, the persisted `codeMode`
+     *  is used — this is the round-trip case (Inspector→Code restores the
+     *  last view). Pass `mode` explicitly to override. */
+    showCode: (mode?: CodeTabView) =>
+      mutateActive({
+        activeTab: "code",
+        ...(mode !== undefined && { codeMode: mode }),
+      }),
+    /** Atomic "open the Code tab at `mode`" — uncollapse the panel,
+     *  switch to Code, set the requested sub-mode. The collapse flip is
+     *  a global write; the tab/mode flip is a per-terminal write. Skip
+     *  both when already in the target state to avoid spurious republishes
+     *  (every diff→browse and browse→browse `openInCodeTab` would otherwise
+     *  round-trip two writes to the server). */
+    openCodeAt: (mode: CodeTabView) => {
+      const cur = activeState();
+      const wasCollapsed = rp().collapsed;
+      if (!wasCollapsed && cur.activeTab === "code" && cur.codeMode === mode) {
+        return;
+      }
+      if (wasCollapsed) {
+        updatePreferences({ rightPanel: { collapsed: false } });
+      }
+      mutateActive({ activeTab: "code", codeMode: mode });
+    },
+    /** Change the sub-mode within the Code tab. */
+    setCodeMode: (mode: CodeTabView) => mutateActive({ codeMode: mode }),
+
+    /** Per-mode file selection — repo-relative path, or null when no file
+     *  is selected in this mode. Keyed by `(activeTerminal, mode)` so each
+     *  terminal remembers its own pick in each of local/branch/browse. */
+    selectedFile: (mode: CodeTabView): string | null =>
+      activeState().selectedFileByMode?.[mode] ?? null,
+    setSelectedFile: (mode: CodeTabView, path: string | null) => {
+      const id = store.activeId();
+      if (id === null) return;
+      ensureState(id);
+      setPerTerminal(
+        id,
+        produce((s: RightPanelPerTerminalState) => {
+          const cur = s.selectedFileByMode ?? {};
+          if (path === null) {
+            if (!(mode in cur)) return;
+            const { [mode]: _, ...rest } = cur;
+            s.selectedFileByMode =
+              Object.keys(rest).length > 0 ? rest : undefined;
+          } else {
+            if (cur[mode] === path) return;
+            s.selectedFileByMode = { ...cur, [mode]: path };
+          }
+        }),
+      );
+      reportToServer(id);
+    },
+
+    // ── Session restore + lifecycle ──────────────────────────────────
+    /** Seed per-terminal state from server data — no report-back to
+     *  server. Called by `useSessionRestore` during hydration and after
+     *  recreating a saved terminal. */
+    seedPanel: (id: TerminalId, state: RightPanelPerTerminalState) => {
+      setPerTerminal(id, state);
+    },
+    /** Clean up state for a terminal that no longer exists. Mirrors
+     *  `useSubPanel.removePanel`. */
+    removePanel: (id: TerminalId) => {
+      setPerTerminal(produce((s) => delete s[id]));
     },
   } as const;
 }

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -138,10 +138,13 @@ export function useRightPanel() {
       }),
     /** Atomic "open the Code tab at `mode`" — uncollapse the panel,
      *  switch to Code, set the requested sub-mode. The collapse flip is
-     *  a global write; the tab/mode flip is a per-terminal write. Skip
-     *  both when already in the target state to avoid spurious republishes
-     *  (every diff→browse and browse→browse `openInCodeTab` would otherwise
-     *  round-trip two writes to the server). */
+     *  a global write; the tab/mode flip is a per-terminal write.
+     *
+     *  Short-circuits when the panel is already open at the right tab+mode —
+     *  every diff→browse and browse→browse `openCodeAt` would otherwise
+     *  round-trip two writes to the server. When the panel is collapsed, the
+     *  per-terminal write still fires (the tab/mode may need updating even
+     *  though the panel is opening fresh). */
     openCodeAt: (mode: CodeTabView) => {
       const cur = activeState();
       const wasCollapsed = rp().collapsed;

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -51,7 +51,9 @@ function reportToServer(id: TerminalId): void {
       codeMode: s.codeMode,
       selectedFileByMode: s.selectedFileByMode,
     })
-    .catch(() => {});
+    .catch((err: Error) =>
+      console.error("useRightPanel: setRightPanel RPC failed", err),
+    );
 }
 
 export function useRightPanel() {

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -72,12 +72,26 @@ export function useRightPanel() {
 
   /** Mutate the active terminal's per-terminal record. No-op when no
    *  terminal is active — clicks on the panel before a terminal exists
-   *  are dropped silently. */
-  function mutateActive(patch: Partial<RightPanelPerTerminalState>): void {
+   *  are dropped silently.
+   *
+   *  Accepts either a shallow patch (`Partial<RightPanelPerTerminalState>`)
+   *  or a producer function for nested updates (e.g. mutating one key in
+   *  `selectedFileByMode`). Both paths share the same `ensureState →
+   *  setStore → reportToServer` triplet so future contract changes
+   *  (client-side equality gate, telemetry) land in one place. */
+  function mutateActive(
+    update:
+      | Partial<RightPanelPerTerminalState>
+      | ((s: RightPanelPerTerminalState) => void),
+  ): void {
     const id = store.activeId();
     if (id === null) return;
     ensureState(id);
-    setPerTerminal(id, patch);
+    if (typeof update === "function") {
+      setPerTerminal(id, produce(update));
+    } else {
+      setPerTerminal(id, update);
+    }
     reportToServer(id);
   }
 
@@ -149,25 +163,18 @@ export function useRightPanel() {
     selectedFile: (mode: CodeTabView): string | null =>
       activeState().selectedFileByMode?.[mode] ?? null,
     setSelectedFile: (mode: CodeTabView, path: string | null) => {
-      const id = store.activeId();
-      if (id === null) return;
-      ensureState(id);
-      setPerTerminal(
-        id,
-        produce((s: RightPanelPerTerminalState) => {
-          const cur = s.selectedFileByMode ?? {};
-          if (path === null) {
-            if (!(mode in cur)) return;
-            const { [mode]: _, ...rest } = cur;
-            s.selectedFileByMode =
-              Object.keys(rest).length > 0 ? rest : undefined;
-          } else {
-            if (cur[mode] === path) return;
-            s.selectedFileByMode = { ...cur, [mode]: path };
-          }
-        }),
-      );
-      reportToServer(id);
+      mutateActive((s) => {
+        const cur = s.selectedFileByMode ?? {};
+        if (path === null) {
+          if (!(mode in cur)) return;
+          const { [mode]: _, ...rest } = cur;
+          s.selectedFileByMode =
+            Object.keys(rest).length > 0 ? rest : undefined;
+        } else {
+          if (cur[mode] === path) return;
+          s.selectedFileByMode = { ...cur, [mode]: path };
+        }
+      });
     },
 
     // ── Session restore + lifecycle ──────────────────────────────────

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -261,10 +261,12 @@ export function useSessionRestore(deps: {
         // to the same tab. The server-persisted fields (collapsed, panelSize)
         // ride along via handleCreate above.
         if (t.subPanel) subPanel.seedPanel(newId, t.subPanel);
-        // Same for right-panel per-terminal state — the persisted record
-        // rides handleCreate, but we also seed the local in-memory store
-        // so reads before the metadata collection resnapshots see the
-        // restored value.
+        // Right-panel per-terminal state: the persisted record rides
+        // `handleCreate` (server seeds `meta.rightPanel` from
+        // `initial.rightPanel` in the first `terminal.list` snapshot);
+        // `seedPanel` here is the early-read optimization for the
+        // in-memory store, so reads that happen before the metadata
+        // collection resnapshots see the restored value.
         if (t.rightPanel) rightPanel.seedPanel(newId, t.rightPanel);
         // Auto-launch the resume form of the previously captured agent
         // command, if the user didn't opt out. The command is already

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -16,6 +16,7 @@ import {
   savedSession as serverSavedSession,
   savedSessionSub,
 } from "../wire";
+import { useRightPanel } from "../right-panel/useRightPanel";
 import { useSubPanel } from "./useSubPanel";
 import type { TerminalStore } from "./useTerminalStore";
 
@@ -38,6 +39,7 @@ export function useSessionRestore(deps: {
 }) {
   const { store } = deps;
   const subPanel = useSubPanel();
+  const rightPanel = useRightPanel();
 
   const [savedSession, setSavedSession] = createSignal<SavedSession | null>(
     null,
@@ -82,9 +84,10 @@ export function useSessionRestore(deps: {
     serverActiveId: string | null,
   ) {
     // Canvas layouts live on metadata — no client-side seeding needed.
-    // Seed sub-panel state from server metadata.
+    // Seed sub-panel + right-panel state from server metadata.
     for (const { t, m } of entries) {
       if (m.subPanel) subPanel.seedPanel(t.id, m.subPanel);
+      if (m.rightPanel) rightPanel.seedPanel(t.id, m.rightPanel);
     }
 
     // Initialize sub-panel active tabs for parents with sub-terminals
@@ -242,6 +245,7 @@ export function useSessionRestore(deps: {
           themeName: t.themeName,
           canvasLayout: t.canvasLayout,
           subPanel: t.subPanel,
+          rightPanel: t.rightPanel,
           lastActivityAt: t.lastActivityAt,
           intent: t.intent,
         });
@@ -257,6 +261,11 @@ export function useSessionRestore(deps: {
         // to the same tab. The server-persisted fields (collapsed, panelSize)
         // ride along via handleCreate above.
         if (t.subPanel) subPanel.seedPanel(newId, t.subPanel);
+        // Same for right-panel per-terminal state — the persisted record
+        // rides handleCreate, but we also seed the local in-memory store
+        // so reads before the metadata collection resnapshots see the
+        // restored value.
+        if (t.rightPanel) rightPanel.seedPanel(newId, t.rightPanel);
         // Auto-launch the resume form of the previously captured agent
         // command, if the user didn't opt out. The command is already
         // normalized (prompts/positionals stripped by the allowlist at

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -131,6 +131,7 @@ export function useTerminalCrud(deps: {
         themeName: theme,
         canvasLayout: initial?.canvasLayout,
         subPanel: initial?.subPanel,
+        rightPanel: initial?.rightPanel,
         lastActivityAt: initial?.lastActivityAt,
         intent: initial?.intent,
       })

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -14,6 +14,7 @@ import { CONTEXTUAL_TIPS } from "../settings/tips";
 import { client, preferences } from "../wire";
 import { useTips } from "../settings/useTips";
 import { writeTextToClipboard } from "../ui/clipboard";
+import { useRightPanel } from "../right-panel/useRightPanel";
 import { useSubPanel } from "./useSubPanel";
 import type { TerminalStore } from "./useTerminalStore";
 
@@ -23,6 +24,7 @@ export function useTerminalCrud(deps: {
 }) {
   const { store } = deps;
   const subPanel = useSubPanel();
+  const rightPanel = useRightPanel();
   const { showTipOnce } = useTips();
 
   /** The terminal the user is currently interacting with —
@@ -86,6 +88,7 @@ export function useTerminalCrud(deps: {
     const ids = store.terminalIds();
     const idx = ids.indexOf(id);
     subPanel.removePanel(id);
+    rightPanel.removePanel(id);
     store.setMruOrder((prev) => prev.filter((x) => x !== id));
     if (store.activeId() === id) {
       const remaining = ids.filter((x) => x !== id);

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import {
   CanvasLayoutSchema,
   InitialTerminalMetadataSchema,
+  RightPanelPerTerminalStateSchema,
   surface,
   TerminalAttachInputSchema,
   TerminalIdSchema,
@@ -73,6 +74,11 @@ export const TerminalSetSubPanelInputSchema = z.object({
   collapsed: z.boolean(),
   panelSize: z.number(),
 });
+
+export const TerminalSetRightPanelInputSchema =
+  RightPanelPerTerminalStateSchema.extend({
+    id: TerminalIdSchema,
+  });
 
 export const SetActiveTerminalInputSchema = z.object({
   id: TerminalIdSchema.nullable(),
@@ -129,6 +135,7 @@ export const contract = oc.router({
       .input(TerminalSetCanvasLayoutInputSchema)
       .output(z.void()),
     setSubPanel: oc.input(TerminalSetSubPanelInputSchema).output(z.void()),
+    setRightPanel: oc.input(TerminalSetRightPanelInputSchema).output(z.void()),
     setActive: oc.input(SetActiveTerminalInputSchema).output(z.void()),
     /** Bidirectional binary stream — clients use `streamCall` with a
      *  custom `onRetry` (xterm buffer reset before re-subscribe). Doesn't

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -90,7 +90,13 @@ export const RightPanelTabKindSchema = z.enum(["inspector", "code"]);
  *
  *  `selectedFileByMode` is per-mode so flipping between local↔branch↔browse
  *  within a single terminal keeps each mode's last-viewed file, mirroring
- *  the prior `(repo, mode)`-keyed localStorage slot behaviour. */
+ *  the prior `(repo, mode)`-keyed localStorage slot behaviour.
+ *
+ *  Storage is flat (`activeTab` + `codeMode` as parallel fields) so Solid's
+ *  shallow-merge `setStore` is correct. Consumption should go through the
+ *  `rightPanelView()` DU projection — pattern-matching on `activeTab` /
+ *  `codeMode` separately leaks the storage shape across the DU seam and
+ *  defeats the "codeMode survives Inspector toggle" invariant. */
 export const RightPanelPerTerminalStateSchema = z.object({
   activeTab: RightPanelTabKindSchema,
   codeMode: CodeTabViewSchema,

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -76,6 +76,35 @@ export const SubPanelStateSchema = z.object({
   panelSize: z.number(),
 });
 
+/** Sub-view of the Code tab: local/branch diff modes or the file browser. */
+export const CodeTabViewSchema = z.enum(["local", "branch", "browse"]);
+
+/** Which tab is currently displayed in the right panel. */
+export const RightPanelTabKindSchema = z.enum(["inspector", "code"]);
+
+/** Per-terminal right-panel state — which tab is open, which sub-mode
+ *  the Code tab is in, and which file the user last selected in each
+ *  mode. The three fields move together because they are *about* the
+ *  terminal's task (reviewing branch X, browsing repo, inspecting agent
+ *  output) — switching terminals should restore them as a unit.
+ *
+ *  `selectedFileByMode` is per-mode so flipping between local↔branch↔browse
+ *  within a single terminal keeps each mode's last-viewed file, mirroring
+ *  the prior `(repo, mode)`-keyed localStorage slot behaviour. */
+export const RightPanelPerTerminalStateSchema = z.object({
+  activeTab: RightPanelTabKindSchema,
+  codeMode: CodeTabViewSchema,
+  /** Repo-relative file paths keyed by Code-tab sub-mode. Absence of a
+   *  key means "no selection" for that mode. */
+  selectedFileByMode: z
+    .object({
+      local: z.string().optional(),
+      branch: z.string().optional(),
+      browse: z.string().optional(),
+    })
+    .optional(),
+});
+
 // ── Terminal metadata fields, organized by write-authority + persistence ──
 //
 // Invariant: every terminal-metadata field appears in EXACTLY ONE of
@@ -136,6 +165,11 @@ export const ClientPersistedTerminalFieldsSchema = z.object({
   canvasLayout: CanvasLayoutSchema.optional(),
   /** Sub-panel collapsed/size state — client-reported, used for session restore. */
   subPanel: SubPanelStateSchema.optional(),
+  /** Right-panel per-terminal state — client-reported. Holds the fields
+   *  that are *about* the terminal's task (active tab, code sub-mode,
+   *  per-mode file selection). The remaining right-panel fields (collapsed,
+   *  size, codeTabTreeSize) stay on preferences as workspace-level chrome. */
+  rightPanel: RightPanelPerTerminalStateSchema.optional(),
   /** User-set freeform annotation — multiline markdown. The first line
    *  doubles as a glanceable tag (rendered as a chip next to the repo
    *  name and painted onto the dock rail swatch); the full body shows
@@ -216,6 +250,7 @@ export const InitialTerminalMetadataSchema = z.object({
   themeName: z.string().min(1).optional(),
   canvasLayout: CanvasLayoutSchema.optional(),
   subPanel: SubPanelStateSchema.optional(),
+  rightPanel: RightPanelPerTerminalStateSchema.optional(),
   lastActivityAt: z.number().optional(),
   intent: z.string().min(1).optional(),
 });
@@ -290,25 +325,15 @@ export const SavedSessionSchema = z.object({
 
 export const ColorSchemeSchema = z.enum(["light", "dark", "system"]);
 
-/** Sub-view of the Code tab: local/branch diff modes or the file browser. */
-export const CodeTabViewSchema = z.enum(["local", "branch", "browse"]);
-
-/** Which tab is currently displayed in the right panel. */
-export const RightPanelTabKindSchema = z.enum(["inspector", "code"]);
-
-/** Right-panel preferences. `activeTab` and `codeMode` live as flat fields so
- *  the storage layer's shallow merge is correct — Solid's `setStore` deep-merge
- *  cannot preserve discriminated-union variant invariants without a per-path
- *  `reconcile` escape hatch. Storing `codeMode` independently of `activeTab`
- *  also lets the Code tab restore its last sub-mode when the user toggles
- *  back from Inspector. The DU view (`{ kind: "inspector" } | { kind: "code",
- *  mode }`) is exposed via `rightPanelView()` for ergonomic pattern-matching
- *  at use sites. */
+/** Right-panel preferences — workspace-level layout chrome. The fields
+ *  *about* what each terminal is doing (active tab, code sub-mode,
+ *  selected file) live on `RightPanelPerTerminalStateSchema` against the
+ *  terminal record, not here. Splitting follows the volatility seam: panel
+ *  width and tree-pane split are tuned once and stay put; active tab and
+ *  code-mode flip per terminal task. */
 export const RightPanelPrefsSchema = z.object({
   collapsed: z.boolean(),
   size: z.number(),
-  activeTab: RightPanelTabKindSchema,
-  codeMode: CodeTabViewSchema,
   /** Vertical split fraction (0–1) inside the Code tab: tree pane occupies
    *  this share, content pane gets the rest. Persisted so layout survives
    *  reload, mirroring the horizontal `size` field's behavior. */
@@ -382,6 +407,9 @@ export type SavedTerminal = z.infer<typeof SavedTerminalSchema>;
 export type ColorScheme = z.infer<typeof ColorSchemeSchema>;
 export type CodeTabView = z.infer<typeof CodeTabViewSchema>;
 export type RightPanelTabKind = z.infer<typeof RightPanelTabKindSchema>;
+export type RightPanelPerTerminalState = z.infer<
+  typeof RightPanelPerTerminalStateSchema
+>;
 
 /** Discriminated-union view of the right panel's active tab. Derived from the
  *  flat `activeTab` + `codeMode` storage shape — see `rightPanelView()`. Use
@@ -405,15 +433,23 @@ export const DEFAULT_PREFERENCES: z.infer<typeof PreferencesSchema> = {
   rightPanel: {
     collapsed: true,
     size: 0.25,
-    activeTab: "inspector",
-    codeMode: "local",
     codeTabTreeSize: 0.35,
   },
 };
 
-/** Project the flat `RightPanelPrefs` shape onto its DU view. Storage stays
- *  flat (Solid's setStore shallow-merges correctly); use sites get the
- *  exhaustive-match-friendly DU. */
+/** Default per-terminal right-panel state — seeded into the in-memory
+ *  store when a terminal has no `rightPanel` record yet (fresh terminals,
+ *  or terminals from a session predating this schema). */
+export const DEFAULT_RIGHT_PANEL_PER_TERMINAL: z.infer<
+  typeof RightPanelPerTerminalStateSchema
+> = {
+  activeTab: "inspector",
+  codeMode: "local",
+};
+
+/** Project the flat `RightPanelPerTerminalState` shape onto its DU view.
+ *  Storage stays flat (Solid's setStore shallow-merges correctly); use sites
+ *  get the exhaustive-match-friendly DU. */
 export function rightPanelView(p: {
   activeTab: RightPanelTabKind;
   codeMode: CodeTabView;

--- a/packages/server/src/meta/index.ts
+++ b/packages/server/src/meta/index.ts
@@ -22,7 +22,8 @@
  *     stream watcher publishes ~150ms during streaming, and most of
  *     those publishes touch only live state.
  *   - `updateClientMetadata` — client-persisted fields (themeName,
- *     parentId, canvasLayout, subPanel). Fires `terminals:dirty`.
+ *     parentId, canvasLayout, subPanel, rightPanel, intent). Fires
+ *     `terminals:dirty`.
  *
  * The mutator-type narrowing is a bidirectional compile-time fence:
  * each helper can only write the fields it owns, so a provider cannot

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -32,6 +32,7 @@ import {
   killTerminal,
   setActiveTerminalId,
   setCanvasLayout,
+  setRightPanelState,
   setSubPanelState,
   setTerminalIntent,
   setTerminalParent,
@@ -59,6 +60,7 @@ export const appRouter = t.router({
         themeName: input.themeName,
         canvasLayout: input.canvasLayout,
         subPanel: input.subPanel,
+        rightPanel: input.rightPanel,
         lastActivityAt: input.lastActivityAt,
         intent: input.intent,
       }),
@@ -98,6 +100,12 @@ export const appRouter = t.router({
         collapsed: input.collapsed,
         panelSize: input.panelSize,
       });
+    }),
+
+    setRightPanel: t.terminal.setRightPanel.handler(async ({ input }) => {
+      requireTerminal(input.id);
+      const { id: _id, ...state } = input;
+      setRightPanelState(input.id, state);
     }),
 
     setActive: t.terminal.setActive.handler(async ({ input }) => {

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -98,7 +98,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.22.0";
+const SCHEMA_VERSION = "1.23.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -392,10 +392,13 @@ export const store = new Conf<PersistedState>({
       const activeTab = tab?.kind === "code" ? "code" : "inspector";
       const codeMode = tab?.kind === "code" ? tab.mode : "local";
       const { tab: _tab, ...rest } = rp;
+      // Cast through `unknown` — the transitional shape carries `activeTab`
+      // and `codeMode` on `rightPanel` that 1.23.0 later strips, so the
+      // value here is intentionally wider than `Preferences`.
       store.set("preferences", {
         ...current,
         rightPanel: { ...rest, activeTab, codeMode },
-      } as Preferences);
+      } as unknown as Preferences);
     },
     // SavedTerminal.lastActivityAt added (#830). Seed legacy terminals to 0
     // so they fall back to canvas-position ordering until an agent
@@ -418,6 +421,24 @@ export const store = new Conf<PersistedState>({
     // would now fail validation, but no path produced that shape — the
     // theme setter always wrote a non-empty value or omitted the key.
     "1.22.0": () => {},
+    // Right-panel `activeTab` and `codeMode` move from the global
+    // `preferences.rightPanel` to per-terminal `TerminalMetadata.rightPanel`
+    // — the two fields are *about* what each terminal is doing, so they
+    // should travel with the terminal. Strip them from the preferences
+    // blob; new per-terminal records seed lazily from
+    // `DEFAULT_RIGHT_PANEL_PER_TERMINAL` at first read. The CodeTab's
+    // legacy `kolu-codetab-selected-files` localStorage key is dropped
+    // client-side (no on-disk state to migrate).
+    "1.23.0": (store: Conf<PersistedState>) => {
+      const current = store.get("preferences") as Record<string, unknown>;
+      const rp = current.rightPanel as Record<string, unknown> | undefined;
+      if (!rp) return;
+      const { activeTab: _activeTab, codeMode: _codeMode, ...rest } = rp;
+      store.set("preferences", {
+        ...current,
+        rightPanel: rest as typeof current.rightPanel,
+      } as Preferences);
+    },
   },
 });
 

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -13,6 +13,7 @@
 
 import type {
   InitialTerminalMetadata,
+  RightPanelPerTerminalState,
   SavedTerminal,
   TerminalId,
   TerminalInfo,
@@ -162,6 +163,7 @@ export function createTerminal(
   if (initial?.themeName) meta.themeName = initial.themeName;
   if (initial?.canvasLayout) meta.canvasLayout = initial.canvasLayout;
   if (initial?.subPanel) meta.subPanel = initial.subPanel;
+  if (initial?.rightPanel) meta.rightPanel = initial.rightPanel;
   if (initial?.lastActivityAt !== undefined)
     meta.lastActivityAt = initial.lastActivityAt;
   if (initial?.intent) meta.intent = initial.intent;
@@ -249,6 +251,43 @@ export function setSubPanelState(
   updateClientMetadata(entry, id, (m) => {
     m.subPanel = state;
   });
+}
+
+/** Store a terminal's right-panel per-terminal state (client-reported).
+ *  Publishes via metadata so other clients (and the same client after a
+ *  refresh) pick up the change from the same channel as every other
+ *  client-owned metadata field.
+ *
+ *  Equality-gated like `setSubPanelState` — the client RPCs this on every
+ *  file-tree click and tab-toggle, so without a guard each interaction
+ *  would fan a full per-key metadata publish. Deep-compares
+ *  `selectedFileByMode` since the user clicks files often. */
+export function setRightPanelState(
+  id: TerminalId,
+  state: RightPanelPerTerminalState,
+): void {
+  const entry = getTerminal(id);
+  if (!entry) return;
+  const cur = entry.meta.rightPanel;
+  if (cur && rightPanelStateEqual(cur, state)) return;
+  updateClientMetadata(entry, id, (m) => {
+    m.rightPanel = state;
+  });
+}
+
+function rightPanelStateEqual(
+  a: RightPanelPerTerminalState,
+  b: RightPanelPerTerminalState,
+): boolean {
+  if (a.activeTab !== b.activeTab || a.codeMode !== b.codeMode) return false;
+  const am = a.selectedFileByMode;
+  const bm = b.selectedFileByMode;
+  if (am === bm) return true;
+  if (!am || !bm) return false;
+  if (am.local !== bm.local) return false;
+  if (am.branch !== bm.branch) return false;
+  if (am.browse !== bm.browse) return false;
+  return true;
 }
 
 // Active terminal ID — client-reported, used only for session snapshots.

--- a/packages/surface/README.md
+++ b/packages/surface/README.md
@@ -343,7 +343,7 @@ Concrete inventory — what every server-pushed reactive surface in Kolu maps to
 
 | Descriptor | Backs | Authority | Mutation | Persistence |
 |---|---|---|---|---|
-| `preferencesCell` | User preferences (theme, scrollLock, sound, rightPanel state, …) | `local` (instant UI) | `client.preferences.update(patch)` | `confStore("preferences")` |
+| `preferencesCell` | User preferences (theme, scrollLock, sound, right-panel workspace chrome — collapsed/size/codeTabTreeSize — …) | `local` (instant UI) | `client.preferences.update(patch)` | `confStore("preferences")` |
 | `terminalListCell` | Live terminal list — drives the dock, canvas tile set, mobile swipe order | `server` | _server-only_ (via `terminal.create` / `kill` mutations) | `inMemoryStore` (registry is canonical) |
 | `activityFeedCell` | Recent repos cd'd into + recent agent CLIs spotted via OSC 633;E | `server` | _server-only_ (via `trackRecentRepo` / `trackRecentAgent`) | `confStore("activityFeed")` |
 | `savedSessionCell` | Last-persisted snapshot of terminals + active id (drives session restore) | `server` | _server-only_ (debounced autosave on `terminals:dirty`) | `confStore("session")` |
@@ -352,7 +352,7 @@ Concrete inventory — what every server-pushed reactive surface in Kolu maps to
 
 | Descriptor | Backs | Mutation |
 |---|---|---|
-| `terminalMetadataCollection` | Per-terminal metadata (cwd, git, PR, agent state, foreground process, last-activity timestamp for switcher recency) — each terminal's tile chrome and inspector reads its own key | _server-only_ (providers under `meta/*.ts` route writes through `updateServerMetadata` for persisted fields and `updateServerLiveMetadata` for live-only fields — `pr`, `agent`, `foreground` — so the high-frequency agent-stream watcher doesn't fire `terminals:dirty` and trigger no-op session autosaves; the agent provider switches to the persisting variant on each semantic-key transition that bumps `lastActivityAt`) |
+| `terminalMetadataCollection` | Per-terminal metadata (cwd, git, PR, agent state, foreground process, last-activity timestamp for switcher recency, **right-panel per-terminal state** — activeTab, codeMode, per-mode selected file — and sub-panel state) — each terminal's tile chrome and inspector reads its own key | _server-only_ (providers under `meta/*.ts` route writes through `updateServerMetadata` for persisted fields and `updateServerLiveMetadata` for live-only fields — `pr`, `agent`, `foreground` — so the high-frequency agent-stream watcher doesn't fire `terminals:dirty` and trigger no-op session autosaves; the agent provider switches to the persisting variant on each semantic-key transition that bumps `lastActivityAt`) |
 
 ### Streams
 
@@ -377,7 +377,7 @@ Shapes that don't fit a descriptor stay as plain oRPC procedures.
 |---|---|---|
 | **Bidirectional binary stream** — subscribe-before-yield ordering, custom `onRetry` (xterm buffer reset before re-subscribe's first frame) | `terminal.attach` | `streamCall(client.terminal.attach, { id }, { signal, onRetry })` |
 | **One-shot queries** — request/response, no subscription dimension | `server.info`, `terminal.screenState`, `terminal.screenText`, `terminal.exportTranscriptHtml` | `await client.X.Y(input)` |
-| **Mutations** — request/response writes | `terminal.create` / `kill` / `killAll` / `resize` / `sendInput` / `setTheme` / `setCanvasLayout` / `setSubPanel` / `setActive` / `setParent` / `pasteImage`, `git.worktreeCreate` / `worktreeRemove`, `preferences.update` | `await client.X.Y(input)` (the retry plugin's `retry: 0` default fails them fast) |
+| **Mutations** — request/response writes | `terminal.create` / `kill` / `killAll` / `resize` / `sendInput` / `setTheme` / `setCanvasLayout` / `setSubPanel` / `setRightPanel` / `setActive` / `setParent` / `pasteImage`, `git.worktreeCreate` / `worktreeRemove`, `preferences.update` | `await client.X.Y(input)` (the retry plugin's `retry: 0` default fails them fast) |
 
 `streamCall` applies the same `STREAM_RETRY` context the descriptor hooks thread (and merges in an optional `onRetry` callback) so transport drops re-subscribe transparently — escape hatch for non-descriptor shapes, same retry semantics.
 

--- a/packages/tests/features/right-panel.feature
+++ b/packages/tests/features/right-panel.feature
@@ -99,6 +99,23 @@ Feature: Right panel (inspector)
     And the Code tab should be active
     And there should be no page errors
 
+  Scenario: Active tab is per-terminal (each terminal remembers its own)
+    # Terminal 1 (from Background) — switch to Code, leaving terminal 2 untouched
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I click the Code tab
+    Then the Code tab should be active
+    # Create terminal 2 — it should have its own default activeTab (Inspector)
+    When I create a terminal
+    Then the Inspector tab should be active
+    # Switch back to terminal 1 — Code tab should still be active for it
+    When I press the switch to terminal 1 shortcut
+    Then the Code tab should be active
+    # Switch forward to terminal 2 — Inspector again
+    When I press the switch to terminal 2 shortcut
+    Then the Inspector tab should be active
+    And there should be no page errors
+
   @mobile
   Scenario: Right panel hidden on mobile even when expanded in preferences
     # Server has collapsed=false (expanded) but mobile viewport should suppress it

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -263,6 +263,13 @@ Then("the Code tab should be active", async function (this: KoluWorld) {
   await btn.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
 });
 
+Then("the Inspector tab should be active", async function (this: KoluWorld) {
+  const btn = this.page.locator(
+    '[data-testid="right-panel-tab-inspector"][data-active="true"]',
+  );
+  await btn.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+});
+
 Then(
   "the Code tab should indicate no git repository",
   async function (this: KoluWorld) {


### PR DESCRIPTION
**Switching terminals no longer flips the right panel's active tab, code sub-mode, or selected file out from under the user.** The panel's state was a single global preference: opening a PR review in one terminal and a build log in another forced both into whichever was last set. Now the panel reads what each terminal was doing, restored on terminal switch.

### The cut

The right-panel state was split along its volatility seam — not "the right panel" as one concept, but two:

| Field | What the user sees | Scope |
|---|---|---|
| `collapsed` | Whether the panel is showing at all | **Global** (workspace chrome) |
| `size` | Horizontal width drag-handle | **Global** |
| `codeTabTreeSize` | Vertical split between file tree and diff/content | **Global** |
| `activeTab` | Inspector vs Code | **Per terminal** |
| `codeMode` | Code tab's local / branch / browse sub-mode | **Per terminal** |
| `selectedFileByMode` | Which file is highlighted in the tree | **Per terminal**, per-mode within terminal |

The three global fields stay on `preferences.rightPanel` unchanged. The three per-terminal fields move to a new `TerminalMetadata.rightPanel` field, end-to-end mirroring the existing `subPanel` pattern — server stores it in the persisted terminal record, client keeps an in-memory store keyed by terminal id with fire-and-forget reportToServer, session restore seeds via `seedPanel`.

### Mechanism

```
client useRightPanel ──┐
  (per-terminal store) │
                       ├─▶ client.terminal.setRightPanel ─▶ server setRightPanelState
  preferences.rightPanel│       (deep-equality gated)         (writes TerminalMetadata.rightPanel)
  (global chrome) ──────┘                                                  │
                                                                           ▼
                                                              survives session restore
```

`useRightPanel()` is parameterless — it resolves the active terminal from `useTerminalStore` internally. _Callers don't thread the terminal id; "the right panel" always means "the active terminal's right panel"._

CodeTab's `kolu-codetab-selected-files` localStorage path is retired; the new `selectedFileByMode` lives on the per-terminal record with per-mode keying preserved so flipping local↔branch↔browse within a terminal still restores each mode's last file.

### Bonus side-effects of the refactor

- **`RightPanelTabKind` dispatch is now compile-enforced end-to-end** — the body renderer iterates the kind tuple and uses `match(kind).exhaustive()`, so adding a new tab variant is a three-place change the compiler catches (previously the body renderer's pairwise `=== "inspector"` / `=== "code"` checks would have silently fallen through).
- **`setRightPanel` RPC failures surface in dev tools** instead of being swallowed by an empty `.catch(() => {})`.
- **Schema-version migration 1.23.0** strips the orphan `activeTab`/`codeMode` fields from existing on-disk preferences blobs.

### Try it locally

```sh
nix run github:juspay/kolu/feat/right-panel-per-terminal
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._