### PR TITLE
Surface malformed OpenCode message.data instead of empty-state

### DIFF
--- a/docs/plans/correctness-review.html
+++ b/docs/plans/correctness-review.html
@@ -142,7 +142,7 @@
 <section id="summary">
   <h2>Summary</h2>
   <div class="callout">
-    <p><strong>Verdict:</strong> I found six correctness issues worth fixing. One high-severity lifecycle issue is now fixed by <a href="https://github.com/juspay/kolu/pull/1105">PR #1105</a>. The remaining open set is one high-severity path-authority bug and four medium-severity issues.</p>
+    <p><strong>Verdict:</strong> I found six correctness issues worth fixing. The high-severity terminal lifecycle leak is fixed by <a href="https://github.com/juspay/kolu/pull/1105">PR #1105</a>, and the OpenCode silent-parse issue by <a href="https://github.com/juspay/kolu/pull/1108">PR #1108</a>. The remaining open set is one high-severity path-authority bug and three medium-severity issues.</p>
   </div>
 
   <table>
@@ -183,7 +183,7 @@
         <td><span class="severity medium">Medium</span></td>
         <td>OpenCode message JSON parse failure is silently treated as "no messages yet".</td>
         <td>OpenCode integration watcher</td>
-        <td><span class="status open">Open</span></td>
+        <td><span class="status fixed">Fixed</span> <a href="https://github.com/juspay/kolu/pull/1108">#1108</a></td>
       </tr>
       <tr>
         <td><span class="severity medium">Medium</span></td>
@@ -273,6 +273,8 @@
     <p><span class="risk">Risk:</span> upstream schema drift or database corruption hides behind a normal empty-state log. The terminal badge can disappear or stale out without an actionable error.</p>
     <p><span class="fix">Fix:</span> return a discriminated parse result or pass logging context into <code>parseMessageState</code>. Treat malformed latest-row JSON as a warn/error condition distinct from "no row". Prefer preserving the last known state or publishing an explicit degraded state.</p>
     <p><span class="fix">Tests:</span> assert that malformed <code>message.data</code> logs a parse failure and is not reported as "no messages yet".</p>
+    <p class="label">Status - fixed</p>
+    <p><span class="fix">Implemented</span> in <a href="https://github.com/juspay/kolu/pull/1108">PR #1108, "Surface malformed OpenCode message.data instead of empty-state"</a>. The fix takes the finding's lighter alternative - pass logging context into <code>parseMessageState</code> rather than thread a discriminated result through the watcher - because the sibling <code>getLatestAssistantContextTokens</code> already logs the same blob's parse failure as an <code>error</code>, so consistency beat a new return type. The two <code>null</code> causes are now logged where each is actually known: <code>parseMessageState</code> logs malformed JSON as <code>error</code> ("opencode message.data parse failed", tagged with the session), and the genuine no-row "no messages yet" <code>debug</code> moved into <code>deriveSessionState</code> at the <code>!row</code> branch. <code>session-watcher.ts</code> no longer flattens both back into one ambiguous line. Covered by unit tests at the <code>parseMessageState</code> and <code>deriveSessionState</code> layers in <a href="../../packages/integrations/opencode/src/index.test.ts">index.test.ts</a> - malformed data logs the parse error and never the empty-state line, an empty session still logs only the debug, and a valid-but-unmodelled role stays silent.</p>
   </article>
 
   <article class="finding medium" id="kill-confirmation">
@@ -297,7 +299,7 @@
     <li><strong>Terminal subscription lifecycle is fixed.</strong> <a href="https://github.com/juspay/kolu/pull/1105">PR #1105</a> landed the list-keyed cleanup and regression coverage.</li>
     <li><strong>Fix channel abort cleanup before daemon work expands.</strong> It is a small primitive with a large downstream blast radius.</li>
     <li><strong>Fix sub-terminal restore and kill-confirmation behavior together with tests.</strong> Both are terminal lifecycle fidelity issues and should be covered by restore/CRUD scenarios.</li>
