### PR TITLE
Mobile sticky key-bar modifiers + touch fixes for tree & dock

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Open http://127.0.0.1:7681 (or the address you chose above).
 - WebGL rendering with canvas fallback, clickable URLs, Unicode 11, inline images (sixel, iTerm2, kitty)
 - Clickable file references — terminal output that contains `path/to/file.ts:42` (with optional `:col` or `-end` line range) is linkified; clicking opens the file in the right panel's Code tab at that line
 - Lazy attach — late-joining clients receive serialized screen state (~4KB) instead of replaying raw buffer
-- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap. Touch-swipe inside the terminal scrolls the scrollback buffer
+- Mobile key bar — on coarse-pointer devices, a thin row above the terminal sends the keys soft keyboards lack (<kbd>Esc</kbd>, <kbd>Tab</kbd>, arrows, <kbd>Ctrl+C</kbd>) plus an IME-bypassing <kbd>Enter</kbd> for Android chat keyboards, with a haptic tick on every tap. Two sticky modifiers (<kbd>Ctrl</kbd>, <kbd>Alt</kbd>) arm one-shot: tap to arm, then the next character — typed on the soft keyboard or sent from the bar — folds into the chord (e.g. <kbd>Ctrl</kbd>+<kbd>R</kbd>, <kbd>Alt</kbd>+<kbd>F</kbd>) and disarms. Touch-swipe inside the terminal scrolls the scrollback buffer
 
 ### Navigation
 

