### PR TITLE
Line-ref clicks scroll to the range and open on the first click

### DIFF
--- a/packages/solid-pierre/src/CodeView.tsx
+++ b/packages/solid-pierre/src/CodeView.tsx
@@ -124,6 +124,27 @@ export const CodeView: Component<CodeViewProps> = (props) => {
     return result.items;
   };
 
+  // Bring a programmatically-set selection into view. Pierre's
+  // `setSelectedLines` paints the highlight but never scrolls — and with
+  // virtualization an off-screen range isn't even in the DOM. A terminal
+  // `path:line` click on a line deep in the file would otherwise open the
+  // file scrolled to the top with the highlight invisible below the fold.
+  // `align: "nearest"` is the no-yank choice for prop-driven updates: it
+  // moves the minimum to reveal the range, so the echo of a user's own
+  // gutter click (which selects an already-visible line) is a no-op.
+  const scrollToSelection = (
+    selection: CodeViewLineSelection | null | undefined,
+    align: "center" | "nearest",
+  ): void => {
+    if (!selection) return;
+    instance?.scrollTo({
+      type: "range",
+      id: selection.id,
+      range: selection.range,
+      align,
+    });
+  };
+
   // Read every reactive prop at call time so a later prop change lands on
   // the existing CodeView instance via `setOptions` (theme toggle, etc.)
   // instead of forcing a reconstruct.
@@ -154,6 +175,10 @@ export const CodeView: Component<CodeViewProps> = (props) => {
         instance.setSelectedLines(props.selectedLines);
       }
       instance.render(true);
+      // An initial selection (e.g. file opened at a terminal `path:line`)
+      // centers — there is no prior scroll position to disturb at mount,
+      // so the navigation intent reads best with the range centered.
+      scrollToSelection(props.selectedLines, "center");
     }, props.onError);
   });
 
