### PR TITLE
fix(server): surface port-in-use as an actionable message, not a fatal crash

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,6 +26,7 @@ import { ensureKoluRoot, shutdownCleanup } from "./koluRoot.ts";
 import { log } from "./log.ts";
 import { pwaIdentityForHostname } from "./pwaIdentity.ts";
 import { appRouter } from "./router.ts";
+import { attachServeErrorHandler } from "./serveError.ts";
 import { initSessionAutoSave } from "./session.ts";
 import { getTerminal } from "./terminal-registry.ts";
 import { snapshotSession } from "./terminals.ts";
@@ -267,6 +268,12 @@ const server = serve(
     startDiagnostics();
   },
 );
+
+// A failed listen (port in use, privileged port, unresolvable host) emits
+// 'error' on the returned http.Server. Without this listener Node rethrows,
+// and the global uncaughtException handler reports it like an internal crash
+// rather than the actionable "port already in use" message it deserves.
+attachServeErrorHandler(server, { host, port, log });
 
 // --- oRPC WebSocket handler (streaming) ---
 const wss = new WebSocketServer({ noServer: true });

--- a/packages/server/src/serveError.test.ts
+++ b/packages/server/src/serveError.test.ts
@@ -1,0 +1,97 @@
+import { createServer, type Server } from "node:http";
+import { serve } from "@hono/node-server";
+import { afterEach, describe, expect, it } from "vitest";
+import { attachServeErrorHandler, describeServeError } from "./serveError.ts";
+
+describe("describeServeError", () => {
+  it("explains a port-in-use failure with the port and a remedy", () => {
+    const msg = describeServeError(
+      { code: "EADDRINUSE" } as NodeJS.ErrnoException,
+      {
+        host: "127.0.0.1",
+        port: 7681,
+      },
+    );
+    expect(msg).toContain("7681");
+    expect(msg).toMatch(/already in use/i);
+    expect(msg).toContain("--port");
+  });
+
+  it("explains a permission failure with the bind target", () => {
+    const msg = describeServeError(
+      { code: "EACCES" } as NodeJS.ErrnoException,
+      {
+        host: "0.0.0.0",
+        port: 80,
+      },
+    );
+    expect(msg).toContain("0.0.0.0:80");
+    expect(msg).toMatch(/permission denied/i);
+  });
+
+  it("returns null for an unrecognized error so the caller logs it raw", () => {
+    const msg = describeServeError(
+      { code: "ECONNRESET" } as NodeJS.ErrnoException,
+      {
+        host: "127.0.0.1",
+        port: 7681,
+      },
+    );
+    expect(msg).toBeNull();
+  });
+});
+
+describe("attachServeErrorHandler", () => {
+  // Reproduces the bug: a second listen on an occupied port emits EADDRINUSE
+  // on the http.Server returned by serve(). Before the fix there was no
+  // listener, so Node rethrew it as an uncaught fatal. The handler turns it
+  // into a friendly fatal + clean exit(1).
+  const open: Server[] = [];
+
+  afterEach(() => {
+    for (const s of open.splice(0)) s.close();
+  });
+
+  function occupyFreePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const blocker = createServer();
+      open.push(blocker);
+      blocker.once("error", reject);
+      blocker.listen(0, "127.0.0.1", () => {
+        const addr = blocker.address();
+        if (addr && typeof addr === "object") resolve(addr.port);
+        else reject(new Error("no port assigned"));
+      });
+    });
+  }
+
+  it("surfaces EADDRINUSE as a friendly fatal and exits cleanly", async () => {
+    const port = await occupyFreePort();
+
+    const fatals: string[] = [];
+    const exits: number[] = [];
+
+    const result = await new Promise<{ message: string }>((resolve) => {
+      const server = serve({
+        fetch: () => new Response("ok"),
+        hostname: "127.0.0.1",
+        port,
+      }) as unknown as Server;
+      open.push(server);
+
+      attachServeErrorHandler(server, {
+        host: "127.0.0.1",
+        port,
+        log: { fatal: (arg: unknown) => fatals.push(String(arg)) } as never,
+        exit: (code) => {
+          exits.push(code);
+          resolve({ message: fatals.join("\n") });
+        },
+      });
+    });
+
+    expect(exits).toEqual([1]);
+    expect(result.message).toMatch(/already in use/i);
+    expect(result.message).toContain(String(port));
+  });
+});

