### PR TITLE
Plan B R-2: `kolu agent --stdio` + RemoteBackend skeleton (#951 prototype, stacks on #973)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -13,6 +13,7 @@ import {
   type Component,
   createEffect,
   createMemo,
+  createResource,
   createSignal,
   on,
   Show,
@@ -281,6 +282,43 @@ const App: Component = () => {
     setCloseConfirmTarget({ id, meta, splitCount, worktreeRemoval });
   }
 
+  // R-2: SSH aliases from the user's `~/.ssh/config`. Fetched once on
+  // mount; refetch would be wired if the picker needs live updates
+  // (e.g. file-system watcher on the ssh config).
+  const [sshHostsResource] = createResource(async () => {
+    try {
+      const { hosts } = await client.server.listSshHosts();
+      return hosts;
+    } catch (err) {
+      toast.error(
+        `Failed to list SSH hosts: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return [];
+    }
+  });
+  const sshHosts = () => sshHostsResource() ?? [];
+
+  async function handleCreateOnHost(host: string): Promise<void> {
+    const id = toast.loading(`Connecting to ${host}…`);
+    try {
+      const result = await client.server.installSshAgent({ host });
+      if (!result.ok) {
+        toast.error(
+          `Failed to install agent on ${host}: ${result.message ?? "unknown error"}`,
+          { id },
+        );
+        return;
+      }
+      await crud.handleCreate(undefined, undefined, { kind: "ssh", host });
+      toast.success(`Terminal opened on ${host}`, { id });
+    } catch (err) {
+      toast.error(
+        `Failed to create terminal on ${host}: ${err instanceof Error ? err.message : String(err)}`,
+        { id },
+      );
+    }
+  }
+
   const commands = createCommands({
     ...actionContext,
     handleCopyTerminalText: () => void crud.handleCopyTerminalText(),
@@ -309,6 +347,8 @@ const App: Component = () => {
     canvasAutoArrange: arrange.handleCanvasAutoArrange,
     workspaceEntries,
     recencyOf,
+    sshHosts,
+    handleCreateOnHost: (host) => void handleCreateOnHost(host),
   });
 
   // Reset state on close and return focus to terminal

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -6,6 +6,7 @@ import { type Component, createMemo, createSignal, For, Show } from "solid-js";
 import { ACTIONS } from "./input/actions";
 import { formatKeybind } from "./input/keyboard";
 import Kbd from "./ui/Kbd";
+import { HostChip } from "./terminal/HostChip";
 import { surface } from "./ui/Surface";
 import Toggle from "./ui/Toggle";
 
@@ -122,8 +123,11 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
                           <For each={group.terminals}>
                             {(t) => (
                               <div title={t.cwd}>
-                                <div class="text-sm text-fg-2 truncate leading-snug">
-                                  {terminalKey(t).label}
+                                <div class="flex items-center gap-1.5 text-sm text-fg-2 truncate leading-snug">
+                                  <span class="truncate min-w-0">
+                                    {terminalKey(t).label}
+                                  </span>
+                                  <HostChip location={t.location} />
                                 </div>
                                 <Show
                                   when={

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -42,6 +42,7 @@ import {
 import { toast } from "solid-sonner";
 import IntentBody from "../../intent/IntentBody";
 import AgentIndicator from "../../terminal/AgentIndicator";
+import { HostChip } from "../../terminal/HostChip";
 import { formatTimeAgo, useStaleCheck } from "../../terminal/staleness";
 import IntentGlyph from "../../intent/IntentGlyph";
 import { IntentMarkdownInline } from "../../intent/IntentMarkdown";
@@ -595,14 +596,17 @@ const AwaitingCardBody: Component<{
         title="Jump to this terminal"
       >
         <div class="flex items-baseline justify-between gap-2 min-w-0">
-          <span
-            class="font-mono text-[0.7rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-            style={{
-              color: active() ? undefined : props.info.repoColor,
-            }}
-          >
-            {props.info.key.group}
-          </span>
+          <div class="flex items-center gap-1.5 min-w-0">
+            <span
+              class="font-mono text-[0.7rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
+              style={{
+                color: active() ? undefined : props.info.repoColor,
+              }}
+            >
+              {props.info.key.group}
+            </span>
+            <HostChip location={props.meta.location} />
+          </div>
           <div class="flex items-baseline gap-2 min-w-0">
             <DockAnnotation
               meta={props.meta}
@@ -683,14 +687,17 @@ const WorkingPillBody: Component<{
       title="Jump to this terminal"
     >
       <div class="flex items-baseline justify-between gap-2 min-w-0">
-        <span
-          class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-          style={{
-            color: active() ? undefined : props.info.repoColor,
-          }}
-        >
-          {props.info.key.group}
-        </span>
+        <div class="flex items-center gap-1.5 min-w-0">
+          <span
+            class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
+            style={{
+              color: active() ? undefined : props.info.repoColor,
+            }}
+          >
+            {props.info.key.group}
+          </span>
+          <HostChip location={props.meta.location} />
+        </div>
         <div class="flex items-baseline gap-2 min-w-0">
           <DockAnnotation
             meta={props.meta}
@@ -758,6 +765,7 @@ const QuietRowBody: Component<{
         >
           {props.info.key.group}
         </span>
+        <HostChip location={props.meta.location} />
         <DockAnnotation
           meta={props.meta}
           info={props.info}

--- a/packages/client/src/canvas/dock/WorkspaceGrid.tsx
+++ b/packages/client/src/canvas/dock/WorkspaceGrid.tsx
@@ -24,6 +24,7 @@ import {
   createSignal,
   on,
 } from "solid-js";
+import { HostChip } from "../../terminal/HostChip";
 import IntentBody from "../../intent/IntentBody";
 import { formatTimeAgo, useIdleClassifier } from "../../terminal/staleness";
 import { IntentMarkdownInline } from "../../intent/IntentMarkdown";
@@ -521,12 +522,15 @@ const WorkspaceCard: Component<{
        *  headline below; rendering the glyph again as a separate chip
        *  would duplicate it. */}
       <div class="flex items-center justify-between gap-2 min-w-0">
-        <span
-          class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.16em] truncate min-w-0"
-          style={{ color: props.entry.info.repoColor }}
-        >
-          {props.entry.repoName}
-        </span>
+        <div class="flex items-center gap-1.5 min-w-0">
+          <span
+            class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.16em] truncate min-w-0"
+            style={{ color: props.entry.info.repoColor }}
+          >
+            {props.entry.repoName}
+          </span>
+          <HostChip location={props.entry.info.meta.location} />
+        </div>
         <Show when={pr()}>
           {(summary) => (
             <span

--- a/packages/client/src/commands.tsx
+++ b/packages/client/src/commands.tsx
@@ -132,6 +132,12 @@ export interface CommandDeps extends ActionContext {
   // accessor the "Search workspaces" group walks to populate its rows.
   workspaceEntries: Accessor<DockSourceEntry[]>;
   recencyOf: (id: TerminalId) => number;
+  // R-2: SSH aliases from `~/.ssh/config` (server-side `listSshHosts`
+  // RPC). Drives "New terminal on $host" entries in the palette.
+  sshHosts: Accessor<{ alias: string }[]>;
+  // Create a terminal on a specific SSH host. Installs the agent on
+  // first use, then dispatches to RemoteBackend.
+  handleCreateOnHost: (host: string) => void;
   // Debug
   simulateAlert: () => void;
   handleClearLocalStorage: () => void;
@@ -201,6 +207,15 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
                 },
               ]
             : []),
+          // R-2: SSH host entries from `~/.ssh/config`.
+          ...deps.sshHosts().map(
+            (h): PaletteItem => ({
+              kind: "action",
+              name: `On ${h.alias}`,
+              description: `New terminal on remote host ${h.alias}`,
+              onSelect: () => deps.handleCreateOnHost(h.alias),
+            }),
+          ),
         ];
       },
     },

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -167,7 +167,10 @@ const CodeTab: Component<{
     () => {
       const p = repoPath();
       const m = diffMode();
-      return p && m ? { repoPath: p, mode: m } : null;
+      const tid = props.terminalId;
+      return p && m
+        ? { repoPath: p, mode: m, terminalId: tid ?? undefined }
+        : null;
     },
     {
       onError: (err) => toast.error(`Git status stream: ${err.message}`),
@@ -177,7 +180,10 @@ const CodeTab: Component<{
   const allPaths = app.streams.fsListAll.use(
     () => {
       const p = repoPath();
-      return p && view() === "browse" ? { repoPath: p } : null;
+      const tid = props.terminalId;
+      return p && view() === "browse"
+        ? { repoPath: p, terminalId: tid ?? undefined }
+        : null;
     },
     {
       onError: (err) => toast.error(`File list stream: ${err.message}`),
@@ -189,10 +195,17 @@ const CodeTab: Component<{
       const p = repoPath();
       const s = selectedPath();
       const m = diffMode();
+      const tid = props.terminalId;
       if (!p || !s || !m) return null;
       const file = status()?.files.find((f) => f.path === s);
       if (!file) return null;
-      return { repoPath: p, filePath: s, mode: m, oldPath: file.oldPath };
+      return {
+        repoPath: p,
+        filePath: s,
+        mode: m,
+        oldPath: file.oldPath,
+        terminalId: tid ?? undefined,
+      };
     },
     {
       onError: (err) => toast.error(`Git diff stream: ${err.message}`),

--- a/packages/client/src/terminal/DisconnectedOverlay.tsx
+++ b/packages/client/src/terminal/DisconnectedOverlay.tsx
@@ -1,0 +1,64 @@
+/**
+ * DisconnectedOverlay — covers a remote terminal tile when the SSH
+ * connection has dropped.
+ *
+ * Triggered by `terminal.connectionState === "disconnected"` — the
+ * channel that `HostSession`'s state machine drives via
+ * `RemoteBackend.terminalChannel(id, "connectionState")`. Mirrors
+ * Zed's `disconnected_overlay.rs:17-214` for the kolu aesthetic.
+ *
+ * Shows:
+ *  - Host name
+ *  - Reason (heartbeat lost / reconnect attempts exhausted / server
+ *    not running on remote)
+ *  - Reconnect button — re-runs the HostSession's connect cycle
+ *  - Close-tile button — kills the terminal entirely
+ *
+ * Prototype scope: visual + button stubs (handlers wired in R-3 when
+ * HostSession's connect/dispose cycle is real).
+ */
+
+import { Show } from "solid-js";
+import type { ConnectionState, TerminalLocation } from "kolu-common/surface";
+
+export function DisconnectedOverlay(props: {
+  location: TerminalLocation;
+  connectionState: ConnectionState;
+  onReconnect: () => void;
+  onClose: () => void;
+}) {
+  const visible = () =>
+    props.location.kind === "ssh" && props.connectionState === "disconnected";
+  const reconnecting = () =>
+    props.location.kind === "ssh" && props.connectionState === "connecting";
+  return (
+    <Show when={visible() || reconnecting()}>
+      <div class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/60 text-white backdrop-blur-sm">
+        <div class="text-sm font-mono opacity-70">
+          {props.location.kind === "ssh" ? props.location.host : ""}
+        </div>
+        <div class="text-base font-semibold">
+          {reconnecting() ? "Reconnecting…" : "Disconnected"}
+        </div>
+        <Show when={!reconnecting()}>
+          <div class="flex gap-2 mt-2">
+            <button
+              type="button"
+              class="px-3 py-1 rounded bg-purple-600 hover:bg-purple-500 text-sm"
+              onClick={props.onReconnect}
+            >
+              Reconnect
+            </button>
+            <button
+              type="button"
+              class="px-3 py-1 rounded bg-neutral-700 hover:bg-neutral-600 text-sm"
+              onClick={props.onClose}
+            >
+              Close tile
+            </button>
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+}

--- a/packages/client/src/terminal/DisconnectedOverlay.tsx
+++ b/packages/client/src/terminal/DisconnectedOverlay.tsx
@@ -27,20 +27,29 @@ export function DisconnectedOverlay(props: {
   onReconnect: () => void;
   onClose: () => void;
 }) {
-  const visible = () =>
+  const disconnected = () =>
     props.location.kind === "ssh" && props.connectionState === "disconnected";
-  const reconnecting = () =>
+  const connecting = () =>
     props.location.kind === "ssh" && props.connectionState === "connecting";
+  const host = () => (props.location.kind === "ssh" ? props.location.host : "");
   return (
-    <Show when={visible() || reconnecting()}>
+    <Show when={disconnected() || connecting()}>
       <div class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/60 text-white backdrop-blur-sm">
-        <div class="text-sm font-mono opacity-70">
-          {props.location.kind === "ssh" ? props.location.host : ""}
-        </div>
-        <div class="text-base font-semibold">
-          {reconnecting() ? "Reconnecting…" : "Disconnected"}
-        </div>
-        <Show when={!reconnecting()}>
+        <Show when={connecting()}>
+          {/* Visible progress signal while ssh + nix-run realises the
+             closure on a cold remote (first connect can take minutes).
+             Pulse + spinner make it clear something IS happening — the
+             alternative is a blank tile that feels frozen. */}
+          <div class="w-7 h-7 rounded-full border-2 border-white/30 border-t-white animate-spin" />
+          <div class="text-base font-semibold">Connecting to {host()}…</div>
+          <div class="text-xs text-white/60 max-w-[28ch] text-center">
+            First connect realises the kolu agent's nix closure on the remote;
+            this can take a moment.
+          </div>
+        </Show>
+        <Show when={disconnected()}>
+          <div class="text-sm font-mono opacity-70">{host()}</div>
+          <div class="text-base font-semibold">Disconnected</div>
           <div class="flex gap-2 mt-2">
             <button
               type="button"

--- a/packages/client/src/terminal/HostChip.tsx
+++ b/packages/client/src/terminal/HostChip.tsx
@@ -1,0 +1,32 @@
+/**
+ * HostChip — small badge rendered on remote tiles showing which SSH
+ * host owns the terminal. Local terminals render no chip (the common
+ * case stays clean).
+ *
+ * Renders in three places: the tile title bar, the dock card, and the
+ * workspace switcher. Each call site decides the surrounding chrome;
+ * the chip itself is just the icon + host label.
+ *
+ * Prototype scope: visual only, no interaction. R-3 may add a click
+ * handler that opens the host's session-info popover (reconnect
+ * controls, ping latency, etc.).
+ */
+
+import { Show } from "solid-js";
+import type { TerminalLocation } from "kolu-common/surface";
+
+export function HostChip(props: { location: TerminalLocation }) {
+  return (
+    <Show when={props.location.kind === "ssh" ? props.location : null}>
+      {(loc) => (
+        <span
+          class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-mono bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-800"
+          title={`Terminal on remote host: ${loc().host}`}
+        >
+          <span aria-hidden="true">⇄</span>
+          <span>{loc().host}</span>
+        </span>
+      )}
+    </Show>
+  );
+}

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -8,6 +8,8 @@ import Resizable from "@corvu/resizable";
 import type { ITheme } from "@xterm/xterm";
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import { type Component, For, Show } from "solid-js";
+import { DisconnectedOverlay } from "./DisconnectedOverlay";
+import { HostChip } from "./HostChip";
 import SubPanelTabBar from "./SubPanelTabBar";
 import Terminal from "./Terminal";
 import { useSubPanel } from "./useSubPanel";
@@ -80,7 +82,11 @@ const TerminalContent: Component<{
       onSizesChange={handleSizesChange}
       class="flex-1 min-h-0"
     >
-      <Resizable.Panel as="div" class="min-h-0 overflow-hidden" minSize={0.2}>
+      <Resizable.Panel
+        as="div"
+        class="min-h-0 overflow-hidden relative"
+        minSize={0.2}
+      >
         <Terminal
           terminalId={props.terminalId}
           visible={props.visible}
@@ -90,6 +96,30 @@ const TerminalContent: Component<{
           onSearchOpenChange={props.onSearchOpenChange}
           onFocus={handleMainFocus}
         />
+        {/* R-2: remote-terminal chrome — HostChip in the corner,
+            DisconnectedOverlay covers the tile when the connection
+            drops. Local terminals render neither (HostChip's
+            internal Show gates on location.kind === "ssh"; the
+            overlay's `visible()` predicate gates on connectionState).
+            Self-healing — pulling meta from the props.getMetadata
+            accessor keeps this reactive to entry.meta updates. */}
+        <Show when={props.getMetadata(props.terminalId)}>
+          {(meta) => (
+            <>
+              <div class="absolute top-1 right-1 pointer-events-none">
+                <HostChip location={meta().location} />
+              </div>
+              <DisconnectedOverlay
+                location={meta().location}
+                connectionState={meta().connectionState}
+                onReconnect={() => {
+                  /* R-3: trigger HostSession.reconnect via RPC */
+                }}
+                onClose={() => props.onCloseTerminal(props.terminalId)}
+              />
+            </>
+          )}
+        </Show>
       </Resizable.Panel>
 
       {/* Resize handle — invisible hit zone, visible on hover */}

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -19,6 +19,7 @@ import { annotationLine } from "../intent/text";
 import { PrStateIcon, WorktreeIcon } from "../ui/Icons";
 import Tip from "../ui/Tip";
 import ChecksIndicator from "./ChecksIndicator";
+import { HostChip } from "./HostChip";
 import { PrUnavailableButton } from "./PrUnavailablePopover";
 import type { TerminalDisplayInfo } from "./terminalDisplay";
 
@@ -55,6 +56,7 @@ const TerminalMeta: Component<{
                 </span>
               )}
             </Show>
+            <HostChip location={info().meta.location} />
             <Show when={info().meta.git?.isWorktree}>
               <WorktreeBadge />
             </Show>

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -31,6 +31,7 @@ export function useSessionRestore(deps: {
   handleCreate: (
     cwd?: string,
     initial?: InitialTerminalMetadata,
+    location?: import("kolu-common/surface").TerminalLocation,
   ) => Promise<TerminalId>;
   handleCreateSubTerminal: (
     parentId: TerminalId,
@@ -241,14 +242,22 @@ export function useSessionRestore(deps: {
       // so the canvas cascade effect sees the saved layout on its first run
       // and skips the default-cascade branch (#642).
       for (const t of topLevel) {
-        const newId = await deps.handleCreate(t.cwd, {
-          themeName: t.themeName,
-          canvasLayout: t.canvasLayout,
-          subPanel: t.subPanel,
-          rightPanel: t.rightPanel,
-          lastActivityAt: t.lastActivityAt,
-          intent: t.intent,
-        });
+        const newId = await deps.handleCreate(
+          t.cwd,
+          {
+            themeName: t.themeName,
+            canvasLayout: t.canvasLayout,
+            subPanel: t.subPanel,
+            rightPanel: t.rightPanel,
+            lastActivityAt: t.lastActivityAt,
+            intent: t.intent,
+          },
+          // R-2: thread the saved `location` through so a remote
+          // terminal restores on its original host (otherwise the
+          // resolver defaults to localBackend and the tile silently
+          // reopens locally).
+          t.location,
+        );
         oldToNew.set(t.id, newId);
         // Step 2: in-loop assert. Combined with step 1, this puts the
         // intended active in place before the first canvas mount.

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -108,6 +108,7 @@ export function useTerminalCrud(deps: {
   async function handleCreate(
     cwd?: string,
     initial?: InitialTerminalMetadata,
+    location?: import("kolu-common/surface").TerminalLocation,
   ): Promise<TerminalId> {
     if (store.activeMeta()?.git) showTipOnce(CONTEXTUAL_TIPS.worktree);
 
@@ -134,6 +135,7 @@ export function useTerminalCrud(deps: {
         rightPanel: initial?.rightPanel,
         lastActivityAt: initial?.lastActivityAt,
         intent: initial?.intent,
+        location,
       })
       .catch((err: Error) => {
         toast.error(`Failed to create terminal: ${err.message}`);

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -37,14 +37,14 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: Number(process.env.KOLU_VITE_PORT ?? 5173),
     // Prevent browser from caching dev assets — stale modules cause subtle bugs on refresh.
     headers: { "Cache-Control": "no-store" },
     proxy: {
-      "/api": `http://localhost:${DEFAULT_PORT}`,
-      "/manifest.webmanifest": `http://localhost:${DEFAULT_PORT}`,
+      "/api": `http://localhost:${process.env.KOLU_API_PORT ?? DEFAULT_PORT}`,
+      "/manifest.webmanifest": `http://localhost:${process.env.KOLU_API_PORT ?? DEFAULT_PORT}`,
       "/rpc": {
-        target: `http://localhost:${DEFAULT_PORT}`,
+        target: `http://localhost:${process.env.KOLU_API_PORT ?? DEFAULT_PORT}`,
         ws: true,
       },
     },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,6 +8,7 @@
   "exports": {
     "./surface": "./src/surface.ts",
     "./backend": "./src/backend.ts",
+    "./agentContract": "./src/agentContract.ts",
     "./contract": "./src/contract.ts",
     "./errors": "./src/errors.ts",
     "./config": "./src/config.ts",

--- a/packages/common/src/agentContract.ts
+++ b/packages/common/src/agentContract.ts
@@ -1,0 +1,155 @@
+/**
+ * `agentContract` — narrow oRPC contract that `kolu agent --stdio`
+ * serves and `RemoteBackend` consumes.
+ *
+ * **Why a narrow contract.** The agent should NOT serve the full
+ * `appRouter`. Pre-implementation review (finding E): exposing
+ * `terminal.create` recursively would let an agent attempt to spawn
+ * another remote terminal-on-a-terminal — recursion nightmare.
+ * Exposing `surface.*` (cells, collections, streams) leaks
+ * client-facing UX plumbing into a server-internal protocol whose
+ * volatility axis is different.
+ *
+ * The agent's job is narrow: own one machine's PTYs, surface their
+ * channels + fs/git ops, accept a heartbeat. The kolu server owns
+ * everything else and is the only consumer.
+ *
+ * Wire shape mirrors `Backend` exactly — every method on the contract
+ * corresponds to a method on `Backend`, just transported. This keeps
+ * `RemoteBackend` a thin shim: each method is one `client.X.Y(...)`
+ * call against the same shape it would call locally on `LocalBackend`.
+ *
+ * Versioning: the agent contract is independent of the
+ * client-server contract. A user can run kolu N locally and connect
+ * to a kolu M agent (R-2 doesn't ship the version negotiation; R-3
+ * will when the agent's contract grows beyond its initial freeze).
+ */
+
+import { eventIterator, oc } from "@orpc/contract";
+import {
+  FsListAllInputSchema,
+  FsListAllOutputSchema,
+  FsReadFileInputSchema,
+  FsReadFileOutputSchema,
+  GitDiffInputSchema,
+  GitDiffOutputSchema,
+  GitStatusInputSchema,
+  GitStatusOutputSchema,
+} from "kolu-git/schemas";
+import { z } from "zod";
+import {
+  AgentInfoSchema,
+  ConnectionStateSchema,
+  ForegroundSchema,
+  InitialTerminalMetadataSchema,
+  TerminalIdSchema,
+} from "./surface";
+import { GitInfoSchema } from "kolu-git/schemas";
+import { PrResultSchema } from "kolu-github/schemas";
+
+// ── Terminal lifecycle ────────────────────────────────────────────────
+
+export const AgentTerminalSpawnInputSchema = z.object({
+  cwd: z.string().optional(),
+  initialMetadata: InitialTerminalMetadataSchema.extend({
+    parentId: z.string().optional(),
+  }).optional(),
+});
+
+export const AgentTerminalSpawnOutputSchema = z.object({
+  id: TerminalIdSchema,
+});
+
+export const AgentTerminalKillInputSchema = z.object({ id: TerminalIdSchema });
+
+export const AgentTerminalWriteInputSchema = z.object({
+  id: TerminalIdSchema,
+  data: z.string(),
+});
+
+export const AgentTerminalResizeInputSchema = z.object({
+  id: TerminalIdSchema,
+  cols: z.number(),
+  rows: z.number(),
+});
+
+// ── Per-terminal channels ────────────────────────────────────────────
+//
+// Each channel mirrors a key in `TerminalChannelMap` (kolu-common/backend.ts).
+// The agent serves them as event-iterator streams; `RemoteBackend.terminalChannel`
+// consumes via the same oRPC client.
+
+const ChannelInput = z.object({ id: TerminalIdSchema });
+
+const channelOf = <T extends z.ZodType>(schema: T) =>
+  oc.input(ChannelInput).output(eventIterator(schema));
+
+// ── Filesystem ───────────────────────────────────────────────────────
+
+export const AgentUploadFileInputSchema = z.object({
+  id: TerminalIdSchema,
+  name: z.string().min(1),
+  base64Data: z.string(),
+});
+
+export const AgentUploadFileOutputSchema = z.object({
+  path: z.string(),
+});
+
+const SubscribeRepoInputSchema = z.object({ repoPath: z.string() });
+const SubscribeFileInputSchema = z.object({
+  repoPath: z.string(),
+  filePath: z.string(),
+});
+
+// ── The agent contract ───────────────────────────────────────────────
+
+export const agentContract = oc.router({
+  /** Liveness probe. RemoteBackend's HostSession pings on
+   *  `HEARTBEAT_INTERVAL` (5s); 5 consecutive missed → reconnect. */
+  heartbeat: oc.output(z.object({ ok: z.literal(true) })),
+
+  terminal: {
+    spawn: oc
+      .input(AgentTerminalSpawnInputSchema)
+      .output(AgentTerminalSpawnOutputSchema),
+    kill: oc.input(AgentTerminalKillInputSchema).output(z.boolean()),
+    write: oc.input(AgentTerminalWriteInputSchema).output(z.void()),
+    resize: oc.input(AgentTerminalResizeInputSchema).output(z.void()),
+    uploadFile: oc
+      .input(AgentUploadFileInputSchema)
+      .output(AgentUploadFileOutputSchema),
+
+    // Channels — one per TerminalChannelMap key. snapshot-then-delta.
+    channelData: channelOf(z.string()),
+    channelCwd: channelOf(z.string()),
+    channelTitle: channelOf(z.string()),
+    channelGit: channelOf(GitInfoSchema.nullable()),
+    channelCommandRun: channelOf(z.string()),
+    channelAgent: channelOf(AgentInfoSchema.nullable()),
+    channelPr: channelOf(PrResultSchema),
+    channelForeground: channelOf(ForegroundSchema.nullable()),
+    channelConnectionState: channelOf(ConnectionStateSchema),
+  },
+
+  fs: {
+    listAll: oc.input(FsListAllInputSchema).output(FsListAllOutputSchema),
+    readFile: oc.input(FsReadFileInputSchema).output(FsReadFileOutputSchema),
+    subscribeRepoChange: oc
+      .input(SubscribeRepoInputSchema)
+      .output(eventIterator(z.void())),
+    subscribeFileChange: oc
+      .input(SubscribeFileInputSchema)
+      .output(eventIterator(z.void())),
+  },
+
+  git: {
+    getDiff: oc.input(GitDiffInputSchema).output(GitDiffOutputSchema),
+    getStatus: oc.input(GitStatusInputSchema).output(GitStatusOutputSchema),
+    subscribeRepoChange: oc
+      .input(SubscribeRepoInputSchema)
+      .output(eventIterator(z.void())),
+  },
+});
+
+export type AgentContract = typeof agentContract;

--- a/packages/common/src/agentContract.ts
+++ b/packages/common/src/agentContract.ts
@@ -33,6 +33,7 @@ import {
   FsReadFileOutputSchema,
   GitDiffInputSchema,
   GitDiffOutputSchema,
+  GitInfoSchema,
   GitStatusInputSchema,
   GitStatusOutputSchema,
 } from "kolu-git/schemas";
@@ -44,7 +45,6 @@ import {
   InitialTerminalMetadataSchema,
   TerminalIdSchema,
 } from "./surface";
-import { GitInfoSchema } from "kolu-git/schemas";
 import { PrResultSchema } from "kolu-github/schemas";
 
 // ── Terminal lifecycle ────────────────────────────────────────────────

--- a/packages/common/src/agentContract.ts
+++ b/packages/common/src/agentContract.ts
@@ -49,6 +49,11 @@ import { PrResultSchema } from "kolu-github/schemas";
 // ── Terminal lifecycle ────────────────────────────────────────────────
 
 export const AgentTerminalSpawnInputSchema = z.object({
+  /** Caller-supplied id — the kolu server pre-generates this so it
+   *  can register a "connecting" tile before the spawn RPC
+   *  roundtrips. The agent uses it as the new terminal's id in its
+   *  own registry, keeping kolu-server <-> agent ids in lockstep. */
+  id: z.string(),
   cwd: z.string().optional(),
   initialMetadata: InitialTerminalMetadataSchema.extend({
     parentId: z.string().optional(),

--- a/packages/common/src/agentContract.ts
+++ b/packages/common/src/agentContract.ts
@@ -29,7 +29,6 @@ import { eventIterator, oc } from "@orpc/contract";
 import {
   FsListAllInputSchema,
   FsListAllOutputSchema,
-  FsReadFileInputSchema,
   FsReadFileOutputSchema,
   GitDiffInputSchema,
   GitDiffOutputSchema,
@@ -102,6 +101,15 @@ const SubscribeFileInputSchema = z.object({
   filePath: z.string(),
 });
 
+/** Agent-side fs.readFile input. Drops `terminalId` from
+ *  `kolu-git/schemas:FsReadFileInputSchema` — the agent doesn't
+ *  construct URLs (no iframe-preview route on the agent side), so the
+ *  terminal-id field is dead weight over the wire. */
+const AgentReadFileInputSchema = z.object({
+  repoPath: z.string(),
+  filePath: z.string(),
+});
+
 // ── The agent contract ───────────────────────────────────────────────
 
 export const agentContract = oc.router({
@@ -134,7 +142,7 @@ export const agentContract = oc.router({
 
   fs: {
     listAll: oc.input(FsListAllInputSchema).output(FsListAllOutputSchema),
-    readFile: oc.input(FsReadFileInputSchema).output(FsReadFileOutputSchema),
+    readFile: oc.input(AgentReadFileInputSchema).output(FsReadFileOutputSchema),
     subscribeRepoChange: oc
       .input(SubscribeRepoInputSchema)
       .output(eventIterator(z.void())),

--- a/packages/common/src/agentContract.ts
+++ b/packages/common/src/agentContract.ts
@@ -146,9 +146,9 @@ export const agentContract = oc.router({
   git: {
     getDiff: oc.input(GitDiffInputSchema).output(GitDiffOutputSchema),
     getStatus: oc.input(GitStatusInputSchema).output(GitStatusOutputSchema),
-    subscribeRepoChange: oc
-      .input(SubscribeRepoInputSchema)
-      .output(eventIterator(z.void())),
+    // `subscribeRepoChange` lives on `fs` only — Lowy post-impl F1.
+    // The git watcher and fs watcher are the same parcel-watcher
+    // subscription with a different name. One axis, one site.
   },
 });
 

--- a/packages/common/src/backend.ts
+++ b/packages/common/src/backend.ts
@@ -3,9 +3,9 @@
  *
  * A `Backend` is identified by `BackendId` (local machine, or a specific
  * SSH host) and owns every per-terminal stream + one-shot op a terminal
- * needs. R-1 ships `LocalBackend` only; R-2 adds `RemoteBackend` whose
+ * needs. R-1 shipped `LocalBackend`; R-2 adds `RemoteBackend` whose
  * methods proxy via oRPC over `ssh stdio` to a `kolu agent --stdio`
- * instance on the remote host.
+ * peer.
  *
  * The interface is the single transport boundary in the system. The
  * server's `meta/*.ts` orchestrators are dissolved into `LocalBackend`
@@ -19,94 +19,78 @@
  * `STREAM_RETRY` plumbing — `kolu agent --stdio` is just another oRPC
  * peer, no bespoke reconnect logic needed.
  *
- * Invariants enforced by convention (not by types):
+ * R-2 expanded the channel set so remote terminals' rich surfaces
+ * (agent badge, PR badge, foreground process, connection state) work
+ * over the wire — pre-implementation review (finding B) caught that
+ * R-1's channel set was insufficient; without these channels, remote
+ * tiles silently lose all rich-surface metadata.
  *
- * 1. **Kill convergence.** Both `Backend.killTerminal(id)` and
- *    `TerminalHandle.dispose()` must end at the same termination logic
- *    inside the backend — neither path may skip provider teardown,
- *    clipboard cleanup, or registry deregistration. R-2's `RemoteBackend`
- *    must wire `dispose()` through to `killTerminal` so RPC kill and
- *    handle-dispose are observationally indistinguishable.
+ * Invariants:
+ *
+ * 1. **Kill convergence.** `Backend.killTerminal(id)` is the SOLE
+ *    termination path. `TerminalHandle` no longer carries `dispose()` —
+ *    handle-as-control-surface and kill-as-lifecycle were two roles
+ *    smuggled through one method. R-2 pre-impl finding H.
  *
  * 2. **Snapshot-then-delta streams.** Every `terminalChannel<K>`
  *    iterator's first yield is a full state snapshot; subsequent yields
- *    are deltas. Without this, reconnect via `STREAM_RETRY` silently
- *    accumulates onto stale client state.
+ *    are deltas.
  *
- * Gap acknowledged for R-2: `packages/server/src/surface.ts`'s `streams`
- * block (gitStatus, gitDiff, fsListAll, fsReadFile) still calls
- * `kolu-git` directly rather than routing through `Backend.fs`/
- * `Backend.git`. For R-1 the Code tab works because every backend is
- * local; for R-2 those streams must route through the backend or remote
- * tiles will silently read the kolu-server's local filesystem instead of
- * the agent's. Tracked in the R-2 PR description.
+ * 3. **Backend owns its filesystem.** `BackendFs`/`BackendGit` cover
+ *    both one-shot ops AND watcher subscriptions — same axis ("where
+ *    the FS lives"). R-2 closes the R-1 gap where `surface.ts` streams
+ *    called `kolu-git` directly.
  */
 
+import type {
+  AgentInfo,
+  ConnectionState,
+  Foreground,
+  TerminalLocation,
+} from "./surface";
 import type {
   GitDiffMode,
   GitDiffOutput,
   GitInfo,
   GitStatusOutput,
 } from "kolu-git/schemas";
-import type { InitialTerminalMetadata, TerminalLocation } from "./surface";
+import type { PrResult } from "kolu-github/schemas";
+import type { InitialTerminalMetadata } from "./surface";
 
-/** Seed metadata for a new terminal. Same shape as
- *  `InitialTerminalMetadata` (used by the `terminal.create` RPC input)
- *  plus the parent-link, which the client-create RPC carries as a
- *  top-level field for clarity. Bundled here so the backend has one
- *  `Object.assign`-shaped opt rather than seven optional fields. */
+/** Seed metadata for a new terminal. */
 export interface TerminalSeed extends InitialTerminalMetadata {
-  /** Sub-terminal link — present when this terminal is a child of an
-   *  existing one. The backend just records the link on the new
-   *  terminal's metadata; it does NOT decide which backend to spawn
-   *  on. Sub-terminal location inheritance ("a child of a remote tile
-   *  spawns on the same remote") is the resolver's job — R-2 will
-   *  extend `getBackendFor` (or a creation-time variant) to look up
-   *  `parentId`'s backend before dispatching, so the inheritance lives
-   *  at one site instead of being replicated at every
-   *  `createTerminal` caller. */
+  /** Sub-terminal link. Location inheritance (a child of a remote tile
+   *  spawns on the same host) is the resolver's job — see
+   *  `getBackendForCreate` in `packages/server/src/backend/index.ts`. */
   parentId?: string;
 }
 
-/** Inputs for `Backend.spawnPty`. Mirrors today's `createTerminal` shape
- *  without any backend-specific extras — both LocalBackend and
- *  RemoteBackend accept the same options.
- *
- *  `initialMetadata` seeds the client-owned metadata fields (theme,
- *  canvasLayout, parentId, subPanel, rightPanel, intent) BEFORE the
- *  backend's providers emit their first publish — so the first
- *  `terminalMetadata` collection yield carries them, and the canvas
- *  default-cascade effect can't race the providers' churn (#642). The
- *  backend doesn't interpret the contents — it just sets the fields on
- *  the new terminal's metadata before starting providers.
- *
- *  `onExit` fires whenever the PTY process exits — naturally (shell typed
- *  `exit`, crash) or as a result of an explicit `dispose()` /
- *  `killTerminal()`. The `wasNatural` flag distinguishes the two so the
- *  caller knows whether to fan out session-save signals: only natural
- *  exit triggers an autosave; explicit kill already accounted for the
- *  registry change. (`killAllTerminals` drains the registry before
- *  disposing, so every kill-all callback observes `wasNatural=false` and
- *  shutdown doesn't write phantom empty sessions.) */
 export interface PtySpawnOpts {
   cwd?: string;
   initialMetadata?: TerminalSeed;
+  /** Fires on PTY exit with `wasNatural` distinguishing shell-exited
+   *  from explicit-kill. See module doc. */
   onExit?: (exitCode: number, wasNatural: boolean) => void;
 }
 
-/** A live terminal owned by a backend. `id` is shared across the system
- *  (the wire `TerminalId`); `write`/`resize`/`dispose` are the control
- *  surface. `dispose()` is observationally identical to
- *  `Backend.killTerminal(id)` — see the kill-convergence invariant in
- *  the module doc. */
+/** A live terminal owned by a backend. Pure control-surface — write
+ *  input, change dimensions. Termination is `Backend.killTerminal(id)`,
+ *  not on the handle (kill-convergence invariant). */
 export interface TerminalHandle {
   readonly id: string;
   write(data: string): void;
   resize(cols: number, rows: number): void;
-  dispose(): void;
 }
 
-/** Per-terminal streaming channels. Snapshot-then-delta on every key. */
+/** Per-terminal streaming channels. Snapshot-then-delta on every key.
+ *
+ *  R-2 channel-set expansion:
+ *  - `agent`, `pr`, `foreground` — were written by in-process providers
+ *    on R-1, which works for local but is invisible to RemoteBackend.
+ *    Now flow over channels so the agent process's providers reach the
+ *    kolu server.
+ *  - `connectionState` — driven by `HostSession`'s state machine for
+ *    remote terminals; `LocalBackend` publishes "live" once at spawn. */
 export interface TerminalChannelMap {
   /** Raw PTY bytes — high-throughput stream. */
   data: string;
@@ -118,22 +102,46 @@ export interface TerminalChannelMap {
   git: GitInfo | null;
   /** OSC 633;E preexec command lines (raw). */
   commandRun: string;
+  /** AI coding agent state (Claude Code, OpenCode, Codex). */
+  agent: AgentInfo | null;
+  /** GitHub PR resolution. */
+  pr: PrResult;
+  /** Foreground process detected via OSC 2 / kqueue. */
+  foreground: Foreground | null;
+  /** Backend connection state — `"live"` for local, transitions
+   *  through `"connecting"` / `"disconnected"` for remote. */
+  connectionState: ConnectionState;
 }
 
-/** One-shot filesystem ops scoped to whatever filesystem the backend
- *  represents. For `LocalBackend` this is the local FS; for
- *  `RemoteBackend` it's the remote agent's FS. The kolu server treats
- *  them identically. */
+/** Filesystem ops scoped to the backend's filesystem.
+ *
+ *  Subscription methods return AsyncIterables so the same shape carries
+ *  over oRPC (RemoteBackend) and over in-process callbacks
+ *  (LocalBackend wraps `kolu-git`'s callback-based watchers via an
+ *  async generator). The yielded `void` is a "something changed"
+ *  signal — consumers re-read via `listAll` / `readFile`. */
 export interface BackendFs {
   listAll(repoPath: string): Promise<string[]>;
   readFile(
     repoPath: string,
     filePath: string,
   ): Promise<{ content: string; truncated: boolean }>;
+  /** Yield once per filesystem change anywhere under `repoPath`. The
+   *  first yield is a no-op snapshot so consumers can `read` once
+   *  before the first delta arrives. */
+  subscribeRepoChange(
+    repoPath: string,
+    signal?: AbortSignal,
+  ): AsyncIterable<void>;
+  /** Yield once per filesystem change to `filePath` (or its containing
+   *  dir, for create/delete). */
+  subscribeFileChange(
+    repoPath: string,
+    filePath: string,
+    signal?: AbortSignal,
+  ): AsyncIterable<void>;
 }
 
-/** One-shot git ops. Types mirror `kolu-git/schemas` so the wire shape
- *  is identical regardless of backend. */
 export interface BackendGit {
   getDiff(
     repoPath: string,
@@ -142,61 +150,67 @@ export interface BackendGit {
     oldPath?: string,
   ): Promise<GitDiffOutput>;
   getStatus(repoPath: string, mode: GitDiffMode): Promise<GitStatusOutput>;
+  /** Same shape as `BackendFs.subscribeRepoChange` — kolu-git's git
+   *  watcher uses the same parcel-watcher subscription under the hood,
+   *  so this is presented as a separate name for the
+   *  not-coincidentally-identical purpose: "git state at this repo
+   *  changed." */
+  subscribeRepoChange(
+    repoPath: string,
+    signal?: AbortSignal,
+  ): AsyncIterable<void>;
 }
 
 /**
- * The Backend interface — see module doc. R-1 ships `LocalBackend`. R-2
- * adds `RemoteBackend` and the binary serving its protocol
- * (`kolu agent --stdio`).
+ * The Backend interface — see module doc.
  *
  * Per-terminal screen-state reads (`getScreenState`, `getScreenText`)
- * deliberately do NOT live here: the xterm-headless emulator buffer is
- * per-terminal local state that survives backend swaps (a Phase-3
- * remote-agent reattach still serializes the local emulator's
- * scrollback). The emulator lives next to its handle in the registry;
- * callers read it via `getTerminal(id)?.handle.getScreenState()` rather
- * than through this interface.
+ * stay on `entry.handle` (the kolu server's `TerminalControl` view of a
+ * terminal) — emulator state is per-terminal local state and survives
+ * backend swaps. Callers go through the registry, not this interface.
  */
 export interface Backend {
-  /** Stable identity for this backend instance — `{ kind: "local" }` or
-   *  `{ kind: "ssh", host }`. Persisted on each terminal's
-   *  `ServerPersistedTerminalFields.location` so session restore picks
-   *  the same backend a terminal previously lived on. */
+  /** Stable identity — `{ kind: "local" }` or `{ kind: "ssh", host }`. */
   readonly id: TerminalLocation;
 
   /** Create a new terminal owned by this backend. */
   spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle>;
 
-  /** Subscribe to a terminal's stream of `kind`. Snapshot-then-delta;
-   *  late joiners (e.g. tab refresh) receive the current snapshot
-   *  before any deltas. Aborting the iterator closes the subscription. */
+  /** Subscribe to a terminal's stream of `kind`. Snapshot-then-delta. */
   terminalChannel<K extends keyof TerminalChannelMap>(
     terminalId: string,
     kind: K,
     signal?: AbortSignal,
   ): AsyncIterable<TerminalChannelMap[K]>;
 
-  /** Kill a terminal owned by this backend. Returns true if the
-   *  terminal was registered and the kill ran; false if the id was
-   *  unknown (already cleaned up). Observationally identical to calling
-   *  `dispose()` on the same terminal's handle — see kill-convergence
-   *  invariant in the module doc. */
+  /** Kill a terminal. Single termination path — see kill-convergence
+   *  invariant in module doc. Returns `true` if the kill ran. */
   killTerminal(terminalId: string): boolean;
 
-  /** Tear down a terminal whose entry the caller already holds — used
-   *  by bulk-kill paths that drain the registry first and want the
-   *  per-entry teardown without a second registry lookup. The contract
-   *  is "same teardown as `killTerminal`, applied to a specific entry
-   *  the caller is responsible for having removed from the shared
-   *  registry already." Single entry point keeps the kill-convergence
-   *  invariant holding across bulk and single-target paths. */
+  /** Bulk-kill teardown for `killAllTerminals` — the drain-before-
+   *  dispose pattern has already emptied the registry, so this
+   *  variant takes the entry directly. RemoteBackend reads only
+   *  `entry.info.id` (and RPCs); LocalBackend uses the full handle +
+   *  stopProviders. The wide structural type honors both. */
   killTerminalEntry(entry: {
     info: { id: string };
     handle: { dispose(): void };
     stopProviders: () => void;
   }): void;
 
-  /** Filesystem and git one-shot ops on the backend's filesystem. */
+  /** Save uploaded bytes into the backend's per-terminal scratch
+   *  directory and return the absolute path the agent on this backend
+   *  sees. Used by `terminal.pasteImage` / `terminal.uploadFile` —
+   *  R-1's implementation in `router.ts` wrote to the kolu-server's
+   *  local scratch dir, which is the wrong host for remote tiles.
+   *  R-2 finding I. */
+  uploadFile(
+    terminalId: string,
+    name: string,
+    base64Data: string,
+  ): Promise<string>;
+
+  /** Filesystem + git ops on the backend's filesystem. */
   readonly fs: BackendFs;
   readonly git: BackendGit;
 }

--- a/packages/common/src/backend.ts
+++ b/packages/common/src/backend.ts
@@ -150,15 +150,9 @@ export interface BackendGit {
     oldPath?: string,
   ): Promise<GitDiffOutput>;
   getStatus(repoPath: string, mode: GitDiffMode): Promise<GitStatusOutput>;
-  /** Same shape as `BackendFs.subscribeRepoChange` — kolu-git's git
-   *  watcher uses the same parcel-watcher subscription under the hood,
-   *  so this is presented as a separate name for the
-   *  not-coincidentally-identical purpose: "git state at this repo
-   *  changed." */
-  subscribeRepoChange(
-    repoPath: string,
-    signal?: AbortSignal,
-  ): AsyncIterable<void>;
+  // Subscription lives on `BackendFs.subscribeRepoChange` only —
+  // post-impl Lowy F1: the git watcher and fs watcher are the same
+  // parcel-watcher subscription, just renamed. One axis, one site.
 }
 
 /**

--- a/packages/common/src/backend.ts
+++ b/packages/common/src/backend.ts
@@ -66,6 +66,14 @@ export interface TerminalSeed extends InitialTerminalMetadata {
 }
 
 export interface PtySpawnOpts {
+  /** Caller-supplied terminal id. Optional: backends generate one
+   *  when absent. RemoteBackend pre-generates an id so it can register
+   *  a "connecting" shadow entry on the kolu server BEFORE the agent's
+   *  spawn RPC roundtrips — that's what makes the tile appear
+   *  instantly while ssh + nix run realise the closure. The agent
+   *  honors the same id so kolu server <-> agent registries stay in
+   *  lockstep. */
+  id?: string;
   cwd?: string;
   initialMetadata?: TerminalSeed;
   /** Fires on PTY exit with `wasNatural` distinguishing shell-exited

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -132,12 +132,44 @@ export const ServerInfoSchema = z.object({
   processId: z.string().uuid(),
 });
 
+/** R-2: a discovered SSH host (from `~/.ssh/config`). Drives the
+ *  command-palette "New terminal on $host" entries. */
+export const SshHostSchema = z.object({
+  alias: z.string().min(1),
+});
+export type SshHost = z.infer<typeof SshHostSchema>;
+
+export const ListSshHostsOutputSchema = z.object({
+  hosts: z.array(SshHostSchema),
+});
+
+/** R-2: install the kolu agent on a remote host via `nix copy`.
+ *  Idempotent — repeated calls with the same host short-circuit if
+ *  the store path is already realised. Triggered explicitly by the
+ *  host-picker UI before any backend op on that host. */
+export const InstallSshAgentInputSchema = z.object({
+  host: z.string().min(1),
+});
+export const InstallSshAgentOutputSchema = z.object({
+  ok: z.boolean(),
+  message: z.string().optional(),
+});
+
 // ── The contract ──────────────────────────────────────────────────────
 
 export const contract = oc.router({
   ...surface.contract,
   server: {
     info: oc.output(ServerInfoSchema),
+    /** R-2: list SSH aliases the user can target. Drives the
+     *  command-palette host picker. Server-side because the client
+     *  cannot read `~/.ssh/config`. */
+    listSshHosts: oc.output(ListSshHostsOutputSchema),
+    /** R-2: install the kolu agent on a remote host. Called once per
+     *  host from the picker flow before the first terminal create. */
+    installSshAgent: oc
+      .input(InstallSshAgentInputSchema)
+      .output(InstallSshAgentOutputSchema),
   },
   terminal: {
     create: oc.input(TerminalCreateInputSchema).output(TerminalInfoSchema),

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -91,6 +91,11 @@ export type GitBaseRef = z.infer<typeof GitBaseRefSchema>;
 export const GitStatusInputSchema = z.object({
   repoPath: z.string(),
   mode: GitDiffModeSchema,
+  /** Terminal whose Code tab is requesting this status — dispatches the
+   *  call to the right Backend (local vs. remote agent). Optional for
+   *  backwards compatibility with non-terminal call sites; surface.ts
+   *  falls back to localBackend when absent. */
+  terminalId: z.string().uuid().optional(),
 });
 
 export const GitStatusOutputSchema = z.object({
@@ -108,6 +113,8 @@ export const GitDiffInputSchema = z.object({
   /** Original path before rename/copy — passed from the file list so
    *  getDiff can read old content at the correct path. */
   oldPath: z.string().optional(),
+  /** Terminal whose Code tab is requesting this diff — see GitStatusInputSchema. */
+  terminalId: z.string().uuid().optional(),
 });
 
 /** Raw parts needed by the client-side diff renderer (`@pierre/diffs`'s
@@ -143,6 +150,8 @@ export type GitDiffOutput = z.infer<typeof GitDiffOutputSchema>;
 export const FsListAllInputSchema = z.object({
   /** Absolute path to the repo root. */
   repoPath: z.string(),
+  /** Terminal whose Code tab is requesting this listing — see GitStatusInputSchema. */
+  terminalId: z.string().uuid().optional(),
 });
 
 export const FsListAllOutputSchema = z.object({

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,8 @@
     "@orpc/experimental-pino": "^1.13.13",
     "@orpc/experimental-publisher": "^1.13.13",
     "@orpc/server": "^1.13.13",
+    "@orpc/standard-server": "^1.13.13",
+    "@orpc/standard-server-peer": "^1.13.13",
     "anyagent": "workspace:*",
     "cleye": "^2.3.0",
     "conf": "^15.1.0",

--- a/packages/server/src/agent.ts
+++ b/packages/server/src/agent.ts
@@ -1,0 +1,276 @@
+/**
+ * `kolu agent --stdio` — runs LocalBackend behind oRPC over
+ * stdin/stdout.
+ *
+ * Plan B's pivot: the agent is the same kolu binary running with a
+ * different transport. Zero remote-specific business logic; the
+ * agent serves `agentContract` (narrow subset, see
+ * `kolu-common/agentContract.ts`) and `RemoteBackend` is the only
+ * consumer.
+ *
+ * **Why narrow contract**: pre-implementation review finding E.
+ * Serving the full `appRouter` would expose `terminal.create` and
+ * `surface.*` to the agent's caller, creating recursion risk and
+ * leaking client-facing primitives into a server-internal protocol.
+ *
+ * Prototype scope: file exists, demonstrates the wiring shape, but the
+ * `@orpc/server/standard-peer` ServerPeer hookup is sketched. R-3 will
+ * complete:
+ *  1. `createServerPeerHandleRequestFn(agentRouter, options)` from
+ *     `@orpc/server/standard-peer`.
+ *  2. Wire `process.stdin` / `process.stdout` as a `ServerPeer`
+ *     (`@orpc/standard-server-peer`).
+ *  3. On stdin EOF, killAll local terminals + exit 0.
+ */
+
+import { implement } from "@orpc/server";
+import { agentContract } from "kolu-common/agentContract";
+import { localBackend } from "./backend/local.ts";
+import { log } from "./log.ts";
+
+/**
+ * The agent's oRPC router — every method delegates to `localBackend`.
+ * The kolu server's `RemoteBackend` calls these via the standard-peer
+ * client; the data flow matches `LocalBackend` invocations one-to-one.
+ *
+ * The body sketches the shape; runtime correctness is R-3.
+ */
+function buildAgentRouter() {
+  const t = implement(agentContract);
+  return t.router({
+    heartbeat: t.heartbeat.handler(async () => ({ ok: true as const })),
+
+    terminal: {
+      spawn: t.terminal.spawn.handler(async ({ input }) => {
+        const handle = await localBackend.spawnPty({
+          cwd: input.cwd,
+          initialMetadata: input.initialMetadata,
+        });
+        return { id: handle.id };
+      }),
+      // The remaining terminal handlers (kill, write, resize, uploadFile,
+      // channel*) follow the same shape: thin wrappers around localBackend
+      // methods. Sketched stubs for prototype scope; the architectural
+      // intent (the agent IS just LocalBackend wrapped in oRPC) is
+      // visible in `spawn` above.
+      kill: t.terminal.kill.handler(async ({ input }) =>
+        localBackend.killTerminal(input.id),
+      ),
+      write: t.terminal.write.handler(async () => {
+        // localBackend doesn't expose a write-by-id today; the handle's
+        // write() is the path. R-3 will adjust LocalBackend to expose
+        // terminal-id-keyed control methods.
+      }),
+      resize: t.terminal.resize.handler(async () => {
+        // Same as write.
+      }),
+      uploadFile: t.terminal.uploadFile.handler(async ({ input }) => ({
+        path: await localBackend.uploadFile(
+          input.id,
+          input.name,
+          input.base64Data,
+        ),
+      })),
+      // channel* handlers iterate localBackend.terminalChannel(id, kind)
+      // and yield via async generators. Sketched here; the per-kind
+      // explicitness keeps the agentContract typed.
+      channelData: t.terminal.channelData.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const data of localBackend.terminalChannel(
+          input.id,
+          "data",
+          signal,
+        )) {
+          yield data;
+        }
+      }),
+      channelCwd: t.terminal.channelCwd.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const v of localBackend.terminalChannel(
+          input.id,
+          "cwd",
+          signal,
+        )) {
+          yield v;
+        }
+      }),
+      channelTitle: t.terminal.channelTitle.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const v of localBackend.terminalChannel(
+          input.id,
+          "title",
+          signal,
+        )) {
+          yield v;
+        }
+      }),
+      channelGit: t.terminal.channelGit.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const v of localBackend.terminalChannel(
+          input.id,
+          "git",
+          signal,
+        )) {
+          yield v;
+        }
+      }),
+      channelCommandRun: t.terminal.channelCommandRun.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const v of localBackend.terminalChannel(
+          input.id,
+          "commandRun",
+          signal,
+        )) {
+          yield v;
+        }
+      }),
+      channelAgent: t.terminal.channelAgent.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const v of localBackend.terminalChannel(
+          input.id,
+          "agent",
+          signal,
+        )) {
+          yield v;
+        }
+      }),
+      channelPr: t.terminal.channelPr.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const v of localBackend.terminalChannel(
+          input.id,
+          "pr",
+          signal,
+        )) {
+          yield v;
+        }
+      }),
+      channelForeground: t.terminal.channelForeground.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const v of localBackend.terminalChannel(
+          input.id,
+          "foreground",
+          signal,
+        )) {
+          yield v;
+        }
+      }),
+      channelConnectionState: t.terminal.channelConnectionState.handler(
+        async function* ({ input, signal }) {
+          for await (const v of localBackend.terminalChannel(
+            input.id,
+            "connectionState",
+            signal,
+          )) {
+            yield v;
+          }
+        },
+      ),
+    },
+
+    fs: {
+      listAll: t.fs.listAll.handler(async ({ input }) => ({
+        paths: await localBackend.fs.listAll(input.repoPath),
+      })),
+      readFile: t.fs.readFile.handler(async ({ input }) => {
+        const result = await localBackend.fs.readFile(
+          input.repoPath,
+          input.filePath,
+        );
+        return { kind: "text" as const, ...result };
+      }),
+      subscribeRepoChange: t.fs.subscribeRepoChange.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const _ of localBackend.fs.subscribeRepoChange(
+          input.repoPath,
+          signal,
+        )) {
+          yield;
+        }
+      }),
+      subscribeFileChange: t.fs.subscribeFileChange.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const _ of localBackend.fs.subscribeFileChange(
+          input.repoPath,
+          input.filePath,
+          signal,
+        )) {
+          yield;
+        }
+      }),
+    },
+
+    git: {
+      getDiff: t.git.getDiff.handler(async ({ input }) =>
+        localBackend.git.getDiff(
+          input.repoPath,
+          input.filePath,
+          input.mode,
+          input.oldPath,
+        ),
+      ),
+      getStatus: t.git.getStatus.handler(async ({ input }) =>
+        localBackend.git.getStatus(input.repoPath, input.mode),
+      ),
+      subscribeRepoChange: t.git.subscribeRepoChange.handler(async function* ({
+        input,
+        signal,
+      }) {
+        for await (const _ of localBackend.git.subscribeRepoChange(
+          input.repoPath,
+          signal,
+        )) {
+          yield;
+        }
+      }),
+    },
+  });
+}
+
+/**
+ * Entry point for `kolu agent --stdio`. The dispatcher in `index.ts`
+ * calls this when the `--stdio` flag is set.
+ *
+ * R-3 wires `@orpc/server/standard-peer` to `process.stdin` /
+ * `process.stdout` so the agent reads request envelopes from stdin and
+ * writes responses to stdout. The router constructed above is the
+ * handler. Sketched for the prototype.
+ */
+export async function runAgent(): Promise<void> {
+  const router = buildAgentRouter();
+  log.info(
+    { procedures: Object.keys(router).length },
+    "kolu agent: built router",
+  );
+  log.warn(
+    "kolu agent --stdio: standard-peer transport wiring is R-3. " +
+      "Router shape is in place. Agent exits immediately in prototype mode.",
+  );
+  // R-3:
+  //   const handler = new StandardRPCHandler(router as unknown as Router, { plugins });
+  //   const peerHandle = createServerPeerHandleRequestFn(handler, { context: {} });
+  //   const peer = new ServerPeer({
+  //     send: (msg) => process.stdout.write(JSON.stringify(msg) + "\n"),
+  //     receive: <iterator from process.stdin lines>,
+  //   });
+  //   await peer.serve(peerHandle);
+}

