### PR TITLE
Fix Linux terminal fd leak: bump node-pty to close inherited fds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -58,7 +58,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-etT3O4sLpavhfLbhNYfFZ8418OOVPj//N0yt1ekychQ=";
+    hash = "sha256-qAGpemq4TbjJgs6u2FaGiXl728K5zTe72+e1Xe+qI9g=";
     fetcherVersion = 3;
   };
 

--- a/packages/pty-host/package.json
+++ b/packages/pty-host/package.json
@@ -23,7 +23,7 @@
     "kolu-common": "workspace:*",
     "kolu-pty": "workspace:*",
     "kolu-shared": "workspace:*",
-    "node-pty": "github:juspay/node-pty#fix/darwin-pty-fd-leak",
+    "node-pty": "github:juspay/node-pty#feat/foreground-pid-dist",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,8 +495,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       node-pty:
-        specifier: github:juspay/node-pty#fix/darwin-pty-fd-leak
-        version: https://codeload.github.com/juspay/node-pty/tar.gz/cc137d90e39bb9e5c72ca8b9d81210e5005c5fa3
+        specifier: github:juspay/node-pty#feat/foreground-pid-dist
+        version: https://codeload.github.com/juspay/node-pty/tar.gz/999e2bdae2aeed45008bd34d8e886258f34eae8d
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -4036,8 +4036,8 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-pty@https://codeload.github.com/juspay/node-pty/tar.gz/cc137d90e39bb9e5c72ca8b9d81210e5005c5fa3:
-    resolution: {tarball: https://codeload.github.com/juspay/node-pty/tar.gz/cc137d90e39bb9e5c72ca8b9d81210e5005c5fa3}
+  node-pty@https://codeload.github.com/juspay/node-pty/tar.gz/999e2bdae2aeed45008bd34d8e886258f34eae8d:
+    resolution: {tarball: https://codeload.github.com/juspay/node-pty/tar.gz/999e2bdae2aeed45008bd34d8e886258f34eae8d}
     version: 1.1.0
 
   node-releases@2.0.37:
@@ -8272,7 +8272,7 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
-  node-pty@https://codeload.github.com/juspay/node-pty/tar.gz/cc137d90e39bb9e5c72ca8b9d81210e5005c5fa3:
+  node-pty@https://codeload.github.com/juspay/node-pty/tar.gz/999e2bdae2aeed45008bd34d8e886258f34eae8d:
     dependencies:
       node-addon-api: 7.1.1
 


### PR DESCRIPTION
**Long-lived Kolu sessions on Linux leak a `/dev/ptmx` master fd into every shell spawned after the first**, and those leaked masters ride along into each shell's children — the suspected cause of the [frozen split-terminal after a raw-mode TUI exits (#1076)](https://github.com/juspay/kolu/issues/1076), plus a steady fd leak that pressures `EMFILE` in busy sessions. The root cause was a **stale node-pty fork**: our pin (`fix/darwin-pty-fd-leak`) branched 2025-12-21 and sat **127 commits behind upstream**, predating the Linux fix for exactly this.

This repoints node-pty to a refreshed fork branch and drops a fork patch that has since landed upstream.

### What changed

| | Before (`fix/darwin-pty-fd-leak`) | After (`feat/foreground-pid-dist`) |
| --- | --- | --- |
| Base | upstream @ 2025-12-21 | upstream `main` (2026-05-18) |
| Linux fd-close fix ([`52417d516`](https://github.com/microsoft/node-pty/commit/52417d516)) | ❌ missing | ✅ included |
| `foregroundPid` accessor | ✅ (fork patch) | ✅ (same patch, now also [PR #918](https://github.com/microsoft/node-pty/pull/918)) |
| macOS `/dev/ptmx` fix (#882) | fork patch | dropped — now upstream |
| built `lib/` for git install | ✅ | ✅ |

Upstream `52417d516` closes inherited fds in the `forkpty()` child before `exec` (`close_range(2)` → `/proc/self/fd` fallback). macOS was never affected (`POSIX_SPAWN_CLOEXEC_DEFAULT`), which is why this bug is **Linux-only**.

### Verification

Measured on this branch with the rebuilt addon:

- **Leak gone:** a 2nd shell spawned after the first now reports **0** leaked `/dev/ptmx` fds (it was **1** before — confirmed in a real Kolu split sub-terminal, whose shell held `fd 29 -> /dev/ptmx`, the main terminal's master).
- **`foregroundPid` intact:** resolves to the foreground pgid (`== pid`), so `pty-host`'s spawn-time sanity check still passes — agent/Dock foreground detection unaffected.
- `just check` clean; native `pty.node` compiles under nix (`node-gyp rebuild`).

### Fork housekeeping

The upstreaming of `foregroundPid` is [microsoft/node-pty#918](https://github.com/microsoft/node-pty/pull/918) (rebased here, mergeable, awaiting maintainer review). Once it merges, the fork shrinks to just the committed-`lib/` packaging shim — and could be retired entirely if we build node-pty from source in the nix derivation.

Refs #1076.

_Generated by Claude Code (model `claude-opus-4-8`)._