### PR TITLE
Decay an abandoned `thinking` pill via the resumed-prompt signal (#1017)

### DIFF
--- a/packages/integrations/claude-code/src/agent-provider.ts
+++ b/packages/integrations/claude-code/src/agent-provider.ts
@@ -41,7 +41,15 @@ export const claudeCodeProvider: AgentProvider<SessionFile, ClaudeCodeInfo> = {
   },
 
   sessionKey(session) {
-    return session.sessionId;
+    // Keyed by transcript identity AND process identity. A `claude -c` resume
+    // reuses the same `sessionId` but writes a new session file with a fresh
+    // `pid` and `startedAt`; the watcher captures `session.pid`/`startedAt`
+    // once (for the #1017 subtree-idle probe and orphaned-prompt age check), so
+    // keying on `sessionId` alone would early-return on resume and leave the
+    // watcher probing the dead pid against a stale `startedAt`. Folding pid and
+    // startedAt into the key forces the orchestrator to recreate the watcher
+    // when either changes for the same transcript.
+    return `${session.sessionId}:${session.pid}:${session.startedAt ?? ""}`;
   },
 
   createWatcher(session, onChange, log) {

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -328,11 +328,17 @@ export function deriveState(
   state: ClaudeCodeInfo["state"];
   model: string | null;
   contextTokens: number | null;
+  /** Epoch-ms timestamp of the entry the state was derived from (the newest
+   *  `user`/`assistant` entry), or null when it lacks a parseable `timestamp`.
+   *  Used to age a trailing `thinking` prompt against the session's `startedAt`
+   *  (the resumed-vs-live discriminator — see the #1017 module note). */
+  timestampMs: number | null;
 } | null {
   let stateAndModel: {
     state: ClaudeCodeInfo["state"];
     model: string | null;
   } | null = null;
+  let timestampMs: number | null = null;
   let contextTokens: number | null = null;
 
   for (let i = lines.length - 1; i >= 0; i--) {
@@ -341,6 +347,7 @@ export function deriveState(
     try {
       const entry: {
         type?: string;
+        timestamp?: string;
         message?: {
           stop_reason?: string | null;
           model?: string | null;
@@ -382,6 +389,13 @@ export function deriveState(
             model: null,
           }))
           .otherwise(() => null);
+        // Capture the timestamp of the very entry the state derives from — the
+        // newest `user`/`assistant` — so the orphaned-prompt age check reads the
+        // same entry, not a parallel walk (null if absent/unparseable).
+        if (stateAndModel !== null) {
+          const ts = entry.timestamp ? Date.parse(entry.timestamp) : Number.NaN;
+          timestampMs = Number.isNaN(ts) ? null : ts;
+        }
       }
 
       if (stateAndModel !== null && contextTokens !== null) break;
@@ -411,7 +425,7 @@ export function deriveState(
     if (bg.some((t) => t.runId !== null)) state = "running_background";
   }
 
-  return { state, model: stateAndModel.model, contextTokens };
+  return { state, model: stateAndModel.model, contextTokens, timestampMs };
 }
 
 // --- Background-task detection (dynamic workflows) ---
@@ -785,27 +799,6 @@ export function nextWorkflowStaleDeadline(
 // Sibling of the `running_background` decay (#1109), which handles the
 // `end_turn`-promotion half on its own workflow-journal signal; the states are
 // disjoint, so the paths never overlap.
-
-/** Timestamp (epoch ms) of the newest `user`/`assistant` entry — the same entry
- *  `deriveState` reads for state. Returns null when there is none or it lacks a
- *  parseable `timestamp`. Used to age a trailing `thinking` prompt against the
- *  session's `startedAt` (the resumed-vs-live discriminator above). */
-export function newestEntryTimestampMs(lines: string[]): number | null {
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const raw = lines[i];
-    if (raw === undefined) continue;
-    try {
-      const e = JSON.parse(raw) as { type?: string; timestamp?: string };
-      if (e.type === "user" || e.type === "assistant") {
-        const t = e.timestamp ? Date.parse(e.timestamp) : Number.NaN;
-        return Number.isNaN(t) ? null : t;
-      }
-    } catch {
-      // skip malformed lines
-    }
-  }
-  return null;
-}
 
 /** How long the transcript may sit unwritten before a dangling `tool_use`
  *  becomes eligible to decay to `waiting`. A live tool writes the transcript as

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -27,6 +27,7 @@ import path from "node:path";
 import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
 import { classifyByAwaiting } from "anyagent";
 import { type Logger, readTailLines } from "kolu-shared";
+import { parseIsoTimestamp } from "kolu-transcript-core";
 import { match } from "ts-pattern";
 import { z } from "zod";
 import type {
@@ -393,8 +394,7 @@ export function deriveState(
         // newest `user`/`assistant` — so the orphaned-prompt age check reads the
         // same entry, not a parallel walk (null if absent/unparseable).
         if (stateAndModel !== null) {
-          const ts = entry.timestamp ? Date.parse(entry.timestamp) : Number.NaN;
-          timestampMs = Number.isNaN(ts) ? null : ts;
+          timestampMs = parseIsoTimestamp(entry.timestamp);
         }
       }
 

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -80,6 +80,13 @@ export interface SessionFile {
   pid: number;
   sessionId: string;
   cwd: string;
+  /** Epoch-ms the claude process started (or resumed via `claude -c`), from the
+   *  session file's `startedAt`. A `claude -c` resume writes a *new* session
+   *  file with a fresh `startedAt`, so a transcript prompt whose timestamp
+   *  predates this value belongs to a previous, killed instance — the current
+   *  claude never processed it. Used to tell a resumed-idle phantom from a live
+   *  turn (see `decayTransientState`). Optional: absent on older session files. */
+  startedAt?: number;
 }
 
 /**
@@ -110,7 +117,13 @@ export function readSessionFile(
       log?.debug({ pid, parsed }, "claude session file shape unexpected");
       return null;
     }
-    return parsed as SessionFile;
+    return {
+      pid: parsed.pid,
+      sessionId: parsed.sessionId,
+      cwd: parsed.cwd,
+      startedAt:
+        typeof parsed.startedAt === "number" ? parsed.startedAt : undefined,
+    };
   } catch (err) {
     log?.debug({ err, pid }, "claude session file parse failed");
     return null;
@@ -749,26 +762,50 @@ export function nextWorkflowStaleDeadline(
 
 // --- Phantom transient de-escalation (#1017) ---
 //
-// A dangling `tool_use` (an assistant tool call with no following
-// `tool_result`) keeps `deriveState` reporting a *working* state indefinitely.
-// That is correct while the tool is genuinely running, but wrong once the
-// session is abandoned (most reliably: claude killed mid-tool, then resumed
-// idle by session-restore) — the dock then spins a "running" pill forever. A
-// genuine in-flight tool and an abandoned one are transcript-indistinguishable
-// from a single snapshot, so two out-of-band signals settle it: the transcript
-// has gone quiet past a window, AND claude's process subtree is idle.
+// A trailing transient state keeps `deriveState` reporting a *working* state
+// indefinitely once the session is abandoned (most reliably: claude killed
+// mid-turn, then resumed idle by session-restore) — the dock then spins a
+// "running" pill forever. Two trailing shapes hit it, each disambiguated by a
+// different out-of-band signal once the transcript has gone quiet past a window:
 //
-// `thinking` is deliberately NOT decayed on this signal. A `thinking` turn that
-// is awaiting the model's first token (the newest transcript entry is the
-// `user` prompt) has spawned no tool child yet and writes nothing until the
-// reply streams back — so a slow or hung model request is indistinguishable
-// from abandonment by "quiet transcript + no descendants". Clearing it there
-// would publish `waiting` over a live turn. The no-descendants probe is only a
-// valid liveness signal for `tool_use`, where live tool work implies a child
-// process (a Bash child, or a sub-agent claude). Sibling of the
-// `running_background` decay (#1109), which handles the `end_turn`-promotion
-// half on its own workflow-journal signal; the states are disjoint, so the
-// paths never overlap.
+//   - dangling `tool_use` (an assistant tool call with no following
+//     `tool_result`): a *live* tool keeps a descendant process (a Bash child, a
+//     sub-agent claude), an abandoned one has none — so "subtree idle (no
+//     descendant)" tells them apart.
+//
+//   - `thinking` (the newest entry is a `user` prompt): childless and quiet
+//     whether the turn is live (awaiting the model's first token) or abandoned,
+//     so the subtree probe alone can't tell them apart. The discriminator is
+//     the prompt's age relative to the claude process: a `claude -c` resume
+//     writes a fresh `startedAt`, so a prompt that *predates* `startedAt`
+//     belongs to a killed instance the current (resumed-idle) claude never
+//     processed. A live turn's prompt always postdates `startedAt`, so it is
+//     never cleared. (`subtree idle` is still required as a second confirm.)
+//
+// Sibling of the `running_background` decay (#1109), which handles the
+// `end_turn`-promotion half on its own workflow-journal signal; the states are
+// disjoint, so the paths never overlap.
+
+/** Timestamp (epoch ms) of the newest `user`/`assistant` entry — the same entry
+ *  `deriveState` reads for state. Returns null when there is none or it lacks a
+ *  parseable `timestamp`. Used to age a trailing `thinking` prompt against the
+ *  session's `startedAt` (the resumed-vs-live discriminator above). */
+export function newestEntryTimestampMs(lines: string[]): number | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const raw = lines[i];
+    if (raw === undefined) continue;
+    try {
+      const e = JSON.parse(raw) as { type?: string; timestamp?: string };
+      if (e.type === "user" || e.type === "assistant") {
+        const t = e.timestamp ? Date.parse(e.timestamp) : Number.NaN;
+        return Number.isNaN(t) ? null : t;
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return null;
+}
 
 /** How long the transcript may sit unwritten before a dangling `tool_use`
  *  becomes eligible to decay to `waiting`. A live tool writes the transcript as
@@ -839,35 +876,41 @@ export function isClaudeSubtreeIdle(pid: number): boolean {
   return hasNoDescendants(pid, procs);
 }
 
-/** Decide the state to publish for a dangling `tool_use`, and when (if ever) to
- *  re-probe. Pure policy: the caller supplies how long the transcript has been
- *  quiet and a subtree-idle probe, invoked only once the quiet window has
- *  elapsed so the real `ps` spawn stays off the common path.
+/** Decide the state to publish for a trailing transient (`tool_use` /
+ *  `thinking`), and when (if ever) to re-probe. Pure policy: the caller supplies
+ *  how long the transcript has been quiet, a subtree-idle probe (invoked only
+ *  once the quiet window has elapsed so the real `ps` spawn stays off the common
+ *  path), and — for `thinking` — whether the trailing prompt is orphaned (it
+ *  predates the current claude's `startedAt`, see the module note).
  *
- *   - not a dangling `tool_use` → unchanged, no recheck. In particular
- *     `thinking` is excluded: a turn awaiting the model's first token has no
- *     descendant and writes nothing, so "quiet + no descendants" cannot tell a
- *     slow/hung model request from abandonment (see the module note above).
+ *   - not a decayable transient → unchanged, no recheck.
+ *   - `thinking` whose prompt is NOT orphaned → unchanged, no recheck: this is a
+ *     live turn (the prompt postdates the running claude), never cleared.
  *   - not yet stale → unchanged; arm a recheck at the moment it would go stale
  *     (a quiet transcript fires no fs event, so the watcher needs a timer).
  *   - stale + subtree idle → decay to `waiting` (the phantom is settled).
- *   - stale + subtree busy → genuine long-running tool; keep it and re-probe
- *     after another window (the tool may yet end silently with no further write).
+ *   - stale + subtree busy → genuine work; keep it and re-probe after another
+ *     window (the work may yet end silently with no further write).
  */
 export function decayTransientState(
   state: ClaudeCodeInfo["state"],
   quietMs: number,
-  probeSubtreeIdle: () => boolean,
+  probes: { subtreeIdle: () => boolean; promptOrphaned: boolean },
   staleMs: number = TRANSIENT_STALE_MS,
   now: number = Date.now(),
 ): { state: ClaudeCodeInfo["state"]; recheckAt: number | null } {
-  if (state !== "tool_use") {
+  if (state !== "tool_use" && state !== "thinking") {
+    return { state, recheckAt: null };
+  }
+  // A `thinking` turn is childless and quiet whether live or abandoned; only an
+  // orphaned prompt (predating this resumed claude) proves abandonment.
+  if (state === "thinking" && !probes.promptOrphaned) {
     return { state, recheckAt: null };
   }
   if (quietMs < staleMs) {
     return { state, recheckAt: now + (staleMs - quietMs) };
   }
-  if (probeSubtreeIdle()) {
+  if (probes.subtreeIdle()) {
     return { state: "waiting", recheckAt: null };
   }
   return { state, recheckAt: now + staleMs };

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -794,7 +794,11 @@ export function nextWorkflowStaleDeadline(
 //     writes a fresh `startedAt`, so a prompt that *predates* `startedAt`
 //     belongs to a killed instance the current (resumed-idle) claude never
 //     processed. A live turn's prompt always postdates `startedAt`, so it is
-//     never cleared. (`subtree idle` is still required as a second confirm.)
+//     never cleared. The subtree is NOT consulted for `thinking`: a
+//     resumed-idle claude often holds a long-lived helper child (a persistent
+//     MCP server such as `chrome-devtools-mcp`), so requiring an idle subtree
+//     would wrongly keep the phantom spinning forever — `orphaned` + stale is
+//     already definitive.
 //
 // Sibling of the `running_background` decay (#1109), which handles the
 // `end_turn`-promotion half on its own workflow-journal signal; the states are
@@ -902,6 +906,19 @@ export function decayTransientState(
   }
   if (quietMs < staleMs) {
     return { state, recheckAt: now + (staleMs - quietMs) };
+  }
+  // Past the window, confirm abandonment with the signal appropriate to the
+  // state. For `thinking`, `promptOrphaned` is already definitive — the prompt
+  // predates this resumed claude, which `claude -c` never auto-continues — so
+  // it settles directly. The subtree is deliberately NOT consulted here: a
+  // resumed-idle claude often holds a long-lived helper child (e.g. a
+  // persistent MCP server like `chrome-devtools-mcp`), so requiring an idle
+  // subtree would wrongly keep the phantom spinning forever (observed on a live
+  // session). For `tool_use` the subtree IS the discriminator — a live tool
+  // keeps a child — so a busy subtree means real work; re-probe after another
+  // window in case it ends silently.
+  if (state === "thinking") {
+    return { state: "waiting", recheckAt: null };
   }
   if (probes.subtreeIdle()) {
     return { state: "waiting", recheckAt: null };

--- a/packages/integrations/claude-code/src/index.test.ts
+++ b/packages/integrations/claude-code/src/index.test.ts
@@ -104,6 +104,7 @@ describe("deriveState", () => {
       state: expected,
       model: "claude-opus-4-6",
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -123,6 +124,7 @@ describe("deriveState", () => {
       state: "awaiting_user",
       model: "claude-opus-4-7",
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -174,6 +176,7 @@ describe("deriveState", () => {
       state: "thinking",
       model: "claude-opus-4-6",
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -183,6 +186,7 @@ describe("deriveState", () => {
       state: "thinking",
       model: null,
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -204,6 +208,7 @@ describe("deriveState", () => {
       state: "waiting",
       model: null,
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -261,6 +266,7 @@ describe("deriveState", () => {
       state: "waiting",
       model: "claude-opus-4-6",
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -271,6 +277,7 @@ describe("deriveState", () => {
       state: "thinking",
       model: null,
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -292,6 +299,7 @@ describe("deriveState", () => {
       state: "waiting",
       model: "claude-opus-4-7",
       contextTokens: 29479,
+      timestampMs: null,
     });
   });
 
@@ -317,6 +325,7 @@ describe("deriveState", () => {
       state: "thinking",
       model: null,
       contextTokens: 29_105,
+      timestampMs: null,
     });
   });
 
@@ -338,6 +347,7 @@ describe("deriveState", () => {
       state: "waiting",
       model: "claude-opus-4-7",
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -353,6 +363,7 @@ describe("deriveState", () => {
       state: "thinking",
       model: "claude-opus-4-7",
       contextTokens: 27871,
+      timestampMs: null,
     });
   });
 
@@ -365,6 +376,7 @@ describe("deriveState", () => {
       state: "waiting",
       model: "claude-opus-4-6",
       contextTokens: null,
+      timestampMs: null,
     });
   });
 
@@ -381,6 +393,7 @@ describe("deriveState", () => {
       state: "waiting",
       model: null,
       contextTokens: null,
+      timestampMs: null,
     });
   });
 

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -23,6 +23,7 @@ import {
   findTranscriptPath,
   isClaudeSubtreeIdle,
   liveOutstandingTasks,
+  newestEntryTimestampMs,
   nextWorkflowStaleDeadline,
   outstandingBackgroundTasks,
   PROJECTS_DIR,
@@ -265,6 +266,19 @@ export function createSessionWatcher(
     }
   }
 
+  /** Whether the trailing prompt belongs to a killed instance the current
+   *  (resumed) claude never processed: its timestamp predates the session's
+   *  `startedAt`. False when either timestamp is unknown — so a live turn, or a
+   *  session file without `startedAt`, is never treated as orphaned. */
+  function isTrailingPromptOrphaned(
+    lines: string[],
+    startedAt: number | undefined,
+  ): boolean {
+    if (startedAt === undefined) return false;
+    const promptMs = newestEntryTimestampMs(lines);
+    return promptMs !== null && promptMs < startedAt;
+  }
+
   function onTranscriptMaybeChanged() {
     if (destroyed) return;
     if (transcriptWatching.kind !== "watching") return;
@@ -296,11 +310,13 @@ export function createSessionWatcher(
     //     stale; the deadline tracks the soonest live-journal stale time.
     //   - dangling tool_use (#1017): demote to `waiting` once the transcript is
     //     quiet past the window AND claude's subtree is idle (no descendant
-    //     process). A genuine long tool keeps a child, so it is never wrongly
-    //     cleared; the probe runs only past the window. `thinking` is left
-    //     untouched — a turn awaiting the model's first token also has no
-    //     descendant and writes nothing, so that signal can't distinguish a
-    //     slow model request from abandonment (see decayTransientState).
+    //     process). A genuine long tool keeps a child, so it is never cleared.
+    //   - thinking (#1017): a trailing `user` prompt is childless and quiet
+    //     whether the turn is live or abandoned, so demote only when the prompt
+    //     is ORPHANED — it predates this claude's `startedAt`, i.e. it belongs
+    //     to a killed instance and the current (resumed) claude never processed
+    //     it. A live turn's prompt postdates `startedAt`, so it is never cleared.
+    //     The subtree-idle probe (only past the window) is a second confirm.
     let publishedState = derived.state;
     let staleDeadline: number | null = null;
     if (derived.state === "running_background") {
@@ -312,7 +328,10 @@ export function createSessionWatcher(
         const decayed = decayTransientState(
           derived.state,
           quietMs,
-          () => isClaudeSubtreeIdle(session.pid),
+          {
+            subtreeIdle: () => isClaudeSubtreeIdle(session.pid),
+            promptOrphaned: isTrailingPromptOrphaned(lines, session.startedAt),
+          },
           undefined,
           now,
         );

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -23,7 +23,6 @@ import {
   findTranscriptPath,
   isClaudeSubtreeIdle,
   liveOutstandingTasks,
-  newestEntryTimestampMs,
   nextWorkflowStaleDeadline,
   outstandingBackgroundTasks,
   PROJECTS_DIR,
@@ -268,14 +267,15 @@ export function createSessionWatcher(
 
   /** Whether the trailing prompt belongs to a killed instance the current
    *  (resumed) claude never processed: its timestamp predates the session's
-   *  `startedAt`. False when either timestamp is unknown — so a live turn, or a
-   *  session file without `startedAt`, is never treated as orphaned. */
+   *  `startedAt`. `promptMs` is the timestamp `deriveState` read for state, so
+   *  the age check and the state share one walk. False when either timestamp is
+   *  unknown — so a live turn, or a session file without `startedAt`, is never
+   *  treated as orphaned. */
   function isTrailingPromptOrphaned(
-    lines: string[],
+    promptMs: number | null,
     startedAt: number | undefined,
   ): boolean {
     if (startedAt === undefined) return false;
-    const promptMs = newestEntryTimestampMs(lines);
     return promptMs !== null && promptMs < startedAt;
   }
 
@@ -330,7 +330,10 @@ export function createSessionWatcher(
           quietMs,
           {
             subtreeIdle: () => isClaudeSubtreeIdle(session.pid),
-            promptOrphaned: isTrailingPromptOrphaned(lines, session.startedAt),
+            promptOrphaned: isTrailingPromptOrphaned(
+              derived.timestampMs,
+              session.startedAt,
+            ),
           },
           undefined,
           now,

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -316,7 +316,9 @@ export function createSessionWatcher(
     //     is ORPHANED — it predates this claude's `startedAt`, i.e. it belongs
     //     to a killed instance and the current (resumed) claude never processed
     //     it. A live turn's prompt postdates `startedAt`, so it is never cleared.
-    //     The subtree-idle probe (only past the window) is a second confirm.
+    //     The subtree is NOT consulted here (unlike tool_use): a resumed-idle
+    //     claude often holds a long-lived MCP/helper child, which would wrongly
+    //     read as "busy" — orphaned + stale is already definitive.
     let publishedState = derived.state;
     let staleDeadline: number | null = null;
     if (derived.state === "running_background") {

--- a/packages/integrations/claude-code/src/transient-decay.test.ts
+++ b/packages/integrations/claude-code/src/transient-decay.test.ts
@@ -91,14 +91,18 @@ describe("decayTransientState (#1017 phantom transient pill)", () => {
     ).toEqual({ state: "tool_use", recheckAt: now + TRANSIENT_STALE_MS });
   });
 
-  it("settles an ORPHANED `thinking` pill to `waiting` once stale and the subtree is idle", () => {
+  it("settles an ORPHANED `thinking` pill to `waiting` past the window WITHOUT probing the subtree", () => {
     // The reproduced case: a trailing `user` prompt from a killed instance, the
     // current claude resumed idle (prompt predates startedAt → promptOrphaned).
+    // `orphaned + stale` is definitive, so the subtree is never consulted
+    // (`neverProbed`) — that's what makes the decay immune to a long-lived MCP/
+    // helper child. (On zest, the `append` session held a `chrome-devtools-mcp`
+    // child; requiring an idle subtree wrongly kept its phantom spinning.)
     expect(
       decayTransientState(
         "thinking",
         TRANSIENT_STALE_MS + 1_000,
-        probes(idle, true),
+        probes(neverProbed, true),
         undefined,
         now,
       ),
@@ -129,18 +133,6 @@ describe("decayTransientState (#1017 phantom transient pill)", () => {
         now,
       ),
     ).toEqual({ state: "thinking", recheckAt: now + 30_000 });
-  });
-
-  it("keeps an orphaned `thinking` whose subtree is still busy (resumed claude actively working)", () => {
-    expect(
-      decayTransientState(
-        "thinking",
-        TRANSIENT_STALE_MS,
-        probes(busy, true),
-        undefined,
-        now,
-      ),
-    ).toEqual({ state: "thinking", recheckAt: now + TRANSIENT_STALE_MS });
   });
 
   it.each([

--- a/packages/integrations/claude-code/src/transient-decay.test.ts
+++ b/packages/integrations/claude-code/src/transient-decay.test.ts
@@ -2,8 +2,8 @@ import { spawn } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   decayTransientState,
+  deriveState,
   hasNoDescendants,
-  newestEntryTimestampMs,
   snapshotProcessTree,
   TRANSIENT_STALE_MS,
 } from "./core.ts";
@@ -162,30 +162,28 @@ describe("decayTransientState (#1017 phantom transient pill)", () => {
   });
 });
 
-describe("newestEntryTimestampMs", () => {
+describe("deriveState timestampMs (the entry the state derives from)", () => {
   const entry = (type: string, ts?: string, extra: object = {}) =>
     JSON.stringify({ type, ...(ts ? { timestamp: ts } : {}), ...extra });
 
-  it("returns the epoch-ms timestamp of the newest user/assistant entry", () => {
+  it("is the epoch-ms timestamp of the newest user/assistant entry", () => {
     const lines = [
       entry("assistant", "2026-06-02T11:33:48.779Z"),
       entry("user", "2026-06-02T11:35:49.791Z"),
       entry("permission-mode"), // metadata after the prompt — skipped
       entry("ai-title"),
     ];
-    expect(newestEntryTimestampMs(lines)).toBe(
+    expect(deriveState(lines)?.timestampMs).toBe(
       Date.parse("2026-06-02T11:35:49.791Z"),
     );
   });
 
-  it("returns null when no user/assistant entry exists", () => {
-    expect(
-      newestEntryTimestampMs([entry("permission-mode"), entry("mode")]),
-    ).toBeNull();
+  it("deriveState returns null when no user/assistant entry exists", () => {
+    expect(deriveState([entry("permission-mode"), entry("mode")])).toBeNull();
   });
 
-  it("returns null when the newest entry lacks a parseable timestamp", () => {
-    expect(newestEntryTimestampMs([entry("user")])).toBeNull();
+  it("is null when the newest entry lacks a parseable timestamp", () => {
+    expect(deriveState([entry("user")])?.timestampMs).toBeNull();
   });
 });
 

--- a/packages/integrations/claude-code/src/transient-decay.test.ts
+++ b/packages/integrations/claude-code/src/transient-decay.test.ts
@@ -3,26 +3,26 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   decayTransientState,
   hasNoDescendants,
+  newestEntryTimestampMs,
   snapshotProcessTree,
   TRANSIENT_STALE_MS,
 } from "./core.ts";
 
 // --- The phantom transient pill (#1017) ---
 //
-// A dangling `tool_use` (an assistant tool call with no following tool_result)
-// keeps `deriveState` reporting a *working* state with no decay. Correct while
-// the tool runs; wrong once the session is abandoned (most reliably: claude
-// killed mid-tool, then resumed idle by session-restore). The dock spins
-// forever. `deriveState` can't tell a live tool from an abandoned one from a
-// single transcript snapshot, so de-escalation needs two out-of-band signals:
-// the transcript has gone quiet past a window AND claude's process subtree is
-// idle (no descendant process — a genuine tool keeps a child).
-// `decayTransientState` is the pure policy that composes them.
-//
-// `thinking` is deliberately NOT decayed on this signal: a turn awaiting the
-// model's first token has no descendant and writes nothing, so "quiet + no
-// descendants" can't distinguish a slow/hung model request (live) from
-// abandonment, and clearing it would publish `waiting` over a live turn.
+// A trailing transient state keeps `deriveState` reporting a *working* state
+// with no decay once the session is abandoned (most reliably: claude killed
+// mid-turn, then resumed idle by session-restore). The dock spins forever. Two
+// trailing shapes hit it, each disambiguated by its own out-of-band signal once
+// the transcript has gone quiet past a window:
+//   - dangling `tool_use`: a live tool keeps a descendant process; an abandoned
+//     one has none — so "subtree idle (no descendant)" tells them apart.
+//   - `thinking` (trailing `user` prompt): childless and quiet whether live or
+//     abandoned, so the discriminator is the prompt's age — an ORPHANED prompt
+//     (predating this resumed claude's `startedAt`) belongs to a killed instance
+//     the current claude never processed. A live turn's prompt postdates
+//     `startedAt`, so it is never cleared.
+// `decayTransientState` is the pure policy that composes these.
 
 describe("decayTransientState (#1017 phantom transient pill)", () => {
   const idle = () => true;
@@ -38,6 +38,16 @@ describe("decayTransientState (#1017 phantom transient pill)", () => {
       "subtree probe must not run before the quiet window elapses",
     );
   };
+  /** Probe bundle: `tool_use` reads `subtreeIdle`; `thinking` also reads
+   *  `promptOrphaned`. Default `promptOrphaned: false` (the safe live-turn
+   *  case); tests that exercise the orphaned path set it true. */
+  const probes = (
+    subtreeIdle: () => boolean,
+    promptOrphaned = false,
+  ): { subtreeIdle: () => boolean; promptOrphaned: boolean } => ({
+    subtreeIdle,
+    promptOrphaned,
+  });
 
   it("settles a dangling `tool_use` pill to `waiting` once stale and the subtree is idle", () => {
     // The reproduced case: claude killed mid-Bash, resumed idle — a dangling
@@ -46,7 +56,7 @@ describe("decayTransientState (#1017 phantom transient pill)", () => {
       decayTransientState(
         "tool_use",
         TRANSIENT_STALE_MS + 1_000,
-        idle,
+        probes(idle),
         undefined,
         now,
       ),
@@ -55,14 +65,12 @@ describe("decayTransientState (#1017 phantom transient pill)", () => {
 
   it("keeps a dangling `tool_use` and schedules a recheck before the window elapses", () => {
     // Not yet stale: never probe the subtree, but arm a one-shot recheck at the
-    // absolute moment the window *would* elapse — `now + (staleMs - quietMs)`
-    // off the caller's single clock sample (a quiet transcript fires no fs
-    // event).
+    // absolute moment the window *would* elapse — `now + (staleMs - quietMs)`.
     expect(
       decayTransientState(
         "tool_use",
         TRANSIENT_STALE_MS - 30_000,
-        neverProbed,
+        probes(neverProbed),
         undefined,
         now,
       ),
@@ -73,33 +81,111 @@ describe("decayTransientState (#1017 phantom transient pill)", () => {
     // Stale transcript but claude still has a descendant (a long Bash / a
     // sub-agent) → real work; never cleared. Re-probe a full window from now.
     expect(
-      decayTransientState("tool_use", TRANSIENT_STALE_MS, busy, undefined, now),
-    ).toEqual({
-      state: "tool_use",
-      recheckAt: now + TRANSIENT_STALE_MS,
-    });
+      decayTransientState(
+        "tool_use",
+        TRANSIENT_STALE_MS,
+        probes(busy),
+        undefined,
+        now,
+      ),
+    ).toEqual({ state: "tool_use", recheckAt: now + TRANSIENT_STALE_MS });
+  });
+
+  it("settles an ORPHANED `thinking` pill to `waiting` once stale and the subtree is idle", () => {
+    // The reproduced case: a trailing `user` prompt from a killed instance, the
+    // current claude resumed idle (prompt predates startedAt → promptOrphaned).
+    expect(
+      decayTransientState(
+        "thinking",
+        TRANSIENT_STALE_MS + 1_000,
+        probes(idle, true),
+        undefined,
+        now,
+      ),
+    ).toEqual({ state: "waiting", recheckAt: null });
+  });
+
+  it("keeps a LIVE `thinking` turn (prompt not orphaned) — never probes, never decays", () => {
+    // A live turn's prompt postdates startedAt → not orphaned. Even long past
+    // the window, it is left alone and the subtree probe is never spawned.
+    expect(
+      decayTransientState(
+        "thinking",
+        TRANSIENT_STALE_MS * 10,
+        probes(neverProbed, false),
+        undefined,
+        now,
+      ),
+    ).toEqual({ state: "thinking", recheckAt: null });
+  });
+
+  it("keeps an orphaned `thinking` and schedules a recheck before the window elapses", () => {
+    expect(
+      decayTransientState(
+        "thinking",
+        TRANSIENT_STALE_MS - 30_000,
+        probes(neverProbed, true),
+        undefined,
+        now,
+      ),
+    ).toEqual({ state: "thinking", recheckAt: now + 30_000 });
+  });
+
+  it("keeps an orphaned `thinking` whose subtree is still busy (resumed claude actively working)", () => {
+    expect(
+      decayTransientState(
+        "thinking",
+        TRANSIENT_STALE_MS,
+        probes(busy, true),
+        undefined,
+        now,
+      ),
+    ).toEqual({ state: "thinking", recheckAt: now + TRANSIENT_STALE_MS });
   });
 
   it.each([
     "waiting",
     "awaiting_user",
     "running_background",
-    "thinking",
-  ] as const)("never decays the non-`tool_use` state `%s`", (state) => {
-    // `thinking` is excluded by design (a slow model request has no
-    // descendant and a quiet transcript — indistinguishable from abandonment
-    // by this probe, so clearing it could mask a live turn).
+  ] as const)("never decays the non-transient state `%s`", (state) => {
     // running_background has its own decay path (#1109); waiting/awaiting_user
     // are settled / a genuine human gate. None should ever probe the subtree.
     expect(
       decayTransientState(
         state,
         TRANSIENT_STALE_MS * 10,
-        neverProbed,
+        probes(neverProbed, true),
         undefined,
         now,
       ),
     ).toEqual({ state, recheckAt: null });
+  });
+});
+
+describe("newestEntryTimestampMs", () => {
+  const entry = (type: string, ts?: string, extra: object = {}) =>
+    JSON.stringify({ type, ...(ts ? { timestamp: ts } : {}), ...extra });
+
+  it("returns the epoch-ms timestamp of the newest user/assistant entry", () => {
+    const lines = [
+      entry("assistant", "2026-06-02T11:33:48.779Z"),
+      entry("user", "2026-06-02T11:35:49.791Z"),
+      entry("permission-mode"), // metadata after the prompt — skipped
+      entry("ai-title"),
+    ];
+    expect(newestEntryTimestampMs(lines)).toBe(
+      Date.parse("2026-06-02T11:35:49.791Z"),
+    );
+  });
+
+  it("returns null when no user/assistant entry exists", () => {
+    expect(
+      newestEntryTimestampMs([entry("permission-mode"), entry("mode")]),
+    ).toBeNull();
+  });
+
+  it("returns null when the newest entry lacks a parseable timestamp", () => {
+    expect(newestEntryTimestampMs([entry("user")])).toBeNull();
   });
 });
 


### PR DESCRIPTION
**Spike to deploy on zest and confirm against the live `~/code/nixos-config` phantom.** The merged #1017 fix decays only a dangling `tool_use`; a trailing **`thinking`** (newest transcript entry is a `user` prompt) still spins the dock pill forever once the session is abandoned and resumed idle. That's the variant stuck on zest right now.

### Why `thinking` needed a different signal

A dangling `tool_use` is distinguishable because a *live* tool keeps a descendant process. A `thinking` turn is **childless and quiet whether live or abandoned** (awaiting the model's first token vs. resumed-idle), so the subtree probe alone can't tell them apart — which is why the earlier review deferred it.

The discriminator that *does* work: **prompt age vs. process age.**

| | trailing prompt timestamp vs. `startedAt` | verdict |
| --- | --- | --- |
| **Live turn** | prompt **postdates** `startedAt` (this claude received it) | keep — never cleared |
| **Resumed-idle phantom** | prompt **predates** `startedAt` (belongs to a killed instance; `claude -c` wrote a fresh `startedAt`) | decay to idle |

So `thinking` decays to `waiting` only when the prompt is **orphaned** *and* the transcript is stale past the window *and* the subtree is idle (a second confirm). `readSessionFile` now parses `startedAt`; `newestEntryTimestampMs` reads the trailing prompt's timestamp.

This is exactly the zest case: the nixos-config prompt (`11:35:49Z`) predates its resumed claude's `startedAt` (`11:35:57`), so it's orphaned → clears on deploy.

### Deploy & verify on zest

```sh
nix run github:juspay/kolu/fix/stale-thinking-pill-1017b -- --host <addr> --port <port>
```

(or your usual zest deploy pointed at this branch). Leave the `~/code/nixos-config` session untouched — on attach the watcher re-derives, sees the orphaned stale prompt with an idle subtree, and the pill should drop from spinning to **idle ☾** within the stale window (immediately, since that transcript is already long-stale).

> Spike — unit tests pass (131) and typecheck is clean, but the full review gauntlet + evidence run comes **after** you confirm it clears the real phantom.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._