### PR TITLE
Reload the Code-tab iframe/image preview when the file changes

### DIFF
--- a/packages/solid-fileview/src/FileView.tsx
+++ b/packages/solid-fileview/src/FileView.tsx
@@ -54,19 +54,26 @@ export const FileView: Component<FileViewProps> = (props) => {
     return hasRendered() ? "rendered" : "source";
   });
 
+  // The active appliance for the resolved mode. Read as a child expression so
+  // Solid tracks `props.file`: a save mints a fresh `FileData` (new `url` for a
+  // binary, new `content` for text), and the matching renderer has to re-run to
+  // pick it up. The earlier `<Show>`-callback form ran the rendered branch once
+  // under `untrack` and keyed it on the (stable) matched-renderer identity, so
+  // an iframe/image preview captured its first `url` and never reloaded after an
+  // edit — only the source view (rendered via the tracked `fallback` slot)
+  // updated. One tracked expression keeps both branches symmetric: each
+  // re-renders its appliance on a fresh snapshot.
+  const active = () =>
+    mode() === "rendered"
+      ? matchedRendered()?.render(props.file)
+      : props.source?.render(props.file);
+
   return (
     <div class="flex h-full w-full flex-col">
       <Show when={both()}>
         <FileViewToggle mode={mode()} onChange={setChosen} />
       </Show>
-      <div class="min-h-0 flex-1">
-        <Show
-          when={mode() === "rendered" && matchedRendered()}
-          fallback={props.source?.render(props.file)}
-        >
-          {(renderer) => renderer().render(props.file)}
-        </Show>
-      </div>
+      <div class="min-h-0 flex-1">{active()}</div>
     </div>
   );
 };

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -648,6 +648,29 @@ Feature: Code tab (review + browse)
     And I run "printf 'second version\n' > letters.txt"
     Then the file content should contain "second version"
 
+  # Live-update for the iframe-previewed kinds (.html/.svg/.pdf): editing the
+  # previewed file must refresh the iframe with no manual reload. Unlike the
+  # text path above (new content arrives on the `fsReadFile` stream and re-feeds
+  # Pierre), the binary path carries only a `url`. The refresh hinges on the
+  # server bumping `?v=<mtime>` on every save (`buildIframePreviewUrl`): the new
+  # URL breaks `fsReadFileOutputEqual` (binary equality is `a.url === b.url`), so
+  # a fresh snapshot pushes, the `binaryFile` memo identity flips, and FileView
+  # re-points the iframe `src`. This reads the rendered content *inside* the
+  # frame — proof the new bytes actually reached the preview, not merely that
+  # the src attribute moved.
+  Scenario: Editing an HTML file refreshes the iframe preview live
+    When I run "rm -rf /tmp/kolu-live-html && git init /tmp/kolu-live-html && cd /tmp/kolu-live-html"
+    And I run "printf '<!doctype html><h1>preview version one</h1>\n' > page.html"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    And I click the file "page.html" in the file browser
+    Then the file preview iframe should be visible
+    And the file preview iframe should contain "preview version one"
+    When I click the terminal canvas
+    And I run "printf '<!doctype html><h1>preview version two</h1>\n' > page.html"
+    Then the file preview iframe should contain "preview version two"
+
   Scenario: Committing the selected local diff clears the stale content pane
     When I run "rm -rf /tmp/kolu-clear-selected-local && git init /tmp/kolu-clear-selected-local && cd /tmp/kolu-clear-selected-local"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -570,7 +570,7 @@ Then(
       .locator("body");
     await pollFor({
       observe: () => body.textContent({ timeout: 1_000 }).catch(() => null),
-      isDone: (text) => (text ?? "").includes(expected),
+      isDone: (text) => text !== null && text.includes(expected),
       onTimeout: (last) =>
         new Error(
           `iframe preview never contained "${expected}"; last body text: ${JSON.stringify(last)}`,

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -554,6 +554,32 @@ Then(
   },
 );
 
+// Reads the rendered DOM *inside* the sandboxed preview iframe. The frame
+// runs at an opaque origin (`allow-scripts`, no `allow-same-origin`), but
+// Playwright resolves it through the browser frame tree, so `frameLocator`
+// reaches its `<body>` regardless of origin. Polling (not a single read)
+// because a save re-points the iframe `src` at a fresh `?v=<mtime>` URL: the
+// old frame detaches and the new one navigates, so `textContent` throws
+// transiently mid-swap — a short per-read timeout + `.catch(() => null)`
+// lets the poll ride through the navigation until the new content lands.
+Then(
+  "the file preview iframe should contain {string}",
+  async function (this: KoluWorld, expected: string) {
+    const body = this.page
+      .frameLocator('[data-testid="browse-preview-iframe"]')
+      .locator("body");
+    await pollFor({
+      observe: () => body.textContent({ timeout: 1_000 }).catch(() => null),
+      isDone: (text) => (text ?? "").includes(expected),
+      onTimeout: (last) =>
+        new Error(
+          `iframe preview never contained "${expected}"; last body text: ${JSON.stringify(last)}`,
+        ),
+      timeoutMs: POLL_TIMEOUT,
+    });
+  },
+);
+
 Then(
   "the file preview image should be visible",
   async function (this: KoluWorld) {


### PR DESCRIPTION
**The Code-tab's HTML / SVG / PDF and image previews now live-reload when the underlying file changes on disk** — edit a previewed `index.html` in the terminal and the iframe refreshes itself. The README has long claimed this ("both live-reload when the file changes — mtime bump on the URL"), but in practice only the text/source view updated; the rendered preview stayed frozen on whatever you first opened.

### Root cause

`@kolu/solid-fileview`'s `FileView` rendered its two preview branches asymmetrically:

| Branch | How it rendered | Tracked `props.file`? |
| --- | --- | --- |
| Source (text) | `<Show fallback={source.render(file)}>` — read in a tracking scope | ✅ re-rendered on every edit |
| Rendered (iframe / image) | `<Show>{(r) => r().render(file)}</Show>` — children callback, runs once under `untrack` | ❌ captured the first `file` forever |

A save bumps `?v=<mtime>` on the served URL, so `BrowseFileDispatcher` mints a fresh `FileData` and `fsReadFileOutputEqual` lets the new snapshot through — but the rendered branch's one-shot callback never saw it, so the iframe kept its original `src`.

### Fix

Collapse the inner content `<Show>` into a single tracked child expression, so the source and rendered branches re-render *symmetrically* on a fresh snapshot:

```tsx
const active = () =>
  mode() === "rendered"
    ? matchedRendered()?.render(props.file)
    : props.source?.render(props.file);
// …
<div class="min-h-0 flex-1">{active()}</div>
```

> _Same code path drove raster-image previews, so this restores their auto-reload too._

### Test

A new `code-tab.feature` scenario opens an `.html` file in browse mode, edits it from the shell, and asserts the **rendered content inside the sandboxed iframe** changes — not merely that the `src` attribute moved. The supporting step reads into the opaque-origin (`sandbox="allow-scripts"`) frame via Playwright's `frameLocator`, polling through the `src`-swap navigation. Full `code-tab.feature` stays green (68/68).

### Try it locally

```sh
nix run github:juspay/kolu/reload-html
```

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._