### PR TITLE
blog(hickey/lowy): add agency.srid.ca quick-start callout at top

### DIFF
--- a/website/src/components/Tip.astro
+++ b/website/src/components/Tip.astro
@@ -6,8 +6,6 @@ const { title = "Tip" } = Astro.props;
 ---
 
 <aside class="tip">
-  <p class="tip-label eyebrow">{title}</p>
-  <div class="tip-body">
-    <slot />
-  </div>
+  <strong class="tip-label">{title}.</strong>
+  <slot />
 </aside>

--- a/website/src/content/blog/hickey-lowy.md
+++ b/website/src/content/blog/hickey-lowy.md
@@ -9,6 +9,13 @@ _Complexity creeps along two axes — space and time. Hickey catches
 one; Löwy catches the other. A single-lens review only audits half
 the code._
 
+<aside class="tip">
+  <p class="tip-label eyebrow">Quick start</p>
+  <div class="tip-body">
+    <p>Want to run the two-lens review on your own PRs? <a href="https://agency.srid.ca/">agency.srid.ca</a> ships <code>/hickey</code> and <code>/lowy</code> as agent skills you drop into Claude Code (and other harnesses) — point them at a diff and read the findings.</p>
+  </div>
+</aside>
+
 Code goes wrong along two axes, not one. The code as it stands
 right now can be _spatially_ wrong — concepts braided together,
 names that mean two things, seams that aren't really seams. The same code can

--- a/website/src/content/blog/hickey-lowy.md
+++ b/website/src/content/blog/hickey-lowy.md
@@ -12,7 +12,7 @@ the code._
 <aside class="tip">
   <p class="tip-label eyebrow">Quick start</p>
   <div class="tip-body">
-    <p>Want to run the two-lens review on your own PRs? <a href="https://agency.srid.ca/">agency.srid.ca</a> ships <code>/hickey</code> and <code>/lowy</code> as agent skills you drop into Claude Code (and other harnesses) — point them at a diff and read the findings.</p>
+    <p>The reviewer agents in this post are available as <code>/hickey</code> and <code>/lowy</code> skills from <a href="https://agency.srid.ca/">agency.srid.ca</a>.</p>
   </div>
 </aside>
 

--- a/website/src/content/blog/hickey-lowy.mdx
+++ b/website/src/content/blog/hickey-lowy.mdx
@@ -5,16 +5,15 @@ pubDate: 2026-04-19
 author: "Sridhar Ratnakumar"
 ---
 
+import Tip from "../../components/Tip.astro";
+
 _Complexity creeps along two axes — space and time. Hickey catches
 one; Löwy catches the other. A single-lens review only audits half
 the code._
 
-<aside class="tip">
-  <p class="tip-label eyebrow">Quick start</p>
-  <div class="tip-body">
-    <p>The reviewer agents in this post are available as <code>/hickey</code> and <code>/lowy</code> skills from <a href="https://agency.srid.ca/">agency.srid.ca</a>.</p>
-  </div>
-</aside>
+<Tip title="Quick start">
+  The reviewer agents in this post are available as `/hickey` and `/lowy` skills from [agency.srid.ca](https://agency.srid.ca/).
+</Tip>
 
 Code goes wrong along two axes, not one. The code as it stands
 right now can be _spatially_ wrong — concepts braided together,
@@ -35,7 +34,7 @@ to justify it is that code has a _spacetime_ — two orthogonal axes
 of complexity creep, not one. **Measure both, or miss half.**
 
 <div class="tweet-embed">
-<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I think the biggest productivity boost from AI will come when we can nearly automate the software architect out of existence.<br><br>I&#39;m refining both /hickey and /lowy toward that end — so I don&#39;t have to babysit the AI after every PR.</p>&mdash; Sridhar Ratnakumar (@sridca) <a href="https://twitter.com/sridca/status/2044792589119832082?ref_src=twsrc%5Etfw">April 16, 2026</a></blockquote>
+<blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I think the biggest productivity boost from AI will come when we can nearly automate the software architect out of existence.<br/><br/>I&#39;m refining both /hickey and /lowy toward that end — so I don&#39;t have to babysit the AI after every PR.</p>&mdash; Sridhar Ratnakumar (@sridca) <a href="https://twitter.com/sridca/status/2044792589119832082?ref_src=twsrc%5Etfw">April 16, 2026</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -552,26 +552,31 @@ body {
   margin-bottom: 1.5em;
 }
 
-/* Tip / callout component — `<Tip title="…">` in MDX posts. Amber
-   accent + a faint amber-tinted background separates it from a regular
-   pull-quote blockquote without going full GitHub-admonition. */
+/* Tip / callout component — `<Tip title="…">` in MDX posts. Rendered as
+   a tinted rounded card with a run-in label, deliberately different
+   visual grammar from blockquotes (which use a left-bar + italic with
+   no fill) so the two don't blur into each other on the page. */
 .prose-editorial .tip {
-  border-left: 3px solid var(--color-amber);
-  background: color-mix(in srgb, var(--color-amber) 8%, transparent);
-  border-radius: 0 0.5rem 0.5rem 0;
+  background: color-mix(
+    in srgb,
+    var(--color-amber) 5%,
+    var(--color-void-raised)
+  );
+  border-radius: 0.5rem;
   padding: 0.9rem 1.15rem;
   margin: 2em 0;
   font-style: normal;
   color: var(--color-ink);
 }
-.prose-editorial .tip .tip-label {
+.prose-editorial .tip > .tip-label {
+  float: left;
+  margin-right: 0.4em;
   color: var(--color-amber);
-  margin: 0 0 0.4em;
 }
-.prose-editorial .tip .tip-body > :first-child {
+.prose-editorial .tip > .tip-label + * {
   margin-top: 0;
 }
-.prose-editorial .tip .tip-body > :last-child {
+.prose-editorial .tip > :last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Adds a **Quick start tip aside near the top of the [hickey/lowy blog post](https://kolu.dev/blog/hickey-lowy/)** that points readers at [agency.srid.ca](https://agency.srid.ca/) — the repo that ships `/hickey` and `/lowy` as agent skills. Readers who already trust the two-lens framing and just want to run it on their own PRs no longer have to scroll through the whole post to find the tooling links buried mid-essay.

The callout uses the existing `<aside class="tip">` pattern already styled in `website/src/styles/global.css:558` (amber accent + tinted background), so it matches the rest of the site's editorial voice rather than dropping in a foreign admonition style. Sits between the italic lead and the body so it functions as a TL;DR without interrupting the spacetime-of-code narrative.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._