### PR TITLE
Run PR evidence on a pu box (like CI); extract pu + evidence skills

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -18,7 +18,7 @@ Invoke the `/test` skill. It selects relevant `.feature` files from the git diff
 
 Use the `/ci` skill for the runner mechanics (subcommands, flags, modes, retry shape). Two Kolu-specific operational notes layered on top of it:
 
-**Ephemeral linux build host per run.** Static darwin (`sincereintent`) lives in `~/.config/ci/hosts.json`; the linux lane uses a throwaway Incus container per CI invocation so prior runs' nix-store cruft can't poison the verdict.
+**Ephemeral linux build host per run.** Static darwin (`sincereintent`) lives in `~/.config/ci/hosts.json`; the linux lane uses a throwaway Incus container per CI invocation so prior runs' nix-store cruft can't poison the verdict. (Box lifecycle — create/connect/destroy, the no-egress retry — is the [`pu`](../.apm/skills/pu/SKILL.md) skill.)
 
 ```sh
 pr=$(gh pr view --json number --jq .number)
@@ -42,119 +42,18 @@ Keep these docs in sync:
 
 ## PR evidence
 
-When the change has visible UI impact, post a `## Evidence` PR comment with screenshots — or **video** when the change is about motion (an animation, a transition, a multi-step interaction a still can't convey; see _Video evidence_ below). Use judgment — server-only diffs sometimes ripple into rendering.
+When the change has visible UI impact, post a `## Evidence` PR comment with screenshots — or **video** when the change is about motion (an animation, a transition, a multi-step interaction a still can't convey). Use judgment — server-only diffs sometimes ripple into rendering.
 
-**Capture runs on a `pu` box, not locally — exactly like CI.** `nix run`, Chrome, and Playwright all execute on an ephemeral Incus container; nothing touches the user's machine. This kills the whole class of local footguns: the box has its own loopback, so kolu binds the default `7681` there with **zero** risk to the user's production kolu — no random-port dance, no `pkill` that might match the user's process, no `git worktree` juggling for "before" shots. Reuse the same provisioning the CI step already documents (`pu create`).
+**The mechanics live in the [`evidence`](../.apm/skills/evidence/SKILL.md) skill** (which builds on the [`pu`](../.apm/skills/pu/SKILL.md) skill): capture runs on an ephemeral `pu` box — `nix run`, Chrome, Playwright, and ffmpeg all off-machine, exactly like CI. Drive it through that skill and plug in kolu's parameters:
 
-**Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so the main context stays clear of capture noise. Brief it with: the box name, what scenarios to capture, a `<slug>`, and the PR number. Have it return only the markdown body it posted.
-
-### Provision the box & serve kolu
-
-Build and serve the **PR's own commit** from the pushed branch, on the box's loopback. (By the evidence step `/do` has already pushed, so the branch flake-ref resolves; `--refresh` busts the flake cache so the box pulls the latest commit.)
-
-```sh
-pr=$(gh pr view --json number --jq .number)
-branch=$(git rev-parse --abbrev-ref HEAD)
-host="kolu-pr-$pr-evidence"
-pu create "$host"                                                      # writes ~/.pu-state/$host/ssh_config
-
-# Serve the PR build on the box's own 7681 (the box has no other kolu — 7681 is safe here).
-pu connect "$host" -- "nohup nix run --refresh 'github:juspay/kolu?ref=$branch' \
-  -- --host 127.0.0.1 --port 7681 >/tmp/kolu.log 2>&1 &"
-pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/api/health; do sleep 2; done'
-```
-
-For a **"before"** shot, point a second box at `github:juspay/kolu` (master) — no flake ref, no worktree, no stash.
-
-### Capture (Playwright on the box)
-
-Chrome and Playwright run on the box too. A self-contained `capture.mjs` drives headless Chromium with the **version-matched** pair Nix already provides — `nixpkgs#playwright-driver` (the `playwright-core` lib) + `nixpkgs#playwright-driver.browsers` (the Chrome-for-Testing build the launcher resolves). One run yields a PNG **and** a `.webm`; no MCP server, no npm install.
-
-```sh
-# Write the capture script onto the box.
-pu connect "$host" -- "cat > /tmp/cap/capture.mjs" <<'MJS'
-// argv: <url> <pngPath> [webmDir] [recordMs]   — runs entirely on the box.
-import { chromium } from 'playwright-core';
-const [url, pngPath, webmDir, recordMsArg] = process.argv.slice(2);
-const recordMs = Number(recordMsArg ?? 0);
-const viewport = { width: 1366, height: 768 };               // landscape, DPR 1
-const browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
-const context = await browser.newContext({
-  viewport, deviceScaleFactor: 1,
-  ...(webmDir ? { recordVideo: { dir: webmDir, size: viewport } } : {}),
-});
-const page = await context.newPage();
-await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
-// …reproduce the relevant state here: page.click(), page.keyboard.type(), etc.
-await page.waitForTimeout(2500);                              // let the canvas settle
-await page.screenshot({ path: pngPath });
-if (recordMs > 0) await page.waitForTimeout(recordMs);
-await context.close();                                        // flushes the .webm
-await browser.close();
-MJS
-
-# Resolve the Nix pair and run it (browsers via PLAYWRIGHT_BROWSERS_PATH, lib via NODE_PATH).
-pu connect "$host" -- 'bash -lc "
-  mkdir -p /tmp/cap/node_modules /tmp/cap/vid
-  DRV=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver)
-  BR=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver.browsers)
-  ln -sfn \$DRV /tmp/cap/node_modules/playwright-core
-  PLAYWRIGHT_BROWSERS_PATH=\$BR NODE_PATH=/tmp/cap/node_modules \
-    nix shell nixpkgs#nodejs -c node /tmp/cap/capture.mjs \
-      http://127.0.0.1:7681/ /tmp/cap/<slug>.png /tmp/cap/vid 6000
-"'
-```
-
-### Host & post
-
-Copy artifacts back over the box's `ssh_config`, then upload to a long-lived `evidence-assets` GitHub release (`gh pr comment` can't attach binaries):
-
-```sh
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
-
-gh release view evidence-assets >/dev/null 2>&1 || \
-  gh release create evidence-assets --prerelease \
-    --title "Evidence assets (auto-uploaded by /do)" --notes "Do not delete."
-gh release upload evidence-assets /tmp/kolu-evidence-<slug>.png --clobber
-```
-
-URL pattern: `https://github.com/juspay/kolu/releases/download/evidence-assets/<filename>`. Use the single-quoted heredoc pattern (`<<'EOF'`) when posting so backticks and `$` survive unescaped. **Tear the box down** when finished: `pu destroy "$host"`.
-
-### Video evidence
-
-For motion, pass a `webmDir` + `recordMs` to `capture.mjs` above — Playwright's `recordVideo` writes a `.webm` on the box. Transcode and copy back with `nix shell nixpkgs#ffmpeg` **on the box**:
-
-**Make the recording legible — this is the #1 quality issue:**
-
-- **Landscape viewport.** The script sets `1366×768` at DPR 1. The default headless window can be portrait and 2×-DPI, which leaves the content tiny in a tall, mostly-empty frame.
-- **Maximize the terminal.** Click the chrome-bar **Maximize terminal** in the script (`page.click(...)`, canvas → maximized) so the terminal fills the frame. Recording *canvas* mode captures a small tile floating in empty space — the most common "why am I squinting" mistake.
-- **High-contrast theme** (e.g. Melange Dark) so the text reads.
-- **Move briskly, then speed up.** Do setup (create terminal, maximize, open the Code panel) *before* the recorded stretch so only the meaningful steps land in the clip; then speed the output up (`setpts=PTS/2`–`/3`) so agent-latency dead time doesn't make it drag.
-
-Two reasons not to just attach the `.mp4`: GitHub renders an inline video *player* only for files dragged into the web composer (a `user-attachments` URL `gh` can't mint), and a `<video>` tag in a comment is stripped. So:
-
-- **Inline (the at-a-glance proof):** transcode to an animated GIF — GitHub renders a GIF inline from any release URL, exactly like the PNG flow above.
-
+- **Serve** the PR's own commit on the box's loopback (`/do` has already pushed by the evidence step, so the branch flake-ref resolves; `--refresh` busts the flake cache):
   ```sh
-  pu connect "$host" -- 'bash -lc "
-    WEBM=\$(ls /tmp/cap/vid/*.webm | head -1)
-    nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM \
-      -vf \"setpts=PTS/2,fps=12,scale=1100:-1:flags=lanczos\" -loop 0 /tmp/cap/<slug>.gif
-    nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM -filter:v setpts=PTS/2 -an /tmp/cap/<slug>.mp4
-  "'
-  scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/kolu-evidence-<slug>.gif
-  gh release upload evidence-assets /tmp/kolu-evidence-<slug>.gif --clobber
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  nix run --refresh "github:juspay/kolu?ref=$branch" -- --host 127.0.0.1 --port 7681
   ```
-
-  Keep it under GitHub's ~10 MB inline limit (the `setpts` speed-up + a palette pass usually land a minute-long capture well under that). Embed with `![](https://github.com/juspay/kolu/releases/download/evidence-assets/<slug>.gif)`.
-
-- **HD (optional):** copy the sped-up `.mp4` back too, upload it to the same release, and link to the shared player — [`juspay/video-evidence`](https://github.com/juspay/video-evidence) hosts a GitHub Pages `<video>` page that streams the clip from kolu's own release:
-
-  ```
-  ▶ HD: https://juspay.github.io/video-evidence/evidence.html?repo=juspay/kolu&v=<slug>.mp4
-  ```
-
-  Clips stay on kolu's `evidence-assets` release; the player is project-agnostic (the `repo` param is org-allowlisted), so it is reused across juspay projects with no per-project hosting.
+  Health is `http://127.0.0.1:7681/api/health`; the app is at `/`. The box has its own loopback, so plain `7681` is safe — no clash with the user's kolu. For a **"before"** shot, serve a second box from `github:juspay/kolu` (master).
+- **Host & player:** upload to the `evidence-assets` release; HD clips use the shared player with `repo=juspay/kolu`.
+- **Legibility:** maximize the terminal in the capture script with `page.click('[data-testid="maximize-toggle"]')`; pick a high-contrast theme (e.g. Melange Dark).
 
 ### Agent-state scenarios
 

--- a/.agency/do.md
+++ b/.agency/do.md
@@ -44,64 +44,111 @@ Keep these docs in sync:
 
 When the change has visible UI impact, post a `## Evidence` PR comment with screenshots — or **video** when the change is about motion (an animation, a transition, a multi-step interaction a still can't convey; see _Video evidence_ below). Use judgment — server-only diffs sometimes ripple into rendering.
 
-**Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so the main context stays clear of MCP and screenshot noise. Brief it with: the dev-server URL, what scenarios to capture, a `/tmp/kolu-evidence-<slug>.png` filename, and the PR number. Have it return only the markdown body it posted.
+**Capture runs on a `pu` box, not locally — exactly like CI.** `nix run`, Chrome, and Playwright all execute on an ephemeral Incus container; nothing touches the user's machine. This kills the whole class of local footguns: the box has its own loopback, so kolu binds the default `7681` there with **zero** risk to the user's production kolu — no random-port dance, no `pkill` that might match the user's process, no `git worktree` juggling for "before" shots. Reuse the same provisioning the CI step already documents (`pu create`).
 
-### Dev server
+**Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so the main context stays clear of capture noise. Brief it with: the box name, what scenarios to capture, a `<slug>`, and the PR number. Have it return only the markdown body it posted.
 
-Run a **production-like** instance: `nix run . -- --port <P>` builds kolu and serves the bundled client + server on a **single** port — the same way kolu actually runs, so the evidence reflects production, not the Vite dev server. Pick **one random free port**; **never** the default `7681` (the user is very likely running their own production kolu there, and a clash or careless cleanup takes it down).
+### Provision the box & serve kolu
+
+Build and serve the **PR's own commit** from the pushed branch, on the box's loopback. (By the evidence step `/do` has already pushed, so the branch flake-ref resolves; `--refresh` busts the flake cache so the box pulls the latest commit.)
 
 ```sh
-# One free port (python3 via nix — no global install needed).
-PORT=$(nix shell nixpkgs#python3 --command python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()')
-nix run . -- --port "$PORT" &
-DEV_PID=$!
-# Kill ONLY this PID at the end. NEVER `pkill -f vite` / `pkill -f src/index.ts`
-# / any pattern match — those also match the user's production kolu and kill it.
-trap 'kill "$DEV_PID" 2>/dev/null' EXIT
-# app is at http://localhost:$PORT  — pass that URL to the subagent
+pr=$(gh pr view --json number --jq .number)
+branch=$(git rev-parse --abbrev-ref HEAD)
+host="kolu-pr-$pr-evidence"
+pu create "$host"                                                      # writes ~/.pu-state/$host/ssh_config
+
+# Serve the PR build on the box's own 7681 (the box has no other kolu — 7681 is safe here).
+pu connect "$host" -- "nohup nix run --refresh 'github:juspay/kolu?ref=$branch' \
+  -- --host 127.0.0.1 --port 7681 >/tmp/kolu.log 2>&1 &"
+pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/api/health; do sleep 2; done'
 ```
 
-For a "before" shot, run a second instance on another free port from a `git worktree` on `master`. Never stash the PR branch. (For fast iteration outside evidence, `just dev-auto` runs the HMR dev server on two free ports instead.)
+For a **"before"** shot, point a second box at `github:juspay/kolu` (master) — no flake ref, no worktree, no stash.
 
-### Capture, host, post
+### Capture (Playwright on the box)
 
-The subagent drives `chrome-devtools` MCP — `new_page` at `http://localhost:$PORT/`, reproduces the relevant state, `take_screenshot` to `/tmp/kolu-evidence-<slug>.png`.
-
-`gh pr comment` can't attach binaries, so upload to a long-lived `evidence-assets` GitHub release and embed the download URL inline:
+Chrome and Playwright run on the box too. A self-contained `capture.mjs` drives headless Chromium with the **version-matched** pair Nix already provides — `nixpkgs#playwright-driver` (the `playwright-core` lib) + `nixpkgs#playwright-driver.browsers` (the Chrome-for-Testing build the launcher resolves). One run yields a PNG **and** a `.webm`; no MCP server, no npm install.
 
 ```sh
+# Write the capture script onto the box.
+pu connect "$host" -- "cat > /tmp/cap/capture.mjs" <<'MJS'
+// argv: <url> <pngPath> [webmDir] [recordMs]   — runs entirely on the box.
+import { chromium } from 'playwright-core';
+const [url, pngPath, webmDir, recordMsArg] = process.argv.slice(2);
+const recordMs = Number(recordMsArg ?? 0);
+const viewport = { width: 1366, height: 768 };               // landscape, DPR 1
+const browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+const context = await browser.newContext({
+  viewport, deviceScaleFactor: 1,
+  ...(webmDir ? { recordVideo: { dir: webmDir, size: viewport } } : {}),
+});
+const page = await context.newPage();
+await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+// …reproduce the relevant state here: page.click(), page.keyboard.type(), etc.
+await page.waitForTimeout(2500);                              // let the canvas settle
+await page.screenshot({ path: pngPath });
+if (recordMs > 0) await page.waitForTimeout(recordMs);
+await context.close();                                        // flushes the .webm
+await browser.close();
+MJS
+
+# Resolve the Nix pair and run it (browsers via PLAYWRIGHT_BROWSERS_PATH, lib via NODE_PATH).
+pu connect "$host" -- 'bash -lc "
+  mkdir -p /tmp/cap/node_modules /tmp/cap/vid
+  DRV=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver)
+  BR=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver.browsers)
+  ln -sfn \$DRV /tmp/cap/node_modules/playwright-core
+  PLAYWRIGHT_BROWSERS_PATH=\$BR NODE_PATH=/tmp/cap/node_modules \
+    nix shell nixpkgs#nodejs -c node /tmp/cap/capture.mjs \
+      http://127.0.0.1:7681/ /tmp/cap/<slug>.png /tmp/cap/vid 6000
+"'
+```
+
+### Host & post
+
+Copy artifacts back over the box's `ssh_config`, then upload to a long-lived `evidence-assets` GitHub release (`gh pr comment` can't attach binaries):
+
+```sh
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
+
 gh release view evidence-assets >/dev/null 2>&1 || \
   gh release create evidence-assets --prerelease \
     --title "Evidence assets (auto-uploaded by /do)" --notes "Do not delete."
 gh release upload evidence-assets /tmp/kolu-evidence-<slug>.png --clobber
 ```
 
-URL pattern: `https://github.com/juspay/kolu/releases/download/evidence-assets/<filename>`. Use the single-quoted heredoc pattern (`<<'EOF'`) when posting so backticks and `$` survive unescaped.
+URL pattern: `https://github.com/juspay/kolu/releases/download/evidence-assets/<filename>`. Use the single-quoted heredoc pattern (`<<'EOF'`) when posting so backticks and `$` survive unescaped. **Tear the box down** when finished: `pu destroy "$host"`.
 
 ### Video evidence
 
-For motion the subagent records the page instead of (or alongside) a still. The `chrome-devtools` MCP exposes `screencast_start` / `screencast_stop` — `screencast_start` with `filePath: /tmp/kolu-evidence-<slug>.mp4`, drive the interaction, then `screencast_stop`. (Capability ships in the [`nix-chrome-devtools-mcp`](https://github.com/juspay/nix-chrome-devtools-mcp) launcher, which runs the server with `--experimentalScreencast` and ffmpeg on PATH.)
+For motion, pass a `webmDir` + `recordMs` to `capture.mjs` above — Playwright's `recordVideo` writes a `.webm` on the box. Transcode and copy back with `nix shell nixpkgs#ffmpeg` **on the box**:
 
 **Make the recording legible — this is the #1 quality issue:**
 
-- **Landscape viewport.** Set a 16:9 viewport before recording (chrome-devtools `emulate` viewport `1366x768x1,landscape`). The default headless window can be portrait and 2×-DPI, which leaves the content tiny in a tall, mostly-empty frame.
-- **Maximize the terminal.** Click the chrome-bar **Maximize terminal** (canvas → maximized) so the terminal fills the frame. Recording *canvas* mode captures a small tile floating in empty space — the most common "why am I squinting" mistake.
+- **Landscape viewport.** The script sets `1366×768` at DPR 1. The default headless window can be portrait and 2×-DPI, which leaves the content tiny in a tall, mostly-empty frame.
+- **Maximize the terminal.** Click the chrome-bar **Maximize terminal** in the script (`page.click(...)`, canvas → maximized) so the terminal fills the frame. Recording *canvas* mode captures a small tile floating in empty space — the most common "why am I squinting" mistake.
 - **High-contrast theme** (e.g. Melange Dark) so the text reads.
-- **Move briskly, then speed up.** Do setup (create terminal, maximize, open the Code panel) *before* `screencast_start` so only the meaningful steps are recorded; run those steps back-to-back; then speed the output up (`setpts=PTS/3`) so agent-latency dead time doesn't make the clip drag.
+- **Move briskly, then speed up.** Do setup (create terminal, maximize, open the Code panel) *before* the recorded stretch so only the meaningful steps land in the clip; then speed the output up (`setpts=PTS/2`–`/3`) so agent-latency dead time doesn't make it drag.
 
 Two reasons not to just attach the `.mp4`: GitHub renders an inline video *player* only for files dragged into the web composer (a `user-attachments` URL `gh` can't mint), and a `<video>` tag in a comment is stripped. So:
 
 - **Inline (the at-a-glance proof):** transcode to an animated GIF — GitHub renders a GIF inline from any release URL, exactly like the PNG flow above.
 
   ```sh
-  nix shell nixpkgs#ffmpeg --command ffmpeg -i /tmp/kolu-evidence-<slug>.mp4 \
-    -vf "setpts=PTS/3,fps=12,scale=1100:-1:flags=lanczos" -loop 0 /tmp/kolu-evidence-<slug>.gif
+  pu connect "$host" -- 'bash -lc "
+    WEBM=\$(ls /tmp/cap/vid/*.webm | head -1)
+    nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM \
+      -vf \"setpts=PTS/2,fps=12,scale=1100:-1:flags=lanczos\" -loop 0 /tmp/cap/<slug>.gif
+    nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM -filter:v setpts=PTS/2 -an /tmp/cap/<slug>.mp4
+  "'
+  scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/kolu-evidence-<slug>.gif
   gh release upload evidence-assets /tmp/kolu-evidence-<slug>.gif --clobber
   ```
 
   Keep it under GitHub's ~10 MB inline limit (the `setpts` speed-up + a palette pass usually land a minute-long capture well under that). Embed with `![](https://github.com/juspay/kolu/releases/download/evidence-assets/<slug>.gif)`.
 
-- **HD (optional):** speed the `.mp4` up too (`ffmpeg -i …mp4 -filter:v "setpts=PTS/3" -an …`), upload it to the same release, and link to the shared player — [`juspay/video-evidence`](https://github.com/juspay/video-evidence) hosts a GitHub Pages `<video>` page that streams the clip from kolu's own release:
+- **HD (optional):** copy the sped-up `.mp4` back too, upload it to the same release, and link to the shared player — [`juspay/video-evidence`](https://github.com/juspay/video-evidence) hosts a GitHub Pages `<video>` page that streams the clip from kolu's own release:
 
   ```
   ▶ HD: https://juspay.github.io/video-evidence/evidence.html?repo=juspay/kolu&v=<slug>.mp4
@@ -111,10 +158,10 @@ Two reasons not to just attach the `.mp4`: GitHub renders an inline video *playe
 
 ### Agent-state scenarios
 
-When the change touches the Dock, terminal, or any UI surface that reflects agent activity, the capture has to show real states — a blank Dock proves nothing. Kolu's opencode integration is first-class: run opencode inside a Kolu terminal and the preexec hook surfaces state in the Dock within ~300ms (states: `thinking`, `tool_use`, `awaiting_user`, `waiting`; bucketed in the Dock as `working ▸`, `awaiting ⏵`, `idle ☾`).
+When the change touches the Dock, terminal, or any UI surface that reflects agent activity, the capture has to show real states — a blank Dock proves nothing. Kolu's opencode integration is first-class: from inside `capture.mjs`, open a terminal and run opencode in it; the preexec hook surfaces state in the Dock within ~300ms (states: `thinking`, `tool_use`, `awaiting_user`, `waiting`; bucketed in the Dock as `working ▸`, `awaiting ⏵`, `idle ☾`).
 
 ```sh
-# Inside a Kolu terminal — no global install needed
+# Inside a Kolu terminal on the box — no global install needed
 nix run github:juspay/AI#opencode
 ```
 

--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -19,8 +19,8 @@ markdown body it posted.
 ## Inputs the calling project supplies
 
 - **Serve command** — a `nix run`-style line that boots the app on the box's loopback
-  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 7681`).
-- **Health URL** and **app URL** (e.g. `http://127.0.0.1:7681/health`, `…/`).
+  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 8080`).
+- **Health URL** and **app URL** (e.g. `http://127.0.0.1:8080/health`, `…/`).
 - **Release name** for hosting binaries (e.g. `evidence-assets`).
 - Any **app-specific scenario** steps (selectors to click, states to reproduce).
 
@@ -108,10 +108,10 @@ pu connect "$host" -- 'bash -lc "
 long-lived GitHub release:
 
 ```sh
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
 gh release view <RELEASE> >/dev/null 2>&1 || \
   gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
-gh release upload <RELEASE> /tmp/kolu-evidence-<slug>.png --clobber
+gh release upload <RELEASE> /tmp/evidence-<slug>.png --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):

--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: evidence
+description: Capture production-like PR evidence (screenshots and video) by running the app on an ephemeral pu box and driving headless Chrome with Playwright — entirely off the user's machine, the way CI builds. Use when a change has visible UI impact and you want to post a `## Evidence` PR comment. Project-agnostic: it parameterizes on a `nix run`-style serve command, so it reuses across any project whose app boots that way. Covers the self-contained Playwright capture, video recording, ffmpeg transcode, GitHub-release hosting, and posting. Triggers on "post evidence", "screenshot the change", "PR evidence", "record a video of this", "capture the UI".
+---
+
+# evidence — PR screenshots & video, captured on a pu box
+
+Capture runs on an ephemeral `pu` box (see the **pu** skill), not locally. `nix run`,
+Chrome, Playwright, and ffmpeg all execute on the box — so evidence reflects a clean,
+CI-like build of the PR's own commit and nothing touches the user's machine. The box
+has its own loopback, so the app binds a plain port there with zero risk to anything
+the user is running; no random-port dance, no `pkill`, no worktree juggling.
+
+**Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`)
+so the main context stays clear of capture noise. Brief it with the box name, the
+serve command, what to capture, a `<slug>`, and the PR number; have it return only the
+markdown body it posted.
+
+## Inputs the calling project supplies
+
+- **Serve command** — a `nix run`-style line that boots the app on the box's loopback
+  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 7681`).
+- **Health URL** and **app URL** (e.g. `http://127.0.0.1:7681/health`, `…/`).
+- **Release name** for hosting binaries (e.g. `evidence-assets`).
+- Any **app-specific scenario** steps (selectors to click, states to reproduce).
+
+## 1. Provision & serve
+
+```sh
+host="<descriptive-name>"
+pu create "$host"                                       # see the pu skill (incl. egress check)
+pu connect "$host" -- "nohup <SERVE COMMAND> >/tmp/app.log 2>&1 &"
+pu connect "$host" -- 'until curl -sf <HEALTH URL>; do sleep 2; done'
+```
+
+For a **"before"** shot, serve a second box from the base ref (e.g. `master`) — no
+worktree, no stash.
+
+## 2. Capture (Playwright on the box)
+
+A self-contained `capture.mjs` drives headless Chromium with the **version-matched**
+pair Nix provides — `nixpkgs#playwright-driver` (the `playwright-core` lib) +
+`nixpkgs#playwright-driver.browsers` (Chrome-for-Testing). No MCP server, no npm
+install. One run yields a PNG **and**, if you pass a video dir, a `.webm`.
+
+```sh
+pu connect "$host" -- "cat > /tmp/cap/capture.mjs" <<'MJS'
+// argv: <url> <pngPath> [webmDir]   — runs entirely on the box.
+import { chromium } from 'playwright-core';
+const [url, pngPath, webmDir] = process.argv.slice(2);
+const viewport = { width: 1366, height: 768 };               // landscape, DPR 1
+const browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+const context = await browser.newContext({
+  viewport, deviceScaleFactor: 1,
+  ...(webmDir ? { recordVideo: { dir: webmDir, size: viewport } } : {}),
+});
+const page = await context.newPage();
+await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+
+// === reproduce the relevant state here ===
+// e.g. page.keyboard.press('Control+Enter'), page.click(sel), page.keyboard.type(cmd)
+await page.waitForTimeout(2500);                             // let it settle
+
+await page.screenshot({ path: pngPath });
+await context.close();                                       // flushes the .webm
+await browser.close();
+MJS
+
+pu connect "$host" -- 'bash -lc "
+  mkdir -p /tmp/cap/node_modules /tmp/cap/vid
+  DRV=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver)
+  BR=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver.browsers)
+  ln -sfn \$DRV /tmp/cap/node_modules/playwright-core
+  PLAYWRIGHT_BROWSERS_PATH=\$BR NODE_PATH=/tmp/cap/node_modules \
+    nix shell nixpkgs#nodejs -c node /tmp/cap/capture.mjs \
+      <APP URL> /tmp/cap/<slug>.png /tmp/cap/vid
+"'
+```
+
+## 3. Video (only when the change is about motion)
+
+Pass a `webmDir` and **script real interaction** — a video that just sits still proves
+nothing. Open the relevant surface, drive the steps back-to-back, let output stream.
+Make it legible (the #1 quality issue):
+
+- **Landscape viewport** — the script sets `1366×768` at DPR 1. The default headless
+  window can be portrait and 2×-DPI, leaving content tiny in a tall empty frame.
+- **Fill the frame** — maximize/expand the surface under test so it isn't a small tile
+  floating in empty space.
+- **High-contrast theme** so text reads.
+- **Move briskly, then speed up** in transcode (`setpts=PTS/2`–`/3`) so agent-latency
+  dead time doesn't make the clip drag.
+
+Transcode on the box with `nix shell nixpkgs#ffmpeg`:
+
+```sh
+pu connect "$host" -- 'bash -lc "
+  WEBM=\$(ls /tmp/cap/vid/*.webm | head -1)
+  nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM \
+    -vf \"setpts=PTS/2,fps=12,scale=1100:-1:flags=lanczos\" -loop 0 /tmp/cap/<slug>.gif
+  nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM -filter:v setpts=PTS/2 -an /tmp/cap/<slug>.mp4
+"'
+```
+
+## 4. Host & post
+
+`gh pr comment` can't attach binaries, so copy artifacts back and upload to a
+long-lived GitHub release:
+
+```sh
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
+gh release view <RELEASE> >/dev/null 2>&1 || \
+  gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
+gh release upload <RELEASE> /tmp/kolu-evidence-<slug>.png --clobber
+```
+
+Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
+
+```
+![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.gif)
+```
+
+A `<video>` tag in a comment is stripped, and GitHub only mints an inline player for
+files dragged into the web composer — so the GIF is the at-a-glance proof. For an HD
+clip, upload the `.mp4` to the same release and link the shared player
+[`juspay/video-evidence`](https://github.com/juspay/video-evidence) (org-allowlisted
+`repo` param, reused across projects):
+
+```
+▶ HD: https://juspay.github.io/video-evidence/evidence.html?repo=<OWNER>/<REPO>&v=<slug>.mp4
+```
+
+Use a single-quoted heredoc (`<<'EOF'`) when posting so backticks and `$` survive.
+Keep the GIF under GitHub's ~10 MB inline limit (the speed-up + palette pass usually
+do). **Tear the box down** when finished: `pu destroy "$host"`.

--- a/.agents/skills/pu/SKILL.md
+++ b/.agents/skills/pu/SKILL.md
@@ -20,7 +20,7 @@ pu connect "$host" -- CMD  # run CMD on the box and return
 pu destroy "$host"         # tear down — always do this when finished
 ```
 
-Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-evidence`).
+Name is positional. Pick a descriptive, collision-free name (e.g. `app-pr-42-evidence`).
 
 ## Run commands on the box
 
@@ -29,10 +29,10 @@ Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-
 pu connect "$host" -- 'uname -a'
 
 # Background a long-running server (nohup so it survives the SSH session)
-pu connect "$host" -- "nohup nix run github:owner/app -- --port 7681 >/tmp/app.log 2>&1 &"
+pu connect "$host" -- "nohup nix run github:owner/app -- --port 8080 >/tmp/app.log 2>&1 &"
 
 # Poll until it's healthy
-pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/health; do sleep 2; done'
+pu connect "$host" -- 'until curl -sf http://127.0.0.1:8080/health; do sleep 2; done'
 ```
 
 The box has its **own loopback** — bind servers to `127.0.0.1` on whatever port you

--- a/.agents/skills/pu/SKILL.md
+++ b/.agents/skills/pu/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pu
+description: Provision and drive an ephemeral `pu` box — a throwaway Incus container used as a clean Linux host for CI, builds, and evidence capture. Use when you need to run something on a fresh remote box instead of the user's machine: `nix run` a build, run CI against a real host, capture screenshots/video off-machine, or reproduce on a pristine environment. Covers create/connect/scp/destroy, running remote commands, copying artifacts back, and the no-egress failure mode. Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host", "pu create/connect/destroy".
+---
+
+# pu — ephemeral Incus boxes
+
+`pu` hands out throwaway Linux containers. Each box is a clean NixOS host with Nix
++ flakes, reachable over SSH through `pu`'s own proxy. Use one whenever work should
+run **off the user's machine** — a CI run, a `nix run` build, evidence capture —
+so nothing local is at risk and the environment is reproducible.
+
+## Lifecycle
+
+```sh
+pu create "$host"          # create; writes ~/.pu-state/$host/ssh_config (included by ~/.ssh/config)
+pu list                    # NAME + LOCATION (the physical host it landed on)
+pu connect "$host"         # interactive ssh
+pu connect "$host" -- CMD  # run CMD on the box and return
+pu destroy "$host"         # tear down — always do this when finished
+```
+
+Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-evidence`).
+
+## Run commands on the box
+
+```sh
+# One-shot
+pu connect "$host" -- 'uname -a'
+
+# Background a long-running server (nohup so it survives the SSH session)
+pu connect "$host" -- "nohup nix run github:owner/app -- --port 7681 >/tmp/app.log 2>&1 &"
+
+# Poll until it's healthy
+pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/health; do sleep 2; done'
+```
+
+The box has its **own loopback** — bind servers to `127.0.0.1` on whatever port you
+like; there is no clash with anything on the user's machine.
+
+## Copy artifacts back
+
+`pu connect` is SSH, so `scp` works against the box's generated config:
+
+```sh
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/out.png /tmp/out.png
+```
+
+## Failure mode: no outbound network
+
+A box occasionally lands on a host with broken egress — DNS and even raw-IP TCP
+time out, so `nix run github:...` hangs on "Resolving timed out". This is
+host-specific, not your fault. **Probe egress first; if it fails, destroy and
+recreate** (a fresh box usually lands on a healthy host):
+
+```sh
+pu connect "$host" -- 'timeout 15 curl -sS -o /dev/null -w "%{http_code}\n" https://api.github.com' \
+  || { echo "no egress — recreating"; pu destroy "$host"; pu create "$host"; }
+```
+
+If retries keep landing on dead hosts, capture diagnostics for the admin — the box's
+`LOCATION` from `pu list`, `/etc/resolv.conf`, `ip route`, and a `/dev/tcp` connect
+test to the gateway and to a raw IP — and hand them over (e.g. a gist).

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -19,8 +19,8 @@ markdown body it posted.
 ## Inputs the calling project supplies
 
 - **Serve command** — a `nix run`-style line that boots the app on the box's loopback
-  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 7681`).
-- **Health URL** and **app URL** (e.g. `http://127.0.0.1:7681/health`, `…/`).
+  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 8080`).
+- **Health URL** and **app URL** (e.g. `http://127.0.0.1:8080/health`, `…/`).
 - **Release name** for hosting binaries (e.g. `evidence-assets`).
 - Any **app-specific scenario** steps (selectors to click, states to reproduce).
 
@@ -108,10 +108,10 @@ pu connect "$host" -- 'bash -lc "
 long-lived GitHub release:
 
 ```sh
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
 gh release view <RELEASE> >/dev/null 2>&1 || \
   gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
-gh release upload <RELEASE> /tmp/kolu-evidence-<slug>.png --clobber
+gh release upload <RELEASE> /tmp/evidence-<slug>.png --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: evidence
+description: Capture production-like PR evidence (screenshots and video) by running the app on an ephemeral pu box and driving headless Chrome with Playwright — entirely off the user's machine, the way CI builds. Use when a change has visible UI impact and you want to post a `## Evidence` PR comment. Project-agnostic: it parameterizes on a `nix run`-style serve command, so it reuses across any project whose app boots that way. Covers the self-contained Playwright capture, video recording, ffmpeg transcode, GitHub-release hosting, and posting. Triggers on "post evidence", "screenshot the change", "PR evidence", "record a video of this", "capture the UI".
+---
+
+# evidence — PR screenshots & video, captured on a pu box
+
+Capture runs on an ephemeral `pu` box (see the **pu** skill), not locally. `nix run`,
+Chrome, Playwright, and ffmpeg all execute on the box — so evidence reflects a clean,
+CI-like build of the PR's own commit and nothing touches the user's machine. The box
+has its own loopback, so the app binds a plain port there with zero risk to anything
+the user is running; no random-port dance, no `pkill`, no worktree juggling.
+
+**Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`)
+so the main context stays clear of capture noise. Brief it with the box name, the
+serve command, what to capture, a `<slug>`, and the PR number; have it return only the
+markdown body it posted.
+
+## Inputs the calling project supplies
+
+- **Serve command** — a `nix run`-style line that boots the app on the box's loopback
+  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 7681`).
+- **Health URL** and **app URL** (e.g. `http://127.0.0.1:7681/health`, `…/`).
+- **Release name** for hosting binaries (e.g. `evidence-assets`).
+- Any **app-specific scenario** steps (selectors to click, states to reproduce).
+
+## 1. Provision & serve
+
+```sh
+host="<descriptive-name>"
+pu create "$host"                                       # see the pu skill (incl. egress check)
+pu connect "$host" -- "nohup <SERVE COMMAND> >/tmp/app.log 2>&1 &"
+pu connect "$host" -- 'until curl -sf <HEALTH URL>; do sleep 2; done'
+```
+
+For a **"before"** shot, serve a second box from the base ref (e.g. `master`) — no
+worktree, no stash.
+
+## 2. Capture (Playwright on the box)
+
+A self-contained `capture.mjs` drives headless Chromium with the **version-matched**
+pair Nix provides — `nixpkgs#playwright-driver` (the `playwright-core` lib) +
+`nixpkgs#playwright-driver.browsers` (Chrome-for-Testing). No MCP server, no npm
+install. One run yields a PNG **and**, if you pass a video dir, a `.webm`.
+
+```sh
+pu connect "$host" -- "cat > /tmp/cap/capture.mjs" <<'MJS'
+// argv: <url> <pngPath> [webmDir]   — runs entirely on the box.
+import { chromium } from 'playwright-core';
+const [url, pngPath, webmDir] = process.argv.slice(2);
+const viewport = { width: 1366, height: 768 };               // landscape, DPR 1
+const browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+const context = await browser.newContext({
+  viewport, deviceScaleFactor: 1,
+  ...(webmDir ? { recordVideo: { dir: webmDir, size: viewport } } : {}),
+});
+const page = await context.newPage();
+await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+
+// === reproduce the relevant state here ===
+// e.g. page.keyboard.press('Control+Enter'), page.click(sel), page.keyboard.type(cmd)
+await page.waitForTimeout(2500);                             // let it settle
+
+await page.screenshot({ path: pngPath });
+await context.close();                                       // flushes the .webm
+await browser.close();
+MJS
+
+pu connect "$host" -- 'bash -lc "
+  mkdir -p /tmp/cap/node_modules /tmp/cap/vid
+  DRV=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver)
+  BR=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver.browsers)
+  ln -sfn \$DRV /tmp/cap/node_modules/playwright-core
+  PLAYWRIGHT_BROWSERS_PATH=\$BR NODE_PATH=/tmp/cap/node_modules \
+    nix shell nixpkgs#nodejs -c node /tmp/cap/capture.mjs \
+      <APP URL> /tmp/cap/<slug>.png /tmp/cap/vid
+"'
+```
+
+## 3. Video (only when the change is about motion)
+
+Pass a `webmDir` and **script real interaction** — a video that just sits still proves
+nothing. Open the relevant surface, drive the steps back-to-back, let output stream.
+Make it legible (the #1 quality issue):
+
+- **Landscape viewport** — the script sets `1366×768` at DPR 1. The default headless
+  window can be portrait and 2×-DPI, leaving content tiny in a tall empty frame.
+- **Fill the frame** — maximize/expand the surface under test so it isn't a small tile
+  floating in empty space.
+- **High-contrast theme** so text reads.
+- **Move briskly, then speed up** in transcode (`setpts=PTS/2`–`/3`) so agent-latency
+  dead time doesn't make the clip drag.
+
+Transcode on the box with `nix shell nixpkgs#ffmpeg`:
+
+```sh
+pu connect "$host" -- 'bash -lc "
+  WEBM=\$(ls /tmp/cap/vid/*.webm | head -1)
+  nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM \
+    -vf \"setpts=PTS/2,fps=12,scale=1100:-1:flags=lanczos\" -loop 0 /tmp/cap/<slug>.gif
+  nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM -filter:v setpts=PTS/2 -an /tmp/cap/<slug>.mp4
+"'
+```
+
+## 4. Host & post
+
+`gh pr comment` can't attach binaries, so copy artifacts back and upload to a
+long-lived GitHub release:
+
+```sh
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
+gh release view <RELEASE> >/dev/null 2>&1 || \
+  gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
+gh release upload <RELEASE> /tmp/kolu-evidence-<slug>.png --clobber
+```
+
+Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
+
+```
+![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.gif)
+```
+
+A `<video>` tag in a comment is stripped, and GitHub only mints an inline player for
+files dragged into the web composer — so the GIF is the at-a-glance proof. For an HD
+clip, upload the `.mp4` to the same release and link the shared player
+[`juspay/video-evidence`](https://github.com/juspay/video-evidence) (org-allowlisted
+`repo` param, reused across projects):
+
+```
+▶ HD: https://juspay.github.io/video-evidence/evidence.html?repo=<OWNER>/<REPO>&v=<slug>.mp4
+```
+
+Use a single-quoted heredoc (`<<'EOF'`) when posting so backticks and `$` survive.
+Keep the GIF under GitHub's ~10 MB inline limit (the speed-up + palette pass usually
+do). **Tear the box down** when finished: `pu destroy "$host"`.

--- a/.apm/skills/pu/SKILL.md
+++ b/.apm/skills/pu/SKILL.md
@@ -20,7 +20,7 @@ pu connect "$host" -- CMD  # run CMD on the box and return
 pu destroy "$host"         # tear down — always do this when finished
 ```
 
-Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-evidence`).
+Name is positional. Pick a descriptive, collision-free name (e.g. `app-pr-42-evidence`).
 
 ## Run commands on the box
 
@@ -29,10 +29,10 @@ Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-
 pu connect "$host" -- 'uname -a'
 
 # Background a long-running server (nohup so it survives the SSH session)
-pu connect "$host" -- "nohup nix run github:owner/app -- --port 7681 >/tmp/app.log 2>&1 &"
+pu connect "$host" -- "nohup nix run github:owner/app -- --port 8080 >/tmp/app.log 2>&1 &"
 
 # Poll until it's healthy
-pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/health; do sleep 2; done'
+pu connect "$host" -- 'until curl -sf http://127.0.0.1:8080/health; do sleep 2; done'
 ```
 
 The box has its **own loopback** — bind servers to `127.0.0.1` on whatever port you

--- a/.apm/skills/pu/SKILL.md
+++ b/.apm/skills/pu/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pu
+description: Provision and drive an ephemeral `pu` box — a throwaway Incus container used as a clean Linux host for CI, builds, and evidence capture. Use when you need to run something on a fresh remote box instead of the user's machine: `nix run` a build, run CI against a real host, capture screenshots/video off-machine, or reproduce on a pristine environment. Covers create/connect/scp/destroy, running remote commands, copying artifacts back, and the no-egress failure mode. Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host", "pu create/connect/destroy".
+---
+
+# pu — ephemeral Incus boxes
+
+`pu` hands out throwaway Linux containers. Each box is a clean NixOS host with Nix
++ flakes, reachable over SSH through `pu`'s own proxy. Use one whenever work should
+run **off the user's machine** — a CI run, a `nix run` build, evidence capture —
+so nothing local is at risk and the environment is reproducible.
+
+## Lifecycle
+
+```sh
+pu create "$host"          # create; writes ~/.pu-state/$host/ssh_config (included by ~/.ssh/config)
+pu list                    # NAME + LOCATION (the physical host it landed on)
+pu connect "$host"         # interactive ssh
+pu connect "$host" -- CMD  # run CMD on the box and return
+pu destroy "$host"         # tear down — always do this when finished
+```
+
+Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-evidence`).
+
+## Run commands on the box
+
+```sh
+# One-shot
+pu connect "$host" -- 'uname -a'
+
+# Background a long-running server (nohup so it survives the SSH session)
+pu connect "$host" -- "nohup nix run github:owner/app -- --port 7681 >/tmp/app.log 2>&1 &"
+
+# Poll until it's healthy
+pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/health; do sleep 2; done'
+```
+
+The box has its **own loopback** — bind servers to `127.0.0.1` on whatever port you
+like; there is no clash with anything on the user's machine.
+
+## Copy artifacts back
+
+`pu connect` is SSH, so `scp` works against the box's generated config:
+
+```sh
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/out.png /tmp/out.png
+```
+
+## Failure mode: no outbound network
+
+A box occasionally lands on a host with broken egress — DNS and even raw-IP TCP
+time out, so `nix run github:...` hangs on "Resolving timed out". This is
+host-specific, not your fault. **Probe egress first; if it fails, destroy and
+recreate** (a fresh box usually lands on a healthy host):
+
+```sh
+pu connect "$host" -- 'timeout 15 curl -sS -o /dev/null -w "%{http_code}\n" https://api.github.com' \
+  || { echo "no egress — recreating"; pu destroy "$host"; pu create "$host"; }
+```
+
+If retries keep landing on dead hosts, capture diagnostics for the admin — the box's
+`LOCATION` from `pu list`, `/etc/resolv.conf`, `ip route`, and a `/dev/tcp` connect
+test to the gateway and to a raw IP — and hand them over (e.g. a gist).

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -19,8 +19,8 @@ markdown body it posted.
 ## Inputs the calling project supplies
 
 - **Serve command** — a `nix run`-style line that boots the app on the box's loopback
