### PR TITLE
fix(surface-nix-host): keepalive on the realise ssh so a degraded host can't wedge the spawn cycle forever

### DIFF
--- a/packages/surface-nix-host/src/host.test.ts
+++ b/packages/surface-nix-host/src/host.test.ts
@@ -21,6 +21,18 @@ function sshOpts(args: readonly string[]): Record<string, string> {
   return opts;
 }
 
+/** Assert an ssh argv carries the full shared dead-peer keepalive policy.
+ *  One invariant ("every non-interactive ssh this package spawns carries
+ *  `SSH_COMMON_OPTS`") asserted in one place, so re-tuning a keepalive
+ *  value can't leave a second hand-synced block green on stale numbers. */
+function assertKeepAlive(args: readonly string[]): void {
+  const opts = sshOpts(args);
+  expect(opts.BatchMode).toBe("yes");
+  expect(opts.ServerAliveInterval).toBe("10");
+  expect(opts.ServerAliveCountMax).toBe("3");
+  expect(opts.ConnectTimeout).toBe("10");
+}
+
 describe("buildSshProbeCommand", () => {
   it("runs the command directly for localhost — no ssh wrapper", () => {
     const { command, args } = buildSshProbeCommand(
@@ -56,13 +68,9 @@ describe("buildSshProbeCommand", () => {
       "--realise",
       "x",
     );
-    const opts = sshOpts(args);
-    expect(opts.BatchMode).toBe("yes");
     // The fix: a degraded host mid-realise must trip ssh's dead-peer
     // detection (~Interval×CountMax) rather than hang forever.
-    expect(opts.ServerAliveInterval).toBe("10");
-    expect(opts.ServerAliveCountMax).toBe("3");
-    expect(opts.ConnectTimeout).toBe("10");
+    assertKeepAlive(args);
   });
 });
 
@@ -90,10 +98,6 @@ describe("buildAgentCommand", () => {
       "/nix/store/x-agent/bin/my-agent",
       "--stdio",
     ]);
-    const opts = sshOpts(args);
-    expect(opts.BatchMode).toBe("yes");
-    expect(opts.ServerAliveInterval).toBe("10");
-    expect(opts.ServerAliveCountMax).toBe("3");
-    expect(opts.ConnectTimeout).toBe("10");
+    assertKeepAlive(args);
   });
 });

--- a/packages/surface-nix-host/src/host.test.ts
+++ b/packages/surface-nix-host/src/host.test.ts
@@ -13,9 +13,10 @@ import { buildAgentCommand, buildSshProbeCommand, NIX_SSHOPTS } from "./host";
 function sshOpts(args: readonly string[]): Record<string, string> {
   const opts: Record<string, string> = {};
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "-o" && args[i + 1]) {
-      const [k, v] = args[i + 1]!.split("=");
-      opts[k!] = v ?? "";
+    const val = args[i + 1];
+    if (args[i] === "-o" && val) {
+      const [k, v] = val.split("=");
+      opts[k ?? val] = v ?? "";
     }
   }
   return opts;

