### PR TITLE
Add Export/Import session palette commands

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -35,6 +35,7 @@ import DiagnosticInfo from "./DiagnosticInfo";
 import EmptyState from "./EmptyState";
 import { exportScrollbackAsPdf } from "./exportScrollbackAsPdf";
 import { exportSessionAsHtml } from "./exportSessionAsHtml";
+import { exportSession, importSession } from "./sessionTransfer";
 import type { ActionContext } from "./input/actions";
 import { useShortcuts } from "./input/useShortcuts";
 import IntentEditorDialog from "./intent/IntentEditorDialog";
@@ -64,7 +65,7 @@ import { surface } from "./ui/Surface";
 import { isMobile } from "./useMobile";
 import { useThemeManager } from "./useThemeManager";
 import { useVisualViewportHeight } from "./useVisualViewportHeight";
-import { client } from "./wire";
+import { client, savedSession } from "./wire";
 
 const App: Component = () => {
   const { store, crud, session, worktree, alerts } = useTerminals();
@@ -304,6 +305,9 @@ const App: Component = () => {
       localStorage.clear();
       location.reload();
     },
+    handleExportSession: () => exportSession(savedSession()),
+    handleImportSession: () =>
+      void importSession((s) => session.handleRestoreSession({ session: s })),
     simulateAlert: alerts.simulateAlert,
     isMobile,
     canvasCenterActive: handleCanvasCenterActive,

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -65,7 +65,7 @@ import { surface } from "./ui/Surface";
 import { isMobile } from "./useMobile";
 import { useThemeManager } from "./useThemeManager";
 import { useVisualViewportHeight } from "./useVisualViewportHeight";
-import { client, savedSession } from "./wire";
+import { client, savedSession as serverSavedSession } from "./wire";
 
 const App: Component = () => {
   const { store, crud, session, worktree, alerts } = useTerminals();
@@ -305,9 +305,11 @@ const App: Component = () => {
       localStorage.clear();
       location.reload();
     },
-    handleExportSession: () => exportSession(savedSession()),
+    handleExportSession: () => exportSession(serverSavedSession()),
     handleImportSession: () =>
-      void importSession((s) => session.handleRestoreSession({ session: s })),
+      void importSession().then(
+        (s) => s && session.handleRestoreSession({ session: s }),
+      ),
     simulateAlert: alerts.simulateAlert,
     isMobile,
     canvasCenterActive: handleCanvasCenterActive,

--- a/packages/client/src/commands.tsx
+++ b/packages/client/src/commands.tsx
@@ -135,6 +135,10 @@ export interface CommandDeps extends ActionContext {
   // Debug
   simulateAlert: () => void;
   handleClearLocalStorage: () => void;
+  /** Download the saved session as JSON (diagnostic backup). */
+  handleExportSession: () => void;
+  /** Pick a session JSON file and restore it on top of the current canvas. */
+  handleImportSession: () => void;
 }
 
 export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
@@ -374,6 +378,18 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
           kind: "action",
           name: "Clear localStorage",
           onSelect: () => deps.handleClearLocalStorage(),
+        },
+        {
+          kind: "action",
+          name: "Export session",
+          description: "Download terminal session state as JSON",
+          onSelect: () => deps.handleExportSession(),
+        },
+        {
+          kind: "action",
+          name: "Import session",
+          description: "Restore terminals from a session JSON file",
+          onSelect: () => deps.handleImportSession(),
         },
       ],
     },

--- a/packages/client/src/download.ts
+++ b/packages/client/src/download.ts
@@ -1,0 +1,14 @@
+/** Trigger a browser download of an existing object URL via a synthetic
+ *  anchor click. The caller owns the URL's lifecycle (creation and
+ *  `URL.revokeObjectURL`) — revoke timing depends on the caller's delivery
+ *  path, so it stays out of here. Shared by `sessionTransfer` (JSON export)
+ *  and `exportSessionAsHtml` (popup-blocked fallback). */
+export function triggerDownload(url: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}

