### PR TITLE
Preserve the file-tree expansion state in the Code tab (in-place tree updates)

### DIFF
--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -230,10 +230,13 @@ export const FileTree: Component<FileTreeProps> = (props) => {
             // nested file). Expanding each directory handle in place
             // preserves every other open folder; routing this through
             // `resetPaths` would rebuild the tree and collapse the user's
-            // hand-expanded siblings. A `getItem` returning a directory
-            // handle exposes `expand()`; re-expanding an open folder is a
-            // no-op, and files/missing paths simply fall through the
-            // `"expand" in item` guard.
+            // hand-expanded siblings. `getItem` returns a directory-or-file
+            // handle union: `"expand" in item` is the narrowing — Pierre's
+            // `isDirectory()` returns a `true`/`false` literal but isn't a
+            // `this is` predicate, so it can't narrow, whereas the `in`
+            // check both compiles and probes for the exact capability we're
+            // about to call. Re-expanding an open folder is a no-op; a file
+            // or a missing path narrows away and is skipped.
             for (const ancestor of ancestorDirectoryPaths(path)) {
               const item = tree?.getItem(ancestor);
               if (item && "expand" in item) item.expand();

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -154,21 +154,22 @@ export const FileTree: Component<FileTreeProps> = (props) => {
   // open in one call (Pierre's `FileTreeResetOptions.initialExpandedPaths`).
   // Tracking the inputs in the same effect means a paths-and-ancestors
   // swap lands atomically — no second effect, no ordering invariant
-  // between "rebuild tree" and "open ancestors". The selected path's
-  // ancestors are merged in too: when an external caller drives selection
-  // (e.g. a terminal `path:line` click resolving into a nested file),
-  // the parents must be expanded for the row to be visible. Pierre's
-  // public surface doesn't expose `expandDirectory` directly, so the
-  // expand-on-select is routed through this same `resetPaths` call.
+  // between "rebuild tree" and "open ancestors". `resetPaths` rebuilds the
+  // tree from scratch, so it can only ever open the directories named here;
+  // it has no memory of folders the user expanded by hand. That's why
+  // `selectedPath` is *not* a dependency: routing selection changes through
+  // here would rebuild the tree on every file click and collapse every
+  // manually-expanded sibling that isn't an ancestor of the new pick. The
+  // selection effect below expands the picked file's ancestors imperatively
+  // instead, leaving the rest of the tree's expansion state untouched. We
+  // still read `selectedPath` untracked so a paths/expandPaths-driven
+  // rebuild keeps the current selection's ancestors open.
   createEffect(
     on(
-      [
-        () => props.paths,
-        () => props.expandPaths,
-        () => props.selectedPath ?? null,
-      ],
-      ([paths, expandPaths, selectedPath]) => {
+      [() => props.paths, () => props.expandPaths],
+      ([paths, expandPaths]) => {
         safeApply(() => {
+          const selectedPath = props.selectedPath ?? null;
           const ancestors = selectedPath
             ? ancestorDirectoryPaths(selectedPath)
             : [];
@@ -223,6 +224,20 @@ export const FileTree: Component<FileTreeProps> = (props) => {
           };
           deselectOthers(path);
           if (path !== null) {
+            // Open the picked file's ancestors so the row is visible —
+            // an external caller can drive selection into a collapsed
+            // subtree (e.g. a terminal `path:line` click resolving into a
+            // nested file). Expanding each directory handle in place
+            // preserves every other open folder; routing this through
+            // `resetPaths` would rebuild the tree and collapse the user's
+            // hand-expanded siblings. A `getItem` returning a directory
+            // handle exposes `expand()`; re-expanding an open folder is a
+            // no-op, and files/missing paths simply fall through the
+            // `"expand" in item` guard.
+            for (const ancestor of ancestorDirectoryPaths(path)) {
+              const item = tree?.getItem(ancestor);
+              if (item && "expand" in item) item.expand();
+            }
             tree?.getItem(path)?.select();
             // `select()` marks aria-selected but doesn't move the
             // virtualizer; deep paths in large worktrees would stay

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -45,30 +45,31 @@ export function ancestorDirectoryPaths(path: string): string[] {
   return out;
 }
 
-/** The directories the tree currently holds open. Pierre exposes no bulk
- *  "expanded paths" getter (only per-handle `isExpanded()`), so we
- *  reconstruct the candidate directory set from the path list the tree was
- *  last built with — every ancestor of every file — and ask each handle
- *  whether it's open. Feeding the result back into `resetPaths` carries the
- *  user's full expansion state across a rebuild, so live-watcher churn (a
- *  file added or removed) and filter changes don't collapse hand-opened
- *  folders. Directories that vanish from the new path list simply aren't
- *  recreated. */
-function currentlyExpandedDirectories(
-  tree: FileTreeClass | undefined,
-  paths: readonly string[] | undefined,
-): string[] {
-  if (!tree || !paths) return [];
-  const dirs = new Set<string>();
-  for (const path of paths) {
-    for (const dir of ancestorDirectoryPaths(path)) dirs.add(dir);
+type FileTreeBatchOperation = Parameters<FileTreeClass["batch"]>[0][number];
+
+/** The add/remove operations that turn the `prev` file inventory into
+ *  `next`, as Pierre `batch` ops. Driving path changes through `batch`
+ *  rather than `resetPaths` mutates the tree in place: Pierre keeps the
+ *  expansion, selection, and scroll state of every node it doesn't touch,
+ *  so live-watcher churn (a file added or removed) and filter changes no
+ *  longer collapse hand-opened folders. A file dropped from `next` takes
+ *  its now-empty ancestor directories with it — Pierre infers directories
+ *  from path prefixes — which is the one expansion loss that's intrinsic,
+ *  not a rebuild artifact (there is no row left to keep open). */
+function pathDiffOperations(
+  prev: readonly string[],
+  next: readonly string[],
+): FileTreeBatchOperation[] {
+  const prevSet = new Set(prev);
+  const nextSet = new Set(next);
+  const ops: FileTreeBatchOperation[] = [];
+  for (const path of prev) {
+    if (!nextSet.has(path)) ops.push({ type: "remove", path });
   }
-  const open: string[] = [];
-  for (const dir of dirs) {
-    const item = tree.getItem(dir);
-    if (item && "isExpanded" in item && item.isExpanded()) open.push(dir);
+  for (const path of next) {
+    if (!prevSet.has(path)) ops.push({ type: "add", path });
   }
-  return open;
+  return ops;
 }
 
 export type FileTreeProps = {
@@ -124,6 +125,12 @@ export type FileTreeProps = {
 export const FileTree: Component<FileTreeProps> = (props) => {
   let container!: HTMLDivElement;
   let tree: FileTreeClass | undefined;
+  // The path inventory Pierre's tree currently holds. Seeded at mount and
+  // updated after every `batch`, so the next path change can be applied as
+  // an in-place delta. Tracked here rather than via `on`'s `prevInput`
+  // because that arg is `undefined` on the first post-`defer` run — which
+  // would drop the very first delta's removals.
+  let appliedPaths: readonly string[] = [];
 
   // Pierre fires `onSelectionChange` for directory clicks too, which would
   // produce an EISDIR if the consumer reads the path as a file. Directories
@@ -173,45 +180,46 @@ export const FileTree: Component<FileTreeProps> = (props) => {
       // path. Idempotent — Pierre's view processes the explicit scroll
       // request in the same render tick as its own first-mount scroll.
       if (props.selectedPath) tree.scrollToPath(props.selectedPath);
+      appliedPaths = props.paths;
     }, props.onError);
   });
 
-  // `resetPaths` takes the new path inventory and the directories to
-  // open in one call (Pierre's `FileTreeResetOptions.initialExpandedPaths`).
-  // Tracking the inputs in the same effect means a paths-and-ancestors
-  // swap lands atomically — no second effect, no ordering invariant
-  // between "rebuild tree" and "open ancestors". `resetPaths` rebuilds the
-  // tree from scratch and reopens *only* the directories named here, with
-  // no memory of folders the user expanded by hand — so the rebuild must
-  // carry the full expansion state forward itself. We snapshot every
-  // currently-open directory (from the path list the tree was last built
-  // with, via `prevPaths`) and merge it with the search-projected ancestors
-  // and the selected file's ancestors. Without the snapshot, every live
-  // watcher tick or filter change would collapse the whole tree.
+  // Push path-inventory changes into Pierre as in-place mutations, not a
+  // `resetPaths` rebuild. `resetPaths` throws the tree's store away and
+  // reopens only the directories it's handed, so it can't preserve the
+  // folders the user expanded by hand; `batch(add/remove)` touches only the
+  // changed nodes and leaves every other node's expansion/selection/scroll
+  // intact. We diff the new inventory against `appliedPaths` (what the tree
+  // currently holds), apply the delta, then record the new inventory. After
+  // the delta we additively open the directories the projection wants
+  // visible: the search-projected ancestors (`expandPaths`) and the selected
+  // file's ancestors, so a freshly-added nested file or a filter match is
+  // revealed. Expanding an already-open folder is a no-op, so this never
+  // collapses anything.
   //
   // `selectedPath` is deliberately *not* a dependency — routing selection
-  // through here would rebuild the tree on every file click. The selection
-  // effect below reveals the picked row imperatively instead; we read
-  // `selectedPath` untracked only so a genuine paths/expandPaths rebuild
-  // keeps the current selection's ancestors open.
+  // through here would re-run on every file click. The selection effect
+  // below reveals the picked row imperatively instead; we read `selectedPath`
+  // untracked only so a genuine paths/expandPaths change reveals the current
+  // selection.
   createEffect(
     on(
       [() => props.paths, () => props.expandPaths],
-      ([paths, expandPaths], prev) => {
+      ([paths, expandPaths]) => {
         safeApply(() => {
-          const previouslyOpen = currentlyExpandedDirectories(tree, prev?.[0]);
+          if (!tree) return;
+          const ops = pathDiffOperations(appliedPaths, paths);
+          if (ops.length > 0) tree.batch(ops);
+          appliedPaths = paths;
           const selectedPath = props.selectedPath ?? null;
-          const ancestors = selectedPath
-            ? ancestorDirectoryPaths(selectedPath)
-            : [];
-          const expanded = [
-            ...new Set([
-              ...previouslyOpen,
-              ...(expandPaths ?? []),
-              ...ancestors,
-            ]),
+          const toOpen = [
+            ...(expandPaths ?? []),
+            ...(selectedPath ? ancestorDirectoryPaths(selectedPath) : []),
           ];
-          tree?.resetPaths(paths, { initialExpandedPaths: expanded });
+          for (const dir of toOpen) {
+            const item = tree.getItem(dir);
+            if (item && "expand" in item) item.expand();
+          }
         }, props.onError);
       },
       { defer: true },

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -45,6 +45,32 @@ export function ancestorDirectoryPaths(path: string): string[] {
   return out;
 }
 
+/** The directories the tree currently holds open. Pierre exposes no bulk
+ *  "expanded paths" getter (only per-handle `isExpanded()`), so we
+ *  reconstruct the candidate directory set from the path list the tree was
+ *  last built with — every ancestor of every file — and ask each handle
+ *  whether it's open. Feeding the result back into `resetPaths` carries the
+ *  user's full expansion state across a rebuild, so live-watcher churn (a
+ *  file added or removed) and filter changes don't collapse hand-opened
+ *  folders. Directories that vanish from the new path list simply aren't
+ *  recreated. */
+function currentlyExpandedDirectories(
+  tree: FileTreeClass | undefined,
+  paths: readonly string[] | undefined,
+): string[] {
+  if (!tree || !paths) return [];
+  const dirs = new Set<string>();
+  for (const path of paths) {
+    for (const dir of ancestorDirectoryPaths(path)) dirs.add(dir);
+  }
+  const open: string[] = [];
+  for (const dir of dirs) {
+    const item = tree.getItem(dir);
+    if (item && "isExpanded" in item && item.isExpanded()) open.push(dir);
+  }
+  return open;
+}
+
 export type FileTreeProps = {
   paths: string[];
   gitStatus?: GitStatusEntry[];
@@ -155,25 +181,36 @@ export const FileTree: Component<FileTreeProps> = (props) => {
   // Tracking the inputs in the same effect means a paths-and-ancestors
   // swap lands atomically — no second effect, no ordering invariant
   // between "rebuild tree" and "open ancestors". `resetPaths` rebuilds the
-  // tree from scratch, so it can only ever open the directories named here;
-  // it has no memory of folders the user expanded by hand. That's why
-  // `selectedPath` is *not* a dependency: routing selection changes through
-  // here would rebuild the tree on every file click and collapse every
-  // manually-expanded sibling that isn't an ancestor of the new pick. The
-  // selection effect below expands the picked file's ancestors imperatively
-  // instead, leaving the rest of the tree's expansion state untouched. We
-  // still read `selectedPath` untracked so a paths/expandPaths-driven
-  // rebuild keeps the current selection's ancestors open.
+  // tree from scratch and reopens *only* the directories named here, with
+  // no memory of folders the user expanded by hand — so the rebuild must
+  // carry the full expansion state forward itself. We snapshot every
+  // currently-open directory (from the path list the tree was last built
+  // with, via `prevPaths`) and merge it with the search-projected ancestors
+  // and the selected file's ancestors. Without the snapshot, every live
+  // watcher tick or filter change would collapse the whole tree.
+  //
+  // `selectedPath` is deliberately *not* a dependency — routing selection
+  // through here would rebuild the tree on every file click. The selection
+  // effect below reveals the picked row imperatively instead; we read
+  // `selectedPath` untracked only so a genuine paths/expandPaths rebuild
+  // keeps the current selection's ancestors open.
   createEffect(
     on(
       [() => props.paths, () => props.expandPaths],
-      ([paths, expandPaths]) => {
+      ([paths, expandPaths], prev) => {
         safeApply(() => {
+          const previouslyOpen = currentlyExpandedDirectories(tree, prev?.[0]);
           const selectedPath = props.selectedPath ?? null;
           const ancestors = selectedPath
             ? ancestorDirectoryPaths(selectedPath)
             : [];
-          const expanded = [...(expandPaths ?? []), ...ancestors];
+          const expanded = [
+            ...new Set([
+              ...previouslyOpen,
+              ...(expandPaths ?? []),
+              ...ancestors,
+            ]),
+          ];
           tree?.resetPaths(paths, { initialExpandedPaths: expanded });
         }, props.onError);
       },

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -460,6 +460,31 @@ Feature: Code tab (review + browse)
     Then the file "beta/b1.txt" should be selected in the file browser
     And the file browser should show a file "alpha/a1.txt"
 
+  # Regression: applying then clearing the filter rebuilds the tree via
+  # `resetPaths`, which reopens only the directories it's handed. Clearing the
+  # filter hands it no ancestors (the query is empty), so without carrying the
+  # prior expansion forward the rebuild collapses every folder the user opened
+  # by hand. The wrapper now snapshots the open directories before each rebuild
+  # and re-applies them, so a folder that stays in view across the filter dance
+  # keeps its expansion. (A folder filtered entirely out of view — `beta` here —
+  # legitimately folds away; Pierre drops it from the projection.)
+  Scenario: File browser keeps a folder expanded across a filter and clear
+    When I run "git init /tmp/kolu-browse-filter && cd /tmp/kolu-browse-filter"
+    And I run "mkdir -p alpha beta && printf 'a1\n' > alpha/a1.txt && printf 'a2\n' > alpha/a2.txt && printf 'b1\n' > beta/b1.txt && printf 'b2\n' > beta/b2.txt"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    And I click the directory "alpha" in the file browser
+    Then the file browser should show a file "alpha/a1.txt"
+    When I click the directory "beta" in the file browser
+    Then the file browser should show a file "beta/b1.txt"
+    When I type "a1" into the Code tab filter
+    Then the file browser should show a file "alpha/a1.txt"
+    And the file browser should not show a file "beta/b1.txt"
+    When I type "" into the Code tab filter
+    Then the file browser should show a file "alpha/a1.txt"
+    And the file browser should show a file "alpha/a2.txt"
+
   # ── Pierre file/diff viewer right-click menu (Copy path:line) ──
 
   Scenario: Right-click on a file content line copies "path:line"

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -439,6 +439,27 @@ Feature: Code tab (review + browse)
     When I click the directory "lib" in the file browser
     Then the file browser should show a file "lib/util.ts"
 
+  # Regression: expanding several directories and then clicking a file to
+  # preview it used to collapse every directory that wasn't an ancestor of
+  # the clicked file. Selection drove a full `resetPaths` in the Pierre
+  # wrapper, rebuilding the tree with only the search-projected and
+  # selected-ancestor directories open — so manually-expanded siblings lost
+  # their state. Selection now expands the picked file's ancestors
+  # imperatively and leaves every other open directory untouched.
+  Scenario: File browser preserves sibling expansion when previewing a file
+    When I run "git init /tmp/kolu-browse-keep && cd /tmp/kolu-browse-keep"
+    And I run "mkdir -p alpha beta && printf 'a1\n' > alpha/a1.txt && printf 'a2\n' > alpha/a2.txt && printf 'b1\n' > beta/b1.txt && printf 'b2\n' > beta/b2.txt"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    And I click the directory "alpha" in the file browser
+    Then the file browser should show a file "alpha/a1.txt"
+    When I click the directory "beta" in the file browser
+    Then the file browser should show a file "beta/b1.txt"
+    When I click the file "beta/b1.txt" in the file browser
+    Then the file "beta/b1.txt" should be selected in the file browser
+    And the file browser should show a file "alpha/a1.txt"
+
   # ── Pierre file/diff viewer right-click menu (Copy path:line) ──
 
   Scenario: Right-click on a file content line copies "path:line"


### PR DESCRIPTION
**Expanding directories in the Code-tab browse tree and then interacting with it — previewing a file, or filtering and clearing — no longer collapses the folders you opened by hand.** The tree used to forget the shape you'd built up the moment you clicked a file, and again whenever the file list rebuilt.

The root cause was *how* the `@pierre/trees` wrapper pushed path changes into the tree. Pierre offers two very different ways to update the file list, and the wrapper was using the wrong one:

| Pierre API | Effect on the tree's store |
| --- | --- |
| `resetPaths` | **Tear down and rebuild.** Discards the store and reopens *only* the directories handed to it — no memory of what the user expanded. |
| `batch(add/remove)` | **Mutate in place.** Touches only the changed nodes; every other node keeps its expansion, selection, and scroll. |

The wrapper called `resetPaths` on every path change, so any rebuild — a watcher tick, a filter, a selection that was (wrongly) routed through the rebuild — collapsed the tree. **The fix switches to `batch`: diff the path inventory and apply the delta, so Pierre preserves the whole tree's state natively.**

### What changed

- **Selection no longer rebuilds the tree.** `selectedPath` was a tracked dependency of the rebuild effect; previewing a file rebuilt the whole tree. It's dropped from the deps — the selection effect reveals the picked row imperatively (`getItem(dir).expand()` for its ancestors, additively), covering external `path:line` navigation into a collapsed subtree.
- **Path changes apply as in-place mutations.** The effect diffs the new inventory against an `appliedPaths` ref (seeded at mount, updated after each `batch`) and applies `add`/`remove` ops. Pierre keeps expansion/selection/scroll for every untouched node. Search-projected and selected ancestors are opened additively afterward to reveal new or filtered rows.
- **The snapshot hack is gone.** An earlier iteration snapshotted every open directory before each `resetPaths` and fed it back; `batch` makes Pierre preserve state natively, so that code (and its `isExpanded()` probing) was deleted.

> _`appliedPaths` is tracked by hand rather than via `on`'s `prevInput`, which is `undefined` on the first post-`defer` run and would have dropped the first delta's removals — a bug caught in review and verified with a red/green e2e._

### One intrinsic limit

A folder whose *every* file is filtered out of the projection still folds away — Pierre infers directories from path prefixes, so once the rows are gone there's no node to keep open. This is true of any approach; everything that **stays in view** keeps its expansion.

### Tests

Two browse-mode regressions, each red before the fix:
- **Preview** — expand two sibling dirs, preview a file in one, assert the other stays open.
- **Filter → clear** — expand two dirs, filter to one, clear, assert the surviving dir is still expanded (collapses without in-place preservation).

### Try it locally

```sh
nix run github:juspay/kolu/bug-colla
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._