### PR TITLE
Fix saved-session crash for sessions predating #1065's git field

### DIFF
--- a/packages/integrations/git/src/schemas.test.ts
+++ b/packages/integrations/git/src/schemas.test.ts
@@ -1,0 +1,35 @@
+/** Migration-safety coverage for the git domain schemas. */
+
+import { describe, expect, it } from "vitest";
+import { GitInfoSchema } from "./schemas.ts";
+
+/** The pre-#1065 persisted shape — a `GitInfoSchema` blob written before
+ *  `unpushedCommitCount` existed. */
+const legacyGitInfo = {
+  repoRoot: "/repo",
+  repoName: "repo",
+  worktreePath: "/repo",
+  branch: "main",
+  isWorktree: false,
+  mainRepoRoot: "/repo",
+};
+
+describe("GitInfoSchema", () => {
+  it("validates a pre-#1065 git blob (no unpushedCommitCount), defaulting it to 0", () => {
+    // Regression for the production break where deploying #1065 over an
+    // existing session made `session.get`'s output validation throw
+    // EVENT_ITERATOR_VALIDATION_FAILED on every reconnect, killing the saved-
+    // session subscription. GitInfoSchema is embedded in the persisted +
+    // streamed SavedSessionSchema, so it must tolerate legacy blobs.
+    const parsed = GitInfoSchema.parse(legacyGitInfo);
+    expect(parsed.unpushedCommitCount).toBe(0);
+  });
+
+  it("preserves an explicit unpushedCommitCount", () => {
+    const parsed = GitInfoSchema.parse({
+      ...legacyGitInfo,
+      unpushedCommitCount: 3,
+    });
+    expect(parsed.unpushedCommitCount).toBe(3);
+  });
+});

--- a/packages/integrations/git/src/schemas.ts
+++ b/packages/integrations/git/src/schemas.ts
@@ -19,8 +19,15 @@ export const GitInfoSchema = z.object({
    *  on `git push` — push only moves the remote-tracking ref, which this
    *  watcher set does not observe, so the value can lag a push until the
    *  next HEAD event. Snapshot-at-dialog-open consumers tolerate this, and
-   *  the stale direction is safe (it errs toward keeping the worktree). */
-  unpushedCommitCount: z.number(),
+   *  the stale direction is safe (it errs toward keeping the worktree).
+   *
+   *  `.default(0)` is load-bearing for migration safety: `GitInfoSchema` is
+   *  embedded in the persisted + streamed `SavedSessionSchema`, so a session
+   *  saved before this field existed must still validate on reload — otherwise
+   *  `session.get`'s output validation throws `EVENT_ITERATOR_VALIDATION_FAILED`
+   *  on every reconnect and the whole saved-session subscription dies. The
+   *  watchers overwrite the 0 with the real count on the next HEAD event. */
+  unpushedCommitCount: z.number().default(0),
 });
 
 // --- Git worktree operations ---


### PR DESCRIPTION
**Deploying [#1065](https://github.com/juspay/kolu/pull/1065) over an existing saved session crashes the saved-session subscription.** #1065 added a *required* `unpushedCommitCount` to `GitInfoSchema`, and that schema is embedded in the **persisted + streamed** `SavedSessionSchema`. A session written by a pre-#1065 build has terminals whose `git` object lacks the field, so on the next deploy `surface.session.get`'s event-iterator **output validation** throws `EVENT_ITERATOR_VALIDATION_FAILED` on every (re)connect — the whole saved-session live query dies. The user sees no session restore and a repeating `Saved-session subscription error` toast; the server logs a 500 per reconnect.

CI never caught it because **CI runs against fresh state** — only an upgrade over a pre-existing on-disk session triggers it. Caught in production on the R-4 A2 deploy ([#1063](https://github.com/juspay/kolu/pull/1063), which merged #1065); it affects **any** existing-state deploy of `master` since #1065, not just that branch.

### Fix

```ts
// packages/integrations/git/src/schemas.ts
unpushedCommitCount: z.number().default(0),   // was z.number()
```

`.default(0)` makes legacy/missing data parse to a usable `number` (consumers need no `undefined` handling), so old persisted sessions validate again; the HEAD/reflog watchers overwrite the `0` with the real count on the next event. This is the "additive fields must be optional / migrate persisted shapes" discipline a persisted **and** wire schema requires.

Regression test (`schemas.test.ts`): a pre-#1065 `GitInfoSchema` blob (no `unpushedCommitCount`) validates and defaults to `0`.

> Once merged: fold into #1063 (or redeploy a build containing it) and the fixed build reads the existing on-disk session directly — no state repair or session loss needed.

_Generated by Claude Code (model `claude-opus-4-8`)._