-  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 7681`).
-- **Health URL** and **app URL** (e.g. `http://127.0.0.1:7681/health`, `…/`).
+  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 8080`).
+- **Health URL** and **app URL** (e.g. `http://127.0.0.1:8080/health`, `…/`).
 - **Release name** for hosting binaries (e.g. `evidence-assets`).
 - Any **app-specific scenario** steps (selectors to click, states to reproduce).
 
@@ -108,10 +108,10 @@ pu connect "$host" -- 'bash -lc "
 long-lived GitHub release:
 
 ```sh
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
 gh release view <RELEASE> >/dev/null 2>&1 || \
   gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
-gh release upload <RELEASE> /tmp/kolu-evidence-<slug>.png --clobber
+gh release upload <RELEASE> /tmp/evidence-<slug>.png --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: evidence
+description: Capture production-like PR evidence (screenshots and video) by running the app on an ephemeral pu box and driving headless Chrome with Playwright — entirely off the user's machine, the way CI builds. Use when a change has visible UI impact and you want to post a `## Evidence` PR comment. Project-agnostic: it parameterizes on a `nix run`-style serve command, so it reuses across any project whose app boots that way. Covers the self-contained Playwright capture, video recording, ffmpeg transcode, GitHub-release hosting, and posting. Triggers on "post evidence", "screenshot the change", "PR evidence", "record a video of this", "capture the UI".
+---
+
+# evidence — PR screenshots & video, captured on a pu box
+
+Capture runs on an ephemeral `pu` box (see the **pu** skill), not locally. `nix run`,
+Chrome, Playwright, and ffmpeg all execute on the box — so evidence reflects a clean,
+CI-like build of the PR's own commit and nothing touches the user's machine. The box
+has its own loopback, so the app binds a plain port there with zero risk to anything
+the user is running; no random-port dance, no `pkill`, no worktree juggling.
+
+**Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`)
+so the main context stays clear of capture noise. Brief it with the box name, the
+serve command, what to capture, a `<slug>`, and the PR number; have it return only the
+markdown body it posted.
+
+## Inputs the calling project supplies
+
+- **Serve command** — a `nix run`-style line that boots the app on the box's loopback
+  (e.g. `nix run --refresh 'github:owner/app?ref=$branch' -- --host 127.0.0.1 --port 7681`).
+- **Health URL** and **app URL** (e.g. `http://127.0.0.1:7681/health`, `…/`).
+- **Release name** for hosting binaries (e.g. `evidence-assets`).
+- Any **app-specific scenario** steps (selectors to click, states to reproduce).
+
+## 1. Provision & serve
+
+```sh
+host="<descriptive-name>"
+pu create "$host"                                       # see the pu skill (incl. egress check)
+pu connect "$host" -- "nohup <SERVE COMMAND> >/tmp/app.log 2>&1 &"
+pu connect "$host" -- 'until curl -sf <HEALTH URL>; do sleep 2; done'
+```
+
+For a **"before"** shot, serve a second box from the base ref (e.g. `master`) — no
+worktree, no stash.
+
+## 2. Capture (Playwright on the box)
+
+A self-contained `capture.mjs` drives headless Chromium with the **version-matched**
+pair Nix provides — `nixpkgs#playwright-driver` (the `playwright-core` lib) +
+`nixpkgs#playwright-driver.browsers` (Chrome-for-Testing). No MCP server, no npm
+install. One run yields a PNG **and**, if you pass a video dir, a `.webm`.
+
+```sh
+pu connect "$host" -- "cat > /tmp/cap/capture.mjs" <<'MJS'
+// argv: <url> <pngPath> [webmDir]   — runs entirely on the box.
+import { chromium } from 'playwright-core';
+const [url, pngPath, webmDir] = process.argv.slice(2);
+const viewport = { width: 1366, height: 768 };               // landscape, DPR 1
+const browser = await chromium.launch({ headless: true, args: ['--no-sandbox'] });
+const context = await browser.newContext({
+  viewport, deviceScaleFactor: 1,
+  ...(webmDir ? { recordVideo: { dir: webmDir, size: viewport } } : {}),
+});
+const page = await context.newPage();
+await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+
+// === reproduce the relevant state here ===
+// e.g. page.keyboard.press('Control+Enter'), page.click(sel), page.keyboard.type(cmd)
+await page.waitForTimeout(2500);                             // let it settle
+
+await page.screenshot({ path: pngPath });
+await context.close();                                       // flushes the .webm
+await browser.close();
+MJS
+
+pu connect "$host" -- 'bash -lc "
+  mkdir -p /tmp/cap/node_modules /tmp/cap/vid
+  DRV=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver)
+  BR=\$(nix build --no-link --print-out-paths nixpkgs#playwright-driver.browsers)
+  ln -sfn \$DRV /tmp/cap/node_modules/playwright-core
+  PLAYWRIGHT_BROWSERS_PATH=\$BR NODE_PATH=/tmp/cap/node_modules \
+    nix shell nixpkgs#nodejs -c node /tmp/cap/capture.mjs \
+      <APP URL> /tmp/cap/<slug>.png /tmp/cap/vid
+"'
+```
+
+## 3. Video (only when the change is about motion)
+
+Pass a `webmDir` and **script real interaction** — a video that just sits still proves
+nothing. Open the relevant surface, drive the steps back-to-back, let output stream.
+Make it legible (the #1 quality issue):
+
+- **Landscape viewport** — the script sets `1366×768` at DPR 1. The default headless
+  window can be portrait and 2×-DPI, leaving content tiny in a tall empty frame.
+- **Fill the frame** — maximize/expand the surface under test so it isn't a small tile
+  floating in empty space.
+- **High-contrast theme** so text reads.
+- **Move briskly, then speed up** in transcode (`setpts=PTS/2`–`/3`) so agent-latency
+  dead time doesn't make the clip drag.
+
+Transcode on the box with `nix shell nixpkgs#ffmpeg`:
+
+```sh
+pu connect "$host" -- 'bash -lc "
+  WEBM=\$(ls /tmp/cap/vid/*.webm | head -1)
+  nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM \
+    -vf \"setpts=PTS/2,fps=12,scale=1100:-1:flags=lanczos\" -loop 0 /tmp/cap/<slug>.gif
+  nix shell nixpkgs#ffmpeg -c ffmpeg -y -i \$WEBM -filter:v setpts=PTS/2 -an /tmp/cap/<slug>.mp4
+"'
+```
+
+## 4. Host & post
+
+`gh pr comment` can't attach binaries, so copy artifacts back and upload to a
+long-lived GitHub release:
+
+```sh
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/kolu-evidence-<slug>.png
+gh release view <RELEASE> >/dev/null 2>&1 || \
+  gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
+gh release upload <RELEASE> /tmp/kolu-evidence-<slug>.png --clobber
+```
+
+Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
+
+```
+![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.gif)
+```
+
+A `<video>` tag in a comment is stripped, and GitHub only mints an inline player for
+files dragged into the web composer — so the GIF is the at-a-glance proof. For an HD
+clip, upload the `.mp4` to the same release and link the shared player
+[`juspay/video-evidence`](https://github.com/juspay/video-evidence) (org-allowlisted
+`repo` param, reused across projects):
+
+```
+▶ HD: https://juspay.github.io/video-evidence/evidence.html?repo=<OWNER>/<REPO>&v=<slug>.mp4
+```
+
+Use a single-quoted heredoc (`<<'EOF'`) when posting so backticks and `$` survive.
+Keep the GIF under GitHub's ~10 MB inline limit (the speed-up + palette pass usually
+do). **Tear the box down** when finished: `pu destroy "$host"`.

