### PR TITLE
Resolve symlinks in repo-root path guard (close symlink escape)

### DIFF
--- a/docs/plans/correctness-review.html
+++ b/docs/plans/correctness-review.html
@@ -142,7 +142,7 @@
 <section id="summary">
   <h2>Summary</h2>
   <div class="callout">
-    <p><strong>Verdict:</strong> I found six correctness issues worth fixing. The high-severity terminal lifecycle leak is fixed by <a href="https://github.com/juspay/kolu/pull/1105">PR #1105</a>, and the OpenCode silent-parse issue by <a href="https://github.com/juspay/kolu/pull/1108">PR #1108</a>. The remaining open set is one high-severity path-authority bug and three medium-severity issues.</p>
+    <p><strong>Verdict:</strong> I found six correctness issues worth fixing. The high-severity terminal lifecycle leak is fixed by <a href="https://github.com/juspay/kolu/pull/1105">PR #1105</a>, the OpenCode silent-parse issue by <a href="https://github.com/juspay/kolu/pull/1108">PR #1108</a>, and the high-severity path-authority symlink escape by <a href="https://github.com/juspay/kolu/pull/1128">PR #1128</a>. The remaining open set is three medium-severity issues.</p>
   </div>
 
   <table>
@@ -159,7 +159,7 @@
         <td><span class="severity high">High</span></td>
         <td>Repo-root guard is lexical only; symlinks can escape the repo for reads, previews, and local diffs.</td>
         <td><code>kolu-git</code>, iframe preview</td>
-        <td><span class="status open">Open</span></td>
+        <td><span class="status fixed">Fixed</span> <a href="https://github.com/juspay/kolu/pull/1128">#1128</a></td>
       </tr>
       <tr>
         <td><span class="severity high">High</span></td>
@@ -216,6 +216,8 @@
     <p><span class="risk">Risk:</span> the Code tab, binary preview route, and local diff fallback can read or render files outside the repository root. That is both a correctness bug and a security boundary failure for any untrusted workspace.</p>
     <p><span class="fix">Fix:</span> split lexical path normalization from filesystem authority checks. For any operation that reads, stats, or diffs an existing file, compare <code>fs.realpath</code> of the root and target before use. Reject targets whose real path is outside the real repo root. Keep the current lexical helper only for paths that may not exist yet.</p>
     <p><span class="fix">Tests:</span> add symlink-to-outside fixtures for <code>readFile</code>, preview serving, and local untracked diff. The expected result should be a rejected path, not the external file content.</p>
+    <p class="label">Status - fixed</p>
+    <p><span class="fix">Implemented</span> in <a href="https://github.com/juspay/kolu/pull/1128">PR #1128, "Resolve symlinks in repo-root path guard (close symlink escape)"</a>. The fix takes the finding's recommended split: a new <code>assertRealpathUnder</code> in <a href="../../packages/integrations/git/src/safe-path.ts">safe-path.ts</a> resolves symlinks on <em>both</em> the root and the target via <code>fs.realpath</code> and rejects any target whose real path escapes the real root (realpath'ing the root too keeps a symlinked checkout or macOS <code>/tmp -&gt; /private/tmp</code> valid). Any <code>realpath</code> failure passes through, so a missing file stays a 404/<code>ENOENT</code> instead of masquerading as an escape. <code>resolveExistingUnder</code> composes it with the lexical <code>resolveUnder</code> for the common read/stat/diff-an-existing-file case; <code>resolveUnder</code> stays the lexical-only helper for not-yet-existing paths and git pathspecs. Wired into <code>browse.ts</code> (<code>readFile</code>/<code>statFileMtimeMs</code>), <code>review.ts</code> (the local untracked <code>--no-index</code> fallback's <code>filePath</code>), and the preview route's I/O half <code>serveResolvedFile</code> (which now 403s a symlink escape while <code>resolvePreviewPath</code> stays a pure, fixture-free unit). Covered by symlink-escape unit tests in <a href="../../packages/integrations/git/src/safe-path.test.ts">safe-path.test.ts</a>, <a href="../../packages/integrations/git/src/browse.test.ts">browse.test.ts</a>, <a href="../../packages/integrations/git/src/review.test.ts">review.test.ts</a>, and <a href="../../packages/server/src/iframePreviewRoute.test.ts">iframePreviewRoute.test.ts</a> - escape rejected, inside-symlink followed, non-existent passes through, intermediate dir-symlink escape rejected, symlinked root stays valid.</p>
   </article>
 
   <article class="finding high" id="terminal-exit-subscriptions">
@@ -295,7 +297,7 @@
 <section id="triage">
   <h2>Triage order</h2>
   <ol>
