### PR TITLE
Mobile: browse code files via a Files drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The desktop workspace is mode-less — every terminal renders as a draggable, re
 - **Identity-collision suffix** — when two terminals share the same repo+branch (or cwd, for non-git), the server assigns each a stable 4-char id suffix (`#a3f2`) so the dock and tile chrome can disambiguate them at a glance
 - **Canvas navigation** — the command palette can center the active tile when panning has moved it out of view, or arrange the canvas by repo to cluster each repo's tiles into a square-ish island while preserving every tile's current size. New tiles join their repo's cluster in the same square-ish layout automatically — opening many worktree terminals fills out a 2×2, 3×2, … grid instead of a 1×N row
 - **Per-tile theming** — title bars and pill swatches derive their colors from each terminal's theme for guaranteed contrast
-- **Mobile** — the canvas, pan/zoom, and the desktop dock are disabled; the active tile fills the viewport and swipe-left/right cycles between terminals in compact switcher order. A pull-down chrome sheet at the top reveals the same logo + vertical switcher list + controls as a touch-sized drawer
+- **Mobile** — the canvas, pan/zoom, and the desktop dock are disabled; the active tile fills the viewport and swipe-left/right cycles between terminals in compact switcher order. A pull-down chrome sheet at the top reveals the same logo + vertical switcher list + controls as a touch-sized drawer. The chrome sheet's **Files** button opens a bottom modal drawer over the active terminal's repo — Pierre's file tree on top, tap any file to view it; HTML, SVG, and PDF files render in the sandboxed iframe preview the desktop Code tab uses, so a phone can review agent-generated artifacts without a desktop
 
 ### Git & GitHub
 

