### PR TITLE
Drop juspay/xterm.js fork — both fixes are upstream

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-qwfcEvHlx0AMwl8OJP1zecPDP+n2C0+r1t4zjZpiH1U=";
+    hash = "sha256-3PHwtkW+K7ciV5GY++U/o0aAnPkTH07jff4XiaznzhY=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
       "fast-uri": "3.1.2",
       "ip-address": "10.1.1",
       "@anthropic-ai/sdk": "^0.91.1",
-      "@xterm/xterm": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built",
-      "@xterm/addon-webgl": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl"
+      "@xterm/xterm": "6.1.0-beta.225",
+      "@xterm/addon-webgl": "0.20.0-beta.224"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ overrides:
   fast-uri: 3.1.2
   ip-address: 10.1.1
   '@anthropic-ai/sdk': ^0.91.1
-  '@xterm/xterm': github:juspay/xterm.js#fix/kolu-xterm-fixes-built
-  '@xterm/addon-webgl': github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
+  '@xterm/xterm': 6.1.0-beta.225
+  '@xterm/addon-webgl': 0.20.0-beta.224
 
 packageExtensionsChecksum: sha256-GuGZA8jCJUaUE/saX+uezWes2nMASx9CFDTN3Aun/K8=
 
@@ -119,11 +119,11 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       '@xterm/addon-webgl':
-        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl
+        specifier: 0.20.0-beta.224
+        version: 0.20.0-beta.224(@xterm/xterm@6.1.0-beta.225)
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
+        specifier: 6.1.0-beta.225
+        version: 6.1.0-beta.225
       fix-webm-duration:
         specifier: ^1.0.6
         version: 1.0.6
@@ -688,8 +688,8 @@ importers:
   packages/terminal-themes:
     dependencies:
       '@xterm/xterm':
-        specifier: github:juspay/xterm.js#fix/kolu-xterm-fixes-built
-        version: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c
+        specifier: 6.1.0-beta.225
+        version: 6.1.0-beta.225
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
@@ -2756,16 +2756,16 @@ packages:
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl':
-    resolution: {path: /addons/addon-webgl, tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c}
-    version: 0.19.0
+  '@xterm/addon-webgl@0.20.0-beta.224':
+    resolution: {integrity: sha512-7d30YLvlLiEomUhGNbtsi61twsT29K6eo1IsX33Oh1bg8ty6eCDzrHrdLb46UEBwAPYQuHmKnvYjW8oGg95Z9A==}
+    peerDependencies:
+      '@xterm/xterm': 6.1.0-beta.225
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c':
-    resolution: {tarball: https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c}
-    version: 6.0.0
+  '@xterm/xterm@6.1.0-beta.225':
+    resolution: {integrity: sha512-IGFDoLj7Lx666ciMFXc5ov7sxJMX1QFAUr4zeEwzSmRTllyzgK5u2Z5uy00QjB4l0YDaN+i6duU6r4Ileqxpww==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -7058,11 +7058,13 @@ snapshots:
 
   '@xterm/addon-web-links@0.12.0': {}
 
-  '@xterm/addon-webgl@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c#path:/addons/addon-webgl': {}
+  '@xterm/addon-webgl@0.20.0-beta.224(@xterm/xterm@6.1.0-beta.225)':
+    dependencies:
+      '@xterm/xterm': 6.1.0-beta.225
 
   '@xterm/headless@6.0.0': {}
 
-  '@xterm/xterm@https://codeload.github.com/juspay/xterm.js/tar.gz/0adc8d2bfe99192df74ff2ab15666d5529c3330c': {}
+  '@xterm/xterm@6.1.0-beta.225': {}
 
   accepts@2.0.0:
     dependencies:

--- a/website/src/content/blog/xtermjs-perf.md
+++ b/website/src/content/blog/xtermjs-perf.md
@@ -218,14 +218,18 @@ retainer-walking, and wrong turns to find. That's the shape of this
 kind of work; the ratio of code-volume to investigation-time is
 always roughly zero.
 
-I consume them via the juspay/xterm.js fork and `pnpm.overrides`,
-stacked as a Kolu-consumption branch:
+While these were unreleased, I consumed them via a `juspay/xterm.js`
+fork pinned in `pnpm.overrides`. #5817 has since merged upstream, and
+#5821 was closed in favour of the equivalent
+[#5831](https://github.com/xtermjs/xterm.js/pull/5831) (clear the
+observer reference on dispose); both shipped in the upstream
+`6.1.0-beta` line, so the override is now a plain version pin against
+the auto-published betas built from `xtermjs/xterm.js@master`:
 
 ```json
-"@xterm/xterm": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built"
+"@xterm/xterm": "6.1.0-beta.225",
+"@xterm/addon-webgl": "0.20.0-beta.224"
 ```
-
-When upstream merges, the override collapses to a plain version bump.
 
 ## What I'd tell past-me
 


### PR DESCRIPTION
**Both Kolu-maintained xterm.js patches landed upstream**, so `pnpm.overrides` no longer needs to point at the `juspay/xterm.js` fork. The override now pins the per-commit npm betas auto-published from `xtermjs/xterm.js@master`, giving us a release channel that is byte-for-byte the unreleased upstream master.

### Patch status

| Fork patch | Upstream PR | State | Landed |
|---|---|---|---|
| `CursorBlinkStateManager` + `_pausedResizeTask` registration | [xtermjs/xterm.js#5817](https://github.com/xtermjs/xterm.js/pull/5817) | merged | 2026-04-21 |
| `WeakRef` in `IntersectionObserver` (variant A) | [xtermjs/xterm.js#5821](https://github.com/xtermjs/xterm.js/pull/5821) | closed → superseded by [#5831](https://github.com/xtermjs/xterm.js/pull/5831) (clear observer on dispose) | 2026-05-26 |

Both fixes ship in upstream master commit `afaed108`, which is the source of `@xterm/xterm@6.1.0-beta.225` and `@xterm/addon-webgl@0.20.0-beta.224`.

### `pnpm.overrides` diff

```diff
-"@xterm/xterm":       "github:juspay/xterm.js#fix/kolu-xterm-fixes-built",
-"@xterm/addon-webgl": "github:juspay/xterm.js#fix/kolu-xterm-fixes-built&path:/addons/addon-webgl"
+"@xterm/xterm":       "6.1.0-beta.225",
+"@xterm/addon-webgl": "0.20.0-beta.224"
```

The two packages are co-versioned upstream (`addon-webgl@beta.224`'s peerDep is `@xterm/xterm: ^6.1.0-beta.225`), so they always move in lockstep. _When xterm 6.1.0 stable releases, the override collapses to a plain `^6.1.0` declaration and these `pnpm.overrides` entries can be dropped entirely._

### Side updates

- The blog post `website/src/content/blog/xtermjs-perf.md` showed the old fork URL in present tense — now describes the move to upstream betas.
- `default.nix` `pnpmDeps.hash` refreshed to match the regenerated `pnpm-lock.yaml`.

### Try it locally

```sh
nix run github:juspay/kolu/chore/xterm-upstream-master
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._