--- a/packages/surface-nix-host/src/host.test.ts
+++ b/packages/surface-nix-host/src/host.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Coverage for the ssh-argv builders in `./host`. The load-bearing
+ * assertion is that the one-shot probe/realise command carries the same
+ * dead-peer keepalive as the long-lived agent session: a `nix-store
+ * --realise` over ssh is a remote *build*, and without keepalive a host
+ * that degrades mid-build wedges the caller's spawn cycle forever (the
+ * "stuck copying to remote for eternity" failure this guards against).
+ */
+import { describe, expect, it } from "vitest";
+import { buildAgentCommand, buildSshProbeCommand } from "./host";
+
+/** Pull the `-o Key=Value` pairs out of an ssh argv into a lookup. */
+function sshOpts(args: readonly string[]): Record<string, string> {
+  const opts: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-o" && args[i + 1]) {
+      const [k, v] = args[i + 1]!.split("=");
+      opts[k!] = v ?? "";
+    }
+  }
+  return opts;
+}
+
+describe("buildSshProbeCommand", () => {
+  it("runs the command directly for localhost — no ssh wrapper", () => {
+    const { command, args } = buildSshProbeCommand(
+      "localhost",
+      "nix-instantiate",
+      "--eval",
+    );
+    expect(command).toBe("nix-instantiate");
+    expect(args).toEqual(["--eval"]);
+  });
+
+  it("wraps a remote command in ssh and forwards the remote argv verbatim", () => {
+    const { command, args } = buildSshProbeCommand(
+      "alice@bob.example",
+      "nix-store",
+      "--realise",
+      "/nix/store/x-agent.drv",
+    );
+    expect(command).toBe("ssh");
+    // host then remote argv, after the -o option block.
+    expect(args.slice(-4)).toEqual([
+      "alice@bob.example",
+      "nix-store",
+      "--realise",
+      "/nix/store/x-agent.drv",
+    ]);
+  });
+
+  it("fails fast on a dead peer: keepalive + connect timeout on the realise ssh", () => {
+    const { args } = buildSshProbeCommand(
+      "host",
+      "nix-store",
+      "--realise",
+      "x",
+    );
+    const opts = sshOpts(args);
+    expect(opts.BatchMode).toBe("yes");
+    // The fix: a degraded host mid-realise must trip ssh's dead-peer
+    // detection (~Interval×CountMax) rather than hang forever.
+    expect(opts.ServerAliveInterval).toBe("10");
+    expect(opts.ServerAliveCountMax).toBe("3");
+    expect(opts.ConnectTimeout).toBe("10");
+  });
+});
+
+describe("buildAgentCommand", () => {
+  it("runs the binary directly for localhost", () => {
+    const cmd = buildAgentCommand({
+      host: "localhost",
+      agentPath: "/nix/store/x-agent",
+      binary: "my-agent",
+    });
+    expect(cmd).toEqual({
+      command: "/nix/store/x-agent/bin/my-agent",
+      args: ["--stdio"],
+    });
+  });
+
+  it("wraps a remote agent in ssh with the shared keepalive opts", () => {
+    const { command, args } = buildAgentCommand({
+      host: "bob.example",
+      agentPath: "/nix/store/x-agent",
+      binary: "my-agent",
+    });
+    expect(command).toBe("ssh");
+    expect(args.slice(-2)).toEqual([
+      "/nix/store/x-agent/bin/my-agent",
+      "--stdio",
+    ]);
+    const opts = sshOpts(args);
+    expect(opts.BatchMode).toBe("yes");
+    expect(opts.ServerAliveInterval).toBe("10");
+    expect(opts.ServerAliveCountMax).toBe("3");
+    expect(opts.ConnectTimeout).toBe("10");
+  });
+});

--- a/packages/surface-nix-host/src/host.test.ts
+++ b/packages/surface-nix-host/src/host.test.ts
@@ -7,7 +7,7 @@
  * "stuck copying to remote for eternity" failure this guards against).
  */
 import { describe, expect, it } from "vitest";
-import { buildAgentCommand, buildSshProbeCommand } from "./host";
+import { buildAgentCommand, buildSshProbeCommand, NIX_SSHOPTS } from "./host";
 
 /** Pull the `-o Key=Value` pairs out of an ssh argv into a lookup. */
 function sshOpts(args: readonly string[]): Record<string, string> {
@@ -99,5 +99,16 @@ describe("buildAgentCommand", () => {
       "--stdio",
     ]);
     assertKeepAlive(args);
+  });
+});
+
+describe("NIX_SSHOPTS", () => {
+  it("renders the same keepalive policy as the spawned-ssh argv", () => {
+    // `nix copy --to ssh-ng://` forks its own ssh out of reach of our
+    // argv; this env string is the only handle on its dead-peer
+    // behaviour, so it must carry the identical policy. Parse it back
+    // through the argv reader (NIX_SSHOPTS is word-split by nix) and
+    // assert the same four flags the spawned ssh gets.
+    assertKeepAlive(NIX_SSHOPTS.split(" "));
   });
 });

