### PR TITLE
Surface sub-terminal count on dock rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Open http://127.0.0.1:7681 (or the address you chose above).
 ### Terminals
 
 - Create, switch, and kill terminals — every terminal renders as a draggable tile on the canvas, with the left-edge **dock** as the canonical at-a-glance navigator (rail / cards levels) and the **command palette** as the canonical search surface
-- Split terminals — <kbd>Ctrl+&#96;</kbd> splits a bottom pane per terminal; <kbd>Ctrl+Shift+&#96;</kbd> adds tabs, <kbd>Ctrl+PageDown</kbd> / <kbd>Ctrl+PageUp</kbd> cycles
+- Split terminals — <kbd>Ctrl+&#96;</kbd> splits a bottom pane per terminal; <kbd>Ctrl+Shift+&#96;</kbd> adds tabs, <kbd>Ctrl+PageDown</kbd> / <kbd>Ctrl+PageUp</kbd> cycles. Open splits surface as an inline `▭ N` chip on the parent's dock row so the count is visible at a glance, not just on the active tile's title bar
 - Font zoom (<kbd>Cmd/Ctrl</kbd> <kbd>+</kbd>/<kbd>-</kbd>), persisted per terminal across sessions
 - WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Clickable file references — terminal output that contains `path/to/file.ts:42` (with optional `:col` or `-end` line range) is linkified; clicking opens the file in the right panel's Code tab at that line

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -263,7 +263,7 @@ const App: Component = () => {
       void crud.handleKill(id);
       return;
     }
