### PR TITLE
fix: open gitignored & untracked files from terminal click

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -223,21 +223,32 @@ const CodeTab: Component<{
   // Consume-once record for the latest pendingOpen tick. Holds the
   // full request object (reference identity discriminates two
   // structurally-identical clicks — `openInCodeTab` mints a fresh
-  // object per call) alongside the resolved path. Storing the
+  // object per call) alongside the resolution stage. Storing the
   // request here lets `selectedRange` derive its value without
   // re-running `resolveLineRefPath` (single resolution site per
   // request).
   //
-  // `outOfTree` distinguishes selections that came from the disk-probe
-  // fallback (the gitignored / freshly-created case below) from those
-  // that matched the live `fsListAll` set. The membership-clear effect
-  // further down reads this so it doesn't wipe a selection that the
-  // tree filter correctly excludes.
-  const [handled, setHandled] = createSignal<{
+  // Discriminated by `stage`: `probing` is the mid-flight placeholder
+  // set before the disk-probe fallback fires; `in-tree`/`out-of-tree`
+  // both carry a resolved path and differ only in provenance (whether
+  // the path lives in the `fsListAll` set or only on disk); `miss` is
+  // the terminal "no candidate exists" state. The membership-clear
+  // effect reads `out-of-tree` so it doesn't wipe selections that the
+  // tree filter correctly excludes (gitignored / freshly-created
+  // files). `handled() === null` is reserved for "no request handled
+  // yet" — keeping freshness on the signal-level absence avoids
+  // multiplying that axis into the payload.
+  type HandledRecord = {
     request: OpenInCodeTabRequest;
-    resolvedPath: string | null;
-    outOfTree: boolean;
-  } | null>(null);
+  } & (
+    | { stage: "probing" }
+    | { stage: "in-tree"; resolvedPath: string }
+    | { stage: "out-of-tree"; resolvedPath: string }
+    | { stage: "miss" }
+  );
+  const [handled, setHandled] = createSignal<HandledRecord | null>(null);
+  const resolvedPathOf = (h: HandledRecord): string | null =>
+    h.stage === "in-tree" || h.stage === "out-of-tree" ? h.resolvedPath : null;
 
   // Honor every `openInCodeTab` request — terminal file-ref clicks,
   // right-click "Open path:N" entries, and any future producer. The
@@ -276,7 +287,7 @@ const CodeTab: Component<{
         });
         if (rel !== null) {
           setSelectedPath(rel);
-          setHandled({ request: req, resolvedPath: rel, outOfTree: false });
+          setHandled({ request: req, stage: "in-tree", resolvedPath: rel });
           return;
         }
         // Tree miss — fall through to a disk probe before giving up.
@@ -285,7 +296,7 @@ const CodeTab: Component<{
         // resolve in `.then`, re-checking that this request is still
         // the latest before writing so a superseding click can't get
         // stomped by a stale fallback result.
-        setHandled({ request: req, resolvedPath: null, outOfTree: false });
+        setHandled({ request: req, stage: "probing" });
         void resolveByDiskProbe(req, repo);
       },
       { defer: true },
@@ -311,11 +322,12 @@ const CodeTab: Component<{
       if (pendingOpen() !== req) return;
       if (exists) {
         setSelectedPath(cand);
-        setHandled({ request: req, resolvedPath: cand, outOfTree: true });
+        setHandled({ request: req, stage: "out-of-tree", resolvedPath: cand });
         return;
       }
     }
     if (pendingOpen() !== req) return;
+    setHandled({ request: req, stage: "miss" });
     toast.error(`File reference not found: ${req.ref.path}`);
   }
 
