### PR TITLE
Un-skip the file-ref re-click regression guard (#1138)

### DIFF
--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -159,12 +159,10 @@ Feature: File-ref autolinking in terminal
 
   # Guards the c89a85f3 regression: a second click on the same `path:line`
   # after manually collapsing the panel must re-open it. The bug was
-  # production-only — the deferred `on(pendingOpen)` effect that drove panel
-  # visibility lost its second fire under the minified Solid build when the
-  # same request flowed through twice, so the panel stayed `aria-hidden`.
-  # `openInCodeTab` now reveals the panel imperatively, sidestepping the
-  # elided-effect path. This scenario is the canary, so it must run against
-  # the bundled build (`just test-quick`), not just dev.
+  # production-only (passes in dev) — see right-panel/openInCodeTab.ts for
+  # the deferred-effect-elision mechanism and the imperative-reveal fix.
+  # This scenario is the canary for that fix, so it must run against the
+  # bundled build (`just test-quick`), not just dev.
   Scenario: Re-clicking the same file-ref after closing the panel re-selects the line
     When I run "git init /tmp/kolu-file-ref-861-reclick && cd /tmp/kolu-file-ref-861-reclick"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -157,15 +157,14 @@ Feature: File-ref autolinking in terminal
     And the file preview iframe should be visible
     And the file preview iframe should contain "electricity"
 
-  # `@skip`: known regression noted in c89a85f3 — the second xterm `path:line`
-  # click after a manual collapse fails to re-open the panel under the bundled
-  # build (passes in dev). Suspected production-Solid reactive elision or
-  # xterm link-decoration cache invalidation after the layout reflow.
-  # `equals: false` on `pendingOpen` and imperative dispatch from
-  # `openInCodeTab` both fail to clear it; deeper diagnosis is tracked
-  # separately. Run with `CUCUMBER_TAGS='@skip' just test-quick
-  # features/file-ref-link.feature` to exercise this scenario locally.
-  @skip
+  # Guards the c89a85f3 regression: a second click on the same `path:line`
+  # after manually collapsing the panel must re-open it. The bug was
+  # production-only — the deferred `on(pendingOpen)` effect that drove panel
+  # visibility lost its second fire under the minified Solid build when the
+  # same request flowed through twice, so the panel stayed `aria-hidden`.
+  # `openInCodeTab` now reveals the panel imperatively, sidestepping the
+  # elided-effect path. This scenario is the canary, so it must run against
+  # the bundled build (`just test-quick`), not just dev.
   Scenario: Re-clicking the same file-ref after closing the panel re-selects the line
     When I run "git init /tmp/kolu-file-ref-861-reclick && cd /tmp/kolu-file-ref-861-reclick"
     And I run "git commit --allow-empty -m init"


### PR DESCRIPTION
**The clickable file-ref "re-click after collapse" scenario is now an active CI guard against the bundled build.** It was quarantined as `@skip` at `c89a85f3`, where a second click on the same `path:line` after manually collapsing the right panel failed to re-open it — but *only* in the production Vite bundle, never in `just dev`. A headline, prominently-documented feature silently misbehaving on second use is exactly the kind of thing a pre-release audit should not let ship un-guarded.

### What was actually wrong

At `c89a85f3`, `openInCodeTab` only wrote the per-terminal tab/mode and the `pendingOpen` request; **panel visibility was driven by a deferred `createEffect(on(pendingOpen, …))` subscriber.** Under the minified production Solid build that effect lost its *second* fire when the same request value flowed through twice with a manual collapse in between, so the panel stayed `aria-hidden` and never re-opened. Dev mode's looser update behavior masked it.

The bug was fixed by the subsequent right-panel rework — *not* by a new commit in this PR:

| Commit | What it changed |
| --- | --- |
| #993 | Moved panel reveal to **imperative dispatch** inside `openInCodeTab` (`expandPanel` / `setDrawerOpen`), off the deferred-effect path |
| #1006 | Returned the desktop host to `@corvu/resizable`, whose `flex-basis` is driven directly by the `collapsed` preference |
| #1088 | Encapsulated the mobile/desktop reveal fork behind `useRightPanel.reveal()` |

`openInCodeTab.ts`'s own comments already document why imperative dispatch *"sidesteps that elision path entirely."* **The fix shipped weeks ago; the `@skip` was simply never lifted.**

### Why this is safe to un-skip

Verified empirically against the production bundle that `just test-quick` builds:

```
c89a85f3  ✖  panel stays aria-hidden on re-click → "right panel should be visible" times out
HEAD      ✔  6/6 consecutive runs green
```

The RED reproduction at the historical commit confirms the scenario is a *genuine* regression guard — it fails exactly when the reveal path breaks — not a vacuous pass. The diff is the un-skip plus a comment recording what the scenario protects and why it must run against the bundled build, not just dev.

Closes #1138

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._