### PR TITLE
feat(be): /be — interactive end-to-end workflow with AI review gauntlet

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<issue-url | prompt>"
 
 # Be
 
-Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous, no questions), `/be` **opens with a short interview**, then runs the full gauntlet. Concise by design — defer mechanics to the skills it calls.
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps (the `EnterPlanMode` approval in §1, only when "plan first" was chosen, is the lone exception). Concise by design — defer mechanics to the skills it calls.
 
 **Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
 
@@ -17,7 +17,7 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 - **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
 
 **Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
 

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<issue-url | prompt>"
 
 # Be
 
-Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps (the `EnterPlanMode` approval in §1, only when "plan first" was chosen, is the lone exception). Concise by design — defer mechanics to the skills it calls.
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps. The single exception is the optional plan-review pause in §1, and only when "plan first" was chosen. Concise by design — defer mechanics to the skills it calls.
 
 **Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
 
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
-- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 
 Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
@@ -24,8 +24,8 @@ Add a question only when something material is genuinely unclear — don't pad. 
 ## 1. Set up
 
 - `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
-- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands. Reuse them throughout.
-- **If "plan first":** write `docs/plans/<slug>.html`, present it (`EnterPlanMode`/`ExitPlanMode`), and only implement once approved.
+- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands and its **`## PR evidence`** section. Reuse them throughout.
+- **If "plan first":** write `docs/plans/<slug>.html`, then **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause.
 
 ## 2. Implement
 
@@ -33,22 +33,29 @@ Add a question only when something material is genuinely unclear — don't pad. 
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 
-Prefer the boring, obvious, simple thing. Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
+Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
 
-## 3. Review gauntlet
+## 3. Open the PR
 
-Run **in order** — each surfaces different defects:
+**Before any review** — so every reviewer's findings land as comments on a real PR. Load **`/forge-pr`** (Skill tool) and `gh pr create --draft` with a genuine title/body covering the scope so far. The PR exists for the rest of the run; later steps push commits and post comments to it.
 
-1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus and commits per round. Let it finish before moving on.
-2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn. Brief each with the diff (`git diff origin/HEAD...HEAD`) and the change rationale only — do **not** seed findings.
+## 4. Review gauntlet
 
-**Apply every finding as its own commit** (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …). No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes to clean. Re-run check/fmt after each fix.
+Run **in order** — each surfaces different defects, each posts its findings to the PR:
 
-## 4. Ship
+1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus, commits per round, and posts its summary as a PR comment by default. Let it finish before moving on.
+2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents on the diff (`git diff origin/HEAD...HEAD`), briefed with the change rationale only — do **not** seed findings. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn.
 
-1. **`/forge-pr`** (Skill tool) — open the PR (draft) with a real title/body. Post the codex-debate summary and the hickey/lowy/police findings as PR comments.
-2. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
-3. **`/evidence`** — capture visual/behavioral proof and post it under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff.
+   **Run `/hickey` and `/lowy` on the main agent's model (Opus) — critical.** Their skill frontmatter declares `model: sonnet`; **override it**, passing `model: opus` on the `Agent`/`Workflow` call so both lenses run at full strength. `/code-police` runs on its default.
+
+**Each finding is its own commit** — never batch. For every finding in turn: apply the narrow fix, re-run **check** and **fmt**, `git add` only the touched files, commit (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …) with the finding restated in one line, and `git push`. No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes until clean.
+
+**Post the findings to the PR.** After the lenses finish, post the hickey/lowy/code-police findings as PR comment(s) — a ledger table (one row per finding with its disposition) plus each lens's rationale — so reviewers see the structural analysis alongside codex-debate's own comment.
+
+## 5. Ship
+
+1. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
+2. **`/evidence`** — follow the **`## PR evidence`** section of `.agency/do.md` for the capture procedure, then post the result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff. Skip only if that section says to (or is absent).
 
 ## Done
 

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -16,10 +16,9 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
 - **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
