### PR TITLE
Drop files onto a terminal to hand them to the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Detects [OpenCode](https://github.com/anomalyco/opencode) sessions and shows the
 ### Clipboard
 
 - <kbd>Ctrl+V</kbd> pastes images into any agent that accepts paste-as-file-path (Claude Code, codex, …) — the server saves the browser's clipboard image and bracketed-pastes its path into the PTY
+- **Drag-and-drop files** onto a terminal — the file uploads to the server (10 MB cap, curated extension allowlist covering text, code, structured data, common docs, and images) and its path is bracketed-pasted into the PTY just like a clipboard image, so agents that accept paste-as-file-path pick it up automatically. Disallowed types and oversize drops are rejected client-side with a toast and never hit the wire
 
 ### Screen recording
 

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -33,6 +33,7 @@ import { SafeClipboardProvider, writeTextToClipboard } from "../ui/clipboard";
 import "@xterm/xterm/css/xterm.css";
 import type { TerminalId } from "kolu-common/surface";
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
+import { rejectionFor } from "kolu-common/upload";
 import { FONT_FAMILY } from "terminal-themes";
 import { ACTIONS, matchesAnyShortcut } from "../input/actions";
 import { matchesKeybind } from "../input/keyboard";
@@ -818,6 +819,56 @@ const Terminal: Component<{
             { capture: true },
           );
 
+          // Drag-and-drop file upload. Files dropped on the terminal are
+          // uploaded to the server, which saves them under the terminal's
+          // clipboard directory and bracketed-pastes the path into the PTY
+          // — the same shape as Ctrl+V image paste, just sourced from
+          // DataTransfer instead of ClipboardData.
+          async function uploadDroppedFile(file: File) {
+            const reason = rejectionFor(file.name, file.size);
+            if (reason !== null) {
+              toast.error(reason);
+              return;
+            }
+            try {
+              const base64 = bufferToBase64(await file.arrayBuffer());
+              await client.terminal.uploadFile({
+                id: props.terminalId,
+                name: file.name,
+                data: base64,
+              });
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              toast.error(`Failed to upload "${file.name}": ${message}`);
+            }
+          }
+
+          makeEventListener(containerRef, "dragover", (e: DragEvent) => {
+            // Only react when the drag carries files — text/HTML drags
+            // belong to the browser / xterm.
+            if (!e.dataTransfer?.types.includes("Files")) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "copy";
+            containerRef.dataset.dropTarget = "";
+          });
+          makeEventListener(containerRef, "dragleave", (e: DragEvent) => {
+            // dragleave fires when the cursor crosses any child element
+            // boundary too; gate on relatedTarget leaving the container so
+            // the highlight doesn't flicker mid-drag.
+            const next = e.relatedTarget as Node | null;
+            if (next && containerRef.contains(next)) return;
+            delete containerRef.dataset.dropTarget;
+          });
+          makeEventListener(containerRef, "drop", (e: DragEvent) => {
+            const files = e.dataTransfer?.files;
+            if (!files || files.length === 0) return;
+            e.preventDefault();
+            delete containerRef.dataset.dropTarget;
+            for (const file of Array.from(files)) {
+              void uploadDroppedFile(file);
+            }
+          });
+
           // Cleanup is registered synchronously near the top of the component body
           // (see comment there). It references `terminal`, `webgl`, and the local
           // refs via closure, and handles null state if this onMount body never ran
@@ -850,8 +901,10 @@ const Terminal: Component<{
       />
       <div
         ref={containerRef}
-        // touch-manipulation: eliminate 300ms tap delay and prevent double-tap-to-zoom on mobile
-        class="w-full h-full overflow-hidden touch-manipulation"
+        // touch-manipulation: eliminate 300ms tap delay and prevent double-tap-to-zoom on mobile.
+        // data-[drop-target]: inset ring while a file drag is hovering — set/cleared by the
+        // dragover/drop/dragleave listeners in onMount.
+        class="w-full h-full overflow-hidden touch-manipulation data-[drop-target]:outline data-[drop-target]:outline-2 data-[drop-target]:-outline-offset-2 data-[drop-target]:outline-sky-400/70"
         data-terminal-id={props.terminalId}
         data-visible={props.visible ? "" : undefined}
         data-focused={props.focused !== false ? "" : undefined}

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -33,7 +33,7 @@ import { SafeClipboardProvider, writeTextToClipboard } from "../ui/clipboard";
 import "@xterm/xterm/css/xterm.css";
 import type { TerminalId } from "kolu-common/surface";
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
-import { rejectionFor } from "kolu-common/upload";
+import { rejectionFor, sizeRejectionFor } from "kolu-common/upload";
 import { FONT_FAMILY } from "terminal-themes";
 import { ACTIONS, matchesAnyShortcut } from "../input/actions";
 import { matchesKeybind } from "../input/keyboard";
@@ -786,14 +786,20 @@ const Terminal: Component<{
           // paste event (not navigator.clipboard.read) so no explicit
           // clipboard-read permission is needed.
           async function uploadPastedImage(file: File) {
-            const base64 = bufferToBase64(await file.arrayBuffer());
+            const reason = sizeRejectionFor("clipboard image", file.size);
+            if (reason !== null) {
+              toast.error(reason);
+              return;
+            }
             try {
+              const base64 = bufferToBase64(await file.arrayBuffer());
               await client.terminal.pasteImage({
                 id: props.terminalId,
                 data: base64,
               });
             } catch (err) {
-              console.error("Failed to upload clipboard image:", err);
+              const message = err instanceof Error ? err.message : String(err);
+              toast.error(`Failed to upload clipboard image: ${message}`);
             }
           }
 

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -141,6 +141,10 @@ function bufferToBase64(buf: ArrayBuffer): string {
   );
 }
 
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 const Terminal: Component<{
   terminalId: TerminalId;
   visible: boolean;
@@ -798,8 +802,7 @@ const Terminal: Component<{
                 data: base64,
               });
             } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              toast.error(`Failed to upload clipboard image: ${message}`);
+              toast.error(`Failed to upload clipboard image: ${errMsg(err)}`);
             }
           }
 
