### PR TITLE
Live-reload Code-tab previews of committed build-output files

### DIFF
--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -13,6 +13,30 @@ import { resolveExistingUnder } from "./safe-path.ts";
 
 const execFileAsync = promisify(execFile);
 
+/** Single spawn/parse/error path shared by the two `git ls-files` listings.
+ *  Owns the maxBuffer ceiling, the newline split + empty-line filter, and the
+ *  GIT_FAILED error envelope; callers supply the args array and the message
+ *  prefix used on failure. */
+async function gitLsFiles(
+  repoPath: string,
+  args: string[],
+  failMsg: string,
+  log?: Logger,
+): Promise<GitResult<string[]>> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd: repoPath,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const paths = stdout.split("\n").filter((l) => l.length > 0);
+    return ok(paths);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log?.error({ err: e, repoPath }, "git ls-files failed");
+    return err({ code: "GIT_FAILED", message: `${failMsg}: ${msg}` });
+  }
+}
+
 /** Flat list of every repo-relative path (tracked + untracked-but-not-ignored).
  *  One-shot snapshot for Pierre's `@pierre/trees`, which builds the tree
  *  hierarchy itself from a flat path list.
@@ -23,19 +47,12 @@ export async function listAll(
   repoPath: string,
   log?: Logger,
 ): Promise<GitResult<string[]>> {
-  try {
-    const { stdout } = await execFileAsync(
-      "git",
-      ["ls-files", "--cached", "--others", "--exclude-standard"],
-      { cwd: repoPath, maxBuffer: 64 * 1024 * 1024 },
-    );
-    const paths = stdout.split("\n").filter((l) => l.length > 0);
-    return ok(paths);
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    log?.error({ err: e, repoPath }, "git ls-files failed");
-    return err({ code: "GIT_FAILED", message: `Failed to list files: ${msg}` });
-  }
+  return gitLsFiles(
+    repoPath,
+    ["ls-files", "--cached", "--others", "--exclude-standard"],
+    "Failed to list files",
+    log,
+  );
 }
 
 /** Repo-relative paths git *ignores* — the exact complement of `listAll`'s
@@ -54,31 +71,14 @@ export async function listIgnoredPaths(
   repoPath: string,
   log?: Logger,
 ): Promise<GitResult<string[]>> {
-  try {
-    const { stdout } = await execFileAsync(
-      "git",
-      [
-        "ls-files",
-        "--others",
-        "--ignored",
-        "--exclude-standard",
-        "--directory",
-      ],
-      { cwd: repoPath, maxBuffer: 64 * 1024 * 1024 },
-    );
-    const paths = stdout
-      .split("\n")
-      .filter((l) => l.length > 0)
-      .map((l) => l.replace(/\/+$/, ""));
-    return ok(paths);
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    log?.error({ err: e, repoPath }, "git ls-files --ignored failed");
-    return err({
-      code: "GIT_FAILED",
-      message: `Failed to list ignored files: ${msg}`,
-    });
-  }
+  const result = await gitLsFiles(
+    repoPath,
+    ["ls-files", "--others", "--ignored", "--exclude-standard", "--directory"],
+    "Failed to list ignored files",
+    log,
+  );
+  if (!result.ok) return result;
+  return ok(result.value.map((l) => l.replace(/\/+$/, "")));
 }
 
 /** Max file size to read (1 MB). Larger files get a truncation notice. */

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -38,6 +38,49 @@ export async function listAll(
   }
 }
 
+/** Repo-relative paths git *ignores* — the exact complement of `listAll`'s
+ *  `--cached --others --exclude-standard` (union the two and you have the whole
+ *  working tree). `--directory` collapses a fully-ignored directory to its name
+ *  (so `node_modules/` is one entry, not thousands), and any trailing slash is
+ *  stripped here. The working-tree watcher feeds these to parcel's `ignore`, so
+ *  it watches exactly what the browse tree shows — committed build outputs
+ *  (Atlas's `docs/atlas/dist/`) included, gitignored ones excluded. Note: this
+ *  does NOT list `.git` (git never reports its own dir); callers that need it
+ *  ignored must add it themselves.
+ *
+ *  @param repoPath  Absolute path to the repo root.
+ *  @param log       Optional logger. */
+export async function listIgnoredPaths(
+  repoPath: string,
+  log?: Logger,
+): Promise<GitResult<string[]>> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      [
+        "ls-files",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "--directory",
+      ],
+      { cwd: repoPath, maxBuffer: 64 * 1024 * 1024 },
+    );
+    const paths = stdout
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => l.replace(/\/+$/, ""));
+    return ok(paths);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log?.error({ err: e, repoPath }, "git ls-files --ignored failed");
+    return err({
+      code: "GIT_FAILED",
+      message: `Failed to list ignored files: ${msg}`,
+    });
+  }
+}
+
 /** Max file size to read (1 MB). Larger files get a truncation notice. */
 const MAX_READ_BYTES = 1_048_576;
 

--- a/packages/integrations/git/src/browse.ts
+++ b/packages/integrations/git/src/browse.ts
@@ -32,7 +32,7 @@ async function gitLsFiles(
     return ok(paths);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    log?.error({ err: e, repoPath }, "git ls-files failed");
+    log?.error({ err: msg, repoPath }, "git ls-files failed");
     return err({ code: "GIT_FAILED", message: `${failMsg}: ${msg}` });
   }
 }

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -43,6 +43,7 @@ import {
 } from "@parcel/watcher";
 import type { Logger } from "kolu-shared";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