+- **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
-
-**Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now (including the ultracode check above), because everything after this is autonomous.
 
 ## 1. Set up
 

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: be
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with an AI review gauntlet (codex debate → hickey/lowy/code-police → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+argument-hint: "<issue-url | prompt>"
+---
+
+# Be
+
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous, no questions), `/be` **opens with a short interview**, then runs the full gauntlet. Concise by design — defer mechanics to the skills it calls.
+
+**Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
+
+## 0. Interview (the differentiator)
+
+Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
+
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
+
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking.
+
+**Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
+
+## 1. Set up
+
+- `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
+- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands. Reuse them throughout.
+- **If "plan first":** write `docs/plans/<slug>.html`, present it (`EnterPlanMode`/`ExitPlanMode`), and only implement once approved.
+
+## 2. Implement
+
+- **Bug:** reproduce first — write a **failing e2e test** that captures the bug (via the `/test` harness), confirm it's red, *then* fix until green. No fix without a reproducing test.
+- **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
+- **Refactor/chore:** no test-first requirement; rely on existing coverage.
+
+Prefer the boring, obvious, simple thing. Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
+
+## 3. Review gauntlet
+
+Run **in order** — each surfaces different defects:
+
+1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus and commits per round. Let it finish before moving on.
+2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn. Brief each with the diff (`git diff origin/HEAD...HEAD`) and the change rationale only — do **not** seed findings.
+
+**Apply every finding as its own commit** (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …). No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes to clean. Re-run check/fmt after each fix.
+
+## 4. Ship
+
+1. **`/forge-pr`** (Skill tool) — open the PR (draft) with a real title/body. Post the codex-debate summary and the hickey/lowy/police findings as PR comments.
+2. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
+3. **`/evidence`** — capture visual/behavioral proof and post it under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff.
+
+## Done
+
+Report the PR URL, the outcome of each review (codex consensus/deadlock, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+
+ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<issue-url | prompt>"
 
 # Be
 
-Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous, no questions), `/be` **opens with a short interview**, then runs the full gauntlet. Concise by design — defer mechanics to the skills it calls.
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps (the `EnterPlanMode` approval in §1, only when "plan first" was chosen, is the lone exception). Concise by design — defer mechanics to the skills it calls.
 
 **Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
 
@@ -17,7 +17,7 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 - **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
 
 **Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
 

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<issue-url | prompt>"
 
 # Be
 
-Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps (the `EnterPlanMode` approval in §1, only when "plan first" was chosen, is the lone exception). Concise by design — defer mechanics to the skills it calls.
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps. The single exception is the optional plan-review pause in §1, and only when "plan first" was chosen. Concise by design — defer mechanics to the skills it calls.
 
 **Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
 
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
-- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 
 Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
@@ -24,8 +24,8 @@ Add a question only when something material is genuinely unclear — don't pad. 
 ## 1. Set up
 
 - `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
-- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands. Reuse them throughout.
-- **If "plan first":** write `docs/plans/<slug>.html`, present it (`EnterPlanMode`/`ExitPlanMode`), and only implement once approved.
+- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands and its **`## PR evidence`** section. Reuse them throughout.
+- **If "plan first":** write `docs/plans/<slug>.html`, then **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause.
 
 ## 2. Implement
 
@@ -33,22 +33,29 @@ Add a question only when something material is genuinely unclear — don't pad. 
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 
-Prefer the boring, obvious, simple thing. Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
+Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
 
-## 3. Review gauntlet
+## 3. Open the PR
 
-Run **in order** — each surfaces different defects:
+**Before any review** — so every reviewer's findings land as comments on a real PR. Load **`/forge-pr`** (Skill tool) and `gh pr create --draft` with a genuine title/body covering the scope so far. The PR exists for the rest of the run; later steps push commits and post comments to it.
 
-1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus and commits per round. Let it finish before moving on.
-2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn. Brief each with the diff (`git diff origin/HEAD...HEAD`) and the change rationale only — do **not** seed findings.
+## 4. Review gauntlet
 
-**Apply every finding as its own commit** (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …). No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes to clean. Re-run check/fmt after each fix.
+Run **in order** — each surfaces different defects, each posts its findings to the PR:
 
-## 4. Ship
+1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus, commits per round, and posts its summary as a PR comment by default. Let it finish before moving on.
+2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents on the diff (`git diff origin/HEAD...HEAD`), briefed with the change rationale only — do **not** seed findings. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn.
 
