### PR TITLE
Right-panel resize handle: hittable above canvas tiles + z-layer catalog

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -47,6 +47,7 @@ import Resizable from "@corvu/resizable";
 import RightPanel from "./right-panel/RightPanel";
 import RightPanelDrawer from "./right-panel/RightPanelDrawer";
 import { useRightPanel } from "./right-panel/useRightPanel";
+import { Z_HANDLE_OUTER } from "./ui/stackLayers";
 import { serverProcessId, wsStatus } from "./rpc/rpc";
 import TransportOverlay from "./rpc/TransportOverlay";
 import ShortcutsHelp from "./ShortcutsHelp";
@@ -647,21 +648,18 @@ const App: Component = () => {
                     <Resizable.Handle
                       data-testid="right-panel-handle"
                       startIntersection={false}
-                      // `z-20` lifts the ::before pseudo-element above the
-                      // canvas tile (`position: absolute; z-index: 10`).
-                      // The handle's ::before extends 4px left into the
+                      // `Z_HANDLE_OUTER` lifts the ::before pseudo above
+                      // the canvas tile (`Z_CANVAS_TILE_ACTIVE`). The
+                      // handle's ::before extends 4px left into the
                       // canvas area (`before:-left-1 before:w-2`); without
-                      // an explicit z-index the tile paints over that half
-                      // of the hit zone wherever its right edge meets or
-                      // passes the right-panel boundary, killing both the
-                      // visual hover indicator and the pointer target.
-                      // Mirrors CodeTab's inner handle defense
-                      // (`z-10` against Pierre's positioned tree rows) —
-                      // higher here because canvas tiles already claim
-                      // z-10. Pierre's rows on the right side of the
-                      // handle are also positioned descendants, so z-20
-                      // doubles as defense against the in-panel side.
-                      class="shrink-0 w-0 relative z-20 before:absolute before:inset-y-0 before:-left-1 before:w-2 before:cursor-col-resize before:hover:bg-accent/30 before:transition-colors"
+                      // the explicit z-index the tile paints over that
+                      // half of the hit zone wherever its right edge
+                      // meets or passes the right-panel boundary, killing
+                      // both the visual hover indicator and the pointer
+                      // target. See `ui/stackLayers.ts` for the full
+                      // layering contract.
+                      class="shrink-0 w-0 relative before:absolute before:inset-y-0 before:-left-1 before:w-2 before:cursor-col-resize before:hover:bg-accent/30 before:transition-colors"
+                      style={{ "z-index": Z_HANDLE_OUTER }}
                       aria-label="Resize inspector panel"
                     />
                   </Show>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -647,7 +647,21 @@ const App: Component = () => {
                     <Resizable.Handle
                       data-testid="right-panel-handle"
                       startIntersection={false}
-                      class="shrink-0 w-0 relative before:absolute before:inset-y-0 before:-left-1 before:w-2 before:cursor-col-resize before:hover:bg-accent/30 before:transition-colors"
+                      // `z-20` lifts the ::before pseudo-element above the
+                      // canvas tile (`position: absolute; z-index: 10`).
+                      // The handle's ::before extends 4px left into the
+                      // canvas area (`before:-left-1 before:w-2`); without
+                      // an explicit z-index the tile paints over that half
+                      // of the hit zone wherever its right edge meets or
+                      // passes the right-panel boundary, killing both the
+                      // visual hover indicator and the pointer target.
+                      // Mirrors CodeTab's inner handle defense
+                      // (`z-10` against Pierre's positioned tree rows) —
+                      // higher here because canvas tiles already claim
+                      // z-10. Pierre's rows on the right side of the
+                      // handle are also positioned descendants, so z-20
+                      // doubles as defense against the in-panel side.
+                      class="shrink-0 w-0 relative z-20 before:absolute before:inset-y-0 before:-left-1 before:w-2 before:cursor-col-resize before:hover:bg-accent/30 before:transition-colors"
                       aria-label="Resize inspector panel"
                     />
                   </Show>

--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -15,6 +15,10 @@
 import { createDraggable } from "@thisbeyond/solid-dnd";
 import { type Component, For, type JSX, Show } from "solid-js";
 import { CHROME_ICON_BUTTON_CLASS } from "../ui/chromeSpacing";
+import {
+  Z_CANVAS_TILE_ACTIVE,
+  Z_CANVAS_TILE_INACTIVE,
+} from "../ui/stackLayers";
 import { MaximizeIcon, RestoreIcon } from "../ui/Icons";
 import { RESIZE_HANDLES, type ResizeDirection } from "./resizeGeometry";
 import type { TileLayout } from "./TileLayout";
@@ -113,7 +117,7 @@ const CanvasTile: Component<{
         props.active && !isMaximized()
           ? "var(--color-accent)"
           : props.repoColor,
-      "z-index": props.active ? 10 : 1,
+      "z-index": props.active ? Z_CANVAS_TILE_ACTIVE : Z_CANVAS_TILE_INACTIVE,
       opacity: props.active ? 1 : inactiveOpacity(),
       "box-shadow": props.active
         ? `0 8px 32px rgba(0,0,0,0.4), 0 0 0 1px var(--color-accent)`

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -51,6 +51,7 @@ import {
   pierreIconConfig,
   pierreTreesStyle,
 } from "../ui/pierreTheme";
+import { Z_HANDLE_INNER } from "../ui/stackLayers";
 import { app } from "../wire";
 import BrowseFileDispatcher from "./BrowseFileDispatcher";
 import CodeMenuFrame from "./CodeMenuFrame";
@@ -546,15 +547,17 @@ const CodeTab: Component<{
             // symmetric `startIntersection={false}` so both sides are
             // defended.
             startIntersection={false}
-            // `z-10` raises the ::before pseudo-element above Pierre's tree
-            // (which is the previous flex sibling). Without it, the tree's
-            // bottom 4px shadow the upper half of the handle's hit area —
-            // Pierre's row hit-targets paint above the handle's absolute
-            // ::before because both use auto z-index and the tree comes
-            // first in document order with positioned descendants. Setting
-            // `z-10` on the handle creates a stacking context that lifts
-            // the ::before in front of the tree's interior.
-            class="shrink-0 h-0 relative z-10 before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors"
+            // `Z_HANDLE_INNER` raises the ::before pseudo-element above
+            // Pierre's tree (the previous flex sibling). Without it, the
+            // tree's bottom 4px shadow the upper half of the handle's hit
+            // area — Pierre's row hit-targets paint above the handle's
+            // absolute ::before because both use auto z-index and the tree
+            // comes first in document order with positioned descendants.
+            // Setting the explicit z-index creates a stacking context that
+            // lifts the ::before in front of the tree's interior.
+            // See `ui/stackLayers.ts` for the full layering contract.
+            class="shrink-0 h-0 relative before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors"
+            style={{ "z-index": Z_HANDLE_INNER }}
           />
 
           <Resizable.Panel

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -113,7 +113,7 @@ const TerminalContent: Component<{
               isExpanded(),
             "h-0": !isExpanded(),
           }}
-          style={isExpanded() ? { "z-index": Z_HANDLE_INNER } : undefined}
+          style={{ "z-index": Z_HANDLE_INNER }}
           aria-label="Resize terminal split"
         />
       </Show>

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -8,6 +8,7 @@ import Resizable from "@corvu/resizable";
 import type { ITheme } from "@xterm/xterm";
 import type { TerminalId, TerminalMetadata } from "kolu-common/surface";
 import { type Component, For, Show } from "solid-js";
+import { Z_HANDLE_INNER } from "../ui/stackLayers";
 import SubPanelTabBar from "./SubPanelTabBar";
 import Terminal from "./Terminal";
 import { useSubPanel } from "./useSubPanel";
@@ -93,23 +94,26 @@ const TerminalContent: Component<{
       </Resizable.Panel>
 
       {/* Resize handle — invisible hit zone, visible on hover.
-       *  `z-10` mirrors CodeTab.tsx's inner-handle defense: the ::before
-       *  pseudo overlaps the previous panel (xterm tile) by 4px and any
-       *  positioned descendant inside that panel with auto/zero z-index
-       *  would otherwise paint over the hit zone. The canvas-tile
-       *  container that hosts this tree creates its own stacking context
-       *  (z-10), so external z-stackers can't intrude — but the defense
-       *  belongs on the handle itself so a future xterm overlay with an
-       *  explicit z-index doesn't silently break drag-to-resize. */}
+       *  `Z_HANDLE_INNER` mirrors CodeTab.tsx's inner-handle defense:
+       *  the ::before pseudo overlaps the previous panel (xterm tile)
+       *  by 4px and any positioned descendant inside that panel with
+       *  auto/zero z-index would otherwise paint over the hit zone.
+       *  The canvas-tile container that hosts this tree creates its
+       *  own stacking context (`Z_CANVAS_TILE_ACTIVE`), so external
+       *  z-stackers can't intrude — but the defense belongs on the
+       *  handle itself so a future xterm overlay with an explicit
+       *  z-index doesn't silently break drag-to-resize.
+       *  See `ui/stackLayers.ts` for the full layering contract. */}
       <Show when={hasSubs()}>
         <Resizable.Handle
           data-testid="resize-handle"
           class="shrink-0 transition-all"
           classList={{
-            "h-0 relative z-10 before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors":
+            "h-0 relative before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors":
               isExpanded(),
             "h-0": !isExpanded(),
           }}
+          style={isExpanded() ? { "z-index": Z_HANDLE_INNER } : undefined}
           aria-label="Resize terminal split"
         />
       </Show>

--- a/packages/client/src/terminal/TerminalContent.tsx
+++ b/packages/client/src/terminal/TerminalContent.tsx
@@ -92,13 +92,21 @@ const TerminalContent: Component<{
         />
       </Resizable.Panel>
 
-      {/* Resize handle — invisible hit zone, visible on hover */}
+      {/* Resize handle — invisible hit zone, visible on hover.
+       *  `z-10` mirrors CodeTab.tsx's inner-handle defense: the ::before
+       *  pseudo overlaps the previous panel (xterm tile) by 4px and any
+       *  positioned descendant inside that panel with auto/zero z-index
+       *  would otherwise paint over the hit zone. The canvas-tile
+       *  container that hosts this tree creates its own stacking context
+       *  (z-10), so external z-stackers can't intrude — but the defense
+       *  belongs on the handle itself so a future xterm overlay with an
+       *  explicit z-index doesn't silently break drag-to-resize. */}
       <Show when={hasSubs()}>
         <Resizable.Handle
           data-testid="resize-handle"
           class="shrink-0 transition-all"
           classList={{
-            "h-0 relative before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors":
+            "h-0 relative z-10 before:absolute before:inset-x-0 before:-top-1 before:h-2 before:cursor-row-resize before:hover:bg-accent/30 before:transition-colors":
               isExpanded(),
             "h-0": !isExpanded(),
           }}

--- a/packages/client/src/ui/stackLayers.ts
+++ b/packages/client/src/ui/stackLayers.ts
@@ -1,4 +1,10 @@
-/** Z-index contract for the canvas + right-panel layout.
+/** Z-index contract for the **canvas-tile / resize-handle stacking
+ *  axis** — the volatility axis that caused the original outer-handle
+ *  shadowing bug. Surrounding chrome surfaces (ChromeBar `z-50`, Dock
+ *  `z-30`, CanvasMinimap `z-20`, maximized-tile `z-40`,
+ *  MobileTileView overlays) sit on their own axes and keep their
+ *  literal Tailwind classes at the call site — they don't participate
+ *  in this catalog's invariant.
  *
  *  Numbers are consumed as inline `z-index` style values at each site
  *  (Tailwind v4's @theme doesn't register custom `z-*` utility scales).
@@ -22,7 +28,18 @@ export const Z_CANVAS_TILE_INACTIVE = 1;
  *  the terminal-split handle inside a canvas tile. Both live inside a
  *  positioned ancestor whose own stacking context insulates them from
  *  the canvas-tile z-axis; the explicit value is defense against
- *  positioned descendants (Pierre's tree rows, xterm overlays). */
+ *  positioned descendants inside that context (Pierre's tree rows,
+ *  potential xterm overlays).
+ *
+ *  Numerically equal to `Z_CANVAS_TILE_ACTIVE` only by coincidence —
+ *  the two values live in different stacking contexts and can move
+ *  independently. The shared 10 reflects "the lowest explicit value
+ *  that beats auto/zero," not a coupling.
+ *
+ *  **Within-tile ceiling:** any positioned descendant inside the
+ *  canvas-tile stacking context (xterm overlays, search affordances,
+ *  scroll-to-bottom buttons, …) that should remain *below* the inner
+ *  handle's hit zone must stay below this value. */
 export const Z_HANDLE_INNER = 10;
 
 /** Outer horizontal handle between the canvas and the right panel.

--- a/packages/client/src/ui/stackLayers.ts
+++ b/packages/client/src/ui/stackLayers.ts
@@ -2,9 +2,11 @@
  *  axis** — the volatility axis that caused the original outer-handle
  *  shadowing bug. Surrounding chrome surfaces (ChromeBar `z-50`, Dock
  *  `z-30`, CanvasMinimap `z-20`, maximized-tile `z-40`,
- *  MobileTileView overlays) sit on their own axes and keep their
- *  literal Tailwind classes at the call site — they don't participate
- *  in this catalog's invariant.
+ *  MobileTileView overlays) keep their literal Tailwind classes at the
+ *  call site and don't participate in this catalog's invariant. They
+ *  share the same stacking context as the canvas (no stacking-context
+ *  isolation exists between them), but are positioned far enough from
+ *  the right-panel boundary that they never compete with these values.
  *
  *  Numbers are consumed as inline `z-index` style values at each site
  *  (Tailwind v4's @theme doesn't register custom `z-*` utility scales).
@@ -15,11 +17,11 @@
  *  hit zone (the half that sits inside the canvas area) — killing
  *  both the hover indicator and the pointer target along that strip.
  *  The `right-panel.feature` "hittable at its full width" scenario
- *  enforces this with a 25-point elementFromPoint sweep.
+ *  enforces this invariant with a 25-point elementFromPoint sweep.
  *
- *  Bump any of these and re-run that scenario — the test is the
- *  contract's only structural enforcement; this file is its
- *  catalog. */
+ *  `Z_HANDLE_INNER` has no dedicated e2e coverage — it is a
+ *  precautionary value that must stay above auto/zero (see its doc
+ *  below); any future refactor to inner handles should add a test. */
 
 export const Z_CANVAS_TILE_ACTIVE = 10;
 export const Z_CANVAS_TILE_INACTIVE = 1;

--- a/packages/client/src/ui/stackLayers.ts
+++ b/packages/client/src/ui/stackLayers.ts
@@ -1,0 +1,31 @@
+/** Z-index contract for the canvas + right-panel layout.
+ *
+ *  Numbers are consumed as inline `z-index` style values at each site
+ *  (Tailwind v4's @theme doesn't register custom `z-*` utility scales).
+ *
+ *  **Invariant:** `Z_HANDLE_OUTER > Z_CANVAS_TILE_ACTIVE`.
+ *  Without this gap, a canvas tile whose right edge reaches the
+ *  right-panel boundary paints over the outer handle's 4px ::before
+ *  hit zone (the half that sits inside the canvas area) — killing
+ *  both the hover indicator and the pointer target along that strip.
+ *  The `right-panel.feature` "hittable at its full width" scenario
+ *  enforces this with a 25-point elementFromPoint sweep.
+ *
+ *  Bump any of these and re-run that scenario — the test is the
+ *  contract's only structural enforcement; this file is its
+ *  catalog. */
+
+export const Z_CANVAS_TILE_ACTIVE = 10;
+export const Z_CANVAS_TILE_INACTIVE = 1;
+
+/** Inner vertical handle inside `CodeTab` (tree ↔ content split) and
+ *  the terminal-split handle inside a canvas tile. Both live inside a
+ *  positioned ancestor whose own stacking context insulates them from
+ *  the canvas-tile z-axis; the explicit value is defense against
+ *  positioned descendants (Pierre's tree rows, xterm overlays). */
+export const Z_HANDLE_INNER = 10;
+
+/** Outer horizontal handle between the canvas and the right panel.
+ *  Must exceed `Z_CANVAS_TILE_ACTIVE` so an active tile butting the
+ *  right-panel boundary doesn't shadow the handle's ::before. */
+export const Z_HANDLE_OUTER = 20;

--- a/packages/client/src/ui/stackLayers.ts
+++ b/packages/client/src/ui/stackLayers.ts
@@ -1,12 +1,21 @@
 /** Z-index contract for the **canvas-tile / resize-handle stacking
  *  axis** — the volatility axis that caused the original outer-handle
  *  shadowing bug. Surrounding chrome surfaces (ChromeBar `z-50`, Dock
- *  `z-30`, CanvasMinimap `z-20`, maximized-tile `z-40`,
- *  MobileTileView overlays) keep their literal Tailwind classes at the
- *  call site and don't participate in this catalog's invariant. They
- *  share the same stacking context as the canvas (no stacking-context
- *  isolation exists between them), but are positioned far enough from
- *  the right-panel boundary that they never compete with these values.
+ *  `z-30`, CanvasMinimap `z-20`, MobileTileView overlays) keep their
+ *  literal Tailwind classes at the call site and don't participate in
+ *  this catalog's invariant. They share the same root stacking context
+ *  as the canvas (`canvas-container` is `overflow-hidden relative`
+ *  with no explicit z-index — no stacking context) but don't overlap
+ *  the right-panel boundary in practice.
+ *
+ *  **Exception — maximized tile `z-40`:** A maximized tile uses
+ *  `absolute inset-0 z-40` within `canvas-container`; its right edge
+ *  coincides with the handle's left edge, so its bounding box covers
+ *  the 4px strip where `::before` extends into the canvas area.
+ *  `z-40 > Z_HANDLE_OUTER=20` means the outer handle's hit zone is
+ *  shadowed during maximized mode. Pre-existing gap (handle had no
+ *  z-index before this catalog). Fix: raise `Z_HANDLE_OUTER` above 40
+ *  or add explicit `z-index` to `canvas-container` to contain tiles.
  *
  *  Numbers are consumed as inline `z-index` style values at each site
  *  (Tailwind v4's @theme doesn't register custom `z-*` utility scales).

--- a/packages/tests/features/right-panel.feature
+++ b/packages/tests/features/right-panel.feature
@@ -67,6 +67,17 @@ Feature: Right panel (inspector)
     And the right panel resize handle should be visible
     And there should be no page errors
 
+  Scenario: Resize handle stays hittable over a canvas tile in Code tab
+    # A tile placed against the canvas's right edge would shadow the
+    # outer handle's ::before hit zone (which extends 4px into the
+    # canvas area) unless the handle stacks above the tile's z-index:10.
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I click the Code tab
+    Then the Code tab should be active
+    Then the right panel resize handle should be hittable at its full width
+    And there should be no page errors
+
   Scenario: Right panel state persists across refresh
     When I press the toggle inspector shortcut
     Then the right panel should be visible

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -121,3 +121,55 @@ Then(
     await handle.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
   },
 );
+
+Then(
+  "the right panel resize handle should be hittable at its full width",
+  async function (this: KoluWorld) {
+    // The outer handle's ::before extends `before:-left-1 before:w-2`
+    // (-4px..+4px from the handle's left edge in Tailwind units). Sample
+    // points across that 8px-wide strip and assert each one resolves to
+    // the handle button via elementFromPoint.
+    //
+    // Force the canvas tile's right edge to coincide with the handle's
+    // left edge before sampling. Canvas tiles use
+    // `position: absolute; z-index: 10`; without this step the default
+    // tile placement might not reach the boundary, and a passing
+    // assertion would only mean "no tile happened to overlap" — not
+    // "the handle stacks above tiles when they do."
+    const result = await this.page.evaluate(() => {
+      const handle = document.querySelector(
+        '[data-testid="right-panel-handle"]',
+      );
+      if (!handle) return { ok: false, dead: [{ reason: "handle missing" }] };
+      const tile = document.querySelector(
+        '[data-testid="canvas-tile"]',
+      ) as HTMLElement | null;
+      if (!tile) return { ok: false, dead: [{ reason: "tile missing" }] };
+      const handleRect = handle.getBoundingClientRect();
+      const tileRect = tile.getBoundingClientRect();
+      // Shift the tile so its right edge lands exactly on handle.left.
+      // CanvasTile sets its transform inline; appending a translateX
+      // shift preserves whatever the canvas arranger computed.
+      const shift = handleRect.left - tileRect.right;
+      tile.style.transform = `${tile.style.transform} translateX(${shift}px)`;
+      const newTileRect = tile.getBoundingClientRect();
+      const dead: { x: number; y: number; covered: string }[] = [];
+      for (const yFrac of [0.1, 0.3, 0.5, 0.7, 0.9]) {
+        const y = newTileRect.top + newTileRect.height * yFrac;
+        for (const dx of [-3, -1.5, 0, 1.5, 3]) {
+          const x = handleRect.left + dx;
+          const el = document.elementFromPoint(x, y);
+          const id = el?.getAttribute("data-testid");
+          if (id !== "right-panel-handle") {
+            dead.push({ x, y, covered: id ?? el?.tagName ?? "<null>" });
+          }
+        }
+      }
+      return { ok: dead.length === 0, dead };
+    });
+    assert.ok(
+      result.ok,
+      `Resize handle is shadowed at: ${JSON.stringify(result.dead)}`,
+    );
+  },
+);

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -166,7 +166,9 @@ Then(
       const dead: { x: number; y: number; covered: string }[] = [];
       for (const yFrac of [0.1, 0.3, 0.5, 0.7, 0.9]) {
         const y = newTileRect.top + newTileRect.height * yFrac;
-        for (const dx of [-3, -1.5, 0, 1.5, 3]) {
+        // ::before extends to ±4px (`before:-left-1 before:w-2`); sample
+        // its full extent so the assertion enforces the whole hit zone.
+        for (const dx of [-4, -2, 0, 2, 4]) {
           const x = handleRect.left + dx;
           const el = document.elementFromPoint(x, y);
           const id = el?.getAttribute("data-testid");

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -159,12 +159,15 @@ Then(
       const handle = document.querySelector(
         '[data-testid="right-panel-handle"]',
       );
-      if (!handle) return { ok: false, dead: [{ reason: "handle missing" }] };
+      if (!handle) return { ok: false, setupError: "handle missing" } as const;
       const tile = document.querySelector(
         '[data-testid="canvas-tile"][data-active="true"]',
       ) as HTMLElement | null;
       if (!tile) {
-        return { ok: false, dead: [{ reason: "active tile missing" }] };
+        return {
+          ok: false,
+          setupError: "active tile missing",
+        } as const;
       }
       const handleRect = handle.getBoundingClientRect();
       const tileRect = tile.getBoundingClientRect();
@@ -186,11 +189,14 @@ Then(
           }
         }
       }
-      return { ok: dead.length === 0, dead };
+      return { ok: dead.length === 0, dead } as const;
     });
+    if (!result.ok && "setupError" in result) {
+      assert.fail(`Setup failed: ${result.setupError}`);
+    }
     assert.ok(
       result.ok,
-      `Resize handle is shadowed at: ${JSON.stringify(result.dead)}`,
+      `Resize handle is shadowed at: ${JSON.stringify("dead" in result ? result.dead : [])}`,
     );
   },
 );

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -178,9 +178,12 @@ Then(
       const dead: { x: number; y: number; covered: string }[] = [];
       for (const yFrac of [0.1, 0.3, 0.5, 0.7, 0.9]) {
         const y = newTileRect.top + newTileRect.height * yFrac;
-        // ::before extends to ±4px (`before:-left-1 before:w-2`); sample
-        // its full extent so the assertion enforces the whole hit zone.
-        for (const dx of [-4, -2, 0, 2, 4]) {
+        // ::before spans [-4, +4) — `before:-left-1` puts its left edge
+        // at -4, `before:w-2` makes it 8px wide, so its painted pixels
+        // run -4..+3 inclusive (right edge at +4 is exclusive per CSS
+        // box geometry). Sample at both inclusive boundaries plus three
+        // interior points so the assertion enforces the full hit zone.
+        for (const dx of [-4, -2, 0, 2, 3]) {
           const x = handleRect.left + dx;
           const el = document.elementFromPoint(x, y);
           const id = el?.getAttribute("data-testid");

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -146,6 +146,15 @@ Then(
     // of riding on `CanvasTile`'s internal transform composition — a
     // separate volatility axis the assertion has no business coupling
     // to.
+    //
+    // Double-rAF before sampling so SolidJS reactivity + Corvu's
+    // Resizable transitions are flushed — without it, a stale layout
+    // snapshot could either silently pass (tile not yet at boundary)
+    // or flake on slower CI runners. The detailed `dead` list in the
+    // failure message is worth keeping over a generic
+    // `waitForFunction` timeout: it names the exact (x, y) and the
+    // covering element so a regression points at its cause.
+    await this.waitForFrame();
     const result = await this.page.evaluate(() => {
       const handle = document.querySelector(
         '[data-testid="right-panel-handle"]',

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -130,28 +130,38 @@ Then(
     // points across that 8px-wide strip and assert each one resolves to
     // the handle button via elementFromPoint.
     //
-    // Force the canvas tile's right edge to coincide with the handle's
-    // left edge before sampling. Canvas tiles use
-    // `position: absolute; z-index: 10`; without this step the default
-    // tile placement might not reach the boundary, and a passing
-    // assertion would only mean "no tile happened to overlap" — not
-    // "the handle stacks above tiles when they do."
+    // Force the active canvas tile's right edge to coincide with the
+    // handle's left edge before sampling. Canvas tiles use
+    // `position: absolute; z-index: 10` only when active (inactive tiles
+    // sit at z-index: 1 and cannot shadow the handle), so a generic
+    // `[data-testid="canvas-tile"]` lookup could pick an inactive tile,
+    // shift an irrelevant element, and silently pass. Without this
+    // step the default tile placement might not reach the boundary at
+    // all, and the assertion would only mean "no tile happened to
+    // overlap" — not "the handle stacks above tiles when they do."
+    //
+    // Positioning happens via the absolute `left` offset rather than by
+    // appending to the inline `transform`. That keeps the test on the
+    // tile's stable boundary (its bounding rect's right edge) instead
+    // of riding on `CanvasTile`'s internal transform composition — a
+    // separate volatility axis the assertion has no business coupling
+    // to.
     const result = await this.page.evaluate(() => {
       const handle = document.querySelector(
         '[data-testid="right-panel-handle"]',
       );
       if (!handle) return { ok: false, dead: [{ reason: "handle missing" }] };
       const tile = document.querySelector(
-        '[data-testid="canvas-tile"]',
+        '[data-testid="canvas-tile"][data-active="true"]',
       ) as HTMLElement | null;
-      if (!tile) return { ok: false, dead: [{ reason: "tile missing" }] };
+      if (!tile) {
+        return { ok: false, dead: [{ reason: "active tile missing" }] };
+      }
       const handleRect = handle.getBoundingClientRect();
       const tileRect = tile.getBoundingClientRect();
-      // Shift the tile so its right edge lands exactly on handle.left.
-      // CanvasTile sets its transform inline; appending a translateX
-      // shift preserves whatever the canvas arranger computed.
+      const currentLeft = parseFloat(tile.style.left || "0");
       const shift = handleRect.left - tileRect.right;
-      tile.style.transform = `${tile.style.transform} translateX(${shift}px)`;
+      tile.style.left = `${currentLeft + shift}px`;
       const newTileRect = tile.getBoundingClientRect();
       const dead: { x: number; y: number; covered: string }[] = [];
       for (const yFrac of [0.1, 0.3, 0.5, 0.7, 0.9]) {


### PR DESCRIPTION
**The outer right-panel resize handle was non-hittable wherever an active canvas tile reached the right-panel boundary** — reproducible on the Code tab with Pierre tree or preview, but the underlying cause was independent of either. The fix is one `z-index`; the rest of the diff catalogs the contract so the next bump doesn't silently break it.

### The bug, in pixels

The outer handle (`App.tsx`) hangs an invisible 8-pixel-wide hit zone over the right-panel boundary as a `::before` pseudo-element — 4 px into the canvas, 4 px into the right panel. Canvas tiles use `position: absolute; z-index: 10`; the handle had `position: relative; z-index: auto`. Wherever an active tile's right edge reached the boundary, the tile painted over the canvas-side half of the hit zone — **both the visual hover indicator and the pointer target died along that strip**.

The user noticed it specifically in Code tab because that's where they actively wanted to widen the panel; Inspector users typically just toggle visibility and don't reach for the handle.

```
   canvas tile          right panel
   (z-index: 10)        (RightPanel)
        │                    │
        │                    │
   ─────┼──┬─┬───────────────┼─────
        │  │ │               │
        │  ┊ ┊               │
        │ ::before (z: auto) │  ← shadowed by tile on the left 4px,
        │  ┊ ┊               │     handle won on the right 4px
        │  │ │               │
   ─────┼──┴─┴───────────────┼─────
                ↑
        handle.left
```

### What landed

| Layer | Change | File(s) |
| --- | --- | --- |
| **Fix** | `Z_HANDLE_OUTER = 20` on the outer handle (beats tile's `Z_CANVAS_TILE_ACTIVE = 10`) | `App.tsx` |
| **Defense** | Symmetric `z-index` on the terminal-split handle (was missing the same defense CodeTab's inner handle already had) | `terminal/TerminalContent.tsx` |
| **Catalog** | New `ui/stackLayers.ts` — names the four layers, documents the invariant, calls out the maximized-tile shadowing as a pre-existing gap with two follow-up paths | `ui/stackLayers.ts`, threaded into 4 sites |
| **Test** | Cucumber scenario _Resize handle stays hittable over a canvas tile in Code tab_ — programmatically shifts the active tile's right edge onto the handle and sweeps 25 points across the `::before` strip via `elementFromPoint` | `right-panel.feature`, `right_panel_steps.ts` |

### Notable details

- _The catalog is intentionally narrow_ — it owns the canvas-tile + handle stacking axis (the one this bug lives on). ChromeBar (`z-50`), Dock (`z-30`), CanvasMinimap (`z-20`) sit on independent axes and keep their literal Tailwind classes at the call site; calling them out in the catalog header keeps the next reader oriented without dragging four more files into the migration.
- _Tailwind v4 doesn't register custom `z-*` utility scales_, so the constants are consumed via inline `style={{ "z-index": ... }}` rather than a class. The handles already mix Tailwind utilities with inline style elsewhere, so this isn't new pattern.
- _The test catches the bug end-to-end_: it selects `[data-active="true"]` (inactive tiles can't shadow the handle), shifts via `style.left` (not `transform`, to decouple from `CanvasTile`'s transform composition strategy), waits a double-rAF for Corvu/SolidJS to flush, and reports the exact `(x, y, covered)` triple on failure.

> The maximized-tile `z-40` shadowing case is documented in the catalog as a pre-existing exception. Fix paths are recorded inline — separate PR.

### Try it locally

```sh
nix run github:juspay/kolu/fix-right-panel-handle-z
```

---

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-7`)._