### PR TITLE
Add video PR evidence: screencast capture + shared Pages player

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -42,7 +42,7 @@ Keep these docs in sync:
 
 ## PR evidence
 
-When the change has visible UI impact, post a `## Evidence` PR comment with screenshots. Use judgment — server-only diffs sometimes ripple into rendering.
+When the change has visible UI impact, post a `## Evidence` PR comment with screenshots — or **video** when the change is about motion (an animation, a transition, a multi-step interaction a still can't convey; see _Video evidence_ below). Use judgment — server-only diffs sometimes ripple into rendering.
 
 **Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so the main context stays clear of MCP and screenshot noise. Brief it with: the dev-server URL, what scenarios to capture, a `/tmp/kolu-evidence-<slug>.png` filename, and the PR number. Have it return only the markdown body it posted.
 
@@ -72,6 +72,30 @@ gh release upload evidence-assets /tmp/kolu-evidence-<slug>.png --clobber
 ```
 
 URL pattern: `https://github.com/juspay/kolu/releases/download/evidence-assets/<filename>`. Use the single-quoted heredoc pattern (`<<'EOF'`) when posting so backticks and `$` survive unescaped.
+
+### Video evidence
+
+For motion the subagent records the page instead of (or alongside) a still. The `chrome-devtools` MCP exposes `screencast_start` / `screencast_stop` — `screencast_start` with `filePath: /tmp/kolu-evidence-<slug>.mp4`, drive the interaction, then `screencast_stop`. (Capability ships in the [`nix-chrome-devtools-mcp`](https://github.com/juspay/nix-chrome-devtools-mcp) launcher, which runs the server with `--experimentalScreencast` and ffmpeg on PATH.)
+
+Two reasons not to just attach the `.mp4`: GitHub renders an inline video *player* only for files dragged into the web composer (a `user-attachments` URL `gh` can't mint), and a `<video>` tag in a comment is stripped. So:
+
+- **Inline (the at-a-glance proof):** transcode to an animated GIF — GitHub renders a GIF inline from any release URL, exactly like the PNG flow above.
+
+  ```sh
+  nix shell nixpkgs#ffmpeg --command ffmpeg -i /tmp/kolu-evidence-<slug>.mp4 \
+    -vf "fps=12,scale=900:-1:flags=lanczos" -loop 0 /tmp/kolu-evidence-<slug>.gif
+  gh release upload evidence-assets /tmp/kolu-evidence-<slug>.gif --clobber
+  ```
+
+  Embed with `![](https://github.com/juspay/kolu/releases/download/evidence-assets/<slug>.gif)`.
+
+- **HD + audio (optional):** upload the `.mp4` to the same release and link to the shared player — [`juspay/video-evidence`](https://github.com/juspay/video-evidence) hosts a GitHub Pages `<video>` page that streams the clip from kolu's own release:
+
+  ```
+  ▶ HD: https://juspay.github.io/video-evidence/evidence.html?repo=juspay/kolu&v=<slug>.mp4
+  ```
+
+  Clips stay on kolu's `evidence-assets` release; the player is project-agnostic (the `repo` param is org-allowlisted), so it is reused across juspay projects with no per-project hosting.
 
 ### Agent-state scenarios
 

--- a/.agency/do.md
+++ b/.agency/do.md
@@ -23,7 +23,7 @@ Use the `/ci` skill for the runner mechanics (subcommands, flags, modes, retry s
 ```sh
 pr=$(gh pr view --json number --jq .number)
 host="kolu-pr-$pr"
-pu create --name "$host"                                                # writes ~/.pu-state/$host/ssh_config (included by ~/.ssh/config)
+pu create "$host"                                                       # name is positional; writes ~/.pu-state/$host/ssh_config (included by ~/.ssh/config)
 CI=true nix run github:juspay/ci -- run --host x86_64-linux="$host"     # --host wins over hosts.json on collision; darwin keeps using sincereintent
 pu destroy "$host"
 ```

--- a/.agency/do.md
+++ b/.agency/do.md
@@ -48,19 +48,20 @@ When the change has visible UI impact, post a `## Evidence` PR comment with scre
 
 ### Dev server
 
-Spawn a dedicated dev server on **two random, unique free ports** — one for the server, one for the client. **Never** reuse the defaults `7681`/`5173`: the user is very likely running their own (production) kolu there, and a port clash or a careless cleanup will take it down. Run `just dev` with both ports explicit (or `just dev-auto`, which picks two free ports for you — it sources `python3` from nix, so it works outside the devshell):
+Run a **production-like** instance: `nix run . -- --port <P>` builds kolu and serves the bundled client + server on a **single** port — the same way kolu actually runs, so the evidence reflects production, not the Vite dev server. Pick **one random free port**; **never** the default `7681` (the user is very likely running their own production kolu there, and a clash or careless cleanup takes it down).
 
 ```sh
-# Two free, unique ports (python3 via nix — no global install needed).
-read -r SP CP < <(nix shell nixpkgs#python3 --command python3 -c 'import socket; a=socket.socket(); a.bind(("",0)); b=socket.socket(); b.bind(("",0)); print(a.getsockname()[1], b.getsockname()[1]); a.close(); b.close()')
-just dev SERVER_PORT="$SP" CLIENT_PORT="$CP" &   # prints "→ client http://localhost:<port>"; pass that URL to the subagent
+# One free port (python3 via nix — no global install needed).
+PORT=$(nix shell nixpkgs#python3 --command python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
+nix run . -- --port "$PORT" &
 DEV_PID=$!
+# Kill ONLY this PID at the end. NEVER `pkill -f vite` / `pkill -f src/index.ts`
+# / any pattern match — those also match the user's production kolu and kill it.
 trap 'kill "$DEV_PID" 2>/dev/null' EXIT
+# app is at http://localhost:$PORT  — pass that URL to the subagent
 ```
 
-**Kill only the PID you spawned.** At the end, `kill "$DEV_PID"` and nothing else. **Never** `pkill -f vite`, `pkill -f src/index.ts`, or any pattern match — those also match the user's production kolu and will kill it.
-
-For bug fixes that need a "before" shot, run a second instance on its own two ports from a `git worktree` on `master` (no collision with the PR-branch instance). Never stash the PR branch.
+For a "before" shot, run a second instance on another free port from a `git worktree` on `master`. Never stash the PR branch. (For fast iteration outside evidence, `just dev-auto` runs the HMR dev server on two free ports instead.)
 
 ### Capture, host, post
 

--- a/.agency/do.md
+++ b/.agency/do.md
@@ -48,15 +48,19 @@ When the change has visible UI impact, post a `## Evidence` PR comment with scre
 
 ### Dev server
 
-Spawn a dedicated dev server on **free random ports** (the user may already hold `7681`/`5173`). `just dev-auto` allocates both ports, wires the Vite proxy to the picked server port, and prints the client URL — grab it from stdout instead of parsing logs. Kill the process at the end:
+Spawn a dedicated dev server on **two random, unique free ports** — one for the server, one for the client. **Never** reuse the defaults `7681`/`5173`: the user is very likely running their own (production) kolu there, and a port clash or a careless cleanup will take it down. Run `just dev` with both ports explicit (or `just dev-auto`, which picks two free ports for you — it sources `python3` from nix, so it works outside the devshell):
 
 ```sh
-just dev-auto &   # prints "→ client http://localhost:<port>"; pass that URL to the subagent
+# Two free, unique ports (python3 via nix — no global install needed).
+read -r SP CP < <(nix shell nixpkgs#python3 --command python3 -c 'import socket; a=socket.socket(); a.bind(("",0)); b=socket.socket(); b.bind(("",0)); print(a.getsockname()[1], b.getsockname()[1]); a.close(); b.close()')
+just dev SERVER_PORT="$SP" CLIENT_PORT="$CP" &   # prints "→ client http://localhost:<port>"; pass that URL to the subagent
 DEV_PID=$!
-trap 'kill $DEV_PID 2>/dev/null' EXIT
+trap 'kill "$DEV_PID" 2>/dev/null' EXIT
 ```
 
-For bug fixes that need a "before" shot, run a second `just dev-auto` from a `git worktree` on `master` (it picks its own free ports, so no collision with the PR-branch instance). Never stash the PR branch.
+**Kill only the PID you spawned.** At the end, `kill "$DEV_PID"` and nothing else. **Never** `pkill -f vite`, `pkill -f src/index.ts`, or any pattern match — those also match the user's production kolu and will kill it.
+
+For bug fixes that need a "before" shot, run a second instance on its own two ports from a `git worktree` on `master` (no collision with the PR-branch instance). Never stash the PR branch.
 
 ### Capture, host, post
 

--- a/.agency/do.md
+++ b/.agency/do.md
@@ -82,19 +82,26 @@ URL pattern: `https://github.com/juspay/kolu/releases/download/evidence-assets/<
 
 For motion the subagent records the page instead of (or alongside) a still. The `chrome-devtools` MCP exposes `screencast_start` / `screencast_stop` — `screencast_start` with `filePath: /tmp/kolu-evidence-<slug>.mp4`, drive the interaction, then `screencast_stop`. (Capability ships in the [`nix-chrome-devtools-mcp`](https://github.com/juspay/nix-chrome-devtools-mcp) launcher, which runs the server with `--experimentalScreencast` and ffmpeg on PATH.)
 
+**Make the recording legible — this is the #1 quality issue:**
+
+- **Landscape viewport.** Set a 16:9 viewport before recording (chrome-devtools `emulate` viewport `1366x768x1,landscape`). The default headless window can be portrait and 2×-DPI, which leaves the content tiny in a tall, mostly-empty frame.
+- **Maximize the terminal.** Click the chrome-bar **Maximize terminal** (canvas → maximized) so the terminal fills the frame. Recording *canvas* mode captures a small tile floating in empty space — the most common "why am I squinting" mistake.
+- **High-contrast theme** (e.g. Melange Dark) so the text reads.
+- **Move briskly, then speed up.** Do setup (create terminal, maximize, open the Code panel) *before* `screencast_start` so only the meaningful steps are recorded; run those steps back-to-back; then speed the output up (`setpts=PTS/3`) so agent-latency dead time doesn't make the clip drag.
+
 Two reasons not to just attach the `.mp4`: GitHub renders an inline video *player* only for files dragged into the web composer (a `user-attachments` URL `gh` can't mint), and a `<video>` tag in a comment is stripped. So:
 
 - **Inline (the at-a-glance proof):** transcode to an animated GIF — GitHub renders a GIF inline from any release URL, exactly like the PNG flow above.
 
   ```sh
   nix shell nixpkgs#ffmpeg --command ffmpeg -i /tmp/kolu-evidence-<slug>.mp4 \
-    -vf "fps=12,scale=900:-1:flags=lanczos" -loop 0 /tmp/kolu-evidence-<slug>.gif
+    -vf "setpts=PTS/3,fps=12,scale=1100:-1:flags=lanczos" -loop 0 /tmp/kolu-evidence-<slug>.gif
   gh release upload evidence-assets /tmp/kolu-evidence-<slug>.gif --clobber
   ```
 
-  Embed with `![](https://github.com/juspay/kolu/releases/download/evidence-assets/<slug>.gif)`.
+  Keep it under GitHub's ~10 MB inline limit (the `setpts` speed-up + a palette pass usually land a minute-long capture well under that). Embed with `![](https://github.com/juspay/kolu/releases/download/evidence-assets/<slug>.gif)`.
 
-- **HD + audio (optional):** upload the `.mp4` to the same release and link to the shared player — [`juspay/video-evidence`](https://github.com/juspay/video-evidence) hosts a GitHub Pages `<video>` page that streams the clip from kolu's own release:
+- **HD (optional):** speed the `.mp4` up too (`ffmpeg -i …mp4 -filter:v "setpts=PTS/3" -an …`), upload it to the same release, and link to the shared player — [`juspay/video-evidence`](https://github.com/juspay/video-evidence) hosts a GitHub Pages `<video>` page that streams the clip from kolu's own release:
 
   ```
   ▶ HD: https://juspay.github.io/video-evidence/evidence.html?repo=juspay/kolu&v=<slug>.mp4

--- a/.agents/skills/nix-chrome-devtools-mcp/bin/serve
+++ b/.agents/skills/nix-chrome-devtools-mcp/bin/serve
@@ -31,8 +31,13 @@ if [[ -z "$chrome" ]]; then
     exit 1
 fi
 
-exec nix shell "${nixpkgs}#nodejs" --command \
+# ffmpeg is on PATH so chrome-devtools-mcp's experimental screencast tools
+# (screencast_start / screencast_stop) can record page video — Puppeteer's
+# page.screencast() shells out to ffmpeg. Without --experimentalScreencast
+# the tools stay hidden; without ffmpeg they error at record time.
+exec nix shell "${nixpkgs}#nodejs" "${nixpkgs}#ffmpeg" --command \
     npx -y "chrome-devtools-mcp@${mcp_version}" \
     --headless=true \
     --isolated=true \
+    --experimentalScreencast=true \
     --executable-path="$chrome"

--- a/.agents/skills/talk/SKILL.md
+++ b/.agents/skills/talk/SKILL.md
@@ -10,7 +10,7 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 
 ## Rules
 
-- **Do NOT edit or mutate the current repo.** No `Edit`, `Write`, `NotebookEdit` tool calls against workspace files, and no Bash commands that create, modify, or delete files in the checked-out repo. (Sole exception: `--html` mode below, which permits writing a single `.html` artifact to `$PWD`.)
+- **Do NOT edit or mutate the current repo.** No `Edit`, `Write`, `NotebookEdit` tool calls against workspace files, and no Bash commands that create, modify, or delete files in the checked-out repo. (Sole exception: `--html` mode below, which permits writing a single `.html` artifact to the repo root or an existing `docs/plans/`.)
 - **Do NOT run destructive repo commands.** No `git commit`, `git push`, `git add`, `git rm`, or anything else that mutates the current repo.
 - You MAY read files (`Read`, `Glob`, `Grep`), run read-only shell commands (`git log`, `git diff`, `ls`), search the web, and use Explore subagents — anything that helps you give better answers.
 - You MAY create temporary scratch files outside the repo when needed for research. Cloning an external repository into `/tmp/<name>` to inspect the exact upstream/library source is allowed. Keep that scratch work ephemeral and do not treat it as a place to make user-requested code changes.
@@ -114,14 +114,16 @@ Laconic mode trims the *output*, not the *investigation*. Do the same reading yo
 
 ## HTML artifact mode (`--html`)
 
-If `ARGUMENTS` contains `--html` (strip the flag before treating the rest as the topic), respond by writing a self-contained `.html` file to `$PWD` instead of replying in chat. Print only the file path — the HTML *is* the response.
+If `ARGUMENTS` contains `--html` (strip the flag before treating the rest as the topic), respond by writing a self-contained `.html` file instead of replying in chat. Print only the file path — the HTML *is* the response.
+
+- **Output directory**: write to `docs/plans/` if that directory already exists; otherwise write to the repo root (`$PWD`). Do not create `docs/plans/` — only use it when it's already there.
 
 The point is to pair with a runner that can render the artifact and let the user select text on it to queue comments back (e.g. [juspay/kolu#922](https://github.com/juspay/kolu/pull/922)). The user reads the rendered HTML, replies with their selected comments as text, you re-emit the updated HTML. The artifact stays the conversation's single source of truth.
 
-- **Filename**: stable for the session — `talk-<short-slug>.html` derived from the topic (lowercase, dashes, no spaces), or `talk.html` if there's no obvious slug. Follow-up turns update the **same** file; do not spawn a new artifact per turn.
+- **Filename**: stable for the session — `talk-<short-slug>.html` derived from the topic (lowercase, dashes, no spaces), or `talk.html` if there's no obvious slug, in the output directory above. Follow-up turns update the **same** file; do not spawn a new artifact per turn.
 - **File contents**: self-contained — embedded `<style>` block, no external assets, no JavaScript, no remote fonts. Plain semantic markup that renders legibly inside an iframe preview. Carry the same `file:line` citations you would put in a text response; the research/citation rules above are unchanged.
 - **UI prototypes for UI work**: if the topic involves UI changes, embed *rendered* HTML/CSS prototypes of the proposed components inside the artifact — not ASCII mockups, not prose descriptions of what the UI would look like. The runner renders the file, so the user sees the proposed UI alongside the rationale and can comment on the visual itself. Approximate the target visual style (colors, spacing, typography); the prototype is static (no JS), but layout and hierarchy should be representative enough to react to.
-- **Repo-write exception**: writing that one `.html` file in `$PWD` is the only mutation `--html` permits. No `Edit` on pre-existing repo files, no `git` writes, no destructive ops — the rest of talk mode's read-only posture holds.
+- **Repo-write exception**: writing that one `.html` file in the output directory above is the only mutation `--html` permits. No `Edit` on pre-existing repo files, no `git` writes, no destructive ops — the rest of talk mode's read-only posture holds.
 - **Follow-up loop**: when the user replies with comments (typically pasted from a select-and-queue surface as a Markdown list), re-emit the **full** revised HTML and print the file path again. Do not narrate the diff in chat; the updated artifact is the reply.
 - **Interaction with `hickey` + `lowy`**: when the artifact is a design sketch, run the reviewers as usual and fold their findings into the HTML body **before** printing the file path — same "post-review proposal, not original sketch + critique appended" rule as text-mode responses.
 - **Interaction with laconic mode**: laconic trims the HTML body the same way it would trim a text response — brief prose, no preamble, no needless bullets, no heading scaffolding unless the answer is genuinely structured. `--html` picks the medium; `--no-laconic` picks the verbosity. UI-prototype markup is the substance of the answer, not prose filler, so it's not what laconic trims.

--- a/.claude/skills/nix-chrome-devtools-mcp/bin/serve
+++ b/.claude/skills/nix-chrome-devtools-mcp/bin/serve
@@ -31,8 +31,13 @@ if [[ -z "$chrome" ]]; then
     exit 1
 fi
 
-exec nix shell "${nixpkgs}#nodejs" --command \
+# ffmpeg is on PATH so chrome-devtools-mcp's experimental screencast tools
+# (screencast_start / screencast_stop) can record page video — Puppeteer's
+# page.screencast() shells out to ffmpeg. Without --experimentalScreencast
+# the tools stay hidden; without ffmpeg they error at record time.
+exec nix shell "${nixpkgs}#nodejs" "${nixpkgs}#ffmpeg" --command \
     npx -y "chrome-devtools-mcp@${mcp_version}" \
     --headless=true \
     --isolated=true \
+    --experimentalScreencast=true \
     --executable-path="$chrome"

--- a/.claude/skills/talk/SKILL.md
+++ b/.claude/skills/talk/SKILL.md
@@ -10,7 +10,7 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 
 ## Rules
 
-- **Do NOT edit or mutate the current repo.** No `Edit`, `Write`, `NotebookEdit` tool calls against workspace files, and no Bash commands that create, modify, or delete files in the checked-out repo. (Sole exception: `--html` mode below, which permits writing a single `.html` artifact to `$PWD`.)
+- **Do NOT edit or mutate the current repo.** No `Edit`, `Write`, `NotebookEdit` tool calls against workspace files, and no Bash commands that create, modify, or delete files in the checked-out repo. (Sole exception: `--html` mode below, which permits writing a single `.html` artifact to the repo root or an existing `docs/plans/`.)
 - **Do NOT run destructive repo commands.** No `git commit`, `git push`, `git add`, `git rm`, or anything else that mutates the current repo.
 - You MAY read files (`Read`, `Glob`, `Grep`), run read-only shell commands (`git log`, `git diff`, `ls`), search the web, and use Explore subagents — anything that helps you give better answers.
 - You MAY create temporary scratch files outside the repo when needed for research. Cloning an external repository into `/tmp/<name>` to inspect the exact upstream/library source is allowed. Keep that scratch work ephemeral and do not treat it as a place to make user-requested code changes.
@@ -114,14 +114,16 @@ Laconic mode trims the *output*, not the *investigation*. Do the same reading yo
 
 ## HTML artifact mode (`--html`)
 
-If `ARGUMENTS` contains `--html` (strip the flag before treating the rest as the topic), respond by writing a self-contained `.html` file to `$PWD` instead of replying in chat. Print only the file path — the HTML *is* the response.
+If `ARGUMENTS` contains `--html` (strip the flag before treating the rest as the topic), respond by writing a self-contained `.html` file instead of replying in chat. Print only the file path — the HTML *is* the response.
+
+- **Output directory**: write to `docs/plans/` if that directory already exists; otherwise write to the repo root (`$PWD`). Do not create `docs/plans/` — only use it when it's already there.
 
 The point is to pair with a runner that can render the artifact and let the user select text on it to queue comments back (e.g. [juspay/kolu#922](https://github.com/juspay/kolu/pull/922)). The user reads the rendered HTML, replies with their selected comments as text, you re-emit the updated HTML. The artifact stays the conversation's single source of truth.
 
-- **Filename**: stable for the session — `talk-<short-slug>.html` derived from the topic (lowercase, dashes, no spaces), or `talk.html` if there's no obvious slug. Follow-up turns update the **same** file; do not spawn a new artifact per turn.
+- **Filename**: stable for the session — `talk-<short-slug>.html` derived from the topic (lowercase, dashes, no spaces), or `talk.html` if there's no obvious slug, in the output directory above. Follow-up turns update the **same** file; do not spawn a new artifact per turn.
 - **File contents**: self-contained — embedded `<style>` block, no external assets, no JavaScript, no remote fonts. Plain semantic markup that renders legibly inside an iframe preview. Carry the same `file:line` citations you would put in a text response; the research/citation rules above are unchanged.
 - **UI prototypes for UI work**: if the topic involves UI changes, embed *rendered* HTML/CSS prototypes of the proposed components inside the artifact — not ASCII mockups, not prose descriptions of what the UI would look like. The runner renders the file, so the user sees the proposed UI alongside the rationale and can comment on the visual itself. Approximate the target visual style (colors, spacing, typography); the prototype is static (no JS), but layout and hierarchy should be representative enough to react to.
-- **Repo-write exception**: writing that one `.html` file in `$PWD` is the only mutation `--html` permits. No `Edit` on pre-existing repo files, no `git` writes, no destructive ops — the rest of talk mode's read-only posture holds.
+- **Repo-write exception**: writing that one `.html` file in the output directory above is the only mutation `--html` permits. No `Edit` on pre-existing repo files, no `git` writes, no destructive ops — the rest of talk mode's read-only posture holds.
 - **Follow-up loop**: when the user replies with comments (typically pasted from a select-and-queue surface as a Markdown list), re-emit the **full** revised HTML and print the file path again. Do not narrate the diff in chat; the updated artifact is the reply.
 - **Interaction with `hickey` + `lowy`**: when the artifact is a design sketch, run the reviewers as usual and fold their findings into the HTML body **before** printing the file path — same "post-review proposal, not original sketch + critique appended" rule as text-mode responses.
 - **Interaction with laconic mode**: laconic trims the HTML body the same way it would trim a text response — brief prose, no preamble, no needless bullets, no heading scaffolding unless the answer is genuinely structured. `--html` picks the medium; `--no-laconic` picks the verbosity. UI-prototype markup is the substance of the answer, not prose filler, so it's not what laconic trims.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-05-28T14:43:18.658839+00:00'
+generated_at: '2026-05-29T21:45:05.352841+00:00'
 apm_version: 0.16.0
 dependencies:
 - repo_url: anthropics/skills
@@ -25,12 +25,13 @@ dependencies:
   content_hash: sha256:dea7f0a0315be995232b9d7153f1a1354ad726b2cbf9121f2e7576bbea256718
 - repo_url: juspay/nix-chrome-devtools-mcp
   host: github.com
-  resolved_commit: 9c28516075f1a22e2cfd8986976ccb4b59bc60ed
+  resolved_commit: 61204063f8ac21527d05969ee4aabe8297d1607e
+  resolved_ref: screencast
   package_type: apm_package
   deployed_files:
   - .agents/skills/nix-chrome-devtools-mcp
   - .claude/skills/nix-chrome-devtools-mcp
-  content_hash: sha256:80738251dd3e2fa09141c16f43244c19ee96a36930946bb94ab58684b129ee30
+  content_hash: sha256:51308bd8cc8b6ae24781a77b67a7c8140bdea5d793e35427e7b8fcbeb0662074
 - repo_url: juspay/skills
   host: github.com
   resolved_commit: 6e2df2d9ab3a4031e89598b50aa1074c3fd87748

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-05-29T21:45:05.352841+00:00'
+generated_at: '2026-05-29T22:25:40.578568+00:00'
 apm_version: 0.16.0
 dependencies:
 - repo_url: anthropics/skills
@@ -25,8 +25,7 @@ dependencies:
   content_hash: sha256:dea7f0a0315be995232b9d7153f1a1354ad726b2cbf9121f2e7576bbea256718
 - repo_url: juspay/nix-chrome-devtools-mcp
   host: github.com
-  resolved_commit: 61204063f8ac21527d05969ee4aabe8297d1607e
-  resolved_ref: screencast
+  resolved_commit: a202612693800c9d9ac9035ca0df80f2e92ded3b
   package_type: apm_package
   deployed_files:
   - .agents/skills/nix-chrome-devtools-mcp
@@ -54,7 +53,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 2037e59c4e58a9ba7f864eab53c18badff59c896
+  resolved_commit: d274039c47ee8d0cc13e9d42d1bbf61e5f5b706f
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -95,7 +94,7 @@ dependencies:
     .codex/hooks/agency/scripts/do-stop-guard.sh: sha256:cb033f86c15ffd3d09d8e4b74a61f55a70def4cc4131cc013b7368a2d23f3f33
     .opencode/agents/hickey.md: sha256:10d9a4350a85752dc6658af8e0efb3d8be41803a2b6c73464e3d5b7a840435ad
     .opencode/agents/lowy.md: sha256:05aff7f6a91149a42c1fb9a3ca382a6f77bc39ac8a8d45436d443dd3349fb11e
-  content_hash: sha256:2ec46fe9157e6fc60d38dd9e85feb67b638c80acef5f70c5ee5bff5ac44cd044
+  content_hash: sha256:5a4a4d50e6298dc5015412eb1000e8c233cf6d872cc27b902b07979c466127b2
 mcp_servers:
 - chrome-devtools
 mcp_configs:

--- a/apm.yml
+++ b/apm.yml
@@ -25,5 +25,7 @@ dependencies:
     - juspay/skills/skills/nix-justfile
     - juspay/skills/skills/nix-typescript
     - anthropics/skills/skills/frontend-design
-    - juspay/nix-chrome-devtools-mcp
+    # Pinned to the screencast branch for video PR evidence until
+    # juspay/nix-chrome-devtools-mcp#2 merges, then drop the ref.
+    - juspay/nix-chrome-devtools-mcp#screencast
     - juspay/justci

--- a/apm.yml
+++ b/apm.yml
@@ -25,7 +25,5 @@ dependencies:
     - juspay/skills/skills/nix-justfile
     - juspay/skills/skills/nix-typescript
     - anthropics/skills/skills/frontend-design
-    # Pinned to the screencast branch for video PR evidence until
-    # juspay/nix-chrome-devtools-mcp#2 merges, then drop the ref.
-    - juspay/nix-chrome-devtools-mcp#screencast
+    - juspay/nix-chrome-devtools-mcp
     - juspay/justci

--- a/docs/plans/video-evidence.html
+++ b/docs/plans/video-evidence.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Video evidence for PRs — screencast capture + shared Pages player</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --panel2:#1c2128; --line:#30363d;
+    --fg:#e6edf3; --dim:#9198a1; --dim2:#6e7681;
+    --accent:#58a6ff; --green:#3fb950; --amber:#d29922; --red:#f85149;
+    --purple:#bc8cff; --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);
+    font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;}
+  .wrap{max-width:1000px;margin:0 auto;padding:32px 28px 80px}
+  h1{font-size:22px;margin:0 0 4px}
+  h2{font-size:17px;margin:34px 0 10px;padding-bottom:6px;border-bottom:1px solid var(--line)}
+  h3{font-size:14px;margin:20px 0 8px;color:var(--accent)}
+  p{margin:10px 0}
+  code,.mono{font-family:var(--mono);font-size:12.5px}
+  code{background:var(--panel2);padding:1px 5px;border-radius:4px;color:#d2a8ff}
+  pre{background:var(--panel2);border:1px solid var(--line);border-radius:8px;padding:12px 14px;overflow-x:auto;font-family:var(--mono);font-size:12px;line-height:1.5}
+  .lede{color:var(--dim);font-size:13px;margin-top:0}
+  .cite{color:var(--dim2);font-family:var(--mono);font-size:11.5px}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:16px 18px;margin:14px 0}
+  .bad{border-left:3px solid var(--red)}
+  .good{border-left:3px solid var(--green)}
+  .note{border-left:3px solid var(--amber)}
+  ul{margin:8px 0;padding-left:22px} li{margin:4px 0}
+  table{border-collapse:collapse;width:100%;margin:12px 0;font-size:13px}
+  th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--dim)}
+  a{color:var(--accent)}
+  .tag{display:inline-block;font-family:var(--mono);font-size:11px;padding:1px 7px;border-radius:10px;border:1px solid var(--line);color:var(--dim)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Video evidence for PRs</h1>
+<p class="lede">Let <code>/do</code> attach <em>video</em> to a PR — not just screenshots — for changes about motion (animations, transitions, multi-step interactions). Shipped as three small pieces across three repos.</p>
+
+<h2>Problem</h2>
+<p>The <code>## PR evidence</code> flow in <code>.agency/do.md</code> captures stills via the <code>chrome-devtools</code> MCP's <code>take_screenshot</code>, uploads them to a long-lived <code>evidence-assets</code> GitHub release, and embeds them inline. A still can't convey a transition or a multi-step interaction. We want the same agent-driven flow to produce video.</p>
+<p>Two independent gaps: <strong>capture</strong> (the MCP wasn't recording video) and <strong>embedding</strong> (getting a clip to render in a PR comment).</p>
+
+<h2>Capture — the MCP already has it, gated</h2>
+<p><code>chrome-devtools-mcp</code> ships <code>screencast_start</code> / <code>screencast_stop</code> (<code>.mp4</code>/<code>.webm</code>) via Puppeteer's <code>page.screencast()</code>, which shells out to <strong>ffmpeg</strong>. They are hidden behind <code>--experimentalScreencast=true</code>, and the kolu launcher didn't pass it or provide ffmpeg.</p>
+<p class="cite">chrome-devtools-mcp build/src/tools/screencast.js:18-70 (tools); :53-66 (ffmpeg shell-out + ENOENT error); cli-options screencast flag.</p>
+<div class="card good">
+<strong>Fix (upstream):</strong> the launcher at <code>.apm/skills/nix-chrome-devtools-mcp/bin/serve</code> now runs <code>nix shell …#nodejs …#ffmpeg</code> and passes <code>--experimentalScreencast=true</code> — ffmpeg and the tools resolve through Nix, no host install.
+<div class="cite" style="margin-top:6px">→ juspay/nix-chrome-devtools-mcp#2 (branch <code>screencast</code>). kolu pins it via <code>apm.yml</code> (<code>juspay/nix-chrome-devtools-mcp#screencast</code>) until merged; <code>just ai::apm-update</code> regenerates the vendored <code>serve</code>. Drop the <code>#screencast</code> ref after merge.</div>
+</div>
+
+<h2>Embedding — the real constraint</h2>
+<p>GitHub auto-mounts a <code>&lt;video&gt;</code> player <strong>only</strong> for files uploaded through the web composer (a <code>user-attachments</code> URL needing a session cookie + CSRF — <code>gh</code>/PAT can't mint it). A git-committed or release-hosted <code>raw.</code> mp4 renders as a download link, and a hand-authored <code>&lt;video&gt;</code> tag is stripped by the comment sanitizer.</p>
+<div class="card note">
+<strong>Proof it's the embed, not hosting:</strong> <code>srid/ema</code>'s README plays an inline clip via a bare <code>user-images.githubusercontent.com</code> URL (a one-time human drag-drop). The repo <em>also</em> commits the same file at <code>docs/static/ema-demo.mp4</code>, yet the README does <em>not</em> use that committed file's <code>raw.</code> URL — because it wouldn't render a player. A dedicated mp4 repo lands on that same non-embedding <code>raw.</code> path.
+<div class="cite" style="margin-top:6px">→ srid/ema README.md:10 (bare user-images URL); git tree has docs/static/ema-demo.mp4.</div>
+</div>
+
+<h3>Two outputs, each for what it's good at</h3>
+<table>
+  <tr><th>Output</th><th>Renders</th><th>Use</th></tr>
+  <tr><td><strong>Animated GIF</strong></td><td>Inline in the comment via <code>![](release-url)</code> — a GIF is an image to GitHub, embeds from any URL like the PNG flow.</td><td>The at-a-glance proof. No audio, larger file, 256-color.</td></tr>
+  <tr><td><strong>MP4 + Pages player</strong></td><td>A real <code>&lt;video&gt;</code> on a GitHub Pages page we control; the comment links to it.</td><td>HD + audio + seeking, on click-through.</td></tr>
+</table>
+
+<h2>Architecture — three repos</h2>
+<table>
+  <tr><th>Repo</th><th>Role</th><th>Change</th></tr>
+  <tr><td><code>juspay/nix-chrome-devtools-mcp</code></td><td>Capture capability</td><td>Launcher enables screencast + ffmpeg (PR&nbsp;#2).</td></tr>
+  <tr><td><code>juspay/video-evidence</code></td><td>Shared player host</td><td>GitHub Pages <code>evidence.html?repo=&lt;owner/repo&gt;&amp;v=&lt;file&gt;</code>, project-agnostic, org-allowlisted.</td></tr>
+  <tr><td><code>juspay/kolu</code> (this PR)</td><td>Consumer</td><td><code>apm.yml</code> pin + regen; <code>.agency/do.md</code> video procedure; this plan.</td></tr>
+</table>
+<div class="card good">
+<strong>Key decision (per review):</strong> clips live on <strong>each project's own <code>evidence-assets</code> release</strong> — kolu's on <code>juspay/kolu</code>, exactly where screenshots already go. The <code>video-evidence</code> repo holds <em>only</em> the player, so it is reused across juspay projects with no per-project hosting and no git-blob bloat. One parametrized player (org-allowlisted <code>repo</code>) rather than per-project HTML pages — avoids multiplying artifacts.
+</div>
+
+<h2>Validated end-to-end</h2>
+<p>Before wiring the launcher, the embed path was proven in a real browser (chrome-devtools): the Pages player loaded a clip from the cross-origin release URL, reached <code>readyState 4</code>, played to completion, and <strong>seeked mid-clip</strong> — confirming HTTP range requests work on release assets. Test clip generated offline with <code>nix shell nixpkgs#ffmpeg</code> (the same ffmpeg-via-nix the launcher now uses).</p>
+
+<h2>The <code>/do</code> flow (documented in <code>.agency/do.md</code>)</h2>
+<pre>screencast_start { filePath: /tmp/kolu-evidence-&lt;slug&gt;.mp4 }
+  → drive the interaction → screencast_stop
+ffmpeg -i …mp4 -vf "fps=12,scale=900:-1:flags=lanczos" -loop 0 …gif   # inline
+gh release upload evidence-assets …gif …mp4 --clobber                # kolu's release
+comment: ![](…/evidence-assets/&lt;slug&gt;.gif)
+         ▶ HD: …/video-evidence/evidence.html?repo=juspay/kolu&amp;v=&lt;slug&gt;.mp4</pre>
+
+<h2>Follow-up</h2>
+<ul>
+  <li>When <a href="https://github.com/juspay/nix-chrome-devtools-mcp/pull/2">nix-chrome-devtools-mcp#2</a> merges, drop the <code>#screencast</code> ref in <code>apm.yml</code> and re-run <code>just ai::apm-update</code>.</li>
+  <li>Picking up the new launcher requires a Claude restart (the MCP server is spawned at session start).</li>
+</ul>
+
+</div>
+</body>
+</html>

--- a/justfile
+++ b/justfile
@@ -49,8 +49,10 @@ dev SERVER_PORT="" CLIENT_PORT="":
 dev-auto:
     #!/usr/bin/env bash
     set -euo pipefail
-    free_port() { python3 -c 'import socket;s=socket.socket();s.bind(("",0));print(s.getsockname()[1]);s.close()'; }
-    exec just dev SERVER_PORT="$(free_port)" CLIENT_PORT="$(free_port)"
+    # python3 via nix (not a global install) so this works outside the devshell.
+    # Both sockets stay open until printed, guaranteeing two *unique* free ports.
+    read -r SERVER_PORT CLIENT_PORT < <(nix shell nixpkgs#python3 --command python3 -c 'import socket; a=socket.socket(); a.bind(("",0)); b=socket.socket(); b.bind(("",0)); print(a.getsockname()[1], b.getsockname()[1]); a.close(); b.close()')
+    exec just dev SERVER_PORT="$SERVER_PORT" CLIENT_PORT="$CLIENT_PORT"
 
 [private]
 _dev: install _dev-parallel

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ install:
 # Bare `just dev` keeps the canonical 7681/5173 (see README). Override either
 # port to run a second instance alongside a primary one; empty falls back to
 # the default. `just dev-auto` picks two free ports for you.
-#   just dev SERVER_PORT=7700 CLIENT_PORT=5180
+#   just dev 7700 5180   (positional: SERVER_PORT then CLIENT_PORT)
 # The env vars must be exported before the parallel fork — Vite reads them once
 # at startup to compute its proxy target — so resolution happens here, in the
 # sequential recipe body, before `_dev` forks server + client.
@@ -52,7 +52,9 @@ dev-auto:
     # python3 via nix (not a global install) so this works outside the devshell.
     # Both sockets stay open until printed, guaranteeing two *unique* free ports.
     read -r SERVER_PORT CLIENT_PORT < <(nix shell nixpkgs#python3 --command python3 -c 'import socket; a=socket.socket(); a.bind(("",0)); b=socket.socket(); b.bind(("",0)); print(a.getsockname()[1], b.getsockname()[1]); a.close(); b.close()')
-    exec just dev SERVER_PORT="$SERVER_PORT" CLIENT_PORT="$CLIENT_PORT"
+    # Positional args — `just dev NAME=VALUE` would bind the literal "NAME=VALUE"
+    # to the param, not the value.
+    exec just dev "$SERVER_PORT" "$CLIENT_PORT"
 
 [private]
 _dev: install _dev-parallel


### PR DESCRIPTION
**`/do` can now attach _video_ to a PR, not just screenshots** — for changes about motion (animations, transitions, multi-step interactions a still can't convey). The `chrome-devtools` MCP already ships screencast tools; they were gated. This wires them on and documents how to get a clip to actually render in a PR comment.

Two independent gaps had to close — **capture** and **embedding**:

| Gap | Resolution |
|---|---|
| MCP wasn't recording video | Launcher now passes `--experimentalScreencast=true` and puts `ffmpeg` on PATH (both via Nix). Lands through [`juspay/nix-chrome-devtools-mcp#2`](https://github.com/juspay/nix-chrome-devtools-mcp/pull/2); `apm.yml` pins that branch until it merges, regenerating the vendored `bin/serve`. |
| GitHub won't embed an agent-uploaded video | GitHub mounts a `<video>` player only for human web-composer uploads (`user-attachments`), and strips `<video>` tags in comments. So: a **GIF** for the inline at-a-glance proof (renders from any release URL like the PNG flow), plus an optional **HD/audio** link to a shared Pages `<video>` player. |

### Where things live

Clips stay on **kolu's own `evidence-assets` release** — exactly where screenshots already go (no git-blob bloat). The player is a separate, project-agnostic Pages page in [`juspay/video-evidence`](https://github.com/juspay/video-evidence) (`?repo=juspay/kolu&v=clip.mp4`, org-allowlisted), reused across juspay projects with zero per-project hosting.

```
screencast_start → drive interaction → screencast_stop → .mp4
  ├─ ffmpeg → .gif → release → ![](…)            inline proof
  └─ .mp4   → release → Pages ?repo=&v=  ▶ HD + audio link
```

The end-to-end embed path (Pages `<video>` streaming a clip from a cross-origin release, with seeking) was validated in a real browser before wiring the launcher. Full rationale and the GitHub-embedding findings are in `docs/plans/video-evidence.html`.

> Picking up the screencast-enabled launcher needs a Claude restart (the MCP server is spawned at session start). After [#2](https://github.com/juspay/nix-chrome-devtools-mcp/pull/2) merges, drop the `#screencast` ref in `apm.yml`.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._