### PR TITLE
Gate /do's CI step on every required status check, not just one e2e

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -30,7 +30,7 @@ pu destroy "$host"
 
 **Flake → comment on [#320](https://github.com/juspay/kolu/issues/320)** with scenario/platform/error excerpt/PR.
 
-**Evidence required → all GitHub status checks green per `just ci protect`.** `/do` is done only when every required status check is green on the PR's current `HEAD`. Source the required list from `just ci protect --dry-run` — it prints the `<recipe>@<platform>` contexts the canonical DAG produces, which are exactly the contexts branch protection gates on. Verify with `gh pr checks` against the SHA from `git rev-parse HEAD`; a green from a positional retry counts (final state matters), but a pass on a stale SHA does not.
+**Evidence required → all GitHub status checks green per `just ci protect`.** `/do` is done only when every required status check is green on the PR's current `HEAD`. Source the required list from `just ci protect --dry-run` — it prints the `<recipe>@<platform>` contexts the canonical DAG produces, which are exactly the contexts branch protection gates on. Verify with `gh pr checks`; a green from a positional retry counts (final state matters).
 
 ## Documentation
 

--- a/.agency/do.md
+++ b/.agency/do.md
@@ -28,7 +28,9 @@ CI=true nix run github:juspay/ci -- run --host x86_64-linux="$host"     # --host
 pu destroy "$host"
 ```
 
-**Flake → comment on [#320](https://github.com/juspay/kolu/issues/320)** with scenario/platform/error excerpt/PR. At least one platform must have `ci::e2e@<platform>` fully passed before `/do` considers itself done, even if the green came from a positional retry.
+**Flake → comment on [#320](https://github.com/juspay/kolu/issues/320)** with scenario/platform/error excerpt/PR.
+
+**Evidence required → all GitHub status checks green per `just ci protect`.** `/do` is done only when every required status check is green on the PR's current `HEAD`. Source the required list from `just ci protect --dry-run` — it prints the `<recipe>@<platform>` contexts the canonical DAG produces, which are exactly the contexts branch protection gates on. Verify with `gh pr checks` against the SHA from `git rev-parse HEAD`; a green from a positional retry counts (final state matters), but a pass on a stale SHA does not.
 
 ## Documentation
 


### PR DESCRIPTION
**`/do`'s CI step now declares done only when every required GitHub status check is green on the PR's `HEAD`** — previously a single platform's `ci::e2e@<platform>` pass was enough, which let `/do` ship while branch protection still had red checks elsewhere.

The new evidence rule sources the required-check list from `just ci protect --dry-run` — the same enumeration that `protect` PATCHes onto GitHub branch protection — so the done-gate matches what the forge will actually enforce. Verification reads via `gh pr checks`, and a positional retry still counts as long as the final state is green. _SHA-freshness ("CI must cover `HEAD`") stays where it already lived, in `.claude/skills/do/SKILL.md`; the project-config layer only states what to verify and where to source the required list._

Edit confined to `.agency/do.md`'s `## CI command` section.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._