### PR TITLE
Live-refresh the browse tree when a file is added to an expanded folder

### DIFF
--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -311,7 +311,18 @@ const CodeTab: Component<{
   });
 
   const treePaths = createMemo(() => {
-    if (view() === "browse") return allPaths()?.paths ?? [];
+    // Copy `paths` out rather than returning the store proxy directly:
+    // `fsListAll` lands in a reconciled store whose `paths` array is
+    // mutated in place, so the proxy's reference is stable across an
+    // in-place add/remove. Returning it bare means this memo never reads
+    // the contents (so an in-place add doesn't re-run it) and, even when it
+    // does re-run, the stable reference defeats the downstream
+    // reference-equality memos/effects that feed Pierre — a file created in
+    // a hand-expanded folder would never surface. Spreading tracks every
+    // element + length and mints a fresh reference, matching the diff
+    // branch's `.map()` below. See `createReactiveSubscription` /
+    // `writeValue.ts` for the reconcile strategy.
+    if (view() === "browse") return [...(allPaths()?.paths ?? [])];
     return status()?.files.map((f) => f.path) ?? [];
   });
 

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -673,6 +673,27 @@ Feature: Code tab (review + browse)
     Then the file browser should not show a file "obsolete.txt"
     And the Code tab content should show the select hint "Select a file to view its content"
 
+  # Regression: creating a new file inside a hand-expanded folder in browse
+  # mode used to leave the tree stale — the new row never appeared until a
+  # mode switch or reload. The `fsListAll` value lands in a reconciled store
+  # whose `paths` array is mutated in place, so a `treePaths()` memo that
+  # returned the array proxy without reading its contents never re-ran on an
+  # in-place add, and even when it did the stable reference defeated the
+  # downstream reference-equality memos/effects feeding Pierre. Copying the
+  # paths out (`[...]`) tracks the contents and mints a fresh reference, so
+  # the in-place add propagates and Pierre's `batch` reveals the file.
+  Scenario: New file in an expanded folder appears in the browse tree live
+    When I run "rm -rf /tmp/kolu-browse-newfile && git init /tmp/kolu-browse-newfile && cd /tmp/kolu-browse-newfile"
+    And I run "mkdir -p lib && printf 'x\n' > lib/util.ts"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    And I click the directory "lib" in the file browser
+    Then the file browser should show a file "lib/util.ts"
+    When I click the terminal canvas
+    And I run "printf 'y\n' > lib/added.ts"
+    Then the file browser should show a file "lib/added.ts"
+
   # ── Comments on files (#881) ──
   #
   # End-to-end coverage of the select → pill → composer → tray → copy


### PR DESCRIPTION
**In the Code tab's "All files" mode, creating a file inside a hand-expanded folder now shows the new row instantly** — no mode switch or reload to coax it out. The tree was going stale because the browse path list leaked a reconciled store proxy into reference-equality reactive contexts.

### Why it went stale

`fsListAll` lands in a SolidJS store written via `reconcile`, which mutates the `paths` array **in place** — the reference stays stable across an add or remove. `treePaths()` returned that proxy bare (`allPaths()?.paths ?? []`), and two things broke at once:

- The memo never *read* the array contents, so an in-place add didn't even re-run it.
- Even when it did re-run, the **stable reference** sailed past the downstream reference-equality memos (`treeSearch`) and the `FileTree` effect (`on([() => props.paths, …])`) that drive Pierre's `batch`.

So the added file was in the data but never reached the tree.

### The fix

Copy the array out in the browse branch — `[...(allPaths()?.paths ?? [])]` — exactly what the diff branch already does with `status()?.files.map(...)`. The spread subscribes the memo to every element + length *and* mints a fresh reference each tick, so an in-place add both re-triggers the memo and propagates through to Pierre. *The reconcile strategy stays untouched — changing it would regress the in-place tree-expansion preservation from #1074.*

A new e2e regression in `code-tab.feature` expands a folder, creates a file in it from the shell, and asserts the row appears live.

### Try it locally

```sh
nix run github:juspay/kolu/newfile-code
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._