@@ -844,8 +847,7 @@ const Terminal: Component<{
                 data: base64,
               });
             } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
-              toast.error(`Failed to upload "${file.name}": ${message}`);
+              toast.error(`Failed to upload "${file.name}": ${errMsg(err)}`);
             }
           }
 
@@ -868,9 +870,12 @@ const Terminal: Component<{
           makeEventListener(containerRef, "drop", (e: DragEvent) => {
             const files = e.dataTransfer?.files;
             if (!files || files.length === 0) return;
+            // Prevent browser navigation (default action when dropping a file
+            // onto a page). Must come after the guard: only cancel drops we
+            // actually handle so text/HTML drags fall through unimpeded.
             e.preventDefault();
             delete containerRef.dataset.dropTarget;
-            for (const file of Array.from(files)) {
+            for (const file of files) {
               void uploadDroppedFile(file);
             }
           });

--- a/packages/client/src/upload.test.ts
+++ b/packages/client/src/upload.test.ts
@@ -1,0 +1,63 @@
+import {
+  ALLOWED_UPLOAD_EXTENSIONS,
+  MAX_UPLOAD_BYTES,
+  extensionOf,
+  isAllowedUploadName,
+  rejectionFor,
+} from "kolu-common/upload";
+import { describe, expect, it } from "vitest";
+
+describe("extensionOf", () => {
+  it.each([
+    { input: "notes.md", expected: "md" },
+    { input: "Cargo.lock", expected: "lock" },
+    { input: "screenshot.PNG", expected: "png" },
+    { input: "archive.tar.gz", expected: "gz" },
+    { input: "README", expected: null },
+    { input: ".gitignore", expected: null },
+    { input: "trailing.", expected: null },
+  ])("extensionOf($input) → $expected", ({ input, expected }) => {
+    expect(extensionOf(input)).toBe(expected);
+  });
+});
+
+describe("isAllowedUploadName", () => {
+  it.each([
+    { input: "notes.md", expected: true },
+    { input: "data.JSON", expected: true },
+    { input: "image.png", expected: true },
+    { input: "malware.exe", expected: false },
+    { input: "shipping.tar", expected: false },
+    { input: "README", expected: false },
+  ])("isAllowedUploadName($input) → $expected", ({ input, expected }) => {
+    expect(isAllowedUploadName(input)).toBe(expected);
+  });
+});
+
+describe("rejectionFor", () => {
+  it("accepts a small allowed file", () => {
+    expect(rejectionFor("notes.md", 1024)).toBeNull();
+  });
+
+  it("rejects a file with disallowed extension", () => {
+    expect(rejectionFor("malware.exe", 1024)).toMatch(/not allowed/);
+  });
+
+  it("rejects a file above the size cap", () => {
+    expect(rejectionFor("big.txt", MAX_UPLOAD_BYTES + 1)).toMatch(/too large/);
+  });
+
+  it("reports the extension rejection before the size rejection", () => {
+    // A malicious file that is also oversized — surfacing the type
+    // mismatch first is the more actionable error for the user.
+    expect(rejectionFor("malware.exe", MAX_UPLOAD_BYTES + 1)).toMatch(
+      /not allowed/,
+    );
+  });
+
+  it("allowlist exposes common code, data, and image extensions", () => {
+    for (const ext of ["ts", "json", "md", "png", "pdf"]) {
+      expect(ALLOWED_UPLOAD_EXTENSIONS).toContain(ext);
+    }
+  });
+});

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,7 +14,8 @@
     "./html": "./src/html.ts",
     "./terminalKey": "./src/terminalKey.ts",
     "./transcript": "./src/transcript.ts",
-    "./test-hooks": "./src/test-hooks.ts"
+    "./test-hooks": "./src/test-hooks.ts",
+    "./upload": "./src/upload.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -100,6 +100,15 @@ export const TerminalPasteImageInputSchema = z.object({
   data: z.string(),
 });
 
