### PR TITLE
chore(apm): build apm-cli from compile-hang fix PR until it merges

### DIFF
--- a/agents/ai.just
+++ b/agents/ai.just
@@ -6,7 +6,12 @@ set working-directory := '..'
 # these recipes need to enter it when invoked from a bare shell.
 nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accept-flake-config -c' }
 
-apm_cmd := nix_shell + ' uvx --from apm-cli apm'
+# TEMPORARY: build apm-cli from the open PR that fixes `apm compile` hanging
+# at 100% CPU / multi-GB RSS on pnpm projects (its `**` applyTo glob followed
+# node_modules/.pnpm symlink cycles). The `refs/pull/1576/head` ref tracks the
+# PR head from the base repo. Revert to `--from apm-cli` once it merges and a
+# release ships. Upstream PR: https://github.com/microsoft/apm/pull/1576
+apm_cmd := nix_shell + ' uvx --from git+https://github.com/microsoft/apm@refs/pull/1576/head apm'
 apm_targets := 'claude,codex,opencode'
 apm_compile_targets := 'codex,opencode'
 


### PR DESCRIPTION
**`just ai::apm` hangs.** `apm compile` pegs one core near 100% CPU and climbs past 4 GB RSS without ever finishing on this repo. The cause is upstream in `apm-cli`: the placement optimizer resolves each instruction's `applyTo` pattern with `glob.glob(pattern, recursive=True)`, whose `**` *follows directory symlinks* and ignores its own excluded-dir list — so it walks pnpm's `node_modules/.pnpm` symlink forest through exponentially many paths and never returns.

Kolu is the unlucky intersection that triggers it: we use **pnpm** (a `.pnpm` store with ~2,400 symlinks) **and** ship `**` `applyTo` patterns — notably `applyTo: "**"`. Either alone is fine; together they detonate.

This builds `apm-cli` from the open upstream fix via the **PR head ref** until it lands:

```diff
-apm_cmd := nix_shell + ' uvx --from apm-cli apm'
+apm_cmd := nix_shell + ' uvx --from git+https://github.com/microsoft/apm@refs/pull/1576/head apm'
```

`refs/pull/1576/head` is served from the base repo and resolves to the PR head, so this tracks the fix without referencing a personal fork. The fix filters the optimizer's cached, symlink-safe file walk through APM's existing `**`-aware matcher instead of re-globbing. On this repo the same compile drops from *never finishing* to **~2.5 s** with byte-identical AGENTS.md output. Verified `uvx` builds and runs it from that ref (`APM CLI 0.16.1`).

> **Revert when upstream merges.** Upstream PR: [microsoft/apm#1576](https://github.com/microsoft/apm/pull/1576). Once it merges and a release ships, restore `--from apm-cli`. The `ai.just` comment points back to it.

---
_Generated by Claude Code (model `claude-opus-4-8`)._