### PR TITLE
Symmetric right-side padding on the cards-mode dock

### DIFF
--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -253,8 +253,11 @@ const DockHeader: Component<{
   const railLayout = () => props.mode === "rail";
   return (
     <div
-      class="flex items-center gap-1 px-1 py-1 border-b border-edge/40 shrink-0"
-      classList={{ "flex-col": railLayout() }}
+      class="flex items-center gap-1 py-1 border-b border-edge/40 shrink-0"
+      classList={{
+        "px-1 flex-col": railLayout(),
+        "pl-1 pr-3": !railLayout(),
+      }}
     >
       <button
         type="button"
@@ -323,7 +326,7 @@ const RepoSection: Component<{
   <section
     data-testid="dock-section"
     data-repo={props.group.name}
-    class="grid grid-cols-[16px_minmax(0,1fr)_auto_auto] gap-x-2 pl-6 pr-3"
+    class="grid grid-cols-[16px_minmax(0,1fr)_auto_auto] gap-x-2 pl-6 pr-6"
   >
     {/* Header is a band — bg-surface-2 plus a hairline divider top
      *  and bottom — so a `KOLU` / `NIXOS-CONFIG` label reads as a
@@ -334,7 +337,7 @@ const RepoSection: Component<{
      *  content sits at `pl-6` (24 px) inside the section's grid, so
      *  the header reads as an outdented parent and the rows nest
      *  visually beneath it. */}
-    <div class="col-span-full flex items-center gap-2 -ml-6 -mr-3 pl-3 pr-3 py-1.5 bg-surface-2/60 border-y border-edge/30">
+    <div class="col-span-full flex items-center gap-2 -ml-6 -mr-6 pl-3 pr-3 py-1.5 bg-surface-2/60 border-y border-edge/30">
       <span
         data-testid="dock-section-name"
         class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
@@ -422,7 +425,7 @@ const DockRow: Component<{
               store.activate(props.id);
             }
           }}
-          class="relative w-full grid grid-cols-subgrid col-span-full items-center py-1.5 -ml-6 -mr-3 border-l-[3px] border-l-transparent text-left cursor-pointer transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 hover:bg-surface-2/40 data-[active]:bg-accent/15 data-[active]:border-l-accent"
+          class="relative w-full grid grid-cols-subgrid col-span-full items-center py-1.5 -ml-6 -mr-6 border-l-[3px] border-l-transparent text-left cursor-pointer transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 hover:bg-surface-2/40 data-[active]:bg-accent/15 data-[active]:border-l-accent"
           title="Jump to this terminal"
         >
           <AgentSlot agent={c().meta.agent} />

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -61,7 +61,11 @@ import { HiddenFooter } from "./HiddenFooter";
 import { chipInitials } from "./chipInitials";
 import { AgentSlot, PrPip, SubCountCell, createDockRowData } from "./RowPips";
 import { rowSubline } from "./rowSubline";
-import { RAIL_WIDTH_PX } from "../../ui/chromeSpacing";
+import {
+  DOCK_CARDS_GUTTER_CLASS,
+  DOCK_CARDS_GUTTER_NEG_CLASS,
+  RAIL_WIDTH_PX,
+} from "../../ui/chromeSpacing";
 import { ChevronDownIcon, PlusIcon, SearchIcon } from "../../ui/Icons";
 import { isPlatformModifier } from "../../input/keyboard";
 import { useViewPosture } from "../useViewPosture";
@@ -326,7 +330,7 @@ const RepoSection: Component<{
   <section
     data-testid="dock-section"
     data-repo={props.group.name}
-    class="grid grid-cols-[16px_minmax(0,1fr)_auto_auto] gap-x-2 pl-6 pr-6"
+    class={`grid grid-cols-[16px_minmax(0,1fr)_auto_auto] gap-x-2 pl-6 ${DOCK_CARDS_GUTTER_CLASS}`}
   >
     {/* Header is a band — bg-surface-2 plus a hairline divider top
      *  and bottom — so a `KOLU` / `NIXOS-CONFIG` label reads as a
@@ -337,7 +341,9 @@ const RepoSection: Component<{
      *  content sits at `pl-6` (24 px) inside the section's grid, so
      *  the header reads as an outdented parent and the rows nest
      *  visually beneath it. */}
-    <div class="col-span-full flex items-center gap-2 -ml-6 -mr-6 pl-3 pr-3 py-1.5 bg-surface-2/60 border-y border-edge/30">
+    <div
+      class={`col-span-full flex items-center gap-2 -ml-6 ${DOCK_CARDS_GUTTER_NEG_CLASS} pl-3 pr-3 py-1.5 bg-surface-2/60 border-y border-edge/30`}
+    >
       <span
         data-testid="dock-section-name"
         class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
@@ -425,7 +431,7 @@ const DockRow: Component<{
               store.activate(props.id);
             }
           }}
