### PR TITLE
Encapsulate mobile volatility behind receptacles

### DIFF
--- a/docs/plans/mobile-architecture-review.html
+++ b/docs/plans/mobile-architecture-review.html
@@ -223,6 +223,7 @@
 
   <div class="diagram" role="img" aria-label="Circuit diagram of kolu mobile wiring">
   <svg viewBox="0 0 980 430" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, monospace">
+    <title>kolu mobile wiring — one source, two receptacles, and the bare-mains consumers</title>
     <defs>
       <marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
         <path d="M0,0 L9,4.5 L0,9 z" fill="#7c8aa3"/>

--- a/docs/plans/mobile-architecture-review.html
+++ b/docs/plans/mobile-architecture-review.html
@@ -1,0 +1,505 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Is Mobile Electricity? — A Hickey / Lowy review of kolu's mobile support</title>
+<style>
+  :root {
+    --bg: #0b0e14;
+    --bg-2: #11151f;
+    --panel: #141a26;
+    --panel-2: #1a2130;
+    --edge: #232c3d;
+    --edge-bright: #2f3b51;
+    --fg: #e7ecf3;
+    --fg-2: #b4c0d4;
+    --fg-3: #7c8aa3;
+    --live: #e8a44c;        /* live wire — copper/amber */
+    --live-soft: #f0c48b;
+    --ground: #4cc4a3;      /* grounded / correct — teal */
+    --ground-soft: #8fe3cd;
+    --spark: #6aa8ff;       /* signal blue */
+    --danger: #ef6f6f;
+    --warn: #e8b84c;
+    --a: #6fd49a; --b: #9bd96f; --c: #e8c24c; --d: #ef9a6f; --f: #ef6f6f;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, monospace;
+    --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: var(--sans); line-height: 1.62; font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+    background-image:
+      radial-gradient(1200px 600px at 80% -10%, rgba(232,164,76,.08), transparent 60%),
+      radial-gradient(900px 500px at 0% 0%, rgba(76,196,163,.06), transparent 55%);
+  }
+  .wrap { max-width: 1020px; margin: 0 auto; padding: 0 24px 120px; }
+
+  /* ---- hero ---- */
+  header.hero { padding: 72px 0 26px; border-bottom: 1px solid var(--edge); }
+  .kicker {
+    font-family: var(--mono); font-size: 12.5px; letter-spacing: .22em;
+    text-transform: uppercase; color: var(--live); display: flex; gap: 10px; align-items: center;
+  }
+  .kicker::before { content: ""; width: 26px; height: 1px; background: var(--live); display: inline-block; }
+  h1 {
+    font-size: clamp(34px, 6vw, 58px); line-height: 1.04; margin: 18px 0 8px;
+    font-weight: 760; letter-spacing: -.02em;
+  }
+  h1 .amp { color: var(--live); font-style: italic; font-weight: 400; }
+  .dek { font-size: 19px; color: var(--fg-2); max-width: 72ch; margin: 14px 0 0; }
+  .verdict-chip {
+    display: inline-flex; align-items: baseline; gap: 12px; margin-top: 28px;
+    padding: 14px 20px; border: 1px solid var(--edge-bright); border-radius: 12px;
+    background: linear-gradient(180deg, rgba(232,164,76,.10), rgba(232,164,76,.02));
+  }
+  .verdict-chip b { font-size: 21px; color: var(--live-soft); letter-spacing: -.01em; }
+  .verdict-chip span { color: var(--fg-3); font-size: 14px; }
+  .meta-row { margin-top: 22px; display: flex; flex-wrap: wrap; gap: 8px 18px; color: var(--fg-3); font-size: 13px; font-family: var(--mono); }
+  .meta-row b { color: var(--fg-2); font-weight: 600; }
+
+  section { padding: 54px 0 0; }
+  h2 {
+    font-size: 13px; font-family: var(--mono); letter-spacing: .2em; text-transform: uppercase;
+    color: var(--fg-3); margin: 0 0 6px; display: flex; align-items: center; gap: 12px;
+  }
+  h2 .n { color: var(--live); }
+  .h2title { font-size: clamp(24px, 3.6vw, 33px); font-weight: 720; letter-spacing: -.015em; margin: 0 0 18px; line-height: 1.12; }
+  p.lead { font-size: 17.5px; color: var(--fg-2); max-width: 76ch; }
+  p { max-width: 78ch; }
+  a { color: var(--live-soft); text-decoration: none; border-bottom: 1px solid rgba(240,196,139,.3); }
+  a:hover { border-color: var(--live-soft); }
+  code, .mono { font-family: var(--mono); font-size: .88em; }
+  p code, li code, td code { background: var(--panel-2); padding: 1.5px 6px; border-radius: 5px; color: var(--live-soft); border: 1px solid var(--edge); white-space: nowrap; }
+
+  /* ---- electricity callout ---- */
+  .quote {
+    border-left: 2px solid var(--live); padding: 6px 0 6px 22px; margin: 22px 0; color: var(--fg-2);
+    font-size: 17px;
+  }
+  .quote cite { display: block; margin-top: 8px; color: var(--fg-3); font-size: 13.5px; font-style: normal; font-family: var(--mono); }
+
+  /* ---- circuit diagram ---- */
+  .diagram { margin: 26px 0 8px; border: 1px solid var(--edge); border-radius: 14px; background: var(--panel); padding: 8px; overflow: hidden; }
+  .diagram svg { display: block; width: 100%; height: auto; }
+  .legend { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 14px; font-size: 13px; color: var(--fg-3); }
+  .legend i { width: 22px; height: 0; border-top-width: 3px; border-top-style: solid; display: inline-block; vertical-align: middle; margin-right: 7px; border-radius: 2px;}
+
+  /* ---- scorecard ---- */
+  .grid { display: grid; gap: 14px; }
+  .cards-3 { grid-template-columns: repeat(3, 1fr); }
+  .cards-2 { grid-template-columns: repeat(2, 1fr); }
+  @media (max-width: 760px) { .cards-3, .cards-2 { grid-template-columns: 1fr; } }
+  .score {
+    border: 1px solid var(--edge); border-radius: 12px; padding: 18px; background: var(--panel);
+    position: relative; overflow: hidden;
+  }
+  .score .dim { font-size: 13px; color: var(--fg-2); font-weight: 600; letter-spacing: .01em; padding-right: 46px; }
+  .score .one { font-size: 13.5px; color: var(--fg-3); margin-top: 10px; line-height: 1.5; }
+  .grade {
+    position: absolute; top: 14px; right: 16px; font-weight: 800; font-size: 26px;
+    font-family: var(--mono); line-height: 1;
+  }
+  .g-A { color: var(--a);} .g-B { color: var(--b);} .g-C { color: var(--c);} .g-D { color: var(--d);} .g-F { color: var(--f);}
+  .score::after { content:""; position:absolute; left:0; top:0; bottom:0; width:3px; }
+  .score.g-A::after{background:var(--a);} .score.g-B::after{background:var(--b);} .score.g-C::after{background:var(--c);} .score.g-D::after{background:var(--d);} .score.g-F::after{background:var(--f);}
+
+  /* ---- findings ---- */
+  .find { border: 1px solid var(--edge); border-radius: 12px; background: var(--panel); padding: 20px 22px; margin: 14px 0; }
+  .find.good { border-left: 3px solid var(--ground); }
+  .find.leak { border-left: 3px solid var(--live); }
+  .find h3 { margin: 0 0 8px; font-size: 18px; letter-spacing: -.01em; display:flex; gap:10px; align-items:flex-start; }
+  .find h3 .ic { flex: none; margin-top: 2px; }
+  .find p { margin: 8px 0; color: var(--fg-2); font-size: 15px; max-width: none; }
+  .files { font-family: var(--mono); font-size: 12px; color: var(--fg-3); margin-top: 12px; padding-top: 12px; border-top: 1px dashed var(--edge); word-break: break-word; }
+  .files b { color: var(--fg-2); }
+  .tags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 12px; }
+  .tag { font-family: var(--mono); font-size: 10.5px; letter-spacing: .08em; text-transform: uppercase; padding: 3px 9px; border-radius: 20px; border: 1px solid var(--edge-bright); color: var(--fg-3); }
+  .tag.hickey { color: var(--spark); border-color: rgba(106,168,255,.4); }
+  .tag.lowy { color: var(--ground-soft); border-color: rgba(76,196,163,.4); }
+  .tag.both { color: var(--live-soft); border-color: rgba(232,164,76,.45); }
+  .tag.confirmed { color: var(--danger); border-color: rgba(239,111,111,.4); }
+
+  /* ---- code block ---- */
+  pre {
+    background: #090c12; border: 1px solid var(--edge); border-radius: 10px; padding: 16px 18px;
+    overflow-x: auto; font-family: var(--mono); font-size: 13px; line-height: 1.6; color: var(--fg-2); margin: 14px 0;
+  }
+  pre .c { color: var(--fg-3); }
+  pre .k { color: var(--live-soft); }
+  pre .g { color: var(--ground-soft); }
+  pre .r { color: var(--danger); }
+
+  /* ---- table ---- */
+  table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 14.5px; }
+  th, td { text-align: left; padding: 13px 14px; border-bottom: 1px solid var(--edge); vertical-align: top; }
+  th { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--fg-3); font-weight: 600; }
+  td .rt { font-weight: 650; color: var(--fg); }
+  .pill { font-family: var(--mono); font-size: 11px; padding: 3px 8px; border-radius: 6px; border: 1px solid var(--edge-bright); white-space: nowrap; }
+  .pill.hi { color: var(--ground-soft); border-color: rgba(76,196,163,.45); }
+  .pill.md { color: var(--warn); border-color: rgba(232,184,76,.4); }
+  .pill.sm { color: var(--ground-soft); }
+  .pill.lg { color: var(--danger); border-color: rgba(239,111,111,.4); }
+
+  .receptacle-box { border:1px solid var(--edge-bright); border-radius:14px; background:linear-gradient(180deg,var(--panel),var(--bg-2)); padding:24px; margin-top:18px;}
+  .seam { display:flex; gap:16px; padding:14px 0; border-top:1px dashed var(--edge); }
+  .seam:first-of-type { border-top:none; }
+  .seam .num { font-family:var(--mono); font-size:13px; color:var(--bg); background:var(--live); width:26px;height:26px;border-radius:50%; display:flex;align-items:center;justify-content:center;flex:none; font-weight:700;}
+  .seam .s-body b { color: var(--live-soft); }
+  .seam .s-body { font-size:14.5px; color:var(--fg-2); }
+
+  .callout { border:1px solid var(--edge-bright); border-radius:12px; padding:18px 20px; background:rgba(106,168,255,.05); margin:18px 0; }
+  .callout.break { background:rgba(232,164,76,.06); border-color:rgba(232,164,76,.3);}
+  .callout .ct { font-family:var(--mono); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--live); margin-bottom:6px;}
+
+  footer { margin-top:70px; padding-top:26px; border-top:1px solid var(--edge); color:var(--fg-3); font-size:13px; font-family:var(--mono); }
+  footer b { color: var(--fg-2); }
+  .toc { display:flex; flex-wrap:wrap; gap:8px 16px; margin-top:18px; font-family:var(--mono); font-size:12.5px;}
+  .toc a { color:var(--fg-3); border:none; }
+  .toc a:hover { color: var(--live-soft); }
+  hr.thin { border:none; border-top:1px solid var(--edge); margin:38px 0 0; }
+  .big-q { font-size: clamp(22px,3vw,30px); font-weight:720; letter-spacing:-.015em; color:var(--fg); margin: 6px 0 2px;}
+  .big-a { color: var(--live-soft); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="hero">
+  <div class="kicker">Architecture Review · kolu/packages/client</div>
+  <h1>Is mobile <span class="amp">electricity?</span></h1>
+  <p class="dek">An adversarially-verified read of kolu's mobile support through two lenses:
+  Rich&nbsp;Hickey's <em>Simple Made Easy</em> (is mobile <em>complected</em> through the app?) and
+  Juval&nbsp;Lowy's volatility-based decomposition (is mobile an <em>encapsulated</em> change, or smeared across every consumer?).</p>
+
+  <div class="verdict-chip">
+    <b>Half-electricity.</b>
+    <span>Two outlets are wired to spec — the rest of the app clips bare leads onto the mains.</span>
+  </div>
+
+  <div class="meta-row">
+    <span><b>Scope</b> ~11 files · 18 signal reads · 5 mobile components</span>
+    <span><b>Method</b> 24 agents — map ▸ dual-lens ▸ verify ▸ synthesize</span>
+    <span><b>Verified</b> 16 claims re-checked vs source</span>
+  </div>
+
+  <div class="toc">
+    <a href="#analogy">① The analogy</a>
+    <a href="#circuit">② The circuit</a>
+    <a href="#scorecard">③ Scorecard</a>
+    <a href="#wired">④ Wired right</a>
+    <a href="#bare">⑤ Bare leads</a>
+    <a href="#breaks">⑥ Where it breaks</a>
+    <a href="#receptacle">⑦ The receptacle</a>
+    <a href="#do">⑧ What to do</a>
+  </div>
+</header>
+
+<!-- ================= 1. ANALOGY ================= -->
+<section id="analogy">
+  <h2><span class="n">01</span> &nbsp;The analogy</h2>
+  <div class="h2title">Lowy's receptacle: hide the volatility, sell a faceplate</div>
+  <p class="lead">Lowy uses household power to argue that you decompose a system by what <em>changes</em>, not by what it <em>does</em>.</p>
+
+  <div class="quote">
+    "Power in a house is highly volatile: AC or DC; 110&nbsp;volts or 220; 50&nbsp;hertz or 60; produced by solar panels, a generator, or grid connectivity. All that volatility is encapsulated behind a receptacle. When it is time to consume power, all the user sees is an opaque receptacle."
+    <cite>Juval Lowy — Righting Software (via informit.com/articles/article.aspx?p=2995357)</cite>
+  </div>
+
+  <p>The toaster never exposes the wires, measures the frequency with an oscilloscope, or certifies the voltage with a voltmeter. It <em>plugs in</em>. The opposite — every appliance carrying its own voltmeter and deciding what to do with the raw mains — is what Lowy calls <strong>functional decomposition</strong>, and Hickey calls <strong>complecting</strong>: one concern braided through everything.</p>
+
+  <p>So the question "is mobile electricity?" is precise: <strong>does feature code plug into a stable interface that has already resolved "where am I running," or does each consumer measure the voltage</strong> (<code>isMobile()</code>) and branch on it itself?</p>
+
+  <p class="big-q">The answer for kolu: <span class="big-a">two outlets, one good extension cord, and a lot of bare wire.</span></p>
+</section>
+
+<!-- ================= 2. CIRCUIT ================= -->
+<section id="circuit">
+  <h2><span class="n">02</span> &nbsp;The circuit as it is wired today</h2>
+  <div class="h2title">One source, two voltages, two clean outlets — then exposed mains</div>
+
+  <div class="diagram" role="img" aria-label="Circuit diagram of kolu mobile wiring">
+  <svg viewBox="0 0 980 430" xmlns="http://www.w3.org/2000/svg" font-family="ui-monospace, monospace">
+    <defs>
+      <marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+        <path d="M0,0 L9,4.5 L0,9 z" fill="#7c8aa3"/>
+      </marker>
+      <marker id="arrowL" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+        <path d="M0,0 L9,4.5 L0,9 z" fill="#e8a44c"/>
+      </marker>
+    </defs>
+
+    <!-- source -->
+    <rect x="24" y="170" width="180" height="92" rx="10" fill="#141a26" stroke="#2f3b51"/>
+    <text x="114" y="196" fill="#e7ecf3" font-size="13" font-weight="700" text-anchor="middle">useMobile.ts</text>
+    <text x="114" y="220" fill="#4cc4a3" font-size="11.5" text-anchor="middle">isMobile · 639px</text>
+    <text x="114" y="238" fill="#6aa8ff" font-size="11.5" text-anchor="middle">isTouch · coarse</text>
+    <text x="114" y="158" fill="#7c8aa3" font-size="10.5" text-anchor="middle">⚡ THE SOURCE (two circuits)</text>
+
+    <!-- outlet 1: layout switch -->
+    <line x1="204" y1="200" x2="330" y2="120" stroke="#4cc4a3" stroke-width="2.5" marker-end="url(#arrow)"/>
+    <rect x="332" y="78" width="220" height="86" rx="10" fill="#141a26" stroke="#4cc4a3"/>
+    <text x="442" y="104" fill="#8fe3cd" font-size="12.5" font-weight="700" text-anchor="middle">OUTLET ✓ App.tsx:546</text>
+    <text x="442" y="124" fill="#b4c0d4" font-size="11" text-anchor="middle">match(isMobile())</text>
+    <text x="442" y="142" fill="#7c8aa3" font-size="10.5" text-anchor="middle">→ MobileTileView | TerminalCanvas</text>
+    <text x="442" y="158" fill="#7c8aa3" font-size="10" text-anchor="middle">leaves plug in blind · no per-leaf if</text>
+
+    <!-- outlet 2: keyboard dismiss -->
+    <line x1="204" y1="216" x2="330" y2="216" stroke="#4cc4a3" stroke-width="2.5" marker-end="url(#arrow)"/>
+    <rect x="332" y="182" width="220" height="70" rx="10" fill="#141a26" stroke="#4cc4a3"/>
+    <text x="442" y="206" fill="#8fe3cd" font-size="12.5" font-weight="700" text-anchor="middle">OUTLET ✓ withKeyboardDismiss</text>
+    <text x="442" y="226" fill="#7c8aa3" font-size="10.5" text-anchor="middle">isTouch guard lives inside</text>
+    <text x="442" y="242" fill="#7c8aa3" font-size="10.5" text-anchor="middle">4 drawers inject only their setter</text>
+
+    <!-- bare wire bus -->
+    <line x1="204" y1="240" x2="330" y2="320" stroke="#e8a44c" stroke-width="2.5" marker-end="url(#arrowL)"/>
+    <line x1="552" y1="320" x2="610" y2="320" stroke="#e8a44c" stroke-width="2.5"/>
+    <rect x="332" y="286" width="220" height="68" rx="10" fill="#1a1206" stroke="#e8a44c" stroke-dasharray="5 4"/>
+    <text x="442" y="312" fill="#f0c48b" font-size="12.5" font-weight="700" text-anchor="middle">⚠ BARE MAINS</text>
+    <text x="442" y="332" fill="#b4c0d4" font-size="10.5" text-anchor="middle">raw isMobile() / isTouch() exported</text>
+    <text x="442" y="348" fill="#7c8aa3" font-size="10" text-anchor="middle">no posture / capability interface</text>
+
+    <!-- consumers each with a voltmeter -->
+    <g font-size="10.5">
+      <rect x="628" y="270" width="330" height="146" rx="10" fill="#141a26" stroke="#2f3b51"/>
+      <text x="644" y="290" fill="#7c8aa3" font-size="10">~18 consumers each measure the voltage:</text>
+      <text x="644" y="312" fill="#f0c48b">🔌 useTips.ts:65,73 — suppress tips ×2</text>
+      <text x="644" y="330" fill="#f0c48b">🔌 commands.tsx:318 — erase canvas section</text>
+      <text x="644" y="348" fill="#f0c48b">🔌 openInCodeTab.ts:76 — fork the intent</text>
+      <text x="644" y="366" fill="#f0c48b">🔌 CodeTab.tsx:103/548 — density + scroll</text>
+      <text x="644" y="384" fill="#f0c48b">🔌 App.tsx:194/225 — center / switcher</text>
+      <text x="644" y="402" fill="#ef6f6f">🔌 Terminal.tsx:538 — contenteditable surgery</text>
+    </g>
+    <line x1="552" y1="320" x2="628" y2="330" stroke="#e8a44c" stroke-width="1.5" marker-end="url(#arrowL)"/>
+
+    <!-- voltage mismatch callout -->
+    <rect x="628" y="78" width="330" height="120" rx="10" fill="#1a0e0e" stroke="#ef6f6f" stroke-dasharray="5 4"/>
+    <text x="793" y="102" fill="#ef9a6f" font-size="12" font-weight="700" text-anchor="middle">⚡ VOLTAGE MISMATCH</text>
+    <text x="793" y="128" fill="#b4c0d4" font-size="11" text-anchor="middle">JS receptacle rated 639px</text>
+    <text x="793" y="146" fill="#b4c0d4" font-size="11" text-anchor="middle">CSS receptacle (Tailwind sm:) 640px</text>
+    <text x="793" y="172" fill="#7c8aa3" font-size="10" text-anchor="middle">639–640 band: JS says mobile,</text>
+    <text x="793" y="187" fill="#7c8aa3" font-size="10" text-anchor="middle">CSS says desktop. Comment misclaims "match".</text>
+  </svg>
+  </div>
+  <div class="legend">
+    <span><i style="border-color:var(--ground)"></i>Encapsulated — appliance plugs in blind</span>
+    <span><i style="border-color:var(--live)"></i>Bare mains — consumer measures the voltage</span>
+    <span><i style="border-color:var(--danger);border-top-style:dashed"></i>Two voltages for one threshold</span>
+  </div>
+</section>
+
+<!-- ================= 3. SCORECARD ================= -->
+<section id="scorecard">
+  <h2><span class="n">03</span> &nbsp;Scorecard</h2>
+  <div class="h2title">Six dimensions, reconciled across both lenses after verification</div>
+  <div class="grid cards-3">
+    <div class="score g-C"><div class="dim">Single source of truth</div><div class="grade g-C">C</div>
+      <div class="one">Each <em>concept</em> has one signal — but the breakpoint <em>value</em> is defined twice: JS query at 639px vs Tailwind <code>sm:</code> at 640px. The comment even misclaims they match.</div></div>
+    <div class="score g-C"><div class="dim">Encapsulation</div><div class="grade g-C">C</div>
+      <div class="one">Two receptacles done right (the layout switch, <code>withKeyboardDismiss</code>); but ~18 consumers branch on the raw signal with no posture/capability layer between.</div></div>
+    <div class="score g-B"><div class="dim">Concept separation</div><div class="grade g-B">B</div>
+      <div class="one"><code>isMobile</code> (size) and <code>isTouch</code> (modality) are correctly orthogonal; <code>useViewPosture</code> refuses to fold mobile in. But "layout-mode" and "capability" own no concept of their own.</div></div>
+    <div class="score g-D"><div class="dim">CSS vs JS discipline</div><div class="grade g-D">D</div>
+      <div class="one">18 JS signal-reads vs 4 Tailwind classes and 0 custom <code>@media</code>. CSS owns almost no structure; the lone <code>sm:</code> classes are orphaned by JS that unmounts their parent.</div></div>
+    <div class="score g-B"><div class="dim">Component duplication</div><div class="grade g-B">B</div>
+      <div class="one">Verification <em>refuted</em> the alarms: row/pip/metadata/activation logic is already extracted into shared modules. Only documented, reviewer-approved JSX shells diverge.</div></div>
+    <div class="score g-D"><div class="dim">Consumer leakage</div><div class="grade g-D">D</div>
+      <div class="one"><code>openInCodeTab</code> forks one intent inline; tips / commands / canvas each independently ask "am I mobile?"; <code>CodeTab</code> samples voltage at mount. The feature layer is functionally decomposed.</div></div>
+  </div>
+</section>
+
+<!-- ================= 4. WIRED RIGHT ================= -->
+<section id="wired">
+  <h2><span class="n">04</span> &nbsp;What's wired right</h2>
+  <div class="h2title">The parts that already are electricity</div>
+  <p class="lead">Credit where due — and these are the templates to copy, not abstract ideals. Each survived a skeptical re-read of the source.</p>
+
+  <div class="find good">
+    <h3><span class="ic">🔋</span> The two-axis split is a correct un-braiding</h3>
+    <p><code>useMobile.ts</code> ships <strong>two</strong> signals for <strong>two genuinely independent volatilities</strong> and refuses the seductive single god-flag: <code>isMobile = (max-width: 639px)</code> is form-factor; <code>isTouch = (pointer: coarse)</code> is interaction model. A 1366px touch iPad correctly resolves to <code>isMobile()=false / isTouch()=true</code> — so it gets <code>MobileKeyBar</code> and soft-keyboard handling while keeping the desktop layout. Conflating them would have forced a wrong choice for every large-format touch device.</p>
+    <div class="files"><b>useMobile.ts</b> · MobileKeyBar.tsx · Terminal.tsx</div>
+    <div class="tags"><span class="tag hickey">Hickey: one fold</span><span class="tag lowy">Lowy: orthogonal volatilities</span></div>
+  </div>
+
+  <div class="find good">
+    <h3><span class="ic">🔌</span> The top-level layout switch is a true receptacle</h3>
+    <p><code>App.tsx:546</code> — <code>match(isMobile()).with(true, MobileTileView).with(false, TerminalCanvas).exhaustive()</code> — routes the whole UI into two <em>compositionally separate</em> subtrees. Leaf components plug into one world and never measure voltage: <code>MobileTileView</code>'s swipe handlers carry <em>no</em> <code>isTouch()</code> guard because they simply aren't mounted on the desktop side; the minimap and auto-arrange are absent from mobile <em>by composition</em>, not by per-component <code>if</code>-checks.</p>
+    <div class="files"><b>App.tsx:507, 546</b> · MobileTileView.tsx</div>
+    <div class="tags"><span class="tag lowy">Lowy: receptacle</span></div>
+  </div>
+
+  <div class="find good">
+    <h3><span class="ic">⭐</span> <code>withKeyboardDismiss</code> — the one feature-level receptacle done right</h3>
+    <p>The <code>isTouch()</code> guard lives <em>inside</em> the wrapper (<code>dismissSoftKeyboard.ts:33</code>), so all four consumers — <code>MobileTileView</code>'s chrome + dock drawers, <code>RightPanelDrawer</code>, <code>ModalDialog</code> — plug in by injecting <em>only their own open-state setter</em>. "Dismissing an overlay leaves the keyboard down" is <strong>structural</strong>, not a per-overlay convention a new drawer could forget. This is exactly the shape <code>openInCodeTab</code>, <code>useTips</code>, and the canvas gates are missing.</p>
+    <div class="files"><b>ui/dismissSoftKeyboard.ts:50-57</b> · ModalDialog.tsx:78 · RightPanelDrawer.tsx:46</div>
+    <div class="tags"><span class="tag both">Both lenses: copy this</span></div>
+  </div>
+
+  <div class="find good">
+    <h3><span class="ic">🧭</span> <code>useViewPosture</code> refuses to fold mobile into canvas posture</h3>
+    <p>The hook's header is Hickey's discipline written in prose: <em>"Mobile is a separate axis … deliberately stays out of this hook — different change frequency, different reactivity source, different blast radius. kolu#628."</em> Two things that change for different reasons are kept as two things.</p>
+    <div class="files"><b>canvas/useViewPosture.ts:13-16</b></div>
+    <div class="tags"><span class="tag hickey">Hickey: de-complect</span><span class="tag lowy">Lowy: distinct change rates</span></div>
+  </div>
+
+  <div class="find good">
+    <h3><span class="ic">✅</span> Verification refuted the loudest duplication alarms</h3>
+    <p>The map phase flagged "duplicated row/pip/metadata/activation logic." The adversarial pass found the opposite: <code>setActiveSilently</code> <em>is</em> the bare <code>setActiveId</code> setter (used widely on desktop too, not a mobile reimplementation); dock-row data, pips, sublines and intent markdown are already extracted into shared modules (<code>RowPips.tsx</code>, <code>rowSubline.ts</code>, <code>createDockRowData</code>, <code>IntentMarkdownInline</code>) consumed identically by both surfaces. Only JSX <em>shells</em> diverge — and <code>Dock.tsx:386-391</code> records two reviewers explicitly choosing that over a <code>BaseRow</code>, for real touch-target/gesture axes.</p>
+    <div class="files"><b>Dock.tsx · MobileDockDrawer.tsx · TerminalMeta.tsx · useViewState.ts</b></div>
+    <div class="tags"><span class="tag hickey">Hickey: not complected</span></div>
+  </div>
+</section>
+
+<!-- ================= 5. BARE LEADS ================= -->
+<section id="bare">
+  <h2><span class="n">05</span> &nbsp;Where the leads are bare</h2>
+  <div class="h2title">Five leaks that survived adversarial verification</div>
+  <p class="lead">Each of these was re-read against source. Several map-phase findings were <em>downgraded</em> to "intentional / low" here — what remains is the verified set. The pattern is Lowy's functional decomposition: "mobile" smeared across consumers, each measuring the voltage.</p>
+
+  <div class="find leak">
+    <h3><span class="ic">⚡</span> Dual breakpoint — one threshold, two voltages</h3>
+    <p>The JS media query is <code>max-width:639px</code> while Tailwind <code>sm:</code> utilities fire at <code>min-width:640px</code> (no <code>tailwind.config</code> exists, so <code>sm:</code> is the v4 default 640px). In the 639–640 band the JS appliance thinks it's mobile while the CSS appliance thinks it's desktop. <code>useMobile.ts</code>'s own comment claims it <em>"Matches Tailwind's sm: breakpoint (640px)"</em> — contradicting its own query. Worse: <code>ChromeBar</code>'s inner <code>hidden sm:flex</code> classes are <strong>dead</strong> at that boundary, because <code>App.tsx:507</code> unmounts the whole <code>ChromeBar</code> via <code>isMobile()</code> — a CSS rule orphaned by a JS rule deciding the same thing.</p>
+    <div class="files"><b>useMobile.ts</b> (line 2 comment, line 7 query) · ChromeBar.tsx:48 · terminal/AgentIndicator.tsx:65</div>
+    <div class="tags"><span class="tag both">Both lenses</span><span class="tag confirmed">Verified · real</span></div>
+  </div>
+
+  <div class="find leak">
+    <h3><span class="ic">⚡</span> <code>openInCodeTab</code> forks one intent into two state mutations inline</h3>
+    <p>The producer of a navigation intent measures the voltage itself:</p>
+    <pre><span class="c">// right-panel/openInCodeTab.ts:76-80 — inside batch()</span>
+rp.openCodeAt(req.targetMode);
+<span class="k">if</span> (isMobile()) rp.setDrawerOpen(<span class="g">true</span>);        <span class="c">// mobile mechanism</span>
+<span class="k">else if</span> (rp.collapsed()) rp.expandPanel();      <span class="c">// desktop mechanism</span></pre>
+    <p>"Reveal the code view" is <em>one</em> concept; how it becomes visible is the host's job. <code>useRightPanel</code> already owns both mechanisms as separate, documented volatilities (session-local <code>drawerOpen</code> vs persisted <code>collapsed</code>) — it is the natural home for a single <code>rp.reveal()</code> that resolves posture internally. Verification confirmed the branch is real and the store owns both arms; it also noted the branch is currently <em>centralized</em> in one front-door function, which keeps the blast radius to a single call site.</p>
+    <div class="files"><b>right-panel/openInCodeTab.ts:76-80</b> · useRightPanel.ts (drawerOpen 149, expandPanel 125, collapsed 120)</div>
+    <div class="tags"><span class="tag both">Both lenses</span><span class="tag confirmed">Verified · real</span></div>
+  </div>
+
+  <div class="find leak">
+    <h3><span class="ic">⚡</span> Feature availability is functionally decomposed</h3>
+    <p>Tips, canvas commands, and palette gates each independently ask "am I mobile?": <code>useTips.ts:65/73</code> guards <code>showTipOnce</code> and <code>pickAmbientTip</code>; <code>commands.tsx:318</code> spreads the canvas section behind <code>...(!deps.isMobile() ? […] : [])</code>; <code>App.tsx:194/225</code> guard canvas-center and the workspace switcher. These are <strong>capability</strong> decisions ("does this surface support a spatial canvas / ambient tips?") spread across consumers as raw <em>viewport</em> checks — and several key off <code>isMobile</code> when "spatial canvas is unusable" is really a touch/pointer-precision concern (the <em>wrong axis</em>). Verification downgraded each individual site to low severity; <strong>the leak is the aggregate pattern</strong>, not any one guard.</p>
+    <div class="files"><b>settings/useTips.ts:65,73</b> · commands.tsx:318 · App.tsx:194,225</div>
+    <div class="tags"><span class="tag lowy">Lowy: functional decomposition</span><span class="tag confirmed">Verified · aggregate</span></div>
+  </div>
+
+  <div class="find leak">
+    <h3><span class="ic">⚡</span> <code>CodeTab</code> samples the viewport at mount — and on the wrong axis</h3>
+    <p>Two non-reactive reads at construction: <code>treeDensity = isMobile() ? "relaxed" : undefined</code> (line 103; Pierre captures density once, by documented contract) and <code>if (isMobile()) attachPierreTouchScroll(el)</code> (line 548, in a ref callback). A viewport that crosses the breakpoint after mount keeps stale wiring. The density freeze is acceptable; the <strong>touch-scroll gate keying off <code>isMobile</code> (viewport) instead of <code>isTouch</code> (modality)</strong> is a genuine wrong-axis bug — a 640px+ touch tablet on the desktop split gets no Pierre touch scroll.</p>
+    <div class="files"><b>right-panel/CodeTab.tsx:103, 548</b> · right-panel/pierreTouchScroll.ts</div>
+    <div class="tags"><span class="tag both">Both lenses</span><span class="tag confirmed">Verified · wrong-axis</span></div>
+  </div>
+
+  <div class="find leak">
+    <h3><span class="ic">🩺</span> Terminal soft-keyboard adaptation leaks as raw shadow-DOM surgery</h3>
+    <p><code>Terminal.tsx:538-549</code> branches on <code>isTouch()</code> and reaches into xterm's internal <code>.xterm-screen</code> element to set <code>contenteditable</code>/<code>spellcheck</code>/<code>autocorrect</code>/<code>caret-color</code>. This is volatility that <strong>legitimately must surface</strong> (see §6) — but the knowledge "touch needs a contenteditable input target" is <em>welded into Terminal.tsx's setup path</em>, coupled to undocumented xterm internals. Verification <strong>confirmed</strong> it (and clarified it's an additive patch over xterm's hidden textarea, not a clean fork; the same <code>.xterm-screen</code> querySelector recurs at lines 246, 823, always null-guarded). The leak is justified; its <em>form</em> is the smell.</p>
+    <div class="files"><b>terminal/Terminal.tsx:538-549</b></div>
+    <div class="tags"><span class="tag lowy">Lowy: leak the right way</span><span class="tag confirmed">Verified · confirmed</span></div>
+  </div>
+</section>
+
+<!-- ================= 6. WHERE IT BREAKS ================= -->
+<section id="breaks">
+  <h2><span class="n">06</span> &nbsp;Where the analogy honestly breaks</h2>
+  <div class="h2title">A phone is not a 110-volt desktop</div>
+
+  <div class="callout break">
+    <div class="ct">The load-bearing nuance</div>
+    <p style="margin:0;color:var(--fg-2)">Electricity's promise is that <em>the same appliance</em> runs on any voltage. That promise does <strong>not</strong> fully hold for mobile — and pretending it does would be the wrong fix.</p>
+  </div>
+
+  <p>Some mobile volatility is not a different <em>voltage</em> of the same signal; it is a categorically different <strong>appliance</strong>. A soft keyboard is not a 220V keyboard — it is a different input device, with its own focus model, its own dismissal lifecycle, its own contenteditable target. Swipe-to-navigate is not a small-screen pan/zoom; the pan/zoom canvas is genuinely <em>unusable</em> on a phone, so <code>MobileTileView</code> and the dock/right-panel drawers are not accidental complexity — they are a second, correctly-built product surface.</p>
+
+  <p>This is why "just move it all to CSS" is wrong. CSS can express the <em>presentational</em> volatility (spacing, hidden labels, max-widths — and <code>AgentIndicator</code>'s <code>hidden sm:inline</code> already does this correctly). It cannot express an <em>interaction-model</em> change. So:</p>
+
+  <div class="grid cards-2">
+    <div class="find" style="border-left:3px solid var(--ground)">
+      <h3 style="font-size:16px">Same appliance, different voltage → CSS</h3>
+      <p>Spacing, inline-label hide/show, max-widths, density presets. Belongs in declarative responsive CSS keyed off <em>one</em> breakpoint. Today kolu does almost none of this in CSS (18 JS reads vs 4 classes) — the recoverable ground.</p>
+    </div>
+    <div class="find" style="border-left:3px solid var(--live)">
+      <h3 style="font-size:16px">Different appliance → JS, behind a seam</h3>
+      <p>Soft-keyboard input surface, focus suppression, swipe nav, touch-scroll. Must live in JS. Lowy's demand isn't "don't branch" — it's "branch in <em>one named place</em> (an input-strategy seam), not as raw <code>isTouch()</code> poking xterm internals from a setup loop."</p>
+    </div>
+  </div>
+
+  <p>So the resolution is clean: there are <strong>four concepts wearing one word</strong> — viewport-size, touch-modality, layout-posture, and feature-availability. The first two are correctly receptacled. The second two are functionally decomposed. The fix is not to erase the mobile/desktop divergence — it is to add the missing posture and capability receptacles so feature code expresses <em>intent</em> and <em>capability</em>, and one resolver converts that to voltage.</p>
+</section>
+
+<!-- ================= 7. RECEPTACLE ================= -->
+<section id="receptacle">
+  <h2><span class="n">07</span> &nbsp;The receptacle that should exist</h2>
+  <div class="h2title">Keep the two-circuit wiring; add three faceplates</div>
+
+  <div class="receptacle-box">
+    <p style="margin-top:0;color:var(--fg-2)"><strong>Keep the wiring.</strong> <code>isMobile</code> and <code>isTouch</code> stay as the two independent axes — but unify the <em>rating</em>: register the breakpoint once (Tailwind v4 <code>@theme { --breakpoint-sm }</code>, or a single shared constant) and derive the JS <code>createMediaQuery</code> from the same number. The 639/640 desync band and the misleading comment both vanish.</p>
+
+    <div style="margin:18px 0 8px; font-family:var(--mono); font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--fg-3)">Three named seams between raw signals and features</div>
+
+    <div class="seam">
+      <div class="num">1</div>
+      <div class="s-body"><b>useRightPanel.reveal() / ensureVisible()</b> — one verb that internally resolves drawer-open (mobile) vs uncollapse-if-collapsed (desktop). <code>openInCodeTab</code> and every future producer call it and never read <code>isMobile</code>. The store already owns both mechanisms — a ~5-line addition. <em>This is the highest payoff-to-effort fix.</em></div>
+    </div>
+    <div class="seam">
+      <div class="num">2</div>
+      <div class="s-body"><b>A resolved capability object</b> — <code>layout.supportsSpatialCanvas</code>, <code>layout.showsAmbientTips</code>, <code>layout.isCompact</code> — computed <em>once</em>, each from the <em>right</em> axis. <code>useTips</code>, the canvas command section, and the center/switcher guards then ask about capability, not pixels. The difference between every appliance owning a voltmeter and the faceplate resolving voltage once.</div>
+    </div>
+    <div class="seam">
+      <div class="num">3</div>
+      <div class="s-body"><b>enableSoftKeyboardInput(term)</b> — owns the "touch needs a contenteditable target" knowledge and the xterm-internal poking, so <code>Terminal.tsx</code> calls one verb. Re-key <code>CodeTab</code>'s touch-scroll attachment off this/touch capability rather than viewport.</div>
+    </div>
+
+    <p style="margin-bottom:0; color:var(--fg-3); font-size:13.5px; border-top:1px dashed var(--edge); padding-top:14px; margin-top:6px"><code>withKeyboardDismiss</code> is the existence proof these work: a drawer plugs in by passing its setter and never measures the voltage. The other three seams are the same move applied to posture, capability, and input-surface.</p>
+  </div>
+</section>
+
+<!-- ================= 8. DO ================= -->
+<section id="do">
+  <h2><span class="n">08</span> &nbsp;What to do — ranked by payoff ÷ effort</h2>
+  <div class="h2title">Two small high-payoff fixes; two seams; one thing to <em>not</em> do</div>
+  <table>
+    <thead><tr><th style="width:34%">Action</th><th>Why</th><th style="width:80px">Effort</th><th style="width:80px">Payoff</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><span class="rt">Unify the breakpoint</span><br><span class="mono" style="color:var(--fg-3); font-size:12px">639px ⟶ one value</span></td>
+        <td>Register <code>--breakpoint-sm</code> once and derive the JS query from it; fix the comment that contradicts the query. Kills the desync band and the orphaned <code>ChromeBar</code> <code>sm:</code> classes.</td>
+        <td><span class="pill sm">small</span></td><td><span class="pill hi">high</span></td>
+      </tr>
+      <tr>
+        <td><span class="rt">Add <code>useRightPanel.reveal()</code></span></td>
+        <td>Move the <code>isMobile</code> fork out of <code>openInCodeTab</code> into one host-owned verb. De-complects a navigation producer from layout; mirrors <code>withKeyboardDismiss</code>. One call site, near-zero blast radius.</td>
+        <td><span class="pill sm">small</span></td><td><span class="pill hi">high</span></td>
+      </tr>
+      <tr>
+        <td><span class="rt">A resolved capability seam</span></td>
+        <td>Replace scattered <code>isMobile()</code> feature checks (<code>useTips</code>, canvas section, center/switcher) with one resolved object, each keyed off the right axis. Consumers ask about capability, not pixels.</td>
+        <td><span class="pill md">medium</span></td><td><span class="pill md">medium</span></td>
+      </tr>
+      <tr>
+        <td><span class="rt"><code>enableSoftKeyboardInput(term)</code></span></td>
+        <td>Wrap the confirmed-real contenteditable surgery behind a named seam; re-key <code>CodeTab</code>'s touch-scroll off touch capability so large touch tablets get it. Keeps xterm-internal knowledge in one testable place.</td>
+        <td><span class="pill md">medium</span></td><td><span class="pill md">medium</span></td>
+      </tr>
+      <tr>
+        <td><span class="rt">Do <u>not</u> extract the dock-row / metadata JSX shells</span></td>
+        <td>Verification refuted the duplication alarm: the volatile logic is already shared; only JSX shells diverge, for documented touch-target reasons two reviewers explicitly chose. A forced <code>BaseRow</code> would be worse. Listed to pre-empt a well-meaning but harmful refactor.</td>
+        <td><span class="pill sm">small</span></td><td><span class="pill md">guard</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr class="thin" />
+  <p class="lead" style="margin-top:26px">The one-line answer: <strong>mobile is electricity for the macro layout switch and the keyboard-dismiss wrapper, and bare mains wire everywhere else.</strong> The wiring discipline is good — two correctly-separated circuits — but neither terminates in enough receptacles, and the one threshold is rated at two voltages. Add the three faceplates above and mobile becomes electricity for the parts that <em>can</em> be; the rest stays honestly, deliberately, a different appliance.</p>
+</section>
+
+<footer>
+  <div><b>Method</b> · 24 subagents over a 4-phase workflow: 5 parallel mappers (66 findings) → independent Hickey + Lowy lenses → 16 structural claims adversarially re-read against source → reconciled synthesis. Claims that failed verification were downgraded, not reported.</div>
+  <div style="margin-top:10px"><b>Lenses</b> · <span style="color:var(--spark)">Hickey</span> = simplicity / complecting (one fold, one concern) · <span style="color:var(--ground-soft)">Lowy</span> = volatility-based decomposition (encapsulate change behind a stable interface; Parnas 1972 / Righting Software).</div>
+  <div style="margin-top:10px"><b>Source</b> · kolu/packages/client/src · review generated for branch <code>brave-second</code> · 2026-06-01</div>
+</footer>
+
+</div>
+</body>
+</html>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -31,6 +31,7 @@ import { buildWorkspaceEntries } from "./canvas/dockModel";
 import TerminalCanvas from "./canvas/TerminalCanvas";
 import TileTitleActions from "./canvas/TileTitleActions";
 import { useCanvasArrange } from "./canvas/useCanvasArrange";
+import { showsWorkspaceSwitcher, supportsSpatialCanvas } from "./capabilities";
 import { createCommands } from "./commands";
 import DiagnosticInfo from "./DiagnosticInfo";
 import EmptyState from "./EmptyState";
@@ -191,7 +192,7 @@ const App: Component = () => {
   }
 
   function handleCanvasCenterActive() {
-    if (isMobile()) return;
+    if (!supportsSpatialCanvas()) return;
     const id = store.activeId();
     if (id) store.activate(id);
   }
@@ -204,7 +205,6 @@ const App: Component = () => {
   const arrange = useCanvasArrange({
     store,
     crud,
-    isMobile,
   });
 
   // Shared between the keyboard dispatcher and the command palette so a single
@@ -222,7 +222,7 @@ const App: Component = () => {
       void crud.handleCreateSubTerminal(parentId, cwd),
     openNewTerminalMenu: () => openPaletteGroup("New terminal"),
     openWorkspaceSwitcher: () => {
-      if (!isMobile()) openPaletteGroup("Search workspaces");
+      if (showsWorkspaceSwitcher()) openPaletteGroup("Search workspaces");
     },
     setPaletteOpen,
     setShortcutsHelpOpen,
@@ -312,7 +312,6 @@ const App: Component = () => {
         (s) => s && session.handleRestoreSession({ session: s }),
       ),
     simulateAlert: alerts.simulateAlert,
-    isMobile,
     canvasCenterActive: handleCanvasCenterActive,
     canvasAutoArrange: arrange.handleCanvasAutoArrange,
     workspaceEntries,

--- a/packages/client/src/canvas/CanvasMinimap.tsx
+++ b/packages/client/src/canvas/CanvasMinimap.tsx
@@ -100,7 +100,7 @@ const CanvasMinimap: Component<{
    *  Why a prop and not `useCanvasArrange()` directly: this minimap
    *  consumes `useCanvasViewport()` and `useTerminalStore()` as
    *  zero-arg singletons, but `useCanvasArrange` takes composition-
-   *  root deps (`{ store, crud, viewport, isMobile }`) bound once at
+   *  root deps (`{ store, crud }`) bound once at
    *  App.tsx. The prop carries the bound result; the minimap stays
    *  ignorant of the arrange policy itself. */
   onAutoArrange?: () => void;

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -96,7 +96,7 @@ const TerminalCanvas: Component<{
    *  Threaded as a prop rather than consumed via a singleton hook
    *  (the way `useCanvasViewport` and `usePendingLayouts` are read
    *  inside `CanvasMinimap`) because `useCanvasArrange` takes
-   *  composition-root deps (`{ store, crud, viewport, isMobile }`) —
+   *  composition-root deps (`{ store, crud }`) —
    *  it's a function, not a zero-arg singleton. The prop captures
    *  the bound result; the minimap doesn't know or care about the
    *  arrange policy. */

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -62,7 +62,7 @@ const TileTitleActions: Component<{
             onClick={(e) => {
               e.stopPropagation();
               store.setActiveSilently(props.id);
-              rightPanel.expandPanel();
+              rightPanel.reveal();
             }}
             title="Open inspector"
           >

--- a/packages/client/src/canvas/useCanvasArrange.ts
+++ b/packages/client/src/canvas/useCanvasArrange.ts
@@ -12,6 +12,7 @@
  *  - `handleCanvasAutoArrange()` — the one-shot palette command. */
 
 import type { TerminalId } from "kolu-common/surface";
+import { supportsSpatialCanvas } from "../capabilities";
 import type { useTerminalCrud } from "../terminal/useTerminalCrud";
 import type { TerminalStore } from "../terminal/useTerminalStore";
 import { getBucketFor, resolvePlacementBucket } from "./placementPolicy";
@@ -26,9 +27,8 @@ import { usePendingLayouts } from "./usePendingLayouts";
 export function useCanvasArrange(deps: {
   store: TerminalStore;
   crud: ReturnType<typeof useTerminalCrud>;
-  isMobile: () => boolean;
 }) {
-  const { store, crud, isMobile } = deps;
+  const { store, crud } = deps;
   const pendingLayouts = usePendingLayouts();
 
   /** Apply a tile's geometry — drag-end, resize-end, default-place,
@@ -93,7 +93,7 @@ export function useCanvasArrange(deps: {
 
   /** One-shot rearrange triggered from the command palette. */
   function handleCanvasAutoArrange() {
-    if (isMobile()) return;
+    if (!supportsSpatialCanvas()) return;
     const tiles = store.terminalIds().flatMap((id) => {
       const layout = store.getMetadata(id)?.canvasLayout;
       if (!layout) return [];

--- a/packages/client/src/capabilities.ts
+++ b/packages/client/src/capabilities.ts
@@ -1,18 +1,21 @@
-/** Resolved view capabilities — named answers to "what does this surface
- *  support?", each computed once from the raw viewport/input signals in
- *  `useMobile`. Feature code asks about a capability instead of re-deriving it
+/** Resolved view capabilities — named answers to "what feature does this surface
+ *  offer?", each computed once from the raw viewport signal in `useMobile`.
+ *  Feature-availability code asks a capability here instead of re-deriving it
  *  from `isMobile()` at every call site, so when the form-factor rule for a
- *  capability changes it changes here, not across every consumer.
+ *  capability changes it changes here, not across every consumer. All three
+ *  currently key off viewport size (`isMobile`) — the canvas isn't mounted on the
+ *  mobile layout, and tips/switcher follow the same compact-layout decision — but
+ *  each is a distinct capability that can change axis independently.
  *
- *  The macro layout fork in `App.tsx` (`match(isMobile())`) and the soft-keyboard
- *  receptacle (`withKeyboardDismiss`) stay where they are — those are the two
- *  places that legitimately resolve the raw signal. Everything that gates a
- *  *feature* on form factor routes through the verbs below.
- *
- *  All three currently key off viewport size (`isMobile`) — the canvas isn't
- *  mounted on the mobile layout, and tips/switcher follow the same compact-layout
- *  decision — but each is a distinct capability that can change axis independently
- *  without touching its consumers. */
+ *  NOT every form-factor read belongs here — only boolean *feature-availability*
+ *  gates do. These raw reads are deliberate and stay raw:
+ *   - `App.tsx`'s `match(isMobile())` macro layout fork — the receptacle that
+ *     mounts the mobile vs. desktop subtree.
+ *   - Layout-specific workarounds keyed on the mobile drawer layout, e.g.
+ *     `CodeTab`'s portaled-tree touch-scroll driver (`isMobile`).
+ *   - Diagnostic display of the signal's current value (`DiagnosticInfo`).
+ *   - Input-modality behavior keyed on `isTouch` (a separate axis): soft-keyboard
+ *     dismissal, tap-target density, the soft-keyboard input surface. */
 
 import { isMobile } from "./useMobile";
 

--- a/packages/client/src/capabilities.ts
+++ b/packages/client/src/capabilities.ts
@@ -1,0 +1,31 @@
+/** Resolved view capabilities — named answers to "what does this surface
+ *  support?", each computed once from the raw viewport/input signals in
+ *  `useMobile`. Feature code asks about a capability instead of re-deriving it
+ *  from `isMobile()` at every call site, so when the form-factor rule for a
+ *  capability changes it changes here, not across every consumer.
+ *
+ *  The macro layout fork in `App.tsx` (`match(isMobile())`) and the soft-keyboard
+ *  receptacle (`withKeyboardDismiss`) stay where they are — those are the two
+ *  places that legitimately resolve the raw signal. Everything that gates a
+ *  *feature* on form factor routes through the verbs below.
+ *
+ *  All three currently key off viewport size (`isMobile`) — the canvas isn't
+ *  mounted on the mobile layout, and tips/switcher follow the same compact-layout
+ *  decision — but each is a distinct capability that can change axis independently
+ *  without touching its consumers. */
+
+import { isMobile } from "./useMobile";
+
+/** The spatial pan/zoom canvas — and the tile commands that act on it
+ *  (center-on-active, arrange-by-repo) — exist only on the desktop layout. On
+ *  mobile `App.tsx` mounts `MobileTileView` instead, so the canvas isn't present
+ *  to target. */
+export const supportsSpatialCanvas = () => !isMobile();
+
+/** Whether the workspace switcher (the palette's "Search workspaces" group) is
+ *  offered. Mobile navigates terminals through its dock drawer instead. */
+export const showsWorkspaceSwitcher = () => !isMobile();
+
+/** Ambient and contextual tips render only where there is room for the banner —
+ *  suppressed on the compact mobile layout. */
+export const showsAmbientTips = () => !isMobile();

--- a/packages/client/src/commands.tsx
+++ b/packages/client/src/commands.tsx
@@ -16,6 +16,7 @@ import type {
 } from "./CommandPalette";
 import WorkspaceGrid from "./canvas/dock/WorkspaceGrid";
 import type { DockSourceEntry } from "./canvas/dockModel";
+import { supportsSpatialCanvas } from "./capabilities";
 import {
   ACTIONS,
   type ActionContext,
@@ -116,9 +117,8 @@ export interface CommandDeps extends ActionContext {
   // Dialogs
   setAboutOpen: (open: boolean) => void;
   setDiagnosticInfoOpen: (open: boolean) => void;
-  // Canvas — desktop only (always active there); hidden on mobile where
-  // the canvas isn't mounted at all.
-  isMobile: () => boolean;
+  // Canvas — desktop only. The canvas isn't mounted on mobile, so these
+  // commands are hidden there via `supportsSpatialCanvas`.
   canvasCenterActive: () => void;
   canvasAutoArrange: () => void;
   // Worktree
@@ -315,7 +315,7 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       : []),
 
     // --- Canvas (desktop only — spatial tile actions) ---
-    ...(!deps.isMobile()
+    ...(supportsSpatialCanvas()
       ? [
           {
             kind: "action" as const,

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -27,6 +27,11 @@ body {
  * Values here double as the dark palette — :root:not(.dark) overrides them for light mode.
  */
 @theme {
+  /* The single definition of the `sm` breakpoint — where "mobile" begins.
+   * `useMobile.ts` reads this token (`--breakpoint-sm`) so the JS media query
+   * and Tailwind's `sm:` / `max-sm:` utilities can never disagree by a pixel. */
+  --breakpoint-sm: 40rem; /* 640px */
+
   --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
 
   --color-surface-0: #0c0c0e;

--- a/packages/client/src/right-panel/CodeTab.tsx
+++ b/packages/client/src/right-panel/CodeTab.tsx
@@ -40,7 +40,7 @@ import { CommentTextSurface } from "../comments/CommentTextSurface";
 import { useComposer } from "../comments/composerState";
 import { useCommentScrollRequest } from "../comments/scrollRequest";
 import { useColorScheme } from "../settings/useColorScheme";
-import { isMobile } from "../useMobile";
+import { isMobile, isTouch } from "../useMobile";
 import { FileBrowseIcon, FileDiffIcon, GitBranchIcon } from "../ui/Icons";
 import { resolveLineRefPath } from "../ui/lineRef";
 import {
@@ -98,9 +98,11 @@ const CodeTab: Component<{
   const rightPanel = useRightPanel();
 
   // Pierre captures `density` once at construction (like `initialExpansion`),
-  // so snapshot the mobile choice here rather than passing a reactive accessor
-  // in the JSX, where it would read as reactive. Roomier rows on touch.
-  const treeDensity = isMobile() ? "relaxed" : undefined;
+  // so snapshot the choice here rather than passing a reactive accessor in the
+  // JSX, where it would read as reactive. Keyed on `isTouch` (input modality),
+  // not `isMobile` (viewport): roomier rows are a tap-target affordance, so a
+  // coarse-pointer tablet wider than `sm` wants them too.
+  const treeDensity = isTouch() ? "relaxed" : undefined;
 
   // Read `codeMode` directly rather than projecting it from `activeTab`.
   // CodeTab now stays mounted across the Inspector tab toggle (#818); a
@@ -541,10 +543,13 @@ const CodeTab: Component<{
                   <div
                     class="h-full w-full min-h-0"
                     ref={(el) => {
-                      // Mobile only: drive Pierre's shadow-DOM scroll from
-                      // touch deltas, since iOS native scroll can't reach it
-                      // inside the portaled drawer (see pierreTouchScroll.ts).
-                      // Inert on desktop — no touch events, no Corvu drawer.
+                      // Keyed on `isMobile` (the mobile drawer layout), NOT
+                      // `isTouch`: the workaround is for iOS native scroll
+                      // failing to reach Pierre's shadow scroller below the
+                      // *portaled* drawer (see pierreTouchScroll.ts). A touch
+                      // tablet on the desktop split uses the non-portaled
+                      // Resizable panel where native scroll works — attaching
+                      // the driver there would preventDefault working scroll.
                       if (isMobile()) attachPierreTouchScroll(el);
                     }}
                   >

--- a/packages/client/src/right-panel/openInCodeTab.ts
+++ b/packages/client/src/right-panel/openInCodeTab.ts
@@ -26,7 +26,6 @@
 import type { CodeTabView } from "kolu-common/surface";
 import { batch, createSignal } from "solid-js";
 import type { LineRef } from "../ui/lineRef";
-import { isMobile } from "../useMobile";
 import { useRightPanel } from "./useRightPanel";
 
 export interface OpenInCodeTabRequest {
@@ -67,17 +66,13 @@ export const pendingOpen = pending;
 /** Open the right panel's Code tab at `req.targetMode` showing `req.ref`.
  *  Three reactive writes wrapped in `batch()` so downstream effects see
  *  the changes in one reactive transaction: per-terminal tab/mode
- *  (`openCodeAt`), workspace visibility (uncollapse desktop / open mobile
- *  drawer), and the producer signal (`setPending`). */
+ *  (`openCodeAt`), workspace visibility (`rp.reveal()` — uncollapse desktop or
+ *  open the mobile drawer), and the producer signal (`setPending`). */
 export function openInCodeTab(req: OpenInCodeTabRequest): void {
   const rp = useRightPanel();
   batch(() => {
     rp.openCodeAt(req.targetMode);
-    if (isMobile()) {
-      rp.setDrawerOpen(true);
-    } else if (rp.collapsed()) {
-      rp.expandPanel();
-    }
+    rp.reveal();
     setPending(req);
   });
 }

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -29,6 +29,7 @@ import {
 import { createSignal } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import { useTerminalStore } from "../terminal/useTerminalStore";
+import { isMobile } from "../useMobile";
 import { client, preferences, updatePreferences } from "../wire";
 
 const MIN_PANEL_SIZE = 0.05;
@@ -148,6 +149,17 @@ export function useRightPanel() {
      *  mobile — desktop reads `collapsed()` instead. Not persisted. */
     drawerOpen,
     setDrawerOpen,
+    /** Reveal the panel by whatever mechanism the current layout uses — open
+     *  the bottom-drawer host on mobile, uncollapse the desktop Resizable
+     *  otherwise. Producers (e.g. `openInCodeTab`) call this to express intent
+     *  ("show the panel") without owning the mobile-vs-desktop fork; the two
+     *  visibility volatilities (session-local `drawerOpen`, persisted
+     *  `collapsed`) stay separate and are resolved here in one place. */
+    reveal: () => {
+      if (isMobile()) setDrawerOpen(true);
+      else if (rp().collapsed)
+        updatePreferences({ rightPanel: { collapsed: false } });
+    },
 
     // ── Per-terminal task state ──────────────────────────────────────
     /** DU view of the active tab — `{ kind: "inspector" }` or

--- a/packages/client/src/settings/useTips.ts
+++ b/packages/client/src/settings/useTips.ts
@@ -7,7 +7,7 @@
 
 import type { TerminalId } from "kolu-common/surface";
 import { type Accessor, createEffect, createSignal } from "solid-js";
-import { isMobile } from "../useMobile";
+import { showsAmbientTips } from "../capabilities";
 import { preferences, updatePreferences } from "../wire";
 import { AMBIENT_TIPS, type Tip, type TipId } from "./tips";
 
@@ -62,7 +62,7 @@ function markSeen(id: TipId) {
 
 /** Show a contextual tip once. Marks it seen so it never reappears. */
 function showTipOnce(tip: Tip) {
-  if (isMobile()) return;
+  if (!showsAmbientTips()) return;
   if (seen().has(tip.id)) return;
   markSeen(tip.id);
   present(tip);
@@ -70,7 +70,7 @@ function showTipOnce(tip: Tip) {
 
 /** Internal pure peek — picks a tip without marking it seen. */
 function pickAmbientTip(): Tip | null {
-  if (isMobile()) return null;
+  if (!showsAmbientTips()) return null;
   const unseen = ambientPool.filter((t) => !seen().has(t.id));
   const pool = unseen.length > 0 ? unseen : ambientPool;
   return pool[Math.floor(Math.random() * pool.length)] ?? null;

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -53,6 +53,7 @@ import {
 import ScrollToBottom from "./ScrollToBottom";
 import { applyStickyModifiers } from "./stickyModifiers";
 import SearchBar from "./SearchBar";
+import { enableSoftKeyboardInput } from "./softKeyboardInput";
 import { registerTerminalRefs, unregisterTerminalRefs } from "./terminalRefs";
 import { registerDiagnostics } from "./useTerminalDiagnostics";
 import { useTerminalStore } from "./useTerminalStore";
@@ -520,115 +521,94 @@ const Terminal: Component<{
           containerRef.addEventListener("click", (e) => {
             if (e.target === containerRef) term.focus();
           });
-          // Mobile: route soft-keyboard input through `.xterm-screen` itself,
-          // the way hterm does (libapps/hterm/js/hterm_scrollport.js:617-655).
-          //
-          // xterm's own hidden helper textarea already has spellcheck/autocorrect
-          // disabled by the library (CoreBrowserTerminal.ts:448-450), but iOS
-          // Safari still runs spell-check against the accumulated `textarea.value`
-          // that `_syncTextArea()` parks at the cursor cell — hence the phantom
-          // underlines. Making the screen element contenteditable gives mobile a
-          // real focus target and lets us opt the whole input surface out of
-          // correction features. `caret-color: transparent` keeps the native
-          // contenteditable caret from fighting xterm's rendered cursor.
-          //
-          // Desktop is left alone — xterm's unmodified mousedown → textarea.focus
-          // path works fine with a hardware keyboard and we don't want to risk
-          // fighting its selection handling.
-          if (isTouch()) {
-            const screen = term.element?.querySelector(
-              ".xterm-screen",
-            ) as HTMLElement | null;
-            if (screen) {
-              screen.setAttribute("contenteditable", "true");
-              screen.setAttribute("spellcheck", "false");
-              screen.setAttribute("autocorrect", "off");
-              screen.setAttribute("autocapitalize", "none");
-              screen.setAttribute("autocomplete", "off");
-              screen.setAttribute("aria-readonly", "true");
-              screen.style.caretColor = "transparent";
-              screen.style.outline = "none";
-              // iOS Safari rejects the soft keyboard when focus shuffles
-              // mid-gesture from the contenteditable above to xterm's
-              // opacity-0 helper textarea — which is exactly what happens
-              // when the wrapper-click handler (line 500) fires
-              // term.focus() right after the browser auto-focuses
-              // .xterm-screen on pointerdown. preventDefault on pointerdown
-              // blocks the contenteditable auto-focus.
-              //
-              // Defer the focus call to pointerup, gated on a tap-sized
-              // movement threshold: taps summon the keyboard, touch-scrolls
-              // don't. pointerup still fires inside the user-gesture window
-              // iOS requires for programmatic focus, and the call sees the
-              // same "single focus event, no shuffle" iOS heuristic the
-              // pointerdown variant did. Threshold is generous enough to
-              // tolerate finger jitter on a real tap but tighter than the
-              // ~1-cell-height step the scroll handler at line 716 reads as
-              // "scroll started".
-              const TAP_THRESHOLD_PX = 10;
-              const isTap = (dx: number, dy: number) =>
-                Math.hypot(dx, dy) <= TAP_THRESHOLD_PX;
-              let activeTap: {
-                pointerId: number;
-                startX: number;
-                startY: number;
-              } | null = null;
-              // Map a tap point to the `path:line` reference under it, if any.
-              // Reads the screen's `getBoundingClientRect()` to convert the
-              // viewport pixel into a (col, buffer-line) cell — both axes plus
-              // the rect offsets, since a tap is 2D (the touch-scroll handler
-              // below needs only `clientHeight`, one dimension, so the two
-              // don't share a geometry helper). Then hit-tests the link parser.
-              const fileRefAtPoint = (
-                clientX: number,
-                clientY: number,
-              ): LineRef | null => {
-                if (!terminal) return null;
-                const rect = screen.getBoundingClientRect();
-                const cellW = rect.width / terminal.cols;
-                const cellH = rect.height / terminal.rows;
-                if (
-                  !Number.isFinite(cellW) ||
-                  cellW <= 0 ||
-                  !Number.isFinite(cellH) ||
-                  cellH <= 0
-                )
-                  return null;
-                const col = Math.floor((clientX - rect.left) / cellW);
-                const row = Math.floor((clientY - rect.top) / cellH);
-                const bufferLine = terminal.buffer.active.viewportY + row;
-                return fileRefAtCell(terminal, col, bufferLine);
+          // Touch: give the soft keyboard a contenteditable `.xterm-screen`
+          // input surface (xterm's hidden helper textarea triggers iOS
+          // spell-check underlines). Extracted to `softKeyboardInput.ts` so the
+          // xterm shadow-DOM knowledge and the `isTouch()` guard live in one
+          // testable place; returns the prepared screen (null on desktop) onto
+          // which the tap-routing gestures below wire link-activation vs. focus.
+          const screen = enableSoftKeyboardInput(term);
+          if (screen) {
+            // iOS Safari rejects the soft keyboard when focus shuffles
+            // mid-gesture from the contenteditable above to xterm's
+            // opacity-0 helper textarea — which is exactly what happens
+            // when the wrapper-click handler (line 500) fires
+            // term.focus() right after the browser auto-focuses
+            // .xterm-screen on pointerdown. preventDefault on pointerdown
+            // blocks the contenteditable auto-focus.
+            //
+            // Defer the focus call to pointerup, gated on a tap-sized
+            // movement threshold: taps summon the keyboard, touch-scrolls
+            // don't. pointerup still fires inside the user-gesture window
+            // iOS requires for programmatic focus, and the call sees the
+            // same "single focus event, no shuffle" iOS heuristic the
+            // pointerdown variant did. Threshold is generous enough to
+            // tolerate finger jitter on a real tap but tighter than the
+            // ~1-cell-height step the scroll handler at line 716 reads as
+            // "scroll started".
+            const TAP_THRESHOLD_PX = 10;
+            const isTap = (dx: number, dy: number) =>
+              Math.hypot(dx, dy) <= TAP_THRESHOLD_PX;
+            let activeTap: {
+              pointerId: number;
+              startX: number;
+              startY: number;
+            } | null = null;
+            // Map a tap point to the `path:line` reference under it, if any.
+            // Reads the screen's `getBoundingClientRect()` to convert the
+            // viewport pixel into a (col, buffer-line) cell — both axes plus
+            // the rect offsets, since a tap is 2D (the touch-scroll handler
+            // below needs only `clientHeight`, one dimension, so the two
+            // don't share a geometry helper). Then hit-tests the link parser.
+            const fileRefAtPoint = (
+              clientX: number,
+              clientY: number,
+            ): LineRef | null => {
+              if (!terminal) return null;
+              const rect = screen.getBoundingClientRect();
+              const cellW = rect.width / terminal.cols;
+              const cellH = rect.height / terminal.rows;
+              if (
+                !Number.isFinite(cellW) ||
+                cellW <= 0 ||
+                !Number.isFinite(cellH) ||
+                cellH <= 0
+              )
+                return null;
+              const col = Math.floor((clientX - rect.left) / cellW);
+              const row = Math.floor((clientY - rect.top) / cellH);
+              const bufferLine = terminal.buffer.active.viewportY + row;
+              return fileRefAtCell(terminal, col, bufferLine);
+            };
+            makeEventListener(screen, "pointerdown", (e: PointerEvent) => {
+              e.preventDefault();
+              activeTap = {
+                pointerId: e.pointerId,
+                startX: e.clientX,
+                startY: e.clientY,
               };
-              makeEventListener(screen, "pointerdown", (e: PointerEvent) => {
-                e.preventDefault();
-                activeTap = {
-                  pointerId: e.pointerId,
-                  startX: e.clientX,
-                  startY: e.clientY,
-                };
-              });
-              makeEventListener(screen, "pointerup", (e: PointerEvent) => {
-                if (activeTap === null || e.pointerId !== activeTap.pointerId)
-                  return;
-                const { startX, startY } = activeTap;
-                activeTap = null;
-                if (!isTap(e.clientX - startX, e.clientY - startY)) return;
-                // What the tap does decides whether the keyboard rises: a tap on
-                // a `path:line` reference follows the link into the Code tab
-                // (xterm's own link activation is mouse/hover-only and never
-                // fires for touch), a tap on plain content focuses to type.
-                // Only the latter summons the soft keyboard.
-                const ref = fileRefAtPoint(e.clientX, e.clientY);
-                if (ref) {
-                  activateFileRef(ref);
-                  return;
-                }
-                term.focus();
-              });
-              makeEventListener(screen, "pointercancel", (e: PointerEvent) => {
-                if (activeTap?.pointerId === e.pointerId) activeTap = null;
-              });
-            }
+            });
+            makeEventListener(screen, "pointerup", (e: PointerEvent) => {
+              if (activeTap === null || e.pointerId !== activeTap.pointerId)
+                return;
+              const { startX, startY } = activeTap;
+              activeTap = null;
+              if (!isTap(e.clientX - startX, e.clientY - startY)) return;
+              // What the tap does decides whether the keyboard rises: a tap on
+              // a `path:line` reference follows the link into the Code tab
+              // (xterm's own link activation is mouse/hover-only and never
+              // fires for touch), a tap on plain content focuses to type.
+              // Only the latter summons the soft keyboard.
+              const ref = fileRefAtPoint(e.clientX, e.clientY);
+              if (ref) {
+                activateFileRef(ref);
+                return;
+              }
+              term.focus();
+            });
+            makeEventListener(screen, "pointercancel", (e: PointerEvent) => {
+              if (activeTap?.pointerId === e.pointerId) activeTap = null;
+            });
           }
           // Kolu-owned bridge consumed by e2e step definitions —
           // `support/buffer.ts`, `step_definitions/file_ref_link_steps.ts`,

--- a/packages/client/src/terminal/softKeyboardInput.ts
+++ b/packages/client/src/terminal/softKeyboardInput.ts
@@ -1,0 +1,41 @@
+/** Soft-keyboard input surface for touch terminals.
+ *
+ *  The one piece of xterm-internal knowledge the touch path needs, kept in one
+ *  testable place: on iOS the soft keyboard must be summoned through a
+ *  *contenteditable* `.xterm-screen`, not xterm's hidden helper textarea. xterm
+ *  already disables spellcheck/autocorrect on that textarea
+ *  (CoreBrowserTerminal.ts), but iOS Safari still runs spell-check against the
+ *  accumulated `textarea.value` that `_syncTextArea()` parks at the cursor cell —
+ *  hence the phantom underlines. Making the screen element contenteditable gives
+ *  mobile a real focus target and lets us opt the whole input surface out of
+ *  correction features. `caret-color: transparent` keeps the native
+ *  contenteditable caret from fighting xterm's rendered cursor.
+ *
+ *  Desktop is left untouched — xterm's mousedown → textarea.focus path works fine
+ *  with a hardware keyboard, and we don't want to risk fighting its selection
+ *  handling. The `isTouch()` guard lives here, so callers invoke this
+ *  unconditionally and never reach into xterm's shadow DOM themselves.
+ *
+ *  Returns the prepared `.xterm-screen` element (the input surface) so the caller
+ *  can wire tap-routing gestures onto it, or `null` on desktop / before xterm's
+ *  DOM exists. */
+
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { isTouch } from "../useMobile";
+
+export function enableSoftKeyboardInput(term: XTerm): HTMLElement | null {
+  if (!isTouch()) return null;
+  const screen = term.element?.querySelector(
+    ".xterm-screen",
+  ) as HTMLElement | null;
+  if (!screen) return null;
+  screen.setAttribute("contenteditable", "true");
+  screen.setAttribute("spellcheck", "false");
+  screen.setAttribute("autocorrect", "off");
+  screen.setAttribute("autocapitalize", "none");
+  screen.setAttribute("autocomplete", "off");
+  screen.setAttribute("aria-readonly", "true");
+  screen.style.caretColor = "transparent";
+  screen.style.outline = "none";
+  return screen;
+}

--- a/packages/client/src/useMobile.ts
+++ b/packages/client/src/useMobile.ts
@@ -1,10 +1,31 @@
 /** Shared viewport/input-mode signals — singleton.
- *  Matches Tailwind's `sm:` breakpoint (640px). */
+ *
+ *  Two orthogonal axes, never conflated:
+ *  - `isMobile` — viewport SIZE (small-screen layout).
+ *  - `isTouch`  — input MODALITY (coarse pointer), independent of size.
+ *
+ *  The size breakpoint has ONE source of truth: Tailwind's `--breakpoint-sm`
+ *  theme token (declared in `index.css`, the same value its `sm:` / `max-sm:`
+ *  utilities compile against). We read it and build the query as the exact
+ *  complement of `sm:` (`width < sm`), so a viewport is "mobile" in JS and
+ *  "below sm" in CSS at precisely the same pixel — no off-by-one desync band.
+ *  Falls back to Tailwind's default `40rem` (640px) before the stylesheet has
+ *  applied (e.g. unit tests with no DOM). */
 
 import { createMediaQuery } from "@solid-primitives/media";
 
-/** Reactive signal: true when viewport is below Tailwind's `sm` breakpoint. */
-export const isMobile = createMediaQuery("(max-width: 639px)");
+/** Tailwind's `sm` breakpoint, read from the generated CSS custom property so
+ *  JS and CSS share one definition of where "mobile" begins. */
+const SM_BREAKPOINT =
+  (typeof document !== "undefined"
+    ? getComputedStyle(document.documentElement)
+        .getPropertyValue("--breakpoint-sm")
+        .trim()
+    : "") || "40rem";
+
+/** Reactive signal: true when the viewport is below the `sm` breakpoint — the
+ *  exact complement of Tailwind's `sm:` utilities (i.e. `max-sm:`). */
+export const isMobile = createMediaQuery(`(width < ${SM_BREAKPOINT})`);
 
 /** Reactive signal: true on touch devices (phones, tablets). */
 export const isTouch = createMediaQuery("(pointer: coarse)");


### PR DESCRIPTION
**Feature code across the client branched on the raw `isMobile()` / `isTouch()` media-query signals at ~18 sites** — picking layouts, gating commands, suppressing tips, forking panel reveal — and the viewport breakpoint was defined twice (JS `max-width: 639px` vs Tailwind `sm:` at `640px`), a 1px desync band. This PR applies a [Hickey/Lowy review](https://github.com/juspay/kolu/blob/brave-second/docs/plans/mobile-architecture-review.html) of mobile support: encapsulate the "mobile vs. desktop" volatility behind small stable interfaces so feature code expresses *intent* and *capability* instead of re-deriving form factor everywhere. `App.tsx`'s `match(isMobile())` layout fork and the `withKeyboardDismiss` wrapper stay as the two legitimate receptacles; everything else now routes through a verb.

### The four receptacles

| Leak it replaces | Receptacle |
| --- | --- |
| JS `639px` vs. CSS `640px` — two definitions of "mobile" | One source: `--breakpoint-sm` in the Tailwind `@theme`, read by `useMobile.ts` as the exact complement of `sm:` (`width < sm`) |
| `openInCodeTab` forked drawer-open vs. uncollapse on `isMobile` inline | `useRightPanel.reveal()` — producers express "show the panel"; the store owns the mobile/desktop fork |
| Tips, canvas commands, and the switcher each asked "am I mobile?" | `capabilities.ts` — `supportsSpatialCanvas` / `showsWorkspaceSwitcher` / `showsAmbientTips`; consumers ask about a capability, not pixels |
| `Terminal.tsx` poked xterm's `.xterm-screen` shadow DOM inline | `enableSoftKeyboardInput(term)` — the touch contenteditable setup in one testable place |

### Caught in review

The Hickey/Lowy pass ran with cross-validation, and it earned its keep: it rejected my first attempt to fold two `CodeTab` reads under one `isCompactLayout` verb, and surfaced a genuine **wrong-axis bug** — the file tree's *density* was keyed on viewport (`isMobile`) when "roomier rows" is a tap-target affordance (`isTouch`), so a coarse-pointer tablet wider than `sm` silently got tight rows. Now `isTouch`. *Its sibling touch-scroll driver correctly stays on `isMobile`* — that workaround targets the **portaled** mobile drawer, not touch presence (`pierreTouchScroll.ts`); a comment now records why so it isn't "fixed" the wrong way later.

> Mostly behavior-preserving — the breakpoint aligns by <1px. The one intentional behavior change is the density fix above (touch tablets now get the roomier file-tree rows they always should have).

181 e2e scenarios pass across the file-ref-link, right-panel, code-tab, command-palette, canvas, and mobile features.

### Try it locally

```sh
nix run github:juspay/kolu/brave-second
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._