### PR TITLE
docs: `justci protect`, not `just ci protect`

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -30,7 +30,7 @@ pu destroy "$host"
 
 **Flake → comment on [#320](https://github.com/juspay/kolu/issues/320)** with scenario/platform/error excerpt/PR.
 
-**Evidence required → all GitHub status checks green per `just ci protect`.** `/do` is done only when every required status check is green on the PR's current `HEAD`. Source the required list from `just ci protect --dry-run` — it prints the `<recipe>@<platform>` contexts the canonical DAG produces, which are exactly the contexts branch protection gates on. Verify with `gh pr checks`; a green from a positional retry counts (final state matters).
+**Evidence required → all GitHub status checks green per `justci protect`.** `/do` is done only when every required status check is green on the PR's current `HEAD`. Source the required list from `justci protect --dry-run` — it prints the `<recipe>@<platform>` contexts the canonical DAG produces, which are exactly the contexts branch protection gates on. Verify with `gh pr checks`; a green from a positional retry counts (final state matters).
 
 ## Documentation
 


### PR DESCRIPTION
**`.agency/do.md` referenced `just ci protect`, but there is no `protect` recipe in `ci/mod.just`.** The runner's subcommand is `justci protect` (and `--dry-run`) — matching the form documented in `.claude/skills/ci/SKILL.md`.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._