### PR TITLE
Unify panel chrome through a single surface() helper

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -60,7 +60,7 @@ import TerminalMeta from "./terminal/TerminalMeta";
 import { useSubPanel } from "./terminal/useSubPanel";
 import { useTerminals } from "./terminal/useTerminals";
 import ModalDialog, { refocusTerminal } from "./ui/ModalDialog";
-import { surfaceClass } from "./ui/Surface";
+import { surface } from "./ui/Surface";
 import { isMobile } from "./useMobile";
 import { useThemeManager } from "./useThemeManager";
 
@@ -375,6 +375,8 @@ const App: Component = () => {
   const showEmpty = () =>
     !session.isLoading() && store.terminalIds().length === 0;
 
+  const aboutChrome = surface({ portalled: true });
+
   return (
     <div
       class="relative flex flex-col bg-surface-0 text-fg font-sans"
@@ -435,7 +437,10 @@ const App: Component = () => {
         onOpenChange={withRefocus(setAboutOpen)}
         size="sm"
       >
-        <Dialog.Content class={`${surfaceClass()} p-6 text-sm`}>
+        <Dialog.Content
+          class={`${aboutChrome.class} p-6 text-sm`}
+          style={aboutChrome.style}
+        >
           <div class="flex items-center gap-2 mb-3">
             <img src="/favicon.svg" alt="kolu" class="w-6 h-6" />
             <span class="font-semibold text-fg">{appTitle()}</span>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -60,6 +60,7 @@ import TerminalMeta from "./terminal/TerminalMeta";
 import { useSubPanel } from "./terminal/useSubPanel";
 import { useTerminals } from "./terminal/useTerminals";
 import ModalDialog, { refocusTerminal } from "./ui/ModalDialog";
+import { surfaceClass } from "./ui/Surface";
 import { isMobile } from "./useMobile";
 import { useThemeManager } from "./useThemeManager";
 
@@ -434,7 +435,7 @@ const App: Component = () => {
         onOpenChange={withRefocus(setAboutOpen)}
         size="sm"
       >
-        <Dialog.Content class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-6 text-sm">
+        <Dialog.Content class={`${surfaceClass()} p-6 text-sm`}>
           <div class="flex items-center gap-2 mb-3">
             <img src="/favicon.svg" alt="kolu" class="w-6 h-6" />
             <span class="font-semibold text-fg">{appTitle()}</span>

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -9,7 +9,7 @@ import { type Component, Show } from "solid-js";
 import ChecksIndicator from "./terminal/ChecksIndicator";
 import { PrStateIcon, WorktreeIcon } from "./ui/Icons";
 import ModalDialog from "./ui/ModalDialog";
-import { surfaceClass, surfaceStyle } from "./ui/Surface";
+import { surface } from "./ui/Surface";
 
 /** Reasons why the "Remove worktree" action is suppressed.
  *
@@ -58,6 +58,7 @@ const CloseConfirm: Component<{
   };
   const splitCount = () => props.target?.splitCount ?? 0;
   const closeLabel = () => (splitCount() > 0 ? "Close all" : "Close terminal");
+  const chrome = surface({ portalled: true });
 
   return (
     <ModalDialog
@@ -69,9 +70,9 @@ const CloseConfirm: Component<{
       size="sm"
     >
       <Dialog.Content
-        class={`${surfaceClass()} p-5 text-sm space-y-4`}
+        class={`${chrome.class} p-5 text-sm space-y-4`}
+        style={chrome.style}
         data-testid="close-confirm"
-        style={surfaceStyle}
       >
         <Dialog.Label class="font-semibold text-fg">
           <Show

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -9,6 +9,7 @@ import { type Component, Show } from "solid-js";
 import ChecksIndicator from "./terminal/ChecksIndicator";
 import { PrStateIcon, WorktreeIcon } from "./ui/Icons";
 import ModalDialog from "./ui/ModalDialog";
+import { surfaceClass, surfaceStyle } from "./ui/Surface";
 
 /** Reasons why the "Remove worktree" action is suppressed.
  *
@@ -68,9 +69,9 @@ const CloseConfirm: Component<{
       size="sm"
     >
       <Dialog.Content
-        class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 text-sm space-y-4"
+        class={`${surfaceClass()} p-5 text-sm space-y-4`}
         data-testid="close-confirm"
-        style={{ "background-color": "var(--color-surface-1)" }}
+        style={surfaceStyle}
       >
         <Dialog.Label class="font-semibold text-fg">
           <Show

--- a/packages/client/src/DiagnosticInfo.tsx
+++ b/packages/client/src/DiagnosticInfo.tsx
@@ -15,6 +15,7 @@ import { writeTextToClipboard } from "./ui/clipboard";
 import ModalDialog, { refocusTerminal } from "./ui/ModalDialog";
 import Row from "./ui/Row";
 import Section from "./ui/Section";
+import { surfaceClass } from "./ui/Surface";
 import { isMobile } from "./useMobile";
 
 /** WebGL2 support detection creates a throwaway canvas + WebGL context
@@ -126,7 +127,7 @@ const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
   }
 
   return (
-    <div class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden flex flex-col max-h-[80vh]">
+    <div class={`${surfaceClass()} overflow-hidden flex flex-col max-h-[80vh]`}>
       <div class="flex items-center justify-between px-4 py-2.5 border-b border-edge shrink-0">
         <Dialog.Label class="font-semibold text-fg text-sm">
           Diagnostic info

--- a/packages/client/src/DiagnosticInfo.tsx
+++ b/packages/client/src/DiagnosticInfo.tsx
@@ -15,7 +15,7 @@ import { writeTextToClipboard } from "./ui/clipboard";
 import ModalDialog, { refocusTerminal } from "./ui/ModalDialog";
 import Row from "./ui/Row";
 import Section from "./ui/Section";
-import { surfaceClass } from "./ui/Surface";
+import { surface } from "./ui/Surface";
 import { isMobile } from "./useMobile";
 
 /** WebGL2 support detection creates a throwaway canvas + WebGL context
@@ -126,8 +126,13 @@ const DiagnosticInfoContent: Component<{ activeId: TerminalId | null }> = (
     }
   }
 
+  const chrome = surface({ portalled: true });
+
   return (
-    <div class={`${surfaceClass()} overflow-hidden flex flex-col max-h-[80vh]`}>
+    <div
+      class={`${chrome.class} overflow-hidden flex flex-col max-h-[80vh]`}
+      style={chrome.style}
+    >
       <div class="flex items-center justify-between px-4 py-2.5 border-b border-edge shrink-0">
         <Dialog.Label class="font-semibold text-fg text-sm">
           Diagnostic info

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -6,7 +6,7 @@ import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { ACTIONS } from "./input/actions";
 import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
-import { surfaceClass } from "./ui/Surface";
+import { surface } from "./ui/Surface";
 import Toggle from "./ui/Toggle";
 
 const features = [
@@ -91,7 +91,7 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
       data-testid="empty-state"
       class="flex items-center justify-center h-full"
     >
-      <div class={`${surfaceClass()} p-5 max-w-md w-full`}>
+      <div class={`${surface().class} p-5 max-w-md w-full`}>
         <Show when={props.savedSession}>
           {(session) => {
             const subCount = () =>

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -9,6 +9,8 @@ import Kbd from "./ui/Kbd";
 import { surface } from "./ui/Surface";
 import Toggle from "./ui/Toggle";
 
+const chrome = surface();
+
 const features = [
   // Show the alt chord (Cmd+Enter): Cmd+T is intercepted by browsers outside
   // PWA-installed mode, so the alt is the more universally-functional advert.
@@ -91,7 +93,7 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
       data-testid="empty-state"
       class="flex items-center justify-center h-full"
     >
-      <div class={`${surface().class} p-5 max-w-md w-full`}>
+      <div class={`${chrome.class} p-5 max-w-md w-full`}>
         <Show when={props.savedSession}>
           {(session) => {
             const subCount = () =>

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -6,6 +6,7 @@ import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { ACTIONS } from "./input/actions";
 import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
+import { surfaceClass } from "./ui/Surface";
 import Toggle from "./ui/Toggle";
 
 const features = [
@@ -90,7 +91,7 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
       data-testid="empty-state"
       class="flex items-center justify-center h-full"
     >
-      <div class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-5 max-w-md w-full">
+      <div class={`${surfaceClass()} p-5 max-w-md w-full`}>
         <Show when={props.savedSession}>
           {(session) => {
             const subCount = () =>

--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -6,6 +6,7 @@ import { ACTIONS, type ActionId } from "./input/actions";
 import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
 import ModalDialog from "./ui/ModalDialog";
+import { surfaceClass, surfaceStyle } from "./ui/Surface";
 
 /** Curated display order for the shortcuts help overlay. Referencing actions
  *  by id (instead of restating label/keybind) keeps the overlay in sync with
@@ -37,8 +38,8 @@ const ShortcutsHelp: Component<{
   <ModalDialog open={props.open} onOpenChange={props.onOpenChange} size="sm">
     <Dialog.Content
       data-testid="shortcuts-help"
-      class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 overflow-hidden"
-      style={{ "background-color": "var(--color-surface-1)" }}
+      class={`${surfaceClass()} overflow-hidden`}
+      style={surfaceStyle}
     >
       <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">
         Keyboard Shortcuts

--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -6,7 +6,7 @@ import { ACTIONS, type ActionId } from "./input/actions";
 import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
 import ModalDialog from "./ui/ModalDialog";
-import { surfaceClass, surfaceStyle } from "./ui/Surface";
+import { surface } from "./ui/Surface";
 
 /** Curated display order for the shortcuts help overlay. Referencing actions
  *  by id (instead of restating label/keybind) keeps the overlay in sync with
@@ -34,38 +34,41 @@ const HELP_ORDER: readonly { id: ActionId; label?: string }[] = [
 const ShortcutsHelp: Component<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}> = (props) => (
-  <ModalDialog open={props.open} onOpenChange={props.onOpenChange} size="sm">
-    <Dialog.Content
-      data-testid="shortcuts-help"
-      class={`${surfaceClass()} overflow-hidden`}
-      style={surfaceStyle}
-    >
-      <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">
-        Keyboard Shortcuts
-      </Dialog.Label>
-      <div class="px-4 py-2">
-        <For each={HELP_ORDER}>
-          {(entry) => {
-            const action = ACTIONS[entry.id];
-            return (
-              <div class="flex items-center justify-between py-1.5">
-                <span class="text-sm text-fg-2">
-                  {entry.label ?? action.label}
-                </span>
-                <span class="flex items-center gap-1.5">
-                  <Kbd>{formatKeybind(action.keybind)}</Kbd>
-                  {action.altKeybind && (
-                    <Kbd>{formatKeybind(action.altKeybind)}</Kbd>
-                  )}
-                </span>
-              </div>
-            );
-          }}
-        </For>
-      </div>
-    </Dialog.Content>
-  </ModalDialog>
-);
+}> = (props) => {
+  const chrome = surface({ portalled: true });
+  return (
+    <ModalDialog open={props.open} onOpenChange={props.onOpenChange} size="sm">
+      <Dialog.Content
+        data-testid="shortcuts-help"
+        class={`${chrome.class} overflow-hidden`}
+        style={chrome.style}
+      >
+        <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">
+          Keyboard Shortcuts
+        </Dialog.Label>
+        <div class="px-4 py-2">
+          <For each={HELP_ORDER}>
+            {(entry) => {
+              const action = ACTIONS[entry.id];
+              return (
+                <div class="flex items-center justify-between py-1.5">
+                  <span class="text-sm text-fg-2">
+                    {entry.label ?? action.label}
+                  </span>
+                  <span class="flex items-center gap-1.5">
+                    <Kbd>{formatKeybind(action.keybind)}</Kbd>
+                    {action.altKeybind && (
+                      <Kbd>{formatKeybind(action.altKeybind)}</Kbd>
+                    )}
+                  </span>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+      </Dialog.Content>
+    </ModalDialog>
+  );
+};
 
 export default ShortcutsHelp;

--- a/packages/client/src/ShortcutsHelp.tsx
+++ b/packages/client/src/ShortcutsHelp.tsx
@@ -31,44 +31,43 @@ const HELP_ORDER: readonly { id: ActionId; label?: string }[] = [
   { id: "shortcutsHelp" },
 ];
 
+const chrome = surface({ portalled: true });
+
 const ShortcutsHelp: Component<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}> = (props) => {
-  const chrome = surface({ portalled: true });
-  return (
-    <ModalDialog open={props.open} onOpenChange={props.onOpenChange} size="sm">
-      <Dialog.Content
-        data-testid="shortcuts-help"
-        class={`${chrome.class} overflow-hidden`}
-        style={chrome.style}
-      >
-        <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">
-          Keyboard Shortcuts
-        </Dialog.Label>
-        <div class="px-4 py-2">
-          <For each={HELP_ORDER}>
-            {(entry) => {
-              const action = ACTIONS[entry.id];
-              return (
-                <div class="flex items-center justify-between py-1.5">
-                  <span class="text-sm text-fg-2">
-                    {entry.label ?? action.label}
-                  </span>
-                  <span class="flex items-center gap-1.5">
-                    <Kbd>{formatKeybind(action.keybind)}</Kbd>
-                    {action.altKeybind && (
-                      <Kbd>{formatKeybind(action.altKeybind)}</Kbd>
-                    )}
-                  </span>
-                </div>
-              );
-            }}
-          </For>
-        </div>
-      </Dialog.Content>
-    </ModalDialog>
-  );
-};
+}> = (props) => (
+  <ModalDialog open={props.open} onOpenChange={props.onOpenChange} size="sm">
+    <Dialog.Content
+      data-testid="shortcuts-help"
+      class={`${chrome.class} overflow-hidden`}
+      style={chrome.style}
+    >
+      <Dialog.Label class="block px-4 py-3 border-b border-edge text-sm font-semibold text-fg">
+        Keyboard Shortcuts
+      </Dialog.Label>
+      <div class="px-4 py-2">
+        <For each={HELP_ORDER}>
+          {(entry) => {
+            const action = ACTIONS[entry.id];
+            return (
+              <div class="flex items-center justify-between py-1.5">
+                <span class="text-sm text-fg-2">
+                  {entry.label ?? action.label}
+                </span>
+                <span class="flex items-center gap-1.5">
+                  <Kbd>{formatKeybind(action.keybind)}</Kbd>
+                  {action.altKeybind && (
+                    <Kbd>{formatKeybind(action.altKeybind)}</Kbd>
+                  )}
+                </span>
+              </div>
+            );
+          }}
+        </For>
+      </div>
+    </Dialog.Content>
+  </ModalDialog>
+);
 
 export default ShortcutsHelp;

--- a/packages/client/src/intent/IntentEditorDialog.tsx
+++ b/packages/client/src/intent/IntentEditorDialog.tsx
@@ -19,7 +19,7 @@ import { toast } from "solid-sonner";
 import { writeTextToClipboard } from "../ui/clipboard";
 import { CloseIcon, CopyIcon } from "../ui/Icons";
 import ModalDialog from "../ui/ModalDialog";
-import { surfaceClass } from "../ui/Surface";
+import { surface } from "../ui/Surface";
 import { IntentMarkdownBlock } from "./IntentMarkdown";
 
 /** Curated emoji quick-row. Pairs glyph with a short label that
@@ -115,6 +115,8 @@ const IntentEditorDialog: Component<{
     }
   }
 
+  const chrome = surface({ radius: "xl", portalled: true });
+
   return (
     <ModalDialog
       open={props.open}
@@ -123,7 +125,8 @@ const IntentEditorDialog: Component<{
     >
       <Dialog.Content
         data-kolu-modal="true"
-        class={`${surfaceClass({ radius: "xl" })} p-4 text-sm w-[min(560px,calc(100vw-2rem))]`}
+        class={`${chrome.class} p-4 text-sm w-[min(560px,calc(100vw-2rem))]`}
+        style={chrome.style}
       >
         <div class="mb-3">
           <Dialog.Label class="block text-sm font-semibold text-fg">

--- a/packages/client/src/intent/IntentEditorDialog.tsx
+++ b/packages/client/src/intent/IntentEditorDialog.tsx
@@ -19,6 +19,7 @@ import { toast } from "solid-sonner";
 import { writeTextToClipboard } from "../ui/clipboard";
 import { CloseIcon, CopyIcon } from "../ui/Icons";
 import ModalDialog from "../ui/ModalDialog";
+import { surfaceClass } from "../ui/Surface";
 import { IntentMarkdownBlock } from "./IntentMarkdown";
 
 /** Curated emoji quick-row. Pairs glyph with a short label that
@@ -122,7 +123,7 @@ const IntentEditorDialog: Component<{
     >
       <Dialog.Content
         data-kolu-modal="true"
-        class="bg-surface-1 border border-edge rounded-xl shadow-2xl shadow-black/50 p-4 text-sm w-[min(560px,calc(100vw-2rem))]"
+        class={`${surfaceClass({ radius: "xl" })} p-4 text-sm w-[min(560px,calc(100vw-2rem))]`}
       >
         <div class="mb-3">
           <Dialog.Label class="block text-sm font-semibold text-fg">

--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -4,6 +4,7 @@
 
 import { type Component, createEffect, For, Show } from "solid-js";
 import { Portal } from "solid-js/web";
+import { surfaceClass, surfaceStyle } from "../ui/Surface";
 import Toggle from "../ui/Toggle";
 import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import LevelMeter from "./LevelMeter";
@@ -71,11 +72,8 @@ const RecordPopover: Component<{
         <div
           ref={panelRef}
           data-testid="record-popover"
-          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-3 min-w-[280px] space-y-3"
-          style={{
-            ...panelStyle(),
-            "background-color": "var(--color-surface-1)",
-          }}
+          class={`fixed z-50 ${surfaceClass()} p-3 min-w-[280px] space-y-3`}
+          style={{ ...panelStyle(), ...surfaceStyle }}
         >
           <div class="text-sm font-medium text-fg">Record workspace</div>
 

--- a/packages/client/src/recorder/RecordPopover.tsx
+++ b/packages/client/src/recorder/RecordPopover.tsx
@@ -4,7 +4,7 @@
 
 import { type Component, createEffect, For, Show } from "solid-js";
 import { Portal } from "solid-js/web";
-import { surfaceClass, surfaceStyle } from "../ui/Surface";
+import { surface } from "../ui/Surface";
 import Toggle from "../ui/Toggle";
 import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import LevelMeter from "./LevelMeter";
@@ -66,14 +66,16 @@ const RecordPopover: Component<{
     return dev?.label || "System default";
   };
 
+  const chrome = surface({ portalled: true });
+
   return (
     <Show when={open()}>
       <Portal>
         <div
           ref={panelRef}
           data-testid="record-popover"
-          class={`fixed z-50 ${surfaceClass()} p-3 min-w-[280px] space-y-3`}
-          style={{ ...panelStyle(), ...surfaceStyle }}
+          class={`fixed z-50 ${chrome.class} p-3 min-w-[280px] space-y-3`}
+          style={{ ...panelStyle(), ...chrome.style }}
         >
           <div class="text-sm font-medium text-fg">Record workspace</div>
 

--- a/packages/client/src/right-panel/ModeChipPicker.tsx
+++ b/packages/client/src/right-panel/ModeChipPicker.tsx
@@ -15,6 +15,7 @@ import type { CodeTabView } from "kolu-common/surface";
 import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { Dynamic, Portal } from "solid-js/web";
 import { ChevronDownIcon } from "../ui/Icons";
+import { surface } from "../ui/Surface";
 import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 
 export type ModeOption = {
@@ -58,6 +59,8 @@ const ModeChipPicker: Component<{
   const chipLabel = (m: ModeOption) =>
     m.group ? `${m.group}: ${m.label}` : m.label;
 
+  const chrome = surface({ radius: "md", shadow: "soft", portalled: true });
+
   return (
     <>
       <button
@@ -91,8 +94,8 @@ const ModeChipPicker: Component<{
         <Portal>
           <div
             ref={panelRef}
-            class="fixed z-50 bg-surface-1 border border-edge rounded-md shadow-2xl shadow-black/40 py-1 min-w-[240px] text-[11px] font-mono"
-            style={panelStyle()}
+            class={`fixed z-50 ${chrome.class} py-1 min-w-[240px] text-[11px] font-mono`}
+            style={{ ...panelStyle(), ...chrome.style }}
             role="menu"
             data-testid="diff-filter-popover"
           >

--- a/packages/client/src/rpc/TransportOverlay.tsx
+++ b/packages/client/src/rpc/TransportOverlay.tsx
@@ -16,6 +16,8 @@ import { forceUpdateAndReload } from "../pwa";
 import { surface } from "../ui/Surface";
 import { lifecycle } from "./rpc";
 
+const chrome = surface();
+
 const TransportOverlay: Component = () => {
   const visible = () => {
     const k = lifecycle().kind;
@@ -26,7 +28,7 @@ const TransportOverlay: Component = () => {
     <Show when={visible()}>
       <div class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center pointer-events-none">
         <div
-          class={`${surface().class} p-6 max-w-sm text-sm pointer-events-auto`}
+          class={`${chrome.class} p-6 max-w-sm text-sm pointer-events-auto`}
           data-testid="transport-overlay"
         >
           {match(lifecycle())

--- a/packages/client/src/rpc/TransportOverlay.tsx
+++ b/packages/client/src/rpc/TransportOverlay.tsx
@@ -13,6 +13,7 @@
 import { type Component, Show } from "solid-js";
 import { match } from "ts-pattern";
 import { forceUpdateAndReload } from "../pwa";
+import { surfaceClass } from "../ui/Surface";
 import { lifecycle } from "./rpc";
 
 const TransportOverlay: Component = () => {
@@ -25,7 +26,7 @@ const TransportOverlay: Component = () => {
     <Show when={visible()}>
       <div class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center pointer-events-none">
         <div
-          class="bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-6 max-w-sm text-sm pointer-events-auto"
+          class={`${surfaceClass()} p-6 max-w-sm text-sm pointer-events-auto`}
           data-testid="transport-overlay"
         >
           {match(lifecycle())

--- a/packages/client/src/rpc/TransportOverlay.tsx
+++ b/packages/client/src/rpc/TransportOverlay.tsx
@@ -13,7 +13,7 @@
 import { type Component, Show } from "solid-js";
 import { match } from "ts-pattern";
 import { forceUpdateAndReload } from "../pwa";
-import { surfaceClass } from "../ui/Surface";
+import { surface } from "../ui/Surface";
 import { lifecycle } from "./rpc";
 
 const TransportOverlay: Component = () => {
@@ -26,7 +26,7 @@ const TransportOverlay: Component = () => {
     <Show when={visible()}>
       <div class="fixed inset-0 bg-black/60 z-50 flex items-center justify-center pointer-events-none">
         <div
-          class={`${surfaceClass()} p-6 max-w-sm text-sm pointer-events-auto`}
+          class={`${surface().class} p-6 max-w-sm text-sm pointer-events-auto`}
           data-testid="transport-overlay"
         >
           {match(lifecycle())

--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -8,7 +8,7 @@ import { Portal } from "solid-js/web";
 import SegmentedControl, {
   type SegmentedControlOption,
 } from "../ui/SegmentedControl";
-import { surfaceClass, surfaceStyle } from "../ui/Surface";
+import { surface } from "../ui/Surface";
 import Toggle from "../ui/Toggle";
 import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import SettingRow, { type Hint } from "./SettingRow";
@@ -65,14 +65,16 @@ const SettingsPopover: Component<{
     anchor: "bottom-end",
   });
 
+  const chrome = surface({ portalled: true });
+
   return (
     <Show when={props.open}>
       <Portal>
         <div
           ref={panelRef}
           data-testid="settings-popover"
-          class={`fixed z-50 ${surfaceClass()} p-4 min-w-[280px] space-y-4`}
-          style={{ ...panelStyle(), ...surfaceStyle }}
+          class={`fixed z-50 ${chrome.class} p-4 min-w-[280px] space-y-4`}
+          style={{ ...panelStyle(), ...chrome.style }}
         >
           <SettingRow label="Theme" hint={SCHEME_HINT[colorScheme()]}>
             <SegmentedControl

--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -8,6 +8,7 @@ import { Portal } from "solid-js/web";
 import SegmentedControl, {
   type SegmentedControlOption,
 } from "../ui/SegmentedControl";
+import { surfaceClass, surfaceStyle } from "../ui/Surface";
 import Toggle from "../ui/Toggle";
 import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import SettingRow, { type Hint } from "./SettingRow";
@@ -70,11 +71,8 @@ const SettingsPopover: Component<{
         <div
           ref={panelRef}
           data-testid="settings-popover"
-          class="fixed z-50 bg-surface-1 border border-edge rounded-2xl shadow-2xl shadow-black/50 p-4 min-w-[280px] space-y-4"
-          style={{
-            ...panelStyle(),
-            "background-color": "var(--color-surface-1)",
-          }}
+          class={`fixed z-50 ${surfaceClass()} p-4 min-w-[280px] space-y-4`}
+          style={{ ...panelStyle(), ...surfaceStyle }}
         >
           <SettingRow label="Theme" hint={SCHEME_HINT[colorScheme()]}>
             <SegmentedControl

--- a/packages/client/src/terminal/PrUnavailablePopover.tsx
+++ b/packages/client/src/terminal/PrUnavailablePopover.tsx
@@ -17,6 +17,7 @@ import { match } from "ts-pattern";
 import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import { WarningIcon } from "../ui/Icons";
 import { writeTextToClipboard } from "../ui/clipboard";
+import { surfaceClass, surfaceStyle } from "../ui/Surface";
 
 const AUTH_COMMAND = "gh auth login -s repo,read:org";
 
@@ -129,11 +130,8 @@ const PrUnavailablePopover: Component<{
           data-testid="pr-unavailable-popover"
           role="dialog"
           aria-label={reasonForSource(props.source)}
-          class="fixed z-50 bg-surface-1 border border-edge rounded-xl shadow-2xl shadow-black/50 p-3 w-[280px] space-y-2 text-xs"
-          style={{
-            ...panelStyle(),
-            "background-color": "var(--color-surface-1)",
-          }}
+          class={`fixed z-50 ${surfaceClass({ radius: "xl" })} p-3 w-[280px] space-y-2 text-xs`}
+          style={{ ...panelStyle(), ...surfaceStyle }}
         >
           <ProviderUnavailableContent source={props.source} />
         </div>

--- a/packages/client/src/terminal/PrUnavailablePopover.tsx
+++ b/packages/client/src/terminal/PrUnavailablePopover.tsx
@@ -17,7 +17,7 @@ import { match } from "ts-pattern";
 import { useAnchoredPopover } from "../ui/useAnchoredPopover";
 import { WarningIcon } from "../ui/Icons";
 import { writeTextToClipboard } from "../ui/clipboard";
-import { surfaceClass, surfaceStyle } from "../ui/Surface";
+import { surface } from "../ui/Surface";
 
 const AUTH_COMMAND = "gh auth login -s repo,read:org";
 
@@ -122,6 +122,8 @@ const PrUnavailablePopover: Component<{
     panelMinWidth: 280,
   });
 
+  const chrome = surface({ radius: "xl", portalled: true });
+
   return (
     <Show when={props.open}>
       <Portal>
@@ -130,8 +132,8 @@ const PrUnavailablePopover: Component<{
           data-testid="pr-unavailable-popover"
           role="dialog"
           aria-label={reasonForSource(props.source)}
-          class={`fixed z-50 ${surfaceClass({ radius: "xl" })} p-3 w-[280px] space-y-2 text-xs`}
-          style={{ ...panelStyle(), ...surfaceStyle }}
+          class={`fixed z-50 ${chrome.class} p-3 w-[280px] space-y-2 text-xs`}
+          style={{ ...panelStyle(), ...chrome.style }}
         >
           <ProviderUnavailableContent source={props.source} />
         </div>

--- a/packages/client/src/terminal/SearchBar.tsx
+++ b/packages/client/src/terminal/SearchBar.tsx
@@ -16,7 +16,7 @@ import {
   Show,
 } from "solid-js";
 import { ChevronDownIcon, ChevronUpIcon, CloseIcon } from "../ui/Icons";
-import { surfaceClass } from "../ui/Surface";
+import { surface } from "../ui/Surface";
 import Tip from "../ui/Tip";
 
 const SEARCH_OPTIONS: ISearchOptions = {
@@ -143,7 +143,7 @@ const SearchBar: Component<{
   return (
     <Show when={props.open}>
       <div
-        class={`absolute top-1 right-3 z-10 flex items-center gap-1.5 ${surfaceClass({ radius: "xl", shadow: "soft" })} px-2 py-1.5`}
+        class={`absolute top-1 right-3 z-10 flex items-center gap-1.5 ${surface({ radius: "xl", shadow: "soft" }).class} px-2 py-1.5`}
       >
         <input
           ref={inputRef}

--- a/packages/client/src/terminal/SearchBar.tsx
+++ b/packages/client/src/terminal/SearchBar.tsx
@@ -16,6 +16,7 @@ import {
   Show,
 } from "solid-js";
 import { ChevronDownIcon, ChevronUpIcon, CloseIcon } from "../ui/Icons";
+import { surfaceClass } from "../ui/Surface";
 import Tip from "../ui/Tip";
 
 const SEARCH_OPTIONS: ISearchOptions = {
@@ -141,7 +142,9 @@ const SearchBar: Component<{
 
   return (
     <Show when={props.open}>
-      <div class="absolute top-1 right-3 z-10 flex items-center gap-1.5 bg-surface-1 border border-edge rounded-xl shadow-2xl shadow-black/40 px-2 py-1.5">
+      <div
+        class={`absolute top-1 right-3 z-10 flex items-center gap-1.5 ${surfaceClass({ radius: "xl", shadow: "soft" })} px-2 py-1.5`}
+      >
         <input
           ref={inputRef}
           type="text"

--- a/packages/client/src/terminal/SearchBar.tsx
+++ b/packages/client/src/terminal/SearchBar.tsx
@@ -117,6 +117,8 @@ const SearchBar: Component<{
     return `${idx} / ${resultCount()}`;
   }
 
+  const chrome = surface({ radius: "xl", shadow: "soft" });
+
   makeEventListener(
     window,
     "keydown",
@@ -143,7 +145,7 @@ const SearchBar: Component<{
   return (
     <Show when={props.open}>
       <div
-        class={`absolute top-1 right-3 z-10 flex items-center gap-1.5 ${surface({ radius: "xl", shadow: "soft" }).class} px-2 py-1.5`}
+        class={`absolute top-1 right-3 z-10 flex items-center gap-1.5 ${chrome.class} px-2 py-1.5`}
       >
         <input
           ref={inputRef}

--- a/packages/client/src/ui/CodeContextMenu.tsx
+++ b/packages/client/src/ui/CodeContextMenu.tsx
@@ -11,6 +11,7 @@ import { Dynamic, Portal } from "solid-js/web";
 import { toast } from "solid-sonner";
 import { match } from "ts-pattern";
 import { writeTextToClipboard } from "./clipboard";
+import { surface } from "./Surface";
 
 /** Two verbs over the same selection noun: copy a string to the clipboard,
  *  or invoke an action callback. The discriminator keeps the dispatch
@@ -101,14 +102,16 @@ export const CodeContextMenu: Component<{
     close();
   };
 
+  const chrome = surface({ radius: "md", shadow: "bare", portalled: true });
+
   return (
     <Show when={open()}>
       <Portal>
         <div
           id="code-context-menu"
           role="menu"
-          class="fixed z-50 min-w-40 rounded-md border border-edge bg-surface-1 p-1 text-[11px] text-fg shadow-lg"
-          style={{ left: `${pos().x}px`, top: `${pos().y}px` }}
+          class={`fixed z-50 min-w-40 ${chrome.class} p-1 text-[11px] text-fg`}
+          style={{ left: `${pos().x}px`, top: `${pos().y}px`, ...chrome.style }}
         >
           <For each={items()}>
             {(item) => (

--- a/packages/client/src/ui/OptionMenu.tsx
+++ b/packages/client/src/ui/OptionMenu.tsx
@@ -48,6 +48,7 @@ export const OptionMenu = <T extends string>(props: {
     // viewport. Matches the panel's own `min-w-[180px]` Tailwind class.
     panelMinWidth: 180,
   });
+
   const chrome = surface({ radius: "lg", shadow: "light", portalled: true });
   return (
     <Show when={props.open()}>

--- a/packages/client/src/ui/OptionMenu.tsx
+++ b/packages/client/src/ui/OptionMenu.tsx
@@ -10,12 +10,14 @@
  *
  *  Distinct from `right-panel/ModeChipPicker` — that picker handles
  *  grouped, hinted, icon-labelled CodeTab modes with a baked-in chip
- *  trigger. Different visual axis; consolidating both would mean
- *  conditionally suppressing the icon/hint/group features at every
- *  call site, which is more complecting than two focused components. */
+ *  trigger; consolidating both would mean conditionally suppressing
+ *  the icon/hint/group features at every call site, which is more
+ *  complecting than two focused components. The panel-chrome itself
+ *  is shared via `surface()`. */
 
 import { For, Show } from "solid-js";
 import { Portal } from "solid-js/web";
+import { surface } from "./Surface";
 import { type AnchorSide, useAnchoredPopover } from "./useAnchoredPopover";
 
 export type OptionMenuItem<T extends string> = {
@@ -46,14 +48,15 @@ export const OptionMenu = <T extends string>(props: {
     // viewport. Matches the panel's own `min-w-[180px]` Tailwind class.
     panelMinWidth: 180,
   });
+  const chrome = surface({ radius: "lg", shadow: "light", portalled: true });
   return (
     <Show when={props.open()}>
       <Portal>
         <div
           ref={panelRef}
           data-testid={`${props.testIdPrefix}-menu`}
-          class="fixed z-50 flex flex-col bg-surface-1 border border-edge rounded-lg shadow-lg shadow-black/40 p-1 min-w-[180px]"
-          style={panelStyle()}
+          class={`fixed z-50 flex flex-col ${chrome.class} p-1 min-w-[180px]`}
+          style={{ ...panelStyle(), ...chrome.style }}
         >
           <For each={props.options}>
             {(opt) => (

--- a/packages/client/src/ui/Surface.ts
+++ b/packages/client/src/ui/Surface.ts
@@ -2,30 +2,36 @@
  *
  *  The canonical incantation behind every floating panel in the app:
  *  dialog content, popovers, the empty-state card, the disconnect overlay.
- *  Each call site previously inlined the same 6-utility string and drifted
+ *  Each call site previously inlined the same six-utility string and drifted
  *  on per-site variations (radius tier, shadow weight) that this helper
  *  now names.
  *
  *  Variants:
  *    - `radius`: `"2xl"` (default) for modal dialogs and primary popovers,
- *      `"xl"` for compact dialogs (intent editor, find bar).
+ *      `"xl"` for compact dialogs (intent editor, find bar), `"lg"`/`"md"`
+ *      for menu surfaces (anchored option lists, context menus).
  *    - `shadow`: `"default"` (`shadow-black/50`, modal weight) or
- *      `"soft"` (`shadow-black/40`, popover/floating weight).
+ *      `"soft"` (`shadow-black/40`, popover/floating weight), or `"light"`
+ *      (`shadow-lg shadow-black/40`, menu weight).
  *
- *  Pair with `surfaceStyle` whenever the surface lives inside a Corvu
- *  portal (`Dialog.Content`, popovers rendered via `solid-js/web` Portal).
- *  Firefox intermittently drops the `bg-surface-1` utility on portalled
- *  content; the inline background-color is a redundant fallback that
- *  guarantees the fill, and the duplication is the workaround. */
+ *  Pass `portalled: true` whenever the panel renders inside a Corvu portal
+ *  (`Dialog.Content`) or a SolidJS `Portal`. The returned `style` then
+ *  carries an inline `background-color` fallback — Firefox intermittently
+ *  drops the `bg-surface-1` utility on portalled content, and the inline
+ *  duplication is the workaround. Non-portal callers receive an empty
+ *  `style` object; spreading it is a no-op. */
 
 import type { JSX } from "solid-js";
 
 const RADIUS_CLASS = {
+  md: "rounded-md",
+  lg: "rounded-lg",
   xl: "rounded-xl",
   "2xl": "rounded-2xl",
 } as const;
 
 const SHADOW_CLASS = {
+  light: "shadow-lg shadow-black/40",
   soft: "shadow-2xl shadow-black/40",
   default: "shadow-2xl shadow-black/50",
 } as const;
@@ -33,15 +39,19 @@ const SHADOW_CLASS = {
 export type SurfaceRadius = keyof typeof RADIUS_CLASS;
 export type SurfaceShadow = keyof typeof SHADOW_CLASS;
 
-export function surfaceClass(opts?: {
-  radius?: SurfaceRadius;
-  shadow?: SurfaceShadow;
-}): string {
-  const radius = RADIUS_CLASS[opts?.radius ?? "2xl"];
-  const shadow = SHADOW_CLASS[opts?.shadow ?? "default"];
-  return `bg-surface-1 border border-edge ${radius} ${shadow}`;
-}
-
-export const surfaceStyle: JSX.CSSProperties = {
+const PORTAL_BG_FALLBACK: JSX.CSSProperties = {
   "background-color": "var(--color-surface-1)",
 };
+
+export function surface(opts?: {
+  radius?: SurfaceRadius;
+  shadow?: SurfaceShadow;
+  portalled?: boolean;
+}): { class: string; style: JSX.CSSProperties } {
+  const radius = RADIUS_CLASS[opts?.radius ?? "2xl"];
+  const shadow = SHADOW_CLASS[opts?.shadow ?? "default"];
+  return {
+    class: `bg-surface-1 border border-edge ${radius} ${shadow}`,
+    style: opts?.portalled ? PORTAL_BG_FALLBACK : {},
+  };
+}

--- a/packages/client/src/ui/Surface.ts
+++ b/packages/client/src/ui/Surface.ts
@@ -31,6 +31,7 @@ const RADIUS_CLASS = {
 } as const;
 
 const SHADOW_CLASS = {
+  bare: "shadow-lg",
   light: "shadow-lg shadow-black/40",
   soft: "shadow-2xl shadow-black/40",
   default: "shadow-2xl shadow-black/50",

--- a/packages/client/src/ui/Surface.ts
+++ b/packages/client/src/ui/Surface.ts
@@ -1,0 +1,47 @@
+/** Panel surface chrome — `bg-surface-1` + edge border + rounded + drop shadow.
+ *
+ *  The canonical incantation behind every floating panel in the app:
+ *  dialog content, popovers, the empty-state card, the disconnect overlay.
+ *  Each call site previously inlined the same 6-utility string and drifted
+ *  on per-site variations (radius tier, shadow weight) that this helper
+ *  now names.
+ *
+ *  Variants:
+ *    - `radius`: `"2xl"` (default) for modal dialogs and primary popovers,
+ *      `"xl"` for compact dialogs (intent editor, find bar).
+ *    - `shadow`: `"default"` (`shadow-black/50`, modal weight) or
+ *      `"soft"` (`shadow-black/40`, popover/floating weight).
+ *
+ *  Pair with `surfaceStyle` whenever the surface lives inside a Corvu
+ *  portal (`Dialog.Content`, popovers rendered via `solid-js/web` Portal).
+ *  Firefox intermittently drops the `bg-surface-1` utility on portalled
+ *  content; the inline background-color is a redundant fallback that
+ *  guarantees the fill, and the duplication is the workaround. */
+
+import type { JSX } from "solid-js";
+
+const RADIUS_CLASS = {
+  xl: "rounded-xl",
+  "2xl": "rounded-2xl",
+} as const;
+
+const SHADOW_CLASS = {
+  soft: "shadow-2xl shadow-black/40",
+  default: "shadow-2xl shadow-black/50",
+} as const;
+
+export type SurfaceRadius = keyof typeof RADIUS_CLASS;
+export type SurfaceShadow = keyof typeof SHADOW_CLASS;
+
+export function surfaceClass(opts?: {
+  radius?: SurfaceRadius;
+  shadow?: SurfaceShadow;
+}): string {
+  const radius = RADIUS_CLASS[opts?.radius ?? "2xl"];
+  const shadow = SHADOW_CLASS[opts?.shadow ?? "default"];
+  return `bg-surface-1 border border-edge ${radius} ${shadow}`;
+}
+
+export const surfaceStyle: JSX.CSSProperties = {
+  "background-color": "var(--color-surface-1)",
+};

--- a/packages/client/src/ui/Surface.ts
+++ b/packages/client/src/ui/Surface.ts
@@ -10,9 +10,10 @@
  *    - `radius`: `"2xl"` (default) for modal dialogs and primary popovers,
  *      `"xl"` for compact dialogs (intent editor, find bar), `"lg"`/`"md"`
  *      for menu surfaces (anchored option lists, context menus).
- *    - `shadow`: `"default"` (`shadow-black/50`, modal weight) or
- *      `"soft"` (`shadow-black/40`, popover/floating weight), or `"light"`
- *      (`shadow-lg shadow-black/40`, menu weight).
+ *    - `shadow`: `"default"` (`shadow-black/50`, modal weight),
+ *      `"soft"` (`shadow-black/40`, popover/floating weight),
+ *      `"light"` (`shadow-lg shadow-black/40`, menu weight), or
+ *      `"bare"` (`shadow-lg`, no color tint — for context menus).
  *
  *  Pass `portalled: true` whenever the panel renders inside a Corvu portal
  *  (`Dialog.Content`) or a SolidJS `Portal`. The returned `style` then


### PR DESCRIPTION
**Fourteen floating panels across the client had been inlining the same six-utility Tailwind incantation for panel chrome** — `bg-surface-1 border border-edge rounded-{xl,2xl} shadow-2xl shadow-black/{40,50}` — and *five of them* duplicated an inline `style={{ "background-color": "var(--color-surface-1)" }}` Firefox workaround for content rendered inside a Corvu portal. The shared "what does a panel surface look like" concept had no home, so each site drifted: radius tier varied, shadow weight varied, and three sites silently lacked the Firefox fallback.

A new `packages/client/src/ui/Surface.ts` module names the volatility:

```ts
const chrome = surface({ radius: "xl", shadow: "soft", portalled: true });
<div class={`fixed z-50 ${chrome.class} p-3`} style={chrome.style}>
```

The `portalled` flag is the structural encoding of the Firefox-fallback invariant — previous attempts kept it as a documented convention (`surfaceClass()` + a separate `surfaceStyle` import), and the convention silently failed at three of the migration sites. Encoding it as a flag means *the type signature itself carries the rule.*

### Vocabulary the helper names

| Axis | Tiers |
| --- | --- |
| `radius` | `md`, `lg`, `xl`, `2xl` (default) |
| `shadow` | `bare` (context menus), `light` (option menus), `soft` (popovers), `default` (modals) |
| `portalled` | `true` adds the `bg-surface-1` inline fallback |

Every tier has ≥1 user; tier names track elevation feel rather than raw class values. Sibling primitives that already encapsulate a different axis (`chromeSpacing.ts` for icon-button density, `ModalDialog.tsx`'s width tier) stay independent — those are different volatility axes and braiding them into `surface()` would defeat the receptacle's purpose.

### Migration scope

| Site | Notes |
| --- | --- |
| `CloseConfirm`, `ShortcutsHelp`, `IntentEditorDialog`, `App.tsx` about, `DiagnosticInfo` | Dialog.Content panels (portalled) |
| `RecordPopover`, `SettingsPopover`, `PrUnavailablePopover` | Anchored popovers (portalled, also merge with `panelStyle()`) |
| `EmptyState`, `TransportOverlay`, `SearchBar` | In-tree panels (not portalled) |
| `ModeChipPicker`, `OptionMenu`, `CodeContextMenu` | Portalled menu surfaces — added `md`/`lg` radii and `light`/`bare` shadow tiers to absorb them |

### Hickey/Lowy

The structural review (parallel hickey + lowy sub-agents, then cross-validation) drove four of the commits on this PR:

- **F3**: collapsing the `surfaceClass` + `surfaceStyle` pair into `surface({ portalled })` came out of Hickey — the original split was unenforced convention; the unified API makes the invariant follow the type.
- **F2a/b, L1**: migrating `ModeChipPicker`, `OptionMenu`, `CodeContextMenu` came from both lenses converging — the receptacle's tier vocabulary needed to grow to cover the actual in-use tiers, not just the modal ones.
- **C1** (move `SIZE_CLASS` from `ModalDialog.tsx` into `Surface.ts`): Lowy cross-validation **overrode** Hickey here — `SIZE_CLASS` is dialog-layout volatility, not chrome volatility, and consolidating them would braid two independent change axes behind one boundary. Recorded as No-op.

The full reviewer transcripts are posted as a PR comment below.

### Try it locally

```sh
nix run github:juspay/kolu/ui/surface-primitive
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._