### PR TITLE
Scope mobile swipe to the tile, keep the keyboard down on dock dismiss, equalize the handles

### DIFF
--- a/packages/client/src/MobileKeyBar.tsx
+++ b/packages/client/src/MobileKeyBar.tsx
@@ -88,6 +88,13 @@ const MobileKeyBar: Component<{
       <div
         class="flex gap-1 px-2 py-1.5 bg-surface-1 border-t border-edge overflow-x-auto"
         data-testid="mobile-key-bar"
+        // The key bar lives inside MobileTileView's swipe wrapper, whose
+        // touchstart/touchend cycle terminals on a horizontal swipe. A
+        // finger drag across these keys (or a scroll of the overflow-x row)
+        // would otherwise bubble up and switch the active terminal mid-type.
+        // stopPropagation on touchstart keeps the wrapper from ever recording
+        // a swipe origin here — same guard the pull/dock handles use.
+        onTouchStart={(e: TouchEvent) => e.stopPropagation()}
       >
         <For each={MODS}>
           {(mod) => (

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -136,7 +136,10 @@ const MobileTileView: Component<{
             pullStartY = null;
           }}
         >
-          <span class="w-10 h-1 rounded-full bg-fg-3/40" aria-hidden="true" />
+          {/* Grip pill — sized to mirror the left dock handle's grab bar
+           *  (`h-16 w-2`, a 64×8 px footprint) so both edges advertise an
+           *  equally large drag affordance, just rotated 90°. */}
+          <span class="w-16 h-2 rounded-full bg-fg-3/40" aria-hidden="true" />
           <div class="flex items-center gap-2 w-full">
             <Show
               when={activeInfo()}
@@ -200,6 +203,11 @@ const MobileTileView: Component<{
         open={chromeOpen()}
         onOpenChange={setChromeOpen}
         snapPoints={[0, 1]}
+        // Don't restore focus to the previously-active element on close. On a
+        // touch device that element is the terminal's contenteditable /
+        // helper textarea (auto-focused on mount); re-focusing it after a
+        // backdrop-tap dismissal pops the soft keyboard with no user intent.
+        restoreFocus={false}
       >
         <Drawer.Portal>
           <Drawer.Overlay
@@ -228,6 +236,10 @@ const MobileTileView: Component<{
         open={dockOpen()}
         onOpenChange={setDockOpen}
         snapPoints={[0, 1]}
+        // See the chrome drawer above: restoring focus on close re-focuses the
+        // terminal textarea and summons the soft keyboard when the user taps
+        // the backdrop to dismiss the dock.
+        restoreFocus={false}
       >
         <Drawer.Portal>
           <Drawer.Overlay

--- a/packages/client/src/MobileTileView.tsx
+++ b/packages/client/src/MobileTileView.tsx
@@ -38,6 +38,14 @@ const VERTICAL_TOLERANCE_RATIO = 0.7;
  *  below a casual finger jitter so a real tap still opens via the
  *  click handler. */
 const PULL_OPEN_THRESHOLD = 24;
+/** Corvu @0.2.4 defaults `snapPoints` to `[0, 1]`, but on the mouse-click
+ *  open path it reads the signal before the default attaches and trips a
+ *  reactive-ordering bug (#977). Passing the value explicitly sidesteps it;
+ *  touch-driven opens hit a different code path and never trip the bug.
+ *  Shared by both drawers below — delete on the Corvu upgrade that fixes
+ *  #977. (Orthogonal to `restoreFocus`, which is a soft-keyboard policy, not
+ *  a library workaround, and so stays inline per-drawer.) */
+const CORVU_SNAP_WORKAROUND: [number, number] = [0, 1];
 
 const MobileTileView: Component<{
   /** Workspace-switcher-ordered ids — same source as the desktop dock, so
@@ -195,14 +203,13 @@ const MobileTileView: Component<{
       </div>
 
       {/* Chrome (top pull-down) drawer — global controls.
-       *  `snapPoints={[0, 1]}` carries the same Corvu 0.2.4 workaround as
-       *  the dock drawer below — both are opened via mouse-click and would
-       *  trip the same reactive-ordering bug (#977) on that path. */}
+       *  Carries `CORVU_SNAP_WORKAROUND` — same #977 sidestep as the dock
+       *  drawer below, since both open via mouse-click. */}
       <Drawer
         side="top"
         open={chromeOpen()}
         onOpenChange={setChromeOpen}
-        snapPoints={[0, 1]}
+        snapPoints={CORVU_SNAP_WORKAROUND}
         // Don't restore focus to the previously-active element on close. On a
         // touch device that element is the terminal's contenteditable /
         // helper textarea (auto-focused on mount); re-focusing it after a
@@ -226,16 +233,13 @@ const MobileTileView: Component<{
       </Drawer>
 
       {/* Dock (left swipe) drawer — terminal navigator.
-       *  `snapPoints={[0, 1]}` is the Corvu default, but passing it
-       *  explicitly sidesteps a reactive-ordering bug in @corvu/drawer@0.2.4
-       *  where the mouse-click open path reads the signal before the default
-       *  attaches (#977). Touch-driven opens hit a different code path and
-       *  don't trip the bug. */}
+       *  Carries `CORVU_SNAP_WORKAROUND` for the same #977 reason as the
+       *  chrome drawer above. */}
       <Drawer
         side="left"
         open={dockOpen()}
         onOpenChange={setDockOpen}
-        snapPoints={[0, 1]}
+        snapPoints={CORVU_SNAP_WORKAROUND}
         // See the chrome drawer above: restoring focus on close re-focuses the
         // terminal textarea and summons the soft keyboard when the user taps
         // the backdrop to dismiss the dock.

--- a/packages/client/src/right-panel/RightPanelDrawer.tsx
+++ b/packages/client/src/right-panel/RightPanelDrawer.tsx
@@ -47,6 +47,10 @@ const RightPanelDrawer: Component<HostProps> = (props) => {
         side="bottom"
         open={rightPanel.drawerOpen()}
         onOpenChange={rightPanel.setDrawerOpen}
+        // Same soft-keyboard policy the dock/chrome drawers carry: don't
+        // restore focus to the terminal textarea on close, or backdrop-
+        // dismissing this bottom sheet pops the keyboard with no intent.
+        restoreFocus={false}
       >
         <Drawer.Portal>
           <Drawer.Overlay

--- a/packages/tests/features/mobile-dock-drawer.feature
+++ b/packages/tests/features/mobile-dock-drawer.feature
@@ -39,3 +39,18 @@ Feature: Mobile dock drawer
     When I tap the mobile dock backdrop
     Then the mobile dock sheet should not be visible
     And there should be no page errors
+
+  @mobile
+  Scenario: Dismissing the dock via the backdrop does not summon the soft keyboard
+    # Corvu's Drawer restores focus on close by default — to the terminal
+    # textarea that was active before the drawer opened — which pops the soft
+    # keyboard the user never asked for. The drawer passes restoreFocus={false};
+    # arm the focus probe, open then backdrop-dismiss the dock, and assert the
+    # textarea stays unfocused through the close.
+    Given I arm the soft-keyboard focus probe
+    When I tap the mobile dock handle
+    Then the mobile dock sheet should be visible
+    When I tap the mobile dock backdrop
+    Then the mobile dock sheet should not be visible
+    And xterm's helper textarea should not have been focused by closing the dock
+    And there should be no page errors

--- a/packages/tests/features/mobile-dock-drawer.feature
+++ b/packages/tests/features/mobile-dock-drawer.feature
@@ -42,13 +42,16 @@ Feature: Mobile dock drawer
 
   @mobile
   Scenario: Dismissing the dock via the backdrop does not summon the soft keyboard
-    # Corvu's Drawer restores focus on close by default — to the terminal
-    # textarea that was active before the drawer opened — which pops the soft
-    # keyboard the user never asked for. The drawer passes restoreFocus={false};
-    # arm the focus probe, open then backdrop-dismiss the dock, and assert the
-    # textarea stays unfocused through the close.
-    Given I arm the soft-keyboard focus probe
-    When I tap the mobile dock handle
+    # Corvu's Drawer restores focus on close by default — to the element that
+    # was active before the drawer opened — which pops the soft keyboard if
+    # that element was the terminal textarea. Reproduce the real-mobile setup:
+    # tap the terminal so its textarea holds focus (keyboard up), open the dock
+    # without moving focus (a real button tap would focus the button and mask
+    # the bug; mobile taps don't move focus off the textarea), then dismiss via
+    # the backdrop. With restoreFocus={false} the textarea must stay unfocused.
+    When I tap the terminal canvas
+    And I arm the soft-keyboard focus probe
+    And I open the dock without moving focus
     Then the mobile dock sheet should be visible
     When I tap the mobile dock backdrop
     Then the mobile dock sheet should not be visible

--- a/packages/tests/features/mobile-swipe.feature
+++ b/packages/tests/features/mobile-swipe.feature
@@ -34,10 +34,11 @@ Feature: Mobile tile swipe
     # The key bar lives inside the swipe wrapper. A finger drag across the
     # keys (or a scroll of its overflow-x row) must NOT bubble up and switch
     # terminals mid-type — the bar stops touchstart propagation. Contrast with
-    # the tile-view scenario above: the same leftward swipe there lands on t0
-    # (showing "from-t0"); here it must stay on the empty t1.
+    # the tile-view scenario above, where the same leftward swipe cycles the
+    # tile; here the active terminal must be unchanged.
     Given I run "echo from-t0"
     And I create a terminal
+    And I remember the active mobile terminal
     When I swipe left on the mobile key bar
-    Then the active terminal should not show "from-t0"
+    Then the active mobile terminal should be unchanged
     And there should be no page errors

--- a/packages/tests/features/mobile-swipe.feature
+++ b/packages/tests/features/mobile-swipe.feature
@@ -28,3 +28,16 @@ Feature: Mobile tile swipe
     When I swipe right on the mobile tile view
     Then the active terminal should show "from-t0"
     And there should be no page errors
+
+  @mobile
+  Scenario: Swiping on the soft key bar does not cycle terminals
+    # The key bar lives inside the swipe wrapper. A finger drag across the
+    # keys (or a scroll of its overflow-x row) must NOT bubble up and switch
+    # terminals mid-type — the bar stops touchstart propagation. Contrast with
+    # the tile-view scenario above: the same leftward swipe there lands on t0
+    # (showing "from-t0"); here it must stay on the empty t1.
+    Given I run "echo from-t0"
+    And I create a terminal
+    When I swipe left on the mobile key bar
+    Then the active terminal should not show "from-t0"
+    And there should be no page errors

--- a/packages/tests/step_definitions/mobile_drawer_steps.ts
+++ b/packages/tests/step_definitions/mobile_drawer_steps.ts
@@ -184,6 +184,17 @@ When("I tap the mobile dock backdrop", async function (this: KoluWorld) {
   await tapBackdropAtSafePoint(this, DOCK_BACKDROP, "left");
 });
 
+When("I open the dock without moving focus", async function (this: KoluWorld) {
+  // Fire the handle's onClick via a synthetic click instead of a real tap.
+  // A real .tap() focuses the <button>, so Corvu would capture the button as
+  // its restore-focus target on open — masking the bug. On real mobile,
+  // tapping a button doesn't move focus, so the terminal textarea stays
+  // active and Corvu captures *it*; the synthetic click reproduces that, so
+  // close-time restoreFocus has the textarea to (wrongly) summon.
+  await this.page.locator(DOCK_HANDLE).dispatchEvent("click");
+  await this.waitForFrame();
+});
+
 When("I tap the inactive mobile dock row", async function (this: KoluWorld) {
   // The drawer always shows every terminal; one carries `data-active`. The
   // other(s) are tap targets to switch. With the two-terminal background

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -355,6 +355,31 @@ Then(
 );
 
 Then(
+  "xterm's helper textarea should not have been focused by closing the dock",
+  async function (this: KoluWorld) {
+    // Reuses the document-capture probe armed above. Corvu's Drawer defaults
+    // to restoreFocus=true, which on close re-focuses the element active
+    // before it opened — the terminal textarea (auto-focused on mount) —
+    // popping the soft keyboard. The drawers pass restoreFocus={false}; this
+    // asserts the backdrop dismissal leaves the keyboard down.
+    const count = await this.page.evaluate(() => {
+      const w = window as FocusProbeWindow;
+      const value = w.__textareaFocusCount ?? 0;
+      if (w.__textareaFocusListener) {
+        document.removeEventListener("focus", w.__textareaFocusListener, true);
+      }
+      w.__textareaFocusListener = undefined;
+      return value;
+    });
+    assert.strictEqual(
+      count,
+      0,
+      `Expected no helper-textarea focus when dismissing the dock on touch (closing must not summon the keyboard), got ${count}`,
+    );
+  },
+);
+
+Then(
   "the --app-h CSS variable should match visualViewport.height",
   async function (this: KoluWorld) {
     // Wire-check: useVisualViewportHeight is mounted and the inline-style

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -29,10 +29,17 @@ const XTERM_TEXTAREA =
 function teardownDocumentCaptureProbe(world: KoluWorld): Promise<number> {
   return world.page.evaluate(() => {
     const w = window as FocusProbeWindow;
-    const value = w.__textareaFocusCount ?? 0;
-    if (w.__textareaFocusListener) {
-      document.removeEventListener("focus", w.__textareaFocusListener, true);
+    // Guard against a vacuous pass: if the probe was never armed, the counter
+    // is undefined and `?? 0` would let the assertion succeed on nothing.
+    // The installed listener is the proof the arm step ran — its absence is a
+    // hard error, not a silent zero.
+    if (!w.__textareaFocusListener) {
+      throw new Error(
+        "Focus probe not armed — call 'I arm the soft-keyboard focus probe' before this assertion",
+      );
     }
+    const value = w.__textareaFocusCount ?? 0;
+    document.removeEventListener("focus", w.__textareaFocusListener, true);
     w.__textareaFocusListener = undefined;
     return value;
   });

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -376,13 +376,24 @@ Then(
   async function (this: KoluWorld) {
     // Reuses the document-capture probe armed above. Corvu's Drawer defaults
     // to restoreFocus=true, which on close re-focuses the element active
-    // before it opened — the terminal textarea (auto-focused on mount) —
-    // popping the soft keyboard. The drawers pass restoreFocus={false}; this
-    // asserts the backdrop dismissal leaves the keyboard down.
+    // before it opened — here the terminal textarea — popping the soft
+    // keyboard. The drawers pass restoreFocus={false}; this asserts the
+    // backdrop dismissal leaves the keyboard down.
+    //
+    // The restore fires asynchronously, AFTER the close transition — later
+    // than the "sheet not visible" wait — so reading the counter immediately
+    // would race ahead of the bug and pass vacuously. Actively wait for a pop
+    // (bounded); if none arrives the keyboard stayed down.
+    const popped = await this.page
+      .waitForFunction(
+        () => ((window as FocusProbeWindow).__textareaFocusCount ?? 0) > 0,
+        { timeout: 1500 },
+      )
+      .then(() => true)
+      .catch(() => false);
     const count = await teardownDocumentCaptureProbe(this);
-    assert.strictEqual(
-      count,
-      0,
+    assert.ok(
+      !popped && count === 0,
       `Expected no helper-textarea focus when dismissing the dock on touch (closing must not summon the keyboard), got ${count}`,
     );
   },

--- a/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
+++ b/packages/tests/step_definitions/mobile_soft_keyboard_steps.ts
@@ -20,6 +20,24 @@ const XTERM_SCREEN = "[data-visible][data-terminal-id] .xterm-screen";
 const XTERM_TEXTAREA =
   "[data-visible][data-terminal-id] .xterm-helper-textarea";
 
+/** Read the document-capture focus counter armed by "I arm the soft-keyboard
+ *  focus probe", detach its listener, and return the count. Shared by every
+ *  Then-step that asserts a touch interaction did NOT focus the helper
+ *  textarea. The element-scoped probes (scroll, canceled-gesture) bind their
+ *  listener to a single textarea and tear down differently, so they don't use
+ *  this. */
+function teardownDocumentCaptureProbe(world: KoluWorld): Promise<number> {
+  return world.page.evaluate(() => {
+    const w = window as FocusProbeWindow;
+    const value = w.__textareaFocusCount ?? 0;
+    if (w.__textareaFocusListener) {
+      document.removeEventListener("focus", w.__textareaFocusListener, true);
+    }
+    w.__textareaFocusListener = undefined;
+    return value;
+  });
+}
+
 When(
   "I tap the mobile key {string}",
   async function (this: KoluWorld, testId: string) {
@@ -337,15 +355,7 @@ When("I arm the soft-keyboard focus probe", async function (this: KoluWorld) {
 Then(
   "xterm's helper textarea should not have been focused by the terminal switch",
   async function (this: KoluWorld) {
-    const count = await this.page.evaluate(() => {
-      const w = window as FocusProbeWindow;
-      const value = w.__textareaFocusCount ?? 0;
-      if (w.__textareaFocusListener) {
-        document.removeEventListener("focus", w.__textareaFocusListener, true);
-      }
-      w.__textareaFocusListener = undefined;
-      return value;
-    });
+    const count = await teardownDocumentCaptureProbe(this);
     assert.strictEqual(
       count,
       0,
@@ -362,15 +372,7 @@ Then(
     // before it opened — the terminal textarea (auto-focused on mount) —
     // popping the soft keyboard. The drawers pass restoreFocus={false}; this
     // asserts the backdrop dismissal leaves the keyboard down.
-    const count = await this.page.evaluate(() => {
-      const w = window as FocusProbeWindow;
-      const value = w.__textareaFocusCount ?? 0;
-      if (w.__textareaFocusListener) {
-        document.removeEventListener("focus", w.__textareaFocusListener, true);
-      }
-      w.__textareaFocusListener = undefined;
-      return value;
-    });
+    const count = await teardownDocumentCaptureProbe(this);
     assert.strictEqual(
       count,
       0,

--- a/packages/tests/step_definitions/mobile_swipe_steps.ts
+++ b/packages/tests/step_definitions/mobile_swipe_steps.ts
@@ -13,10 +13,14 @@ Then(
   },
 );
 
-async function dispatchSwipe(world: KoluWorld, dx: number) {
-  const view = world.page.locator(VIEW_SELECTOR);
+async function dispatchSwipe(
+  world: KoluWorld,
+  dx: number,
+  selector = VIEW_SELECTOR,
+) {
+  const view = world.page.locator(selector);
   const box = await view.boundingBox();
-  assert.ok(box, "Mobile tile view has no bounding box");
+  assert.ok(box, `Swipe target ${selector} has no bounding box`);
   const startX = box.x + box.width / 2;
   const y = box.y + box.height / 2;
   // Synthesize a touch sequence — Playwright's touchscreen.tap() doesn't
@@ -26,10 +30,15 @@ async function dispatchSwipe(world: KoluWorld, dx: number) {
   // which doesn't exist in the browser. page.evaluate ships the function
   // body as a string — the workaround is to ship plain JS source via
   // page.evaluate(string) so esbuild never touches it.
+  //
+  // touchstart/touchend dispatch on `target` and bubble, so the gesture
+  // originates from the chosen element. Pointing it at the key bar lets a
+  // test assert the bar's stopPropagation guard keeps the wrapper from
+  // cycling tiles when a finger drags across the keys.
   const src = `
     (() => {
-      const target = document.querySelector(${JSON.stringify(VIEW_SELECTOR)});
-      if (!target) throw new Error("mobile tile view not found");
+      const target = document.querySelector(${JSON.stringify(selector)});
+      if (!target) throw new Error("swipe target not found");
       const t = (x, y) => new Touch({
         identifier: 1, target, clientX: x, clientY: y,
         pageX: x, pageY: y, screenX: x, screenY: y,
@@ -58,6 +67,10 @@ When("I swipe left on the mobile tile view", async function (this: KoluWorld) {
 
 When("I swipe right on the mobile tile view", async function (this: KoluWorld) {
   await dispatchSwipe(this, 200);
+});
+
+When("I swipe left on the mobile key bar", async function (this: KoluWorld) {
+  await dispatchSwipe(this, -200, '[data-testid="mobile-key-bar"]');
 });
 
 Then(

--- a/packages/tests/step_definitions/mobile_swipe_steps.ts
+++ b/packages/tests/step_definitions/mobile_swipe_steps.ts
@@ -73,6 +73,41 @@ When("I swipe left on the mobile key bar", async function (this: KoluWorld) {
   await dispatchSwipe(this, -200, '[data-testid="mobile-key-bar"]');
 });
 
+// The active mobile tile is the one whose body is shown (`data-visible`).
+// Capturing its terminal id before/after a gesture is renderer-independent —
+// unlike reading xterm's canvas-backed `.xterm-screen` text — so it cleanly
+// proves whether a swipe cycled the tile.
+const ACTIVE_TILE = "[data-visible][data-terminal-id]";
+
+When("I remember the active mobile terminal", async function (this: KoluWorld) {
+  const id = await this.page
+    .locator(ACTIVE_TILE)
+    .first()
+    .getAttribute("data-terminal-id");
+  assert.ok(id, "No active mobile terminal to remember");
+  this.savedActiveTerminalId = id;
+});
+
+Then(
+  "the active mobile terminal should be unchanged",
+  async function (this: KoluWorld) {
+    const before = this.savedActiveTerminalId;
+    assert.ok(
+      before,
+      "No remembered active terminal — call 'I remember the active mobile terminal' first",
+    );
+    const after = await this.page
+      .locator(ACTIVE_TILE)
+      .first()
+      .getAttribute("data-terminal-id");
+    assert.strictEqual(
+      after,
+      before,
+      `Expected the active mobile terminal to stay ${before}, but it switched to ${after}`,
+    );
+  },
+);
+
 Then(
   "the active terminal should not show {string}",
   async function (this: KoluWorld, text: string) {


### PR DESCRIPTION
On mobile, three touch annoyances around the fullscreen tile and its drawers. **Swiping across the soft key bar now stays put instead of cycling terminals, dismissing a drawer no longer pops the soft keyboard, and the top pull-handle grip matches the left dock handle's size.**

### The three fixes

| Symptom | Cause | Fix |
| --- | --- | --- |
| A finger drag across the soft key bar cycled to another terminal mid-type | The key bar sits inside the swipe wrapper, so its touch events bubbled up to the tile-cycle handler | The bar stops `touchstart` propagation — the same guard the pull/dock handles already use |
| Tapping the backdrop to close the dock popped the soft keyboard | Corvu's `Drawer` defaults `restoreFocus={true}`, re-focusing the terminal textarea that was active before the drawer opened | `restoreFocus={false}` on every mobile drawer |
| The top drag handle's grip looked much smaller than the left one | Top grip was `w-10 h-1` (40×4 px); left grip is `h-16 w-2` (64×8 px) | Top grip enlarged to `w-16 h-2` — same 64×8 footprint, rotated 90° |

### Structural-review follow-ups

The `restoreFocus` fix surfaced a **latent twin bug**: `RightPanelDrawer` (the mobile bottom-sheet inspector) carried no focus guard either, so backdrop-dismissing it would pop the keyboard the same way. It's now aligned with the dock and chrome drawers. The two drawers' duplicated `snapPoints={[0,1]}` Corvu `#977` workaround was also pulled into a named `CORVU_SNAP_WORKAROUND` const — kept _separate_ from `restoreFocus`, which is a soft-keyboard policy on a different volatility axis, not a library workaround.

> _The two e2e regression guards initially passed even with their fixes reverted — both were vacuous (one read xterm's canvas-backed `.xterm-screen` as text; the other raced ahead of Corvu's async focus restore). They're now verified to fail without their fix._

### Try it locally

```sh
nix run github:juspay/kolu/mobile-swipe
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._