-    <li><strong>Harden OpenCode parser errors.</strong> This is a low-risk observability/correctness change, but it prevents future upstream changes from failing silently.</li>
+    <li><strong>OpenCode parser errors are hardened.</strong> <a href="https://github.com/juspay/kolu/pull/1108">PR #1108</a> landed the malformed-JSON error path and the empty-vs-malformed log split, so future upstream schema drift surfaces instead of failing silently.</li>
   </ol>
 </section>
 

--- a/packages/integrations/opencode/src/core.ts
+++ b/packages/integrations/opencode/src/core.ts
@@ -312,13 +312,10 @@ export function deriveSessionState(
         // Genuinely empty session — an expected-absent condition, logged at
         // the layer that knows the row is missing. A malformed latest row is
         // a different story: parseMessageState logs that as an error below.
-        log?.debug(
-          { session: sessionId },
-          "no messages yet for opencode session",
-        );
+        log?.debug({ sessionId }, "no messages yet for opencode session");
         return null;
       }
-      const parsed = parseMessageState(row.data, log, { session: sessionId });
+      const parsed = parseMessageState(row.data, log, sessionId);
       if (!parsed) return null;
       return { ...parsed, messageId: row.id };
     },
@@ -332,12 +329,12 @@ export function deriveSessionState(
 /** Parse a `message.data` JSON blob into derived state. Returns null for a
  *  blob whose role we don't model, and for malformed JSON — but the latter
  *  is logged as an error (OpenCode owns this JSON, so a parse failure is
- *  real schema drift or corruption, not an empty session). Pass `ctx`
- *  (e.g. `{ session }`) to tag that error. Exported for unit testing. */
+ *  real schema drift or corruption, not an empty session). Pass `sessionId`
+ *  to tag that error. Exported for unit testing. */
 export function parseMessageState(
   data: string,
   log?: Logger,
-  ctx?: Record<string, unknown>,
+  sessionId?: string,
 ): ParsedMessageState | null {
   let parsed: MessageData;
   try {
@@ -346,8 +343,9 @@ export function parseMessageState(
     // Distinct from "no row": there IS a latest message, we just can't read
     // it. Surface it as a dropped-state error so the watcher never reports
     // it as the benign "no messages yet". Mirrors
-    // getLatestAssistantContextTokens' handling of the same blob.
-    log?.error({ err, ...ctx }, "opencode message.data parse failed");
+    // getLatestAssistantContextTokens' handling of the same blob — same
+    // `{ err, sessionId }` shape, same error level.
+    log?.error({ err, sessionId }, "opencode message.data parse failed");
     return null;
   }
 

--- a/packages/integrations/opencode/src/core.ts
+++ b/packages/integrations/opencode/src/core.ts
@@ -308,8 +308,17 @@ export function deriveSessionState(
           "SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created DESC LIMIT 1",
         )
         .get(sessionId) as { id: string; data: string } | undefined;
-      if (!row) return null;
-      const parsed = parseMessageState(row.data);
+      if (!row) {
+        // Genuinely empty session — an expected-absent condition, logged at
+        // the layer that knows the row is missing. A malformed latest row is
+        // a different story: parseMessageState logs that as an error below.
+        log?.debug(
+          { session: sessionId },
+          "no messages yet for opencode session",
+        );
+        return null;
+      }
+      const parsed = parseMessageState(row.data, log, { session: sessionId });
       if (!parsed) return null;
       return { ...parsed, messageId: row.id };
     },
@@ -320,13 +329,25 @@ export function deriveSessionState(
   );
 }
 
