### PR TITLE
feat(surface-nix-host): resolve agent .drv lazily inside the spawn cycle

### DIFF
--- a/packages/surface-nix-host/README.md
+++ b/packages/surface-nix-host/README.md
@@ -36,7 +36,7 @@ const sys = client.system.get({});           // typed oRPC — same shape your b
 ## What it's NOT
 
 - **Not a transport.** That's [`@kolu/surface/links/stdio`](../surface/src/links/stdio.ts). This package sits *on top of* the stdio link and adds: process supervision (spawn/respawn ssh), `.drv` provisioning (the Nix bit), and a reactive state cell for the connection's own lifecycle.
-- **Not a Nix utility.** `provisionAgent` is purposely minimal — `nix copy --derivation`, then `ssh $host nix-store --realise`, then return the resulting path. If you want richer flake handling (e.g. resolve a flake ref to a `.drv` at startup), compute the `.drv` outside and pass `{ drvPath }`.
+- **Not a Nix utility.** `provisionAgent` is purposely minimal — `nix copy --derivation`, then `ssh $host nix-store --realise`, then return the resulting path. If you want richer flake handling (e.g. resolve a flake ref to a `.drv`), do it inside the `resolveDrvPath` callback you pass.
 - **Not opinionated about UI.** The package returns a typed RPC client. Mirroring its streams into your parent server's local surface (so the browser can consume them) is the consumer's job. See the [`remote-process-monitor` example](../surface/example/remote-process-monitor/src/server/router.ts) for the canonical bridge pattern.
 
 ## Why Nix (locked-in)

--- a/packages/surface-nix-host/README.md
+++ b/packages/surface-nix-host/README.md
@@ -18,8 +18,8 @@ import { contract } from "./your-surface";  // your typed @kolu/surface contract
 
 const session: HostSession<typeof contract> = getHostSession<typeof contract>({
   host: "alice@bob.example",                 // any ssh target; "localhost" short-circuits
-  drvPath: process.env.MY_AGENT_DRV!,        // operator-supplied; the derivation of
-                                              // the agent binary for the *target* arch
+  resolveDrvPath: () =>                       // resolve the agent's .drv for the *target*
+    Promise.resolve(process.env.MY_AGENT_DRV!),//   arch; called inside each spawn (see below)
   binary: "my-agent",                        // exe name inside the realised closure
 });
 

--- a/packages/surface-nix-host/README.md
+++ b/packages/surface-nix-host/README.md
@@ -116,9 +116,14 @@ async function resolveDrv(host: string): Promise<string> {
   return drv;
 }
 
