### PR TITLE
Fix mobile right-panel popover items not responding to taps

### DIFF
--- a/packages/client/src/ui/useAnchoredPopover.test.ts
+++ b/packages/client/src/ui/useAnchoredPopover.test.ts
@@ -1,0 +1,26 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it } from "vitest";
+import { useAnchoredPopover } from "./useAnchoredPopover";
+
+describe("useAnchoredPopover", () => {
+  // Regression for the mobile Code-tab mode picker: the popover panel is
+  // rendered via `<Portal>` to `document.body`. On mobile the right panel
+  // lives inside a Corvu `Drawer` (`@corvu/dialog`, `modal: true`), which
+  // sets `body { pointer-events: none }` and only re-enables pointer events
+  // on its own dialog content. A body-level portal therefore inherits `none`
+  // unless the panel re-enables it — without this the dropdown opens but
+  // tapping any of its items does nothing. The panel style must always carry
+  // `pointer-events: auto` so the popover stays interactive under any ambient
+  // modal layer.
+  it("always emits pointer-events: auto so a body-level portal stays tappable", () => {
+    createRoot((dispose) => {
+      const { panelStyle } = useAnchoredPopover({
+        triggerRef: () => undefined,
+        open: () => false,
+        onDismiss: () => {},
+      });
+      expect(panelStyle()["pointer-events"]).toBe("auto");
+      dispose();
+    });
+  });
+});

--- a/packages/client/src/ui/useAnchoredPopover.ts
+++ b/packages/client/src/ui/useAnchoredPopover.ts
@@ -123,7 +123,15 @@ export function useAnchoredPopover(
 
   const panelStyle = (): JSX.CSSProperties => {
     const p = pos();
-    const css: JSX.CSSProperties = {};
+    // `pointer-events: auto` is mandatory, not cosmetic. Callers render the
+    // panel via `<Portal>` to `document.body`, so when the trigger lives
+    // inside a Corvu modal layer (the mobile right-panel `Drawer`, built on
+    // `@corvu/dialog` with `modal: true`), that layer sets
+    // `body { pointer-events: none }` and only re-enables it on its own
+    // dialog content. A body-level portal would otherwise inherit `none` and
+    // swallow every tap — the panel opens but its items do nothing. Re-enable
+    // here so the popover is interactive regardless of any ambient modal.
+    const css: JSX.CSSProperties = { "pointer-events": "auto" };
     if (p.top !== undefined) css.top = `${p.top}px`;
     if (p.bottom !== undefined) css.bottom = `${p.bottom}px`;
     if (p.left !== undefined) css.left = `${p.left}px`;


### PR DESCRIPTION
On mobile, opening the Code tab's mode dropdown and tapping any of its three items (**Browse / Local / Branch**) did nothing — the popover opened but every tap was swallowed. **The culprit was an inherited `pointer-events: none`**, not the click handlers.

The mobile right panel hosts inside a Corvu `Drawer`, which is built on `@corvu/dialog` with `modal: true`. While open, that modal sets `body { pointer-events: none }` and re-enables pointer events *only* on its own dialog content. Every anchored popover renders its panel through a `<Portal>` to `document.body` — a sibling of the drawer content, not a descendant — so the panel inherited `none`:

```
body { pointer-events: none }   ← set by the open Corvu modal
├─ Drawer.Content { pointer-events: auto }   ← re-enabled by the dialog
│    └─ chip trigger              ✓ tappable (opens the popover)
└─ Portal → popover panel         ✗ inherits none → taps fall through
     ├─ Browse / Local / Branch   ✗ dead
```

Desktop was unaffected because it hosts the panel in a Corvu `Resizable`, not a modal dialog.

The fix re-enables `pointer-events: auto` on the panel style returned by the shared `useAnchoredPopover` hook. This is the single socket all six anchored popovers spread onto their portalled panel (mode picker, settings, record, PR-unavailable, activity-window, option-menu), so it fixes the whole class of bug — any popover opened under any ambient modal layer — not just the mode picker.

*A reactive unit test guards the regression: it asserts the panel style always carries `pointer-events: auto` so a body-level portal stays interactive regardless of open state. Verified red→green by reverting the fix.* The directly-relevant mobile e2e is blocked by a [documented Corvu-drawer transition-duration test quirk](https://github.com/juspay/kolu/blob/master/packages/tests/features/mobile-code-browse.feature); the desktop `code-tab.feature` suite (63 scenarios) exercises the same mode picker via `useAnchoredPopover` and stays green.

### Try it locally

```sh
nix run github:juspay/kolu/fix/mobile-code-tab-mode-picker-pointer-events
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._