### PR TITLE
Make agent-boundary tests hermetic (isolate from ~/.claude, ~/.codex)

### DIFF
--- a/packages/server/src/terminalBackend/agent.test.ts
+++ b/packages/server/src/terminalBackend/agent.test.ts
@@ -95,7 +95,7 @@ describe("createAgent", () => {
     delete process.env.KOLU_CLAUDE_PROJECTS_DIR;
     delete process.env.KOLU_CODEX_DIR;
     delete process.env.KOLU_OPENCODE_DB;
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    if (tmpRoot) fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
   async function start(): Promise<void> {

--- a/packages/server/src/terminalBackend/agent.test.ts
+++ b/packages/server/src/terminalBackend/agent.test.ts
@@ -124,16 +124,14 @@ describe("createAgent", () => {
       env: shellEnv,
       cwd: "/tmp",
     });
-    await waitFor(() =>
-      events.some(
+    let event: AgentMetadataEvent | undefined;
+    await waitFor(() => {
+      event = events.find(
         (e) => e.kind === "metadataPersisted" && e.fields.cwd === osc7Cwd,
-      ),
-    );
-    expect(
-      events.find(
-        (e) => e.kind === "metadataPersisted" && e.fields.cwd === osc7Cwd,
-      ),
-    ).toMatchObject({ kind: "metadataPersisted", id });
+      );
+      return event !== undefined;
+    });
+    expect(event).toMatchObject({ kind: "metadataPersisted", id });
   });
 
   it("seeds the recency clock from restoredActivityAt", async () => {

--- a/packages/server/src/terminalBackend/agent.test.ts
+++ b/packages/server/src/terminalBackend/agent.test.ts
@@ -11,8 +11,19 @@
  *     client cleanup) — the regression guard for the pre-R4b behavior.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
-import { type Agent, type AgentMetadataEvent, createAgent } from "./agent.ts";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { Agent, AgentMetadataEvent } from "./agent.ts";
 
 const silentLog = {
   debug: () => {},
@@ -42,9 +53,50 @@ function settle(): Promise<void> {
 }
 
 describe("createAgent", () => {
+  // The agent's provider DAG (claude-code, codex, opencode) resolves its
+  // watch dirs from KOLU_* env vars at *module import time* (top-level
+  // consts in each integration's config). Point them at throwaway temp dirs
+  // and import `agent.ts` only after they're set, so the test never installs
+  // watchers on the developer's real ~/.claude / ~/.codex / opencode state.
+  // Mirrors the e2e harness's per-worker isolation in
+  // `packages/tests/support/hooks.ts`. (#1029)
+  let createAgent: typeof import("./agent.ts").createAgent;
+  let tmpRoot: string;
+  // A real, existing cwd for the OSC 7 test — a non-existent target (the old
+  // hardcoded /tmp/agent-osc7) makes the git cwd-watcher log a noisy
+  // "failed to watch dir" / "resolveGitInfo failed".
+  let osc7Cwd: string;
+
   let agent: Agent;
   let events: AgentMetadataEvent[];
   let stop: (() => void) | undefined;
+
+  beforeAll(async () => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-agent-test-"));
+    const sub = (name: string) => {
+      const dir = path.join(tmpRoot, name);
+      fs.mkdirSync(dir);
+      return dir;
+    };
+    process.env.KOLU_CLAUDE_SESSIONS_DIR = sub("claude-sessions");
+    process.env.KOLU_CLAUDE_PROJECTS_DIR = sub("claude-projects");
+    process.env.KOLU_CODEX_DIR = sub("codex");
+    process.env.KOLU_OPENCODE_DB = path.join(sub("opencode"), "opencode.db");
+    osc7Cwd = sub("osc7-cwd");
+
+    // Env must be set before the provider modules are first imported; a
+    // static import of `agent.ts` would hoist above these assignments.
+    vi.resetModules();
+    ({ createAgent } = await import("./agent.ts"));
+  });
+
+  afterAll(() => {
+    delete process.env.KOLU_CLAUDE_SESSIONS_DIR;
+    delete process.env.KOLU_CLAUDE_PROJECTS_DIR;
+    delete process.env.KOLU_CODEX_DIR;
+    delete process.env.KOLU_OPENCODE_DB;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
 
   async function start(): Promise<void> {
     agent = createAgent({ log: silentLog });
@@ -67,21 +119,19 @@ describe("createAgent", () => {
       shell: "/bin/sh",
       args: [
         "-c",
-        "printf '\\033]7;file://localhost/tmp/agent-osc7\\033\\\\'; sleep 0.5",
+        `printf '\\033]7;file://localhost${osc7Cwd}\\033\\\\'; sleep 0.5`,
       ],
       env: shellEnv,
       cwd: "/tmp",
     });
     await waitFor(() =>
       events.some(
-        (e) =>
-          e.kind === "metadataPersisted" && e.fields.cwd === "/tmp/agent-osc7",
+        (e) => e.kind === "metadataPersisted" && e.fields.cwd === osc7Cwd,
       ),
     );
     expect(
       events.find(
-        (e) =>
-          e.kind === "metadataPersisted" && e.fields.cwd === "/tmp/agent-osc7",
+        (e) => e.kind === "metadataPersisted" && e.fields.cwd === osc7Cwd,
       ),
     ).toMatchObject({ kind: "metadataPersisted", id });
   });


### PR DESCRIPTION
The agent-boundary tests in `packages/server/src/terminalBackend/agent.test.ts` called `createAgent()` against the real provider DAG, which **installed filesystem watchers on the developer's own `~/.claude` and `~/.codex` state** and logged a `resolveGitInfo failed` / `failed to watch dir` error for the non-existent `/tmp/agent-osc7` cwd. The tests passed, but their behavior and log noise depended on whatever agent state the runner happened to have on disk — and they put inotify pressure on real watcher resources.

The fix points every provider at throwaway temp dirs and gives the OSC 7 test a real cwd to land in:

| Knob | Isolated to |
| --- | --- |
| `KOLU_CLAUDE_SESSIONS_DIR`, `KOLU_CLAUDE_PROJECTS_DIR` | per-run temp subdirs |
| `KOLU_CODEX_DIR` | per-run temp subdir |
| `KOLU_OPENCODE_DB` | per-run temp subdir |
| OSC 7 target cwd | a real `mkdtemp` dir (was the hardcoded, non-existent `/tmp/agent-osc7`) |

The subtlety: each integration resolves its watch dir from its `KOLU_*` env var in a **top-level `const`, evaluated at module import time**. So setting the env in `beforeAll` only works if `agent.ts` is imported *after* — the runtime `createAgent` import is converted to a type-only import plus a `vi.resetModules()` + dynamic `import()`. This mirrors the e2e harness's per-worker isolation in `packages/tests/support/hooks.ts`.

> The structural review (hickey + lowy) first suggested extracting a shared isolation helper across the test files. **Cross-validation reversed that** — every placement for such a helper either inverts the package layering (`kolu-server` ← a leaf integration test) or braids three independent providers' env knowledge into one module. The inline `beforeAll` is the correct, simplest form; see the analysis comment below.

Closes #1029

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._