+// Pass the probe as `resolveDrvPath` — do NOT `await resolveDrv(host)` at
+// the call site. Eager resolution runs the ssh probe *before* the session
+// exists, so an unreachable host throws here instead of degrading to
+// `failed`. Deferred, the same failure flows through the session's own
+// `disconnected → backoff → failed → reconnect()` machinery.
 const session = getHostSession({
   host,
-  drvPath: await resolveDrv(host),
+  resolveDrvPath: () => resolveDrv(host),
   binary: "my-agent",
 });
 ```

--- a/packages/surface-nix-host/README.md
+++ b/packages/surface-nix-host/README.md
@@ -61,8 +61,8 @@ Remote-side requirement: the parent's user must be in `trusted-users` in the rem
 
 | Export | Role |
 |---|---|
-| `HostSession<C>` | One ssh subprocess per `(host, drvPath, binary)`. Ref-counted. State machine. Survives drops via `scheduleReconnect`. Snapshot-then-delta `onState`. Generic over the contract type `C`. |
-| `getHostSession<C>(opts)` | Pool lookup — repeated calls with the same `(host, drvPath, binary)` return the same session. |
+| `HostSession<C>` | One ssh subprocess per `(host, binary)`. Ref-counted. State machine. Survives drops via `scheduleReconnect`. Snapshot-then-delta `onState`. Generic over the contract type `C`. |
+| `getHostSession<C>(opts)` | Pool lookup — repeated calls with the same `(host, binary)` return the same session (first call's `opts` win). |
 | `destroyAllSessions()` | Tear down every pooled session. Call on parent shutdown. |
 | `provisionAgent({ host, drvPath, onProgress })` | Ship the `.drv` to the host (skipped for localhost), `nix-store --realise` it there, return the realised output path. Progress lines forwarded to `onProgress`. |
 | `mirrorRemoteCollection<K,V>(opts)` | Helper: bridge a remote `Collection<K,V>` to a local one — keys stream + per-key value streams, with abort cleanup on key departure. |

--- a/packages/surface-nix-host/src/arch.ts
+++ b/packages/surface-nix-host/src/arch.ts
@@ -23,12 +23,20 @@
  * package. The probe adds no dependency the realise step didn't.
  *
  * Typical use, paired with a per-system `.drv` map the caller builds at
- * its own build time:
+ * its own build time. Pass the probe as `resolveDrvPath` so it runs
+ * inside the session's spawn cycle — an unreachable host then degrades to
+ * `failed` and retries, instead of throwing before the session exists:
  *
- *   const sys = await resolveSystem(host);
- *   const drv = myDrvBySystem[sys];
- *   if (!drv) throw new Error(`${host}: no .drv for ${sys}`);
- *   const session = getHostSession({ host, drvPath: drv, binary });
+ *   const session = getHostSession({
+ *     host,
+ *     binary,
+ *     resolveDrvPath: async () => {
+ *       const sys = await resolveSystem(host);
+ *       const drv = myDrvBySystem[sys];
+ *       if (!drv) throw new Error(`${host}: no .drv for ${sys}`);
+ *       return drv;
+ *     },
+ *   });
  */
 
 import { buildSshProbeCommand } from "./host";

--- a/packages/surface-nix-host/src/hostSession.test.ts
+++ b/packages/surface-nix-host/src/hostSession.test.ts
@@ -1,18 +1,25 @@
 /**
- * Regression coverage for the "Reconnect does nothing" bug.
+ * Regression coverage for two failure paths through `spawn()`, both of
+ * which short-circuit before any ssh child is created:
  *
- * When the link gives up because the `nix copy --derivation`
- * provisioning step failed (vs. the agent process exiting), `spawn()`
- * throws BEFORE any ssh child is created — so `handleChildDone`, the
- * usual site that nulls `clientPromise`, never runs. If the terminal
- * `failed` transition doesn't clear the slot itself, it keeps the last
- * *rejected* spawn promise, and `reconnect()`'s `clientPromise !== null`
- * guard makes the "Reconnect" button a silent no-op. See
- * `clearClientPromise` / `scheduleReconnect`.
+ *   1. "Reconnect does nothing" — when the link gives up because
+ *      `nix copy --derivation` provisioning failed, `spawn()` throws
+ *      before any child exists, so `handleChildDone` (the usual site that
+ *      nulls `clientPromise`) never runs. If the terminal `failed`
+ *      transition doesn't clear the slot itself, it keeps the last
+ *      *rejected* spawn promise, and `reconnect()`'s `clientPromise !==
+ *      null` guard makes the "Reconnect" button a silent no-op. See
+ *      `clearClientPromise` / `scheduleReconnect`.
  *
- * `provisionAgent` is the only collaborator mocked: forcing it to fail
- * keeps the whole test off real ssh / `nix copy`, and short-circuits
- * `spawn()` before it ever reaches `child_process.spawn`.
+ *   2. "Unreachable at boot" — the `.drv` resolver (typically an ssh arch
+ *      probe, deferred into `resolveDrvPath`) rejects because the host is
+ *      unreachable. The session must degrade to `failed` through its own
+ *      reconnect machinery, not throw out of construction — that's what
+ *      keeps one unreachable initial host from crashing the parent server
+ *      before any session exists.
+ *
+ * Both keep off real ssh / `nix copy`: case 1 mocks `provisionAgent` to
+ * fail; case 2's resolver rejects before `provisionAgent` is ever reached.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostSession } from "./hostSession";
@@ -30,7 +37,24 @@ const PROVISION_FAILURE = {
 function failingSession() {
   return new HostSession({
     host: "testhost",
-    drvPath: "/nix/store/deadbeef-agent.drv",
+    resolveDrvPath: () => Promise.resolve("/nix/store/deadbeef-agent.drv"),
+    binary: "agent",
+    reconnectDelayMs: 1000,
+  });
+}
+
+/** A session whose `.drv` resolver always rejects — models a host that's
+ *  unreachable at arch-probe time (`resolveSystem` ssh exits non-zero).
+ *  `provisionAgent` is never reached, so it stays unmocked here. */
+function unresolvableSession() {
+  return new HostSession({
+    host: "testhost",
+    resolveDrvPath: () =>
+      Promise.reject(
+        new Error(
+          "testhost: `nix-instantiate --eval builtins.currentSystem` exited 255",
+        ),
+      ),
     binary: "agent",
     reconnectDelayMs: 1000,
   });
@@ -85,5 +109,44 @@ describe("HostSession reconnect after give-up", () => {
 
     session.destroy();
     await vi.advanceTimersByTimeAsync(20_000);
+  });
+});
+
+describe("HostSession with a failing drv resolver", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("degrades to failed instead of throwing out of construction", async () => {
+    const session = unresolvableSession();
+
+    // The session exists and is observable even though the very first
+    // round-trip (the arch probe, deferred into `resolveDrvPath`) can't
+    // reach the host. This is the regression fix: the probe failure flows
+    // through the session's own reconnect machinery rather than rejecting
+    // before any session is created (which previously crashed the parent
+    // server at boot when one initial host was unreachable).
+    session.pin().catch(() => {});
+
+    // A rejecting resolver is handled exactly like a `provisionAgent`
+    // failure: copying → disconnected → backoff (1s+2s+4s+8s) → failed.
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(session.current().connection).toBe("failed");
+    expect(session.current().lastError).toMatch(/exited 255/);
+    expect(session.currentClient()).toBeNull();
+
+    // And the terminal state is re-armable — `reconnect()` re-runs the
+    // resolver on the next spawn, the same path a transiently-unreachable
+    // host recovers through once ssh comes back.
+    session.reconnect();
+    expect(session.current().connection).toBe("copying");
+    expect(session.currentClient()).not.toBeNull();
+
+    session.destroy();
   });
 });

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -459,7 +459,9 @@ export class HostSession<C extends AnyContractRouter> {
    *  clears `clientPromise` (via `clearClientPromise`) and leaves
    *  `pendingTimer` null, so a genuinely-failed session always passes the
    *  guard — including the `nix copy`-driven failure that never spawned a
-   *  child. */
+   *  child. Like every spawn, this re-runs `resolveDrvPath` from scratch
+   *  (it is not cached) — a manual re-arm re-pays whatever the resolver
+   *  costs, e.g. an ssh arch probe. */
   reconnect(): void {
     if (this.destroyed || this.refCount === 0) return;
     if (this.clientPromise !== null || this.pendingTimer !== null) return;

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -67,10 +67,20 @@ export interface HostSessionState {
 
 export interface HostSessionOptions {
   host: string;
-  /** Path to the agent's `.drv`. The session ships this derivation to
-   *  the target host (no-op for localhost) and realises it there to
-   *  get a target-arch-correct output path. */
-  drvPath: string;
+  /** Resolve the agent's `.drv` for this host. Called at the top of
+   *  *every* spawn attempt (not once up front), so the round-trip that
+   *  picks the derivation — typically an ssh `nix-instantiate` arch
+   *  probe via `resolveSystem` — lives inside the session's own
+   *  reconnect machinery. An unreachable host makes the resolver reject,
+   *  which the session treats exactly like a `provisionAgent` failure:
+   *  `disconnected` → backoff → `failed`, re-armable via `reconnect()`.
+   *  The session ships the resolved derivation to the target host (no-op
+   *  for localhost) and realises it there to get a target-arch-correct
+   *  output path.
+   *
+   *  Pass a constant as `() => Promise.resolve(drv)` when the caller
+   *  already knows the path and has no probe to defer. */
+  resolveDrvPath: () => Promise<string>;
   /** Executable name inside the realised closure (e.g.
    *  `process-monitor-agent`, `kolu-terminal-agent`). The full spawn
    *  path is `${agentPath}/bin/${binary}`. */
@@ -326,9 +336,26 @@ export class HostSession<C extends AnyContractRouter> {
 
   private async spawn(): Promise<AgentClient<C>> {
     this.updateState({ connection: "copying", lastError: null });
+    // Resolve the derivation first. This is where the arch probe (or any
+    // other per-host drv lookup the caller deferred) actually runs, so a
+    // host that's unreachable at probe time fails here — and is handled
+    // identically to the `provisionAgent` failure below: surface the
+    // error on the connection cell, schedule a backoff retry, and throw.
+    // Folding the probe into the spawn cycle is what lets a boot-time
+    // unreachable host degrade to `failed` instead of crashing the caller
+    // before any session exists.
+    let drvPath: string;
+    try {
+      drvPath = await this.opts.resolveDrvPath();
+    } catch (err) {
+      const reason = (err as Error).message;
+      this.updateState({ connection: "disconnected", lastError: reason });
+      this.scheduleReconnect();
+      throw err;
+    }
     const provision = await provisionAgent({
       host: this.opts.host,
-      drvPath: this.opts.drvPath,
+      drvPath,
       onProgress: (line) => this.addLocalProgress(line),
     });
     if (!provision.ok) {
@@ -500,12 +527,17 @@ export class HostSession<C extends AnyContractRouter> {
   }
 }
 
-// ── HostSession pool (one per (host, drvPath, binary)) ─────────────────
+// ── HostSession pool (one per (host, binary)) ──────────────────────────
 
 const pool = new Map<string, HostSession<AnyContractRouter>>();
 
-/** Get-or-create a `HostSession` for `(host, drvPath, binary)`.
- *  Multiple callers asking for the same triple share the same session.
+/** Get-or-create a `HostSession` for `(host, binary)`.
+ *  Multiple callers asking for the same pair share the same session.
+ *
+ *  The `.drv` is deliberately NOT part of the key: it's now resolved per
+ *  spawn attempt via `resolveDrvPath` (so a host whose nix-system changes
+ *  is picked up on the next reconnect), and a single host should map to a
+ *  single session regardless of which derivation a given resolve yields.
  *
  *  Generic over `C extends AnyContractRouter` — the contract type the
  *  agent on the other side serves. Pass it explicitly so the returned
@@ -519,7 +551,7 @@ const pool = new Map<string, HostSession<AnyContractRouter>>();
 export function getHostSession<C extends AnyContractRouter>(
   opts: HostSessionOptions,
 ): HostSession<C> {
-  const key = `${opts.host}::${opts.drvPath}::${opts.binary}`;
+  const key = `${opts.host}::${opts.binary}`;
   let session = pool.get(key);
   if (session === undefined) {
     session = new HostSession<C>(opts) as HostSession<AnyContractRouter>;

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -1,5 +1,5 @@
 /**
- * `HostSession<C>` — ref-counted ssh subprocess per `(host, drvPath)`,
+ * `HostSession<C>` — ref-counted ssh subprocess per `(host, binary)`,
  * generic over a `@kolu/surface` contract type `C`.
  *
  * Multiple subscriptions against the same host share ONE ssh

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -344,10 +344,7 @@ export class HostSession<C extends AnyContractRouter> {
     // Folding the probe into the spawn cycle is what lets a boot-time
     // unreachable host degrade to `failed` instead of crashing the caller
     // before any session exists.
-    let drvPath: string;
-    try {
-      drvPath = await this.opts.resolveDrvPath();
-    } catch (err) {
+    const drvPath = await this.opts.resolveDrvPath().catch((err: unknown) => {
       // Mirror the `provisionAgent` failure path's message fidelity: that
       // branch surfaces `provision.reason` (always a real string), so a
       // non-Error rejection here mustn't degrade `lastError` to the string
@@ -356,7 +353,7 @@ export class HostSession<C extends AnyContractRouter> {
       this.updateState({ connection: "disconnected", lastError: reason });
       this.scheduleReconnect();
       throw err;
-    }
+    });
     const provision = await provisionAgent({
       host: this.opts.host,
       drvPath,

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -348,7 +348,11 @@ export class HostSession<C extends AnyContractRouter> {
     try {
       drvPath = await this.opts.resolveDrvPath();
     } catch (err) {
-      const reason = (err as Error).message;
+      // Mirror the `provisionAgent` failure path's message fidelity: that
+      // branch surfaces `provision.reason` (always a real string), so a
+      // non-Error rejection here mustn't degrade `lastError` to the string
+      // "undefined" on the connection cell the UI reads.
+      const reason = err instanceof Error ? err.message : String(err);
       this.updateState({ connection: "disconnected", lastError: reason });
       this.scheduleReconnect();
       throw err;

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -11,6 +11,7 @@
  * Connection state lifecycle (snapshot-then-delta on `onState`):
  *
  *     copying      ──provisionAgent ok──▶ connecting
+ *     copying      ──resolve/provision fail─▶ disconnected (backoff, then retry)
  *     connecting   ──first RPC ────────▶ connected
  *     connecting   ──watchdog timeout ─▶ disconnected (kill child, then retry)
  *     connected    ──read end  ────────▶ disconnected ──reconnect──▶ copying

--- a/packages/surface-nix-host/src/hostSession.ts
+++ b/packages/surface-nix-host/src/hostSession.ts
@@ -540,6 +540,13 @@ const pool = new Map<string, HostSession<AnyContractRouter>>();
  *  is picked up on the next reconnect), and a single host should map to a
  *  single session regardless of which derivation a given resolve yields.
  *
+ *  First call wins: once a `(host, binary)` session exists, later calls
+ *  return it and ignore their `opts` entirely — including a different
+ *  `resolveDrvPath`. A second caller wanting a different resolver for the
+ *  same host/binary is a key collision, not a new session; resolve the
+ *  conflict at the call site (one resolver per host/binary) rather than
+ *  expecting the pool to honour the second one.
+ *
  *  Generic over `C extends AnyContractRouter` — the contract type the
  *  agent on the other side serves. Pass it explicitly so the returned
  *  session's `acquire()`/`pin()`/`currentClient()` return a typed

--- a/packages/surface/example/remote-process-monitor/src/server/main.ts
+++ b/packages/surface/example/remote-process-monitor/src/server/main.ts
@@ -59,7 +59,11 @@ async function main(): Promise<void> {
 
   const session = getHostSession<typeof surface.contract>({
     host: HOST,
-    drvPath: DRV_PATH,
+    // This example takes the .drv straight from the environment (no arch
+    // probe), so the resolver is a constant. Consumers that pick the .drv
+    // per host's nix-system pass an async probe here instead — see
+    // `resolveSystem` in @kolu/surface-nix-host.
+    resolveDrvPath: () => Promise.resolve(DRV_PATH),
     binary: "process-monitor-agent",
   });
   const { router } = buildRouter({ session });


### PR DESCRIPTION
## Why

`HostSession` took a fixed `drvPath: string` up front, forcing the caller to run the arch probe (`resolveSystem` — an ssh `nix-instantiate --eval builtins.currentSystem`) **before** the session existed. When that probe failed for an unreachable host, it threw before any session was created, so the session's `disconnected → backoff → failed → reconnect()` machinery had nothing to catch.

A consumer that seeds several hosts at boot ([drishti](https://github.com/srid/drishti/issues/32)) crash-looped at startup whenever a single initial host was unreachable — and never bound its HTTP port, so the very Reconnect surface meant to re-arm the host was unreachable too.

## What

- `HostSessionOptions.drvPath: string` → `resolveDrvPath: () => Promise<string>`, awaited at the top of every `spawn()`. A rejecting resolver routes through the **existing** provision-failure path (surface the error on the connection cell, schedule a backoff retry, throw) — so an unreachable host degrades to `failed` and is re-armable, identical to a host that drops later.
- Pool key `(host, drvPath, binary)` → `(host, binary)`. The derivation is resolved per spawn now, so a host whose nix-system changes is picked up on the next reconnect, and one host maps to one session regardless of which drv a resolve yields. _First call wins: a repeat caller's `resolveDrvPath` is ignored — now documented on `getHostSession`._
- Callers that already know the path pass a constant resolver: `resolveDrvPath: () => Promise.resolve(drv)` (see the updated `remote-process-monitor` example).

## Test

New case in `hostSession.test.ts`: a session whose resolver always rejects degrades `copying → disconnected → … → failed` (not a throw out of construction) and `reconnect()` re-arms it. Existing reconnect-after-give-up coverage is unchanged (helper updated to the resolver shape). `pnpm -r typecheck` and `surface-nix-host` unit tests pass locally (3/3).

### Structural-review refinements

A post-implement hickey + lowy pass (with cross-validation) landed ten follow-up commits — two behavioral, the rest legibility/docs:

| Lens | Refinement |
| --- | --- |
| Hickey | `lastError` stays faithful for a non-`Error` resolver rejection (was casting every throw to `Error`, degrading the connection cell to the string `"undefined"`) |
| Hickey | `let` + try/catch in `spawn()` → a `const` `.catch` chain |
| Hickey | `getHostSession` documents the first-caller-wins pool contract |
| Lowy | `hostSession.ts` header: stale `(host, drvPath)`, missing `copying → disconnected` failure arc, `reconnect()` re-runs the resolver |
| Lowy | `packages/surface-nix-host/README.md` synced off the removed `drvPath` API — quick-start, "Not a Nix utility" note, exports table, and the "Computing drvPath" section (which taught the very eager-resolve anti-pattern this PR removes) |

> _Cross-validation rejected an optional dev-mode resolver-identity warning — both lenses flagged it as braiding a diagnostic concern into the pool and forcing a private-`opts` visibility change — so the pool hazard is fixed by documenting the contract, not by runtime machinery._

### Try it locally

```sh
nix run github:juspay/kolu/fix/host-session-lazy-drv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._