-1. **`/forge-pr`** (Skill tool) — open the PR (draft) with a real title/body. Post the codex-debate summary and the hickey/lowy/police findings as PR comments.
-2. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
-3. **`/evidence`** — capture visual/behavioral proof and post it under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff.
+   **Run `/hickey` and `/lowy` on the main agent's model (Opus) — critical.** Their skill frontmatter declares `model: sonnet`; **override it**, passing `model: opus` on the `Agent`/`Workflow` call so both lenses run at full strength. `/code-police` runs on its default.
+
+**Each finding is its own commit** — never batch. For every finding in turn: apply the narrow fix, re-run **check** and **fmt**, `git add` only the touched files, commit (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …) with the finding restated in one line, and `git push`. No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes until clean.
+
+**Post the findings to the PR.** After the lenses finish, post the hickey/lowy/code-police findings as PR comment(s) — a ledger table (one row per finding with its disposition) plus each lens's rationale — so reviewers see the structural analysis alongside codex-debate's own comment.
+
+## 5. Ship
+
+1. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
+2. **`/evidence`** — follow the **`## PR evidence`** section of `.agency/do.md` for the capture procedure, then post the result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff. Skip only if that section says to (or is absent).
 
 ## Done
 

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -16,10 +16,9 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
 - **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
+- **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
-
-**Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now (including the ultracode check above), because everything after this is autonomous.
 
 ## 1. Set up
 

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: be
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with an AI review gauntlet (codex debate → hickey/lowy/code-police → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+argument-hint: "<issue-url | prompt>"
+---
+
+# Be
+
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous, no questions), `/be` **opens with a short interview**, then runs the full gauntlet. Concise by design — defer mechanics to the skills it calls.
+
+**Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
+
+## 0. Interview (the differentiator)
+
+Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
+
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
+
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking.
+
+**Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
+
+## 1. Set up
+
+- `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
+- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands. Reuse them throughout.
+- **If "plan first":** write `docs/plans/<slug>.html`, present it (`EnterPlanMode`/`ExitPlanMode`), and only implement once approved.
+
+## 2. Implement
+
+- **Bug:** reproduce first — write a **failing e2e test** that captures the bug (via the `/test` harness), confirm it's red, *then* fix until green. No fix without a reproducing test.
+- **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
+- **Refactor/chore:** no test-first requirement; rely on existing coverage.
+
+Prefer the boring, obvious, simple thing. Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
+
+## 3. Review gauntlet
+
+Run **in order** — each surfaces different defects:
+
+1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus and commits per round. Let it finish before moving on.
+2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn. Brief each with the diff (`git diff origin/HEAD...HEAD`) and the change rationale only — do **not** seed findings.
+
+**Apply every finding as its own commit** (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …). No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes to clean. Re-run check/fmt after each fix.
+
+## 4. Ship
+
+1. **`/forge-pr`** (Skill tool) — open the PR (draft) with a real title/body. Post the codex-debate summary and the hickey/lowy/police findings as PR comments.
+2. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
+3. **`/evidence`** — capture visual/behavioral proof and post it under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff.
+
+## Done
+
+Report the PR URL, the outcome of each review (codex consensus/deadlock, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+
+ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<issue-url | prompt>"
 
 # Be
 
-Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous, no questions), `/be` **opens with a short interview**, then runs the full gauntlet. Concise by design — defer mechanics to the skills it calls.
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps (the `EnterPlanMode` approval in §1, only when "plan first" was chosen, is the lone exception). Concise by design — defer mechanics to the skills it calls.
 
 **Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
 
@@ -17,7 +17,7 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 - **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
 
 **Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
 

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<issue-url | prompt>"
 
 # Be
 
-Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps (the `EnterPlanMode` approval in §1, only when "plan first" was chosen, is the lone exception). Concise by design — defer mechanics to the skills it calls.
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish), `/be` **opens with a short interview** — and is then **fully autonomous**, exactly like `/do`, from §1 onward. The interview is the *only* place `/be` asks the user anything; after it, make sensible defaults and keep moving — no further `AskUserQuestion`, no stopping between steps. The single exception is the optional plan-review pause in §1, and only when "plan first" was chosen. Concise by design — defer mechanics to the skills it calls.
 
 **Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
 
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
-- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 
 Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
@@ -24,8 +24,8 @@ Add a question only when something material is genuinely unclear — don't pad. 
 ## 1. Set up
 
 - `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
-- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands. Reuse them throughout.
-- **If "plan first":** write `docs/plans/<slug>.html`, present it (`EnterPlanMode`/`ExitPlanMode`), and only implement once approved.
+- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands and its **`## PR evidence`** section. Reuse them throughout.
+- **If "plan first":** write `docs/plans/<slug>.html`, then **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause.
 
 ## 2. Implement
 
@@ -33,22 +33,29 @@ Add a question only when something material is genuinely unclear — don't pad. 
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 
-Prefer the boring, obvious, simple thing. Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
+Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
 