--- a/packages/surface-nix-host/src/host.ts
+++ b/packages/surface-nix-host/src/host.ts
@@ -19,13 +19,44 @@ export function forEachLine(
   }
 }
 
+/** ssh options shared by *every* non-interactive ssh this package
+ *  spawns — the long-lived agent session and the one-shot
+ *  probe/realise/pin commands alike. They split into two jobs:
+ *
+ *   - `BatchMode=yes` — never block on a password/passphrase prompt.
+ *   - `ServerAliveInterval` / `ServerAliveCountMax` + `ConnectTimeout` —
+ *     make ssh detect a *dead peer* and exit non-zero instead of
+ *     blocking forever on a half-open connection.
+ *
+ *  That second job is load-bearing for the one-shot commands too, which
+ *  is why these opts are no longer agent-only. `nix-store --realise`
+ *  over ssh is a *remote build*, not a quick round-trip: the channel can
+ *  sit idle for minutes while the far end compiles. If the host degrades
+ *  mid-realise (network drop, sshd wedge, box overload), an ssh with no
+ *  keepalive parks on the half-open socket until the OS TCP stack gives
+ *  up — effectively forever — and wedges the caller's spawn cycle in
+ *  `copying`/`connecting` with no recovery. The keepalive turns that
+ *  eternity into a bounded ~Interval×CountMax (≈30s) failure the
+ *  reconnect loop can retry.
+ *
+ *  Crucially this does NOT cap a healthy-but-slow build: ssh keepalives
+ *  ride the protocol layer independently of channel data, so a
+ *  responsive sshd answers them no matter how long the build's stdout
+ *  stays quiet. Only an actually-unresponsive peer trips the limit. */
+const SSH_COMMON_OPTS = [
+  "-o",
+  "BatchMode=yes",
+  "-o",
+  "ServerAliveInterval=10",
+  "-o",
+  "ServerAliveCountMax=3",
+  "-o",
+  "ConnectTimeout=10",
+] as const;
+
 /** Argv to spawn the agent on `host` against the realised `agentPath`.
  *  Localhost runs the binary directly (no ssh round-trip); a real
- *  remote wraps in `ssh -o BatchMode=yes -o ServerAliveInterval=10`.
- *
- *  Distinct from `buildSshProbeCommand` below — agent connections are
- *  long-lived and need `ServerAliveInterval` to keep the ssh channel
- *  warm; probes are one-shot and deliberately omit it.
+ *  remote wraps in `ssh` with `SSH_COMMON_OPTS`.
  *
  *  `binary` is the executable name *inside* the realised closure (e.g.
  *  `process-monitor-agent` for the demo, `kolu-terminal-agent` for the
@@ -41,22 +72,14 @@ export function buildAgentCommand(opts: {
   }
   return {
     command: "ssh",
-    args: [
-      "-o",
-      "BatchMode=yes",
-      "-o",
-      "ServerAliveInterval=10",
-      opts.host,
-      exe,
-      "--stdio",
-    ],
+    args: [...SSH_COMMON_OPTS, opts.host, exe, "--stdio"],
   };
 }
 
 /** Argv to run a one-shot command against `host`. Localhost runs the
- *  command directly; remote wraps in `ssh -o BatchMode=yes`. No
- *  `ServerAliveInterval` (that flag belongs only on long-lived agent
- *  sessions — see `buildAgentCommand`).
+ *  command directly; remote wraps in `ssh` with `SSH_COMMON_OPTS` — same
+ *  dead-peer fast-fail as the agent session (see `SSH_COMMON_OPTS` for
+ *  why a "one-shot" realise needs it just as much as a long-lived link).
  *
  *  Used for `nix-instantiate --eval` arch probes and `nix-store
  *  --realise` invocations that need to round-trip and return. */
@@ -70,6 +93,6 @@ export function buildSshProbeCommand(
   }
   return {
     command: "ssh",
-    args: ["-o", "BatchMode=yes", host, ...remoteArgv],
+    args: [...SSH_COMMON_OPTS, host, ...remoteArgv],
   };
 }

