### PR TITLE
feat(surface-nix-host): terminal `failed` state + `reconnect()`

### DIFF
--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -13,6 +13,7 @@
  *     copying      ──provisionAgent ok──▶ connecting
  *     connecting   ──first RPC ────────▶ connected
  *     connected    ──read end  ────────▶ disconnected ──reconnect──▶ copying
+ *     disconnected ──gave up (N fails)──▶ failed   (terminal; `reconnect()` re-arms)
  *
  * New listeners attached via `onState` see the *current* state
  * synchronously before any deltas arrive — matching the snapshot-then-
@@ -38,14 +39,19 @@ export type ConnectionState =
   | "copying"
   | "connecting"
   | "connected"
-  | "disconnected";
+  | "disconnected"
+  // Terminal: the reconnect loop exhausted `MAX_CONSECUTIVE_FAILURES`
+  // and stopped retrying. Distinct from `disconnected` (which is the
+  // brief gap between attempts) so consumers can tell "still trying"
+  // from "gave up — needs intervention". `reconnect()` re-arms it.
+  | "failed";
 
 export interface HostSessionState {
   connection: ConnectionState;
   /** Free-form progress lines (last 20) — `nix copy` output, ssh
    *  start, agent fatal-error tails. */
   progressLines: readonly string[];
-  /** Last error if `connection === "disconnected"`. */
+  /** Last error if `connection === "disconnected"` or `"failed"`. */
   lastError: string | null;
 }
 
@@ -95,9 +101,10 @@ export class HostSession<C extends AnyContractRouter> {
   /** Count of consecutive failures since the last successful "connected"
    *  transition. Drives the exponential backoff on `scheduleReconnect`
    *  AND the give-up gate (after `MAX_CONSECUTIVE_FAILURES` we stop
-   *  retrying and surface a permanent disconnect — useful when the
-   *  remote nix-daemon won't accept the closure at all and the loop
-   *  would otherwise spam forever). */
+   *  retrying and transition to the terminal `failed` state — useful
+   *  when the remote nix-daemon won't accept the closure at all and the
+   *  loop would otherwise spam forever). Reset to 0 on a successful
+   *  `markConnected` or a manual `reconnect()`. */
   private consecutiveFailures = 0;
 
   constructor(private readonly opts: HostSessionOptions) {}
@@ -316,6 +323,24 @@ export class HostSession<C extends AnyContractRouter> {
     }
   }
 