-## 3. Review gauntlet
+## 3. Open the PR
 
-Run **in order** — each surfaces different defects:
+**Before any review** — so every reviewer's findings land as comments on a real PR. Load **`/forge-pr`** (Skill tool) and `gh pr create --draft` with a genuine title/body covering the scope so far. The PR exists for the rest of the run; later steps push commits and post comments to it.
 
-1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus and commits per round. Let it finish before moving on.
-2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn. Brief each with the diff (`git diff origin/HEAD...HEAD`) and the change rationale only — do **not** seed findings.
+## 4. Review gauntlet
 
-**Apply every finding as its own commit** (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …). No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes to clean. Re-run check/fmt after each fix.
+Run **in order** — each surfaces different defects, each posts its findings to the PR:
 
-## 4. Ship
+1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus, commits per round, and posts its summary as a PR comment by default. Let it finish before moving on.
+2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents on the diff (`git diff origin/HEAD...HEAD`), briefed with the change rationale only — do **not** seed findings. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn.
 
-1. **`/forge-pr`** (Skill tool) — open the PR (draft) with a real title/body. Post the codex-debate summary and the hickey/lowy/police findings as PR comments.
-2. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
-3. **`/evidence`** — capture visual/behavioral proof and post it under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff.
+   **Run `/hickey` and `/lowy` on the main agent's model (Opus) — critical.** Their skill frontmatter declares `model: sonnet`; **override it**, passing `model: opus` on the `Agent`/`Workflow` call so both lenses run at full strength. `/code-police` runs on its default.
+
+**Each finding is its own commit** — never batch. For every finding in turn: apply the narrow fix, re-run **check** and **fmt**, `git add` only the touched files, commit (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …) with the finding restated in one line, and `git push`. No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes until clean.
+
+**Post the findings to the PR.** After the lenses finish, post the hickey/lowy/code-police findings as PR comment(s) — a ledger table (one row per finding with its disposition) plus each lens's rationale — so reviewers see the structural analysis alongside codex-debate's own comment.
+
+## 5. Ship
+
+1. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
+2. **`/evidence`** — follow the **`## PR evidence`** section of `.agency/do.md` for the capture procedure, then post the result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff. Skip only if that section says to (or is absent).
 
 ## Done
 

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -16,10 +16,9 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
 - **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
