### PR TITLE
docs(do): fire PR-evidence on behavioral/round-trip fixes, not just visual ones

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -42,7 +42,11 @@ Keep these docs in sync:
 
 ## PR evidence
 
-When the change has visible UI impact, post a `## Evidence` PR comment with screenshots — or **video** when the change is about motion (an animation, a transition, a multi-step interaction a still can't convey). Use judgment — server-only diffs sometimes ripple into rendering.
+Post a `## Evidence` PR comment when **any** of these holds — the trigger is "is there behavior worth proving?", not "does a pixel change?":
+
+1. **Visible UI impact** — capture screenshots, or **video** when the change is about motion (an animation, a transition, a multi-step interaction a still can't convey). Use judgment — server-only diffs sometimes ripple into rendering.
+2. **Behavioral / round-trip changes** — the diff touches a persistence, restore, session, autosave, debounce/coalesce, or reconnect path, and the proof is *"state survives an interaction or a restart,"* not a pixel change. Capture the before→after **behavior** — often with **zero visual diff** (e.g. resize → stop kolu → start → restore session → the panel returns at the resized width). A video of the round-trip is the proof the fix didn't break recoverability.
+3. **Bug fixes generally** — the default for a fix is *"demonstrate the fixed behavior."* The bug was often a storm, a lost write, or a hang, so a before/after or survives-restart clip is the evidence **even when nothing looks different**. Don't skip evidence just because a fix has no visual diff; skip only when the behavior genuinely can't be observed (e.g. a pure internal refactor with no externally visible effect).
 
 **The mechanics live in the [`evidence`](../.apm/skills/evidence/SKILL.md) skill** (which builds on the [`pu`](../.apm/skills/pu/SKILL.md) skill): capture runs on an ephemeral `pu` box — `nix run`, Chrome, Playwright, and ffmpeg all off-machine, exactly like CI. Drive it through that skill and plug in kolu's parameters:
 

--- a/.agents/skills/do/SKILL.md
+++ b/.agents/skills/do/SKILL.md
@@ -389,7 +389,13 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 ### evidence
 
-**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did the feature actually work" needs — UI screenshots, performance benchmarks, demo recordings, output transcripts — can attach that evidence to the PR without baking the mechanism into agency.
+**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did this actually work" needs can attach proof to the PR without baking the mechanism into agency. That proof is **visual** _or_ **behavioral** — and the second kind is easy to under-fire on, because it often has zero visual diff:
+
+- **Visual** — UI screenshots, before/after stills, demo recordings; **video** when the change is about motion (an animation, a transition).
+- **Behavioral** — proof that _state survives an interaction or a restart_. When the diff touches a persistence, restore, session, autosave, debounce/coalesce, or reconnect path, the evidence that matters is "does the round-trip still hold?", not a pixel change. These changes routinely have **no visual diff** yet are exactly where a survives-restart capture proves the fix didn't break recoverability (e.g. resize → stop the app → restart → restore session → panel returns at the resized width).
+- **Other empirical** — performance benchmarks, output transcripts.
+
+**Bug fixes default to "demonstrate the fixed behavior."** The bug was usually invisible — a lost write, a storm, a hang, a broken round-trip — so a before→after or survives-restart clip is the evidence even when nothing _looks_ different. Don't gate evidence on a pixel changing; gate it on "is there a behavior worth proving."
 
 **If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **done**.
 
@@ -402,6 +408,8 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 **If the section is present**:
 
 The section is project-specific and free-form: it can be inline prose describing the capture procedure, a pointer to another file (`See ./scripts/capture-evidence.md`), a script reference (`Run ./scripts/capture-pr-evidence.sh and use its stdout`), or any combination. Don't second-guess the form — read it, then **spawn a sub-agent** (`Agent(subagent_type: "general-purpose", ...)`) so the capture work (MCP calls, screenshot uploads, gh API requests) doesn't pollute `/do`'s main context.
+
+**Read the trigger broadly.** A project's section supplies the _capture mechanism_; the criterion for _when to fire_ is the visual-or-behavioral framing above. If the section's wording leans visual ("when the change has visible UI impact") but the diff is a behavioral fix on a persistence/restore/round-trip/debounce/reconnect path, capture the **behavior** anyway — the absence of a visual diff is not a reason to skip. Only skip when there is genuinely no behavior worth proving (a pure refactor, a docs change, an internal cleanup with no observable before→after).
 
 The sub-agent prompt should include:
 

--- a/.claude/skills/do/SKILL.md
+++ b/.claude/skills/do/SKILL.md
@@ -389,7 +389,13 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 ### evidence
 
-**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did the feature actually work" needs — UI screenshots, performance benchmarks, demo recordings, output transcripts — can attach that evidence to the PR without baking the mechanism into agency.
+**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did this actually work" needs can attach proof to the PR without baking the mechanism into agency. That proof is **visual** _or_ **behavioral** — and the second kind is easy to under-fire on, because it often has zero visual diff:
+
+- **Visual** — UI screenshots, before/after stills, demo recordings; **video** when the change is about motion (an animation, a transition).
+- **Behavioral** — proof that _state survives an interaction or a restart_. When the diff touches a persistence, restore, session, autosave, debounce/coalesce, or reconnect path, the evidence that matters is "does the round-trip still hold?", not a pixel change. These changes routinely have **no visual diff** yet are exactly where a survives-restart capture proves the fix didn't break recoverability (e.g. resize → stop the app → restart → restore session → panel returns at the resized width).
+- **Other empirical** — performance benchmarks, output transcripts.
+
+**Bug fixes default to "demonstrate the fixed behavior."** The bug was usually invisible — a lost write, a storm, a hang, a broken round-trip — so a before→after or survives-restart clip is the evidence even when nothing _looks_ different. Don't gate evidence on a pixel changing; gate it on "is there a behavior worth proving."
 
 **If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **done**.
 
@@ -402,6 +408,8 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 **If the section is present**:
 
 The section is project-specific and free-form: it can be inline prose describing the capture procedure, a pointer to another file (`See ./scripts/capture-evidence.md`), a script reference (`Run ./scripts/capture-pr-evidence.sh and use its stdout`), or any combination. Don't second-guess the form — read it, then **spawn a sub-agent** (`Agent(subagent_type: "general-purpose", ...)`) so the capture work (MCP calls, screenshot uploads, gh API requests) doesn't pollute `/do`'s main context.
+
+**Read the trigger broadly.** A project's section supplies the _capture mechanism_; the criterion for _when to fire_ is the visual-or-behavioral framing above. If the section's wording leans visual ("when the change has visible UI impact") but the diff is a behavioral fix on a persistence/restore/round-trip/debounce/reconnect path, capture the **behavior** anyway — the absence of a visual diff is not a reason to skip. Only skip when there is genuinely no behavior worth proving (a pure refactor, a docs change, an internal cleanup with no observable before→after).
 
 The sub-agent prompt should include:
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-05-30T01:10:18.052343+00:00'
+generated_at: '2026-05-30T18:43:45.258766+00:00'
 apm_version: 0.16.0
 dependencies:
 - repo_url: anthropics/skills
@@ -53,7 +53,7 @@ dependencies:
   content_hash: sha256:67ff7ce606ad0378af382ad6cb84d9853bf70ec52d6fe40ed6b6f82ecd2c48c3
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: d274039c47ee8d0cc13e9d42d1bbf61e5f5b706f
+  resolved_commit: 6d53751b5fb42cc2c55b9072b314f3cdd0449ecb
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -94,7 +94,7 @@ dependencies:
     .codex/hooks/agency/scripts/do-stop-guard.sh: sha256:cb033f86c15ffd3d09d8e4b74a61f55a70def4cc4131cc013b7368a2d23f3f33
     .opencode/agents/hickey.md: sha256:10d9a4350a85752dc6658af8e0efb3d8be41803a2b6c73464e3d5b7a840435ad
     .opencode/agents/lowy.md: sha256:05aff7f6a91149a42c1fb9a3ca382a6f77bc39ac8a8d45436d443dd3349fb11e
-  content_hash: sha256:5a4a4d50e6298dc5015412eb1000e8c233cf6d872cc27b902b07979c466127b2
+  content_hash: sha256:703dc7eb1a510ab80f5daa4cd7d9997ed1c748cb0942ff3ced88ac7bd062944b
 mcp_servers:
 - chrome-devtools
 mcp_configs:


### PR DESCRIPTION
Closes #1051.

`/do`'s `## PR evidence` step gated on **visible UI impact / motion**. On #1050 (the pref-storm write-coalescing fix) that criterion faithfully told `/do` to *skip* evidence — "no visible UI impact, not motion" — even though the fix's entire risk was a **debounced preference write getting lost on a quick reload/restart**. The user then had to ask for the survives-restart video by hand, which is the tell that the criterion was wrong, not the judgment.

The fix gates on the wrong thing. For persistence / restore / round-trip / write-coalescing / reconnect changes, the evidence that matters is **behavioral** — *does state survive the round-trip?* — and those changes have **zero visual diff** by nature. They're exactly where a "survives-restart" capture is the proof.

This PR makes the change in two places:

**1. Repo-local trigger (`.agency/do.md`).** Broadens the `## PR evidence` section to fire when **any** of three conditions holds, reframing its question from "does a pixel change?" to "is there behavior worth proving?":

1. **Visible UI impact** — the existing branch, unchanged (screenshots, or video for motion).
2. **Behavioral / round-trip changes** — the diff touches a persistence, restore, session, autosave, debounce/coalesce, or reconnect path; capture the before→after behavior even with no visual diff (e.g. resize → stop kolu → start → restore → panel returns at the resized width).
3. **Bug fixes generally** — the default for a fix is *demonstrate the fixed behavior*; a before/after or survives-restart clip is the evidence even when nothing looks different. Skip only when the behavior genuinely can't be observed.

**2. Upstream alignment (`srid/agency`), now pulled in.** The same visual/opt-in bias lived in the `/do` skill's evidence step upstream, which the kolu plug-in inherits. That's now fixed upstream and bumped here: `just ai apm-update srid/agency` advances the pinned commit (`d274039` → `6d53751`) in `apm.lock.yaml`, and the regenerated `do/SKILL.md` carries the visual-*or*-behavioral framing plus a "read the trigger broadly" instruction so the skill no longer under-fires on invisible-but-verifiable fixes regardless of how a project's section is worded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)