### PR TITLE
Fix /lens-debate launch: hoist meta to first statement, inline model literal

### DIFF
--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -1,19 +1,25 @@
-// The model every lens/agent runs on. SKILL.md flags this as load-bearing
-// (lenses run on Opus, overriding their `model: sonnet` frontmatter) and model
-// migrations are a recurring change — keep it to one socket. `meta` is evaluated
-// before inputs, so this lives module-level; the `model` input below defaults to it.
-const MODEL = 'opus'
-
+// The Workflow runtime requires `export const meta` to be the FIRST statement
+// and a PURE LITERAL (no variable interpolation), so the model is inlined as
+// 'opus' in each phase below. The single `const MODEL` socket lives just after
+// meta — every other model reference in this script reads it lazily at
+// input-resolution time, well after meta is evaluated.
 export const meta = {
   name: 'lens-debate',
   description:
     'lowy + hickey review a diff independently in parallel, then debate every finding to consensus; apply the agreed fixes',
   phases: [
-    { title: 'Review', detail: 'lowy and hickey (and optionally code-police) review the diff independently, in parallel', model: MODEL },
-    { title: 'Debate', detail: 'lowy and hickey cross-examine every finding until they agree per-finding', model: MODEL },
-    { title: 'Apply', detail: 'implement each agreed fix as its own commit', model: MODEL },
+    { title: 'Review', detail: 'lowy and hickey (and optionally code-police) review the diff independently, in parallel', model: 'opus' },
+    { title: 'Debate', detail: 'lowy and hickey cross-examine every finding until they agree per-finding', model: 'opus' },
+    { title: 'Apply', detail: 'implement each agreed fix as its own commit', model: 'opus' },
   ],
 }
+
+// The model every lens/agent runs on. SKILL.md flags this as load-bearing
+// (lenses run on Opus, overriding their `model: sonnet` frontmatter) and model
+// migrations are a recurring change — keep it to one socket. Inlined into the
+// phase entries above (meta must be a pure literal); the `model` input below
+// defaults to it.
+const MODEL = 'opus'
 
 // ---------------------------------------------------------------------------
 // Inputs (passed via the Workflow tool's `args`)

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -1,19 +1,25 @@
-// The model every lens/agent runs on. SKILL.md flags this as load-bearing
-// (lenses run on Opus, overriding their `model: sonnet` frontmatter) and model
-// migrations are a recurring change — keep it to one socket. `meta` is evaluated
-// before inputs, so this lives module-level; the `model` input below defaults to it.
-const MODEL = 'opus'
-
+// The Workflow runtime requires `export const meta` to be the FIRST statement
+// and a PURE LITERAL (no variable interpolation), so the model is inlined as
+// 'opus' in each phase below. The single `const MODEL` socket lives just after
+// meta — every other model reference in this script reads it lazily at
+// input-resolution time, well after meta is evaluated.
 export const meta = {
   name: 'lens-debate',
   description:
     'lowy + hickey review a diff independently in parallel, then debate every finding to consensus; apply the agreed fixes',
   phases: [
-    { title: 'Review', detail: 'lowy and hickey (and optionally code-police) review the diff independently, in parallel', model: MODEL },
-    { title: 'Debate', detail: 'lowy and hickey cross-examine every finding until they agree per-finding', model: MODEL },
-    { title: 'Apply', detail: 'implement each agreed fix as its own commit', model: MODEL },
+    { title: 'Review', detail: 'lowy and hickey (and optionally code-police) review the diff independently, in parallel', model: 'opus' },
+    { title: 'Debate', detail: 'lowy and hickey cross-examine every finding until they agree per-finding', model: 'opus' },
+    { title: 'Apply', detail: 'implement each agreed fix as its own commit', model: 'opus' },
   ],
 }
