### PR TITLE
fix(justfile): stop leaking ./result GC roots from nix build

### DIFF
--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ test-unit: install
 test: install
     #!/usr/bin/env bash
     set -euo pipefail
-    KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --print-out-paths)/bin/kolu}"
+    KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
     cd packages/tests
     {{ nix_shell_e2e }} pnpm install
     KOLU_SERVER="$KOLU_SERVER" CUCUMBER_PARALLEL={{ cucumber_parallel }} {{ nix_shell_e2e }} pnpm test
@@ -116,9 +116,9 @@ fmt: install
 fmt-check: install
     {{ nix_shell }} sh -c 'biome format . && nixpkgs-fmt --check *.nix nix/**/*.nix website/*.nix'
 
-# Nix build (server + client)
+# Nix build (server + client) — prints store path, no ./result symlink
 build:
-    nix build
+    nix build --no-link --print-out-paths
 
 # Run the combined server+client binary
 run:


### PR DESCRIPTION
## Summary

`nix build --print-out-paths` does not imply `--no-link` — both `just build` and `just test` (the e2e recipe) silently drop `./result` symlinks in cwd on every invocation. Each symlink is a GC root pinning ~2 GiB of derivation closure indefinitely, so `nix-store --gc` can't reclaim them without a manual `rm result*` sweep. Across multiple worktrees and frequent `just test` cycles, the leak adds up.

This passes `--no-link` to both call sites. `just build` keeps `--print-out-paths` so the store path still surfaces — useful for scripts and CI without polluting the working tree.

## Changes

- `just test`: `nix build .#koluBin --no-link --print-out-paths` (was missing `--no-link`).
- `just build`: `nix build --no-link --print-out-paths` (was bare `nix build`, which always creates `./result`).

Interactive users who want a `./result` symlink for inspection can still run `nix build` directly — the recipe is for automation.

## Test plan

- [x] `just --list` parses the modified recipes
- [ ] `just build` no longer creates `./result` in the worktree
- [ ] `just test` no longer creates `./result` in the worktree
- [ ] `nix-store --query --roots` no longer reports the kolu closure as rooted via `./result` after a build

Closes #991