### PR TITLE
Suppress 'Remove worktree' when the branch has unpushed work or an open PR

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -285,18 +285,22 @@ const App: Component = () => {
     // re-fetch), keeping the dialog a frozen confirmation. Only an `open` PR
     // blocks — closed/merged PRs mean the work has landed. `prValue` is null
     // for pending/absent PRs, so an unconfirmed PR never blocks.
+    const pr = prValue(meta.pr);
     const blocker: WorktreeRemovalBlocker | undefined = !worktreePath
       ? undefined
       : (meta.git?.unpushedCommitCount ?? 0) > 0
         ? "hasUnpushedCommits"
-        : prValue(meta.pr)?.state === "open"
+        : pr?.state === "open"
           ? "hasOpenPullRequest"
           : store.isWorktreeShared(worktreePath, id)
             ? "sharedWithOtherTerminals"
             : undefined;
     const worktreeRemoval = worktreePath
       ? blocker
-        ? ({ eligible: false, reason: blocker } as const)
+        ? // Freeze the PR number here, at decision time, so the dialog's
+          // message reads it off this snapshot rather than the reactive
+          // `meta.pr`. Only `hasOpenPullRequest` carries one.
+          ({ eligible: false, reason: blocker, prNumber: pr?.number } as const)
         : ({ eligible: true } as const)
       : undefined;
     setCloseConfirmTarget({ id, meta, splitCount, worktreeRemoval });

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -9,6 +9,7 @@ import Dialog from "@corvu/dialog";
 import { Meta, Title } from "@solidjs/meta";
 import type { ServerIdentity } from "kolu-common/contract";
 import type { TerminalId } from "kolu-common/surface";
+import { prValue } from "kolu-github/schemas";
 import {
   type Component,
   createEffect,
@@ -20,7 +21,10 @@ import {
 import { Toaster } from "solid-sonner";
 import { match } from "ts-pattern";
 import ChromeBar from "./ChromeBar";
-import CloseConfirm, { type CloseConfirmTarget } from "./CloseConfirm";
+import CloseConfirm, {
+  type CloseConfirmTarget,
+  type WorktreeRemovalBlocker,
+} from "./CloseConfirm";
 import CommandPalette from "./CommandPalette";
 import "kolu-common/test-hooks";
 import CanvasWatermark from "./canvas/CanvasWatermark";
@@ -275,9 +279,24 @@ const App: Component = () => {
     const worktreePath = meta.git?.isWorktree
       ? meta.git.worktreePath
       : undefined;
+    // Priority: unpushed local work > open PR > shared worktree — the first
+    // match wins, so the highest-stakes reason to keep the worktree is what
+    // the user sees. Every read is synchronous off the metadata snapshot (no
+    // re-fetch), keeping the dialog a frozen confirmation. Only an `open` PR
+    // blocks — closed/merged PRs mean the work has landed. `prValue` is null
+    // for pending/absent PRs, so an unconfirmed PR never blocks.
+    const blocker: WorktreeRemovalBlocker | undefined = !worktreePath
+      ? undefined
+      : (meta.git?.unpushedCommitCount ?? 0) > 0
+        ? "hasUnpushedCommits"
+        : prValue(meta.pr)?.state === "open"
+          ? "hasOpenPullRequest"
+          : store.isWorktreeShared(worktreePath, id)
+            ? "sharedWithOtherTerminals"
+            : undefined;
     const worktreeRemoval = worktreePath
-      ? store.isWorktreeShared(worktreePath, id)
-        ? ({ eligible: false, reason: "sharedWithOtherTerminals" } as const)
+      ? blocker
+        ? ({ eligible: false, reason: blocker } as const)
         : ({ eligible: true } as const)
       : undefined;
     setCloseConfirmTarget({ id, meta, splitCount, worktreeRemoval });

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -12,20 +12,40 @@ import { PrStateIcon, WorktreeIcon } from "./ui/Icons";
 import ModalDialog from "./ui/ModalDialog";
 import { surface } from "./ui/Surface";
 
-/** Reasons why the "Remove worktree" action is suppressed.
+/** Reasons why the "Remove worktree" action is suppressed, in priority
+ *  order — the first that applies is the one shown (the ordering lives in
+ *  `closeTerminal` in `App.tsx`):
  *
- *  One blocker today (`"sharedWithOtherTerminals"`); the union shape
- *  is ready for future reasons (unpushed commits, per-user preference,
- *  running agent) without a breaking change to `CloseConfirmTarget`. */
-export type WorktreeRemovalBlocker = "sharedWithOtherTerminals";
+ *  1. `hasUnpushedCommits` — local commits not on any remote (data-loss risk).
+ *  2. `hasOpenPullRequest` — an open PR the user is iterating on.
+ *  3. `sharedWithOtherTerminals` — another terminal lives on the worktree. */
+export type WorktreeRemovalBlocker =
+  | "hasUnpushedCommits"
+  | "hasOpenPullRequest"
+  | "sharedWithOtherTerminals";
 
 /** Whether the close dialog may offer worktree removal. */
 export type WorktreeRemovalEligibility =
   | { eligible: true }
   | { eligible: false; reason: WorktreeRemovalBlocker };
 
-const BLOCKER_MESSAGES: Record<WorktreeRemovalBlocker, string> = {
-  sharedWithOtherTerminals:
+/** Synchronously-available context for a blocker message, built at
+ *  dialog-open time from the same frozen metadata snapshot the dialog
+ *  renders — so the message can embed details (e.g. the PR number) without
+ *  a reactive read that would shift under the user's eyes. */
+type BlockerContext = { prNumber?: number };
+
+const BLOCKER_MESSAGES: Record<
+  WorktreeRemovalBlocker,
+  (ctx: BlockerContext) => string
+> = {
+  hasUnpushedCommits: () =>
+    "This branch has commits that aren't pushed — it will remain on disk so you don't lose work.",
+  hasOpenPullRequest: ({ prNumber }) =>
+    prNumber != null
+      ? `This branch has an open pull request (#${prNumber}) — it will remain on disk.`
+      : "This branch has an open pull request — it will remain on disk.",
+  sharedWithOtherTerminals: () =>
     "Another terminal is using this worktree — it will remain on disk.",
 };
 
@@ -99,7 +119,11 @@ const CloseConfirm: Component<{
                 data-testid="close-confirm-removal-blocker"
                 data-blocker={reason()}
               >
-                {BLOCKER_MESSAGES[reason()]}
+                {BLOCKER_MESSAGES[reason()]({
+                  prNumber: props.target
+                    ? (prValue(props.target.meta.pr)?.number ?? undefined)
+                    : undefined,
+                })}
               </p>
             )}
           </Show>

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -12,13 +12,15 @@ import { PrStateIcon, WorktreeIcon } from "./ui/Icons";
 import ModalDialog from "./ui/ModalDialog";
 import { surface } from "./ui/Surface";
 
-/** Reasons why the "Remove worktree" action is suppressed, in priority
- *  order — the first that applies is the one shown (the ordering lives in
- *  `closeTerminal` in `App.tsx`):
+/** Reasons the "Remove worktree" action is suppressed. Each names a kind of
+ *  unfinished work the worktree still holds:
  *
- *  1. `hasUnpushedCommits` — local commits not on any remote (data-loss risk).
- *  2. `hasOpenPullRequest` — an open PR the user is iterating on.
- *  3. `sharedWithOtherTerminals` — another terminal lives on the worktree. */
+ *  - `hasUnpushedCommits` — local commits not on any remote (data-loss risk).
+ *  - `hasOpenPullRequest` — an open PR the user is iterating on.
+ *  - `sharedWithOtherTerminals` — another terminal lives on the worktree.
+ *
+ *  When more than one applies, the priority among them is decided at the
+ *  single enforcement site — `closeTerminal` in `App.tsx`. */
 export type WorktreeRemovalBlocker =
   | "hasUnpushedCommits"
   | "hasOpenPullRequest"

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -24,15 +24,18 @@ export type WorktreeRemovalBlocker =
   | "hasOpenPullRequest"
   | "sharedWithOtherTerminals";
 
-/** Whether the close dialog may offer worktree removal. */
+/** Whether the close dialog may offer worktree removal.
+ *
+ *  The ineligible arm carries `prNumber` so the `hasOpenPullRequest` message
+ *  can name the PR. It's resolved once, at decision time, in `closeTerminal`
+ *  — the dialog reads it off this frozen value rather than re-reading the
+ *  reactive `meta.pr`, which would shift under the user's eyes. */
 export type WorktreeRemovalEligibility =
   | { eligible: true }
-  | { eligible: false; reason: WorktreeRemovalBlocker };
+  | { eligible: false; reason: WorktreeRemovalBlocker; prNumber?: number };
 
-/** Synchronously-available context for a blocker message, built at
- *  dialog-open time from the same frozen metadata snapshot the dialog
- *  renders — so the message can embed details (e.g. the PR number) without
- *  a reactive read that would shift under the user's eyes. */
+/** Presentation context for a blocker message, built from the frozen
+ *  eligibility value above (never from live metadata). */
 type BlockerContext = { prNumber?: number };
 
 const BLOCKER_MESSAGES: Record<
@@ -73,9 +76,9 @@ const CloseConfirm: Component<{
   const removalEligibility = () => props.target?.worktreeRemoval;
   const canRemoveWorktree = () =>
     isWorktree() && removalEligibility()?.eligible === true;
-  const removalBlocker = (): WorktreeRemovalBlocker | undefined => {
+  const removalBlocker = () => {
     const e = removalEligibility();
-    return e && !e.eligible ? e.reason : undefined;
+    return e && !e.eligible ? e : undefined;
   };
   const splitCount = () => props.target?.splitCount ?? 0;
   const closeLabel = () => (splitCount() > 0 ? "Close all" : "Close terminal");
@@ -114,15 +117,13 @@ const CloseConfirm: Component<{
           </Show>
 
           <Show when={removalBlocker()}>
-            {(reason) => (
+            {(blocker) => (
               <p
                 data-testid="close-confirm-removal-blocker"
-                data-blocker={reason()}
+                data-blocker={blocker().reason}
               >
-                {BLOCKER_MESSAGES[reason()]({
-                  prNumber: props.target
-                    ? (prValue(props.target.meta.pr)?.number ?? undefined)
-                    : undefined,
+                {BLOCKER_MESSAGES[blocker().reason]({
+                  prNumber: blocker().prNumber,
                 })}
               </p>
             )}

--- a/packages/client/src/CloseConfirm.tsx
+++ b/packages/client/src/CloseConfirm.tsx
@@ -36,13 +36,9 @@ export type WorktreeRemovalEligibility =
   | { eligible: true }
   | { eligible: false; reason: WorktreeRemovalBlocker; prNumber?: number };
 
-/** Presentation context for a blocker message, built from the frozen
- *  eligibility value above (never from live metadata). */
-type BlockerContext = { prNumber?: number };
-
 const BLOCKER_MESSAGES: Record<
   WorktreeRemovalBlocker,
-  (ctx: BlockerContext) => string
+  (ctx: { prNumber?: number }) => string
 > = {
   hasUnpushedCommits: () =>
     "This branch has commits that aren't pushed — it will remain on disk so you don't lose work.",

--- a/packages/client/src/canvas/dockModel.test.ts
+++ b/packages/client/src/canvas/dockModel.test.ts
@@ -19,6 +19,7 @@ function makeGit(overrides: Partial<GitInfo> = {}): GitInfo {
     branch: "main",
     isWorktree: false,
     mainRepoRoot: "/home/user/kolu",
+    unpushedCommitCount: 0,
     ...overrides,
   };
 }

--- a/packages/client/src/canvas/placementPolicy.test.ts
+++ b/packages/client/src/canvas/placementPolicy.test.ts
@@ -22,6 +22,7 @@ function git(overrides: Partial<GitInfo>): GitInfo {
     branch: "main",
     isWorktree: false,
     mainRepoRoot: "/r",
+    unpushedCommitCount: 0,
     ...overrides,
   };
 }

--- a/packages/client/src/terminal/terminalDisplay.test.ts
+++ b/packages/client/src/terminal/terminalDisplay.test.ts
@@ -23,6 +23,7 @@ function makeGit(overrides: Partial<GitInfo> = {}): GitInfo {
     branch: "main",
     isWorktree: false,
     mainRepoRoot: "/home/user/repo",
+    unpushedCommitCount: 0,
     ...overrides,
   };
 }

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -983,18 +983,25 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
     expect(_sharedReflogWatcherCount()).toBe(0);
   });
 
-  /** Tracks watcher install/retire log lines as a vitest-friendly counter. */
+  /** Tracks watcher install/retire log lines as a vitest-friendly counter.
+   *  `in-repo` mode installs both the head watcher and the reflog watcher, so
+   *  each `in-repo` transition increments both `installs` and `reflogInstalls`
+   *  by 1. */
   function makeLog() {
     let installs = 0;
     let retires = 0;
     let cwdInstalls = 0;
     let cwdRetires = 0;
+    let reflogInstalls = 0;
+    let reflogRetires = 0;
     const log = {
       info(_obj: unknown, msg: string) {
         if (msg === "git: head watcher installed") installs++;
         if (msg === "git: head watcher retired") retires++;
         if (msg === "git: cwd watcher installed") cwdInstalls++;
         if (msg === "git: cwd watcher retired") cwdRetires++;
+        if (msg === "git: reflog watcher installed") reflogInstalls++;
+        if (msg === "git: reflog watcher retired") reflogRetires++;
       },
       debug() {},
       warn() {},
@@ -1013,6 +1020,12 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
       },
       get cwdRetires() {
         return cwdRetires;
+      },
+      get reflogInstalls() {
+        return reflogInstalls;
+      },
+      get reflogRetires() {
+        return reflogRetires;
       },
     };
   }
@@ -1048,8 +1061,12 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
     // The bug: 2 installs + 1 retire on a single cd into a repo, plus
     // 1 retire on stop. The fix: 1 install on cd into the repo,
     // 1 retire on stop. (No watcher on the initial non-git dir.)
+    // Each `in-repo` transition installs both head and reflog watchers,
+    // so both counts are 1.
     expect(counter.installs).toBe(1);
     expect(counter.retires).toBe(1);
+    expect(counter.reflogInstalls).toBe(1);
+    expect(counter.reflogRetires).toBe(1);
   });
 
   // `git init` in the cwd a terminal is already sitting in must reach the
@@ -1092,6 +1109,8 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
 
     expect(counter.installs).toBe(1);
     expect(counter.retires).toBe(1);
+    expect(counter.reflogInstalls).toBe(1);
+    expect(counter.reflogRetires).toBe(1);
     expect(counter.cwdRetires).toBe(1);
   });
 
@@ -1128,10 +1147,12 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
 
     sub.stop();
 
-    // Even with both paths potentially firing, the HEAD watcher is
-    // installed exactly once.
+    // Even with both paths potentially firing, head and reflog watchers are
+    // each installed exactly once.
     expect(counter.installs).toBe(1);
     expect(counter.retires).toBe(1);
+    expect(counter.reflogInstalls).toBe(1);
+    expect(counter.reflogRetires).toBe(1);
   });
 
   it("setCwd between two distinct git repos: 1 install + 1 retire per transition", async () => {
@@ -1148,8 +1169,9 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
       counter.log,
     );
 
-    // Initial subscribe installed on a's gitDir synchronously.
+    // Initial subscribe installed on a's gitDir synchronously (head + reflog).
     expect(counter.installs).toBe(1);
+    expect(counter.reflogInstalls).toBe(1);
 
     // Wait for the initial GitInfo to publish before swapping.
     await waitFor(() => updates.length >= 1);
@@ -1160,8 +1182,11 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
     sub.stop();
 
     // Initial install on a + retire on transition + install on b + retire on stop.
+    // Both head and reflog watchers follow the same lifecycle, so both are 2.
     expect(counter.installs).toBe(2);
     expect(counter.retires).toBe(2);
+    expect(counter.reflogInstalls).toBe(2);
+    expect(counter.reflogRetires).toBe(2);
   });
 
   // Regression: an fs watcher event fires after the test's last awaited