--- a/packages/surface-nix-host/src/host.ts
+++ b/packages/surface-nix-host/src/host.ts
@@ -19,9 +19,10 @@ export function forEachLine(
   }
 }
 
-/** ssh options shared by *every* non-interactive ssh this package
- *  spawns — the long-lived agent session and the one-shot
- *  probe/realise/pin commands alike. They split into two jobs:
+/** ssh options shared by *every* non-interactive ssh this package causes
+ *  to be spawned — the long-lived agent session, the one-shot
+ *  probe/realise/pin commands, AND the ssh that `nix copy --to ssh-ng://`
+ *  forks internally. They split into two jobs:
  *
  *   - `BatchMode=yes` — never block on a password/passphrase prompt.
  *   - `ServerAliveInterval` / `ServerAliveCountMax` + `ConnectTimeout` —
@@ -30,29 +31,50 @@ export function forEachLine(
  *
  *  That second job is load-bearing for the one-shot commands too, which
  *  is why these opts are no longer agent-only. `nix-store --realise`
- *  over ssh is a *remote build*, not a quick round-trip: the channel can
- *  sit idle for minutes while the far end compiles. If the host degrades
- *  mid-realise (network drop, sshd wedge, box overload), an ssh with no
- *  keepalive parks on the half-open socket until the OS TCP stack gives
- *  up — effectively forever — and wedges the caller's spawn cycle in
- *  `copying`/`connecting` with no recovery. The keepalive turns that
- *  eternity into a bounded ~Interval×CountMax (≈30s) failure the
+ *  over ssh — and the `nix copy` that precedes it — is a *remote build*
+ *  / *remote transfer*, not a quick round-trip: the channel can sit idle
+ *  for minutes while the far end compiles or fetches. If the host
+ *  degrades mid-flight (network drop, sshd wedge, box overload), an ssh
+ *  with no keepalive parks on the half-open socket until the OS TCP
+ *  stack gives up — effectively forever — and wedges the caller's spawn
+ *  cycle in `copying`/`connecting` with no recovery. The keepalive turns
+ *  that eternity into a bounded ~Interval×CountMax (≈30s) failure the
  *  reconnect loop can retry.
  *
  *  Crucially this does NOT cap a healthy-but-slow build: ssh keepalives
  *  ride the protocol layer independently of channel data, so a
  *  responsive sshd answers them no matter how long the build's stdout
- *  stays quiet. Only an actually-unresponsive peer trips the limit. */
-const SSH_COMMON_OPTS = [
-  "-o",
-  "BatchMode=yes",
-  "-o",
-  "ServerAliveInterval=10",
-  "-o",
-  "ServerAliveCountMax=3",
-  "-o",
-  "ConnectTimeout=10",
+ *  stays quiet. Only an actually-unresponsive peer trips the limit.
+ *
+ *  Declared once as `(key, value)` pairs — the single source of truth —
+ *  then rendered into the two shapes its consumers need: an ssh `-o`
+ *  argv (`SSH_COMMON_OPTS`) for the ssh commands we spawn directly, and
+ *  a whitespace-joined `NIX_SSHOPTS` string for the ssh `nix copy` forks
+ *  out of reach of our argv. Values MUST stay whitespace-free: the argv
+ *  renderer emits one option per pair and nix word-splits `NIX_SSHOPTS`,
+ *  so a value with a space would silently corrupt the env form while the
+ *  argv form stayed correct. */
+const SSH_OPT_PAIRS = [
+  ["BatchMode", "yes"],
+  ["ServerAliveInterval", "10"],
+  ["ServerAliveCountMax", "3"],
+  ["ConnectTimeout", "10"],
 ] as const;
+
+/** The policy as an ssh `-o Key=Value` argv, for the ssh commands this
+ *  package spawns directly (agent session, probe/realise/pin). */
+const SSH_COMMON_OPTS: readonly string[] = SSH_OPT_PAIRS.flatMap(
+  ([key, value]) => ["-o", `${key}=${value}`],
+);
+
+/** The same policy as the `NIX_SSHOPTS` env string that `nix copy --to
+ *  ssh-ng://` reads. That copy spawns its *own* ssh which never sees our
+ *  argv, so this env var is the only handle on its dead-peer behaviour —
+ *  without it the copy step is exposed to the exact hang `SSH_COMMON_OPTS`
+ *  closes for the commands we spawn directly. */
+export const NIX_SSHOPTS: string = SSH_OPT_PAIRS.map(
+  ([key, value]) => `-o ${key}=${value}`,
+).join(" ");
 
 /** Argv to spawn the agent on `host` against the realised `agentPath`.
  *  Localhost runs the binary directly (no ssh round-trip); a real

--- a/packages/surface-nix-host/src/nixCopy.ts
+++ b/packages/surface-nix-host/src/nixCopy.ts
@@ -34,7 +34,7 @@
  * transport layer.
  */
 
-import { buildSshProbeCommand, isLocalHost } from "./host";
+import { buildSshProbeCommand, isLocalHost, NIX_SSHOPTS } from "./host";
 import { runCapture, runProgress } from "./process";
 
 export interface ProvisionOptions {
@@ -106,6 +106,10 @@ export async function provisionAgent(
         opts.drvPath,
       ],
       opts.onProgress,
+      // The copy is a remote transfer that can sit idle for minutes; the
+      // ssh it forks internally only honours dead-peer keepalive through
+      // NIX_SSHOPTS. Without it a degraded host wedges this step forever.
+      { NIX_SSHOPTS },
     );
     if (!copyRes.ok) {
       return {

--- a/packages/surface-nix-host/src/process.ts
+++ b/packages/surface-nix-host/src/process.ts
@@ -44,7 +44,7 @@ export function runProgress(
   return new Promise((resolve) => {
     const proc = spawn(cmd, [...args], {
       stdio: ["ignore", "ignore", "pipe"],
-      ...(env && { env: { ...process.env, ...env } }),
+      env: env ? { ...process.env, ...env } : undefined,
     });
     proc.stderr?.setEncoding("utf-8");
     proc.stderr?.on("data", (chunk: string) => forEachLine(chunk, onProgress));

--- a/packages/surface-nix-host/src/process.ts
+++ b/packages/surface-nix-host/src/process.ts
@@ -29,14 +29,23 @@ export interface CaptureResult extends ExitResult {
  *  `onProgress`. Used for `nix copy` where the only output the parent
  *  cares about is progress chatter on stderr. Pass no callback for
  *  silent-stderr behaviour (e.g. probe commands where there's no
- *  progress channel to forward into). */
+ *  progress channel to forward into).
+ *
+ *  `env`, when given, is *merged onto* the parent environment (not a
+ *  replacement) — the `nix copy` caller uses it to inject `NIX_SSHOPTS`
+ *  so the ssh that copy forks internally inherits the same dead-peer
+ *  keepalive as the ssh we spawn directly. */
 export function runProgress(
   cmd: string,
   args: readonly string[],
   onProgress: (line: string) => void = () => {},
+  env?: Readonly<Record<string, string>>,
 ): Promise<ExitResult> {
   return new Promise((resolve) => {
-    const proc = spawn(cmd, [...args], { stdio: ["ignore", "ignore", "pipe"] });
+    const proc = spawn(cmd, [...args], {
+      stdio: ["ignore", "ignore", "pipe"],
+      ...(env && { env: { ...process.env, ...env } }),
+    });
     proc.stderr?.setEncoding("utf-8");
     proc.stderr?.on("data", (chunk: string) => forEachLine(chunk, onProgress));
     // Use "close" (not "exit") so the last stderr chunk is guaranteed


### PR DESCRIPTION
## The bug, from production

A drishti host (`vanjaram`) sat stuck on **"Copying agent to remote…" for hours**. The copy had actually finished long before — what was wedged was the *next* step, the remote realise:

```
15:59:51  derivation copy complete
15:59:51  realising '…-drishti-agent.drv' on remote…   ← last line, then nothing for 11+ min
```

The smoking gun: the host **pinged fine** (0% loss, 218 ms via tailscale) but **refused new TCP/22 connections**, while the in-flight realise ssh — spawned *before* the degradation — sat parked:

```
ssh -o BatchMode=yes vanjaram nix-store --realise /nix/store/…-drishti-agent.drv   (etime 11:21, 0.03s CPU)
```

It used 0.03s of CPU in 11 minutes. It wasn't working — it was blocked on a half-open socket, and would stay that way until the OS TCP stack eventually gave up. The caller's spawn cycle never saw a result, so the connection cell never left `copying`/`connecting`: stuck for eternity, no retry.

## Root cause

`buildSshProbeCommand` wrapped realise/probe commands in bare `ssh -o BatchMode=yes`, **deliberately omitting** the `ServerAliveInterval` that the long-lived `buildAgentCommand` session gets. The old rationale — *"probes are one-shot and deliberately omit it"* — is the bug:

`nix-store --realise` over ssh is **a remote build, not a quick round-trip.** The channel sits idle for minutes while the far end compiles. With no keepalive, a one-shot command blocks on a dead peer exactly as hard as a long-lived one — arguably worse, since nothing downstream watchdogs the pre-spawn provisioning step.

## The fix

Fold the ssh options into one shared keepalive policy carried by **both** builders, and add dead-peer detection:

```
-o BatchMode=yes
-o ServerAliveInterval=10
-o ServerAliveCountMax=3   (was the implicit default for the agent session; now explicit + applied to probes)
-o ConnectTimeout=10
```

A dead peer now trips ssh's keepalive in **~30s** and the command exits non-zero → `runCapture` returns `{ok:false}` → `provisionAgent` fails → the reconnect loop retries with backoff, instead of wedging.

Crucially this does **not** cap a healthy-but-slow build: ssh keepalives ride the protocol layer independently of channel data, so a responsive sshd answers them no matter how long the build's stdout stays quiet. Only an *actually unresponsive* peer trips the limit.

This is the same fast-fail discipline #1060 gave the stdio RPC link — now applied to the provisioning ssh it never covered.

### The wider gap: the copy step had the same hole

The observed wedge was on *realise*, but the structural review found the **`nix copy --derivation --to ssh-ng://` step one stage earlier was exposed to the identical hang** — it forks its *own* ssh, out of reach of the argv we build, and was running with no keepalive at all. A host that degrades mid-copy (the literal "Copying agent to remote…" line in the report) wedges the spawn cycle just as hard. The only handle on that internal ssh is the `NIX_SSHOPTS` env var, so the same policy now flows there too.

To avoid two drifting copies of the option set, the policy is declared **once** as `(key, value)` pairs and rendered into the two encodings its consumers actually need — rather than casting one from the other:

```
                       ┌─▶ SSH_COMMON_OPTS  (-o k=v argv)  ─▶ agent / probe / realise / pin ssh
SSH_OPT_PAIRS  ────────┤
  (single source)      └─▶ NIX_SSHOPTS      (word-split string) ─▶ ssh that `nix copy` forks
```

*Two peer renderings, neither derived-from-the-other — a value with whitespace would corrupt the env string while the argv stayed correct, so the pair-list keeps the invariant in one place.* `runProgress` gains a small `env` param (merged onto the parent env) so the copy step can inject `NIX_SSHOPTS`.

## Tests

`host.test.ts` asserts both argv builders carry the keepalive + connect-timeout (and that localhost still short-circuits the ssh wrapper), and pins that `NIX_SSHOPTS` renders the *same* four-flag policy as the spawned-ssh argv — so the copy path can't silently drift from the realise path. Full `surface-nix-host` suite: **19/19 green**; `just check` (typecheck + biome) clean.

### Try it locally

```sh
nix run github:juspay/kolu/fix-realise-ssh-hang
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._