+- **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
-
-**Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now (including the ultracode check above), because everything after this is autonomous.
 
 ## 1. Set up
 

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: be
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with an AI review gauntlet (codex debate → hickey/lowy/code-police → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+argument-hint: "<issue-url | prompt>"
+---
+
+# Be
+
+Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous, no questions), `/be` **opens with a short interview**, then runs the full gauntlet. Concise by design — defer mechanics to the skills it calls.
+
+**Requires Claude Code's `Workflow` and `Skill` tools.** Under codex/opencode the review fan-out degrades to sequential subagents.
+
+## 0. Interview (the differentiator)
+
+Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
+
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for approval *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
+
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking.
+
+**Ultracode reminder:** if no system-reminder says ultracode is *on*, tell the user once — "`/be` runs richer with ultracode (deeper review fan-out, more verification). Enable it for max effort; otherwise I'll run the standard pass." Then proceed; don't block on it.
+
+## 1. Set up
+
+- `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
+- Read `.agency/do.md` for the project's **check / fmt / test / ci** commands. Reuse them throughout.
+- **If "plan first":** write `docs/plans/<slug>.html`, present it (`EnterPlanMode`/`ExitPlanMode`), and only implement once approved.
+
+## 2. Implement
+
+- **Bug:** reproduce first — write a **failing e2e test** that captures the bug (via the `/test` harness), confirm it's red, *then* fix until green. No fix without a reproducing test.
+- **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
+- **Refactor/chore:** no test-first requirement; rely on existing coverage.
+
+Prefer the boring, obvious, simple thing. Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
+
+## 3. Review gauntlet
+
+Run **in order** — each surfaces different defects:
+
+1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus and commits per round. Let it finish before moving on.
+2. **`/hickey` + `/lowy` + `/code-police`** as parallel subagents. Under ultracode, orchestrate them with the **`Workflow` tool** (fan-out + adversarial verify of each finding); otherwise emit the three `Agent` calls in a single turn. Brief each with the diff (`git diff origin/HEAD...HEAD`) and the change rationale only — do **not** seed findings.
+
+**Apply every finding as its own commit** (`refactor(hickey):` / `refactor(lowy):` / `fix(police):` …). No deferrals — hickey/lowy emit only *Fix in this PR* / *No-op*; `/code-police` runs its rules → fact-check → elegance passes to clean. Re-run check/fmt after each fix.
+
+## 4. Ship
+
+1. **`/forge-pr`** (Skill tool) — open the PR (draft) with a real title/body. Post the codex-debate summary and the hickey/lowy/police findings as PR comments.
+2. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
+3. **`/evidence`** — capture visual/behavioral proof and post it under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff.
+
+## Done
+
+Report the PR URL, the outcome of each review (codex consensus/deadlock, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+
+ARGUMENTS: $ARGUMENTS

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-01T22:54:52.324574+00:00'
+generated_at: '2026-06-01T22:58:51.670177+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-01T22:41:52.274915+00:00'
+generated_at: '2026-06-01T22:54:52.324574+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-01T20:04:16.971175+00:00'
+generated_at: '2026-06-01T22:41:52.274915+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills
@@ -112,6 +112,7 @@ mcp_configs:
     registry: false
     command: .agents/skills/nix-chrome-devtools-mcp/bin/serve
 local_deployed_files:
+- .agents/skills/be
 - .agents/skills/codex-debate
 - .agents/skills/evidence
 - .agents/skills/hk
@@ -131,6 +132,7 @@ local_deployed_files:
 - .claude/rules/state.md
 - .claude/rules/streaming.md
 - .claude/rules/toast-conventions.md
+- .claude/skills/be
 - .claude/skills/codex-debate
 - .claude/skills/evidence
 - .claude/skills/hk

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-01T22:58:51.670177+00:00'
+generated_at: '2026-06-01T23:00:36.868657+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
**`/be` is the interactive counterpart to [`/do`](https://github.com/srid/agency).** Where `/do` is deliberately heads-down — no questions, sensible defaults, ship — `/be` opens with a short interview and is then **fully autonomous from there**, driving the task through a stacked AI review gauntlet. Same destination (a reviewed PR), different temperament: `/do` never asks; `/be` asks *once*, up front, then gets out of your way exactly like `/do`.

### The flow

```
0. Interview   AskUserQuestion: plan-first? · task kind?   + ultracode reminder   ← the ONLY questions
1. Set up      fetch · branch off origin/HEAD · read .agency/do.md · optional HTML plan (read & comment)
2. Implement   bug ⇒ failing e2e repro FIRST, then fix · check · fmt · commit
3. Open PR     /forge-pr — draft PR exists BEFORE review, so every finding lands as a comment
4. Review      /codex-debate  →  /hickey + /lowy (Opus) + /code-police  (parallel) — each finding its own commit
5. Ship        /ci  →  /evidence
```

### How it differs from `/do`

| | `/do` | `/be` |
|---|---|---|
| Questions | never asks — autonomous throughout | **asks once** in the opening interview, then **fully autonomous** |
| Plan artifact | none | optional **HTML plan** in `docs/plans/` — handed to you to read & comment (no plan mode) |
| Reviewers | hickey · lowy · code-police | **+ `/codex-debate`** (codex⇄claude consensus loop) runs first |
| Reviewer model | hickey/lowy on Sonnet | **hickey/lowy forced to Opus** — full-strength structural review |
| Effort | fixed | **ultracode-aware** — reminds the user, fans review out via `Workflow` when on |

### Notes

- **The PR opens before the review gauntlet**, so codex-debate, hickey, lowy, and code-police all post their findings as comments on a real PR rather than buffering them in chat.
- **The interview is the one and only ask.** Everything else runs without stopping — the lone exception is the plan-review handoff *if* "plan first" was chosen: `/be` writes the HTML plan, hands it over for comment, and resumes on your go-ahead.
- **Each finding is its own commit** (apply → check/fmt → add → commit → push). No deferrals — the only way out of a finding is through it.
- **Concise by design** (~75 lines). It's an *orchestrator* that defers all mechanics — the CI runner, PR writing, evidence capture, the structural lenses — to the skills it calls, rather than being a second copy of `/do`.

> _Source of truth is `.apm/skills/be/SKILL.md`; the `.claude/` and `.agents/` copies are generated — regenerate with `just ai::apm`, never hand-edit._

_Generated by Claude Code (model \`claude-opus-4-8\`)._