@@ -343,8 +355,9 @@ const CodeTab: Component<{
     const req = pendingOpen();
     if (!req) return null;
     const h = handled();
-    if (!h || h.request !== req || h.resolvedPath === null) return null;
-    if (h.resolvedPath !== selectedPath()) return null;
+    if (!h || h.request !== req) return null;
+    const rel = resolvedPathOf(h);
+    if (rel === null || rel !== selectedPath()) return null;
     // No-line refs (`src/Main.hs` with no `:N`) open the file with no
     // highlight — the user asked for the file, not a specific line.
     if (req.ref.startLine === null || req.ref.endLine === null) return null;
@@ -391,7 +404,8 @@ const CodeTab: Component<{
         // `treePaths()` — the tree filter is correct, but their
         // presence in `selectedPath` is also correct. Treat the
         // current handled record as authoritative for that case.
-        const outOfTree = h !== null && h.outOfTree && h.resolvedPath === s;
+        const outOfTree =
+          h !== null && h.stage === "out-of-tree" && h.resolvedPath === s;
         return {
           s,
           sk,
@@ -426,11 +440,12 @@ const CodeTab: Component<{
     // user who treated their tree click as a fresh intent. Same-file
     // tree-clicks don't trip this branch (Pierre fires `onSelect(rel)`
     // after our own programmatic `setSelectedPath(rel)` and the path
-    // equals `handled.resolvedPath` in that case — leaving the highlight
-    // intact for the lifetime of the request).
+    // equals the handled record's resolvedPath in that case — leaving
+    // the highlight intact for the lifetime of the request).
     const h = handled();
-    if (h && h.resolvedPath !== null && h.resolvedPath !== path) {
-      setHandled(null);
+    if (h !== null) {
+      const rel = resolvedPathOf(h);
+      if (rel !== null && rel !== path) setHandled(null);
     }
     setSelectedPath(path);
   };

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -321,9 +321,15 @@ const CodeTab: Component<{
         // entirely. Continuing to the next candidate would produce another
         // identical error, then a misleading "not found" toast (the server
         // may be reachable but temporarily unavailable; file presence
-        // is unknown, not denied).
+        // is unknown, not denied). Transition handled out of `probing` so
+        // the membership-clear effect stops treating this request as an
+        // in-flight probe; `miss` is the right terminal stage since we
+        // couldn't confirm existence either way.
         const message = err instanceof Error ? err.message : String(err);
         toast.error(`File reference probe failed: ${message}`);
+        if (pendingOpen() === req && handled()?.stage === "probing") {
+          setHandled({ request: req, stage: "miss" });
+        }
         return;
       }
       // Superseded by a newer click or an explicit user tree-navigation:

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -315,8 +315,9 @@ const CodeTab: Component<{
     for (const cand of cands) {
       const { exists } = await client.git
         .fsExists({ repoPath: repo, filePath: cand })
-        .catch((err: Error) => {
-          toast.error(`File reference probe failed: ${err.message}`);
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          toast.error(`File reference probe failed: ${message}`);
           return { exists: false };
         });
       if (pendingOpen() !== req) return;

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -320,14 +320,17 @@ const CodeTab: Component<{
           toast.error(`File reference probe failed: ${message}`);
           return { exists: false };
         });
-      if (pendingOpen() !== req) return;
+      // Superseded by a newer click or an explicit user tree-navigation:
+      // `handleSelect` clears `handled` on a probing-stage tree-click so the
+      // probe can detect the user's choice and bow out without stomping it.
+      if (pendingOpen() !== req || handled()?.stage !== "probing") return;
       if (exists) {
         setSelectedPath(cand);
         setHandled({ request: req, stage: "out-of-tree", resolvedPath: cand });
         return;
       }
     }
-    if (pendingOpen() !== req) return;
+    if (pendingOpen() !== req || handled()?.stage !== "probing") return;
     setHandled({ request: req, stage: "miss" });
     toast.error(`File reference not found: ${req.ref.path}`);
   }
@@ -453,7 +456,13 @@ const CodeTab: Component<{
     const h = handled();
     if (h !== null) {
       const rel = resolvedPathOf(h);
-      if (rel !== null && rel !== path) setHandled(null);
+      // `probing` has no `resolvedPath` to compare against, so the
+      // `rel !== null` guard alone would skip the clear. But the user
+      // just navigated away, so the in-flight probe must not overwrite
+      // their choice — clear unconditionally for probing.
+      if (h.stage === "probing" || (rel !== null && rel !== path)) {
+        setHandled(null);
+      }
     }
     setSelectedPath(path);
   };

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -40,7 +40,7 @@ import { CommentTextSurface } from "../comments/CommentTextSurface";
 import { useComposer } from "../comments/composerState";
 import { useCommentScrollRequest } from "../comments/scrollRequest";
 import { useColorScheme } from "../settings/useColorScheme";
-import { app } from "../wire";
+import { app, client } from "../wire";
 import { FileBrowseIcon, FileDiffIcon, GitBranchIcon } from "../ui/Icons";
 import {
   renderTreeContextMenu,
@@ -51,7 +51,7 @@ import {
   pierreIconConfig,
   pierreTreesStyle,
 } from "../ui/pierreTheme";
-import { resolveLineRefPath } from "../ui/lineRef";
+import { lineRefCandidates, resolveLineRefPath } from "../ui/lineRef";
 import BrowseFileDispatcher from "./BrowseFileDispatcher";
 import CodeMenuFrame from "./CodeMenuFrame";
 import {
@@ -227,9 +227,16 @@ const CodeTab: Component<{
   // request here lets `selectedRange` derive its value without
   // re-running `resolveLineRefPath` (single resolution site per
   // request).
+  //
+  // `outOfTree` distinguishes selections that came from the disk-probe
+  // fallback (the gitignored / freshly-created case below) from those
+  // that matched the live `fsListAll` set. The membership-clear effect
+  // further down reads this so it doesn't wipe a selection that the
+  // tree filter correctly excludes.
   const [handled, setHandled] = createSignal<{
     request: OpenInCodeTabRequest;
     resolvedPath: string | null;
+    outOfTree: boolean;
   } | null>(null);
 
   // Honor every `openInCodeTab` request — terminal file-ref clicks,
@@ -239,6 +246,15 @@ const CodeTab: Component<{
   // a request fired during boot would toast "not found" on a path
   // that just hasn't been enumerated yet. `openInCodeTab` flips the
   // panel to browse mode itself; this effect only sets `selectedPath`.
+  //
+  // Two-stage resolution: first against the tree's file list (cheap,
+  // sync, and preserves the basename-uniqueness fallback for compiler
+  // output like `Foo.hs:42`); on miss, probe each composed candidate
+  // against the server's filesystem via `client.git.fsExists`. The
+  // second stage opens gitignored files (build artifacts, scratch
+  // HTML, log files) and freshly-created untracked files the stream
+  // snapshot hasn't picked up yet — both legitimate click targets the
+  // tree filter intentionally hides.
   createEffect(
     on(
       () => {
@@ -258,17 +274,50 @@ const CodeTab: Component<{
           cwd: req.cwd,
           repoPaths: paths,
         });
-        if (rel === null) {
-          toast.error(`File reference not found: ${req.ref.path}`);
-          setHandled({ request: req, resolvedPath: null });
+        if (rel !== null) {
+          setSelectedPath(rel);
+          setHandled({ request: req, resolvedPath: rel, outOfTree: false });
           return;
         }
-        setSelectedPath(rel);
-        setHandled({ request: req, resolvedPath: rel });
+        // Tree miss — fall through to a disk probe before giving up.
+        // Stay synchronous inside the effect body (SolidJS reactive
+        // tracking ends at the first `await`); fire the probe and
+        // resolve in `.then`, re-checking that this request is still
+        // the latest before writing so a superseding click can't get
+        // stomped by a stale fallback result.
+        setHandled({ request: req, resolvedPath: null, outOfTree: false });
+        void resolveByDiskProbe(req, repo);
       },
       { defer: true },
     ),
   );
+
+  async function resolveByDiskProbe(
+    req: OpenInCodeTabRequest,
+    repo: string,
+  ): Promise<void> {
+    const cands = lineRefCandidates({
+      rawPath: req.ref.path,
+      repoRoot: repo,
+      cwd: req.cwd,
+    });
+    for (const cand of cands) {
+      const { exists } = await client.git
+        .fsExists({ repoPath: repo, filePath: cand })
+        .catch((err: Error) => {
+          toast.error(`File reference probe failed: ${err.message}`);
+          return { exists: false };
+        });
+      if (pendingOpen() !== req) return;
+      if (exists) {
+        setSelectedPath(cand);
+        setHandled({ request: req, resolvedPath: cand, outOfTree: true });
+        return;
+      }
+    }
+    if (pendingOpen() !== req) return;
+    toast.error(`File reference not found: ${req.ref.path}`);
+  }
 
   // Highlight range derives from the consume-once record: if the
   // request we last handled matches the latest pending one AND its
@@ -336,7 +385,18 @@ const CodeTab: Component<{
         const sk = slotKey();
         const isPending = isDiffView() ? status.pending() : allPaths.pending();
         const paths = treePaths();
-        return { s, sk, pathExists: !s || isPending || paths.includes(s) };
+        const h = handled();
+        // Out-of-tree selections (gitignored / untracked files opened
+        // via the fsExists fallback) intentionally won't appear in
+        // `treePaths()` — the tree filter is correct, but their
+        // presence in `selectedPath` is also correct. Treat the
+        // current handled record as authoritative for that case.
+        const outOfTree = h !== null && h.outOfTree && h.resolvedPath === s;
+        return {
+          s,
+          sk,
+          pathExists: !s || isPending || paths.includes(s) || outOfTree,
+        };
       },
       (cur, prev) => {
         if (prev && prev.sk !== cur.sk) return;

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -405,8 +405,15 @@ const CodeTab: Component<{
         // `treePaths()` — the tree filter is correct, but their
         // presence in `selectedPath` is also correct. Treat the
         // current handled record as authoritative for that case.
+        // Also suppress clearing during `probing`: the disk probe is
+        // mid-flight and the previous selection (which may itself be
+        // out-of-tree) should stay visible until the probe resolves —
+        // otherwise the gutter flashes "Select a file" for the duration
+        // of the RPC round-trip.
         const outOfTree =
-          h !== null && h.stage === "out-of-tree" && h.resolvedPath === s;
+          h !== null &&
+          (h.stage === "probing" ||
+            (h.stage === "out-of-tree" && h.resolvedPath === s));
         return {
           s,
           sk,

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -313,18 +313,24 @@ const CodeTab: Component<{
       cwd: req.cwd,
     });
     for (const cand of cands) {
-      const { exists } = await client.git
-        .fsExists({ repoPath: repo, filePath: cand })
-        .catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          toast.error(`File reference probe failed: ${message}`);
-          return { exists: false };
-        });
+      let result: { exists: boolean };
+      try {
+        result = await client.git.fsExists({ repoPath: repo, filePath: cand });
+      } catch (err: unknown) {
+        // RPC failure (network down, server error) — abort the probe
+        // entirely. Continuing to the next candidate would produce another
+        // identical error, then a misleading "not found" toast (the server
+        // may be reachable but temporarily unavailable; file presence
+        // is unknown, not denied).
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(`File reference probe failed: ${message}`);
+        return;
+      }
       // Superseded by a newer click or an explicit user tree-navigation:
       // `handleSelect` clears `handled` on a probing-stage tree-click so the
       // probe can detect the user's choice and bow out without stomping it.
       if (pendingOpen() !== req || handled()?.stage !== "probing") return;
-      if (exists) {
+      if (result.exists) {
         setSelectedPath(cand);
         setHandled({ request: req, stage: "out-of-tree", resolvedPath: cand });
         return;

--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatLineRef, parseLineRefs, resolveLineRefPath } from "./lineRef";
+import {
+  formatLineRef,
+  lineRefCandidates,
+  parseLineRefs,
+  resolveLineRefPath,
+} from "./lineRef";
 
 describe("formatLineRef", () => {
   it("formats a single line and a range", () => {
@@ -269,5 +274,59 @@ describe("resolveLineRefPath", () => {
         repoPaths,
       }),
     ).toBe("src/app.ts");
+  });
+});
+
+describe("lineRefCandidates", () => {
+  const repoRoot = "/tmp/work";
+
+  it("yields cwd-relative then repo-relative for a bare path in a subdirectory", () => {
+    expect(
+      lineRefCandidates({
+        rawPath: "app.ts",
+        repoRoot,
+        cwd: "/tmp/work/nested/src",
+      }),
+    ).toEqual(["nested/src/app.ts", "app.ts"]);
+  });
+
+  it("yields only the repo-stripped form for an absolute path under repoRoot", () => {
+    expect(
+      lineRefCandidates({
+        rawPath: "/tmp/work/dist/build.js",
+        repoRoot,
+        cwd: repoRoot,
+      }),
+    ).toEqual(["dist/build.js"]);
+  });
+
+  it("yields nothing for an absolute path outside repoRoot", () => {
+    expect(
+      lineRefCandidates({
+        rawPath: "/tmp/other/foo.ts",
+        repoRoot,
+        cwd: repoRoot,
+      }),
+    ).toEqual([]);
+  });
+
+  it("yields the repo-relative candidate when cwd is undefined", () => {
+    expect(
+      lineRefCandidates({
+        rawPath: "src/app.ts",
+        repoRoot,
+        cwd: undefined,
+      }),
+    ).toEqual(["src/app.ts"]);
+  });
+
+  it("yields the repo-relative form even when the cwd-relative compose escapes the root", () => {
+    expect(
+      lineRefCandidates({
+        rawPath: "../app.ts",
+        repoRoot,
+        cwd: "/tmp/work",
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -157,7 +157,7 @@ function basename(path: string): string {
  *  could resolve to. The same composition `resolveLineRefPath` runs
  *  internally, exposed for callers that need to probe candidates against
  *  an authority other than the `fsListAll` file set — e.g. a server-side
- *  `fsExists` probe for files git doesn't track (#TODO).
+ *  `fsExists` probe for files git doesn't track.
  *
  *  Order is significant: cwd-relative composition comes first because
  *  that's the disambiguation the user expects when they typed a

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -153,6 +153,28 @@ function basename(path: string): string {
   return i < 0 ? path : path.slice(i + 1);
 }
 
+/** Compose the candidate repo-relative paths a raw terminal-supplied path
+ *  could resolve to. The same composition `resolveLineRefPath` runs
+ *  internally, exposed for callers that need to probe candidates against
+ *  an authority other than the `fsListAll` file set — e.g. a server-side
+ *  `fsExists` probe for files git doesn't track (#TODO).
+ *
+ *  Order is significant: cwd-relative composition comes first because
+ *  that's the disambiguation the user expects when they typed a
+ *  short path while standing in a subdirectory. Absolute paths return a
+ *  single candidate (their repo-stripped form, when under `repoRoot`).
+ *  Basename-uniqueness fallback is not included here — it inherently
+ *  requires the file list to know what's unique, and a gitignored file
+ *  whose basename collides with a tracked one shouldn't quietly take
+ *  over the click target. */
+export function lineRefCandidates(args: {
+  rawPath: string;
+  repoRoot: string;
+  cwd: string | undefined;
+}): string[] {
+  return Array.from(candidates(args));
+}
+
 function* candidates(args: {
   rawPath: string;
   repoRoot: string;

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -14,6 +14,8 @@
 
 import { eventIterator, oc } from "@orpc/contract";
 import {
+  FsExistsInputSchema,
+  FsExistsOutputSchema,
   WorktreeCreateInputSchema,
   WorktreeCreateOutputSchema,
   WorktreeRemoveInputSchema,
@@ -171,5 +173,11 @@ export const contract = oc.router({
       .input(WorktreeCreateInputSchema)
       .output(WorktreeCreateOutputSchema),
     worktreeRemove: oc.input(WorktreeRemoveInputSchema).output(z.void()),
+    /** Existence probe for the terminal file-ref click resolver — falls
+     *  back to disk when `fsListAll` (which honors `.gitignore`) doesn't
+     *  see the path. The tree-display filter is intentional; this lets a
+     *  click on a gitignored or freshly-created file still open in
+     *  preview. */
+    fsExists: oc.input(FsExistsInputSchema).output(FsExistsOutputSchema),
   },
 });

--- a/packages/common/src/terminalBackend.ts
+++ b/packages/common/src/terminalBackend.ts
@@ -114,6 +114,10 @@ export interface TerminalBackendFs {
     repoPath: string,
     filePath: string,
   ): Promise<{ content: string; truncated: boolean }>;
+  /** Existence probe for the terminal file-ref click resolver — falls
+   *  back to disk when `listAll` (which honors `.gitignore`) doesn't
+   *  see the path. Returns `true` only for regular files. */
+  fsExists(repoPath: string, filePath: string): Promise<boolean>;
   statFileMtimeMs(repoPath: string, filePath: string): Promise<number>;
   subscribeRepoChange(repoPath: string, onChange: () => void): () => void;
   subscribeFileChange(

--- a/packages/integrations/git/src/browse.test.ts
+++ b/packages/integrations/git/src/browse.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { readFile } from "./browse.ts";
+import { fsExists, readFile } from "./browse.ts";
 
 describe("readFile", () => {
   let tmpDir: string;
@@ -38,5 +38,56 @@ describe("readFile", () => {
     if (!result.ok) {
       expect(result.error.code).toBe("GIT_FAILED");
     }
+  });
+});
+
+describe("fsExists", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-fsexists-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns true for an existing file", async () => {
+    fs.writeFileSync(path.join(tmpDir, "present.txt"), "x");
+    const result = await fsExists(tmpDir, "present.txt");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(true);
+  });
+
+  it("returns false for a missing file", async () => {
+    const result = await fsExists(tmpDir, "missing.txt");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(false);
+  });
+
+  it("returns false for a directory (not a regular file)", async () => {
+    fs.mkdirSync(path.join(tmpDir, "subdir"));
+    const result = await fsExists(tmpDir, "subdir");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(false);
+  });
+
+  it("rejects path traversal", async () => {
+    const result = await fsExists(tmpDir, "../../etc/passwd");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+    }
+  });
+
+  it("treats a non-directory path segment as a miss, not an error", async () => {
+    fs.writeFileSync(path.join(tmpDir, "leaf.txt"), "x");
+    const result = await fsExists(tmpDir, "leaf.txt/deeper.txt");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(false);
   });
 });

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -72,6 +72,32 @@ export async function readFile(
   }
 }
 
+/** Check whether a file exists on disk under `repoPath`, regardless of
+ *  whether git tracks or ignores it. The fallback oracle for terminal
+ *  file-ref clicks when `listAll` (which honors `.gitignore`) doesn't
+ *  see the path. Same path-traversal guard as `readFile` — a `..` that
+ *  escapes the root is rejected, not reported as `false`.
+ *
+ *  Returns `true` only for regular files. Directories return `false`
+ *  because the click consumer (`CodeTab` preview) can't render them. */
+export async function fsExists(
+  repoPath: string,
+  filePath: string,
+  log?: Logger,
+): Promise<GitResult<boolean>> {
+  const resolved = resolveUnder(repoPath, filePath, log);
+  if (!resolved.ok) return resolved as GitResult<boolean>;
+  try {
+    const s = await fsStat(resolved.value.abs);
+    return ok(s.isFile());
+  } catch (e: unknown) {
+    const errno = (e as NodeJS.ErrnoException).code;
+    if (errno === "ENOENT" || errno === "ENOTDIR") return ok(false);
+    const msg = e instanceof Error ? e.message : String(e);
+    return err({ code: "GIT_FAILED", message: `Failed to stat file: ${msg}` });
+  }
+}
+
 /** Stat a file's mtime in ms-since-epoch, used to cache-bust the iframe URL
  *  for binary previewable kinds. Same path-traversal guard as `readFile`. */
 export async function statFileMtimeMs(

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -6,7 +6,7 @@
 // Name generation
 export { randomName } from "memorable-names";
 // File tree browsing
-export { listAll, readFile, statFileMtimeMs } from "./browse.ts";
+export { fsExists, listAll, readFile, statFileMtimeMs } from "./browse.ts";
 // Equality predicates for streamed snapshot dedup
 export {
   fsListAllOutputEqual,
@@ -38,6 +38,9 @@ export { getDiff, getStatus, parseNameStatus } from "./review.ts";
 export { resolveUnder } from "./safe-path.ts";
 // Schemas
 export {
+  FsExistsInputSchema,
+  type FsExistsOutput,
+  FsExistsOutputSchema,
   FsListAllInputSchema,
   type FsListAllOutput,
   FsListAllOutputSchema,

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -184,6 +184,20 @@ export const FsReadFileOutputSchema = z.discriminatedUnion("kind", [
 ]);
 export type FsReadFileOutput = z.infer<typeof FsReadFileOutputSchema>;
 
+export const FsExistsInputSchema = z.object({
+  /** Absolute path to the repo root. */
+  repoPath: z.string(),
+  /** Path relative to repo root. The same path-traversal guard `readFile`
+   *  uses applies — paths escaping `repoPath` are rejected, not reported
+   *  as `false`. */
+  filePath: z.string(),
+});
+
+export const FsExistsOutputSchema = z.object({
+  exists: z.boolean(),
+});
+export type FsExistsOutput = z.infer<typeof FsExistsOutputSchema>;
+
 // --- Derived types ---
 
 export type GitInfo = z.infer<typeof GitInfoSchema>;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -15,7 +15,7 @@ import { loadCodexTranscript } from "kolu-codex";
 import type { Transcript, TranscriptPr } from "kolu-common/transcript";
 import { TerminalNotFoundError } from "kolu-common/errors";
 import { rejectionFor, sizeRejectionFor } from "kolu-common/upload";
-import { fsExists, worktreeCreate, worktreeRemove } from "kolu-git";
+import { worktreeCreate, worktreeRemove } from "kolu-git";
 import { prValue } from "kolu-github/schemas";
 import { loadOpenCodeTranscript } from "kolu-opencode";
 import { transcriptToHtml } from "kolu-transcript-html";
@@ -287,8 +287,9 @@ export const appRouter = t.router({
       unwrapGit(await worktreeRemove(input.worktreePath, log));
     }),
     fsExists: t.git.fsExists.handler(async ({ input }) => {
-      const exists = unwrapGit(
-        await fsExists(input.repoPath, input.filePath, log),
+      const exists = await getTerminalBackendFor({ kind: "local" }).fs.fsExists(
+        input.repoPath,
+        input.filePath,
       );
       return { exists };
     }),

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -15,7 +15,7 @@ import { loadCodexTranscript } from "kolu-codex";
 import type { Transcript, TranscriptPr } from "kolu-common/transcript";
 import { TerminalNotFoundError } from "kolu-common/errors";
 import { rejectionFor, sizeRejectionFor } from "kolu-common/upload";
-import { worktreeCreate, worktreeRemove } from "kolu-git";
+import { fsExists, worktreeCreate, worktreeRemove } from "kolu-git";
 import { prValue } from "kolu-github/schemas";
 import { loadOpenCodeTranscript } from "kolu-opencode";
 import { transcriptToHtml } from "kolu-transcript-html";
@@ -285,6 +285,12 @@ export const appRouter = t.router({
     worktreeRemove: t.git.worktreeRemove.handler(async ({ input }) => {
       log.info({ worktree: input.worktreePath }, "worktree remove");
       unwrapGit(await worktreeRemove(input.worktreePath, log));
+    }),
+    fsExists: t.git.fsExists.handler(async ({ input }) => {
+      const exists = unwrapGit(
+        await fsExists(input.repoPath, input.filePath, log),
+      );
+      return { exists };
     }),
   },
 });

--- a/packages/server/src/terminalBackend/local.ts
+++ b/packages/server/src/terminalBackend/local.ts
@@ -52,6 +52,7 @@ import type { AgentInfo, TerminalId, TerminalInfo } from "kolu-common/surface";
 import type { GitDiffMode } from "kolu-git/schemas";
 import {
   type FsListAllOutput,
+  fsExists,
   type GitDiffOutput,
   type GitStatusOutput,
   getDiff,
@@ -571,6 +572,9 @@ const localFs: TerminalBackendFs = {
   },
   async readFile(repoPath, filePath) {
     return unwrapGit(await readFile(repoPath, filePath, log));
+  },
+  async fsExists(repoPath, filePath) {
+    return unwrapGit(await fsExists(repoPath, filePath, log));
   },
   async statFileMtimeMs(repoPath, filePath) {
     return unwrapGit(await statFileMtimeMs(repoPath, filePath, log));

--- a/packages/surface/README.md
+++ b/packages/surface/README.md
@@ -379,7 +379,7 @@ Shapes that don't fit a descriptor stay as plain oRPC procedures.
 | Pattern | Procedures | How to consume |
 |---|---|---|
 | **Bidirectional binary stream** — subscribe-before-yield ordering, custom `onRetry` (xterm buffer reset before re-subscribe's first frame) | `terminal.attach` | `streamCall(client.terminal.attach, { id }, { signal, onRetry })` |
-| **One-shot queries** — request/response, no subscription dimension | `server.info`, `terminal.screenState`, `terminal.screenText`, `terminal.exportTranscriptHtml` | `await client.X.Y(input)` |
+| **One-shot queries** — request/response, no subscription dimension | `server.info`, `terminal.screenState`, `terminal.screenText`, `terminal.exportTranscriptHtml`, `git.fsExists` | `await client.X.Y(input)` |
 | **Mutations** — request/response writes | `terminal.create` / `kill` / `killAll` / `resize` / `sendInput` / `setTheme` / `setCanvasLayout` / `setSubPanel` / `setRightPanel` / `setActive` / `setParent` / `pasteImage` / `uploadFile`, `git.worktreeCreate` / `worktreeRemove`, `preferences.update` | `await client.X.Y(input)` (the retry plugin's `retry: 0` default fails them fast) |
 
 `streamCall` applies the same `STREAM_RETRY` context the descriptor hooks thread (and merges in an optional `onRetry` callback) so transport drops re-subscribe transparently — escape hatch for non-descriptor shapes, same retry semantics.

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -72,6 +72,19 @@ Feature: File-ref autolinking in terminal
     And the selected file should show content "alpha"
     And no line should be selected in the file content
 
+  Scenario: Clicking a gitignored path opens the file via the disk-probe fallback
+    When I run "git init /tmp/kolu-file-ref-ignored && cd /tmp/kolu-file-ref-ignored"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'build/\n' > .gitignore"
+    And I run "mkdir -p build && printf 'red\ngreen\nblue\n' > build/artifact.txt"
+    And I run "echo 'see build/artifact.txt:2 for the color'"
+    And I trigger the terminal file-ref link "build/artifact.txt:2"
+    Then the right panel should be visible
+    And the Code tab should be active
+    And the Code tab mode should be "browse"
+    And the selected file should show content "green"
+    And line 2 should be selected in the file content
+
   Scenario: Bare basename without a line number resolves via unique-basename fallback
     When I run "git init /tmp/kolu-file-ref-noline-basename && cd /tmp/kolu-file-ref-noline-basename"
     And I run "git commit --allow-empty -m init"


### PR DESCRIPTION
**Clicking a `path:line` reference in the terminal now opens the file in the Code-tab preview even when git doesn't track it** — build artifacts, generated docs, scratch HTML, log files, freshly-created untracked files the `fsListAll` snapshot hasn't picked up yet. Previously the click silently failed with a "File reference not found" toast for anything outside the tree-display set, even though the server's `readFile` would have happily served the content.

### Why it was broken

The resolver in `lineRef.ts:resolveLineRefPath` gated on a `repoPaths` set that the call site filled from `app.streams.fsListAll` — which on the server runs `git ls-files --cached --others --exclude-standard`. The `--exclude-standard` flag drops gitignored files, and the stream snapshot is read-once-per-mount so anything created post-snapshot is also missing. The tree-display filter is _correct_ (the user explicitly wants gitignored files hidden from "All files"); the resolver had borrowed the wrong oracle.

### Two-stage resolution

```
                    ┌──────────────────────────────────────┐
click ─▶ resolve ──▶│ stage 1: tree-set lookup (sync)      │──▶ hit ─▶ open
                    │   preserves basename-uniqueness      │
                    │   fallback for `Foo.hs:42`           │
                    └──────────────────────────────────────┘
                                    │ miss
                                    ▼
                    ┌──────────────────────────────────────┐
                    │ stage 2: fsExists probe (async)      │──▶ exists ─▶ open
                    │   one RPC per composed candidate     │           (out-of-tree)
                    │   path-traversal guard reused from   │──▶ miss   ─▶ toast
                    │   `readFile`'s `resolveUnder`        │
                    └──────────────────────────────────────┘
```

The probe stays out of the synchronous effect body — SolidJS reactive tracking ends at the first `await` — so it fires fire-and-forget through `.then`, with `pendingOpen() !== req` + `handled()?.stage !== "probing"` staleness checks before any write so a superseding click can't get stomped by a stale fallback result.

### Pieces that landed

- **`fsExists` on `TerminalBackendFs`** — `(repoPath, filePath) → Promise<boolean>`, implemented in `localFs` delegating to the new `kolu-git` helper, exposed on the wire as `git.fsExists`. Reuses `resolveUnder` (same path-traversal guard `readFile`/`statFileMtimeMs` already trust) and matches the abstraction every sibling fs op already routes through.
- **`lineRefCandidates(args) → string[]`** — sibling of `resolveLineRefPath`, materializes the existing private `candidates()` generator so callers can probe candidates against an authority other than the tree's file list. Basename fallback _intentionally_ omitted — it requires the file list to know what's unique, and a gitignored file whose basename collides with a tracked one shouldn't quietly take over the click target.
- **`handled` as a discriminated union** — `pending` (signal-level `null`), `probing`, `in-tree`, `out-of-tree`, `miss`. The old `{resolvedPath: string | null; outOfTree: boolean}` shape admitted an illegal `(null, true)` combination; the tagged union makes that unrepresentable and gives the mid-probe state its own stage so it's distinguishable from a confirmed miss at the type level.
- **Membership-clear effect respects `probing` and `out-of-tree`** — out-of-tree selections legitimately won't appear in `treePaths()`, and a mid-flight probe shouldn't wipe the previously-displayed file for the duration of an RPC round-trip.

### Refinements during review

The first commit landed the user-visible fix; hickey/lowy and code-police caught a handful of state-machine correctness issues that landed as follow-up commits before merge:

| What was off | Fix |
| --- | --- |
| `outOfTree: boolean` paired with nullable `resolvedPath` admitted an illegal state | Discriminated union with explicit `probing` / `miss` stages |
| `fsExists` router handler imported from `kolu-git` directly, bypassing `TerminalBackendFs` | Routed through `localBackend.fs.fsExists` like every other fs op |
| Membership-clear effect wiped `selectedPath` the instant `probing` started | `probing` joins `out-of-tree` as a "trust the current selection" signal |
| In-flight probe overwrote an explicit user tree-click | `handleSelect` clears `handled` on a probing-stage click; probe staleness-checks `handled().stage !== "probing"` |
| RPC error fired three toasts (probe-failed × N + misleading "not found") | `try/catch` with early return — one accurate toast, no spurious follow-up |
| RPC error left `handled` stuck at `probing` forever | Transition to `miss` on error too — `miss` is the right terminal stage for "couldn't confirm existence either way" |

### Tests

- **`browse.test.ts`** — five `fsExists` unit tests covering present file, missing file, directory-not-a-regular-file, path traversal, and the `ENOTDIR` case (probing under a non-directory leaf).
- **`lineRef.test.ts`** — five `lineRefCandidates` unit tests covering subdirectory cwd composition, absolute repo-stripped form, escape rejection, undefined cwd, and parent-escape.
- **`file-ref-link.feature:75`** — new e2e scenario: gitignored build artifact opens from terminal click at the right line.

### Try it locally

```sh
nix run github:juspay/kolu/fix-gitignored-fileref-click
```

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._