-    <li><strong>Fix path authority first.</strong> It is the only issue that crosses from correctness into a direct workspace boundary violation.</li>
+    <li><strong>Path authority is fixed.</strong> <a href="https://github.com/juspay/kolu/pull/1128">PR #1128</a> split lexical normalization from <code>fs.realpath</code> authority and closed the symlink escape across reads, previews, and local diffs. It was the only issue that crossed from correctness into a direct workspace boundary violation.</li>
     <li><strong>Terminal subscription lifecycle is fixed.</strong> <a href="https://github.com/juspay/kolu/pull/1105">PR #1105</a> landed the list-keyed cleanup and regression coverage.</li>
     <li><strong>Fix channel abort cleanup before daemon work expands.</strong> It is a small primitive with a large downstream blast radius.</li>
     <li><strong>Fix sub-terminal restore and kill-confirmation behavior together with tests.</strong> Both are terminal lifecycle fidelity issues and should be covered by restore/CRUD scenarios.</li>

--- a/packages/integrations/git/src/browse.test.ts
+++ b/packages/integrations/git/src/browse.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { readFile } from "./browse.ts";
+import { readFile, statFileMtimeMs } from "./browse.ts";
 
 describe("readFile", () => {
   let tmpDir: string;
@@ -37,6 +37,61 @@ describe("readFile", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.code).toBe("GIT_FAILED");
+    }
+  });
+
+  it("rejects a symlink that escapes the repo root", async () => {
+    const outside = fs.mkdtempSync(
+      path.join(os.tmpdir(), "kolu-readfile-outside-"),
+    );
+    try {
+      const secret = path.join(outside, "secret.txt");
+      fs.writeFileSync(secret, "TOP SECRET\n");
+      fs.symlinkSync(secret, path.join(tmpDir, "leak.txt"));
+      const result = await readFile(tmpDir, "leak.txt");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("follows a symlink that stays inside the repo", async () => {
+    fs.writeFileSync(path.join(tmpDir, "target.txt"), "inside\n");
+    fs.symlinkSync(
+      path.join(tmpDir, "target.txt"),
+      path.join(tmpDir, "alias.txt"),
+    );
+    const result = await readFile(tmpDir, "alias.txt");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.content).toBe("inside\n");
+  });
+});
+
+describe("statFileMtimeMs", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-statmtime-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects a symlink that escapes the repo root", async () => {
+    const outside = fs.mkdtempSync(
+      path.join(os.tmpdir(), "kolu-statmtime-outside-"),
+    );
+    try {
+      const secret = path.join(outside, "secret.txt");
+      fs.writeFileSync(secret, "TOP SECRET\n");
+      fs.symlinkSync(secret, path.join(tmpDir, "leak.txt"));
+      const result = await statFileMtimeMs(tmpDir, "leak.txt");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
     }
   });
 });

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -9,7 +9,7 @@ import { readFile as fsReadFile, stat as fsStat } from "node:fs/promises";
 import { promisify } from "node:util";
 import type { Logger } from "kolu-shared";
 import { err, type GitResult, ok } from "./errors.ts";
