### PR TITLE
Run codex-debate at xhigh effort, looping until consensus

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -55,6 +55,6 @@ Run **in order** — each surfaces different defects, each posts its findings to
 
 ## Done
 
-Report the PR URL, the outcome of each review (codex consensus/deadlock, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+Report the PR URL, the outcome of each review (codex consensus or reviewer-error, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-debate
-description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus, deadlock, or a round cap. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
-argument-hint: "[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-comment]"
+description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus — no round cap, no deadlock exit. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
+argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]"
 ---
 
 # Codex ⇄ Claude review debate
@@ -9,8 +9,10 @@ argument-hint: "[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit]
 Automate the back-and-forth you'd otherwise courier by hand: **codex** (the
 reviewer) critiques the current change, a **Claude subagent** (the author)
 fixes what it agrees with and disputes what it doesn't, codex re-reviews, and so
-on — until they reach **consensus**, hit a **deadlock**, or burn the **round
-cap**. You stay out of the middle: each round lands as its own commit whose
+on — round after round, **until they reach consensus**. There is no round cap and
+no "deadlock" surrender: a debate that quits without agreement defeats the
+purpose, so the two sides keep arguing until one concedes. You stay out of the
+middle: each round lands as its own commit whose
 message carries the debate context (codex's findings + Claude's dispositions) so
 the PR history reads as the debate, and the summary is **posted to the PR** as a
 comment at the end.
@@ -35,7 +37,7 @@ codex/opencode runtimes the skill is inert.
 
 ## Arguments
 
-Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-comment]`:
+Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -46,7 +48,6 @@ Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-co
   (e.g. `origin/master`) — used **as-is**, NOT stripped to local `master` (which
   can lag the remote). Fallback `origin/master`. Step 1 runs `git fetch origin`
   first so the ref is current.
-- **`--max-rounds <n>`**: hard cap on codex review rounds. Default **5**.
 - **`--no-commit`**: don't commit per round — leave all agreed changes
   uncommitted in the working tree for you to commit yourself. Default is to
   **commit each round** (see below).
@@ -79,7 +80,6 @@ Workflow({
   args: {
     repoPath: "<worktree root>",        // also the per-worktree scratch dir root
     base: "<base branch>",
-    maxRounds: <n, default 5>,
     commit: <false only if --no-commit>,
     skillDir: ".claude/skills/codex-debate"
   }
@@ -98,23 +98,24 @@ Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
 collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 ```
-{ status: "consensus" | "deadlock" | "max-rounds",
+{ status: "consensus",   // the only terminal state
   rounds, base, finalVerdict, filesChanged, transcript }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
-- **consensus** — codex approved with no blocking/major findings open.
-- **deadlock** — codex kept raising the same blocking findings while Claude
-  disputed them all; the script stopped rather than burn rounds. Needs you.
-- **max-rounds** — the cap was hit with findings still open.
+- **consensus** — codex approved with no blocking/major findings open. This is
+  the *only* way the loop ends: it keeps running rounds until codex and Claude
+  agree. (The harness's own per-workflow agent backstop is the sole hard ceiling;
+  if you ever need to stop a debate by hand, interrupt it via `/workflows` or
+  `TaskStop`.)
 
 ### 3. Present the result
 
 Report in chat (do **not** push or merge — the per-round commits sit on the
 local branch for the human to review):
 
-- The outcome (`status`) and round count.
+- The outcome — always **consensus** — and how many rounds it took to get there.
 - **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
   debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
   of the user's global codex default). State this so the depth of the review is
@@ -123,19 +124,16 @@ local branch for the human to review):
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
   (approved? open blocking/major count), Claude's dispositions, and the