-    const splitCount = store.getSubTerminalIds(id).length;
+    const splitCount = store.getDisplayInfo(id)?.subCount ?? 0;
     const worktreePath = meta.git?.isWorktree
       ? meta.git.worktreePath
       : undefined;

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -47,7 +47,7 @@ const TileTitleActions: Component<{
   const meta = () => store.getMetadata(props.id);
   const themeName = () =>
     store.activeId() === props.id ? activeThemeName() : meta()?.themeName;
-  const subCount = () => store.getSubTerminalIds(props.id).length;
+  const subCount = () => store.getDisplayInfo(props.id)?.subCount ?? 0;
   const splitExpanded = () =>
     subCount() > 0 && !subPanel.getSubPanel(props.id).collapsed;
 

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -54,7 +54,12 @@ import {
   WINDOW_OPTIONS,
   windowOption,
 } from "../../terminal/activityWindow";
-import { ChevronDownIcon, PlusIcon, SearchIcon } from "../../ui/Icons";
+import {
+  ChevronDownIcon,
+  PlusIcon,
+  SearchIcon,
+  SplitToggleIcon,
+} from "../../ui/Icons";
 import { OptionMenu } from "../../ui/OptionMenu";
 import { client } from "../../wire";
 import { isPlatformModifier } from "../../input/keyboard";
@@ -362,6 +367,7 @@ const DockRow: Component<{
           data-agent-state={c().meta.agent?.state}
           data-active={active() ? "" : undefined}
           data-unread={unread() ? "" : undefined}
+          data-sub-count={c().info.subCount > 0 ? c().info.subCount : undefined}
         >
           <Show when={unread()}>
             <span
@@ -488,6 +494,40 @@ const DockAnnotation: Component<{
   </span>
 );
 
+/** Sub-terminal count chip — surfaces `subCount > 0` in the dock row
+ *  title bar so a glance at the dock alone reveals which terminals have
+ *  splits open, without diving into the canvas. Same `SplitToggleIcon`
+ *  vocabulary the tile header uses (`TileTitleActions`) so the symbol
+ *  reads consistently across surfaces. Active rows get a translucent-
+ *  white treatment to survive the accent flood; inactive rows mix
+ *  `currentColor` so the chip inherits the row's text tone. */
+const SubCountChip: Component<{
+  count: number;
+  active: boolean;
+  class?: string;
+}> = (props) => {
+  const label = () =>
+    `${props.count} sub-terminal${props.count === 1 ? "" : "s"}`;
+  return (
+    <span
+      data-testid="dock-sub-count"
+      class={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0 ${props.class ?? ""}`}
+      style={{
+        "background-color": props.active
+          ? "rgba(255, 255, 255, 0.18)"
+          : "color-mix(in oklch, currentColor 10%, transparent)",
+        border: props.active
+          ? "1px solid rgba(255, 255, 255, 0.32)"
+          : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
+      }}
+      title={label()}
+    >
+      <SplitToggleIcon class="w-3 h-3" />
+      <span>{props.count}</span>
+    </span>
+  );
+};
+
 /** Dispatches each row to its variant body. Bundling the variant switch
  *  in one place keeps `DockRow` shape uniform — every bucket has the
  *  same outer "rail + body" geometry regardless of which variant the
@@ -601,12 +641,17 @@ const AwaitingCardBody: Component<{
           >
             {props.info.key.group}
           </span>
-          <DockAnnotation
-            meta={props.meta}
-            info={props.info}
-            class="text-[0.95rem] font-semibold leading-tight"
-            active={active()}
-          />
+          <div class="flex items-baseline gap-2 min-w-0">
+            <DockAnnotation
+              meta={props.meta}
+              info={props.info}
+              class="text-[0.95rem] font-semibold leading-tight"
+              active={active()}
+            />
+            <Show when={props.info.subCount > 0}>
+              <SubCountChip count={props.info.subCount} active={active()} />
+            </Show>
+          </div>
         </div>
         <DockMetaRow meta={props.meta} />
         <PrLine meta={props.meta} />
@@ -680,12 +725,17 @@ const WorkingPillBody: Component<{
         >
           {props.info.key.group}
         </span>
-        <DockAnnotation
-          meta={props.meta}
-          info={props.info}
-          class="text-[0.85rem] font-semibold leading-tight"
-          active={active()}
-        />
+        <div class="flex items-baseline gap-2 min-w-0">
+          <DockAnnotation
+            meta={props.meta}
+            info={props.info}
+            class="text-[0.85rem] font-semibold leading-tight"
+            active={active()}
+          />
+          <Show when={props.info.subCount > 0}>
+            <SubCountChip count={props.info.subCount} active={active()} />
+          </Show>
+        </div>
       </div>
       <DockMetaRow meta={props.meta} />
       <PrLine meta={props.meta} />
@@ -744,6 +794,13 @@ const QuietRowBody: Component<{
           class="text-[0.75rem]"
           active={active()}
         />
+        <Show when={props.info.subCount > 0}>
+          <SubCountChip
+            count={props.info.subCount}
+            active={active()}
+            class="ml-auto"
+          />
+        </Show>
         <Show when={formatTimeAgo(props.meta.lastActivityAt)}>
           {(label) => (
             <span class="ml-auto font-mono text-[0.55rem] tabular-nums text-fg-3 shrink-0">

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -54,12 +54,7 @@ import {
   WINDOW_OPTIONS,
   windowOption,
 } from "../../terminal/activityWindow";
-import {
-  ChevronDownIcon,
-  PlusIcon,
-  SearchIcon,
-  SplitToggleIcon,
-} from "../../ui/Icons";
+import { ChevronDownIcon, PlusIcon, SearchIcon } from "../../ui/Icons";
 import { OptionMenu } from "../../ui/OptionMenu";
 import { client } from "../../wire";
 import { isPlatformModifier } from "../../input/keyboard";
@@ -67,6 +62,7 @@ import { useTileTheme } from "../useTileTheme";
 import { useViewPosture } from "../useViewPosture";
 import { resolvedPr } from "../dockModel";
 import { type DockRowBucket, rankDockRows } from "./dockRowRanking";
+import { SubCountChip } from "./SubCountChip";
 
 export type DockMode = "rail" | "cards";
 
@@ -494,40 +490,6 @@ const DockAnnotation: Component<{
   </span>
 );
 
-/** Sub-terminal count chip — surfaces `subCount > 0` in the dock row
- *  title bar so a glance at the dock alone reveals which terminals have
- *  splits open, without diving into the canvas. Same `SplitToggleIcon`
- *  vocabulary the tile header uses (`TileTitleActions`) so the symbol
- *  reads consistently across surfaces. Active rows get a translucent-
- *  white treatment to survive the accent flood; inactive rows mix
- *  `currentColor` so the chip inherits the row's text tone. */
-const SubCountChip: Component<{
-  count: number;
-  active: boolean;
-  class?: string;
-}> = (props) => {
-  const label = () =>
-    `${props.count} sub-terminal${props.count === 1 ? "" : "s"}`;
-  return (
-    <span
-      data-testid="dock-sub-count"
-      class={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0 ${props.class ?? ""}`}
-      style={{
-        "background-color": props.active
-          ? "rgba(255, 255, 255, 0.18)"
-          : "color-mix(in oklch, currentColor 10%, transparent)",
-        border: props.active
-          ? "1px solid rgba(255, 255, 255, 0.32)"
-          : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
-      }}
-      title={label()}
-    >
-      <SplitToggleIcon class="w-3 h-3" />
-      <span>{props.count}</span>
-    </span>
-  );
-};
-
 /** Dispatches each row to its variant body. Bundling the variant switch
  *  in one place keeps `DockRow` shape uniform — every bucket has the
  *  same outer "rail + body" geometry regardless of which variant the
@@ -649,7 +611,11 @@ const AwaitingCardBody: Component<{
               active={active()}
             />
             <Show when={props.info.subCount > 0}>
-              <SubCountChip count={props.info.subCount} active={active()} />
+              <SubCountChip
+                count={props.info.subCount}
+                active={active()}
+                testId="dock-sub-count"
+              />
             </Show>
           </div>
         </div>
@@ -733,7 +699,11 @@ const WorkingPillBody: Component<{
             active={active()}
           />
           <Show when={props.info.subCount > 0}>
-            <SubCountChip count={props.info.subCount} active={active()} />
+            <SubCountChip
+              count={props.info.subCount}
+              active={active()}
+              testId="dock-sub-count"
+            />
           </Show>
         </div>
       </div>
@@ -801,7 +771,11 @@ const QuietRowBody: Component<{
         >
           <div class="ml-auto flex items-baseline gap-2 shrink-0">
             <Show when={props.info.subCount > 0}>
-              <SubCountChip count={props.info.subCount} active={active()} />
+              <SubCountChip
+                count={props.info.subCount}
+                active={active()}
+                testId="dock-sub-count"
+              />
             </Show>
             <Show when={formatTimeAgo(props.meta.lastActivityAt)}>
               {(label) => (

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -794,19 +794,23 @@ const QuietRowBody: Component<{
           class="text-[0.75rem]"
           active={active()}
         />
-        <Show when={props.info.subCount > 0}>
-          <SubCountChip
-            count={props.info.subCount}
-            active={active()}
-            class="ml-auto"
-          />
-        </Show>
-        <Show when={formatTimeAgo(props.meta.lastActivityAt)}>
-          {(label) => (
-            <span class="ml-auto font-mono text-[0.55rem] tabular-nums text-fg-3 shrink-0">
-              {label()}
-            </span>
-          )}
+        <Show
+          when={
+            props.info.subCount > 0 || formatTimeAgo(props.meta.lastActivityAt)
+          }
+        >
+          <div class="ml-auto flex items-baseline gap-2 shrink-0">
+            <Show when={props.info.subCount > 0}>
+              <SubCountChip count={props.info.subCount} active={active()} />
+            </Show>
+            <Show when={formatTimeAgo(props.meta.lastActivityAt)}>
+              {(label) => (
+                <span class="font-mono text-[0.55rem] tabular-nums text-fg-3 shrink-0">
+                  {label()}
+                </span>
+              )}
+            </Show>
+          </div>
         </Show>
       </div>
       {/* Identity preservation for parked-but-known agent terminals:

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -24,6 +24,7 @@ import { annotationLine } from "../../intent/text";
 import AgentIndicator from "../../terminal/AgentIndicator";
 import { formatTimeAgo, useStaleCheck } from "../../terminal/staleness";
 import { useTerminalStore } from "../../terminal/useTerminalStore";
+import { SplitToggleIcon } from "../../ui/Icons";
 import { resolvedPr } from "../dockModel";
 import { type DockRowBucket, rankDockRows } from "./dockRowRanking";
 
@@ -95,6 +96,9 @@ const Row: Component<{
         data-bucket={props.bucket}
         data-active={active() ? "" : undefined}
         data-unread={unread() ? "" : undefined}
+        data-sub-count={
+          (info()?.subCount ?? 0) > 0 ? info()?.subCount : undefined
+        }
         // stopPropagation on pointerdown keeps Corvu Drawer's
         // drag-to-dismiss from claiming the tap.
         onPointerDown={(e) => e.stopPropagation()}
@@ -126,23 +130,31 @@ const Row: Component<{
             >
               {info()?.key.group}
             </span>
-            <span
-              class="font-medium leading-tight truncate min-w-0"
-              classList={{
-                "text-[0.95rem]": live(),
-                "text-[0.8rem]": !live(),
-              }}
-              style={{
-                color: active() ? undefined : info()?.annotationColor,
-              }}
-            >
-              <IntentMarkdownInline
-                markdown={annotationLine(
-                  meta()?.intent,
-                  info()?.key.label ?? "",
-                )}
-              />
-            </span>
+            <div class="flex items-baseline gap-2 min-w-0">
+              <span
+                class="font-medium leading-tight truncate min-w-0"
+                classList={{
+                  "text-[0.95rem]": live(),
+                  "text-[0.8rem]": !live(),
+                }}
+                style={{
+                  color: active() ? undefined : info()?.annotationColor,
+                }}
+              >
+                <IntentMarkdownInline
+                  markdown={annotationLine(
+                    meta()?.intent,
+                    info()?.key.label ?? "",
+                  )}
+                />
+              </span>
+              <Show when={(info()?.subCount ?? 0) > 0}>
+                <MobileSubCountChip
+                  count={info()?.subCount ?? 0}
+                  active={active()}
+                />
+              </Show>
+            </div>
           </div>
           {/* AgentIndicator surfaces on every row that carries a known
            *  agent — live (awaiting/working) AND parked. Without this
@@ -179,6 +191,36 @@ const Row: Component<{
         </Show>
       </button>
     </Show>
+  );
+};
+
+/** Mirrors the desktop dock's `SubCountChip` (Dock.tsx): surfaces the
+ *  open-sub-terminal count on the mobile row's title bar with the same
+ *  `SplitToggleIcon`+count vocabulary so the symbol reads consistently
+ *  across surfaces. Active rows get a translucent-white treatment to
+ *  survive the accent flood. */
+const MobileSubCountChip: Component<{ count: number; active: boolean }> = (
+  props,
+) => {
+  const label = () =>
+    `${props.count} sub-terminal${props.count === 1 ? "" : "s"}`;
+  return (
+    <span
+      data-testid="mobile-dock-sub-count"
+      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0"
+      style={{
+        "background-color": props.active
+          ? "rgba(255, 255, 255, 0.18)"
+          : "color-mix(in oklch, currentColor 10%, transparent)",
+        border: props.active
+          ? "1px solid rgba(255, 255, 255, 0.32)"
+          : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
+      }}
+      title={label()}
+    >
+      <SplitToggleIcon class="w-3 h-3" />
+      <span>{props.count}</span>
+    </span>
   );
 };
 

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -24,9 +24,9 @@ import { annotationLine } from "../../intent/text";
 import AgentIndicator from "../../terminal/AgentIndicator";
 import { formatTimeAgo, useStaleCheck } from "../../terminal/staleness";
 import { useTerminalStore } from "../../terminal/useTerminalStore";
-import { SplitToggleIcon } from "../../ui/Icons";
 import { resolvedPr } from "../dockModel";
 import { type DockRowBucket, rankDockRows } from "./dockRowRanking";
+import { SubCountChip } from "./SubCountChip";
 
 const MobileDockDrawer: Component<{
   onSelect: (id: TerminalId) => void;
@@ -149,9 +149,10 @@ const Row: Component<{
                 />
               </span>
               <Show when={(info()?.subCount ?? 0) > 0}>
-                <MobileSubCountChip
+                <SubCountChip
                   count={info()?.subCount ?? 0}
                   active={active()}
+                  testId="mobile-dock-sub-count"
                 />
               </Show>
             </div>
@@ -191,36 +192,6 @@ const Row: Component<{
         </Show>
       </button>
     </Show>
-  );
-};
-
-/** Mirrors the desktop dock's `SubCountChip` (Dock.tsx): surfaces the
- *  open-sub-terminal count on the mobile row's title bar with the same
- *  `SplitToggleIcon`+count vocabulary so the symbol reads consistently
- *  across surfaces. Active rows get a translucent-white treatment to
- *  survive the accent flood. */
-const MobileSubCountChip: Component<{ count: number; active: boolean }> = (
-  props,
-) => {
-  const label = () =>
-    `${props.count} sub-terminal${props.count === 1 ? "" : "s"}`;
-  return (
-    <span
-      data-testid="mobile-dock-sub-count"
-      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0"
-      style={{
-        "background-color": props.active
-          ? "rgba(255, 255, 255, 0.18)"
-          : "color-mix(in oklch, currentColor 10%, transparent)",
-        border: props.active
-          ? "1px solid rgba(255, 255, 255, 0.32)"
-          : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
-      }}
-      title={label()}
-    >
-      <SplitToggleIcon class="w-3 h-3" />
-      <span>{props.count}</span>
-    </span>
   );
 };
 

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -96,9 +96,7 @@ const Row: Component<{
         data-bucket={props.bucket}
         data-active={active() ? "" : undefined}
         data-unread={unread() ? "" : undefined}
-        data-sub-count={
-          (info()?.subCount ?? 0) > 0 ? info()?.subCount : undefined
-        }
+        data-sub-count={info()?.subCount || undefined}
         // stopPropagation on pointerdown keeps Corvu Drawer's
         // drag-to-dismiss from claiming the tap.
         onPointerDown={(e) => e.stopPropagation()}
@@ -148,12 +146,14 @@ const Row: Component<{
                   )}
                 />
               </span>
-              <Show when={(info()?.subCount ?? 0) > 0}>
-                <SubCountChip
-                  count={info()?.subCount ?? 0}
-                  active={active()}
-                  testId="mobile-dock-sub-count"
-                />
+              <Show when={info()?.subCount}>
+                {(n) => (
+                  <SubCountChip
+                    count={n()}
+                    active={active()}
+                    testId="mobile-dock-sub-count"
+                  />
+                )}
               </Show>
             </div>
           </div>

--- a/packages/client/src/canvas/dock/SubCountChip.tsx
+++ b/packages/client/src/canvas/dock/SubCountChip.tsx
@@ -19,27 +19,21 @@ export const SubCountChip: Component<{
   count: number;
   active: boolean;
   testId: string;
-}> = (props) => {
-  const label = () =>
-    `${props.count} sub-terminal${props.count === 1 ? "" : "s"}`;
-  return (
-    <span
-      data-testid={props.testId}
-      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0"
-      style={{
-        "background-color": props.active
-          ? "rgba(255, 255, 255, 0.18)"
-          : "color-mix(in oklch, currentColor 10%, transparent)",
-        border: props.active
-          ? "1px solid rgba(255, 255, 255, 0.32)"
-          : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
-      }}
-      title={label()}
-    >
-      <SplitToggleIcon class="w-3 h-3" />
-      <span>{props.count}</span>
-    </span>
-  );
-};
-
-export default SubCountChip;
+}> = (props) => (
+  <span
+    data-testid={props.testId}
+    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0"
+    style={{
+      "background-color": props.active
+        ? "rgba(255, 255, 255, 0.18)"
+        : "color-mix(in oklch, currentColor 10%, transparent)",
+      border: props.active
+        ? "1px solid rgba(255, 255, 255, 0.32)"
+        : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
+    }}
+    title={`${props.count} sub-terminal${props.count === 1 ? "" : "s"}`}
+  >
+    <SplitToggleIcon class="w-3 h-3" />
+    <span>{props.count}</span>
+  </span>
+);

--- a/packages/client/src/canvas/dock/SubCountChip.tsx
+++ b/packages/client/src/canvas/dock/SubCountChip.tsx
@@ -1,0 +1,45 @@
+/** Sub-terminal count chip — shared between the desktop dock body
+ *  variants and the mobile dock row. Surfaces `subCount > 0` on the
+ *  row's title bar so a glance at the dock alone reveals which
+ *  terminals have splits open, without diving into the canvas. Uses
+ *  the same `SplitToggleIcon` + numeric vocabulary the tile header
+ *  already uses (`TileTitleActions`), so the symbol reads consistently
+ *  across surfaces. Active rows get a translucent-white treatment to
+ *  survive the accent flood; inactive rows mix `currentColor` so the
+ *  chip inherits the row's text tone.
+ *
+ *  `testId` is required (not optional with a default) so each call
+ *  site is testable by a stable, distinct id — desktop uses
+ *  `dock-sub-count`, mobile uses `mobile-dock-sub-count`. */
+
+import type { Component } from "solid-js";
+import { SplitToggleIcon } from "../../ui/Icons";
+
+export const SubCountChip: Component<{
+  count: number;
+  active: boolean;
+  testId: string;
+}> = (props) => {
+  const label = () =>
+    `${props.count} sub-terminal${props.count === 1 ? "" : "s"}`;
+  return (
+    <span
+      data-testid={props.testId}
+      class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0"
+      style={{
+        "background-color": props.active
+          ? "rgba(255, 255, 255, 0.18)"
+          : "color-mix(in oklch, currentColor 10%, transparent)",
+        border: props.active
+          ? "1px solid rgba(255, 255, 255, 0.32)"
+          : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
+      }}
+      title={label()}
+    >
+      <SplitToggleIcon class="w-3 h-3" />
+      <span>{props.count}</span>
+    </span>
+  );
+};
+
+export default SubCountChip;

--- a/packages/tests/features/sub-terminal.feature
+++ b/packages/tests/features/sub-terminal.feature
@@ -125,3 +125,18 @@ Feature: Sub-terminals
     When I create a sub-terminal via command palette
     Then the resize handle should be visible
     And there should be no page errors
+
+  Scenario: Dock row surfaces sub-terminal count
+    When I create a sub-terminal via command palette
+    Then the active dock row should show sub-terminal count 1
+    When I create another sub-terminal via command palette
+    Then the active dock row should show sub-terminal count 2
+    And there should be no page errors
+
+  Scenario: Dock row drops sub-terminal count when sub-terminal exits
+    When I create a sub-terminal via command palette
+    Then the active dock row should show sub-terminal count 1
+    When I run "exit" in the sub-terminal
+    Then the sub-panel should eventually collapse
+    And the active dock row should not show a sub-terminal count
+    And there should be no page errors

--- a/packages/tests/step_definitions/sub_terminal_steps.ts
+++ b/packages/tests/step_definitions/sub_terminal_steps.ts
@@ -257,6 +257,43 @@ Then(
 );
 
 Then(
+  "the active dock row should show sub-terminal count {int}",
+  async function (this: KoluWorld, expected: number) {
+    const row = this.page.locator('[data-testid="dock-row"][data-active]');
+    await row.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
+    const attr = await row.getAttribute("data-sub-count");
+    assert.strictEqual(
+      attr,
+      `${expected}`,
+      `Expected dock row data-sub-count="${expected}", got "${attr}"`,
+    );
+    const chip = row.locator('[data-testid="dock-sub-count"]');
+    const text = await chip.textContent({ timeout: POLL_TIMEOUT });
+    assert.ok(
+      text?.includes(`${expected}`),
+      `Expected dock chip to show "${expected}", got "${text}"`,
+    );
+  },
+);
+
+Then(
+  "the active dock row should not show a sub-terminal count",
+  async function (this: KoluWorld) {
+    const row = this.page.locator('[data-testid="dock-row"][data-active]');
+    await row.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
+    const attr = await row.getAttribute("data-sub-count");
+    assert.strictEqual(
+      attr,
+      null,
+      `Expected no data-sub-count on dock row, got "${attr}"`,
+    );
+    const chip = row.locator('[data-testid="dock-sub-count"]');
+    const count = await chip.count();
+    assert.strictEqual(count, 0, "Expected no dock-sub-count chip");
+  },
+);
+
+Then(
   "the collapsed indicator should be visible",
   async function (this: KoluWorld) {
     // First wait for the tab bar to disappear (confirms collapse state settled)

--- a/packages/tests/step_definitions/sub_terminal_steps.ts
+++ b/packages/tests/step_definitions/sub_terminal_steps.ts
@@ -259,16 +259,21 @@ Then(
 Then(
   "the active dock row should show sub-terminal count {int}",
   async function (this: KoluWorld, expected: number) {
-    const row = this.page.locator('[data-testid="dock-row"][data-active]');
-    await row.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
-    const attr = await row.getAttribute("data-sub-count");
-    assert.strictEqual(
-      attr,
-      `${expected}`,
-      `Expected dock row data-sub-count="${expected}", got "${attr}"`,
+    // Poll until data-sub-count reaches the expected value — the reactive
+    // attribute update is async relative to the sub-terminal DOM mounting.
+    await this.page.waitForFunction(
+      (n) =>
+        document
+          .querySelector('[data-testid="dock-row"][data-active]')
+          ?.getAttribute("data-sub-count") === String(n),
+      expected,
+      { timeout: POLL_TIMEOUT },
     );
-    const chip = row.locator('[data-testid="dock-sub-count"]');
-    const text = await chip.textContent({ timeout: POLL_TIMEOUT });
+    const chip = this.page.locator(
+      '[data-testid="dock-row"][data-active] [data-testid="dock-sub-count"]',
+    );
+    await chip.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    const text = await chip.textContent();
     assert.ok(
       text?.includes(`${expected}`),
       `Expected dock chip to show "${expected}", got "${text}"`,
@@ -279,15 +284,17 @@ Then(
 Then(
   "the active dock row should not show a sub-terminal count",
   async function (this: KoluWorld) {
-    const row = this.page.locator('[data-testid="dock-row"][data-active]');
-    await row.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
-    const attr = await row.getAttribute("data-sub-count");
-    assert.strictEqual(
-      attr,
-      null,
-      `Expected no data-sub-count on dock row, got "${attr}"`,
+    // Poll until data-sub-count is absent — reactive removal is async.
+    await this.page.waitForFunction(
+      () =>
+        document
+          .querySelector('[data-testid="dock-row"][data-active]')
+          ?.getAttribute("data-sub-count") === null,
+      { timeout: POLL_TIMEOUT },
     );
-    const chip = row.locator('[data-testid="dock-sub-count"]');
+    const chip = this.page.locator(
+      '[data-testid="dock-row"][data-active] [data-testid="dock-sub-count"]',
+    );
     const count = await chip.count();
     assert.strictEqual(count, 0, "Expected no dock-sub-count chip");
   },


### PR DESCRIPTION
**Open splits now read at a glance from the Dock alone.** Each row gets an inline `SplitToggleIcon + N` chip when its terminal has live sub-terminals — the same icon-and-count vocabulary the tile header already uses, so the symbol means the same thing on every surface. Without this, you had to switch to the active tile (or open its canvas) to learn that a terminal had splits at all.

### What the chip looks like

The chip sits in the row's title baseline, sized so it reads without squinting (`text-[0.7rem]`, mono, tabular nums). Active rows get a translucent-white treatment so the chip survives the accent flood; inactive rows mix `currentColor` so the chip inherits the row's text tone.

| Surface | Render path | Test id |
| --- | --- | --- |
| Desktop dock — awaiting card | `AwaitingCardBody` | `dock-sub-count` |
| Desktop dock — working pill | `WorkingPillBody` | `dock-sub-count` |
| Desktop dock — quiet row (idle / parked) | `QuietRowBody` | `dock-sub-count` |
| Mobile dock row | `MobileDockDrawer.Row` | `mobile-dock-sub-count` |

`data-sub-count="N"` lands on the outer dock-row element alongside the existing `data-active` / `data-unread` / `data-bucket` row attributes, so step definitions key off it the same way they already key off the other row-level decorations.

### Structural follow-ups that landed during review

A parallel [hickey + lowy](https://kolu.dev/blog/hickey-lowy/) pass on the first feature commit produced three convergent findings — each shipped as its own commit so the history reads as a structural refinement, not a grab bag.

| # | Lens | Finding | Disposition |
| --- | --- | --- | --- |
| 1 | Hickey + Lowy | `SubCountChip` and `MobileSubCountChip` were byte-equivalent components | Extracted to `packages/client/src/canvas/dock/SubCountChip.tsx` (required `testId`) |
| 2 | Hickey | `App.tsx`'s close-confirm dialog derived `splitCount` straight from `store.getSubTerminalIds(id).length`, bypassing the canonical `TerminalDisplayInfo.subCount` | Folded through `displayInfo.subCount` so every UI consumer reads off one derivation |
| 3 | Hickey + Lowy | `QuietRowBody` had two `ml-auto` siblings in the same flex container — layout worked only because of source order | Wrapped chip + time-ago in a single `ml-auto` cluster |

The fold-back in finding 2 completes the consolidation the original implementation started in `TileTitleActions.tsx:50`. `TerminalDisplayInfo.subCount` is now the single source of truth for sub-terminal counts across dock chips, tile header, and close-confirm dialog.

### Test coverage

Two new scenarios in `sub-terminal.feature`:

- _Dock row surfaces sub-terminal count_ — create a sub-terminal, assert `data-sub-count="1"` and chip text `1` on the active dock row; create a second, assert `2`.
- _Dock row drops sub-terminal count when sub-terminal exits_ — exit the sub-terminal, assert the attribute and chip both disappear.

Step definitions in `sub_terminal_steps.ts` poll for the reactive `data-sub-count` value rather than reading it synchronously — the attribute lands asynchronously relative to the sub-terminal DOM mount.

### Try it locally

```sh
nix run github:juspay/kolu/dock-sub-terminal-indicator
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._