+export const TerminalUploadFileInputSchema = z.object({
+  id: TerminalIdSchema,
+  /** Filename as the user dropped it. The server sanitizes before writing
+   *  — only the basename's safe characters survive. */
+  name: z.string().min(1),
+  /** Base64-encoded file bytes. */
+  data: z.string(),
+});
+
 export const TerminalSetParentInputSchema = z.object({
   id: TerminalIdSchema,
   parentId: TerminalIdSchema.nullable(),
@@ -146,6 +155,7 @@ export const contract = oc.router({
     screenState: oc.input(TerminalAttachInputSchema).output(z.string()),
     screenText: oc.input(TerminalScreenTextInputSchema).output(z.string()),
     pasteImage: oc.input(TerminalPasteImageInputSchema).output(z.void()),
+    uploadFile: oc.input(TerminalUploadFileInputSchema).output(z.void()),
     kill: oc.input(TerminalAttachInputSchema).output(TerminalInfoSchema),
     setParent: oc.input(TerminalSetParentInputSchema).output(z.void()),
     /** Test-only: kill and remove all terminals. */

--- a/packages/common/src/upload.ts
+++ b/packages/common/src/upload.ts
@@ -97,9 +97,16 @@ export function rejectionFor(name: string, bytes: number): string | null {
   if (!isAllowedUploadName(name)) {
     return `File type not allowed: "${name}". Allowed extensions: ${ALLOWED_UPLOAD_EXTENSIONS.join(", ")}`;
   }
+  return sizeRejectionFor(name, bytes);
+}
+
+/** Size-only rejection — for upload surfaces that have no filename to
+ *  validate (clipboard image paste). Same wording as the full
+ *  `rejectionFor` size branch so the message is consistent. */
+export function sizeRejectionFor(label: string, bytes: number): string | null {
   if (bytes > MAX_UPLOAD_BYTES) {
     const mb = (MAX_UPLOAD_BYTES / (1024 * 1024)).toFixed(0);
-    return `File too large: "${name}" exceeds the ${mb} MB limit`;
+    return `File too large: "${label}" exceeds the ${mb} MB limit`;
   }
   return null;
 }

--- a/packages/common/src/upload.ts
+++ b/packages/common/src/upload.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared policy for file drops onto a terminal. Both the client (pre-flight
+ * gate before encoding/sending) and the server (authoritative gate before
+ * writing to disk) consume these constants — keeping them in one place
+ * means the two sides cannot drift on the rejection threshold.
+ */
+
+/** Hard cap on a single dropped file. Agents don't need huge binaries;
+ *  the goal is "paste me a snippet/log/screenshot", not "ship me a tarball". */
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+/** Lowercase file extensions (without leading dot) that may be dropped.
+ *  Curated to text, code, structured data, common docs, and images. New
+ *  entries land here, not at the call sites. */
+export const ALLOWED_UPLOAD_EXTENSIONS: readonly string[] = [
+  // Text & docs
+  "txt",
+  "md",
+  "rst",
+  "pdf",
+  // Structured data
+  "json",
+  "jsonc",
+  "yaml",
+  "yml",
+  "toml",
+  "xml",
+  "csv",
+  "tsv",
+  "log",
+  "ini",
+  "env",
+  "lock",
+  // Web
+  "html",
+  "htm",
+  "css",
+  // Code
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "py",
+  "rb",
+  "go",
+  "rs",
+  "java",
+  "kt",
+  "kts",
+  "scala",
+  "c",
+  "h",
+  "cpp",
+  "hpp",
+  "cs",
+  "swift",
+  "sh",
+  "bash",
+  "zsh",
+  "fish",
+  "sql",
+  "nix",
+  "hs",
+  "elm",
+  "lua",
+  "vim",
+  // Images
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+] as const;
+
+/** Return the lowercase extension (no dot) of `name`, or `null` if there
+ *  isn't one. `.DS_Store` → `ds_store`; `Cargo.lock` → `lock`; `README` →
+ *  `null`. */
+export function extensionOf(name: string): string | null {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return null;
+  return name.slice(dot + 1).toLowerCase();
+}
+
+/** Whether a dropped filename is permitted by the extension allowlist. */
+export function isAllowedUploadName(name: string): boolean {
+  const ext = extensionOf(name);
+  return ext !== null && ALLOWED_UPLOAD_EXTENSIONS.includes(ext);
+}
+
+/** Human-readable rejection reason for a dropped file, or `null` if it
+ *  passes. Shared so the client toast and the server `ORPCError` message
+ *  match verbatim. */
+export function rejectionFor(name: string, bytes: number): string | null {
+  if (!isAllowedUploadName(name)) {
+    return `File type not allowed: "${name}". Allowed extensions: ${ALLOWED_UPLOAD_EXTENSIONS.join(", ")}`;
+  }
+  if (bytes > MAX_UPLOAD_BYTES) {
+    const mb = (MAX_UPLOAD_BYTES / (1024 * 1024)).toFixed(0);
+    return `File too large: "${name}" exceeds the ${mb} MB limit`;
+  }
+  return null;
+}

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { basename, extname, join } from "node:path";
+import { basename, join, parse } from "node:path";
 import { koluClipboardDir } from "./koluRoot.ts";
 
 function dirFor(terminalId: string): string {
@@ -31,12 +31,11 @@ function sanitizeUploadName(rawName: string): string {
 /** Pick a path that doesn't collide with an existing file in the same
  *  terminal directory. Appends `-1`, `-2`, … before the extension. */
 function uniquePath(dir: string, name: string): string {
-  const base = name.slice(0, name.length - extname(name).length);
-  const ext = extname(name);
+  const { name: stem, ext } = parse(name);
   let candidate = join(dir, name);
   let i = 1;
   while (existsSync(candidate)) {
-    candidate = join(dir, `${base}-${i}${ext}`);
+    candidate = join(dir, `${stem}-${i}${ext}`);
     i++;
   }
   return candidate;

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -1,12 +1,13 @@
 /**
- * Per-terminal on-disk storage for images pasted from the browser clipboard.
- * The `router.ts` `pasteImage` handler calls `saveClipboardImage` and then
- * bracketed-pastes the returned path into the PTY so agents that accept
- * paste-as-file-path (codex, Claude Code) auto-attach the image.
+ * Per-terminal on-disk storage for content uploaded from the browser —
+ * clipboard image pastes (`saveClipboardImage`) and drag-and-drop file
+ * drops (`saveDroppedFile`). The `router.ts` handlers call these and then
+ * bracketed-paste the returned path into the PTY so agents that accept
+ * paste-as-file-path (codex, Claude Code) can read the file.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { basename, extname, join } from "node:path";
 import { koluClipboardDir } from "./koluRoot.ts";
 
 function dirFor(terminalId: string): string {
@@ -25,6 +26,48 @@ export function saveClipboardImage(
   const imagePath = join(dir, "image.png");
   writeFileSync(imagePath, Buffer.from(base64Data, "base64"));
   return imagePath;
+}
+
+/** Strip everything but the basename and collapse any character that
+ *  would let a dropped name escape the per-terminal directory or break
+ *  shell tools that consume the path. Preserves the extension so the
+ *  receiving agent still sees a meaningful suffix. Always returns a
+ *  non-empty string. */
+function sanitizeUploadName(rawName: string): string {
+  const base = basename(rawName);
+  const sanitized = base.replace(/[^A-Za-z0-9._-]/g, "_");
+  // Strip leading dots so the result is never a hidden file or `..`.
+  const trimmed = sanitized.replace(/^\.+/, "");
+  return trimmed.length > 0 ? trimmed : "upload";
+}
+
+/** Pick a path that doesn't collide with an existing dropped file in the
+ *  same terminal directory. Appends `-1`, `-2`, … before the extension. */
+function uniquePath(dir: string, name: string): string {
+  const base = name.slice(0, name.length - extname(name).length);
+  const ext = extname(name);
+  let candidate = join(dir, name);
+  let i = 1;
+  while (existsSync(candidate)) {
+    candidate = join(dir, `${base}-${i}${ext}`);
+    i++;
+  }
+  return candidate;
+}
+
+/** Save a base64-encoded dropped file into the terminal's clipboard
+ *  directory, preserving the (sanitized) original name so the agent can
+ *  recognize what it received. Returns the on-disk path. */
+export function saveDroppedFile(
+  terminalId: string,
+  rawName: string,
+  base64Data: string,
+): string {
+  const dir = dirFor(terminalId);
+  mkdirSync(dir, { recursive: true });
+  const path = uniquePath(dir, sanitizeUploadName(rawName));
+  writeFileSync(path, Buffer.from(base64Data, "base64"));
+  return path;
 }
 
 /** Remove a terminal's clipboard directory. Safe to call when the dir was

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -45,22 +45,19 @@ function uniquePath(dir: string, name: string): string {
  *  creating the dir on first use. Returns the on-disk path so the
  *  caller can bracketed-paste it into the PTY.
  *
- *  `name` is sanitized first. When `unique` is true (default), a
- *  collision suffix protects existing files in the dir — this is the
- *  drag-and-drop path. When `unique` is false, the path is reused as-is
- *  and a prior file with the same name is overwritten — that's the
- *  clipboard-image path, where every paste is "the latest screenshot"
- *  and accumulating `image-N.png` artifacts would be noise. */
+ *  `name` is sanitized; a collision suffix (`-1`, `-2`, …) protects
+ *  any prior file in the dir from being clobbered. Two pastes in
+ *  flight — image then drop, drop then drop, or two pastes before the
+ *  agent has consumed the first — each get their own path so the
+ *  bracketed-paste references survive a late read. */
 export function saveTerminalFile(
   terminalId: string,
   name: string,
   base64Data: string,
-  { unique = true }: { unique?: boolean } = {},
 ): string {
   const dir = dirFor(terminalId);
   mkdirSync(dir, { recursive: true });
-  const safeName = sanitizeUploadName(name);
-  const path = unique ? uniquePath(dir, safeName) : join(dir, safeName);
+  const path = uniquePath(dir, sanitizeUploadName(name));
   writeFileSync(path, Buffer.from(base64Data, "base64"));
   return path;
 }

--- a/packages/server/src/clipboard.ts
+++ b/packages/server/src/clipboard.ts
@@ -1,9 +1,10 @@
 /**
- * Per-terminal on-disk storage for content uploaded from the browser —
- * clipboard image pastes (`saveClipboardImage`) and drag-and-drop file
- * drops (`saveDroppedFile`). The `router.ts` handlers call these and then
- * bracketed-paste the returned path into the PTY so agents that accept
- * paste-as-file-path (codex, Claude Code) can read the file.
+ * Per-terminal on-disk scratch storage for content uploaded from the
+ * browser — clipboard image pastes and drag-and-drop file drops both
+ * land here via `saveTerminalFile`. The `router.ts` handlers call it
+ * and then bracketed-paste the returned path into the PTY so agents
+ * that accept paste-as-file-path (codex, Claude Code) can read the
+ * file.
  */
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -12,20 +13,6 @@ import { koluClipboardDir } from "./koluRoot.ts";
 
 function dirFor(terminalId: string): string {
   return join(koluClipboardDir, terminalId);
-}
-
-/** Save base64-encoded image data into the terminal's clipboard directory,
- *  creating the dir on first use. Returns the on-disk path so the caller
- *  can bracketed-paste it into the PTY. */
-export function saveClipboardImage(
-  terminalId: string,
-  base64Data: string,
-): string {
-  const dir = dirFor(terminalId);
-  mkdirSync(dir, { recursive: true });
-  const imagePath = join(dir, "image.png");
-  writeFileSync(imagePath, Buffer.from(base64Data, "base64"));
-  return imagePath;
 }
 
 /** Strip everything but the basename and collapse any character that
@@ -41,8 +28,8 @@ function sanitizeUploadName(rawName: string): string {
   return trimmed.length > 0 ? trimmed : "upload";
 }
 
-/** Pick a path that doesn't collide with an existing dropped file in the
- *  same terminal directory. Appends `-1`, `-2`, … before the extension. */
+/** Pick a path that doesn't collide with an existing file in the same
+ *  terminal directory. Appends `-1`, `-2`, … before the extension. */
 function uniquePath(dir: string, name: string): string {
   const base = name.slice(0, name.length - extname(name).length);
   const ext = extname(name);
@@ -55,23 +42,32 @@ function uniquePath(dir: string, name: string): string {
   return candidate;
 }
 
-/** Save a base64-encoded dropped file into the terminal's clipboard
- *  directory, preserving the (sanitized) original name so the agent can
- *  recognize what it received. Returns the on-disk path. */
-export function saveDroppedFile(
+/** Save base64-encoded data into the terminal's scratch directory,
+ *  creating the dir on first use. Returns the on-disk path so the
+ *  caller can bracketed-paste it into the PTY.
+ *
+ *  `name` is sanitized first. When `unique` is true (default), a
+ *  collision suffix protects existing files in the dir — this is the
+ *  drag-and-drop path. When `unique` is false, the path is reused as-is
+ *  and a prior file with the same name is overwritten — that's the
+ *  clipboard-image path, where every paste is "the latest screenshot"
+ *  and accumulating `image-N.png` artifacts would be noise. */
+export function saveTerminalFile(
   terminalId: string,
-  rawName: string,
+  name: string,
   base64Data: string,
+  { unique = true }: { unique?: boolean } = {},
 ): string {
   const dir = dirFor(terminalId);
   mkdirSync(dir, { recursive: true });
-  const path = uniquePath(dir, sanitizeUploadName(rawName));
+  const safeName = sanitizeUploadName(name);
+  const path = unique ? uniquePath(dir, safeName) : join(dir, safeName);
   writeFileSync(path, Buffer.from(base64Data, "base64"));
   return path;
 }
 
-/** Remove a terminal's clipboard directory. Safe to call when the dir was
- *  never created. */
+/** Remove a terminal's scratch directory. Safe to call when the dir
+ *  was never created. */
 export function cleanupClipboardDir(terminalId: string): void {
   rmSync(dirFor(terminalId), { recursive: true, force: true });
 }

--- a/packages/server/src/koluRoot.ts
+++ b/packages/server/src/koluRoot.ts
@@ -1,14 +1,14 @@
 /**
  * Per-server-instance temp root for server-generated files.
  *
- * Kolu writes shell rc files and pasted clipboard images on a per-terminal
- * basis. Those go under a single root keyed by the server's startup UUID,
- * rooted at $XDG_RUNTIME_DIR when available.
+ * Kolu writes shell rc files and per-terminal scratch storage (clipboard
+ * image pastes, drag-and-drop file drops) under a single root keyed by
+ * the server's startup UUID, rooted at $XDG_RUNTIME_DIR when available.
  *
  * Privacy: $XDG_RUNTIME_DIR on Linux is /run/user/$UID — tmpfs, mode 0700,
- * wiped at logout. Clipboard images can contain screenshots, drag-dropped
- * files, and secrets; sharing /tmp with every other user on the host was
- * the wrong default. macOS os.tmpdir() already returns a per-user dir.
+ * wiped at logout. Scratch files can contain screenshots, dropped files,
+ * and secrets; sharing /tmp with every other user on the host was the
+ * wrong default. macOS os.tmpdir() already returns a per-user dir.
  * Non-systemd Linux falls back to /tmp with no regression.
  */
 import { mkdirSync, rmSync } from "node:fs";
@@ -25,14 +25,15 @@ export const koluRoot = join(runtimeRoot, `kolu-${serverProcessId}`);
 /** Injected bash rc files and zsh ZDOTDIRs, one pair per spawned terminal. */
 export const koluShellDir = join(koluRoot, "shell");
 
-/** Per-terminal directories where pasted clipboard images land on disk. */
-export const koluClipboardDir = join(koluRoot, "clipboard");
+/** Per-terminal scratch directories where clipboard image pastes and
+ *  drag-and-drop file drops land on disk. */
+export const koluScratchDir = join(koluRoot, "scratch");
 
 /** Create the root + subdirs with owner-only mode. Called once at server
  *  startup before any terminal spawns. Idempotent. */
 export function ensureKoluRoot(): void {
   mkdirSync(koluShellDir, { recursive: true, mode: 0o700 });
-  mkdirSync(koluClipboardDir, { recursive: true, mode: 0o700 });
+  mkdirSync(koluScratchDir, { recursive: true, mode: 0o700 });
 }
 
 /** Remove the whole per-instance root on shutdown. Registered on the

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -160,9 +160,7 @@ export const appRouter = t.router({
       if (reason !== null) {
         throw new ORPCError("BAD_REQUEST", { message: reason });
       }
-      const path = saveTerminalFile(input.id, "image.png", input.data, {
-        unique: false,
-      });
+      const path = saveTerminalFile(input.id, "image.png", input.data);
       bracketedPastePath(entry, path);
       log.info({ terminal: input.id, bytes, path }, "paste image");
     }),

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -14,12 +14,13 @@ import { loadClaudeCodeTranscript } from "kolu-claude-code";
 import { loadCodexTranscript } from "kolu-codex";
 import type { Transcript, TranscriptPr } from "kolu-common/transcript";
 import { TerminalNotFoundError } from "kolu-common/errors";
+import { rejectionFor } from "kolu-common/upload";
 import { worktreeCreate, worktreeRemove } from "kolu-git";
 import { prValue } from "kolu-github/schemas";
 import { loadOpenCodeTranscript } from "kolu-opencode";
 import { transcriptToHtml } from "kolu-transcript-html";
 import { match } from "ts-pattern";
-import { saveClipboardImage } from "./clipboard.ts";
+import { saveClipboardImage, saveDroppedFile } from "./clipboard.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import { log } from "./log.ts";
 import { terminalChannels } from "./publisher.ts";
@@ -44,6 +45,13 @@ function requireTerminal(id: string): TerminalProcess {
   const entry = getTerminal(id);
   if (!entry) throw new TerminalNotFoundError(id);
   return entry;
+}
+
+/** Decoded byte length of a base64 string — `(len * 3/4)` minus padding.
+ *  Lets handlers gate on size without materializing the Buffer. */
+function base64DecodedLength(data: string): number {
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  return Math.floor((data.length * 3) / 4) - padding;
 }
 
 export const appRouter = t.router({
@@ -140,18 +148,29 @@ export const appRouter = t.router({
 
     pasteImage: t.terminal.pasteImage.handler(async ({ input }) => {
       const entry = requireTerminal(input.id);
-      // base64 → decoded byte count: (len * 3/4) minus padding
-      const padding = input.data.endsWith("==")
-        ? 2
-        : input.data.endsWith("=")
-          ? 1
-          : 0;
-      const bytes = Math.floor((input.data.length * 3) / 4) - padding;
+      const bytes = base64DecodedLength(input.data);
       const path = saveClipboardImage(input.id, input.data);
       // Bracketed-paste the saved path into the PTY. Agents that accept
       // paste-as-file-path (codex, Claude Code) auto-attach the image.
       entry.handle.write(`\x1b[200~${path}\x1b[201~`);
       log.info({ terminal: input.id, bytes, path }, "paste image");
+    }),
+
+    uploadFile: t.terminal.uploadFile.handler(async ({ input }) => {
+      const entry = requireTerminal(input.id);
+      const bytes = base64DecodedLength(input.data);
+      const reason = rejectionFor(input.name, bytes);
+      if (reason !== null) {
+        throw new ORPCError("BAD_REQUEST", { message: reason });
+      }
+      const path = saveDroppedFile(input.id, input.name, input.data);
+      // Bracketed-paste the saved path into the PTY so agents that accept
+      // paste-as-file-path (codex, Claude Code) pick it up.
+      entry.handle.write(`\x1b[200~${path}\x1b[201~`);
+      log.info(
+        { terminal: input.id, name: input.name, bytes, path },
+        "upload file",
+      );
     }),
 
     kill: t.terminal.kill.handler(async ({ input }) => {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -20,7 +20,7 @@ import { prValue } from "kolu-github/schemas";
 import { loadOpenCodeTranscript } from "kolu-opencode";
 import { transcriptToHtml } from "kolu-transcript-html";
 import { match } from "ts-pattern";
-import { saveClipboardImage, saveDroppedFile } from "./clipboard.ts";
+import { saveTerminalFile } from "./clipboard.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import { log } from "./log.ts";
 import { terminalChannels } from "./publisher.ts";
@@ -160,7 +160,9 @@ export const appRouter = t.router({
       if (reason !== null) {
         throw new ORPCError("BAD_REQUEST", { message: reason });
       }
-      const path = saveClipboardImage(input.id, input.data);
+      const path = saveTerminalFile(input.id, "image.png", input.data, {
+        unique: false,
+      });
       bracketedPastePath(entry, path);
       log.info({ terminal: input.id, bytes, path }, "paste image");
     }),
@@ -172,7 +174,7 @@ export const appRouter = t.router({
       if (reason !== null) {
         throw new ORPCError("BAD_REQUEST", { message: reason });
       }
-      const path = saveDroppedFile(input.id, input.name, input.data);
+      const path = saveTerminalFile(input.id, input.name, input.data);
       bracketedPastePath(entry, path);
       log.info(
         { terminal: input.id, name: input.name, bytes, path },

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -14,7 +14,7 @@ import { loadClaudeCodeTranscript } from "kolu-claude-code";
 import { loadCodexTranscript } from "kolu-codex";
 import type { Transcript, TranscriptPr } from "kolu-common/transcript";
 import { TerminalNotFoundError } from "kolu-common/errors";
-import { rejectionFor } from "kolu-common/upload";
+import { rejectionFor, sizeRejectionFor } from "kolu-common/upload";
 import { worktreeCreate, worktreeRemove } from "kolu-git";
 import { prValue } from "kolu-github/schemas";
 import { loadOpenCodeTranscript } from "kolu-opencode";
@@ -156,6 +156,10 @@ export const appRouter = t.router({
     pasteImage: t.terminal.pasteImage.handler(async ({ input }) => {
       const entry = requireTerminal(input.id);
       const bytes = base64DecodedLength(input.data);
+      const reason = sizeRejectionFor("clipboard image", bytes);
+      if (reason !== null) {
+        throw new ORPCError("BAD_REQUEST", { message: reason });
+      }
       const path = saveClipboardImage(input.id, input.data);
       bracketedPastePath(entry, path);
       log.info({ terminal: input.id, bytes, path }, "paste image");

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -20,7 +20,7 @@ import { prValue } from "kolu-github/schemas";
 import { loadOpenCodeTranscript } from "kolu-opencode";
 import { transcriptToHtml } from "kolu-transcript-html";
 import { match } from "ts-pattern";
-import { saveTerminalFile } from "./clipboard.ts";
+import { saveTerminalFile } from "./terminalScratch.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import { log } from "./log.ts";
 import { terminalChannels } from "./publisher.ts";

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -54,6 +54,13 @@ function base64DecodedLength(data: string): number {
   return Math.floor((data.length * 3) / 4) - padding;
 }
 
+/** Bracketed-paste an on-disk path into a terminal so agents that accept
+ *  paste-as-file-path (codex, Claude Code) attach the file. Shared by every
+ *  handler that uploads content to per-terminal scratch storage. */
+function bracketedPastePath(entry: TerminalProcess, path: string): void {
+  entry.handle.write(`\x1b[200~${path}\x1b[201~`);
+}
+
 export const appRouter = t.router({
   ...surfaceRouter,
   server: {
@@ -150,9 +157,7 @@ export const appRouter = t.router({
       const entry = requireTerminal(input.id);
       const bytes = base64DecodedLength(input.data);
       const path = saveClipboardImage(input.id, input.data);
-      // Bracketed-paste the saved path into the PTY. Agents that accept
-      // paste-as-file-path (codex, Claude Code) auto-attach the image.
-      entry.handle.write(`\x1b[200~${path}\x1b[201~`);
+      bracketedPastePath(entry, path);
       log.info({ terminal: input.id, bytes, path }, "paste image");
     }),
 
@@ -164,9 +169,7 @@ export const appRouter = t.router({
         throw new ORPCError("BAD_REQUEST", { message: reason });
       }
       const path = saveDroppedFile(input.id, input.name, input.data);
-      // Bracketed-paste the saved path into the PTY so agents that accept
-      // paste-as-file-path (codex, Claude Code) pick it up.
-      entry.handle.write(`\x1b[200~${path}\x1b[201~`);
+      bracketedPastePath(entry, path);
       log.info(
         { terminal: input.id, name: input.name, bytes, path },
         "upload file",

--- a/packages/server/src/terminalScratch.ts
+++ b/packages/server/src/terminalScratch.ts
@@ -4,15 +4,15 @@
  * land here via `saveTerminalFile`. The `router.ts` handlers call it
  * and then bracketed-paste the returned path into the PTY so agents
  * that accept paste-as-file-path (codex, Claude Code) can read the
- * file.
+ * file. `cleanupTerminalScratch` wipes the dir on terminal exit.
  */
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, join, parse } from "node:path";
-import { koluClipboardDir } from "./koluRoot.ts";
+import { koluScratchDir } from "./koluRoot.ts";
 
 function dirFor(terminalId: string): string {
-  return join(koluClipboardDir, terminalId);
+  return join(koluScratchDir, terminalId);
 }
 
 /** Strip everything but the basename and collapse any character that
@@ -64,6 +64,6 @@ export function saveTerminalFile(
 
 /** Remove a terminal's scratch directory. Safe to call when the dir
  *  was never created. */
-export function cleanupClipboardDir(terminalId: string): void {
+export function cleanupTerminalScratch(terminalId: string): void {
   rmSync(dirFor(terminalId), { recursive: true, force: true });
 }

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -21,7 +21,7 @@ import type {
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
 import { spawnPty } from "kolu-pty";
 import pkg from "../package.json" with { type: "json" };
-import { cleanupClipboardDir } from "./clipboard.ts";
+import { cleanupTerminalScratch } from "./terminalScratch.ts";
 import { koluShellDir } from "./koluRoot.ts";
 import { log } from "./log.ts";
 import {
@@ -121,7 +121,7 @@ export function createTerminal(
         const entry = getTerminal(id);
         if (entry) {
           entry.stopProviders();
-          cleanupClipboardDir(id);
+          cleanupTerminalScratch(id);
         }
         surfaceCtx.events.terminalExit.publish({ id }, exitCode);
         // Only save session on natural exit (entry still in map).
@@ -191,7 +191,7 @@ export function killTerminal(id: TerminalId): TerminalInfo | undefined {
   log.child({ terminal: id }).info({ pid: entry.handle.pid }, "killing");
   entry.stopProviders();
   entry.handle.dispose();
-  cleanupClipboardDir(id);
+  cleanupTerminalScratch(id);
   unregisterTerminal(id);
   emitChanged();
   emitListChanged();
@@ -332,7 +332,7 @@ export function killAllTerminals(): void {
   for (const entry of entries) {
     entry.stopProviders();
     entry.handle.dispose();
-    cleanupClipboardDir(entry.info.id);
+    cleanupTerminalScratch(entry.info.id);
   }
   emitListChanged();
 }

--- a/packages/surface/README.md
+++ b/packages/surface/README.md
@@ -377,7 +377,7 @@ Shapes that don't fit a descriptor stay as plain oRPC procedures.
 |---|---|---|
 | **Bidirectional binary stream** — subscribe-before-yield ordering, custom `onRetry` (xterm buffer reset before re-subscribe's first frame) | `terminal.attach` | `streamCall(client.terminal.attach, { id }, { signal, onRetry })` |
 | **One-shot queries** — request/response, no subscription dimension | `server.info`, `terminal.screenState`, `terminal.screenText`, `terminal.exportTranscriptHtml` | `await client.X.Y(input)` |
-| **Mutations** — request/response writes | `terminal.create` / `kill` / `killAll` / `resize` / `sendInput` / `setTheme` / `setCanvasLayout` / `setSubPanel` / `setRightPanel` / `setActive` / `setParent` / `pasteImage`, `git.worktreeCreate` / `worktreeRemove`, `preferences.update` | `await client.X.Y(input)` (the retry plugin's `retry: 0` default fails them fast) |
+| **Mutations** — request/response writes | `terminal.create` / `kill` / `killAll` / `resize` / `sendInput` / `setTheme` / `setCanvasLayout` / `setSubPanel` / `setRightPanel` / `setActive` / `setParent` / `pasteImage` / `uploadFile`, `git.worktreeCreate` / `worktreeRemove`, `preferences.update` | `await client.X.Y(input)` (the retry plugin's `retry: 0` default fails them fast) |
 
 `streamCall` applies the same `STREAM_RETRY` context the descriptor hooks thread (and merges in an optional `onRetry` callback) so transport drops re-subscribe transparently — escape hatch for non-descriptor shapes, same retry semantics.
 

--- a/packages/tests/features/file-drop.feature
+++ b/packages/tests/features/file-drop.feature
@@ -1,0 +1,12 @@
+Feature: Drag-and-drop file upload
+  When the user drops a file onto a terminal, the server saves the
+  file under the terminal's clipboard directory and bracketed-pastes
+  the path into the PTY. Agents that accept paste-as-file-path
+  (codex, Claude Code) can then read the file.
+
+  Background:
+    Given the terminal is ready
+
+  Scenario: dropped file path is delivered to the PTY
+    When I drop a file named "notes.md" with content "hello drop" onto the terminal
+    Then the screen state should contain "notes.md"

--- a/packages/tests/step_definitions/file_drop_steps.ts
+++ b/packages/tests/step_definitions/file_drop_steps.ts
@@ -21,16 +21,17 @@ When(
         if (!target) throw new Error("No focused terminal container");
         const dt = new DataTransfer();
         dt.items.add(new File([content], name, { type: "text/plain" }));
-        const fire = (type: string) =>
-          target.dispatchEvent(
-            new DragEvent(type, {
-              bubbles: true,
-              cancelable: true,
-              dataTransfer: dt,
-            }),
-          );
-        fire("dragover");
-        fire("drop");
+        // Inline the two dispatches rather than a `fire(type)` helper:
+        // esbuild's keep-names transform decorates inner functions with
+        // a `__name(...)` call that doesn't exist inside page.evaluate's
+        // browser-side eval context, so a named arrow here would crash.
+        const init = {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: dt,
+        } as const;
+        target.dispatchEvent(new DragEvent("dragover", init));
+        target.dispatchEvent(new DragEvent("drop", init));
       },
       { name, content },
     );

--- a/packages/tests/step_definitions/file_drop_steps.ts
+++ b/packages/tests/step_definitions/file_drop_steps.ts
@@ -19,23 +19,18 @@ When(
           "[data-focused][data-terminal-id]",
         );
         if (!target) throw new Error("No focused terminal container");
-        const file = new File([content], name, { type: "text/plain" });
         const dt = new DataTransfer();
-        dt.items.add(file);
-        target.dispatchEvent(
-          new DragEvent("dragover", {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer: dt,
-          }),
-        );
-        target.dispatchEvent(
-          new DragEvent("drop", {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer: dt,
-          }),
-        );
+        dt.items.add(new File([content], name, { type: "text/plain" }));
+        const fire = (type: string) =>
+          target.dispatchEvent(
+            new DragEvent(type, {
+              bubbles: true,
+              cancelable: true,
+              dataTransfer: dt,
+            }),
+          );
+        fire("dragover");
+        fire("drop");
       },
       { name, content },
     );

--- a/packages/tests/step_definitions/file_drop_steps.ts
+++ b/packages/tests/step_definitions/file_drop_steps.ts
@@ -1,0 +1,47 @@
+import { When } from "@cucumber/cucumber";
+import type { KoluWorld } from "../support/world.ts";
+
+/**
+ * Simulate a real file drop on the terminal container. Construct a
+ * `DataTransfer` with a synthetic `File`, then dispatch the
+ * dragover/drop sequence Chrome would emit. The terminal's drop
+ * listener uploads via oRPC; the server saves the file and bracketed-
+ * pastes the path into the PTY, so the file's name shows up in the
+ * screen buffer once the round trip completes.
+ */
+When(
+  "I drop a file named {string} with content {string} onto the terminal",
+  async function (this: KoluWorld, name: string, content: string) {
+    await this.canvas.click();
+    await this.page.evaluate(
+      ({ name, content }) => {
+        const target = document.querySelector(
+          "[data-focused][data-terminal-id]",
+        );
+        if (!target) throw new Error("No focused terminal container");
+        const file = new File([content], name, { type: "text/plain" });
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        target.dispatchEvent(
+          new DragEvent("dragover", {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: dt,
+          }),
+        );
+        target.dispatchEvent(
+          new DragEvent("drop", {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: dt,
+          }),
+        );
+      },
+      { name, content },
+    );
+    // Wait for the upload RPC round trip; the terminal buffer contains
+    // the path once the server bracketed-pastes it back.
+    await this.waitForFrame();
+    await this.waitForFrame();
+  },
+);


### PR DESCRIPTION
**Drag any small file onto a terminal tile and the agent picks it up** — the server saves the bytes under the per-terminal scratch dir and bracketed-pastes the absolute path into the PTY, the same shape that has powered <kbd>Ctrl+V</kbd> image paste. Claude Code, codex, and OpenCode all auto-attach the file because they already accept paste-as-file-path.

The interesting design choice is that **client pre-flight and server gate share one policy module** (`kolu-common/upload`). The allowlist and the 10 MB cap live in one constant; the browser refuses oversize / disallowed drops with a toast before encoding, and the server re-checks before writing — so they cannot drift on what counts as a permissible upload.

### Flow

```
                                                ┌─ rejectionFor() (10 MB + ext allowlist) ─┐
DataTransfer.files ─▶ Terminal.tsx drop listener ▼                                          │
                                                 client.terminal.uploadFile({ id, name, base64 })
                                                                                   │
                                                                                   ▼
                                                                            server handler
                                                                                   │
                                                          rejectionFor()  ─────────┤
                                                          saveTerminalFile() ──────┤
                                                          bracketedPastePath() ────┘
                                                                                   │
                                                                                   ▼
                                                                              PTY
```

### What landed

- **`kolu-common/upload`** — single source of truth for what's droppable. `MAX_UPLOAD_BYTES`, `ALLOWED_UPLOAD_EXTENSIONS`, `rejectionFor(name, bytes)`, plus a `sizeRejectionFor(label, bytes)` for surfaces with no filename (clipboard paste).
- **`terminal.uploadFile`** raw oRPC procedure on the contract; server handler mirrors `pasteImage` (size+ext gate → save → bracketed-paste). Files land under `koluScratchDir/<terminalId>/`, sanitized basename, `-N` suffix on collision; existing `cleanupTerminalScratch` wipes them when the terminal exits.
- **`saveTerminalFile(id, name, base64)`** in `packages/server/src/terminalScratch.ts` replaces the prior `saveClipboardImage` + `saveDroppedFile` split — same 4-step pipeline, one function. Both consumers (clipboard image paste, drag-and-drop file drops) route through `uniquePath` so two pastes in flight each get their own bracketed-paste reference and a late agent read can't silently resolve to a clobbered file.
- **`Terminal.tsx` drop handlers** — `dragover`/`dragleave`/`drop` on the existing `containerRef`. A `data-drop-target` attribute drives a Tailwind inset ring while a file drag is hovering. Multi-file drops upload in parallel.
- **Allowlist** — text/docs (`md`, `txt`, `pdf`), structured data (`json`, `yaml`, `toml`, `csv`, `log`, `lock`, …), code in 25+ languages, web (`html`, `css`), and the usual image set. Disallowed types are rejected at the client with a toast naming the allowlist; the server re-rejects with the same wording.

### Refinements caught by Hickey / Lowy and `/code-police`

| Pass | Finding | Fix |
|---|---|---|
| Hickey | `\x1b[200~…\x1b[201~` literal duplicated across two router handlers | Extracted `bracketedPastePath(entry, path)` private helper |
| Hickey + Lowy | `pasteImage` bypassed the new upload policy module entirely | Added `sizeRejectionFor` (name-less variant), routed paste handler + client through it |
| Lowy | `uploadPastedImage` swallowed errors into `console.error` while the new drop path used `toast.error` | Aligned both onto `toast.error` with the server message |
| Hickey | `saveClipboardImage` and `saveDroppedFile` shared a 4-step pipeline, differed only in filename derivation | Collapsed into `saveTerminalFile(id, name, base64)` |
| Lowy (revisit) | `saveClipboardImage` overwrote `image.png` instead of routing through `uniquePath` — initially dispositioned No-op on a post-hoc "intentional" rationalization that turned out to be undocumented | Routed `pasteImage` through `uniquePath` like drops; with no caller needing the carve-out, dropped the `{ unique }` parameter on `saveTerminalFile` |
| Lowy (revisit) | `clipboard.ts` named after a consumer rather than its volatility axis — initially No-op'd, but after the save-function collapse the module is unambiguously per-terminal scratch storage and the consumer-name was misleading | Renamed module (`clipboard.ts` → `terminalScratch.ts`), function (`cleanupClipboardDir` → `cleanupTerminalScratch`), constant (`koluClipboardDir` → `koluScratchDir`), and on-disk path component (`clipboard/` → `scratch/`) |
| Elegance | Two `err instanceof Error ? err.message : String(err)` chains | Extracted `errMsg(err: unknown)` |
| Elegance | `saveDroppedFile`'s `extname()` + manual slice for stem/ext | Replaced with `path.parse(name)` destructure |
| Tests | The `fire(type)` helper inside `page.evaluate` triggered esbuild's keep-names `__name(...)` decoration that doesn't exist in the browser eval context | Inlined the two `dispatchEvent` calls with a shared init object |

The hickey/lowy commits and the police-elegance commits are split one-per-finding so the PR history reads as a progression rather than an opaque squash.

### Coverage

- New cucumber scenario `features/file-drop.feature` — synthesises a `File` + `DataTransfer`, dispatches dragover→drop, asserts the dropped filename appears in the screen buffer.
- New vitest at `packages/client/src/upload.test.ts` exercises `extensionOf`, `isAllowedUploadName`, and every branch of `rejectionFor`.
- Existing `features/clipboard.feature` re-run to confirm the paste path still works after being routed through the shared policy.

Closes #745

### Try it locally

```sh
nix run github:juspay/kolu/fsupload
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._