### PR TITLE
Drop --host when pu provisioning fails in the CI step

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -18,14 +18,17 @@ Invoke the `/test` skill. It selects relevant `.feature` files from the git diff
 
 Use the `/ci` skill for the runner mechanics (subcommands, flags, modes, retry shape). Two Kolu-specific operational notes layered on top of it:
 
-**Ephemeral linux build host per run.** Static darwin (`sincereintent`) lives in `~/.config/ci/hosts.json`; the linux lane uses a throwaway Incus container per CI invocation so prior runs' nix-store cruft can't poison the verdict. (Box lifecycle — create/connect/destroy, the no-egress retry — is the [`pu`](../.apm/skills/pu/SKILL.md) skill.)
+**Ephemeral linux build host per run.** Static darwin (`sincereintent`) lives in `~/.config/ci/hosts.json`; the linux lane uses a throwaway Incus container per CI invocation so prior runs' nix-store cruft can't poison the verdict. (Box lifecycle — create/connect/destroy, the no-egress retry — is the [`pu`](../.apm/skills/pu/SKILL.md) skill.) If `pu create` fails (e.g. no-egress), drop the `--host` flag and let justci fall back to `hosts.json` resolution for the linux lane rather than blocking the run.
 
 ```sh
 pr=$(gh pr view --json number --jq .number)
 host="kolu-pr-$pr"
-pu create "$host"                                                       # name is positional; writes ~/.pu-state/$host/ssh_config (included by ~/.ssh/config)
-CI=true nix run github:juspay/ci -- run --host x86_64-linux="$host"     # --host wins over hosts.json on collision; darwin keeps using sincereintent
-pu destroy "$host"
+if pu create "$host"; then                                             # name is positional; writes ~/.pu-state/$host/ssh_config (included by ~/.ssh/config)
+  CI=true nix run github:juspay/ci -- run --host x86_64-linux="$host"   # --host wins over hosts.json on collision; darwin keeps using sincereintent
+  pu destroy "$host"
+else                                                                    # pu provisioning failed (e.g. no-egress) — drop --host and let hosts.json resolve the linux lane
+  CI=true nix run github:juspay/ci -- run
+fi
 ```
 
 **Flake → comment on [#320](https://github.com/juspay/kolu/issues/320)** with scenario/platform/error excerpt/PR.


### PR DESCRIPTION
**The `/do` CI step no longer wedges when the ephemeral linux box can't come up.** The linux lane provisions a throwaway `pu` container and pins justci to it with `--host`; if `pu create` fails (the no-egress failure mode), the run previously had no path forward.

Now `pu create` is guarded by an `if/else`: on success the run pins `--host` and tears the box down as before; on failure it drops `--host` entirely and lets justci fall back to `hosts.json` resolution for the linux lane.

```sh
if pu create "$host"; then
  CI=true nix run github:juspay/ci -- run --host x86_64-linux="$host"
  pu destroy "$host"
else                 # no-egress etc. — fall back to hosts.json
  CI=true nix run github:juspay/ci -- run
fi
```

Docs-only change to `.agency/do.md`; the surrounding prose gains a one-line note describing the fallback.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._