### PR TITLE
Fix reconnect bridge busy-spin (thenable client identity)

### DIFF
--- a/packages/surface-nix-host/package.json
+++ b/packages/surface-nix-host/package.json
@@ -20,8 +20,10 @@
     "@orpc/contract": "^1.13.13"
   },
   "devDependencies": {
+    "@orpc/server": "^1.13.13",
     "@types/node": "^22.0.0",
     "typescript": "^5.8.0",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "zod": "^4.3.6"
   }
 }

--- a/packages/surface-nix-host/src/index.ts
+++ b/packages/surface-nix-host/src/index.ts
@@ -34,4 +34,4 @@ export {
   runCapture,
   runProgress,
 } from "./process";
-export { waitForNextClient } from "./waitForNextClient";
+export { type NextClient, waitForNextClient } from "./waitForNextClient";

--- a/packages/surface-nix-host/src/index.ts
+++ b/packages/surface-nix-host/src/index.ts
@@ -34,4 +34,4 @@ export {
   runCapture,
   runProgress,
 } from "./process";
-export { type NextClient, waitForNextClient } from "./waitForNextClient";
+export { type ClientCursor, makeClientCursor } from "./waitForNextClient";

--- a/packages/surface-nix-host/src/reconnect-spin.test.ts
+++ b/packages/surface-nix-host/src/reconnect-spin.test.ts
@@ -23,7 +23,7 @@ import { z } from "zod";
 import type { AgentClient } from "./hostSession";
 import { HostSession } from "./hostSession";
 import { provisionAgent } from "./nixCopy";
-import { waitForNextClient } from "./waitForNextClient";
+import { makeClientCursor } from "./waitForNextClient";
 
 vi.mock("./nixCopy", () => ({ provisionAgent: vi.fn() }));
 vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
@@ -96,21 +96,24 @@ describe("reconnect bridge loop", () => {
     });
     session.pin().catch(() => {});
 
+    // The cursor threads the spawn-identity token internally, so this loop is
+    // the exact shape a real consumer writes. If the fix regressed (comparing
+    // the thenable client instead of the clientPromise), `next()` would
+    // resolve every iteration and the count would explode into the thousands.
+    const cursor = makeClientCursor(session);
     let iterations = 0;