-          class="relative w-full grid grid-cols-subgrid col-span-full items-center py-1.5 -ml-6 -mr-6 border-l-[3px] border-l-transparent text-left cursor-pointer transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 hover:bg-surface-2/40 data-[active]:bg-accent/15 data-[active]:border-l-accent"
+          class={`relative w-full grid grid-cols-subgrid col-span-full items-center py-1.5 -ml-6 ${DOCK_CARDS_GUTTER_NEG_CLASS} border-l-[3px] border-l-transparent text-left cursor-pointer transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 hover:bg-surface-2/40 data-[active]:bg-accent/15 data-[active]:border-l-accent`}
           title="Jump to this terminal"
         >
           <AgentSlot agent={c().meta.agent} />

--- a/packages/client/src/canvas/dock/HiddenFooter.tsx
+++ b/packages/client/src/canvas/dock/HiddenFooter.tsx
@@ -48,8 +48,10 @@ export const HiddenFooter: Component<{
         // Touch (mobile drawer): larger vertical padding, slightly bigger
         // type so the strip clears 44px tap target.
         "px-3 py-3 text-[0.75rem]": props.compact === true,
-        // Pointer (desktop): tight padding.
-        "px-3 py-2 text-[0.65rem]": props.compact !== true,
+        // Pointer (desktop): right padding matches the dock cards' row
+        // gutter (`pr-6`) so "show all" sits in the same column as the
+        // time labels above it.
+        "pl-3 pr-6 py-2 text-[0.65rem]": props.compact !== true,
       }}
     >
       <Show when={filterActive()} fallback={<span>Activity window</span>}>

--- a/packages/client/src/canvas/dock/HiddenFooter.tsx
+++ b/packages/client/src/canvas/dock/HiddenFooter.tsx
@@ -17,6 +17,7 @@
 
 import { type Component, createMemo, Show } from "solid-js";
 import { ActivityWindowChip } from "../../ui/ActivityWindowChip";
+import { DOCK_CARDS_GUTTER_CLASS } from "../../ui/chromeSpacing";
 import {
   activityWindow,
   setActivityWindow,
@@ -48,10 +49,11 @@ export const HiddenFooter: Component<{
         // Touch (mobile drawer): larger vertical padding, slightly bigger
         // type so the strip clears 44px tap target.
         "px-3 py-3 text-[0.75rem]": props.compact === true,
-        // Pointer (desktop): right padding matches the dock cards' row
-        // gutter (`pr-6`) so "show all" sits in the same column as the
-        // time labels above it.
-        "pl-3 pr-6 py-2 text-[0.65rem]": props.compact !== true,
+        // Pointer (desktop): right padding tracks the dock cards' row
+        // gutter so "show all" sits in the same column as the time
+        // labels above it.
+        [`pl-3 ${DOCK_CARDS_GUTTER_CLASS} py-2 text-[0.65rem]`]:
+          props.compact !== true,
       }}
     >
       <Show when={filterActive()} fallback={<span>Activity window</span>}>

