### PR TITLE
Only summon the iOS soft keyboard on tap, not touch-scroll

### DIFF
--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -544,25 +544,31 @@ const Terminal: Component<{
               // ~1-cell-height step the scroll handler at line 716 reads as
               // "scroll started".
               const TAP_THRESHOLD_PX = 10;
-              let tapStartX = 0;
-              let tapStartY = 0;
-              let tapPointerId: number | null = null;
+              let activeTap: {
+                pointerId: number;
+                startX: number;
+                startY: number;
+              } | null = null;
               makeEventListener(screen, "pointerdown", (e: PointerEvent) => {
                 e.preventDefault();
-                tapStartX = e.clientX;
-                tapStartY = e.clientY;
-                tapPointerId = e.pointerId;
+                activeTap = {
+                  pointerId: e.pointerId,
+                  startX: e.clientX,
+                  startY: e.clientY,
+                };
               });
               makeEventListener(screen, "pointerup", (e: PointerEvent) => {
-                if (e.pointerId !== tapPointerId) return;
-                tapPointerId = null;
-                const dx = e.clientX - tapStartX;
-                const dy = e.clientY - tapStartY;
+                if (activeTap === null || e.pointerId !== activeTap.pointerId)
+                  return;
+                const { startX, startY } = activeTap;
+                activeTap = null;
+                const dx = e.clientX - startX;
+                const dy = e.clientY - startY;
                 if (Math.hypot(dx, dy) > TAP_THRESHOLD_PX) return;
                 term.focus();
               });
               makeEventListener(screen, "pointercancel", (e: PointerEvent) => {
-                if (e.pointerId === tapPointerId) tapPointerId = null;
+                if (activeTap?.pointerId === e.pointerId) activeTap = null;
               });
             }
           }

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -532,14 +532,37 @@ const Terminal: Component<{
               // when the wrapper-click handler (line 500) fires
               // term.focus() right after the browser auto-focuses
               // .xterm-screen on pointerdown. preventDefault on pointerdown
-              // blocks the contenteditable auto-focus, and the same handler
-              // routes focus straight to xterm's input surface — a single
-              // focus event in the user-gesture window, no shuffle for iOS
-              // to reject. Mirrors the MobileKeyBar.tsx:60 pattern that
-              // already keeps the textarea focused across key taps.
+              // blocks the contenteditable auto-focus.
+              //
+              // Defer the focus call to pointerup, gated on a tap-sized
+              // movement threshold: taps summon the keyboard, touch-scrolls
+              // don't. pointerup still fires inside the user-gesture window
+              // iOS requires for programmatic focus, and the call sees the
+              // same "single focus event, no shuffle" iOS heuristic the
+              // pointerdown variant did. Threshold is generous enough to
+              // tolerate finger jitter on a real tap but tighter than the
+              // ~1-cell-height step the scroll handler at line 716 reads as
+              // "scroll started".
+              const TAP_THRESHOLD_PX = 10;
+              let tapStartX = 0;
+              let tapStartY = 0;
+              let tapPointerId: number | null = null;
               makeEventListener(screen, "pointerdown", (e: PointerEvent) => {
                 e.preventDefault();
+                tapStartX = e.clientX;
+                tapStartY = e.clientY;
+                tapPointerId = e.pointerId;
+              });
+              makeEventListener(screen, "pointerup", (e: PointerEvent) => {
+                if (e.pointerId !== tapPointerId) return;
+                tapPointerId = null;
+                const dx = e.clientX - tapStartX;
+                const dy = e.clientY - tapStartY;
+                if (Math.hypot(dx, dy) > TAP_THRESHOLD_PX) return;
                 term.focus();
+              });
+              makeEventListener(screen, "pointercancel", (e: PointerEvent) => {
+                if (e.pointerId === tapPointerId) tapPointerId = null;
               });
             }
           }

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -544,6 +544,8 @@ const Terminal: Component<{
               // ~1-cell-height step the scroll handler at line 716 reads as
               // "scroll started".
               const TAP_THRESHOLD_PX = 10;
+              const isTap = (dx: number, dy: number) =>
+                Math.hypot(dx, dy) <= TAP_THRESHOLD_PX;
               let activeTap: {
                 pointerId: number;
                 startX: number;
@@ -562,9 +564,7 @@ const Terminal: Component<{
                   return;
                 const { startX, startY } = activeTap;
                 activeTap = null;
-                const dx = e.clientX - startX;
-                const dy = e.clientY - startY;
-                if (Math.hypot(dx, dy) > TAP_THRESHOLD_PX) return;
+                if (!isTap(e.clientX - startX, e.clientY - startY)) return;
                 term.focus();
               });
               makeEventListener(screen, "pointercancel", (e: PointerEvent) => {

--- a/packages/tests/features/mobile-soft-keyboard.feature
+++ b/packages/tests/features/mobile-soft-keyboard.feature
@@ -48,6 +48,16 @@ Feature: Mobile soft keyboard
     And there should be no page errors
 
   @mobile
+  Scenario: Touch-scrolling the terminal does not summon the soft keyboard
+    # The pointerdown→focus pattern that unstuck the iOS keyboard would also
+    # fire at scroll-start — every swipe popped the keyboard mid-read. Defer
+    # the focus call to pointerup, gated on a tap-sized movement threshold:
+    # taps still summon the keyboard; scrolls don't.
+    When I touch-scroll inside the terminal canvas
+    Then xterm's helper textarea should not have been focused by the scroll
+    And there should be no page errors
+
+  @mobile
   Scenario: App root tracks visualViewport.height so the keyboard doesn't overlap the terminal
     # iOS Safari overlays the soft keyboard on top of the layout viewport;
     # `100dvh` doesn't shrink. useVisualViewportHeight sets `--app-h` on

--- a/packages/tests/features/mobile-soft-keyboard.feature
+++ b/packages/tests/features/mobile-soft-keyboard.feature
@@ -58,6 +58,16 @@ Feature: Mobile soft keyboard
     And there should be no page errors
 
   @mobile
+  Scenario: A canceled gesture clears state so a trailing pointerup does not focus
+    # The pointercancel branch in the tap handler clears activeTap so a
+    # later pointerup (system-cancelled gesture, browser-glitch sequence)
+    # can't slip through and focus the textarea on its way past — popping
+    # the soft keyboard with nothing behind it.
+    When I cancel a pointer gesture on the terminal canvas mid-tap
+    Then xterm's helper textarea should not have been focused by the canceled gesture
+    And there should be no page errors
+
+  @mobile
   Scenario: App root tracks visualViewport.height so the keyboard doesn't overlap the terminal
     # iOS Safari overlays the soft keyboard on top of the layout viewport;
     # `100dvh` doesn't shrink. useVisualViewportHeight sets `--app-h` on

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -137,11 +137,11 @@ When(
     const x = box.x + box.width / 2;
     const startY = box.y + box.height - 30;
     const endY = box.y + 30;
-    const steps = 6;
-    const ys: number[] = [];
-    for (let i = 1; i <= steps; i++) {
-      ys.push(startY + ((endY - startY) * i) / steps);
-    }
+    // 6 intermediate y-positions from startY toward endY — simulates an upward swipe.
+    const ys = Array.from(
+      { length: 6 },
+      (_, i) => startY + ((endY - startY) * (i + 1)) / 6,
+    );
 
     await this.page.evaluate(
       ({ sel, x, startY, ys }) => {
@@ -162,7 +162,7 @@ When(
         };
         dispatch("pointerdown", startY);
         for (const y of ys) dispatch("pointermove", y);
-        dispatch("pointerup", ys[ys.length - 1] ?? startY);
+        dispatch("pointerup", ys.at(-1) ?? startY);
       },
       { sel: XTERM_SCREEN, x, startY, ys },
     );

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -4,10 +4,14 @@ import { ACTIVE_TERMINAL } from "../support/buffer.ts";
 import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
 /** Browser-side window augmentation used by the focus-shuffle detection probe
- *  and the touch-scroll-no-focus probe (textarea focus counter). */
+ *  and the touch-scroll-no-focus probe. Listener refs are stashed alongside
+ *  the counters so the Then-step can detach them after asserting, keeping
+ *  state from leaking across scenarios that share the same page. */
 type FocusProbeWindow = Window & {
   __screenFocusCount?: number;
+  __screenFocusListener?: EventListener;
   __textareaFocusCount?: number;
+  __textareaFocusListener?: EventListener;
 };
 
 const KEY_BAR = '[data-testid="mobile-key-bar"]';
@@ -46,9 +50,10 @@ When("I tap the terminal canvas", async function (this: KoluWorld) {
     if (!screen) throw new Error("No .xterm-screen on active terminal");
     const w = window as FocusProbeWindow;
     w.__screenFocusCount = 0;
-    screen.addEventListener("focus", () => {
+    w.__screenFocusListener = () => {
       w.__screenFocusCount = (w.__screenFocusCount ?? 0) + 1;
-    });
+    };
+    screen.addEventListener("focus", w.__screenFocusListener);
   });
 
   // Real CDP touch via Playwright's touchscreen triggers the browser's native
@@ -68,9 +73,18 @@ When("I tap the terminal canvas", async function (this: KoluWorld) {
 Then(
   "the xterm contenteditable screen should never have been focused",
   async function (this: KoluWorld) {
-    const count = await this.page.evaluate(
-      () => (window as FocusProbeWindow).__screenFocusCount ?? 0,
-    );
+    const count = await this.page.evaluate(() => {
+      const w = window as FocusProbeWindow;
+      const value = w.__screenFocusCount ?? 0;
+      const screen = document.querySelector(
+        "[data-visible][data-terminal-id] .xterm-screen",
+      );
+      if (screen && w.__screenFocusListener) {
+        screen.removeEventListener("focus", w.__screenFocusListener);
+      }
+      w.__screenFocusListener = undefined;
+      return value;
+    });
     assert.strictEqual(
       count,
       0,
@@ -114,9 +128,10 @@ When(
       if (!textarea) throw new Error("No xterm helper textarea found");
       const w = window as FocusProbeWindow;
       w.__textareaFocusCount = 0;
-      textarea.addEventListener("focus", () => {
+      w.__textareaFocusListener = () => {
         w.__textareaFocusCount = (w.__textareaFocusCount ?? 0) + 1;
-      });
+      };
+      textarea.addEventListener("focus", w.__textareaFocusListener);
     });
 
     const screen = this.page
@@ -163,9 +178,18 @@ When(
 Then(
   "xterm's helper textarea should not have been focused by the scroll",
   async function (this: KoluWorld) {
-    const count = await this.page.evaluate(
-      () => (window as FocusProbeWindow).__textareaFocusCount ?? 0,
-    );
+    const count = await this.page.evaluate(() => {
+      const w = window as FocusProbeWindow;
+      const value = w.__textareaFocusCount ?? 0;
+      const textarea = document.querySelector(
+        "[data-visible][data-terminal-id] .xterm-helper-textarea",
+      );
+      if (textarea && w.__textareaFocusListener) {
+        textarea.removeEventListener("focus", w.__textareaFocusListener);
+      }
+      w.__textareaFocusListener = undefined;
+      return value;
+    });
     assert.strictEqual(
       count,
       0,

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -198,6 +198,87 @@ Then(
   },
 );
 
+When(
+  "I cancel a pointer gesture on the terminal canvas mid-tap",
+  async function (this: KoluWorld) {
+    // Same install pattern as the touch-scroll step — blur the textarea and
+    // install a focus counter so a stray focus during the sequence trips the
+    // assertion. Then dispatch pointerdown → pointercancel → pointerup at the
+    // same position. With the cancel branch live, the pointerup sees activeTap
+    // cleared and short-circuits; without it, the pointerup would meet the
+    // tap-threshold check (zero movement) and focus the textarea.
+    await this.page.evaluate(() => {
+      const ta = document.activeElement;
+      if (ta instanceof HTMLElement) ta.blur();
+      const textarea = document.querySelector(
+        "[data-visible][data-terminal-id] .xterm-helper-textarea",
+      ) as HTMLTextAreaElement | null;
+      if (!textarea) throw new Error("No xterm helper textarea found");
+      const w = window as FocusProbeWindow;
+      w.__textareaFocusCount = 0;
+      w.__textareaFocusListener = () => {
+        w.__textareaFocusCount = (w.__textareaFocusCount ?? 0) + 1;
+      };
+      textarea.addEventListener("focus", w.__textareaFocusListener);
+    });
+
+    const screen = this.page
+      .locator("[data-visible][data-terminal-id] .xterm-screen")
+      .first();
+    const box = await screen.boundingBox();
+    assert.ok(box, "xterm screen has no bounding box");
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    await this.page.evaluate(
+      ({ sel, x, y }) => {
+        const target = document.querySelector(sel) as HTMLElement | null;
+        if (!target) throw new Error(`No element matches ${sel}`);
+        const dispatch = (type: string) => {
+          target.dispatchEvent(
+            new PointerEvent(type, {
+              clientX: x,
+              clientY: y,
+              pointerId: 1,
+              pointerType: "touch",
+              isPrimary: true,
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        };
+        dispatch("pointerdown");
+        dispatch("pointercancel");
+        dispatch("pointerup");
+      },
+      { sel: "[data-visible][data-terminal-id] .xterm-screen", x, y },
+    );
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "xterm's helper textarea should not have been focused by the canceled gesture",
+  async function (this: KoluWorld) {
+    const count = await this.page.evaluate(() => {
+      const w = window as FocusProbeWindow;
+      const value = w.__textareaFocusCount ?? 0;
+      const textarea = document.querySelector(
+        "[data-visible][data-terminal-id] .xterm-helper-textarea",
+      );
+      if (textarea && w.__textareaFocusListener) {
+        textarea.removeEventListener("focus", w.__textareaFocusListener);
+      }
+      w.__textareaFocusListener = undefined;
+      return value;
+    });
+    assert.strictEqual(
+      count,
+      0,
+      `Expected the textarea to receive no focus event after a canceled gesture, got ${count}`,
+    );
+  },
+);
+
 Then(
   "the --app-h CSS variable should match visualViewport.height",
   async function (this: KoluWorld) {

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -16,6 +16,9 @@ type FocusProbeWindow = Window & {
 
 const KEY_BAR = '[data-testid="mobile-key-bar"]';
 const KEY = (testId: string) => `[data-testid="mobile-key-${testId}"]`;
+const XTERM_SCREEN = "[data-visible][data-terminal-id] .xterm-screen";
+const XTERM_TEXTAREA =
+  "[data-visible][data-terminal-id] .xterm-helper-textarea";
 
 When(
   "I tap the mobile key {string}",
@@ -43,10 +46,8 @@ When("I tap the terminal canvas", async function (this: KoluWorld) {
   // browser focuses the contenteditable on pointerdown and our wrapper-click
   // handler then shuffles to the helper textarea — the smoking gun is a focus
   // event landing on .xterm-screen during the gesture.
-  await this.page.evaluate(() => {
-    const screen = document.querySelector(
-      "[data-visible][data-terminal-id] .xterm-screen",
-    ) as HTMLElement | null;
+  await this.page.evaluate((sel) => {
+    const screen = document.querySelector(sel) as HTMLElement | null;
     if (!screen) throw new Error("No .xterm-screen on active terminal");
     const w = window as FocusProbeWindow;
     w.__screenFocusCount = 0;
@@ -54,13 +55,11 @@ When("I tap the terminal canvas", async function (this: KoluWorld) {
       w.__screenFocusCount = (w.__screenFocusCount ?? 0) + 1;
     };
     screen.addEventListener("focus", w.__screenFocusListener);
-  });
+  }, XTERM_SCREEN);
 
   // Real CDP touch via Playwright's touchscreen triggers the browser's native
   // contenteditable auto-focus heuristic — synthetic dispatchEvent doesn't.
-  const canvas = this.page
-    .locator("[data-visible][data-terminal-id] .xterm-screen canvas")
-    .first();
+  const canvas = this.page.locator(`${XTERM_SCREEN} canvas`).first();
   const box = await canvas.boundingBox();
   assert.ok(box, "xterm canvas has no bounding box");
   await this.page.touchscreen.tap(
@@ -73,18 +72,16 @@ When("I tap the terminal canvas", async function (this: KoluWorld) {
 Then(
   "the xterm contenteditable screen should never have been focused",
   async function (this: KoluWorld) {
-    const count = await this.page.evaluate(() => {
+    const count = await this.page.evaluate((sel) => {
       const w = window as FocusProbeWindow;
       const value = w.__screenFocusCount ?? 0;
-      const screen = document.querySelector(
-        "[data-visible][data-terminal-id] .xterm-screen",
-      );
+      const screen = document.querySelector(sel);
       if (screen && w.__screenFocusListener) {
         screen.removeEventListener("focus", w.__screenFocusListener);
       }
       w.__screenFocusListener = undefined;
       return value;
-    });
+    }, XTERM_SCREEN);
     assert.strictEqual(
       count,
       0,
@@ -119,11 +116,11 @@ When(
     // listens on pointerdown/pointerup. Playwright's touchscreen primitive is
     // tap-only and CDP swipes don't translate to PointerEvents in the same
     // shape the browser emits for real touch.
-    await this.page.evaluate(() => {
+    await this.page.evaluate((sel) => {
       const ta = document.activeElement;
       if (ta instanceof HTMLElement) ta.blur();
       const textarea = document.querySelector(
-        "[data-visible][data-terminal-id] .xterm-helper-textarea",
+        sel,
       ) as HTMLTextAreaElement | null;
       if (!textarea) throw new Error("No xterm helper textarea found");
       const w = window as FocusProbeWindow;
@@ -132,11 +129,9 @@ When(
         w.__textareaFocusCount = (w.__textareaFocusCount ?? 0) + 1;
       };
       textarea.addEventListener("focus", w.__textareaFocusListener);
-    });
+    }, XTERM_TEXTAREA);
 
-    const screen = this.page
-      .locator("[data-visible][data-terminal-id] .xterm-screen")
-      .first();
+    const screen = this.page.locator(XTERM_SCREEN).first();
     const box = await screen.boundingBox();
     assert.ok(box, "xterm screen has no bounding box");
     const x = box.x + box.width / 2;
@@ -169,7 +164,7 @@ When(
         for (const y of ys) dispatch("pointermove", y);
         dispatch("pointerup", ys[ys.length - 1] ?? startY);
       },
-      { sel: "[data-visible][data-terminal-id] .xterm-screen", x, startY, ys },
+      { sel: XTERM_SCREEN, x, startY, ys },
     );
     await this.waitForFrame();
   },
@@ -178,18 +173,16 @@ When(
 Then(
   "xterm's helper textarea should not have been focused by the scroll",
   async function (this: KoluWorld) {
-    const count = await this.page.evaluate(() => {
+    const count = await this.page.evaluate((sel) => {
       const w = window as FocusProbeWindow;
       const value = w.__textareaFocusCount ?? 0;
-      const textarea = document.querySelector(
-        "[data-visible][data-terminal-id] .xterm-helper-textarea",
-      );
+      const textarea = document.querySelector(sel);
       if (textarea && w.__textareaFocusListener) {
         textarea.removeEventListener("focus", w.__textareaFocusListener);
       }
       w.__textareaFocusListener = undefined;
       return value;
-    });
+    }, XTERM_TEXTAREA);
     assert.strictEqual(
       count,
       0,
@@ -207,11 +200,11 @@ When(
     // same position. With the cancel branch live, the pointerup sees activeTap
     // cleared and short-circuits; without it, the pointerup would meet the
     // tap-threshold check (zero movement) and focus the textarea.
-    await this.page.evaluate(() => {
+    await this.page.evaluate((sel) => {
       const ta = document.activeElement;
       if (ta instanceof HTMLElement) ta.blur();
       const textarea = document.querySelector(
-        "[data-visible][data-terminal-id] .xterm-helper-textarea",
+        sel,
       ) as HTMLTextAreaElement | null;
       if (!textarea) throw new Error("No xterm helper textarea found");
       const w = window as FocusProbeWindow;
@@ -220,11 +213,9 @@ When(
         w.__textareaFocusCount = (w.__textareaFocusCount ?? 0) + 1;
       };
       textarea.addEventListener("focus", w.__textareaFocusListener);
-    });
+    }, XTERM_TEXTAREA);
 
-    const screen = this.page
-      .locator("[data-visible][data-terminal-id] .xterm-screen")
-      .first();
+    const screen = this.page.locator(XTERM_SCREEN).first();
     const box = await screen.boundingBox();
     assert.ok(box, "xterm screen has no bounding box");
     const x = box.x + box.width / 2;
@@ -250,7 +241,7 @@ When(
         dispatch("pointercancel");
         dispatch("pointerup");
       },
-      { sel: "[data-visible][data-terminal-id] .xterm-screen", x, y },
+      { sel: XTERM_SCREEN, x, y },
     );
     await this.waitForFrame();
   },
@@ -259,18 +250,16 @@ When(
 Then(
   "xterm's helper textarea should not have been focused by the canceled gesture",
   async function (this: KoluWorld) {
-    const count = await this.page.evaluate(() => {
+    const count = await this.page.evaluate((sel) => {
       const w = window as FocusProbeWindow;
       const value = w.__textareaFocusCount ?? 0;
-      const textarea = document.querySelector(
-        "[data-visible][data-terminal-id] .xterm-helper-textarea",
-      );
+      const textarea = document.querySelector(sel);
       if (textarea && w.__textareaFocusListener) {
         textarea.removeEventListener("focus", w.__textareaFocusListener);
       }
       w.__textareaFocusListener = undefined;
       return value;
-    });
+    }, XTERM_TEXTAREA);
     assert.strictEqual(
       count,
       0,

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -137,21 +137,30 @@ When(
     const x = box.x + box.width / 2;
     const startY = box.y + box.height - 30;
     const endY = box.y + 30;
-    // 6 intermediate y-positions from startY toward endY — simulates an upward swipe.
-    const ys = Array.from(
-      { length: 6 },
-      (_, i) => startY + ((endY - startY) * (i + 1)) / 6,
-    );
+    // Pre-compute the (type, clientY) pairs Node-side and pass as data.
+    // No nested function declarations inside page.evaluate: swc wraps named
+    // functions with a `__name` debug helper that doesn't exist in the
+    // browser, so a dispatch arrow inside evaluate crashes the gesture (see
+    // mobile_terminal_scroll_steps.ts for the same constraint).
+    const intermediate = Array.from({ length: 6 }, (_, i) => ({
+      type: "pointermove",
+      y: startY + ((endY - startY) * (i + 1)) / 6,
+    }));
+    const events: { type: string; y: number }[] = [
+      { type: "pointerdown", y: startY },
+      ...intermediate,
+      { type: "pointerup", y: intermediate.at(-1)?.y ?? startY },
+    ];
 
     await this.page.evaluate(
-      ({ sel, x, startY, ys }) => {
+      ({ sel, x, events }) => {
         const target = document.querySelector(sel) as HTMLElement | null;
         if (!target) throw new Error(`No element matches ${sel}`);
-        const dispatch = (type: string, clientY: number) => {
+        for (const { type, y } of events) {
           target.dispatchEvent(
             new PointerEvent(type, {
               clientX: x,
-              clientY,
+              clientY: y,
               pointerId: 1,
               pointerType: "touch",
               isPrimary: true,
@@ -159,12 +168,9 @@ When(
               cancelable: true,
             }),
           );
-        };
-        dispatch("pointerdown", startY);
-        for (const y of ys) dispatch("pointermove", y);
-        dispatch("pointerup", ys.at(-1) ?? startY);
+        }
       },
-      { sel: XTERM_SCREEN, x, startY, ys },
+      { sel: XTERM_SCREEN, x, events },
     );
     await this.waitForFrame();
   },
@@ -220,11 +226,14 @@ When(
     assert.ok(box, "xterm screen has no bounding box");
     const x = box.x + box.width / 2;
     const y = box.y + box.height / 2;
+    // No nested function declarations inside page.evaluate — see
+    // mobile_terminal_scroll_steps.ts for the swc __name pitfall.
+    const types = ["pointerdown", "pointercancel", "pointerup"];
     await this.page.evaluate(
-      ({ sel, x, y }) => {
+      ({ sel, x, y, types }) => {
         const target = document.querySelector(sel) as HTMLElement | null;
         if (!target) throw new Error(`No element matches ${sel}`);
-        const dispatch = (type: string) => {
+        for (const type of types) {
           target.dispatchEvent(
             new PointerEvent(type, {
               clientX: x,
@@ -236,12 +245,9 @@ When(
               cancelable: true,
             }),
           );
-        };
-        dispatch("pointerdown");
-        dispatch("pointercancel");
-        dispatch("pointerup");
+        }
       },
-      { sel: XTERM_SCREEN, x, y },
+      { sel: XTERM_SCREEN, x, y, types },
     );
     await this.waitForFrame();
   },

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -3,8 +3,12 @@ import { Then, When } from "@cucumber/cucumber";
 import { ACTIVE_TERMINAL } from "../support/buffer.ts";
 import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
-/** Browser-side window augmentation used by the focus-shuffle detection probe. */
-type FocusProbeWindow = Window & { __screenFocusCount?: number };
+/** Browser-side window augmentation used by the focus-shuffle detection probe
+ *  and the touch-scroll-no-focus probe (textarea focus counter). */
+type FocusProbeWindow = Window & {
+  __screenFocusCount?: number;
+  __textareaFocusCount?: number;
+};
 
 const KEY_BAR = '[data-testid="mobile-key-bar"]';
 const KEY = (testId: string) => `[data-testid="mobile-key-${testId}"]`;
@@ -86,6 +90,86 @@ Then(
         document.activeElement?.tagName === "TEXTAREA" &&
         document.activeElement.classList.contains("xterm-helper-textarea"),
       { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+When(
+  "I touch-scroll inside the terminal canvas",
+  async function (this: KoluWorld) {
+    // Blur the textarea (mount auto-focuses it) and install a focus counter
+    // before the gesture, so the assertion below can prove the scroll itself
+    // didn't summon focus — not just that focus was already there.
+    //
+    // Synthetic PointerEvents drive the test because the handler under test
+    // listens on pointerdown/pointerup. Playwright's touchscreen primitive is
+    // tap-only and CDP swipes don't translate to PointerEvents in the same
+    // shape the browser emits for real touch.
+    await this.page.evaluate(() => {
+      const ta = document.activeElement;
+      if (ta instanceof HTMLElement) ta.blur();
+      const textarea = document.querySelector(
+        "[data-visible][data-terminal-id] .xterm-helper-textarea",
+      ) as HTMLTextAreaElement | null;
+      if (!textarea) throw new Error("No xterm helper textarea found");
+      const w = window as FocusProbeWindow;
+      w.__textareaFocusCount = 0;
+      textarea.addEventListener("focus", () => {
+        w.__textareaFocusCount = (w.__textareaFocusCount ?? 0) + 1;
+      });
+    });
+
+    const screen = this.page
+      .locator("[data-visible][data-terminal-id] .xterm-screen")
+      .first();
+    const box = await screen.boundingBox();
+    assert.ok(box, "xterm screen has no bounding box");
+    const x = box.x + box.width / 2;
+    const startY = box.y + box.height - 30;
+    const endY = box.y + 30;
+    const steps = 6;
+    const ys: number[] = [];
+    for (let i = 1; i <= steps; i++) {
+      ys.push(startY + ((endY - startY) * i) / steps);
+    }
+
+    await this.page.evaluate(
+      ({ sel, x, startY, ys }) => {
+        const target = document.querySelector(sel) as HTMLElement | null;
+        if (!target) throw new Error(`No element matches ${sel}`);
+        const dispatch = (type: string, clientY: number) => {
+          target.dispatchEvent(
+            new PointerEvent(type, {
+              clientX: x,
+              clientY,
+              pointerId: 1,
+              pointerType: "touch",
+              isPrimary: true,
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        };
+        dispatch("pointerdown", startY);
+        for (const y of ys) dispatch("pointermove", y);
+        dispatch("pointerup", ys[ys.length - 1] ?? startY);
+      },
+      { sel: "[data-visible][data-terminal-id] .xterm-screen", x, startY, ys },
+    );
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "xterm's helper textarea should not have been focused by the scroll",
+  async function (this: KoluWorld) {
+    const count = await this.page.evaluate(
+      () => (window as FocusProbeWindow).__textareaFocusCount ?? 0,
+    );
+    assert.strictEqual(
+      count,
+      0,
+      `Expected the textarea to receive no focus event during a touch-scroll, got ${count}`,
     );
   },
 );


### PR DESCRIPTION
PR #963 unstuck the iOS soft keyboard by calling `term.focus()` synchronously on `pointerdown` — but **`pointerdown` also fires at the start of every touch-scroll**, so swiping through the terminal popped the keyboard mid-read. On a phone the keyboard then covers the rows the user was scrolling toward, which is the exact frustration the previous PR was trying to fix in the other direction.

Defer the focus call to `pointerup`, gated on a 10px tap-sized movement threshold. Taps still summon the keyboard — `pointerup` is still inside the user-gesture window iOS requires for programmatic focus, and the call still produces the same _single focus event, no shuffle_ shape PR #963's iOS heuristic note relies on. Touch-scroll gestures move past the threshold and the focus call short-circuits.

### Gesture → outcome

| Gesture          | `pointerdown` | `pointerup` displacement | `term.focus()` fires? |
|------------------|---------------|--------------------------|-----------------------|
| Tap              | records start | ≤ 10px                   | ✓ keyboard appears    |
| Touch-scroll     | records start | > 10px                   | — keyboard stays put  |
| Cancelled tap    | records start | (pointercancel clears)   | — keyboard stays put  |

The threshold is generous enough to tolerate finger jitter on a real tap but tighter than the ~1-cell-height step the existing touch-scroll handler (`Terminal.tsx:716`) treats as ''scroll started''.

### What landed where

| Commit        | What                                                                 | Why                                                                                |
|---------------|----------------------------------------------------------------------|------------------------------------------------------------------------------------|
| `5d30b0a0` `fix(mobile)` | `pointerup` + 10px-displacement gate on `.xterm-screen`             | Primary fix — tap focuses, scroll doesn't                                          |
| `9ffcca4a` `refactor(hickey)` | Collapse 3 `let` bindings into one nullable `activeTap` record | Idle/active invariant becomes structural; type-narrowing replaces a manual guard   |
| `eaac2e06` `refactor(hickey)` | Extract `isTap(dx, dy)` predicate inside the closure          | Naming the displacement check; cross-validated by lowy to stay scope-local         |
| `3e2da1da` `refactor(hickey)` | Teardown for both focus-counter probes in mobile soft-keyboard steps | `addEventListener` had no removal path — stashed listener refs cleared after asserts |
| `c27eba98` `test(hickey)` | New `@mobile` scenario covering the `pointercancel` branch        | Pointerdown → pointercancel → pointerup must not focus the textarea                |
| `387de78f` `refactor(police)` | Extract `XTERM_SCREEN` / `XTERM_TEXTAREA` selector constants   | Six inline magic-string selectors collapsed into two named constants               |
| `6962e317` `refactor(police)` | `Array.from` + `at(-1)` for the synthetic-swipe y-positions     | Immutable expression replaces for-push mutation                                    |
| `b169b013` `fix(test)`       | Inline page.evaluate dispatch loops to dodge swc `__name` crash | Nested arrow inside `page.evaluate` got wrapped with an undefined debug helper     |

### How the tests catch regressions

Two new `@mobile` scenarios in `mobile-soft-keyboard.feature`:

- **Touch-scroll wire-check** — install a focus counter on xterm's helper textarea, dispatch a synthetic `pointerdown` + 6 `pointermove`s + `pointerup` with vertical travel well past the 10px gate, assert the counter stays at 0. The pre-fix code (focus on every `pointerdown`) would tip the counter to 1.
- **Pointercancel wire-check** — `pointerdown` → `pointercancel` → `pointerup` at the same position; with the cancel branch live, the trailing `pointerup` sees `activeTap === null` and short-circuits. Without the cancel branch, the zero-displacement `pointerup` would pass the tap-threshold check and focus the textarea.

Real-device verification on a physical iPhone is still the authoritative final check — Chromium with iOS UA does not run WebKit's soft-keyboard heuristic. The mechanism evidence (focus counters, displacement gate) is what the e2e suite locks in.

### Try it locally

```sh
nix run github:juspay/kolu/fix/ios-keyboard-only-on-tap
```

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._