### PR TITLE
fix(surface-nix-host): re-arm a session that gave up on a nix-copy failure

### DIFF
--- a/packages/surface-nix-host/package.json
+++ b/packages/surface-nix-host/package.json
@@ -11,7 +11,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@kolu/surface": "workspace:*",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "typescript": "^5.8.0"
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/surface-nix-host/src/hostSession.test.ts
+++ b/packages/surface-nix-host/src/hostSession.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression coverage for the "Reconnect does nothing" bug.
+ *
+ * When the link gives up because the `nix copy --derivation`
+ * provisioning step failed (vs. the agent process exiting), `spawn()`
+ * throws BEFORE any ssh child is created — so `handleChildDone`, the
+ * usual site that nulls `clientPromise`, never runs. If the terminal
+ * `failed` transition doesn't clear the slot itself, it keeps the last
+ * *rejected* spawn promise, and `reconnect()`'s `clientPromise !== null`
+ * guard makes the "Reconnect" button a silent no-op. See
+ * `clearClientPromise` / `scheduleReconnect`.
+ *
+ * `provisionAgent` is the only collaborator mocked: forcing it to fail
+ * keeps the whole test off real ssh / `nix copy`, and short-circuits
+ * `spawn()` before it ever reaches `child_process.spawn`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostSession } from "./hostSession";
+import { provisionAgent } from "./nixCopy";
+
+vi.mock("./nixCopy", () => ({
+  provisionAgent: vi.fn(),
+}));
+
+const PROVISION_FAILURE = {
+  ok: false as const,
+  reason: "testhost: 'nix copy --derivation' exited with code 1",
+};
+
+function failingSession() {
+  return new HostSession({
+    host: "testhost",
+    drvPath: "/nix/store/deadbeef-agent.drv",
+    binary: "agent",
+    reconnectDelayMs: 1000,
+  });
+}
+
+describe("HostSession reconnect after give-up", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(provisionAgent).mockResolvedValue(PROVISION_FAILURE);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("re-arms a session that gave up on a nix-copy failure", async () => {
+    const session = failingSession();
+
+    // Pin spawns; provision fails every attempt. Drive the backoff
+    // (1s + 2s + 4s + 8s) through all 5 attempts to the terminal state.
+    session.pin().catch(() => {});
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(session.current().connection).toBe("failed");
+    // The invariant the fix restores: no spawn in flight ⇒ the slot the
+    // reconnect guard reads is null. Pre-fix this held the last rejected
+    // spawn promise because no child ever exited to clear it.
+    expect(session.currentClient()).toBeNull();
+
+    // The button. `spawn()` sets "copying" synchronously before its first
+    // await, so re-arming is observable immediately. Pre-fix, the guard
+    // saw a non-null slot and returned without spawning — state stuck.
+    session.reconnect();
+    expect(session.current().connection).toBe("copying");
+    expect(session.currentClient()).not.toBeNull();
+
+    session.destroy();
+  });
+
+  it("ignores reconnect() while a spawn is genuinely in flight", async () => {
+    const session = failingSession();
+
+    session.pin().catch(() => {});
+    // First spawn is mid-provision (awaiting the mocked promise). The
+    // guard must hold so a double-tapped Reconnect can't stack spawns.
+    const inFlight = session.currentClient();
+    expect(inFlight).not.toBeNull();
+
+    session.reconnect();
+    expect(session.currentClient()).toBe(inFlight);
+
+    session.destroy();
+    await vi.advanceTimersByTimeAsync(20_000);
+  });
+});

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -227,6 +227,22 @@ export class HostSession<C extends AnyContractRouter> {
     return this.clientPromise;
   }
 