--- a/packages/client/src/canvas/dock/MobileDockDrawer.tsx
+++ b/packages/client/src/canvas/dock/MobileDockDrawer.tsx
@@ -73,6 +73,14 @@ const MobileSection: Component<{
   // agent · branch · sub-count · time. PR pip lives on line 2 (left)
   // alongside the subline, anchored to col 2 left edge so PR icons
   // align across every section.
+  //
+  // Mobile keeps a tighter right gutter (`pr-3` / `-mr-3`) than the
+  // desktop dock's `DOCK_CARDS_GUTTER_CLASS` (`pr-6` / `-mr-6`) —
+  // touch rows already pad vertically with `py-3`, and the drawer
+  // hugs the viewport edge rather than floating as a rounded card.
+  // Promote to a `MOBILE_DOCK_GUTTER_CLASS` constant the moment a
+  // second file consumes it; until then the three literal sites here
+  // are colocated within ~70 lines.
   <section
     data-testid="mobile-dock-section"
     data-repo={props.group.name}

--- a/packages/client/src/ui/chromeSpacing.ts
+++ b/packages/client/src/ui/chromeSpacing.ts
@@ -33,3 +33,20 @@ export const CHROME_ICON_BUTTON_CLASS =
  *  three-button pill row. Used by right panel sub-tabs. */
 export const COMPACT_ICON_BUTTON_CLASS =
   "flex items-center justify-center w-6 h-6 rounded transition-colors cursor-pointer";
+
+/** Cards-mode dock right-gutter — Tailwind class string applied to
+ *  `RepoSection`'s grid container so the right-aligned columns (time
+ *  label, "show all" footer link) sit a consistent distance from the
+ *  card's rounded right edge. Mirrors the 24 px left indent (`pl-6`).
+ *
+ *  Paired with `DOCK_CARDS_GUTTER_NEG_CLASS`: any descendant that
+ *  bleeds to the dock card's right edge (hover/active row backgrounds,
+ *  section-header full-bleed band) cancels this padding with the
+ *  negative-margin twin. Move them together. */
+export const DOCK_CARDS_GUTTER_CLASS = "pr-6";
+
+/** Negative-margin twin of `DOCK_CARDS_GUTTER_CLASS`. Applied to
+ *  descendants of `RepoSection` whose background must extend through
+ *  the parent's right padding to the dock card's right edge — row
+ *  hover/active surfaces and the section-header band. */
+export const DOCK_CARDS_GUTTER_NEG_CLASS = "-mr-6";


### PR DESCRIPTION
**The cards-mode dock's right side now breathes the way the left already does.** Time labels, the section-header count, the mode-toggle chevron, and the "show all" footer link were all hugging the rounded right corner — the screenshot in the issue showed `1h ago` and `just now` essentially touching the edge. The fix is symmetric padding (`pr-6` mirroring the existing `pl-6` indent), plus a small extraction so the *next* gutter change can't miss a site again.

### What was actually misaligned

| Surface | Before | After |
| --- | --- | --- |
| `RepoSection` row content (time, sub-count) | 12 px from card right | 24 px |
| `HiddenFooter` "show all" | 12 px (out of column with times above) | 24 px (column-aligned) |
| `DockHeader` chevron in cards mode | 4 px from rounded corner | 12 px |

Mobile keeps its tighter `pr-3` — the drawer hugs the viewport edge and rows already pad vertically with `py-3`, so the visual problem doesn't repeat there. *Annotated explicitly in `MobileDockDrawer.tsx` so the divergence reads as intentional, not as drift.*

### Architecture refinement (riding along)

Hickey and Lowy both independently flagged that `pr-6` / `-mr-6` lived as bare literals at four sites across `Dock.tsx` and `HiddenFooter.tsx`, held coherent only by a prose comment — which is exactly how the original `HiddenFooter` miss happened. Encapsulated as `DOCK_CARDS_GUTTER_CLASS` and `DOCK_CARDS_GUTTER_NEG_CLASS` in `ui/chromeSpacing.ts`, next to the existing `RAIL_WIDTH_PX` token. Two flat string exports rather than a shaped `{ padding, breakout }` object — no schema for consumers to dereference. `HiddenFooter` reads the constant directly rather than receiving it through a new prop, which would have leaked Dock geometry into a sibling's interface.

### Try it locally

```sh
nix run github:juspay/kolu/fix/dock-right-padding
```

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._