### PR TITLE
Contain per-terminal provider failures behind one error boundary

### DIFF
--- a/.agency/code-police.md
+++ b/.agency/code-police.md
@@ -215,6 +215,32 @@ function useEvent(..., options: { onError: (err) => void; ... }): void {
 
 _Rationale_: a hook returning `Subscription<T>` with `.error()` lets consumers read the error reactively and render it — optional `onError` is fine there. Void return with no error surface in the result type is a category mismatch; the type system has to require the handler or the failure is invisible by construction. Codified after `useEvent.onError` and `pollOnEvent.onReadError` were tightened to required in `@kolu/surface`.
 
+### callback-fanout-guarded-at-funnel
+
+A watcher/subscription that invokes a caller-supplied callback (`onChange`, `onEvent`, an `emit` helper) from **more than one emission path** must place the try/catch at the single shared funnel the callback passes through — never on a subset of the call sites. A throwing consumer that escapes is not a benign log line: floated through a `void fetchAndEmit()` it surfaces as an **unhandled rejection** (fatal — the global handler in `index.ts` calls `process.exit(1)`), and from a synchronous `channel.consume({ onEvent })` callback it **breaks out of `buildConsume`'s `for await` loop** (`@kolu/surface`), silently freezing that subscription for the rest of the terminal's life.
+
+Bad — boundary on the async path only, leaving the synchronous pending emit uncontained:
+```ts
+async function fetchAndEmit(root) {
+  try { emit(await resolveGitHubPr(root)); } catch (err) { log?.error(…); }
+}
+function setGit(...) {
+  emit({ kind: "pending" }); // ← still runs onChange synchronously, unguarded
+  void fetchAndEmit(root);
+}
+```
+
+Good — boundary inside `emit`, the one point every path funnels through:
+```ts
+function emit(pr) {
+  if (stopped || prResultEqual(pr, lastPr)) return;
+  lastPr = pr;
+  try { onChange(pr); } catch (err) { log?.error({ err }, "…: emit failed"); }
+}
+```
+
+_Rationale_: the dangerous escape is the *uncovered* path, and watchers routinely emit from several (a synchronous "pending" on change + an async resolved value + a poll tick). Guarding one path reads as "handled" in review while another stays a live throw vector. Putting the boundary at the shared invocation point makes "the consumer callback cannot throw out of this watcher" a single-site invariant instead of a per-call-site discipline. Complements `silent-handler-required-on-void-subscriptions` (which requires the *primitive's* `onError` at the type level); this rule is about the *watcher implementation* containing the consumer it fans out to. Codified after a `subscribeGitHubPr` fix guarded `fetchAndEmit` but missed `setGit`'s synchronous `emit({ pending })` ([kolu#1143](https://github.com/juspay/kolu/pull/1143)).
+
 ### migration-shape-guard
 
 A `Conf` (or analogous schema) migration that acts on a specific value shape must early-return when the on-disk shape doesn't match its preconditions. Never write transient orphan fields that subsequent migrations are expected to destructure-out.

--- a/packages/integrations/github/src/resolve.test.ts
+++ b/packages/integrations/github/src/resolve.test.ts
@@ -48,4 +48,50 @@ describe("subscribeGitHubPr", () => {
       else process.env.KOLU_GH_BIN = original;
     }
   });
+
+  it("contains a throwing onChange on the synchronous pending emit after the watcher has left its initial pending state", async () => {
+    // Regression for the synchronous path: `setGit` emits `{ kind: "pending" }`
+    // directly (not via the floated `fetchAndEmit`). On the *first* branch the
+    // initial `lastPr` is already pending, so dedup suppresses it. But once a
+    // resolve has driven `lastPr` to a non-pending value, a *later* branch
+    // change re-emits pending through the consumer — synchronously, inside
+    // `setGit`. If the boundary lived only in `fetchAndEmit`, this throw would
+    // escape straight out of `setGit` into the server's `channels.git.consume`
+    // and freeze the subscription. The boundary belongs on the shared `emit`.
+    const original = process.env.KOLU_GH_BIN;
+    process.env.KOLU_GH_BIN = "/nonexistent/gh-for-test";
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    const log = spyLogger();
+    // First, let a real resolve land so `lastPr` becomes non-pending, *without*
+    // throwing yet.
+    let shouldThrow = false;
+    const watcher = subscribeGitHubPr(() => {
+      if (shouldThrow) throw new Error("metadata write blew up");
+    }, log);
+
+    try {
+      watcher.setGit("/repo", "feature");
+      await new Promise((r) => setTimeout(r, 50)); // resolve settles → lastPr non-pending
+
+      // Now arm the throw and change branch. This drives the synchronous
+      // pending emit through the throwing consumer.
+      shouldThrow = true;
+      expect(() => watcher.setGit("/repo", "other-branch")).not.toThrow();
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(log.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.anything() }),
+        "github pr watcher: emit failed",
+      );
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      watcher.stop();
+      process.off("unhandledRejection", unhandled);
+      if (original === undefined) delete process.env.KOLU_GH_BIN;
+      else process.env.KOLU_GH_BIN = original;
+    }
+  });
 });

