### PR TITLE
Let Codex load pu and evidence skills

### DIFF
--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: evidence
-description: Capture production-like PR evidence (screenshots and video) by running the app on an ephemeral pu box and driving headless Chrome with Playwright — entirely off the user's machine, the way CI builds. Use when a change has visible UI impact and you want to post a `## Evidence` PR comment. Project-agnostic: it parameterizes on a `nix run`-style serve command, so it reuses across any project whose app boots that way. Covers the self-contained Playwright capture, video recording, ffmpeg transcode, GitHub-release hosting, and posting. Triggers on "post evidence", "screenshot the change", "PR evidence", "record a video of this", "capture the UI".
+description: >-
+  Capture production-like PR evidence (screenshots and video) by running the app
+  on an ephemeral pu box and driving headless Chrome with Playwright — entirely
+  off the user's machine, the way CI builds. Use when a change has visible UI
+  impact and you want to post a `## Evidence` PR comment. Project-agnostic: it
+  parameterizes on a `nix run`-style serve command, so it reuses across any
+  project whose app boots that way. Covers the self-contained Playwright capture,
+  video recording, ffmpeg transcode, GitHub-release hosting, and posting.
+  Triggers on "post evidence", "screenshot the change", "PR evidence", "record a
+  video of this", "capture the UI".
 ---
 
 # evidence — PR screenshots & video, captured on a pu box

--- a/.agents/skills/pu/SKILL.md
+++ b/.agents/skills/pu/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: pu
-description: Provision and drive an ephemeral `pu` box — a throwaway Incus container used as a clean Linux host for CI, builds, and evidence capture. Use when you need to run something on a fresh remote box instead of the user's machine: `nix run` a build, run CI against a real host, capture screenshots/video off-machine, or reproduce on a pristine environment. Covers create/connect/scp/destroy, running remote commands, copying artifacts back, and the no-egress failure mode. Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host", "pu create/connect/destroy".
+description: >-
+  Provision and drive an ephemeral `pu` box — a throwaway Incus container used as
+  a clean Linux host for CI, builds, and evidence capture. Use when you need to
+  run something on a fresh remote box instead of the user's machine: `nix run` a
+  build, run CI against a real host, capture screenshots/video off-machine, or
+  reproduce on a pristine environment. Covers create/connect/scp/destroy, running
+  remote commands, copying artifacts back, and the no-egress failure mode.
+  Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host",
+  "pu create/connect/destroy".
 ---
 
 # pu — ephemeral Incus boxes

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: evidence
-description: Capture production-like PR evidence (screenshots and video) by running the app on an ephemeral pu box and driving headless Chrome with Playwright — entirely off the user's machine, the way CI builds. Use when a change has visible UI impact and you want to post a `## Evidence` PR comment. Project-agnostic: it parameterizes on a `nix run`-style serve command, so it reuses across any project whose app boots that way. Covers the self-contained Playwright capture, video recording, ffmpeg transcode, GitHub-release hosting, and posting. Triggers on "post evidence", "screenshot the change", "PR evidence", "record a video of this", "capture the UI".
+description: >-
+  Capture production-like PR evidence (screenshots and video) by running the app
+  on an ephemeral pu box and driving headless Chrome with Playwright — entirely
+  off the user's machine, the way CI builds. Use when a change has visible UI
+  impact and you want to post a `## Evidence` PR comment. Project-agnostic: it
+  parameterizes on a `nix run`-style serve command, so it reuses across any
+  project whose app boots that way. Covers the self-contained Playwright capture,
+  video recording, ffmpeg transcode, GitHub-release hosting, and posting.
+  Triggers on "post evidence", "screenshot the change", "PR evidence", "record a
+  video of this", "capture the UI".
 ---
 
 # evidence — PR screenshots & video, captured on a pu box

