### PR TITLE
fix(restore): don't show an empty canvas before the saved session loads

### DIFF
--- a/packages/client/src/terminal/useSessionRestore.test.ts
+++ b/packages/client/src/terminal/useSessionRestore.test.ts
@@ -1,0 +1,110 @@
+import type { TerminalId, TerminalInfo } from "kolu-common/surface";
+import { createRoot } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+
+// `isLoading` is a pure read over three reactive inputs: the terminal list's
+// pending flag, the live terminal count, and the saved-session cell's pending
+// flag. Drive those three through a plain hoisted bag and stub every module
+// `useSessionRestore` pulls at import time so the hook loads under Node without
+// a live socket, toast DOM, or the SSR-only `solid-js/web` build.
+const h = vi.hoisted(() => ({
+  listPending: true,
+  list: undefined as TerminalInfo[] | undefined,
+  terminalIds: [] as TerminalId[],
+  sessionPending: true,
+  savedSession: null as unknown,
+}));
+
+vi.mock("../wire", () => ({
+  client: {},
+  savedSessionSub: { pending: () => h.sessionPending },
+  savedSession: () => h.savedSession,
+}));
+vi.mock("../rpc/rpc", () => ({ lifecycle: () => ({ kind: "connected" }) }));
+vi.mock("../right-panel/useRightPanel", () => ({
+  useRightPanel: () => ({ seedPanel: () => {} }),
+}));
+vi.mock("./useSubPanel", () => ({
+  useSubPanel: () => ({
+    seedPanel: () => {},
+    getSubPanel: () => ({ activeSubTab: null }),
+    setActiveSubTab: () => {},
+  }),
+}));
+vi.mock("solid-sonner", () => ({
+  toast: Object.assign(() => {}, {
+    loading: () => 0,
+    success: () => {},
+    error: () => {},
+    warning: () => {},
+  }),
+}));
+vi.mock("anyagent/cli", () => ({ resumeAgentCommand: () => null }));
+
+import { useSessionRestore } from "./useSessionRestore";
+import type { TerminalStore } from "./useTerminalStore";
+
+/** A `TerminalStore` whose `listSub`/`terminalIds` read the hoisted bag, so a
+ *  test can flip a flag and call `isLoading()` to observe the gate directly. */
+function makeStore(): TerminalStore {
+  const listSub = Object.assign(() => h.list, { pending: () => h.listPending });
+  return {
+    listSub,
+    terminalIds: () => h.terminalIds,
+    getMetadata: () => undefined,
+    setActiveSilently: () => {},
+    activeId: () => null,
+    setMruOrder: () => {},
+  } as unknown as TerminalStore;
+}
+
+const mount = () =>
+  useSessionRestore({
+    store: makeStore(),
+    handleCreate: vi.fn(),
+    handleCreateSubTerminal: vi.fn(),
+  });
+
+describe("useSessionRestore — isLoading gate (cold-launch restore race)", () => {
+  it("keeps loading on an empty list until the saved-session cell reports", () => {
+    createRoot((dispose) => {
+      h.listPending = true;
+      h.list = undefined;
+      h.terminalIds = [];
+      h.sessionPending = true;
+      const session = mount();
+
+      // Terminal list still pending → loading.
+      expect(session.isLoading()).toBe(true);
+
+      // List yields empty (terminals were killed on the previous shutdown) but
+      // the session cell hasn't reported yet. The regression: this flipped to
+      // NOT loading and rendered the bare empty state, hiding the restore card
+      // until a full reload. The gate must stay loading here.
+      h.listPending = false;
+      h.list = [];
+      h.terminalIds = [];
+      expect(session.isLoading()).toBe(true);
+
+      // Session cell reports → an honest empty-vs-restore decision can be made.
+      h.sessionPending = false;
+      expect(session.isLoading()).toBe(false);
+
+      dispose();
+    });
+  });
+
+  it("does not wait on the session cell when terminals exist", () => {
+    createRoot((dispose) => {
+      h.listPending = false;
+      h.list = [{ id: "t1" } as TerminalInfo];
+      h.terminalIds = ["t1" as TerminalId];
+      h.sessionPending = true; // still in flight — must not delay the canvas
+      const session = mount();
+
+      expect(session.isLoading()).toBe(false);
+
+      dispose();
+    });
+  });
+});

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -319,10 +319,14 @@ export function useSessionRestore(deps: {
     // restore" while the saved-session snapshot is still in flight, so the
     // restore card only appears after a full reload re-subs.
     // When `terminalIds()` is empty we therefore also wait on `savedSessionSub`
-    // so the decision is made with the session snapshot in hand. When terminals
-    // exist, the canvas renders immediately — the session cell is irrelevant.
+    // so the decision is made with the session snapshot in hand. When at least
+    // one terminal's metadata has arrived (`terminalIds().length > 0`), the
+    // canvas renders immediately — the session cell is irrelevant.
+    // Note: `terminalIds()` excludes terminals whose per-terminal metadata
+    // hasn't arrived yet, so there is a brief window after `listSub` resolves
+    // where all metadata is still in-flight and the gate also holds loading.
     // `terminalIds()` is the same signal the empty-state branch reads at
-    // App.tsx:398 (`showEmpty = !session.isLoading() && terminalIds().length
+    // App.tsx:397 (`showEmpty = !session.isLoading() && terminalIds().length
     // === 0`), so the loading gate and the empty-state branch agree on what
     // "empty" means.
     isLoading: () =>

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -312,14 +312,19 @@ export function useSessionRestore(deps: {
 
   return {
     // Loading is true until we can make an HONEST empty-vs-restore decision.
-    // The terminal list alone isn't enough: the list yields `[]` (terminals
-    // were killed on the previous shutdown) before the `session` cell has
-    // reported, and rendering the bare empty state in that window is a *lie* —
-    // it claims "nothing to restore" while the saved-session snapshot is still
-    // in flight, so the restore card only appears after a full reload re-subs.
-    // When the list is empty we therefore also wait on `savedSessionSub` so the
-    // decision is made with the session snapshot in hand. When terminals exist,
-    // the canvas renders immediately — the session cell is irrelevant then.
+    // The terminal count alone isn't enough: `store.terminalIds()` (the
+    // metadata-derived top-level IDs) yields `[]` (terminals were killed on the
+    // previous shutdown) before the `session` cell has reported, and rendering
+    // the bare empty state in that window is a *lie* — it claims "nothing to
+    // restore" while the saved-session snapshot is still in flight, so the
+    // restore card only appears after a full reload re-subs.
+    // When `terminalIds()` is empty we therefore also wait on `savedSessionSub`
+    // so the decision is made with the session snapshot in hand. When terminals
+    // exist, the canvas renders immediately — the session cell is irrelevant.
+    // `terminalIds()` is the same signal the empty-state branch reads at
+    // App.tsx:398 (`showEmpty = !session.isLoading() && terminalIds().length
+    // === 0`), so the loading gate and the empty-state branch agree on what
+    // "empty" means.
     isLoading: () =>
       store.listSub.pending() ||
       (store.terminalIds().length === 0 && savedSessionSub.pending()),

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -311,7 +311,18 @@ export function useSessionRestore(deps: {
   }
 
   return {
-    isLoading: () => store.listSub.pending(),
+    // Loading is true until we can make an HONEST empty-vs-restore decision.
+    // The terminal list alone isn't enough: the list yields `[]` (terminals
+    // were killed on the previous shutdown) before the `session` cell has
+    // reported, and rendering the bare empty state in that window is a *lie* —
+    // it claims "nothing to restore" while the saved-session snapshot is still
+    // in flight, so the restore card only appears after a full reload re-subs.
+    // When the list is empty we therefore also wait on `savedSessionSub` so the
+    // decision is made with the session snapshot in hand. When terminals exist,
+    // the canvas renders immediately — the session cell is irrelevant then.
+    isLoading: () =>
+      store.listSub.pending() ||
+      (store.terminalIds().length === 0 && savedSessionSub.pending()),
     savedSession,
     isRestoring,
     handleRestoreSession,


### PR DESCRIPTION
**On a cold launch with terminals from a previous session, Kolu sometimes flashed an empty canvas instead of the session-restore dialog — and the dialog only appeared after a full reload.** The empty-vs-restore decision was being made before the saved-session snapshot had arrived, so the UI claimed *"nothing to restore"* while that snapshot was still in flight.

### The race

The render gate keys off a single signal, `isLoading()`, which was defined as just `store.listSub.pending()` — *"has the terminal list reported yet?"*. On a cold launch the list yields `[]` (the terminals were killed on the previous shutdown) **before** the `session` cell reports:

```
list yields []  ─▶ isLoading() = false  ─▶ bare empty state renders
                                            (savedSession() still null —
session cell yields ────────────────────▶  restore card never gets its turn)
```

Because the `session` cell doesn't re-push its already-loaded value to that subscription, only a full reload — a fresh subscription — recovered the card. The server side was never at fault: the saved session lives in a synchronous `conf` store and was present the whole time. This is purely a client first-snapshot ordering bug.

### The fix

Gate the empty-vs-restore decision on the saved-session cell too. When the list is empty, stay in the existing **"Connecting…"** state until `savedSessionSub` has reported — *then* decide, with the snapshot in hand. When terminals exist the canvas renders immediately; the session cell is irrelevant in that case, so it's never waited on.

```ts
isLoading: () =>
  store.listSub.pending() ||
  (store.terminalIds().length === 0 && savedSessionSub.pending())
```

The new unit test pins both halves: the gate **stays loading** on an empty list until the session cell reports (red against the old single-input gate), and **never delays the canvas** when terminals exist.

> _The latent gap has existed since the loading flag was first wired to the list alone (#361); recent boot-timing shifts surfaced it as a regular flake. If an intermittent empty-then-reload persists after this, the next thread is a deeper transport bug where a cold-launch subscription receives a stale `null` snapshot that never re-pushes._

### Try it locally

```sh
nix run github:juspay/kolu/fix/restore-loading-gate
```

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._