-/** Parse a `message.data` JSON blob into derived state.
- *  Exported for unit testing. */
-export function parseMessageState(data: string): ParsedMessageState | null {
+/** Parse a `message.data` JSON blob into derived state. Returns null for a
+ *  blob whose role we don't model, and for malformed JSON — but the latter
+ *  is logged as an error (OpenCode owns this JSON, so a parse failure is
+ *  real schema drift or corruption, not an empty session). Pass `ctx`
+ *  (e.g. `{ session }`) to tag that error. Exported for unit testing. */
+export function parseMessageState(
+  data: string,
+  log?: Logger,
+  ctx?: Record<string, unknown>,
+): ParsedMessageState | null {
   let parsed: MessageData;
   try {
     parsed = JSON.parse(data) as MessageData;
-  } catch {
+  } catch (err) {
+    // Distinct from "no row": there IS a latest message, we just can't read
+    // it. Surface it as a dropped-state error so the watcher never reports
+    // it as the benign "no messages yet". Mirrors
+    // getLatestAssistantContextTokens' handling of the same blob.
+    log?.error({ err, ...ctx }, "opencode message.data parse failed");
     return null;
   }
 

--- a/packages/integrations/opencode/src/index.test.ts
+++ b/packages/integrations/opencode/src/index.test.ts
@@ -136,11 +136,11 @@ describe("parseMessageState", () => {
     expect(parseMessageState("not json")).toBeNull();
   });
 
-  it("logs an error (not silence) for malformed JSON, tagged with ctx", () => {
+  it("logs an error (not silence) for malformed JSON, tagged with sessionId", () => {
     const log = spyLog();
-    expect(parseMessageState("not json", log, { session: "s1" })).toBeNull();
+    expect(parseMessageState("not json", log, "s1")).toBeNull();
     expect(log.error).toHaveBeenCalledWith(
-      expect.objectContaining({ session: "s1" }),
+      expect.objectContaining({ sessionId: "s1" }),
       PARSE_FAILED_MSG,
     );
   });
@@ -170,7 +170,7 @@ describe("deriveSessionState", () => {
     const db = withMessages([{ id: "m1", data: "not json", time_created: 1 }]);
     expect(deriveSessionState("s1", log, db)).toBeNull();
     expect(log.error).toHaveBeenCalledWith(
-      expect.objectContaining({ session: "s1" }),
+      expect.objectContaining({ sessionId: "s1" }),
       PARSE_FAILED_MSG,
     );
     expect(log.debug).not.toHaveBeenCalledWith(

--- a/packages/integrations/opencode/src/index.test.ts
+++ b/packages/integrations/opencode/src/index.test.ts
@@ -1,6 +1,38 @@
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it } from "vitest";
-import { parseMessageState, runningToolsBucket } from "./core.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  deriveSessionState,
+  parseMessageState,
+  runningToolsBucket,
+} from "./core.ts";
+
+/** A Logger whose four methods are vi spies — lets a test assert which
+ *  level fired and with what message/context. */
+function spyLog() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+/** Minimal `message` schema OpenCode writes — enough for `deriveSessionState`
+ *  to pick the latest row by `time_created`. */
+const MESSAGE_SCHEMA = `
+CREATE TABLE message (id TEXT, session_id TEXT NOT NULL, data TEXT NOT NULL, time_created INTEGER);
+`;
+
+function withMessages(
+  rows: Array<{ id: string; data: string; time_created: number }>,
+): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(MESSAGE_SCHEMA);
+  for (const r of rows) {
+    db.prepare(
+      "INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)",
+    ).run(r.id, "s1", r.data, r.time_created);
+  }
+  return db;
+}
+
+const NO_MESSAGES_MSG = "no messages yet for opencode session";
+const PARSE_FAILED_MSG = "opencode message.data parse failed";
 
 /** Minimal `part` schema OpenCode writes — enough for `runningToolsBucket`
  *  to do its single index scan. The fixture builder in `packages/tests`
@@ -102,6 +134,69 @@ describe("parseMessageState", () => {
 
   it("returns null for malformed JSON", () => {
     expect(parseMessageState("not json")).toBeNull();
+  });
+
+  it("logs an error (not silence) for malformed JSON, tagged with ctx", () => {
+    const log = spyLog();
+    expect(parseMessageState("not json", log, { session: "s1" })).toBeNull();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ session: "s1" }),
+      PARSE_FAILED_MSG,
+    );
+  });
+
+  it("stays silent for valid JSON with an unmodelled role", () => {
+    // A parseable blob is not an anomaly worth an error — only malformed
+    // JSON is. This guards the error path from firing on schema we simply
+    // don't map to a state.
+    const log = spyLog();
+    expect(
+      parseMessageState(JSON.stringify({ role: "system" }), log),
+    ).toBeNull();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("deriveSessionState", () => {
+  it("logs 'no messages yet' at debug for a genuinely empty session", () => {
+    const log = spyLog();
+    expect(deriveSessionState("s1", log, withMessages([]))).toBeNull();
+    expect(log.debug).toHaveBeenCalledWith(expect.anything(), NO_MESSAGES_MSG);
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("logs a parse error — never 'no messages yet' — for a malformed latest row", () => {
+    const log = spyLog();
+    const db = withMessages([{ id: "m1", data: "not json", time_created: 1 }]);
+    expect(deriveSessionState("s1", log, db)).toBeNull();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ session: "s1" }),
+      PARSE_FAILED_MSG,
+    );
+    expect(log.debug).not.toHaveBeenCalledWith(
+      expect.anything(),
+      NO_MESSAGES_MSG,
+    );
+  });
+
+  it("derives state from the latest message by time_created", () => {
+    const db = withMessages([
+      { id: "m0", data: JSON.stringify({ role: "user" }), time_created: 1 },
+      {
+        id: "m1",
+        data: JSON.stringify({
+          role: "assistant",
+          finish: "stop",
+          time: { created: 2, completed: 3 },
+        }),
+        time_created: 2,
+      },
+    ]);
+    expect(deriveSessionState("s1", undefined, db)).toEqual({
+      state: "waiting",
+      model: null,
+      messageId: "m1",
+    });
   });
 });
 

--- a/packages/integrations/opencode/src/session-watcher.ts
+++ b/packages/integrations/opencode/src/session-watcher.ts
@@ -59,10 +59,9 @@ export function createOpenCodeWatcher(
   function refresh(db: DatabaseSync): OpenCodeInfo | null {
     const derived = deriveSessionState(session.id, log, db);
     if (!derived) {
-      log?.debug(
-        { session: session.id },
-        "no messages yet for opencode session",
-      );
+      // deriveSessionState already logged the precise cause — a debug
+      // "no messages yet" for an empty session, or an error for a malformed
+      // latest row. Don't flatten both back into one ambiguous line here.
       return null;
     }
 


### PR DESCRIPTION
**A malformed latest `message.data` row no longer masquerades as an empty OpenCode session.** When the newest message JSON failed to parse, `parseMessageState` returned `null`, and the watcher logged it with the *same* debug line used for a brand-new session with no messages — `"no messages yet"`. So upstream schema drift or DB corruption hid behind a benign empty-state log while the terminal badge silently blanked. This is the `opencode-parse` finding from the [whole-codebase correctness review](../blob/opebcode-warn/docs/plans/correctness-review.html).

The root cause is two distinct conditions collapsed into one `null` + one log line. They're now de-complected — each cause is logged at the layer that actually knows it:

| Condition | Before | After |
| --- | --- | --- |
| Session has no rows | debug `"no messages yet"` (in watcher) | debug `"no messages yet"` (in `deriveSessionState`, where the missing row is observed) |
| Latest row is malformed JSON | **swallowed → also `"no messages yet"`** | **error `"opencode message.data parse failed"` with the parse error + session ctx** |

The error path mirrors the sibling `getLatestAssistantContextTokens`, which already logs `log?.error(…, "opencode assistant message.data parse failed")` for the very same blob — `parseMessageState` was the lone swallower. The watcher's `if (!derived)` branch no longer re-flattens the two causes into a single ambiguous line; it just returns, trusting the lower layers to have logged the real reason.

*This is `error`-level by the `@kolu/log` contract's own guidance — "actual failures … dropped state" — versus `debug` for "expected-absent conditions" like an empty session.*

Covered by unit tests at both layers (`parseMessageState` and `deriveSessionState`): malformed `message.data` logs a parse error and is **never** reported as "no messages yet"; a genuinely empty session still logs only the debug line; and a valid-but-unmodelled role stays silent (no spurious error).

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._