### PR TITLE
Re-license @kolu/surface and @kolu/surface-nix-host under MIT

### DIFF
--- a/packages/surface-nix-host/LICENSE
+++ b/packages/surface-nix-host/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juspay Technologies Pvt. Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/surface-nix-host/package.json
+++ b/packages/surface-nix-host/package.json
@@ -2,7 +2,7 @@
   "name": "@kolu/surface-nix-host",
   "version": "0.1.0",
   "private": true,
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "main": "./src/index.ts",

--- a/packages/surface/LICENSE
+++ b/packages/surface/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juspay Technologies Pvt. Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -2,7 +2,7 @@
   "name": "@kolu/surface",
   "version": "0.1.0",
   "private": true,
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "main": "./src/index.ts",


### PR DESCRIPTION
**Both `@kolu/surface` and `@kolu/surface-nix-host` are now MIT-licensed**, matching the license of their oRPC foundation (`@orpc/*` is MIT). The two packages are workspace-private today but are designed to be liftable into standalone publishes — the surface framework as a SolidJS-flavoured layer atop oRPC, and `surface-nix-host` as the Node-side ssh/Nix supervisor — and that path is straightforward only if the license is permissive.

The repo-root `LICENSE` remains **AGPL-3.0-or-later**; only these two packages move. Each now carries its own `LICENSE` file (standard MIT text, `Copyright (c) 2026 Juspay Technologies Pvt. Ltd.`), which becomes canonical when either package is consumed in isolation — the per-package `license` field in `package.json` and the file on disk agree.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._