-import { resolveUnder } from "./safe-path.ts";
+import { resolveExistingUnder } from "./safe-path.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -51,7 +51,7 @@ export async function readFile(
   filePath: string,
   log?: Logger,
 ): Promise<GitResult<{ content: string; truncated: boolean }>> {
-  const resolved = resolveUnder(repoPath, filePath, log);
+  const resolved = await resolveExistingUnder(repoPath, filePath, log);
   if (!resolved.ok)
     return resolved as GitResult<{ content: string; truncated: boolean }>;
 
@@ -79,7 +79,7 @@ export async function statFileMtimeMs(
   filePath: string,
   log?: Logger,
 ): Promise<GitResult<number>> {
-  const resolved = resolveUnder(repoPath, filePath, log);
+  const resolved = await resolveExistingUnder(repoPath, filePath, log);
   if (!resolved.ok) return resolved as GitResult<number>;
   try {
     const s = await fsStat(resolved.value.abs);

--- a/packages/integrations/git/src/index.ts
+++ b/packages/integrations/git/src/index.ts
@@ -35,7 +35,11 @@ export {
 // Diff review
 export { getDiff, getStatus, parseNameStatus } from "./review.ts";
 // Path security
-export { resolveUnder } from "./safe-path.ts";
+export {
+  assertRealpathUnder,
+  resolveExistingUnder,
+  resolveUnder,
+} from "./safe-path.ts";
 // File-preview classification used to live here; it moved to the node-free
 // `kolu-common/preview` (a preview concern shared by client + server, not a
 // git operation). The `FsReadFileOutput` schema it feeds stays below.

--- a/packages/integrations/git/src/review.test.ts
+++ b/packages/integrations/git/src/review.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getDiff } from "./review.ts";
+
+describe("getDiff path authority", () => {
+  let repo: string;
+  let outside: string;
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-review-repo-"));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-review-outside-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("rejects a repo-local symlink escaping the root before the --no-index fallback reads it", async () => {
+    // The local-untracked branch diffs `/dev/null` against the resolved
+    // absolute path; a `leak.txt -> /outside/secret.txt` symlink would
+    // surface the external file's content verbatim without the realpath guard.
+    const secret = path.join(outside, "secret.txt");
+    fs.writeFileSync(secret, "TOP SECRET\n");
+    fs.symlinkSync(secret, path.join(repo, "leak.txt"));
+
+    const result = await getDiff(repo, "leak.txt", "local");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+
+  it("still rejects lexical traversal", async () => {
+    const result = await getDiff(repo, "../../etc/passwd", "local");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+});

--- a/packages/integrations/git/src/review.test.ts
+++ b/packages/integrations/git/src/review.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { simpleGit } from "simple-git";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getDiff } from "./review.ts";
 
@@ -35,5 +36,33 @@ describe("getDiff path authority", () => {
     const result = await getDiff(repo, "../../etc/passwd", "local");
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+
+  it("renders a tracked symlink pointing outside the repo (pathspec, never read off disk)", async () => {
+    // A *tracked* symlink to an outside target is diffed via `git diff HEAD --
+    // <rel>`, where `rel` is a pathspec git resolves against the tree — it
+    // never dereferences the working-tree link. The realpath guard must stay
+    // scoped to the untracked `--no-index` fallback so this case keeps
+    // rendering regardless of whether the target exists on the host.
+    const secret = path.join(outside, "secret.txt");
+    fs.writeFileSync(secret, "TOP SECRET\n");
+
+    const git = simpleGit(repo);
+    await git.init();
+    await git.addConfig("user.email", "test@example.com");
+    await git.addConfig("user.name", "Test");
+    await git.checkoutLocalBranch("main");
+    // Commit the symlink, then retarget it in the working tree so the tracked
+    // `git diff HEAD -- <rel>` path produces a real (non-empty) diff.
+    fs.symlinkSync(secret, path.join(repo, "link"));
+    await git.add("link");
+    await git.commit("add link");
+    fs.rmSync(path.join(repo, "link"));
+    fs.symlinkSync(path.join(outside, "other.txt"), path.join(repo, "link"));
+
+    const result = await getDiff(repo, "link", "local");
+    // The only requirement is that the symlink-resolving guard does NOT reject
+    // this tracked diff based on the host filesystem.
+    expect(result.ok).toBe(true);
   });
 });

--- a/packages/integrations/git/src/review.ts
+++ b/packages/integrations/git/src/review.ts
@@ -23,7 +23,7 @@ import { promisify } from "node:util";
 import type { Logger } from "kolu-shared";
 import { simpleGit } from "simple-git";
 import { err, type GitResult, ok } from "./errors.ts";
-import { resolveUnder } from "./safe-path.ts";
+import { resolveExistingUnder, resolveUnder } from "./safe-path.ts";
 import {
   type GitBaseRef,
   type GitChangedFile,
@@ -223,12 +223,19 @@ export async function getDiff(
   log?: Logger,
   oldPath?: string,
 ): Promise<GitResult<GitDiffOutput>> {
-  const pathResult = resolveUnder(repoPath, filePath, log);
+  // `filePath` feeds the local-untracked `git diff --no-index /dev/null <abs>`
+  // fallback below, which reads `abs` straight off disk — so it needs the
+  // symlink-resolving guard, not just the lexical one. A repo-local
+  // `leak -> /etc/passwd` would otherwise be diffed (and its content
+  // surfaced) verbatim.
+  const pathResult = await resolveExistingUnder(repoPath, filePath, log);
   if (!pathResult.ok) return pathResult;
   const { abs, rel } = pathResult.value;
 
   // Validate oldPath the same way filePath is validated — it comes from
-  // the client and must not escape the repo root.
+  // the client and must not escape the repo root. Lexical-only is enough
+  // here: oldRel is only ever passed to git as a pathspec (never read off
+  // disk), and a rename's old name typically no longer exists to realpath.
   let oldRel = rel;
   if (oldPath) {
     const oldPathResult = resolveUnder(repoPath, oldPath, log);

--- a/packages/integrations/git/src/review.ts
+++ b/packages/integrations/git/src/review.ts
@@ -23,7 +23,7 @@ import { promisify } from "node:util";
 import type { Logger } from "kolu-shared";
 import { simpleGit } from "simple-git";
 import { err, type GitResult, ok } from "./errors.ts";
-import { resolveExistingUnder, resolveUnder } from "./safe-path.ts";
+import { assertRealpathUnder, resolveUnder } from "./safe-path.ts";
 import {
   type GitBaseRef,
   type GitChangedFile,
@@ -223,12 +223,16 @@ export async function getDiff(
   log?: Logger,
   oldPath?: string,
 ): Promise<GitResult<GitDiffOutput>> {
-  // `filePath` feeds the local-untracked `git diff --no-index /dev/null <abs>`
-  // fallback below, which reads `abs` straight off disk — so it needs the
-  // symlink-resolving guard, not just the lexical one. A repo-local
-  // `leak -> /etc/passwd` would otherwise be diffed (and its content
-  // surfaced) verbatim.
-  const pathResult = await resolveExistingUnder(repoPath, filePath, log);
+  // Lexical-only here: in branch mode and tracked-local mode `rel` is only
+  // ever handed to `git diff` as a pathspec (git resolves it against the tree,
+  // never dereferencing the working-tree symlink), so a tracked/branch symlink
+  // to an outside target must still render. The symlink-resolving authority
+  // check is applied below, scoped to the one path that actually reads `abs`
+  // off disk: the local-untracked `git diff --no-index /dev/null <abs>`
+  // fallback. Hoisting it here would make Code-tab diffs host-dependent —
+  // rejecting a legitimate `link -> /usr/bin/node` whenever that target happens
+  // to exist on the reviewer's machine.
+  const pathResult = resolveUnder(repoPath, filePath, log);
   if (!pathResult.ok) return pathResult;
   const { abs, rel } = pathResult.value;
 
@@ -263,16 +267,24 @@ export async function getDiff(
     // mode, on the other hand, also surfaces untracked files (via
     // `git.status().not_added`); those yield empty output from the normal
     // `git diff HEAD --` path, so we synthesize a diff against `/dev/null`.
-    const rawDiff =
-      mode === "local" && tracked.trim().length === 0
-        ? await gitOutput(repoPath, [
-            "diff",
-            "--no-index",
-            "--",
-            "/dev/null",
-            abs,
-          ])
-        : tracked;
+    let rawDiff: string;
+    if (mode === "local" && tracked.trim().length === 0) {
+      // This is the only path that reads `abs` straight off disk, so it's
+      // the only one that needs the symlink-resolving authority check — a
+      // repo-local `leak -> /etc/passwd` would otherwise be diffed (and its
+      // content surfaced) verbatim.
+      const guard = await assertRealpathUnder(repoPath, abs, log);
+      if (!guard.ok) return guard;
+      rawDiff = await gitOutput(repoPath, [
+        "diff",
+        "--no-index",
+        "--",
+        "/dev/null",
+        abs,
+      ]);
+    } else {
+      rawDiff = tracked;
+    }
 
     if (!rawDiff.trim().length) {
       log?.warn(

--- a/packages/integrations/git/src/safe-path.test.ts
+++ b/packages/integrations/git/src/safe-path.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assertRealpathUnder,
+  resolveExistingUnder,
+  resolveUnder,
+} from "./safe-path.ts";
+
+describe("resolveUnder (lexical)", () => {
+  const root = "/tmp/some-repo";
+
+  it("accepts a path inside the root", () => {
+    const res = resolveUnder(root, "docs/output.html");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.value.abs).toBe(path.join(root, "docs/output.html"));
+    expect(res.value.rel).toBe(path.join("docs", "output.html"));
+  });
+
+  it("rejects lexical traversal", () => {
+    const res = resolveUnder(root, "../../etc/passwd");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+
+  it("does NOT resolve symlinks — a symlink string still under root passes", () => {
+    // The whole reason resolveExistingUnder exists: this lexical check is
+    // blind to where `leak` actually points on disk.
+    const res = resolveUnder(root, "leak");
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe("resolveExistingUnder (lexical + symlink authority)", () => {
+  let root: string;
+  let outside: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-safepath-root-"));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-safepath-outside-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("accepts a real file inside the root", async () => {
+    fs.writeFileSync(path.join(root, "real.txt"), "x");
+    const res = await resolveExistingUnder(root, "real.txt");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.value.abs).toBe(path.join(root, "real.txt"));
+    expect(res.value.rel).toBe("real.txt");
+  });
+
+  it("follows a symlink that stays inside the root", async () => {
+    fs.writeFileSync(path.join(root, "target.txt"), "x");
+    fs.symlinkSync(path.join(root, "target.txt"), path.join(root, "alias.txt"));
+    const res = await resolveExistingUnder(root, "alias.txt");
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects a symlink that escapes the root (the finding)", async () => {
+    const secret = path.join(outside, "secret.txt");
+    fs.writeFileSync(secret, "TOP SECRET");
+    fs.symlinkSync(secret, path.join(root, "leak.txt"));
+    const res = await resolveExistingUnder(root, "leak.txt");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+
+  it("rejects a path under an intermediate directory symlink that escapes", async () => {
+    fs.writeFileSync(path.join(outside, "secret.txt"), "TOP SECRET");
+    // `escape/` is a directory symlink pointing out of the repo; reading
+    // `escape/secret.txt` must be rejected even though no `..` appears.
+    fs.symlinkSync(outside, path.join(root, "escape"));
+    const res = await resolveExistingUnder(root, "escape/secret.txt");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+
+  it("rejects lexical traversal before touching the filesystem", async () => {
+    const res = await resolveExistingUnder(root, "../../etc/passwd");
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+
+  it("passes a non-existent path through so the caller's fs op can 404/ENOENT", async () => {
+    // No realpath target → no readable file to leak → not an escape.
+    const res = await resolveExistingUnder(root, "does-not-exist.txt");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.value.abs).toBe(path.join(root, "does-not-exist.txt"));
+  });
+});
+
+describe("assertRealpathUnder", () => {
+  let root: string;
+  let outside: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-assert-root-"));
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-assert-outside-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("accepts a real file inside the root", async () => {
+    fs.writeFileSync(path.join(root, "real.txt"), "x");
+    const res = await assertRealpathUnder(root, path.join(root, "real.txt"));
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects an abs whose real path escapes via a symlink", async () => {
+    const secret = path.join(outside, "secret.txt");
+    fs.writeFileSync(secret, "TOP SECRET");
+    fs.symlinkSync(secret, path.join(root, "leak.txt"));
+    const res = await assertRealpathUnder(root, path.join(root, "leak.txt"));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe("PATH_ESCAPES_ROOT");
+  });
+
+  it("passes through when the target does not exist", async () => {
+    const res = await assertRealpathUnder(root, path.join(root, "nope.txt"));
+    expect(res.ok).toBe(true);
+  });
+
+  it("resolves symlinks on the root too (symlinked checkout stays valid)", async () => {
+    // `realpath(root)` matters: if we only realpath'd the target, a repo
+    // reached through a symlink (macOS /tmp -> /private/tmp, a symlinked
+    // checkout) would make every legitimate file look like an escape.
+    fs.writeFileSync(path.join(root, "real.txt"), "x");
+    const rootLink = path.join(outside, "rootlink");
+    fs.symlinkSync(root, rootLink);
+    const res = await assertRealpathUnder(
+      rootLink,
+      path.join(rootLink, "real.txt"),
+    );
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/integrations/git/src/safe-path.ts
+++ b/packages/integrations/git/src/safe-path.ts
@@ -5,6 +5,7 @@
  * we normalize and reject it up front.
  */
 
+import { realpath } from "node:fs/promises";
 import path from "node:path";
 import type { Logger } from "kolu-shared";
 import { err, type GitResult, ok } from "./errors.ts";
@@ -20,6 +21,15 @@ import { err, type GitResult, ok } from "./errors.ts";
  * `startsWith(rootAbs + path.sep)` prefix check; same guarantee, no
  * trailing-slash gotcha, and we get `rel` out of the computation for
  * free.
+ *
+ * This is a *lexical* guard only — it operates on the path string and does
+ * not touch the filesystem, so it does NOT resolve symlinks. A repo-local
+ * `leak -> /etc/passwd` passes this check (the string still lives under the
+ * root) yet a later `fs.readFile` follows the link out of the repo. For any
+ * operation that reads, stats, or diffs an *existing* file, use
+ * `resolveExistingUnder` (lexical + symlink-resolving). Keep `resolveUnder`
+ * for paths that may not exist yet, or where only lexical canonicalization
+ * is needed (e.g. deriving a `rel` pathspec for a subprocess).
  */
 export function resolveUnder(
   root: string,
@@ -34,4 +44,60 @@ export function resolveUnder(
     return err({ code: "PATH_ESCAPES_ROOT", root, child });
   }
   return ok({ abs, rel });
+}
+
+/**
+ * Filesystem-authority guard: assert that an already-lexically-validated
+ * absolute path stays under `root` *after symlinks are resolved on both
+ * sides*. This is the half `resolveUnder` can't do — it follows symlinks via
+ * `fs.realpath`, so a repo-local `leak -> /etc/passwd` is rejected instead of
+ * read. We `realpath` the root too, because the root itself may be reached
+ * through a symlink (macOS `/tmp -> /private/tmp`, a symlinked checkout); only
+ * a real-to-real comparison is sound.
+ *
+ * `abs` must be absolute and should already have passed `resolveUnder`.
+ *
+ * On any `realpath` failure (target missing, `EACCES`, symlink loop) this
+ * resolves `ok`: there is no resolvable on-disk file to leak, and the
+ * caller's own fs op will reproduce the same errno — so a missing file stays
+ * a 404/`ENOENT` rather than being masked as a path escape.
+ */
+export async function assertRealpathUnder(
+  root: string,
+  abs: string,
+  log?: Logger,
+): Promise<GitResult<void>> {
+  let realRoot: string;
+  let realAbs: string;
+  try {
+    [realRoot, realAbs] = await Promise.all([realpath(root), realpath(abs)]);
+  } catch {
+    return ok(undefined);
+  }
+  const rel = path.relative(realRoot, realAbs);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    log?.error({ root, abs }, "safe-path: real path escapes root (symlink)");
+    return err({ code: "PATH_ESCAPES_ROOT", root, child: abs });
+  }
+  return ok(undefined);
+}
+
+/**
+ * `resolveUnder` + `assertRealpathUnder` in one call — the guard to use
+ * whenever a caller-supplied `child` path is about to read, stat, or diff an
+ * *existing* file. Lexical normalization first (rejects `../../` traversal and
+ * yields the canonical `rel`), then the symlink-resolving authority check.
+ * Returns the same `{ abs, rel }` as `resolveUnder` so call sites swap one for
+ * the other with only an added `await`.
+ */
+export async function resolveExistingUnder(
+  root: string,
+  child: string,
+  log?: Logger,
+): Promise<GitResult<{ abs: string; rel: string }>> {
+  const lexical = resolveUnder(root, child, log);
+  if (!lexical.ok) return lexical;
+  const guard = await assertRealpathUnder(root, lexical.value.abs, log);
+  if (!guard.ok) return guard;
+  return lexical;
 }

--- a/packages/integrations/git/src/safe-path.ts
+++ b/packages/integrations/git/src/safe-path.ts
@@ -72,6 +72,10 @@ export async function assertRealpathUnder(
   try {
     [realRoot, realAbs] = await Promise.all([realpath(root), realpath(abs)]);
   } catch {
+    // realpath failed (ENOENT / EACCES / ELOOP): there is no resolvable
+    // on-disk file to leak, and the caller's own read/stat faces the
+    // identical kernel checks, so it reproduces the same errno. Fail open
+    // rather than mask a 404/permission error as a path escape (see JSDoc).
     return ok(undefined);
   }
   const rel = path.relative(realRoot, realAbs);

--- a/packages/server/src/iframePreviewRoute.test.ts
+++ b/packages/server/src/iframePreviewRoute.test.ts
@@ -177,4 +177,25 @@ describe("serveResolvedFile", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it("403s for a symlink that escapes the repo root (and never leaks content)", async () => {
+    // Lexically `leak.html` is a clean in-root segment; only resolving the
+    // symlink reveals it points outside. serveResolvedFile's fs-authority
+    // stage must reject it before reading.
+    const outside = fs.mkdtempSync(
+      path.join(os.tmpdir(), "kolu-iframe-route-outside-"),
+    );
+    try {
+      const secret = path.join(outside, "secret.html");
+      fs.writeFileSync(secret, "<!doctype html><h1>SECRET</h1>");
+      fs.symlinkSync(secret, path.join(tmpRoot, "leak.html"));
+      const res = await serveResolvedFile(
+        resolvePreviewPath(tmpRoot, "leak.html"),
+      );
+      expect(res.status).toBe(403);
+      expect(res.body.toString()).not.toContain("SECRET");
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/server/src/iframePreviewRoute.test.ts
+++ b/packages/server/src/iframePreviewRoute.test.ts
@@ -146,6 +146,7 @@ describe("serveResolvedFile", () => {
   it("serves an existing HTML file with the right Content-Type", async () => {
     const res = await serveResolvedFile(
       resolvePreviewPath(tmpRoot, "page.html"),
+      tmpRoot,
     );
     expect(res.status).toBe(200);
     expect(res.headers["Content-Type"]).toBe("text/html; charset=utf-8");
@@ -156,24 +157,32 @@ describe("serveResolvedFile", () => {
   it("serves a nested asset", async () => {
     const res = await serveResolvedFile(
       resolvePreviewPath(tmpRoot, "sub/child.svg"),
+      tmpRoot,
     );
     expect(res.status).toBe(200);
     expect(res.headers["Content-Type"]).toBe("image/svg+xml");
   });
 
   it("404s for missing files (with valid path)", async () => {
-    const res = await serveResolvedFile(resolvePreviewPath(tmpRoot, "no.html"));
+    const res = await serveResolvedFile(
+      resolvePreviewPath(tmpRoot, "no.html"),
+      tmpRoot,
+    );
     expect(res.status).toBe(404);
   });
 
   it("404s for a directory (not a file)", async () => {
-    const res = await serveResolvedFile(resolvePreviewPath(tmpRoot, "sub"));
+    const res = await serveResolvedFile(
+      resolvePreviewPath(tmpRoot, "sub"),
+      tmpRoot,
+    );
     expect(res.status).toBe(404);
   });
 
   it("propagates the resolver's 400 verbatim", async () => {
     const res = await serveResolvedFile(
       resolvePreviewPath(tmpRoot, "../escape"),
+      tmpRoot,
     );
     expect(res.status).toBe(400);
   });
@@ -191,6 +200,7 @@ describe("serveResolvedFile", () => {
       fs.symlinkSync(secret, path.join(tmpRoot, "leak.html"));
       const res = await serveResolvedFile(
         resolvePreviewPath(tmpRoot, "leak.html"),
+        tmpRoot,
       );
       expect(res.status).toBe(403);
       expect(res.body.toString()).not.toContain("SECRET");

--- a/packages/server/src/iframePreviewRoute.ts
+++ b/packages/server/src/iframePreviewRoute.ts
@@ -80,13 +80,12 @@ export function contentTypeForPath(filePath: string): string {
 }
 
 export type PathResolution =
-  | { ok: true; root: string; abs: string; mime: string }
+  | { ok: true; abs: string; mime: string }
   | { ok: false; status: 400 | 403 | 404; reason: string };
 
 /** Parse the URL tail, run both *lexical* guard stages, return the absolute
- *  file path (plus the repo root, for the fs-authority check `serveResolvedFile`
- *  runs before reading) or the HTTP status to respond with. Pure function — no
- *  I/O — so the Hono route stays a thin adapter and the guard is unit-testable.
+ *  file path or the HTTP status to respond with. Pure function — no I/O — so
+ *  the Hono route stays a thin adapter and the guard is unit-testable.
  *
  *  Symlink resolution can't happen here (it touches the filesystem); it lives
  *  in `serveResolvedFile`, the I/O half, which rejects a repo-local symlink
@@ -127,7 +126,6 @@ export function resolvePreviewPath(
 
   return {
     ok: true,
-    root: repoRoot,
     abs: resolved.value.abs,
     mime: contentTypeForPath(relPath),
   };
@@ -147,6 +145,7 @@ export interface ServeResult {
  *  fixtures, and the I/O failure modes are testable without crafting URLs. */
 export async function serveResolvedFile(
   res: PathResolution,
+  root: string,
 ): Promise<ServeResult> {
   if (!res.ok) {
     return {
@@ -158,7 +157,7 @@ export async function serveResolvedFile(
   // Stage 3: fs-authority check. `resolvePreviewPath` is lexical only, so a
   // repo-local `leak.html -> /etc/passwd` slips through it; resolve symlinks
   // and reject anything whose real path escapes the root before we read it.
-  const authority = await assertRealpathUnder(res.root, res.abs);
+  const authority = await assertRealpathUnder(root, res.abs);
   if (!authority.ok) {
     return {
       status: 403,

--- a/packages/server/src/iframePreviewRoute.ts
+++ b/packages/server/src/iframePreviewRoute.ts
@@ -18,7 +18,7 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { encodePreviewPath } from "kolu-common/preview";
-import { resolveUnder } from "kolu-git";
+import { assertRealpathUnder, resolveUnder } from "kolu-git";
 
 /** Base URL for the iframe-preview file route. Used by both
  *  `buildIframePreviewUrl` (server emits URLs in this shape) and the Hono
@@ -80,12 +80,17 @@ export function contentTypeForPath(filePath: string): string {
 }
 
 export type PathResolution =
-  | { ok: true; abs: string; mime: string }
+  | { ok: true; root: string; abs: string; mime: string }
   | { ok: false; status: 400 | 403 | 404; reason: string };
 
-/** Parse the URL tail, run both guard stages, return the absolute file path
- *  or the HTTP status to respond with. Pure function — no I/O — so the
- *  Hono route stays a thin adapter and the guard is unit-testable. */
+/** Parse the URL tail, run both *lexical* guard stages, return the absolute
+ *  file path (plus the repo root, for the fs-authority check `serveResolvedFile`
+ *  runs before reading) or the HTTP status to respond with. Pure function — no
+ *  I/O — so the Hono route stays a thin adapter and the guard is unit-testable.
+ *
+ *  Symlink resolution can't happen here (it touches the filesystem); it lives
+ *  in `serveResolvedFile`, the I/O half, which rejects a repo-local symlink
+ *  escaping the root with the same 403 the lexical stage uses. */
 export function resolvePreviewPath(
   repoRoot: string,
   rawTail: string,
@@ -115,12 +120,14 @@ export function resolvePreviewPath(
   }
   const relPath = segments.join("/");
 
-  // Stage 2: canonical resolve + relative-prefix check (kolu-git's guard).
+  // Stage 2: canonical resolve + relative-prefix check (kolu-git's lexical
+  // guard). Stage 3 (symlink resolution) runs in `serveResolvedFile`.
   const resolved = resolveUnder(repoRoot, relPath);
   if (!resolved.ok) return { ok: false, status: 403, reason: "escapes root" };
 
   return {
     ok: true,
+    root: repoRoot,
     abs: resolved.value.abs,
     mime: contentTypeForPath(relPath),
   };
@@ -146,6 +153,17 @@ export async function serveResolvedFile(
       status: res.status,
       headers: { "Content-Type": "text/plain; charset=utf-8" },
       body: res.reason,
+    };
+  }
+  // Stage 3: fs-authority check. `resolvePreviewPath` is lexical only, so a
+  // repo-local `leak.html -> /etc/passwd` slips through it; resolve symlinks
+  // and reject anything whose real path escapes the root before we read it.
+  const authority = await assertRealpathUnder(res.root, res.abs);
+  if (!authority.ok) {
+    return {
+      status: 403,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+      body: "escapes root",
     };
   }
   try {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -189,7 +189,10 @@ app.get(
     const repoRoot = term?.meta.git?.repoRoot;
     if (!repoRoot) return c.text("terminal has no repo", 404);
 
-    const res = await serveResolvedFile(resolvePreviewPath(repoRoot, rawTail));
+    const res = await serveResolvedFile(
+      resolvePreviewPath(repoRoot, rawTail),
+      repoRoot,
+    );
     // `Buffer` (subclass of `Uint8Array<ArrayBufferLike>`) is a runtime-valid
     // `BodyInit` but the DOM-typed lib.dom.d.ts narrows `BodyInit` to
     // `Uint8Array<ArrayBuffer>` — the unions don't align in TS even though


### PR DESCRIPTION
**The repo-root guard was lexical only — it stopped `../../` traversal but followed symlinks, so a repo-local `leak -> /etc/passwd` passed the string check and the later filesystem call read straight out of the repo.** That's a correctness bug and a workspace-boundary failure for any untrusted checkout. This splits *lexical path normalization* from *filesystem authority*: existing-file reads now compare `fs.realpath` of the root and target before touching the file.

`resolveUnder` does `path.resolve` + `path.relative` on the string — it never consults the disk, so it can't know where a symlink actually points. Three surfaces leaned on it for operations that read real files:

```
                resolveUnder (lexical)        assertRealpathUnder (fs authority)
  child path ─▶ reject ../../ traversal  ─▶   realpath(root) vs realpath(target)
                returns {abs, rel}            reject if real target escapes real root
```

### Surfaces closed

| Surface | Operation | Guard now |
| --- | --- | --- |
| `kolu-git/browse.ts` | Code-tab `readFile` / `statFileMtimeMs` | `resolveExistingUnder` |
| `kolu-git/review.ts` | local untracked `git diff --no-index /dev/null <abs>` | `assertRealpathUnder`, scoped to the disk-read fallback only |
| `server/iframePreviewRoute.ts` | binary-preview byte serving | `assertRealpathUnder` in `serveResolvedFile` → **403** |

The new authority lives in one place — `safe-path.ts`, the module that decides *what path is allowed*:

- **`assertRealpathUnder(root, abs)`** — resolves symlinks on *both* sides (`realpath(root)` matters too: a symlinked checkout or macOS `/tmp -> /private/tmp` would otherwise make every legitimate file look like an escape). Any `realpath` failure (missing / `EACCES` / `ELOOP`) *fails open* — there's no resolvable file to leak, and the caller's own fs op faces the identical kernel checks and reproduces the errno, so a missing file stays a 404/`ENOENT` rather than masquerading as an escape.
- **`resolveExistingUnder(root, child)`** = `resolveUnder` + the above, for the common read/stat-an-existing-file case.
- **`resolveUnder`** stays the lexical helper for not-yet-existing paths and git pathspecs (`review.ts`'s `oldPath`, and tracked/branch diffs — where `rel` is only a pathspec git resolves against the tree and never dereferences, so realpathing it would make Code-tab diffs host-dependent).

> The preview route's `resolvePreviewPath` stays a *pure, no-I/O* function (its URL-decoding guard is unit-tested without fixtures); the symlink resolution lands in `serveResolvedFile`, the existing I/O half — consistent with that module's deliberate split.

### Tests

Symlink-to-outside **rejected**, inside-symlink **followed**, non-existent path **passes through**, intermediate directory-symlink escape **rejected**, symlinked root **stays valid**, tracked-symlink diff **still renders** — covered at the `safe-path` authority layer and at each of the three call sites (`browse`, `review`, preview route).

### Review gauntlet

Built start-to-finish with `/be`; every stage's trail is in the PR comments. **codex-debate** (consensus, 2 rounds, xhigh) caught a real regression — the guard was initially applied to *all* `getDiff` modes, which would reject legitimate tracked/branch symlink diffs host-dependently; rescoped to the `--no-index` disk-read path. **lens-debate** (lowy ⇄ hickey, consensus) removed a `root` value smuggled through the pure `PathResolution` result. **code-police** added the fail-open rationale inline in the catch. CI is green on `x86_64-linux` + `aarch64-darwin` (all 22 nodes).

Implements the `#symlink-escape` finding from [`docs/plans/correctness-review.html`](docs/plans/correctness-review.html) (high severity, the last open path-authority bug in that review).

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._