### PR TITLE
docs: reposition launch messaging to "the best terminal app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # kolu
 
-Your terminals are the workspace. Real `xterm.js` tiles on an infinite 2D canvas, for `claude`, `codex`, `opencode` — anything you run in a shell.
+kolu is a terminal app built for scale: real `xterm.js` tiles on an infinite 2D canvas, with a dock that never loses one — for `claude`, `codex`, `opencode`, or anything you run in a shell, especially many at once.
 
 Unlike agent command centers that wrap a single model behind their own chat UI, kolu stays out of the agent's way: the terminal is the universal interface, so `claude`, `opencode`, or whatever ships next week works out of the box — and you can drop to a plain shell whenever you want. Kolu treats terminals as the thesis, not the substrate.
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -131,13 +131,13 @@ const features = [
       <div class="reveal reveal-1 flex flex-col justify-center">
         <p class="eyebrow flex items-center gap-2">
           <span class="text-amber-dim">$</span>
-          <span>kolu — terminals as the thesis</span>
+          <span>kolu — the terminal, done right</span>
         </p>
 
         <h1
           class="display reveal reveal-2 mt-5 text-[3rem] sm:text-[3.6rem] md:text-[4.4rem]"
         >
-          Your <span class="text-amber">terminals</span><br />are the workspace.<span
+          The terminal<br />built for <span class="text-amber">many</span>.<span
             class="cursor"
             aria-hidden="true"></span>
         </h1>
@@ -145,17 +145,17 @@ const features = [
         <p
           class="reveal reveal-3 mt-6 mono text-[0.78rem] text-ink-muted leading-relaxed"
         >
-          Not a chat-UI wrapper.<br />Not an editor fork.
+          Not a chat-UI wrapper.<br />Not an editor fork.<br />A real terminal — just better at scale.
         </p>
 
         <p
           class="reveal reveal-3 mt-6 max-w-xl text-lg leading-relaxed text-ink-dim"
         >
+          Real <span class="mono text-ink">xterm.js</span> tiles on an infinite 2D
+          canvas, with a dock that surfaces every terminal's live state at a glance.
           <span class="mono text-ink">claude</span>, <span class="mono text-ink">codex</span>, <span
             class="mono text-ink">opencode</span
-          > — anything you can run in a shell, runs in kolu. Real <span class="mono text-ink">xterm.js</span>
-          tiles on an infinite 2D canvas, with a dock that surfaces every agent's
-          live state at a glance.
+          > — anything you can run in a shell, runs in kolu.
         </p>
 
         <div class="reveal reveal-4 mt-8 flex flex-wrap items-center gap-3">
@@ -446,8 +446,8 @@ const features = [
           </div>
           <div class="ckv2-source">
             <div class="ckv2-source-line"><span class="ckv2-lineno">137</span><span class="ckv2-tok-keyword">&lt;h1</span> <span class="ckv2-tok-attr">class</span>=<span class="ckv2-tok-str">"display"</span><span class="ckv2-tok-keyword">&gt;</span></div>
-            <div class="ckv2-source-line"><span class="ckv2-lineno">138</span>  Your <span class="ckv2-tok-keyword">&lt;span&gt;</span><span class="ckv2-tok-em">terminals</span><span class="ckv2-tok-keyword">&lt;/span&gt;</span></div>
-            <div class="ckv2-source-line"><span class="ckv2-lineno">139</span>  are the workspace.</div>
+            <div class="ckv2-source-line"><span class="ckv2-lineno">138</span>  The terminal built for</div>
+            <div class="ckv2-source-line"><span class="ckv2-lineno">139</span>  <span class="ckv2-tok-keyword">&lt;span&gt;</span><span class="ckv2-tok-em">many</span><span class="ckv2-tok-keyword">&lt;/span&gt;</span>.</div>
             <div class="ckv2-source-line"><span class="ckv2-lineno">140</span><span class="ckv2-tok-keyword">&lt;/h1&gt;</span></div>
             <div class="ckv2-source-line ckv2-source-empty"><span class="ckv2-lineno">141</span></div>
             <div class="ckv2-source-line"><span class="ckv2-lineno">142</span><span class="ckv2-tok-comment">{/* anti-positioning */}</span></div>

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -10,6 +10,6 @@
  */
 
 export const SITE_DESCRIPTION =
-  "Your terminals are the workspace. Real xterm.js tiles on an infinite 2D canvas — claude, codex, opencode, anything you run in a shell.";
+  "kolu is a terminal app built for scale: real xterm.js tiles on an infinite canvas, with a dock that never loses one — especially when you're running five agents at once.";
 
-export const SITE_TAGLINE = "your terminals are the workspace";
+export const SITE_TAGLINE = "the best way to run terminals";


### PR DESCRIPTION
For the first public release, the site led with **"Your terminals are the workspace."** This drops the *workspace* framing and stakes a sharper claim: **kolu is the best terminal app** — the best way to run terminals locally or remotely, and *especially* many at once. Parallel agentic work stays the sharpest edge, but it's now framed as *one* reason kolu wins the terminal category, not the whole pitch — so a developer who never touches an AI agent still reads themselves in.

Names no competitors.

## Before → after

| | before | after |
|---|---|---|
| **tagline** | your terminals are the workspace | the best way to run terminals |
| **eyebrow** | kolu — terminals as the thesis | kolu — the terminal, done right |
| **H1** | Your **terminals** are the workspace. | The terminal built for **many.** |
| **anti-line** | Not a chat-UI wrapper. Not an editor fork. | …Not an editor fork. **A real terminal — just better at scale.** |
| **description** | Your terminals are the workspace. Real xterm.js tiles… | kolu is a terminal app **built for scale**: real xterm.js tiles on an infinite canvas, with a dock that never loses one — especially when you're running five agents at once. |

## What changed

- **`website/src/site.ts`** — `SITE_TAGLINE` + `SITE_DESCRIPTION`, the single source of truth that fans out to `<title>`, meta description, OG/Twitter cards, and the OG image card.
- **`website/src/pages/index.astro`** — hero eyebrow, H1 (the accent word moves from `terminals` → `many`), anti-line, and the body paragraph reordered to lead terminal-first. The faux code-browser mock that literally quotes the old headline is updated so it doesn't contradict the new hero.
- **`README.md`** — opening sentence rewritten. Line 9's "treats terminals as the thesis, not the substrate" is **kept on purpose** — it already reads terminal-first and reinforces the new thesis.

## Honesty guardrails

- All present-tense claims ship today (xterm.js tiles, infinite 2D canvas, the live-terminal dock, per-terminal agent state). The "five agents at once" line is honest — the dock tracks per-terminal agent state now.
- Remote is deliberately left at "browser-reachable" framing (true via `--host 0.0.0.0`); native SSH and pty attach/detach stay roadmap and are **not** implied.
- "workspace" is purged only as the *positioning* emphasis — incidental feature-level uses (`Canvas workspace`, palette workspace search) are untouched.

## Process

Copy was generated by a kolu workflow — 5 positioning angles → a 3-judge adversarial panel (intent / honesty / craft) → 3 synthesized finalists. The chosen direction won the intent and honesty judges 9/9; the iTerm/Ghostty lineage clause from the original draft was removed per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)