### PR TITLE
Bring up the mobile right-panel drawer when a terminal link is tapped

### DIFF
--- a/packages/client/src/right-panel/RightPanelDrawer.tsx
+++ b/packages/client/src/right-panel/RightPanelDrawer.tsx
@@ -63,7 +63,16 @@ const RightPanelDrawer: Component<HostProps> = (props) => {
             data-testid="right-panel-drawer-backdrop"
             class="fixed inset-0 z-40 bg-black/40 opacity-0 transition-opacity duration-200 data-open:opacity-100"
           />
-          <Drawer.Content class="fixed bottom-0 left-0 right-0 z-50 bg-surface-0 border-t border-edge shadow-xl h-[85vh] flex flex-col rounded-t-lg overflow-hidden">
+          {/* `transition-transform` is load-bearing, not cosmetic: Corvu's
+           *  drawer drives its open/close state machine off the *computed*
+           *  `transition-duration` of this content element. With none set it
+           *  reads 0s and mishandles a programmatic open (the terminal file-ref
+           *  tap flips `drawerOpen` via `openInCodeTab` rather than dragging the
+           *  sheet) — the drawer never settles open, so on mobile a tapped
+           *  `.html`/code link "does nothing": the tree selection updates but
+           *  the sheet is never brought up. A real transform transition gives
+           *  Corvu a non-zero duration to settle against. */}
+          <Drawer.Content class="fixed bottom-0 left-0 right-0 z-50 bg-surface-0 border-t border-edge shadow-xl h-[85vh] flex flex-col rounded-t-lg overflow-hidden transition-transform duration-200 ease-out">
             <div class="flex justify-center py-1.5 shrink-0" aria-hidden="true">
               <span class="w-10 h-1 rounded-full bg-fg-3/40" />
             </div>

--- a/packages/tests/features/file-ref-link.feature
+++ b/packages/tests/features/file-ref-link.feature
@@ -35,6 +35,46 @@ Feature: File-ref autolinking in terminal
     And xterm's helper textarea should not have been focused by tapping the link
     And there should be no page errors
 
+  @mobile
+  Scenario: Tapping a .html file-ref on touch brings up the code-browser preview
+    # Reported bug: on iPhone, tapping a terminal link to a `.html` file should
+    # open the code browser's file preview (the sandboxed iframe). Instead
+    # nothing visible comes up — the tree selection updates but the preview is
+    # never brought on screen. A `.html` ref takes the binary/iframe render
+    # path (BrowseFileDispatcher), unlike the text scenario above, so this
+    # asserts the preview iframe actually mounts after a touch tap.
+    When I run "git init /tmp/kolu-file-ref-html-mobile && cd /tmp/kolu-file-ref-html-mobile"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf '<h1>preview me</h1>\n' > page.html"
+    And I run "echo 'open page.html in the browser'"
+    And I watch for the right-panel drawer to open
+    And I watch for the file preview iframe to appear
+    And I tap the terminal file-ref link "page.html"
+    Then the right-panel drawer should have opened
+    And the file preview iframe should have appeared
+    And there should be no page errors
+
+  @mobile
+  Scenario: Re-tapping a .html file-ref after dismissing the drawer re-opens the preview
+    # The user-reported iPhone bug: tap a terminal `.html` link, it opens the
+    # code-browser preview; dismiss the drawer; tap the same link again and
+    # "nothing happens" — the tree selection updates but the drawer is never
+    # brought back up. Mobile counterpart of the desktop "re-click after
+    # collapse" canary, which only reproduces under the bundled build.
+    When I run "git init /tmp/kolu-file-ref-html-retap && cd /tmp/kolu-file-ref-html-retap"
+    And I run "git commit --allow-empty -m init"
+    And I run "printf '<h1>preview me</h1>\n' > page.html"
+    And I run "echo 'open page.html in the browser'"
+    And I watch for the file preview iframe to appear
+    And I tap the terminal file-ref link "page.html"
+    Then the file preview iframe should have appeared
+    When I dismiss the right-panel drawer
+    Then the right panel should not be visible
+    When I watch for the file preview iframe to appear
+    And I tap the terminal file-ref link "page.html"
+    Then the file preview iframe should have appeared
+    And there should be no page errors
+
   Scenario: Clicking a line-range file-ref opens the file
     When I run "git init /tmp/kolu-file-ref-861-range && cd /tmp/kolu-file-ref-861-range"
     And I run "git commit --allow-empty -m init"

--- a/packages/tests/step_definitions/file_ref_link_steps.ts
+++ b/packages/tests/step_definitions/file_ref_link_steps.ts
@@ -15,9 +15,12 @@ type RefClickPoint = { x: number; y: number } | null;
 type DrawerWatchWindow = Window & {
   __rpDrawerOpened?: boolean;
   __rpDrawerObs?: MutationObserver;
+  __previewIframeAppeared?: boolean;
+  __previewIframeObs?: MutationObserver;
 };
 
 const RIGHT_PANEL_MARKER = '[data-testid="right-panel-tab-inspector"]';
+const PREVIEW_IFRAME_MARKER = '[data-testid="browse-preview-iframe"]';
 
 /** Locate a clickable file-ref in the active terminal and compute
  *  pixel coordinates from the **public** xterm API
@@ -172,6 +175,62 @@ Then(
           const w = window as DrawerWatchWindow;
           w.__rpDrawerObs?.disconnect();
           w.__rpDrawerObs = undefined;
+        }),
+      );
+  },
+);
+
+// Dismiss the mobile right-panel drawer the way a user does — a tap on the
+// backdrop above the 85vh bottom sheet. The in-panel collapse chevron sits
+// under the content wrapper's pointer-event layer on mobile, so we tap the
+// exposed top strip of the backdrop instead (Corvu's onOpenChange(false)).
+When("I dismiss the right-panel drawer", async function (this: KoluWorld) {
+  const backdrop = this.page.locator(
+    '[data-testid="right-panel-drawer-backdrop"]',
+  );
+  await backdrop.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  const box = await backdrop.boundingBox();
+  if (!box) throw new Error("drawer backdrop had no bounding box");
+  // Tap near the top of the viewport — the sheet occupies the bottom 85vh,
+  // so this strip is backdrop-only and not covered by the content.
+  await this.page.touchscreen.tap(box.x + box.width / 2, box.y + 24);
+  await this.waitForFrame();
+});
+
+// Same transient-latch shape as the drawer watcher above, but keyed on the
+// `.html`/`.svg`/`.pdf` preview iframe. The user-reported mobile bug is that
+// tapping a terminal `.html` file-ref does NOT bring up the code-browser
+// preview at all — so this records whether the iframe ever mounted, surviving
+// the test-env's instant-transition drawer flicker (see DrawerWatchWindow).
+When(
+  "I watch for the file preview iframe to appear",
+  async function (this: KoluWorld) {
+    await this.page.evaluate((marker) => {
+      const w = window as DrawerWatchWindow;
+      w.__previewIframeObs?.disconnect();
+      w.__previewIframeAppeared = !!document.querySelector(marker);
+      const obs = new MutationObserver(() => {
+        if (document.querySelector(marker)) w.__previewIframeAppeared = true;
+      });
+      obs.observe(document.body, { childList: true, subtree: true });
+      w.__previewIframeObs = obs;
+    }, PREVIEW_IFRAME_MARKER);
+  },
+);
+
+Then(
+  "the file preview iframe should have appeared",
+  async function (this: KoluWorld) {
+    await this.page
+      .waitForFunction(
+        () => (window as DrawerWatchWindow).__previewIframeAppeared === true,
+        { timeout: POLL_TIMEOUT },
+      )
+      .finally(() =>
+        this.page.evaluate(() => {
+          const w = window as DrawerWatchWindow;
+          w.__previewIframeObs?.disconnect();
+          w.__previewIframeObs = undefined;
         }),
       );
   },

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -450,7 +450,16 @@ Before(async function (this: KoluWorld, scenario) {
     await this.page.addInitScript(`
       document.addEventListener("DOMContentLoaded", function() {
         var style = document.createElement("style");
-        style.textContent = "*, *::before, *::after { transition-duration: 0s !important; animation-duration: 0s !important; }";
+        // Zero out transitions so Corvu dialogs settle instantly — but EXEMPT
+        // the bottom-drawer content element (not its descendants). Corvu's
+        // drawer reads that element's *computed* transition-duration to run its
+        // open/close state machine; forcing it to 0s breaks a programmatic open
+        // (the mobile right panel never settles open after openInCodeTab). The
+        // exemption lets the component's own \`transition-transform duration-200\`
+        // apply, so this test exercises — and guards — the real production fix
+        // rather than a harness-injected duration.
+        style.textContent =
+          "*:not([data-corvu-drawer-content]), *::before, *::after { transition-duration: 0s !important; animation-duration: 0s !important; }";
         document.head.appendChild(style);
       });
     `);


### PR DESCRIPTION
**Tapping a terminal file-ref link on mobile now actually brings up the code-browser drawer.** Before this, tapping a link to a `.html` (or any) file in the terminal appeared to do *nothing* — the tree selection updated under the hood, but the bottom sheet never came on screen.

The mobile right panel hosts as a Corvu `Drawer side="bottom"`, and **Corvu drives its open/close state machine off the *computed* `transition-duration` of the content element.** That `Drawer.Content` carried no CSS transition, so Corvu read `0s` and mishandled a *programmatic* open — the terminal tap flips `drawerOpen` via `openInCodeTab`, it doesn't drag the sheet. The drawer never settled open. The fix gives the content a real `transition-transform duration-200` so Corvu has a non-zero duration to settle against.

> _It read as `.html`-specific only because an `.html` ref renders the iframe **preview**; the underlying failure was the drawer itself never settling, which affected every code link on mobile. Notably **not** the cause: the `#977` `snapPoints` workaround the sibling drawers carry — adding it here didn't fix this; the missing transition did._

### A masked test-harness gap

The e2e env forced `transition-duration: 0s` on **everything**, including the drawer content — reproducing the exact mis-settle in tests. That's why prior mobile drawer scenarios could only ever assert a *transient* open latch and never rendered content, so the bug was invisible to CI. This PR exempts `[data-corvu-drawer-content]` from the override so the new tests exercise — and guard — the real production transition.

### Coverage

Two new `@mobile` scenarios in `file-ref-link.feature`:

- Tapping a `.html` file-ref brings up the code-browser preview iframe.
- Re-tapping after dismissing the drawer re-opens it.

Verified by negative control: reverting the `Drawer.Content` transition makes the iframe scenario fail; restoring it passes. Full mobile suite **39/39**, full `file-ref-link.feature` **14/14**.

### Try it locally

```sh
nix run github:juspay/kolu/mobile-click
```

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._