### PR TITLE
fix(website): deterministic pnpm-deps fetch on linux (#1097)

### DIFF
--- a/website/default.nix
+++ b/website/default.nix
@@ -29,6 +29,28 @@ let
     pname = "kolu-website";
     version = "0.1.0";
     inherit src;
+    # Determinism guard (juspay/kolu#1097). The fetcher runs `pnpm install
+    # --force`, which pulls every platform's optional binaries (so Darwin and
+    # Linux share one hash) — but `--force` treats those cross-platform
+    # packages as *best-effort*: a slow or timed-out download of a heavy blob
+    # (@img/sharp's libvips ~8MB each, canvaskit-wasm) is silently dropped, so
+    # a network-pressured box ends up with fewer packages and a different store
+    # hash. That flaked `ci::pnpm-hash-fresh@x86_64-linux` at random, ~1/3 of
+    # linux runs. Declaring the full os/cpu/libc matrix in supportedArchitectures
+    # makes those binaries *required*: pnpm must fetch all of them (erroring or
+    # retrying, never silently skipping) under --frozen-lockfile, so every box
+    # converges on the same store. We inject it via prePnpmInstall (here, in the
+    # Nix sandbox) rather than committing it to package.json so a local
+    # `pnpm install` in website/ still fetches only the host's binaries.
+    # The matrix is a superset of every platform in pnpm-lock.yaml, so the
+    # fetched set — and this hash — is identical to the pre-fix `--force` set.
+    prePnpmInstall = ''
+      jq '.pnpm.supportedArchitectures = {
+        os: ["linux", "darwin", "win32", "freebsd", "openbsd", "netbsd", "sunos", "android", "openharmony", "aix"],
+        cpu: ["x64", "ia32", "arm64", "arm", "ppc64", "ppc", "s390x", "riscv64", "loong64", "mips64el", "wasm32"],
+        libc: ["glibc", "musl"]
+      }' package.json | sponge package.json
+    '';
     hash = "sha256-EgCvlKgSv86ecZR7aL1J2uGFWnaCMyQjkvUlpqXjaTo=";
     fetcherVersion = 3;
   };


### PR DESCRIPTION
## What

Fixes #1097 — `ci::pnpm-hash-fresh@x86_64-linux` flakes because the fixed-output `kolu-website-pnpm-deps` derivation produces a **different store hash per box** from byte-identical inputs (the `.drv` is identical across runs). It red-flagged unrelated PRs at random, ~1/3 of linux runs, while Darwin always reproduced the pin.

## Root cause

`fetchPnpmDeps` runs `pnpm install --force`, which pulls *every* platform's optional binaries so Darwin and Linux can share one hash. But `--force` treats those cross-platform packages as **best-effort**: when a heavy blob is slow or times out (`@img/sharp`'s libvips binaries are ~8 MB each; `canvaskit-wasm`), pnpm silently drops it and completes. A network-pressured box therefore ends up with *fewer* packages in the store → a different hash. Fast boxes (and Darwin) happened to fetch the full set and land on the pin; slow boxes diverged. The website triggers this where the main app doesn't because it pulls those large binary packages (sharp via `astro-og-canvas`, canvaskit).

The store is a pure content-addressed pnpm CAS, so the only thing that can change the FOD hash is **which packages land** — confirmed by reproduction below.

## Fix

Declare the full `os`/`cpu`/`libc` matrix in `pnpm.supportedArchitectures`, injected via `prePnpmInstall` (so it lives only in the Nix sandbox — a local `pnpm install` in `website/` still fetches just the host's binaries). This makes the cross-platform binaries **required** rather than best-effort: under `--frozen-lockfile` pnpm must fetch all of them, erroring or retrying instead of silently skipping. Every box converges on the same store.

The matrix is a superset of every platform present in `pnpm-lock.yaml`, so the fetched set — and the pinned hash — is **unchanged**.

## Verification

| check | result |
|---|---|
| fetched-package set: `supportedArchitectures` (no `--force`) vs `--force` vs both | **511 ≡ 511 ≡ 511**, identical sets |
| `nix build --rebuild .#website-pnpm-deps` — local, **glibc 2.42** | ✅ reproduces pin `sha256-EgCv…aTo=` |
| `nix build --rebuild .#website-pnpm-deps` — fresh box, **glibc 2.40** | ✅ reproduces same pin |
| `nix build .#website` (astro build still works on fixed deps) | ✅ |
| `pnpm-lock.yaml` touched by the change | ❌ unchanged (`supportedArchitectures` isn't a resolution input) |

Because the fix makes the set *required*, the silent-drop failure mode it targets cannot recur regardless of box network conditions — that path now errors the build instead of producing a divergent hash.

## Scope

Limited to `website/default.nix` per the issue. The root `default.nix` uses the same `--force` fetcher and is theoretically susceptible, but pulls no comparably heavy best-effort binaries and hasn't been observed to flake; left untouched to keep this focused and hash-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)