### PR TITLE
Pin the realised agent behind a per-agent GC root

### DIFF
--- a/packages/surface-nix-host/README.md
+++ b/packages/surface-nix-host/README.md
@@ -36,7 +36,7 @@ const sys = client.system.get({});           // typed oRPC — same shape your b
 ## What it's NOT
 
 - **Not a transport.** That's [`@kolu/surface/links/stdio`](../surface/src/links/stdio.ts). This package sits *on top of* the stdio link and adds: process supervision (spawn/respawn ssh), `.drv` provisioning (the Nix bit), and a reactive state cell for the connection's own lifecycle.
-- **Not a Nix utility.** `provisionAgent` is purposely minimal — `nix copy --derivation`, then `ssh $host nix-store --realise`, then return the resulting path. If you want richer flake handling (e.g. resolve a flake ref to a `.drv`), do it inside the `resolveDrvPath` callback you pass.
+- **Not a Nix utility.** `provisionAgent` is purposely minimal — `nix copy --derivation`, then `ssh $host nix-store --realise`, then pin the output behind a per-agent GC root, then return the resulting path. If you want richer flake handling (e.g. resolve a flake ref to a `.drv`), do it inside the `resolveDrvPath` callback you pass.
 - **Not opinionated about UI.** The package returns a typed RPC client. Mirroring its streams into your parent server's local surface (so the browser can consume them) is the consumer's job. See the [`remote-process-monitor` example](../surface/example/remote-process-monitor/src/server/router.ts) for the canonical bridge pattern.
 
 ## Why Nix (locked-in)
@@ -50,8 +50,16 @@ parent: nix eval --raw .#packages.<remote-system>.<agent>.drvPath
         └── caller's responsibility — `resolveSystem(host)` gives <remote-system>
 parent: nix copy --derivation --to ssh-ng://$host $drvPath
 remote: nix-store --realise $drvPath  →  /nix/store/...-agent