--- a/.claude/skills/pu/SKILL.md
+++ b/.claude/skills/pu/SKILL.md
@@ -20,7 +20,7 @@ pu connect "$host" -- CMD  # run CMD on the box and return
 pu destroy "$host"         # tear down — always do this when finished
 ```
 
-Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-evidence`).
+Name is positional. Pick a descriptive, collision-free name (e.g. `app-pr-42-evidence`).
 
 ## Run commands on the box
 
@@ -29,10 +29,10 @@ Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-
 pu connect "$host" -- 'uname -a'
 
 # Background a long-running server (nohup so it survives the SSH session)
-pu connect "$host" -- "nohup nix run github:owner/app -- --port 7681 >/tmp/app.log 2>&1 &"
+pu connect "$host" -- "nohup nix run github:owner/app -- --port 8080 >/tmp/app.log 2>&1 &"
 
 # Poll until it's healthy
-pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/health; do sleep 2; done'
+pu connect "$host" -- 'until curl -sf http://127.0.0.1:8080/health; do sleep 2; done'
 ```
 
 The box has its **own loopback** — bind servers to `127.0.0.1` on whatever port you

--- a/.claude/skills/pu/SKILL.md
+++ b/.claude/skills/pu/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pu
+description: Provision and drive an ephemeral `pu` box — a throwaway Incus container used as a clean Linux host for CI, builds, and evidence capture. Use when you need to run something on a fresh remote box instead of the user's machine: `nix run` a build, run CI against a real host, capture screenshots/video off-machine, or reproduce on a pristine environment. Covers create/connect/scp/destroy, running remote commands, copying artifacts back, and the no-egress failure mode. Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host", "pu create/connect/destroy".
+---
+
+# pu — ephemeral Incus boxes
+
+`pu` hands out throwaway Linux containers. Each box is a clean NixOS host with Nix
++ flakes, reachable over SSH through `pu`'s own proxy. Use one whenever work should
+run **off the user's machine** — a CI run, a `nix run` build, evidence capture —
+so nothing local is at risk and the environment is reproducible.
+
+## Lifecycle
+
+```sh
+pu create "$host"          # create; writes ~/.pu-state/$host/ssh_config (included by ~/.ssh/config)
+pu list                    # NAME + LOCATION (the physical host it landed on)
+pu connect "$host"         # interactive ssh
+pu connect "$host" -- CMD  # run CMD on the box and return
+pu destroy "$host"         # tear down — always do this when finished
+```
+
+Name is positional. Pick a descriptive, collision-free name (e.g. `kolu-pr-1037-evidence`).
+
+## Run commands on the box
+
+```sh
+# One-shot
+pu connect "$host" -- 'uname -a'
+
+# Background a long-running server (nohup so it survives the SSH session)
+pu connect "$host" -- "nohup nix run github:owner/app -- --port 7681 >/tmp/app.log 2>&1 &"
+
+# Poll until it's healthy
+pu connect "$host" -- 'until curl -sf http://127.0.0.1:7681/health; do sleep 2; done'
+```
+
+The box has its **own loopback** — bind servers to `127.0.0.1` on whatever port you
+like; there is no clash with anything on the user's machine.
+
+## Copy artifacts back
+
+`pu connect` is SSH, so `scp` works against the box's generated config:
+
+```sh
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/out.png /tmp/out.png
+```
+
+## Failure mode: no outbound network
+
+A box occasionally lands on a host with broken egress — DNS and even raw-IP TCP
+time out, so `nix run github:...` hangs on "Resolving timed out". This is
+host-specific, not your fault. **Probe egress first; if it fails, destroy and
+recreate** (a fresh box usually lands on a healthy host):
+
+```sh
+pu connect "$host" -- 'timeout 15 curl -sS -o /dev/null -w "%{http_code}\n" https://api.github.com' \
+  || { echo "no egress — recreating"; pu destroy "$host"; pu create "$host"; }
+```
+
+If retries keep landing on dead hosts, capture diagnostics for the admin — the box's
+`LOCATION` from `pu list`, `/etc/resolv.conf`, `ip route`, and a `/dev/tcp` connect
+test to the gateway and to a raw IP — and hand them over (e.g. a gist).

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-05-29T22:25:40.578568+00:00'
+generated_at: '2026-05-30T01:10:18.052343+00:00'
 apm_version: 0.16.0
 dependencies:
 - repo_url: anthropics/skills
@@ -104,10 +104,12 @@ mcp_configs:
     registry: false
     command: .agents/skills/nix-chrome-devtools-mcp/bin/serve
 local_deployed_files:
+- .agents/skills/evidence
 - .agents/skills/hk
 - .agents/skills/parcel
 - .agents/skills/perf-diagnose
 - .agents/skills/pierre
+- .agents/skills/pu
 - .agents/skills/test
 - .claude/commands/whatchanged.md
 - .claude/rules/apm-sources.md
@@ -120,10 +122,12 @@ local_deployed_files:
 - .claude/rules/state.md
 - .claude/rules/streaming.md
 - .claude/rules/toast-conventions.md
+- .claude/skills/evidence
 - .claude/skills/hk
 - .claude/skills/parcel
 - .claude/skills/perf-diagnose
 - .claude/skills/pierre
+- .claude/skills/pu
 - .claude/skills/test
 - .opencode/commands/whatchanged.md
 local_deployed_file_hashes:


### PR DESCRIPTION
## What

Moves the `/do` **Evidence** step off the user's machine and onto an ephemeral `pu` box — the same Incus container CI provisions. `nix run`, Chrome, Playwright, and ffmpeg all run **on the box**. The reusable mechanics are extracted into two project-agnostic APM skills:

- **`.apm/skills/pu`** — ephemeral box lifecycle: create / connect / scp / destroy, running remote commands, and the no-egress retry (a box occasionally lands on a host with dead egress).
- **`.apm/skills/evidence`** — capture production-like PR screenshots/video on a pu box with self-contained Playwright (version-matched `nixpkgs#playwright-driver` lib + `.browsers`), transcode with ffmpeg, host on a GitHub release, post. Parameterized on a `nix run`-style serve command, so it reuses across any project that boots that way.