--- a/packages/server/src/serveError.ts
+++ b/packages/server/src/serveError.ts
@@ -1,0 +1,60 @@
+/** Server-bind failure handling.
+ *
+ * `serve()` from `@hono/node-server` returns the underlying `http.Server`,
+ * which emits an `'error'` event when the listen fails (port in use,
+ * privileged port, unresolvable host). With no listener Node rethrows, and
+ * the rethrow lands in the global `uncaughtException` handler — so a routine
+ * "port already in use" reads like an internal crash. This module turns the
+ * common bind failures into a one-line, actionable message and a clean exit.
+ */
+import type { Logger } from "./log.ts";
+
+export interface ServeBindTarget {
+  host: string;
+  port: number;
+}
+
+/** Map a server-bind failure to a human-readable fatal message, or `null`
+ * for an unrecognized error (the caller logs the raw error with structured
+ * context so nothing diagnostic is lost). */
+export function describeServeError(
+  err: NodeJS.ErrnoException,
+  { host, port }: ServeBindTarget,
+): string | null {
+  switch (err.code) {
+    case "EADDRINUSE":
+      return `Port ${port} is already in use — is kolu already running? Try --port <n>.`;
+    case "EACCES":
+      return `Permission denied binding ${host}:${port} (privileged port?).`;
+    default:
+      return null;
+  }
+}
+
+/** Minimal shape of the server returned by `serve()` that we attach to. */
+interface ErrorEmitter {
+  on(event: "error", listener: (err: NodeJS.ErrnoException) => void): unknown;
+}
+
+/** Attach an `error` handler that reports bind failures and exits cleanly.
+ * `log`/`exit` are injected so the handler is testable without a real
+ * process exit. */
+export function attachServeErrorHandler(
+  server: ErrorEmitter,
+  {
+    host,
+    port,
+    log,
+    exit = process.exit,
+  }: ServeBindTarget & {
+    log: Pick<Logger, "fatal">;
+    exit?: (code: number) => void;
+  },
+): void {
+  server.on("error", (err) => {
+    const message = describeServeError(err, { host, port });
+    if (message) log.fatal(message);
+    else log.fatal({ err }, "failed to start server");
+    exit(1);
+  });
+}


### PR DESCRIPTION
**Starting kolu on a port that's already taken now prints a one-line remedy and exits cleanly**, instead of a stack-shaped `"uncaught exception"` fatal that reads like an internal crash. Running a second instance on the same port (or leaving an old one alive) is one of the most common first-run friction points — for a public release it deserves a human answer, not a rethrow.

`serve()` from `@hono/node-server` returns the underlying `http.Server`, but it had **no `'error'` listener**. A failed listen emits `'error'`; with no handler Node rethrows, and the rethrow lands in the global `uncaughtException` handler. So the message you saw was generic and the exit looked like a fault.

### What you see now

| Failure | Before | After |
| --- | --- | --- |
| Port in use (`EADDRINUSE`) | `uncaught exception` + stack-shaped fatal | `Port 7681 is already in use — is kolu already running? Try --port <n>.` |
| Privileged port (`EACCES`) | same generic fatal | `Permission denied binding <host>:<port> (privileged port?).` |
| Anything else | `uncaught exception` | `failed to start server` with the structured `err` preserved |

All three paths end in a clean `exit(1)`.

### Shape

The error→message mapping and the `server.on("error", …)` wiring live in a small `serveError` module with `log`/`exit` injected, so the real `EADDRINUSE` path is exercised by a unit test that occupies a port and starts `serve()` on it — no subprocess, no mock of the failure. _Unknown errors still log structured `{ err }` so nothing diagnostic is lost._

Closes #1137

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._