### PR TITLE
Plan B R-1: dissolve meta/* behind a single `Backend` interface (#951 prototype)

### DIFF
--- a/packages/client/src/canvas/dock/dockRowRanking.test.ts
+++ b/packages/client/src/canvas/dock/dockRowRanking.test.ts
@@ -20,11 +20,13 @@ function makeAgent(state: AgentInfo["state"]): AgentInfo {
 
 function makeMeta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
+    location: { kind: "local" },
     cwd: "/tmp",
     git: null,
     pr: { kind: "absent" },
     agent: null,
     foreground: null,
+    connectionState: "live",
     lastActivityAt: 0,
     ...overrides,
   };

--- a/packages/client/src/canvas/dockModel.test.ts
+++ b/packages/client/src/canvas/dockModel.test.ts
@@ -38,11 +38,13 @@ function makeAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
 
 function makeMeta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
+    location: { kind: "local" },
     cwd: "/home/user/kolu",
     git: makeGit(),
     pr: { kind: "absent" },
     agent: null,
     foreground: null,
+    connectionState: "live",
     lastActivityAt: 0,
     ...overrides,
   };

--- a/packages/client/src/terminal/terminalDisplay.test.ts
+++ b/packages/client/src/terminal/terminalDisplay.test.ts
@@ -5,11 +5,13 @@ import { assignColors, buildTerminalDisplayInfos } from "./terminalDisplay";
 
 function makeMeta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
+    location: { kind: "local" },
     cwd: "/home/user/project",
     git: null,
     pr: { kind: "pending" },
     agent: null,
     foreground: null,
+    connectionState: "live",
     lastActivityAt: 0,
     ...overrides,
   };

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     "./surface": "./src/surface.ts",
+    "./backend": "./src/backend.ts",
     "./contract": "./src/contract.ts",
     "./errors": "./src/errors.ts",
     "./config": "./src/config.ts",

--- a/packages/common/src/backend.ts
+++ b/packages/common/src/backend.ts
@@ -1,0 +1,187 @@
+/**
+ * Backend — the per-terminal world a terminal lives in.
+ *
+ * A `Backend` is identified by `BackendId` (local machine, or a specific
+ * SSH host) and owns every per-terminal stream + one-shot op a terminal
+ * needs. R-1 ships `LocalBackend` only; R-2 adds `RemoteBackend` whose
+ * methods proxy via oRPC over `ssh stdio` to a `kolu agent --stdio`
+ * instance on the remote host.
+ *
+ * The interface is the single transport boundary in the system. The
+ * server's `meta/*.ts` orchestrators are dissolved into `LocalBackend`
+ * (provider startup is now internal to `spawnPty`); the kolu server
+ * invokes `backend.terminalChannel(id, "git")` and forwards. It does
+ * not import from `kolu-git` directly for terminal-scoped work.
+ *
+ * Streaming methods follow the snapshot-then-delta invariant
+ * (`.claude/rules/streaming.md`). The first yield is always a snapshot;
+ * subsequent yields are deltas. `RemoteBackend` reuses oRPC's
+ * `STREAM_RETRY` plumbing — `kolu agent --stdio` is just another oRPC
+ * peer, no bespoke reconnect logic needed.
+ *
+ * Invariants enforced by convention (not by types):
+ *
+ * 1. **Kill convergence.** Both `Backend.killTerminal(id)` and
+ *    `TerminalHandle.dispose()` must end at the same termination logic
+ *    inside the backend — neither path may skip provider teardown,
+ *    clipboard cleanup, or registry deregistration. R-2's `RemoteBackend`
+ *    must wire `dispose()` through to `killTerminal` so RPC kill and
+ *    handle-dispose are observationally indistinguishable.
+ *
+ * 2. **Snapshot-then-delta streams.** Every `terminalChannel<K>`
+ *    iterator's first yield is a full state snapshot; subsequent yields
+ *    are deltas. Without this, reconnect via `STREAM_RETRY` silently
+ *    accumulates onto stale client state.
+ *
+ * Gap acknowledged for R-2: `packages/server/src/surface.ts`'s `streams`
+ * block (gitStatus, gitDiff, fsListAll, fsReadFile) still calls
+ * `kolu-git` directly rather than routing through `Backend.fs`/
+ * `Backend.git`. For R-1 the Code tab works because every backend is
+ * local; for R-2 those streams must route through the backend or remote
+ * tiles will silently read the kolu-server's local filesystem instead of
+ * the agent's. Tracked in the R-2 PR description.
+ */
+
+import type {
+  GitDiffMode,
+  GitDiffOutput,
+  GitInfo,
+  GitStatusOutput,
+} from "kolu-git/schemas";
+import type { InitialTerminalMetadata, TerminalLocation } from "./surface";
+
+/** Seed metadata for a new terminal. Same shape as
+ *  `InitialTerminalMetadata` (used by the `terminal.create` RPC input)
+ *  plus the parent-link, which the client-create RPC carries as a
+ *  top-level field for clarity. Bundled here so the backend has one
+ *  `Object.assign`-shaped opt rather than seven optional fields. */
+export interface TerminalSeed extends InitialTerminalMetadata {
+  /** Sub-terminal link — present when this terminal is a child of an
+   *  existing one. The lifecycle layer (terminals.ts) decides whether
+   *  to inherit the parent's location; the backend just sets the
+   *  field. */
+  parentId?: string;
+}
+
+/**
+ * Stable identity for a backend instance. Persisted to disk as part of
+ * `ServerPersistedTerminalFields.location` so restore picks the same
+ * backend a terminal previously lived on.
+ */
+export type BackendId = TerminalLocation;
+
+/** Inputs for `Backend.spawnPty`. Mirrors today's `createTerminal` shape
+ *  without any backend-specific extras — both LocalBackend and
+ *  RemoteBackend accept the same options.
+ *
+ *  `initialMetadata` seeds the client-owned metadata fields (theme,
+ *  canvasLayout, parentId, subPanel, rightPanel, intent) BEFORE the
+ *  backend's providers emit their first publish — so the first
+ *  `terminalMetadata` collection yield carries them, and the canvas
+ *  default-cascade effect can't race the providers' churn (#642). The
+ *  backend doesn't interpret the contents — it just sets the fields on
+ *  the new terminal's metadata before starting providers.
+ *
+ *  `onExit` fires whenever the PTY process exits — naturally (shell typed
+ *  `exit`, crash) or as a result of an explicit `dispose()` /
+ *  `killTerminal()`. The `wasNatural` flag distinguishes the two so the
+ *  caller knows whether to fan out session-save signals: only natural
+ *  exit triggers an autosave; explicit kill already accounted for the
+ *  registry change. (`killAllTerminals` drains the registry before
+ *  disposing, so every kill-all callback observes `wasNatural=false` and
+ *  shutdown doesn't write phantom empty sessions.) */
+export interface PtySpawnOpts {
+  cwd?: string;
+  initialMetadata?: TerminalSeed;
+  onExit?: (exitCode: number, wasNatural: boolean) => void;
+}
+
+/** A live terminal owned by a backend. `id` is shared across the system
+ *  (the wire `TerminalId`); `write`/`resize`/`dispose` are the control
+ *  surface. `dispose()` is observationally identical to
+ *  `Backend.killTerminal(id)` — see the kill-convergence invariant in
+ *  the module doc. */
+export interface TerminalHandle {
+  readonly id: string;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  dispose(): void;
+}
+
+/** Per-terminal streaming channels. Snapshot-then-delta on every key. */
+export interface TerminalChannelMap {
+  /** Raw PTY bytes — high-throughput stream. */
+  data: string;
+  /** OSC 7 cwd updates. */
+  cwd: string;
+  /** OSC 0/2 title updates. */
+  title: string;
+  /** Git context for the terminal's cwd. */
+  git: GitInfo | null;
+  /** OSC 633;E preexec command lines (raw). */
+  commandRun: string;
+}
+
+/** One-shot filesystem ops scoped to whatever filesystem the backend
+ *  represents. For `LocalBackend` this is the local FS; for
+ *  `RemoteBackend` it's the remote agent's FS. The kolu server treats
+ *  them identically. */
+export interface BackendFs {
+  listAll(repoPath: string): Promise<string[]>;
+  readFile(
+    repoPath: string,
+    filePath: string,
+  ): Promise<{ content: string; truncated: boolean }>;
+}
+
+/** One-shot git ops. Types mirror `kolu-git/schemas` so the wire shape
+ *  is identical regardless of backend. */
+export interface BackendGit {
+  getDiff(
+    repoPath: string,
+    filePath: string,
+    mode: GitDiffMode,
+    oldPath?: string,
+  ): Promise<GitDiffOutput>;
+  getStatus(repoPath: string, mode: GitDiffMode): Promise<GitStatusOutput>;
+}
+
+/**
+ * The Backend interface — see module doc. R-1 ships `LocalBackend`. R-2
+ * adds `RemoteBackend` and the binary serving its protocol
+ * (`kolu agent --stdio`).
+ *
+ * Per-terminal screen-state reads (`getScreenState`, `getScreenText`)
+ * deliberately do NOT live here: the xterm-headless emulator buffer is
+ * per-terminal local state that survives backend swaps (a Phase-3
+ * remote-agent reattach still serializes the local emulator's
+ * scrollback). The emulator lives next to its handle in the registry;
+ * callers read it via `getTerminal(id)?.handle.getScreenState()` rather
+ * than through this interface.
+ */
+export interface Backend {
+  readonly id: BackendId;
+
+  /** Create a new terminal owned by this backend. */
+  spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle>;
+
+  /** Subscribe to a terminal's stream of `kind`. Snapshot-then-delta;
+   *  late joiners (e.g. tab refresh) receive the current snapshot
+   *  before any deltas. Aborting the iterator closes the subscription. */
+  terminalChannel<K extends keyof TerminalChannelMap>(
+    terminalId: string,
+    kind: K,
+    signal?: AbortSignal,
+  ): AsyncIterable<TerminalChannelMap[K]>;
+
+  /** Kill a terminal owned by this backend. Returns true if the
+   *  terminal was registered and the kill ran; false if the id was
+   *  unknown (already cleaned up). Observationally identical to calling
+   *  `dispose()` on the same terminal's handle — see kill-convergence
+   *  invariant in the module doc. */
+  killTerminal(terminalId: string): boolean;
+
+  /** Filesystem and git one-shot ops on the backend's filesystem. */
+  readonly fs: BackendFs;
+  readonly git: BackendGit;
+}