`.agency/do.md`'s Evidence section shrinks to kolu's parameters (serve command, `/api/health`, the `evidence-assets` release, the `[data-testid="maximize-toggle"]` selector) and the kolu-specific opencode agent-state scenarios, delegating the rest to the skills.

## Why

Running capture locally carried a pile of footguns the doc spent paragraphs defending against:

| Local (before) | On a pu box (after) |
|---|---|
| Pick a random free port, **never 7681** | Box has its own loopback → bind plain `7681`, zero risk to the user's kolu |
| `pkill` could match the user's production kolu | Nothing local to kill; `pu destroy` the box |
| `git worktree` on master for "before" shots | Second box pointed at `github:juspay/kolu` |
| Local `chrome-devtools` MCP drives Chrome | Self-contained Playwright script on the box |
| Capture reflects *your* machine | Reflects a clean CI-like build of the PR's own commit |

`nix-chrome-devtools-mcp` can't be driven remotely (it's a stdio MCP server, not a CLI), so capture switches to a ~20-line Playwright script using the Nix-provided, version-matched browser pair — no MCP server, no npm install.

## Evidence

Captured end-to-end with **exactly this new flow** (Playwright + ffmpeg on a pu box, `scp` back) — see the [`## Evidence` comment](https://github.com/juspay/kolu/pull/1037#issuecomment-4581034134): a screenshot **and** an interactive video (open terminal → maximize → type commands → stream output). The shell prompt in both is the box's own hostname, proving nothing ran locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)