### PR TITLE
fix(mobile): mobile drawers crash via mouse-click in Corvu 0.2.4

### DIFF
--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -201,8 +201,18 @@ const MobileTileView: Component<{
         </Drawer.Portal>
       </Drawer>
 
-      {/* Dock (left swipe) drawer — terminal navigator. */}
-      <Drawer side="left" open={dockOpen()} onOpenChange={setDockOpen}>
+      {/* Dock (left swipe) drawer — terminal navigator.
+       *  `snapPoints={[0, 1]}` is the Corvu default, but passing it
+       *  explicitly sidesteps a reactive-ordering bug in @corvu/drawer@0.2.4
+       *  where the mouse-click open path reads the signal before the default
+       *  attaches (#977). Touch-driven opens hit a different code path and
+       *  don't trip the bug. */}
+      <Drawer
+        side="left"
+        open={dockOpen()}
+        onOpenChange={setDockOpen}
+        snapPoints={[0, 1]}
+      >
         <Drawer.Portal>
           <Drawer.Overlay
             data-testid="mobile-dock-backdrop"

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -183,8 +183,16 @@ const MobileTileView: Component<{
         {props.bottomBar}
       </div>
 
-      {/* Chrome (top pull-down) drawer — global controls. */}
-      <Drawer side="top" open={chromeOpen()} onOpenChange={setChromeOpen}>
+      {/* Chrome (top pull-down) drawer — global controls.
+       *  `snapPoints={[0, 1]}` carries the same Corvu 0.2.4 workaround as
+       *  the dock drawer below — both are opened via mouse-click and would
+       *  trip the same reactive-ordering bug (#977) on that path. */}
+      <Drawer
+        side="top"
+        open={chromeOpen()}
+        onOpenChange={setChromeOpen}
+        snapPoints={[0, 1]}
+      >
         <Drawer.Portal>
           <Drawer.Overlay
             data-testid="mobile-chrome-backdrop"

--- a/packages/tests/features/mobile-dock-drawer.feature
+++ b/packages/tests/features/mobile-dock-drawer.feature
@@ -14,6 +14,15 @@ Feature: Mobile dock drawer
     And there should be no page errors
 
   @mobile
+  Scenario: Clicking the dock handle (mouse path) opens the drawer without errors
+    # Regression cover for #977 — Corvu @0.2.4 crashed on the mouse-click
+    # path because snapPoints defaults weren't applied in time. The tap-based
+    # scenario above exercises a different Corvu code path and so missed it.
+    When I click the mobile dock handle
+    Then the mobile dock sheet should be visible
+    And there should be no page errors
+
+  @mobile
   Scenario: Selecting a row switches active terminal and closes the drawer
     Given I run "echo from-t0"
     And I create a terminal

--- a/packages/tests/features/mobile-drawer.feature
+++ b/packages/tests/features/mobile-drawer.feature
@@ -17,6 +17,15 @@ Feature: Mobile chrome drawer
     And there should be no page errors
 
   @mobile
+  Scenario: Clicking the pull handle (mouse path) opens the drawer without errors
+    # Companion regression cover for #977 — the chrome drawer is structurally
+    # exposed to the same Corvu @0.2.4 mouse-click crash as the dock drawer,
+    # and now carries the same `snapPoints={[0, 1]}` workaround.
+    When I click the mobile pull handle
+    Then the mobile chrome sheet should be visible
+    And there should be no page errors
+
+  @mobile
   Scenario: Tapping the backdrop dismisses the drawer
     When I tap the mobile pull handle
     Then the mobile chrome sheet should be visible

--- a/packages/tests/step_definitions/mobile_drawer_steps.ts
+++ b/packages/tests/step_definitions/mobile_drawer_steps.ts
@@ -23,6 +23,12 @@ When("I tap the mobile pull handle", async function (this: KoluWorld) {
   await this.page.locator(PULL_HANDLE).tap();
 });
 
+// Mouse-click path companion — see `I click the mobile dock handle` below
+// for the rationale (Corvu touch vs. mouse open paths differ; #977).
+When("I click the mobile pull handle", async function (this: KoluWorld) {
+  await this.page.locator(PULL_HANDLE).click();
+});
+
 When("I tap the mobile chrome backdrop", async function (this: KoluWorld) {
   await this.page.locator(CHROME_BACKDROP).tap();
 });

--- a/packages/tests/step_definitions/mobile_drawer_steps.ts
+++ b/packages/tests/step_definitions/mobile_drawer_steps.ts
@@ -167,6 +167,13 @@ When("I tap the mobile dock handle", async function (this: KoluWorld) {
   await this.page.locator(DOCK_HANDLE).tap();
 });
 
+// Mouse-click path: Playwright's `.tap()` synthesises touch events, which
+// take a different code path in Corvu than mouse clicks. Desktop debugging
+// (DevTools touch emulation) lands on this path — see #977.
+When("I click the mobile dock handle", async function (this: KoluWorld) {
+  await this.page.locator(DOCK_HANDLE).click();
+});
+
 When("I tap the mobile dock backdrop", async function (this: KoluWorld) {
   await tapBackdropAtSafePoint(this, DOCK_BACKDROP, "left");
 });


### PR DESCRIPTION
**Mobile dock and chrome drawers no longer crash when opened by mouse-click.** `@corvu/drawer@0.2.4` has a reactive-ordering bug on its mouse-click open path where the `snapPoints` signal is read before the default has attached, throwing two `TypeError`s from inside `findNearbySnapPoint` and the open-animation prep. Touch-driven `.tap()` walks a different code path inside Corvu and never trips it — which is exactly why the existing `mobile-dock-drawer.feature` (all `.tap()`-based) stayed green.

The fix is one prop per drawer: passing Corvu's documented default `snapPoints={[0, 1]}` explicitly sidesteps the reactive-ordering window. Both `<Drawer side="left">` (dock) and `<Drawer side="top">` (chrome) get it — they share the same Corvu version and the same `onClick={() => setXxxOpen(true)}` open path, so they're structurally exposed to the same bug.

### Regression coverage

CI missed the original crash because both feature files exclusively used Playwright's `.tap()`. This PR adds a matching `.click()`-based scenario per drawer:

| Drawer | Existing tap path | New click path |
|--------|------------------|----------------|
| Dock (`side="left"`) | `mobile-dock-drawer.feature` | _"Clicking the dock handle (mouse path) opens the drawer without errors"_ |
| Chrome (`side="top"`) | `mobile-drawer.feature` | _"Clicking the pull handle (mouse path) opens the drawer without errors"_ |

Closes #977.

### Try it locally

```sh
nix run github:juspay/kolu/bug
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._