--- a/packages/integrations/github/src/resolve.test.ts
+++ b/packages/integrations/github/src/resolve.test.ts
@@ -1,5 +1,13 @@
 import type { Logger } from "kolu-shared";
-import { describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
 import { subscribeGitHubPr } from "./resolve.ts";
 
 /** A `Logger` whose `error` is a spy, so we can assert the watcher contained a
@@ -8,19 +16,37 @@ function spyLogger(): Logger {
   return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 }
 
+/** Wait for in-flight micro/macro tasks to settle (ENOENT resolves instantly, so
+ *  50 ms is generous headroom for the floated `fetchAndEmit` to land). */
+const settle = () => new Promise<void>((r) => setTimeout(r, 50));
+
 describe("subscribeGitHubPr", () => {
+  let originalGhBin: string | undefined;
+  // Precise mock type: a bare `ReturnType<typeof vi.fn>` widens to the
+  // `Procedure | Constructable` union (a construct signature), which doesn't
+  // match `process.on`'s listener overload.
+  let unhandled: Mock<(reason: unknown, promise: Promise<unknown>) => void>;
+
+  beforeEach(() => {
+    originalGhBin = process.env.KOLU_GH_BIN;
+    process.env.KOLU_GH_BIN = "/nonexistent/gh-for-test";
+    unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", unhandled);
+    if (originalGhBin === undefined) delete process.env.KOLU_GH_BIN;
+    else process.env.KOLU_GH_BIN = originalGhBin;
+  });
+
   it("contains a throwing onChange instead of escaping as an unhandled rejection", async () => {
     // No `gh` binary available in the test env: `resolveGitHubPr` catches the
-    // missing-`KOLU_GH_BIN` internally and returns a classified result, then
-    // `emit` runs our `onChange` with it. We make that callback throw — the
-    // shape of a metadata write blowing up — and assert it is logged, not
-    // propagated. Without the `fetchAndEmit` try/catch this rejects the
-    // floated promise and crashes the process via the global handler.
-    const original = process.env.KOLU_GH_BIN;
-    process.env.KOLU_GH_BIN = "/nonexistent/gh-for-test";
-    const unhandled = vi.fn();
-    process.on("unhandledRejection", unhandled);
-
+    // missing-binary internally and returns a classified result, then `emit`
+    // runs our `onChange` with it. We make that callback throw — the shape of
+    // a metadata write blowing up — and assert it is logged, not propagated.
+    // Without the try/catch inside `emit` this propagates back through the
+    // floated `fetchAndEmit` as an unhandled rejection that crashes the process.
     const log = spyLogger();
     let calls = 0;
     const watcher = subscribeGitHubPr(() => {
@@ -32,8 +58,7 @@ describe("subscribeGitHubPr", () => {
       // Real change → pending dedup is a no-op on first call, then a floated
       // `fetchAndEmit` resolves and calls our throwing `onChange`.
       watcher.setGit("/repo", "feature");
-      // Let the floated async settle.
-      await new Promise((r) => setTimeout(r, 50));
+      await settle(); // let the floated async settle
 
       expect(calls).toBeGreaterThan(0); // the throwing consumer ran
       expect(log.error).toHaveBeenCalledWith(
@@ -43,9 +68,6 @@ describe("subscribeGitHubPr", () => {
       expect(unhandled).not.toHaveBeenCalled(); // nothing escaped
     } finally {
       watcher.stop();
-      process.off("unhandledRejection", unhandled);
-      if (original === undefined) delete process.env.KOLU_GH_BIN;
-      else process.env.KOLU_GH_BIN = original;
     }
   });
 
@@ -58,11 +80,6 @@ describe("subscribeGitHubPr", () => {
     // `setGit`. If the boundary lived only in `fetchAndEmit`, this throw would
     // escape straight out of `setGit` into the server's `channels.git.consume`
     // and freeze the subscription. The boundary belongs on the shared `emit`.
-    const original = process.env.KOLU_GH_BIN;
-    process.env.KOLU_GH_BIN = "/nonexistent/gh-for-test";
-    const unhandled = vi.fn();
-    process.on("unhandledRejection", unhandled);
-
     const log = spyLogger();
     // First, let a real resolve land so `lastPr` becomes non-pending, *without*
     // throwing yet.
@@ -73,14 +90,14 @@ describe("subscribeGitHubPr", () => {
 
     try {
       watcher.setGit("/repo", "feature");
-      await new Promise((r) => setTimeout(r, 50)); // resolve settles → lastPr non-pending
+      await settle(); // resolve settles → lastPr non-pending
 
       // Now arm the throw and change branch. This drives the synchronous
       // pending emit through the throwing consumer.
       shouldThrow = true;
       expect(() => watcher.setGit("/repo", "other-branch")).not.toThrow();
 
-      await new Promise((r) => setTimeout(r, 50));
+      await settle();
 
       expect(log.error).toHaveBeenCalledWith(
         expect.objectContaining({ err: expect.anything() }),
@@ -89,9 +106,6 @@ describe("subscribeGitHubPr", () => {
       expect(unhandled).not.toHaveBeenCalled();
     } finally {
       watcher.stop();
-      process.off("unhandledRejection", unhandled);
-      if (original === undefined) delete process.env.KOLU_GH_BIN;
-      else process.env.KOLU_GH_BIN = original;
     }
   });
 });

--- a/packages/integrations/github/src/resolve.test.ts
+++ b/packages/integrations/github/src/resolve.test.ts
@@ -1,0 +1,51 @@
+import type { Logger } from "kolu-shared";
+import { describe, expect, it, vi } from "vitest";
+import { subscribeGitHubPr } from "./resolve.ts";
+
+/** A `Logger` whose `error` is a spy, so we can assert the watcher contained a
+ *  throwing consumer instead of letting it escape as an unhandled rejection. */
+function spyLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe("subscribeGitHubPr", () => {
+  it("contains a throwing onChange instead of escaping as an unhandled rejection", async () => {
+    // No `gh` binary available in the test env: `resolveGitHubPr` catches the
+    // missing-`KOLU_GH_BIN` internally and returns a classified result, then
+    // `emit` runs our `onChange` with it. We make that callback throw — the
+    // shape of a metadata write blowing up — and assert it is logged, not
+    // propagated. Without the `fetchAndEmit` try/catch this rejects the
+    // floated promise and crashes the process via the global handler.
+    const original = process.env.KOLU_GH_BIN;
+    process.env.KOLU_GH_BIN = "/nonexistent/gh-for-test";
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    const log = spyLogger();
+    let calls = 0;
+    const watcher = subscribeGitHubPr(() => {
+      calls += 1;
+      throw new Error("metadata write blew up");
+    }, log);
+
+    try {
+      // Real change → pending dedup is a no-op on first call, then a floated
+      // `fetchAndEmit` resolves and calls our throwing `onChange`.
+      watcher.setGit("/repo", "feature");
+      // Let the floated async settle.
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(calls).toBeGreaterThan(0); // the throwing consumer ran
+      expect(log.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.anything() }),
+        "github pr watcher: emit failed",
+      );
+      expect(unhandled).not.toHaveBeenCalled(); // nothing escaped
+    } finally {
+      watcher.stop();
+      process.off("unhandledRejection", unhandled);
+      if (original === undefined) delete process.env.KOLU_GH_BIN;
+      else process.env.KOLU_GH_BIN = original;
+    }
+  });
+});

--- a/packages/integrations/github/src/resolve.ts
+++ b/packages/integrations/github/src/resolve.ts
@@ -146,22 +146,22 @@ export function subscribeGitHubPr(
   function emit(pr: PrResult): void {
     if (stopped || prResultEqual(pr, lastPr)) return;
     lastPr = pr;
-    onChange(pr);
-  }
-
-  async function fetchAndEmit(repoRoot: string): Promise<void> {
-    // Both call sites float this with `void`, so its rejection has no catch
-    // upstream. `resolveGitHubPr` already swallows its own failures, but
-    // `emit` → `onChange` runs the caller's callback (a metadata write that
-    // can throw). Contain it here, at the single point both paths funnel
-    // through, so a throwing consumer degrades this terminal's PR metadata
-    // instead of escaping as an unhandled rejection.
+    // `onChange` runs the caller's callback (a metadata write that can throw).
+    // Contain it here, the single point every emission — the synchronous
+    // pending emit in `setGit` and the resolved emit in `fetchAndEmit` —
+    // funnels through, so a throwing consumer degrades this terminal's PR
+    // metadata instead of escaping (sync into `setGit`, or as an unhandled
+    // rejection out of the floated `fetchAndEmit`).
     try {
-      const pr = await resolveGitHubPr(repoRoot, log);
-      emit(pr);
+      onChange(pr);
     } catch (err) {
       log?.error({ err }, "github pr watcher: emit failed");
     }
+  }
+
+  async function fetchAndEmit(repoRoot: string): Promise<void> {
+    const pr = await resolveGitHubPr(repoRoot, log);
+    emit(pr);
   }
 
   function setGit(repoRoot: string | null, branch: string | null): void {

--- a/packages/integrations/github/src/resolve.ts
+++ b/packages/integrations/github/src/resolve.ts
@@ -150,8 +150,18 @@ export function subscribeGitHubPr(
   }
 
   async function fetchAndEmit(repoRoot: string): Promise<void> {
-    const pr = await resolveGitHubPr(repoRoot, log);
-    emit(pr);
+    // Both call sites float this with `void`, so its rejection has no catch
+    // upstream. `resolveGitHubPr` already swallows its own failures, but
+    // `emit` → `onChange` runs the caller's callback (a metadata write that
+    // can throw). Contain it here, at the single point both paths funnel
+    // through, so a throwing consumer degrades this terminal's PR metadata
+    // instead of escaping as an unhandled rejection.
+    try {
+      const pr = await resolveGitHubPr(repoRoot, log);
+      emit(pr);
+    } catch (err) {
+      log?.error({ err }, "github pr watcher: emit failed");
+    }
   }
 
   function setGit(repoRoot: string | null, branch: string | null): void {

--- a/packages/integrations/github/src/resolve.ts
+++ b/packages/integrations/github/src/resolve.ts
@@ -146,12 +146,11 @@ export function subscribeGitHubPr(
   function emit(pr: PrResult): void {
     if (stopped || prResultEqual(pr, lastPr)) return;
     lastPr = pr;
-    // `onChange` runs the caller's callback (a metadata write that can throw).
-    // Contain it here, the single point every emission — the synchronous
-    // pending emit in `setGit` and the resolved emit in `fetchAndEmit` —
-    // funnels through, so a throwing consumer degrades this terminal's PR
-    // metadata instead of escaping (sync into `setGit`, or as an unhandled
-    // rejection out of the floated `fetchAndEmit`).
+    // `onChange` is the caller's callback (a metadata write that can throw).
+    // Guard it here — the single funnel every emission path passes through —
+    // so a throwing consumer degrades this terminal's PR metadata instead of
+    // escaping: synchronously out of `setGit` into the git channel's consume
+    // loop, or as an unhandled rejection out of the floated `fetchAndEmit`.
     try {
       onChange(pr);
     } catch (err) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -150,7 +150,16 @@ process.on("uncaughtException", (err) => {
   process.exit(1);
 });
 process.on("unhandledRejection", (reason) => {
-  log.fatal({ reason }, "unhandled rejection");
+  // Deliberately fatal — same as an uncaught exception. A floating promise
+  // is as corrupting as a sync throw, and a context-free global handler is
+  // the wrong place to make a recover-or-die call (per-task error boundaries
+  // own that; see the provider DAG). If this fires, a background task is
+  // missing its boundary — fix the source, don't soften the net. The
+  // supervisor (systemd `Restart=on-failure` / launchd) restarts clean.
+  log.fatal(
+    { reason },
+    "unhandled rejection — a background task is missing its error boundary",
+  );
   process.exit(1);
 });
 

--- a/packages/server/src/terminalBackend/providers.ts
+++ b/packages/server/src/terminalBackend/providers.ts
@@ -406,7 +406,20 @@ function startAgentProvider<Session, Info extends AgentInfoShape>(
   };
   plog.debug("started");
 
+  // `reconcile` must never throw. It is called bare from four channel
+  // `onEvent` callbacks — and a throw inside `onEvent` breaks out of
+  // `buildConsume`'s `for await` loop (see surface/server.ts), silently
+  // freezing that subscription for the terminal's life — and synchronously
+  // on the foreground snapshot fire. One try/catch here is the single place
+  // that invariant lives, so the bare call sites stay honest.
   function reconcile() {
+    try {
+      reconcileInner();
+    } catch (err) {
+      plog.error({ err }, "reconcile failed");
+    }
+  }
+  function reconcileInner() {
     const state = snapshotTerminalState(
       currentForeground,
       record.pid,
@@ -422,13 +435,9 @@ function startAgentProvider<Session, Info extends AgentInfoShape>(
         const slog = log.child({ provider: provider.kind });
         provider.externalChanges.install(
           () => {
-            for (const fn of [...activation.reconcilers]) {
-              try {
-                fn();
-              } catch (err) {
-                slog.error({ err }, "reconcile threw on external change");
-              }
-            }
+            // Every reconciler is a `reconcile` (above) and cannot throw, so
+            // the fan-out needs no per-callback guard.
+            for (const fn of [...activation.reconcilers]) fn();
           },
           (err) => slog.error({ err }, "external-change listener threw"),
           slog,
@@ -467,11 +476,7 @@ function startAgentProvider<Session, Info extends AgentInfoShape>(
   }
   function reconcileFromCommandRun(idx: number) {
     if (stopped) return;
-    try {
-      reconcile();
-    } catch (err) {
-      plog.error({ err }, "command-run reconcile failed");
-    }
+    reconcile();
     if (current !== null) return;
     const nextIdx = idx + 1;
     const next = COMMAND_RUN_RECONCILE_DELAYS_MS[nextIdx];


### PR DESCRIPTION
A single background metadata task that threw could escape as an unhandled rejection and take down the **whole server** — and because pty-host runs in-process today, that kills *every* terminal at once. The default `nix run` path has no supervisor, so the app just dies. **This contains those failures at their source and consolidates the per-terminal "never throw" invariant into one place**, so one bad git/PR/agent read degrades that terminal's metadata instead of crashing the process.

This was reviewed through the `hickey` (structural simplicity) and `lowy` (volatility/boundaries) lenses first. Both independently rejected the tempting-but-wrong move — flipping the global `unhandledRejection` handler to log-and-continue — because a floating promise is as corrupting as a sync throw, and a context-free global handler is the wrong layer to make a recover-or-die decision. The fix belongs at the per-task boundary.

### What changed

| Site | Problem | Fix |
| --- | --- | --- |
| `github/resolve.ts` | `void fetchAndEmit(...)` floated a promise whose `emit → onChange` runs the caller's metadata write; a throw there became an unhandled rejection | Contain it inside `fetchAndEmit` — the single point both the branch-change and 30s-poll paths funnel through |
| `terminalBackend/providers.ts` | `reconcile()` was called bare from four channel `onEvent` callbacks; a throw there silently breaks `buildConsume`'s `for await` loop, **freezing that subscription for the terminal's life** | Make `reconcile()` never throw via one try/catch; removed the two now-redundant outer guards so the invariant lives in *one* place, not a three-layer chain |
| `index.ts` | `unhandledRejection` fatal message was generic | Kept fatal *(supervisor restarts clean)*, but named the cause so a firing reads as "a background task is missing its error boundary" |

> _The lint half of this is already enforced — `noFloatingPromises: "error"` is on in `biome.jsonc`. That's why the audit surfaced exactly one real uncontained leak (`fetchAndEmit`); the rest of the work is consolidating an invariant, not wrapping 40 sites._

### Test

A covering unit test drives a throwing `onChange` through the watcher and asserts it is **logged, not propagated** (no `unhandledRejection` fires). Without the `fetchAndEmit` guard, the floated promise rejects and the process exits via the global handler.

### Try it locally

```sh
nix run github:juspay/kolu/release-bugs
```

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._