### PR TITLE
feat(be): ship the HTML plan in the PR and finalize it as-merged

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
-- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 - **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
@@ -24,7 +24,7 @@ Add a question only when something material is genuinely unclear — don't pad. 
 
 - `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
 - Read `.agency/do.md` for the project's **check / fmt / test / ci** commands and its **`## PR evidence`** section. Reuse them throughout.
-- **If "plan first":** write `docs/plans/<slug>.html`, then **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause.
+- **If "plan first" (or working off an existing plan):** the `docs/plans/<slug>.html` file is the **plan of record**. If new, write it; either way **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause. **The plan ships in the PR** — commit it onto the branch (with the §2 work or its own commit) so the merged diff carries the plan it was built from.
 
 ## 2. Implement
 
@@ -37,6 +37,8 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 ## 3. Open the PR
 
 **Before any review** — so every reviewer's findings land as comments on a real PR. Load **`/forge-pr`** (Skill tool) and `gh pr create --draft` with a genuine title/body covering the scope so far. The PR exists for the rest of the run; later steps push commits and post comments to it.
+
+**If there's a plan of record, finalize it now.** Once the PR URL exists, update `docs/plans/<slug>.html` to read as it will *after merge* — flip its status to implemented/done and **link the PR** (e.g. a header line `Implemented in #<n>`) — then commit (`docs(plan): link PR #<n>`) and push so the finalized plan is part of this PR. This applies equally to a freshly-written plan and one the user brought in.
 
 ## 4. Review gauntlet
 

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
-- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 - **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
@@ -24,7 +24,7 @@ Add a question only when something material is genuinely unclear — don't pad. 
 
 - `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
 - Read `.agency/do.md` for the project's **check / fmt / test / ci** commands and its **`## PR evidence`** section. Reuse them throughout.
-- **If "plan first":** write `docs/plans/<slug>.html`, then **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause.
+- **If "plan first" (or working off an existing plan):** the `docs/plans/<slug>.html` file is the **plan of record**. If new, write it; either way **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause. **The plan ships in the PR** — commit it onto the branch (with the §2 work or its own commit) so the merged diff carries the plan it was built from.
 
 ## 2. Implement
 
@@ -37,6 +37,8 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 ## 3. Open the PR
 
 **Before any review** — so every reviewer's findings land as comments on a real PR. Load **`/forge-pr`** (Skill tool) and `gh pr create --draft` with a genuine title/body covering the scope so far. The PR exists for the rest of the run; later steps push commits and post comments to it.
+
+**If there's a plan of record, finalize it now.** Once the PR URL exists, update `docs/plans/<slug>.html` to read as it will *after merge* — flip its status to implemented/done and **link the PR** (e.g. a header line `Implemented in #<n>`) — then commit (`docs(plan): link PR #<n>`) and push so the finalized plan is part of this PR. This applies equally to a freshly-written plan and one the user brought in.
 
 ## 4. Review gauntlet
 

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
-- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous.
+- **Plan first?** — write an HTML plan to `docs/plans/<slug>.html` for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
 - **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
@@ -24,7 +24,7 @@ Add a question only when something material is genuinely unclear — don't pad. 
 
 - `git fetch origin`; branch off `origin/<default>` (`git symbolic-ref --short refs/remotes/origin/HEAD`). Feature branches only — never commit to master.
 - Read `.agency/do.md` for the project's **check / fmt / test / ci** commands and its **`## PR evidence`** section. Reuse them throughout.
-- **If "plan first":** write `docs/plans/<slug>.html`, then **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause.
+- **If "plan first" (or working off an existing plan):** the `docs/plans/<slug>.html` file is the **plan of record**. If new, write it; either way **stop and hand it to the user to read and comment** — do *not* use plan mode. Wait for them to reply; incorporate their feedback, and resume the workflow only once they say proceed. This is the one sanctioned pause. **The plan ships in the PR** — commit it onto the branch (with the §2 work or its own commit) so the merged diff carries the plan it was built from.
 
 ## 2. Implement
 
@@ -37,6 +37,8 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 ## 3. Open the PR
 
 **Before any review** — so every reviewer's findings land as comments on a real PR. Load **`/forge-pr`** (Skill tool) and `gh pr create --draft` with a genuine title/body covering the scope so far. The PR exists for the rest of the run; later steps push commits and post comments to it.
+
+**If there's a plan of record, finalize it now.** Once the PR URL exists, update `docs/plans/<slug>.html` to read as it will *after merge* — flip its status to implemented/done and **link the PR** (e.g. a header line `Implemented in #<n>`) — then commit (`docs(plan): link PR #<n>`) and push so the finalized plan is part of this PR. This applies equally to a freshly-written plan and one the user brought in.
 
 ## 4. Review gauntlet
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-01T23:00:36.868657+00:00'
+generated_at: '2026-06-01T23:04:50.752792+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
Follow-up to #1106. When `/be` works from a `docs/plans/*.html` plan, **that plan now travels with the PR** — committed onto the branch and finalized to read as it will once merged.

### What changes

- **The plan ships in the PR.** Whether `/be` writes the plan in §1 or the user points at an **existing** `docs/plans/*.html`, it's the *plan of record* and gets committed onto the branch, so the merged diff carries the plan it was built from.
- **Finalized as-merged, right after the PR opens.** The moment the PR URL exists (§3), `/be` updates the plan's status to implemented/done and **links the PR** (`Implemented in #<n>`), then commits `docs(plan): link PR #<n>` — so the plan a reader opens later already points at the change that fulfilled it.
- **Existing plans are first-class.** If the prompt already references a plan file, `/be` skips the "plan first?" question and reuses it — same finalize-and-link treatment.

> _A plan and the work that fulfilled it land as one merged artifact, with the plan pointing back at the PR — no orphaned `docs/plans/*.html` that never got linked to what implemented it._

Source is `.apm/skills/be/SKILL.md`; `.claude/` and `.agents/` copies are generated via `just ai::apm`.

_Generated by Claude Code (model \`claude-opus-4-8\`)._