--- a/packages/common/src/backend.ts
+++ b/packages/common/src/backend.ts
@@ -178,6 +178,19 @@ export interface Backend {
    *  invariant in the module doc. */
   killTerminal(terminalId: string): boolean;
 
+  /** Tear down a terminal whose entry the caller already holds — used
+   *  by bulk-kill paths that drain the registry first and want the
+   *  per-entry teardown without a second registry lookup. The contract
+   *  is "same teardown as `killTerminal`, applied to a specific entry
+   *  the caller is responsible for having removed from the shared
+   *  registry already." Single entry point keeps the kill-convergence
+   *  invariant holding across bulk and single-target paths. */
+  killTerminalEntry(entry: {
+    info: { id: string };
+    handle: { dispose(): void };
+    stopProviders: () => void;
+  }): void;
+
   /** Filesystem and git one-shot ops on the backend's filesystem. */
   readonly fs: BackendFs;
   readonly git: BackendGit;

--- a/packages/common/src/backend.ts
+++ b/packages/common/src/backend.ts
@@ -57,9 +57,14 @@ import type { InitialTerminalMetadata, TerminalLocation } from "./surface";
  *  `Object.assign`-shaped opt rather than seven optional fields. */
 export interface TerminalSeed extends InitialTerminalMetadata {
   /** Sub-terminal link — present when this terminal is a child of an
-   *  existing one. The lifecycle layer (terminals.ts) decides whether
-   *  to inherit the parent's location; the backend just sets the
-   *  field. */
+   *  existing one. The backend just records the link on the new
+   *  terminal's metadata; it does NOT decide which backend to spawn
+   *  on. Sub-terminal location inheritance ("a child of a remote tile
+   *  spawns on the same remote") is the resolver's job — R-2 will
+   *  extend `getBackendFor` (or a creation-time variant) to look up
+   *  `parentId`'s backend before dispatching, so the inheritance lives
+   *  at one site instead of being replicated at every
+   *  `createTerminal` caller. */
   parentId?: string;
 }
 

--- a/packages/common/src/backend.ts
+++ b/packages/common/src/backend.ts
@@ -63,13 +63,6 @@ export interface TerminalSeed extends InitialTerminalMetadata {
   parentId?: string;
 }
 
-/**
- * Stable identity for a backend instance. Persisted to disk as part of
- * `ServerPersistedTerminalFields.location` so restore picks the same
- * backend a terminal previously lived on.
- */
-export type BackendId = TerminalLocation;
-
 /** Inputs for `Backend.spawnPty`. Mirrors today's `createTerminal` shape
  *  without any backend-specific extras — both LocalBackend and
  *  RemoteBackend accept the same options.
@@ -160,7 +153,11 @@ export interface BackendGit {
  * than through this interface.
  */
 export interface Backend {
-  readonly id: BackendId;
+  /** Stable identity for this backend instance — `{ kind: "local" }` or
+   *  `{ kind: "ssh", host }`. Persisted on each terminal's
+   *  `ServerPersistedTerminalFields.location` so session restore picks
+   *  the same backend a terminal previously lived on. */
+  readonly id: TerminalLocation;
 
   /** Create a new terminal owned by this backend. */
   spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle>;

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -27,6 +27,7 @@ import {
   TerminalAttachInputSchema,
   TerminalIdSchema,
   TerminalInfoSchema,
+  TerminalLocationSchema,
 } from "./surface";
 import {
   ExportTranscriptHtmlInputSchema,
@@ -39,6 +40,10 @@ export const TerminalCreateInputSchema = z
   .object({
     cwd: z.string().optional(),
     parentId: TerminalIdSchema.optional(),
+    /** Backend location for this terminal. Sub-terminals inherit the
+     *  parent's location regardless of what the caller sends. Absent =
+     *  `{ kind: "local" }`. */
+    location: TerminalLocationSchema.optional(),
   })
   .merge(InitialTerminalMetadataSchema);
 

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -48,6 +48,33 @@ import { z } from "zod";
 
 export const TerminalIdSchema = z.string().uuid();
 
+/**
+ * Backend identity — discriminated union picking the per-terminal world a
+ * terminal lives in. `LocalBackend` (this machine) is the only kind in
+ * R-1; `RemoteBackend` (`{ kind: "ssh"; host }`) lands in R-2. The shape
+ * is on the persisted schema so saved sessions remember which backend a
+ * terminal belonged to and restore picks the same one. Default
+ * (`{ kind: "local" }`) absorbs every saved session shipped before R-1
+ * via Zod `.default(...)`.
+ */
+export const TerminalLocationSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("local") }),
+  z.object({ kind: z.literal("ssh"), host: z.string().min(1) }),
+]);
+export type TerminalLocation = z.infer<typeof TerminalLocationSchema>;
+
+/**
+ * Connection state — per-terminal, observable when the backend is remote.
+ * Local terminals are always `"live"`. The enum sits on the live fields
+ * because reconnect activity is transient state never written to disk.
+ */
+export const ConnectionStateSchema = z.enum([
+  "live",
+  "connecting",
+  "disconnected",
+]);
+export type ConnectionState = z.infer<typeof ConnectionStateSchema>;
+
 export const AgentKindSchema = z.enum(["claude-code", "codex", "opencode"]);
 
 export const AgentInfoSchema = z.discriminatedUnion("kind", [
@@ -141,6 +168,12 @@ export const RightPanelPerTerminalStateSchema = z.object({
  * `LiveTerminalFieldsSchema`. See the partition comment above.
  */
 export const ServerPersistedTerminalFieldsSchema = z.object({
+  /** Where this terminal lives — local (default, every pre-R-1 saved
+   *  session resolves here) or a specific SSH host. Backend identity, not
+   *  a parallel `host?: string` field — keeping the discriminated-union
+   *  shape means every consumer pattern-matches and can never see a half-
+   *  filled host string. */
+  location: TerminalLocationSchema.default({ kind: "local" }),
   cwd: z.string(),
   git: GitInfoSchema.nullable(),
   /** Normalized agent CLI invocation last observed in this terminal (e.g.
@@ -204,6 +237,9 @@ export const LiveTerminalFieldsSchema = z.object({
   agent: AgentInfoSchema.nullable(),
   /** Foreground process name — detected via OSC 2 title change events. */
   foreground: ForegroundSchema.nullable(),
+  /** Backend connection state — observable when `location.kind === "ssh"`.
+   *  Always `"live"` for local terminals (RemoteBackend lands in R-2). */
+  connectionState: ConnectionStateSchema.default("live"),
 });
 
 /**
@@ -264,10 +300,13 @@ export const InitialTerminalMetadataSchema = z.object({
 // ── Terminal cell value + raw-procedure shared schemas ────────────────
 
 /** Wire shape for the `terminalList` cell. Identity only — metadata
- *  flows through the `terminalMetadata` collection. */
+ *  flows through the `terminalMetadata` collection. `pid` was dropped in
+ *  R-1 because a remote terminal has no local pid and no client renders
+ *  it (a remote tile would have leaked a misleading local-ssh-subprocess
+ *  pid). Server-side debug logging keeps the pid inside `TerminalProcess`
+ *  out of band. */
 export const TerminalInfoSchema = z.object({
   id: TerminalIdSchema,
-  pid: z.number(),
 });
 
 /** Shared by both `terminal.attach` (raw oRPC streaming) and the

--- a/packages/server/src/backend/index.ts
+++ b/packages/server/src/backend/index.ts
@@ -1,10 +1,10 @@
 /**
- * Backend registry — resolves which `Backend` owns a given terminal.
+ * Backend registry — resolves which `Backend` owns a given location.
  *
  * R-1: only `LocalBackend` exists, so the resolver returns the
  * singleton unconditionally. R-2 will add a per-host `RemoteBackend`
- * map keyed by `entry.meta.location.host`, and the resolver becomes a
- * `switch` on `entry.meta.location.kind`.
+ * map keyed by `location.host`, and the resolver becomes a `switch` on
+ * `location.kind`.
  *
  * Keeping the resolver behind a single function — even when it's
  * trivial — means R-2 is a localized change (this file + a new
@@ -12,16 +12,20 @@
  */
 
 import type { Backend } from "kolu-common/backend";
-import type { TerminalProcess } from "../terminal-registry.ts";
+import type { TerminalLocation } from "kolu-common/surface";
 import { localBackend } from "./local.ts";
 
 export { localBackend } from "./local.ts";
 
-/** Resolve which backend owns a terminal — read from its persisted
- *  location. R-1: always returns the local singleton; R-2 will look up
- *  a per-host `RemoteBackend` instance. */
-export function getBackendFor(_entry: TerminalProcess): Backend {
-  // R-1: only `LocalBackend` exists. Once `RemoteBackend` lands in R-2
-  // this becomes a switch on `entry.meta.location.kind`.
+/** Resolve which backend owns a given terminal location. Takes
+ *  `TerminalLocation` directly so create-path callers (who don't yet
+ *  have a registry entry) and read-path callers (who have an entry's
+ *  `meta.location`) share one signature.
+ *
+ *  R-1: every location resolves to the local singleton. R-2 makes this
+ *  `match(location).with({ kind: "local" }, …).with({ kind: "ssh" }, …)`
+ *  against a per-host `RemoteBackend` cache. */
+export function getBackendFor(_location: TerminalLocation): Backend {
+  // R-1: only `LocalBackend` exists. R-2 dispatches by `_location.kind`.
   return localBackend;
 }

--- a/packages/server/src/backend/index.ts
+++ b/packages/server/src/backend/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Backend registry — resolves which `Backend` owns a given terminal.
+ *
+ * R-1: only `LocalBackend` exists, so the resolver returns the
+ * singleton unconditionally. R-2 will add a per-host `RemoteBackend`
+ * map keyed by `entry.meta.location.host`, and the resolver becomes a
+ * `switch` on `entry.meta.location.kind`.
+ *
+ * Keeping the resolver behind a single function — even when it's
+ * trivial — means R-2 is a localized change (this file + a new
+ * `remote.ts`) rather than a hunt-and-replace across the codebase.
+ */
+
+import type { Backend } from "kolu-common/backend";
+import type { TerminalProcess } from "../terminal-registry.ts";
+import { localBackend } from "./local.ts";
+
+export { localBackend } from "./local.ts";
+
+/** Resolve which backend owns a terminal — read from its persisted
+ *  location. R-1: always returns the local singleton; R-2 will look up
+ *  a per-host `RemoteBackend` instance. */
+export function getBackendFor(_entry: TerminalProcess): Backend {
+  // R-1: only `LocalBackend` exists. Once `RemoteBackend` lands in R-2
+  // this becomes a switch on `entry.meta.location.kind`.
+  return localBackend;
+}

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -107,22 +107,15 @@ export class LocalBackend implements Backend {
         onData: (data) => terminalChannels.data(id).publish(data),
         onExit: (exitCode) => {
           tlog.info({ exitCode }, "exited");
-          // `wasNatural` is decided by whether the entry was still in
-          // the registry at the moment the PTY exited. Explicit kills
-          // (`killTerminal` here, or `killAllTerminals` via the
-          // drain-before-dispose ordering) unregister first, so this
-          // callback sees `wasNatural=false` and the caller knows to
-          // skip the session-save fanout (which they already did at
-          // explicit-kill time, or are intentionally skipping during
-          // shutdown).
-          const wasNatural = getTerminal(id) !== undefined;
-          if (wasNatural) {
-            const entry = getTerminal(id);
-            if (entry) {
-              entry.stopProviders();
-              cleanupTerminalScratch(id);
-              unregisterTerminal(id);
-            }
+          // `wasNatural`: entry still in registry ⟹ PTY exited on its own.
+          // Explicit kills (`killTerminal` / `killAllTerminals`) unregister
+          // first, so `getTerminal` returns `undefined` here for killed PTYs.
+          const entry = getTerminal(id);
+          const wasNatural = entry !== undefined;
+          if (entry) {
+            entry.stopProviders();
+            cleanupTerminalScratch(id);
+            unregisterTerminal(id);
           }
           opts.onExit?.(exitCode, wasNatural);
         },

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -196,11 +196,19 @@ export class LocalBackend implements Backend {
     // PTY. The PTY's `onExit` callback (above) checks `getTerminal(id)`
     // to decide `wasNatural`; if we disposed first, it could race and
     // mis-classify this kill as natural.
-    entry.stopProviders();
-    cleanupTerminalScratch(terminalId);
     unregisterTerminal(terminalId);
-    entry.handle.dispose();
+    this.killTerminalEntry(entry);
     return true;
+  }
+
+  killTerminalEntry(entry: {
+    info: { id: string };
+    handle: { dispose(): void };
+    stopProviders: () => void;
+  }): void {
+    entry.stopProviders();
+    cleanupTerminalScratch(entry.info.id);
+    entry.handle.dispose();
   }
 
   fs: BackendFs = {

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -141,10 +141,7 @@ export class LocalBackend implements Backend {
       opts.cwd,
     );
 
-    const meta = createMetadata(handle.cwd);
-    // Backend identity is persisted on the metadata so session restore
-    // picks the same backend (R-2 adds SSH).
-    meta.location = { kind: "local" };
+    const meta = createMetadata(handle.cwd, this.id);
     // Seed client-owned initial metadata BEFORE startProviders so the first
     // `terminalMetadata` collection yield carries these fields (see #642).
     // `createMetadata` is the source of truth for which fields exist;

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -1,0 +1,225 @@
+/**
+ * LocalBackend — the `Backend` implementation for the local machine.
+ *
+ * Owns the PTY lifecycle, every per-terminal provider that watches the
+ * local filesystem (git, github, foreground process, agent reconcilers),
+ * and the local one-shot fs/git ops the Code tab consumes. The kolu
+ * server's `terminals.ts` / `router.ts` no longer reach into
+ * `kolu-git` / `kolu-anyagent` / `kolu-pty` directly for terminal-scoped
+ * work — every per-terminal entry point goes through this class. The
+ * `meta/*` orchestrators stay where they sit in `../meta/`, but the only
+ * caller is this file; from outside the backend they are invisible.
+ *
+ * R-2 will add `RemoteBackend(connection)` that satisfies the same
+ * interface by proxying every op via oRPC over `ssh stdio` to a
+ * `kolu agent --stdio` peer.
+ */
+
+import { ORPCError } from "@orpc/server";
+import type {
+  Backend,
+  BackendFs,
+  BackendGit,
+  BackendId,
+  PtySpawnOpts,
+  TerminalChannelMap,
+  TerminalHandle,
+} from "kolu-common/backend";
+import { DEFAULT_SCROLLBACK } from "kolu-common/config";
+import {
+  type GitResult,
+  getDiff,
+  getStatus,
+  listAll,
+  readFile,
+} from "kolu-git";
+import { spawnPty } from "kolu-pty";
+import pkg from "../../package.json" with { type: "json" };
+import { cleanupTerminalScratch } from "../terminalScratch.ts";
+import { koluShellDir } from "../koluRoot.ts";
+import { log } from "../log.ts";
+import {
+  createMetadata,
+  startProviders,
+  updateServerMetadata,
+} from "../meta/index.ts";
+import { terminalChannels } from "../publisher.ts";
+import {
+  getTerminal,
+  registerTerminal,
+  type TerminalProcess,
+  unregisterTerminal,
+} from "../terminal-registry.ts";
+
+/** Throw an `ORPCError` if a `GitResult` is `err`; otherwise return the
+ *  value. The router used to do this — moved here so the kolu-git error
+ *  taxonomy is bound at the backend boundary, not at the wire. */
+function unwrap<T>(result: GitResult<T>): T {
+  if (result.ok) return result.value;
+  switch (result.error.code) {
+    case "NOT_A_REPO":
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "Not a git repository",
+      });
+    case "GIT_FAILED":
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: result.error.message,
+      });
+    case "PATH_ESCAPES_ROOT":
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: `path escapes root: ${result.error.child}`,
+      });
+    default:
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: String(result.error),
+      });
+  }
+}
+
+export class LocalBackend implements Backend {
+  readonly id: BackendId = { kind: "local" };
+
+  /**
+   * Spawn a new terminal on this backend.
+   *
+   * Pipeline:
+   *  1. Spawn the PTY with `kolu-pty` and wire its OSC callbacks to the
+   *     in-process `terminalChannels.*` publishers.
+   *  2. Create metadata (`createMetadata`), seed client-owned fields
+   *     from `opts.initialMetadata` BEFORE starting providers so the
+   *     first `terminalMetadata` collection yield carries them (#642).
+   *  3. Register the entry in the shared `terminal-registry`.
+   *  4. Start the meta/* provider DAG (`startProviders`).
+   *  5. Return a `TerminalHandle` whose `dispose()` calls back into
+   *     `killTerminal(id)` — kill-convergence invariant.
+   */
+  async spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle> {
+    const id = crypto.randomUUID();
+    const tlog = log.child({ terminal: id });
+
+    const handle = spawnPty(
+      tlog,
+      id,
+      {
+        rcDir: koluShellDir,
+        termProgramVersion: pkg.version,
+        scrollback: DEFAULT_SCROLLBACK,
+        onData: (data) => terminalChannels.data(id).publish(data),
+        onExit: (exitCode) => {
+          tlog.info({ exitCode }, "exited");
+          // `wasNatural` is decided by whether the entry was still in
+          // the registry at the moment the PTY exited. Explicit kills
+          // (`killTerminal` here, or `killAllTerminals` via the
+          // drain-before-dispose ordering) unregister first, so this
+          // callback sees `wasNatural=false` and the caller knows to
+          // skip the session-save fanout (which they already did at
+          // explicit-kill time, or are intentionally skipping during
+          // shutdown).
+          const wasNatural = getTerminal(id) !== undefined;
+          if (wasNatural) {
+            const entry = getTerminal(id);
+            if (entry) {
+              entry.stopProviders();
+              cleanupTerminalScratch(id);
+              unregisterTerminal(id);
+            }
+          }
+          opts.onExit?.(exitCode, wasNatural);
+        },
+        onTitleChange: (title) => terminalChannels.title(id).publish(title),
+        onCommandRun: (raw) => terminalChannels.commandRun(id).publish(raw),
+        onCwd: (newCwd) => {
+          const entry = getTerminal(id);
+          if (entry) {
+            updateServerMetadata(entry, id, (m) => {
+              m.cwd = newCwd;
+            });
+            terminalChannels.cwd(id).publish(newCwd);
+          }
+        },
+      },
+      opts.cwd,
+    );
+
+    const meta = createMetadata(handle.cwd);
+    // Backend identity is persisted on the metadata so session restore
+    // picks the same backend (R-2 adds SSH).
+    meta.location = { kind: "local" };
+    // Seed client-owned initial metadata BEFORE startProviders so the first
+    // `terminalMetadata` collection yield carries these fields (see #642).
+    // `createMetadata` is the source of truth for which fields exist;
+    // `Object.assign` only writes the ones the caller supplied.
+    if (opts.initialMetadata) Object.assign(meta, opts.initialMetadata);
+
+    const entry: TerminalProcess = {
+      info: { id },
+      meta,
+      handle,
+      stopProviders: () => {},
+    };
+    // Register BEFORE starting providers (providers may emit immediately).
+    registerTerminal(id, entry);
+    entry.stopProviders = startProviders(entry, id);
+
+    tlog.info({ pid: handle.pid }, "created");
+
+    return {
+      id,
+      write: (data) => handle.write(data),
+      resize: (cols, rows) => handle.resize(cols, rows),
+      // Kill-convergence: dispose() is observationally identical to
+      // backend.killTerminal(id). Both end at the same teardown path
+      // (`killTerminal` below).
+      dispose: () => {
+        this.killTerminal(id);
+      },
+    };
+  }
+
+  terminalChannel<K extends keyof TerminalChannelMap>(
+    terminalId: string,
+    kind: K,
+    signal?: AbortSignal,
+  ): AsyncIterable<TerminalChannelMap[K]> {
+    // The publisher's typed channels already enforce a per-kind payload
+    // type; cast back to the public Backend shape (which the interface
+    // narrows per K).
+    return terminalChannels[kind](terminalId).subscribe(
+      signal,
+    ) as AsyncIterable<TerminalChannelMap[K]>;
+  }
+
+  killTerminal(terminalId: string): boolean {
+    const entry = getTerminal(terminalId);
+    if (!entry) return false;
+    log
+      .child({ terminal: terminalId })
+      .info({ pid: entry.handle.pid }, "killing");
+    // Order matters: stop providers and unregister BEFORE disposing the
+    // PTY. The PTY's `onExit` callback (above) checks `getTerminal(id)`
+    // to decide `wasNatural`; if we disposed first, it could race and
+    // mis-classify this kill as natural.
+    entry.stopProviders();
+    cleanupTerminalScratch(terminalId);
+    unregisterTerminal(terminalId);
+    entry.handle.dispose();
+    return true;
+  }
+
+  fs: BackendFs = {
+    listAll: async (path) => unwrap(await listAll(path, log)),
+    readFile: async (repoPath, filePath) =>
+      unwrap(await readFile(repoPath, filePath, log)),
+  };
+
+  git: BackendGit = {
+    getDiff: async (repoPath, filePath, mode, oldPath) =>
+      unwrap(await getDiff(repoPath, filePath, mode, log, oldPath)),
+    getStatus: async (repoPath, mode) =>
+      unwrap(await getStatus(repoPath, mode, log)),
+  };
+}
+
+/** Singleton — the kolu server's one local backend. R-2 adds a
+ *  per-host `RemoteBackend` registry; this stays the local instance. */
+export const localBackend = new LocalBackend();

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -20,11 +20,11 @@ import type {
   Backend,
   BackendFs,
   BackendGit,
-  BackendId,
   PtySpawnOpts,
   TerminalChannelMap,
   TerminalHandle,
 } from "kolu-common/backend";