+  /** Re-arm a session that gave up (`connection === "failed"`). Resets
+   *  the consecutive-failure gate and respawns immediately — the bridge
+   *  picks up the fresh client via `currentClient()` identity drift,
+   *  the same path the automatic reconnect timer uses, minus the backoff
+   *  wait. No-op if the session is destroyed, unreferenced, or a spawn
+   *  is already in flight (so a double-tapped "Reconnect" can't stack
+   *  spawns). The give-up gate left `reconnectTimer` and `clientPromise`
+   *  null, so a genuinely-failed session always passes the guard. */
+  reconnect(): void {
+    if (this.destroyed || this.refCount === 0) return;
+    if (this.clientPromise !== null || this.reconnectTimer !== null) return;
+    this.consecutiveFailures = 0;
+    this.clientPromise = this.spawn();
+    this.clientPromise.catch(() => {
+      /* spawn surfaces failure via state; we just clear the promise */
+    });
+  }
+
   private scheduleReconnect(): void {
     if (this.destroyed || this.reconnectTimer !== null) return;
     // Exponential backoff is keyed on attempts-so-far, not "this is
@@ -329,8 +354,12 @@ export class HostSession<C extends AnyContractRouter> {
     this.consecutiveFailures += 1;
     if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
       this.addLocalProgress(
-        `gave up after ${MAX_CONSECUTIVE_FAILURES} consecutive failures — fix the underlying issue (often: remote nix-daemon needs your user in 'trusted-users' to accept unsigned closures) and restart the parent`,
+        `gave up after ${MAX_CONSECUTIVE_FAILURES} consecutive failures — fix the underlying issue (often: remote nix-daemon needs your user in 'trusted-users' to accept unsigned closures), then reconnect`,
       );
+      // Move off `disconnected` so consumers can distinguish "still
+      // retrying" from "gave up". `lastError` is already set by the
+      // spawn-failure path that led here; preserve it.
+      this.updateState({ connection: "failed" });
       return;
     }
     const baseDelay = this.opts.reconnectDelayMs ?? 2000;

--- a/packages/surface/example/remote-process-monitor/src/client/App.tsx
+++ b/packages/surface/example/remote-process-monitor/src/client/App.tsx
@@ -28,9 +28,10 @@ import { app } from "./wire";
 
 const STATE_COLOR: Record<string, string> = {
   connected: "text-emerald-500",
-  disconnected: "text-red-500",
+  disconnected: "text-amber-500",
   copying: "text-amber-500",
   connecting: "text-amber-500",
+  failed: "text-red-500",
 };
 
 type SortKey = "cpu" | "mem" | "pid" | "user";
@@ -292,7 +293,8 @@ function ConnectingOverlay(props: { state: string }) {
     ({
       copying: "Copying agent to remote…",
       connecting: "Connecting…",
-      disconnected: "Disconnected. Retrying…",
+      disconnected: "Reconnecting…",
+      failed: "Connection failed — gave up retrying.",
     })[props.state] ?? "Initializing…";
   return (
     <div class="px-4 py-12 text-center text-gray-600 dark:text-gray-400">

--- a/packages/surface/example/remote-process-monitor/src/common/surface.ts
+++ b/packages/surface/example/remote-process-monitor/src/common/surface.ts
@@ -66,7 +66,16 @@ const SystemSchema = z.object({
  *  attaches its overlay before `connect()` returns and still sees the
  *  initial `connecting` state. */
 const ConnectionSchema = z.object({
-  state: z.enum(["copying", "connecting", "connected", "disconnected"]),
+  state: z.enum([
+    "copying",
+    "connecting",
+    "connected",
+    "disconnected",
+    // Terminal: the parent's reconnect loop gave up. Mirrors the
+    // `HostSession` `failed` state so the overlay can distinguish
+    // "still retrying" from "needs intervention".
+    "failed",
+  ]),
 });
 
 export const DEFAULT_SYSTEM: z.infer<typeof SystemSchema> = {


### PR DESCRIPTION
## What

`HostSession`'s reconnect loop already gives up after `MAX_CONSECUTIVE_FAILURES` (e.g. a remote whose nix-daemon won't accept the closure because the parent's user isn't in `trusted-users`). But on give-up it stayed on `connection: "disconnected"` — the *same* value as the brief gap between retry attempts — and the only way to re-arm was restarting the parent process. A consumer (drishti, the process monitor) therefore can't tell "still retrying" from "gave up forever", and shows a misleading "Disconnected. Retrying…" overlay long after the loop has stopped.

This adds the missing distinction at the layer that owns it:

- **`failed` — a terminal `ConnectionState`** set when the give-up gate trips. `disconnected` keeps its meaning (link down, will retry); `failed` means the loop stopped. `lastError` already carries the underlying cause across both.
- **`reconnect()` — a public re-arm.** Resets the consecutive-failure gate and respawns. The bridge picks up the fresh client via `currentClient()` identity drift, exactly like the auto-reconnect timer, minus the backoff wait. No-op if destroyed, unreferenced, or a spawn is already in flight (so a double-tapped "Reconnect" can't stack spawns).

## Consumer

The downstream [drishti](https://github.com/srid/drishti) PR pins this commit, widens its wire schema to forward `failed` + `lastError`, renders a terminal error card with the real remediation hint, and wires a "Reconnect" button to a new `hosts.reconnect` RPC that calls `session.reconnect()`.

## Notes

- The `remote-process-monitor` example is updated to mirror the new state (enum + overlay copy): `disconnected` now reads "Reconnecting…" in amber since it's the transient gap; `failed` is terminal red.
- No unit test: `HostSession` is subprocess-bound (real `ssh` + `nix copy`) and the package has no mocking harness; the state machine is exercised by the example and by drishti's integration. `just check` (typecheck + biome lint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)