### PR TITLE
fix(canvas): stop the canvas flash when creating a terminal while maximized

### DIFF
--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -135,6 +135,22 @@ const CanvasTile: Component<{
     };
   };
 
+  // A `"covered"` tile must hide intrinsically, not by relying on the
+  // maximized tile's `z-40` cover painting over it. During the window where
+  // `activeId` already points at a just-created tile that hasn't entered
+  // `terminalIds` yet, no maximized tile exists — a covered tile carrying only
+  // `inert`/`aria-hidden` would paint at its canvas coords, flashing the whole
+  // freeform canvas for a frame (regressed in #989, which dropped the pre-#988
+  // `visibility: hidden`). Keep the subtree mounted (`visibility`, not
+  // `display`) so xterm keeps writing its buffer and the dock previews stay
+  // populated (#904).
+  const tileStyle = (): JSX.CSSProperties =>
+    isMaximized()
+      ? { "background-color": bg() }
+      : isCovered()
+        ? { ...tiledStyle(), visibility: "hidden" }
+        : tiledStyle();
+
   return (
     <div
       ref={draggable.ref}
@@ -167,7 +183,7 @@ const CanvasTile: Component<{
         "shadow-xl": props.active && !isMaximized(),
         "border-transparent": isMaximized(),
       }}
-      style={isMaximized() ? { "background-color": bg() } : tiledStyle()}
+      style={tileStyle()}
       onMouseDown={() => props.onSelect()}
     >
       {/* Title bar — uses tile foreground at low opacity for guaranteed

--- a/packages/tests/features/canvas.feature
+++ b/packages/tests/features/canvas.feature
@@ -410,6 +410,22 @@ Feature: Canvas workspace
     And the tagged xterm element should still exist in the DOM
     And there should be no page errors
 
+  Scenario: Covered tiles stay hidden in maximized mode
+    # Regression for the new-terminal canvas flash: a covered tile must hide
+    # itself (visibility:hidden), not rely on the active tile's z-40 cover
+    # painting over it. When activeId points at a tile not yet in the render
+    # list (e.g. a just-created terminal), no maximized z-40 tile exists, and
+    # a covered tile that only carries inert/aria-hidden paints at its canvas
+    # coords — the whole freeform canvas flashing for a frame (#989 dropped
+    # the pre-#988 visibility:hidden). This asserts the intrinsic-hide
+    # invariant that prevents the flash.
+    Given I create a terminal
+    Then there should be 2 canvas tiles
+    When I double-click the title bar of canvas tile 1
+    Then canvas tile 1 should be maximized
+    Then every non-maximized canvas tile should be hidden
+    And there should be no page errors
+
   @mobile
   Scenario: Canvas is not rendered on mobile
     Then the canvas grid background should not be visible

--- a/packages/tests/step_definitions/canvas_steps.ts
+++ b/packages/tests/step_definitions/canvas_steps.ts
@@ -1332,6 +1332,32 @@ Then("no canvas tile should be maximized", async function (this: KoluWorld) {
   );
 });
 
+// A covered tile (non-maximized, in maximized posture) must hide itself via
+// computed `visibility: hidden` — Playwright reports it as not visible. Before
+// the fix the covered tile shared `tiledStyle()` (computed visibility
+// "visible") and was only occluded by the maximized tile's z-40 cover, so this
+// assertion fails; it passes once covered tiles hide intrinsically.
+Then(
+  "every non-maximized canvas tile should be hidden",
+  async function (this: KoluWorld) {
+    await this.page.waitForFunction(
+      (sel: string) => {
+        const covered = [...document.querySelectorAll(sel)].filter(
+          (t) => t.getAttribute("data-maximized") !== "true",
+        );
+        return (
+          covered.length > 0 &&
+          covered.every(
+            (t) => getComputedStyle(t as HTMLElement).visibility === "hidden",
+          )
+        );
+      },
+      TILE_SELECTOR,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 // ── Tile xterm-instance stability (regression for #988) ──
 //
 // Detect xterm.js remounts across an active-id switch in maximized mode.


### PR DESCRIPTION
**Creating a new terminal in maximized mode briefly flashed the entire freeform canvas** — every tile splayed out at its spatial position for a fraction of a second — before the new terminal snapped to fullscreen. The flicker was jarring and read like a mode switch that never actually happened.

### Why it flashed

In maximized posture every tile stays mounted: the active one paints `absolute inset-0 z-40`, the rest render `"covered"`. But a covered tile was **never hidden on its own** — it carried only `inert`/`aria-hidden` (which don't hide visually) and was occluded purely because the active tile's `z-40` layer painted over it.

On create, `activeId` flips to the new terminal *synchronously*, but the new tile only enters the render list (`terminalIds()`) once its metadata arrives over a subscription. For that window, **no rendered tile is active → no `z-40` cover exists → every covered tile is exposed at its canvas coords.**

```
handleCreate → setActiveSilently(newId)     activeId = newId   (sync)
                                            newId ∉ terminalIds()  (metadata not here yet)
  <For> finds no active tile → all tiles "covered" → NO z-40 cover
  → covered tiles paint at their canvas positions   ────── flash ──────
metadata arrives → newId renders maximized (z-40) → cover restored
```

This regressed in #989, which unified the old split render (a separate maximized branch + `visibility: hidden` on the others) into one list and dropped the intrinsic `visibility: hidden`, making "covered is hidden" depend on a sibling existing.

### The fix

Make `"covered"` tiles hide **intrinsically** rather than by relying on the `z-40` cover. The two-arm `style=` (maximized vs. everything-else, where covered silently fell through to the visible `tiledStyle()`) becomes an exhaustive three-arm match:

| Mode | Style |
| --- | --- |
| `maximized` | background only (fills viewport) |
| `covered` | `tiledStyle()` **+ `visibility: hidden`** |
| `tiled` | `tiledStyle()` (unchanged) |

`visibility: hidden` keeps the subtree mounted, so xterm keeps writing its buffer and the dock previews (#904) are unaffected. Now no cross-tile timing — create, close, session restore — can resurface the flash.

A new `canvas.feature` scenario asserts the invariant directly (*every non-maximized tile reports computed `visibility: hidden` in maximized mode*); reverting the fix fails it, the existing maximize scenarios still pass.

### Try it locally

```sh
nix run github:juspay/kolu/fix-maximized-canvas-flash
```

---
_Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-8\`)._