### PR TITLE
Coalesce the rightPanel resize preference write storm (#1041)

### DIFF
--- a/docs/plans/talk-pref-storm.html
+++ b/docs/plans/talk-pref-storm.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Preferences storm — debounce the rightPanel resize feedback loop (#1041)</title>
+<style>
+  :root {
+    --bg: #0d1117; --panel: #161b22; --border: #30363d; --ink: #e6edf3;
+    --muted: #9da7b3; --accent: #58a6ff; --warn: #d29922; --bad: #f85149;
+    --good: #3fb950; --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    padding: 2rem 1.25rem 5rem;
+  }
+  main { max-width: 860px; margin: 0 auto; }
+  h1 { font-size: 1.5rem; line-height: 1.25; margin: 0 0 .25rem; }
+  h2 { font-size: 1.12rem; margin: 2.2rem 0 .6rem; padding-bottom: .3rem; border-bottom: 1px solid var(--border); }
+  h3 { font-size: .98rem; margin: 1.3rem 0 .4rem; color: var(--accent); }
+  p { margin: .5rem 0; }
+  code { font-family: var(--mono); font-size: .85em; background: #1f2630; padding: .1em .35em; border-radius: 4px; }
+  pre { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: .8rem 1rem; overflow-x: auto; }
+  pre code { background: none; padding: 0; font-size: .8rem; line-height: 1.5; }
+  .sub { color: var(--muted); font-size: .9rem; margin-top: 0; }
+  .cite { font-family: var(--mono); font-size: .78rem; color: var(--muted); }
+  .pill { display: inline-block; font-size: .7rem; font-family: var(--mono); padding: .1em .5em; border-radius: 999px; border: 1px solid var(--border); vertical-align: middle; }
+  .pill.fix { color: var(--good); border-color: #1d572b; background: #0e2a16; }
+  .pill.dx { color: var(--warn); border-color: #5a4513; background: #2a2008; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: .9rem 1.1rem; margin: .8rem 0; }
+  .loop { display: flex; flex-direction: column; gap: .35rem; font-family: var(--mono); font-size: .78rem; }
+  .loop .step { background: #1f2630; border: 1px solid var(--border); border-radius: 6px; padding: .4rem .6rem; }
+  .loop .arrow { color: var(--muted); padding-left: .6rem; }
+  .loop .kill { border-color: #1d572b; }
+  table { width: 100%; border-collapse: collapse; margin: .6rem 0; font-size: .86rem; }
+  th, td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; font-size: .78rem; text-transform: uppercase; letter-spacing: .03em; }
+  .rev { border-left: 3px solid var(--accent); padding-left: .9rem; margin: .7rem 0; }
+  .rev.rej { border-color: var(--muted); }
+  .tag { font-family: var(--mono); font-size: .72rem; color: var(--accent); }
+  ul { margin: .4rem 0; padding-left: 1.3rem; }
+  li { margin: .25rem 0; }
+  .add { color: var(--good); }
+  .del { color: var(--bad); }
+  .muted { color: var(--muted); }
+</style>
+</head>
+<body>
+<main>
+
+<h1>Preferences storm: debounce the rightPanel resize feedback loop</h1>
+<p class="sub">Issue #1041 · part of #951 · pre-existing, surfaced by the #1034 daemon-restart postmortem</p>
+
+<h2>What's actually happening</h2>
+
+<p>The right-panel splitter and the Code-tab tree splitter are both <code>@corvu/resizable</code>
+<strong>fully controlled</strong> by a <code>sizes</code> prop fed from the local-authority
+<code>preferences</code> store. Two facts about Corvu turn that into a write storm:</p>
+
+<div class="card">
+<p style="margin-top:0"><strong>1. Corvu re-emits on every reactive change to <code>sizes</code>.</strong>
+Its root component runs <code>createEffect(() =&gt; onSizesChange(sizes()))</code>, and
+<code>sizes()</code> is a controllable signal whose value <em>is</em> the prop. So any reactive
+invalidation of the <code>sizes</code> prop re-fires <code>onSizesChange</code> with the same array.</p>
+<p class="cite">@corvu/resizable/dist/index.js (createEffect on sizes) · @corvu/utils controllableSignal.js:8-23 (controlled ⇒ no internal state)</p>
+<p><strong>2. Corvu emits a minSize-<em>corrected</em> array on panel re-registration.</strong>
+<code>registerPanel</code> calls <code>setSizes(redistribute)</code> enforcing each panel's
+<code>minSize</code> — a value that differs from what the app passed. Every mount/unmount of the
+panel subtree re-registers and re-emits.</p>
+<p class="cite">@corvu/resizable/dist/index.js registerPanel/unregisterPanel · createSize uses a ResizeObserver (size.js:4-30)</p>
+</div>
+
+<p>The handler persists it on every emission, with <strong>no</strong> equality gate and
+<strong>no</strong> coalescing:</p>
+
+<pre><code>// App.tsx:604-614  (and CodeTab.tsx:482-483, vertical split)
+onSizesChange={(sizes) =&gt; {
+  if (sizes[1] !== undefined) rightPanel.setPanelSize(sizes[1]);
+}}
+
+// useRightPanel.ts:118-128
+setPanelSize: (size) =&gt; { if (size &gt; MIN_PANEL_SIZE) updatePreferences({ rightPanel: { size } }); },
+setCodeTabTreeSize: (size) =&gt; { if (size &gt;= MIN_TREE_SIZE &amp;&amp; size &lt;= MAX_TREE_SIZE) updatePreferences({ rightPanel: { codeTabTreeSize: size } }); },
+
+// wire.ts:72-78 → useCell.ts:189-192 (local authority)
+patch: async (p) =&gt; { applyLocal(p); await options.mutate(p); }   // sync store write + server RPC, every call</code></pre>
+
+<div class="loop card">
+  <div class="step">panel re-registers / collapsed toggles during restart churn</div>
+  <div class="arrow">↓ reactive invalidation of the <code>sizes</code> prop</div>
+  <div class="step">Corvu <code>createEffect</code> fires <code>onSizesChange([…])</code></div>
+  <div class="arrow">↓</div>
+  <div class="step"><code>setPanelSize</code> → <code>updatePreferences({rightPanel:{size}})</code></div>
+  <div class="arrow">↓</div>
+  <div class="step"><code>useCell.patch</code>: <code>applyLocal</code> (sync store) <span class="muted">+</span> <code>mutate</code> → <strong>server RPC</strong></div>
+  <div class="arrow">↓ server writes <code>state.json</code> on every patch (no <code>equals</code> on the prefs cell)</div>
+  <div class="step kill">~200 patches/min · contends with the session autosave on the shared Conf store</div>
+</div>
+
+<p>The shared sink is real: <code>preferences</code> and the session autosave are two keys in
+<em>one</em> <code>Conf</code> store writing <em>one</em> <code>state.json</code>; the autosave is a
+500&nbsp;ms throttle, preferences is one-disk-write-per-patch.</p>
+<p class="cite">state.ts:88-127 (single Conf, prefs+session keys) · session.ts:114-133 (500ms autosave) · server.ts:134-143 (<code>applyAndPublish</code> equals gate) · surface.ts:99-114 prefs cell has <em>no</em> equals; :128 session cell does</p>
+
+<h2>The pivotal constraint (this is what picks the design)</h2>
+
+<p>Could we just stop controlling Corvu (pass <code>initialSizes</code>, let Corvu own live size,
+debounce the whole write)? <strong>No.</strong> <code>ChromeBar</code> reads the panel size
+<em>reactively, mid-drag</em>, to keep the floating chrome's right edge pinned to the panel's
+left edge:</p>
+
+<pre><code>// ChromeBar.tsx:112-114
+right: rightPanel.collapsed() ? 0 : `${rightPanel.panelSize() * 100}vw`,</code></pre>
+
+<p>If the store lagged the drag, the chrome controls would visibly trail the splitter. So the
+<strong>local store write must stay synchronous every frame</strong>; only the
+<strong>server RPC</strong> may be deferred. That rules out the uncontrolled-Corvu refactor and
+forces a split: apply-local-now, flush-to-server-later.</p>
+
+<h2>The fix</h2>
+
+<h3><span class="pill fix">1</span> Drop Corvu's idempotent re-emits <span class="cite">useRightPanel.ts</span></h3>
+<p>The size mutators are the adapter for Corvu's re-emit quirk — so they filter it. Skip the write
+when the value matches the stored value within Corvu's precision (it rounds to 6 decimals). This
+alone kills the <em>steady-state</em> storm: every unchanged re-emit becomes a true no-op (today it
+still fires an RPC before <code>reconcile</code> dedups the store).</p>
+<pre><code>const EPSILON = 1e-6; // Corvu fixToPrecision rounds to PRECISION=6
+setPanelSize: (size) =&gt; {
+  <span class="add">if (size &gt; MIN_PANEL_SIZE &amp;&amp; Math.abs(size - rp().size) &gt; EPSILON)</span>
+    updatePreferences({ rightPanel: { size } });
+},
+// same Math.abs(size - rp().codeTabTreeSize) &gt; EPSILON guard on setCodeTabTreeSize</code></pre>
+<p class="muted">Framed as "filter Corvu's idempotent re-emits," not "reduce server load" — that's why it
+lives at the adapter and not in the transport layer (per Lowy).</p>
+
+<h3><span class="pill fix">2</span> Coalesce the server flush at the local/server seam <span class="cite">useCell.ts (useCellLocal)</span></h3>
+<p>A real drag emits dozens of <em>distinct</em> values/sec, each passing guard&nbsp;1. Those are the
+legitimate burst to collapse. The split lives where the local/server boundary already lives — inside
+<code>useCellLocal</code>, the one place that owns "apply locally, then tell the server." Add an
+opt-in <code>coalesceMs</code>; the cell <em>owner</em> declares its flush cadence in <code>wire.ts</code>:</p>
+<pre><code>// useCellLocal: apply locally every call (sync — ChromeBar tracks live),
+// trailing-debounce only the server mutate.
+patch: async (p) =&gt; {
+  applyLocal(p);                         // sync store write, unchanged
+  if (coalesce) coalesce.push(p);        // trailing debounce → mutate(merged)
+  else await options.mutate(p);
+},
+
+// wire.ts — opt in for preferences only:
+app.cells.preferences.use({ authority: "local", initial: DEFAULT_PREFERENCES,
+  <span class="add">coalesceMs: 150,</span> onError });</code></pre>
+<p><strong>Merge in patch-space, don't snapshot.</strong> The coalescer accumulates pending patches by
+folding them through the cell's existing patch-merge into one <code>PreferencesPatch</code>, then
+flushes that. This keeps the wire payload in <code>P</code> (patch) space — so an interleaved
+<code>{collapsed}</code> write inside the 150&nbsp;ms window is <em>merged in</em>, not clobbered, and
+we never push a full <code>Preferences</code> (<code>T</code>) through a <code>patch</code>-typed
+<code>mutate</code>. <span class="muted">(This is the post-review shape — see below.)</span></p>
+
+<h3><span class="pill fix">3</span> <span class="muted">Defense-in-depth:</span> <code>equals</code> on the server prefs cell <span class="cite">server surface.ts</span></h3>
+<p>Mirror the <code>session</code> cell's <code>equals</code> so any no-op patch that still reaches the
+server skips the disk write + republish. Honest billing: once the client drops no-ops (1) and
+coalesces (2), this is belt-and-suspenders — it only catches the rare unchanged-final-value case. One
+line, established precedent, fine to land; not load-bearing.</p>
+
+<h3><span class="pill fix">test</span> Regression guard</h3>
+<p>Unit test asserting bounded patch rate during a resize interaction: a tight loop of
+<em>unchanged</em> values emits zero RPCs (guard 1); a rapid sequence of <em>changing</em> values
+emits ≤1 trailing RPC per window (coalesce 2). Sits next to the <code>useRightPanel</code> tests.</p>
+
+<h2>Reviewer pass — what changed</h2>
+
+<div class="rev">
+<p class="tag">Hickey + Lowy converged · ADOPTED</p>
+<p><strong>The original sketch flushed "the latest full store snapshot."</strong> Both reviewers
+flagged this complects two decisions under one flag: <em>timing</em> (debounce) and
+<em>payload shape</em> (patch → full replacement). It also pushes a full <code>Preferences</code>
+(<code>T</code>) through a <code>mutate</code> bound to <code>ns.patch</code> (<code>P</code>) — works by
+accident for prefs only, breaks for any future cell where <code>P≠T</code> or <code>patch</code> is
+non-idempotent. <strong>Revised:</strong> coalesce by <em>merging patches in P-space</em> (fold through
+the cell's own patch-merge). <code>coalesceMs</code> now governs timing only.</p>
+</div>
+
+<div class="rev">
+<p class="tag">Lowy · ADOPTED (deciding fact)</p>
+<p>Pinned the controlled-vs-uncontrolled fork to a single fact — "does anything read the size
+mid-drag?" — and it does (<code>ChromeBar.tsx:114</code>). Uncontrolled Corvu is the cleaner boundary
+<em>only if</em> nothing reads the store live; since ChromeBar does, controlled + coalesce is forced.
+Recorded as the pivotal constraint above.</p>
+</div>
+
+<div class="rev">
+<p class="tag">Lowy · ADOPTED (reframe)</p>
+<p>No-op drop (1) is <em>not</em> patch-rate control duplicating the coalesce — it's
+Corvu-re-emit/idempotency filtering at the adapter. Keeping it in <code>useRightPanel</code> is right
+<em>under that framing</em>; the comment names it accordingly. The 1-in-useRightPanel / 2-in-useCell
+split is a correct layer split (domain quirk vs. generic transport), confirmed by both — not
+fragmentation.</p>
+</div>
+
+<div class="rev">
+<p class="tag">Hickey · ADOPTED (DX) <span class="pill dx">contract</span></p>
+<p>Debouncing changes what <code>useCellLocal.patch</code>'s returned promise <em>means</em>: "parked
+in the queue," not "server has it." Document on the <code>coalesceMs</code> option. The only consumer
+today (<code>updatePreferences</code>) is fire-and-forget, so no caller breaks — but any future
+awaiting caller (e2e step gating on server state) must gate on the server echo, not the
+<code>patch</code> return.</p>
+</div>
+
+<div class="rev rej">
+<p class="tag">Lowy · REJECTED</p>
+<p>Lowy's resolution for the snapshot problem was "make preferences <em>always</em> flush full
+snapshots." Rejected: the prefs contract has no <code>set</code>/full-replacement verb — its
+<code>mutate</code> is patch-typed — so "always snapshot" reintroduces exactly the <code>T</code>-through-<code>P</code>
+type confusion. Hickey's patch-space merge achieves the same "no key lost" guarantee without a new
+verb.</p>
+</div>
+
+<div class="rev rej">
+<p class="tag">Both · CONFIRMED no duplication</p>
+<p>The client trailing coalesce does <em>not</em> reinvent the server 500ms autosave (different side
+of the wire; leading vs. trailing is semantically required), <code>debouncedFit</code> (local-only,
+no server), or the <code>equals</code> gate (which part 3 <em>extends</em>). Reaching for
+<code>@solid-primitives/scheduled</code> matches the repo's "prefer community primitives" convention.</p>
+</div>
+
+<h2>Surface &amp; sequencing</h2>
+<table>
+<tr><th>File</th><th>Change</th><th>Part</th></tr>
+<tr><td><code>useRightPanel.ts</code></td><td>EPSILON no-op guard in the two size mutators</td><td>1</td></tr>
+<tr><td><code>useCell.ts</code></td><td><code>coalesceMs</code> opt-in: sync local apply + trailing patch-merge flush; doc the await-contract change</td><td>2</td></tr>
+<tr><td><code>wire.ts</code></td><td><code>coalesceMs: 150</code> on the preferences cell; add <code>@solid-primitives/scheduled</code> dep</td><td>2</td></tr>
+<tr><td><code>server/src/surface.ts</code></td><td><code>equals</code> on the prefs cell (mirror session)</td><td>3 · optional</td></tr>
+<tr><td><code>*.test.ts</code></td><td>bounded-patch-rate regression near useRightPanel tests</td><td>test</td></tr>
+</table>
+<p class="muted">Bug fix, not user-visible feature work — single PR, no phase split. When ready,
+<code>/do</code> this issue.</p>
+
+</main>
+</body>
+</html>

--- a/packages/client/src/right-panel/useRightPanel.test.ts
+++ b/packages/client/src/right-panel/useRightPanel.test.ts
@@ -35,11 +35,12 @@ describe("useRightPanel — size writes drop Corvu's idempotent re-emits (#1041)
     expect(h.updatePreferences).not.toHaveBeenCalled();
   });
 
-  it("setPanelSize persists a changed size", () => {
+  it("setPanelSize persists a changed size, opting into coalescing", () => {
     useRightPanel().setPanelSize(0.5);
-    expect(h.updatePreferences).toHaveBeenCalledExactlyOnceWith({
-      rightPanel: { size: 0.5 },
-    });
+    expect(h.updatePreferences).toHaveBeenCalledExactlyOnceWith(
+      { rightPanel: { size: 0.5 } },
+      { coalesce: true },
+    );
   });
 
   it("setPanelSize ignores sizes at or below the minimum", () => {
@@ -52,11 +53,12 @@ describe("useRightPanel — size writes drop Corvu's idempotent re-emits (#1041)
     expect(h.updatePreferences).not.toHaveBeenCalled();
   });
 
-  it("setCodeTabTreeSize persists a changed value within bounds", () => {
+  it("setCodeTabTreeSize persists a changed value within bounds, opting into coalescing", () => {
     useRightPanel().setCodeTabTreeSize(0.6);
-    expect(h.updatePreferences).toHaveBeenCalledExactlyOnceWith({
-      rightPanel: { codeTabTreeSize: 0.6 },
-    });
+    expect(h.updatePreferences).toHaveBeenCalledExactlyOnceWith(
+      { rightPanel: { codeTabTreeSize: 0.6 } },
+      { coalesce: true },
+    );
   });
 
   it("setCodeTabTreeSize ignores out-of-bounds values", () => {

--- a/packages/client/src/right-panel/useRightPanel.test.ts
+++ b/packages/client/src/right-panel/useRightPanel.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// useRightPanel reads `preferences()` and writes via `updatePreferences` from
+// the wire singleton, and resolves the active terminal from useTerminalStore.
+// Stub both so the size mutators can be exercised without a live socket.
+const h = vi.hoisted(() => ({
+  updatePreferences: vi.fn(),
+  prefs: {
+    rightPanel: { collapsed: false, size: 0.25, codeTabTreeSize: 0.35 },
+  },
+}));
+
+vi.mock("../wire", () => ({
+  client: {},
+  updatePreferences: h.updatePreferences,
+  preferences: () => h.prefs,
+}));
+
+vi.mock("../terminal/useTerminalStore", () => ({
+  useTerminalStore: () => ({ activeId: () => null }),
+}));
+
+import { useRightPanel } from "./useRightPanel";
+
+beforeEach(() => {
+  h.updatePreferences.mockClear();
+  h.prefs = {
+    rightPanel: { collapsed: false, size: 0.25, codeTabTreeSize: 0.35 },
+  };
+});
+
+describe("useRightPanel — size writes drop Corvu's idempotent re-emits (#1041)", () => {
+  it("setPanelSize drops a write equal to the stored size", () => {
+    useRightPanel().setPanelSize(0.25);
+    expect(h.updatePreferences).not.toHaveBeenCalled();
+  });
+
+  it("setPanelSize persists a changed size", () => {
+    useRightPanel().setPanelSize(0.5);
+    expect(h.updatePreferences).toHaveBeenCalledExactlyOnceWith({
+      rightPanel: { size: 0.5 },
+    });
+  });
+
+  it("setPanelSize ignores sizes at or below the minimum", () => {
+    useRightPanel().setPanelSize(0.01);
+    expect(h.updatePreferences).not.toHaveBeenCalled();
+  });
+
+  it("setCodeTabTreeSize drops a write equal to the stored value", () => {
+    useRightPanel().setCodeTabTreeSize(0.35);
+    expect(h.updatePreferences).not.toHaveBeenCalled();
+  });
+
+  it("setCodeTabTreeSize persists a changed value within bounds", () => {
+    useRightPanel().setCodeTabTreeSize(0.6);
+    expect(h.updatePreferences).toHaveBeenCalledExactlyOnceWith({
+      rightPanel: { codeTabTreeSize: 0.6 },
+    });
+  });
+
+  it("setCodeTabTreeSize ignores out-of-bounds values", () => {
+    useRightPanel().setCodeTabTreeSize(0.95);
+    expect(h.updatePreferences).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -125,7 +125,7 @@ export function useRightPanel() {
     expandPanel: () => updatePreferences({ rightPanel: { collapsed: false } }),
     setPanelSize: (size: number) => {
       if (size > MIN_PANEL_SIZE && Math.abs(size - rp().size) > SIZE_EPSILON)
-        updatePreferences({ rightPanel: { size } });
+        updatePreferences({ rightPanel: { size } }, { coalesce: true });
     },
     /** Vertical split fraction inside the Code tab — tree pane occupies
      *  this share, content pane gets the rest. Persisted across reload. */
@@ -136,7 +136,10 @@ export function useRightPanel() {
         size <= MAX_TREE_SIZE &&
         Math.abs(size - rp().codeTabTreeSize) > SIZE_EPSILON
       ) {
-        updatePreferences({ rightPanel: { codeTabTreeSize: size } });
+        updatePreferences(
+          { rightPanel: { codeTabTreeSize: size } },
+          { coalesce: true },
+        );
       }
     },
 

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -37,6 +37,14 @@ const MIN_PANEL_SIZE = 0.05;
  *  role for the horizontal split. */
 const MIN_TREE_SIZE = 0.1;
 const MAX_TREE_SIZE = 0.9;
+/** Drop a size write when it matches the stored value. Corvu's `Resizable`
+ *  runs `createEffect(() => onSizesChange(sizes()))`, so it re-emits the
+ *  *current* `sizes` prop on every reactive invalidation — and re-registers
+ *  panels (re-emitting again) on every mount during restart churn. Those
+ *  re-emits carry the value we already hold; persisting them is pure noise
+ *  (#1041). Corvu rounds sizes to 6 decimals, so a tolerance below that
+ *  catches the echo without dropping a real one-pixel drag step. */
+const SIZE_EPSILON = 1e-6;
 
 const [perTerminal, setPerTerminal] = createStore<
   Record<TerminalId, RightPanelPerTerminalState>
@@ -116,13 +124,18 @@ export function useRightPanel() {
     collapsePanel: () => updatePreferences({ rightPanel: { collapsed: true } }),
     expandPanel: () => updatePreferences({ rightPanel: { collapsed: false } }),
     setPanelSize: (size: number) => {
-      if (size > MIN_PANEL_SIZE) updatePreferences({ rightPanel: { size } });
+      if (size > MIN_PANEL_SIZE && Math.abs(size - rp().size) > SIZE_EPSILON)
+        updatePreferences({ rightPanel: { size } });
     },
     /** Vertical split fraction inside the Code tab — tree pane occupies
      *  this share, content pane gets the rest. Persisted across reload. */
     codeTabTreeSize: () => rp().codeTabTreeSize,
     setCodeTabTreeSize: (size: number) => {
-      if (size >= MIN_TREE_SIZE && size <= MAX_TREE_SIZE) {
+      if (
+        size >= MIN_TREE_SIZE &&
+        size <= MAX_TREE_SIZE &&
+        Math.abs(size - rp().codeTabTreeSize) > SIZE_EPSILON
+      ) {
         updatePreferences({ rightPanel: { codeTabTreeSize: size } });
       }
     },

--- a/packages/client/src/wire.ts
+++ b/packages/client/src/wire.ts
@@ -55,8 +55,16 @@ export const client = app.rpc;
 const _preferences = app.cells.preferences.use({
   authority: "local",
   initial: DEFAULT_PREFERENCES,
-  onError: (err) =>
-    toast.error(`Preferences subscription error: ${err.message}`),
+  // Coalesce server writes: the rightPanel splitter's `onSizesChange` fires
+  // a preference patch per frame during a drag (and re-fires on Corvu panel
+  // re-registration), which storms the server. Local apply stays synchronous
+  // (ChromeBar tracks `rightPanel.size` to position itself mid-drag); only
+  // the server round-trip is debounced to the settled value. See #1041.
+  coalesceMs: 150,
+  // Covers both subscription drops and coalesced-flush failures — with
+  // `coalesceMs` set, a failed `mutate` surfaces here, not on `patch`'s
+  // returned promise.
+  onError: (err) => toast.error(`Preferences error: ${err.message}`),
 });
 
 /** Local-store accessor for user preferences — authoritative after the

--- a/packages/client/src/wire.ts
+++ b/packages/client/src/wire.ts
@@ -55,15 +55,14 @@ export const client = app.rpc;
 const _preferences = app.cells.preferences.use({
   authority: "local",
   initial: DEFAULT_PREFERENCES,
-  // Coalesce server writes: the rightPanel splitter's `onSizesChange` fires
-  // a preference patch per frame during a drag (and re-fires on Corvu panel
-  // re-registration), which storms the server. Local apply stays synchronous
-  // (ChromeBar tracks `rightPanel.size` to position itself mid-drag); only
-  // the server round-trip is debounced to the settled value. See #1041.
+  // Debounce window for size writes that opt in via `{ coalesce: true }`. The
+  // rightPanel splitter's `onSizesChange` fires a patch per frame during a drag
+  // (and re-fires on Corvu panel re-registration), which storms the server.
+  // Coalescing is per-write, so discrete toggles (colorScheme, scrollLock) keep
+  // flushing immediately and survive a quick reload. See #1041.
   coalesceMs: 150,
-  // Covers both subscription drops and coalesced-flush failures — with
-  // `coalesceMs` set, a failed `mutate` surfaces here, not on `patch`'s
-  // returned promise.
+  // Covers both subscription drops and coalesced-flush failures — a coalesced
+  // write's `mutate` failure surfaces here, not on `patch`'s returned promise.
   onError: (err) => toast.error(`Preferences error: ${err.message}`),
 });
 
@@ -76,10 +75,15 @@ export const preferences = (): Preferences =>
  *  `.pending()` / `.error()` (e.g. boot gating) rather than the value. */
 export const preferencesSub = _preferences.sub;
 
-/** Patch user preferences; reports failures via `toast`. */
-export function updatePreferences(patch: PreferencesPatch): void {
+/** Patch user preferences; reports failures via `toast`. Pass
+ *  `{ coalesce: true }` for high-frequency writes (panel-size drags) to
+ *  trailing-debounce the server round-trip — see the cell's `coalesceMs`. */
+export function updatePreferences(
+  patch: PreferencesPatch,
+  opts?: { coalesce?: boolean },
+): void {
   void _preferences
-    .patch(patch)
+    .patch(patch, opts)
     .catch((err: Error) =>
       toast.error(`Failed to save preferences: ${err.message}`),
     );

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -98,6 +98,13 @@ const { router: surfaceRouterFragment, ctx: surfaceCtxBuilt } =
     cells: {
       preferences: {
         store: preferencesStore,
+        // Content-level dedup, mirroring the `session` cell below. Defence in
+        // depth behind the client's coalescing + no-op drop (#1041): a patch
+        // that doesn't change the value skips the `state.json` write and the
+        // bus publish, so it can't contend with the session autosave on the
+        // shared Conf store. `JSON.stringify` is fine — Preferences is small
+        // and writes are rare once the client stops storming.
+        equals: (a, b) => JSON.stringify(a) === JSON.stringify(b),
         // Log only patched keys — values may carry user-identifying state
         // (themes, file paths in rightPanel.tab) that have no business in
         // operator logs.

--- a/packages/surface/README.md
+++ b/packages/surface/README.md
@@ -196,6 +196,19 @@ mergeIntoStore: (setStore, patch) => {
 }
 ```
 
+For high-frequency local-authority writes (a resize splitter firing a patch per frame during a drag), pass `coalesceMs` to debounce the **server** round-trip while keeping the **local** apply synchronous:
+
+```ts
+useCell(preferences, {
+  authority: "local",
+  initial: DEFAULT_PREFERENCES,
+  applyPatch: deepMergePrefs,
+  coalesceMs: 150,   // local apply every call; one trailing server flush per quiescence
+});
+```
+
+Pending patches accumulate through `applyPatch`, so heterogeneous keys written inside one window land in a single flush (the payload stays a patch, not a full-value snapshot) — this requires `applyPatch` to be a pure spread-merge. With `coalesceMs` set, the promise `patch` / `set` returns resolves after the local apply, not the server ack; flush failures surface via `onError`.
+
 ## Collection
 
 A keyed dictionary of typed values. Each key is independently observable; the live key set is its own subscription.

--- a/packages/surface/README.md
+++ b/packages/surface/README.md
@@ -196,18 +196,21 @@ mergeIntoStore: (setStore, patch) => {
 }
 ```
 
-For high-frequency local-authority writes (a resize splitter firing a patch per frame during a drag), pass `coalesceMs` to debounce the **server** round-trip while keeping the **local** apply synchronous:
+For high-frequency local-authority writes (a resize splitter firing a patch per frame during a drag), configure `coalesceMs` and opt the individual write in with `{ coalesce: true }` — the **server** round-trip is debounced while the **local** apply stays synchronous:
 
 ```ts
-useCell(preferences, {
+const prefs = useCell(preferences, {
   authority: "local",
   initial: DEFAULT_PREFERENCES,
   applyPatch: deepMergePrefs,
-  coalesceMs: 150,   // local apply every call; one trailing server flush per quiescence
+  coalesceMs: 150,           // debounce window for opted-in writes
 });
+
+prefs.patch({ rightPanel: { size } }, { coalesce: true }); // drag — debounced
+prefs.patch({ colorScheme: "dark" });                      // toggle — immediate
 ```
 
-Pending patches accumulate through `applyPatch`, so heterogeneous keys written inside one window land in a single flush (the payload stays a patch, not a full-value snapshot) — this requires `applyPatch` to be a pure spread-merge. With `coalesceMs` set, the promise `patch` / `set` returns resolves after the local apply, not the server ack; flush failures surface via `onError`.
+Coalescing is **per-write, not per-cell**: a plain `patch(p)` still flushes immediately, so a cell mixing volatilities (continuous panel sizes + discrete toggles) doesn't debounce the toggles — a quick reload after a toggle can't lose it. Opted-in patches accumulate through `applyPatch`, so heterogeneous keys written inside one window land in a single flush (the payload stays a patch, not a full-value snapshot) — this requires `applyPatch` to be a pure spread-merge, enforced at construction. A coalesced `patch` resolves after the local apply, not the server ack; flush failures surface via `onError`.
 
 ## Collection
 

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@orpc/client": "^1.13.13",
+    "@solid-primitives/scheduled": "^1.5.3",
     "@orpc/contract": "^1.13.13",
     "@orpc/server": "^1.13.13",
     "@orpc/standard-server": "^1.13.13",

--- a/packages/surface/src/solid/surfaceClient.ts
+++ b/packages/surface/src/solid/surfaceClient.ts
@@ -51,6 +51,7 @@ export type BoundCellOptions<T, P = T> = T extends object
           initial: T;
           applyPatch?: (current: T, patch: P) => T;
           mergeIntoStore?: (setStore: SetStoreFunction<T>, patch: P) => void;
+          coalesceMs?: number;
           onError?: (err: Error) => void;
         }
   : { authority?: "server"; onError?: (err: Error) => void };

--- a/packages/surface/src/solid/useCell.ts
+++ b/packages/surface/src/solid/useCell.ts
@@ -65,26 +65,29 @@ export interface UseCellLocalOptions<T extends object, P = T> {
    *  at the call site (1) why `applyPatch` is insufficient and (2) the
    *  specific nested mutation required. */
   mergeIntoStore?: (setStore: SetStoreFunction<T>, patch: P) => void;
-  /** When set, `patch` / `set` apply to the local store synchronously (the
-   *  instant-UI guarantee local authority exists for) but defer the server
-   *  `mutate` to a trailing-debounced flush — rapid writes within `coalesceMs`
-   *  of each other collapse into one server round-trip. The motivating case is
-   *  a resize splitter whose `onSizesChange` fires dozens of times/sec during a
-   *  drag: the local store must update every frame (a sibling reads it to track
-   *  the handle), but only the settled value needs to reach the server.
+  /** Trailing-debounce window (ms) for writes that opt in via
+   *  `patch(p, { coalesce: true })`. Such a write applies to the local store
+   *  synchronously (the instant-UI guarantee local authority exists for) but
+   *  defers the server `mutate` — opted-in writes within `coalesceMs` of each
+   *  other collapse into one server round-trip. The motivating case is a resize
+   *  splitter whose `onSizesChange` fires dozens of times/sec during a drag: the
+   *  local store must update every frame (a sibling reads it to track the
+   *  handle), but only the settled value needs to reach the server.
+   *
+   *  Coalescing is per-write, not per-cell: a plain `patch(p)` still flushes
+   *  immediately. This matters when one cell mixes volatilities — preferences
+   *  holds both continuous panel sizes (coalesce) and discrete toggles like
+   *  `colorScheme` (must persist immediately, or a quick reload loses them).
    *
    *  Pending patches accumulate via `applyPatch` (the same merge the cell runs
-   *  locally), so heterogeneous keys written inside one window — e.g. a panel
-   *  `size` followed by a `collapsed` toggle — both land in the single flush;
-   *  the payload stays a real patch `P`, never a full-value snapshot. This
-   *  requires `applyPatch` to be a pure spread-merge (missing keys absent, not
-   *  defaulted); cells with a non-spread merge must not set `coalesceMs`.
+   *  locally), so heterogeneous keys written inside one window both land in the
+   *  single flush; the payload stays a real patch `P`, never a full-value
+   *  snapshot. This requires `applyPatch` to be a pure spread-merge (missing
+   *  keys absent, not defaulted) — enforced at construction.
    *
-   *  CONTRACT CHANGE: with `coalesceMs` set, the promise `patch` / `set` returns
-   *  resolves after the *local* apply, not after the server ack. A caller that
-   *  must observe server acknowledgement has to gate on the server echo, not on
-   *  this promise. Flush failures surface via `onError`, not the returned
-   *  promise. */
+   *  CONTRACT: a coalesced `patch` resolves after the *local* apply, not the
+   *  server ack; callers needing acknowledgement must gate on the server echo.
+   *  Flush failures surface via `onError`, not the returned promise. */
   coalesceMs?: number;
   onError?: (err: Error) => void;
 }
@@ -93,12 +96,19 @@ export type UseCellOptions<T, P = T> =
   | UseCellServerOptions<T, P>
   | (T extends object ? UseCellLocalOptions<T, P> : never);
 
+/** Per-write options for `patch`. `coalesce` opts an individual write into the
+ *  cell's trailing-debounced server flush (requires `coalesceMs` configured);
+ *  it is the per-write half of the cadence decision — see `coalesceMs`. */
+export interface PatchOptions {
+  coalesce?: boolean;
+}
+
 export interface UseCellResult<T, P> {
   value: Accessor<T | undefined>;
   pending: Accessor<boolean>;
   error: Accessor<Error | undefined>;
   set: (next: T) => Promise<void>;
-  patch: (p: P) => Promise<void>;
+  patch: (p: P, opts?: PatchOptions) => Promise<void>;
   sub: Subscription<T>;
 }
 
@@ -150,7 +160,9 @@ function useCellServer<Name extends string, T, P>(
     pending: sub.pending,
     error: sub.error,
     set: (next) => callMutate(next as unknown as P),
-    patch: callMutate,
+    // Server authority has no local store to coalesce against — every write is
+    // a round-trip; the `opts` arg is accepted for signature parity and ignored.
+    patch: (p) => callMutate(p),
     sub,
   };
 }
@@ -252,12 +264,11 @@ function useCellLocal<Name extends string, T extends object, P>(
     error: sub.error,
     set: async (next) => {
       applyLocal(next as unknown as P);
-      if (scheduleFlush) enqueue(next as unknown as P);
-      else await options.mutate(next as unknown as P);
+      await options.mutate(next as unknown as P);
     },
-    patch: async (p) => {
+    patch: async (p, opts) => {
       applyLocal(p);
-      if (scheduleFlush) enqueue(p);
+      if (opts?.coalesce && scheduleFlush) enqueue(p);
       else await options.mutate(p);
     },
     sub,

--- a/packages/surface/src/solid/useCell.ts
+++ b/packages/surface/src/solid/useCell.ts
@@ -26,6 +26,7 @@
  * fail fast (no retry) per the plugin default.
  */
 
+import { debounce } from "@solid-primitives/scheduled";
 import { type Accessor, createEffect, createRoot, on } from "solid-js";
 import { createStore, reconcile, type SetStoreFunction } from "solid-js/store";
 import { STREAM_RETRY, type StreamingProcedure } from "../client";
@@ -150,22 +151,6 @@ function useCellServer<Name extends string, T, P>(
   };
 }
 
-/** Trailing-edge debounce: coalesce rapid calls into one invocation after
- *  `ms` of quiescence. Hand-rolled rather than pulling
- *  `@solid-primitives/scheduled` so `@kolu/surface` keeps its deliberately
- *  minimal dependency surface (orpc, solid-js, zod). Mirrors the setTimeout
- *  debounce the client already hand-rolls in `useTextSelection.ts`. */
-function trailingDebounce(fn: () => void, ms: number): () => void {
-  let handle: ReturnType<typeof setTimeout> | undefined;
-  return () => {
-    if (handle !== undefined) clearTimeout(handle);
-    handle = setTimeout(() => {
-      handle = undefined;
-      fn();
-    }, ms);
-  };
-}
-
 function useCellLocal<Name extends string, T extends object, P>(
   _cell: Cell<Name, T>,
   options: UseCellLocalOptions<T, P>,
@@ -225,7 +210,7 @@ function useCellLocal<Name extends string, T extends object, P>(
   }
   const scheduleFlush =
     options.coalesceMs !== undefined
-      ? trailingDebounce(flushPending, options.coalesceMs)
+      ? debounce(flushPending, options.coalesceMs)
       : undefined;
   function enqueue(p: P): void {
     pendingPatch =

--- a/packages/surface/src/solid/useCell.ts
+++ b/packages/surface/src/solid/useCell.ts
@@ -115,6 +115,10 @@ export function useCell<Name extends string, T, P = T>(
   return useCellServer(cell, options as UseCellServerOptions<T, P>);
 }
 
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
 /** Wrap a streaming procedure ref into the thunk shape `createSubscription`
  *  expects, threading `STREAM_RETRY` context so transport drops re-subscribe
  *  transparently. */
@@ -204,9 +208,13 @@ function useCellLocal<Name extends string, T extends object, P>(
     const p = pendingPatch;
     if (p === undefined) return;
     pendingPatch = undefined;
-    void Promise.resolve(options.mutate(p)).catch((err: unknown) => {
-      options.onError?.(err instanceof Error ? err : new Error(String(err)));
-    });
+    void (async () => {
+      try {
+        await options.mutate(p);
+      } catch (err: unknown) {
+        options.onError?.(toError(err));
+      }
+    })();
   }
   // Coalescing merges queued patches through `applyPatch`; without it, two
   // patches in one window would collapse to last-write-wins and silently drop

--- a/packages/surface/src/solid/useCell.ts
+++ b/packages/surface/src/solid/useCell.ts
@@ -64,6 +64,27 @@ export interface UseCellLocalOptions<T extends object, P = T> {
    *  at the call site (1) why `applyPatch` is insufficient and (2) the
    *  specific nested mutation required. */
   mergeIntoStore?: (setStore: SetStoreFunction<T>, patch: P) => void;
+  /** When set, `patch` / `set` apply to the local store synchronously (the
+   *  instant-UI guarantee local authority exists for) but defer the server
+   *  `mutate` to a trailing-debounced flush — rapid writes within `coalesceMs`
+   *  of each other collapse into one server round-trip. The motivating case is
+   *  a resize splitter whose `onSizesChange` fires dozens of times/sec during a
+   *  drag: the local store must update every frame (a sibling reads it to track
+   *  the handle), but only the settled value needs to reach the server.
+   *
+   *  Pending patches accumulate via `applyPatch` (the same merge the cell runs
+   *  locally), so heterogeneous keys written inside one window — e.g. a panel
+   *  `size` followed by a `collapsed` toggle — both land in the single flush;
+   *  the payload stays a real patch `P`, never a full-value snapshot. This
+   *  requires `applyPatch` to be a pure spread-merge (missing keys absent, not
+   *  defaulted); cells with a non-spread merge must not set `coalesceMs`.
+   *
+   *  CONTRACT CHANGE: with `coalesceMs` set, the promise `patch` / `set` returns
+   *  resolves after the *local* apply, not after the server ack. A caller that
+   *  must observe server acknowledgement has to gate on the server echo, not on
+   *  this promise. Flush failures surface via `onError`, not the returned
+   *  promise. */
+  coalesceMs?: number;
   onError?: (err: Error) => void;
 }
 
@@ -129,6 +150,22 @@ function useCellServer<Name extends string, T, P>(
   };
 }
 
+/** Trailing-edge debounce: coalesce rapid calls into one invocation after
+ *  `ms` of quiescence. Hand-rolled rather than pulling
+ *  `@solid-primitives/scheduled` so `@kolu/surface` keeps its deliberately
+ *  minimal dependency surface (orpc, solid-js, zod). Mirrors the setTimeout
+ *  debounce the client already hand-rolls in `useTextSelection.ts`. */
+function trailingDebounce(fn: () => void, ms: number): () => void {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  return () => {
+    if (handle !== undefined) clearTimeout(handle);
+    handle = setTimeout(() => {
+      handle = undefined;
+      fn();
+    }, ms);
+  };
+}
+
 function useCellLocal<Name extends string, T extends object, P>(
   _cell: Cell<Name, T>,
   options: UseCellLocalOptions<T, P>,
@@ -173,6 +210,36 @@ function useCellLocal<Name extends string, T extends object, P>(
     setStore(reconcile(p as unknown as T));
   }
 
+  // Coalesced server flush (opt-in via `coalesceMs`). `applyLocal` has already
+  // run by the time we enqueue, so the store is current; we defer only the
+  // server round-trip. Patches merge through `applyPatch` so a flush carries
+  // every key touched in the window, not just the last write.
+  let pendingPatch: P | undefined;
+  function flushPending(): void {
+    const p = pendingPatch;
+    if (p === undefined) return;
+    pendingPatch = undefined;
+    void Promise.resolve(options.mutate(p)).catch((err: unknown) => {
+      options.onError?.(err instanceof Error ? err : new Error(String(err)));
+    });
+  }
+  const scheduleFlush =
+    options.coalesceMs !== undefined
+      ? trailingDebounce(flushPending, options.coalesceMs)
+      : undefined;
+  function enqueue(p: P): void {
+    pendingPatch =
+      pendingPatch === undefined
+        ? p
+        : options.applyPatch
+          ? (options.applyPatch(
+              pendingPatch as unknown as T,
+              p,
+            ) as unknown as P)
+          : p; // no applyPatch → last-write-wins
+    scheduleFlush?.();
+  }
+
   return {
     // Always read the seeded store — `options.initial` is visible to
     // consumers before the first server yield (matching the existing
@@ -184,11 +251,13 @@ function useCellLocal<Name extends string, T extends object, P>(
     error: sub.error,
     set: async (next) => {
       applyLocal(next as unknown as P);
-      await options.mutate(next as unknown as P);
+      if (scheduleFlush) enqueue(next as unknown as P);
+      else await options.mutate(next as unknown as P);
     },
     patch: async (p) => {
       applyLocal(p);
-      await options.mutate(p);
+      if (scheduleFlush) enqueue(p);
+      else await options.mutate(p);
     },
     sub,
   };

--- a/packages/surface/src/solid/useCell.ts
+++ b/packages/surface/src/solid/useCell.ts
@@ -208,20 +208,28 @@ function useCellLocal<Name extends string, T extends object, P>(
       options.onError?.(err instanceof Error ? err : new Error(String(err)));
     });
   }
+  // Coalescing merges queued patches through `applyPatch`; without it, two
+  // patches in one window would collapse to last-write-wins and silently drop
+  // the earlier keys. Enforce the documented precondition at construction so a
+  // misconfigured cell fails loudly here, not as missing data at runtime.
+  if (options.coalesceMs !== undefined && options.applyPatch === undefined) {
+    throw new Error(
+      "useCell: coalesceMs requires applyPatch — coalescing merges queued " +
+        "patches through it, so without it interleaved writes would be lost.",
+    );
+  }
   const scheduleFlush =
     options.coalesceMs !== undefined
       ? debounce(flushPending, options.coalesceMs)
       : undefined;
   function enqueue(p: P): void {
+    const merge = options.applyPatch;
+    // `merge === undefined` can't happen once `scheduleFlush` is set (the guard
+    // above threw); the check is here only to narrow the optional for TS.
     pendingPatch =
-      pendingPatch === undefined
+      pendingPatch === undefined || merge === undefined
         ? p
-        : options.applyPatch
-          ? (options.applyPatch(
-              pendingPatch as unknown as T,
-              p,
-            ) as unknown as P)
-          : p; // no applyPatch → last-write-wins
+        : (merge(pendingPatch as unknown as T, p) as unknown as P);
     scheduleFlush?.();
   }
 

--- a/packages/surface/src/solid/useCellCoalesce.test.ts
+++ b/packages/surface/src/solid/useCellCoalesce.test.ts
@@ -1,0 +1,105 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import type { StreamingProcedure } from "../client";
+import type { Cell } from "../index";
+import { useCell } from "./useCell";
+
+/** Minimal preferences-shaped cell to exercise `coalesceMs`. Mirrors the
+ *  real preferences cell: a spread-merge `applyPatch`, local authority, and
+ *  a mutate spy standing in for the server RPC. */
+type Prefs = { size: number; collapsed: boolean };
+type PrefsPatch = Partial<Prefs>;
+
+const applyPatch = (cur: Prefs, p: PrefsPatch): Prefs => ({ ...cur, ...p });
+
+// An empty server stream: the local store stays at `initial`, which is all
+// these tests need (they exercise the client-side write path, not seeding).
+async function* emptyStream(): AsyncGenerator<Prefs> {}
+
+function makeCell(
+  mutate: (p: PrefsPatch) => Promise<void>,
+  coalesceMs: number | undefined,
+  onError?: (err: Error) => void,
+) {
+  return useCell({} as Cell<"prefs", Prefs>, {
+    authority: "local",
+    initial: { size: 0.25, collapsed: false },
+    source: (() => emptyStream()) as unknown as StreamingProcedure<
+      undefined,
+      Prefs
+    >,
+    applyPatch,
+    mutate,
+    coalesceMs,
+    onError,
+  });
+}
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("useCell local authority — coalesceMs", () => {
+  it("coalesces a burst of distinct patches into one trailing mutate with merged keys", async () => {
+    const mutate = vi.fn(async () => {});
+    await createRoot(async (dispose) => {
+      const cell = makeCell(mutate, 30);
+      // Fire without awaiting — local apply is synchronous; the server flush
+      // is what we're testing is deferred.
+      void cell.patch({ size: 0.3 });
+      void cell.patch({ size: 0.4 });
+      void cell.patch({ collapsed: true });
+      // Local apply is synchronous — a mid-drag reader sees every step.
+      expect(cell.value()).toEqual({ size: 0.4, collapsed: true });
+      // The server round-trip is deferred, not fired per patch.
+      expect(mutate).not.toHaveBeenCalled();
+      await tick(60);
+      // One flush, carrying both the last size AND the interleaved collapsed
+      // toggle — heterogeneous keys are merged, not clobbered.
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(mutate).toHaveBeenCalledWith({ size: 0.4, collapsed: true });
+      dispose();
+    });
+  });
+
+  it("a 50-write resize drag produces a single server write (regression guard for #1041)", async () => {
+    const mutate = vi.fn<(p: PrefsPatch) => Promise<void>>(async () => {});
+    await createRoot(async (dispose) => {
+      const cell = makeCell(mutate, 30);
+      for (let i = 1; i <= 50; i++) void cell.patch({ size: 0.2 + i * 0.001 });
+      expect(mutate).not.toHaveBeenCalled();
+      await tick(60);
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ size: expect.closeTo(0.25) }),
+      );
+      dispose();
+    });
+  });
+
+  it("without coalesceMs every patch flushes immediately (proves the guard bites)", async () => {
+    const mutate = vi.fn(async () => {});
+    await createRoot(async (dispose) => {
+      const cell = makeCell(mutate, undefined);
+      await cell.patch({ size: 0.3 });
+      await cell.patch({ size: 0.4 });
+      expect(mutate).toHaveBeenCalledTimes(2);
+      dispose();
+    });
+  });
+
+  it("routes a coalesced-flush failure to onError, not the patch promise", async () => {
+    const boom = new Error("flush failed");
+    const mutate = vi.fn(async () => {
+      throw boom;
+    });
+    const onError = vi.fn();
+    await createRoot(async (dispose) => {
+      const cell = makeCell(mutate, 30, onError);
+      // The returned promise resolves on local apply — it does not reject
+      // with the deferred server error.
+      await expect(cell.patch({ size: 0.3 })).resolves.toBeUndefined();
+      await tick(60);
+      expect(onError).toHaveBeenCalledWith(boom);
+      dispose();
+    });
+  });
+});

--- a/packages/surface/src/solid/useCellCoalesce.test.ts
+++ b/packages/surface/src/solid/useCellCoalesce.test.ts
@@ -86,6 +86,25 @@ describe("useCell local authority — coalesceMs", () => {
     });
   });
 
+  it("throws when coalesceMs is set without applyPatch (fail-fast misconfiguration)", () => {
+    createRoot((dispose) => {
+      expect(() =>
+        useCell({} as Cell<"prefs", Prefs>, {
+          authority: "local",
+          initial: { size: 0.25, collapsed: false },
+          source: (() => emptyStream()) as unknown as StreamingProcedure<
+            undefined,
+            Prefs
+          >,
+          mutate: async () => {},
+          coalesceMs: 30,
+          // applyPatch intentionally omitted
+        }),
+      ).toThrow(/coalesceMs requires applyPatch/);
+      dispose();
+    });
+  });
+
   it("routes a coalesced-flush failure to onError, not the patch promise", async () => {
     const boom = new Error("flush failed");
     const mutate = vi.fn(async () => {

--- a/packages/surface/src/solid/useCellCoalesce.test.ts
+++ b/packages/surface/src/solid/useCellCoalesce.test.ts
@@ -43,10 +43,11 @@ describe("useCell local authority — coalesceMs", () => {
     await createRoot(async (dispose) => {
       const cell = makeCell(mutate, 30);
       // Fire without awaiting — local apply is synchronous; the server flush
-      // is what we're testing is deferred.
-      void cell.patch({ size: 0.3 });
-      void cell.patch({ size: 0.4 });
-      void cell.patch({ collapsed: true });
+      // is what we're testing is deferred. `{ coalesce: true }` opts each write
+      // into the debounce.
+      void cell.patch({ size: 0.3 }, { coalesce: true });
+      void cell.patch({ size: 0.4 }, { coalesce: true });
+      void cell.patch({ collapsed: true }, { coalesce: true });
       // Local apply is synchronous — a mid-drag reader sees every step.
       expect(cell.value()).toEqual({ size: 0.4, collapsed: true });
       // The server round-trip is deferred, not fired per patch.
@@ -64,7 +65,8 @@ describe("useCell local authority — coalesceMs", () => {
     const mutate = vi.fn<(p: PrefsPatch) => Promise<void>>(async () => {});
     await createRoot(async (dispose) => {
       const cell = makeCell(mutate, 30);
-      for (let i = 1; i <= 50; i++) void cell.patch({ size: 0.2 + i * 0.001 });
+      for (let i = 1; i <= 50; i++)
+        void cell.patch({ size: 0.2 + i * 0.001 }, { coalesce: true });
       expect(mutate).not.toHaveBeenCalled();
       await tick(60);
       expect(mutate).toHaveBeenCalledTimes(1);
@@ -79,9 +81,22 @@ describe("useCell local authority — coalesceMs", () => {
     const mutate = vi.fn(async () => {});
     await createRoot(async (dispose) => {
       const cell = makeCell(mutate, undefined);
-      await cell.patch({ size: 0.3 });
-      await cell.patch({ size: 0.4 });
+      await cell.patch({ size: 0.3 }, { coalesce: true });
+      await cell.patch({ size: 0.4 }, { coalesce: true });
       expect(mutate).toHaveBeenCalledTimes(2);
+      dispose();
+    });
+  });
+
+  it("a plain patch flushes immediately even when coalesceMs is configured (per-write opt-in)", async () => {
+    const mutate = vi.fn(async () => {});
+    await createRoot(async (dispose) => {
+      const cell = makeCell(mutate, 30);
+      // No `{ coalesce: true }` — a discrete write (e.g. a settings toggle)
+      // must reach the server now, not after the debounce window.
+      await cell.patch({ collapsed: true });
+      expect(mutate).toHaveBeenCalledTimes(1);
+      expect(mutate).toHaveBeenCalledWith({ collapsed: true });
       dispose();
     });
   });
@@ -115,7 +130,9 @@ describe("useCell local authority — coalesceMs", () => {
       const cell = makeCell(mutate, 30, onError);
       // The returned promise resolves on local apply — it does not reject
       // with the deferred server error.
-      await expect(cell.patch({ size: 0.3 })).resolves.toBeUndefined();
+      await expect(
+        cell.patch({ size: 0.3 }, { coalesce: true }),
+      ).resolves.toBeUndefined();
       await tick(60);
       expect(onError).toHaveBeenCalledWith(boom);
       dispose();

--- a/packages/surface/vitest.config.ts
+++ b/packages/surface/vitest.config.ts
@@ -7,10 +7,21 @@ export default defineConfig({
   // createReactiveSubscription) need the browser build's real `createEffect`.
   // Aliasing pins the import to the browser bundle directly — `resolve.conditions`
   // alone is ignored for externalized CJS deps under Vitest 4 + Node ESM.
+  //
+  // `solid-js/web` must alias to the browser build too: under Node it resolves
+  // to the server bundle where `isServer === true`, which turns
+  // `@solid-primitives/scheduled`'s `debounce` into a no-op (it short-circuits
+  // on SSR). The `useCellLocal` coalesce test needs the real timer-backed
+  // debounce. Order matters — the `solid-js` catch-all is a prefix of the
+  // others, so the specific keys must precede it.
   resolve: {
     alias: {
       "solid-js/store": new URL(
         "./node_modules/solid-js/store/dist/store.js",
+        import.meta.url,
+      ).pathname,
+      "solid-js/web": new URL(
+        "./node_modules/solid-js/web/dist/web.js",
         import.meta.url,
       ).pathname,
       "solid-js": new URL(
@@ -21,5 +32,10 @@ export default defineConfig({
   },
   test: {
     include: ["src/**/*.test.ts"],
+    // Inline `@solid-primitives/scheduled` so the `solid-js/web` alias above
+    // reaches inside it — externalized node_modules deps bypass Vitest's
+    // resolver, leaving `isServer === true` and turning `debounce` into a
+    // no-op (the useCellLocal coalesce test would never see a flush).
+    server: { deps: { inline: ["@solid-primitives/scheduled"] } },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,9 @@ importers:
       '@orpc/standard-server-peer':
         specifier: ^1.13.13
         version: 1.13.13
+      '@solid-primitives/scheduled':
+        specifier: ^1.5.3
+        version: 1.5.3(solid-js@1.9.11)
       solid-js:
         specifier: ^1.9.0
         version: 1.9.11


### PR DESCRIPTION
During the #1034 daemon-restart churn the client emitted **200+ `rightPanel` size preference patches per minute** — a `@corvu/resizable` feedback loop that storms the server and contends with the session autosave on the shared `state.json` Conf store. This **debounces and de-dupes those writes so a resize interaction settles to a single server round-trip**, while keeping the live drag perfectly smooth.

### Why it stormed

The right-panel and code-tab splitters are Corvu `Resizable`s *fully controlled* by the local-authority `preferences` store. Corvu runs `createEffect(() => onSizesChange(sizes()))`, so it re-emits the current `sizes` prop on every reactive invalidation — and re-registers panels (re-emitting again) on every mount during restart churn. Each emission persisted a patch, with no equality gate and no coalescing.

A hard constraint shapes the fix: `ChromeBar` reads `rightPanel.size` *mid-drag* to pin its right edge to the panel (`ChromeBar.tsx:112-114`), so the local store write **must stay synchronous** — only the server round-trip may be deferred. That rules out an uncontrolled-Corvu rewrite.

### Three guards, three layers

```
Corvu re-emits size ─▶ useRightPanel ─▶ updatePreferences ─▶ useCell ─▶ RPC ─▶ server cell
                        (1) drop echo                     (2) coalesce        (3) equals
```

| # | Where | Guard |
| --- | --- | --- |
| 1 | `useRightPanel.ts` | Drop a size write equal to the stored value — Corvu's idempotent re-emit becomes a true no-op |
| 2 | `useCell` (`@kolu/surface`) | New `coalesceMs` option: apply locally now (smooth drag), trailing-debounce the server flush, merging queued patches via `applyPatch` |
| 3 | server preferences cell | `equals` dedup mirroring the `session` cell — a no-op patch that still reaches the server skips the disk write + bus publish |

Each layer stands alone; together they take a resize drag from dozens of RPCs/sec down to one.

### Coalescing is per-write, not per-cell

A first cut debounced the *cell*, which silently delayed discrete toggles (`colorScheme`, `scrollLock`) too — a toggle-then-reload within 150ms lost the write, and `preferences.feature` caught it. Coalescing is now opt-in per write: `patch(p, { coalesce: true })` debounces, a plain `patch(p)` stays immediate. Only the two continuous panel-size writes opt in. *The cadence decision belongs to the write, not the cell, since preferences mixes continuous and discrete fields.*

> Structural review (hickey + lowy) ran on the diff and is posted as a PR comment. Notable outcomes folded in: swapped the hand-rolled debounce for `@solid-primitives/scheduled`, and made `coalesceMs` throw at construction when `applyPatch` is absent (it would otherwise lose interleaved keys to last-write-wins).

Regression guards: a 50-write drag collapses to one server write (surface unit), Corvu echoes are dropped (client unit), and `preferences.feature` (4) + `right-panel`/`code-tab` (78) stay green.

Closes #1041.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._