### PR TITLE
fix(terminal): keep file-ref links from swallowing a trailing period

### DIFF
--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -143,6 +143,36 @@ describe("parseLineRefs", () => {
     expect(parseLineRefs("git init")).toEqual([]);
     expect(parseLineRefs("run Makefile")).toEqual([]);
   });
+
+  it("does not absorb a trailing sentence period into a slash-path", () => {
+    // The reported bug: `…a single docs/plans/electricity.html.` — the
+    // sentence period sat in the path char class, so the greedy match
+    // swallowed it and the link pointed at `…electricity.html.`, which
+    // never resolved. The reference must stop at the real filename.
+    const refs = parseLineRefs(
+      "There is now a single docs/plans/electricity.html.",
+    );
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      path: "docs/plans/electricity.html",
+      text: "docs/plans/electricity.html",
+      startLine: null,
+      endLine: null,
+    });
+  });
+
+  it("drops a run of trailing periods (ellipsis after a path)", () => {
+    expect(parseLineRefs("opened src/notes.txt...")[0]).toMatchObject({
+      path: "src/notes.txt",
+      text: "src/notes.txt",
+    });
+  });
+
+  it("keeps a trailing `+` so C++-style extensions still link", () => {
+    // Only `.` is stripped from the end — `+`/`@`/`-` are legitimate path
+    // tails (`foo.c++`, `bin/g++`), so the dot-only rule must leave them.
+    expect(parseLineRefs("see src/foo.c++ now")[0]?.path).toBe("src/foo.c++");
+  });
 });
 
 describe("resolveLineRefPath", () => {

--- a/packages/client/src/ui/lineRef.test.ts
+++ b/packages/client/src/ui/lineRef.test.ts
@@ -173,6 +173,22 @@ describe("parseLineRefs", () => {
     // tails (`foo.c++`, `bin/g++`), so the dot-only rule must leave them.
     expect(parseLineRefs("see src/foo.c++ now")[0]?.path).toBe("src/foo.c++");
   });
+
+  it("keeps a :line suffix intact when a sentence period follows", () => {
+    // The end-anchored `(?<!\.)` lookbehind is placed after the whole
+    // regex rather than inside the slash-path branch — safe only because
+    // a `:line` suffix ends in a digit, so the lookbehind never trims it.
+    // This pins that invariant: moving the lookbehind into the path branch
+    // would change `:line` immunity, and this test would catch it.
+    const refs = parseLineRefs("see a/b.c:42.");
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      path: "a/b.c",
+      startLine: 42,
+      endLine: 42,
+      text: "a/b.c:42",
+    });
+  });
 });
 
 describe("resolveLineRefPath", () => {

--- a/packages/client/src/ui/lineRef.ts
+++ b/packages/client/src/ui/lineRef.ts
@@ -53,7 +53,15 @@ const LINE_REF_RE = new RegExp(
   `((?:\\.\\.?\\/|\\/)?(?:${PATH_CHARS}+\\/)+${PATH_CHARS}+|${PATH_CHARS}+\\.[A-Za-z]\\w*)` +
     // Optional `:line[:col|-end]`. When absent the bare path links to
     // the file with no line selected.
-    `(?::(\\d+)(?::\\d+|-(\\d+))?)?`,
+    `(?::(\\d+)(?::\\d+|-(\\d+))?)?` +
+    // The reference must not END in a literal `.`. `.` is a path char
+    // (extensions, dotfiles), so a greedy slash-path used to swallow the
+    // sentence period in prose like `…a single docs/plans/electricity.html.`
+    // and the link resolved to a nonexistent `…html.`. Only the dot is
+    // excluded from the tail — `+`/`@`/`-` are kept so `foo.c++` and
+    // `bin/g++` still link in full. A `:line` suffix ends in a digit, so
+    // this only ever trims a bare path's trailing dot.
+    `(?<!\\.)`,
   "g",
 );
 

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -135,6 +135,28 @@ Feature: File-ref autolinking in terminal
     And the selected file should show content "gamma"
     And line 3 should be selected in the file content
 
+  Scenario: A trailing sentence period does not break a slash-containing file-ref
+    # The reported bug: prose like "There's now a single
+    # docs/plans/electricity.html." ends the path with a sentence period. `.`
+    # is a path char (extensions, dotfiles), so the greedy match used to
+    # swallow the period and the link pointed at a nonexistent
+    # `…electricity.html.` — clicking it silently no-opped. The link must stop
+    # at the real filename and open the file.
+    When I run "git init /tmp/kolu-file-ref-trailing-dot && cd /tmp/kolu-file-ref-trailing-dot"
+    And I run "git commit --allow-empty -m init"
+    And I run "mkdir -p docs/plans"
+    # Create the file via a subshell so the full `docs/plans/electricity.html`
+    # only ever appears contiguously in the period-bearing prose below — if a
+    # setup line printed the clean path, the link hit-test would land there and
+    # mask the bug.
+    And I run "(cd docs/plans && printf '<h1>electricity</h1>\n' > electricity.html)"
+    And I run "echo 'There is now a single docs/plans/electricity.html.'"
+    And I trigger the terminal file-ref link "docs/plans/electricity.html"
+    Then the right panel should be visible
+    And the Code tab should be active
+    And the file preview iframe should be visible
+    And the file preview iframe should contain "electricity"
+
   # `@skip`: known regression noted in c89a85f3 — the second xterm `path:line`
   # click after a manual collapse fails to re-open the panel under the bundled
   # build (passes in dev). Suspected production-Solid reactive elision or


### PR DESCRIPTION
**A file path that ends a sentence in terminal output was no longer clickable.** When prose like `There's now a single docs/plans/electricity.html.` scrolled by, the link grabbed the trailing sentence period too — pointing at a nonexistent `…electricity.html.` — so clicking it silently did nothing instead of opening the file in the Code tab.

The culprit is the reference regex in `lineRef.ts`: `.` is a legal path char (extensions, dotfiles), and the slash-containing branch's final segment matched greedily, so it happily ate the period at the end of the line.

### The fix

Anchor the whole reference with a trailing negative lookbehind so a match can **never end in a literal dot**:

```
…(?::(\d+)(?::\d+|-(\d+))?)?(?<!\.)
```

Only `.` is excluded from the tail — `+`, `@`, and `-` stay valid path tails, and a `:line` suffix ends in a digit, so the rule *only ever trims a bare path's trailing dot*:

| Terminal text | Linkified before | Linkified after |
| --- | --- | --- |
| `…a single docs/plans/electricity.html.` | `docs/plans/electricity.html.` ❌ (won't resolve) | `docs/plans/electricity.html` ✅ |
| `opened src/notes.txt...` | `src/notes.txt...` ❌ | `src/notes.txt` ✅ |
| `see src/foo.c++ now` | `src/foo.c++` ✅ | `src/foo.c++` ✅ (unchanged) |
| `fixed in src/app.ts:42.` | `src/app.ts:42` ✅ | `src/app.ts:42` ✅ (unchanged) |

### Tests

- Three new `lineRef` unit tests — trailing period on a slash-path, a run of trailing dots (ellipsis), and the `foo.c++` guard that proves the dot-only rule doesn't over-strip.
- A new e2e scenario reproducing the reported case end-to-end (`docs/plans/electricity.html.` → click → preview iframe opens with the file's content). It was confirmed red on the unfixed regex and green after. *The file is created via a subshell so the full path appears contiguously only in the period-bearing prose — otherwise the link hit-test lands on a clean setup line and masks the bug.*

### Try it locally

```sh
nix run github:juspay/kolu/dot-in-link
```

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._