@@ -173,7 +198,10 @@ export const CodeView: Component<CodeViewProps> = (props) => {
     on(
       () => props.selectedLines,
       (s) =>
-        safeApply(() => instance?.setSelectedLines(s ?? null), props.onError),
+        safeApply(() => {
+          instance?.setSelectedLines(s ?? null);
+          scrollToSelection(s, "nearest");
+        }, props.onError),
       { defer: true },
     ),
   );

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -205,6 +205,17 @@ export const FileTree: Component<FileTreeProps> = (props) => {
               tree?.getItem(p)?.deselect();
             }
           } else {
+            // Pierre's `select()` is additive — it does not clear the
+            // prior pick. Deselect every other selected row first so the
+            // tree lands in the single-select state kolu models. Without
+            // this, switching files leaves both rows selected, Pierre
+            // fires `onSelectionChange` with the stale path at `paths[0]`,
+            // and the host reads that back as a selection revert (the
+            // "first click after a file is already open does nothing,
+            // second click works" bug).
+            for (const p of tree?.getSelectedPaths() ?? []) {
+              if (p !== path) tree?.getItem(p)?.deselect();
+            }
             tree?.getItem(path)?.select();
             // `select()` marks aria-selected but doesn't move the
             // virtualizer; deep paths in large worktrees would stay

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -200,22 +200,24 @@ export const FileTree: Component<FileTreeProps> = (props) => {
         safeApply(() => {
           const current = tree?.getSelectedPaths()[0] ?? null;
           if (current === path) return;
+          // Drop every selected row except `keep` (pass null to clear
+          // all). Pierre's `select()` is additive — it never clears the
+          // prior pick — so a switch must deselect the old row first or
+          // the tree holds both, fires `onSelectionChange` with the stale
+          // path at `paths[0]`, and the host reads that back as a
+          // selection revert (the "first click after a file is already
+          // open does nothing, second click works" bug).
+          const deselectOthers = (keep: string | null) => {
+            for (const p of tree?.getSelectedPaths() ?? []) {
+              if (p !== keep) tree?.getItem(p)?.deselect();
+            }
+          };
           if (path === null) {
-            for (const p of tree?.getSelectedPaths() ?? []) {
-              tree?.getItem(p)?.deselect();
-            }
+            // Clearing selection.
+            deselectOthers(null);
           } else {
-            // Pierre's `select()` is additive — it does not clear the
-            // prior pick. Deselect every other selected row first so the
-            // tree lands in the single-select state kolu models. Without
-            // this, switching files leaves both rows selected, Pierre
-            // fires `onSelectionChange` with the stale path at `paths[0]`,
-            // and the host reads that back as a selection revert (the
-            // "first click after a file is already open does nothing,
-            // second click works" bug).
-            for (const p of tree?.getSelectedPaths() ?? []) {
-              if (p !== path) tree?.getItem(p)?.deselect();
-            }
+            // Switching selection.
+            deselectOthers(path);
             tree?.getItem(path)?.select();
             // `select()` marks aria-selected but doesn't move the
             // virtualizer; deep paths in large worktrees would stay

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -212,12 +212,8 @@ export const FileTree: Component<FileTreeProps> = (props) => {
               if (p !== keep) tree?.getItem(p)?.deselect();
             }
           };
-          if (path === null) {
-            // Clearing selection.
-            deselectOthers(null);
-          } else {
-            // Switching selection.
-            deselectOthers(path);
+          deselectOthers(path);
+          if (path !== null) {
             tree?.getItem(path)?.select();
             // `select()` marks aria-selected but doesn't move the
             // virtualizer; deep paths in large worktrees would stay

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -83,6 +83,40 @@ Feature: File-ref autolinking in terminal
     And the selected file should show content "alpha"
     And no line should be selected in the file content
 
+  Scenario: Clicking a line-range file-ref selects the whole range
+    When I run "git init /tmp/kolu-file-ref-range-sel && cd /tmp/kolu-file-ref-range-sel"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf 'one\ntwo\nthree\nfour\nfive\nsix\n' > range.txt"
+    And I run "echo 'block at range.txt:2-4 needs attention'"
+    And I trigger the terminal file-ref link "range.txt:2-4"
+    Then the selected file should show content "three"
+    And line 2 should be selected in the file content
+    And line 3 should be selected in the file content
+    And line 4 should be selected in the file content
+
+  Scenario: Clicking a line-range deep in a long file scrolls the selection into view
+    When I run "git init /tmp/kolu-file-ref-deep && cd /tmp/kolu-file-ref-deep"
+    And I run "git commit --allow-empty -m init"
+    And I run "seq 1 200 > big.txt"
+    And I run "echo 'hot spot at big.txt:161-165 here'"
+    And I trigger the terminal file-ref link "big.txt:161-165"
+    Then line 161 should be selected in the file content
+    And line 165 should be selected in the file content
+
+  Scenario: A file-ref opens on the first click when an iframe preview is already showing
+    When I run "git init /tmp/kolu-file-ref-preview && cd /tmp/kolu-file-ref-preview"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf '<h1>hi</h1>\n' > page.html"
+    And I run "printf 'alpha\nbeta\ngamma\ndelta\n' > world.ts"
+    And I run "echo 'open page.html first'"
+    And I trigger the terminal file-ref link "page.html"
+    Then the file preview iframe should be visible
+    When I run "echo 'now jump to world.ts:3'"
+    And I trigger the terminal file-ref link "world.ts:3"
+    Then the file preview iframe should not be visible
+    And the selected file should show content "gamma"
+    And line 3 should be selected in the file content
+
   # `@skip`: known regression noted in c89a85f3 — the second xterm `path:line`
   # click after a manual collapse fails to re-open the panel under the bundled
   # build (passes in dev). Suspected production-Solid reactive elision or


### PR DESCRIPTION
Two terminal `path:line` link regressions in the Code tab's browse mode — the kind you hit the moment you click a `world.ts:161-165` link in agent output. **A deep line range opened scrolled to the top with the highlight invisible, and clicking a ref while another file was already on screen did nothing until the second click.** Both are reproduced by new e2e scenarios before the fix.

### Two bugs, two one-line root causes

| Symptom | Root cause | Fix |
| --- | --- | --- |
| File opens but the line range isn't shown — highlight is set but off-screen (and virtualized out of the DOM) | Pierre's `setSelectedLines` paints the highlight but never scrolls; the wrapper's old rAF scroll-to-line fallback was dropped when advanced mode became unconditional | `CodeView` calls Pierre's `scrollTo({type:"range"})` after pushing a selection |
| Clicking a ref while a different file (e.g. an `.html` iframe preview) is showing does nothing on the **first** click, works on the second | `FileTree`'s programmatic selection-sync called Pierre's _additive_ `select()` without clearing the prior pick, so the tree held both rows and fired `onSelectionChange` with the stale path at `paths[0]` — which the host read back as a selection revert | Deselect every other row before `select()` |

The second one was subtle: the openInCodeTab effect _did_ resolve and set the new path on the first click — the tree's own selection echo then clobbered it one tick later. That's why the second click always worked (no stale row left to echo).

### Scroll alignment

`scrollToSelection` centers on mount (a fresh file open at a line has no prior scroll position to disturb) and uses `nearest` on reactive prop updates — so the echo of a user's _own_ gutter click, which selects an already-visible line, never yanks the viewport.

### Coverage

- **deep-file scroll-into-view** — `big.txt:161-165` in a 200-line file asserts lines 161 and 165 are rendered + selected (they're virtualized away unless scrolled to)
- **first-click open over an iframe preview** — opens an `.html` preview, then clicks a `.ts` ref and asserts the iframe is gone and the file is shown on the first click

> The `@skip`-tagged "re-click after collapse" canary in the same feature file is a related but distinct production-Solid path and stays skipped.

### Try it locally

```sh
nix run github:juspay/kolu/link-open
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._