--- a/packages/client/src/exportSessionAsHtml.ts
+++ b/packages/client/src/exportSessionAsHtml.ts
@@ -14,6 +14,7 @@
 
 import type { TerminalId } from "kolu-common/surface";
 import { toast } from "solid-sonner";
+import { triggerDownload } from "./download";
 import { client } from "./wire";
 
 export async function exportSessionAsHtml(id: TerminalId): Promise<void> {
@@ -29,16 +30,9 @@ export async function exportSessionAsHtml(id: TerminalId): Promise<void> {
     // has time to fetch and parse it.
     const win = window.open(url, "_blank", "noopener");
     if (!win) {
-      // Popup blocked — fall back to a download via an anchor click. Same
-      // origin (blob:) and no user-supplied content in the path so this
-      // is safe.
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      a.rel = "noopener";
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
+      // Popup blocked — fall back to a download. Same origin (blob:) and no
+      // user-supplied content in the path so this is safe.
+      triggerDownload(url, filename);
     }
     setTimeout(() => URL.revokeObjectURL(url), 60_000);
     toast.success("Session exported", { id: loadingId });

--- a/packages/client/src/sessionTransfer.test.ts
+++ b/packages/client/src/sessionTransfer.test.ts
@@ -1,5 +1,12 @@
 import type { SavedSession } from "kolu-common/surface";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// `sessionTransfer` imports `solid-sonner` (for toast) at module scope, which
+// transitively pulls `solid-js/web`'s SSR build and fails to load under the
+// Node test runner. `parseSavedSession` is pure (no toast, no DOM) by design,
+// so stub the module out — the test never exercises the toast path.
+vi.mock("solid-sonner", () => ({ toast: {} }));
+
 import { parseSavedSession } from "./sessionTransfer";
 
 const valid: SavedSession = {

--- a/packages/client/src/sessionTransfer.test.ts
+++ b/packages/client/src/sessionTransfer.test.ts
@@ -1,0 +1,37 @@
+import type { SavedSession } from "kolu-common/surface";
+import { describe, expect, it } from "vitest";
+import { parseSavedSession } from "./sessionTransfer";
+
+const valid: SavedSession = {
+  terminals: [{ id: "t1", cwd: "/home/user", git: null, lastActivityAt: 0 }],
+  activeTerminalId: "t1",
+  savedAt: 1_700_000_000_000,
+};
+
+describe("parseSavedSession", () => {
+  it("accepts a valid session export and round-trips it", () => {
+    expect(parseSavedSession(JSON.stringify(valid))).toEqual(valid);
+  });
+
+  it("accepts an empty-terminals session", () => {
+    const empty: SavedSession = { terminals: [], savedAt: 1 };
+    expect(parseSavedSession(JSON.stringify(empty))).toEqual(empty);
+  });
+
+  it("rejects text that is not JSON", () => {
+    expect(() => parseSavedSession("not json")).toThrow(/valid JSON/);
+  });
+
+  it("rejects JSON that is not a session export", () => {
+    expect(() => parseSavedSession(JSON.stringify({ foo: "bar" }))).toThrow(
+      /valid kolu session export/,
+    );
+  });
+
+  it("rejects a session whose terminals are malformed", () => {
+    const bad = { terminals: [{ id: "t1" }], savedAt: 1 };
+    expect(() => parseSavedSession(JSON.stringify(bad))).toThrow(
+      /valid kolu session export/,
+    );
+  });
+});

--- a/packages/client/src/sessionTransfer.ts
+++ b/packages/client/src/sessionTransfer.ts
@@ -15,6 +15,7 @@
 
 import { type SavedSession, SavedSessionSchema } from "kolu-common/surface";
 import { toast } from "solid-sonner";
+import { triggerDownload } from "./download";
 
 const EXPORT_FILENAME = "kolu-session.json";
 
@@ -29,14 +30,7 @@ export function exportSession(session: SavedSession | null): void {
     type: "application/json",
   });
   const url = URL.createObjectURL(blob);
-  // Anchor-click download, mirroring `exportSessionAsHtml`'s fallback path.
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = EXPORT_FILENAME;
-  a.rel = "noopener";
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
+  triggerDownload(url, EXPORT_FILENAME);
   // Revoke after the download has had time to start (same delay as
   // `exportSessionAsHtml`); revoking synchronously can abort the download.
   setTimeout(() => URL.revokeObjectURL(url), 60_000);

--- a/packages/client/src/sessionTransfer.ts
+++ b/packages/client/src/sessionTransfer.ts
@@ -47,7 +47,16 @@ export function parseSavedSession(text: string): SavedSession {
   } catch {
     throw new Error("file is not valid JSON");
   }
-  const result = SavedSessionSchema.safeParse(parsed);
+  // `safeParse` can *throw* (not just return `success: false`) on some
+  // malformed shapes — a nested refinement in `GitInfoSchema` dereferences
+  // `git.isWorktree`, which blows up when `git` is absent. We're parsing an
+  // untrusted file here, so treat any throw as a validation failure.
+  let result: ReturnType<typeof SavedSessionSchema.safeParse>;
+  try {
+    result = SavedSessionSchema.safeParse(parsed);
+  } catch {
+    throw new Error("not a valid kolu session export");
+  }
   if (!result.success) {
     throw new Error("not a valid kolu session export");
   }
@@ -60,15 +69,9 @@ export function parseSavedSession(text: string): SavedSession {
  *  here means restore rejections are handled at the call site rather than
  *  swallowed. */
 export async function importSession(): Promise<SavedSession | null> {
-  let text: string | null;
   try {
-    text = await pickJsonFile();
-  } catch (err) {
-    toast.error(`Import failed: ${(err as Error).message}`);
-    return null;
-  }
-  if (text === null) return null; // picker dismissed
-  try {
+    const text = await pickJsonFile();
+    if (text === null) return null; // picker dismissed
     return parseSavedSession(text);
   } catch (err) {
     toast.error(`Import failed: ${(err as Error).message}`);

--- a/packages/client/src/sessionTransfer.ts
+++ b/packages/client/src/sessionTransfer.ts
@@ -54,29 +54,26 @@ export function parseSavedSession(text: string): SavedSession {
   return result.data;
 }
 
-/** Prompt for a JSON file, validate it, and hand the session to `restore`
- *  (which appends its terminals to the current canvas and reports its own
- *  progress). Pre-restore failures — dismissed picker excepted — surface as
- *  an error toast. */
-export async function importSession(
-  restore: (session: SavedSession) => Promise<void>,
-): Promise<void> {
+/** Prompt for a JSON file and return the validated session, or null if the
+ *  user dismisses the picker or the file is malformed (errors surface as a
+ *  toast). The caller owns restoring it — keeping the restore call out of
+ *  here means restore rejections are handled at the call site rather than
+ *  swallowed. */
+export async function importSession(): Promise<SavedSession | null> {
   let text: string | null;
   try {
     text = await pickJsonFile();
   } catch (err) {
     toast.error(`Import failed: ${(err as Error).message}`);
-    return;
+    return null;
   }
-  if (text === null) return; // picker dismissed
-  let session: SavedSession;
+  if (text === null) return null; // picker dismissed
   try {
-    session = parseSavedSession(text);
+    return parseSavedSession(text);
   } catch (err) {
     toast.error(`Import failed: ${(err as Error).message}`);
-    return;
+    return null;
   }
-  await restore(session);
 }
 
 /** Resolve with the picked file's text, or null if the user dismisses the

--- a/packages/client/src/sessionTransfer.ts
+++ b/packages/client/src/sessionTransfer.ts
@@ -1,0 +1,109 @@
+/** Export / import of terminal session state as JSON.
+ *
+ *  A diagnostic backup/restore hatch for the same `SavedSession` blob that
+ *  session restore consumes — snapshot session state to a file before a
+ *  deploy, and re-import it if the server-persisted state is later lost or
+ *  corrupted. Surfaced from the command palette's Debug group, not the
+ *  primary flow.
+ *
+ *  Export serializes the current `SavedSession` to a download; import
+ *  validates a picked file against `SavedSessionSchema` (the single source
+ *  of truth — no hand-rolled guard) and hands it to `handleRestoreSession`,
+ *  which recreates the terminals on top of whatever is already open. The
+ *  JSON-parse/validation step is split out as `parseSavedSession` so it can
+ *  be unit-tested without a DOM. */
+
+import { type SavedSession, SavedSessionSchema } from "kolu-common/surface";
+import { toast } from "solid-sonner";
+
+const EXPORT_FILENAME = "kolu-session.json";
+
+/** Download the saved session as a pretty-printed JSON file. No-op (with a
+ *  toast) when there is nothing to export. */
+export function exportSession(session: SavedSession | null): void {
+  if (!session || session.terminals.length === 0) {
+    toast.warning("No saved session to export");
+    return;
+  }
+  const blob = new Blob([JSON.stringify(session, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  // Anchor-click download, mirroring `exportSessionAsHtml`'s fallback path.
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = EXPORT_FILENAME;
+  a.rel = "noopener";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke after the download has had time to start (same delay as
+  // `exportSessionAsHtml`); revoking synchronously can abort the download.
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  toast.success(`Exported ${session.terminals.length} terminals`);
+}
+
+/** Parse + validate JSON text as a `SavedSession`, throwing an `Error` with
+ *  a user-facing message on malformed input. Pure — no DOM, no toasts — so
+ *  the validation path is unit-testable. */
+export function parseSavedSession(text: string): SavedSession {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("file is not valid JSON");
+  }
+  const result = SavedSessionSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error("not a valid kolu session export");
+  }
+  return result.data;
+}
+
+/** Prompt for a JSON file, validate it, and hand the session to `restore`
+ *  (which appends its terminals to the current canvas and reports its own
+ *  progress). Pre-restore failures — dismissed picker excepted — surface as
+ *  an error toast. */
+export async function importSession(
+  restore: (session: SavedSession) => Promise<void>,
+): Promise<void> {
+  let text: string | null;
+  try {
+    text = await pickJsonFile();
+  } catch (err) {
+    toast.error(`Import failed: ${(err as Error).message}`);
+    return;
+  }
+  if (text === null) return; // picker dismissed
+  let session: SavedSession;
+  try {
+    session = parseSavedSession(text);
+  } catch (err) {
+    toast.error(`Import failed: ${(err as Error).message}`);
+    return;
+  }
+  await restore(session);
+}
+
+/** Resolve with the picked file's text, or null if the user dismisses the
+ *  picker without choosing a file. */
+function pickJsonFile(): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "application/json,.json";
+    input.addEventListener("change", () => {
+      const file = input.files?.[0];
+      if (!file) {
+        resolve(null);
+        return;
+      }
+      file
+        .text()
+        .then(resolve, () =>
+          reject(new Error("could not read the selected file")),
+        );
+    });
+    input.click();
+  });
+}

--- a/packages/client/src/sessionTransfer.ts
+++ b/packages/client/src/sessionTransfer.ts
@@ -92,6 +92,9 @@ function pickJsonFile(): Promise<string | null> {
     const input = document.createElement("input");
     input.type = "file";
     input.accept = "application/json,.json";
+    // Dismissing the picker fires `cancel`, not `change`, in modern browsers —
+    // without this listener `change` never fires and the Promise hangs forever.
+    input.addEventListener("cancel", () => resolve(null));
     input.addEventListener("change", () => {
       const file = input.files?.[0];
       if (!file) {

--- a/packages/client/src/sessionTransfer.ts
+++ b/packages/client/src/sessionTransfer.ts
@@ -47,16 +47,7 @@ export function parseSavedSession(text: string): SavedSession {
   } catch {
     throw new Error("file is not valid JSON");
   }
-  // `safeParse` can *throw* (not just return `success: false`) on some
-  // malformed shapes — a nested refinement in `GitInfoSchema` dereferences
-  // `git.isWorktree`, which blows up when `git` is absent. We're parsing an
-  // untrusted file here, so treat any throw as a validation failure.
-  let result: ReturnType<typeof SavedSessionSchema.safeParse>;
-  try {
-    result = SavedSessionSchema.safeParse(parsed);
-  } catch {
-    throw new Error("not a valid kolu session export");
-  }
+  const result = SavedSessionSchema.safeParse(parsed);
   if (!result.success) {
     throw new Error("not a valid kolu session export");
   }

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -152,12 +152,13 @@ export function useSessionRestore(deps: {
   });
 
   async function handleRestoreSession(
+    // `session` selects the input source: the server-persisted snapshot
+    // (default) or an arbitrary blob from a caller like the diagnostic
+    // "Import session" command. If a third source ever appears, replace this
+    // optional bag with a discriminated `source` union rather than widening it.
     options: { resumeIds?: ReadonlySet<string>; session?: SavedSession } = {},
   ) {
     if (isRestoring()) return;
-    // `options.session` lets a caller (e.g. the diagnostic "Import session"
-    // command) restore an arbitrary blob on top of the current canvas; the
-    // default is the server-persisted snapshot the empty-state offers.
     const session = options.session ?? savedSession();
     if (!session) return;
     // Keep the restore card mounted until terminal creation actually

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -152,10 +152,13 @@ export function useSessionRestore(deps: {
   });
 
   async function handleRestoreSession(
-    options: { resumeIds?: ReadonlySet<string> } = {},
+    options: { resumeIds?: ReadonlySet<string>; session?: SavedSession } = {},
   ) {
     if (isRestoring()) return;
-    const session = savedSession();
+    // `options.session` lets a caller (e.g. the diagnostic "Import session"
+    // command) restore an arbitrary blob on top of the current canvas; the
+    // default is the server-persisted snapshot the empty-state offers.
+    const session = options.session ?? savedSession();
     if (!session) return;
     // Keep the restore card mounted until terminal creation actually
     // succeeds. Synchronously clearing `savedSession` before the async


### PR DESCRIPTION
**Kolu can now export and re-import terminal session state as JSON** from the command palette's Debug group — a diagnostic backup/restore hatch for the exact `SavedSession` blob that session restore already consumes. The motivating case: snapshot your sessions before a deploy, and re-import them if the server-persisted state is later lost or corrupted, without DB surgery.

Both commands live under **Help → Debug** alongside "Clear localStorage" — they're an out-of-band utility, intentionally undocumented in the README.

### How it fits together

```
Export:  savedSession()  ──▶ JSON file (kolu-session.json)
Import:  JSON file ──▶ parseSavedSession (SavedSessionSchema) ──▶ handleRestoreSession({ session })
```

Export reads the live `savedSession()` accessor and downloads it. Import picks a file, validates it against the existing **`SavedSessionSchema`** (the single source of truth — no hand-rolled guard), then hands it to `handleRestoreSession`, which already recreates terminals *on top of* whatever is open — including the active-terminal protocol, sub-terminals, and agent-resume. The only change to restore was threading an optional `session` parameter so a caller can supply an arbitrary blob instead of the server snapshot.

### Notable bits

- **`parseSavedSession` is pure** (no DOM, no toast) so the validation path is unit-tested directly; the file-picker and download DOM IO stay separate.
- **`triggerDownload`** was extracted and is now shared with `exportSessionAsHtml`'s popup-blocked fallback, deduping the anchor-click pattern.
- The picker listens for the `cancel` event — without it a dismissed file dialog leaves the promise hanging forever in modern browsers.

### Try it locally

```sh
nix run github:juspay/kolu/export-session
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._