+import { resolveUnder } from "./safe-path.ts";
 
 /** Directory basenames the watch skips: VCS internals, dependency trees, and
  *  build outputs. Single source of truth — the parcel ignore globs below AND
@@ -87,12 +88,21 @@ const IGNORE_GLOBS = [
  *  so the file — now directly under the root — is no longer swallowed by
  *  `**\/dist/**`, while any `node_modules`/`.git` *within* that directory stay
  *  ignored. Files outside ignored dirs keep `repoRoot` and so keep sharing the
- *  one repo-wide watcher (no extra OS handles for the common case). */
-function watchRootFor(repoRoot: string, filePath: string | undefined): string {
-  if (filePath === undefined) return repoRoot;
-  const dirSegments = filePath.split("/").slice(0, -1);
+ *  one repo-wide watcher (no extra OS handles for the common case).
+ *
+ *  `rel`/`abs` must already have passed `resolveUnder` — re-rooting at a file's
+ *  own directory means the ignore globs no longer protect against escaping the
+ *  repo, so the lexical boundary check has to happen *before* we get here.
+ *  `rel` is the normalized repo-relative path (no `..`, never absolute). */
+function watchRootFor(
+  repoRoot: string,
+  rel: string | undefined,
+  abs: string | undefined,
+): string {
+  if (rel === undefined || abs === undefined) return repoRoot;
+  const dirSegments = rel.split(path.sep).slice(0, -1);
   if (dirSegments.some((seg) => IGNORED_DIR_BASENAMES.includes(seg))) {
-    return path.dirname(path.resolve(repoRoot, filePath));
+    return path.dirname(abs);
   }
   return repoRoot;
 }
@@ -257,11 +267,20 @@ export function watchWorkingTree(
   log?: Logger,
   options?: WatchWorkingTreeOptions,
 ): () => void {
-  const watchRoot = watchRootFor(repoRoot, options?.filePath);
-  const matchAbs =
-    options?.filePath === undefined
-      ? null
-      : path.resolve(repoRoot, options.filePath);
+  // Validate the caller-supplied filePath *before* it can steer the watch
+  // root. `watchWorkingTree` is exported, so we can't trust the raw string:
+  // a crafted `dist/../../../etc/passwd` would otherwise re-root parcel
+  // outside the repo (re-rooting bypasses the ignore globs that are this
+  // module's only other escape guard). On escape, install nothing and hand
+  // back a no-op unsubscribe.
+  let resolved: { abs: string; rel: string } | undefined;
+  if (options?.filePath !== undefined) {
+    const guard = resolveUnder(repoRoot, options.filePath, log);
+    if (!guard.ok) return () => {};
+    resolved = guard.value;
+  }
+  const watchRoot = watchRootFor(repoRoot, resolved?.rel, resolved?.abs);
+  const matchAbs = resolved?.abs ?? null;
   let entry = sharedWorkingTreeWatchers.get(watchRoot);
   if (!entry) {
     entry = installSharedWorkingTreeWatcher(

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -16,24 +16,32 @@
  *   - VS Code switched here in 1.62 for the same reasons.
  *
  * On Linux without watchman both libraries pay one inotify slot per
- * directory — that's a kernel constraint, not a library choice. With
- * `.git`, `node_modules`, and common build outputs ignored, a typical repo
- * uses ~500–2000 slots out of the kernel's default budget.
+ * directory — that's a kernel constraint, not a library choice. With git's
+ * ignored paths (`node_modules`, gitignored build outputs) pruned, a typical
+ * repo uses ~500–2000 slots out of the kernel's default budget.
  *
  * Container/WSL2 caveat: parcel-watcher silently falls back to ~1s polling
  * when neither inotify nor FSEvents nor watchman is available (e.g.
  * dev-containers on bind-mounted filesystems). Latency degrades but
  * correctness is preserved.
  *
- * Subscribers can pass a `filePath` to receive only events for that exact
- * file (the `BrowseFileView` case — one selected file, not the whole tree)
- * or omit it to receive every event (the `subscribeRepoChange` case). The
- * filter happens at the listener layer, so a single shared watcher serves
- * both consumers. The one exception: a previewed file that lives under an
- * ignored build-output dir (Atlas commits and previews `docs/atlas/dist/`)
- * re-roots parcel at the file's own directory (`watchRootFor`) — otherwise
- * the repo-root ignore globs would prune the very file the user opened and
- * its live-reload would silently never fire.
+ * The ignore set is derived from git, not a hardcoded list: `listIgnoredPaths`
+ * runs the exact complement of the browse tree's `git ls-files --cached
+ * --others --exclude-standard`, so *anything the Code-tab tree shows is
+ * watched* and anything git ignores is skipped. That single source of truth is
+ * what lets Atlas's **committed** `docs/atlas/dist/*.html` live-reload while a
+ * normal repo's **gitignored** `dist/` stays unwatched — the two used to
+ * disagree (tree gitignore-aware, watcher hardcoded), which silently broke
+ * live-reload for committed build outputs. `.git` is added explicitly (git
+ * never lists its own dir; the git-dir watchers cover it). The set is a
+ * snapshot at install time — a `.gitignore` edit mid-watch isn't reflected
+ * until the next (re)subscribe.
+ *
+ * Subscribers can pass a `filePath` to receive only events for that exact file
+ * (the `BrowseFileView` case — one selected file, not the whole tree) or omit
+ * it to receive every event (the `subscribeRepoChange` case). The filter
+ * happens at the listener layer, so a single shared watcher per repo serves
+ * both consumers — no separate single-file watcher.
  */
 
 import path from "node:path";
@@ -42,77 +50,33 @@ import {
   subscribe as parcelSubscribe,
 } from "@parcel/watcher";
 import type { Logger } from "kolu-shared";
+import { listIgnoredPaths } from "./browse.ts";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
-import { assertRealpathUnder, resolveUnder } from "./safe-path.ts";
 
-/** Directory basenames the watch skips: VCS internals, dependency trees, and
- *  build outputs. Single source of truth — the parcel ignore globs below AND
- *  `watchRootFor` (which re-roots a single-file watch out of an ignored
- *  ancestor) both derive from this list, so "what the repo-wide watch skips"
- *  and "which previewed files the repo root would hide" can't drift apart. */
-const IGNORED_DIR_BASENAMES = [
-  ".git",
-  "node_modules",
-  ".kolu-dev",
-  ".kolu-state",
-  "dist",
-  "build",
-  "target",
-  ".next",
-  ".turbo",
-  ".cache",
-  ".parcel-cache",
-];
+/** `.git` is always ignored: git never lists its own dir, and the git-dir
+ *  watchers (HEAD/reflog/index) cover the parts we care about — watching it
+ *  here would just fire on every git operation. */
+const ALWAYS_IGNORE_RELS = [".git"];
 
-/** Globs are matched against paths relative to the watched root by
- *  parcel-watcher's picomatch integration. The leading `**\/` wildcards catch
- *  nested instances (e.g. `packages/foo/node_modules`).
- *
- *  Not gitignore-aware. We accept some over-firing on user-generated build
- *  outputs that aren't in this list — the upstream debounce + the streaming
- *  endpoint's snapshot equality check absorb noise events. */
-const IGNORE_GLOBS = [
-  ...IGNORED_DIR_BASENAMES.flatMap((d) => [`**/${d}`, `**/${d}/**`]),
-  "**/.DS_Store",
-];
+/** Degraded fallback when git can't enumerate ignores (not a repo, git error).
+ *  Keeps `node_modules` — the one unbounded recursive subtree whose watch
+ *  actually threatens the inotify budget — out of the watch, so a git hiccup
+ *  can't unleash a watch storm. The healthy path derives the full set from
+ *  git via `listIgnoredPaths`. */
+const FALLBACK_IGNORE_RELS = ["node_modules"];
 
-/** Pick the parcel watch root for a subscription.
- *
- *  The repo-wide watch (no `filePath`) roots at `repoRoot` and lets the ignore
- *  globs prune build outputs — correct, since the tree/status views don't care
- *  about `dist/`. But a single-file preview watch for a file that LIVES under
- *  an ignored dir (Atlas commits and previews `docs/atlas/dist/*.html`) would
- *  get zero events: parcel never reports an ignored path. So when the
- *  previewed file sits under an ignored ancestor, root parcel at the file's own
- *  directory instead. The ignore globs are matched relative to the watch root,
- *  so the file — now directly under the root — is no longer swallowed by
- *  `**\/dist/**`, while any `node_modules`/`.git` *within* that directory stay
- *  ignored. Files outside ignored dirs keep `repoRoot` and so keep sharing the
- *  one repo-wide watcher (no extra OS handles for the common case).
- *
- *  `rel`/`abs` must already have passed `resolveUnder` — re-rooting at a file's
- *  own directory means the ignore globs no longer protect against escaping the
- *  repo, so the lexical boundary check has to happen *before* we get here.
- *  `rel` is the normalized repo-relative path (no `..`, never absolute).
- *
- *  Lexical containment is necessary but NOT sufficient for the re-rooted path:
- *  `resolveUnder` does not resolve symlinks, so a *symlinked* ignored ancestor
- *  (`docs/atlas/dist -> /tmp/evil`) yields a `rel` that still lives under the
- *  repo lexically, yet `path.dirname(abs)` points parcel at a directory the OS
- *  backend will canonicalize outside the repo. Callers that re-root MUST also
- *  realpath-check the returned root against the repo (`assertRealpathUnder`)
- *  before installing parcel — see `watchWorkingTree`. */
-function watchRootFor(
+/** Absolute paths parcel must not emit events for. parcel treats a non-glob
+ *  path entry as "ignore this file/dir and all its children", so absolute
+ *  directory paths prune whole subtrees. */
+async function computeIgnore(
   repoRoot: string,
-  rel: string | undefined,
-  abs: string | undefined,
-): string {
-  if (rel === undefined || abs === undefined) return repoRoot;
-  const dirSegments = rel.split(path.sep).slice(0, -1);
-  if (dirSegments.some((seg) => IGNORED_DIR_BASENAMES.includes(seg))) {
-    return path.dirname(abs);
-  }
-  return repoRoot;
+  log?: Logger,
+): Promise<string[]> {
+  const ignored = await listIgnoredPaths(repoRoot, log);
+  const rels = ignored.ok
+    ? [...ALWAYS_IGNORE_RELS, ...ignored.value]
+    : [...ALWAYS_IGNORE_RELS, ...FALLBACK_IGNORE_RELS];
+  return rels.map((rel) => path.resolve(repoRoot, rel));
 }
 
 interface Listener {
@@ -129,15 +93,9 @@ interface SharedWorkingTreeWatcher {
 const sharedWorkingTreeWatchers = new Map<string, SharedWorkingTreeWatcher>();
 
 function installSharedWorkingTreeWatcher(
-  watchRoot: string,
+  repoRoot: string,
   onLast: () => void,
   log?: Logger,
-  /** When the watch root was re-rooted away from `repoRoot`, an async
-   *  symlink-aware authority check that must resolve `ok` before parcel is
-   *  installed. Resolving falsy means the re-rooted directory canonicalizes
-   *  outside the repo (a symlinked ignored ancestor) — install nothing and
-   *  retire the entry. Omitted for the repo-root watch, which never escapes. */
-  guard?: () => Promise<boolean>,
 ): SharedWorkingTreeWatcher {
   const listeners = new Set<Listener>();
   const pending = new Set<Listener>();
@@ -158,7 +116,7 @@ function installSharedWorkingTreeWatcher(
           listener.onChange();
         } catch (e) {
           log?.error(
-            { err: e instanceof Error ? e.message : String(e), watchRoot },
+            { err: e instanceof Error ? e.message : String(e), repoRoot },
             "git: working-tree listener threw",
           );
         }
@@ -166,106 +124,79 @@ function installSharedWorkingTreeWatcher(
     }, WATCHER_DEBOUNCE_MS);
   };
 
-  // Async install. Filesystem mutations between this call and parcel's
-  // resolve are invisible to parcel — the streaming endpoint already
-  // yielded its initial snapshot before this subscribe ran, so any change
-  // landing in that window leaves the client with a stale view that no
-  // future event will correct on its own. Fire a synthetic tick once
-  // parcel is ready so consumers re-read state and reconcile.
-  const startParcel = (): void => {
-    parcelSubscribe(
-      watchRoot,
-      (err, events) => {
-        if (cancelled) return;
-        if (err) {
-          log?.error(
-            { err: err.message, watchRoot },
-            "git: working-tree watcher callback error",
-          );
-          return;
-        }
+  // Async install: derive the ignore set from git, then subscribe. Filesystem
+  // mutations between this call and parcel's resolve are invisible to parcel —
+  // the streaming endpoint already yielded its initial snapshot before this
+  // ran, so any change landing in that window leaves the client with a stale
+  // view that no future event would correct on its own. Fire a synthetic tick
+  // once parcel is ready so consumers re-read state and reconcile.
+  void (async () => {
+    const ignore = await computeIgnore(repoRoot, log);
+    if (cancelled) return;
+    try {
+      const sub = await parcelSubscribe(
+        repoRoot,
+        (err, events) => {
+          if (cancelled) return;
+          if (err) {
+            log?.error(
+              { err: err.message, repoRoot },
+              "git: working-tree watcher callback error",
+            );
+            return;
+          }
 
-        // Bucket events into the listeners they match. A single batch can
-        // hit several listeners (different filePaths) or none (all-ignored
-        // paths slipped through somehow).
-        for (const event of events) {
-          for (const listener of listeners) {
-            if (
-              listener.matchAbs === null ||
-              listener.matchAbs === event.path
-            ) {
-              pending.add(listener);
+          // Bucket events into the listeners they match. A single batch can
+          // hit several listeners (different filePaths) or none (all-ignored
+          // paths slipped through somehow).
+          for (const event of events) {
+            for (const listener of listeners) {
+              if (
+                listener.matchAbs === null ||
+                listener.matchAbs === event.path
+              ) {
+                pending.add(listener);
+              }
             }
           }
-        }
 
-        if (pending.size === 0) return;
+          if (pending.size === 0) return;
 
-        // Trailing-edge debounce — a burst of events fires the listeners
-        // exactly once, after the burst settles. Reset on every new batch.
-        scheduleFire();
-      },
-      { ignore: IGNORE_GLOBS },
-    )
-      .then((sub) => {
-        if (cancelled) {
-          void sub.unsubscribe().catch((e: Error) => {
-            log?.error(
-              { err: e.message, watchRoot },
-              "git: working-tree late-unsubscribe failed",
-            );
-          });
-          return;
-        }
-        subscription = sub;
-        log?.info({ watchRoot }, "git: working-tree watcher installed");
-
-        // Reconcile any mutations that landed in the install window —
-        // parcel didn't see them, but the listener's own re-read will. Add
-        // every current listener to `pending` (the filter doesn't matter
-        // here; reconciliation is a "re-derive your state" signal, not a
-        // path-specific event) and schedule one debounced fire.
-        if (listeners.size > 0) {
-          for (const listener of listeners) pending.add(listener);
+          // Trailing-edge debounce — a burst of events fires the listeners
+          // exactly once, after the burst settles. Reset on every new batch.
           scheduleFire();
-        }
-      })
-      .catch((e: Error) => {
-        log?.error(
-          { err: e.message, watchRoot },
-          "git: working-tree watcher install failed",
-        );
-      });
-  };
+        },
+        { ignore },
+      );
 
-  if (guard) {
-    // Re-rooted watch: prove the watch root canonicalizes inside the repo
-    // before handing it to parcel (a symlinked ignored ancestor would point
-    // the OS backend outside repo authority — lexical containment can't
-    // catch that). On failure, retire the entry so a later subscriber forces
-    // a fresh, re-guarded install instead of binding to a dead watcher.
-    void guard()
-      .then((allowed) => {
-        if (cancelled) return;
-        if (!allowed) {
-          cancelled = true;
-          onLast();
-          return;
-        }
-        startParcel();
-      })
-      .catch((e: Error) => {
-        log?.error(
-          { err: e.message, watchRoot },
-          "git: working-tree watch-root guard failed",
-        );
-        if (cancelled) return;
-        cancelled = true;
-        onLast();
-      });
-  } else {
-    startParcel();
-  }
+      if (cancelled) {
+        void sub.unsubscribe().catch((e: Error) => {
+          log?.error(
+            { err: e.message, repoRoot },
+            "git: working-tree late-unsubscribe failed",
+          );
+        });
+        return;
+      }
+      subscription = sub;
+      log?.info({ repoRoot }, "git: working-tree watcher installed");
+
+      // Reconcile any mutations that landed in the install window — parcel
+      // didn't see them, but the listener's own re-read will. Add every
+      // current listener to `pending` (the filter doesn't matter here;
+      // reconciliation is a "re-derive your state" signal, not a path-specific
+      // event) and schedule one debounced fire.
+      if (listeners.size > 0) {
+        for (const listener of listeners) pending.add(listener);
+        scheduleFire();
+      }
+    } catch (e) {
+      log?.error(
+        { err: e instanceof Error ? e.message : String(e), repoRoot },
+        "git: working-tree watcher install failed",
+      );
+    }
+  })();
 
   return {
     subscribe(matchAbs, onChange) {
@@ -280,14 +211,14 @@ function installSharedWorkingTreeWatcher(
           if (subscription) {
             void subscription.unsubscribe().catch((e: Error) => {
               log?.error(
-                { err: e.message, watchRoot },
+                { err: e.message, repoRoot },
                 "git: working-tree unsubscribe failed",
               );
             });
             subscription = null;
           }
           onLast();
-          log?.info({ watchRoot }, "git: working-tree watcher retired");
+          log?.info({ repoRoot }, "git: working-tree watcher retired");
         }
       };
     },
@@ -302,12 +233,14 @@ export interface WatchWorkingTreeOptions {
 
 /**
  * Subscribe to working-tree changes for `repoRoot`. Returns a cleanup
- * function. Callers sharing a watch root collapse to one shared
+ * function. N callers on the same `repoRoot` collapse to one shared
  * `@parcel/watcher` subscription; each listener installs its own optional
- * filePath filter without installing a separate OS handle. A single-file
- * watch whose file lives under an ignored build-output dir re-roots at that
- * file's directory (see `watchRootFor`) so it isn't pruned by the ignore
- * globs — otherwise it shares `repoRoot` with the repo-wide watch.
+ * filePath filter without installing a separate OS handle.
+ *
+ * The watch is always rooted at `repoRoot`; the optional `filePath` only
+ * narrows which events a listener receives (it's resolved to an absolute path
+ * and compared against parcel's event paths), so it can't steer the watch root
+ * or escape the repo.
  */
 export function watchWorkingTree(
   repoRoot: string,
@@ -315,44 +248,23 @@ export function watchWorkingTree(
   log?: Logger,
   options?: WatchWorkingTreeOptions,
 ): () => void {
-  // Validate the caller-supplied filePath *before* it can steer the watch
-  // root. `watchWorkingTree` is exported, so we can't trust the raw string:
-  // a crafted `dist/../../../etc/passwd` would otherwise re-root parcel
-  // outside the repo (re-rooting bypasses the ignore globs that are this
-  // module's only other escape guard). On escape, install nothing and hand
-  // back a no-op unsubscribe.
-  let resolved: { abs: string; rel: string } | undefined;
-  if (options?.filePath !== undefined) {
-    const guard = resolveUnder(repoRoot, options.filePath, log);
-    if (!guard.ok) return () => {};
-    resolved = guard.value;
-  }
-  const watchRoot = watchRootFor(repoRoot, resolved?.rel, resolved?.abs);
-  const matchAbs = resolved?.abs ?? null;
-  // A re-rooted watch (root moved off `repoRoot` into an ignored ancestor)
-  // escaped the ignore globs *and* `resolveUnder`'s lexical check, so a
-  // symlinked ignored ancestor could canonicalize the watch root outside the
-  // repo. Guard that re-rooted install with the symlink-aware authority check
-  // before parcel touches it. The repo-root watch can't escape, so it skips
-  // the (async, filesystem-touching) guard and stays synchronous.
-  const guard =
-    watchRoot === repoRoot
-      ? undefined
-      : async () => (await assertRealpathUnder(repoRoot, watchRoot, log)).ok;
-  let entry = sharedWorkingTreeWatchers.get(watchRoot);
+  const matchAbs =
+    options?.filePath === undefined
+      ? null
+      : path.resolve(repoRoot, options.filePath);
+  let entry = sharedWorkingTreeWatchers.get(repoRoot);
   if (!entry) {
     entry = installSharedWorkingTreeWatcher(
-      watchRoot,
-      () => sharedWorkingTreeWatchers.delete(watchRoot),
+      repoRoot,
+      () => sharedWorkingTreeWatchers.delete(repoRoot),
       log,
-      guard,
     );
-    sharedWorkingTreeWatchers.set(watchRoot, entry);
+    sharedWorkingTreeWatchers.set(repoRoot, entry);
   }
   return entry.subscribe(matchAbs, onChange);
 }
 
-/** Test-only inspector — number of distinct watch roots with active shared
+/** Test-only inspector — number of distinct repoRoots with active shared
  *  working-tree watchers. Mirrors `_sharedHeadWatcherCount`. */
 export function _sharedWorkingTreeWatcherCount(): number {
   return sharedWorkingTreeWatchers.size;

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -28,8 +28,12 @@
  * Subscribers can pass a `filePath` to receive only events for that exact
  * file (the `BrowseFileView` case — one selected file, not the whole tree)
  * or omit it to receive every event (the `subscribeRepoChange` case). The
- * filter happens at the listener layer so a single shared watcher serves
- * both consumers — no separate single-file watcher module needed.
+ * filter happens at the listener layer, so a single shared watcher serves
+ * both consumers. The one exception: a previewed file that lives under an
+ * ignored build-output dir (Atlas commits and previews `docs/atlas/dist/`)
+ * re-roots parcel at the file's own directory (`watchRootFor`) — otherwise
+ * the repo-root ignore globs would prune the very file the user opened and
+ * its live-reload would silently never fire.
  */
 
 import path from "node:path";
@@ -40,38 +44,58 @@ import {
 import type { Logger } from "kolu-shared";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
 
-/** Hard-coded ignore list. Globs are matched against paths relative to the
- *  watched repo root by parcel-watcher's picomatch integration. The leading
- *  `**\/` wildcards catch nested instances (e.g. `packages/foo/node_modules`).
+/** Directory basenames the watch skips: VCS internals, dependency trees, and
+ *  build outputs. Single source of truth — the parcel ignore globs below AND
+ *  `watchRootFor` (which re-roots a single-file watch out of an ignored
+ *  ancestor) both derive from this list, so "what the repo-wide watch skips"
+ *  and "which previewed files the repo root would hide" can't drift apart. */
+const IGNORED_DIR_BASENAMES = [
+  ".git",
+  "node_modules",
+  ".kolu-dev",
+  ".kolu-state",
+  "dist",
+  "build",
+  "target",
+  ".next",
+  ".turbo",
+  ".cache",
+  ".parcel-cache",
+];
+
+/** Globs are matched against paths relative to the watched root by
+ *  parcel-watcher's picomatch integration. The leading `**\/` wildcards catch
+ *  nested instances (e.g. `packages/foo/node_modules`).
  *
  *  Not gitignore-aware. We accept some over-firing on user-generated build
  *  outputs that aren't in this list — the upstream debounce + the streaming
  *  endpoint's snapshot equality check absorb noise events. */
 const IGNORE_GLOBS = [
-  "**/.git",
-  "**/.git/**",
-  "**/node_modules",
-  "**/node_modules/**",
-  "**/.kolu-dev",
-  "**/.kolu-dev/**",
-  "**/.kolu-state",
-  "**/.kolu-state/**",
-  "**/dist",
-  "**/dist/**",
-  "**/build",
-  "**/build/**",
-  "**/target",
-  "**/target/**",
-  "**/.next",
-  "**/.next/**",
-  "**/.turbo",
-  "**/.turbo/**",
-  "**/.cache",
-  "**/.cache/**",
-  "**/.parcel-cache",
-  "**/.parcel-cache/**",
+  ...IGNORED_DIR_BASENAMES.flatMap((d) => [`**/${d}`, `**/${d}/**`]),
   "**/.DS_Store",
 ];
+
+/** Pick the parcel watch root for a subscription.
+ *
+ *  The repo-wide watch (no `filePath`) roots at `repoRoot` and lets the ignore
+ *  globs prune build outputs — correct, since the tree/status views don't care
+ *  about `dist/`. But a single-file preview watch for a file that LIVES under
+ *  an ignored dir (Atlas commits and previews `docs/atlas/dist/*.html`) would
+ *  get zero events: parcel never reports an ignored path. So when the
+ *  previewed file sits under an ignored ancestor, root parcel at the file's own
+ *  directory instead. The ignore globs are matched relative to the watch root,
+ *  so the file — now directly under the root — is no longer swallowed by
+ *  `**\/dist/**`, while any `node_modules`/`.git` *within* that directory stay
+ *  ignored. Files outside ignored dirs keep `repoRoot` and so keep sharing the
+ *  one repo-wide watcher (no extra OS handles for the common case). */
+function watchRootFor(repoRoot: string, filePath: string | undefined): string {
+  if (filePath === undefined) return repoRoot;
+  const dirSegments = filePath.split("/").slice(0, -1);
+  if (dirSegments.some((seg) => IGNORED_DIR_BASENAMES.includes(seg))) {
+    return path.dirname(path.resolve(repoRoot, filePath));
+  }
+  return repoRoot;
+}
 
 interface Listener {
   /** Absolute path to match against incoming events, or `null` to receive
@@ -81,13 +105,13 @@ interface Listener {
 }
 
 interface SharedWorkingTreeWatcher {
-  subscribe(filePath: string | undefined, onChange: () => void): () => void;
+  subscribe(matchAbs: string | null, onChange: () => void): () => void;
 }
 
 const sharedWorkingTreeWatchers = new Map<string, SharedWorkingTreeWatcher>();
 
 function installSharedWorkingTreeWatcher(
-  repoRoot: string,
+  watchRoot: string,
   onLast: () => void,
   log?: Logger,
 ): SharedWorkingTreeWatcher {
@@ -110,7 +134,7 @@ function installSharedWorkingTreeWatcher(
           listener.onChange();
         } catch (e) {
           log?.error(
-            { err: e instanceof Error ? e.message : String(e), repoRoot },
+            { err: e instanceof Error ? e.message : String(e), watchRoot },
             "git: working-tree listener threw",
           );
         }
@@ -125,12 +149,12 @@ function installSharedWorkingTreeWatcher(
   // future event will correct on its own. Fire a synthetic tick once
   // parcel is ready so consumers re-read state and reconcile.
   parcelSubscribe(
-    repoRoot,
+    watchRoot,
     (err, events) => {
       if (cancelled) return;
       if (err) {
         log?.error(
-          { err: err.message, repoRoot },
+          { err: err.message, watchRoot },
           "git: working-tree watcher callback error",
         );
         return;
@@ -159,14 +183,14 @@ function installSharedWorkingTreeWatcher(
       if (cancelled) {
         void sub.unsubscribe().catch((e: Error) => {
           log?.error(
-            { err: e.message, repoRoot },
+            { err: e.message, watchRoot },
             "git: working-tree late-unsubscribe failed",
           );
         });
         return;
       }
       subscription = sub;
-      log?.info({ repoRoot }, "git: working-tree watcher installed");
+      log?.info({ watchRoot }, "git: working-tree watcher installed");
 
       // Reconcile any mutations that landed in the install window —
       // parcel didn't see them, but the listener's own re-read will. Add
@@ -180,15 +204,13 @@ function installSharedWorkingTreeWatcher(
     })
     .catch((e: Error) => {
       log?.error(
-        { err: e.message, repoRoot },
+        { err: e.message, watchRoot },
         "git: working-tree watcher install failed",
       );
     });
 
   return {
-    subscribe(filePath, onChange) {
-      const matchAbs =
-        filePath === undefined ? null : path.resolve(repoRoot, filePath);
+    subscribe(matchAbs, onChange) {
       const listener: Listener = { matchAbs, onChange };
       listeners.add(listener);
       return () => {
@@ -200,14 +222,14 @@ function installSharedWorkingTreeWatcher(
           if (subscription) {
             void subscription.unsubscribe().catch((e: Error) => {
               log?.error(
-                { err: e.message, repoRoot },
+                { err: e.message, watchRoot },
                 "git: working-tree unsubscribe failed",
               );
             });
             subscription = null;
           }
           onLast();
-          log?.info({ repoRoot }, "git: working-tree watcher retired");
+          log?.info({ watchRoot }, "git: working-tree watcher retired");
         }
       };
     },
@@ -222,9 +244,12 @@ export interface WatchWorkingTreeOptions {
 
 /**
  * Subscribe to working-tree changes for `repoRoot`. Returns a cleanup
- * function. N callers on the same `repoRoot` collapse to one shared
+ * function. Callers sharing a watch root collapse to one shared
  * `@parcel/watcher` subscription; each listener installs its own optional
- * filePath filter without installing a separate OS handle.
+ * filePath filter without installing a separate OS handle. A single-file
+ * watch whose file lives under an ignored build-output dir re-roots at that
+ * file's directory (see `watchRootFor`) so it isn't pruned by the ignore
+ * globs — otherwise it shares `repoRoot` with the repo-wide watch.
  */
 export function watchWorkingTree(
   repoRoot: string,
@@ -232,19 +257,24 @@ export function watchWorkingTree(
   log?: Logger,
   options?: WatchWorkingTreeOptions,
 ): () => void {
-  let entry = sharedWorkingTreeWatchers.get(repoRoot);
+  const watchRoot = watchRootFor(repoRoot, options?.filePath);
+  const matchAbs =
+    options?.filePath === undefined
+      ? null
+      : path.resolve(repoRoot, options.filePath);
+  let entry = sharedWorkingTreeWatchers.get(watchRoot);
   if (!entry) {
     entry = installSharedWorkingTreeWatcher(
-      repoRoot,
-      () => sharedWorkingTreeWatchers.delete(repoRoot),
+      watchRoot,
+      () => sharedWorkingTreeWatchers.delete(watchRoot),
       log,
     );
-    sharedWorkingTreeWatchers.set(repoRoot, entry);
+    sharedWorkingTreeWatchers.set(watchRoot, entry);
   }
-  return entry.subscribe(options?.filePath, onChange);
+  return entry.subscribe(matchAbs, onChange);
 }
 
-/** Test-only inspector — number of distinct repoRoots with active shared
+/** Test-only inspector — number of distinct watch roots with active shared
  *  working-tree watchers. Mirrors `_sharedHeadWatcherCount`. */
 export function _sharedWorkingTreeWatcherCount(): number {
   return sharedWorkingTreeWatchers.size;

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -43,7 +43,7 @@ import {
 } from "@parcel/watcher";
 import type { Logger } from "kolu-shared";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
-import { resolveUnder } from "./safe-path.ts";
+import { assertRealpathUnder, resolveUnder } from "./safe-path.ts";
 
 /** Directory basenames the watch skips: VCS internals, dependency trees, and
  *  build outputs. Single source of truth — the parcel ignore globs below AND
@@ -93,7 +93,15 @@ const IGNORE_GLOBS = [
  *  `rel`/`abs` must already have passed `resolveUnder` — re-rooting at a file's
  *  own directory means the ignore globs no longer protect against escaping the
  *  repo, so the lexical boundary check has to happen *before* we get here.
- *  `rel` is the normalized repo-relative path (no `..`, never absolute). */
+ *  `rel` is the normalized repo-relative path (no `..`, never absolute).
+ *
+ *  Lexical containment is necessary but NOT sufficient for the re-rooted path:
+ *  `resolveUnder` does not resolve symlinks, so a *symlinked* ignored ancestor
+ *  (`docs/atlas/dist -> /tmp/evil`) yields a `rel` that still lives under the
+ *  repo lexically, yet `path.dirname(abs)` points parcel at a directory the OS
+ *  backend will canonicalize outside the repo. Callers that re-root MUST also
+ *  realpath-check the returned root against the repo (`assertRealpathUnder`)
+ *  before installing parcel — see `watchWorkingTree`. */
 function watchRootFor(
   repoRoot: string,
   rel: string | undefined,
@@ -124,6 +132,12 @@ function installSharedWorkingTreeWatcher(
   watchRoot: string,
   onLast: () => void,
   log?: Logger,
+  /** When the watch root was re-rooted away from `repoRoot`, an async
+   *  symlink-aware authority check that must resolve `ok` before parcel is
+   *  installed. Resolving falsy means the re-rooted directory canonicalizes
+   *  outside the repo (a symlinked ignored ancestor) — install nothing and
+   *  retire the entry. Omitted for the repo-root watch, which never escapes. */
+  guard?: () => Promise<boolean>,
 ): SharedWorkingTreeWatcher {
   const listeners = new Set<Listener>();
   const pending = new Set<Listener>();
@@ -158,66 +172,100 @@ function installSharedWorkingTreeWatcher(
   // landing in that window leaves the client with a stale view that no
   // future event will correct on its own. Fire a synthetic tick once
   // parcel is ready so consumers re-read state and reconcile.
-  parcelSubscribe(
-    watchRoot,
-    (err, events) => {
-      if (cancelled) return;
-      if (err) {
-        log?.error(
-          { err: err.message, watchRoot },
-          "git: working-tree watcher callback error",
-        );
-        return;
-      }
+  const startParcel = (): void => {
+    parcelSubscribe(
+      watchRoot,
+      (err, events) => {
+        if (cancelled) return;
+        if (err) {
+          log?.error(
+            { err: err.message, watchRoot },
+            "git: working-tree watcher callback error",
+          );
+          return;
+        }
 
-      // Bucket events into the listeners they match. A single batch can
-      // hit several listeners (different filePaths) or none (all-ignored
-      // paths slipped through somehow).
-      for (const event of events) {
-        for (const listener of listeners) {
-          if (listener.matchAbs === null || listener.matchAbs === event.path) {
-            pending.add(listener);
+        // Bucket events into the listeners they match. A single batch can
+        // hit several listeners (different filePaths) or none (all-ignored
+        // paths slipped through somehow).
+        for (const event of events) {
+          for (const listener of listeners) {
+            if (
+              listener.matchAbs === null ||
+              listener.matchAbs === event.path
+            ) {
+              pending.add(listener);
+            }
           }
         }
-      }
 
-      if (pending.size === 0) return;
+        if (pending.size === 0) return;
 
-      // Trailing-edge debounce — a burst of events fires the listeners
-      // exactly once, after the burst settles. Reset on every new batch.
-      scheduleFire();
-    },
-    { ignore: IGNORE_GLOBS },
-  )
-    .then((sub) => {
-      if (cancelled) {
-        void sub.unsubscribe().catch((e: Error) => {
-          log?.error(
-            { err: e.message, watchRoot },
-            "git: working-tree late-unsubscribe failed",
-          );
-        });
-        return;
-      }
-      subscription = sub;
-      log?.info({ watchRoot }, "git: working-tree watcher installed");
-
-      // Reconcile any mutations that landed in the install window —
-      // parcel didn't see them, but the listener's own re-read will. Add
-      // every current listener to `pending` (the filter doesn't matter
-      // here; reconciliation is a "re-derive your state" signal, not a
-      // path-specific event) and schedule one debounced fire.
-      if (listeners.size > 0) {
-        for (const listener of listeners) pending.add(listener);
+        // Trailing-edge debounce — a burst of events fires the listeners
+        // exactly once, after the burst settles. Reset on every new batch.
         scheduleFire();
-      }
-    })
-    .catch((e: Error) => {
-      log?.error(
-        { err: e.message, watchRoot },
-        "git: working-tree watcher install failed",
-      );
-    });
+      },
+      { ignore: IGNORE_GLOBS },
+    )
+      .then((sub) => {
+        if (cancelled) {
+          void sub.unsubscribe().catch((e: Error) => {
+            log?.error(
+              { err: e.message, watchRoot },
+              "git: working-tree late-unsubscribe failed",
+            );
+          });
+          return;
+        }
+        subscription = sub;
+        log?.info({ watchRoot }, "git: working-tree watcher installed");
+
+        // Reconcile any mutations that landed in the install window —
+        // parcel didn't see them, but the listener's own re-read will. Add
+        // every current listener to `pending` (the filter doesn't matter
+        // here; reconciliation is a "re-derive your state" signal, not a
+        // path-specific event) and schedule one debounced fire.
+        if (listeners.size > 0) {
+          for (const listener of listeners) pending.add(listener);
+          scheduleFire();
+        }
+      })
+      .catch((e: Error) => {
+        log?.error(
+          { err: e.message, watchRoot },
+          "git: working-tree watcher install failed",
+        );
+      });
+  };
+
+  if (guard) {
+    // Re-rooted watch: prove the watch root canonicalizes inside the repo
+    // before handing it to parcel (a symlinked ignored ancestor would point
+    // the OS backend outside repo authority — lexical containment can't
+    // catch that). On failure, retire the entry so a later subscriber forces
+    // a fresh, re-guarded install instead of binding to a dead watcher.
+    void guard()
+      .then((allowed) => {
+        if (cancelled) return;
+        if (!allowed) {
+          cancelled = true;
+          onLast();
+          return;
+        }
+        startParcel();
+      })
+      .catch((e: Error) => {
+        log?.error(
+          { err: e.message, watchRoot },
+          "git: working-tree watch-root guard failed",
+        );
+        if (cancelled) return;
+        cancelled = true;
+        onLast();
+      });
+  } else {
+    startParcel();
+  }
 
   return {
     subscribe(matchAbs, onChange) {
@@ -281,12 +329,23 @@ export function watchWorkingTree(
   }
   const watchRoot = watchRootFor(repoRoot, resolved?.rel, resolved?.abs);
   const matchAbs = resolved?.abs ?? null;
+  // A re-rooted watch (root moved off `repoRoot` into an ignored ancestor)
+  // escaped the ignore globs *and* `resolveUnder`'s lexical check, so a
+  // symlinked ignored ancestor could canonicalize the watch root outside the
+  // repo. Guard that re-rooted install with the symlink-aware authority check
+  // before parcel touches it. The repo-root watch can't escape, so it skips
+  // the (async, filesystem-touching) guard and stays synchronous.
+  const guard =
+    watchRoot === repoRoot
+      ? undefined
+      : async () => (await assertRealpathUnder(repoRoot, watchRoot, log)).ok;
   let entry = sharedWorkingTreeWatchers.get(watchRoot);
   if (!entry) {
     entry = installSharedWorkingTreeWatcher(
       watchRoot,
       () => sharedWorkingTreeWatchers.delete(watchRoot),
       log,
+      guard,
     );
     sharedWorkingTreeWatchers.set(watchRoot, entry);
   }

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -73,9 +73,16 @@ async function computeIgnore(
   log?: Logger,
 ): Promise<string[]> {
   const ignored = await listIgnoredPaths(repoRoot, log);
-  const rels = ignored.ok
-    ? [...ALWAYS_IGNORE_RELS, ...ignored.value]
-    : [...ALWAYS_IGNORE_RELS, ...FALLBACK_IGNORE_RELS];
+  let rels: string[];
+  if (ignored.ok) {
+    rels = [...ALWAYS_IGNORE_RELS, ...ignored.value];
+  } else {
+    log?.warn(
+      { repoRoot },
+      "git: working-tree ignore enumeration failed, using fallback ignore set",
+    );
+    rels = [...ALWAYS_IGNORE_RELS, ...FALLBACK_IGNORE_RELS];
+  }
   return rels.map((rel) => path.resolve(repoRoot, rel));
 }
 

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -766,6 +766,35 @@ Feature: Code tab (review + browse)
     Then the file preview iframe should contain "second page"
     And the file "second.html" should be selected in the file browser
 
+  # Regression (CONFIRMED live on the Atlas docs): reaching a file via an
+  # IN-IFRAME LINK CLICK (not a tree click) desyncs the live-reload watch from
+  # the displayed file. Mirrors the real case: an index.html in a nested dist/
+  # dir links (relative href) to a sibling page; the inner document navigates
+  # browser-side, the tree highlight + iframe `src` follow via the artifact-sdk
+  # `ReadyMsg.pathname` report — but the `fsReadFile` WATCH does not re-arm on
+  # the navigated-to file, so a later edit fires events nobody listens for and
+  # the preview freezes on the navigated content. (Re-selecting the file via a
+  # tree click repairs it.) The nested dist/ layout matches the live repro;
+  # a flat repo did NOT trip the bug.
+  Scenario: Editing a file reached via an in-iframe link still refreshes the preview live
+    When I run "rm -rf /tmp/kolu-nav-edit && git init /tmp/kolu-nav-edit && cd /tmp/kolu-nav-edit"
+    And I run "mkdir dist"
+    And I run "printf '<!doctype html><h1>first page</h1><a href=second.html>go to second</a>\n' > dist/index.html"
+    And I run "printf '<!doctype html><h1>second page ALPHA</h1>\n' > dist/second.html"
+    And I run "git add . && git commit -m init"
+    And I click the Code tab
+    And I click the Code tab mode "browse"
+    And I click the directory "dist" in the file browser
+    And I click the file "dist/index.html" in the file browser
+    Then the file preview iframe should be visible
+    And the file preview iframe should contain "first page"
+    When I click the link "go to second" in the file preview iframe
+    Then the file preview iframe should contain "second page ALPHA"
+    And the file "dist/second.html" should be selected in the file browser
+    When I click the terminal canvas
+    And I run "printf '<!doctype html><h1>second page BETA</h1>\n' > dist/second.html"
+    Then the file preview iframe should contain "second page BETA"
+
   Scenario: Committing the selected local diff clears the stale content pane
     When I run "rm -rf /tmp/kolu-clear-selected-local && git init /tmp/kolu-clear-selected-local && cd /tmp/kolu-clear-selected-local"
     And I run "git commit --allow-empty -m init"


### PR DESCRIPTION
**The Code-tab preview now live-reloads files under a committed build-output directory** — the Atlas docs project commits *and* previews `docs/atlas/dist/*.html`, but editing/rebuilding one of those pages never refreshed the iframe; it stayed frozen on whatever you first opened.

### Root cause: two ignore lists that disagreed

The Code-tab **tree** lists files with git's own ignore semantics:

```
git ls-files --cached --others --exclude-standard      # gitignore-aware
```

…but the working-tree **watcher** pruned with a *hardcoded* glob list (`**/dist/**`, `**/build/**`, …) that diverged from git. So a **committed** `dist/` file was **shown by the tree but hidden from the watcher** → its `@parcel/watcher` change events were never emitted → `install` ran but the callback never fired → the preview froze.

It looked intermittent because re-selecting a file does a fresh read; the reliable trigger is **clicking an in-iframe link** to another page (e.g. `index.html` → `second-brain.html`), which re-points the iframe `src` correctly but then relies on the now-silent watch — so the next edit is never seen.

### Fix: align the watcher's ignore set with git

Derive the watcher's ignore set from git instead of a hardcoded list — the exact **complement** of the tree's listing:

```
git ls-files --others --ignored --exclude-standard --directory
```

Now the watcher ignores precisely what git ignores and watches precisely what the tree shows:

| File | gitignored? | In tree? | Watched (before) | Watched (after) |
| --- | --- | --- | --- | --- |
| Atlas `docs/atlas/dist/index.html` (committed) | no | ✅ | ❌ (hardcoded `**/dist/**`) | ✅ |
| a normal repo's `dist/` (gitignored) | yes | ❌ | ❌ | ❌ |
| `node_modules/` | yes | ❌ | ❌ | ❌ |

`.git` is added explicitly (git never lists its own dir; the git-dir watchers cover it), and a degraded fallback keeps `node_modules` pruned if git can't enumerate. _The set is a snapshot at install time, same as the static list it replaces._

This **deletes** `IGNORE_GLOBS`, `IGNORED_DIR_BASENAMES`, and the earlier re-root machinery (`watchRootFor` + `resolveUnder`/`assertRealpathUnder` guards): the watch root is always `repoRoot` and `filePath` only narrows a listener's event filter, so it can't steer the watch root or escape the repo.

> This PR was first cut as a single-file *re-root* fix, then re-cut to the git-aligned approach after review. The re-root version's hardening commits remain in history; the [codex-debate](https://github.com/juspay/kolu/pull/1141#issuecomment-4607522975) findings F1/F2/F3 were all artifacts of that approach and are **moot** here (no caller-influenced watch root).

### Tests

A `code-tab.feature` scenario captures the trigger: a nested `dist/index.html` linking to `dist/second.html`, navigate via the in-iframe link, edit `dist/second.html`, assert the preview reflects the new bytes — **red before, green after**. Full `code-tab.feature` 77/77; the git package's 86 unit tests pass; `just check`/`just fmt` clean.

### Try it locally

```sh
nix run github:juspay/kolu/code-tree-prview-reload
```

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._