--- a/.apm/skills/pu/SKILL.md
+++ b/.apm/skills/pu/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: pu
-description: Provision and drive an ephemeral `pu` box — a throwaway Incus container used as a clean Linux host for CI, builds, and evidence capture. Use when you need to run something on a fresh remote box instead of the user's machine: `nix run` a build, run CI against a real host, capture screenshots/video off-machine, or reproduce on a pristine environment. Covers create/connect/scp/destroy, running remote commands, copying artifacts back, and the no-egress failure mode. Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host", "pu create/connect/destroy".
+description: >-
+  Provision and drive an ephemeral `pu` box — a throwaway Incus container used as
+  a clean Linux host for CI, builds, and evidence capture. Use when you need to
+  run something on a fresh remote box instead of the user's machine: `nix run` a
+  build, run CI against a real host, capture screenshots/video off-machine, or
+  reproduce on a pristine environment. Covers create/connect/scp/destroy, running
+  remote commands, copying artifacts back, and the no-egress failure mode.
+  Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host",
+  "pu create/connect/destroy".
 ---
 
 # pu — ephemeral Incus boxes

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: evidence
-description: Capture production-like PR evidence (screenshots and video) by running the app on an ephemeral pu box and driving headless Chrome with Playwright — entirely off the user's machine, the way CI builds. Use when a change has visible UI impact and you want to post a `## Evidence` PR comment. Project-agnostic: it parameterizes on a `nix run`-style serve command, so it reuses across any project whose app boots that way. Covers the self-contained Playwright capture, video recording, ffmpeg transcode, GitHub-release hosting, and posting. Triggers on "post evidence", "screenshot the change", "PR evidence", "record a video of this", "capture the UI".
+description: >-
+  Capture production-like PR evidence (screenshots and video) by running the app
+  on an ephemeral pu box and driving headless Chrome with Playwright — entirely
+  off the user's machine, the way CI builds. Use when a change has visible UI
+  impact and you want to post a `## Evidence` PR comment. Project-agnostic: it
+  parameterizes on a `nix run`-style serve command, so it reuses across any
+  project whose app boots that way. Covers the self-contained Playwright capture,
+  video recording, ffmpeg transcode, GitHub-release hosting, and posting.
+  Triggers on "post evidence", "screenshot the change", "PR evidence", "record a
+  video of this", "capture the UI".
 ---
 
 # evidence — PR screenshots & video, captured on a pu box

--- a/.claude/skills/pu/SKILL.md
+++ b/.claude/skills/pu/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: pu
-description: Provision and drive an ephemeral `pu` box — a throwaway Incus container used as a clean Linux host for CI, builds, and evidence capture. Use when you need to run something on a fresh remote box instead of the user's machine: `nix run` a build, run CI against a real host, capture screenshots/video off-machine, or reproduce on a pristine environment. Covers create/connect/scp/destroy, running remote commands, copying artifacts back, and the no-egress failure mode. Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host", "pu create/connect/destroy".
+description: >-
+  Provision and drive an ephemeral `pu` box — a throwaway Incus container used as
+  a clean Linux host for CI, builds, and evidence capture. Use when you need to
+  run something on a fresh remote box instead of the user's machine: `nix run` a
+  build, run CI against a real host, capture screenshots/video off-machine, or
+  reproduce on a pristine environment. Covers create/connect/scp/destroy, running
+  remote commands, copying artifacts back, and the no-egress failure mode.
+  Triggers on "pu box", "spin up a box", "run this on a box", "ephemeral host",
+  "pu create/connect/destroy".
 ---
 
 # pu — ephemeral Incus boxes


### PR DESCRIPTION
**Codex can load the `evidence` and `pu` skills again** because their long descriptions now use folded YAML scalars instead of plain one-line scalars containing an unquoted `:`. The previous shape tripped YAML parsing during skill discovery, so both skills were skipped before a task even started.

The source `.apm/skills` files were updated first, then APM regenerated the Codex and Claude skill copies so the runtime directories stay in sync with the source.

### Verified

- `just ai::apm`
- `codex debug prompt-input "validate skill frontmatter"`
- `just fmt`
- `git diff --check`

_Generated by Codex (model `gpt-5`)._