+  /** Clear the in-flight client handle. Centralizes the "no spawn in
+   *  flight ⇒ `clientPromise` is null" invariant that three terminal
+   *  paths must uphold: the child died (`handleChildDone`), the session
+   *  was torn down (`teardown`), or the retry gate gave up
+   *  (`scheduleReconnect`). `reconnect()`'s "already spawning?" guard and
+   *  the bridge's `currentClient()` identity check both read this slot, so
+   *  a path that forgets to null it strands `reconnect()` behind a stale
+   *  *rejected* promise — exactly the bug where a `nix copy`-driven
+   *  give-up (which throws before any child spawns, so `handleChildDone`
+   *  never runs) left the slot non-null and made the "Reconnect" button a
+   *  silent no-op. Naming it keeps the invariant searchable instead of
+   *  conventional. */
+  private clearClientPromise(): void {
+    this.clientPromise = null;
+  }
+
   private updateState(patch: Partial<HostSessionState>): void {
     const prev = this.stateCell.current();
     const next: HostSessionState = { ...prev, ...patch };
@@ -351,7 +367,7 @@ export class HostSession<C extends AnyContractRouter> {
       this.addLocalProgress(reason);
       this.updateState({ connection: "disconnected", lastError: reason });
       this.child = null;
-      this.clientPromise = null;
+      this.clearClientPromise();
       if (!this.destroyed && this.refCount > 0) this.scheduleReconnect();
     };
 
@@ -410,8 +426,11 @@ export class HostSession<C extends AnyContractRouter> {
    *  the same path the automatic reconnect timer uses, minus the backoff
    *  wait. No-op if the session is destroyed, unreferenced, or a spawn
    *  is already in flight (so a double-tapped "Reconnect" can't stack
-   *  spawns). The give-up gate left `pendingTimer` and `clientPromise`
-   *  null, so a genuinely-failed session always passes the guard. */
+   *  spawns). On entering the terminal `failed` state the give-up gate
+   *  clears `clientPromise` (via `clearClientPromise`) and leaves
+   *  `pendingTimer` null, so a genuinely-failed session always passes the
+   *  guard — including the `nix copy`-driven failure that never spawned a
+   *  child. */
   reconnect(): void {
     if (this.destroyed || this.refCount === 0) return;
     if (this.clientPromise !== null || this.pendingTimer !== null) return;
@@ -437,6 +456,15 @@ export class HostSession<C extends AnyContractRouter> {
       this.addLocalProgress(
         `gave up after ${MAX_CONSECUTIVE_FAILURES} consecutive failures — fix the underlying issue (often: remote nix-daemon needs your user in 'trusted-users' to accept unsigned closures), then reconnect`,
       );
+      // Clear the in-flight handle BEFORE entering the terminal state.
+      // The provision-failure path (`nix copy` exited non-zero) throws
+      // out of `spawn()` without ever creating a child, so
+      // `handleChildDone` — the only other site that nulls the slot —
+      // never ran; the slot still holds the last *rejected* spawn
+      // promise. Without this, `reconnect()`'s `clientPromise !== null`
+      // guard sees a non-null slot and silently no-ops, stranding a
+      // genuinely-failed session. (See `clearClientPromise`.)
+      this.clearClientPromise();
       // Move off `disconnected` so consumers can distinguish "still
       // retrying" from "gave up". `lastError` is already set by the
       // spawn-failure path that led here; preserve it.
@@ -468,7 +496,7 @@ export class HostSession<C extends AnyContractRouter> {
       }
       this.child = null;
     }
-    this.clientPromise = null;
+    this.clearClientPromise();
   }
 }
 

--- a/packages/surface-nix-host/vitest.config.ts
+++ b/packages/surface-nix-host/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,6 +657,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/surface/example:
     dependencies:


### PR DESCRIPTION
## What

`HostSession.reconnect()` is a silent no-op when the link gave up because the `nix copy --derivation` provisioning step failed (as opposed to the agent process exiting). The terminal `failed` state is unrecoverable from the UI — clicking "Reconnect" in a consumer (drishti) does nothing, with no error logged anywhere.

## Why

`reconnect()` guards on `this.clientPromise !== null` to avoid stacking spawns. `clientPromise` is nulled only in `handleChildDone` (the ssh child's `exit`/`error` handler) and `teardown`. But the provision-failure path throws out of `spawn()` **before any child is created**, so `handleChildDone` never runs, and the give-up branch of `scheduleReconnect()` transitioned to `failed` **without** clearing the slot. It kept the last *rejected* spawn promise → `clientPromise !== null` → `reconnect()` returns immediately.

The `reconnect()` docstring even claimed "the give-up gate left `clientPromise` null" — false for this path. A child-exit-driven give-up *did* null it, so reconnect worked there; only the `nix copy` / `nix-store --realise` provision paths were affected.

## Fix

Clear `clientPromise` on entry to the terminal `failed` state, via a named `clearClientPromise()` that all three terminal paths (`handleChildDone`, `teardown`, give-up) route through — so the "no spawn in flight ⇒ slot is null" invariant is searchable instead of an implicit convention three sites must remember. Nulling the slot is verified-safe against the bridge: `waitForNextClient` already treats `currentClient() === null` as "keep waiting" and wakes on the next state change, which `reconnect() → spawn() → updateState("copying")` delivers.

## Tests

Adds the first vitest suite for this package (`hostSession.test.ts`) — mocks `provisionAgent` so it never touches real ssh / `nix copy`:

- **re-arms after a nix-copy give-up** — drives the backoff through all 5 attempts to `failed`, asserts `currentClient()` is null, then asserts `reconnect()` transitions back to `copying`. Fails on `main` (`expected Promise{…} to be null`).
- **ignores reconnect() while a spawn is in flight** — the double-tap guard still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)