--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -36,14 +36,11 @@ const MobileChromeSheet: Component<{
   status: WsStatus;
   appTitle: string;
   onOpenPalette: () => void;
-  /** Request the mobile file-browser drawer. `MobileTileView` owns
-   *  the cross-drawer sequencing — it closes the chrome drawer first,
-   *  watches Corvu's `transitionState` for the close to finish, then
-   *  opens the files drawer. Sheet has nothing to coordinate here. */
+  /** Open the mobile file-browser drawer. Owned by `MobileTileView`. */
   onOpenFiles: () => void;
-  /** Close the drawer after the user takes an action (palette open).
-   *  The drawer is otherwise dismissed by drag-down or overlay tap,
-   *  both handled by Corvu. */
+  /** Close the drawer after the user takes an action (palette open,
+   *  files open). The drawer is otherwise dismissed by drag-down or
+   *  overlay tap, both handled by Corvu. */
   onClose: () => void;
 }> = (props) => {
   let settingsTriggerRef!: HTMLButtonElement;
@@ -111,7 +108,20 @@ const MobileChromeSheet: Component<{
           data-testid="mobile-files-trigger"
           class="h-9 w-9 flex items-center justify-center text-fg-2 bg-surface-2 rounded-lg border border-edge active:bg-surface-3"
           onPointerDown={(e) => e.stopPropagation()}
-          onClick={() => props.onOpenFiles()}
+          onClick={() => {
+            // Sequence the two drawer transitions across the chrome
+            // drawer's close animation (~200ms). When both `open`
+            // signals flip in the same tick, Corvu's chrome-drawer
+            // close fires a synthetic outside-pointer event that the
+            // freshly-opened files drawer interprets as a dismiss tap
+            // — the drawer mounts and immediately tears down again,
+            // which is what users on iOS see as "Files button does
+            // nothing but pop the keyboard". The 220ms timeout lets
+            // the chrome overlay fully unmount before the files
+            // drawer mounts its own overlay.
+            props.onClose();
+            setTimeout(() => props.onOpenFiles(), 220);
+          }}
           aria-label="Browse files"
         >
           <FileBrowseIcon class="w-4 h-4" />

--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -4,12 +4,14 @@
  *  global controls live behind a pull-handle at the top of the
  *  terminal. Tap or pull the handle to reveal this sheet. Contents:
  *  identity (logo + connection dot) and the control cluster (command
- *  palette, settings, inspector toggle).
+ *  palette, settings, file browser trigger).
  *
  *  Terminal navigation moved out of this sheet to its own left-edge
  *  swipe drawer — see `MobileDockDrawer`. The split mirrors the
  *  desktop: the dock owns the live-terminal navigator, the
- *  chrome bar owns global controls.
+ *  chrome bar owns global controls. The Files button opens the
+ *  bottom-modal `MobileCodeSheet`; the right panel is hidden on mobile,
+ *  so a desktop-style inspector toggle has nothing to act on.
  *
  *  Sheet machinery (open state, drag-to-dismiss, overlay, portal) is
  *  owned by `MobileTileView` via `@corvu/drawer`. This component only
@@ -19,10 +21,9 @@
 import { type Component, createSignal } from "solid-js";
 import { ACTIONS } from "./input/actions";
 import { formatKeybind } from "./input/keyboard";
-import { useRightPanel } from "./right-panel/useRightPanel";
 import type { WsStatus } from "./rpc/rpc";
 import SettingsPopover from "./settings/SettingsPopover";
-import { SettingsIcon } from "./ui/Icons";
+import { FileBrowseIcon, SettingsIcon } from "./ui/Icons";
 import Kbd from "./ui/Kbd";
 
 const statusStyles: Record<WsStatus, string> = {
@@ -35,12 +36,13 @@ const MobileChromeSheet: Component<{
   status: WsStatus;
   appTitle: string;
   onOpenPalette: () => void;
+  /** Open the mobile file-browser drawer. Owned by `MobileTileView`. */
+  onOpenFiles: () => void;
   /** Close the drawer after the user takes an action (palette open,
-   *  inspector toggle). The drawer is otherwise dismissed by drag-down
-   *  or overlay tap, both handled by Corvu. */
+   *  files open). The drawer is otherwise dismissed by drag-down or
+   *  overlay tap, both handled by Corvu. */
   onClose: () => void;
 }> = (props) => {
-  const rightPanel = useRightPanel();
   let settingsTriggerRef!: HTMLButtonElement;
   const [settingsOpen, setSettingsOpen] = createSignal(false);
 
@@ -103,19 +105,16 @@ const MobileChromeSheet: Component<{
         </div>
         <button
           type="button"
-          data-testid="inspector-toggle"
+          data-testid="mobile-files-trigger"
           class="h-9 w-9 flex items-center justify-center text-fg-2 bg-surface-2 rounded-lg border border-edge active:bg-surface-3"
-          classList={{
-            "bg-surface-3 text-fg": !rightPanel.collapsed(),
-          }}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={() => {
-            rightPanel.togglePanel();
+            props.onOpenFiles();
             props.onClose();
           }}
-          aria-label="Toggle inspector"
+          aria-label="Browse files"
         >
-          ⟳
+          <FileBrowseIcon class="w-4 h-4" />
         </button>
       </div>
     </div>

--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -109,8 +109,18 @@ const MobileChromeSheet: Component<{
           class="h-9 w-9 flex items-center justify-center text-fg-2 bg-surface-2 rounded-lg border border-edge active:bg-surface-3"
           onPointerDown={(e) => e.stopPropagation()}
           onClick={() => {
-            props.onOpenFiles();
+            // Sequence the two drawer transitions across the chrome
+            // drawer's close animation (~200ms). When both `open`
+            // signals flip in the same tick, Corvu's chrome-drawer
+            // close fires a synthetic outside-pointer event that the
+            // freshly-opened files drawer interprets as a dismiss tap
+            // — the drawer mounts and immediately tears down again,
+            // which is what users on iOS see as "Files button does
+            // nothing but pop the keyboard". The 220ms timeout lets
+            // the chrome overlay fully unmount before the files
+            // drawer mounts its own overlay.
             props.onClose();
+            setTimeout(() => props.onOpenFiles(), 220);
           }}
           aria-label="Browse files"
         >

--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -36,11 +36,14 @@ const MobileChromeSheet: Component<{
   status: WsStatus;
   appTitle: string;
   onOpenPalette: () => void;
-  /** Open the mobile file-browser drawer. Owned by `MobileTileView`. */
+  /** Request the mobile file-browser drawer. `MobileTileView` owns
+   *  the cross-drawer sequencing — it closes the chrome drawer first,
+   *  watches Corvu's `transitionState` for the close to finish, then
+   *  opens the files drawer. Sheet has nothing to coordinate here. */
   onOpenFiles: () => void;
-  /** Close the drawer after the user takes an action (palette open,
-   *  files open). The drawer is otherwise dismissed by drag-down or
-   *  overlay tap, both handled by Corvu. */
+  /** Close the drawer after the user takes an action (palette open).
+   *  The drawer is otherwise dismissed by drag-down or overlay tap,
+   *  both handled by Corvu. */
   onClose: () => void;
 }> = (props) => {
   let settingsTriggerRef!: HTMLButtonElement;
@@ -108,20 +111,7 @@ const MobileChromeSheet: Component<{
           data-testid="mobile-files-trigger"
           class="h-9 w-9 flex items-center justify-center text-fg-2 bg-surface-2 rounded-lg border border-edge active:bg-surface-3"
           onPointerDown={(e) => e.stopPropagation()}
-          onClick={() => {
-            // Sequence the two drawer transitions across the chrome
-            // drawer's close animation (~200ms). When both `open`
-            // signals flip in the same tick, Corvu's chrome-drawer
-            // close fires a synthetic outside-pointer event that the
-            // freshly-opened files drawer interprets as a dismiss tap
-            // — the drawer mounts and immediately tears down again,
-            // which is what users on iOS see as "Files button does
-            // nothing but pop the keyboard". The 220ms timeout lets
-            // the chrome overlay fully unmount before the files
-            // drawer mounts its own overlay.
-            props.onClose();
-            setTimeout(() => props.onOpenFiles(), 220);
-          }}
+          onClick={() => props.onOpenFiles()}
           aria-label="Browse files"
         >
           <FileBrowseIcon class="w-4 h-4" />

--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -67,7 +67,7 @@ const MobileChromeSheet: Component<{
         />
       </div>
 
-      {/* Control cluster — palette, settings, inspector. Each button
+      {/* Control cluster — palette, settings, files. Each button
        *  stops propagation on pointerdown so Corvu Drawer's drag handler
        *  on Drawer.Content can't claim the tap as the start of a drag
        *  (which would suppress the click). */}

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -184,79 +184,144 @@ const MobileCodeSheet: Component<{
             </div>
           }
         >
-          {(repo) => (
-            <>
-              <div
-                class="absolute inset-0"
-                // Pierre's `<file-tree-container>` keeps its scroll
-                // viewport inside a shadow root, and Corvu's
-                // drag-to-dismiss runs a `parentElement`/`_$host` walk
-                // to find scrollable ancestors — Pierre uses neither
-                // shadow-host convention, so the walk reports no
-                // scroll and Corvu claims every vertical touch as a
-                // drag-to-dismiss. Stop pointerdown here so Corvu's
-                // delegated listener on `Drawer.Content` never sees
-                // the touch; Pierre's internal pointerdown handlers
-                // (which live inside the shadow root, before the
-                // event escapes) keep firing for row clicks and the
-                // tree scrolls natively.
-                onPointerDown={(e) => e.stopPropagation()}
-                onTouchStart={(e) => e.stopPropagation()}
-              >
-                <Switch
-                  fallback={
-                    <div class="px-2 py-1 text-fg-3/50 text-[11px]">
-                      Loading…
-                    </div>
-                  }
+          {(repo) => {
+            // Pierre's `<file-tree-container>` keeps its scroll viewport
+            // inside a shadow root. iOS Safari's native scroll discovery
+            // walks the composed tree for a scrollable ancestor — but in
+            // practice (real iPhone, not Playwright emulation), shadow-
+            // contained scrollers below a Corvu `Drawer.Content` don't
+            // receive the touchmove deltas at all and the tree appears
+            // frozen below the visible band.
+            //
+            // Two compounding causes: (a) Corvu's drag-to-dismiss walks
+            // `parentElement`/`_$host` to find scrollables — Pierre uses
+            // neither host convention, so Corvu reports zero scroll and
+            // claims the touch as a drag; (b) iOS's own native-scroll
+            // pathway is unreliable inside a portaled drawer above a
+            // shadow-rooted scroller.
+            //
+            // Drive the scroll ourselves: capture touchstart/move on the
+            // wrapper, locate Pierre's shadow-DOM scroller, and set
+            // `scrollTop` directly. Stops Corvu via stopPropagation in
+            // the same handler. Pierre's own pointerdown handlers (row
+            // clicks) live inside the shadow root and fire before the
+            // event escapes — they still work because we only act on
+            // movements past a small threshold, and a stationary tap
+            // never crosses it.
+            let scrollState: {
+              startY: number;
+              startTop: number;
+              scroller: HTMLElement;
+              moved: boolean;
+            } | null = null;
+            const findScroller = (
+              container: HTMLElement,
+            ): HTMLElement | null => {
+              const ftc = container.querySelector("file-tree-container");
+              const root = (ftc as Element | null)?.shadowRoot;
+              if (!root) return null;
+              for (const el of root.querySelectorAll<HTMLElement>("*")) {
+                if (el.scrollHeight > el.clientHeight + 1) return el;
+              }
+              return null;
+            };
+            const onTreeTouchStart = (e: TouchEvent) => {
+              e.stopPropagation();
+              const touch = e.touches[0];
+              if (!touch) return;
+              const scroller = findScroller(e.currentTarget as HTMLElement);
+              if (!scroller) return;
+              scrollState = {
+                startY: touch.clientY,
+                startTop: scroller.scrollTop,
+                scroller,
+                moved: false,
+              };
+            };
+            const onTreeTouchMove = (e: TouchEvent) => {
+              if (!scrollState) return;
+              const touch = e.touches[0];
+              if (!touch) return;
+              const dy = touch.clientY - scrollState.startY;
+              if (!scrollState.moved && Math.abs(dy) < 4) return;
+              scrollState.moved = true;
+              scrollState.scroller.scrollTop = scrollState.startTop - dy;
+              // Once we've committed to scrolling, eat the touchmove so
+              // iOS doesn't fight us with its own scroll attempt and so
+              // Pierre's row-click logic doesn't fire on touchend.
+              e.preventDefault();
+              e.stopPropagation();
+            };
+            const onTreeTouchEnd = () => {
+              scrollState = null;
+            };
+            return (
+              <>
+                <div
+                  class="absolute inset-0"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onTouchStart={onTreeTouchStart}
+                  onTouchMove={onTreeTouchMove}
+                  onTouchEnd={onTreeTouchEnd}
+                  onTouchCancel={onTreeTouchEnd}
                 >
-                  <Match when={allPaths.error()}>
-                    {(err) => (
-                      <div class="px-2 py-1 text-danger text-[11px]">
-                        Error: {err().message}
+                  <Switch
+                    fallback={
+                      <div class="px-2 py-1 text-fg-3/50 text-[11px]">
+                        Loading…
                       </div>
-                    )}
-                  </Match>
-                  <Match when={allPaths()}>
-                    {(paths) => (
-                      <FileTree
-                        paths={paths().paths}
-                        selectedPath={null}
-                        onSelect={(p) => {
-                          if (p !== null)
-                            rightPanel.setSelectedFile("browse", p);
-                        }}
-                        initialExpansion="closed"
-                        search={true}
-                        icons={pierreIconConfig}
-                        onError={(err) =>
-                          toast.error(`File tree render failed: ${err.message}`)
-                        }
-                        class="h-full w-full"
-                        style={pierreTreesStyle}
-                      />
-                    )}
-                  </Match>
-                </Switch>
-              </div>
-              <Show when={selectedPath()} keyed>
-                {(path) => {
-                  const tid = props.terminalId;
-                  if (tid === null) return null;
-                  return (
-                    <div class="absolute inset-0 bg-surface-1">
-                      <BrowseFileDispatcher
-                        terminalId={tid}
-                        repoPath={repo()}
-                        filePath={path}
-                        theme={diffTheme()}
-                      />
-                    </div>
-                  );
-                }}
-              </Show>
-            </>
-          )}
+                    }
+                  >
+                    <Match when={allPaths.error()}>
+                      {(err) => (
+                        <div class="px-2 py-1 text-danger text-[11px]">
+                          Error: {err().message}
+                        </div>
+                      )}
+                    </Match>
+                    <Match when={allPaths()}>
+                      {(paths) => (
+                        <FileTree
+                          paths={paths().paths}
+                          selectedPath={null}
+                          onSelect={(p) => {
+                            if (p !== null)
+                              rightPanel.setSelectedFile("browse", p);
+                          }}
+                          initialExpansion="closed"
+                          search={true}
+                          icons={pierreIconConfig}
+                          onError={(err) =>
+                            toast.error(
+                              `File tree render failed: ${err.message}`,
+                            )
+                          }
+                          class="h-full w-full"
+                          style={pierreTreesStyle}
+                        />
+                      )}
+                    </Match>
+                  </Switch>
+                </div>
+                <Show when={selectedPath()} keyed>
+                  {(path) => {
+                    const tid = props.terminalId;
+                    if (tid === null) return null;
+                    return (
+                      <div class="absolute inset-0 bg-surface-1">
+                        <BrowseFileDispatcher
+                          terminalId={tid}
+                          repoPath={repo()}
+                          filePath={path}
+                          theme={diffTheme()}
+                        />
+                      </div>
+                    );
+                  }}
+                </Show>
+              </>
+            );
+          }}
         </Show>
       </div>
     </div>

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -132,7 +132,23 @@ const MobileCodeSheet: Component<{
         >
           {(repo) => (
             <>
-              <div class="absolute inset-0">
+              <div
+                class="absolute inset-0"
+                // Pierre's `<file-tree-container>` keeps its scroll
+                // viewport inside a shadow root, and Corvu's
+                // drag-to-dismiss runs a `parentElement`/`_$host` walk
+                // to find scrollable ancestors — Pierre uses neither
+                // shadow-host convention, so the walk reports no
+                // scroll and Corvu claims every vertical touch as a
+                // drag-to-dismiss. Stop pointerdown here so Corvu's
+                // delegated listener on `Drawer.Content` never sees
+                // the touch; Pierre's internal pointerdown handlers
+                // (which live inside the shadow root, before the
+                // event escapes) keep firing for row clicks and the
+                // tree scrolls natively.
+                onPointerDown={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
+              >
                 <Switch
                   fallback={
                     <div class="px-2 py-1 text-fg-3/50 text-[11px]">

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -1,0 +1,178 @@
+/** MobileCodeSheet — content of the mobile file-browser drawer.
+ *
+ *  On mobile the right panel is hidden (`RightPanelLayout` returns its
+ *  children directly when `isMobile()` is true), so the Code tab's file
+ *  tree + content split has nowhere to live. This sheet is the mobile
+ *  surface for the same data — a bottom drawer with a master-detail
+ *  flow:
+ *
+ *  - **Master**: Pierre's `FileTree` over the active terminal's repo
+ *    (`fsListAll` stream).
+ *  - **Detail**: `BrowseFileDispatcher` — text files render via Pierre's
+ *    `CodeView`, `.html`/`.svg`/`.pdf` render via the sandboxed
+ *    `iframe` preview the desktop Code tab uses. Identical components,
+ *    no mobile-specific viewer.
+ *
+ *  Selection persists per-terminal via `useRightPanel.selectedFile`,
+ *  keyed by `"browse"` mode — the same slot the desktop CodeTab writes,
+ *  so opening the same terminal on desktop after a mobile session
+ *  restores the last-viewed file. The back arrow clears the slot;
+ *  the close button dismisses the whole drawer without touching
+ *  selection. */
+
+import { FileTree } from "@kolu/solid-pierre";
+import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
+import { type Component, Show } from "solid-js";
+import { toast } from "solid-sonner";
+import BrowseFileDispatcher from "./right-panel/BrowseFileDispatcher";
+import { useRightPanel } from "./right-panel/useRightPanel";
+import { useColorScheme } from "./settings/useColorScheme";
+import { pierreIconConfig, pierreTreesStyle } from "./ui/pierreTheme";
+import { app } from "./wire";
+import { FileBrowseIcon, GitBranchIcon } from "./ui/Icons";
+
+const MobileCodeSheet: Component<{
+  terminalId: TerminalId | null;
+  meta: TerminalMetadata | null;
+  onClose: () => void;
+}> = (props) => {
+  const { themeTypeLiteral: diffTheme } = useColorScheme();
+  const rightPanel = useRightPanel();
+  const repoPath = () => props.meta?.git?.repoRoot ?? null;
+  const selectedPath = () => rightPanel.selectedFile("browse");
+  const setSelectedPath = (p: string | null) =>
+    rightPanel.setSelectedFile("browse", p);
+
+  const allPaths = app.streams.fsListAll.use(
+    () => {
+      const p = repoPath();
+      return p ? { repoPath: p } : null;
+    },
+    {
+      onError: (err) => toast.error(`File list stream: ${err.message}`),
+    },
+  );
+
+  return (
+    <div
+      data-testid="mobile-code-sheet"
+      class="flex flex-col h-full bg-surface-1 text-fg"
+    >
+      {/* Header — back arrow (detail only), title, close (×). */}
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-edge shrink-0 min-h-11">
+        <Show
+          when={selectedPath()}
+          fallback={
+            <span class="flex items-center gap-2 flex-1 min-w-0 text-sm font-semibold">
+              <FileBrowseIcon class="w-4 h-4 shrink-0" />
+              Files
+            </span>
+          }
+        >
+          {(path) => (
+            <>
+              <button
+                type="button"
+                data-testid="mobile-code-back"
+                class="h-8 w-8 flex items-center justify-center text-fg-2 rounded-md active:bg-surface-2"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={() => setSelectedPath(null)}
+                aria-label="Back to file tree"
+              >
+                ‹
+              </button>
+              <span
+                class="flex-1 min-w-0 text-sm font-mono truncate"
+                title={path()}
+              >
+                {path()}
+              </span>
+            </>
+          )}
+        </Show>
+        <button
+          type="button"
+          data-testid="mobile-code-close"
+          class="h-8 w-8 flex items-center justify-center text-fg-2 rounded-md active:bg-surface-2 shrink-0"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={props.onClose}
+          aria-label="Close files"
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Body — tree or detail. */}
+      <div class="flex-1 min-h-0 overflow-hidden">
+        <Show
+          when={repoPath()}
+          fallback={
+            <div
+              class="flex flex-col items-center justify-center h-full text-fg-3/40 gap-2 text-[11px]"
+              data-testid="mobile-code-no-repo"
+            >
+              <GitBranchIcon class="w-8 h-8 opacity-40" />
+              Not in a git repository
+            </div>
+          }
+        >
+          {(repo) => (
+            <Show
+              when={selectedPath()}
+              fallback={
+                <Show
+                  when={!allPaths.error()}
+                  fallback={
+                    <div class="px-2 py-1 text-danger text-[11px]">
+                      Error: {allPaths.error()?.message}
+                    </div>
+                  }
+                >
+                  <Show
+                    when={allPaths()}
+                    fallback={
+                      <div class="px-2 py-1 text-fg-3/50 text-[11px]">
+                        Loading…
+                      </div>
+                    }
+                  >
+                    <FileTree
+                      paths={allPaths()?.paths ?? []}
+                      selectedPath={null}
+                      onSelect={(p) => {
+                        if (p !== null) setSelectedPath(p);
+                      }}
+                      initialExpansion="closed"
+                      search={true}
+                      icons={pierreIconConfig}
+                      onError={(err) =>
+                        toast.error(`File tree render failed: ${err.message}`)
+                      }
+                      class="h-full w-full"
+                      style={pierreTreesStyle}
+                    />
+                  </Show>
+                </Show>
+              }
+            >
+              {(path) => {
+                const tid = props.terminalId;
+                if (tid === null) return null;
+                return (
+                  <BrowseFileDispatcher
+                    terminalId={tid}
+                    repoPath={repo()}
+                    filePath={path()}
+                    theme={diffTheme()}
+                  />
+                );
+              }}
+            </Show>
+          )}
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default MobileCodeSheet;

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -39,6 +39,12 @@ const MobileCodeSheet: Component<{
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
   const repoPath = () => props.meta?.git?.repoRoot ?? null;
+  // Deliberate divergence from `CodeTab.tsx`: no membership-check effect
+  // that nulls the slot when the selected path leaves `treePaths()`.
+  // The drawer is short-lived (user closes it after viewing), so the
+  // round-trip "file disappeared mid-session" failure mode is moot —
+  // and the friendlier UX is to land the user back on the detail view
+  // they last had open on reopen, not drop them to the tree.
   const selectedPath = () => rightPanel.selectedFile("browse");
 
   const allPaths = app.streams.fsListAll.use(

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -40,8 +40,6 @@ const MobileCodeSheet: Component<{
   const rightPanel = useRightPanel();
   const repoPath = () => props.meta?.git?.repoRoot ?? null;
   const selectedPath = () => rightPanel.selectedFile("browse");
-  const setSelectedPath = (p: string | null) =>
-    rightPanel.setSelectedFile("browse", p);
 
   const allPaths = app.streams.fsListAll.use(
     () => {
@@ -76,7 +74,7 @@ const MobileCodeSheet: Component<{
                 data-testid="mobile-code-back"
                 class="h-8 w-8 flex items-center justify-center text-fg-2 rounded-md active:bg-surface-2"
                 onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => setSelectedPath(null)}
+                onClick={() => rightPanel.clearSelectedFile("browse")}
                 aria-label="Back to file tree"
               >
                 ‹
@@ -140,7 +138,8 @@ const MobileCodeSheet: Component<{
                         paths={paths().paths}
                         selectedPath={null}
                         onSelect={(p) => {
-                          if (p !== null) setSelectedPath(p);
+                          if (p !== null)
+                            rightPanel.setSelectedFile("browse", p);
                         }}
                         initialExpansion="closed"
                         search={true}

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -62,10 +62,28 @@ const MobileCodeSheet: Component<{
       data-testid="mobile-code-sheet"
       class="flex flex-col h-full bg-surface-1 text-fg"
     >
-      {/* Header — back arrow (detail only), title, close (×). */}
+      {/* Header — back arrow (detail only), title, close (×). The back
+       *  button stays mounted with a `hidden` class toggle instead of
+       *  `<Show>`; remount cycles racing with the body's overlay
+       *  transition occasionally left the button missing from the DOM
+       *  for the next reactive tick, which was enough for an immediate
+       *  tap to whiff. CSS toggling keeps the element present and the
+       *  selector stable. */}
       <div class="flex items-center gap-2 px-3 py-2 border-b border-edge shrink-0 min-h-11">
+        <button
+          type="button"
+          data-testid="mobile-code-back"
+          class="h-8 w-8 flex items-center justify-center text-fg-2 rounded-md active:bg-surface-2"
+          classList={{ hidden: selectedPath() === null }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => rightPanel.clearSelectedFile("browse")}
+          aria-label="Back to file tree"
+        >
+          ‹
+        </button>
         <Show
           when={selectedPath()}
+          keyed
           fallback={
             <span class="flex items-center gap-2 flex-1 min-w-0 text-sm font-semibold">
               <FileBrowseIcon class="w-4 h-4 shrink-0" />
@@ -74,24 +92,12 @@ const MobileCodeSheet: Component<{
           }
         >
           {(path) => (
-            <>
-              <button
-                type="button"
-                data-testid="mobile-code-back"
-                class="h-8 w-8 flex items-center justify-center text-fg-2 rounded-md active:bg-surface-2"
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => rightPanel.clearSelectedFile("browse")}
-                aria-label="Back to file tree"
-              >
-                ‹
-              </button>
-              <span
-                class="flex-1 min-w-0 text-sm font-mono truncate"
-                title={path()}
-              >
-                {path()}
-              </span>
-            </>
+            <span
+              class="flex-1 min-w-0 text-sm font-mono truncate"
+              title={path}
+            >
+              {path}
+            </span>
           )}
         </Show>
         <button
@@ -106,8 +112,12 @@ const MobileCodeSheet: Component<{
         </button>
       </div>
 
-      {/* Body — tree or detail. */}
-      <div class="flex-1 min-h-0 overflow-hidden">
+      {/* Body — tree always mounted, detail overlays on top when a file
+       *  is selected. Pierre's `FileTree` keeps its subscription warm
+       *  across back-and-forth navigation; remounting it on every back
+       *  click sometimes left its virtualizer in a stuck state where
+       *  rows wouldn't repaint until the next reactive tick. */}
+      <div class="flex-1 min-h-0 overflow-hidden relative">
         <Show
           when={repoPath()}
           fallback={
@@ -121,9 +131,8 @@ const MobileCodeSheet: Component<{
           }
         >
           {(repo) => (
-            <Show
-              when={selectedPath()}
-              fallback={
+            <>
+              <div class="absolute inset-0">
                 <Switch
                   fallback={
                     <div class="px-2 py-1 text-fg-3/50 text-[11px]">
@@ -159,21 +168,24 @@ const MobileCodeSheet: Component<{
                     )}
                   </Match>
                 </Switch>
-              }
-            >
-              {(path) => {
-                const tid = props.terminalId;
-                if (tid === null) return null;
-                return (
-                  <BrowseFileDispatcher
-                    terminalId={tid}
-                    repoPath={repo()}
-                    filePath={path()}
-                    theme={diffTheme()}
-                  />
-                );
-              }}
-            </Show>
+              </div>
+              <Show when={selectedPath()} keyed>
+                {(path) => {
+                  const tid = props.terminalId;
+                  if (tid === null) return null;
+                  return (
+                    <div class="absolute inset-0 bg-surface-1">
+                      <BrowseFileDispatcher
+                        terminalId={tid}
+                        repoPath={repo()}
+                        filePath={path}
+                        theme={diffTheme()}
+                      />
+                    </div>
+                  );
+                }}
+              </Show>
+            </>
           )}
         </Show>
       </div>

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -25,6 +25,8 @@ import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import {
   type Component,
   createEffect,
+  createMemo,
+  createSignal,
   Match,
   on,
   Show,
@@ -66,17 +68,29 @@ const MobileCodeSheet: Component<{
     },
   );
 
+  // Consume-once record for the latest pendingMobileOpen tick. Mirrors
+  // `CodeTab.tsx`'s `handled` signal — the request reference
+  // discriminates two structurally-identical taps (`openInMobileFiles`
+  // mints a fresh object per call), and the resolved path lets
+  // `selectedRange` decide whether the current selection is the one
+  // this request produced (so a subsequent tree-tap that changes
+  // `selectedFile` invalidates the highlight without a second
+  // resolution call).
+  const [handled, setHandled] = createSignal<{
+    request: NavRequest;
+    resolvedPath: string | null;
+  } | null>(null);
+
   // Consume `openInMobileFiles` requests once `fsListAll` has settled.
   // Mirrors `CodeTab.tsx`'s `pendingOpen` consumer — terminal output
   // emits absolute paths (`/abs/path`), cwd-relative paths
   // (`error in foo.ts:42` while in a subdir), and basename-only
   // references (`Foo.hs:42` from compiler output that drops the
-  // `src/lib/` prefix); `resolveLineRefPath` normalizes them against
+  // `src/lib/` prefix); `resolveNavPath` normalizes them against
   // the live repo file set. Writing `req.ref.path` raw into the
   // selection slot (the bug this effect fixes) pushes
   // un-resolvable strings at `fsReadFile` and the server returns
   // `path escapes root` or `EISDIR`.
-  let lastHandled: NavRequest | null = null;
   createEffect(
     on(
       () => {
@@ -87,20 +101,40 @@ const MobileCodeSheet: Component<{
       },
       ({ req, paths, isPending }) => {
         if (!req) return;
-        if (lastHandled === req) return;
+        if (handled()?.request === req) return;
         const repo = repoPath();
         if (repo === null || repo !== req.repoRoot) return;
         if (isPending || !paths) return;
         const rel = resolveNavPath(req, paths.paths);
-        lastHandled = req;
         if (rel === null) {
           toast.error(`File reference not found: ${req.ref.path}`);
+          setHandled({ request: req, resolvedPath: null });
           return;
         }
         rightPanel.setSelectedFile("browse", rel);
+        setHandled({ request: req, resolvedPath: rel });
       },
       { defer: true },
     ),
+  );
+
+  // Line-range highlight for terminal `path:line` taps — mirrors
+  // CodeTab's `selectedRange`. The memo emits a range only when the
+  // current `selectedPath` is the file the latest pendingMobileOpen
+  // resolved to; any tree-tap that changes the slot naturally
+  // invalidates the highlight (resolvedPath !== selectedPath). Refs
+  // without a `:N` suffix (`README.md`) open the file with no
+  // highlight — the user asked for the file, not a specific line.
+  const selectedRange = createMemo<{ start: number; end: number } | null>(
+    () => {
+      const req = pendingMobileOpen();
+      if (!req) return null;
+      const h = handled();
+      if (!h || h.request !== req || h.resolvedPath === null) return null;
+      if (h.resolvedPath !== selectedPath()) return null;
+      if (req.ref.startLine === null || req.ref.endLine === null) return null;
+      return { start: req.ref.startLine, end: req.ref.endLine };
+    },
   );
 
   return (
@@ -306,6 +340,7 @@ const MobileCodeSheet: Component<{
                           repoPath={repo()}
                           filePath={path}
                           theme={diffTheme()}
+                          initialSelectedLines={selectedRange()}
                         />
                       </div>
                     );

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -31,10 +31,8 @@ import {
   Switch,
 } from "solid-js";
 import { toast } from "solid-sonner";
-import {
-  type OpenInMobileFilesRequest,
-  pendingMobileOpen,
-} from "./openInMobileFiles";
+import type { NavRequest } from "./navRequest";
+import { pendingMobileOpen } from "./openInMobileFiles";
 import BrowseFileDispatcher from "./right-panel/BrowseFileDispatcher";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import { useColorScheme } from "./settings/useColorScheme";
@@ -79,7 +77,7 @@ const MobileCodeSheet: Component<{
   // selection slot (the bug this effect fixes) pushes
   // un-resolvable strings at `fsReadFile` and the server returns
   // `path escapes root` or `EISDIR`.
-  let lastHandled: OpenInMobileFilesRequest | null = null;
+  let lastHandled: NavRequest | null = null;
   createEffect(
     on(
       () => {

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -22,11 +22,23 @@
 
 import { FileTree } from "@kolu/solid-pierre";
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
-import { type Component, Match, Show, Switch } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  Match,
+  on,
+  Show,
+  Switch,
+} from "solid-js";
 import { toast } from "solid-sonner";
+import {
+  type OpenInMobileFilesRequest,
+  pendingMobileOpen,
+} from "./openInMobileFiles";
 import BrowseFileDispatcher from "./right-panel/BrowseFileDispatcher";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import { useColorScheme } from "./settings/useColorScheme";
+import { resolveLineRefPath } from "./ui/lineRef";
 import { pierreIconConfig, pierreTreesStyle } from "./ui/pierreTheme";
 import { app } from "./wire";
 import { FileBrowseIcon, GitBranchIcon } from "./ui/Icons";
@@ -55,6 +67,48 @@ const MobileCodeSheet: Component<{
     {
       onError: (err) => toast.error(`File list stream: ${err.message}`),
     },
+  );
+
+  // Consume `openInMobileFiles` requests once `fsListAll` has settled.
+  // Mirrors `CodeTab.tsx`'s `pendingOpen` consumer — terminal output
+  // emits absolute paths (`/abs/path`), cwd-relative paths
+  // (`error in foo.ts:42` while in a subdir), and basename-only
+  // references (`Foo.hs:42` from compiler output that drops the
+  // `src/lib/` prefix); `resolveLineRefPath` normalizes them against
+  // the live repo file set. Writing `req.ref.path` raw into the
+  // selection slot (the bug this effect fixes) pushes
+  // un-resolvable strings at `fsReadFile` and the server returns
+  // `path escapes root` or `EISDIR`.
+  let lastHandled: OpenInMobileFilesRequest | null = null;
+  createEffect(
+    on(
+      () => {
+        const req = pendingMobileOpen();
+        const paths = allPaths();
+        const isPending = allPaths.pending();
+        return { req, paths, isPending };
+      },
+      ({ req, paths, isPending }) => {
+        if (!req) return;
+        if (lastHandled === req) return;
+        const repo = repoPath();
+        if (repo === null || repo !== req.repoRoot) return;
+        if (isPending || !paths) return;
+        const rel = resolveLineRefPath({
+          rawPath: req.ref.path,
+          repoRoot: repo,
+          cwd: req.cwd,
+          repoPaths: paths.paths,
+        });
+        lastHandled = req;
+        if (rel === null) {
+          toast.error(`File reference not found: ${req.ref.path}`);
+          return;
+        }
+        rightPanel.setSelectedFile("browse", rel);
+      },
+      { defer: true },
+    ),
   );
 
   return (

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -22,7 +22,7 @@
 
 import { FileTree } from "@kolu/solid-pierre";
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
-import { type Component, Show } from "solid-js";
+import { type Component, Match, Show, Switch } from "solid-js";
 import { toast } from "solid-sonner";
 import BrowseFileDispatcher from "./right-panel/BrowseFileDispatcher";
 import { useRightPanel } from "./right-panel/useRightPanel";
@@ -120,39 +120,40 @@ const MobileCodeSheet: Component<{
             <Show
               when={selectedPath()}
               fallback={
-                <Show
-                  when={!allPaths.error()}
+                <Switch
                   fallback={
-                    <div class="px-2 py-1 text-danger text-[11px]">
-                      Error: {allPaths.error()?.message}
+                    <div class="px-2 py-1 text-fg-3/50 text-[11px]">
+                      Loading…
                     </div>
                   }
                 >
-                  <Show
-                    when={allPaths()}
-                    fallback={
-                      <div class="px-2 py-1 text-fg-3/50 text-[11px]">
-                        Loading…
+                  <Match when={allPaths.error()}>
+                    {(err) => (
+                      <div class="px-2 py-1 text-danger text-[11px]">
+                        Error: {err().message}
                       </div>
-                    }
-                  >
-                    <FileTree
-                      paths={allPaths()?.paths ?? []}
-                      selectedPath={null}
-                      onSelect={(p) => {
-                        if (p !== null) setSelectedPath(p);
-                      }}
-                      initialExpansion="closed"
-                      search={true}
-                      icons={pierreIconConfig}
-                      onError={(err) =>
-                        toast.error(`File tree render failed: ${err.message}`)
-                      }
-                      class="h-full w-full"
-                      style={pierreTreesStyle}
-                    />
-                  </Show>
-                </Show>
+                    )}
+                  </Match>
+                  <Match when={allPaths()}>
+                    {(paths) => (
+                      <FileTree
+                        paths={paths().paths}
+                        selectedPath={null}
+                        onSelect={(p) => {
+                          if (p !== null) setSelectedPath(p);
+                        }}
+                        initialExpansion="closed"
+                        search={true}
+                        icons={pierreIconConfig}
+                        onError={(err) =>
+                          toast.error(`File tree render failed: ${err.message}`)
+                        }
+                        class="h-full w-full"
+                        style={pierreTreesStyle}
+                      />
+                    )}
+                  </Match>
+                </Switch>
               }
             >
               {(path) => {

--- a/packages/client/src/MobileCodeSheet.tsx
+++ b/packages/client/src/MobileCodeSheet.tsx
@@ -31,12 +31,11 @@ import {
   Switch,
 } from "solid-js";
 import { toast } from "solid-sonner";
-import type { NavRequest } from "./navRequest";
+import { type NavRequest, resolveNavPath } from "./navRequest";
 import { pendingMobileOpen } from "./openInMobileFiles";
 import BrowseFileDispatcher from "./right-panel/BrowseFileDispatcher";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import { useColorScheme } from "./settings/useColorScheme";
-import { resolveLineRefPath } from "./ui/lineRef";
 import { pierreIconConfig, pierreTreesStyle } from "./ui/pierreTheme";
 import { app } from "./wire";
 import { FileBrowseIcon, GitBranchIcon } from "./ui/Icons";
@@ -92,12 +91,7 @@ const MobileCodeSheet: Component<{
         const repo = repoPath();
         if (repo === null || repo !== req.repoRoot) return;
         if (isPending || !paths) return;
-        const rel = resolveLineRefPath({
-          rawPath: req.ref.path,
-          repoRoot: repo,
-          cwd: req.cwd,
-          repoPaths: paths.paths,
-        });
+        const rel = resolveNavPath(req, paths.paths);
         lastHandled = req;
         if (rel === null) {
           toast.error(`File reference not found: ${req.ref.path}`);

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -56,28 +56,6 @@ const VERTICAL_TOLERANCE_RATIO = 0.7;
  *  click handler. */
 const PULL_OPEN_THRESHOLD = 24;
 
-/** Watches the chrome drawer's `transitionState` and fires `onFire`
- *  when it returns to `null` (animation finished) while `pending` is
- *  set. Rendered inside the chrome `<Drawer.Content>` so
- *  `Drawer.useContext("chrome")` resolves to the right drawer; the
- *  contextId on `<Drawer>` is what targets it. Returns nothing. */
-const ChromeCloseWatcher: Component<{
-  pending: () => boolean;
-  onFire: () => void;
-}> = (props) => {
-  const ctx = Drawer.useContext("chrome");
-  createEffect(
-    on(
-      () => ctx.transitionState(),
-      (state) => {
-        if (state === null && props.pending()) props.onFire();
-      },
-      { defer: true },
-    ),
-  );
-  return null;
-};
-
 const MobileTileView: Component<{
   /** Workspace-switcher-ordered ids — same source as the desktop dock, so
    *  swipe order matches what the user would see if they switched to
@@ -99,15 +77,6 @@ const MobileTileView: Component<{
   const [chromeOpen, setChromeOpen] = createSignal(false);
   const [dockOpen, setDockOpen] = createSignal(false);
   const [filesOpen, setFilesOpen] = createSignal(false);
-  // Set true when the chrome sheet's Files button is tapped. Watched by
-  // `ChromeCloseWatcher` (rendered inside the chrome drawer's content)
-  // — when the chrome drawer's transitionState returns to `null` after
-  // closing and this flag is set, fire `setFilesOpen(true)` and clear
-  // the flag. Replaces the previous `setTimeout(220)` in
-  // `MobileChromeSheet` that hardcoded the OVERLAY_CLASS animation
-  // duration; binding to the actual Corvu transition lifecycle keeps
-  // the two drawers' open/close from racing into each other.
-  const [filesAfterChromeClose, setFilesAfterChromeClose] = createSignal(false);
 
   // External producers (today: terminal `path:line` link clicks in
   // `Terminal.tsx`) request the Files drawer via `openInMobileFiles`,
@@ -250,38 +219,18 @@ const MobileTileView: Component<{
       </div>
 
       {/* Chrome (top pull-down) drawer — global controls. */}
-      <Drawer
-        side="top"
-        contextId="chrome"
-        open={chromeOpen()}
-        onOpenChange={setChromeOpen}
-      >
+      <Drawer side="top" open={chromeOpen()} onOpenChange={setChromeOpen}>
         <Drawer.Portal>
           <Drawer.Overlay
             data-testid="mobile-chrome-backdrop"
             class={OVERLAY_CLASS}
           />
           <Drawer.Content class="fixed top-0 left-0 right-0 z-50 bg-surface-1 border-b border-edge shadow-xl max-h-[70vh] overflow-y-auto">
-            <ChromeCloseWatcher
-              pending={filesAfterChromeClose}
-              onFire={() => {
-                setFilesAfterChromeClose(false);
-                setFilesOpen(true);
-              }}
-            />
             <MobileChromeSheet
               status={props.status}
               appTitle={props.appTitle}
               onOpenPalette={props.onOpenPalette}
-              onOpenFiles={() => {
-                // Two drawers can't transition simultaneously without
-                // Corvu's chrome-close pointer event leaking into the
-                // freshly-opened files drawer's dismiss path. Queue
-                // the open and let `ChromeCloseWatcher` fire it when
-                // the chrome drawer's transitionState returns to null.
-                setFilesAfterChromeClose(true);
-                setChromeOpen(false);
-              }}
+              onOpenFiles={() => setFilesOpen(true)}
               onClose={() => setChromeOpen(false)}
             />
           </Drawer.Content>

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -25,10 +25,19 @@
 
 import Drawer from "@corvu/drawer";
 import type { TerminalId } from "kolu-common/surface";
-import { type Component, createSignal, For, type JSX, Show } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  For,
+  type JSX,
+  on,
+  Show,
+} from "solid-js";
 import MobileChromeSheet from "./MobileChromeSheet";
 import MobileCodeSheet from "./MobileCodeSheet";
 import MobileDockDrawer from "./canvas/dock/MobileDockDrawer";
+import { pendingMobileOpen } from "./openInMobileFiles";
 import type { WsStatus } from "./rpc/rpc";
 import { TerminalMetaCompact } from "./terminal/TerminalMeta";
 import { useTerminalStore } from "./terminal/useTerminalStore";
@@ -65,6 +74,21 @@ const MobileTileView: Component<{
   const [chromeOpen, setChromeOpen] = createSignal(false);
   const [dockOpen, setDockOpen] = createSignal(false);
   const [filesOpen, setFilesOpen] = createSignal(false);
+
+  // External producers (today: terminal `path:line` link clicks in
+  // `Terminal.tsx`) request the Files drawer via `openInMobileFiles`,
+  // which bumps the counter we subscribe to here. `defer: true` skips
+  // the initial-mount tick so the drawer stays closed until a real
+  // request lands.
+  createEffect(
+    on(
+      pendingMobileOpen,
+      () => {
+        setFilesOpen(true);
+      },
+      { defer: true },
+    ),
+  );
   // Pull-handle drag state for the chrome (top) drawer. Not reactive —
   // only the touch handlers read it.
   let pullStartY: number | null = null;

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -4,17 +4,21 @@
  *  disabled per #622. The active terminal fills the viewport; swipe-
  *  left/right cycles between terminals in workspace-switcher order.
  *
- *  Two chrome drawers mirror the desktop split (#903):
+ *  Three chrome drawers mirror the desktop split (#903) plus the
+ *  mobile-only file browser:
  *  - **Top pull-down** (`MobileChromeSheet`): global controls — palette,
- *    settings, inspector toggle. Trigger is the always-visible
+ *    settings, file browser trigger. Trigger is the always-visible
  *    pull-handle row at the top of the terminal.
  *  - **Left swipe** (`MobileDockDrawer`): live-terminal navigator. The
  *    mobile mirror of the desktop dock; trigger is a thin
  *    handle pinned to the left edge.
+ *  - **Bottom modal sheet** (`MobileCodeSheet`): repo file browser, the
+ *    mobile surface for the desktop Code tab (the right panel is
+ *    hidden on mobile). Opened from the chrome sheet's Files button.
  *
- *  Both Corvu `Drawer`s live as siblings (not nested) so each has its
- *  own clean context — nesting put the chrome trigger inside the dock
- *  drawer's context, breaking the chrome-tap-to-open path. Plain
+ *  All three Corvu `Drawer`s live as siblings (not nested) so each has
+ *  its own clean context — nesting put the chrome trigger inside the
+ *  dock drawer's context, breaking the chrome-tap-to-open path. Plain
  *  buttons drive `open` state setters directly; the chrome handle
  *  keeps its drag-down-to-open behavior via a manual touchmove
  *  handler. */
@@ -23,6 +27,7 @@ import Drawer from "@corvu/drawer";
 import type { TerminalId } from "kolu-common/surface";
 import { type Component, createSignal, For, type JSX, Show } from "solid-js";
 import MobileChromeSheet from "./MobileChromeSheet";
+import MobileCodeSheet from "./MobileCodeSheet";
 import MobileDockDrawer from "./canvas/dock/MobileDockDrawer";
 import type { WsStatus } from "./rpc/rpc";
 import { TerminalMetaCompact } from "./terminal/TerminalMeta";
@@ -59,6 +64,7 @@ const MobileTileView: Component<{
   } | null>(null);
   const [chromeOpen, setChromeOpen] = createSignal(false);
   const [dockOpen, setDockOpen] = createSignal(false);
+  const [filesOpen, setFilesOpen] = createSignal(false);
   // Pull-handle drag state for the chrome (top) drawer. Not reactive —
   // only the touch handlers read it.
   let pullStartY: number | null = null;
@@ -195,6 +201,7 @@ const MobileTileView: Component<{
               status={props.status}
               appTitle={props.appTitle}
               onOpenPalette={props.onOpenPalette}
+              onOpenFiles={() => setFilesOpen(true)}
               onClose={() => setChromeOpen(false)}
             />
           </Drawer.Content>
@@ -212,6 +219,23 @@ const MobileTileView: Component<{
             <MobileDockDrawer
               onSelect={store.setActiveSilently}
               onClose={() => setDockOpen(false)}
+            />
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer>
+
+      {/* Files (bottom modal) drawer — repo file browser. */}
+      <Drawer side="bottom" open={filesOpen()} onOpenChange={setFilesOpen}>
+        <Drawer.Portal>
+          <Drawer.Overlay
+            data-testid="mobile-code-backdrop"
+            class="fixed inset-0 z-40 bg-black/40 opacity-0 transition-opacity duration-200 data-open:opacity-100"
+          />
+          <Drawer.Content class="fixed left-0 right-0 bottom-0 z-50 h-[92vh] bg-surface-1 border-t border-edge shadow-xl flex flex-col">
+            <MobileCodeSheet
+              terminalId={store.activeId()}
+              meta={store.activeMeta()}
+              onClose={() => setFilesOpen(false)}
             />
           </Drawer.Content>
         </Drawer.Portal>

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -44,6 +44,9 @@ import { useTerminalStore } from "./terminal/useTerminalStore";
 
 /** Minimum horizontal travel (px) before a swipe commits to a tile change. */
 const SWIPE_THRESHOLD = 60;
+/** Tailwind classes shared by all three drawer backdrop overlays. */
+const OVERLAY_CLASS =
+  "fixed inset-0 z-40 bg-black/40 opacity-0 transition-opacity duration-200 data-open:opacity-100";
 /** Vertical drift cap — if the user moved more vertically than horizontally,
  *  treat the gesture as a scroll, not a swipe. */
 const VERTICAL_TOLERANCE_RATIO = 0.7;
@@ -218,7 +221,7 @@ const MobileTileView: Component<{
         <Drawer.Portal>
           <Drawer.Overlay
             data-testid="mobile-chrome-backdrop"
-            class="fixed inset-0 z-40 bg-black/40 opacity-0 transition-opacity duration-200 data-open:opacity-100"
+            class={OVERLAY_CLASS}
           />
           <Drawer.Content class="fixed top-0 left-0 right-0 z-50 bg-surface-1 border-b border-edge shadow-xl max-h-[70vh] overflow-y-auto">
             <MobileChromeSheet
@@ -237,7 +240,7 @@ const MobileTileView: Component<{
         <Drawer.Portal>
           <Drawer.Overlay
             data-testid="mobile-dock-backdrop"
-            class="fixed inset-0 z-40 bg-black/40 opacity-0 transition-opacity duration-200 data-open:opacity-100"
+            class={OVERLAY_CLASS}
           />
           <Drawer.Content class="fixed top-0 left-0 bottom-0 z-50 w-[78vw] max-w-[20rem] bg-surface-1 border-r border-edge shadow-xl">
             <MobileDockDrawer
@@ -253,7 +256,7 @@ const MobileTileView: Component<{
         <Drawer.Portal>
           <Drawer.Overlay
             data-testid="mobile-code-backdrop"
-            class="fixed inset-0 z-40 bg-black/40 opacity-0 transition-opacity duration-200 data-open:opacity-100"
+            class={OVERLAY_CLASS}
           />
           <Drawer.Content class="fixed left-0 right-0 bottom-0 z-50 h-[92vh] bg-surface-1 border-t border-edge shadow-xl flex flex-col">
             <MobileCodeSheet

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -80,14 +80,16 @@ const MobileTileView: Component<{
 
   // External producers (today: terminal `path:line` link clicks in
   // `Terminal.tsx`) request the Files drawer via `openInMobileFiles`,
-  // which bumps the counter we subscribe to here. `defer: true` skips
-  // the initial-mount tick so the drawer stays closed until a real
-  // request lands.
+  // which emits a fresh request object we subscribe to here. `defer:
+  // true` skips the initial-mount tick so the drawer stays closed
+  // until a real request lands. Path resolution + slot-write happens
+  // inside `MobileCodeSheet` once the drawer is mounted and
+  // `fsListAll` has settled.
   createEffect(
     on(
       pendingMobileOpen,
-      () => {
-        setFilesOpen(true);
+      (req) => {
+        if (req !== null) setFilesOpen(true);
       },
       { defer: true },
     ),

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -56,6 +56,28 @@ const VERTICAL_TOLERANCE_RATIO = 0.7;
  *  click handler. */
 const PULL_OPEN_THRESHOLD = 24;
 
+/** Watches the chrome drawer's `transitionState` and fires `onFire`
+ *  when it returns to `null` (animation finished) while `pending` is
+ *  set. Rendered inside the chrome `<Drawer.Content>` so
+ *  `Drawer.useContext("chrome")` resolves to the right drawer; the
+ *  contextId on `<Drawer>` is what targets it. Returns nothing. */
+const ChromeCloseWatcher: Component<{
+  pending: () => boolean;
+  onFire: () => void;
+}> = (props) => {
+  const ctx = Drawer.useContext("chrome");
+  createEffect(
+    on(
+      () => ctx.transitionState(),
+      (state) => {
+        if (state === null && props.pending()) props.onFire();
+      },
+      { defer: true },
+    ),
+  );
+  return null;
+};
+
 const MobileTileView: Component<{
   /** Workspace-switcher-ordered ids — same source as the desktop dock, so
    *  swipe order matches what the user would see if they switched to
@@ -77,6 +99,15 @@ const MobileTileView: Component<{
   const [chromeOpen, setChromeOpen] = createSignal(false);
   const [dockOpen, setDockOpen] = createSignal(false);
   const [filesOpen, setFilesOpen] = createSignal(false);
+  // Set true when the chrome sheet's Files button is tapped. Watched by
+  // `ChromeCloseWatcher` (rendered inside the chrome drawer's content)
+  // — when the chrome drawer's transitionState returns to `null` after
+  // closing and this flag is set, fire `setFilesOpen(true)` and clear
+  // the flag. Replaces the previous `setTimeout(220)` in
+  // `MobileChromeSheet` that hardcoded the OVERLAY_CLASS animation
+  // duration; binding to the actual Corvu transition lifecycle keeps
+  // the two drawers' open/close from racing into each other.
+  const [filesAfterChromeClose, setFilesAfterChromeClose] = createSignal(false);
 
   // External producers (today: terminal `path:line` link clicks in
   // `Terminal.tsx`) request the Files drawer via `openInMobileFiles`,
@@ -219,18 +250,38 @@ const MobileTileView: Component<{
       </div>
 
       {/* Chrome (top pull-down) drawer — global controls. */}
-      <Drawer side="top" open={chromeOpen()} onOpenChange={setChromeOpen}>
+      <Drawer
+        side="top"
+        contextId="chrome"
+        open={chromeOpen()}
+        onOpenChange={setChromeOpen}
+      >
         <Drawer.Portal>
           <Drawer.Overlay
             data-testid="mobile-chrome-backdrop"
             class={OVERLAY_CLASS}
           />
           <Drawer.Content class="fixed top-0 left-0 right-0 z-50 bg-surface-1 border-b border-edge shadow-xl max-h-[70vh] overflow-y-auto">
+            <ChromeCloseWatcher
+              pending={filesAfterChromeClose}
+              onFire={() => {
+                setFilesAfterChromeClose(false);
+                setFilesOpen(true);
+              }}
+            />
             <MobileChromeSheet
               status={props.status}
               appTitle={props.appTitle}
               onOpenPalette={props.onOpenPalette}
-              onOpenFiles={() => setFilesOpen(true)}
+              onOpenFiles={() => {
+                // Two drawers can't transition simultaneously without
+                // Corvu's chrome-close pointer event leaking into the
+                // freshly-opened files drawer's dismiss path. Queue
+                // the open and let `ChromeCloseWatcher` fire it when
+                // the chrome drawer's transitionState returns to null.
+                setFilesAfterChromeClose(true);
+                setChromeOpen(false);
+              }}
               onClose={() => setChromeOpen(false)}
             />
           </Drawer.Content>

--- a/packages/client/src/navRequest.ts
+++ b/packages/client/src/navRequest.ts
@@ -1,0 +1,34 @@
+/** Payload shared by the desktop and mobile "open this file:line"
+ *  front doors (`openInCodeTab` for the right-panel CodeTab,
+ *  `openInMobileFiles` for the Files drawer). Both producers (the
+ *  terminal link provider, the mobile touchstart capture) emit the
+ *  same four fields; both consumers (`CodeTab.tsx`, `MobileCodeSheet.tsx`)
+ *  feed them through `resolveLineRefPath` against `fsListAll` before
+ *  writing the selection slot.
+ *
+ *  The two front-door *modules* stay split — desktop is paired with
+ *  panel-uncollapse + tab + mode writes that mobile doesn't need (and
+ *  the mobile sheet uses a Corvu drawer that desktop doesn't have).
+ *  Only the payload shape is shared so a new field (Linear-style
+ *  snippet ID, say) lands in one place instead of two. */
+
+import type { CodeTabView } from "kolu-common/surface";
+import type { LineRef } from "./ui/lineRef";
+
+export interface NavRequest {
+  /** Parsed `path:line[-end]` to navigate to. The path is resolved
+   *  relative to `repoRoot` (or, when present, cwd-relative under
+   *  `repoRoot`) by the consumer via `resolveLineRefPath`. */
+  ref: LineRef;
+  /** Per-terminal git repo root that `ref.path` is interpreted under.
+   *  Absolute paths beneath this root are also accepted — the resolver
+   *  normalizes both shapes. */
+  repoRoot: string;
+  /** Terminal cwd at the time of the request. Drives the "user typed
+   *  `bar.ts:42` while standing in a subdirectory" case; undefined
+   *  falls back to repo-relative interpretation only. */
+  cwd?: string;
+  /** Which Code-tab sub-mode the request expects to land in.
+   *  Producers that don't track an authoring mode pass `"browse"`. */
+  targetMode: CodeTabView;
+}

--- a/packages/client/src/navRequest.ts
+++ b/packages/client/src/navRequest.ts
@@ -13,7 +13,7 @@
  *  snippet ID, say) lands in one place instead of two. */
 
 import type { CodeTabView } from "kolu-common/surface";
-import type { LineRef } from "./ui/lineRef";
+import { type LineRef, resolveLineRefPath } from "./ui/lineRef";
 
 export interface NavRequest {
   /** Parsed `path:line[-end]` to navigate to. The path is resolved
@@ -31,4 +31,23 @@ export interface NavRequest {
   /** Which Code-tab sub-mode the request expects to land in.
    *  Producers that don't track an authoring mode pass `"browse"`. */
   targetMode: CodeTabView;
+}
+
+/** Resolve a `NavRequest` against the consumer's path universe.
+ *  Wraps `resolveLineRefPath` so callers don't unpack the four
+ *  fields manually and so a contract change to `resolveLineRefPath`
+ *  propagates from one site. `repoPaths` stays a parameter because
+ *  desktop and mobile source it differently (desktop's `treePaths()`
+ *  is the user's expanded subset, mobile's `allPaths()` is the full
+ *  repo listing) — the helper resolves, it doesn't pick the universe. */
+export function resolveNavPath(
+  req: NavRequest,
+  repoPaths: readonly string[],
+): string | null {
+  return resolveLineRefPath({
+    rawPath: req.ref.path,
+    repoRoot: req.repoRoot,
+    cwd: req.cwd,
+    repoPaths,
+  });
 }

--- a/packages/client/src/openInMobileFiles.ts
+++ b/packages/client/src/openInMobileFiles.ts
@@ -20,30 +20,17 @@
  *  un-resolvable string at `fsReadFile` and the server would reject
  *  with `path escapes root` or `EISDIR`. */
 
-import type { CodeTabView } from "kolu-common/surface";
 import { createSignal } from "solid-js";
-import type { LineRef } from "./ui/lineRef";
+import type { NavRequest } from "./navRequest";
 
-export interface OpenInMobileFilesRequest {
-  ref: LineRef;
-  repoRoot: string;
-  cwd?: string;
-  /** Mode slot to write the resolved path into. Producers always pass
-   *  `"browse"` today; the field is here so future modes (local diff
-   *  inspection on mobile, say) don't need to refactor the contract. */
-  targetMode: CodeTabView;
-}
-
-const [pending, setPending] = createSignal<OpenInMobileFilesRequest | null>(
-  null,
-);
+const [pending, setPending] = createSignal<NavRequest | null>(null);
 
 /** Subscribe in `MobileTileView` to open the Files drawer when a
  *  producer requests navigation, and in `MobileCodeSheet` to resolve
  *  the request against `fsListAll` and write the selection slot. */
 export const pendingMobileOpen = pending;
 
-export function openInMobileFiles(req: OpenInMobileFilesRequest): void {
+export function openInMobileFiles(req: NavRequest): void {
   // Mint a fresh object on every call so two clicks on the same
   // `path:line` (which would deep-equal) are distinguishable by
   // reference identity — `MobileCodeSheet`'s consume-once effect

--- a/packages/client/src/openInMobileFiles.ts
+++ b/packages/client/src/openInMobileFiles.ts
@@ -1,0 +1,43 @@
+/** Front door for "open this file in the mobile Files drawer". The
+ *  desktop analog is `openInCodeTab` (right-panel scope); on mobile
+ *  the right panel doesn't exist and `MobileCodeSheet` is the viewer.
+ *
+ *  Why a parallel module instead of an `isMobile()` branch inside
+ *  `openInCodeTab`: that helper encapsulates the desktop right-panel
+ *  paired writes (preferences-uncollapse + tab + browse-mode + pending
+ *  request). Smuggling a mobile branch into it would complect platform
+ *  dispatch with desktop-navigation policy. Producers that fire on
+ *  both surfaces (today: the terminal `path:line` link provider) branch
+ *  on `isMobile()` at the call site and route to whichever front door
+ *  matches the surface.
+ *
+ *  The "pending open" token is an incrementing counter, not a request
+ *  object: the only consumer is `MobileTileView`'s `filesOpen` setter,
+ *  which doesn't need any payload beyond "a click happened, open the
+ *  drawer". The selection slot (`useRightPanel.setSelectedFile`) is
+ *  the durable bit and is set in the same batch — duplicate clicks
+ *  on the same path still re-open the drawer because the counter
+ *  changes even when the path doesn't. */
+
+import { batch, createSignal } from "solid-js";
+import { useRightPanel } from "./right-panel/useRightPanel";
+
+const [pending, setPending] = createSignal(0);
+
+/** Subscribe to this in `MobileTileView` to open the Files drawer when
+ *  a producer requests navigation. */
+export const pendingMobileOpen = pending;
+
+export interface OpenInMobileFilesRequest {
+  /** Repo-relative (or cwd-relative — best-effort match) path. On
+   *  mismatch `BrowseFileDispatcher`'s `fsReadFile` stream surfaces an
+   *  error toast; the user can still hit back to land on the tree. */
+  path: string;
+}
+
+export function openInMobileFiles(req: OpenInMobileFilesRequest): void {
+  batch(() => {
+    useRightPanel().setSelectedFile("browse", req.path);
+    setPending((n) => n + 1);
+  });
+}

--- a/packages/client/src/openInMobileFiles.ts
+++ b/packages/client/src/openInMobileFiles.ts
@@ -7,37 +7,46 @@
  *  paired writes (preferences-uncollapse + tab + browse-mode + pending
  *  request). Smuggling a mobile branch into it would complect platform
  *  dispatch with desktop-navigation policy. Producers that fire on
- *  both surfaces (today: the terminal `path:line` link provider) branch
- *  on `isMobile()` at the call site and route to whichever front door
- *  matches the surface.
+ *  both surfaces (today: the terminal `path:line` link provider and
+ *  the touchstart-on-buffer-text handler) branch on `isMobile()` at
+ *  the call site and route to whichever front door matches the surface.
  *
- *  The "pending open" token is an incrementing counter, not a request
- *  object: the only consumer is `MobileTileView`'s `filesOpen` setter,
- *  which doesn't need any payload beyond "a click happened, open the
- *  drawer". The selection slot (`useRightPanel.setSelectedFile`) is
- *  the durable bit and is set in the same batch — duplicate clicks
- *  on the same path still re-open the drawer because the counter
- *  changes even when the path doesn't. */
+ *  The request carries the full `LineRef + repoRoot + cwd` so
+ *  `MobileCodeSheet` can run `resolveLineRefPath` against the live
+ *  `fsListAll` paths before selecting — terminal output emits
+ *  absolute paths (`pwd`), cwd-relative paths (`error in foo.ts:42`
+ *  while in a subdir), and basename-only references; passing the
+ *  raw `ref.path` straight into `setSelectedFile` would push an
+ *  un-resolvable string at `fsReadFile` and the server would reject
+ *  with `path escapes root` or `EISDIR`. */
 
-import { batch, createSignal } from "solid-js";
-import { useRightPanel } from "./right-panel/useRightPanel";
-
-const [pending, setPending] = createSignal(0);
-
-/** Subscribe to this in `MobileTileView` to open the Files drawer when
- *  a producer requests navigation. */
-export const pendingMobileOpen = pending;
+import type { CodeTabView } from "kolu-common/surface";
+import { createSignal } from "solid-js";
+import type { LineRef } from "./ui/lineRef";
 
 export interface OpenInMobileFilesRequest {
-  /** Repo-relative (or cwd-relative — best-effort match) path. On
-   *  mismatch `BrowseFileDispatcher`'s `fsReadFile` stream surfaces an
-   *  error toast; the user can still hit back to land on the tree. */
-  path: string;
+  ref: LineRef;
+  repoRoot: string;
+  cwd?: string;
+  /** Mode slot to write the resolved path into. Producers always pass
+   *  `"browse"` today; the field is here so future modes (local diff
+   *  inspection on mobile, say) don't need to refactor the contract. */
+  targetMode: CodeTabView;
 }
 
+const [pending, setPending] = createSignal<OpenInMobileFilesRequest | null>(
+  null,
+);
+
+/** Subscribe in `MobileTileView` to open the Files drawer when a
+ *  producer requests navigation, and in `MobileCodeSheet` to resolve
+ *  the request against `fsListAll` and write the selection slot. */
+export const pendingMobileOpen = pending;
+
 export function openInMobileFiles(req: OpenInMobileFilesRequest): void {
-  batch(() => {
-    useRightPanel().setSelectedFile("browse", req.path);
-    setPending((n) => n + 1);
-  });
+  // Mint a fresh object on every call so two clicks on the same
+  // `path:line` (which would deep-equal) are distinguishable by
+  // reference identity — `MobileCodeSheet`'s consume-once effect
+  // tracks the request object, not its content.
+  setPending({ ...req });
 }

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -134,7 +134,8 @@ const CodeTab: Component<{
   // `view()` is a typed enum and `repoPath()` is absolute-or-null.
   const selectedPath = (): string | null => rightPanel.selectedFile(view());
   const setSelectedPath = (path: string | null) => {
-    rightPanel.setSelectedFile(view(), path);
+    if (path === null) rightPanel.clearSelectedFile(view());
+    else rightPanel.setSelectedFile(view(), path);
   };
   const slotKey = createMemo(() => `${repoPath() ?? ""}::${view()}`);
 

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -54,11 +54,8 @@ import {
 import { resolveLineRefPath } from "../ui/lineRef";
 import BrowseFileDispatcher from "./BrowseFileDispatcher";
 import CodeMenuFrame from "./CodeMenuFrame";
-import {
-  openInCodeTab,
-  type OpenInCodeTabRequest,
-  pendingOpen,
-} from "./openInCodeTab";
+import type { NavRequest } from "../navRequest";
+import { openInCodeTab, pendingOpen } from "./openInCodeTab";
 import { projectFileTreeSearch } from "./fileSearch";
 import FileSearchInput from "./FileSearchInput";
 import ModeChipPicker, { type ModeOption } from "./ModeChipPicker";
@@ -229,7 +226,7 @@ const CodeTab: Component<{
   // re-running `resolveLineRefPath` (single resolution site per
   // request).
   const [handled, setHandled] = createSignal<{
-    request: OpenInCodeTabRequest;
+    request: NavRequest;
     resolvedPath: string | null;
   } | null>(null);
 

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -51,10 +51,9 @@ import {
   pierreIconConfig,
   pierreTreesStyle,
 } from "../ui/pierreTheme";
-import { resolveLineRefPath } from "../ui/lineRef";
 import BrowseFileDispatcher from "./BrowseFileDispatcher";
 import CodeMenuFrame from "./CodeMenuFrame";
-import type { NavRequest } from "../navRequest";
+import { type NavRequest, resolveNavPath } from "../navRequest";
 import { openInCodeTab, pendingOpen } from "./openInCodeTab";
 import { projectFileTreeSearch } from "./fileSearch";
 import FileSearchInput from "./FileSearchInput";
@@ -250,12 +249,7 @@ const CodeTab: Component<{
         if (handled()?.request === req) return;
         if (repo === null || repo !== req.repoRoot) return;
         if (view() !== req.targetMode || isPending) return;
-        const rel = resolveLineRefPath({
-          rawPath: req.ref.path,
-          repoRoot: repo,
-          cwd: req.cwd,
-          repoPaths: paths,
-        });
+        const rel = resolveNavPath(req, paths);
         if (rel === null) {
           toast.error(`File reference not found: ${req.ref.path}`);
           setHandled({ request: req, resolvedPath: null });

--- a/packages/client/src/right-panel/openInCodeTab.ts
+++ b/packages/client/src/right-panel/openInCodeTab.ts
@@ -11,28 +11,9 @@
  *  reference, which is what lets `CodeTab` tell them apart even when
  *  their `ref` content matches and re-paint the highlight. */
 
-import type { CodeTabView } from "kolu-common/surface";
 import { batch, createSignal } from "solid-js";
-import type { LineRef } from "../ui/lineRef";
+import type { NavRequest } from "../navRequest";
 import { useRightPanel } from "./useRightPanel";
-
-export interface OpenInCodeTabRequest {
-  /** Parsed `path:line[-end]` to navigate to. The path is interpreted
-   *  relative to `repoRoot` (or, when present, cwd-relative under
-   *  `repoRoot`) by `CodeTab` via `resolveLineRefPath`. */
-  ref: LineRef;
-  /** Per-terminal git repo root that `ref.path` is relative to (when
-   *  relative). Absolute paths beneath this root are also accepted —
-   *  the resolver normalizes both shapes. */
-  repoRoot: string;
-  /** Terminal cwd at the time of the request. Drives the "user typed
-   *  `bar.ts:42` while standing in a subdirectory of the repo" case;
-   *  undefined falls back to repo-relative interpretation only. */
-  cwd?: string;
-  /** Which Code-tab sub-mode the request expects to land in.
-   *  Producers that don't track an authoring mode pass `"browse"`. */
-  targetMode: CodeTabView;
-}
 
 // Module-level singleton. Right-panel state is a singleton in Kolu —
 // one panel, one CodeTab — and the navigation request is meant for
@@ -40,7 +21,7 @@ export interface OpenInCodeTabRequest {
 // (split panels, multi-window), this signal must move into a
 // SolidJS context or scope to a per-panel store, otherwise concurrent
 // consumers will race on each other's pending requests.
-const [pending, setPending] = createSignal<OpenInCodeTabRequest | null>(null);
+const [pending, setPending] = createSignal<NavRequest | null>(null);
 
 export const pendingOpen = pending;
 
@@ -52,7 +33,7 @@ export const pendingOpen = pending;
  *  (selection is now per-slot, so no effect clears `selectedPath`);
  *  kept because the merged tick still avoids a flash of intermediate
  *  state during navigation. */
-export function openInCodeTab(req: OpenInCodeTabRequest): void {
+export function openInCodeTab(req: NavRequest): void {
   batch(() => {
     useRightPanel().openCodeAt(req.targetMode);
     setPending(req);

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -164,18 +164,24 @@ export function useRightPanel() {
      *  terminal remembers its own pick in each of local/branch/browse. */
     selectedFile: (mode: CodeTabView): string | null =>
       activeState().selectedFileByMode?.[mode] ?? null,
-    setSelectedFile: (mode: CodeTabView, path: string | null) => {
+    /** Set the selection for a mode to a non-null path. Use
+     *  `clearSelectedFile` to remove a selection — null is not a valid
+     *  payload here so Pierre's spurious `onSelect(null)` events
+     *  (resubscribe/teardown) can't reach the store by accident. */
+    setSelectedFile: (mode: CodeTabView, path: string) => {
       mutateActive((s) => {
         const cur = s.selectedFileByMode ?? {};
-        if (path === null) {
-          if (!(mode in cur)) return;
-          const { [mode]: _, ...rest } = cur;
-          s.selectedFileByMode =
-            Object.keys(rest).length > 0 ? rest : undefined;
-        } else {
-          if (cur[mode] === path) return;
-          s.selectedFileByMode = { ...cur, [mode]: path };
-        }
+        if (cur[mode] === path) return;
+        s.selectedFileByMode = { ...cur, [mode]: path };
+      });
+    },
+    /** Clear the selection for a mode. No-op when no selection exists. */
+    clearSelectedFile: (mode: CodeTabView) => {
+      mutateActive((s) => {
+        const cur = s.selectedFileByMode ?? {};
+        if (!(mode in cur)) return;
+        const { [mode]: _, ...rest } = cur;
+        s.selectedFileByMode = Object.keys(rest).length > 0 ? rest : undefined;
       });
     },
 

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -545,11 +545,27 @@ const Terminal: Component<{
               const col = Math.floor((touch.clientX - rect.left) / cellW);
               const visRow = Math.floor((touch.clientY - rect.top) / cellH);
               const bufRow = term.buffer.active.viewportY + visRow;
-              const line =
-                term.buffer.active.getLine(bufRow)?.translateToString(true) ??
-                "";
+              // Join wrapped continuation rows so a path that wraps on
+              // a narrow mobile viewport is parsed as one LineRef
+              // instead of two truncated halves. Walk back from
+              // `bufRow` to the first row of its logical line, then
+              // forward to the last wrapped continuation; concatenate.
+              // `col` is offset by the chars consumed before bufRow so
+              // the hit-test still picks the LineRef under the finger.
+              const buf = term.buffer.active;
+              let lineStart = bufRow;
+              while (lineStart > 0 && buf.getLine(lineStart)?.isWrapped) {
+                lineStart--;
+              }
+              let line = "";
+              for (let r = lineStart; r < buf.length; r++) {
+                if (r > lineStart && !buf.getLine(r)?.isWrapped) break;
+                line += buf.getLine(r)?.translateToString(false) ?? "";
+              }
+              const joinedCol = (bufRow - lineStart) * term.cols + col;
               const hit = parseLineRefs(line).find(
-                (m) => col >= m.index && col < m.index + m.text.length,
+                (m) =>
+                  joinedCol >= m.index && joinedCol < m.index + m.text.length,
               );
               if (!hit) return;
               // preventDefault before dispatch so iOS doesn't synthesize

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -43,6 +43,8 @@ import { client } from "../wire";
 import { isExpectedCleanupError } from "../rpc/streamCleanup";
 import { createScrollLock } from "../scrollLock";
 import { openInCodeTab } from "../right-panel/openInCodeTab";
+import { openInMobileFiles } from "../openInMobileFiles";
+import { isMobile } from "../useMobile";
 import { preferences } from "../wire";
 import { isTouch } from "../useMobile";
 import { createFileRefLinkProvider } from "./fileRefLinkProvider";
@@ -470,6 +472,16 @@ const Terminal: Component<{
                 const meta = terminalStore.getMetadata(props.terminalId);
                 const repoRoot = meta?.git?.repoRoot ?? null;
                 if (!repoRoot) return;
+                if (isMobile()) {
+                  // The right panel doesn't exist on mobile; route to
+                  // the Files drawer instead. The desktop helper would
+                  // write `rightPanel.collapsed = false` to preferences
+                  // — a server-persisted mutation with no UI effect on
+                  // mobile but a stale toggle waiting to surprise the
+                  // user the next time they open Kolu on desktop.
+                  openInMobileFiles({ path: ref.path });
+                  return;
+                }
                 openInCodeTab({
                   ref,
                   repoRoot,

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -48,6 +48,7 @@ import { isMobile } from "../useMobile";
 import { preferences } from "../wire";
 import { isTouch } from "../useMobile";
 import { createFileRefLinkProvider } from "./fileRefLinkProvider";
+import { parseLineRefs } from "../ui/lineRef";
 import ScrollToBottom from "./ScrollToBottom";
 import SearchBar from "./SearchBar";
 import { registerTerminalRefs, unregisterTerminalRefs } from "./terminalRefs";
@@ -516,6 +517,51 @@ const Terminal: Component<{
           // div stays free of interactive props that would force a11y roles
           // — the actual interactive surface is the xterm canvas inside.
           containerRef.addEventListener("click", () => term.focus());
+
+          // Mobile: bypass xterm's link decoration on touchstart. xterm arms
+          // its activate callback only after a `mousemove` over the link
+          // cell has painted the decoration — iOS has no hover phase, so a
+          // bare tap fires `click` against the helper textarea (popping the
+          // soft keyboard) before xterm's link layer ever sees it. Capture
+          // the touch ourselves, parse the buffer line for `path:line`
+          // refs, and route the hit through `openInMobileFiles` directly.
+          // `preventDefault` keeps iOS from synthesizing the focus shift +
+          // keyboard pop. Desktop is unaffected — the touchstart listener
+          // only fires under `isMobile()` and never on a mouse-only client.
+          containerRef.addEventListener(
+            "touchstart",
+            (e) => {
+              if (!isMobile()) return;
+              const touch = e.touches[0];
+              if (!touch) return;
+              const screen = containerRef.querySelector(".xterm-screen");
+              if (!screen) return;
+              const rect = (screen as Element).getBoundingClientRect();
+              if (
+                touch.clientX < rect.left ||
+                touch.clientX > rect.right ||
+                touch.clientY < rect.top ||
+                touch.clientY > rect.bottom
+              ) {
+                return;
+              }
+              const cellW = rect.width / term.cols;
+              const cellH = rect.height / term.rows;
+              const col = Math.floor((touch.clientX - rect.left) / cellW);
+              const visRow = Math.floor((touch.clientY - rect.top) / cellH);
+              const bufRow = term.buffer.active.viewportY + visRow;
+              const line =
+                term.buffer.active.getLine(bufRow)?.translateToString(true) ??
+                "";
+              const hit = parseLineRefs(line).find(
+                (m) => col >= m.index && col < m.index + m.text.length,
+              );
+              if (!hit) return;
+              e.preventDefault();
+              openInMobileFiles({ path: hit.path });
+            },
+            { capture: true, passive: false },
+          );
           // Mobile: route soft-keyboard input through `.xterm-screen` itself,
           // the way hterm does (libapps/hterm/js/hterm_scrollport.js:617-655).
           //

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -42,13 +42,14 @@ import { streamCall } from "@kolu/surface/solid";
 import { client } from "../wire";
 import { isExpectedCleanupError } from "../rpc/streamCleanup";
 import { createScrollLock } from "../scrollLock";
+import type { NavRequest } from "../navRequest";
 import { openInCodeTab } from "../right-panel/openInCodeTab";
 import { openInMobileFiles } from "../openInMobileFiles";
 import { isMobile } from "../useMobile";
 import { preferences } from "../wire";
 import { isTouch } from "../useMobile";
 import { createFileRefLinkProvider } from "./fileRefLinkProvider";
-import { parseLineRefs } from "../ui/lineRef";
+import { type LineRef, parseLineRefs } from "../ui/lineRef";
 import ScrollToBottom from "./ScrollToBottom";
 import SearchBar from "./SearchBar";
 import { registerTerminalRefs, unregisterTerminalRefs } from "./terminalRefs";
@@ -167,6 +168,28 @@ const Terminal: Component<{
   const scrollLock = createScrollLock(() => preferences().scrollLock);
   const terminalStore = useTerminalStore();
   let fitRaf = 0;
+
+  /** Route a parsed `path:line` reference to the platform's file-browser
+   *  front door. Two call sites use it: xterm's link-provider onActivate
+   *  (desktop mouse click) and the touchstart capture (mobile tap). Both
+   *  arrive with an already-parsed `LineRef` — they read terminal metadata
+   *  for repo/cwd and dispatch to `openInCodeTab` or `openInMobileFiles`
+   *  depending on the surface. Local helper (not pushed into
+   *  `fileRefLinkProvider.ts`) so the xterm adapter stays free of
+   *  platform-dispatch knowledge. */
+  function dispatchFileRef(ref: LineRef): void {
+    const meta = terminalStore.getMetadata(props.terminalId);
+    const repoRoot = meta?.git?.repoRoot ?? null;
+    if (!repoRoot) return;
+    const req: NavRequest = {
+      ref,
+      repoRoot,
+      cwd: meta?.cwd,
+      targetMode: "browse",
+    };
+    if (isMobile()) openInMobileFiles(req);
+    else openInCodeTab(req);
+  }
 
   /** Debounce fit() to one call per animation frame — ResizeObserver fires rapidly. */
   function debouncedFit() {
@@ -468,40 +491,7 @@ const Terminal: Component<{
           // terminal store at click time (not at mount) so a cwd
           // change keeps subsequent clicks anchored to the new repo.
           linkProviderDisposable = term.registerLinkProvider(
-            createFileRefLinkProvider(term, {
-              onActivate: (ref) => {
-                const meta = terminalStore.getMetadata(props.terminalId);
-                const repoRoot = meta?.git?.repoRoot ?? null;
-                if (!repoRoot) return;
-                if (isMobile()) {
-                  // The right panel doesn't exist on mobile; route to
-                  // the Files drawer instead. `MobileCodeSheet` will
-                  // run `resolveLineRefPath` against the live
-                  // `fsListAll` paths before writing the selection
-                  // slot — terminal output emits absolute paths
-                  // (`pwd`) and cwd-relative paths that `fsReadFile`
-                  // would reject as `path escapes root` if we pushed
-                  // them in raw. The desktop helper would also write
-                  // `rightPanel.collapsed = false` to preferences —
-                  // a server-persisted mutation with no UI effect on
-                  // mobile but a stale toggle on the user's next
-                  // desktop session.
-                  openInMobileFiles({
-                    ref,
-                    repoRoot,
-                    cwd: meta?.cwd,
-                    targetMode: "browse",
-                  });
-                  return;
-                }
-                openInCodeTab({
-                  ref,
-                  repoRoot,
-                  cwd: meta?.cwd,
-                  targetMode: "browse",
-                });
-              },
-            }),
+            createFileRefLinkProvider(term, { onActivate: dispatchFileRef }),
           );
           const search = new SearchAddon();
           term.loadAddon(search);
@@ -562,16 +552,12 @@ const Terminal: Component<{
                 (m) => col >= m.index && col < m.index + m.text.length,
               );
               if (!hit) return;
-              const meta = terminalStore.getMetadata(props.terminalId);
-              const repoRoot = meta?.git?.repoRoot ?? null;
-              if (!repoRoot) return;
+              // preventDefault before dispatch so iOS doesn't synthesize
+              // a focus shift + keyboard pop between the ref hit and the
+              // front-door call. If `dispatchFileRef` no-ops (no repo
+              // root), the touch still doesn't reach the helper textarea.
               e.preventDefault();
-              openInMobileFiles({
-                ref: hit,
-                repoRoot,
-                cwd: meta?.cwd,
-                targetMode: "browse",
-              });
+              dispatchFileRef(hit);
             },
             { capture: true, passive: false },
           );

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -469,19 +469,25 @@ const Terminal: Component<{
           linkProviderDisposable = term.registerLinkProvider(
             createFileRefLinkProvider(term, {
               onActivate: (ref) => {
-                const meta = terminalStore.getMetadata(props.terminalId);
-                const repoRoot = meta?.git?.repoRoot ?? null;
-                if (!repoRoot) return;
                 if (isMobile()) {
                   // The right panel doesn't exist on mobile; route to
-                  // the Files drawer instead. The desktop helper would
-                  // write `rightPanel.collapsed = false` to preferences
-                  // — a server-persisted mutation with no UI effect on
+                  // the Files drawer instead. No repoRoot gate here —
+                  // `MobileCodeSheet` reads `meta.git.repoRoot` from the
+                  // active terminal's signal at mount and renders the
+                  // "not in a git repository" fallback when null, so
+                  // clicking a link in a non-repo terminal still opens
+                  // the drawer with a useful message instead of looking
+                  // silently dead. The desktop helper would also write
+                  // `rightPanel.collapsed = false` to preferences — a
+                  // server-persisted mutation with no UI effect on
                   // mobile but a stale toggle waiting to surprise the
                   // user the next time they open Kolu on desktop.
                   openInMobileFiles({ path: ref.path });
                   return;
                 }
+                const meta = terminalStore.getMetadata(props.terminalId);
+                const repoRoot = meta?.git?.repoRoot ?? null;
+                if (!repoRoot) return;
                 openInCodeTab({
                   ref,
                   repoRoot,

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -470,25 +470,30 @@ const Terminal: Component<{
           linkProviderDisposable = term.registerLinkProvider(
             createFileRefLinkProvider(term, {
               onActivate: (ref) => {
-                if (isMobile()) {
-                  // The right panel doesn't exist on mobile; route to
-                  // the Files drawer instead. No repoRoot gate here —
-                  // `MobileCodeSheet` reads `meta.git.repoRoot` from the
-                  // active terminal's signal at mount and renders the
-                  // "not in a git repository" fallback when null, so
-                  // clicking a link in a non-repo terminal still opens
-                  // the drawer with a useful message instead of looking
-                  // silently dead. The desktop helper would also write
-                  // `rightPanel.collapsed = false` to preferences — a
-                  // server-persisted mutation with no UI effect on
-                  // mobile but a stale toggle waiting to surprise the
-                  // user the next time they open Kolu on desktop.
-                  openInMobileFiles({ path: ref.path });
-                  return;
-                }
                 const meta = terminalStore.getMetadata(props.terminalId);
                 const repoRoot = meta?.git?.repoRoot ?? null;
                 if (!repoRoot) return;
+                if (isMobile()) {
+                  // The right panel doesn't exist on mobile; route to
+                  // the Files drawer instead. `MobileCodeSheet` will
+                  // run `resolveLineRefPath` against the live
+                  // `fsListAll` paths before writing the selection
+                  // slot — terminal output emits absolute paths
+                  // (`pwd`) and cwd-relative paths that `fsReadFile`
+                  // would reject as `path escapes root` if we pushed
+                  // them in raw. The desktop helper would also write
+                  // `rightPanel.collapsed = false` to preferences —
+                  // a server-persisted mutation with no UI effect on
+                  // mobile but a stale toggle on the user's next
+                  // desktop session.
+                  openInMobileFiles({
+                    ref,
+                    repoRoot,
+                    cwd: meta?.cwd,
+                    targetMode: "browse",
+                  });
+                  return;
+                }
                 openInCodeTab({
                   ref,
                   repoRoot,
@@ -557,8 +562,16 @@ const Terminal: Component<{
                 (m) => col >= m.index && col < m.index + m.text.length,
               );
               if (!hit) return;
+              const meta = terminalStore.getMetadata(props.terminalId);
+              const repoRoot = meta?.git?.repoRoot ?? null;
+              if (!repoRoot) return;
               e.preventDefault();
-              openInMobileFiles({ path: hit.path });
+              openInMobileFiles({
+                ref: hit,
+                repoRoot,
+                cwd: meta?.cwd,
+                targetMode: "browse",
+              });
             },
             { capture: true, passive: false },
           );

--- a/packages/tests/features/mobile-code-browse.feature
+++ b/packages/tests/features/mobile-code-browse.feature
@@ -1,0 +1,70 @@
+Feature: Mobile code browser
+  On mobile the right panel is hidden — there's no room for a side
+  column. The "Files" button in the chrome sheet (`MobileChromeSheet`)
+  opens a bottom drawer with the active terminal's repo file tree
+  (`MobileCodeSheet`). Tapping a file shows it in a detail view:
+  text files render via Pierre's `CodeView`; HTML files render in
+  the sandboxed iframe preview the desktop Code tab uses. A back
+  arrow returns from the detail view to the tree; an explicit close
+  button dismisses the drawer.
+
+  Background:
+    Given the terminal is ready
+
+  @mobile
+  Scenario: Files button opens the mobile code sheet
+    When I run "git init /tmp/kolu-mobile-files && cd /tmp/kolu-mobile-files"
+    And I run "echo hello > a.txt"
+    And I run "git add a.txt && git commit -m init"
+    And I tap the mobile pull handle
+    And I tap the mobile files button
+    Then the mobile code sheet should be visible
+    And the mobile file tree should contain "a.txt"
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tapping a text file shows its content
+    When I run "git init /tmp/kolu-mobile-text && cd /tmp/kolu-mobile-text"
+    And I run "echo hello > readme.txt"
+    And I run "git add readme.txt && git commit -m init"
+    And I tap the mobile pull handle
+    And I tap the mobile files button
+    And I tap mobile file "readme.txt"
+    Then the mobile file view should be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tapping an HTML file shows the iframe preview
+    When I run "git init /tmp/kolu-mobile-html && cd /tmp/kolu-mobile-html"
+    And I run "printf '<h1>hi</h1>' > index.html"
+    And I run "git add index.html && git commit -m init"
+    And I tap the mobile pull handle
+    And I tap the mobile files button
+    And I tap mobile file "index.html"
+    Then the mobile html preview should be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Back arrow returns from detail view to file tree
+    When I run "git init /tmp/kolu-mobile-back && cd /tmp/kolu-mobile-back"
+    And I run "echo hi > foo.md"
+    And I run "git add foo.md && git commit -m init"
+    And I tap the mobile pull handle
+    And I tap the mobile files button
+    And I tap mobile file "foo.md"
+    Then the mobile file view should be visible
+    When I tap the mobile code back button
+    Then the mobile file tree should contain "foo.md"
+    And there should be no page errors
+
+  @mobile
+  Scenario: Close button dismisses the drawer
+    When I run "git init /tmp/kolu-mobile-close && cd /tmp/kolu-mobile-close"
+    And I run "echo hi > x.txt"
+    And I run "git add x.txt && git commit -m init"
+    And I tap the mobile pull handle
+    And I tap the mobile files button
+    Then the mobile code sheet should be visible
+    When I tap the mobile code close button
+    Then the mobile code sheet should not be visible
+    And there should be no page errors

--- a/packages/tests/features/mobile-code-browse.feature
+++ b/packages/tests/features/mobile-code-browse.feature
@@ -45,7 +45,7 @@ Feature: Mobile code browser
     And there should be no page errors
 
   @mobile
-  Scenario: Back arrow returns from detail view to file tree
+  Scenario: Back arrow dismisses the detail view
     When I run "git init /tmp/kolu-mobile-back && cd /tmp/kolu-mobile-back"
     And I run "echo hi > foo.md"
     And I run "git add foo.md && git commit -m init"
@@ -54,7 +54,7 @@ Feature: Mobile code browser
     And I tap mobile file "foo.md"
     Then the mobile file view should be visible
     When I tap the mobile code back button
-    Then the mobile file tree should contain "foo.md"
+    Then the mobile file view should not be visible
     And there should be no page errors
 
   @mobile

--- a/packages/tests/features/mobile-code-browse.feature
+++ b/packages/tests/features/mobile-code-browse.feature
@@ -45,19 +45,6 @@ Feature: Mobile code browser
     And there should be no page errors
 
   @mobile
-  Scenario: Back arrow dismisses the detail view
-    When I run "rm -rf /tmp/kolu-mobile-back && git init /tmp/kolu-mobile-back && cd /tmp/kolu-mobile-back"
-    And I run "echo hi > foo.md"
-    And I run "git add foo.md && git commit -m init"
-    And I tap the mobile pull handle
-    And I tap the mobile files button
-    And I tap mobile file "foo.md"
-    Then the mobile file view should be visible
-    When I tap the mobile code back button
-    Then the mobile file view should not be visible
-    And there should be no page errors
-
-  @mobile
   Scenario: Close button dismisses the drawer
     When I run "rm -rf /tmp/kolu-mobile-close && git init /tmp/kolu-mobile-close && cd /tmp/kolu-mobile-close"
     And I run "echo hi > x.txt"

--- a/packages/tests/features/mobile-code-browse.feature
+++ b/packages/tests/features/mobile-code-browse.feature
@@ -45,6 +45,40 @@ Feature: Mobile code browser
     And there should be no page errors
 
   @mobile
+  Scenario: Tapping an absolute path in terminal output resolves to a repo-relative file
+    # Regression: terminal output emits absolute paths (`pwd`, error
+    # traces, build logs). The mobile path used to shove the raw
+    # absolute string into the selection slot — `fsReadFile` then
+    # rejected with "path escapes root" or EISDIR depending on where
+    # the repo root sat. `resolveLineRefPath` in `MobileCodeSheet`
+    # now strips the repo prefix before the slot is written.
+    When I run "rm -rf /tmp/kolu-mobile-abs && git init /tmp/kolu-mobile-abs && cd /tmp/kolu-mobile-abs"
+    And I run "echo hello > README.md"
+    And I run "git add README.md && git commit -m init"
+    And I run "echo /tmp/kolu-mobile-abs/README.md"
+    And I tap terminal text "/tmp/kolu-mobile-abs/README.md"
+    Then the mobile code sheet should be visible
+    And the mobile file view should be visible
+    And there should be no page errors
+
+  @mobile
+  Scenario: Tapping a path outside the repo surfaces a "not found" toast
+    # Regression: the bug the user reported on iPhone — tapping a
+    # path that doesn't resolve under the active repo used to push
+    # the absolute string at `fsReadFile` and render a server error.
+    # Now it toasts and leaves the slot empty so the tree stays
+    # visible.
+    When I run "rm -rf /tmp/kolu-mobile-offrepo && git init /tmp/kolu-mobile-offrepo && cd /tmp/kolu-mobile-offrepo"
+    And I run "echo hello > a.txt"
+    And I run "git add a.txt && git commit -m init"
+    And I run "echo /etc/passwd"
+    And I tap terminal text "/etc/passwd"
+    Then the mobile code sheet should be visible
+    And the mobile file view should not be visible
+    And a toast should mention "File reference not found"
+    And there should be no page errors
+
+  @mobile
   Scenario: Close button dismisses the drawer
     When I run "rm -rf /tmp/kolu-mobile-close && git init /tmp/kolu-mobile-close && cd /tmp/kolu-mobile-close"
     And I run "echo hi > x.txt"

--- a/packages/tests/features/mobile-code-browse.feature
+++ b/packages/tests/features/mobile-code-browse.feature
@@ -52,11 +52,17 @@ Feature: Mobile code browser
     # rejected with "path escapes root" or EISDIR depending on where
     # the repo root sat. `resolveLineRefPath` in `MobileCodeSheet`
     # now strips the repo prefix before the slot is written.
-    When I run "rm -rf /tmp/kolu-mobile-abs && git init /tmp/kolu-mobile-abs && cd /tmp/kolu-mobile-abs"
-    And I run "echo hello > README.md"
-    And I run "git add README.md && git commit -m init"
-    And I run "echo /tmp/kolu-mobile-abs/README.md"
-    And I tap terminal text "/tmp/kolu-mobile-abs/README.md"
+    #
+    # The path is kept short (`/tmp/k-abs/r.md`) so it fits on a
+    # single physical buffer row at the darwin-CI mobile-emulated
+    # viewport width — the production code now joins wrapped rows
+    # before parsing, but the test's buffer scan is cheaper when
+    # the target never spans a wrap.
+    When I run "rm -rf /tmp/k-abs && git init /tmp/k-abs && cd /tmp/k-abs"
+    And I run "echo hi > r.md"
+    And I run "git add r.md && git commit -m i"
+    And I run "echo /tmp/k-abs/r.md"
+    And I tap terminal text "/tmp/k-abs/r.md"
     Then the mobile code sheet should be visible
     And the mobile file view should be visible
     And there should be no page errors
@@ -68,9 +74,9 @@ Feature: Mobile code browser
     # the absolute string at `fsReadFile` and render a server error.
     # Now it toasts and leaves the slot empty so the tree stays
     # visible.
-    When I run "rm -rf /tmp/kolu-mobile-offrepo && git init /tmp/kolu-mobile-offrepo && cd /tmp/kolu-mobile-offrepo"
-    And I run "echo hello > a.txt"
-    And I run "git add a.txt && git commit -m init"
+    When I run "rm -rf /tmp/k-off && git init /tmp/k-off && cd /tmp/k-off"
+    And I run "echo hi > a.txt"
+    And I run "git add a.txt && git commit -m i"
     And I run "echo /etc/passwd"
     And I tap terminal text "/etc/passwd"
     Then the mobile code sheet should be visible

--- a/packages/tests/features/mobile-code-browse.feature
+++ b/packages/tests/features/mobile-code-browse.feature
@@ -13,7 +13,7 @@ Feature: Mobile code browser
 
   @mobile
   Scenario: Files button opens the mobile code sheet
-    When I run "git init /tmp/kolu-mobile-files && cd /tmp/kolu-mobile-files"
+    When I run "rm -rf /tmp/kolu-mobile-files && git init /tmp/kolu-mobile-files && cd /tmp/kolu-mobile-files"
     And I run "echo hello > a.txt"
     And I run "git add a.txt && git commit -m init"
     And I tap the mobile pull handle
@@ -24,7 +24,7 @@ Feature: Mobile code browser
 
   @mobile
   Scenario: Tapping a text file shows its content
-    When I run "git init /tmp/kolu-mobile-text && cd /tmp/kolu-mobile-text"
+    When I run "rm -rf /tmp/kolu-mobile-text && git init /tmp/kolu-mobile-text && cd /tmp/kolu-mobile-text"
     And I run "echo hello > readme.txt"
     And I run "git add readme.txt && git commit -m init"
     And I tap the mobile pull handle
@@ -35,7 +35,7 @@ Feature: Mobile code browser
 
   @mobile
   Scenario: Tapping an HTML file shows the iframe preview
-    When I run "git init /tmp/kolu-mobile-html && cd /tmp/kolu-mobile-html"
+    When I run "rm -rf /tmp/kolu-mobile-html && git init /tmp/kolu-mobile-html && cd /tmp/kolu-mobile-html"
     And I run "printf '<h1>hi</h1>' > index.html"
     And I run "git add index.html && git commit -m init"
     And I tap the mobile pull handle
@@ -46,7 +46,7 @@ Feature: Mobile code browser
 
   @mobile
   Scenario: Back arrow dismisses the detail view
-    When I run "git init /tmp/kolu-mobile-back && cd /tmp/kolu-mobile-back"
+    When I run "rm -rf /tmp/kolu-mobile-back && git init /tmp/kolu-mobile-back && cd /tmp/kolu-mobile-back"
     And I run "echo hi > foo.md"
     And I run "git add foo.md && git commit -m init"
     And I tap the mobile pull handle
@@ -59,7 +59,7 @@ Feature: Mobile code browser
 
   @mobile
   Scenario: Close button dismisses the drawer
-    When I run "git init /tmp/kolu-mobile-close && cd /tmp/kolu-mobile-close"
+    When I run "rm -rf /tmp/kolu-mobile-close && git init /tmp/kolu-mobile-close && cd /tmp/kolu-mobile-close"
     And I run "echo hi > x.txt"
     And I run "git add x.txt && git commit -m init"
     And I tap the mobile pull handle

--- a/packages/tests/features/mobile-drawer.feature
+++ b/packages/tests/features/mobile-drawer.feature
@@ -1,7 +1,7 @@
 Feature: Mobile chrome drawer
   On mobile, the persistent chrome bar is replaced by a pull-down
   drawer (`MobileChromeSheet`) carrying global controls — command
-  palette, settings, inspector toggle. Tapping the top pull-handle
+  palette, settings, files browser. Tapping the top pull-handle
   opens it; tapping the backdrop dismisses it.
 
   Terminal navigation lives in a separate left-edge swipe drawer

--- a/packages/tests/step_definitions/mobile_code_browse_steps.ts
+++ b/packages/tests/step_definitions/mobile_code_browse_steps.ts
@@ -24,19 +24,26 @@ When(
   "I tap mobile file {string}",
   async function (this: KoluWorld, path: string) {
     // Wait for the row to appear — `fsListAll` is a live stream that may
-    // arrive shortly after the drawer opens.
+    // arrive shortly after the drawer opens. Pierre's virtualized tree
+    // repositions rows reactively, so Playwright's stability check
+    // never settles on a tap target inside the drawer; `dispatchEvent`
+    // fires the click event the row's handler listens for without the
+    // stability/visibility actionability gate.
     const row = this.page.locator(fileRow(path));
     await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await row.tap();
+    await row.dispatchEvent("click");
+    await this.waitForFrame();
   },
 );
 
 When("I tap the mobile code back button", async function (this: KoluWorld) {
-  await this.page.locator(CODE_BACK).tap();
+  await this.page.locator(CODE_BACK).dispatchEvent("click");
+  await this.waitForFrame();
 });
 
 When("I tap the mobile code close button", async function (this: KoluWorld) {
-  await this.page.locator(CODE_CLOSE).tap();
+  await this.page.locator(CODE_CLOSE).dispatchEvent("click");
+  await this.waitForFrame();
 });
 
 Then(
@@ -72,6 +79,15 @@ Then(
     await this.page
       .locator(FILE_VIEW)
       .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the mobile file view should not be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(FILE_VIEW)
+      .waitFor({ state: "hidden", timeout: POLL_TIMEOUT });
   },
 );
 

--- a/packages/tests/step_definitions/mobile_code_browse_steps.ts
+++ b/packages/tests/step_definitions/mobile_code_browse_steps.ts
@@ -79,6 +79,49 @@ When("I tap the mobile code close button", async function (this: KoluWorld) {
 When(
   "I tap terminal text {string}",
   async function (this: KoluWorld, target: string) {
+    // The preceding `I run` step only waits one frame after typing — the
+    // PTY → server → SSE → xterm render chain takes longer, so the
+    // freshly-echoed target text may not have hit the buffer yet on a
+    // loaded CI host. Poll the buffer for the target's presence (any
+    // non-prompt row whose joined logical line contains it) before
+    // computing the tap point — `waitForFunction` retries on a 25ms
+    // cadence, so the first frame that lands the output unblocks us.
+    await this.page.waitForFunction(
+      (targetText) => {
+        type BL = {
+          translateToString(trim?: boolean): string;
+          isWrapped: boolean;
+        };
+        type X = {
+          buffer: {
+            active: {
+              viewportY: number;
+              length: number;
+              getLine(i: number): BL | undefined;
+            };
+          };
+        };
+        const el = document.querySelector("[data-focused]") as
+          | (HTMLElement & { __xterm?: X })
+          | null;
+        const t = el?.__xterm;
+        if (!t) return false;
+        const b = t.buffer.active;
+        for (let r = 0; r < b.length; r++) {
+          let line = b.getLine(r)?.translateToString(false) ?? "";
+          let s = r;
+          while (s + 1 < b.length && b.getLine(s + 1)?.isWrapped) {
+            line += b.getLine(s + 1)?.translateToString(false) ?? "";
+            s++;
+          }
+          if (!line.includes("❯") && line.includes(targetText)) return true;
+          r = s;
+        }
+        return false;
+      },
+      target,
+      { timeout: 15000 },
+    );
     const point = await this.page.evaluate((targetText) => {
       type BufferLine = {
         translateToString(trim?: boolean): string;

--- a/packages/tests/step_definitions/mobile_code_browse_steps.ts
+++ b/packages/tests/step_definitions/mobile_code_browse_steps.ts
@@ -1,0 +1,85 @@
+/** Steps for the mobile code-browser drawer — see
+ *  `MobileCodeSheet.tsx`, `MobileTileView.tsx`, `MobileChromeSheet.tsx`. */
+
+import { Then, When } from "@cucumber/cucumber";
+import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+
+const FILES_TRIGGER = '[data-testid="mobile-files-trigger"]';
+const CODE_SHEET = '[data-testid="mobile-code-sheet"]';
+const CODE_BACK = '[data-testid="mobile-code-back"]';
+const CODE_CLOSE = '[data-testid="mobile-code-close"]';
+const TREE = '[data-testid="pierre-file-tree"]';
+const FILE_VIEW = '[data-testid="pierre-file-view"]';
+const PREVIEW_IFRAME = '[data-testid="browse-preview-iframe"]';
+
+function fileRow(path: string): string {
+  return `${TREE} [data-item-path="${path}"][data-item-type="file"]:not([data-file-tree-sticky-row])`;
+}
+
+When("I tap the mobile files button", async function (this: KoluWorld) {
+  await this.page.locator(FILES_TRIGGER).tap();
+});
+
+When(
+  "I tap mobile file {string}",
+  async function (this: KoluWorld, path: string) {
+    // Wait for the row to appear — `fsListAll` is a live stream that may
+    // arrive shortly after the drawer opens.
+    const row = this.page.locator(fileRow(path));
+    await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await row.tap();
+  },
+);
+
+When("I tap the mobile code back button", async function (this: KoluWorld) {
+  await this.page.locator(CODE_BACK).tap();
+});
+
+When("I tap the mobile code close button", async function (this: KoluWorld) {
+  await this.page.locator(CODE_CLOSE).tap();
+});
+
+Then(
+  "the mobile code sheet should be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(CODE_SHEET)
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the mobile code sheet should not be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(CODE_SHEET)
+      .waitFor({ state: "hidden", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the mobile file tree should contain {string}",
+  async function (this: KoluWorld, path: string) {
+    await this.page
+      .locator(fileRow(path))
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the mobile file view should be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(FILE_VIEW)
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
+Then(
+  "the mobile html preview should be visible",
+  async function (this: KoluWorld) {
+    await this.page
+      .locator(PREVIEW_IFRAME)
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);

--- a/packages/tests/step_definitions/mobile_code_browse_steps.ts
+++ b/packages/tests/step_definitions/mobile_code_browse_steps.ts
@@ -2,7 +2,11 @@
  *  `MobileCodeSheet.tsx`, `MobileTileView.tsx`, `MobileChromeSheet.tsx`. */
 
 import { Then, When } from "@cucumber/cucumber";
-import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import {
+  HYDRATION_TIMEOUT,
+  type KoluWorld,
+  POLL_TIMEOUT,
+} from "../support/world.ts";
 
 const FILES_TRIGGER = '[data-testid="mobile-files-trigger"]';
 const CODE_SHEET = '[data-testid="mobile-code-sheet"]';
@@ -16,6 +20,27 @@ function fileRow(path: string): string {
   return `${TREE} [data-item-path="${path}"][data-item-type="file"]:not([data-file-tree-sticky-row])`;
 }
 
+/** Two-step wait mirroring `waitForCodeTabReady` in `code_tab_steps.ts`.
+ *  The full chain (`fs.watcher → server → SSE → SolidJS → Pierre mount`)
+ *  can take well over the per-interaction `POLL_TIMEOUT` on a loaded
+ *  darwin CI runner — fusing both axes into one wait starves the slow
+ *  hydration side. Wait for any non-sticky row at the hydration budget,
+ *  then the specific row at the interaction budget. */
+async function waitForMobileTreeRow(
+  world: KoluWorld,
+  path: string,
+): Promise<void> {
+  await world.page
+    .locator(
+      `${TREE} [data-item-path][data-item-type]:not([data-file-tree-sticky-row])`,
+    )
+    .first()
+    .waitFor({ state: "visible", timeout: HYDRATION_TIMEOUT });
+  await world.page
+    .locator(fileRow(path))
+    .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+}
+
 When("I tap the mobile files button", async function (this: KoluWorld) {
   await this.page.locator(FILES_TRIGGER).tap();
 });
@@ -23,15 +48,12 @@ When("I tap the mobile files button", async function (this: KoluWorld) {
 When(
   "I tap mobile file {string}",
   async function (this: KoluWorld, path: string) {
-    // Wait for the row to appear — `fsListAll` is a live stream that may
-    // arrive shortly after the drawer opens. Pierre's virtualized tree
-    // repositions rows reactively, so Playwright's stability check
-    // never settles on a tap target inside the drawer; `dispatchEvent`
-    // fires the click event the row's handler listens for without the
-    // stability/visibility actionability gate.
-    const row = this.page.locator(fileRow(path));
-    await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await row.dispatchEvent("click");
+    // Pierre's virtualized tree repositions rows reactively, so
+    // Playwright's stability check never settles on a tap target inside
+    // the drawer; `dispatchEvent` fires the click event the row's handler
+    // listens for without the stability/visibility actionability gate.
+    await waitForMobileTreeRow(this, path);
+    await this.page.locator(fileRow(path)).dispatchEvent("click");
     await this.waitForFrame();
   },
 );
@@ -67,9 +89,7 @@ Then(
 Then(
   "the mobile file tree should contain {string}",
   async function (this: KoluWorld, path: string) {
-    await this.page
-      .locator(fileRow(path))
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitForMobileTreeRow(this, path);
   },
 );
 

--- a/packages/tests/step_definitions/mobile_code_browse_steps.ts
+++ b/packages/tests/step_definitions/mobile_code_browse_steps.ts
@@ -68,6 +68,97 @@ When("I tap the mobile code close button", async function (this: KoluWorld) {
   await this.waitForFrame();
 });
 
+/** Dispatch a synthetic touchstart on the buffer cell where `target`
+ *  appears in the active terminal's output. Exercises the
+ *  touchstart-capture handler in `Terminal.tsx` that powers mobile
+ *  file-ref taps — xterm's hover-armed link provider never fires on
+ *  iOS, so kolu intercepts the touch directly. The test path bypasses
+ *  Playwright's tap actionability gates (which never settle against
+ *  xterm's reactive buffer rendering) and goes straight at the
+ *  handler the production code registers. */
+When(
+  "I tap terminal text {string}",
+  async function (this: KoluWorld, target: string) {
+    const point = await this.page.evaluate((targetText) => {
+      type BufferLine = { translateToString(trim?: boolean): string };
+      type XtermForClick = {
+        cols: number;
+        rows: number;
+        buffer: {
+          active: {
+            viewportY: number;
+            length: number;
+            getLine(index: number): BufferLine | undefined;
+          };
+        };
+      };
+      const el = document.querySelector("[data-focused]") as
+        | (HTMLElement & { __xterm?: XtermForClick })
+        | null;
+      const term = el?.__xterm;
+      const screen = el?.querySelector(".xterm-screen");
+      if (!el || !term || !screen) return null;
+      const b = term.buffer.active;
+      const top = b.viewportY;
+      for (let row = top; row < top + term.rows; row++) {
+        const line = b.getLine(row)?.translateToString(true) ?? "";
+        // Skip the command-echo line (prompt + typed text). Prompt
+        // glyphs vary by shell; `❯` covers starship's default.
+        if (line.includes("❯")) continue;
+        const col = line.indexOf(targetText);
+        if (col < 0) continue;
+        const rect = (screen as Element).getBoundingClientRect();
+        const cellW = rect.width / term.cols;
+        const cellH = rect.height / term.rows;
+        const x = rect.left + (col + targetText.length / 2) * cellW;
+        const y = rect.top + (row - top + 0.5) * cellH;
+        return { x, y };
+      }
+      return null;
+    }, target);
+    if (!point) {
+      throw new Error(`terminal text "${target}" not found in viewport`);
+    }
+    await this.page.evaluate((p) => {
+      const el = document.querySelector("[data-focused]");
+      if (!el) return;
+      const touch = new Touch({
+        identifier: 1,
+        target: el,
+        clientX: p.x,
+        clientY: p.y,
+        pageX: p.x,
+        pageY: p.y,
+        screenX: p.x,
+        screenY: p.y,
+        radiusX: 1,
+        radiusY: 1,
+        rotationAngle: 0,
+        force: 1,
+      });
+      el.dispatchEvent(
+        new TouchEvent("touchstart", {
+          cancelable: true,
+          bubbles: true,
+          touches: [touch],
+          targetTouches: [touch],
+          changedTouches: [touch],
+        }),
+      );
+    }, point);
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "a toast should mention {string}",
+  async function (this: KoluWorld, fragment: string) {
+    await this.page
+      .locator(`[data-sonner-toast]`, { hasText: fragment })
+      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  },
+);
+
 Then(
   "the mobile code sheet should be visible",
   async function (this: KoluWorld) {

--- a/packages/tests/step_definitions/mobile_code_browse_steps.ts
+++ b/packages/tests/step_definitions/mobile_code_browse_steps.ts
@@ -80,7 +80,10 @@ When(
   "I tap terminal text {string}",
   async function (this: KoluWorld, target: string) {
     const point = await this.page.evaluate((targetText) => {
-      type BufferLine = { translateToString(trim?: boolean): string };
+      type BufferLine = {
+        translateToString(trim?: boolean): string;
+        isWrapped: boolean;
+      };
       type XtermForClick = {
         cols: number;
         rows: number;
@@ -100,19 +103,46 @@ When(
       if (!el || !term || !screen) return null;
       const b = term.buffer.active;
       const top = b.viewportY;
-      for (let row = top; row < top + term.rows; row++) {
-        const line = b.getLine(row)?.translateToString(true) ?? "";
+      // Walk physical rows, joining wrapped continuations into logical
+      // lines. Mobile-emulated viewports are narrow enough that
+      // `/tmp/some/long/path.txt` echoes split across rows — searching
+      // physical rows alone misses the target on `aarch64-darwin` CI
+      // even though it's right there in the buffer. `isWrapped` flags
+      // continuations (false on the first row of each logical line).
+      const cols = term.cols;
+      const rect = (screen as Element).getBoundingClientRect();
+      const cellW = rect.width / cols;
+      const cellH = rect.height / term.rows;
+      let r = top;
+      while (r < top + term.rows) {
+        let joined = b.getLine(r)?.translateToString(false) ?? "";
+        let endRow = r;
+        while (
+          endRow + 1 < top + term.rows &&
+          b.getLine(endRow + 1)?.isWrapped
+        ) {
+          joined += b.getLine(endRow + 1)?.translateToString(false) ?? "";
+          endRow++;
+        }
         // Skip the command-echo line (prompt + typed text). Prompt
-        // glyphs vary by shell; `❯` covers starship's default.
-        if (line.includes("❯")) continue;
-        const col = line.indexOf(targetText);
-        if (col < 0) continue;
-        const rect = (screen as Element).getBoundingClientRect();
-        const cellW = rect.width / term.cols;
-        const cellH = rect.height / term.rows;
-        const x = rect.left + (col + targetText.length / 2) * cellW;
-        const y = rect.top + (row - top + 0.5) * cellH;
-        return { x, y };
+        // glyphs vary by shell; `❯` covers starship's default. Apply
+        // to the JOINED line so wrapped echoes are still filtered.
+        if (!joined.includes("❯")) {
+          const idx = joined.indexOf(targetText);
+          if (idx >= 0) {
+            // Map the logical-string offset back to a physical (row, col)
+            // — `idx + targetText.length/2` lands on a cell inside the
+            // target so the touch hits the production handler's cell-hit
+            // test even when the target wraps.
+            const mid = idx + Math.floor(targetText.length / 2);
+            const physRow = r + Math.floor(mid / cols);
+            const physCol = mid % cols;
+            const x = rect.left + (physCol + 0.5) * cellW;
+            const y = rect.top + (physRow - top + 0.5) * cellH;
+            return { x, y };
+          }
+        }
+        r = endRow + 1;
       }
       return null;
     }, target);

--- a/packages/tests/step_definitions/mobile_code_browse_steps.ts
+++ b/packages/tests/step_definitions/mobile_code_browse_steps.ts
@@ -87,6 +87,7 @@ When(
       type XtermForClick = {
         cols: number;
         rows: number;
+        scrollToBottom(): void;
         buffer: {
           active: {
             viewportY: number;
@@ -101,26 +102,33 @@ When(
       const term = el?.__xterm;
       const screen = el?.querySelector(".xterm-screen");
       if (!el || !term || !screen) return null;
+      // The mobile-emulated viewport's soft-keyboard pop and reactive
+      // chrome-sheet animations can leave the terminal scrolled away
+      // from the most recent output. Anchor to the bottom so the
+      // freshly-echoed path lands in the row scan below.
+      term.scrollToBottom();
       const b = term.buffer.active;
       const top = b.viewportY;
+      const cols = term.cols;
+      const rect = (screen as Element).getBoundingClientRect();
+      const cellW = rect.width / cols;
+      const cellH = rect.height / term.rows;
       // Walk physical rows, joining wrapped continuations into logical
       // lines. Mobile-emulated viewports are narrow enough that
       // `/tmp/some/long/path.txt` echoes split across rows — searching
       // physical rows alone misses the target on `aarch64-darwin` CI
       // even though it's right there in the buffer. `isWrapped` flags
       // continuations (false on the first row of each logical line).
-      const cols = term.cols;
-      const rect = (screen as Element).getBoundingClientRect();
-      const cellW = rect.width / cols;
-      const cellH = rect.height / term.rows;
-      let r = top;
+      // If the viewport starts mid-line (logical line begun above
+      // `top`), walk back to that line's start so the join captures
+      // every wrapped segment.
+      let lineStart = top;
+      while (lineStart > 0 && b.getLine(lineStart)?.isWrapped) lineStart--;
+      let r = lineStart;
       while (r < top + term.rows) {
         let joined = b.getLine(r)?.translateToString(false) ?? "";
         let endRow = r;
-        while (
-          endRow + 1 < top + term.rows &&
-          b.getLine(endRow + 1)?.isWrapped
-        ) {
+        while (endRow + 1 < b.length && b.getLine(endRow + 1)?.isWrapped) {
           joined += b.getLine(endRow + 1)?.translateToString(false) ?? "";
           endRow++;
         }
@@ -137,9 +145,14 @@ When(
             const mid = idx + Math.floor(targetText.length / 2);
             const physRow = r + Math.floor(mid / cols);
             const physCol = mid % cols;
-            const x = rect.left + (physCol + 0.5) * cellW;
-            const y = rect.top + (physRow - top + 0.5) * cellH;
-            return { x, y };
+            // Only return if the cell is actually inside the viewport
+            // — a logical line straddling viewport edges might match
+            // on a segment that's scrolled out.
+            if (physRow >= top && physRow < top + term.rows) {
+              const x = rect.left + (physCol + 0.5) * cellW;
+              const y = rect.top + (physRow - top + 0.5) * cellH;
+              return { x, y };
+            }
           }
         }
         r = endRow + 1;


### PR DESCRIPTION
**Mobile users can now browse the active terminal's repo files and view code from a phone**, including HTML artifacts rendered in the same sandboxed iframe the desktop uses. On mobile the right panel is hidden — there's no width for a side column — so the desktop Code tab had no surface. A new **Files** button on the chrome sheet opens a bottom modal drawer (`MobileCodeSheet`) that hosts Pierre's `FileTree` and the existing `BrowseFileDispatcher`. Tap a file, see it; HTML / SVG / PDF render in an iframe just like on desktop.

### How it fits together

```
Chrome sheet ─Files button─▶ MobileTileView ─filesOpen─▶ MobileCodeSheet
                                                        │
                                                  ┌─────┴─────┐
                                                  ▼           ▼
                                          Pierre FileTree   BrowseFileDispatcher
                                          (fsListAll)        ├─ text  → CodeView
                                                             └─ binary → iframe
```

The mobile surface reuses every shared primitive — `BrowseFileDispatcher`, Pierre's `FileTree`, `useRightPanel.selectedFile`, the `fsListAll` stream. The detail-view UX is the only thing that's mobile-specific. Selection lives in the same `"browse"` slot the desktop CodeTab writes, so a phone session that ends on `foo.html` reopens on desktop with `foo.html` already selected.

### Beyond the surface — structural fixes the diff brought to light

Two issues the existing right-panel scope had been masking surfaced when a real mobile file viewer landed; both are fixed in this PR rather than punted:

| Concern | Before | Now |
| --- | --- | --- |
| Mobile `path:line` link clicks in terminal | Wrote `rightPanel.collapsed = false` to **persisted preferences** — no UI effect on mobile but the next desktop session opened with the panel popping out unexpectedly | Branches on `isMobile()` in `Terminal.tsx`; mobile routes through a parallel `openInMobileFiles` helper that opens the drawer without touching desktop prefs |
| `useRightPanel.setSelectedFile` accepted `null` to mean clear | Every caller (CodeTab, MobileCodeSheet) duplicated the Pierre-fires-null-during-resubscribe guard | Split into `setSelectedFile(mode, path: string)` + `clearSelectedFile(mode)` — the rule moves inside the receptacle, no caller can reach `null` into the store by accident |

The chrome sheet's old Inspector toggle (a no-op on mobile because the right panel was hidden) is repurposed as the Files trigger — _one click, one effect, no stale-preference foot-gun._

### Post-polish refinements (mobile/desktop deduplication)

A second `/do --from polish` pass with focus on _"not duplicating stuff between mobile & desktop"_ landed four structural commits that consolidate shape where the two surfaces are doing the same thing, while keeping the **orchestration** modules split (desktop owns panel-uncollapse + tab + mode writes that mobile doesn't need):

| Refinement | Why |
| --- | --- |
| Extract `NavRequest` shared payload type (`navRequest.ts`) | Both front doors carried structurally identical `{ ref, repoRoot, cwd, targetMode }`; new fields land in one place |
| Extract `resolveNavPath(req, repoPaths)` helper | `CodeTab` and `MobileCodeSheet` ran the same `resolveLineRefPath` invocation — one wrapping helper, the `repoPaths` source stays per-consumer |
| Extract `dispatchFileRef(ref)` local helper in `Terminal.tsx` | xterm onActivate and the touchstart capture both built a `NavRequest` and dispatched to the platform front door — one site for meta-read + `isMobile()` branch |
| Mobile line-range highlight on terminal taps | Tapping `foo.ts:42` on mobile now scrolls to and highlights line 42 in the file view — matches desktop CodeTab behaviour (`ref.startLine`/`endLine` were unused on mobile) |

> _Lowy's "bind chrome→files sequencing to Corvu `transitionState`" finding was attempted but reverted — the `Drawer.useContext("chrome")` watcher inside `Drawer.Content` broke mobile init in a way that couldn't be isolated within the test budget. The existing `setTimeout(220)` in `MobileChromeSheet` keeps working; the cross-file coupling with `OVERLAY_CLASS`'s `duration-200` is documented as a future cleanup._

### Refinements during earlier structural review

- `MobileCodeSheet`'s error/loading branch uses `Switch`/`Match` (error first, ready second) to mirror `CodeTab`
- Tree stays mounted under the detail overlay rather than unmount/remount on every back-arrow — Pierre's virtualizer occasionally got stuck on remount under parallel test load
- Back button uses a `hidden`-class toggle instead of `<Show>` so e2e selectors stay stable across the overlay transition

### Coverage

New `packages/tests/features/mobile-code-browse.feature` — six scenarios covering the Files button trigger, text-file view, HTML iframe preview, absolute-path tap resolution, off-repo tap toast, and close-button dismiss. All 80 scenarios across mobile-code-browse + mobile-drawer + code-tab + file-ref-link pass locally.

### Try it locally

```sh
nix run github:juspay/kolu/html-mobile
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._