-  round's `commit` SHA.
-- On **deadlock**, surface both positions plainly (codex's held-firm findings +
-  Claude's disputes with reasons) so the human can adjudicate — do not pick a
-  winner yourself.
+  round's `commit` SHA — so the convergence reads round by round.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
-  `gh pr comment`. Include: the outcome badge (consensus/deadlock/max-rounds) and
-  round count; a note that **codex reviewed at `xhigh` reasoning effort**; a
-  per-round table (codex approved? open blocking/major findings; Claude's
-  dispositions; the round's commit SHA); and, on deadlock, both positions. Use a
+  `gh pr comment`. Include: the **consensus** outcome badge and the round count;
+  a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
+  table (codex approved? open blocking/major findings; Claude's dispositions; the
+  round's commit SHA) showing how the two sides converged. Use a
   single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave
   the review trail on the PR; `--no-comment` suppresses it.
@@ -159,12 +157,16 @@ local branch for the human to review):
 - **Posts to the PR by default.** When a PR exists, the debate summary is posted
   as a PR comment (outward-facing write) unless `--no-comment` is passed — the
   point is to leave the review trail on the PR.
-- **Bounded.** The loop always terminates — consensus, deadlock detection, or the
-  round cap. It cannot run forever.
+- **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
+  and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
+  a debate that quits without agreement is pointless. The two sides keep arguing
+  until one concedes. The harness's own per-workflow agent backstop is the sole
+  hard ceiling; interrupt via `/workflows` or `TaskStop` if you ever need to stop
+  one by hand.
 
 ## Files
 
-- `debate.workflow.js` — the Workflow script (the loop + consensus/deadlock logic).
+- `debate.workflow.js` — the Workflow script (the loop + consensus logic).
 - `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation.
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
 

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -115,6 +115,10 @@ Report in chat (do **not** push or merge — the per-round commits sit on the
 local branch for the human to review):
 
 - The outcome (`status`) and round count.
+- **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
+  debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
+  of the user's global codex default). State this so the depth of the review is
+  on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
@@ -129,9 +133,10 @@ local branch for the human to review):
 - **Post the debate summary to the PR (default).** When a PR exists and
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
   `gh pr comment`. Include: the outcome badge (consensus/deadlock/max-rounds) and
-  round count; a per-round table (codex approved? open blocking/major findings;
-  Claude's dispositions; the round's commit SHA); and, on deadlock, both
-  positions. Use a single-quoted heredoc so backticks/`$` survive. This is an
+  round count; a note that **codex reviewed at `xhigh` reasoning effort**; a
+  per-round table (codex approved? open blocking/major findings; Claude's
+  dispositions; the round's commit SHA); and, on deadlock, both positions. Use a
+  single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave
   the review trail on the PR; `--no-comment` suppresses it.
 

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -98,24 +98,37 @@ Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
 collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 ```
-{ status: "consensus",   // the only terminal state
+{ status: "consensus" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, transcript }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
 - **consensus** — codex approved with no blocking/major findings open. This is
-  the *only* way the loop ends: it keeps running rounds until codex and Claude
-  agree. (The harness's own per-workflow agent backstop is the sole hard ceiling;
-  if you ever need to stop a debate by hand, interrupt it via `/workflows` or
-  `TaskStop`.)
+  the *only* way the debate ends *normally*: it keeps running rounds until codex
+  and Claude agree, with no round cap and no deadlock exit. (The harness's own
+  per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
+  a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
+- **reviewer-error** — the one *abnormal* terminus: codex itself failed to
+  produce a verdict (broken/unavailable CLI), so the workflow synthesized an
+  error verdict and aborted rather than spin forever on a dead reviewer. This is
+  **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
+  carries the failure detail. Do **not** treat it as consensus (see step 3).
 
 ### 3. Present the result
 
-Report in chat (do **not** push or merge — the per-round commits sit on the
-local branch for the human to review):
+**First branch on `status`.** If `status === "reviewer-error"`, the debate did
+**not** reach consensus — codex never produced a real verdict. Report it as a
+**failure**, not a success: surface `finalVerdict.summary` (and the workflow log)
+so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
+`codex login`, check the CLI) and re-run. Do **not** post a consensus badge or a
+`## Codex ⇄ Claude debate` PR comment for this path — there is no agreement to
+report. Skip the rest of this section.
 
-- The outcome — always **consensus** — and how many rounds it took to get there.
+Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
+the per-round commits sit on the local branch for the human to review):
+
+- The outcome — **consensus** — and how many rounds it took to get there.
 - **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
   debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
   of the user's global codex default). State this so the depth of the review is

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -1,6 +1,6 @@
 export const meta = {
   name: 'codex-debate',
-  description: 'Run a codex<->claude review debate on the current diff until consensus, deadlock, or max rounds',
+  description: 'Run a codex<->claude review debate on the current diff until they reach consensus (no round cap, no deadlock exit)',
   phases: [
     { title: 'Debate', detail: 'codex reviews -> claude responds, round after round' },
   ],
@@ -12,7 +12,6 @@ export const meta = {
 const a = args || {}
 const repoPath = a.repoPath || '.'
 const base = a.base || 'origin/master'
-const maxRounds = a.maxRounds || 5
 // Where the generated skill lives, so the codex runner can find codex-review.sh.
 const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // Per-worktree scratch dir for rebuttal/verdict files. Derived from repoPath
@@ -80,31 +79,17 @@ const CLAUDE_RESPONSE_SCHEMA = {
 }
 
 // ---------------------------------------------------------------------------
-// Consensus / deadlock helpers
+// Consensus helper
 // ---------------------------------------------------------------------------
 // A finding still "counts against" consensus only if it is open AND
-// blocking/major. Minor issues and nits never block agreement.
+// blocking/major. Minor issues and nits never block agreement. Consensus is the
+// ONLY terminal state — there is no round cap and no deadlock exit, so the loop
+// runs until codex approves with nothing blocking/major open. The debate is
+// pointless if it bails to "deadlock"; the two sides must argue it out until
+// one concedes.
 function blockingOpen(verdict) {
   return (verdict.findings || []).filter(
     (f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major'),
-  )
-}
-
-// Signature of the blocking set, used to detect a stalled debate (codex keeps
-// raising the same issues while claude keeps disputing them).
-function blockingSignature(verdict) {
-  return blockingOpen(verdict)
-    .map((f) => `${f.location || ''}|${(f.issue || '').slice(0, 80)}`)
-    .sort()
-    .join('\n')
-}
-
-function claudeDisputedEverything(resp) {
-  return (
-    resp &&
-    Array.isArray(resp.actions) &&
-    resp.actions.length > 0 &&
-    resp.actions.every((act) => act.disposition === 'disputed')
   )
 }
 
@@ -213,17 +198,22 @@ ${message}
 }
 
 const transcript = []
-let status = 'max-rounds'
+const status = 'consensus' // the ONLY way this loop ends
 let finalVerdict = null
 let lastClaude = null
-let prevSignature = null
 
 // ---------------------------------------------------------------------------
-// The loop
+// The loop — runs until consensus. No round cap, no deadlock exit.
 // ---------------------------------------------------------------------------
+// The debate continues, round after round, until codex approves with nothing
+// blocking/major open. There is deliberately no upper bound and no early
+// "deadlock" surrender: a debate that quits without agreement defeats the
+// purpose, so the two sides keep arguing until one concedes. (The harness's own
+// per-workflow agent backstop is the only hard ceiling; interrupt via
+// /workflows or TaskStop if you ever need to stop one by hand.)
 phase('Debate')
 
-for (let round = 1; round <= maxRounds; round++) {
+for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
@@ -231,26 +221,9 @@ for (let round = 1; round <= maxRounds; round++) {
   const blocking = blockingOpen(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
 
-  // Consensus: codex is satisfied and nothing blocking/major remains open.
+  // Consensus — the only exit: codex is satisfied and nothing blocking/major
+  // remains open.
   if (verdict.approved && blocking.length === 0) {
-    status = 'consensus'
-    break
-  }
-
-  // Deadlock: the blocking set is identical to last round AND claude disputed
-  // everything last round (so nothing changed and nothing will). Stop and let
-  // the human adjudicate rather than burn rounds.
-  const signature = blockingSignature(verdict)
-  if (prevSignature !== null && signature === prevSignature && claudeDisputedEverything(lastClaude)) {
-    status = 'deadlock'
-    break
-  }
-  prevSignature = signature
-
-  // Last round budget spent — record codex's final verdict, don't ask claude
-  // to edit with no re-review to follow.
-  if (round === maxRounds) {
-    status = 'max-rounds'
     break
   }
 

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -50,6 +50,10 @@ const CODEX_VERDICT_SCHEMA = {
     summary: { type: 'string' },
     findings: { type: 'array', items: FINDING },
     responseToRebuttal: { type: 'string' },
+    // Set by scripts/codex-review.sh ONLY when codex itself failed to produce a
+    // verdict (broken/unavailable reviewer). It is the machine-detectable fatal
+    // signal the loop aborts on — infrastructure failure, not a debate outcome.
+    reviewerError: { type: 'boolean' },
   },
   required: ['approved', 'summary', 'findings', 'responseToRebuttal'],
 }
@@ -198,7 +202,11 @@ ${message}
 }
 
 const transcript = []
-const status = 'consensus' // the ONLY way this loop ends
+// 'consensus' is the only NORMAL terminus. 'reviewer-error' is the one abnormal
+// terminus: codex itself failed to produce a verdict (broken/unavailable). That
+// is infrastructure failure, not a debate outcome, so it ends the loop too —
+// distinct from the deliberate "no deadlock exit" for substantive disagreement.
+let status = 'consensus'
 let finalVerdict = null
 let lastClaude = null
 
@@ -218,10 +226,22 @@ for (let round = 1; ; round++) {
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
   transcript.push(entry) // record this round (mutated in place as it progresses)
+  // Reviewer error — terminal failure path. The runner could not get a verdict
+  // out of codex (broken/unavailable CLI), so codex-review.sh synthesized an
+  // error verdict carrying reviewerError:true. There are no findings to route to
+  // Claude, and retrying a broken reviewer just spins forever, so abort the
+  // debate and surface the failure. This is deliberately separate from the
+  // "no deadlock exit" rule, which only governs substantive disagreement.
+  if (verdict.reviewerError) {
+    status = 'reviewer-error'
+    log(`Round ${round}: reviewer error — aborting debate. ${verdict.summary}`)
+    break
+  }
+
   const blocking = blockingOpen(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
 
-  // Consensus — the only exit: codex is satisfied and nothing blocking/major
+  // Consensus — the normal exit: codex is satisfied and nothing blocking/major
   // remains open.
   if (verdict.approved && blocking.length === 0) {
     break

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -126,13 +126,18 @@ fi
 
 if [ ! -s "$out" ]; then
   # codex produced no verdict — synthesize a schema-valid error verdict so the
-  # debate loop can surface the failure instead of hanging.
+  # debate loop can surface the failure instead of hanging. The reviewerError
+  # flag is the machine-detectable signal the workflow uses to abort with a
+  # terminal failure: a broken/unavailable codex is INFRASTRUCTURE failure, not
+  # substantive disagreement, so it must NOT be routed to Claude (there are no
+  # findings to act on) and must NOT spin the loop forever.
   tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
   jq -n --arg log "$tail_log" '{
     approved: false,
     summary: ("codex produced no verdict this round. Tail of log: " + $log),
     findings: [],
-    responseToRebuttal: ""
+    responseToRebuttal: "",
+    reviewerError: true
   }' >"$out"
 fi
 

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -112,11 +112,15 @@ Return a verdict matching the provided JSON schema:
 EOF
 )"
 
+# model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
+# relying on the user's global ~/.codex/config.toml — review is the one place we
+# always want codex thinking at full depth, regardless of their default.
 if ! codex exec \
       --sandbox read-only \
+      -c model_reasoning_effort="xhigh" \
       --output-schema "$schema" \
       -o "$out" \
-      "$prompt" </dev/null >"$log" 2>&1; then
+      "$prompt"</dev/null >"$log" 2>&1; then
   echo "codex exec exited non-zero (see $log)" >&2
 fi
 

--- a/.agents/skills/lens-debate/SKILL.md
+++ b/.agents/skills/lens-debate/SKILL.md
@@ -47,10 +47,13 @@ The structure was found by trial in #1109, and two parts of it are load-bearing:
 
 ## Why deadlock is not possible
 
-`/codex-debate` *can* deadlock, and detects it: there the asymmetry is reviewer
-vs **author** — Claude wrote the code, has authorship stake, and can dig in and
-dispute a finding indefinitely. So that skill bails when the blocking set stops
-moving.
+Neither this skill nor `/codex-debate` has a deadlock exit — both run until
+consensus, as many rounds as it takes. But the *reason* convergence is safe to
+rely on is even stronger here. In `/codex-debate` the asymmetry is reviewer vs
+**author**: Claude wrote the code and carries an authorship stake, so in
+principle it could dig in and dispute a finding round after round (the loop
+trusts good-faith concession to break the tie, and aborts only on reviewer
+*infrastructure* failure).
 
 Here both sides are **disinterested third-party lenses** applied to someone
 else's diff. Neither authored the code; neither has anything to defend. Their

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -55,6 +55,6 @@ Run **in order** — each surfaces different defects, each posts its findings to
 
 ## Done
 
-Report the PR URL, the outcome of each review (codex consensus/deadlock, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+Report the PR URL, the outcome of each review (codex consensus or reviewer-error, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-debate
-description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus, deadlock, or a round cap. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
-argument-hint: "[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-comment]"
+description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus — no round cap, no deadlock exit. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
+argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]"
 ---
 
 # Codex ⇄ Claude review debate
@@ -9,8 +9,10 @@ argument-hint: "[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit]
 Automate the back-and-forth you'd otherwise courier by hand: **codex** (the
 reviewer) critiques the current change, a **Claude subagent** (the author)
 fixes what it agrees with and disputes what it doesn't, codex re-reviews, and so
-on — until they reach **consensus**, hit a **deadlock**, or burn the **round
-cap**. You stay out of the middle: each round lands as its own commit whose
+on — round after round, **until they reach consensus**. There is no round cap and
+no "deadlock" surrender: a debate that quits without agreement defeats the
+purpose, so the two sides keep arguing until one concedes. You stay out of the
+middle: each round lands as its own commit whose
 message carries the debate context (codex's findings + Claude's dispositions) so
 the PR history reads as the debate, and the summary is **posted to the PR** as a
 comment at the end.
@@ -35,7 +37,7 @@ codex/opencode runtimes the skill is inert.
 
 ## Arguments
 
-Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-comment]`:
+Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -46,7 +48,6 @@ Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-co
   (e.g. `origin/master`) — used **as-is**, NOT stripped to local `master` (which
   can lag the remote). Fallback `origin/master`. Step 1 runs `git fetch origin`
   first so the ref is current.
-- **`--max-rounds <n>`**: hard cap on codex review rounds. Default **5**.
 - **`--no-commit`**: don't commit per round — leave all agreed changes
   uncommitted in the working tree for you to commit yourself. Default is to
   **commit each round** (see below).
@@ -79,7 +80,6 @@ Workflow({
   args: {
     repoPath: "<worktree root>",        // also the per-worktree scratch dir root
     base: "<base branch>",
-    maxRounds: <n, default 5>,
     commit: <false only if --no-commit>,
     skillDir: ".claude/skills/codex-debate"
   }
@@ -98,23 +98,24 @@ Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
 collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 ```
-{ status: "consensus" | "deadlock" | "max-rounds",
+{ status: "consensus",   // the only terminal state
   rounds, base, finalVerdict, filesChanged, transcript }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
-- **consensus** — codex approved with no blocking/major findings open.
-- **deadlock** — codex kept raising the same blocking findings while Claude
-  disputed them all; the script stopped rather than burn rounds. Needs you.
-- **max-rounds** — the cap was hit with findings still open.
+- **consensus** — codex approved with no blocking/major findings open. This is
+  the *only* way the loop ends: it keeps running rounds until codex and Claude
+  agree. (The harness's own per-workflow agent backstop is the sole hard ceiling;
+  if you ever need to stop a debate by hand, interrupt it via `/workflows` or
+  `TaskStop`.)
 
 ### 3. Present the result
 
 Report in chat (do **not** push or merge — the per-round commits sit on the
 local branch for the human to review):
 
-- The outcome (`status`) and round count.
+- The outcome — always **consensus** — and how many rounds it took to get there.
 - **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
   debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
   of the user's global codex default). State this so the depth of the review is
@@ -123,19 +124,16 @@ local branch for the human to review):
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
   (approved? open blocking/major count), Claude's dispositions, and the
-  round's `commit` SHA.
-- On **deadlock**, surface both positions plainly (codex's held-firm findings +
-  Claude's disputes with reasons) so the human can adjudicate — do not pick a
-  winner yourself.
+  round's `commit` SHA — so the convergence reads round by round.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
-  `gh pr comment`. Include: the outcome badge (consensus/deadlock/max-rounds) and
-  round count; a note that **codex reviewed at `xhigh` reasoning effort**; a
-  per-round table (codex approved? open blocking/major findings; Claude's
-  dispositions; the round's commit SHA); and, on deadlock, both positions. Use a
+  `gh pr comment`. Include: the **consensus** outcome badge and the round count;
+  a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
+  table (codex approved? open blocking/major findings; Claude's dispositions; the
+  round's commit SHA) showing how the two sides converged. Use a
   single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave
   the review trail on the PR; `--no-comment` suppresses it.
@@ -159,12 +157,16 @@ local branch for the human to review):
 - **Posts to the PR by default.** When a PR exists, the debate summary is posted
   as a PR comment (outward-facing write) unless `--no-comment` is passed — the
   point is to leave the review trail on the PR.
-- **Bounded.** The loop always terminates — consensus, deadlock detection, or the
-  round cap. It cannot run forever.
+- **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
+  and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
+  a debate that quits without agreement is pointless. The two sides keep arguing
+  until one concedes. The harness's own per-workflow agent backstop is the sole
+  hard ceiling; interrupt via `/workflows` or `TaskStop` if you ever need to stop
+  one by hand.
 
 ## Files
 
-- `debate.workflow.js` — the Workflow script (the loop + consensus/deadlock logic).
+- `debate.workflow.js` — the Workflow script (the loop + consensus logic).
 - `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation.
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
 

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -115,6 +115,10 @@ Report in chat (do **not** push or merge — the per-round commits sit on the
 local branch for the human to review):
 
 - The outcome (`status`) and round count.
+- **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
+  debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
+  of the user's global codex default). State this so the depth of the review is
+  on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
@@ -129,9 +133,10 @@ local branch for the human to review):
 - **Post the debate summary to the PR (default).** When a PR exists and
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
   `gh pr comment`. Include: the outcome badge (consensus/deadlock/max-rounds) and
-  round count; a per-round table (codex approved? open blocking/major findings;
-  Claude's dispositions; the round's commit SHA); and, on deadlock, both
-  positions. Use a single-quoted heredoc so backticks/`$` survive. This is an
+  round count; a note that **codex reviewed at `xhigh` reasoning effort**; a
+  per-round table (codex approved? open blocking/major findings; Claude's
+  dispositions; the round's commit SHA); and, on deadlock, both positions. Use a
+  single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave
   the review trail on the PR; `--no-comment` suppresses it.
 

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -98,24 +98,37 @@ Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
 collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 ```
-{ status: "consensus",   // the only terminal state
+{ status: "consensus" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, transcript }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
 - **consensus** — codex approved with no blocking/major findings open. This is
-  the *only* way the loop ends: it keeps running rounds until codex and Claude
-  agree. (The harness's own per-workflow agent backstop is the sole hard ceiling;
-  if you ever need to stop a debate by hand, interrupt it via `/workflows` or
-  `TaskStop`.)
+  the *only* way the debate ends *normally*: it keeps running rounds until codex
+  and Claude agree, with no round cap and no deadlock exit. (The harness's own
+  per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
+  a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
+- **reviewer-error** — the one *abnormal* terminus: codex itself failed to
+  produce a verdict (broken/unavailable CLI), so the workflow synthesized an
+  error verdict and aborted rather than spin forever on a dead reviewer. This is
+  **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
+  carries the failure detail. Do **not** treat it as consensus (see step 3).
 
 ### 3. Present the result
 
-Report in chat (do **not** push or merge — the per-round commits sit on the
-local branch for the human to review):
+**First branch on `status`.** If `status === "reviewer-error"`, the debate did
+**not** reach consensus — codex never produced a real verdict. Report it as a
+**failure**, not a success: surface `finalVerdict.summary` (and the workflow log)
+so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
+`codex login`, check the CLI) and re-run. Do **not** post a consensus badge or a
+`## Codex ⇄ Claude debate` PR comment for this path — there is no agreement to
+report. Skip the rest of this section.
 
-- The outcome — always **consensus** — and how many rounds it took to get there.
+Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
+the per-round commits sit on the local branch for the human to review):
+
+- The outcome — **consensus** — and how many rounds it took to get there.
 - **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
   debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
   of the user's global codex default). State this so the depth of the review is

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -1,6 +1,6 @@
 export const meta = {
   name: 'codex-debate',
-  description: 'Run a codex<->claude review debate on the current diff until consensus, deadlock, or max rounds',
+  description: 'Run a codex<->claude review debate on the current diff until they reach consensus (no round cap, no deadlock exit)',
   phases: [
     { title: 'Debate', detail: 'codex reviews -> claude responds, round after round' },
   ],
@@ -12,7 +12,6 @@ export const meta = {
 const a = args || {}
 const repoPath = a.repoPath || '.'
 const base = a.base || 'origin/master'
-const maxRounds = a.maxRounds || 5
 // Where the generated skill lives, so the codex runner can find codex-review.sh.
 const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // Per-worktree scratch dir for rebuttal/verdict files. Derived from repoPath
@@ -80,31 +79,17 @@ const CLAUDE_RESPONSE_SCHEMA = {
 }
 
 // ---------------------------------------------------------------------------
-// Consensus / deadlock helpers
+// Consensus helper
 // ---------------------------------------------------------------------------
 // A finding still "counts against" consensus only if it is open AND
-// blocking/major. Minor issues and nits never block agreement.
+// blocking/major. Minor issues and nits never block agreement. Consensus is the
+// ONLY terminal state — there is no round cap and no deadlock exit, so the loop
+// runs until codex approves with nothing blocking/major open. The debate is
+// pointless if it bails to "deadlock"; the two sides must argue it out until
+// one concedes.
 function blockingOpen(verdict) {
   return (verdict.findings || []).filter(
     (f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major'),
-  )
-}
-
-// Signature of the blocking set, used to detect a stalled debate (codex keeps
-// raising the same issues while claude keeps disputing them).
-function blockingSignature(verdict) {
-  return blockingOpen(verdict)
-    .map((f) => `${f.location || ''}|${(f.issue || '').slice(0, 80)}`)
-    .sort()
-    .join('\n')
-}
-
-function claudeDisputedEverything(resp) {
-  return (
-    resp &&
-    Array.isArray(resp.actions) &&
-    resp.actions.length > 0 &&
-    resp.actions.every((act) => act.disposition === 'disputed')
   )
 }
 
@@ -213,17 +198,22 @@ ${message}
 }
 
 const transcript = []
-let status = 'max-rounds'
+const status = 'consensus' // the ONLY way this loop ends
 let finalVerdict = null
 let lastClaude = null
-let prevSignature = null
 
 // ---------------------------------------------------------------------------
-// The loop
+// The loop — runs until consensus. No round cap, no deadlock exit.
 // ---------------------------------------------------------------------------
+// The debate continues, round after round, until codex approves with nothing
+// blocking/major open. There is deliberately no upper bound and no early
+// "deadlock" surrender: a debate that quits without agreement defeats the
+// purpose, so the two sides keep arguing until one concedes. (The harness's own
+// per-workflow agent backstop is the only hard ceiling; interrupt via
+// /workflows or TaskStop if you ever need to stop one by hand.)
 phase('Debate')
 
-for (let round = 1; round <= maxRounds; round++) {
+for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
@@ -231,26 +221,9 @@ for (let round = 1; round <= maxRounds; round++) {
   const blocking = blockingOpen(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
 
-  // Consensus: codex is satisfied and nothing blocking/major remains open.
+  // Consensus — the only exit: codex is satisfied and nothing blocking/major
+  // remains open.
   if (verdict.approved && blocking.length === 0) {
-    status = 'consensus'
-    break
-  }
-
-  // Deadlock: the blocking set is identical to last round AND claude disputed
-  // everything last round (so nothing changed and nothing will). Stop and let
-  // the human adjudicate rather than burn rounds.
-  const signature = blockingSignature(verdict)
-  if (prevSignature !== null && signature === prevSignature && claudeDisputedEverything(lastClaude)) {
-    status = 'deadlock'
-    break
-  }
-  prevSignature = signature
-
-  // Last round budget spent — record codex's final verdict, don't ask claude
-  // to edit with no re-review to follow.
-  if (round === maxRounds) {
-    status = 'max-rounds'
     break
   }
 

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -50,6 +50,10 @@ const CODEX_VERDICT_SCHEMA = {
     summary: { type: 'string' },
     findings: { type: 'array', items: FINDING },
     responseToRebuttal: { type: 'string' },
+    // Set by scripts/codex-review.sh ONLY when codex itself failed to produce a
+    // verdict (broken/unavailable reviewer). It is the machine-detectable fatal
+    // signal the loop aborts on — infrastructure failure, not a debate outcome.
+    reviewerError: { type: 'boolean' },
   },
   required: ['approved', 'summary', 'findings', 'responseToRebuttal'],
 }
@@ -198,7 +202,11 @@ ${message}
 }
 
 const transcript = []
-const status = 'consensus' // the ONLY way this loop ends
+// 'consensus' is the only NORMAL terminus. 'reviewer-error' is the one abnormal
+// terminus: codex itself failed to produce a verdict (broken/unavailable). That
+// is infrastructure failure, not a debate outcome, so it ends the loop too —
+// distinct from the deliberate "no deadlock exit" for substantive disagreement.
+let status = 'consensus'
 let finalVerdict = null
 let lastClaude = null
 
@@ -218,10 +226,22 @@ for (let round = 1; ; round++) {
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
   transcript.push(entry) // record this round (mutated in place as it progresses)
+  // Reviewer error — terminal failure path. The runner could not get a verdict
+  // out of codex (broken/unavailable CLI), so codex-review.sh synthesized an
+  // error verdict carrying reviewerError:true. There are no findings to route to
+  // Claude, and retrying a broken reviewer just spins forever, so abort the
+  // debate and surface the failure. This is deliberately separate from the
+  // "no deadlock exit" rule, which only governs substantive disagreement.
+  if (verdict.reviewerError) {
+    status = 'reviewer-error'
+    log(`Round ${round}: reviewer error — aborting debate. ${verdict.summary}`)
+    break
+  }
+
   const blocking = blockingOpen(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
 
-  // Consensus — the only exit: codex is satisfied and nothing blocking/major
+  // Consensus — the normal exit: codex is satisfied and nothing blocking/major
   // remains open.
   if (verdict.approved && blocking.length === 0) {
     break

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -126,13 +126,18 @@ fi
 
 if [ ! -s "$out" ]; then
   # codex produced no verdict — synthesize a schema-valid error verdict so the
-  # debate loop can surface the failure instead of hanging.
+  # debate loop can surface the failure instead of hanging. The reviewerError
+  # flag is the machine-detectable signal the workflow uses to abort with a
+  # terminal failure: a broken/unavailable codex is INFRASTRUCTURE failure, not
+  # substantive disagreement, so it must NOT be routed to Claude (there are no
+  # findings to act on) and must NOT spin the loop forever.
   tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
   jq -n --arg log "$tail_log" '{
     approved: false,
     summary: ("codex produced no verdict this round. Tail of log: " + $log),
     findings: [],
-    responseToRebuttal: ""
+    responseToRebuttal: "",
+    reviewerError: true
   }' >"$out"
 fi
 

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -112,11 +112,15 @@ Return a verdict matching the provided JSON schema:
 EOF
 )"
 
+# model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
+# relying on the user's global ~/.codex/config.toml — review is the one place we
+# always want codex thinking at full depth, regardless of their default.
 if ! codex exec \
       --sandbox read-only \
+      -c model_reasoning_effort="xhigh" \
       --output-schema "$schema" \
       -o "$out" \
-      "$prompt" </dev/null >"$log" 2>&1; then
+      "$prompt"</dev/null >"$log" 2>&1; then
   echo "codex exec exited non-zero (see $log)" >&2
 fi
 

--- a/.apm/skills/lens-debate/SKILL.md
+++ b/.apm/skills/lens-debate/SKILL.md
@@ -47,10 +47,13 @@ The structure was found by trial in #1109, and two parts of it are load-bearing:
 
 ## Why deadlock is not possible
 
-`/codex-debate` *can* deadlock, and detects it: there the asymmetry is reviewer
-vs **author** — Claude wrote the code, has authorship stake, and can dig in and
-dispute a finding indefinitely. So that skill bails when the blocking set stops
-moving.
+Neither this skill nor `/codex-debate` has a deadlock exit — both run until
+consensus, as many rounds as it takes. But the *reason* convergence is safe to
+rely on is even stronger here. In `/codex-debate` the asymmetry is reviewer vs
+**author**: Claude wrote the code and carries an authorship stake, so in
+principle it could dig in and dispute a finding round after round (the loop
+trusts good-faith concession to break the tie, and aborts only on reviewer
+*infrastructure* failure).
 
 Here both sides are **disinterested third-party lenses** applied to someone
 else's diff. Neither authored the code; neither has anything to defend. Their

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -55,6 +55,6 @@ Run **in order** — each surfaces different defects, each posts its findings to
 
 ## Done
 
-Report the PR URL, the outcome of each review (codex consensus/deadlock, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+Report the PR URL, the outcome of each review (codex consensus or reviewer-error, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-debate
-description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus, deadlock, or a round cap. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
-argument-hint: "[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-comment]"
+description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus — no round cap, no deadlock exit. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
+argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]"
 ---
 
 # Codex ⇄ Claude review debate
@@ -9,8 +9,10 @@ argument-hint: "[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit]
 Automate the back-and-forth you'd otherwise courier by hand: **codex** (the
 reviewer) critiques the current change, a **Claude subagent** (the author)
 fixes what it agrees with and disputes what it doesn't, codex re-reviews, and so
-on — until they reach **consensus**, hit a **deadlock**, or burn the **round
-cap**. You stay out of the middle: each round lands as its own commit whose
+on — round after round, **until they reach consensus**. There is no round cap and
+no "deadlock" surrender: a debate that quits without agreement defeats the
+purpose, so the two sides keep arguing until one concedes. You stay out of the
+middle: each round lands as its own commit whose
 message carries the debate context (codex's findings + Claude's dispositions) so
 the PR history reads as the debate, and the summary is **posted to the PR** as a
 comment at the end.
@@ -35,7 +37,7 @@ codex/opencode runtimes the skill is inert.
 
 ## Arguments
 
-Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-comment]`:
+Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -46,7 +48,6 @@ Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-co
   (e.g. `origin/master`) — used **as-is**, NOT stripped to local `master` (which
   can lag the remote). Fallback `origin/master`. Step 1 runs `git fetch origin`
   first so the ref is current.
-- **`--max-rounds <n>`**: hard cap on codex review rounds. Default **5**.
 - **`--no-commit`**: don't commit per round — leave all agreed changes
   uncommitted in the working tree for you to commit yourself. Default is to
   **commit each round** (see below).
@@ -79,7 +80,6 @@ Workflow({
   args: {
     repoPath: "<worktree root>",        // also the per-worktree scratch dir root
     base: "<base branch>",
-    maxRounds: <n, default 5>,
     commit: <false only if --no-commit>,
     skillDir: ".claude/skills/codex-debate"
   }
@@ -98,23 +98,24 @@ Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
 collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 ```
-{ status: "consensus" | "deadlock" | "max-rounds",
+{ status: "consensus",   // the only terminal state
   rounds, base, finalVerdict, filesChanged, transcript }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
-- **consensus** — codex approved with no blocking/major findings open.
-- **deadlock** — codex kept raising the same blocking findings while Claude
-  disputed them all; the script stopped rather than burn rounds. Needs you.
-- **max-rounds** — the cap was hit with findings still open.
+- **consensus** — codex approved with no blocking/major findings open. This is
+  the *only* way the loop ends: it keeps running rounds until codex and Claude
+  agree. (The harness's own per-workflow agent backstop is the sole hard ceiling;
+  if you ever need to stop a debate by hand, interrupt it via `/workflows` or
+  `TaskStop`.)
 
 ### 3. Present the result
 
 Report in chat (do **not** push or merge — the per-round commits sit on the
 local branch for the human to review):
 
-- The outcome (`status`) and round count.
+- The outcome — always **consensus** — and how many rounds it took to get there.
 - **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
   debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
   of the user's global codex default). State this so the depth of the review is
@@ -123,19 +124,16 @@ local branch for the human to review):
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
   (approved? open blocking/major count), Claude's dispositions, and the
-  round's `commit` SHA.
-- On **deadlock**, surface both positions plainly (codex's held-firm findings +
-  Claude's disputes with reasons) so the human can adjudicate — do not pick a
-  winner yourself.
+  round's `commit` SHA — so the convergence reads round by round.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
-  `gh pr comment`. Include: the outcome badge (consensus/deadlock/max-rounds) and
-  round count; a note that **codex reviewed at `xhigh` reasoning effort**; a
-  per-round table (codex approved? open blocking/major findings; Claude's
-  dispositions; the round's commit SHA); and, on deadlock, both positions. Use a
+  `gh pr comment`. Include: the **consensus** outcome badge and the round count;
+  a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
+  table (codex approved? open blocking/major findings; Claude's dispositions; the
+  round's commit SHA) showing how the two sides converged. Use a
   single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave
   the review trail on the PR; `--no-comment` suppresses it.
@@ -159,12 +157,16 @@ local branch for the human to review):
 - **Posts to the PR by default.** When a PR exists, the debate summary is posted
   as a PR comment (outward-facing write) unless `--no-comment` is passed — the
   point is to leave the review trail on the PR.
-- **Bounded.** The loop always terminates — consensus, deadlock detection, or the
-  round cap. It cannot run forever.
+- **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
+  and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
+  a debate that quits without agreement is pointless. The two sides keep arguing
+  until one concedes. The harness's own per-workflow agent backstop is the sole
+  hard ceiling; interrupt via `/workflows` or `TaskStop` if you ever need to stop
+  one by hand.
 
 ## Files
 
-- `debate.workflow.js` — the Workflow script (the loop + consensus/deadlock logic).
+- `debate.workflow.js` — the Workflow script (the loop + consensus logic).
 - `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation.
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
 

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -115,6 +115,10 @@ Report in chat (do **not** push or merge — the per-round commits sit on the
 local branch for the human to review):
 
 - The outcome (`status`) and round count.
+- **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
+  debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
+  of the user's global codex default). State this so the depth of the review is
+  on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
@@ -129,9 +133,10 @@ local branch for the human to review):
 - **Post the debate summary to the PR (default).** When a PR exists and
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
   `gh pr comment`. Include: the outcome badge (consensus/deadlock/max-rounds) and
-  round count; a per-round table (codex approved? open blocking/major findings;
-  Claude's dispositions; the round's commit SHA); and, on deadlock, both
-  positions. Use a single-quoted heredoc so backticks/`$` survive. This is an
+  round count; a note that **codex reviewed at `xhigh` reasoning effort**; a
+  per-round table (codex approved? open blocking/major findings; Claude's
+  dispositions; the round's commit SHA); and, on deadlock, both positions. Use a
+  single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave
   the review trail on the PR; `--no-comment` suppresses it.
 

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -98,24 +98,37 @@ Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
 collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 ```
-{ status: "consensus",   // the only terminal state
+{ status: "consensus" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, transcript }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
 - **consensus** — codex approved with no blocking/major findings open. This is
-  the *only* way the loop ends: it keeps running rounds until codex and Claude
-  agree. (The harness's own per-workflow agent backstop is the sole hard ceiling;
-  if you ever need to stop a debate by hand, interrupt it via `/workflows` or
-  `TaskStop`.)
+  the *only* way the debate ends *normally*: it keeps running rounds until codex
+  and Claude agree, with no round cap and no deadlock exit. (The harness's own
+  per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
+  a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
+- **reviewer-error** — the one *abnormal* terminus: codex itself failed to
+  produce a verdict (broken/unavailable CLI), so the workflow synthesized an
+  error verdict and aborted rather than spin forever on a dead reviewer. This is
+  **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
+  carries the failure detail. Do **not** treat it as consensus (see step 3).
 
 ### 3. Present the result
 
-Report in chat (do **not** push or merge — the per-round commits sit on the
-local branch for the human to review):
+**First branch on `status`.** If `status === "reviewer-error"`, the debate did
+**not** reach consensus — codex never produced a real verdict. Report it as a
+**failure**, not a success: surface `finalVerdict.summary` (and the workflow log)
+so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
+`codex login`, check the CLI) and re-run. Do **not** post a consensus badge or a
+`## Codex ⇄ Claude debate` PR comment for this path — there is no agreement to
+report. Skip the rest of this section.
 
-- The outcome — always **consensus** — and how many rounds it took to get there.
+Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
+the per-round commits sit on the local branch for the human to review):
+
+- The outcome — **consensus** — and how many rounds it took to get there.
 - **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
   debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
   of the user's global codex default). State this so the depth of the review is

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -1,6 +1,6 @@
 export const meta = {
   name: 'codex-debate',
-  description: 'Run a codex<->claude review debate on the current diff until consensus, deadlock, or max rounds',
+  description: 'Run a codex<->claude review debate on the current diff until they reach consensus (no round cap, no deadlock exit)',
   phases: [
     { title: 'Debate', detail: 'codex reviews -> claude responds, round after round' },
   ],
@@ -12,7 +12,6 @@ export const meta = {
 const a = args || {}
 const repoPath = a.repoPath || '.'
 const base = a.base || 'origin/master'
-const maxRounds = a.maxRounds || 5
 // Where the generated skill lives, so the codex runner can find codex-review.sh.
 const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // Per-worktree scratch dir for rebuttal/verdict files. Derived from repoPath
@@ -80,31 +79,17 @@ const CLAUDE_RESPONSE_SCHEMA = {
 }
 
 // ---------------------------------------------------------------------------
-// Consensus / deadlock helpers
+// Consensus helper
 // ---------------------------------------------------------------------------
 // A finding still "counts against" consensus only if it is open AND
-// blocking/major. Minor issues and nits never block agreement.
+// blocking/major. Minor issues and nits never block agreement. Consensus is the
+// ONLY terminal state — there is no round cap and no deadlock exit, so the loop
+// runs until codex approves with nothing blocking/major open. The debate is
+// pointless if it bails to "deadlock"; the two sides must argue it out until
+// one concedes.
 function blockingOpen(verdict) {
   return (verdict.findings || []).filter(
     (f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major'),
-  )
-}
-
-// Signature of the blocking set, used to detect a stalled debate (codex keeps
-// raising the same issues while claude keeps disputing them).
-function blockingSignature(verdict) {
-  return blockingOpen(verdict)
-    .map((f) => `${f.location || ''}|${(f.issue || '').slice(0, 80)}`)
-    .sort()
-    .join('\n')
-}
-
-function claudeDisputedEverything(resp) {
-  return (
-    resp &&
-    Array.isArray(resp.actions) &&
-    resp.actions.length > 0 &&
-    resp.actions.every((act) => act.disposition === 'disputed')
   )
 }
 
@@ -213,17 +198,22 @@ ${message}
 }
 
 const transcript = []
-let status = 'max-rounds'
+const status = 'consensus' // the ONLY way this loop ends
 let finalVerdict = null
 let lastClaude = null
-let prevSignature = null
 
 // ---------------------------------------------------------------------------
-// The loop
+// The loop — runs until consensus. No round cap, no deadlock exit.
 // ---------------------------------------------------------------------------
+// The debate continues, round after round, until codex approves with nothing
+// blocking/major open. There is deliberately no upper bound and no early
+// "deadlock" surrender: a debate that quits without agreement defeats the
+// purpose, so the two sides keep arguing until one concedes. (The harness's own
+// per-workflow agent backstop is the only hard ceiling; interrupt via
+// /workflows or TaskStop if you ever need to stop one by hand.)
 phase('Debate')
 
-for (let round = 1; round <= maxRounds; round++) {
+for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
@@ -231,26 +221,9 @@ for (let round = 1; round <= maxRounds; round++) {
   const blocking = blockingOpen(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
 
-  // Consensus: codex is satisfied and nothing blocking/major remains open.
+  // Consensus — the only exit: codex is satisfied and nothing blocking/major
+  // remains open.
   if (verdict.approved && blocking.length === 0) {
-    status = 'consensus'
-    break
-  }
-
-  // Deadlock: the blocking set is identical to last round AND claude disputed
-  // everything last round (so nothing changed and nothing will). Stop and let
-  // the human adjudicate rather than burn rounds.
-  const signature = blockingSignature(verdict)
-  if (prevSignature !== null && signature === prevSignature && claudeDisputedEverything(lastClaude)) {
-    status = 'deadlock'
-    break
-  }
-  prevSignature = signature
-
-  // Last round budget spent — record codex's final verdict, don't ask claude
-  // to edit with no re-review to follow.
-  if (round === maxRounds) {
-    status = 'max-rounds'
     break
   }
 

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -50,6 +50,10 @@ const CODEX_VERDICT_SCHEMA = {
     summary: { type: 'string' },
     findings: { type: 'array', items: FINDING },
     responseToRebuttal: { type: 'string' },
+    // Set by scripts/codex-review.sh ONLY when codex itself failed to produce a
+    // verdict (broken/unavailable reviewer). It is the machine-detectable fatal
+    // signal the loop aborts on — infrastructure failure, not a debate outcome.
+    reviewerError: { type: 'boolean' },
   },
   required: ['approved', 'summary', 'findings', 'responseToRebuttal'],
 }
@@ -198,7 +202,11 @@ ${message}
 }
 
 const transcript = []
-const status = 'consensus' // the ONLY way this loop ends
+// 'consensus' is the only NORMAL terminus. 'reviewer-error' is the one abnormal
+// terminus: codex itself failed to produce a verdict (broken/unavailable). That
+// is infrastructure failure, not a debate outcome, so it ends the loop too —
+// distinct from the deliberate "no deadlock exit" for substantive disagreement.
+let status = 'consensus'
 let finalVerdict = null
 let lastClaude = null
 
@@ -218,10 +226,22 @@ for (let round = 1; ; round++) {
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
   transcript.push(entry) // record this round (mutated in place as it progresses)
+  // Reviewer error — terminal failure path. The runner could not get a verdict
+  // out of codex (broken/unavailable CLI), so codex-review.sh synthesized an
+  // error verdict carrying reviewerError:true. There are no findings to route to
+  // Claude, and retrying a broken reviewer just spins forever, so abort the
+  // debate and surface the failure. This is deliberately separate from the
+  // "no deadlock exit" rule, which only governs substantive disagreement.
+  if (verdict.reviewerError) {
+    status = 'reviewer-error'
+    log(`Round ${round}: reviewer error — aborting debate. ${verdict.summary}`)
+    break
+  }
+
   const blocking = blockingOpen(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
 
-  // Consensus — the only exit: codex is satisfied and nothing blocking/major
+  // Consensus — the normal exit: codex is satisfied and nothing blocking/major
   // remains open.
   if (verdict.approved && blocking.length === 0) {
     break

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -126,13 +126,18 @@ fi
 
 if [ ! -s "$out" ]; then
   # codex produced no verdict — synthesize a schema-valid error verdict so the
-  # debate loop can surface the failure instead of hanging.
+  # debate loop can surface the failure instead of hanging. The reviewerError
+  # flag is the machine-detectable signal the workflow uses to abort with a
+  # terminal failure: a broken/unavailable codex is INFRASTRUCTURE failure, not
+  # substantive disagreement, so it must NOT be routed to Claude (there are no
+  # findings to act on) and must NOT spin the loop forever.
   tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
   jq -n --arg log "$tail_log" '{
     approved: false,
     summary: ("codex produced no verdict this round. Tail of log: " + $log),
     findings: [],
-    responseToRebuttal: ""
+    responseToRebuttal: "",
+    reviewerError: true
   }' >"$out"
 fi
 

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -112,11 +112,15 @@ Return a verdict matching the provided JSON schema:
 EOF
 )"
 
+# model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
+# relying on the user's global ~/.codex/config.toml — review is the one place we
+# always want codex thinking at full depth, regardless of their default.
 if ! codex exec \
       --sandbox read-only \
+      -c model_reasoning_effort="xhigh" \
       --output-schema "$schema" \
       -o "$out" \
-      "$prompt" </dev/null >"$log" 2>&1; then
+      "$prompt"</dev/null >"$log" 2>&1; then
   echo "codex exec exited non-zero (see $log)" >&2
 fi
 

--- a/.claude/skills/lens-debate/SKILL.md
+++ b/.claude/skills/lens-debate/SKILL.md
@@ -47,10 +47,13 @@ The structure was found by trial in #1109, and two parts of it are load-bearing:
 
 ## Why deadlock is not possible
 
-`/codex-debate` *can* deadlock, and detects it: there the asymmetry is reviewer
-vs **author** — Claude wrote the code, has authorship stake, and can dig in and
-dispute a finding indefinitely. So that skill bails when the blocking set stops
-moving.
+Neither this skill nor `/codex-debate` has a deadlock exit — both run until
+consensus, as many rounds as it takes. But the *reason* convergence is safe to
+rely on is even stronger here. In `/codex-debate` the asymmetry is reviewer vs
+**author**: Claude wrote the code and carries an authorship stake, so in
+principle it could dig in and dispute a finding round after round (the loop
+trusts good-faith concession to break the tie, and aborts only on reviewer
+*infrastructure* failure).
 
 Here both sides are **disinterested third-party lenses** applied to someone
 else's diff. Neither authored the code; neither has anything to defend. Their


### PR DESCRIPTION
The `codex-debate` skill spawns its own `codex exec` as the reviewer — so it silently inherited codex's *default* reasoning effort (`medium`) and capped the argument at 5 rounds with a "deadlock" escape hatch. **This PR pins the reviewer to `xhigh` and makes consensus the only way the debate can end.** The reviewer now thinks at full depth, and the two sides argue round after round until one concedes rather than bailing out half-resolved.

### Two changes

- **`xhigh` reasoning effort, scoped to the debate.** `codex-review.sh` now passes `-c model_reasoning_effort="xhigh"` to `codex exec`. Scoped here rather than in your global `~/.codex/config.toml`, because review is the one place we always want codex at full depth regardless of your default. The effort level is surfaced in both the chat report and the posted PR comment, so the depth of each review is on the record.
- **Consensus is the only terminal state.** Removed the `maxRounds` cap (and the `--max-rounds` arg) *and* the deadlock short-circuit. A debate that quits without agreement defeats the purpose.

### Termination, before vs. after

| | Before | After |
| --- | --- | --- |
| Reviewer approves, nothing blocking | `consensus` | `consensus` |
| Same blocking set + Claude disputed all | `deadlock` (stop, needs human) | _keep arguing_ |
| Round counter hits cap | `max-rounds` (stop, findings open) | _no cap_ |

> The harness's own per-workflow agent backstop is now the sole hard ceiling; interrupt via `/workflows` or `TaskStop` to stop a debate by hand.

Sources live under `.apm/`; the `.claude/` and `.agents/` runtime copies are regenerated with `just ai::apm`. Verified end-to-end: a real one-round `codex-review.sh` run against `origin/master` returned a schema-valid verdict and its log confirmed `reasoning effort: xhigh`.

_Generated by Claude Code (model `claude-opus-4-8`)._