--- a/packages/client/src/MobileKeyBar.tsx
+++ b/packages/client/src/MobileKeyBar.tsx
@@ -3,12 +3,26 @@
  *  the IME (some Android keyboards swallow Enter as a literal newline
  *  in xterm's hidden textarea instead of dispatching a keydown).
  *
- *  Shown only on coarse-pointer devices. Stateless — writes escape
- *  sequences straight to the PTY via client.terminal.sendInput, with
- *  a 10ms haptic tick on devices that support navigator.vibrate. */
+ *  Two leading toggles arm sticky Ctrl / Alt: tap to arm, then the next
+ *  character — typed on the soft keyboard or sent from this bar — folds
+ *  into the chord (Ctrl+R, Alt+f, …) and the modifier disarms. See
+ *  `terminal/stickyModifiers.ts`; the fold itself is applied both here and
+ *  in the terminal's `onData`, so soft-keyboard letters compose too.
+ *
+ *  Shown only on coarse-pointer devices. Stateless beyond the shared
+ *  sticky-modifier signal — writes escape sequences straight to the PTY via
+ *  client.terminal.sendInput, with a 10ms haptic tick on devices that
+ *  support navigator.vibrate. */
 
 import type { TerminalId } from "kolu-common/surface";
 import { type Component, For, Show } from "solid-js";
+import {
+  applyStickyModifiers,
+  stickyAlt,
+  stickyCtrl,
+  toggleStickyAlt,
+  toggleStickyCtrl,
+} from "./terminal/stickyModifiers";
 import { isTouch } from "./useMobile";
 import { client } from "./wire";
 
@@ -31,18 +45,42 @@ const KEYS: readonly Key[] = [
   { label: "⏎", data: "\r", testId: "enter" },
 ];
 
+interface Mod {
+  label: string;
+  testId: string;
+  armed: () => boolean;
+  toggle: () => void;
+}
+
+const MODS: readonly Mod[] = [
+  {
+    label: "Ctrl",
+    testId: "ctrl",
+    armed: stickyCtrl,
+    toggle: toggleStickyCtrl,
+  },
+  { label: "Alt", testId: "alt", armed: stickyAlt, toggle: toggleStickyAlt },
+];
+
+const KEY_CLASS =
+  "shrink-0 min-w-[2.5rem] px-2 py-1.5 text-xs rounded-md transition-colors cursor-pointer font-mono";
+
 const MobileKeyBar: Component<{
   activeId: () => TerminalId | null;
 }> = (props) => {
   const isCoarse = isTouch;
 
+  // 10ms haptic tick — Android only; iOS Safari doesn't implement
+  // navigator.vibrate, so the guard makes it a silent no-op there.
+  function tick() {
+    if ("vibrate" in navigator) navigator.vibrate(10);
+  }
+
   function send(data: string) {
     const id = props.activeId();
     if (!id) return;
-    // 10ms haptic tick — Android only; iOS Safari doesn't implement
-    // navigator.vibrate, so the guard makes it a silent no-op there.
-    if ("vibrate" in navigator) navigator.vibrate(10);
-    void client.terminal.sendInput({ id, data });
+    tick();
+    void client.terminal.sendInput({ id, data: applyStickyModifiers(data) });
   }
 
   return (
@@ -51,17 +89,39 @@ const MobileKeyBar: Component<{
         class="flex gap-1 px-2 py-1.5 bg-surface-1 border-t border-edge overflow-x-auto"
         data-testid="mobile-key-bar"
       >
-        <For each={KEYS}>
-          {(key) => (
+        <For each={MODS}>
+          {(mod) => (
             <button
               type="button"
+              aria-pressed={mod.armed()}
               // preventDefault on pointerdown keeps xterm's hidden textarea
               // focused — otherwise iOS dismisses the soft keyboard on every tap.
               onPointerDown={(e) => {
                 e.preventDefault();
+                tick();
+                mod.toggle();
+              }}
+              class={KEY_CLASS}
+              classList={{
+                "bg-accent/20 text-fg ring-1 ring-accent": mod.armed(),
+                "bg-surface-2 text-fg-2 hover:bg-surface-3 active:bg-surface-3":
+                  !mod.armed(),
+              }}
+              data-testid={`mobile-key-${mod.testId}`}
+            >
+              {mod.label}
+            </button>
+          )}
+        </For>
+        <For each={KEYS}>
+          {(key) => (
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
                 send(key.data);
               }}
-              class="shrink-0 min-w-[2.5rem] px-2 py-1.5 text-xs rounded-md bg-surface-2 text-fg-2 hover:bg-surface-3 active:bg-surface-3 transition-colors cursor-pointer font-mono"
+              class={`${KEY_CLASS} bg-surface-2 text-fg-2 hover:bg-surface-3 active:bg-surface-3`}
               data-testid={`mobile-key-${key.testId}`}
             >
               {key.label}

--- a/packages/client/src/MobileKeyBar.tsx
+++ b/packages/client/src/MobileKeyBar.tsx
@@ -64,12 +64,12 @@ const MODS: readonly Mod[] = [
 
 const KEY_CLASS =
   "shrink-0 min-w-[2.5rem] px-2 py-1.5 text-xs rounded-md transition-colors cursor-pointer font-mono";
+const KEY_UNARMED_CLASS =
+  "bg-surface-2 text-fg-2 hover:bg-surface-3 active:bg-surface-3";
 
 const MobileKeyBar: Component<{
   activeId: () => TerminalId | null;
 }> = (props) => {
-  const isCoarse = isTouch;
-
   // 10ms haptic tick — Android only; iOS Safari doesn't implement
   // navigator.vibrate, so the guard makes it a silent no-op there.
   function tick() {
@@ -84,7 +84,7 @@ const MobileKeyBar: Component<{
   }
 
   return (
-    <Show when={isCoarse()}>
+    <Show when={isTouch()}>
       <div
         class="flex gap-1 px-2 py-1.5 bg-surface-1 border-t border-edge overflow-x-auto"
         data-testid="mobile-key-bar"
@@ -104,8 +104,7 @@ const MobileKeyBar: Component<{
               class={KEY_CLASS}
               classList={{
                 "bg-accent/20 text-fg ring-1 ring-accent": mod.armed(),
-                "bg-surface-2 text-fg-2 hover:bg-surface-3 active:bg-surface-3":
-                  !mod.armed(),
+                [KEY_UNARMED_CLASS]: !mod.armed(),
               }}
               data-testid={`mobile-key-${mod.testId}`}
             >
@@ -121,7 +120,7 @@ const MobileKeyBar: Component<{
                 e.preventDefault();
                 send(key.data);
               }}
-              class={`${KEY_CLASS} bg-surface-2 text-fg-2 hover:bg-surface-3 active:bg-surface-3`}
+              class={`${KEY_CLASS} ${KEY_UNARMED_CLASS}`}
               data-testid={`mobile-key-${key.testId}`}
             >
               {key.label}

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -151,17 +151,25 @@ const MobileTileView: Component<{
           </div>
         </button>
 
-        {/* Left-edge dock handle — opens the dock drawer on tap. */}
+        {/* Left-edge dock handle — opens the dock drawer on tap. The button
+         *  is a 32px-wide transparent hit target (clears the WCAG 2.2 24px
+         *  touch-target floor) wrapping an 8px visible bar, so the grab zone
+         *  is comfortable on a phone without a chunky edge intrusion. */}
         <button
           type="button"
           data-testid="mobile-dock-handle"
-          class="absolute top-1/2 left-0 -translate-y-1/2 z-10 w-2 h-16 rounded-r bg-fg-3/30 active:bg-fg-3/60 transition-colors cursor-pointer"
+          class="group absolute top-1/2 left-0 -translate-y-1/2 z-10 flex h-16 w-8 items-center justify-start cursor-pointer"
           aria-label="Open dock"
           onClick={() => setDockOpen(true)}
           // Don't let the wrapper's horizontal-swipe handler claim
           // an edge-grab as a tile cycle gesture.
           onTouchStart={(e: TouchEvent) => e.stopPropagation()}
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="h-16 w-2 rounded-r bg-fg-3/30 transition-colors group-active:bg-fg-3/60"
+          />
+        </button>
 
         {/* Body container — relative so per-terminal absolutely-positioned
          *  search overlays anchor here, not the dvh root. */}

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -40,6 +40,7 @@ import { CommentTextSurface } from "../comments/CommentTextSurface";
 import { useComposer } from "../comments/composerState";
 import { useCommentScrollRequest } from "../comments/scrollRequest";
 import { useColorScheme } from "../settings/useColorScheme";
+import { isMobile } from "../useMobile";
 import { FileBrowseIcon, FileDiffIcon, GitBranchIcon } from "../ui/Icons";
 import { resolveLineRefPath } from "../ui/lineRef";
 import {
@@ -480,6 +481,17 @@ const CodeTab: Component<{
           <Resizable.Panel
             as="div"
             data-testid="diff-file-list"
+            // Pierre renders its scroller inside a shadow root. The mobile
+            // right-panel host is a Corvu bottom-sheet drawer, and Corvu
+            // decides whether a touch drag dismisses the sheet by walking up
+            // from the (shadow-retargeted) event target looking for a
+            // scrollable ancestor — which it never finds across the shadow
+            // boundary, so it claims every vertical drag and the tree won't
+            // scroll. `data-corvu-no-drag` opts this subtree out of the
+            // sheet-drag so Pierre's native scroll works. Inert on desktop
+            // (no Corvu drawer there). The sibling diff panel scrolls fine —
+            // its `overflow-auto` is a light-DOM scroller Corvu can see.
+            data-corvu-no-drag=""
             class="min-h-0 border-b border-edge"
             minSize={0.1}
           >
@@ -525,6 +537,9 @@ const CodeTab: Component<{
                     onError={(err) =>
                       toast.error(`File tree render failed: ${err.message}`)
                     }
+                    // Roomier rows on touch (36px vs 30px) for a comfortable
+                    // tap target; clears the WCAG 2.2 24px floor with margin.
+                    density={isMobile() ? "relaxed" : undefined}
                     class="h-full w-full"
                     style={pierreTreesStyle}
                   />

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -96,6 +96,11 @@ const CodeTab: Component<{
   const { themeTypeLiteral: diffTheme } = useColorScheme();
   const rightPanel = useRightPanel();
 
+  // Pierre captures `density` once at construction (like `initialExpansion`),
+  // so snapshot the mobile choice here rather than passing a reactive accessor
+  // in the JSX, where it would read as reactive. Roomier rows on touch.
+  const treeDensity = isMobile() ? "relaxed" : undefined;
+
   // Read `codeMode` directly rather than projecting it from `activeTab`.
   // CodeTab now stays mounted across the Inspector tab toggle (#818); a
   // projection-with-fallback (`activeTab.kind === "code" ? mode : "local"`)
@@ -539,7 +544,8 @@ const CodeTab: Component<{
                     }
                     // Roomier rows on touch (36px vs 30px) for a comfortable
                     // tap target; clears the WCAG 2.2 24px floor with margin.
-                    density={isMobile() ? "relaxed" : undefined}
+                    // Snapshotted above — Pierre reads density at construction.
+                    density={treeDensity}
                     class="h-full w-full"
                     style={pierreTreesStyle}
                   />

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -47,6 +47,7 @@ import { isTouch } from "../useMobile";
 import { client, preferences } from "../wire";
 import { createFileRefLinkProvider } from "./fileRefLinkProvider";
 import ScrollToBottom from "./ScrollToBottom";
+import { applyStickyModifiers } from "./stickyModifiers";
 import SearchBar from "./SearchBar";
 import { registerTerminalRefs, unregisterTerminalRefs } from "./terminalRefs";
 import { registerDiagnostics } from "./useTerminalDiagnostics";
@@ -720,7 +721,12 @@ const Terminal: Component<{
           const csiResponse = /\x1b\[[?>=]?[\d;]*[cnRy]/; // DA1/DA2/DSR/CPR/DECRPM
           term.onData((data: string) => {
             if (csiResponse.test(data) || data.startsWith("\x1b]")) return;
-            void client.terminal.sendInput({ id: props.terminalId, data });
+            // Fold any sticky Ctrl/Alt armed on the mobile key bar into this
+            // keystroke (no-op on desktop, where nothing is ever armed).
+            void client.terminal.sendInput({
+              id: props.terminalId,
+              data: applyStickyModifiers(data),
+            });
           });
 
           createResizeObserver(

--- a/packages/client/src/terminal/stickyModifiers.test.ts
+++ b/packages/client/src/terminal/stickyModifiers.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  applyStickyModifiers,
+  clearStickyModifiers,
+  stickyAlt,
+  stickyCtrl,
+  toggleStickyAlt,
+  toggleStickyCtrl,
+} from "./stickyModifiers";
+
+// Module-level singleton state — reset before each case so order doesn't leak.
+beforeEach(() => clearStickyModifiers());
+
+describe("toggle / clear", () => {
+  it("toggles each modifier independently", () => {
+    expect(stickyCtrl()).toBe(false);
+    toggleStickyCtrl();
+    expect(stickyCtrl()).toBe(true);
+    expect(stickyAlt()).toBe(false);
+    toggleStickyAlt();
+    expect(stickyAlt()).toBe(true);
+    toggleStickyCtrl();
+    expect(stickyCtrl()).toBe(false);
+    expect(stickyAlt()).toBe(true);
+  });
+
+  it("clears both", () => {
+    toggleStickyCtrl();
+    toggleStickyAlt();
+    clearStickyModifiers();
+    expect(stickyCtrl()).toBe(false);
+    expect(stickyAlt()).toBe(false);
+  });
+});
+
+describe("applyStickyModifiers", () => {
+  it("is a no-op when nothing is armed", () => {
+    expect(applyStickyModifiers("r")).toBe("r");
+    expect(applyStickyModifiers("\x1b[A")).toBe("\x1b[A");
+  });
+
+  it("folds Ctrl into a lowercase letter (Ctrl+R → 0x12)", () => {
+    toggleStickyCtrl();
+    expect(applyStickyModifiers("r")).toBe("\x12");
+  });
+
+  it("treats Ctrl as shift-invariant (Ctrl+R === Ctrl+r)", () => {
+    toggleStickyCtrl();
+    expect(applyStickyModifiers("R")).toBe("\x12");
+  });
+
+  it("prefixes ESC for Alt (Alt+f)", () => {
+    toggleStickyAlt();
+    expect(applyStickyModifiers("f")).toBe("\x1bf");
+  });
+
+  it("composes Ctrl then Alt (Alt+Ctrl+C → ESC + 0x03)", () => {
+    toggleStickyCtrl();
+    toggleStickyAlt();
+    expect(applyStickyModifiers("c")).toBe("\x1b\x03");
+  });
+
+  it("leaves a non-control char unmapped under Ctrl but still disarms", () => {
+    toggleStickyCtrl();
+    expect(applyStickyModifiers("5")).toBe("5");
+    expect(stickyCtrl()).toBe(false);
+  });
+
+  it("disarms after one keystroke (one-shot)", () => {
+    toggleStickyCtrl();
+    expect(applyStickyModifiers("a")).toBe("\x01");
+    expect(stickyCtrl()).toBe(false);
+    // Subsequent input is no longer modified.
+    expect(applyStickyModifiers("a")).toBe("a");
+  });
+
+  it("passes escape sequences and pastes through untouched, but disarms", () => {
+    toggleStickyCtrl();
+    expect(applyStickyModifiers("\x1b[A")).toBe("\x1b[A");
+    expect(stickyCtrl()).toBe(false);
+    toggleStickyAlt();
+    expect(applyStickyModifiers("hello world")).toBe("hello world");
+    expect(stickyAlt()).toBe(false);
+  });
+});

--- a/packages/client/src/terminal/stickyModifiers.ts
+++ b/packages/client/src/terminal/stickyModifiers.ts
@@ -1,0 +1,67 @@
+/** Sticky terminal modifiers for the mobile key bar.
+ *
+ *  Soft keyboards can't produce Ctrl/Alt chords (Ctrl+R, Alt+f, …) and the
+ *  global app shortcuts never reach the PTY, so on a phone those chords are
+ *  otherwise unreachable. The key bar *arms* a modifier here; the next single
+ *  character of terminal input — whether typed on the soft keyboard (xterm
+ *  `onData`) or sent by a key-bar key — is folded into the chord and the
+ *  modifier disarms. One-shot, like a sticky-keys press.
+ *
+ *  Only the two terminal-meaningful modifiers are offered: Ctrl encodes a
+ *  control byte, Alt prefixes ESC (a.k.a. Meta). Shift is left to the keyboard
+ *  (it already produces uppercase / shifted symbols), and Cmd/Meta has no PTY
+ *  encoding.
+ *
+ *  State is a module-level singleton: arming happens in the key bar but the
+ *  fold is applied at two input sites (the key bar's own `sendInput` and the
+ *  terminal's `onData`), so the armed flag can't live inside either. */
+
+import { createSignal } from "solid-js";
+
+const [ctrlArmed, setCtrlArmed] = createSignal(false);
+const [altArmed, setAltArmed] = createSignal(false);
+
+/** Whether the Ctrl modifier is armed for the next keystroke. */
+export const stickyCtrl = ctrlArmed;
+/** Whether the Alt modifier is armed for the next keystroke. */
+export const stickyAlt = altArmed;
+
+export function toggleStickyCtrl(): void {
+  setCtrlArmed((v) => !v);
+}
+
+export function toggleStickyAlt(): void {
+  setAltArmed((v) => !v);
+}
+
+export function clearStickyModifiers(): void {
+  setCtrlArmed(false);
+  setAltArmed(false);
+}
+
+/** Fold any armed modifiers into a single character of input, then disarm.
+ *
+ *  Returns `data` unchanged (and skips the disarm) when nothing is armed, so
+ *  the desktop/no-modifier path is a cheap no-op. When a modifier *is* armed
+ *  the press is consumed regardless of whether it composes: escape sequences
+ *  and multi-character pastes pass through untouched but still disarm, so a
+ *  stray arm never lingers onto a later keystroke. */
+export function applyStickyModifiers(data: string): string {
+  const ctrl = ctrlArmed();
+  const alt = altArmed();
+  if (!ctrl && !alt) return data;
+  clearStickyModifiers();
+  // Only lone characters compose; CSI sequences (arrows, etc.) and pastes are
+  // left alone. Spread-count so a surrogate-pair emoji counts as one.
+  if ([...data].length !== 1) return data;
+  let out = data;
+  if (ctrl) {
+    // Control bytes exist for @ A–Z [ \ ] ^ _ (0x40–0x5F) → 0x00–0x1F.
+    // Upper-case first so a lowercase letter maps to the same byte as its
+    // shifted form (Ctrl+r === Ctrl+R === 0x12).
+    const code = data.toUpperCase().charCodeAt(0);
+    if (code >= 0x40 && code <= 0x5f) out = String.fromCharCode(code & 0x1f);
+  }
+  if (alt) out = `\x1b${out}`;
+  return out;
+}

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -69,6 +69,14 @@ export type FileTreeProps = {
   /** Collapse single-child directory chains (e.g. `packages/client/src` →
    *  one row). Default `true`. */
   flattenEmptyDirectories?: boolean;
+  /** Row density — a Pierre preset (`compact` 24px / `default` 30px /
+   *  `relaxed` 36px rows) or a numeric scale factor. Drives both the CSS row
+   *  height and the virtualizer's row math, so it's the correct lever for
+   *  touch-friendly rows (a CSS-only `--trees-item-height` override would
+   *  desync the virtualizer). Snapshot at construction — **not reactive**;
+   *  re-mount to change it (matches `initialExpansion`). Defaults to
+   *  Pierre's `default`. */
+  density?: FileTreeOptions["density"];
   /** Pin parent directory headers to the top of the scroll viewport.
    *  Default `true`. */
   stickyFolders?: boolean;
@@ -115,6 +123,7 @@ export const FileTree: Component<FileTreeProps> = (props) => {
           ...selectedAncestors,
         ],
         flattenEmptyDirectories: props.flattenEmptyDirectories ?? true,
+        density: props.density,
         stickyFolders: props.stickyFolders ?? true,
         icons: props.icons,
         search: props.search ?? true,

--- a/packages/tests/features/mobile-soft-keyboard.feature
+++ b/packages/tests/features/mobile-soft-keyboard.feature
@@ -29,6 +29,31 @@ Feature: Mobile soft keyboard
     And there should be no page errors
 
   @mobile
+  Scenario: Sticky Ctrl folds into the next character typed on the soft keyboard
+    # Soft keyboards can't send Ctrl chords. The key bar arms a sticky Ctrl;
+    # the next character typed (xterm onData) is folded into the chord — here
+    # "c" becomes 0x03 and interrupts the running command. Exercises the
+    # onData fold, which the key bar's own sendInput path can't reach.
+    Given I run "sleep 30"
+    When I tap the mobile key "ctrl"
+    Then the mobile key "ctrl" should be armed
+    When I type "c" on the soft keyboard
+    Then the active terminal should show "^C"
+    And the mobile key "ctrl" should not be armed
+    And there should be no page errors
+
+  @mobile
+  Scenario: An armed sticky modifier is consumed one-shot by the next key-bar key
+    # Arming Ctrl then tapping a key-bar key routes through the same fold.
+    # "/" has no control byte so it passes through unchanged, but the modifier
+    # still disarms — a stray arm never lingers onto a later keystroke.
+    When I tap the mobile key "ctrl"
+    And I tap the mobile key "slash"
+    Then the active terminal should show "/"
+    And the mobile key "ctrl" should not be armed
+    And there should be no page errors
+
+  @mobile
   Scenario: Tapping ↑ then ⏎ recalls and resubmits the previous command
     Given I run "echo soft-recall-marker"
     When I tap the mobile key "up"

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -40,6 +40,43 @@ Then(
   },
 );
 
+When(
+  "I type {string} on the soft keyboard",
+  async function (this: KoluWorld, text: string) {
+    // Focus xterm's hidden textarea — what the OS soft keyboard actually
+    // targets — and type. This drives the `onData` path (where sticky
+    // modifiers are folded in), distinct from the key-bar buttons that
+    // `sendInput` directly.
+    await this.page.locator(XTERM_TEXTAREA).focus();
+    await this.page.keyboard.type(text);
+    await this.waitForFrame();
+  },
+);
+
+Then(
+  "the mobile key {string} should be armed",
+  async function (this: KoluWorld, testId: string) {
+    await this.page.waitForFunction(
+      (sel) =>
+        document.querySelector(sel)?.getAttribute("aria-pressed") === "true",
+      KEY(testId),
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+Then(
+  "the mobile key {string} should not be armed",
+  async function (this: KoluWorld, testId: string) {
+    await this.page.waitForFunction(
+      (sel) =>
+        document.querySelector(sel)?.getAttribute("aria-pressed") === "false",
+      KEY(testId),
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
 When("I tap the terminal canvas", async function (this: KoluWorld) {
   // Install a focus-event observer on .xterm-screen BEFORE the tap so we can
   // detect the iOS-style contenteditable auto-focus. The bug surfaces when the


### PR DESCRIPTION
**On a phone, the soft keyboard can't produce `Ctrl`/`Alt` chords and the global app shortcuts never reach the PTY — so `Ctrl+R`, `Alt+f` and friends were simply unreachable.** This adds sticky modifiers to the mobile key bar and clears three smaller touch rough-edges in the Code tab and tile view, so a phone can drive the terminal and file tree closer to the way the desktop does.

### Sticky `Ctrl` / `Alt`

Tap to arm, and the **next character — whether typed on the soft keyboard or sent from the key bar — folds into the chord and disarms** (one-shot, like sticky-keys). `Ctrl` encodes a control byte (`Ctrl+R` → `0x12`), `Alt` prefixes `ESC`. Shift is left to the keyboard; `Cmd`/`Meta` has no PTY encoding, so neither is offered.

The fold lives in one small module and is applied at the *two* places input reaches the PTY — because they're genuinely disjoint paths:

```
key bar button ──▶ client.terminal.sendInput ─┐
                                               ├─▶ applyStickyModifiers ─▶ PTY
soft-keyboard key ──▶ xterm onData ────────────┘
```

### Touch fixes alongside it

| Area | Before | After |
| --- | --- | --- |
| **File tree scroll** (mobile bottom sheet) | Pierre's scroller lives in a shadow root; Corvu's drawer couldn't see it and claimed every vertical drag as a sheet-dismiss — the tree never scrolled | `data-corvu-no-drag` opts the tree panel out, so Pierre's native scroll works. _The sibling diff panel is a light-DOM scroller Corvu can already see, so it needs nothing._ |
| **File-tree row height** | 30px rows (Pierre default) on touch | `relaxed` density (36px) on mobile via a new `density` passthrough — clears the WCAG 2.2 24px floor with margin. _Drives both the CSS and the virtualizer, so a CSS-only bump wouldn't desync row math._ |
| **Left dock handle** | 8px-wide hit target | 32px transparent hit zone wrapping the same thin 8px visible bar |

> Implements P1.1 / P2.4 / P3.2 + the tree-scroll bug from the mobile improvement plan. Covered by a `stickyModifiers` unit test (10 cases) and two e2e scenarios — one per input chokepoint.

### Try it locally

```sh
nix run github:juspay/kolu/feat/mobile-touch-improvements
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._