### PR TITLE
Actually scroll the mobile file tree in the bottom-sheet drawer

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -58,6 +58,7 @@ import BrowseFileDispatcher from "./BrowseFileDispatcher";
 import CodeMenuFrame from "./CodeMenuFrame";
 import FileSearchInput from "./FileSearchInput";
 import { projectFileTreeSearch } from "./fileSearch";
+import { attachPierreTouchScroll } from "./pierreTouchScroll";
 import ModeChipPicker, { type ModeOption } from "./ModeChipPicker";
 import {
   type OpenInCodeTabRequest,
@@ -487,15 +488,16 @@ const CodeTab: Component<{
             as="div"
             data-testid="diff-file-list"
             // Pierre renders its scroller inside a shadow root. The mobile
-            // right-panel host is a Corvu bottom-sheet drawer, and Corvu
-            // decides whether a touch drag dismisses the sheet by walking up
-            // from the (shadow-retargeted) event target looking for a
-            // scrollable ancestor — which it never finds across the shadow
-            // boundary, so it claims every vertical drag and the tree won't
-            // scroll. `data-corvu-no-drag` opts this subtree out of the
-            // sheet-drag so Pierre's native scroll works. Inert on desktop
-            // (no Corvu drawer there). The sibling diff panel scrolls fine —
-            // its `overflow-auto` is a light-DOM scroller Corvu can see.
+            // right-panel host is a Corvu bottom-sheet drawer that walks up
+            // from the event target looking for a `data-corvu-no-drag` opt-out
+            // before claiming a vertical drag as a sheet-dismiss; without it,
+            // Corvu eats every drag and the tree can't scroll. So this is
+            // necessary — but NOT sufficient on real hardware: with Corvu out
+            // of the way, iOS Safari's own native scroll still can't reach the
+            // shadow-rooted scroller below the portaled drawer. The manual
+            // touch-scroll driver below closes that gap. Inert on desktop (no
+            // Corvu drawer there). The sibling diff panel scrolls fine — its
+            // `overflow-auto` is a light-DOM scroller Corvu can see.
             data-corvu-no-drag=""
             class="min-h-0 border-b border-edge"
             minSize={0.1}
@@ -525,30 +527,41 @@ const CodeTab: Component<{
                     </div>
                   }
                 >
-                  <FileTree
-                    paths={treeSearch().projectedPaths}
-                    gitStatus={treeGitStatus()}
-                    selectedPath={selectedPath()}
-                    onSelect={handleSelect}
-                    initialExpansion={isDiffView() ? "open" : "closed"}
-                    search={false}
-                    expandPaths={treeSearch().expandedAncestors}
-                    icons={pierreIconConfig}
-                    contextMenu={{
-                      enabled: true,
-                      triggerMode: "both",
-                      render: renderTreeContextMenu,
+                  <div
+                    class="h-full w-full min-h-0"
+                    ref={(el) => {
+                      // Mobile only: drive Pierre's shadow-DOM scroll from
+                      // touch deltas, since iOS native scroll can't reach it
+                      // inside the portaled drawer (see pierreTouchScroll.ts).
+                      // Inert on desktop — no touch events, no Corvu drawer.
+                      if (isMobile()) attachPierreTouchScroll(el);
                     }}
-                    onError={(err) =>
-                      toast.error(`File tree render failed: ${err.message}`)
-                    }
-                    // Roomier rows on touch (36px vs 30px) for a comfortable
-                    // tap target; clears the WCAG 2.2 24px floor with margin.
-                    // Snapshotted above — Pierre reads density at construction.
-                    density={treeDensity}
-                    class="h-full w-full"
-                    style={pierreTreesStyle}
-                  />
+                  >
+                    <FileTree
+                      paths={treeSearch().projectedPaths}
+                      gitStatus={treeGitStatus()}
+                      selectedPath={selectedPath()}
+                      onSelect={handleSelect}
+                      initialExpansion={isDiffView() ? "open" : "closed"}
+                      search={false}
+                      expandPaths={treeSearch().expandedAncestors}
+                      icons={pierreIconConfig}
+                      contextMenu={{
+                        enabled: true,
+                        triggerMode: "both",
+                        render: renderTreeContextMenu,
+                      }}
+                      onError={(err) =>
+                        toast.error(`File tree render failed: ${err.message}`)
+                      }
+                      // Roomier rows on touch (36px vs 30px) for a comfortable
+                      // tap target; clears the WCAG 2.2 24px floor with margin.
+                      // Snapshotted above — Pierre reads density at construction.
+                      density={treeDensity}
+                      class="h-full w-full"
+                      style={pierreTreesStyle}
+                    />
+                  </div>
                 </Show>
               </Match>
             </Switch>

--- a/packages/client/src/right-panel/pierreTouchScroll.test.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { findPierreScroller, nextScrollTop } from "./pierreTouchScroll";
+
+describe("nextScrollTop", () => {
+  const base = {
+    startY: 100,
+    startTop: 50,
+    scroller: {} as HTMLElement,
+    moved: false,
+  };
+
+  it("ignores sub-threshold jitter before a drag commits", () => {
+    // 3px of finger drift while not yet moving → no scroll (a tap, not a
+    // drag). The 4px commit threshold lets Pierre's row-click fire on
+    // touchend instead of being eaten as a scroll.
+    expect(nextScrollTop({ ...base, moved: false }, 100 + 3)).toBeNull();
+    expect(nextScrollTop({ ...base, moved: false }, 100 - 3)).toBeNull();
+  });
+
+  it("commits once the drag passes the threshold", () => {
+    // Drag finger UP by 20px (clientY decreases) → content scrolls DOWN:
+    // scrollTop = startTop - dy = 50 - (-20) = 70.
+    expect(nextScrollTop({ ...base, moved: false }, 100 - 20)).toBe(70);
+    // Drag finger DOWN by 20px → scrollTop = 50 - 20 = 30.
+    expect(nextScrollTop({ ...base, moved: false }, 100 + 20)).toBe(30);
+  });
+
+  it("keeps tracking once moved, even back inside the threshold band", () => {
+    // After the drag commits, every subsequent delta applies — a momentary
+    // return near the start must not re-freeze the scroll.
+    expect(nextScrollTop({ ...base, moved: true }, 100 + 1)).toBe(49);
+    expect(nextScrollTop({ ...base, moved: true }, 100)).toBe(50);
+  });
+});
+
+describe("findPierreScroller", () => {
+  // findPierreScroller only touches `.querySelector`, `?.shadowRoot`,
+  // `.querySelectorAll`, `.scrollHeight`, `.clientHeight` — so a structural
+  // mock exercises it without a real DOM (vitest runs in Node here).
+  const el = (scrollHeight: number, clientHeight: number) =>
+    ({ scrollHeight, clientHeight }) as HTMLElement;
+
+  const container = (host: unknown): HTMLElement =>
+    ({ querySelector: () => host }) as unknown as HTMLElement;
+
+  it("returns the first overflowing descendant of the tree's shadow root", () => {
+    const scroller = el(500, 200);
+    const host = {
+      shadowRoot: {
+        querySelectorAll: () => [el(100, 100), scroller, el(300, 50)],
+      },
+    };
+    expect(findPierreScroller(container(host))).toBe(scroller);
+  });
+
+  it("returns null when the tree host is absent", () => {
+    expect(findPierreScroller(container(null))).toBeNull();
+  });
+
+  it("returns null when no descendant overflows", () => {
+    const host = {
+      shadowRoot: { querySelectorAll: () => [el(100, 100), el(50, 200)] },
+    };
+    expect(findPierreScroller(container(host))).toBeNull();
+  });
+});

--- a/packages/client/src/right-panel/pierreTouchScroll.test.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.test.ts
@@ -34,33 +34,32 @@ describe("nextScrollTop", () => {
 });
 
 describe("findPierreScroller", () => {
-  // findPierreScroller only touches `.querySelector`, `?.shadowRoot`,
-  // `.querySelectorAll`, `.scrollHeight`, `.clientHeight` — so a structural
-  // mock exercises it without a real DOM (vitest runs in Node here).
+  // findPierreScroller only touches `.querySelectorAll`, `.shadowRoot`,
+  // `.scrollHeight`, `.clientHeight` — so a structural mock exercises it
+  // without a real DOM (vitest runs in Node here).
   const el = (scrollHeight: number, clientHeight: number) =>
     ({ scrollHeight, clientHeight }) as HTMLElement;
 
-  const container = (host: unknown): HTMLElement =>
-    ({ querySelector: () => host }) as unknown as HTMLElement;
+  // `container.querySelectorAll("*")` yields the light-DOM descendants; the
+  // one carrying a `shadowRoot` is Pierre's host. Mock just those surfaces.
+  const container = (lightChildren: unknown[]): HTMLElement =>
+    ({ querySelectorAll: () => lightChildren }) as unknown as HTMLElement;
+  const host = (shadowChildren: unknown[]) => ({
+    shadowRoot: { querySelectorAll: () => shadowChildren },
+  });
 
   it("returns the first overflowing descendant of the tree's shadow root", () => {
     const scroller = el(500, 200);
-    const host = {
-      shadowRoot: {
-        querySelectorAll: () => [el(100, 100), scroller, el(300, 50)],
-      },
-    };
-    expect(findPierreScroller(container(host))).toBe(scroller);
+    const h = host([el(100, 100), scroller, el(300, 50)]);
+    expect(findPierreScroller(container([h]))).toBe(scroller);
   });
 
-  it("returns null when the tree host is absent", () => {
-    expect(findPierreScroller(container(null))).toBeNull();
+  it("returns null when no shadow host is present", () => {
+    expect(findPierreScroller(container([{}, {}]))).toBeNull();
   });
 
   it("returns null when no descendant overflows", () => {
-    const host = {
-      shadowRoot: { querySelectorAll: () => [el(100, 100), el(50, 200)] },
-    };
-    expect(findPierreScroller(container(host))).toBeNull();
+    const h = host([el(100, 100), el(50, 200)]);
+    expect(findPierreScroller(container([h]))).toBeNull();
   });
 });

--- a/packages/client/src/right-panel/pierreTouchScroll.test.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.test.ts
@@ -34,19 +34,25 @@ describe("nextScrollTop", () => {
 });
 
 describe("findPierreScroller", () => {
-  // findPierreScroller only touches `.querySelectorAll`, `.shadowRoot`,
-  // `.scrollHeight`, `.clientHeight` — so a structural mock exercises it
-  // without a real DOM (vitest runs in Node here).
+  // findPierreScroller delegates shadow-root traversal to `walkShadowRoots`,
+  // which uses `.children` (not `querySelectorAll`) on the container element,
+  // and `.querySelectorAll("*")` inside the shadow root. Mock those surfaces.
   const el = (scrollHeight: number, clientHeight: number) =>
     ({ scrollHeight, clientHeight }) as HTMLElement;
 
-  // `container.querySelectorAll("*")` yields the light-DOM descendants; the
-  // one carrying a `shadowRoot` is Pierre's host. Mock just those surfaces.
-  const container = (lightChildren: unknown[]): HTMLElement =>
-    ({ querySelectorAll: () => lightChildren }) as unknown as HTMLElement;
-  const host = (shadowChildren: unknown[]) => ({
-    shadowRoot: { querySelectorAll: () => shadowChildren },
-  });
+  // A shadow host: `children` yields nothing (we only need the host found),
+  // `shadowRoot.querySelectorAll("*")` yields the viewport candidates.
+  // `shadowRoot.children` must exist (walkShadowRoots iterates it after the
+  // visitor returns to recurse into nested shadow roots).
+  const host = (shadowChildren: HTMLElement[]) =>
+    ({
+      shadowRoot: { querySelectorAll: () => shadowChildren, children: [] },
+      children: [],
+    }) as unknown as Element;
+
+  // A container whose `children` list is the direct light-DOM kids.
+  const container = (children: Element[]): HTMLElement =>
+    ({ children }) as unknown as HTMLElement;
 
   it("returns the first overflowing descendant of the tree's shadow root", () => {
     const scroller = el(500, 200);
@@ -55,7 +61,8 @@ describe("findPierreScroller", () => {
   });
 
   it("returns null when no shadow host is present", () => {
-    expect(findPierreScroller(container([{}, {}]))).toBeNull();
+    const noShadow = { children: [] } as unknown as Element;
+    expect(findPierreScroller(container([noShadow, noShadow]))).toBeNull();
   });
 
   it("returns null when no descendant overflows", () => {

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -47,8 +47,7 @@ export function findPierreScroller(container: HTMLElement): HTMLElement | null {
   // `walkShadowRoots` visits every shadow root reachable from `container`.
   // We visit the first one (Pierre's `file-tree-container` custom element)
   // and search its internals for the first overflowing descendant — the
-  // scroll viewport. Both probes are by capability, not by tag/class name,
-  // so a Pierre internal rename can't silently return null.
+  // scroll viewport.
   // +1: guards against fractional-pixel rounding where scrollHeight and
   // clientHeight can both be integers that differ by less than 1px on
   // high-DPI displays.

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -23,7 +23,7 @@
  *  (Originally lived in `MobileCodeSheet.tsx`; restored here after the mobile
  *  Code tab was unified into `CodeTab.tsx` + `RightPanelDrawer.tsx`.) */
 
-import { onCleanup } from "solid-js";
+import { makeEventListener } from "@solid-primitives/event-listener";
 
 /** Below this many pixels of finger travel, a touch is still a tap — let
  *  Pierre's row-click fire on `touchend` rather than eating it as a scroll. */
@@ -134,14 +134,12 @@ export function attachPierreTouchScroll(container: HTMLElement): void {
     state = null;
   };
 
-  container.addEventListener("touchstart", onStart, { passive: false });
-  container.addEventListener("touchmove", onMove, { passive: false });
-  container.addEventListener("touchend", onEnd);
-  container.addEventListener("touchcancel", onEnd);
-  onCleanup(() => {
-    container.removeEventListener("touchstart", onStart);
-    container.removeEventListener("touchmove", onMove);
-    container.removeEventListener("touchend", onEnd);
-    container.removeEventListener("touchcancel", onEnd);
-  });
+  // `makeEventListener` registers its own `onCleanup` against the current
+  // reactive owner (hence the call-site requirement below). `{ passive: false }`
+  // on touchmove is load-bearing — it's what lets `preventDefault` suppress
+  // iOS's native scroll.
+  makeEventListener(container, "touchstart", onStart, { passive: false });
+  makeEventListener(container, "touchmove", onMove, { passive: false });
+  makeEventListener(container, "touchend", onEnd);
+  makeEventListener(container, "touchcancel", onEnd);
 }

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -24,6 +24,7 @@
  *  Code tab was unified into `CodeTab.tsx` + `RightPanelDrawer.tsx`.) */
 
 import { makeEventListener } from "@solid-primitives/event-listener";
+import { walkShadowRoots } from "../comments/shadowWalk";
 
 /** Below this many pixels of finger travel, a touch is still a tap — let
  *  Pierre's row-click fire on `touchend` rather than eating it as a scroll. */
@@ -43,27 +44,22 @@ export type TouchScrollState = {
  *  break us. Returns null when the tree hasn't rendered yet or nothing
  *  overflows (short tree: nothing to scroll anyway). */
 export function findPierreScroller(container: HTMLElement): HTMLElement | null {
-  // Pierre mounts its tree into a custom element with an open shadow root.
-  // Locate that host as the (only) light-DOM descendant carrying a shadowRoot
-  // rather than by Pierre's `file-tree-container` tag name: a tag literal is a
-  // detached copy of a `@pierre/trees` internal — a rename would silently
-  // return null with no build error — and importing the tag constant would
-  // reach past the `@kolu/solid-pierre` firewall. The capability probe has
-  // neither failure mode.
-  let root: ShadowRoot | null = null;
-  for (const el of container.querySelectorAll("*")) {
-    if (el.shadowRoot) {
-      root = el.shadowRoot;
-      break;
-    }
-  }
-  if (!root) return null;
-  // The viewport inside the shadow root is likewise probed by capability —
-  // the first overflowing descendant — since it has no stable exported name.
-  for (const el of root.querySelectorAll<HTMLElement>("*")) {
-    if (el.scrollHeight > el.clientHeight + 1) return el;
-  }
-  return null;
+  // `walkShadowRoots` visits every shadow root reachable from `container`.
+  // We visit the first one (Pierre's `file-tree-container` custom element)
+  // and search its internals for the first overflowing descendant — the
+  // scroll viewport. Both probes are by capability, not by tag/class name,
+  // so a Pierre internal rename can't silently return null.
+  // +1: guards against fractional-pixel rounding where scrollHeight and
+  // clientHeight can both be integers that differ by less than 1px on
+  // high-DPI displays.
+  return (
+    walkShadowRoots(container, (root) => {
+      for (const el of root.querySelectorAll<HTMLElement>("*")) {
+        if (el.scrollHeight > el.clientHeight + 1) return el;
+      }
+      return undefined;
+    }) ?? null
+  );
 }
 
 /** Pure delta math: the `scrollTop` to apply for a finger at `clientY`, or

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -86,10 +86,23 @@ export function nextScrollTop(
 export function attachPierreTouchScroll(container: HTMLElement): void {
   let state: TouchScrollState | null = null;
 
+  // Cache the located scroller — re-probing Pierre's whole shadow root on
+  // every touchstart is wasteful, and the scroller is stable for the lifetime
+  // of a `<FileTree>` mount. Re-probe when the cache is empty or its node was
+  // detached (Pierre remount on mode switch), so the cache never outlives the
+  // element it points at — this keeps the driver from owning a stale-node
+  // invalidation invariant.
+  let cached: HTMLElement | null = null;
+  const resolveScroller = (): HTMLElement | null => {
+    if (cached?.isConnected) return cached;
+    cached = findPierreScroller(container);
+    return cached;
+  };
+
   const onStart = (e: TouchEvent) => {
     const touch = e.touches[0];
     if (!touch) return;
-    const scroller = findPierreScroller(container);
+    const scroller = resolveScroller();
     // Short tree (nothing overflows): leave the gesture to the drawer so a
     // drag can still dismiss the sheet. Only claim the touch below, once we
     // know we'll actually drive a scroll.

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -64,7 +64,11 @@ export function findPierreScroller(container: HTMLElement): HTMLElement | null {
 
 /** Pure delta math: the `scrollTop` to apply for a finger at `clientY`, or
  *  null while the drag is still below the commit threshold (a tap). Exported
- *  so the threshold + direction logic is unit-tested without a DOM. */
+ *  so the threshold + direction logic is unit-tested without a DOM.
+ *
+ *  The returned value is unclamped — it may be negative or past
+ *  `scrollHeight - clientHeight`; assigning it to `el.scrollTop` lets the
+ *  browser clamp into range (over-scroll is a no-op, by contract). */
 export function nextScrollTop(
   state: TouchScrollState,
   clientY: number,

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -124,8 +124,11 @@ export function attachPierreTouchScroll(container: HTMLElement): void {
     if (top === null) return;
     state.moved = true;
     state.scroller.scrollTop = top;
-    // Eat the committed move so iOS doesn't run its own scroll attempt and
-    // Pierre's row-click doesn't fire on the following touchend.
+    // preventDefault is the load-bearing call: it suppresses iOS's native
+    // scroll so our scrollTop write wins, and stops Pierre's row-click from
+    // firing on the touchend after a drag. stopPropagation is belt-and-braces
+    // — it keeps the move off document-level handlers — NOT what neutralizes
+    // Corvu's drag-to-dismiss; that's `data-corvu-no-drag` on the pointer path.
     e.preventDefault();
     e.stopPropagation();
   };

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -1,0 +1,117 @@
+/** Manual touch-scroll driver for Pierre's file tree inside the mobile
+ *  bottom-sheet drawer.
+ *
+ *  Two layers conspire to freeze the tree on a real phone, and only one of
+ *  them is fixed by `data-corvu-no-drag`:
+ *
+ *    1. Corvu's drawer claims vertical drags as a sheet-dismiss. The
+ *       `data-corvu-no-drag` attribute on the tree panel (see `CodeTab.tsx`)
+ *       makes Corvu's `locationIsDraggable` walk bail, so this part is
+ *       handled — but it's necessary, not sufficient.
+ *    2. iOS Safari's *own* native-scroll discovery is unreliable for a
+ *       shadow-rooted scroller below a portaled `Drawer.Content`: the
+ *       `touchmove` deltas never reach Pierre's inner viewport, so the tree
+ *       stays frozen below the visible band even with Corvu out of the way.
+ *       Playwright emulation does not reproduce this — only real hardware.
+ *
+ *  So we drive the scroll ourselves: on `touchstart` we locate Pierre's
+ *  shadow-DOM scroller and snapshot its `scrollTop`; on each committed
+ *  `touchmove` we set `scrollTop` directly from the finger delta and
+ *  `preventDefault` so iOS doesn't fight us. A stationary tap stays under
+ *  the commit threshold and falls through to Pierre's row-click path.
+ *
+ *  (Originally lived in `MobileCodeSheet.tsx`; restored here after the mobile
+ *  Code tab was unified into `CodeTab.tsx` + `RightPanelDrawer.tsx`.) */
+
+import { onCleanup } from "solid-js";
+
+/** Below this many pixels of finger travel, a touch is still a tap — let
+ *  Pierre's row-click fire on `touchend` rather than eating it as a scroll. */
+const COMMIT_THRESHOLD_PX = 4;
+
+/** The scroll state captured at `touchstart`, carried across `touchmove`s. */
+export type TouchScrollState = {
+  startY: number;
+  startTop: number;
+  scroller: HTMLElement;
+  moved: boolean;
+};
+
+/** Find Pierre's scroll viewport inside the `<file-tree-container>` shadow
+ *  root. Pierre owns the element's internal structure, so probe by
+ *  capability — the first descendant whose content overflows — rather than a
+ *  brittle tag/class path. Returns null when the tree hasn't rendered yet or
+ *  nothing overflows (short tree: nothing to scroll anyway). */
+export function findPierreScroller(container: HTMLElement): HTMLElement | null {
+  const host = container.querySelector("file-tree-container");
+  const root = (host as Element | null)?.shadowRoot;
+  if (!root) return null;
+  for (const el of root.querySelectorAll<HTMLElement>("*")) {
+    if (el.scrollHeight > el.clientHeight + 1) return el;
+  }
+  return null;
+}
+
+/** Pure delta math: the `scrollTop` to apply for a finger at `clientY`, or
+ *  null while the drag is still below the commit threshold (a tap). Exported
+ *  so the threshold + direction logic is unit-tested without a DOM. */
+export function nextScrollTop(
+  state: TouchScrollState,
+  clientY: number,
+): number | null {
+  const dy = clientY - state.startY;
+  if (!state.moved && Math.abs(dy) < COMMIT_THRESHOLD_PX) return null;
+  // Finger up (clientY decreases, dy < 0) scrolls content down, so subtract.
+  return state.startTop - dy;
+}
+
+/** Wire the manual touch-scroll driver onto `container` (the element wrapping
+ *  the Pierre tree). Registers non-passive `touchmove` so `preventDefault`
+ *  actually suppresses iOS native scroll, and tears the listeners down via
+ *  `onCleanup`. Call from a ref callback inside a reactive owner. */
+export function attachPierreTouchScroll(container: HTMLElement): void {
+  let state: TouchScrollState | null = null;
+
+  const onStart = (e: TouchEvent) => {
+    e.stopPropagation();
+    const touch = e.touches[0];
+    if (!touch) return;
+    const scroller = findPierreScroller(container);
+    if (!scroller) return;
+    state = {
+      startY: touch.clientY,
+      startTop: scroller.scrollTop,
+      scroller,
+      moved: false,
+    };
+  };
+
+  const onMove = (e: TouchEvent) => {
+    if (!state) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const top = nextScrollTop(state, touch.clientY);
+    if (top === null) return;
+    state.moved = true;
+    state.scroller.scrollTop = top;
+    // Eat the committed move so iOS doesn't run its own scroll attempt and
+    // Pierre's row-click doesn't fire on the following touchend.
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const onEnd = () => {
+    state = null;
+  };
+
+  container.addEventListener("touchstart", onStart, { passive: false });
+  container.addEventListener("touchmove", onMove, { passive: false });
+  container.addEventListener("touchend", onEnd);
+  container.addEventListener("touchcancel", onEnd);
+  onCleanup(() => {
+    container.removeEventListener("touchstart", onStart);
+    container.removeEventListener("touchmove", onMove);
+    container.removeEventListener("touchend", onEnd);
+    container.removeEventListener("touchcancel", onEnd);
+  });
+}

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -87,11 +87,14 @@ export function attachPierreTouchScroll(container: HTMLElement): void {
   let state: TouchScrollState | null = null;
 
   const onStart = (e: TouchEvent) => {
-    e.stopPropagation();
     const touch = e.touches[0];
     if (!touch) return;
     const scroller = findPierreScroller(container);
+    // Short tree (nothing overflows): leave the gesture to the drawer so a
+    // drag can still dismiss the sheet. Only claim the touch below, once we
+    // know we'll actually drive a scroll.
     if (!scroller) return;
+    e.stopPropagation();
     state = {
       startY: touch.clientY,
       startTop: scroller.scrollTop,

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -37,15 +37,29 @@ export type TouchScrollState = {
   moved: boolean;
 };
 
-/** Find Pierre's scroll viewport inside the `<file-tree-container>` shadow
- *  root. Pierre owns the element's internal structure, so probe by
- *  capability — the first descendant whose content overflows — rather than a
- *  brittle tag/class path. Returns null when the tree hasn't rendered yet or
- *  nothing overflows (short tree: nothing to scroll anyway). */
+/** Find Pierre's scroll viewport — the overflowing element inside the tree's
+ *  shadow root. Both the shadow host and the viewport are located by
+ *  capability, not by tag/class, so a Pierre internal rename can't silently
+ *  break us. Returns null when the tree hasn't rendered yet or nothing
+ *  overflows (short tree: nothing to scroll anyway). */
 export function findPierreScroller(container: HTMLElement): HTMLElement | null {
-  const host = container.querySelector("file-tree-container");
-  const root = (host as Element | null)?.shadowRoot;
+  // Pierre mounts its tree into a custom element with an open shadow root.
+  // Locate that host as the (only) light-DOM descendant carrying a shadowRoot
+  // rather than by Pierre's `file-tree-container` tag name: a tag literal is a
+  // detached copy of a `@pierre/trees` internal — a rename would silently
+  // return null with no build error — and importing the tag constant would
+  // reach past the `@kolu/solid-pierre` firewall. The capability probe has
+  // neither failure mode.
+  let root: ShadowRoot | null = null;
+  for (const el of container.querySelectorAll("*")) {
+    if (el.shadowRoot) {
+      root = el.shadowRoot;
+      break;
+    }
+  }
   if (!root) return null;
+  // The viewport inside the shadow root is likewise probed by capability —
+  // the first overflowing descendant — since it has no stable exported name.
   for (const el of root.querySelectorAll<HTMLElement>("*")) {
     if (el.scrollHeight > el.clientHeight + 1) return el;
   }

--- a/packages/client/src/right-panel/pierreTouchScroll.ts
+++ b/packages/client/src/right-panel/pierreTouchScroll.ts
@@ -80,9 +80,13 @@ export function nextScrollTop(
 }
 
 /** Wire the manual touch-scroll driver onto `container` (the element wrapping
- *  the Pierre tree). Registers non-passive `touchmove` so `preventDefault`
- *  actually suppresses iOS native scroll, and tears the listeners down via
- *  `onCleanup`. Call from a ref callback inside a reactive owner. */
+ *  the Pierre tree). Registers a non-passive `touchmove` so `preventDefault`
+ *  can suppress iOS native scroll.
+ *
+ *  MUST be called synchronously inside a SolidJS reactive owner — a `ref`
+ *  callback or `onMount`, never after an `await`. Listener teardown rides on
+ *  `makeEventListener`'s `onCleanup`, which silently no-ops outside an owner
+ *  and would leak the four listeners. */
 export function attachPierreTouchScroll(container: HTMLElement): void {
   let state: TouchScrollState | null = null;
 


### PR DESCRIPTION
**The mobile Code-tab file tree still wouldn't scroll on a real phone**, even after [#1020](https://github.com/juspay/kolu/pull/1020) marked that bug fixed. That PR added `data-corvu-no-drag` to the tree panel — which *is* necessary, but only solves half the problem.

`data-corvu-no-drag` stops Corvu's drawer from claiming the vertical drag as a sheet-dismiss (its `locationIsDraggable` walk hits the attribute and bails). But Pierre renders its scroller inside a **shadow root**, and on real iOS Safari the browser's *own* native scroll can't reach a shadow-rooted scroller sitting below a portaled `Drawer.Content` — so with Corvu out of the way the tree still sat frozen below the visible band. _Playwright emulation never reproduced this, which is how it slipped through._

```
data-corvu-no-drag  ──▶ stops Corvu's drag-to-dismiss        ✓ (was done in #1020)
manual touch driver ──▶ feeds touchmove deltas to scrollTop  ✓ (this PR — the missing half)
```

### The fix

This restores a **manual touch-scroll driver** that used to live in `MobileCodeSheet.tsx` and was lost when the mobile Code tab was unified into `CodeTab.tsx` + `RightPanelDrawer.tsx`. On `touchstart` it locates Pierre's shadow-DOM scroller and snapshots `scrollTop`; on each committed `touchmove` it sets `scrollTop` directly from the finger delta and `preventDefault`s so iOS doesn't fight it. A sub-4px tap falls through to Pierre's row-click. It lives in a small, unit-tested `pierreTouchScroll` module, wired into the tree panel mobile-only.

The shadow host and its scroll viewport are both located **by capability** (`walkShadowRoots` + first overflowing descendant) rather than by Pierre's `file-tree-container` tag name — so a Pierre internal rename can't silently break scrolling, and no Pierre internal leaks past the `@kolu/solid-pierre` boundary.

### Coverage

`stickyModifiers`-style unit tests cover the pure kernel (`nextScrollTop` threshold + direction, `findPierreScroller` host/viewport discovery). The DOM touch-driving itself is **only reproducible on real iOS hardware**, not Playwright — so the `code-tab` / `mobile-code-browse` e2e suites (62 scenarios) serve as the regression guard that the new wrapper didn't disturb tree rendering or selection.

### Try it locally (on a phone)

```sh
nix run github:juspay/kolu/fix/mobile-file-tree-scroll
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._