+
+// The model every lens/agent runs on. SKILL.md flags this as load-bearing
+// (lenses run on Opus, overriding their `model: sonnet` frontmatter) and model
+// migrations are a recurring change — keep it to one socket. Inlined into the
+// phase entries above (meta must be a pure literal); the `model` input below
+// defaults to it.
+const MODEL = 'opus'
 
 // ---------------------------------------------------------------------------
 // Inputs (passed via the Workflow tool's `args`)

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -1,19 +1,25 @@
-// The model every lens/agent runs on. SKILL.md flags this as load-bearing
-// (lenses run on Opus, overriding their `model: sonnet` frontmatter) and model
-// migrations are a recurring change — keep it to one socket. `meta` is evaluated
-// before inputs, so this lives module-level; the `model` input below defaults to it.
-const MODEL = 'opus'
-
+// The Workflow runtime requires `export const meta` to be the FIRST statement
+// and a PURE LITERAL (no variable interpolation), so the model is inlined as
+// 'opus' in each phase below. The single `const MODEL` socket lives just after
+// meta — every other model reference in this script reads it lazily at
+// input-resolution time, well after meta is evaluated.
 export const meta = {
   name: 'lens-debate',
   description:
     'lowy + hickey review a diff independently in parallel, then debate every finding to consensus; apply the agreed fixes',
   phases: [
-    { title: 'Review', detail: 'lowy and hickey (and optionally code-police) review the diff independently, in parallel', model: MODEL },
-    { title: 'Debate', detail: 'lowy and hickey cross-examine every finding until they agree per-finding', model: MODEL },
-    { title: 'Apply', detail: 'implement each agreed fix as its own commit', model: MODEL },
+    { title: 'Review', detail: 'lowy and hickey (and optionally code-police) review the diff independently, in parallel', model: 'opus' },
+    { title: 'Debate', detail: 'lowy and hickey cross-examine every finding until they agree per-finding', model: 'opus' },
+    { title: 'Apply', detail: 'implement each agreed fix as its own commit', model: 'opus' },
   ],
 }
+
+// The model every lens/agent runs on. SKILL.md flags this as load-bearing
+// (lenses run on Opus, overriding their `model: sonnet` frontmatter) and model
+// migrations are a recurring change — keep it to one socket. Inlined into the
+// phase entries above (meta must be a pure literal); the `model` input below
+// defaults to it.
+const MODEL = 'opus'
 
 // ---------------------------------------------------------------------------
 // Inputs (passed via the Workflow tool's `args`)


### PR DESCRIPTION
**`/lens-debate` aborted at launch** — and with it the structural step of `/be` — because its workflow script violated two rules the current `Workflow` runtime enforces: `export const meta` must be the *first* statement, and `meta` must be a *pure literal*. The script opened with `const MODEL = 'opus'` and then interpolated `model: MODEL` into each phase entry, tripping:

```
Invalid workflow script: `export const meta = {...}` must be the FIRST statement in the script
```

No lowy/hickey review, no PR comment — the whole gauntlet step was dead. `/codex-debate` was unaffected because its `meta` is already a literal-first block; that's the shape lens-debate now matches.

### The fix

Hoist `meta` to the top with `'opus'` inlined in all three phases, and move the single `const MODEL` socket *just after* it — the rest of the script reads `MODEL` lazily at input-resolution time, well after `meta` is evaluated.

```js
export const meta = {
  name: 'lens-debate',
  phases: [
    { title: 'Review', detail: '…', model: 'opus' },
    { title: 'Debate', detail: '…', model: 'opus' },
    { title: 'Apply',  detail: '…', model: 'opus' },
  ],
}

const MODEL = 'opus'   // one socket, now after meta
```

_The "one socket for the model" intent is preserved — `MODEL` is still defined exactly once, and the `model` input still defaults to it. The only real change is ordering plus dropping interpolation from `meta`._ The stale "`meta` is evaluated before inputs, so this lives module-level" comment is updated to reflect the stricter contract.

Edited in the `.apm/` source and regenerated via `just ai::apm`, so the `.claude/` and `.agents/` copies stay in sync.

Closes #1120

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._