+import type { TerminalLocation } from "kolu-common/surface";
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
 import {
   type GitResult,
@@ -77,7 +77,7 @@ function unwrap<T>(result: GitResult<T>): T {
 }
 
 export class LocalBackend implements Backend {
-  readonly id: BackendId = { kind: "local" };
+  readonly id: TerminalLocation = { kind: "local" };
 
   /**
    * Spawn a new terminal on this backend.

--- a/packages/server/src/meta/state.test.ts
+++ b/packages/server/src/meta/state.test.ts
@@ -19,13 +19,15 @@ import {
 
 function fakeTerminal(): TerminalProcess {
   return {
-    info: { id: "term-pub-test", pid: 0 },
+    info: { id: "term-pub-test" },
     meta: {
+      location: { kind: "local" },
       cwd: "/tmp",
       git: null,
       pr: { kind: "pending" },
       agent: null,
       foreground: null,
+      connectionState: "live",
       lastActivityAt: 0,
     },
     // Tests never touch the PTY handle; the publish path doesn't read it.

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -18,6 +18,7 @@ import type {
   LiveTerminalFields,
   ServerPersistedTerminalFields,
   TerminalClientMetadata,
+  TerminalLocation,
   TerminalMetadata,
 } from "kolu-common/surface";
 import { prUnavailableReason, prValue } from "kolu-github/schemas";
@@ -26,15 +27,22 @@ import { terminalsDirtyChannel } from "../publisher.ts";
 import { surfaceCtx } from "../surface.ts";
 import type { TerminalProcess } from "../terminal-registry.ts";
 
-/** Create initial metadata state for a new terminal. `lastActivityAt: 0`
- *  means "no agent transition observed yet" — the only event that lifts
- *  the recency clock. Idle terminals tie at 0 and fall back to canvas
- *  position. `location` and `connectionState` default to local + live;
- *  the R-2 spawn path on a remote backend overwrites `location` and
- *  drives `connectionState` from the host session's state machine. */
-export function createMetadata(cwd: string): TerminalMetadata {
+/** Create initial metadata state for a new terminal. `lastActivityAt:
+ *  0` means "no agent transition observed yet" — the only event that
+ *  lifts the recency clock. Idle terminals tie at 0 and fall back to
+ *  canvas position.
+ *
+ *  `location` is supplied by the caller (the backend that's creating
+ *  the terminal — `LocalBackend` passes `{ kind: "local" }`,
+ *  `RemoteBackend` will pass `{ kind: "ssh", host }` in R-2). Making
+ *  the caller pass it removes the "default-then-override" pattern that
+ *  earlier let two write sites disagree silently. */
+export function createMetadata(
+  cwd: string,
+  location: TerminalLocation,
+): TerminalMetadata {
   return {
-    location: { kind: "local" },
+    location,
     cwd,
     git: null,
     pr: { kind: "pending" },

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -29,14 +29,18 @@ import type { TerminalProcess } from "../terminal-registry.ts";
 /** Create initial metadata state for a new terminal. `lastActivityAt: 0`
  *  means "no agent transition observed yet" — the only event that lifts
  *  the recency clock. Idle terminals tie at 0 and fall back to canvas
- *  position. */
+ *  position. `location` and `connectionState` default to local + live;
+ *  the R-2 spawn path on a remote backend overwrites `location` and
+ *  drives `connectionState` from the host session's state machine. */
 export function createMetadata(cwd: string): TerminalMetadata {
   return {
+    location: { kind: "local" },
     cwd,
     git: null,
     pr: { kind: "pending" },
     agent: null,
     foreground: null,
+    connectionState: "live",
     lastActivityAt: 0,
   };
 }

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -20,10 +20,10 @@ import { prValue } from "kolu-github/schemas";
 import { loadOpenCodeTranscript } from "kolu-opencode";
 import { transcriptToHtml } from "kolu-transcript-html";
 import { match } from "ts-pattern";
+import { getBackendFor } from "./backend/index.ts";
 import { saveTerminalFile } from "./terminalScratch.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import { log } from "./log.ts";
-import { terminalChannels } from "./publisher.ts";
 import { pwaIdentityForHostname } from "./pwaIdentity.ts";
 import { surfaceRouter, t, unwrapGit } from "./surface.ts";
 import { getTerminal, type TerminalProcess } from "./terminal-registry.ts";
@@ -133,10 +133,18 @@ export const appRouter = t.router({
      * Yields serialized screen state first (for late-joining clients),
      * then streams live output. Subscribe-before-serialize ordering
      * guarantees no output is lost between snapshot and live stream.
+     *
+     * The data stream is routed through `backend.terminalChannel(id,
+     * "data")` so R-2's `RemoteBackend` swaps in without a router
+     * change. The emulator's `getScreenState()` stays on the local
+     * `entry.handle` — emulator state is per-terminal, not
+     * per-backend (the xterm-headless buffer survives backend swaps,
+     * e.g. R-3's reattach).
      */
     attach: t.terminal.attach.handler(async function* ({ input, signal }) {
       const entry = requireTerminal(input.id);
-      const live = terminalChannels.data(input.id).subscribe(signal);
+      const backend = getBackendFor(entry);
+      const live = backend.terminalChannel(input.id, "data", signal);
       const screenState = entry.handle.getScreenState();
       if (screenState) yield screenState;
       for await (const data of live) yield data;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -143,7 +143,7 @@ export const appRouter = t.router({
      */
     attach: t.terminal.attach.handler(async function* ({ input, signal }) {
       const entry = requireTerminal(input.id);
-      const backend = getBackendFor(entry);
+      const backend = getBackendFor(entry.meta.location);
       const live = backend.terminalChannel(input.id, "data", signal);
       const screenState = entry.handle.getScreenState();
       if (screenState) yield screenState;

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "node:assert";
-import type { SavedTerminal } from "kolu-common/surface";
+import { SavedSessionSchema, type SavedTerminal } from "kolu-common/surface";
 import { afterAll, describe, expect, it } from "vitest";
 import {
   clearSavedSession,
@@ -7,6 +7,7 @@ import {
   saveSession,
   setSavedSession,
 } from "./session.ts";
+import { injectLocalLocation } from "./state.ts";
 
 // KOLU_STATE_DIR is set by the `test:unit` script in package.json to route
 // conf state into $TMPDIR, keeping ~/.config clean. state.ts reads it at
@@ -14,6 +15,7 @@ import {
 
 const terminal: SavedTerminal = {
   id: "term-1",
+  location: { kind: "local" },
   cwd: "/home/user/project",
   git: {
     repoRoot: "/home/user/project",
@@ -73,9 +75,28 @@ describe("session persistence", () => {
 
   it("preserves multiple terminals with array order", () => {
     const terminals: SavedTerminal[] = [
-      { id: "a", cwd: "/a", git: null, lastActivityAt: 0 },
-      { id: "b", cwd: "/b", git: null, lastActivityAt: 0 },
-      { id: "c", cwd: "/c", git: null, parentId: "a", lastActivityAt: 0 },
+      {
+        id: "a",
+        location: { kind: "local" },
+        cwd: "/a",
+        git: null,
+        lastActivityAt: 0,
+      },
+      {
+        id: "b",
+        location: { kind: "local" },
+        cwd: "/b",
+        git: null,
+        lastActivityAt: 0,
+      },
+      {
+        id: "c",
+        location: { kind: "local" },
+        cwd: "/c",
+        git: null,
+        parentId: "a",
+        lastActivityAt: 0,
+      },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();
@@ -89,12 +110,19 @@ describe("session persistence", () => {
     const terminals: SavedTerminal[] = [
       {
         id: "a",
+        location: { kind: "local" },
         cwd: "/a",
         git: null,
         themeName: "Dracula",
         lastActivityAt: 0,
       },
-      { id: "b", cwd: "/b", git: null, lastActivityAt: 0 },
+      {
+        id: "b",
+        location: { kind: "local" },
+        cwd: "/b",
+        git: null,
+        lastActivityAt: 0,
+      },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();
@@ -110,8 +138,20 @@ describe("session persistence", () => {
     const t1 = 1_700_000_000_000;
     const t2 = 1_700_000_900_000;
     const terminals: SavedTerminal[] = [
-      { id: "a", cwd: "/a", git: null, lastActivityAt: t1 },
-      { id: "b", cwd: "/b", git: null, lastActivityAt: t2 },
+      {
+        id: "a",
+        location: { kind: "local" },
+        cwd: "/a",
+        git: null,
+        lastActivityAt: t1,
+      },
+      {
+        id: "b",
+        location: { kind: "local" },
+        cwd: "/b",
+        git: null,
+        lastActivityAt: t2,
+      },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();
@@ -128,5 +168,109 @@ describe("session persistence", () => {
     expect(getSavedSession()).not.toBeNull();
     clearSavedSession();
     expect(getSavedSession()).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────
+//  R-1 migration: old saved sessions (without `location`/
+//  `connectionState`) must round-trip cleanly. Two paths cover the
+//  contract:
+//
+//    1. **On-disk migration** (`state.ts:"1.24.0"` → `injectLocalLocation`)
+//       — what real users hit when their kolu first boots into R-1.
+//       Stamps `location: { kind: "local" }` onto every saved terminal
+//       that doesn't already have one. Idempotent on already-migrated
+//       data.
+//    2. **Schema default** (`TerminalLocationSchema.default(...)` on
+//       `ServerPersistedTerminalFieldsSchema`) — secondary safety net
+//       for disk shapes that somehow skip the Conf migration (e.g.
+//       tests bypassing the Conf instance). `SavedSessionSchema.parse`
+//       on a pre-R-1 blob succeeds and fills in the default.
+//
+//  Both layers MUST hold; either alone is brittle. Migration is the
+//  forward fix; schema default is the recovery path. Tested
+//  independently so a regression in one doesn't hide behind the other.
+// ────────────────────────────────────────────────────────────────
+describe("R-1 saved-session migration", () => {
+  /** Golden fixture: shape a kolu shipped before R-1 wrote to disk.
+   *  No `location` field. Other fields match what `snapshotSession()`
+   *  produced on master @ b5413c60. */
+  const preR1Terminals = [
+    {
+      id: "pre-r1-a",
+      cwd: "/home/user/old-project",
+      git: {
+        repoRoot: "/home/user/old-project",
+        repoName: "old-project",
+        worktreePath: "/home/user/old-project",
+        branch: "main",
+        isWorktree: false,
+        mainRepoRoot: "/home/user/old-project",
+      },
+      themeName: "Solarized",
+      lastActivityAt: 1_700_000_000_000,
+    },
+    {
+      id: "pre-r1-b",
+      cwd: "/tmp",
+      git: null,
+      parentId: "pre-r1-a",
+      lastActivityAt: 0,
+    },
+  ];
+
+  it("injectLocalLocation stamps `{ kind: 'local' }` on legacy terminals", () => {
+    const migrated = preR1Terminals.map(injectLocalLocation);
+    expect(migrated[0]?.location).toEqual({ kind: "local" });
+    expect(migrated[1]?.location).toEqual({ kind: "local" });
+    // Original fields survive byte-equal.
+    expect(migrated[0]?.themeName).toBe("Solarized");
+    expect((migrated[0]?.git as { repoName?: string } | null)?.repoName).toBe(
+      "old-project",
+    );
+    expect(migrated[1]?.parentId).toBe("pre-r1-a");
+  });
+
+  it("injectLocalLocation is idempotent", () => {
+    const once = preR1Terminals.map(injectLocalLocation);
+    const twice = once.map(injectLocalLocation);
+    expect(twice).toEqual(once);
+  });
+
+  it("SavedSessionSchema.parse on a pre-R-1 blob fills the default", () => {
+    // The schema's `.default({ kind: "local" })` is the safety net for
+    // disk shapes that skip the Conf migration. Direct parse to verify
+    // the schema accepts old terminals and produces the post-R-1 shape.
+    const result = SavedSessionSchema.safeParse({
+      terminals: preR1Terminals,
+      activeTerminalId: "pre-r1-a",
+      savedAt: 1_700_000_900_000,
+    });
+    assert.ok(
+      result.success,
+      `pre-R-1 fixture must parse cleanly: ${
+        result.success ? "ok" : JSON.stringify(result.error.issues)
+      }`,
+    );
+    expect(result.data.terminals[0]?.location).toEqual({ kind: "local" });
+    expect(result.data.terminals[1]?.location).toEqual({ kind: "local" });
+  });
+
+  it("migrated terminals round-trip through saveSession/getSavedSession", () => {
+    // End-to-end: take a fixture-migrated session, write it, read it
+    // back, verify location survives and no field disappears on the
+    // second save (the "field disappears on resave" bug class).
+    const migratedTerminals = preR1Terminals.map(injectLocalLocation);
+    saveSession({
+      terminals: migratedTerminals as unknown as SavedTerminal[],
+      activeTerminalId: "pre-r1-a",
+    });
+    const reloaded = getSavedSession();
+    assert.ok(reloaded !== null, "round-trip lost the saved value");
+    expect(reloaded.terminals[0]?.location).toEqual({ kind: "local" });
+    expect(reloaded.terminals[0]?.themeName).toBe("Solarized");
+    expect(reloaded.terminals[1]?.location).toEqual({ kind: "local" });
+    expect(reloaded.terminals[1]?.parentId).toBe("pre-r1-a");
+    clearSavedSession();
   });
 });

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -98,7 +98,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.23.0";
+const SCHEMA_VERSION = "1.24.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -439,8 +439,39 @@ export const store = new Conf<PersistedState>({
         rightPanel: rest as typeof current.rightPanel,
       } as Preferences);
     },
+    // R-1: `TerminalLocation` discriminated union added on
+    // `ServerPersistedTerminalFieldsSchema`. Every pre-R-1 terminal
+    // lived on the local machine, so the migration stamps each saved
+    // terminal with `{ kind: "local" }`. Idempotent — re-running on
+    // already-migrated data leaves the field alone. The schema's
+    // `.default({ kind: "local" })` is the secondary safety net for
+    // disk shapes that somehow skip this migration (e.g. tests
+    // bypassing the Conf instance); the migration is the primary path
+    // that flips real users' disks forward at server start.
+    "1.24.0": (store: Conf<PersistedState>) => {
+      const session = store.get("session");
+      if (!session) return;
+      const terminals = (
+        session.terminals as unknown as Record<string, unknown>[]
+      ).map(injectLocalLocation);
+      store.set("session", {
+        ...session,
+        terminals: terminals as typeof session.terminals,
+      });
+    },
   },
 });
+
+/** Pure helper for the 1.24.0 migration: inject `location: { kind:
+ *  "local" }` if absent. Exposed so tests can exercise the migration
+ *  shape directly without spinning up a fresh Conf instance with the
+ *  prior `projectVersion`. */
+export function injectLocalLocation(
+  t: Record<string, unknown>,
+): Record<string, unknown> {
+  if ("location" in t) return t;
+  return { ...t, location: { kind: "local" } };
+}
 
 // Early validation so corrupt state shows up in journalctl immediately at
 // startup, not only when the first client connects. Validates the aggregate

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -1,14 +1,27 @@
 /**
- * Terminal lifecycle: spawn PTYs, wire them to metadata providers, and
- * manage create/kill/update operations. The underlying `Map` and its
- * simple accessors (`getTerminal`, `listTerminals`, `terminalCount`,
- * `countActiveClaudeSessions`, the `TerminalProcess` shape) live in
- * `./terminal-registry.ts` so `./meta/*` can depend on the registry
- * without closing a cycle back through this file.
+ * Terminal lifecycle adapter — translates the wire-level
+ * (`router.ts`-facing) terminal verbs into `LocalBackend` operations
+ * and fans the surface side effects (`terminalList`, `terminals:dirty`,
+ * `terminalExit` event) into the framework.
  *
- * External callers that used to import state-reads + lifecycle from
- * `./terminals.ts` as a single module keep their import path — this
- * file re-exports the registry surface they need.
+ * After R-1, `LocalBackend` is the canonical owner of PTY lifecycle and
+ * the `meta/*` provider DAG. This file is the thin shim where router
+ * handlers (`terminal.create`, `terminal.kill`, `terminal.setX`)
+ * delegate. The underlying `Map` + the registry accessors
+ * (`getTerminal`, `listTerminals`, `terminalCount`, …) still live in
+ * `./terminal-registry.ts` — both the backend and this file mutate the
+ * same shared store.
+ *
+ * Client-owned metadata setters (theme/intent/canvas/sub-panel/right-
+ * panel/parent/active) live here too — they're surface-level mutations
+ * that don't belong to a specific backend (they describe the kolu UI's
+ * relationship to a terminal, not the terminal's relationship to its
+ * host).
+ *
+ * R-2 will introduce a `getBackendFor(location)` registry that returns
+ * either `localBackend` or a `RemoteBackend(host)`; `createTerminal`
+ * will pick the right one. For R-1 every terminal lives on
+ * `localBackend`.
  */
 
 import type {
@@ -18,28 +31,17 @@ import type {
   TerminalId,
   TerminalInfo,
 } from "kolu-common/surface";
-import { DEFAULT_SCROLLBACK } from "kolu-common/config";
-import { spawnPty } from "kolu-pty";
-import pkg from "../package.json" with { type: "json" };
+import { localBackend } from "./backend/local.ts";
 import { cleanupTerminalScratch } from "./terminalScratch.ts";
-import { koluShellDir } from "./koluRoot.ts";
 import { log } from "./log.ts";
-import {
-  createMetadata,
-  startProviders,
-  updateClientMetadata,
-  updateServerMetadata,
-} from "./meta/index.ts";
-import { terminalChannels, terminalsDirtyChannel } from "./publisher.ts";
+import { updateClientMetadata } from "./meta/index.ts";
+import { terminalsDirtyChannel } from "./publisher.ts";
 import { surfaceCtx } from "./surface.ts";
 import {
   drainTerminals,
-  getTerminal,
   listTerminals,
-  registerTerminal,
-  type TerminalProcess,
   terminalEntries,
-  unregisterTerminal,
+  getTerminal,
 } from "./terminal-registry.ts";
 
 // Re-export registry accessors + type so external callers (router.ts,
@@ -70,6 +72,7 @@ export function snapshotSession(): {
         pr: _pr,
         agent: _agent,
         foreground: _foreground,
+        connectionState: _connectionState,
         ...persisted
       } = entry.meta;
       return { id, ...persisted };
@@ -86,116 +89,68 @@ function emitChanged(): void {
 /** Notify that terminal membership changed (create/kill).
  *  Drives the live `surface.terminalList.get` stream to clients. The
  *  surface owns the publish channel; calling `set` triggers the
- *  framework's apply+publish chain (the `terminalList` cell's store is a
- *  no-op since the registry is canonical). */
+ *  framework's apply+publish chain (the `terminalList` cell's store is
+ *  a no-op since the registry is canonical). */
 function emitListChanged(): void {
   surfaceCtx.cells.terminalList.set(listTerminals());
 }
 
-/** Create a new terminal, spawn a PTY process. `initial` seeds
- *  client-owned metadata before `startProviders` runs, so the first
- *  `terminalMetadata` collection read carries it — used by session
- *  restore to avoid racing post-hoc `setCanvasLayout` / `setTheme` /
- *  `setSubPanel` RPCs against the client's canvas-cascade effect (#642). */
-export function createTerminal(
+/** Create a new terminal on the backend identified by the (resolved)
+ *  location. R-1: every terminal lives on `localBackend`; R-2 picks the
+ *  backend by `initial.location` (with sub-terminals inheriting their
+ *  parent's location regardless of the input).
+ *
+ *  `initial` seeds the client-owned metadata fields before the
+ *  backend's providers emit their first publish, so the first
+ *  `terminalMetadata` collection yield carries them — required by the
+ *  canvas-cascade race fix in #642. */
+export async function createTerminal(
   cwd?: string,
   parentId?: string,
   initial?: InitialTerminalMetadata,
-): TerminalInfo {
-  const id = crypto.randomUUID();
-  const tlog = log.child({ terminal: id });
-
-  const handle = spawnPty(
-    tlog,
-    id,
-    {
-      rcDir: koluShellDir,
-      termProgramVersion: pkg.version,
-      scrollback: DEFAULT_SCROLLBACK,
-      onData: (data) => {
-        terminalChannels.data(id).publish(data);
-      },
-      // On natural exit: notify clients, then remove from server state
-      onExit: (exitCode) => {
-        tlog.info({ exitCode }, "exited");
-        const entry = getTerminal(id);
-        if (entry) {
-          entry.stopProviders();
-          cleanupTerminalScratch(id);
-        }
-        surfaceCtx.events.terminalExit.publish({ id }, exitCode);
-        // Only save session on natural exit (entry still in map).
-        // killAllTerminals clears the map first, so entry is gone — skip.
-        const wasNaturalExit = unregisterTerminal(id);
-        if (wasNaturalExit) {
-          emitChanged();
-          emitListChanged();
-        }
-      },
-      // PTY callback (OSC 0/2): notify process provider that title changed
-      onTitleChange: (title) => {
-        terminalChannels.title(id).publish(title);
-      },
-      // PTY callback (OSC 633;E): raw preexec command line. Agent parsing,
-      // the per-terminal stash, and the recent-agents MRU all live in
-      // `meta/agent-command.ts`, fed via this channel.
-      onCommandRun: (raw) => {
-        terminalChannels.commandRun(id).publish(raw);
-      },
-      // PTY callback (OSC 7): update metadata CWD, notify providers via cwd channel
-      onCwd: (newCwd) => {
-        const entry = getTerminal(id);
-        if (entry) {
-          updateServerMetadata(entry, id, (m) => {
-            m.cwd = newCwd;
-          });
-          terminalChannels.cwd(id).publish(newCwd);
-        }
-      },
-    },
+): Promise<TerminalInfo> {
+  const handle = await localBackend.spawnPty({
     cwd,
-  );
+    initialMetadata: {
+      ...(parentId !== undefined && { parentId }),
+      ...(initial?.themeName && { themeName: initial.themeName }),
+      ...(initial?.canvasLayout && { canvasLayout: initial.canvasLayout }),
+      ...(initial?.subPanel && { subPanel: initial.subPanel }),
+      ...(initial?.rightPanel && { rightPanel: initial.rightPanel }),
+      ...(initial?.lastActivityAt !== undefined && {
+        lastActivityAt: initial.lastActivityAt,
+      }),
+      ...(initial?.intent && { intent: initial.intent }),
+    },
+    onExit: (exitCode, wasNatural) => {
+      surfaceCtx.events.terminalExit.publish({ id: handle.id }, exitCode);
+      // Only fire dirty/list signals on natural exit. Explicit kills
+      // (`killTerminal`, `killAllTerminals`) already handled the fanout
+      // at their entry point — see kill-convergence invariant in
+      // backend.ts's module doc.
+      if (wasNatural) {
+        emitChanged();
+        emitListChanged();
+      }
+    },
+  });
 
-  const meta = createMetadata(handle.cwd);
-  if (parentId) meta.parentId = parentId;
-  // Seed client-owned initial metadata BEFORE startProviders so the first
-  // `terminalMetadata` collection yield carries these fields (see #642).
-  if (initial?.themeName) meta.themeName = initial.themeName;
-  if (initial?.canvasLayout) meta.canvasLayout = initial.canvasLayout;
-  if (initial?.subPanel) meta.subPanel = initial.subPanel;
-  if (initial?.rightPanel) meta.rightPanel = initial.rightPanel;
-  if (initial?.lastActivityAt !== undefined)
-    meta.lastActivityAt = initial.lastActivityAt;
-  if (initial?.intent) meta.intent = initial.intent;
-  const entry: TerminalProcess = {
-    info: { id, pid: handle.pid },
-    meta,
-    handle,
-    stopProviders: () => {},
-  };
-  // Start providers after entry is in the map (providers may emit immediately)
-  registerTerminal(id, entry);
-  entry.stopProviders = startProviders(entry, id);
-
-  tlog.info({ pid: handle.pid, total: listTerminals().length }, "created");
   emitChanged();
   emitListChanged();
-  return entry.info;
+  return { id: handle.id };
 }
 
-/** Kill a terminal's PTY process and remove it from the map. Returns final info, or undefined if not found. */
+/** Kill a terminal: backend tears down PTY + providers, then surface
+ *  signals fan out. Returns final `TerminalInfo` for the killed
+ *  terminal, or undefined if the id was unknown. */
 export function killTerminal(id: TerminalId): TerminalInfo | undefined {
   const entry = getTerminal(id);
   if (!entry) return undefined;
-
-  log.child({ terminal: id }).info({ pid: entry.handle.pid }, "killing");
-  entry.stopProviders();
-  entry.handle.dispose();
-  cleanupTerminalScratch(id);
-  unregisterTerminal(id);
+  const info = entry.info;
+  localBackend.killTerminal(id);
   emitChanged();
   emitListChanged();
-  return entry.info;
+  return info;
 }
 
 /** Set or clear a terminal's parent relationship. */
@@ -233,8 +188,7 @@ export function setCanvasLayout(
  *
  *  Equality-gated: the client RPCs this on every drag tick of the
  *  resizable handle, so without a guard each mouse-move would fan a
- *  full per-key metadata publish to every connected client. Same shape
- *  as `meta/agent-command.ts`'s `lastAgentCommand` gate. */
+ *  full per-key metadata publish to every connected client. */
 export function setSubPanelState(
   id: TerminalId,
   state: { collapsed: boolean; panelSize: number },
@@ -254,14 +208,7 @@ export function setSubPanelState(
 }
 
 /** Store a terminal's right-panel per-terminal state (client-reported).
- *  Publishes via metadata so other clients (and the same client after a
- *  refresh) pick up the change from the same channel as every other
- *  client-owned metadata field.
- *
- *  Equality-gated like `setSubPanelState` — the client RPCs this on every
- *  file-tree click and tab-toggle, so without a guard each interaction
- *  would fan a full per-key metadata publish. Deep-compares
- *  `selectedFileByMode` since the user clicks files often. */
+ *  Equality-gated like `setSubPanelState`. */
 export function setRightPanelState(
   id: TerminalId,
   state: RightPanelPerTerminalState,
@@ -323,10 +270,14 @@ export function setTerminalIntent(id: TerminalId, intent: string): void {
   });
 }
 
-/** Kill and remove all terminals. Used by tests to reset server state between scenarios. */
+/** Kill and remove all terminals. Used by tests to reset server state
+ *  between scenarios.
+ *
+ *  Drain-before-dispose ordering: the registry is cleared FIRST so each
+ *  PTY's `onExit` callback observes `getTerminal(id) === undefined` and
+ *  reports `wasNatural=false`. That gate prevents shutdown from writing
+ *  phantom empty sessions to disk via the autosave loop. */
 export function killAllTerminals(): void {
-  // Snapshot entries and clear map BEFORE disposing — prevents onExit
-  // callbacks from finding terminals and triggering session saves.
   const entries = drainTerminals();
   log.info({ count: entries.length }, "killing all terminals");
   for (const entry of entries) {

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -111,17 +111,11 @@ export async function createTerminal(
   const handle = await localBackend.spawnPty({
     cwd,
     initialMetadata: {
+      ...initial,
       ...(parentId !== undefined && { parentId }),
-      ...(initial?.themeName && { themeName: initial.themeName }),
-      ...(initial?.canvasLayout && { canvasLayout: initial.canvasLayout }),
-      ...(initial?.subPanel && { subPanel: initial.subPanel }),
-      ...(initial?.rightPanel && { rightPanel: initial.rightPanel }),
-      ...(initial?.lastActivityAt !== undefined && {
-        lastActivityAt: initial.lastActivityAt,
-      }),
-      ...(initial?.intent && { intent: initial.intent }),
     },
     onExit: (exitCode, wasNatural) => {
+      // `handle` is assigned before `onExit` can fire (PTY exits after spawn).
       surfaceCtx.events.terminalExit.publish({ id: handle.id }, exitCode);
       // Only fire dirty/list signals on natural exit. Explicit kills
       // (`killTerminal`, `killAllTerminals`) already handled the fanout

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -31,8 +31,7 @@ import type {
   TerminalId,
   TerminalInfo,
 } from "kolu-common/surface";
-import { localBackend } from "./backend/local.ts";
-import { cleanupTerminalScratch } from "./terminalScratch.ts";
+import { getBackendFor, localBackend } from "./backend/index.ts";
 import { log } from "./log.ts";
 import { updateClientMetadata } from "./meta/index.ts";
 import { terminalsDirtyChannel } from "./publisher.ts";
@@ -147,7 +146,7 @@ export function killTerminal(id: TerminalId): TerminalInfo | undefined {
   const entry = getTerminal(id);
   if (!entry) return undefined;
   const info = entry.info;
-  localBackend.killTerminal(id);
+  getBackendFor(entry.meta.location).killTerminal(id);
   emitChanged();
   emitListChanged();
   return info;
@@ -280,10 +279,13 @@ export function setTerminalIntent(id: TerminalId, intent: string): void {
 export function killAllTerminals(): void {
   const entries = drainTerminals();
   log.info({ count: entries.length }, "killing all terminals");
+  // Route per-entry teardown through each terminal's backend so this
+  // path stays in lockstep with `killTerminal` and `dispose()` — see
+  // the kill-convergence invariant in `backend.ts`. R-2's
+  // `RemoteBackend.killTerminalEntry` will issue the RPC kill against
+  // the agent without the loop ever knowing the backend kind.
   for (const entry of entries) {
-    entry.stopProviders();
-    entry.handle.dispose();
-    cleanupTerminalScratch(entry.info.id);
+    getBackendFor(entry.meta.location).killTerminalEntry(entry);
   }
   emitListChanged();
 }


### PR DESCRIPTION
**This PR introduces a single `Backend` abstraction in the kolu server and dissolves `packages/server/src/meta/*` behind it** — a structural rewrite that prepares the codebase for remote terminals over SSH ([#951](https://github.com/juspay/kolu/issues/951)) without yet adding remote support. R-2 (stacked on this one) will add `RemoteBackend` + a `kolu agent --stdio` subcommand against the same interface.

> _Prototype PR — will be discarded after the user evaluates Plan B vs Plan A._ The Plan-A prototypes ([#969](https://github.com/juspay/kolu/pull/969) + [#972](https://github.com/juspay/kolu/pull/972)) ship the additive design's twelve PRs as two stacked artifacts; this PR + R-2 ship the rewrite-freedom design's two PRs. The full plan lives in `talk-zed-skill-and-951-plan.html` (worktree-local).

### The pivot

```
Before                                After
──────                                ─────
router.ts ──────────────▶ kolu-pty    router.ts
              ┌────────▶ kolu-git         │
terminals.ts ─┼────────▶ anyagent         ▼
              └────────▶ kolu-github   Backend  (one transport boundary)
meta/*.ts: 7 orchestrators                │
              ┌────────▶ ...              ├── LocalBackend  (R-1, this PR)
publisher.ts ─┘                           └── RemoteBackend (R-2, next PR)
                                                 over oRPC/ssh stdio
```

The kolu server no longer imports from `kolu-pty` / `kolu-git` / `anyagent` directly for terminal-scoped work. Every per-terminal operation — spawn PTY, subscribe to a stream, kill, fs/git one-shot ops — flows through `Backend`. The `meta/*` provider DAG is now private wiring inside `LocalBackend.spawnPty`.

### Schema redesign

| Field | Before | After |
|---|---|---|
| `TerminalInfoSchema` | `{ id, pid }` | `{ id }` — `pid` was a local leak (a remote tile would have shown a misleading ssh-subprocess pid) |
| `ServerPersistedTerminalFieldsSchema.location` | absent | `TerminalLocation` discriminated union, `.default({ kind: "local" })` |
| `LiveTerminalFieldsSchema.connectionState` | absent | `"live" \| "connecting" \| "disconnected"`, `.default("live")` |

### Migration — every saved session must round-trip

Plan B's claim was "**migrate cleanly**, no `start fresh` fallback." Two-layer defense:

1. **`state.ts:\"1.24.0\"` migration** (`injectLocalLocation`) — eager, runs on disk at server startup, stamps `{ kind: "local" }` onto every pre-R-1 terminal. Idempotent.
2. **Schema `.default(...)`** — lazy, parse-time fallback for disk shapes that skip the migration (tests, future edge cases).

Four new tests pin both paths (`session.test.ts` describe block 'R-1 saved-session migration').

### Structural review trail

Hickey and Lowy ran twice in parallel — **pre-implementation** (on the interface sketch) and **post-implementation** (on the rebased diff). Twelve total findings, all applied as separate commits before this PR opened.

| Phase | Findings | Sample |
|---|---|---|
| Pre-implement (interface design) | 6 | `getScreenState`/`getScreenText` moved off `Backend` — wrong volatility axis (Lowy). `wasNatural` flag moved onto the contract instead of a mutable hook (Hickey). |
| Post-implement (final diff) | 5 | `killTerminal` + `killAllTerminals` routed through `getBackendFor` (kill-convergence; both lenses). `BackendId` alias deleted as concept duplication (Hickey). `createMetadata(cwd, location)` made the backend the single authority for location (Hickey). |
| /code-police elegance | 1 | Collapsed double registry lookup in `onExit`; spread `TerminalSeed extends InitialTerminalMetadata` in place of 7 conditional spreads. |

### What R-2 will add (stacked PR)

- `kolu agent --stdio` — same kolu binary, oRPC transport set to stdio (zero remote-specific logic in the agent itself).
- `RemoteBackend(connection)` against the same interface; \`STREAM_RETRY\` carries reconnect automatically.
- Binary shipping via `nix copy --to ssh://\$host .#kolu` — the remote has Nix, so this replaces Zed's three-strategy install dance with one line.
- SSH host picker, host chip, disconnected overlay.

> _The kill-convergence invariant, the surface-streams-bypass note, and the resolver-as-home-for-sub-terminal-inheritance note in `backend.ts` are the contracts R-2 must honor. Documented in module comments where the next implementer will look._

### Trying it locally

```sh
nix run github:juspay/kolu/remote-terminals-plan-b-r1
```

R-1 has no user-visible behavior change — every existing test passes — so the test you'd do here is "kolu still works." Restore a pre-R-1 saved session to see the migration in action.

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._