@@ -1201,5 +1226,6 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
 
     expect(_sharedHeadWatcherCount()).toBe(0);
     expect(counter.installs).toBe(counter.retires);
+    expect(counter.reflogInstalls).toBe(counter.reflogRetires);
   });
 });

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -34,6 +34,10 @@ import {
   _sharedHeadWatcherCount,
 } from "./head-watcher.ts";
 import {
+  _resetSharedReflogWatchers,
+  _sharedReflogWatcherCount,
+} from "./reflog-watcher.ts";
+import {
   type GitInfo,
   getDiff,
   getStatus,
@@ -966,14 +970,17 @@ describe.skipIf(SKIP_DARWIN_FSWATCH)("subscribeGitInfo watcher churn", () => {
 
   beforeEach(() => {
     // See companion comment in the `watchGitHead` describe — module-scope
-    // registry reset breaks the leak-cascade (#955).
+    // registry reset breaks the leak-cascade (#955). Reflog is reset here
+    // too: `in-repo` mode now installs both head and reflog watchers.
     _resetSharedHeadWatchers();
     _resetSharedCwdGitWatchers();
+    _resetSharedReflogWatchers();
   });
 
   afterEach(() => {
     expect(_sharedHeadWatcherCount()).toBe(0);
     expect(_sharedCwdGitWatcherCount()).toBe(0);
+    expect(_sharedReflogWatcherCount()).toBe(0);
   });
 
   /** Tracks watcher install/retire log lines as a vitest-friendly counter. */

--- a/packages/integrations/git/src/index.test.ts
+++ b/packages/integrations/git/src/index.test.ts
@@ -344,6 +344,7 @@ describe("gitInfoEqual", () => {
     branch: "main",
     isWorktree: false,
     mainRepoRoot: "/home/user/repo",
+    unpushedCommitCount: 0,
   };
 
   it("returns true for identical references", () => {
@@ -368,6 +369,10 @@ describe("gitInfoEqual", () => {
     { field: "repoRoot", value: "/other" },
     { field: "branch", value: "develop" },
     { field: "worktreePath", value: "/other" },
+    // unpushedCommitCount must be compared, or a fresh commit (which moves
+    // only the count) is deduped away and the close-confirm blocker never
+    // sees the new unpushed work.
+    { field: "unpushedCommitCount", value: 1 },
   ] as const)("detects different $field", ({ field, value }) => {
     expect(gitInfoEqual(info, { ...info, [field]: value })).toBe(false);
   });
@@ -513,6 +518,39 @@ describe("resolveGitInfo", () => {
     expect(result.value.repoName).toBe("proj");
     expect(result.value.repoName).not.toBe(".worktrees");
     expect(result.value.mainRepoRoot).toBe(fs.realpathSync(proj));
+  });
+
+  it("reports 0 unpushed commits when the branch has no upstream", async () => {
+    // initRepo's branch tracks nothing — `@{u}` can't resolve, which must
+    // surface as 0 (not throw, not NaN).
+    const { dir } = await initRepo("no-upstream");
+
+    const result = await resolveGitInfo(dir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.unpushedCommitCount).toBe(0);
+  });
+
+  it("counts commits ahead of the upstream", async () => {
+    const { dir, git } = await initRepo("ahead-of-upstream");
+    // Configure a self-pointing `origin` (url + default fetch refspec) so
+    // `@{u}` resolves, stand its tracking ref at the current tip, point the
+    // branch's upstream at it, then commit twice on top — HEAD is now 2 ahead
+    // of @{u}. No network: the remote-tracking ref is set directly.
+    await git.addConfig("remote.origin.url", dir);
+    await git.addConfig(
+      "remote.origin.fetch",
+      "+refs/heads/*:refs/remotes/origin/*",
+    );
+    await git.raw(["update-ref", "refs/remotes/origin/main", "HEAD"]);
+    await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
+    await git.raw(["commit", "--allow-empty", "-m", "ahead 1"]);
+    await git.raw(["commit", "--allow-empty", "-m", "ahead 2"]);
+
+    const result = await resolveGitInfo(dir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.unpushedCommitCount).toBe(2);
   });
 });
 

--- a/packages/integrations/git/src/reflog-watcher.ts
+++ b/packages/integrations/git/src/reflog-watcher.ts
@@ -40,4 +40,11 @@ const reflogWatcher = createDirFilenameWatcher({
  *  creates the dir, and a subscribe after that point installs cleanly). */
 export const watchGitReflog = reflogWatcher.watch;
 
+/** Test-only inspector — number of distinct dirs with active shared
+ *  watchers. Mirrors `_sharedHeadWatcherCount`. */
 export const _sharedReflogWatcherCount = reflogWatcher._watcherCount;
+
+/** Test-only teardown — symmetric with `_resetSharedHeadWatchers`. See
+ *  there for the cascade-breaking rationale (#955). Production code must
+ *  never call this. */
+export const _resetSharedReflogWatchers = reflogWatcher._reset;

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -170,7 +170,10 @@ export function gitInfoEqual(a: GitInfo | null, b: GitInfo | null): boolean {
  * tears down whichever watcher is active; `setCwd(next)` swaps the watched
  * directory.
  */
-type WatcherMode = "head" | "cwd";
+// `in-repo` installs the full in-repo HEAD-movement signal set (`.git/HEAD`
+// + reflog), not just the HEAD file — the label names the volatility axis,
+// not the first watcher. `cwd` watches the parent for `.git` appearing.
+type WatcherMode = "in-repo" | "cwd";
 type WatcherSlot = { mode: WatcherMode; stop: () => void };
 
 export function subscribeGitInfo(
@@ -180,8 +183,8 @@ export function subscribeGitInfo(
 ): { setCwd(next: string): void; stop(): void } {
   let currentCwd = initialCwd;
   let currentInfo: GitInfo | null = null;
-  // Head mode watches `.git/HEAD` (in-repo); cwd mode watches the parent
-  // for `.git` appearing (out-of-repo). The two are mutually exclusive.
+  // `in-repo` mode watches HEAD + reflog (in-repo); cwd mode watches the
+  // parent for `.git` appearing (out-of-repo). The two are mutually exclusive.
   let watcher: WatcherSlot | null = null;
   // Set by `stop()` so an in-flight `resolve()` that resumes after teardown
   // can't re-install a watcher via `ensureMode` — the resulting orphan
@@ -239,7 +242,7 @@ export function subscribeGitInfo(
         "git resolution failed",
       );
     }
-    ensureMode(next !== null ? "head" : "cwd");
+    ensureMode(next !== null ? "in-repo" : "cwd");
     if (gitInfoEqual(next, currentInfo)) return;
     currentInfo = next;
     onChange(next);
@@ -247,7 +250,7 @@ export function subscribeGitInfo(
 
   // Install synchronously so fs events during the first `resolve()` await
   // aren't dropped on the floor.
-  ensureMode(hasGitDir(currentCwd) ? "head" : "cwd");
+  ensureMode(hasGitDir(currentCwd) ? "in-repo" : "cwd");
   void resolve();
 
   return {
@@ -263,7 +266,7 @@ export function subscribeGitInfo(
       }
       currentCwd = next;
       tearDownWatchers();
-      ensureMode(hasGitDir(next) ? "head" : "cwd");
+      ensureMode(hasGitDir(next) ? "in-repo" : "cwd");
       void resolve();
     },
     stop(): void {

--- a/packages/integrations/git/src/resolve.ts
+++ b/packages/integrations/git/src/resolve.ts
@@ -12,6 +12,7 @@ import { simpleGit } from "simple-git";
 import { watchCwdForGitDir } from "./cwd-git-watcher.ts";
 import { err, type GitResult, ok } from "./errors.ts";
 import { watchGitHead } from "./head-watcher.ts";
+import { watchGitReflog } from "./reflog-watcher.ts";
 import type { GitInfo } from "./schemas.ts";
 
 /** Fast check: does a .git entry exist in this directory? (stat, not a git subprocess) */
@@ -21,6 +22,26 @@ export function hasGitDir(cwd: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/** Commits on HEAD ahead of its upstream (`@{u}..HEAD`). Returns 0 — never
+ *  throws — when there is no upstream branch or HEAD is detached: `rev-list
+ *  @{u}` fails loudly in both cases, and "no upstream" means "nothing tracked
+ *  to be ahead of", which we surface as 0 unpushed. Kept in its own try/catch
+ *  so it can never trip `resolveGitInfo`'s outer catch (which would misreport
+ *  the whole directory as NOT_A_REPO). */
+async function countUnpushedCommits(
+  git: ReturnType<typeof simpleGit>,
+): Promise<number> {
+  try {
+    // One subprocess; `@{u}` is git's upstream shorthand. Throws with no
+    // upstream configured or a detached HEAD — both mean 0 unpushed.
+    const out = (await git.raw(["rev-list", "--count", "@{u}..HEAD"])).trim();
+    const n = Number.parseInt(out, 10);
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
   }
 }
 
@@ -72,6 +93,8 @@ export async function resolveGitInfo(
         branch,
         isWorktree: false,
         mainRepoRoot: repoRoot,
+        // Bare repos have no working HEAD to be ahead of an upstream.
+        unpushedCommitCount: 0,
       });
     }
     const repoRoot = (await git.revparse(["--show-toplevel"])).trim();
@@ -98,6 +121,7 @@ export async function resolveGitInfo(
       branch,
       isWorktree,
       mainRepoRoot,
+      unpushedCommitCount: await countUnpushedCommits(git),
     });
   } catch (e) {
     // Log so unexpected failures (permission errors, missing git binary)
@@ -120,7 +144,11 @@ export function gitInfoEqual(a: GitInfo | null, b: GitInfo | null): boolean {
   return (
     a.repoRoot === b.repoRoot &&
     a.branch === b.branch &&
-    a.worktreePath === b.worktreePath
+    a.worktreePath === b.worktreePath &&
+    // Without this, a commit (which moves only the count, not the identity
+    // fields) would be deduped away and the close-confirm blocker would
+    // never see fresh unpushed work.
+    a.unpushedCommitCount === b.unpushedCommitCount
   );
 }
 
@@ -165,9 +193,20 @@ export function subscribeGitInfo(
   }
 
   function install(mode: WatcherMode): () => void {
-    return mode === "head"
-      ? watchGitHead(currentCwd, handleWatcherEvent, log)
-      : watchCwdForGitDir(currentCwd, handleWatcherEvent, log);
+    if (mode === "cwd") {
+      return watchCwdForGitDir(currentCwd, handleWatcherEvent, log);
+    }
+    // In-repo: HEAD catches branch identity changes (checkout / switch);
+    // the reflog (`.git/logs/HEAD`) catches HEAD movement that leaves
+    // `.git/HEAD` untouched (commit / reset / merge on the current branch) —
+    // needed so `unpushedCommitCount` refreshes after a local commit. Both
+    // share refcounted singletons, so this is two handles, not a new tree.
+    const stopHead = watchGitHead(currentCwd, handleWatcherEvent, log);
+    const stopReflog = watchGitReflog(currentCwd, handleWatcherEvent, log);
+    return () => {
+      stopHead();
+      stopReflog();
+    };
   }
 
   function ensureMode(mode: WatcherMode): void {

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -12,6 +12,15 @@ export const GitInfoSchema = z.object({
   branch: z.string(),
   isWorktree: z.boolean(),
   mainRepoRoot: z.string(),
+  /** Commits on the current branch that are ahead of its upstream
+   *  (`@{u}..HEAD`). 0 when there is no upstream, a detached HEAD, or the
+   *  count can't be computed — never throws. Refreshed on HEAD movement
+   *  (commit / checkout / reset, via the HEAD and reflog watchers) but NOT
+   *  on `git push` — push only moves the remote-tracking ref, which this
+   *  watcher set does not observe, so the value can lag a push until the
+   *  next HEAD event. Snapshot-at-dialog-open consumers tolerate this, and
+   *  the stale direction is safe (it errs toward keeping the worktree). */
+  unpushedCommitCount: z.number(),
 });
 
 // --- Git worktree operations ---

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -25,6 +25,7 @@ const terminal: SavedTerminal = {
     branch: "main",
     isWorktree: false,
     mainRepoRoot: "/home/user/project",
+    unpushedCommitCount: 0,
   },
   lastActivityAt: 0,
 };

--- a/packages/tests/features/worktree.feature
+++ b/packages/tests/features/worktree.feature
@@ -147,7 +147,7 @@ Feature: Git worktree management
     And I select "Close terminal" in the palette
     Then the close confirmation should be visible
     And the close confirmation should not offer worktree removal because "hasUnpushedCommits"
-    When I click close only in the close confirmation
+    When I confirm close all in the close confirmation
     Then the workspace switcher should have 1 fewer terminal entry
     And there should be no page errors
 
@@ -168,7 +168,7 @@ Feature: Git worktree management
     And I select "Close terminal" in the palette
     Then the close confirmation should be visible
     And the close confirmation should not offer worktree removal because "hasOpenPullRequest"
-    When I click close only in the close confirmation
+    When I confirm close all in the close confirmation
     Then the workspace switcher should have 1 fewer terminal entry
     And there should be no page errors
 

--- a/packages/tests/features/worktree.feature
+++ b/packages/tests/features/worktree.feature
@@ -136,6 +136,42 @@ Feature: Git worktree management
     Then the workspace switcher should have 1 fewer terminal entry
     And there should be no page errors
 
+  Scenario: Remove option is hidden when the branch has unpushed commits
+    When I set up a git repo at "/tmp/kolu-wt-unpushed"
+    And I add a git worktree at "/tmp/kolu-wt-unpushed/.worktrees/unpushed-wt" in repo "/tmp/kolu-wt-unpushed" on branch "unpushed-wt"
+    And the worktree "/tmp/kolu-wt-unpushed/.worktrees/unpushed-wt" has an unpushed commit
+    And I run "cd /tmp/kolu-wt-unpushed/.worktrees/unpushed-wt"
+    Then the header should show a branch name
+    Given I note the workspace switcher entry count
+    When I open the command palette
+    And I select "Close terminal" in the palette
+    Then the close confirmation should be visible
+    And the close confirmation should not offer worktree removal because "hasUnpushedCommits"
+    When I click close only in the close confirmation
+    Then the workspace switcher should have 1 fewer terminal entry
+    And there should be no page errors
+
+  # PR metadata is fetched server-side by spawning the real `gh pr view`
+  # binary (KOLU_GH_BIN, the pinned Nix gh). The e2e harness ships no fake gh
+  # and has no meta.pr injection seam, so an "open PR" snapshot can't be
+  # produced deterministically offline. Unskip once a fake gh is wired via
+  # KOLU_GH_BIN in support/hooks.ts (or a server-side meta.pr test seam
+  # exists). See #707.
+  @skip
+  Scenario: Remove option is hidden when the branch has an open pull request
+    When I set up a git repo at "/tmp/kolu-wt-openpr"
+    And I add a git worktree at "/tmp/kolu-wt-openpr/.worktrees/openpr-wt" in repo "/tmp/kolu-wt-openpr" on branch "openpr-wt"
+    And I run "cd /tmp/kolu-wt-openpr/.worktrees/openpr-wt"
+    Then the header should show a branch name
+    Given I note the workspace switcher entry count
+    When I open the command palette
+    And I select "Close terminal" in the palette
+    Then the close confirmation should be visible
+    And the close confirmation should not offer worktree removal because "hasOpenPullRequest"
+    When I click close only in the close confirmation
+    Then the workspace switcher should have 1 fewer terminal entry
+    And there should be no page errors
+
   # Sub-terminal create-via-palette in a worktree-spawned terminal stalls
   # waiting for [data-sub-terminal] to appear. Reproduces only when the
   # right panel is open AND the parent was created through the worktree

--- a/packages/tests/step_definitions/worktree_steps.ts
+++ b/packages/tests/step_definitions/worktree_steps.ts
@@ -61,6 +61,47 @@ When(
   },
 );
 
+When(
+  "the worktree {string} has an unpushed commit",
+  async function (this: KoluWorld, worktreePath: string) {
+    // Give the branch an upstream pointing at its current tip, then commit on
+    // top so HEAD is exactly one ahead of `@{u}`. Driven host-side (the same
+    // deterministic pattern as the repo/worktree setup steps) so the unpushed
+    // state exists before the terminal cd's in and the git provider resolves.
+    const branch = execFileSync("git", [
+      "-C",
+      worktreePath,
+      "rev-parse",
+      "--abbrev-ref",
+      "HEAD",
+    ])
+      .toString()
+      .trim();
+    execFileSync("git", [
+      "-C",
+      worktreePath,
+      "update-ref",
+      `refs/remotes/origin/${branch}`,
+      "HEAD",
+    ]);
+    execFileSync("git", [
+      "-C",
+      worktreePath,
+      "branch",
+      `--set-upstream-to=origin/${branch}`,
+      branch,
+    ]);
+    execFileSync("git", [
+      "-C",
+      worktreePath,
+      "commit",
+      "--allow-empty",
+      "-m",
+      "wip",
+    ]);
+  },
+);
+
 Then(
   "the close confirmation should be visible",
   async function (this: KoluWorld) {


### PR DESCRIPTION
Closes #707.

## Why

The close-confirmation dialog offered **"Remove worktree too?"** whenever no other terminal shared the worktree. Two real cases lose work or context when the user confirms:

1. **Unpushed commits** — `git worktree remove` doesn't guard against local commits that aren't on any remote; deleting the branch afterward makes them unreachable.
2. **Open PR** — removing the worktree leaves the PR dangling, when the user usually wants to keep iterating, respond to review, and re-run CI.

Both are "the branch has unfinished work", but the copy and remediation differ, so they're modelled as two new removal blockers alongside the existing shared-worktree one.

## What changed

**Client (`CloseConfirm.tsx`, `App.tsx`).** `WorktreeRemovalBlocker` gains `hasUnpushedCommits` and `hasOpenPullRequest`. `BLOCKER_MESSAGES` widens from `Record<Blocker, string>` to context-taking functions so the open-PR copy can embed the PR number. `closeTerminal` — still the single, **synchronous** writer of `worktreeRemoval` (preserving the snapshot-at-open invariant) — picks the highest-stakes blocker by priority:

| Priority | Blocker | Source |
|---|---|---|
| 1 | `hasUnpushedCommits` | `meta.git.unpushedCommitCount > 0` (data-loss risk) |
| 2 | `hasOpenPullRequest` | `prValue(meta.pr)?.state === "open"` (coordination risk) |
| 3 | `sharedWithOtherTerminals` | `store.isWorktreeShared(...)` |

> The issue suggested `state in {open, draft}`, but the PR schema enum is only `open | closed | merged` — there is **no** `draft` state. Only `open` blocks; `closed`/`merged` mean the work has landed.

**Server (`integrations/git`).** `unpushedCommitCount` (`@{u}..HEAD`, never throws — 0 on no-upstream/detached HEAD) is derived onto `GitInfo`, compared in `gitInfoEqual` so a commit isn't deduped away, and `subscribeGitInfo` now also installs the reflog watcher so a local commit refreshes the count.

> **Known limitation (documented in the schema JSDoc):** `git push` moves only the remote-tracking ref, which this watcher set doesn't observe, so the count can briefly lag a push until the next HEAD movement. The stale direction is safe — it errs toward *keeping* the worktree, never toward silently deleting unpushed work.

## Tests

- Unit: `unpushedCommitCount` (no-upstream → 0; two ahead → 2) and a `gitInfoEqual` case proving the count is compared.
- e2e: a `hasUnpushedCommits` scenario in `worktree.feature` (passes locally via `just test-quick`).
- e2e (`@skip`): a `hasOpenPullRequest` scenario. PR metadata is fetched server-side by spawning the real `gh pr view` binary (`KOLU_GH_BIN`); the harness ships no fake `gh` and no `meta.pr` injection seam, so an open-PR snapshot can't be produced offline. The scenario is written and skipped with a comment pointing at the fixture work needed to unskip it.

## Approach note

Scoped with a dynamic multi-agent workflow: parallel research agents nailed down the server metadata seam, the PR-state plumbing, and the e2e harness's mocking limits; a synthesis agent produced the implementation plan that this PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)