--- a/packages/server/src/agent.ts
+++ b/packages/server/src/agent.ts
@@ -61,6 +61,7 @@ function buildAgentRouter() {
     terminal: {
       spawn: t.terminal.spawn.handler(async ({ input }) => {
         const handle = await localBackend.spawnPty({
+          id: input.id,
           cwd: input.cwd,
           initialMetadata: input.initialMetadata,
         });

--- a/packages/server/src/agent.ts
+++ b/packages/server/src/agent.ts
@@ -24,10 +24,15 @@
  */
 
 import { implement, ORPCError } from "@orpc/server";
+import { StandardRPCHandler } from "@orpc/server/standard";
+import { createServerPeerHandleRequestFn } from "@orpc/server/standard-peer";
+import { ServerPeer } from "@orpc/standard-server-peer";
 import { agentContract } from "kolu-common/agentContract";
 import type { TerminalChannelMap } from "kolu-common/backend";
 import { localBackend } from "./backend/local.ts";
+import { makeStdioSend, readStdioMessages } from "./backend/stdio-peer.ts";
 import { log } from "./log.ts";
+import { getTerminal } from "./terminal-registry.ts";
 
 /** Body of every per-channel handler. The kind literal is the single
  *  binding-site source of typo risk — TS catches a mismatched key. */
@@ -64,22 +69,23 @@ function buildAgentRouter() {
       kill: t.terminal.kill.handler(async ({ input }) =>
         localBackend.killTerminal(input.id),
       ),
-      // Lowy post-impl finding F4: silent no-op handlers violate the
-      // contract — RemoteBackend's caller would receive success while
-      // the PTY received no input (silent data loss). Honest prototype
-      // contract throws until R-3 plumbs terminal-id-keyed control on
-      // LocalBackend.
-      write: t.terminal.write.handler(async () => {
-        throw new ORPCError("NOT_IMPLEMENTED", {
-          message:
-            "terminal.write on the agent contract is R-3 — LocalBackend doesn't expose terminal-id-keyed write today; the handle.write() path is in-process only.",
-        });
+      write: t.terminal.write.handler(async ({ input }) => {
+        const entry = getTerminal(input.id);
+        if (!entry) {
+          throw new ORPCError("NOT_FOUND", {
+            message: `terminal ${input.id} not found on agent`,
+          });
+        }
+        entry.handle.write(input.data);
       }),
-      resize: t.terminal.resize.handler(async () => {
-        throw new ORPCError("NOT_IMPLEMENTED", {
-          message:
-            "terminal.resize on the agent contract is R-3 — same as write.",
-        });
+      resize: t.terminal.resize.handler(async ({ input }) => {
+        const entry = getTerminal(input.id);
+        if (!entry) {
+          throw new ORPCError("NOT_FOUND", {
+            message: `terminal ${input.id} not found on agent`,
+          });
+        }
+        entry.handle.resize(input.cols, input.rows);
       }),
       uploadFile: t.terminal.uploadFile.handler(async ({ input }) => ({
         path: await localBackend.uploadFile(
@@ -184,20 +190,44 @@ function buildAgentRouter() {
  */
 export async function runAgent(): Promise<void> {
   const router = buildAgentRouter();
-  log.info(
-    { procedures: Object.keys(router).length },
-    "kolu agent: built router",
+  // biome-ignore lint/suspicious/noExplicitAny: implement() returns a typed
+  // router; StandardRPCHandler accepts the broader oRPC `Router` shape.
+  // Runtime structure is compatible — same cast pattern as `index.ts`.
+  const handler = new StandardRPCHandler(router as any, {});
+  const peerHandle = createServerPeerHandleRequestFn(handler, {
+    context: {},
+  });
+  const peer = new ServerPeer(makeStdioSend(process.stdout));
+  log.info("kolu agent --stdio: serving on stdin/stdout");
+
+  const stop = readStdioMessages(
+    process.stdin,
+    async (msg) => {
+      try {
+        await peer.message(msg, peerHandle);
+      } catch (err) {
+        log.error({ err }, "kolu agent: message handler error");
+      }
+    },
+    () => {
+      log.info("kolu agent: stdin closed, shutting down");
+      peer.close();
+      // Clean up any spawned terminals before exiting.
+      void import("./terminals.ts").then(({ killAllTerminals }) => {
+        killAllTerminals();
+        process.exit(0);
+      });
+    },
   );
-  log.warn(
-    "kolu agent --stdio: standard-peer transport wiring is R-3. " +
-      "Router shape is in place. Agent exits immediately in prototype mode.",
-  );
-  // R-3:
-  //   const handler = new StandardRPCHandler(router as unknown as Router, { plugins });
-  //   const peerHandle = createServerPeerHandleRequestFn(handler, { context: {} });
-  //   const peer = new ServerPeer({
-  //     send: (msg) => process.stdout.write(JSON.stringify(msg) + "\n"),
-  //     receive: <iterator from process.stdin lines>,
-  //   });
-  //   await peer.serve(peerHandle);
+
+  // Resume stdin to start data flowing. node defaults paused for raw streams.
+  process.stdin.resume();
+
+  // Keep the event loop alive until stdin closes.
+  await new Promise<void>((resolve) => {
+    process.stdin.once("close", () => {
+      stop();
+      resolve();
+    });
+  });
 }

--- a/packages/server/src/agent.ts
+++ b/packages/server/src/agent.ts
@@ -23,10 +23,23 @@
  *  3. On stdin EOF, killAll local terminals + exit 0.
  */
 
-import { implement } from "@orpc/server";
+import { implement, ORPCError } from "@orpc/server";
 import { agentContract } from "kolu-common/agentContract";
+import type { TerminalChannelMap } from "kolu-common/backend";
 import { localBackend } from "./backend/local.ts";
 import { log } from "./log.ts";
+
+/** Body of every per-channel handler. The kind literal is the single
+ *  binding-site source of typo risk — TS catches a mismatched key. */
+async function* relayChannel<K extends keyof TerminalChannelMap>(
+  id: string,
+  kind: K,
+  signal: AbortSignal | undefined,
+): AsyncGenerator<TerminalChannelMap[K]> {
+  for await (const v of localBackend.terminalChannel(id, kind, signal)) {
+    yield v;
+  }
+}
 
 /**
  * The agent's oRPC router — every method delegates to `localBackend`.
@@ -48,21 +61,25 @@ function buildAgentRouter() {
         });
         return { id: handle.id };
       }),
-      // The remaining terminal handlers (kill, write, resize, uploadFile,
-      // channel*) follow the same shape: thin wrappers around localBackend
-      // methods. Sketched stubs for prototype scope; the architectural
-      // intent (the agent IS just LocalBackend wrapped in oRPC) is
-      // visible in `spawn` above.
       kill: t.terminal.kill.handler(async ({ input }) =>
         localBackend.killTerminal(input.id),
       ),
+      // Lowy post-impl finding F4: silent no-op handlers violate the
+      // contract — RemoteBackend's caller would receive success while
+      // the PTY received no input (silent data loss). Honest prototype
+      // contract throws until R-3 plumbs terminal-id-keyed control on
+      // LocalBackend.
       write: t.terminal.write.handler(async () => {
-        // localBackend doesn't expose a write-by-id today; the handle's
-        // write() is the path. R-3 will adjust LocalBackend to expose
-        // terminal-id-keyed control methods.
+        throw new ORPCError("NOT_IMPLEMENTED", {
+          message:
+            "terminal.write on the agent contract is R-3 — LocalBackend doesn't expose terminal-id-keyed write today; the handle.write() path is in-process only.",
+        });
       }),
       resize: t.terminal.resize.handler(async () => {
-        // Same as write.
+        throw new ORPCError("NOT_IMPLEMENTED", {
+          message:
+            "terminal.resize on the agent contract is R-3 — same as write.",
+        });
       }),
       uploadFile: t.terminal.uploadFile.handler(async ({ input }) => ({
         path: await localBackend.uploadFile(
@@ -71,115 +88,36 @@ function buildAgentRouter() {
           input.base64Data,
         ),
       })),
-      // channel* handlers iterate localBackend.terminalChannel(id, kind)
-      // and yield via async generators. Sketched here; the per-kind
-      // explicitness keeps the agentContract typed.
-      channelData: t.terminal.channelData.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const data of localBackend.terminalChannel(
-          input.id,
-          "data",
-          signal,
-        )) {
-          yield data;
-        }
-      }),
-      channelCwd: t.terminal.channelCwd.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const v of localBackend.terminalChannel(
-          input.id,
-          "cwd",
-          signal,
-        )) {
-          yield v;
-        }
-      }),
-      channelTitle: t.terminal.channelTitle.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const v of localBackend.terminalChannel(
-          input.id,
-          "title",
-          signal,
-        )) {
-          yield v;
-        }
-      }),
-      channelGit: t.terminal.channelGit.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const v of localBackend.terminalChannel(
-          input.id,
-          "git",
-          signal,
-        )) {
-          yield v;
-        }
-      }),
-      channelCommandRun: t.terminal.channelCommandRun.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const v of localBackend.terminalChannel(
-          input.id,
-          "commandRun",
-          signal,
-        )) {
-          yield v;
-        }
-      }),
-      channelAgent: t.terminal.channelAgent.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const v of localBackend.terminalChannel(
-          input.id,
-          "agent",
-          signal,
-        )) {
-          yield v;
-        }
-      }),
-      channelPr: t.terminal.channelPr.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const v of localBackend.terminalChannel(
-          input.id,
-          "pr",
-          signal,
-        )) {
-          yield v;
-        }
-      }),
-      channelForeground: t.terminal.channelForeground.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const v of localBackend.terminalChannel(
-          input.id,
-          "foreground",
-          signal,
-        )) {
-          yield v;
-        }
-      }),
+      // One handler per TerminalChannelMap key; the body is one line
+      // that delegates to `relayChannel`. The kind literal is the only
+      // varying piece per row — typos cost a type error.
+      channelData: t.terminal.channelData.handler(({ input, signal }) =>
+        relayChannel(input.id, "data", signal),
+      ),
+      channelCwd: t.terminal.channelCwd.handler(({ input, signal }) =>
+        relayChannel(input.id, "cwd", signal),
+      ),
+      channelTitle: t.terminal.channelTitle.handler(({ input, signal }) =>
+        relayChannel(input.id, "title", signal),
+      ),
+      channelGit: t.terminal.channelGit.handler(({ input, signal }) =>
+        relayChannel(input.id, "git", signal),
+      ),
+      channelCommandRun: t.terminal.channelCommandRun.handler(
+        ({ input, signal }) => relayChannel(input.id, "commandRun", signal),
+      ),
+      channelAgent: t.terminal.channelAgent.handler(({ input, signal }) =>
+        relayChannel(input.id, "agent", signal),
+      ),
+      channelPr: t.terminal.channelPr.handler(({ input, signal }) =>
+        relayChannel(input.id, "pr", signal),
+      ),
+      channelForeground: t.terminal.channelForeground.handler(
+        ({ input, signal }) => relayChannel(input.id, "foreground", signal),
+      ),
       channelConnectionState: t.terminal.channelConnectionState.handler(
-        async function* ({ input, signal }) {
-          for await (const v of localBackend.terminalChannel(
-            input.id,
-            "connectionState",
-            signal,
-          )) {
-            yield v;
-          }
-        },
+        ({ input, signal }) =>
+          relayChannel(input.id, "connectionState", signal),
       ),
     },
 
@@ -231,17 +169,6 @@ function buildAgentRouter() {
       getStatus: t.git.getStatus.handler(async ({ input }) =>
         localBackend.git.getStatus(input.repoPath, input.mode),
       ),
-      subscribeRepoChange: t.git.subscribeRepoChange.handler(async function* ({
-        input,
-        signal,
-      }) {
-        for await (const _ of localBackend.git.subscribeRepoChange(
-          input.repoPath,
-          signal,
-        )) {
-          yield;
-        }
-      }),
     },
   });
 }

--- a/packages/server/src/backend/host-session.ts
+++ b/packages/server/src/backend/host-session.ts
@@ -120,7 +120,16 @@ export class HostSession {
       "HostSession: state transition",
     );
     if (prevExternal !== nextExternal) {
-      for (const cb of this.stateListeners) cb(nextExternal);
+      for (const cb of this.stateListeners) {
+        try {
+          cb(nextExternal);
+        } catch (err) {
+          log.error(
+            { host: this.host, err },
+            "HostSession: state listener threw",
+          );
+        }
+      }
     }
   }
 

--- a/packages/server/src/backend/host-session.ts
+++ b/packages/server/src/backend/host-session.ts
@@ -1,0 +1,171 @@
+/**
+ * HostSession — owns the SSH stdio oRPC connection to one remote
+ * `kolu agent --stdio` peer plus the connection state machine.
+ *
+ * One HostSession per host; multiple terminals on the same host share
+ * one session. The state machine + heartbeat live here (R-2 pre-impl
+ * finding W1: HostSession and RemoteBackend are two axes — transport
+ * vs. Backend-interface adapter).
+ *
+ * **State machine** (ported from Zed `/tmp/zed/crates/remote/src/remote_client.rs:157-293`):
+ *
+ *   Connecting ─┬──▶ Connected ──ping miss×5──▶ Reconnecting ─┬─▶ Connected
+ *               │                                              │
+ *               │                                              └─▶ Disconnected (3 attempts exhausted)
+ *               │
+ *               └──▶ Disconnected (initial connect failed)
+ *
+ * **Heartbeat** (Zed constants verbatim, `/tmp/zed/crates/remote/src/remote_client.rs:149-155`):
+ *
+ *   HEARTBEAT_INTERVAL  = 5s
+ *   HEARTBEAT_TIMEOUT   = 5s
+ *   MAX_MISSED          = 5
+ *   MAX_RECONNECT_ATTEMPTS = 3
+ *
+ * **Per-terminal `connectionState` write seam** (R-2 finding D / W4):
+ * The state machine fires `connectionStateChanged(newState)` events.
+ * Each terminal known to this session gets the per-terminal
+ * `connectionState` channel published. Subscribers (typically the
+ * kolu server's metadata-aggregator wired into `RemoteBackend`)
+ * propagate to `entry.meta.connectionState`.
+ *
+ * Prototype scope: the state machine + heartbeat are sketched
+ * functionally but lifecycle (subprocess spawn, oRPC peer wiring,
+ * reconnect logic) are marked TODO. The shape is what matters for
+ * Plan B evaluation.
+ */
+
+import type { ConnectionState } from "kolu-common/surface";
+import { log } from "../log.ts";
+
+/** Zed-ported heartbeat constants. */
+export const HEARTBEAT_INTERVAL_MS = 5_000;
+export const HEARTBEAT_TIMEOUT_MS = 5_000;
+export const MAX_MISSED_HEARTBEATS = 5;
+export const MAX_RECONNECT_ATTEMPTS = 3;
+
+/** Internal state machine state. The wire-visible `ConnectionState`
+ *  enum (`"live" | "connecting" | "disconnected"`) is a projection —
+ *  see `projectExternal()` below. */
+type InternalState =
+  | { kind: "connecting" }
+  | { kind: "connected" }
+  | { kind: "heartbeat-missed"; count: number }
+  | { kind: "reconnecting"; attempt: number }
+  | {
+      kind: "disconnected";
+      reason: "exhausted" | "server-not-running" | "user-closed";
+    };
+
+function projectExternal(s: InternalState): ConnectionState {
+  switch (s.kind) {
+    case "connecting":
+    case "reconnecting":
+      return "connecting";
+    case "connected":
+    case "heartbeat-missed":
+      return "live";
+    case "disconnected":
+      return "disconnected";
+  }
+}
+
+export class HostSession {
+  private state: InternalState = { kind: "connecting" };
+  private terminals = new Set<string>();
+  private stateListeners = new Set<(s: ConnectionState) => void>();
+  private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(public readonly host: string) {
+    // Subprocess spawn + oRPC peer wiring is the R-3 follow-up. The
+    // prototype demonstrates the shape; the actual transport hookup
+    // requires installAgent + child_process.spawn("ssh", …) + bridging
+    // stdin/stdout to oRPC's standard-peer client. See
+    // `packages/server/src/backend/install.ts:remoteAgentCommand` for
+    // the spawn argv.
+    log.info({ host }, "HostSession: created (transport wiring is R-3)");
+  }
+
+  /** Register a terminal as belonging to this session — when the
+   *  state machine transitions, this terminal's `connectionState`
+   *  channel gets published. */
+  registerTerminal(id: string): void {
+    this.terminals.add(id);
+  }
+
+  unregisterTerminal(id: string): void {
+    this.terminals.delete(id);
+  }
+
+  /** External state for the connection. */
+  connectionState(): ConnectionState {
+    return projectExternal(this.state);
+  }
+
+  /** Subscribe to state changes — `RemoteBackend.terminalChannel(id,
+   *  "connectionState")` consumers and the per-terminal metadata
+   *  aggregator both listen here. Returns the unsubscribe fn. */
+  onStateChange(cb: (s: ConnectionState) => void): () => void {
+    this.stateListeners.add(cb);
+    cb(this.connectionState()); // snapshot-then-delta
+    return () => this.stateListeners.delete(cb);
+  }
+
+  private transition(next: InternalState): void {
+    const prevExternal = projectExternal(this.state);
+    this.state = next;
+    const nextExternal = projectExternal(next);
+    log.info(
+      { host: this.host, state: next.kind, external: nextExternal },
+      "HostSession: state transition",
+    );
+    if (prevExternal !== nextExternal) {
+      for (const cb of this.stateListeners) cb(nextExternal);
+    }
+  }
+
+  /** Initial connect. Sketched — full implementation:
+   *
+   *  1. await installAgent(host)
+   *  2. spawn `ssh -tt host kolu agent --stdio` subprocess
+   *  3. wire stdio to oRPC standard-peer client
+   *  4. set state to `connected`, start heartbeat loop
+   *  5. on `ssh` subprocess exit → reconnect attempt
+   */
+  async connect(): Promise<void> {
+    log.warn(
+      { host: this.host },
+      "HostSession.connect: prototype stub — full impl in R-3",
+    );
+    // Sketch: the wiring chain.
+    // await installAgent(this.host);
+    // this.subprocess = spawn("ssh", await remoteAgentCommand(this.host), { stdio: ["pipe","pipe","inherit"] });
+    // this.client = createClient<typeof agentContract>(...);
+    // this.transition({ kind: "connected" });
+    // this.startHeartbeat();
+    this.transition({ kind: "connected" });
+    this.startHeartbeat();
+  }
+
+  private startHeartbeat(): void {
+    this.heartbeatTimer = setInterval(() => {
+      // Real impl: `await this.client.heartbeat()` with HEARTBEAT_TIMEOUT.
+      // On timeout/throw, increment heartbeat-missed; on success, reset.
+      // After MAX_MISSED, transition to reconnecting and try MAX_RECONNECT_ATTEMPTS.
+      void this.tickHeartbeat();
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private async tickHeartbeat(): Promise<void> {
+    // Prototype stub. Real implementation calls
+    // `this.client.heartbeat()` with timeout HEARTBEAT_TIMEOUT_MS.
+  }
+
+  /** Tear down. */
+  dispose(): void {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.transition({ kind: "disconnected", reason: "user-closed" });
+    this.stateListeners.clear();
+    this.terminals.clear();
+  }
+}

--- a/packages/server/src/backend/host-session.ts
+++ b/packages/server/src/backend/host-session.ts
@@ -139,7 +139,7 @@ export class HostSession {
       log.warn({ host: this.host }, "HostSession.connect: already connected");
       return;
     }
-    const argv = await remoteAgentCommand(this.host);
+    const argv = remoteAgentCommand(this.host);
     log.info({ host: this.host, argv }, "HostSession: spawning ssh subprocess");
 
     // First arg is "ssh", rest are args. spawn() takes them split.

--- a/packages/server/src/backend/host-session.ts
+++ b/packages/server/src/backend/host-session.ts
@@ -188,6 +188,23 @@ export class HostSession {
     });
     this.client = createORPCClient<AgentClient>(this.link);
 
+    // Don't transition to "connected" until we've actually heard from
+    // the agent. First-time `nix run` on a cold remote can take
+    // minutes to realise the closure; starting the heartbeat clock now
+    // would tear down the connection before the agent even boots. The
+    // first successful RPC (typically `terminal.spawn` from
+    // RemoteBackend) calls `markReady()` to flip the state and start
+    // the heartbeat loop.
+    log.info(
+      { host: this.host },
+      "HostSession.connect: subprocess spawned; waiting for first RPC",
+    );
+  }
+
+  /** Called by RemoteBackend after the first RPC roundtrips. Marks the
+   *  session ready and starts the heartbeat loop. Idempotent. */
+  markReady(): void {
+    if (this.state.kind === "connected") return;
     this.transition({ kind: "connected" });
     this.startHeartbeat();
   }

--- a/packages/server/src/backend/host-session.ts
+++ b/packages/server/src/backend/host-session.ts
@@ -81,7 +81,7 @@ export class HostSession {
     // prototype demonstrates the shape; the actual transport hookup
     // requires installAgent + child_process.spawn("ssh", …) + bridging
     // stdin/stdout to oRPC's standard-peer client. See
-    // `packages/server/src/backend/install.ts:remoteAgentCommand` for
+    // `packages/server/src/install.ts:remoteAgentCommand` for
     // the spawn argv.
     log.info({ host }, "HostSession: created (transport wiring is R-3)");
   }

--- a/packages/server/src/backend/host-session.ts
+++ b/packages/server/src/backend/host-session.ts
@@ -3,7 +3,7 @@
  * `kolu agent --stdio` peer plus the connection state machine.
  *
  * One HostSession per host; multiple terminals on the same host share
- * one session. The state machine + heartbeat live here (R-2 pre-impl
+ * one session. State machine + heartbeat live here (R-2 pre-impl
  * finding W1: HostSession and RemoteBackend are two axes — transport
  * vs. Backend-interface adapter).
  *
@@ -21,22 +21,17 @@
  *   HEARTBEAT_TIMEOUT   = 5s
  *   MAX_MISSED          = 5
  *   MAX_RECONNECT_ATTEMPTS = 3
- *
- * **Per-terminal `connectionState` write seam** (R-2 finding D / W4):
- * The state machine fires `connectionStateChanged(newState)` events.
- * Each terminal known to this session gets the per-terminal
- * `connectionState` channel published. Subscribers (typically the
- * kolu server's metadata-aggregator wired into `RemoteBackend`)
- * propagate to `entry.meta.connectionState`.
- *
- * Prototype scope: the state machine + heartbeat are sketched
- * functionally but lifecycle (subprocess spawn, oRPC peer wiring,
- * reconnect logic) are marked TODO. The shape is what matters for
- * Plan B evaluation.
  */
 
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable, Writable } from "node:stream";
+import { createORPCClient } from "@orpc/client";
+import type { ContractRouterClient } from "@orpc/contract";
+import type { agentContract } from "kolu-common/agentContract";
 import type { ConnectionState } from "kolu-common/surface";
+import { remoteAgentCommand } from "../install.ts";
 import { log } from "../log.ts";
+import { StdioRPCLink } from "./stdio-client.ts";
 
 /** Zed-ported heartbeat constants. */
 export const HEARTBEAT_INTERVAL_MS = 5_000;
@@ -44,9 +39,6 @@ export const HEARTBEAT_TIMEOUT_MS = 5_000;
 export const MAX_MISSED_HEARTBEATS = 5;
 export const MAX_RECONNECT_ATTEMPTS = 3;
 
-/** Internal state machine state. The wire-visible `ConnectionState`
- *  enum (`"live" | "connecting" | "disconnected"`) is a projection —
- *  see `projectExternal()` below. */
 type InternalState =
   | { kind: "connecting" }
   | { kind: "connected" }
@@ -54,7 +46,11 @@ type InternalState =
   | { kind: "reconnecting"; attempt: number }
   | {
       kind: "disconnected";
-      reason: "exhausted" | "server-not-running" | "user-closed";
+      reason:
+        | "exhausted"
+        | "server-not-running"
+        | "user-closed"
+        | "init-failed";
     };
 
 function projectExternal(s: InternalState): ConnectionState {
@@ -70,25 +66,25 @@ function projectExternal(s: InternalState): ConnectionState {
   }
 }
 
+/** Typed client against `agentContract`. */
+export type AgentClient = ContractRouterClient<typeof agentContract>;
+
 export class HostSession {
   private state: InternalState = { kind: "connecting" };
-  private terminals = new Set<string>();
-  private stateListeners = new Set<(s: ConnectionState) => void>();
+  private readonly terminals = new Set<string>();
+  private readonly stateListeners = new Set<(s: ConnectionState) => void>();
   private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  private subprocess:
+    | ChildProcessByStdio<Writable, Readable, Readable>
+    | undefined;
+  private link: StdioRPCLink | undefined;
+  /** Typed agent client — undefined until `connect()` finishes. */
+  client: AgentClient | undefined;
 
   constructor(public readonly host: string) {
-    // Subprocess spawn + oRPC peer wiring is the R-3 follow-up. The
-    // prototype demonstrates the shape; the actual transport hookup
-    // requires installAgent + child_process.spawn("ssh", …) + bridging
-    // stdin/stdout to oRPC's standard-peer client. See
-    // `packages/server/src/install.ts:remoteAgentCommand` for
-    // the spawn argv.
-    log.info({ host }, "HostSession: created (transport wiring is R-3)");
+    log.info({ host }, "HostSession: created");
   }
 
-  /** Register a terminal as belonging to this session — when the
-   *  state machine transitions, this terminal's `connectionState`
-   *  channel gets published. */
   registerTerminal(id: string): void {
     this.terminals.add(id);
   }
@@ -97,17 +93,13 @@ export class HostSession {
     this.terminals.delete(id);
   }
 
-  /** External state for the connection. */
   connectionState(): ConnectionState {
     return projectExternal(this.state);
   }
 
-  /** Subscribe to state changes — `RemoteBackend.terminalChannel(id,
-   *  "connectionState")` consumers and the per-terminal metadata
-   *  aggregator both listen here. Returns the unsubscribe fn. */
   onStateChange(cb: (s: ConnectionState) => void): () => void {
     this.stateListeners.add(cb);
-    cb(this.connectionState()); // snapshot-then-delta
+    cb(this.connectionState());
     return () => this.stateListeners.delete(cb);
   }
 
@@ -133,46 +125,139 @@ export class HostSession {
     }
   }
 
-  /** Initial connect. Sketched — full implementation:
+  /**
+   * Spawn `ssh -tt $host kolu --stdio` and wire the oRPC client to its
+   * stdio. Caller (e.g. `installSshAgent` RPC handler) should call
+   * `installAgent(host)` first to ensure the binary is on the remote.
    *
-   *  1. await installAgent(host)
-   *  2. spawn `ssh -tt host kolu agent --stdio` subprocess
-   *  3. wire stdio to oRPC standard-peer client
-   *  4. set state to `connected`, start heartbeat loop
-   *  5. on `ssh` subprocess exit → reconnect attempt
+   * Returns once the subprocess is spawned and the typed client is
+   * ready. State transitions to `connected`. If spawn fails, transitions
+   * to `disconnected` with `reason: "init-failed"` and rethrows.
    */
   async connect(): Promise<void> {
-    log.warn(
-      { host: this.host },
-      "HostSession.connect: prototype stub — full impl in R-3",
-    );
-    // Sketch: the wiring chain.
-    // await installAgent(this.host);
-    // this.subprocess = spawn("ssh", await remoteAgentCommand(this.host), { stdio: ["pipe","pipe","inherit"] });
-    // this.client = createClient<typeof agentContract>(...);
-    // this.transition({ kind: "connected" });
-    // this.startHeartbeat();
+    if (this.subprocess) {
+      log.warn({ host: this.host }, "HostSession.connect: already connected");
+      return;
+    }
+    const argv = await remoteAgentCommand(this.host);
+    log.info({ host: this.host, argv }, "HostSession: spawning ssh subprocess");
+
+    // First arg is "ssh", rest are args. spawn() takes them split.
+    const [cmd, ...args] = argv;
+    if (!cmd) {
+      this.transition({ kind: "disconnected", reason: "init-failed" });
+      throw new Error("HostSession.connect: empty remoteAgentCommand");
+    }
+    const subprocess = spawn(cmd, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    }) as ChildProcessByStdio<Writable, Readable, Readable>;
+    this.subprocess = subprocess;
+
+    // Pipe stderr to our log so ssh errors / agent log lines are visible.
+    subprocess.stderr.on("data", (chunk: Buffer) => {
+      log.warn(
+        { host: this.host, msg: chunk.toString("utf8").trim() },
+        "HostSession: subprocess stderr",
+      );
+    });
+    subprocess.on("exit", (code, signal) => {
+      log.info(
+        { host: this.host, code, signal },
+        "HostSession: subprocess exited",
+      );
+      this.transition({
+        kind: "disconnected",
+        reason: code === 0 ? "user-closed" : "server-not-running",
+      });
+      this.subprocess = undefined;
+      this.client = undefined;
+      this.link?.dispose();
+      this.link = undefined;
+      if (this.heartbeatTimer) {
+        clearInterval(this.heartbeatTimer);
+        this.heartbeatTimer = undefined;
+      }
+    });
+    subprocess.on("error", (err) => {
+      log.error({ host: this.host, err }, "HostSession: subprocess error");
+    });
+
+    this.link = new StdioRPCLink({
+      stdin: subprocess.stdin,
+      stdout: subprocess.stdout,
+    });
+    this.client = createORPCClient<AgentClient>(this.link);
+
     this.transition({ kind: "connected" });
     this.startHeartbeat();
   }
 
   private startHeartbeat(): void {
     this.heartbeatTimer = setInterval(() => {
-      // Real impl: `await this.client.heartbeat()` with HEARTBEAT_TIMEOUT.
-      // On timeout/throw, increment heartbeat-missed; on success, reset.
-      // After MAX_MISSED, transition to reconnecting and try MAX_RECONNECT_ATTEMPTS.
       void this.tickHeartbeat();
     }, HEARTBEAT_INTERVAL_MS);
   }
 
   private async tickHeartbeat(): Promise<void> {
-    // Prototype stub. Real implementation calls
-    // `this.client.heartbeat()` with timeout HEARTBEAT_TIMEOUT_MS.
+    if (!this.client) return;
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("heartbeat timeout")),
+        HEARTBEAT_TIMEOUT_MS,
+      ),
+    );
+    try {
+      await Promise.race([this.client.heartbeat(), timeout]);
+      // Reset missed counter on success.
+      if (this.state.kind === "heartbeat-missed") {
+        this.transition({ kind: "connected" });
+      }
+    } catch (err) {
+      const missed =
+        this.state.kind === "heartbeat-missed" ? this.state.count + 1 : 1;
+      log.warn(
+        { host: this.host, missed, err },
+        "HostSession: heartbeat missed",
+      );
+      if (missed >= MAX_MISSED_HEARTBEATS) {
+        this.transition({ kind: "reconnecting", attempt: 1 });
+        void this.attemptReconnect();
+      } else {
+        this.transition({ kind: "heartbeat-missed", count: missed });
+      }
+    }
   }
 
-  /** Tear down. */
+  private async attemptReconnect(): Promise<void> {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+    this.subprocess?.kill();
+    this.subprocess = undefined;
+    this.link?.dispose();
+    this.link = undefined;
+    this.client = undefined;
+
+    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+      this.transition({ kind: "reconnecting", attempt });
+      try {
+        await this.connect();
+        return;
+      } catch (err) {
+        log.warn(
+          { host: this.host, attempt, err },
+          "HostSession: reconnect attempt failed",
+        );
+      }
+    }
+    this.transition({ kind: "disconnected", reason: "exhausted" });
+  }
+
   dispose(): void {
     if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.subprocess?.kill();
+    this.link?.dispose();
     this.transition({ kind: "disconnected", reason: "user-closed" });
     this.stateListeners.clear();
     this.terminals.clear();

--- a/packages/server/src/backend/index.ts
+++ b/packages/server/src/backend/index.ts
@@ -1,31 +1,68 @@
 /**
  * Backend registry — resolves which `Backend` owns a given location.
  *
- * R-1: only `LocalBackend` exists, so the resolver returns the
- * singleton unconditionally. R-2 will add a per-host `RemoteBackend`
- * map keyed by `location.host`, and the resolver becomes a `switch` on
- * `location.kind`.
+ * R-2 introduces:
+ *  - `RemoteBackend` cache keyed by host (per `HostSession` is per-host
+ *    singleton; multiple terminals on one host share one session).
+ *  - `getBackendForCreate` — variant for the create path that resolves
+ *    sub-terminal inheritance (a child of a remote tile spawns on the
+ *    same host regardless of what the client requested).
  *
- * Keeping the resolver behind a single function — even when it's
- * trivial — means R-2 is a localized change (this file + a new
- * `remote.ts`) rather than a hunt-and-replace across the codebase.
+ * Pre-implementation review finding J: keep `installAgent` OUT of
+ * resolver. The resolver returns synchronously and is called on every
+ * read path (`terminal.attach`, etc.). `installAgent` is an ssh
+ * round-trip that must happen ONCE per host, explicitly, before any
+ * other backend op. The SSH host picker triggers it (see
+ * `../sshHosts.ts:installSshHost`).
  */
 
 import type { Backend } from "kolu-common/backend";
 import type { TerminalLocation } from "kolu-common/surface";
+import { getTerminal } from "../terminal-registry.ts";
+import { HostSession } from "./host-session.ts";
 import { localBackend } from "./local.ts";
+import { RemoteBackend } from "./remote.ts";
 
 export { localBackend } from "./local.ts";
 
-/** Resolve which backend owns a given terminal location. Takes
- *  `TerminalLocation` directly so create-path callers (who don't yet
- *  have a registry entry) and read-path callers (who have an entry's
- *  `meta.location`) share one signature.
- *
- *  R-1: every location resolves to the local singleton. R-2 makes this
- *  `match(location).with({ kind: "local" }, …).with({ kind: "ssh" }, …)`
- *  against a per-host `RemoteBackend` cache. */
-export function getBackendFor(_location: TerminalLocation): Backend {
-  // R-1: only `LocalBackend` exists. R-2 dispatches by `_location.kind`.
-  return localBackend;
+const remoteCache = new Map<string, RemoteBackend>();
+
+/** Resolve which backend owns a given terminal location. R-2: switches
+ *  on `location.kind`; SSH branch returns a cached `RemoteBackend` (or
+ *  constructs one — but does NOT install the agent; that's
+ *  `installSshHost` in the host-picker flow). */
+export function getBackendFor(location: TerminalLocation): Backend {
+  if (location.kind === "local") return localBackend;
+  let backend = remoteCache.get(location.host);
+  if (!backend) {
+    backend = new RemoteBackend(new HostSession(location.host));
+    remoteCache.set(location.host, backend);
+  }
+  return backend;
+}
+
+/** Create-path variant. Resolves sub-terminal location inheritance: a
+ *  child of a remote tile spawns on the same host regardless of what
+ *  the input specifies. Centralizing this here means
+ *  `terminals.ts:createTerminal` doesn't pattern-match on parent
+ *  state — pre-impl review finding J. */
+export function getBackendForCreate(opts: {
+  location?: TerminalLocation;
+  parentId?: string;
+}): Backend {
+  // Sub-terminal: inherit parent's location.
+  if (opts.parentId) {
+    const parent = getTerminal(opts.parentId);
+    if (parent) return getBackendFor(parent.meta.location);
+  }
+  return getBackendFor(opts.location ?? { kind: "local" });
+}
+
+/** For shutdown: tear down all cached `HostSession`s. */
+export function disposeAllRemoteBackends(): void {
+  for (const _backend of remoteCache.values()) {
+    // R-3: RemoteBackend.dispose() would call session.dispose().
+    // Sketch only for the prototype.
+  }
+  remoteCache.clear();
 }

--- a/packages/server/src/backend/install.ts
+++ b/packages/server/src/backend/install.ts
@@ -1,0 +1,139 @@
+/**
+ * Agent installation — ship the kolu binary to a remote SSH host via
+ * `nix copy`.
+ *
+ * Plan B's pivot for binary shipping: the remote already has Nix
+ * (kolu's entire user base does — that's how they got kolu), so
+ * shipping the agent reduces to:
+ *
+ *   nix copy --to ssh://$host .#kolu
+ *
+ * Nix handles arch resolution, closure transfer, content-addressed
+ * dedup, and verification. Replaces Zed's three-strategy
+ * `ensure_server_binary` dance with one nix call.
+ *
+ * **Pre-implementation review finding G**: `nix copy` of the local-arch
+ * store path to a different-arch remote SILENTLY FAILS (substitution
+ * misses). We detect the remote system first and either build for that
+ * system locally (`nix build --system <remote-system>`) or fail with an
+ * explicit error if cross-compilation isn't available. The prototype
+ * implements the detection + explicit error path; cross-system build is
+ * a TODO for R-3.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { log } from "../log.ts";
+
+const execFileP = promisify(execFile);
+
+/** Run `ssh $host nix eval --raw --impure --expr 'builtins.currentSystem'`
+ *  to learn the remote's nix system tuple. */
+async function probeRemoteSystem(host: string): Promise<string> {
+  const { stdout } = await execFileP("ssh", [
+    host,
+    "nix",
+    "eval",
+    "--raw",
+    "--impure",
+    "--expr",
+    "builtins.currentSystem",
+  ]);
+  return stdout.trim();
+}
+
+/** Local nix system (e.g. `x86_64-linux`, `aarch64-darwin`). */
+async function localSystem(): Promise<string> {
+  const { stdout } = await execFileP("nix", [
+    "eval",
+    "--raw",
+    "--impure",
+    "--expr",
+    "builtins.currentSystem",
+  ]);
+  return stdout.trim();
+}
+
+/** Probe whether `storePath` is already realised on the remote — skip
+ *  the copy if so. */
+async function isPathRealisedOnRemote(
+  host: string,
+  storePath: string,
+): Promise<boolean> {
+  try {
+    await execFileP("ssh", [
+      host,
+      "nix-store",
+      "--query",
+      "--requisites",
+      storePath,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the running kolu binary's store path. The wrapper sets
+ *  `KOLU_STORE_PATH` at install time, or we fall back to `nix eval`
+ *  on the flake's `.#kolu` attribute. */
+async function getKoluStorePath(): Promise<string> {
+  const envHint = process.env.KOLU_STORE_PATH;
+  if (envHint) return envHint;
+  // Fallback: build the flake and read the store path.
+  const { stdout } = await execFileP("nix", ["eval", "--raw", ".#kolu"]);
+  return stdout.trim();
+}
+
+/**
+ * Install the kolu agent on `host`. Idempotent — if the store path is
+ * already realised on the remote, returns early.
+ *
+ * For cross-arch (local x86_64-linux ↔ remote aarch64-darwin), the
+ * caller's local `.#kolu` derivation isn't valid on the remote's
+ * system. The prototype detects this and throws `CrossArchUnsupported`
+ * with a clear message; R-3 will add `nix build .#packages.<remoteSystem>.kolu`
+ * before copying.
+ */
+export async function installAgent(host: string): Promise<void> {
+  const [remoteSystem, lSystem] = await Promise.all([
+    probeRemoteSystem(host).catch(() => {
+      throw new Error(
+        `installAgent(${host}): could not probe remote nix system. ` +
+          `Is Nix installed on the remote? Plan B assumes Nix-on-remote.`,
+      );
+    }),
+    localSystem(),
+  ]);
+
+  if (remoteSystem !== lSystem) {
+    throw new Error(
+      `installAgent(${host}): cross-system not yet implemented (R-3). ` +
+        `Local: ${lSystem}, remote: ${remoteSystem}. Build the remote-system ` +
+        `derivation locally first: nix build .#packages.${remoteSystem}.kolu`,
+    );
+  }
+
+  const storePath = await getKoluStorePath();
+  log.info(
+    { host, storePath, system: lSystem },
+    "installAgent: probing remote",
+  );
+
+  if (await isPathRealisedOnRemote(host, storePath)) {
+    log.info({ host, storePath }, "installAgent: already realised, skipping");
+    return;
+  }
+
+  log.info({ host, storePath }, "installAgent: nix copy");
+  await execFileP("nix", ["copy", "--to", `ssh://${host}`, storePath]);
+  log.info({ host, storePath }, "installAgent: done");
+}
+
+/** Build the remote command that runs `kolu agent --stdio` from the
+ *  copied store path. Used by `HostSession` when spawning the ssh
+ *  subprocess. */
+export async function remoteAgentCommand(host: string): Promise<string[]> {
+  const storePath = await getKoluStorePath();
+  return ["ssh", host, `${storePath}/bin/kolu`, "agent", "--stdio"];
+}

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -3,16 +3,34 @@
  *
  * Owns the PTY lifecycle, every per-terminal provider that watches the
  * local filesystem (git, github, foreground process, agent reconcilers),
- * and the local one-shot fs/git ops the Code tab consumes. The kolu
- * server's `terminals.ts` / `router.ts` no longer reach into
- * `kolu-git` / `kolu-anyagent` / `kolu-pty` directly for terminal-scoped
- * work — every per-terminal entry point goes through this class. The
- * `meta/*` orchestrators stay where they sit in `../meta/`, but the only
- * caller is this file; from outside the backend they are invisible.
+ * and the local fs/git ops the Code tab consumes (one-shot and
+ * subscription forms). The kolu server's `terminals.ts` / `router.ts`
+ * no longer reach into `kolu-git` / `kolu-anyagent` / `kolu-pty`
+ * directly for terminal-scoped work — every per-terminal entry point
+ * goes through this class.
  *
- * R-2 will add `RemoteBackend(connection)` that satisfies the same
- * interface by proxying every op via oRPC over `ssh stdio` to a
- * `kolu agent --stdio` peer.
+ * R-2 expansions over R-1:
+ *  - Publishes to the new `agent` / `pr` / `foreground` /
+ *    `connectionState` channels so `RemoteBackend` (or the kolu server
+ *    when it consumes channels uniformly) sees the same data stream
+ *    the in-process providers produce.
+ *  - Implements `BackendFs`/`BackendGit` subscription methods — wraps
+ *    `kolu-git`'s callback-based watchers in async generators so the
+ *    interface shape carries over to `RemoteBackend` (where the
+ *    subscriptions flow over oRPC streams).
+ *  - Implements `Backend.uploadFile` — wraps the existing
+ *    `saveTerminalFile` (server's local scratch). `RemoteBackend`'s
+ *    `uploadFile` will RPC to the agent so paste/upload targets the
+ *    agent's filesystem, not the kolu-server's.
+ *
+ * The agent-detection providers (`claude-code`, `codex`, `opencode`,
+ * `github` PR poll, foreground process) currently run inside this
+ * class via `startProviders` — they read PIDs from the local PtyHandle.
+ * In a full R-2 world, the agent host's `LocalBackend` runs these and
+ * publishes to channels; the kolu server's `RemoteBackend` subscribes.
+ * The prototype keeps the providers running server-side for local
+ * tiles; the channel publishes below are the seam that R-3 will
+ * complete by routing remote terminals' provider output through them.
  */
 
 import { ORPCError } from "@orpc/server";
@@ -24,18 +42,19 @@ import type {
   TerminalChannelMap,
   TerminalHandle,
 } from "kolu-common/backend";
-import type { TerminalLocation } from "kolu-common/surface";
 import { DEFAULT_SCROLLBACK } from "kolu-common/config";
+import type { TerminalLocation } from "kolu-common/surface";
 import {
   type GitResult,
   getDiff,
   getStatus,
   listAll,
   readFile,
+  subscribeFileChange,
+  subscribeRepoChange,
 } from "kolu-git";
 import { spawnPty } from "kolu-pty";
 import pkg from "../../package.json" with { type: "json" };
-import { cleanupTerminalScratch } from "../terminalScratch.ts";
 import { koluShellDir } from "../koluRoot.ts";
 import { log } from "../log.ts";
 import {
@@ -44,6 +63,8 @@ import {
   updateServerMetadata,
 } from "../meta/index.ts";
 import { terminalChannels } from "../publisher.ts";
+import { saveTerminalFile } from "../terminalScratch.ts";
+import { cleanupTerminalScratch } from "../terminalScratch.ts";
 import {
   getTerminal,
   registerTerminal,
@@ -51,10 +72,10 @@ import {
   unregisterTerminal,
 } from "../terminal-registry.ts";
 
-/** Throw an `ORPCError` if a `GitResult` is `err`; otherwise return the
- *  value. The router used to do this — moved here so the kolu-git error
- *  taxonomy is bound at the backend boundary, not at the wire. */
-function unwrap<T>(result: GitResult<T>): T {
+/** Shared `GitResult` unwrap → `ORPCError` mapping. Both backends import
+ *  this so the kolu-git error taxonomy is bound once at the backend
+ *  boundary. R-2 finding M. */
+export function unwrapBackendGit<T>(result: GitResult<T>): T {
   if (result.ok) return result.value;
   switch (result.error.code) {
     case "NOT_A_REPO":
@@ -76,23 +97,58 @@ function unwrap<T>(result: GitResult<T>): T {
   }
 }
 
+/** Wrap a callback-based watcher (the shape `kolu-git`'s subscribe
+ *  functions expose) as an `AsyncIterable<void>` for `Backend.fs/git`
+ *  consumers. First yield is the initial "subscription armed" tick;
+ *  subsequent yields fire on each watcher event. */
+function watcherToAsyncIterable(
+  install: (cb: () => void) => () => void,
+  signal?: AbortSignal,
+): AsyncIterable<void> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const queue: Array<void> = [];
+      let resolveNext: ((v: void) => void) | null = null;
+      const stop = install(() => {
+        if (resolveNext) {
+          const r = resolveNext;
+          resolveNext = null;
+          r();
+        } else queue.push(undefined);
+      });
+      const onAbort = () => {
+        stop();
+        if (resolveNext) {
+          const r = resolveNext;
+          resolveNext = null;
+          r();
+        }
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        // Initial snapshot tick.
+        yield;
+        while (!signal?.aborted) {
+          if (queue.length > 0) {
+            queue.shift();
+            yield;
+          } else {
+            await new Promise<void>((r) => {
+              resolveNext = r;
+            });
+          }
+        }
+      } finally {
+        stop();
+        signal?.removeEventListener("abort", onAbort);
+      }
+    },
+  };
+}
+
 export class LocalBackend implements Backend {
   readonly id: TerminalLocation = { kind: "local" };
 
-  /**
-   * Spawn a new terminal on this backend.
-   *
-   * Pipeline:
-   *  1. Spawn the PTY with `kolu-pty` and wire its OSC callbacks to the
-   *     in-process `terminalChannels.*` publishers.
-   *  2. Create metadata (`createMetadata`), seed client-owned fields
-   *     from `opts.initialMetadata` BEFORE starting providers so the
-   *     first `terminalMetadata` collection yield carries them (#642).
-   *  3. Register the entry in the shared `terminal-registry`.
-   *  4. Start the meta/* provider DAG (`startProviders`).
-   *  5. Return a `TerminalHandle` whose `dispose()` calls back into
-   *     `killTerminal(id)` — kill-convergence invariant.
-   */
   async spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle> {
     const id = crypto.randomUUID();
     const tlog = log.child({ terminal: id });
@@ -107,9 +163,6 @@ export class LocalBackend implements Backend {
         onData: (data) => terminalChannels.data(id).publish(data),
         onExit: (exitCode) => {
           tlog.info({ exitCode }, "exited");
-          // `wasNatural`: entry still in registry ⟹ PTY exited on its own.
-          // Explicit kills (`killTerminal` / `killAllTerminals`) unregister
-          // first, so `getTerminal` returns `undefined` here for killed PTYs.
           const entry = getTerminal(id);
           const wasNatural = entry !== undefined;
           if (entry) {
@@ -135,10 +188,6 @@ export class LocalBackend implements Backend {
     );
 
     const meta = createMetadata(handle.cwd, this.id);
-    // Seed client-owned initial metadata BEFORE startProviders so the first
-    // `terminalMetadata` collection yield carries these fields (see #642).
-    // `createMetadata` is the source of truth for which fields exist;
-    // `Object.assign` only writes the ones the caller supplied.
     if (opts.initialMetadata) Object.assign(meta, opts.initialMetadata);
 
     const entry: TerminalProcess = {
@@ -147,22 +196,20 @@ export class LocalBackend implements Backend {
       handle,
       stopProviders: () => {},
     };
-    // Register BEFORE starting providers (providers may emit immediately).
     registerTerminal(id, entry);
     entry.stopProviders = startProviders(entry, id);
 
     tlog.info({ pid: handle.pid }, "created");
 
+    // Connection state is `"live"` from spawn for local terminals;
+    // publish once so any subscriber sees the initial snapshot.
+    // RemoteBackend's HostSession drives this from its state machine.
+    terminalChannels.connectionState(id).publish("live");
+
     return {
       id,
       write: (data) => handle.write(data),
       resize: (cols, rows) => handle.resize(cols, rows),
-      // Kill-convergence: dispose() is observationally identical to
-      // backend.killTerminal(id). Both end at the same teardown path
-      // (`killTerminal` below).
-      dispose: () => {
-        this.killTerminal(id);
-      },
     };
   }
 
@@ -171,9 +218,6 @@ export class LocalBackend implements Backend {
     kind: K,
     signal?: AbortSignal,
   ): AsyncIterable<TerminalChannelMap[K]> {
-    // The publisher's typed channels already enforce a per-kind payload
-    // type; cast back to the public Backend shape (which the interface
-    // narrows per K).
     return terminalChannels[kind](terminalId).subscribe(
       signal,
     ) as AsyncIterable<TerminalChannelMap[K]>;
@@ -185,10 +229,6 @@ export class LocalBackend implements Backend {
     log
       .child({ terminal: terminalId })
       .info({ pid: entry.handle.pid }, "killing");
-    // Order matters: stop providers and unregister BEFORE disposing the
-    // PTY. The PTY's `onExit` callback (above) checks `getTerminal(id)`
-    // to decide `wasNatural`; if we disposed first, it could race and
-    // mis-classify this kill as natural.
     unregisterTerminal(terminalId);
     this.killTerminalEntry(entry);
     return true;
@@ -204,20 +244,44 @@ export class LocalBackend implements Backend {
     entry.handle.dispose();
   }
 
+  async uploadFile(
+    terminalId: string,
+    name: string,
+    base64Data: string,
+  ): Promise<string> {
+    // Local-side scratch dir (per-terminal). `RemoteBackend.uploadFile`
+    // will RPC to the agent so the file lands on the agent's
+    // filesystem.
+    return saveTerminalFile(terminalId, name, base64Data);
+  }
+
   fs: BackendFs = {
-    listAll: async (path) => unwrap(await listAll(path, log)),
+    listAll: async (path) => unwrapBackendGit(await listAll(path, log)),
     readFile: async (repoPath, filePath) =>
-      unwrap(await readFile(repoPath, filePath, log)),
+      unwrapBackendGit(await readFile(repoPath, filePath, log)),
+    subscribeRepoChange: (repoPath, signal) =>
+      watcherToAsyncIterable(
+        (cb) => subscribeRepoChange(repoPath, cb, log),
+        signal,
+      ),
+    subscribeFileChange: (repoPath, filePath, signal) =>
+      watcherToAsyncIterable(
+        (cb) => subscribeFileChange(repoPath, filePath, cb, log),
+        signal,
+      ),
   };
 
   git: BackendGit = {
     getDiff: async (repoPath, filePath, mode, oldPath) =>
-      unwrap(await getDiff(repoPath, filePath, mode, log, oldPath)),
+      unwrapBackendGit(await getDiff(repoPath, filePath, mode, log, oldPath)),
     getStatus: async (repoPath, mode) =>
-      unwrap(await getStatus(repoPath, mode, log)),
+      unwrapBackendGit(await getStatus(repoPath, mode, log)),
+    subscribeRepoChange: (repoPath, signal) =>
+      watcherToAsyncIterable(
+        (cb) => subscribeRepoChange(repoPath, cb, log),
+        signal,
+      ),
   };
 }
 
-/** Singleton — the kolu server's one local backend. R-2 adds a
- *  per-host `RemoteBackend` registry; this stays the local instance. */
 export const localBackend = new LocalBackend();

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -63,8 +63,10 @@ import {
   updateServerMetadata,
 } from "../meta/index.ts";
 import { terminalChannels } from "../publisher.ts";
-import { saveTerminalFile } from "../terminalScratch.ts";
-import { cleanupTerminalScratch } from "../terminalScratch.ts";
+import {
+  cleanupTerminalScratch,
+  saveTerminalFile,
+} from "../terminalScratch.ts";
 import {
   getTerminal,
   registerTerminal,
@@ -100,37 +102,41 @@ export function unwrapBackendGit<T>(result: GitResult<T>): T {
 /** Wrap a callback-based watcher (the shape `kolu-git`'s subscribe
  *  functions expose) as an `AsyncIterable<void>` for `Backend.fs/git`
  *  consumers. First yield is the initial "subscription armed" tick;
- *  subsequent yields fire on each watcher event. */
+ *  subsequent yields fire on each watcher event.
+ *
+ *  The pending flag is a single boolean, not a queue — since the payload
+ *  is `void`, coalescing all pending events into one is always correct
+ *  (the consumer re-reads the full state on each yield regardless). This
+ *  prevents unbounded growth on high-frequency event bursts (e.g. a
+ *  large `git checkout` touching hundreds of files). */
 function watcherToAsyncIterable(
   install: (cb: () => void) => () => void,
   signal?: AbortSignal,
 ): AsyncIterable<void> {
   return {
     async *[Symbol.asyncIterator]() {
-      const queue: Array<void> = [];
-      let resolveNext: ((v: void) => void) | null = null;
+      let pending = false;
+      let resolveNext: (() => void) | null = null;
       const stop = install(() => {
         if (resolveNext) {
           const r = resolveNext;
           resolveNext = null;
           r();
-        } else queue.push(undefined);
+        } else {
+          pending = true;
+        }
       });
       const onAbort = () => {
         stop();
-        if (resolveNext) {
-          const r = resolveNext;
-          resolveNext = null;
-          r();
-        }
+        resolveNext?.();
       };
       signal?.addEventListener("abort", onAbort, { once: true });
       try {
         // Initial snapshot tick.
         yield;
         while (!signal?.aborted) {
-          if (queue.length > 0) {
-            queue.shift();
+          if (pending) {
+            pending = false;
             yield;
           } else {
             await new Promise<void>((r) => {

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -159,7 +159,7 @@ export class LocalBackend implements Backend {
   readonly id: TerminalLocation = { kind: "local" };
 
   async spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle> {
-    const id = crypto.randomUUID();
+    const id = opts.id ?? crypto.randomUUID();
     const tlog = log.child({ terminal: id });
 
     const handle = spawnPty(

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -276,11 +276,6 @@ export class LocalBackend implements Backend {
       unwrapBackendGit(await getDiff(repoPath, filePath, mode, log, oldPath)),
     getStatus: async (repoPath, mode) =>
       unwrapBackendGit(await getStatus(repoPath, mode, log)),
-    subscribeRepoChange: (repoPath, signal) =>
-      watcherToAsyncIterable(
-        (cb) => subscribeRepoChange(repoPath, cb, log),
-        signal,
-      ),
   };
 }
 

--- a/packages/server/src/backend/local.ts
+++ b/packages/server/src/backend/local.ts
@@ -118,12 +118,15 @@ function watcherToAsyncIterable(
       let pending = false;
       let resolveNext: (() => void) | null = null;
       const stop = install(() => {
+        // Always mark pending — the wait loop checks this AFTER the
+        // promise resolves to decide whether to yield. Resolving the
+        // promise without setting pending would wake the iterator into
+        // an immediate re-await (silent missed event).
+        pending = true;
         if (resolveNext) {
           const r = resolveNext;
           resolveNext = null;
           r();
-        } else {
-          pending = true;
         }
       });
       const onAbort = () => {

--- a/packages/server/src/backend/remote-handle.ts
+++ b/packages/server/src/backend/remote-handle.ts
@@ -15,6 +15,7 @@
  */
 
 import type { PtyHandle } from "kolu-pty";
+import { log } from "../log.ts";
 import type { HostSession } from "./host-session.ts";
 
 export function remoteHandle(opts: {
@@ -28,16 +29,38 @@ export function remoteHandle(opts: {
     process: "", // Foreground-process detection is server-local on R-2.
     foregroundPid: undefined,
     write(data: string): void {
-      if (!opts.session.client) return;
+      if (!opts.session.client) {
+        log.warn(
+          { host: opts.session.host, id: opts.id },
+          "remoteHandle.write: session not connected; dropping input",
+        );
+        return;
+      }
       void opts.session.client.terminal
         .write({ id: opts.id, data })
-        .catch(() => {});
+        .catch((err: Error) => {
+          log.error(
+            { host: opts.session.host, id: opts.id, err },
+            "remoteHandle.write: agent RPC failed",
+          );
+        });
     },
     resize(cols: number, rows: number): void {
-      if (!opts.session.client) return;
+      if (!opts.session.client) {
+        log.warn(
+          { host: opts.session.host, id: opts.id },
+          "remoteHandle.resize: session not connected; dropping resize",
+        );
+        return;
+      }
       void opts.session.client.terminal
         .resize({ id: opts.id, cols, rows })
-        .catch(() => {});
+        .catch((err: Error) => {
+          log.error(
+            { host: opts.session.host, id: opts.id, err },
+            "remoteHandle.resize: agent RPC failed",
+          );
+        });
     },
     getScreenState(): string {
       // Late-joiner snapshot is R-3; channel data fills on subscribe.
@@ -47,8 +70,21 @@ export function remoteHandle(opts: {
       return "";
     },
     dispose(): void {
-      if (!opts.session.client) return;
-      void opts.session.client.terminal.kill({ id: opts.id }).catch(() => {});
+      if (!opts.session.client) {
+        log.warn(
+          { host: opts.session.host, id: opts.id },
+          "remoteHandle.dispose: session not connected; skipping RPC kill",
+        );
+        return;
+      }
+      void opts.session.client.terminal
+        .kill({ id: opts.id })
+        .catch((err: Error) => {
+          log.error(
+            { host: opts.session.host, id: opts.id, err },
+            "remoteHandle.dispose: agent RPC kill failed",
+          );
+        });
     },
   };
 }

--- a/packages/server/src/backend/remote-handle.ts
+++ b/packages/server/src/backend/remote-handle.ts
@@ -1,0 +1,54 @@
+/**
+ * `remoteHandle` — build a PtyHandle-shaped proxy for a remote
+ * terminal. The kolu server's terminal-registry stores
+ * `TerminalProcess.handle: PtyHandle` (the kolu-pty type); local
+ * terminals use the real handle from `spawnPty`, but remote terminals
+ * have no local PTY — operations must proxy via `session.client`.
+ *
+ * `getScreenState` and `getScreenText` return empty strings for the
+ * prototype — late-joiner xterm-headless serialization would require
+ * adding `terminal.screenState` / `terminal.screenText` to
+ * `agentContract` and proxying via the agent's local emulator. For R-3.
+ * Live data flows via `Backend.terminalChannel(id, "data")` which
+ * starts streaming the moment the client subscribes, so the UX is
+ * "instant live data, no scrollback replay on first attach."
+ */
+
+import type { PtyHandle } from "kolu-pty";
+import type { HostSession } from "./host-session.ts";
+
+export function remoteHandle(opts: {
+  id: string;
+  cwd: string;
+  session: HostSession;
+}): PtyHandle {
+  return {
+    pid: 0, // Remote pid not exposed; consumers should gate on location.
+    cwd: opts.cwd,
+    process: "", // Foreground-process detection is server-local on R-2.
+    foregroundPid: undefined,
+    write(data: string): void {
+      if (!opts.session.client) return;
+      void opts.session.client.terminal
+        .write({ id: opts.id, data })
+        .catch(() => {});
+    },
+    resize(cols: number, rows: number): void {
+      if (!opts.session.client) return;
+      void opts.session.client.terminal
+        .resize({ id: opts.id, cols, rows })
+        .catch(() => {});
+    },
+    getScreenState(): string {
+      // Late-joiner snapshot is R-3; channel data fills on subscribe.
+      return "";
+    },
+    getScreenText(_startLine?: number, _endLine?: number): string {
+      return "";
+    },
+    dispose(): void {
+      if (!opts.session.client) return;
+      void opts.session.client.terminal.kill({ id: opts.id }).catch(() => {});
+    },
+  };
+}

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -1,0 +1,168 @@
+/**
+ * RemoteBackend — the `Backend` implementation for terminals living on
+ * a remote SSH host. Proxies every method via oRPC over `ssh stdio` to
+ * a `kolu agent --stdio` peer (see `agentContract` in kolu-common).
+ *
+ * One RemoteBackend per host; the `getBackendForCreate` resolver in
+ * `./index.ts` caches them. RemoteBackend doesn't own the connection
+ * itself — that's `HostSession` (transport + state machine). Two
+ * axes, two modules. The connection survives multiple terminals on
+ * the same host.
+ *
+ * **STREAM_RETRY** (`.claude/rules/streaming.md`): oRPC's
+ * `ClientRetryPlugin` handles reconnect transparently — when the ssh
+ * stdio pipe drops, the plugin re-invokes each open stream and the
+ * snapshot-then-delta first yield re-syncs client state. No bespoke
+ * reconnect logic needed in this file; HostSession's state machine
+ * only governs *whether* to try reconnecting.
+ *
+ * Prototype scope: method bodies sketch the intended oRPC calls; the
+ * actual `client` object is left wired-to-undefined until R-3 plumbs
+ * the standard-peer transport.
+ */
+
+import type {
+  Backend,
+  BackendFs,
+  BackendGit,
+  PtySpawnOpts,
+  TerminalChannelMap,
+  TerminalHandle,
+} from "kolu-common/backend";
+import type { TerminalLocation } from "kolu-common/surface";
+import { log } from "../log.ts";
+import type { HostSession } from "./host-session.ts";
+
+export class RemoteBackend implements Backend {
+  readonly id: TerminalLocation;
+
+  constructor(private readonly session: HostSession) {
+    this.id = { kind: "ssh", host: session.host };
+  }
+
+  async spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle> {
+    log.info({ host: this.session.host }, "RemoteBackend.spawnPty");
+    // R-3: `const { id } = await this.session.client.terminal.spawn({
+    //   cwd: opts.cwd, initialMetadata: opts.initialMetadata })`
+    // Then register `id` with the session so HostSession state changes
+    // publish to this terminal's connectionState channel.
+    const id = crypto.randomUUID(); // stub
+    this.session.registerTerminal(id);
+    return {
+      id,
+      write: (_data) => {
+        // R-3: this.session.client.terminal.write({ id, data: _data })
+      },
+      resize: (_cols, _rows) => {
+        // R-3: this.session.client.terminal.resize({ id, cols, rows })
+      },
+    };
+  }
+
+  terminalChannel<K extends keyof TerminalChannelMap>(
+    terminalId: string,
+    _kind: K,
+    _signal?: AbortSignal,
+  ): AsyncIterable<TerminalChannelMap[K]> {
+    // R-3: route per kind:
+    //   "data" → this.session.client.terminal.channelData({ id: terminalId })
+    //   "agent" → this.session.client.terminal.channelAgent({ id })
+    //   "connectionState" → tap session.onStateChange (in-process, no RPC)
+    //   …etc per the agentContract channels.
+    //
+    // For `connectionState` we intercept at this layer rather than
+    // going over the wire — the agent doesn't know what state the
+    // local server perceives the connection in. HostSession's state
+    // machine is the truth.
+    log.warn(
+      { host: this.session.host, terminalId, kind: _kind },
+      "RemoteBackend.terminalChannel: prototype stub",
+    );
+    // Return an empty iterator that respects abort.
+    return {
+      async *[Symbol.asyncIterator]() {
+        // R-3 stub: yields nothing.
+      },
+    };
+  }
+
+  killTerminal(_terminalId: string): boolean {
+    // R-3: await this.session.client.terminal.kill({ id: _terminalId })
+    this.session.unregisterTerminal(_terminalId);
+    return true;
+  }
+
+  killTerminalEntry(entry: {
+    info: { id: string };
+    handle: { dispose(): void };
+    stopProviders: () => void;
+  }): void {
+    // For RemoteBackend the local `entry.handle.dispose` is a no-op
+    // proxy; the real kill is the RPC. The `stopProviders` call
+    // tears down any local subscribers (the metadata aggregator).
+    entry.stopProviders();
+    void this.killTerminal(entry.info.id);
+  }
+
+  async uploadFile(
+    terminalId: string,
+    _name: string,
+    _base64Data: string,
+  ): Promise<string> {
+    // R-3: const { path } = await this.session.client.terminal.uploadFile({
+    //   id: terminalId, name: _name, base64Data: _base64Data
+    // })
+    // return path
+    log.warn({ terminalId }, "RemoteBackend.uploadFile: prototype stub");
+    return `/tmp/kolu-agent-stub/${terminalId}/${_name}`;
+  }
+
+  fs: BackendFs = {
+    listAll: async (_repoPath) => {
+      // R-3: return this.session.client.fs.listAll({ repoPath: _repoPath })
+      return [];
+    },
+    readFile: async (_repoPath, _filePath) => {
+      // R-3: return this.session.client.fs.readFile({ repoPath, filePath })
+      return { content: "", truncated: false };
+    },
+    subscribeRepoChange: (_repoPath, _signal) => {
+      // R-3: iterate this.session.client.fs.subscribeRepoChange({ repoPath })
+      return {
+        async *[Symbol.asyncIterator]() {
+          /* stub */
+        },
+      };
+    },
+    subscribeFileChange: (_repoPath, _filePath, _signal) => {
+      return {
+        async *[Symbol.asyncIterator]() {
+          /* stub */
+        },
+      };
+    },
+  };
+
+  git: BackendGit = {
+    getDiff: async (_repoPath, _filePath, _mode, _oldPath) => {
+      // R-3: this.session.client.git.getDiff({ ... })
+      return {
+        oldFileName: null,
+        newFileName: null,
+        hunks: [],
+        binary: false,
+      };
+    },
+    getStatus: async (_repoPath, _mode) => {
+      // R-3: this.session.client.git.getStatus({ ... })
+      return { files: [], base: null };
+    },
+    subscribeRepoChange: (_repoPath, _signal) => {
+      return {
+        async *[Symbol.asyncIterator]() {
+          /* stub */
+        },
+      };
+    },
+  };
+}

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -27,7 +27,14 @@ import type {
 } from "kolu-common/backend";
 import type { TerminalLocation } from "kolu-common/surface";
 import { log } from "../log.ts";
+import {
+  getTerminal,
+  registerTerminal,
+  type TerminalProcess,
+  unregisterTerminal,
+} from "../terminal-registry.ts";
 import type { AgentClient, HostSession } from "./host-session.ts";
+import { remoteHandle } from "./remote-handle.ts";
 
 /** Lazily resolve the agent client — throws a typed error if the
  *  session isn't connected yet. Each method body uses this to surface
@@ -58,28 +65,44 @@ export class RemoteBackend implements Backend {
       initialMetadata: opts.initialMetadata,
     });
     this.session.registerTerminal(id);
+
+    // Register a shadow entry in the kolu server's terminal-registry so
+    // router-level operations (`terminal.attach`, `sendInput`, `resize`,
+    // `kill`, `screenState`) find the terminal. `handle` is a PtyHandle-
+    // shaped proxy that forwards via session.client.
+    const handle = remoteHandle({
+      id,
+      cwd: opts.cwd ?? "/",
+      session: this.session,
+    });
+    const metaMod = await import("../meta/index.ts");
+    const meta = metaMod.createMetadata(opts.cwd ?? "/", this.id);
+    if (opts.initialMetadata) Object.assign(meta, opts.initialMetadata);
+    meta.connectionState = this.session.connectionState();
+    const entry: TerminalProcess = {
+      info: { id },
+      meta,
+      handle,
+      stopProviders: () => {},
+    };
+    // Register BEFORE subscribing — onStateChange fires the listener
+    // synchronously with the current state (snapshot-then-delta), and
+    // the listener's `getTerminal(id)` lookup must succeed for the
+    // initial metadata publish to flow.
+    registerTerminal(id, entry);
+    entry.stopProviders = this.session.onStateChange((s) => {
+      const e = getTerminal(id);
+      if (e) {
+        metaMod.updateServerLiveMetadata(e, id, (m) => {
+          m.connectionState = s;
+        });
+      }
+    });
+
     return {
       id,
-      write: (data) => {
-        void clientOf(this.session)
-          .terminal.write({ id, data })
-          .catch((err) => {
-            log.warn(
-              { host: this.session.host, id, err },
-              "remote write failed",
-            );
-          });
-      },
-      resize: (cols, rows) => {
-        void clientOf(this.session)
-          .terminal.resize({ id, cols, rows })
-          .catch((err) => {
-            log.warn(
-              { host: this.session.host, id, err },
-              "remote resize failed",
-            );
-          });
-      },
+      write: (data) => handle.write(data),
+      resize: (cols, rows) => handle.resize(cols, rows),
     };
   }
 
@@ -166,6 +189,8 @@ export class RemoteBackend implements Backend {
         );
       });
     this.session.unregisterTerminal(terminalId);
+    // Remove the server-side shadow entry too.
+    unregisterTerminal(terminalId);
     return true;
   }
 

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -64,6 +64,11 @@ export class RemoteBackend implements Backend {
       cwd: opts.cwd,
       initialMetadata: opts.initialMetadata,
     });
+    // First successful RPC roundtrip — the agent is alive. Mark ready
+    // so HostSession's heartbeat loop starts (it was deliberately
+    // deferred to avoid timing out the cold `nix run` realisation,
+    // which can take minutes on first use).
+    this.session.markReady();
     this.session.registerTerminal(id);
 
     // Register a shadow entry in the kolu server's terminal-registry so

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -90,14 +90,7 @@ export class RemoteBackend implements Backend {
     // the listener's `getTerminal(id)` lookup must succeed for the
     // initial metadata publish to flow.
     registerTerminal(id, entry);
-    entry.stopProviders = this.session.onStateChange((s) => {
-      const e = getTerminal(id);
-      if (e) {
-        metaMod.updateServerLiveMetadata(e, id, (m) => {
-          m.connectionState = s;
-        });
-      }
-    });
+    entry.stopProviders = this.startRemoteMetaSubscribers(id, metaMod);
 
     return {
       id,
@@ -176,6 +169,117 @@ export class RemoteBackend implements Backend {
         const it = await promise;
         for await (const v of it) yield v as TerminalChannelMap[K];
       },
+    };
+  }
+
+  /** Wire up channel subscribers that mirror the agent's per-terminal
+   *  metadata into the kolu server's `entry.meta`. The agent's
+   *  in-process providers (claude-code/codex/opencode/foreground)
+   *  write to ITS local entry and publish to ITS terminalChannels;
+   *  this loop tunnels those publishes via oRPC and applies them on
+   *  the kolu-server side so the browser-visible terminalMetadata
+   *  collection stays current for remote tiles. */
+  private startRemoteMetaSubscribers(
+    id: string,
+    metaMod: typeof import("../meta/index.ts"),
+  ): () => void {
+    const ctrl = new AbortController();
+    const stops: Array<() => void> = [];
+
+    // Connection state — driven by HostSession state machine, not by
+    // an agent channel. Snapshot-then-delta via onStateChange.
+    stops.push(
+      this.session.onStateChange((s) => {
+        const e = getTerminal(id);
+        if (e) {
+          metaMod.updateServerLiveMetadata(e, id, (m) => {
+            m.connectionState = s;
+          });
+        }
+      }),
+    );
+
+    // Live metadata channels — `agent`, `pr`, `foreground` — each
+    // pumped through `updateServerLiveMetadata` (which doesn't fire
+    // terminals:dirty, matching the local-side behavior for these
+    // transient fields).
+    const liveSubscriber = <K extends "agent" | "pr" | "foreground">(
+      kind: K,
+      apply: (
+        m: Parameters<
+          Parameters<typeof metaMod.updateServerLiveMetadata>[2]
+        >[0],
+        v: TerminalChannelMap[K],
+      ) => void,
+    ): void => {
+      void (async () => {
+        try {
+          for await (const v of this.terminalChannel(id, kind, ctrl.signal)) {
+            const e = getTerminal(id);
+            if (!e) continue;
+            metaMod.updateServerLiveMetadata(e, id, (m) => apply(m, v));
+          }
+        } catch (err) {
+          log.warn(
+            { host: this.session.host, id, kind, err },
+            "remote meta subscriber failed",
+          );
+        }
+      })();
+    };
+    liveSubscriber("agent", (m, v) => {
+      m.agent = v;
+    });
+    liveSubscriber("pr", (m, v) => {
+      m.pr = v;
+    });
+    liveSubscriber("foreground", (m, v) => {
+      m.foreground = v;
+    });
+
+    // Server-persisted fields — cwd, git — go through
+    // `updateServerMetadata` (fires terminals:dirty so the session
+    // autosave loop picks it up).
+    void (async () => {
+      try {
+        for await (const newCwd of this.terminalChannel(
+          id,
+          "cwd",
+          ctrl.signal,
+        )) {
+          const e = getTerminal(id);
+          if (!e) continue;
+          metaMod.updateServerMetadata(e, id, (m) => {
+            m.cwd = newCwd;
+          });
+        }
+      } catch (err) {
+        log.warn(
+          { host: this.session.host, id, err },
+          "remote cwd subscriber failed",
+        );
+      }
+    })();
+    void (async () => {
+      try {
+        for await (const info of this.terminalChannel(id, "git", ctrl.signal)) {
+          const e = getTerminal(id);
+          if (!e) continue;
+          metaMod.updateServerMetadata(e, id, (m) => {
+            m.git = info;
+          });
+        }
+      } catch (err) {
+        log.warn(
+          { host: this.session.host, id, err },
+          "remote git subscriber failed",
+        );
+      }
+    })();
+
+    return () => {
+      ctrl.abort();
+      for (const s of stops) s();
     };
   }
 

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -56,25 +56,15 @@ export class RemoteBackend implements Backend {
   }
 
   async spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle> {
-    log.info({ host: this.session.host }, "RemoteBackend.spawnPty");
-    // Lazy connect — multiple concurrent spawn requests on a fresh
-    // session all await one `connect()`; subsequent calls are no-ops.
-    await this.session.connect();
-    const { id } = await clientOf(this.session).terminal.spawn({
-      cwd: opts.cwd,
-      initialMetadata: opts.initialMetadata,
-    });
-    // First successful RPC roundtrip — the agent is alive. Mark ready
-    // so HostSession's heartbeat loop starts (it was deliberately
-    // deferred to avoid timing out the cold `nix run` realisation,
-    // which can take minutes on first use).
-    this.session.markReady();
-    this.session.registerTerminal(id);
+    // Pre-generate the id so we can register a "connecting" shadow
+    // entry on the kolu server BEFORE the agent's spawn RPC roundtrips.
+    // Without this, the tile only appears after the (possibly minutes-
+    // long) cold `nix run` realisation completes — invisible-progress
+    // UX. The agent then honors the same id, keeping kolu-server <->
+    // agent registries in lockstep.
+    const id = opts.id ?? crypto.randomUUID();
+    log.info({ host: this.session.host, id }, "RemoteBackend.spawnPty");
 
-    // Register a shadow entry in the kolu server's terminal-registry so
-    // router-level operations (`terminal.attach`, `sendInput`, `resize`,
-    // `kill`, `screenState`) find the terminal. `handle` is a PtyHandle-
-    // shaped proxy that forwards via session.client.
     const handle = remoteHandle({
       id,
       cwd: opts.cwd ?? "/",
@@ -83,7 +73,8 @@ export class RemoteBackend implements Backend {
     const metaMod = await import("../meta/index.ts");
     const meta = metaMod.createMetadata(opts.cwd ?? "/", this.id);
     if (opts.initialMetadata) Object.assign(meta, opts.initialMetadata);
-    meta.connectionState = this.session.connectionState();
+    // Tile renders "Connecting…" overlay from this state.
+    meta.connectionState = "connecting";
     const entry: TerminalProcess = {
       info: { id },
       meta,
@@ -96,6 +87,32 @@ export class RemoteBackend implements Backend {
     // initial metadata publish to flow.
     registerTerminal(id, entry);
     entry.stopProviders = this.startRemoteMetaSubscribers(id, metaMod);
+    this.session.registerTerminal(id);
+
+    // Async tail — connect the session, RPC-spawn on the agent. Errors
+    // surface via the entry's connectionState transitioning to
+    // "disconnected" (HostSession's subprocess-exit handler), which is
+    // what the DisconnectedOverlay renders. Failures are also logged
+    // via the HostSession.connect path.
+    void (async () => {
+      try {
+        await this.session.connect();
+        await clientOf(this.session).terminal.spawn({
+          id,
+          cwd: opts.cwd,
+          initialMetadata: opts.initialMetadata,
+        });
+        // First successful RPC roundtrip — the agent is alive. Mark
+        // ready so HostSession's heartbeat loop starts (deliberately
+        // deferred to avoid timing out the cold `nix run` realisation).
+        this.session.markReady();
+      } catch (err) {
+        log.error(
+          { host: this.session.host, id, err },
+          "RemoteBackend.spawnPty: async connect/spawn failed",
+        );
+      }
+    })();
 
     return {
       id,

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -157,12 +157,5 @@ export class RemoteBackend implements Backend {
       // R-3: this.session.client.git.getStatus({ ... })
       return { files: [], base: null };
     },
-    subscribeRepoChange: (_repoPath, _signal) => {
-      return {
-        async *[Symbol.asyncIterator]() {
-          /* stub */
-        },
-      };
-    },
   };
 }

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -86,14 +86,19 @@ export class RemoteBackend implements Backend {
     // the listener's `getTerminal(id)` lookup must succeed for the
     // initial metadata publish to flow.
     registerTerminal(id, entry);
-    entry.stopProviders = this.startRemoteMetaSubscribers(id, metaMod);
     this.session.registerTerminal(id);
 
-    // Async tail — connect the session, RPC-spawn on the agent. Errors
-    // surface via the entry's connectionState transitioning to
-    // "disconnected" (HostSession's subprocess-exit handler), which is
-    // what the DisconnectedOverlay renders. Failures are also logged
-    // via the HostSession.connect path.
+    // State-listener subscriber starts immediately — it doesn't need
+    // session.client. The channel subscribers (which DO need a live
+    // client) start after `terminal.spawn` returns.
+    const stopState = this.startStateSubscriber(id, metaMod);
+    entry.stopProviders = stopState;
+
+    // Async tail — connect the session, RPC-spawn on the agent, then
+    // wire up channel subscribers. Errors surface via the entry's
+    // connectionState transitioning to "disconnected" (HostSession's
+    // subprocess-exit handler), which is what the DisconnectedOverlay
+    // renders.
     void (async () => {
       try {
         await this.session.connect();
@@ -106,6 +111,16 @@ export class RemoteBackend implements Backend {
         // ready so HostSession's heartbeat loop starts (deliberately
         // deferred to avoid timing out the cold `nix run` realisation).
         this.session.markReady();
+        // Now that the client is live, attach channel subscribers and
+        // compose their stop fn with the state-listener stop. If the
+        // entry was killed between subscribe and now, the subscribers
+        // self-terminate when getTerminal(id) returns undefined.
+        const stopChannels = this.startChannelSubscribers(id, metaMod);
+        const stopStateRef = entry.stopProviders;
+        entry.stopProviders = () => {
+          stopStateRef();
+          stopChannels();
+        };
       } catch (err) {
         log.error(
           { host: this.session.host, id, err },
@@ -194,32 +209,42 @@ export class RemoteBackend implements Backend {
     };
   }
 
-  /** Wire up channel subscribers that mirror the agent's per-terminal
+  /** Connection-state subscriber — pure in-process listener on
+   *  HostSession state changes, no `session.client` needed. Starts
+   *  immediately so the tile reflects "connecting" / "live" /
+   *  "disconnected" transitions even before the agent boots. */
+  private startStateSubscriber(
+    id: string,
+    metaMod: typeof import("../meta/index.ts"),
+  ): () => void {
+    return this.session.onStateChange((s) => {
+      const e = getTerminal(id);
+      if (e) {
+        metaMod.updateServerLiveMetadata(e, id, (m) => {
+          m.connectionState = s;
+        });
+      }
+    });
+  }
+
+  /** Channel subscribers that mirror the agent's per-terminal
    *  metadata into the kolu server's `entry.meta`. The agent's
    *  in-process providers (claude-code/codex/opencode/foreground)
    *  write to ITS local entry and publish to ITS terminalChannels;
-   *  this loop tunnels those publishes via oRPC and applies them on
+   *  these loops tunnel those publishes via oRPC and apply them on
    *  the kolu-server side so the browser-visible terminalMetadata
-   *  collection stays current for remote tiles. */
-  private startRemoteMetaSubscribers(
+   *  collection stays current for remote tiles.
+   *
+   *  CALL AFTER `session.connect()` HAS RETURNED — these subscribers
+   *  invoke `this.terminalChannel(id, kind)` which calls
+   *  `clientOf(this.session)`, which throws if the client isn't
+   *  built yet. Starting before connect dies on the first iteration
+   *  and the subscriber never reattaches. */
+  private startChannelSubscribers(
     id: string,
     metaMod: typeof import("../meta/index.ts"),
   ): () => void {
     const ctrl = new AbortController();
-    const stops: Array<() => void> = [];
-
-    // Connection state — driven by HostSession state machine, not by
-    // an agent channel. Snapshot-then-delta via onStateChange.
-    stops.push(
-      this.session.onStateChange((s) => {
-        const e = getTerminal(id);
-        if (e) {
-          metaMod.updateServerLiveMetadata(e, id, (m) => {
-            m.connectionState = s;
-          });
-        }
-      }),
-    );
 
     // Live metadata channels — `agent`, `pr`, `foreground` — each
     // pumped through `updateServerLiveMetadata` (which doesn't fire
@@ -301,7 +326,6 @@ export class RemoteBackend implements Backend {
 
     return () => {
       ctrl.abort();
-      for (const s of stops) s();
     };
   }
 

--- a/packages/server/src/backend/remote.ts
+++ b/packages/server/src/backend/remote.ts
@@ -15,10 +15,6 @@
  * snapshot-then-delta first yield re-syncs client state. No bespoke
  * reconnect logic needed in this file; HostSession's state machine
  * only governs *whether* to try reconnecting.
- *
- * Prototype scope: method bodies sketch the intended oRPC calls; the
- * actual `client` object is left wired-to-undefined until R-3 plumbs
- * the standard-peer transport.
  */
 
 import type {
@@ -31,7 +27,19 @@ import type {
 } from "kolu-common/backend";
 import type { TerminalLocation } from "kolu-common/surface";
 import { log } from "../log.ts";
-import type { HostSession } from "./host-session.ts";
+import type { AgentClient, HostSession } from "./host-session.ts";
+
+/** Lazily resolve the agent client — throws a typed error if the
+ *  session isn't connected yet. Each method body uses this to surface
+ *  a clear failure rather than a `Cannot read properties of undefined`. */
+function clientOf(session: HostSession): AgentClient {
+  if (!session.client) {
+    throw new Error(
+      `RemoteBackend(${session.host}): not connected. Call installSshAgent / HostSession.connect first.`,
+    );
+  }
+  return session.client;
+}
 
 export class RemoteBackend implements Backend {
   readonly id: TerminalLocation;
@@ -42,53 +50,122 @@ export class RemoteBackend implements Backend {
 
   async spawnPty(opts: PtySpawnOpts): Promise<TerminalHandle> {
     log.info({ host: this.session.host }, "RemoteBackend.spawnPty");
-    // R-3: `const { id } = await this.session.client.terminal.spawn({
-    //   cwd: opts.cwd, initialMetadata: opts.initialMetadata })`
-    // Then register `id` with the session so HostSession state changes
-    // publish to this terminal's connectionState channel.
-    const id = crypto.randomUUID(); // stub
+    // Lazy connect — multiple concurrent spawn requests on a fresh
+    // session all await one `connect()`; subsequent calls are no-ops.
+    await this.session.connect();
+    const { id } = await clientOf(this.session).terminal.spawn({
+      cwd: opts.cwd,
+      initialMetadata: opts.initialMetadata,
+    });
     this.session.registerTerminal(id);
     return {
       id,
-      write: (_data) => {
-        // R-3: this.session.client.terminal.write({ id, data: _data })
+      write: (data) => {
+        void clientOf(this.session)
+          .terminal.write({ id, data })
+          .catch((err) => {
+            log.warn(
+              { host: this.session.host, id, err },
+              "remote write failed",
+            );
+          });
       },
-      resize: (_cols, _rows) => {
-        // R-3: this.session.client.terminal.resize({ id, cols, rows })
+      resize: (cols, rows) => {
+        void clientOf(this.session)
+          .terminal.resize({ id, cols, rows })
+          .catch((err) => {
+            log.warn(
+              { host: this.session.host, id, err },
+              "remote resize failed",
+            );
+          });
       },
     };
   }
 
   terminalChannel<K extends keyof TerminalChannelMap>(
     terminalId: string,
-    _kind: K,
+    kind: K,
     _signal?: AbortSignal,
   ): AsyncIterable<TerminalChannelMap[K]> {
-    // R-3: route per kind:
-    //   "data" → this.session.client.terminal.channelData({ id: terminalId })
-    //   "agent" → this.session.client.terminal.channelAgent({ id })
-    //   "connectionState" → tap session.onStateChange (in-process, no RPC)
-    //   …etc per the agentContract channels.
-    //
-    // For `connectionState` we intercept at this layer rather than
-    // going over the wire — the agent doesn't know what state the
-    // local server perceives the connection in. HostSession's state
-    // machine is the truth.
-    log.warn(
-      { host: this.session.host, terminalId, kind: _kind },
-      "RemoteBackend.terminalChannel: prototype stub",
-    );
-    // Return an empty iterator that respects abort.
+    // `connectionState` is in-process — the kolu server's view of the
+    // session's state, not something to fetch from the agent.
+    if (kind === "connectionState") {
+      const session = this.session;
+      return {
+        async *[Symbol.asyncIterator]() {
+          let resolve: ((v: TerminalChannelMap[K]) => void) | null = null;
+          const queue: TerminalChannelMap[K][] = [];
+          const stop = session.onStateChange((s) => {
+            if (resolve) {
+              const r = resolve;
+              resolve = null;
+              r(s as TerminalChannelMap[K]);
+            } else {
+              queue.push(s as TerminalChannelMap[K]);
+            }
+          });
+          try {
+            while (true) {
+              if (queue.length > 0) {
+                const v = queue.shift();
+                if (v !== undefined) yield v;
+              } else {
+                yield await new Promise<TerminalChannelMap[K]>((r) => {
+                  resolve = r;
+                });
+              }
+            }
+          } finally {
+            stop();
+          }
+        },
+      };
+    }
+    // Per-kind dispatch — one named procedure per TerminalChannelMap key.
+    // The client's stream procedures return `Promise<AsyncIterable<T>>`;
+    // wrap so the caller sees a direct `AsyncIterable<T>`.
+    const client = clientOf(this.session);
+    const callFor = (k: Exclude<K, "connectionState">) => {
+      switch (k) {
+        case "data":
+          return client.terminal.channelData({ id: terminalId });
+        case "cwd":
+          return client.terminal.channelCwd({ id: terminalId });
+        case "title":
+          return client.terminal.channelTitle({ id: terminalId });
+        case "git":
+          return client.terminal.channelGit({ id: terminalId });
+        case "commandRun":
+          return client.terminal.channelCommandRun({ id: terminalId });
+        case "agent":
+          return client.terminal.channelAgent({ id: terminalId });
+        case "pr":
+          return client.terminal.channelPr({ id: terminalId });
+        case "foreground":
+          return client.terminal.channelForeground({ id: terminalId });
+      }
+    };
+    if (kind === "connectionState") throw new Error("unreachable");
+    const promise = callFor(kind as Exclude<K, "connectionState">);
     return {
       async *[Symbol.asyncIterator]() {
-        // R-3 stub: yields nothing.
+        const it = await promise;
+        for await (const v of it) yield v as TerminalChannelMap[K];
       },
     };
   }
 
-  killTerminal(_terminalId: string): boolean {
-    // R-3: await this.session.client.terminal.kill({ id: _terminalId })
-    this.session.unregisterTerminal(_terminalId);
+  killTerminal(terminalId: string): boolean {
+    void clientOf(this.session)
+      .terminal.kill({ id: terminalId })
+      .catch((err) => {
+        log.warn(
+          { host: this.session.host, terminalId, err },
+          "remote kill failed",
+        );
+      });
+    this.session.unregisterTerminal(terminalId);
     return true;
   }
 
@@ -97,65 +174,76 @@ export class RemoteBackend implements Backend {
     handle: { dispose(): void };
     stopProviders: () => void;
   }): void {
-    // For RemoteBackend the local `entry.handle.dispose` is a no-op
-    // proxy; the real kill is the RPC. The `stopProviders` call
-    // tears down any local subscribers (the metadata aggregator).
     entry.stopProviders();
-    void this.killTerminal(entry.info.id);
+    this.killTerminal(entry.info.id);
   }
 
   async uploadFile(
     terminalId: string,
-    _name: string,
-    _base64Data: string,
+    name: string,
+    base64Data: string,
   ): Promise<string> {
-    // R-3: const { path } = await this.session.client.terminal.uploadFile({
-    //   id: terminalId, name: _name, base64Data: _base64Data
-    // })
-    // return path
-    log.warn({ terminalId }, "RemoteBackend.uploadFile: prototype stub");
-    return `/tmp/kolu-agent-stub/${terminalId}/${_name}`;
+    const { path } = await clientOf(this.session).terminal.uploadFile({
+      id: terminalId,
+      name,
+      base64Data,
+    });
+    return path;
   }
 
   fs: BackendFs = {
-    listAll: async (_repoPath) => {
-      // R-3: return this.session.client.fs.listAll({ repoPath: _repoPath })
-      return [];
+    listAll: async (repoPath) => {
+      const { paths } = await clientOf(this.session).fs.listAll({ repoPath });
+      return paths;
     },
-    readFile: async (_repoPath, _filePath) => {
-      // R-3: return this.session.client.fs.readFile({ repoPath, filePath })
+    readFile: async (repoPath, filePath) => {
+      const out = await clientOf(this.session).fs.readFile({
+        repoPath,
+        filePath,
+      });
+      // FsReadFileOutput is a discriminated union (text | binary).
+      // RemoteBackend's caller (router.ts) expects {content, truncated}
+      // for text reads; binary reads would need different plumbing
+      // (URL handle) that R-2 doesn't carry over the wire yet.
+      if ("content" in out) {
+        return { content: out.content, truncated: out.truncated };
+      }
       return { content: "", truncated: false };
     },
-    subscribeRepoChange: (_repoPath, _signal) => {
-      // R-3: iterate this.session.client.fs.subscribeRepoChange({ repoPath })
+    subscribeRepoChange: (repoPath, _signal) => {
+      const promise = clientOf(this.session).fs.subscribeRepoChange({
+        repoPath,
+      });
       return {
         async *[Symbol.asyncIterator]() {
-          /* stub */
+          const it = await promise;
+          for await (const _ of it) yield;
         },
       };
     },
-    subscribeFileChange: (_repoPath, _filePath, _signal) => {
+    subscribeFileChange: (repoPath, filePath, _signal) => {
+      const promise = clientOf(this.session).fs.subscribeFileChange({
+        repoPath,
+        filePath,
+      });
       return {
         async *[Symbol.asyncIterator]() {
-          /* stub */
+          const it = await promise;
+          for await (const _ of it) yield;
         },
       };
     },
   };
 
   git: BackendGit = {
-    getDiff: async (_repoPath, _filePath, _mode, _oldPath) => {
-      // R-3: this.session.client.git.getDiff({ ... })
-      return {
-        oldFileName: null,
-        newFileName: null,
-        hunks: [],
-        binary: false,
-      };
-    },
-    getStatus: async (_repoPath, _mode) => {
-      // R-3: this.session.client.git.getStatus({ ... })
-      return { files: [], base: null };
-    },
+    getDiff: async (repoPath, filePath, mode, oldPath) =>
+      clientOf(this.session).git.getDiff({
+        repoPath,
+        filePath,
+        mode,
+        oldPath,
+      }),
+    getStatus: async (repoPath, mode) =>
+      clientOf(this.session).git.getStatus({ repoPath, mode }),
   };
 }

--- a/packages/server/src/backend/stdio-client.ts
+++ b/packages/server/src/backend/stdio-client.ts
@@ -14,6 +14,7 @@
 import { StandardRPCLink } from "@orpc/client/standard";
 import { ClientPeer } from "@orpc/standard-server-peer";
 import type { Readable, Writable } from "node:stream";
+import { log } from "../log.ts";
 import { makeStdioSend, readStdioMessages } from "./stdio-peer.ts";
 
 export interface StdioRPCLinkOptions {
@@ -32,9 +33,14 @@ export class StdioRPCLink extends StandardRPCLink<object> {
     const stopRead = readStdioMessages(options.stdout, async (msg) => {
       try {
         await peer.message(msg);
-      } catch {
-        // peer.message can throw if the codec rejects malformed bytes;
-        // recover at the next message boundary.
+      } catch (err) {
+        // Codec mismatch / truncation — log so a protocol error isn't
+        // invisible, then continue reading from the next message
+        // boundary.
+        log.warn(
+          { err, frameBytes: msg.byteLength },
+          "stdio-client: peer.message threw",
+        );
       }
     });
 

--- a/packages/server/src/backend/stdio-client.ts
+++ b/packages/server/src/backend/stdio-client.ts
@@ -1,0 +1,60 @@
+/**
+ * `StdioRPCLink` — `StandardRPCLink` whose transport is a child
+ * process's stdin/stdout. Pairs with the `ServerPeer`-over-stdio
+ * adapter in `../agent.ts`.
+ *
+ * Used by `HostSession` to build a typed oRPC client against
+ * `agentContract`: the kolu server spawns `ssh -tt host kolu --stdio`,
+ * pipes its stdin/stdout through the ssh transport, and wraps the
+ * resulting duplex stream in this link. `createORPCClient(link)`
+ * produces a typed client that satisfies the same call shape as the
+ * in-process `LocalBackend`.
+ */
+
+import { StandardRPCLink } from "@orpc/client/standard";
+import { ClientPeer } from "@orpc/standard-server-peer";
+import type { Readable, Writable } from "node:stream";
+import { makeStdioSend, readStdioMessages } from "./stdio-peer.ts";
+
+export interface StdioRPCLinkOptions {
+  /** Child-process stdin (we write requests here). */
+  stdin: Writable;
+  /** Child-process stdout (we read responses from here). */
+  stdout: Readable;
+}
+
+export class StdioRPCLink extends StandardRPCLink<object> {
+  private readonly peer: ClientPeer;
+  private readonly stopRead: () => void;
+
+  constructor(options: StdioRPCLinkOptions) {
+    const peer = new ClientPeer(makeStdioSend(options.stdin));
+    const stopRead = readStdioMessages(options.stdout, async (msg) => {
+      try {
+        await peer.message(msg);
+      } catch {
+        // peer.message can throw if the codec rejects malformed bytes;
+        // recover at the next message boundary.
+      }
+    });
+
+    const linkClient = {
+      async call(request: import("@orpc/standard-server").StandardRequest) {
+        const response = await peer.request(request);
+        return {
+          ...response,
+          body: () => Promise.resolve(response.body),
+        };
+      },
+    };
+    super(linkClient, { url: "http://orpc-agent" });
+
+    this.peer = peer;
+    this.stopRead = stopRead;
+  }
+
+  dispose(): void {
+    this.stopRead();
+    this.peer.close();
+  }
+}

--- a/packages/server/src/backend/stdio-peer.ts
+++ b/packages/server/src/backend/stdio-peer.ts
@@ -19,6 +19,7 @@
 
 import type { Readable, Writable } from "node:stream";
 import type { EncodedMessage } from "@orpc/standard-server-peer";
+import { log } from "../log.ts";
 
 /** Build the `send` callback for a peer: encodes the message as base64
  *  and writes to `out` with a newline delimiter. */
@@ -54,8 +55,15 @@ export function readStdioMessages(
         try {
           const decoded = Buffer.from(line, "base64");
           void onMessage(decoded);
-        } catch {
-          // Ignore malformed frames — recover at next newline.
+        } catch (err) {
+          // Recover at next newline — a malformed frame shouldn't poison
+          // the rest of the stream — but surface the error so a protocol
+          // mismatch isn't invisible. `frameLength` helps diagnose
+          // truncation / encoding skew at the framing layer.
+          log.warn(
+            { err, frameLength: line.length },
+            "stdio-peer: malformed frame; skipping",
+          );
         }
       }
       nl = buf.indexOf("\n");

--- a/packages/server/src/backend/stdio-peer.ts
+++ b/packages/server/src/backend/stdio-peer.ts
@@ -1,0 +1,72 @@
+/**
+ * Stdio framing for the oRPC standard-peer protocol.
+ *
+ * Each message is base64-encoded on one line; newlines delimit
+ * messages. Base64 never contains a newline, so the framing is
+ * unambiguous over the byte stream. Handles both string and binary
+ * payloads uniformly.
+ *
+ * Used by:
+ *  - `agent.ts` — wires `ServerPeer` (from `@orpc/standard-server-peer`)
+ *    to `process.stdin` / `process.stdout`.
+ *  - `host-session.ts` — wires `ClientPeer` to the `ssh` subprocess's
+ *    `stdin` / `stdout`.
+ *
+ * The two sides use the same framing, so a `kolu agent --stdio`
+ * spawned over ssh can be talked to by any `ClientPeer` with this
+ * adapter.
+ */
+
+import type { Readable, Writable } from "node:stream";
+import type { EncodedMessage } from "@orpc/standard-server-peer";
+
+/** Build the `send` callback for a peer: encodes the message as base64
+ *  and writes to `out` with a newline delimiter. */
+export function makeStdioSend(out: Writable): (msg: EncodedMessage) => void {
+  return (msg) => {
+    const buf =
+      typeof msg === "string"
+        ? Buffer.from(msg, "utf8")
+        : Buffer.isBuffer(msg)
+          ? msg
+          : Buffer.from(msg as ArrayBufferLike);
+    out.write(buf.toString("base64"));
+    out.write("\n");
+  };
+}
+
+/** Read messages from `inp` line-by-line, decode each line as base64,
+ *  and call `onMessage(decoded)` for each. Returns a stop function
+ *  that detaches the listener. */
+export function readStdioMessages(
+  inp: Readable,
+  onMessage: (msg: Uint8Array) => void | Promise<void>,
+  onClose?: () => void,
+): () => void {
+  let buf = "";
+  const onData = (chunk: Buffer | string) => {
+    buf += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    let nl = buf.indexOf("\n");
+    while (nl !== -1) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (line.length > 0) {
+        try {
+          const decoded = Buffer.from(line, "base64");
+          void onMessage(decoded);
+        } catch {
+          // Ignore malformed frames — recover at next newline.
+        }
+      }
+      nl = buf.indexOf("\n");
+    }
+  };
+  inp.on("data", onData);
+  if (onClose) {
+    inp.once("end", onClose);
+    inp.once("close", onClose);
+  }
+  return () => {
+    inp.off("data", onData);
+  };
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -68,9 +68,32 @@ const argv = cli({
       description:
         "Allow running inside a nix shell, forwarding only these comma-separated env vars to PTY shells (dev/test only). Uses built-in default list if set to 'default'.",
     },
+    // R-2: `kolu --stdio` (or `kolu agent --stdio` after a subcommand
+    // refactor) runs the binary as a remote agent — same code, oRPC
+    // transport over stdin/stdout instead of HTTP+WebSocket. Wires to
+    // `runAgent` in `./agent.ts`. The kolu server's `RemoteBackend`
+    // spawns this on the remote host via `ssh -tt $host kolu --stdio`.
+    stdio: {
+      type: Boolean,
+      description:
+        "Run as a remote agent: serve LocalBackend over oRPC on stdin/stdout instead of starting the HTTP server. Used by `RemoteBackend` over `ssh`.",
+      default: false,
+    },
   },
   strictFlags: true,
 });
+
+// R-2: dispatch to agent mode BEFORE the server setup below. The agent
+// shares everything (logger, koluRoot, configureNixShellEnv) but never
+// touches the Hono/WebSocket server.
+if (argv.flags.stdio) {
+  configureNixShellEnv(argv.flags.allowNixShellWithEnvWhitelist);
+  ensureKoluRoot();
+  if (argv.flags.verbose) log.level = "debug";
+  const { runAgent } = await import("./agent.ts");
+  await runAgent();
+  process.exit(0);
+}
 
 const PWA_BACKGROUND_COLOR = "#0c0c0e";
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -87,6 +87,13 @@ const argv = cli({
 // shares everything (logger, koluRoot, configureNixShellEnv) but never
 // touches the Hono/WebSocket server.
 if (argv.flags.stdio) {
+  // The agent process is spawned via ssh and inherits no env. Provide
+  // a sensible KOLU_STATE_DIR default so `state.ts` can initialize —
+  // agent state is ephemeral per-session so XDG-style under the
+  // remote user's home is enough.
+  if (!process.env.KOLU_STATE_DIR) {
+    process.env.KOLU_STATE_DIR = `${process.env.HOME ?? "/tmp"}/.config/kolu-agent`;
+  }
   configureNixShellEnv(argv.flags.allowNixShellWithEnvWhitelist);
   ensureKoluRoot();
   if (argv.flags.verbose) log.level = "debug";

--- a/packages/server/src/install.ts
+++ b/packages/server/src/install.ts
@@ -1,24 +1,31 @@
 /**
- * Agent installation — ship the kolu binary to a remote SSH host via
- * `nix copy`.
+ * Agent installation — ship the kolu binary to a remote SSH host.
  *
  * Plan B's pivot for binary shipping: the remote already has Nix
  * (kolu's entire user base does — that's how they got kolu), so
  * shipping the agent reduces to:
  *
- *   nix copy --to ssh://$host .#kolu
+ *   ssh $host nix run <flakeRef> -- --stdio
  *
- * Nix handles arch resolution, closure transfer, content-addressed
- * dedup, and verification. Replaces Zed's three-strategy
- * `ensure_server_binary` dance with one nix call.
+ * Nix on the remote handles arch resolution, closure realisation,
+ * substitution, content-addressed dedup, and verification. The remote
+ * builds (or substitutes) the right derivation for its own system —
+ * no local cross-build, no nix copy of cross-arch closures (which
+ * fail with `Exec format error` when the local builder can't run the
+ * remote's binaries).
  *
- * **Pre-implementation review finding G**: `nix copy` of the local-arch
- * store path to a different-arch remote SILENTLY FAILS (substitution
- * misses). We detect the remote system first and either build for that
- * system locally (`nix build --system <remote-system>`) or fail with an
- * explicit error if cross-compilation isn't available. The prototype
- * implements the detection + explicit error path; cross-system build is
- * a TODO for R-3.
+ * **Configuration**: `KOLU_AGENT_FLAKE_REF` env var (default
+ * `github:juspay/kolu/remote-terminals-plan-b-r2`). For dev: set it to
+ * a local-pushed branch. For prod: pin to a tag.
+ *
+ * **Why not `nix copy` from local?** The earlier draft built kolu for
+ * the remote system locally (`nix build --system <remoteSystem>`) and
+ * `nix copy`'d the result. Cross-arch builds fail without a remote
+ * builder set up exactly right (the linux box has to either own the
+ * darwin binaries via substituter or offload to a remote darwin
+ * builder; the latter requires `max-jobs 0` plus `system-features
+ * matching plus trusted-user permission). Side-stepping all of that
+ * by having the remote do `nix run` natively is the simpler shape.
  */
 
 import { execFile } from "node:child_process";
@@ -27,146 +34,63 @@ import { log } from "./log.ts";
 
 const execFileP = promisify(execFile);
 
-/** Run `ssh $host nix eval --raw --impure --expr 'builtins.currentSystem'`
- *  to learn the remote's nix system tuple. */
-async function probeRemoteSystem(host: string): Promise<string> {
-  const { stdout } = await execFileP("ssh", [
-    host,
-    "nix",
-    "eval",
-    "--raw",
-    "--impure",
-    "--expr",
-    "builtins.currentSystem",
-  ]);
-  return stdout.trim();
-}
-
-/** Local nix system (e.g. `x86_64-linux`, `aarch64-darwin`). */
-async function localSystem(): Promise<string> {
-  const { stdout } = await execFileP("nix", [
-    "eval",
-    "--raw",
-    "--impure",
-    "--expr",
-    "builtins.currentSystem",
-  ]);
-  return stdout.trim();
-}
-
-/** Probe whether `storePath` is already realised on the remote — skip
- *  the copy if so. A non-zero exit from `nix-store --query` means the
- *  path is absent; any other error (SSH unreachable, auth failure) is
- *  logged and treated as "not realised" so the caller proceeds to
- *  `nix copy`, which will surface the real error. */
-async function isPathRealisedOnRemote(
-  host: string,
-  storePath: string,
-): Promise<boolean> {
-  try {
-    await execFileP("ssh", [
-      host,
-      "nix-store",
-      "--query",
-      "--requisites",
-      storePath,
-    ]);
-    return true;
-  } catch (err) {
-    log.warn(
-      { host, storePath, err },
-      "isPathRealisedOnRemote: probe failed, treating as not realised",
-    );
-    return false;
-  }
-}
-
-/** Resolve the running kolu binary's store path. The wrapper sets
- *  `KOLU_STORE_PATH` at install time, or we fall back to `nix eval`
- *  on the flake's `.#kolu` attribute. */
-async function getKoluStorePath(): Promise<string> {
-  const envHint = process.env.KOLU_STORE_PATH;
-  if (envHint) return envHint;
-  // Fallback: build the flake and read the store path.
-  const { stdout } = await execFileP("nix", ["eval", "--raw", ".#kolu"]);
-  return stdout.trim();
-}
-
-/** Build the kolu derivation for a specific Nix system tuple — used
- *  when the remote's `currentSystem` differs from ours. Returns the
- *  resulting store path. Falls back to "binary cache miss" error if
- *  the local builder can't cross-compile and no substituter has the
- *  artifact. */
-async function buildKoluForSystem(system: string): Promise<string> {
-  const { stdout } = await execFileP("nix", [
-    "build",
-    "--print-out-paths",
-    "--no-link",
-    "--system",
-    system,
-    `.#kolu`,
-  ]);
-  return stdout.trim();
+/** Flake ref that exposes the kolu `default` package. Settable via
+ *  `KOLU_AGENT_FLAKE_REF` env var; defaults to the remote-terminals
+ *  branch on juspay/kolu (the only branch with `kolu --stdio` until
+ *  R-2 lands on master). */
+function getAgentFlakeRef(): string {
+  return (
+    process.env.KOLU_AGENT_FLAKE_REF ??
+    "github:juspay/kolu/remote-terminals-plan-b-r2"
+  );
 }
 
 /**
- * Install the kolu agent on `host`. Idempotent — if the store path is
- * already realised on the remote, returns early.
+ * "Install" the kolu agent on `host` — for the `nix run` strategy this
+ * is a no-op probe: we ssh once to verify the host responds and nix is
+ * available. The first `nix run` invocation on the remote does the
+ * real "install" (substitute or build the closure).
  *
- * For cross-arch (local x86_64-linux ↔ remote aarch64-darwin), the
- * caller's local `.#kolu` derivation isn't valid on the remote's
- * system. The prototype detects this and throws `CrossArchUnsupported`
- * with a clear message; R-3 will add `nix build .#packages.<remoteSystem>.kolu`
- * before copying.
+ * Future enhancement: pre-warm the closure with a one-off
+ * `ssh $host nix build --no-link <flakeRef>` so the first real
+ * terminal-spawn isn't waiting on the cold build.
  */
 export async function installAgent(host: string): Promise<void> {
-  const [remoteSystem, lSystem] = await Promise.all([
-    probeRemoteSystem(host).catch(() => {
-      throw new Error(
-        `installAgent(${host}): could not probe remote nix system. ` +
-          `Is Nix installed on the remote? Plan B assumes Nix-on-remote.`,
-      );
-    }),
-    localSystem(),
-  ]);
-
-  let storePath: string;
-  if (remoteSystem !== lSystem) {
-    // Cross-arch: build kolu for the remote's system tuple locally
-    // before copying. Requires either a remote builder, a binary
-    // cache that has the derivation, or a local builder that can
-    // cross-compile. The `nix build --system` invocation surfaces
-    // the failure clearly if none of those are available.
-    log.info(
-      { host, localSystem: lSystem, remoteSystem },
-      "installAgent: cross-system build",
+  const flakeRef = getAgentFlakeRef();
+  log.info({ host, flakeRef }, "installAgent: probing remote nix");
+  try {
+    const { stdout } = await execFileP("ssh", [host, "nix", "--version"]);
+    log.info({ host, nixVersion: stdout.trim() }, "installAgent: nix probe ok");
+  } catch (err) {
+    log.error({ host, err }, "installAgent: nix probe failed");
+    throw new Error(
+      `installAgent(${host}): nix not available on remote. Plan B assumes Nix-on-remote. ` +
+        `Underlying: ${err instanceof Error ? err.message : String(err)}`,
     );
-    storePath = await buildKoluForSystem(remoteSystem);
-  } else {
-    storePath = await getKoluStorePath();
   }
-
   log.info(
-    { host, storePath, system: remoteSystem },
-    "installAgent: probing remote",
+    { host, flakeRef },
+    "installAgent: ok (the closure realises lazily on first agent spawn)",
   );
-
-  if (await isPathRealisedOnRemote(host, storePath)) {
-    log.info({ host, storePath }, "installAgent: already realised, skipping");
-    return;
-  }
-
-  log.info({ host, storePath }, "installAgent: nix copy");
-  await execFileP("nix", ["copy", "--to", `ssh://${host}`, storePath]);
-  log.info({ host, storePath }, "installAgent: done");
 }
 
 /** Build the remote command that runs `kolu --stdio` from the
- *  copied store path. Used by `HostSession` when spawning the ssh
- *  subprocess. The kolu CLI dispatches on the `--stdio` flag (see
- *  `index.ts`) — no positional subcommand is parsed by cleye in
- *  `strictFlags: true` mode. */
-export async function remoteAgentCommand(host: string): Promise<string[]> {
-  const storePath = await getKoluStorePath();
-  return ["ssh", host, `${storePath}/bin/kolu`, "--stdio"];
+ *  configured flake ref via `nix run`. Used by `HostSession` when
+ *  spawning the ssh subprocess.
+ *
+ *  The chain is: `ssh $host -- nix run <flakeRef> -- --stdio`. The
+ *  remote nix realises the closure (substituter cache hit, or local
+ *  build) and executes `<storePath>/bin/kolu --stdio`. */
+export function remoteAgentCommand(host: string): string[] {
+  const flakeRef = getAgentFlakeRef();
+  return [
+    "ssh",
+    host,
+    "nix",
+    "run",
+    "--accept-flake-config",
+    flakeRef,
+    "--",
+    "--stdio",
+  ];
 }

--- a/packages/server/src/install.ts
+++ b/packages/server/src/install.ts
@@ -89,6 +89,14 @@ export function remoteAgentCommand(host: string): string[] {
     "nix",
     "run",
     "--accept-flake-config",
+    // `--refresh` so nix re-resolves the flake ref on every connect.
+    // Without it, the remote caches the resolved store path and keeps
+    // running an older build of the agent — which silently breaks
+    // contract changes (e.g. terminal.spawn input added an `id` field
+    // and old agents ignore it, so their generated id mismatches the
+    // kolu server's pre-generated id and every later terminal.write /
+    // resize fails with "terminal not found on agent").
+    "--refresh",
     flakeRef,
     "--",
     "--stdio",

--- a/packages/server/src/install.ts
+++ b/packages/server/src/install.ts
@@ -55,7 +55,10 @@ async function localSystem(): Promise<string> {
 }
 
 /** Probe whether `storePath` is already realised on the remote — skip
- *  the copy if so. */
+ *  the copy if so. A non-zero exit from `nix-store --query` means the
+ *  path is absent; any other error (SSH unreachable, auth failure) is
+ *  logged and treated as "not realised" so the caller proceeds to
+ *  `nix copy`, which will surface the real error. */
 async function isPathRealisedOnRemote(
   host: string,
   storePath: string,
@@ -69,7 +72,11 @@ async function isPathRealisedOnRemote(
       storePath,
     ]);
     return true;
-  } catch {
+  } catch (err) {
+    log.warn(
+      { host, storePath, err },
+      "isPathRealisedOnRemote: probe failed, treating as not realised",
+    );
     return false;
   }
 }

--- a/packages/server/src/install.ts
+++ b/packages/server/src/install.ts
@@ -92,6 +92,23 @@ async function getKoluStorePath(): Promise<string> {
   return stdout.trim();
 }
 
+/** Build the kolu derivation for a specific Nix system tuple — used
+ *  when the remote's `currentSystem` differs from ours. Returns the
+ *  resulting store path. Falls back to "binary cache miss" error if
+ *  the local builder can't cross-compile and no substituter has the
+ *  artifact. */
+async function buildKoluForSystem(system: string): Promise<string> {
+  const { stdout } = await execFileP("nix", [
+    "build",
+    "--print-out-paths",
+    "--no-link",
+    "--system",
+    system,
+    `.#kolu`,
+  ]);
+  return stdout.trim();
+}
+
 /**
  * Install the kolu agent on `host`. Idempotent — if the store path is
  * already realised on the remote, returns early.
@@ -113,17 +130,24 @@ export async function installAgent(host: string): Promise<void> {
     localSystem(),
   ]);
 
+  let storePath: string;
   if (remoteSystem !== lSystem) {
-    throw new Error(
-      `installAgent(${host}): cross-system not yet implemented (R-3). ` +
-        `Local: ${lSystem}, remote: ${remoteSystem}. Build the remote-system ` +
-        `derivation locally first: nix build .#packages.${remoteSystem}.kolu`,
+    // Cross-arch: build kolu for the remote's system tuple locally
+    // before copying. Requires either a remote builder, a binary
+    // cache that has the derivation, or a local builder that can
+    // cross-compile. The `nix build --system` invocation surfaces
+    // the failure clearly if none of those are available.
+    log.info(
+      { host, localSystem: lSystem, remoteSystem },
+      "installAgent: cross-system build",
     );
+    storePath = await buildKoluForSystem(remoteSystem);
+  } else {
+    storePath = await getKoluStorePath();
   }
 
-  const storePath = await getKoluStorePath();
   log.info(
-    { host, storePath, system: lSystem },
+    { host, storePath, system: remoteSystem },
     "installAgent: probing remote",
   );
 

--- a/packages/server/src/install.ts
+++ b/packages/server/src/install.ts
@@ -137,10 +137,12 @@ export async function installAgent(host: string): Promise<void> {
   log.info({ host, storePath }, "installAgent: done");
 }
 
-/** Build the remote command that runs `kolu agent --stdio` from the
+/** Build the remote command that runs `kolu --stdio` from the
  *  copied store path. Used by `HostSession` when spawning the ssh
- *  subprocess. */
+ *  subprocess. The kolu CLI dispatches on the `--stdio` flag (see
+ *  `index.ts`) — no positional subcommand is parsed by cleye in
+ *  `strictFlags: true` mode. */
 export async function remoteAgentCommand(host: string): Promise<string[]> {
   const storePath = await getKoluStorePath();
-  return ["ssh", host, `${storePath}/bin/kolu`, "agent", "--stdio"];
+  return ["ssh", host, `${storePath}/bin/kolu`, "--stdio"];
 }

--- a/packages/server/src/install.ts
+++ b/packages/server/src/install.ts
@@ -23,7 +23,7 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { log } from "../log.ts";
+import { log } from "./log.ts";
 
 const execFileP = promisify(execFile);
 

--- a/packages/server/src/log.ts
+++ b/packages/server/src/log.ts
@@ -18,6 +18,13 @@ const base = {
   serverId: serverProcessId,
 };
 
+// In `kolu --stdio` (agent) mode, stdout is the oRPC channel — any
+// non-protocol bytes there corrupt the framing and the client peer
+// barfs `Unexpected token '«'` on the next message. Force ALL
+// log output to stderr in that mode. Check process.argv directly so
+// the redirect kicks in before any import-time log call fires.
+const isAgentMode = process.argv.includes("--stdio");
+
 export const log = pino(
   process.env.NODE_ENV === "production"
     ? { level, base }
@@ -26,9 +33,20 @@ export const log = pino(
         base,
         transport: {
           target: "pino-pretty",
-          options: { colorize: true, singleLine: true },
+          options: {
+            colorize: true,
+            singleLine: true,
+            // pino-pretty supports `destination: <fd>` to redirect.
+            // FD 2 = stderr. In agent mode we MUST use stderr.
+            destination: isAgentMode ? 2 : 1,
+          },
         },
       },
+  // For production mode, also pipe to stderr in agent mode — pino
+  // defaults to stdout, which would clobber the protocol channel.
+  isAgentMode && process.env.NODE_ENV === "production"
+    ? pino.destination(2)
+    : undefined,
 );
 
 export type { Logger };

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -23,7 +23,7 @@ import type {
 } from "kolu-common/surface";
 import { prUnavailableReason, prValue } from "kolu-github/schemas";
 import { log } from "../log.ts";
-import { terminalsDirtyChannel } from "../publisher.ts";
+import { terminalChannels, terminalsDirtyChannel } from "../publisher.ts";
 import { surfaceCtx } from "../surface.ts";
 import type { TerminalProcess } from "../terminal-registry.ts";
 
@@ -85,6 +85,17 @@ function publishSnapshot(entry: TerminalProcess, terminalId: string): void {
     "metadata publish",
   );
   surfaceCtx.collections.terminalMetadata.upsert(terminalId, { ...m });
+  // R-2: publish per-channel snapshots so `Backend.terminalChannel`
+  // consumers (notably `RemoteBackend` proxying via oRPC) see the same
+  // data the in-process providers produce. For local-only deployments
+  // there are no subscribers to these channels, so the cost is the
+  // publisher's empty-subscriber-list branch. Required for the
+  // agent-side `LocalBackend` (the binary running on the SSH host) to
+  // surface rich metadata back to the kolu server.
+  terminalChannels.agent(terminalId).publish(m.agent);
+  terminalChannels.pr(terminalId).publish(m.pr);
+  terminalChannels.foreground(terminalId).publish(m.foreground);
+  terminalChannels.connectionState(terminalId).publish(m.connectionState);
 }
 
 /** `publishSnapshot` + fire `terminals:dirty`. Use this from any path

--- a/packages/server/src/meta/state.ts
+++ b/packages/server/src/meta/state.ts
@@ -89,13 +89,17 @@ function publishSnapshot(entry: TerminalProcess, terminalId: string): void {
   // consumers (notably `RemoteBackend` proxying via oRPC) see the same
   // data the in-process providers produce. For local-only deployments
   // there are no subscribers to these channels, so the cost is the
-  // publisher's empty-subscriber-list branch. Required for the
-  // agent-side `LocalBackend` (the binary running on the SSH host) to
-  // surface rich metadata back to the kolu server.
+  // publisher's empty-subscriber-list branch.
+  //
+  // `connectionState` is NOT republished here (Lowy post-impl F3) —
+  // its drivers are `LocalBackend.spawnPty` (one-time "live" at spawn)
+  // and `HostSession.onStateChange` (remote state machine).
+  // Republishing in publishSnapshot would create a third write site
+  // that disagrees with neither driver but maintains stale state
+  // independently.
   terminalChannels.agent(terminalId).publish(m.agent);
   terminalChannels.pr(terminalId).publish(m.pr);
   terminalChannels.foreground(terminalId).publish(m.foreground);
-  terminalChannels.connectionState(terminalId).publish(m.connectionState);
 }
 
 /** `publishSnapshot` + fire `terminals:dirty`. Use this from any path

--- a/packages/server/src/publisher.ts
+++ b/packages/server/src/publisher.ts
@@ -25,6 +25,12 @@
 import { publisherChannel } from "@kolu/surface/server";
 import { MemoryPublisher } from "@orpc/experimental-publisher/memory";
 import type { GitInfo } from "kolu-git/schemas";
+import type { PrResult } from "kolu-github/schemas";
+import type {
+  AgentInfo,
+  ConnectionState,
+  Foreground,
+} from "kolu-common/surface";
 
 // `MemoryPublisher` constrains its generic to `Record<string, object>`,
 // which excludes the primitive payloads we publish (data strings, exit
@@ -59,6 +65,25 @@ export const terminalChannels = {
    *  each event is an isolated "the user just typed this" notice. */
   commandRun: (id: string) =>
     publisherChannel<string>(publisher, `commandRun:${id}`),
+  // ── R-2 channels: rich-surface metadata that previously was written
+  // by in-process providers via direct entry.meta mutation. Made wire-
+  // visible so RemoteBackend can subscribe to the agent's providers
+  // (the agent runs the provider DAG locally; the kolu server consumes
+  // the resulting streams). LocalBackend publishes these alongside its
+  // in-process mutations so the channels carry the same data either way.
+  /** AI coding agent state. Null between sessions. */
+  agent: (id: string) =>
+    publisherChannel<AgentInfo | null>(publisher, `agent:${id}`),
+  /** GitHub PR resolution for the terminal's current branch. */
+  pr: (id: string) => publisherChannel<PrResult>(publisher, `pr:${id}`),
+  /** Foreground process name + title (OSC 2 / proc-fs). */
+  foreground: (id: string) =>
+    publisherChannel<Foreground | null>(publisher, `foreground:${id}`),
+  /** Backend connection state — always `"live"` for local; transitions
+   *  through `"connecting"` / `"disconnected"` for remote via
+   *  HostSession's state machine. */
+  connectionState: (id: string) =>
+    publisherChannel<ConnectionState>(publisher, `connectionState:${id}`),
 } as const;
 
 /** Singleton broadcast: terminal state mutated. Drives session

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -21,7 +21,6 @@ import { loadOpenCodeTranscript } from "kolu-opencode";
 import { transcriptToHtml } from "kolu-transcript-html";
 import { match } from "ts-pattern";
 import { getBackendFor } from "./backend/index.ts";
-import { saveTerminalFile } from "./terminalScratch.ts";
 import { serverHostname, serverProcessId } from "./hostname.ts";
 import { log } from "./log.ts";
 import { pwaIdentityForHostname } from "./pwaIdentity.ts";
@@ -68,6 +67,22 @@ export const appRouter = t.router({
       identity: pwaIdentityForHostname(serverHostname),
       processId: serverProcessId,
     })),
+    listSshHosts: t.server.listSshHosts.handler(async () => {
+      const { parseSshConfig } = await import("./sshHosts.ts");
+      return { hosts: parseSshConfig() };
+    }),
+    installSshAgent: t.server.installSshAgent.handler(async ({ input }) => {
+      try {
+        const { installAgent } = await import("./backend/install.ts");
+        await installAgent(input.host);
+        return { ok: true };
+      } catch (e) {
+        return {
+          ok: false,
+          message: e instanceof Error ? e.message : String(e),
+        };
+      }
+    }),
   },
   terminal: {
     create: t.terminal.create.handler(async ({ input }) =>
@@ -168,7 +183,14 @@ export const appRouter = t.router({
       if (reason !== null) {
         throw new ORPCError("BAD_REQUEST", { message: reason });
       }
-      const path = saveTerminalFile(input.id, "image.png", input.data);
+      // R-2 finding I: route through Backend.uploadFile so remote
+      // tiles land bytes on the agent's filesystem, not the kolu
+      // server's. The path returned is what the agent's PTY sees.
+      const path = await getBackendFor(entry.meta.location).uploadFile(
+        input.id,
+        "image.png",
+        input.data,
+      );
       bracketedPastePath(entry, path);
       log.info({ terminal: input.id, bytes, path }, "paste image");
     }),
@@ -180,7 +202,11 @@ export const appRouter = t.router({
       if (reason !== null) {
         throw new ORPCError("BAD_REQUEST", { message: reason });
       }
-      const path = saveTerminalFile(input.id, input.name, input.data);
+      const path = await getBackendFor(entry.meta.location).uploadFile(
+        input.id,
+        input.name,
+        input.data,
+      );
       bracketedPastePath(entry, path);
       log.info(
         { terminal: input.id, name: input.name, bytes, path },
@@ -210,6 +236,17 @@ export const appRouter = t.router({
     exportTranscriptHtml: t.terminal.exportTranscriptHtml.handler(
       async ({ input }) => {
         const term = requireTerminal(input.id);
+        // R-2 finding L: explicitly guard remote terminals until the
+        // agent-side provider relocation lands (the transcript loaders
+        // read on-disk session files that only exist on the agent
+        // host). Without this guard the loader silently fails with
+        // "transcript not found" — misleading.
+        if (term.meta.location.kind === "ssh") {
+          throw new ORPCError("NOT_IMPLEMENTED", {
+            message:
+              "Transcript export for remote terminals lands in R-3 — the transcript files live on the agent host, not the kolu server. Today's loader reads server-local paths only.",
+          });
+        }
         const agent = term.meta.agent;
         if (!agent) {
           throw new ORPCError("PRECONDITION_FAILED", {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -73,7 +73,7 @@ export const appRouter = t.router({
     }),
     installSshAgent: t.server.installSshAgent.handler(async ({ input }) => {
       try {
-        const { installAgent } = await import("./backend/install.ts");
+        const { installAgent } = await import("./install.ts");
         await installAgent(input.host);
         return { ok: true };
       } catch (e) {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -86,14 +86,19 @@ export const appRouter = t.router({
   },
   terminal: {
     create: t.terminal.create.handler(async ({ input }) =>
-      createTerminal(input.cwd, input.parentId, {
-        themeName: input.themeName,
-        canvasLayout: input.canvasLayout,
-        subPanel: input.subPanel,
-        rightPanel: input.rightPanel,
-        lastActivityAt: input.lastActivityAt,
-        intent: input.intent,
-      }),
+      createTerminal(
+        input.cwd,
+        input.parentId,
+        {
+          themeName: input.themeName,
+          canvasLayout: input.canvasLayout,
+          subPanel: input.subPanel,
+          rightPanel: input.rightPanel,
+          lastActivityAt: input.lastActivityAt,
+          intent: input.intent,
+        },
+        input.location,
+      ),
     ),
 
     resize: t.terminal.resize.handler(async ({ input }) => {

--- a/packages/server/src/sshHosts.ts
+++ b/packages/server/src/sshHosts.ts
@@ -16,7 +16,7 @@
  * `server.listSshHosts` oRPC procedure.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -29,9 +29,13 @@ export interface SshHost {
 function aliasesFromHostLine(value: string): string[] {
   return value
     .split(/\s+/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .filter((s) => !s.startsWith("!") && !s.includes("*") && !s.includes("?"));
+    .filter(
+      (s) =>
+        s.length > 0 &&
+        !s.startsWith("!") &&
+        !s.includes("*") &&
+        !s.includes("?"),
+    );
 }
 
 /**
@@ -44,8 +48,14 @@ function aliasesFromHostLine(value: string): string[] {
  */
 export function parseSshConfig(): SshHost[] {
   const path = join(homedir(), ".ssh", "config");
-  if (!existsSync(path)) return [];
-  const raw = readFileSync(path, "utf8");
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (e: unknown) {
+    // File absent is expected; any other error is a real problem.
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw e;
+  }
   const out: SshHost[] = [];
   const seen = new Set<string>();
   for (const line of raw.split("\n")) {

--- a/packages/server/src/sshHosts.ts
+++ b/packages/server/src/sshHosts.ts
@@ -1,0 +1,67 @@
+/**
+ * SSH host discovery — list aliases from `~/.ssh/config` so the kolu
+ * command palette can offer "New terminal on `$host`".
+ *
+ * Implementation: parse `~/.ssh/config` directly (cheap, no fork) for
+ * the `Host` directive entries, filtering wildcards like `Host *` and
+ * negations (`!foo`). For each candidate, `ssh -G $host` could
+ * resolve actual connect params (Hostname / Port / User) — but for
+ * the prototype we just list the literal alias.
+ *
+ * **Why server-side, not client-side**: pre-implementation review
+ * finding K. The client is browser-shaped; reading `~/.ssh/config`
+ * from the browser is impossible. The server already owns "ssh
+ * subprocess spawning" (that's what `HostSession` does), so the host
+ * list belongs on the same axis as that capability. Exposed via the
+ * `server.listSshHosts` oRPC procedure.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface SshHost {
+  alias: string;
+}
+
+/** Strip wildcards/negations from a `Host` line's space-separated
+ *  patterns and return the literal alias candidates. */
+function aliasesFromHostLine(value: string): string[] {
+  return value
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .filter((s) => !s.startsWith("!") && !s.includes("*") && !s.includes("?"));
+}
+
+/**
+ * Parse `~/.ssh/config` and return literal `Host` aliases. Missing
+ * config file → empty list (graceful).
+ *
+ * Limitations (R-3): `Include` directives aren't followed; `Match`
+ * blocks are ignored; per-host wildcards beyond `*` aren't expanded.
+ * The literal-aliases set is sufficient for the command-palette MVP.
+ */
+export function parseSshConfig(): SshHost[] {
+  const path = join(homedir(), ".ssh", "config");
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const out: SshHost[] = [];
+  const seen = new Set<string>();
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || trimmed.length === 0) continue;
+    // Match "Host " (case-insensitive), permitting tabs.
+    const m = /^Host\s+(.+)$/i.exec(trimmed);
+    if (!m) continue;
+    const value = m[1];
+    if (!value) continue;
+    for (const alias of aliasesFromHostLine(value)) {
+      if (!seen.has(alias)) {
+        seen.add(alias);
+        out.push({ alias });
+      }
+    }
+  }
+  return out;
+}

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -113,6 +113,52 @@ export function unwrapGit<T>(result: GitResult<T>): T {
   throw new ORPCError(status, { message });
 }
 
+/** Install a repo-change watcher on the right backend.
+ *
+ *  R-2: routes through `Backend.fs.subscribeRepoChange` so remote tiles'
+ *  Code tab watches the agent's filesystem changes. The terminal-id
+ *  dispatch axis is what tells us which backend owns the repo. When
+ *  absent (legacy non-terminal callers), falls back to localBackend.
+ *  Adapter wraps the AsyncIterable contract back into the install/cb
+ *  shape `@kolu/surface` expects. */
+function repoWatcherInstall(
+  terminalId: string | undefined,
+  repoPath: string,
+  cb: () => void,
+): () => void {
+  let stopped = false;
+  let abortFn: (() => void) | undefined;
+  void (async () => {
+    const { getBackendFor, localBackend } = await import("./backend/index.ts");
+    const { getTerminal } = await import("./terminal-registry.ts");
+    const entry = terminalId ? getTerminal(terminalId) : undefined;
+    const backend = entry ? getBackendFor(entry.meta.location) : localBackend;
+    const ctrl = new AbortController();
+    abortFn = () => ctrl.abort();
+    if (stopped) {
+      ctrl.abort();
+      return;
+    }
+    try {
+      for await (const _ of backend.fs.subscribeRepoChange(
+        repoPath,
+        ctrl.signal,
+      )) {
+        cb();
+      }
+    } catch (err) {
+      log.error(
+        { err, terminalId, repoPath },
+        "repoWatcherInstall: watcher iterator threw",
+      );
+    }
+  })();
+  return () => {
+    stopped = true;
+    abortFn?.();
+  };
+}
+
 const { router: surfaceRouterFragment, ctx: surfaceCtxBuilt } =
   implementSurface(surface, {
     channel: <T>(name: string) => publisherChannel<T>(publisher, name),
@@ -203,30 +249,62 @@ const { router: surfaceRouterFragment, ctx: surfaceCtxBuilt } =
 
     streams: {
       gitStatus: {
-        read: async (input) =>
-          unwrapGit(await getStatus(input.repoPath, input.mode, log)),
-        install: (input, cb) => subscribeRepoChange(input.repoPath, cb, log),
+        read: async (input) => {
+          const { getBackendFor, localBackend } = await import(
+            "./backend/index.ts"
+          );
+          const { getTerminal } = await import("./terminal-registry.ts");
+          const entry = input.terminalId
+            ? getTerminal(input.terminalId)
+            : undefined;
+          const backend = entry
+            ? getBackendFor(entry.meta.location)
+            : localBackend;
+          return backend.git.getStatus(input.repoPath, input.mode);
+        },
+        install: (input, cb) =>
+          repoWatcherInstall(input.terminalId, input.repoPath, cb),
         isEqual: gitStatusOutputEqual,
       },
       gitDiff: {
-        read: async (input) =>
-          unwrapGit(
-            await getDiff(
-              input.repoPath,
-              input.filePath,
-              input.mode,
-              log,
-              input.oldPath,
-            ),
-          ),
-        install: (input, cb) => subscribeRepoChange(input.repoPath, cb, log),
+        read: async (input) => {
+          const { getBackendFor, localBackend } = await import(
+            "./backend/index.ts"
+          );
+          const { getTerminal } = await import("./terminal-registry.ts");
+          const entry = input.terminalId
+            ? getTerminal(input.terminalId)
+            : undefined;
+          const backend = entry
+            ? getBackendFor(entry.meta.location)
+            : localBackend;
+          return backend.git.getDiff(
+            input.repoPath,
+            input.filePath,
+            input.mode,
+            input.oldPath,
+          );
+        },
+        install: (input, cb) =>
+          repoWatcherInstall(input.terminalId, input.repoPath, cb),
         isEqual: gitDiffOutputEqual,
       },
       fsListAll: {
-        read: async (input) => ({
-          paths: unwrapGit(await listAll(input.repoPath, log)),
-        }),
-        install: (input, cb) => subscribeRepoChange(input.repoPath, cb, log),
+        read: async (input) => {
+          const { getBackendFor, localBackend } = await import(
+            "./backend/index.ts"
+          );
+          const { getTerminal } = await import("./terminal-registry.ts");
+          const entry = input.terminalId
+            ? getTerminal(input.terminalId)
+            : undefined;
+          const backend = entry
+            ? getBackendFor(entry.meta.location)
+            : localBackend;
+          return { paths: await backend.fs.listAll(input.repoPath) };
+        },
+        install: (input, cb) =>
+          repoWatcherInstall(input.terminalId, input.repoPath, cb),
         isEqual: fsListAllOutputEqual,
       },
       fsReadFile: {

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -244,13 +244,65 @@ const { router: surfaceRouterFragment, ctx: surfaceCtxBuilt } =
               ),
             };
           }
-          const { content, truncated } = unwrapGit(
-            await readFile(input.repoPath, input.filePath, log),
+          // R-2: route through Backend.fs so remote tiles' Code tab
+          // reads the agent's filesystem, not the kolu server's local
+          // FS. `terminalId` carries the dispatch axis. Falls back to
+          // localBackend if the terminal isn't found (e.g. race with
+          // unregister).
+          const { getBackendFor, localBackend } = await import(
+            "./backend/index.ts"
+          );
+          const { getTerminal } = await import("./terminal-registry.ts");
+          const entry = getTerminal(input.terminalId);
+          const backend = entry
+            ? getBackendFor(entry.meta.location)
+            : localBackend;
+          const { content, truncated } = await backend.fs.readFile(
+            input.repoPath,
+            input.filePath,
           );
           return { kind: "text", content, truncated };
         },
-        install: (input, cb) =>
-          subscribeFileChange(input.repoPath, input.filePath, cb, log),
+        install: (input, cb) => {
+          // Route the file watcher through Backend.fs too — remote
+          // tiles' Code tab watches the agent's filesystem changes.
+          let stopped = false;
+          let stopFn: (() => void) | undefined;
+          void (async () => {
+            const { getBackendFor, localBackend } = await import(
+              "./backend/index.ts"
+            );
+            const { getTerminal } = await import("./terminal-registry.ts");
+            const entry = getTerminal(input.terminalId);
+            const backend = entry
+              ? getBackendFor(entry.meta.location)
+              : localBackend;
+            const ctrl = new AbortController();
+            stopFn = () => ctrl.abort();
+            if (stopped) {
+              ctrl.abort();
+              return;
+            }
+            try {
+              for await (const _ of backend.fs.subscribeFileChange(
+                input.repoPath,
+                input.filePath,
+                ctrl.signal,
+              )) {
+                cb();
+              }
+            } catch (err) {
+              log.error(
+                { err, input },
+                "fsReadFile.install: watcher iterator threw",
+              );
+            }
+          })();
+          return () => {
+            stopped = true;
+            stopFn?.();
+          };
+        },
         isEqual: fsReadFileOutputEqual,
       },
     },

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -31,7 +31,7 @@ import type {
   TerminalId,
   TerminalInfo,
 } from "kolu-common/surface";
-import { getBackendFor, localBackend } from "./backend/index.ts";
+import { getBackendFor, getBackendForCreate } from "./backend/index.ts";
 import { log } from "./log.ts";
 import { updateClientMetadata } from "./meta/index.ts";
 import { terminalsDirtyChannel } from "./publisher.ts";
@@ -108,7 +108,12 @@ export async function createTerminal(
   parentId?: string,
   initial?: InitialTerminalMetadata,
 ): Promise<TerminalInfo> {
-  const handle = await localBackend.spawnPty({
+  // R-2 finding (Hickey post-impl): route through the resolver so
+  // sub-terminals inherit the parent's location and (in R-3) remote
+  // requests land on the right backend. R-1's `localBackend` direct
+  // call left `getBackendForCreate` as dead code.
+  const backend = getBackendForCreate({ parentId });
+  const handle = await backend.spawnPty({
     cwd,
     initialMetadata: {
       ...initial,

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -107,12 +107,11 @@ export async function createTerminal(
   cwd?: string,
   parentId?: string,
   initial?: InitialTerminalMetadata,
+  location?: import("kolu-common/surface").TerminalLocation,
 ): Promise<TerminalInfo> {
-  // R-2 finding (Hickey post-impl): route through the resolver so
-  // sub-terminals inherit the parent's location and (in R-3) remote
-  // requests land on the right backend. R-1's `localBackend` direct
-  // call left `getBackendForCreate` as dead code.
-  const backend = getBackendForCreate({ parentId });
+  // Route through the resolver so sub-terminals inherit the parent's
+  // location and explicit-location requests land on the right backend.
+  const backend = getBackendForCreate({ parentId, location });
   const handle = await backend.spawnPty({
     cwd,
     initialMetadata: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,12 @@ importers:
       '@orpc/server':
         specifier: ^1.13.13
         version: 1.13.13(ws@8.20.1)
+      '@orpc/standard-server':
+        specifier: ^1.13.13
+        version: 1.13.13
+      '@orpc/standard-server-peer':
+        specifier: ^1.13.13
+        version: 1.13.13
       anyagent:
         specifier: workspace:*
         version: link:../integrations/anyagent


### PR DESCRIPTION
**Stacks on [#973](https://github.com/juspay/kolu/pull/973)** (Plan B R-1). Adds the architectural pieces R-2 needs for remote terminals over SSH — without yet plumbing the runtime ssh-stdio transport (R-3 follow-up). The PR demonstrates the full Plan B shape so the user can evaluate it concretely against Plan A's stacked prototypes ([#969](https://github.com/juspay/kolu/pull/969) + [#972](https://github.com/juspay/kolu/pull/972)).

> _Prototype PR — will be discarded after the user evaluates Plan B vs Plan A._

### What R-2 ships

| Layer | New | Updated |
|---|---|---|
| **`kolu-common`** | `agentContract.ts` (narrow oRPC subset the agent serves) | `backend.ts` (4 new channels: agent/pr/foreground/connectionState; `BackendFs.subscribeRepoChange`/`subscribeFileChange`; `Backend.uploadFile`; removed `TerminalHandle.dispose()`) |
| **kolu binary** | `agent.ts` (\`kolu agent --stdio\` main, narrow-contract router) | `index.ts` (CLI dispatch on `--stdio` flag) |
| **Backend impl** | `backend/remote.ts` (RemoteBackend skeleton), `backend/host-session.ts` (state machine + heartbeat, Zed constants), `install.ts` (\`nix copy\` installer with cross-arch detection) | `backend/local.ts` (channel publishes, subscribe methods, uploadFile), `backend/index.ts` (RemoteBackend cache, `getBackendForCreate` resolver with sub-terminal inheritance) |
| **Server glue** | `sshHosts.ts` (`~/.ssh/config` parser → server-side RPC) | `router.ts` (3 new RPCs: `listSshHosts`, `installSshAgent`; paste/upload routed via `Backend.uploadFile`; `exportTranscriptHtml` guards remote with `NOT_IMPLEMENTED`), `publisher.ts` (4 new channels), `meta/state.ts` (publish 3 of the 4 new channels alongside metadata mutation) |
| **UI** | `terminal/HostChip.tsx` (badge for remote tiles), `terminal/DisconnectedOverlay.tsx` (overlay when connectionState === \"disconnected\") | — |

### The pivot, end-to-end

```
                 kolu serve (local server)
                          │
                          │  getBackendFor(location)
                          ▼
                 ┌────────┴───────┐
            local│                │ssh
                 ▼                ▼
         LocalBackend       RemoteBackend(HostSession)
         (in-process)              │
                                   │ oRPC over ssh stdio
                                   │ (agentContract subset)
                                   ▼
                              ssh -tt $host kolu agent --stdio
                                   │
                                   ▼
                            LocalBackend (in the agent process)
```

The agent IS just kolu running with a different transport. Zero remote-specific business logic on the agent side. The kolu server's \`RemoteBackend\` is a thin shim — each method is one \`session.client.X.Y(...)\` call against the same shape \`LocalBackend\` would have called locally.

### Auto-install via \`nix copy\`

The remote already has Nix (kolu's whole user base does — that's how they got kolu), so shipping the agent reduces to one call:

```sh
nix copy --to ssh://\$host \$KOLU_STORE_PATH
```

Replaces Zed's three-strategy [\`ensure_server_binary\`](/tmp/zed/crates/remote/src/transport/ssh.rs:785-916) dance with one nix call. Cross-arch is explicitly detected and refused with a clear message (R-3 will add \`nix build .#packages.\$remoteSystem.kolu\` before copying).

### Connection state machine

State enum + heartbeat constants ported verbatim from Zed:

```
HEARTBEAT_INTERVAL  = 5s   (/tmp/zed/crates/remote/src/remote_client.rs:149-155)
HEARTBEAT_TIMEOUT   = 5s
MAX_MISSED          = 5
MAX_RECONNECT_ATTEMPTS = 3
```

Internal state machine is a 5-variant tagged union; the wire-visible \`ConnectionState\` enum (\`\"live\" | \"connecting\" | \"disconnected\"\`) is a projection.

### Structural review trail

**Pre-implementation review** caught 14 structural findings on the R-2 design — most consequential: R-1's \`Backend\` interface was *incomplete*. agent/pr/foreground metadata weren't in \`TerminalChannelMap\` (silent regression for remote tiles), kill-convergence was enforced by convention (not interface shape), \`Backend.uploadFile\` was missing (paste/upload would have landed bytes on the kolu-server's local FS for remote terminals). All 14 applied as the R-2 design before writing code.

**Post-implementation review** caught 6 drift items on the rebased diff:

| # | Lens | Finding | Disposition |
|---|---|---|---|
| 1 | Hickey | 9 channel handlers in `agent.ts` were repetitive — typo at binding site (e.g. \`channelTitle(kind:\"cwd\")\`) compiled silently | Fixed: \`relayChannel<K>\` helper makes kind literal type-checked |
| 2 | Hickey | \`getBackendForCreate\` was dead code — \`terminals.ts:createTerminal\` bypassed it | Fixed: routed through resolver |
| 3 | Lowy F1 | \`BackendGit.subscribeRepoChange\` and \`BackendFs.subscribeRepoChange\` were same parcel-watcher subscription with two names | Fixed: collapsed to \`fs\` only |
| 4 | Lowy F2 | \`install.ts\` lived in \`backend/\` but had zero Backend coupling | Fixed: moved to \`packages/server/src/install.ts\` |
| 5 | Lowy F3 | \`connectionState\` had three write sites; \`publishSnapshot\` republish was redundant | Fixed: single-sourced to LocalBackend.spawnPty + HostSession.onStateChange |
| 6 | Lowy F4 | \`agent.ts\` \`write\`/\`resize\` handlers were silent no-ops — contract promised what it couldn't deliver | Fixed: throw \`NOT_IMPLEMENTED\` with R-3 scope note |

**`/code-police` elegance pass** applied 5 more refinements (bounded-queue replacement, listener-loop try/catch, ENOENT vs other-error discrimination, TOCTOU elimination, log-on-error in install probe).

### What R-3 still needs

Documented in module comments where the next implementer will look:

- \`@orpc/server/standard-peer\` ServerPeer wiring on both sides (transport)
- \`HostSession.connect/reconnect\` cycle full implementation (spawn ssh subprocess, bridge stdio to client)
- Provider relocation: agent-detection code currently runs on the kolu server reading local PIDs; for remote it must run on the agent
- \`surface.ts\` stream routing through \`Backend.fs/git\` (requires adding \`terminalId\` to three input schemas in \`kolu-git/schemas\`)
- Cross-arch \`nix build --system \$remoteSystem\` strategy

### Trying it locally

```sh
nix run github:juspay/kolu/remote-terminals-plan-b-r2 -- --help
```

The \`--stdio\` flag now appears in the help output. Running with \`--stdio\` builds the agent router and exits (transport wiring is R-3). Running without flags continues to start the HTTP server unchanged — no behavior regression for the common case.

_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._