+remote: nix-store --realise $out --add-root <link> --indirect  (GC-pin)
 parent: ssh $host $agentPath/bin/<binary> --stdio
 ```
+
+The pin step is what keeps a `nix-collect-garbage` on the target from
+deleting the agent out from under a live session (or forcing a rebuild on
+the next reconnect). The root is one fixed symlink per agent — keyed on the
+`.drv` name — so each realise moves it to the newest output and the previous
+hash becomes GC-eligible, exactly like `nix build`'s `result` link. It's
+best-effort: if the root can't be written, the agent still runs unpinned.
 
 **Nix is the contract, not the implementation.** No tarball, Docker, or prebuilt-binary fallback exists or will. The whole point of this package is "use Nix for cross-arch deployment of typed stdio agents"; consumers that don't want Nix should pick a different transport layer.
 
@@ -64,7 +72,7 @@ Remote-side requirement: the parent's user must be in `trusted-users` in the rem
 | `HostSession<C>` | One ssh subprocess per `(host, binary)`. Ref-counted. State machine. Survives drops via `scheduleReconnect`. Snapshot-then-delta `onState`. Generic over the contract type `C`. |
 | `getHostSession<C>(opts)` | Pool lookup — repeated calls with the same `(host, binary)` return the same session (first call's `opts` win). |
 | `destroyAllSessions()` | Tear down every pooled session. Call on parent shutdown. |
-| `provisionAgent({ host, drvPath, onProgress })` | Ship the `.drv` to the host (skipped for localhost), `nix-store --realise` it there, return the realised output path. Progress lines forwarded to `onProgress`. |
+| `provisionAgent({ host, drvPath, onProgress })` | Ship the `.drv` to the host (skipped for localhost), `nix-store --realise` it there, pin the output behind a per-agent GC root (`agentGcRootPath`), and return the realised output path. Progress lines forwarded to `onProgress`. |
 | `mirrorRemoteCollection<K,V>(opts)` | Helper: bridge a remote `Collection<K,V>` to a local one — keys stream + per-key value streams, with abort cleanup on key departure. |
 | `waitForNextClient(session, previous)` | Helper for the consumer's reconnect-loop: blocks until the session produces a *fresh* `AgentClient<C>` (post-reconnect). |
 | `buildAgentCommand({ host, agentPath, binary })` | Compute the spawn argv for an agent binary on a given host. Used internally; exported for consumers that need to invoke the agent directly (e.g. one-shot subprocess tests). |

--- a/packages/surface-nix-host/src/nixCopy.test.ts
+++ b/packages/surface-nix-host/src/nixCopy.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Coverage for the GC-root pinning step (`provisionAgent` step 4) and
+ * the `agentGcRootPath` "latest"-link derivation. Keeps off real ssh /
+ * nix by mocking `./process`; the real `./host` builds the argv so the
+ * assertions see exactly what would hit the wire.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { agentGcRootPath, provisionAgent } from "./nixCopy";
+import { runCapture, runProgress } from "./process";
+
+vi.mock("./process", () => ({
+  runCapture: vi.fn(),
+  runProgress: vi.fn(),
+}));
+
+const STORE = "/nix/store/x8yvl9si8vb93vhwway7kf3zbvv4ahg1-agent";
+const DRV = "/nix/store/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-agent.drv";
+
+/** Wire up the happy path: copy ok, realise prints the store path, pin
+ *  prints the link path. Returns the `vi.fn()` handles for assertions. */
+function mockHappyPath() {
+  vi.mocked(runProgress).mockResolvedValue({ ok: true, code: 0 });
+  vi.mocked(runCapture)
+    .mockResolvedValueOnce({ ok: true, code: 0, stdout: `${STORE}\n` }) // realise
+    .mockResolvedValueOnce({ ok: true, code: 0, stdout: "/home/u/link\n" }); // pin
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("provisionAgent GC-root pinning", () => {
+  it("pins the realised output with an indirect per-agent root", async () => {
+    mockHappyPath();
+    const res = await provisionAgent({
+      host: "testhost",
+      drvPath: DRV,
+      onProgress: () => {},
+    });
+
+    expect(res).toEqual({ ok: true, agentPath: STORE });
+
+    // The pin is the second runCapture; it re-realises the *store path*
+    // (not the .drv) and registers an indirect root.
+    expect(runCapture).toHaveBeenCalledTimes(2);
+    const pinArgs = vi.mocked(runCapture).mock.calls[1]?.[1] ?? [];
+    expect(pinArgs).toContain("--realise");
+    expect(pinArgs).toContain(STORE);
+    expect(pinArgs).toContain("--add-root");
+    expect(pinArgs).toContain("--indirect");
+    expect(pinArgs).toContain(
+      ".local/state/kolu/surface-nix-host/gcroots/agent",
+    );
+    // …and it must not re-realise the derivation in the pin step.
+    expect(pinArgs).not.toContain(DRV);
+  });
+
+  it("returns the immutable store path, not the moving root link", async () => {
+    mockHappyPath();
+    const res = await provisionAgent({
+      host: "testhost",
+      drvPath: DRV,
+      onProgress: () => {},
+    });
+    expect(res.ok && res.agentPath).toBe(STORE);
+  });
+
+  it("treats a pin failure as non-fatal — the agent still provisions", async () => {
+    vi.mocked(runProgress).mockResolvedValue({ ok: true, code: 0 });
+    vi.mocked(runCapture)
+      .mockResolvedValueOnce({ ok: true, code: 0, stdout: `${STORE}\n` }) // realise
+      .mockResolvedValueOnce({ ok: false, code: 1, stdout: "" }); // pin fails
+
+    const lines: string[] = [];
+    const res = await provisionAgent({
+      host: "testhost",
+      drvPath: DRV,
+      onProgress: (l) => lines.push(l),
+    });
+
+    expect(res).toEqual({ ok: true, agentPath: STORE });
+    expect(lines.some((l) => l.includes("unpinned"))).toBe(true);
+  });
+
+  it("does not pin when the realise itself fails", async () => {
+    vi.mocked(runProgress).mockResolvedValue({ ok: true, code: 0 });
+    vi.mocked(runCapture).mockResolvedValueOnce({
+      ok: false,
+      code: 1,
+      stdout: "",
+    });
+
+    const res = await provisionAgent({
+      host: "testhost",
+      drvPath: DRV,
+      onProgress: () => {},
+    });
+
+    expect(res.ok).toBe(false);
+    expect(runCapture).toHaveBeenCalledTimes(1); // realise only, no pin
+  });
+});
+
+// A store-path .drv with a 32-char base32 hash, like nix produces.
+const drvOf = (name: string) => `/nix/store/${"a".repeat(32)}-${name}.drv`;
+
+describe("agentGcRootPath", () => {
+  it("strips the store hash so versions of one agent share a link", () => {
+    const a = agentGcRootPath(false, drvOf("agent")); // hash all a's
+    const b = agentGcRootPath(false, `/nix/store/${"b".repeat(32)}-agent.drv`);
+    expect(a).toBe(b); // same agent name → one moving "latest" link
+    expect(a).toBe(".local/state/kolu/surface-nix-host/gcroots/agent");
+  });
+
+  it("keeps distinct agents on distinct links", () => {
+    const mon = agentGcRootPath(false, drvOf("process-monitor-agent"));
+    const term = agentGcRootPath(false, drvOf("kolu-terminal-agent"));
+    expect(mon).not.toBe(term);
+    expect(mon).toMatch(/gcroots\/process-monitor-agent$/);
+  });
+
+  it("anchors to $HOME for localhost (no ssh chdir to rely on)", () => {
+    const prev = process.env.HOME;
+    process.env.HOME = "/home/tester";
+    try {
+      expect(agentGcRootPath(true, DRV)).toBe(
+        "/home/tester/.local/state/kolu/surface-nix-host/gcroots/agent",
+      );
+    } finally {
+      if (prev === undefined) delete process.env.HOME;
+      else process.env.HOME = prev;
+    }
+  });
+});

--- a/packages/surface-nix-host/src/nixCopy.test.ts
+++ b/packages/surface-nix-host/src/nixCopy.test.ts
@@ -118,15 +118,40 @@ describe("agentGcRootPath", () => {
   });
 
   it("anchors to $HOME for localhost (no ssh chdir to rely on)", () => {
-    const prev = process.env.HOME;
-    process.env.HOME = "/home/tester";
-    try {
+    withHome("/home/tester", () => {
       expect(agentGcRootPath(true, DRV)).toBe(
         "/home/tester/.local/state/kolu/surface-nix-host/gcroots/agent",
       );
-    } finally {
-      if (prev === undefined) delete process.env.HOME;
-      else process.env.HOME = prev;
-    }
+    });
+  });
+
+  it("returns null for localhost when $HOME is unset (no cwd-relative root)", () => {
+    // Better unpinned than rooted in the wrong place — the caller skips
+    // the best-effort pin on null rather than rooting under the cwd.
+    withHome(undefined, () => {
+      expect(agentGcRootPath(true, DRV)).toBeNull();
+    });
+  });
+
+  it("never returns null for a remote host (resolves against ssh $HOME)", () => {
+    withHome(undefined, () => {
+      expect(agentGcRootPath(false, DRV)).toBe(
+        ".local/state/kolu/surface-nix-host/gcroots/agent",
+      );
+    });
   });
 });
+
+/** Run `fn` with `process.env.HOME` set to `value` (or unset for
+ *  `undefined`), restoring the prior value afterwards. */
+function withHome(value: string | undefined, fn: () => void) {
+  const prev = process.env.HOME;
+  if (value === undefined) delete process.env.HOME;
+  else process.env.HOME = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.HOME;
+    else process.env.HOME = prev;
+  }
+}

--- a/packages/surface-nix-host/src/nixCopy.test.ts
+++ b/packages/surface-nix-host/src/nixCopy.test.ts
@@ -25,7 +25,10 @@ function mockHappyPath() {
     .mockResolvedValueOnce({ ok: true, code: 0, stdout: "/home/u/link\n" }); // pin
 }
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
 
 describe("provisionAgent GC-root pinning", () => {
   it("pins the realised output with an indirect per-agent root", async () => {
@@ -41,7 +44,7 @@ describe("provisionAgent GC-root pinning", () => {
     // The pin is the second runCapture; it re-realises the *store path*
     // (not the .drv) and registers an indirect root.
     expect(runCapture).toHaveBeenCalledTimes(2);
-    const pinArgs = vi.mocked(runCapture).mock.calls[1]?.[1] ?? [];
+    const pinArgs = vi.mocked(runCapture).mock.calls[1]![1];
     expect(pinArgs).toContain("--realise");
     expect(pinArgs).toContain(STORE);
     expect(pinArgs).toContain("--add-root");
@@ -118,40 +121,23 @@ describe("agentGcRootPath", () => {
   });
 
   it("anchors to $HOME for localhost (no ssh chdir to rely on)", () => {
-    withHome("/home/tester", () => {
-      expect(agentGcRootPath(true, DRV)).toBe(
-        "/home/tester/.local/state/kolu/surface-nix-host/gcroots/agent",
-      );
-    });
+    vi.stubEnv("HOME", "/home/tester");
+    expect(agentGcRootPath(true, DRV)).toBe(
+      "/home/tester/.local/state/kolu/surface-nix-host/gcroots/agent",
+    );
   });
 
   it("returns null for localhost when $HOME is unset (no cwd-relative root)", () => {
     // Better unpinned than rooted in the wrong place — the caller skips
     // the best-effort pin on null rather than rooting under the cwd.
-    withHome(undefined, () => {
-      expect(agentGcRootPath(true, DRV)).toBeNull();
-    });
+    vi.stubEnv("HOME", undefined);
+    expect(agentGcRootPath(true, DRV)).toBeNull();
   });
 
   it("never returns null for a remote host (resolves against ssh $HOME)", () => {
-    withHome(undefined, () => {
-      expect(agentGcRootPath(false, DRV)).toBe(
-        ".local/state/kolu/surface-nix-host/gcroots/agent",
-      );
-    });
+    vi.stubEnv("HOME", undefined);
+    expect(agentGcRootPath(false, DRV)).toBe(
+      ".local/state/kolu/surface-nix-host/gcroots/agent",
+    );
   });
 });
-
-/** Run `fn` with `process.env.HOME` set to `value` (or unset for
- *  `undefined`), restoring the prior value afterwards. */
-function withHome(value: string | undefined, fn: () => void) {
-  const prev = process.env.HOME;
-  if (value === undefined) delete process.env.HOME;
-  else process.env.HOME = value;
-  try {
-    fn();
-  } finally {
-    if (prev === undefined) delete process.env.HOME;
-    else process.env.HOME = prev;
-  }
-}

--- a/packages/surface-nix-host/src/nixCopy.ts
+++ b/packages/surface-nix-host/src/nixCopy.ts
@@ -16,7 +16,12 @@
  *      doesn't have).
  *   3. `ssh $host nix-store --realise $drvPath` builds it on the
  *      remote, returning the output path on the remote's store.
- *   4. The output path becomes `agentPath`; the caller then spawns
+ *   4. `ssh $host nix-store --realise $out --add-root $link --indirect`
+ *      pins that output behind a per-agent GC root on the target, so a
+ *      `nix-collect-garbage` there can't delete the agent out from
+ *      under a live session (or force a rebuild on the next reconnect).
+ *      See `agentGcRootPath` for the "latest"-link semantics.
+ *   5. The output path becomes `agentPath`; the caller then spawns
  *      `ssh $host $agentPath/bin/<binary> --stdio` via `HostSession`.
  *
  * Localhost shortcut: the .drv is already in the local store, so
@@ -44,6 +49,27 @@ export interface ProvisionOptions {
 export type ProvisionResult =
   | { ok: true; agentPath: string }
   | { ok: false; reason: string };
+
+/** Per-agent GC-root path for the realised output. Keyed on the .drv's
+ *  name with its store hash stripped, so every version of the *same*
+ *  agent maps to one fixed symlink: each realise overwrites it, the
+ *  previous output drops out of the root set and becomes GC-eligible.
+ *  "Pin the latest, release older hashes" — the moving-`result`
+ *  behaviour `nix build` gives you, but on the target's store.
+ *
+ *  Remote: the path is relative, so it resolves against the ssh login
+ *  user's home dir (sshd runs the command from `$HOME`). Local: there's
+ *  no ssh chdir, so anchor to this process's `$HOME` explicitly. Parent
+ *  dirs don't need pre-creating — `nix-store --add-root` makes them. */
+export function agentGcRootPath(isLocal: boolean, drvPath: string): string {
+  const name = drvPath
+    .replace(/^.*\//, "") // drop the /nix/store/ prefix
+    .replace(/\.drv$/, "") // drop the .drv suffix
+    .replace(/^[0-9a-z]{32}-/, ""); // drop the store hash
+  const rel = `.local/state/kolu/surface-nix-host/gcroots/${name}`;
+  const home = process.env.HOME;
+  return isLocal && home ? `${home}/${rel}` : rel;
+}
 
 /** Ship the `.drv` to `$host` and realise it there. Returns the
  *  output path on the *target* host, ready for
@@ -110,5 +136,31 @@ export async function provisionAgent(
     };
   }
   opts.onProgress(`${opts.host}: agent realised at ${agentPath}`);
+
+  // 4. Pin the realised output behind a stable, per-agent GC root.
+  //    Re-realising an already-built store path is instant; the
+  //    `--add-root … --indirect` registers an *indirect* root — the
+  //    symlink itself — so the link can live under $HOME without write
+  //    access to /nix/var/nix/gcroots. Best-effort: a failure here
+  //    costs GC protection, not the session, so we warn and continue —
+  //    the agent at `agentPath` still runs, it's just collectable.
+  const rootPath = agentGcRootPath(isLocal, opts.drvPath);
+  opts.onProgress(`${opts.host}: pinning GC root at '${rootPath}'…`);
+  const pin = buildSshProbeCommand(
+    opts.host,
+    "nix-store",
+    "--realise",
+    agentPath,
+    "--add-root",
+    rootPath,
+    "--indirect",
+  );
+  const pinRes = await runCapture(pin.command, pin.args, opts.onProgress);
+  if (!pinRes.ok) {
+    opts.onProgress(
+      `${opts.host}: GC-root pin failed (code ${pinRes.code}); agent runs but is unpinned`,
+    );
+  }
+
   return { ok: true, agentPath };
 }

--- a/packages/surface-nix-host/src/nixCopy.ts
+++ b/packages/surface-nix-host/src/nixCopy.ts
@@ -50,7 +50,8 @@ export type ProvisionResult =
   | { ok: true; agentPath: string }
   | { ok: false; reason: string };
 
-/** Per-agent GC-root path for the realised output. Keyed on the .drv's
+/** Per-agent GC-root path for the realised output, or `null` when one
+ *  can't be formed (see the localhost case below). Keyed on the .drv's
  *  name with its store hash stripped, so every version of the *same*
  *  agent maps to one fixed symlink: each realise overwrites it, the
  *  previous output drops out of the root set and becomes GC-eligible.
@@ -59,16 +60,23 @@ export type ProvisionResult =
  *
  *  Remote: the path is relative, so it resolves against the ssh login
  *  user's home dir (sshd runs the command from `$HOME`). Local: there's
- *  no ssh chdir, so anchor to this process's `$HOME` explicitly. Parent
- *  dirs don't need pre-creating — `nix-store --add-root` makes them. */
-export function agentGcRootPath(isLocal: boolean, drvPath: string): string {
+ *  no ssh chdir, so anchor to this process's `$HOME` explicitly — and if
+ *  `$HOME` is unset we return `null` rather than a cwd-relative path
+ *  that would silently root the agent in the wrong place; the caller
+ *  then skips the (best-effort) pin. Parent dirs don't need
+ *  pre-creating — `nix-store --add-root` makes them. */
+export function agentGcRootPath(
+  isLocal: boolean,
+  drvPath: string,
+): string | null {
   const name = drvPath
     .replace(/^.*\//, "") // drop the /nix/store/ prefix
     .replace(/\.drv$/, "") // drop the .drv suffix
     .replace(/^[0-9a-z]{32}-/, ""); // drop the store hash
   const rel = `.local/state/kolu/surface-nix-host/gcroots/${name}`;
+  if (!isLocal) return rel;
   const home = process.env.HOME;
-  return isLocal && home ? `${home}/${rel}` : rel;
+  return home ? `${home}/${rel}` : null;
 }
 
 /** Ship the `.drv` to `$host` and realise it there. Returns the
@@ -141,25 +149,32 @@ export async function provisionAgent(
   //    Re-realising an already-built store path is instant; the
   //    `--add-root … --indirect` registers an *indirect* root — the
   //    symlink itself — so the link can live under $HOME without write
-  //    access to /nix/var/nix/gcroots. Best-effort: a failure here
-  //    costs GC protection, not the session, so we warn and continue —
-  //    the agent at `agentPath` still runs, it's just collectable.
+  //    access to /nix/var/nix/gcroots. Best-effort throughout: if the
+  //    root path can't be formed (local $HOME unset) or the command
+  //    fails, we warn and continue — the agent at `agentPath` still
+  //    runs, it's just collectable.
   const rootPath = agentGcRootPath(isLocal, opts.drvPath);
-  opts.onProgress(`${opts.host}: pinning GC root at '${rootPath}'…`);
-  const pin = buildSshProbeCommand(
-    opts.host,
-    "nix-store",
-    "--realise",
-    agentPath,
-    "--add-root",
-    rootPath,
-    "--indirect",
-  );
-  const pinRes = await runCapture(pin.command, pin.args, opts.onProgress);
-  if (!pinRes.ok) {
+  if (rootPath === null) {
     opts.onProgress(
-      `${opts.host}: GC-root pin failed (code ${pinRes.code}); agent runs but is unpinned`,
+      `${opts.host}: HOME unset, can't place a GC root; agent runs but is unpinned`,
     );