-    let prev: Promise<AgentClient<typeof contract>> | null = null;
     const deadline = Date.now() + 500;
     while (!session.isDestroyed() && Date.now() < deadline) {
-      let next: { client: unknown; clientPromise: Promise<unknown> };
+      let client: AgentClient<typeof contract>;
       try {
-        next = await waitForNextClient(session, prev);
+        client = await cursor.next();
       } catch {
         break;
       }
-      prev = next.clientPromise as Promise<AgentClient<typeof contract>>;
       iterations += 1;
       try {
         // biome-ignore lint/suspicious/noExplicitAny: proxy call in a repro
-        for await (const _ of await (next.client as any).tick({})) {
+        for await (const _ of await (client as any).tick({})) {
           session.markConnected();
         }
       } catch {

--- a/packages/surface-nix-host/src/reconnect-spin.test.ts
+++ b/packages/surface-nix-host/src/reconnect-spin.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression: the reconnect bridge loop must not busy-spin after a
+ * connected link drops.
+ *
+ * The client is an oRPC proxy that intercepts `.then` as a procedure path,
+ * so it is *thenable*: `await session.currentClient()` re-invokes it and
+ * yields a fresh object every call. A `waitForNextClient` that compared the
+ * awaited *client* by identity therefore resolved on every consumer
+ * iteration; once the stdio link fails fast (#1060) instead of hanging, the
+ * consumer loop spun at CPU speed — pegging the event loop so the child
+ * `exit` handler and reconnect-backoff timer never ran. `waitForNextClient`
+ * now keys on the `clientPromise` identity (stable per spawn), so the loop
+ * blocks until a real reconnect.
+ */
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { eventIterator, oc } from "@orpc/contract";
+import { implement } from "@orpc/server";
+import { serveOverStdio } from "@kolu/surface/peer-server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { AgentClient } from "./hostSession";
+import { HostSession } from "./hostSession";
+import { provisionAgent } from "./nixCopy";
+import { waitForNextClient } from "./waitForNextClient";
+
+vi.mock("./nixCopy", () => ({ provisionAgent: vi.fn() }));
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+
+const contract = {
+  tick: oc
+    .input(z.object({}))
+    .output(eventIterator(z.object({ n: z.number() }))),
+};
+
+// Cross-piped PassThroughs — an in-process stdio pair (inlined to avoid a
+// cross-package subpath-export snag in the runner).
+function createLoopbackPair() {
+  const c2s = new PassThrough();
+  const s2c = new PassThrough();
+  return {
+    client: { read: s2c, write: c2s },
+    server: { read: c2s, write: s2c },
+  };
+}
+
+// A child that serves a real agent (so the pump gets a first yield and the
+// consumer calls `markConnected`), then drops its link by ending the
+// agent's stdout — WITHOUT emitting a child `exit` (mirrors an ssh pipe
+// whose stdout closes while the bridge is mid-loop, the case that pegged
+// the event loop so the real `exit` could never be delivered).
+function flakyChild(liveMs: number) {
+  const pair = createLoopbackPair();
+  const t = implement(contract);
+  const router = t.router({
+    tick: t.tick.handler(async function* () {
+      yield { n: 0 };
+      await new Promise((r) => setTimeout(r, 60_000));
+    }),
+  });
+  void serveOverStdio({ router, transport: pair.server });
+
+  const child = new EventEmitter() as unknown as Record<string, unknown>;
+  child.stdin = pair.client.write;
+  child.stdout = pair.client.read;
+  child.stderr = new PassThrough();
+  child.pid = 4321;
+  child.kill = () => true;
+  setTimeout(() => {
+    pair.server.write.end(); // agent stdout EOF → link closed (fast-fail)
+    // The ssh child also exits — which fires the session's reconnect path.
+    // Pre-fix the busy-spin pegged the event loop so this `exit` could
+    // never be delivered; post-fix the loop blocks, so it is.
+    (child as unknown as EventEmitter).emit("exit", 1, null);
+  }, liveMs);
+  return child;
+}
+
+describe("reconnect bridge loop", () => {
+  beforeEach(() => {
+    vi.mocked(provisionAgent).mockResolvedValue({
+      ok: true,
+      agentPath: "/nix/store/deadbeef-agent",
+    } as never);
+    vi.mocked(spawn).mockImplementation(() => flakyChild(40) as never);
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("does not busy-spin after a connected link drops", async () => {
+    const session = new HostSession<typeof contract>({
+      host: "testhost",
+      resolveDrvPath: () => Promise.resolve("/nix/store/deadbeef-agent.drv"),
+      binary: "agent",
+      reconnectDelayMs: 50,
+    });
+    session.pin().catch(() => {});
+
+    let iterations = 0;
+    let prev: Promise<AgentClient<typeof contract>> | null = null;
+    const deadline = Date.now() + 500;
+    while (!session.isDestroyed() && Date.now() < deadline) {
+      let next: { client: unknown; clientPromise: Promise<unknown> };
+      try {
+        next = await waitForNextClient(session, prev);
+      } catch {
+        break;
+      }
+      prev = next.clientPromise as Promise<AgentClient<typeof contract>>;
+      iterations += 1;
+      try {
+        // biome-ignore lint/suspicious/noExplicitAny: proxy call in a repro
+        for await (const _ of await (next.client as any).tick({})) {
+          session.markConnected();
+        }
+      } catch {
+        /* link drop surfaces as rejection */
+      }
+    }
+
+    // A sane reconnect cadence is a handful of attempts in 500ms; the
+    // pre-fix busy-spin did tens of thousands.
+    expect(iterations).toBeLessThan(50);
+  });
+});

--- a/packages/surface-nix-host/src/reconnect-spin.test.ts
+++ b/packages/surface-nix-host/src/reconnect-spin.test.ts
@@ -68,6 +68,8 @@ function flakyChild(liveMs: number) {
 }
 
 describe("reconnect bridge loop", () => {
+  let session: HostSession<typeof contract>;
+
   beforeEach(() => {
     vi.mocked(provisionAgent).mockResolvedValue({
       ok: true,
@@ -75,10 +77,13 @@ describe("reconnect bridge loop", () => {
     } as never);
     vi.mocked(spawn).mockImplementation(() => flakyChild(40) as never);
   });
-  afterEach(() => vi.clearAllMocks());
+  afterEach(() => {
+    session.destroy();
+    vi.clearAllMocks();
+  });
 
   it("does not busy-spin after a connected link drops", async () => {
-    const session = new HostSession<typeof contract>({
+    session = new HostSession<typeof contract>({
       host: "testhost",
       resolveDrvPath: () => Promise.resolve("/nix/store/deadbeef-agent.drv"),
       binary: "agent",

--- a/packages/surface-nix-host/src/reconnect-spin.test.ts
+++ b/packages/surface-nix-host/src/reconnect-spin.test.ts
@@ -17,6 +17,7 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { eventIterator, oc } from "@orpc/contract";
 import { implement } from "@orpc/server";
+import { createLoopbackPair } from "@kolu/surface/loopback";
 import { serveOverStdio } from "@kolu/surface/peer-server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
@@ -33,17 +34,6 @@ const contract = {
     .input(z.object({}))
     .output(eventIterator(z.object({ n: z.number() }))),
 };
-
-// Cross-piped PassThroughs — an in-process stdio pair (inlined to avoid a
-// cross-package subpath-export snag in the runner).
-function createLoopbackPair() {
-  const c2s = new PassThrough();
-  const s2c = new PassThrough();
-  return {
-    client: { read: s2c, write: c2s },
-    server: { read: c2s, write: s2c },
-  };
-}
 
 // A child that serves a real agent (so the pump gets a first yield and the
 // consumer calls `markConnected`), then drops its link by ending the

--- a/packages/surface-nix-host/src/waitForNextClient.ts
+++ b/packages/surface-nix-host/src/waitForNextClient.ts
@@ -1,50 +1,66 @@
 import type { AnyContractRouter } from "@orpc/contract";
 import type { AgentClient, HostSession } from "./hostSession";
 
-/** Block until the session exposes a NEW `clientPromise` instance
- *  (one whose resolved client differs from `previous`). Resolves with
- *  the awaited client. Rejects if the session is destroyed before a
- *  fresh client appears.
+/** The result of `waitForNextClient`: the freshly-live `client` to pump,
+ *  plus the `clientPromise` it came from. Callers thread `clientPromise`
+ *  back in as `previous` so the next wait blocks until a genuinely new
+ *  spawn appears. */
+export interface NextClient<C extends AnyContractRouter> {
+  client: AgentClient<C>;
+  clientPromise: Promise<AgentClient<C>>;
+}
+
+/** Block until the session exposes a NEW spawn — a `clientPromise`
+ *  *instance* distinct from `previous` — then resolve with that spawn's
+ *  client. Rejects if the session is destroyed before a fresh spawn
+ *  appears.
  *
- *  Identity-comparison is the trick that avoids spinning: when a pump
- *  loop's `for await` ends because the link errored, the child's
- *  `exit` handler clears `clientPromise` to null and `scheduleReconnect`
- *  later sets it to a new Promise. Until that new Promise resolves,
- *  `currentClient()` returns either null or the same dead handle the
- *  pumps just abandoned — we wait through both.
+ *  **Compare the promise, never the awaited client.** The client is an
+ *  oRPC proxy that intercepts every property — including `.then` — as a
+ *  procedure path, which makes it *thenable*: `await clientPromise`
+ *  re-invokes the proxy and yields a fresh object on every call, so a
+ *  resolved-client identity check (`client !== previous`) is *always*
+ *  true. A consumer reconnect-loop that re-pumps on each
+ *  `waitForNextClient` would then resolve instantly every iteration and
+ *  busy-spin — pegging the event loop so the child-`exit` handler and the
+ *  reconnect-backoff timer never run, which is self-sustaining. The
+ *  `clientPromise` reference, by contrast, is reassigned exactly once per
+ *  spawn (`pin`/`reconnect`/`scheduleReconnect`) and is null between a
+ *  child's death and the next spawn — so comparing *it* correctly blocks
+ *  until a real reconnect.
  *
  *  Typical usage from a consumer's reconnect-loop:
  *
  *  ```ts
- *  let last: AgentClient<C> | null = null;
+ *  let last: Promise<AgentClient<C>> | null = null;
  *  while (!session.isDestroyed()) {
- *    const client = await waitForNextClient(session, last);
- *    last = client;
+ *    const { client, clientPromise } = await waitForNextClient(session, last);
+ *    last = clientPromise;
  *    await Promise.allSettled([pumpA(client), pumpB(client)]);
  *  }
  *  ``` */
 export function waitForNextClient<C extends AnyContractRouter>(
   session: HostSession<C>,
-  previous: AgentClient<C> | null,
-): Promise<AgentClient<C>> {
+  previous: Promise<AgentClient<C>> | null,
+): Promise<NextClient<C>> {
   return new Promise((resolve, reject) => {
     const tryResolve = async (): Promise<boolean> => {
       if (session.isDestroyed()) {
         reject(new Error("session destroyed"));
         return true;
       }
-      const cp = session.currentClient();
-      if (cp === null) return false;
+      const clientPromise = session.currentClient();
+      // null (no spawn in flight) or the same promise the caller already
+      // pumped (link still down / unchanged) → keep waiting. This identity
+      // check on the *promise* is what stops the busy-spin.
+      if (clientPromise === null || clientPromise === previous) return false;
       try {
-        const c = await cp;
-        if (c !== previous) {
-          resolve(c);
-          return true;
-        }
+        const client = await clientPromise;
+        resolve({ client, clientPromise });
+        return true;
       } catch {
         // Spawn rejected — stay in the loop; the next state change
-        // (scheduleReconnect's timer firing) will surface a fresh
-        // clientPromise.
+        // (scheduleReconnect's timer firing) surfaces a fresh promise.
       }
       return false;
     };

--- a/packages/surface-nix-host/src/waitForNextClient.ts
+++ b/packages/surface-nix-host/src/waitForNextClient.ts
@@ -1,11 +1,59 @@
 import type { AnyContractRouter } from "@orpc/contract";
 import type { AgentClient, HostSession } from "./hostSession";
 
-/** The result of `waitForNextClient`: the freshly-live `client` to pump,
- *  plus the `clientPromise` it came from. Callers thread `clientPromise`
- *  back in as `previous` so the next wait blocks until a genuinely new
- *  spawn appears. */
-export interface NextClient<C extends AnyContractRouter> {
+/** A stateful cursor over a session's spawn lifecycle. Each `next()` blocks
+ *  until the session exposes a genuinely NEW spawn, then resolves with that
+ *  spawn's live client. The cursor owns the spawn-identity token internally,
+ *  so consumers never thread it by hand.
+ *
+ *  Rejects (from `next()`) if the session is destroyed before a fresh spawn
+ *  appears.
+ *
+ *  Typical usage from a consumer's reconnect-loop:
+ *
+ *  ```ts
+ *  const cursor = makeClientCursor(session);
+ *  while (!session.isDestroyed()) {
+ *    const client = await cursor.next();
+ *    await Promise.allSettled([pumpA(client), pumpB(client)]);
+ *  }
+ *  ``` */
+export interface ClientCursor<C extends AnyContractRouter> {
+  /** Block until the session exposes a new spawn; resolve with its client. */
+  next(): Promise<AgentClient<C>>;
+}
+
+/** Build a {@link ClientCursor} over `session`.
+ *
+ *  The cursor closes over the spawn-identity token (a `clientPromise`
+ *  reference) and advances it on every `next()`, so the comparison axis stays
+ *  an implementation detail of this module — consumers see only "give me the
+ *  next live client." That encapsulation is load-bearing, not cosmetic:
+ *  hand-threading the token (the shape this replaces) had a silent footgun —
+ *  forget to advance it and `next()` resolves instantly every iteration,
+ *  busy-spinning exactly as the bug below describes. With the token hidden,
+ *  there is nothing to forget. */
+export function makeClientCursor<C extends AnyContractRouter>(
+  session: HostSession<C>,
+): ClientCursor<C> {
+  let previous: Promise<AgentClient<C>> | null = null;
+  return {
+    async next(): Promise<AgentClient<C>> {
+      const { client, clientPromise } = await waitForNextClient(
+        session,
+        previous,
+      );
+      previous = clientPromise;
+      return client;
+    },
+  };
+}
+
+/** The result of `waitForNextClient`: the freshly-live `client` to pump, plus
+ *  the `clientPromise` it came from. `makeClientCursor` threads `clientPromise`
+ *  back in as `previous` so the next wait blocks until a genuinely new spawn
+ *  appears. */
+interface NextClient<C extends AnyContractRouter> {
   client: AgentClient<C>;
   clientPromise: Promise<AgentClient<C>>;
 }
@@ -14,6 +62,9 @@ export interface NextClient<C extends AnyContractRouter> {
  *  *instance* distinct from `previous` — then resolve with that spawn's
  *  client. Rejects if the session is destroyed before a fresh spawn
  *  appears.
+ *
+ *  Internal primitive behind {@link makeClientCursor}; callers go through the
+ *  cursor rather than threading `previous` themselves.
  *
  *  **Compare the promise, never the awaited client.** The client is an
  *  oRPC proxy that intercepts every property — including `.then` — as a
@@ -27,19 +78,8 @@ export interface NextClient<C extends AnyContractRouter> {
  *  `clientPromise` reference, by contrast, is reassigned exactly once per
  *  spawn (`pin`/`reconnect`/`scheduleReconnect`) and is null between a
  *  child's death and the next spawn — so comparing *it* correctly blocks
- *  until a real reconnect.
- *
- *  Typical usage from a consumer's reconnect-loop:
- *
- *  ```ts
- *  let last: Promise<AgentClient<C>> | null = null;
- *  while (!session.isDestroyed()) {
- *    const { client, clientPromise } = await waitForNextClient(session, last);
- *    last = clientPromise;
- *    await Promise.allSettled([pumpA(client), pumpB(client)]);
- *  }
- *  ``` */
-export function waitForNextClient<C extends AnyContractRouter>(
+ *  until a real reconnect. */
+function waitForNextClient<C extends AnyContractRouter>(
   session: HostSession<C>,
   previous: Promise<AgentClient<C>> | null,
 ): Promise<NextClient<C>> {

--- a/packages/surface-nix-host/src/waitForNextClient.ts
+++ b/packages/surface-nix-host/src/waitForNextClient.ts
@@ -38,7 +38,7 @@ export function makeClientCursor<C extends AnyContractRouter>(
 ): ClientCursor<C> {
   let previous: Promise<AgentClient<C>> | null = null;
   return {
-    async next(): Promise<AgentClient<C>> {
+    async next() {
       const { client, clientPromise } = await waitForNextClient(
         session,
         previous,

--- a/packages/surface/example/remote-process-monitor/src/server/router.ts
+++ b/packages/surface/example/remote-process-monitor/src/server/router.ts
@@ -222,16 +222,20 @@ async function bridgeAgentToParent(
     /* logged via state cell; loop handles recovery */
   });
 
-  let lastClient: ProcessMonitorAgent | null = null;
+  // Thread the *clientPromise* (not the awaited client) back in — see
+  // `waitForNextClient`: the client proxy is thenable, so comparing it by
+  // identity busy-spins once the link fails fast.
+  let lastClientPromise: Promise<ProcessMonitorAgent> | null = null;
   while (!session.isDestroyed()) {
     let client: ProcessMonitorAgent;
     try {
-      client = await waitForNextClient(session, lastClient);
+      const next = await waitForNextClient(session, lastClientPromise);
+      client = next.client;
+      lastClientPromise = next.clientPromise;
     } catch (err) {
       log(`bridge: waiting for next client failed: ${(err as Error).message}`);
       break;
     }
-    lastClient = client;
     log("agent client ready; starting pumps");
     await Promise.allSettled([
       pumpSystemCell(client, session, fragment),

--- a/packages/surface/example/remote-process-monitor/src/server/router.ts
+++ b/packages/surface/example/remote-process-monitor/src/server/router.ts
@@ -28,8 +28,8 @@ import {
 import {
   type AgentClient,
   type HostSession,
+  makeClientCursor,
   mirrorRemoteCollection,
-  waitForNextClient,
 } from "@kolu/surface-nix-host";
 import { implement } from "@orpc/server";
 import {
@@ -206,7 +206,7 @@ function log(line: string): void {
  *  happens when the link errors — stdio process death), then wait for
  *  the session to provide a fresh client (post-reconnect) and repeat.
  *
- *  The reconnect-loop primitive itself (`waitForNextClient`) lives in
+ *  The reconnect-loop primitive itself (`makeClientCursor`) lives in
  *  `@kolu/surface-nix-host`; this function is the demo-specific
  *  composition (which pumps to run on each cycle). */
 async function bridgeAgentToParent(
@@ -222,16 +222,16 @@ async function bridgeAgentToParent(
     /* logged via state cell; loop handles recovery */
   });
 
-  // Thread the *clientPromise* (not the awaited client) back in — see
-  // `waitForNextClient`: the client proxy is thenable, so comparing it by
-  // identity busy-spins once the link fails fast.
-  let lastClientPromise: Promise<ProcessMonitorAgent> | null = null;
+  // A cursor over the session's spawn lifecycle — `next()` blocks until a
+  // genuinely new spawn appears. It owns the spawn-identity token internally,
+  // so this loop can't re-introduce the busy-spin by mis-threading it (the
+  // client proxy is thenable, so comparing *it* spins once the link fails
+  // fast; the cursor compares the stable clientPromise for us).
+  const cursor = makeClientCursor(session);
   while (!session.isDestroyed()) {
     let client: ProcessMonitorAgent;
     try {
-      const next = await waitForNextClient(session, lastClientPromise);
-      client = next.client;
-      lastClientPromise = next.clientPromise;
+      client = await cursor.next();
     } catch (err) {
       log(`bridge: waiting for next client failed: ${(err as Error).message}`);
       break;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -672,6 +672,9 @@ importers:
         specifier: ^1.13.13
         version: 1.13.13
     devDependencies:
+      '@orpc/server':
+        specifier: ^1.13.13
+        version: 1.13.13(ws@8.20.1)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
@@ -681,6 +684,9 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@22.19.15)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/surface/example:
     dependencies:


### PR DESCRIPTION
After #1060 made the stdio link fail fast, the reconnect bridge **busy-spun at CPU speed** when a *connected* link dropped — pegging the single-threaded event loop so the child `exit` handler and reconnect-backoff timer never ran, taking the whole parent server unresponsive from one host's drop. (Observed in drishti prod: one killed ssh child → ~2M loop iterations in 2 min, server at 70% CPU, HTTP unresponsive.)

**Root cause (reproduced in `reconnect-spin.test.ts`):** the agent client is an oRPC proxy that forwards every property access — including `.then` — as a procedure path, so it is **thenable**. `await session.currentClient()` therefore re-invokes the proxy and yields a *fresh object* every call, making `waitForNextClient`'s `client !== previous` identity check **always** true → it resolved on every consumer iteration. Pre-#1060 the pump *hung*, so the loop never came back to call it repeatedly (the hang was an accidental brake); #1060's fail-fast removed the brake → spin.

Proof from the repro instrumentation: `samePromise≈100%` (the `clientPromise` is one stable Promise — a single spawn) while `sameAsPrev=0` (the awaited client differs every call).

**Fix:** compare the `clientPromise` reference — reassigned exactly once per spawn, `null` between a child's death and the next spawn — instead of the thenable client. The comparison axis is now owned by a **`makeClientCursor(session)`** cursor: each `cursor.next()` blocks until a genuinely new spawn appears, then resolves with that spawn's live client. The loop blocks until a real reconnect, which frees the event loop so `exit` + `scheduleReconnect` fire and recovery proceeds.

Regression test: pre-fix **36,683** iterations in 500ms; post-fix blocks until a real reconnect.

### Why a cursor, not a return-the-token shape

The first cut had `waitForNextClient` return `{ client, clientPromise }` and asked every consumer to thread `clientPromise` back in as `previous`. That leaked the promise-identity comparison axis into the public contract *and* carried a silent footgun: forget to advance the token and `next()` resolves every iteration — the exact busy-spin this PR fixes. `makeClientCursor` closes over the token internally, so consumers just call `cursor.next()` and there is nothing to mis-thread. `waitForNextClient` / `NextClient` are now module-private.

### Refinements landed during structural + quality review

| What was off | Fix |
| --- | --- |
| `{ client, clientPromise }` leaked the spawn-identity token into every consumer | Encapsulated behind `makeClientCursor`; `waitForNextClient` demoted to private (Lowy) |
| Test inlined a `createLoopbackPair` copy, justified by a non-existent "subpath snag" | Import the canonical `@kolu/surface/loopback` (Hickey) |
| Test leaked `HostSession`'s real 50ms reconnect timers after exit | `session.destroy()` in `afterEach`, matching `hostSession.test.ts` |

_Follow-up to #1060._

### Try it locally

```sh
nix run github:juspay/kolu/fix-reconnect-busy-spin
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._