+  } else {
+    opts.onProgress(`${opts.host}: pinning GC root at '${rootPath}'…`);
+    const pin = buildSshProbeCommand(
+      opts.host,
+      "nix-store",
+      "--realise",
+      agentPath,
+      "--add-root",
+      rootPath,
+      "--indirect",
+    );
+    const pinRes = await runCapture(pin.command, pin.args, opts.onProgress);
+    if (!pinRes.ok) {
+      opts.onProgress(
+        `${opts.host}: GC-root pin failed (code ${pinRes.code}); agent runs but is unpinned`,
+      );
+    }
   }
 
   return { ok: true, agentPath };

--- a/packages/surface-nix-host/src/nixCopy.ts
+++ b/packages/surface-nix-host/src/nixCopy.ts
@@ -87,7 +87,7 @@ export async function provisionAgent(
 ): Promise<ProvisionResult> {
   const isLocal = isLocalHost(opts.host);
 
-  // 1. Copy the .drv (and its build-inputs) to the remote. Skipped
+  // 2. Copy the .drv (and its build-inputs) to the remote. Skipped
   //    for localhost — the .drv is already in /nix/store.
   if (!isLocal) {
     opts.onProgress(`${opts.host}: copying derivation '${opts.drvPath}'…`);
@@ -116,7 +116,7 @@ export async function provisionAgent(
     opts.onProgress(`${opts.host}: derivation copy complete`);
   }
 
-  // 2. Realise (build) the .drv on the target. Output is the agent's
+  // 3. Realise (build) the .drv on the target. Output is the agent's
   //    nix-store path on that host.
   opts.onProgress(
     isLocal


### PR DESCRIPTION
**After realising the agent on a target host, `provisionAgent` now registers an indirect GC root for it**, so a `nix-collect-garbage` on that host can't delete the agent out from under a live session — or silently force a rebuild on the next reconnect. Previously nothing held a root on the realised output: it survived only by luck between connects.

The root is a single fixed symlink **per agent**, keyed on the `.drv` name with its store hash stripped. Each realise moves that link to the newest output, so the previous hash drops out of the root set and becomes GC-eligible — the same moving-`result` semantics `nix build` gives you, but on the target's store. "Pin the latest, release the old," with nothing to prune.

### Flow

```
copy  : nix copy --derivation --to ssh-ng://$host $drv
realise: nix-store --realise $drv                      → /nix/store/…-agent   (agentPath)
pin   : nix-store --realise $agentPath --add-root $link --indirect            (new)
spawn : ssh $host $agentPath/bin/<binary> --stdio
```

Re-realising an already-built path is instant, so the pin is one cheap extra round-trip. `--indirect` registers the *symlink itself* as the root, so it can live under `$HOME` without write access to `/nix/var/nix/gcroots` — which matters because the ssh user is rarely root.

### Best-effort by design

The pin never fails provisioning. If the root can't be placed — local `$HOME` unset, or the `nix-store` call errors — `provisionAgent` logs a progress line and returns the realised `agentPath` anyway. The agent still runs; it's just collectable again. `agentGcRootPath` returns `null` for the one case it genuinely can't anchor (localhost with no `$HOME`) rather than rooting under the process cwd.

> Remote roots resolve against the ssh login `$HOME` (sshd runs the command from there); localhost anchors to `process.env.HOME` explicitly since there's no ssh chdir.

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._