### PR TITLE
feat(be): run the review gauntlet in parallel via /be-review

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -62,9 +62,13 @@ to `cd`.
   its own commit. Pass the change rationale so deliberate decisions aren't flagged.
 - **police** — `/code-police`'s three cold passes (rule checklist, fact-check,
   elegance) reproduced as parallel agents, each finding applied as its own commit
-  (`fix(police):`). Per-finding `just check` is **deferred** to the
-  post-consolidation check + `/be` §5 CI rather than run 3× concurrently across
-  the parallel worktrees; `fmt`-on-touched-files still runs in each apply.
+  (`fix(police):`). The passes run **until a sweep is clean** (re-reviewing the
+  updated worktree after each apply, so a fix that introduces or only partially
+  resolves an issue is caught), capped at a few sweeps; hitting the cap with issues
+  still open reports `incomplete` rather than a false consensus.
+  `fmt`-on-touched-files runs in every apply. Per-finding `just check` is
+  **deferred** to the post-consolidation check + `/be` §5 CI rather than run 3×
+  concurrently across the parallel worktrees.
 
 ## Arguments
 
@@ -144,18 +148,31 @@ track + the consolidation ledger), **Cleanup** (tear down the worktrees). It
 returns:
 
 ```
-{ status,                  // 'done' | 'no-commit' | 'setup-failed'
+{ status,                  // 'done' | 'consolidation-incomplete' | 'consolidation-aborted' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'
   consolidation,           // { finalHead, picks[] }  (null when not consolidated)
+  preservedTracks,         // tracks NOT consolidated (worktrees kept); non-empty ⇒ status incomplete/aborted
   conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
   comments }               // { consolidation, codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
-  and re-run) or no worktree could be created. `tracks` carries the per-track
-  `track-error` detail.
+  and re-run), an unresolvable merge-base, a malformed `runId`/`tracks` argument,
+  or no worktree could be created. `tracks` carries the per-track `track-error`
+  detail.
+- `consolidation-incomplete` — the picks ran, but at least one requested track was
+  **preserved** (left uncommitted edits, couldn't be confirmed clean, or crashed
+  with committed-but-unreplayed work), so its fixes live only in its worktree.
+  `preservedTracks` names them and each `tracks[t].note` has the recovery
+  cherry-pick. `/be` should adjudicate these before continuing rather than treat
+  the gauntlet as fully landed.
+- `consolidation-aborted` — the branch HEAD moved or the main worktree went dirty
+  **during** the (long) parallel tracks phase, so the cherry-pick base is no longer
+  the reviewed `branchHead`. Nothing was consolidated and **all** track worktrees
+  are preserved (`preservedTracks` + per-track recovery cherry-picks). Resolve the
+  drift, then consolidate by hand or re-run.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
   **uncommitted in its preserved `.worktrees/be-review-<runId>-<track>` worktree**
   and nothing is consolidated, reported, or cleaned up. The result lists those

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: be-review
+description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled). Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
+argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit]"
+---
+
+# Parallel review gauntlet
+
+`/be`'s §4 gauntlet runs three reviewers **serially** today (`/codex-debate` →
+`/lens-debate` → `/code-police`) for one structural reason: each step **commits
+fixes**, so the next reviewer sees the mutated tree. That chaining is the *only*
+thing forcing order — the reviews themselves are independent and read-only.
+
+This skill removes the chaining by giving each reviewer its **own detached git
+worktree** forked from the branch HEAD. All three multi-round debates run **at
+once**, each mutating only its own worktree, each running to full consensus (no
+depth is lost — every reviewer keeps its complete loop). When they finish, the
+orchestrator **consolidates** by cherry-picking each track's commits onto the
+branch in order. The common case is no overlap (clean picks); the rare overlap —
+two tracks editing the same lines — surfaces as a cherry-pick conflict that is
+**reconciled to honor both fixes**.
+
+```
+            ┌─ wt-codex   ─ codex⇄claude debate ─→ commits ─┐
+branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick onto branch
+            └─ wt-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
+```
+
+## Why this shape
+
+- **The debates were built for it.** `/codex-debate` and `/lens-debate` are
+  already `repoPath`-parameterized workflows whose docs promise "parallel debates
+  in different worktrees never collide." This skill is the orchestrator that
+  finally drives them that way — invoking each as a **child workflow** (one level
+  of nesting, which the runtime allows) pointed at a different worktree.
+- **No depth is traded for the parallelism.** Each track runs its *full*
+  multi-round loop to consensus — codex re-reviews its own fixes round after
+  round, the lenses debate every finding, police runs all three cold passes. The
+  only thing that changed is that the three loops run concurrently instead of
+  end-to-end.
+- **Consolidation is git, not vibes.** Each track's conclusions are real commits;
+  replaying them with `git cherry-pick` preserves each debate's per-commit ledger
+  in history and makes overlap a *detectable* conflict (`--diff-filter=U`) rather
+  than a silent clobber.
+
+## What runs in each track
+
+- **codex** — the `/codex-debate` workflow: codex (read-only, `xhigh`) ⇄ claude
+  author, to consensus, committing per round.
+- **lens** — the `/lens-debate` workflow: lowy + hickey review independently in
+  parallel (on Opus), debate every finding to consensus, apply each agreed fix as
+  its own commit. Pass the change rationale so deliberate decisions aren't flagged.
+- **police** — `/code-police`'s three cold passes (rule checklist, fact-check,
+  elegance) reproduced as parallel agents, each finding applied as its own commit
+  (`fix(police):`). Per-finding `just check` is **deferred** to the
+  post-consolidation check + `/be` §5 CI rather than run 3× concurrently across
+  the parallel worktrees; `fmt`-on-touched-files still runs in each apply.
+
+## Arguments
+
+- **`--base <branch>`**: remote-tracking ref to diff against (e.g. `origin/master`).
+  Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
+- **`--tracks codex,lens,police`**: which tracks to run *and the order they
+  consolidate in*. Default all three; codex first (it changes the most), police
+  last (lightest touch), so an overlap surfaces picking the later track.
+- **`--no-commit`**: leave each track's fixes uncommitted (debugging a single
+  track); default is to commit, since consolidation cherry-picks those commits.
+
+## Steps
+
+### 1. Resolve context
+
+- Determine `repoPath` (the worktree root, normally the cwd).
+- `git fetch origin` so the base remote-tracking ref is current.
+- Resolve `base` (a remote-tracking ref like `origin/master`).
+- Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
+- **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
+  not logged in, tell the user to run `codex login` (suggest the `!` prefix).
+
+### 2. Run the orchestrator Workflow
+
+```
+Workflow({
+  scriptPath: ".claude/skills/be-review/be-review.workflow.js",
+  args: {
+    repoPath: "<worktree root>",
+    base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
+    rationale: "<optional author note on deliberate decisions>",
+    tracks: ["codex", "lens", "police"],   // also the consolidation order
+    commit: <false only if --no-commit>
+  }
+})
+```
+
+It runs four phases the user can watch via `/workflows`: **Setup** (fan out one
+detached worktree per track), **Tracks** (the three gauntlets run concurrently to
+consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
+reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
+
+```
+{ status,                  // 'done' | 'setup-failed'
+  branchHead, finalHead, base, order,
+  tracks,                  // per-track result (codex/lens consensus, police findings/applied)
+  consolidation,           // { finalHead, picks[], conflicts[] }
+  conflicts }              // the overlaps reconciled (empty in the common case)
+```
+
+### 3. Present the result
+
+Report in chat and post **one** consolidated PR comment (this replaces the three
+separate per-reviewer comments): a `## Review gauntlet (parallel)` section with,
+per track, its outcome (codex consensus + rounds, lens consensus + per-finding
+table, police findings actioned); then the **consolidation ledger** — each
+cherry-picked commit and its outcome (`clean`/`reconciled`/`dropped`), with any
+overlap reconciliation explained. Then `git log --oneline <base>..HEAD` and
+`git diff --stat <base>` so the user sees the combined result. Never push or
+merge — the human reviews the per-track commits and merges.
+
+## Safety & notes
+
+- **Reviewers are read-only; only their own worktree is written.** Each track's
+  fixes land in `.be-review/wt-<track>/`; the branch is touched only by the
+  consolidation cherry-picks, which never push or merge.
+- **Overlap is reconciled, never silently dropped.** A cherry-pick conflict means
+  two debates changed the same lines; the orchestrator merges both intents (it
+  has both commit messages) and only drops a commit if an earlier track fully
+  subsumes it, saying so in the ledger.
+- **Cross-track staleness is the known limitation.** Because all three review the
+  *same* pre-fix branch HEAD, a track can't see another track's fixes mid-run
+  (the price of parallelism). Textual collisions are caught by consolidation;
+  residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
+  change is small and correctness-critical, the serial `/codex-debate` →
+  `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
+- **Parallel-safe.** Worktrees + scratch live under the gitignored, per-worktree
+  `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
+  scratch nests inside its worktree.
+
+## Files
+
+- `be-review.workflow.js` — the orchestrator (worktree fan-out → parallel tracks
+  → cherry-pick consolidation → cleanup). It invokes
+  `.claude/skills/{codex-debate,lens-debate}/debate.workflow.js` as child
+  workflows and reads `.claude/skills/code-police/SKILL.md` at runtime.
+
+This is generated from `.apm/skills/be-review/`; edit the source there and run
+`just ai::apm` to regenerate.
+
+ARGUMENTS: $ARGUMENTS

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -63,8 +63,11 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.
-- **`--no-commit`**: leave each track's fixes uncommitted (debugging a single
-  track); default is to commit, since consolidation cherry-picks those commits.
+- **`--no-commit`**: leave each track's fixes uncommitted for inspection
+  (debugging a single track). Consolidation cherry-picks per-track *commits*, so
+  with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
+  worktrees** (status `no-commit`) rather than silently discarding the uncommitted
+  edits. Default is to commit, which is what actually ships fixes.
 
 ## Steps
 
@@ -74,6 +77,12 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - `git fetch origin` so the base remote-tracking ref is current.
 - Resolve `base` (a remote-tracking ref like `origin/master`).
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
+- **Commit the change first.** Every track forks a detached worktree from the
+  branch HEAD, so only *committed* work is reviewed. If the main worktree has
+  staged/unstaged/untracked changes (outside `.be-review/`), commit (or stash)
+  them before invoking — the orchestrator's Setup preflight aborts with
+  `status: 'setup-failed'` on a dirty tree rather than reviewing an incomplete set.
+  (In `/be` this is automatic: §2/§3 commit and push before §4.)
 - **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
   not logged in, tell the user to run `codex login` (suggest the `!` prefix).
 
@@ -98,12 +107,24 @@ consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
 reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
 
 ```
-{ status,                  // 'done' | 'setup-failed'
+{ status,                  // 'done' | 'setup-failed' | 'no-commit'
   branchHead, finalHead, base, order,
-  tracks,                  // per-track result (codex/lens consensus, police findings/applied)
-  consolidation,           // { finalHead, picks[], conflicts[] }
+  tracks,                  // per-track result; ALWAYS one entry per requested track —
+                           //   a track whose worktree setup failed is status:'track-error'
+  consolidation,           // { finalHead, picks[], conflicts[] }  (null when not consolidated)
   conflicts }              // the overlaps reconciled (empty in the common case)
 ```
+
+- `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
+  and re-run) or no worktree could be created. `tracks` carries the per-track
+  `track-error` detail.
+- `no-commit` — `--no-commit` was set, so each track's fixes are left
+  **uncommitted in its preserved `.be-review/wt-<track>` worktree** and nothing is
+  consolidated or cleaned up. The result lists those `worktrees` to inspect; re-run
+  with commit enabled to actually consolidate. (`--no-commit` is a
+  single-track-debugging mode, not a way to ship fixes.)
+- For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
+  to the serial path for that track.
 
 ### 3. Present the result
 

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -143,7 +143,7 @@ returns:
                            //   a track whose worktree setup failed is status:'track-error'
   consolidation,           // { finalHead, picks[] }  (null when not consolidated)
   conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
-  comments }               // { codex, lens, police } → posted comment URLs ({} under --no-comment)
+  comments }               // { consolidation, codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -66,8 +66,10 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - **`--no-commit`**: leave each track's fixes uncommitted for inspection
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
   with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
-  worktrees** (status `no-commit`) rather than silently discarding the uncommitted
-  edits. Default is to commit, which is what actually ships fixes.
+  worktrees** (status `no-commit`) — leaving every track's worktree in place under
+  `.be-review/wt-<track>/` (the branch is untouched) rather than silently discarding
+  the uncommitted edits; inspect and tear them down yourself. Default is to commit,
+  which is what actually ships fixes.
 
 ## Steps
 
@@ -107,7 +109,7 @@ consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
 reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
 
 ```
-{ status,                  // 'done' | 'setup-failed' | 'no-commit'
+{ status,                  // 'done' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
-description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled). Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
-argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit]"
+description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled) and post a detailed PR comment per track. Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
+argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit] [--no-comment]"
 ---
 
 # Parallel review gauntlet
@@ -21,10 +21,18 @@ two tracks editing the same lines — surfaces as a cherry-pick conflict that is
 **reconciled to honor both fixes**.
 
 ```
-            ┌─ wt-codex   ─ codex⇄claude debate ─→ commits ─┐
-branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick onto branch
-            └─ wt-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
+            ┌─ be-review-codex   ─ codex⇄claude debate ─→ commits ─┐
+branch HEAD ┼─ be-review-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick → PR comments
+            └─ be-review-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
 ```
+
+The per-track worktrees live under the repo's conventional `.worktrees/`
+(gitignored) — `.worktrees/be-review-<track>`. **Isolation is structural, not
+behavioral:** every workflow agent inherits the *session* cwd (the harness has no
+per-agent cwd, and `isolation:'worktree'` can't host a multi-round debate that
+accumulates commits in one tree), so every git command is `git -C <worktree>` and
+every file path is absolute — no agent can leak into the wrong tree by forgetting
+to `cd`.
 
 ## Why this shape
 
@@ -65,11 +73,15 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
   last (lightest touch), so an overlap surfaces picking the later track.
 - **`--no-commit`**: leave each track's fixes uncommitted for inspection
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
-  with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
-  worktrees** (status `no-commit`) — leaving every track's worktree in place under
-  `.be-review/wt-<track>/` (the branch is untouched) rather than silently discarding
-  the uncommitted edits; inspect and tear them down yourself. Default is to commit,
-  which is what actually ships fixes.
+  with this flag the orchestrator **skips Consolidate + Report + Cleanup and
+  preserves the worktrees** (status `no-commit`) — leaving every track's worktree
+  in place under `.worktrees/be-review-<track>/` (the branch is untouched) rather
+  than silently discarding the uncommitted edits; inspect and tear them down
+  yourself. Default is to commit, which is what actually ships fixes.
+- **`--no-comment`**: suppress the PR comments. By default the **Report** phase
+  posts a detailed PR comment per track (codex debate table, lens per-finding
+  ledger, police findings) plus the consolidation ledger — the review trail the
+  gauntlet exists to leave. This flag reports in chat only.
 
 ## Steps
 
@@ -81,10 +93,11 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
 - **Commit the change first.** Every track forks a detached worktree from the
   branch HEAD, so only *committed* work is reviewed. If the main worktree has
-  staged/unstaged/untracked changes (outside `.be-review/`), commit (or stash)
-  them before invoking — the orchestrator's Setup preflight aborts with
-  `status: 'setup-failed'` on a dirty tree rather than reviewing an incomplete set.
-  (In `/be` this is automatic: §2/§3 commit and push before §4.)
+  staged/unstaged/untracked changes (outside the gitignored `.worktrees/` and
+  `.be-review/` scratch), commit (or stash) them before invoking — the
+  orchestrator's Setup preflight aborts with `status: 'setup-failed'` on a dirty
+  tree rather than reviewing an incomplete set. (In `/be` this is automatic: §2/§3
+  commit and push before §4.)
 - **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
   not logged in, tell the user to run `codex login` (suggest the `!` prefix).
 
@@ -98,52 +111,61 @@ Workflow({
     base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
     rationale: "<optional author note on deliberate decisions>",
     tracks: ["codex", "lens", "police"],   // also the consolidation order
-    commit: <false only if --no-commit>
+    commit: <false only if --no-commit>,
+    comment: <false only if --no-comment>
   }
 })
 ```
 
-It runs four phases the user can watch via `/workflows`: **Setup** (fan out one
-detached worktree per track), **Tracks** (the three gauntlets run concurrently to
-consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
-reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
+It runs five phases the user can watch via `/workflows`: **Setup** (fan out one
+detached worktree per track under `.worktrees/`), **Tracks** (the three gauntlets
+run concurrently to consensus), **Consolidate** (cherry-pick each track's commits
+onto the branch, reconciling overlap), **Report** (post a detailed PR comment per
+track + the consolidation ledger), **Cleanup** (tear down the worktrees). It
+returns:
 
 ```
 { status,                  // 'done' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'
-  consolidation,           // { finalHead, picks[], conflicts[] }  (null when not consolidated)
-  conflicts }              // the overlaps reconciled (empty in the common case)
+  consolidation,           // { finalHead, picks[] }  (null when not consolidated)
+  conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
+  comments }               // { codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
   and re-run) or no worktree could be created. `tracks` carries the per-track
   `track-error` detail.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
-  **uncommitted in its preserved `.be-review/wt-<track>` worktree** and nothing is
-  consolidated or cleaned up. The result lists those `worktrees` to inspect; re-run
-  with commit enabled to actually consolidate. (`--no-commit` is a
-  single-track-debugging mode, not a way to ship fixes.)
+  **uncommitted in its preserved `.worktrees/be-review-<track>` worktree** and
+  nothing is consolidated, reported, or cleaned up. The result lists those
+  `worktrees` to inspect; re-run with commit enabled to actually consolidate.
+  (`--no-commit` is a single-track-debugging mode, not a way to ship fixes.)
 - For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
   to the serial path for that track.
 
 ### 3. Present the result
 
-Report in chat and post **one** consolidated PR comment (this replaces the three
-separate per-reviewer comments): a `## Review gauntlet (parallel)` section with,
-per track, its outcome (codex consensus + rounds, lens consensus + per-finding
-table, police findings actioned); then the **consolidation ledger** — each
-cherry-picked commit and its outcome (`clean`/`reconciled`/`dropped`), with any
-overlap reconciliation explained. Then `git log --oneline <base>..HEAD` and
-`git diff --stat <base>` so the user sees the combined result. Never push or
-merge — the human reviews the per-track commits and merges.
+**The workflow already posted the PR comments** — one detailed comment per track
+(codex debate table, lens per-finding ledger, police findings) plus the
+consolidation ledger — in its **Report** phase, so the trail is on the PR no
+matter who invoked it (the `comments` field carries the URLs). Confirm they landed
+(re-post any that returned "no PR" once the PR exists). Then summarize in chat:
+the per-track outcomes, the consolidation ledger (`clean`/`reconciled`/`dropped`),
+and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the user sees
+the combined result. Never push or merge — the human reviews the per-track commits
+and merges.
 
 ## Safety & notes
 
 - **Reviewers are read-only; only their own worktree is written.** Each track's
-  fixes land in `.be-review/wt-<track>/`; the branch is touched only by the
+  fixes land in `.worktrees/be-review-<track>/`; the branch is touched only by the
   consolidation cherry-picks, which never push or merge.
+- **Isolation is structural (cwd-independent).** Workflow agents share the session
+  cwd; the orchestrator and both child workflows (`/codex-debate`, `/lens-debate`)
+  therefore use `git -C <worktree>` and absolute paths throughout, so a forgotten
+  `cd` can't make an agent edit or commit into the wrong tree.
 - **Overlap is reconciled, never silently dropped.** A cherry-pick conflict means
   two debates changed the same lines; the orchestrator merges both intents (it
   has both commit messages) and only drops a commit if an earlier track fully
@@ -154,14 +176,16 @@ merge — the human reviews the per-track commits and merges.
   residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
   change is small and correctness-critical, the serial `/codex-debate` →
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
-- **Parallel-safe.** Worktrees + scratch live under the gitignored, per-worktree
+- **Parallel-safe.** Worktrees live under the gitignored `<repoPath>/.worktrees/`
+  and commit-message + PR-comment scratch under the gitignored
   `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
-  scratch nests inside its worktree.
+  scratch nests inside its worktree. All paths are absolute and
+  per-main-worktree, so parallel `/be-review` runs never collide.
 
 ## Files
 
 - `be-review.workflow.js` — the orchestrator (worktree fan-out → parallel tracks
-  → cherry-pick consolidation → cleanup). It invokes
+  → cherry-pick consolidation → per-track PR comments → cleanup). It invokes
   `.claude/skills/{codex-debate,lens-debate}/debate.workflow.js` as child
   workflows and reads `.claude/skills/code-police/SKILL.md` at runtime.
 

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -121,6 +121,7 @@ Workflow({
   args: {
     repoPath: "<worktree root>",
     base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
+    runId: "<unique id, e.g. current epoch ms>", // isolates this run's worktrees/scratch
     rationale: "<optional author note on deliberate decisions>",
     tracks: ["codex", "lens", "police"],   // also the consolidation order
     commit: <false only if --no-commit>,
@@ -128,6 +129,12 @@ Workflow({
   }
 })
 ```
+
+**Pass a unique `runId`** (the workflow can't call `Date.now()` itself — the runtime
+forbids it to keep resume deterministic). Stamp the current epoch ms (or any unique
+token) so two `/be-review` runs in the same main worktree don't clobber each other's
+worktrees/scratch. Omitting it defaults to `'run'` — safe for a single run, unsafe
+for concurrent ones.
 
 It runs five phases the user can watch via `/workflows`: **Setup** (fan out one
 detached worktree per track under `.worktrees/`), **Tracks** (the three gauntlets

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -70,7 +70,10 @@ to `cd`.
   Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
   Setup resolves this to the **merge-base** of the branch and `base`, and *that* is
   what every reviewer diffs against — so commits `base` gained since the branch
-  forked are NOT reviewed as if this PR made them (no master-drift noise).
+  forked are NOT reviewed as if this PR made them (no master-drift noise). If the
+  merge-base can't be resolved (missing/typoed/stale base ref), Setup aborts with
+  `status: 'setup-failed'` rather than falling back to the raw `base` tip and
+  reviewing an untrustworthy scope — fix the ref (`git fetch`) and re-run.
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.
@@ -90,7 +93,10 @@ to `cd`.
 
 ### 1. Resolve context
 
-- Determine `repoPath` (the worktree root, normally the cwd).
+- Determine `repoPath` — the **absolute** worktree root (normally the cwd; resolve
+  it with `git -C . rev-parse --show-toplevel`). The orchestrator rejects a
+  relative `repoPath` with `status: 'setup-failed'`, since every git command and
+  scratch/worktree path it builds is absolute and cwd-independent.
 - `git fetch origin` so the base remote-tracking ref is current.
 - Resolve `base` (a remote-tracking ref like `origin/master`).
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
@@ -179,11 +185,22 @@ and merges.
   residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
   change is small and correctness-critical, the serial `/codex-debate` →
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
-- **Parallel-safe.** Worktrees live under the gitignored `<repoPath>/.worktrees/`
-  and commit-message + PR-comment scratch under the gitignored
-  `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
-  scratch nests inside its worktree. All paths are absolute and
-  per-main-worktree, so parallel `/be-review` runs never collide.
+- **Uncommitted track edits are never silently dropped.** Consolidation replays
+  only *committed* commits and Cleanup force-removes the worktrees, so before
+  consolidating the orchestrator mechanically checks each track's worktree with
+  `git status --short`. A track that left uncommitted/untracked edits (a failed
+  commit helper, a formatter touching an unlisted file) is **excluded from
+  consolidation and its worktree is preserved** (not torn down), and surfaced in
+  the result so the human can recover it — rather than cherry-picked-around and
+  deleted.
+- **Parallel-safe — even in the same worktree.** Worktrees live under the
+  gitignored `<repoPath>/.worktrees/` as `be-review-<runId>-<track>` and the
+  commit-message + PR-comment scratch under the gitignored
+  `<repoPath>/.be-review/<runId>/`, where `<runId>` is unique per invocation; each
+  track's own `.codex-debate/`/`.lens-debate/` scratch nests inside its worktree.
+  All paths are absolute and per-run, so two `/be-review` runs — in different
+  worktrees *or the same one* — never clobber each other's live worktrees or
+  scratch. Setup never `rm -rf`s a path that could belong to a concurrent run.
 
 ## Files
 

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -68,6 +68,9 @@ to `cd`.
 
 - **`--base <branch>`**: remote-tracking ref to diff against (e.g. `origin/master`).
   Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
+  Setup resolves this to the **merge-base** of the branch and `base`, and *that* is
+  what every reviewer diffs against — so commits `base` gained since the branch
+  forked are NOT reviewed as if this PR made them (no master-drift noise).
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -27,7 +27,9 @@ branch HEAD ┼─ be-review-lens    ─ lowy⇄hickey debate  ─→ commits �
 ```
 
 The per-track worktrees live under the repo's conventional `.worktrees/`
-(gitignored) — `.worktrees/be-review-<track>`. **Isolation is structural, not
+(gitignored) — `.worktrees/be-review-<runId>-<track>`, where `<runId>` is unique
+per invocation (the returned `worktrees` field carries each track's exact path).
+**Isolation is structural, not
 behavioral:** every workflow agent inherits the *session* cwd (the harness has no
 per-agent cwd, and `isolation:'worktree'` can't host a multi-round debate that
 accumulates commits in one tree), so every git command is `git -C <worktree>` and
@@ -81,9 +83,10 @@ to `cd`.
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
   with this flag the orchestrator **skips Consolidate + Report + Cleanup and
   preserves the worktrees** (status `no-commit`) — leaving every track's worktree
-  in place under `.worktrees/be-review-<track>/` (the branch is untouched) rather
-  than silently discarding the uncommitted edits; inspect and tear them down
-  yourself. Default is to commit, which is what actually ships fixes.
+  in place under `.worktrees/be-review-<runId>-<track>/` (the branch is untouched;
+  the returned `worktrees` field carries each exact path) rather than silently
+  discarding the uncommitted edits; inspect and tear them down yourself. Default is
+  to commit, which is what actually ships fixes.
 - **`--no-comment`**: suppress the PR comments. By default the **Report** phase
   posts a detailed PR comment per track (codex debate table, lens per-finding
   ledger, police findings) plus the consolidation ledger — the review trail the
@@ -147,9 +150,10 @@ returns:
   and re-run) or no worktree could be created. `tracks` carries the per-track
   `track-error` detail.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
-  **uncommitted in its preserved `.worktrees/be-review-<track>` worktree** and
-  nothing is consolidated, reported, or cleaned up. The result lists those
-  `worktrees` to inspect; re-run with commit enabled to actually consolidate.
+  **uncommitted in its preserved `.worktrees/be-review-<runId>-<track>` worktree**
+  and nothing is consolidated, reported, or cleaned up. The result lists those
+  `worktrees` (with exact paths) to inspect; re-run with commit enabled to
+  actually consolidate.
   (`--no-commit` is a single-track-debugging mode, not a way to ship fixes.)
 - For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
   to the serial path for that track.
@@ -169,8 +173,8 @@ and merges.
 ## Safety & notes
 
 - **Reviewers are read-only; only their own worktree is written.** Each track's
-  fixes land in `.worktrees/be-review-<track>/`; the branch is touched only by the
-  consolidation cherry-picks, which never push or merge.
+  fixes land in `.worktrees/be-review-<runId>-<track>/`; the branch is touched only
+  by the consolidation cherry-picks, which never push or merge.
 - **Isolation is structural (cwd-independent).** Workflow agents share the session
   cwd; the orchestrator and both child workflows (`/codex-debate`, `/lens-debate`)
   therefore use `git -C <worktree>` and absolute paths throughout, so a forgotten
@@ -187,11 +191,15 @@ and merges.
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
 - **Uncommitted track edits are never silently dropped.** Consolidation replays
   only *committed* commits and Cleanup force-removes the worktrees, so before
-  consolidating the orchestrator mechanically checks each track's worktree with
-  `git status --short`. A track that left uncommitted/untracked edits (a failed
-  commit helper, a formatter touching an unlisted file) is **excluded from
-  consolidation and its worktree is preserved** (not torn down), and surfaced in
-  the result so the human can recover it — rather than cherry-picked-around and
+  consolidating the orchestrator mechanically checks **every live worktree** with
+  `git status --short` — including a track whose gauntlet *crashed*
+  (`track-error`), since a crash after edits-applied-but-before-commit is exactly
+  when uncommitted work is most likely. Cleanup **fails closed**: only a worktree
+  the checker reports *explicitly clean* is torn down; one that left
+  uncommitted/untracked edits (a failed commit helper, a formatter touching an
+  unlisted file, a mid-run crash) — or that the checker never reported on — is
+  **excluded from consolidation and its worktree is preserved**, and surfaced in
+  the result so the human can recover it, rather than cherry-picked-around and
   deleted.
 - **Parallel-safe — even in the same worktree.** Worktrees live under the
   gitignored `<repoPath>/.worktrees/` as `be-review-<runId>-<track>` and the

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -74,10 +74,13 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the worktree name and the scratch subdir so two /be-review runs in the SAME
 // main worktree never clobber each other's live worktrees or scratch files (the
 // old fixed `be-review-<track>` / `.be-review/*` paths let a second run `rm -rf`
-// the first run's in-flight worktree). The id is the start-time epoch ms — unique
-// per invocation, and the actual paths are reported back in the result so manual
-// inspection doesn't need to guess them.
-const RUN_ID = String(Date.now())
+// the first run's in-flight worktree). The id comes from `args.runId`: the
+// workflow runtime forbids `Date.now()`/`Math.random()` (they'd break resume), so
+// the CALLER stamps a unique value (the /be-review skill passes the launch epoch
+// ms). Defaults to 'run' when absent — fine for a single run; CONCURRENT runs in
+// the same main worktree must pass distinct ids. The actual paths are reported in
+// the result so manual inspection doesn't need to guess them.
+const RUN_ID = String(a.runId || 'run')
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -542,14 +542,18 @@ phase('Consolidate')
 // worktree — so any edit a track left UNcommitted (an apply agent that produced
 // files but whose commit helper failed, a formatter that touched an unlisted
 // file, an untracked new file) would be invisible to cherry-pick and then deleted
-// for good. Mechanically check each candidate track's worktree is clean; a dirty
-// one is excluded from both consolidation AND cleanup (its worktree is preserved
-// for the human) and surfaced in the result, instead of silently discarded.
-const consolidateCandidates = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const cleanCheck = consolidateCandidates.length
+// for good. The check runs for EVERY live worktree — including a track whose
+// gauntlet CRASHED (`track-error`): a crash after edits-applied-but-before-commit
+// is exactly when uncommitted work is most likely, so skipping crashed tracks
+// here would force-remove the very edits this gate exists to save. We only USE the
+// clean result to decide consolidation eligibility (a `track-error` track is never
+// cherry-picked regardless); for cleanup we FAIL CLOSED — any worktree that isn't
+// EXPLICITLY clean (dirty, or missing from the checker's response) is preserved,
+// never torn down. A dirty/unknown track is surfaced in the result for the human.
+const cleanCheck = liveTracks.length
   ? await agent(
-      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Do not edit anything. Tracks and their worktrees:
-${consolidateCandidates.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
+${liveTracks.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
 For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
       {
         label: 'consolidate:clean-check',
@@ -578,21 +582,31 @@ For each track return { track, clean (boolean), dirtyStatus (the offending \`sta
       },
     )
   : { tracks: [] }
-const dirtyTracks = consolidateCandidates.filter((t) => (cleanCheck?.tracks || []).find((c) => c.track === t && c.clean === false))
-for (const t of dirtyTracks) {
-  const ds = (cleanCheck?.tracks || []).find((c) => c.track === t)?.dirtyStatus || ''
+// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless the
+// checker EXPLICITLY reported it clean. So a missing row, or a row that says it's
+// dirty, both keep the worktree. `cleanTracks` is the allowlist of explicitly-clean
+// worktrees; everything else is preserved.
+const cleanResultFor = (t) => (cleanCheck?.tracks || []).find((c) => c.track === t)
+const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
+const preservedTracks = liveTracks.filter((t) => !cleanTracks.includes(t))
+for (const t of preservedTracks) {
+  const row = cleanResultFor(t)
+  const ds = row?.dirtyStatus || ''
+  const reason = row ? 'left UNcommitted changes in its worktree' : "could not be confirmed clean (no clean-check result — failing closed)"
   tracks[t] = {
     ...tracks[t],
     consolidated: false,
     dirtyStatus: ds,
-    note: `track left UNcommitted changes in its worktree (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so the edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
   }
-  log(`Consolidate: track ${t} has UNcommitted changes — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
+  log(`Consolidate: track ${t} not confirmed clean — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
 }
 
-// Only replay tracks that are clean (every agreed fix really is a commit) and made
-// real work — the agent only picks committed work.
-const consolidateOrder = consolidateCandidates.filter((t) => !dirtyTracks.includes(t))
+// Only replay tracks that are explicitly clean (every agreed fix really is a
+// commit) AND completed without crashing — a `track-error` track is never
+// cherry-picked even if its worktree happens to be clean, since its commit ledger
+// is untrustworthy. The agent only picks committed work.
+const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
@@ -651,14 +665,16 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees. Dirty tracks (uncommitted edits
-// the clean-check caught) are PRESERVED, not removed — their worktree is the only
-// place those edits live, so force-removing it would discard them.
+// Phase 5 — tear down the per-track worktrees. Only EXPLICITLY-clean worktrees are
+// torn down; anything not confirmed clean (uncommitted edits the clean-check
+// caught, OR a worktree the checker never reported on — including a crashed
+// `track-error` track) is PRESERVED, since its worktree may be the only place
+// those edits live and force-removing it would discard them. Fail closed.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-const teardownTracks = liveTracks.filter((t) => !dirtyTracks.includes(t))
-if (dirtyTracks.length) log(`Cleanup: preserving ${dirtyTracks.length} dirty worktree(s) (${dirtyTracks.join(', ')}) — they hold uncommitted edits.`)
+const teardownTracks = cleanTracks
+if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not confirmed clean (${preservedTracks.join(', ')}) — they may hold uncommitted edits.`)
 if (teardownTracks.length) {
   await agent(
     `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -582,31 +582,47 @@ For each track return { track, clean (boolean), dirtyStatus (the offending \`sta
       },
     )
   : { tracks: [] }
-// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless the
-// checker EXPLICITLY reported it clean. So a missing row, or a row that says it's
-// dirty, both keep the worktree. `cleanTracks` is the allowlist of explicitly-clean
-// worktrees; everything else is preserved.
+// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless it is
+// safe to discard. A worktree is safe to discard ONLY if it was both (a) EXPLICITLY
+// reported clean by the checker AND (b) successfully replayed onto the branch — i.e.
+// it ends up in `consolidateOrder`. Everything else is preserved:
+//   - a missing clean-check row, or a row that says it's dirty → may hold UNcommitted
+//     edits (fail closed on the checker);
+//   - a `track-error` track, even one that `git status` calls clean → may hold
+//     COMMITTED-but-unreplayed work, since `consolidateOrder` deliberately excludes
+//     it (its commit ledger is untrustworthy, so the consolidator never cherry-picks
+//     it). Removing its detached worktree would make those commits unreachable.
+// `cleanTracks` is the allowlist of explicitly-clean worktrees; `consolidateOrder`
+// narrows that to the ones we actually replayed; teardown only touches the latter.
 const cleanResultFor = (t) => (cleanCheck?.tracks || []).find((c) => c.track === t)
 const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
-const preservedTracks = liveTracks.filter((t) => !cleanTracks.includes(t))
-for (const t of preservedTracks) {
-  const row = cleanResultFor(t)
-  const ds = row?.dirtyStatus || ''
-  const reason = row ? 'left UNcommitted changes in its worktree' : "could not be confirmed clean (no clean-check result — failing closed)"
-  tracks[t] = {
-    ...tracks[t],
-    consolidated: false,
-    dirtyStatus: ds,
-    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
-  }
-  log(`Consolidate: track ${t} not confirmed clean — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
-}
 
 // Only replay tracks that are explicitly clean (every agreed fix really is a
 // commit) AND completed without crashing — a `track-error` track is never
 // cherry-picked even if its worktree happens to be clean, since its commit ledger
 // is untrustworthy. The agent only picks committed work.
 const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
+
+// Preserve every live track we did NOT consolidate, so neither uncommitted edits
+// nor committed-but-unreplayed commits are lost.
+const preservedTracks = liveTracks.filter((t) => !consolidateOrder.includes(t))
+for (const t of preservedTracks) {
+  const row = cleanResultFor(t)
+  const ds = row?.dirtyStatus || ''
+  const reason =
+    tracks[t]?.status === 'track-error'
+      ? 'CRASHED (track-error) so its commit ledger is untrustworthy and it was never replayed — its worktree may hold committed-but-unconsolidated fixes'
+      : row
+        ? 'left UNcommitted changes in its worktree'
+        : 'could not be confirmed clean (no clean-check result — failing closed)'
+  tracks[t] = {
+    ...tracks[t],
+    consolidated: false,
+    dirtyStatus: ds,
+    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} log ${branchHead}..HEAD\` and \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+  }
+  log(`Consolidate: track ${t} not consolidated — worktree preserved at ${wtDir(t)}.`)
+}
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
@@ -665,16 +681,18 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees. Only EXPLICITLY-clean worktrees are
-// torn down; anything not confirmed clean (uncommitted edits the clean-check
-// caught, OR a worktree the checker never reported on — including a crashed
-// `track-error` track) is PRESERVED, since its worktree may be the only place
-// those edits live and force-removing it would discard them. Fail closed.
+// Phase 5 — tear down the per-track worktrees. Only worktrees we actually
+// CONSOLIDATED (explicitly clean AND replayed onto the branch — i.e.
+// `consolidateOrder`) are torn down. Everything else is PRESERVED, since its
+// worktree may be the only place its edits live and force-removing it would
+// discard them: uncommitted edits the clean-check caught, a worktree the checker
+// never reported on, OR a crashed `track-error` track whose committed-but-
+// unreplayed fixes were deliberately excluded from consolidation. Fail closed.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-const teardownTracks = cleanTracks
-if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not confirmed clean (${preservedTracks.join(', ')}) — they may hold uncommitted edits.`)
+const teardownTracks = consolidateOrder
+if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not consolidated (${preservedTracks.join(', ')}) — they may hold uncommitted or unreplayed committed edits.`)
 if (teardownTracks.length) {
   await agent(
     `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
@@ -683,7 +701,7 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
     { label: 'cleanup:worktrees', phase: 'Cleanup', model },
   )
 } else {
-  log('Cleanup: no clean worktrees to tear down (all preserved or none live).')
+  log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
 return {

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -130,7 +130,7 @@ const IMPL_SCHEMA = {
 const CONSOLIDATE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['picks', 'conflicts'],
+  required: ['picks'],
   properties: {
     finalHead: { type: 'string', description: 'branch HEAD SHA after all picks' },
     picks: {
@@ -145,23 +145,8 @@ const CONSOLIDATE_SCHEMA = {
           sourceCommit: { type: 'string', description: 'the short SHA from the track worktree' },
           newCommit: { type: 'string', description: 'the resulting SHA on the branch' },
           outcome: { type: 'string', enum: ['clean', 'reconciled', 'dropped'] },
+          files: { type: 'array', items: { type: 'string' }, description: 'for reconciled/dropped: the overlapping files' },
           note: { type: 'string', description: 'for reconciled/dropped: how you resolved it and why' },
-        },
-      },
-    },
-    conflicts: {
-      type: 'array',
-      description: 'the overlaps you had to reconcile (subset of picks); empty in the common no-overlap case',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        required: ['track', 'sourceCommit', 'files', 'resolution'],
-        properties: {
-          track: { type: 'string' },
-          sourceCommit: { type: 'string' },
-          files: { type: 'array', items: { type: 'string' } },
-          resolution: { type: 'string', enum: ['merged', 'dropped'] },
-          note: { type: 'string' },
         },
       },
     },
@@ -228,19 +213,31 @@ if (!branchHead || liveTracks.length === 0) {
 // ---------------------------------------------------------------------------
 phase('Tracks')
 
-// The police track. /code-police is a skill, not a workflow, so its three cold
-// passes (rules / fact-check / elegance) are reproduced here as parallel agents,
-// then each agreed fix is applied as its own commit — matching /be §4.3's
-// "each finding is its own commit". Per-finding `just check` is deferred to the
-// post-consolidation check + §5 CI rather than run 3× concurrently across the
-// parallel worktrees (it would thrash the toolchain); fmt-on-touched-files still
-// runs in each apply.
+// The police track. /code-police is a skill, not a workflow, so its cold passes
+// (rules / fact-check / elegance) are fanned out here as parallel agents — but
+// each pass's *definition* stays single-sourced to code-police's SKILL.md (the
+// agents Read it; the briefs only name which section/pass to apply), and the
+// elegance pass honors the skill's tiny-diff skip. Each agreed fix is then
+// applied as its own commit — matching /be §4.3's "each finding is its own
+// commit". Per-finding `just check` is deferred to the post-consolidation check
+// + §5 CI rather than run 3× concurrently across the parallel worktrees (it
+// would thrash the toolchain); fmt-on-touched-files still runs in each apply.
 async function policeTrack(wt) {
+  // Pass *definitions* are single-sourced to code-police's SKILL.md: each brief
+  // names that pass's section so the agent (which Reads the skill below) reviews
+  // it exactly as written there — no inline checklist to drift. The elegance pass
+  // is gated on the tiny-diff heuristic the skill mandates (SKILL.md:141 — skip
+  // when the worktree diff against base is <10 lines).
+  const tinyDiff = await agent(
+    `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
+    { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
+  )
   const passes = [
-    { key: 'rules', brief: 'the built-in code-police rule checklist (dry-rule-of-three, prefer-focused-library, invalid-states-unrepresentable, no-dead-code, no-silent-error-swallowing, and the rest) PLUS any project rules' },
-    { key: 'fact-check', brief: 'a CORRECTNESS audit: logic errors, silently swallowed errors, wishful thinking, unjustified fallbacks — not style' },
-    { key: 'elegance', brief: 'simplicity and idiom: hand-rolled code that a focused library or a simpler shape would replace' },
-  ]
+    { key: 'rules', brief: 'the **Rule checklist** pass exactly as defined in that skill\'s "Running the passes" section (Pass 1) — every built-in rule plus any project rules' },
+    { key: 'fact-check', brief: 'the **Fact-check** correctness audit exactly as defined in that skill\'s "Running the passes" section (Pass 2)' },
+    { key: 'elegance', brief: 'the **Elegance** pass exactly as defined in that skill\'s "Running the passes" section (Pass 3) — simplicity and idiom' },
+  ].filter((p) => p.key !== 'elegance' || !tinyDiff?.tiny)
+  if (tinyDiff?.tiny) log('police: skipping elegance pass (tiny diff <10 lines, per code-police SKILL.md)')
   const reviews = await parallel(
     passes.map((p) => () =>
       agent(
@@ -264,7 +261,7 @@ async function policeTrack(wt) {
     const files = impl?.filesChanged ?? []
     let sha = null
     if (commit && files.length) {
-      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files) || '').trim()
+      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
     }
     applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
@@ -289,7 +286,16 @@ ${message}
 
 3. Run: \`git -C ${wt} add -- ${fileArgs} && git -C ${wt} commit -F ${msgPath}\`. Stage ONLY those files; do NOT use \`git add -A\`/\`git add .\`.
 4. Return the new commit SHA from \`git -C ${wt} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `police-commit:${id}`, phase: 'Tracks' })
+  return agent(prompt, {
+    label: `police-commit:${id}`,
+    phase: 'Tracks',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['sha'],
+      properties: { sha: { type: 'string', description: 'the new HEAD commit SHA, hex only' } },
+    },
+  })
 }
 
 // One thunk per live track. codex and lens are existing repoPath-parameterized
@@ -320,10 +326,10 @@ for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
 // `--no-commit` short-circuit. With commit=false the tracks deliberately leave
 // their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
-// (rev-list ${branchHead}..HEAD) and cleanup tears the worktrees down — so running
-// them now would discard every reviewer's edits. Instead, stop here and hand the
-// live worktrees to the user to inspect; nothing is consolidated and nothing is
-// cleaned up. (This is the documented single-track-debugging mode.)
+// (rev-list ${branchHead}..HEAD) and cleanup's `worktree remove --force` tears the
+// worktrees down — so running them now would silently discard every reviewer's edits.
+// Instead, stop here and hand the live worktrees to the user to inspect; nothing is
+// consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
 if (!commit) {
   log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
   return {
@@ -350,7 +356,7 @@ phase('Consolidate')
 
 // Skip tracks that errored or made no commits — the agent only picks real work.
 const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Three review tracks each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
@@ -362,12 +368,12 @@ Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits 
   \`git -C ${repoPath} cherry-pick <sha>\`
 
 - **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
-- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — say so in \`note\`; never drop to avoid the work of merging.
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
 
-Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD, the per-commit \`picks\` ledger (in processing order), and the \`conflicts\` subset you had to reconcile.`
+Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
 const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
-const conflicts = consolidation?.conflicts ?? []
+const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clean')
 log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -120,6 +120,18 @@ if (!/^[A-Za-z0-9._-]+$/.test(RUN_ID) || RUN_ID === '..' || RUN_ID === '.') {
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
+// The two gitignored scratch dirs this orchestrator owns: live per-track
+// worktrees under `.worktrees/` and commit-message/PR-comment scratch under
+// `.be-review/`. Two prompts must name them in lockstep — the DIFF brief tells
+// reviewers to ignore them, and the Setup preflight excludes them from the
+// clean-tree check — so the list lives here once and both interpolate it.
+const ORCHESTRATOR_SCRATCH = ['.worktrees/', '.be-review/']
+const scratchList = ORCHESTRATOR_SCRATCH.map((d) => `\`${d}\``).join(' and ')
+// The per-track debate scratch dirs the child workflows own (codex/lens write
+// their transcripts here). The consolidation clean-check must ignore these when
+// judging whether a track left uncommitted work, so the list lives here once.
+const TRACK_SCRATCH = ['.codex-debate/', '.lens-debate/']
+const trackScratchList = TRACK_SCRATCH.map((d) => `\`${d}\``).join(', ')
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -130,11 +142,20 @@ const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 // not the raw `${base}` tip — see SETUP_SCHEMA.mergeBase. DIFF is an arrow, so it
 // reads `mergeBase` lazily at call time (Tracks phase, after Setup has set it).
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored ${scratchList} scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
   : ''
+
+// Single source of the cwd-safety contract every mechanical git agent runs under.
+// The Workflow runtime can't run git/gh itself, so a thin agent shells out — and
+// because all agents share the SESSION cwd (see SHARED-CWD NOTE), each MUST use
+// absolute paths + `git -C` and never rely on the current directory. This sentence
+// was copy-pasted across the six mechanical-agent prompts; hoisting it here means
+// the contract lives in ONE place if the shared-cwd guarantee ever changes.
+const mechanicalPreamble = (role) =>
+  `You are a MECHANICAL ${role}. Every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory.`
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -242,11 +263,11 @@ const CONSOLIDATE_SCHEMA = {
 // ---------------------------------------------------------------------------
 phase('Setup')
 
-const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
+const setupPrompt = `${mechanicalPreamble('SETUP RUNNER')} You are preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps; do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
 1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command FAILS (missing/typoed base, stale ref, or unrelated history), the review scope is untrustworthy — do NOT fall back to the raw \`${base}\`; instead set \`mergeBase\`: "" and put the exact git error in \`mergeBaseError\`, then STOP (skip worktree creation, return an empty \`worktrees\` array). (The orchestrator aborts the whole run when \`mergeBase\` is empty.)
-2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (${scratchList}). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — create a fresh detached worktree at \`branchHead\` for each track, at these EXACT absolute paths (per-run unique, so they cannot belong to another in-flight run):
 ${TRACKS.map((t) => `   - ${t}: \`git -C ${repoPath} worktree add --detach ${wtDir(t)} <branchHead>\``).join('\n')}
@@ -411,7 +432,7 @@ async function commitFix(wt, id, subject, body, files) {
   const fileArgs = rel.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
   const msgPath = `${SCRATCH}/commit-msg-${id}.txt`
   const message = `${subject}\n\n${body}`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files. Every path is absolute / \`git -C\`; do not rely on the current directory.
+  const prompt = `${mechanicalPreamble('COMMITTER')} Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
@@ -563,6 +584,16 @@ function policeComment(t) {
 ${rows || '| — | — | — | — |'}`
 }
 
+// Fallback comment for any requested track that has NO bespoke builder. It leans
+// only on the always-present per-track fields (`track`, `status`, and `error`/
+// `note` when present), so a newly-added reviewer track gets a real PR comment
+// instead of being silently dropped — keeping Report total over `TRACKS`.
+function genericComment(t) {
+  return `## ${t?.track || 'unknown'} track
+
+**Outcome:** \`${t?.status || 'unknown'}\`.${t?.error ? ` Track error: ${esc(t.error)}.` : ''}${t?.note ? `\n\n${esc(t.note)}` : ''}`
+}
+
 function consolidationSection(c, order) {
   const rows = (c?.picks || [])
     .map((p) => `| ${esc(p.track)} | ${sha9(p.sourceCommit)} | \`${esc(p.outcome)}\` | ${sha9(p.newCommit)} | ${esc(p.note) || ''} |`)
@@ -578,7 +609,7 @@ ${rows || '| — | — | — | — | — |'}`
 // MAIN worktree (gh uses cwd's repo; the agent runs `gh -C`-equivalent by cd-ing).
 async function postComment(slug, body) {
   const file = `${SCRATCH}/comment-${slug}.md`
-  const prompt = `You are a MECHANICAL PR COMMENTER. Do exactly these steps and nothing else.
+  const prompt = `${mechanicalPreamble('PR COMMENTER')} Do exactly these steps and nothing else.
 
 1. \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${file}\` with EXACTLY this markdown content:
@@ -610,7 +641,6 @@ if (!commit) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
@@ -680,7 +710,6 @@ if (branchMoved || branchDirty) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     preservedTracks: liveTracks,
     note: `consolidation aborted: ${why}. Cherry-picking onto the changed base would review against an untrustworthy scope, so nothing was consolidated and every track worktree was PRESERVED (see each track's note for the recovery cherry-pick).${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
@@ -702,7 +731,7 @@ if (branchMoved || branchDirty) {
 // never torn down. A dirty/unknown track is surfaced in the result for the human.
 const cleanCheck = liveTracks.length
   ? await agent(
-      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
+      `${mechanicalPreamble('CLEANLINESS CHECKER')} For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (${trackScratchList}); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
 ${liveTracks.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
 For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
       {
@@ -826,13 +855,12 @@ if (currentHead !== branchHead) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     note: `consolidation precondition failed: the branch in \`${repoPath}\` is at \`${currentHead || '(unknown)'}\` but the review tracks forked from \`${branchHead}\`. The HEAD has advanced past the shared fork point — likely a re-run in an already-consolidated worktree — so cherry-picking the track commits would stack them a SECOND time and double-apply every fix. Nothing was consolidated and the per-track worktrees are PRESERVED. Reset the branch to \`${branchHead}\` (\`git -C ${repoPath} reset --hard ${branchHead}\`) or start from a clean worktree, then re-run.`,
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
 
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `${mechanicalPreamble('CONSOLIDATOR')} You are consolidating the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
@@ -872,13 +900,16 @@ if (postComments) {
   // requested-track audit trail instead of silently omitting the dropped track. A
   // per-track comment builder keyed by track name; adding/removing a reviewer costs
   // Report nothing — no hardcoded track literal to keep in sync.
+  // Bespoke per-track builders; any requested track without one falls back to
+  // `genericComment`, so the map below stays TOTAL over `TRACKS` — a new reviewer
+  // track gets a comment even before it grows a hand-written builder.
   const builder = { codex: codexComment, lens: lensComment, police: policeComment }
   // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
   // it posts as its own comment — surviving any track subset instead of being
   // string-stapled onto whichever track happens to be present.
   const bodies = [
     ['consolidation', consolidationSection(consolidation, consolidateOrder)],
-    ...TRACKS.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+    ...TRACKS.map((t) => [t, (builder[t] || genericComment)(tracks[t])]),
   ]
   // Post sequentially so the comments land in a stable order (consolidation, then
   // the tracks in canonical order).
@@ -906,7 +937,7 @@ const teardownTracks = consolidateOrder
 if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not consolidated (${preservedTracks.join(', ')}) — they may hold uncommitted or unreplayed committed edits.`)
 if (teardownTracks.length) {
   await agent(
-    `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
+    `${mechanicalPreamble('CLEANUP RUNNER')} Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
 ${teardownTracks.map((t) => `  - \`git -C ${repoPath} worktree remove --force ${wtDir(t)}\``).join('\n')}
 Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
     { label: 'cleanup:worktrees', phase: 'Cleanup', model },
@@ -952,8 +983,5 @@ return {
   // (police `incomplete`, lens `unresolved`, codex `reviewer-error`); their fixes
   // landed but the gauntlet didn't fully finish. Non-empty ⇒ 'consolidation-incomplete'.
   incompleteTracks,
-  // back-compat: the union of non-clean picks. Consumers keying on a discarded
-  // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
-  conflicts: [...reconciled, ...dropped],
   comments,
 }

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -5,11 +5,12 @@
 export const meta = {
   name: 'be-review',
   description:
-    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile)',
+    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile) and post a detailed PR comment per track',
   phases: [
     { title: 'Setup', detail: 'fan out one detached worktree per review track off the branch HEAD', model: 'opus' },
     { title: 'Tracks', detail: 'codex, lens, and police gauntlets each run to consensus, concurrently and isolated', model: 'opus' },
     { title: 'Consolidate', detail: 'cherry-pick each track’s commits onto the branch in order; reconcile the rare overlap', model: 'opus' },
+    { title: 'Report', detail: 'post a detailed PR comment for each track plus the consolidation ledger', model: 'opus' },
     { title: 'Cleanup', detail: 'tear down the per-track worktrees', model: 'opus' },
   ],
 }
@@ -33,17 +34,28 @@ const rationale = (a.rationale || '').trim()
 // per-track commits are what consolidation cherry-picks, so leaving it on is the
 // norm. (`--no-commit` is for debugging a single track in isolation.)
 const commit = a.commit !== false
+// Post a detailed PR comment per track + the consolidation ledger (default on).
+// `--no-comment` (comment:false) suppresses the outward-facing write.
+const postComments = a.comment !== false
 const model = a.model || MODEL
 // The review tracks to run AND the order they consolidate in. codex first (it
 // changes the most — bug fixes), then the structural lenses, then police, so an
 // overlap surfaces as a conflict picking the later, lighter-touch track.
 const TRACKS = a.tracks || ['codex', 'lens', 'police']
 
-// Per-track worktrees + commit-message scratch live here. Gitignored (`.be-review/`),
-// so they never pollute the diff the reviewers inspect, and a track's own
-// `.codex-debate/`/`.lens-debate/` scratch nests harmlessly inside its worktree.
-const workRoot = `${repoPath}/.be-review`
-const wtPath = (track) => `${workRoot}/wt-${track}`
+// SHARED-CWD NOTE. Every workflow agent inherits the SESSION cwd (the main
+// worktree) — the harness offers no per-agent cwd, and `isolation:'worktree'`
+// can't host a multi-round debate (each agent would get a fresh tree and lose
+// the prior round's commits). So isolation here is STRUCTURAL, not behavioral:
+// every path below is ABSOLUTE and every git command is `git -C <worktree>`, so
+// the shared cwd is irrelevant — no agent can leak into the wrong tree by
+// forgetting to `cd`. The per-track worktrees live under the repo's conventional
+// `.worktrees/` (gitignored); commit-message + PR-comment scratch lives under
+// the gitignored `.be-review/`. Both are absolute and per-main-worktree, so
+// parallel /be-review runs in different worktrees never collide.
+const WT_ROOT = `${repoPath}/.worktrees`
+const wtDir = (track) => `${WT_ROOT}/be-review-${track}`
+const SCRATCH = `${repoPath}/.be-review`
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -51,7 +63,7 @@ const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
 const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore any \`.be-review/\`, \`.codex-debate/\`, or \`.lens-debate/\` scratch dirs.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
@@ -68,7 +80,7 @@ const SETUP_SCHEMA = {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
     cleanTree: {
       type: 'boolean',
-      description: 'true iff the main worktree had NO uncommitted changes (outside .be-review/) when checked',
+      description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
     },
     dirtyStatus: {
       type: 'string',
@@ -158,18 +170,18 @@ const CONSOLIDATE_SCHEMA = {
 // ---------------------------------------------------------------------------
 phase('Setup')
 
-const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
+const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under \`.be-review/\` (the gitignored scratch root). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
-3. Only if \`cleanTree\` is true — ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
-   - Path: \`${workRoot}/wt-<track>\`.
-   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
-   - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
+   - Path: \`${WT_ROOT}/be-review-<track>\` (absolute).
+   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if it's not registered), then \`rm -rf ${WT_ROOT}/be-review-<track>\`.
+   - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
@@ -187,7 +199,7 @@ if (setup?.cleanTree === false) {
     base,
     tracks: {},
     consolidation: null,
-    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside .be-review/) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside the scratch dirs) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
   }
 }
 
@@ -226,8 +238,8 @@ async function policeTrack(wt) {
   // Pass *definitions* are single-sourced to code-police's SKILL.md: each brief
   // names that pass's section so the agent (which Reads the skill below) reviews
   // it exactly as written there — no inline checklist to drift. The elegance pass
-  // is gated on the tiny-diff heuristic the skill mandates (SKILL.md:141 — skip
-  // when the worktree diff against base is <10 lines).
+  // is gated on the tiny-diff heuristic the skill mandates (skip when the worktree
+  // diff against base is <10 lines).
   const tinyDiff = await agent(
     `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
     { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
@@ -241,7 +253,7 @@ async function policeTrack(wt) {
   const reviews = await parallel(
     passes.map((p) => () =>
       agent(
-        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`.claude/skills/code-police/SKILL.md\` (and \`.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
         { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
       ),
     ),
@@ -251,11 +263,11 @@ async function policeTrack(wt) {
   log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
   // Apply each finding as its own commit, sequentially (same-file edits can't be
-  // parallel-applied). Mechanical committer stages only the touched files.
+  // parallel-applied). Every edit and git command targets the absolute worktree.
   const applied = []
   for (const f of findings) {
     const impl = await agent(
-      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change in the working tree. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`,
+      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
       { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
     )
     const files = impl?.filesChanged ?? []
@@ -263,23 +275,25 @@ async function policeTrack(wt) {
     if (commit && files.length) {
       sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
     }
-    applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
+    applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
   }
   return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
-// files in worktree `wt` and commits with the given message. The workflow can't
-// run git itself, so a thin agent does. (codex/lens commit via their own
-// workflows.)
+// files in worktree `wt` and commits with the given message — all via `git -C`
+// so it never depends on the shell cwd. The workflow can't run git itself, so a
+// thin agent does. (codex/lens commit via their own workflows.)
 async function commitFix(wt, id, subject, body, files) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workRoot}/commit-msg-${id}.txt`
+  // Files may arrive as absolute worktree paths; git -C wants them relative to wt.
+  const rel = files.map((f) => f.replace(`${wt}/`, '').replace(/^\/+/, ''))
+  const fileArgs = rel.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
+  const msgPath = `${SCRATCH}/commit-msg-${id}.txt`
   const message = `${subject}\n\n${body}`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
+  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files. Every path is absolute / \`git -C\`; do not rely on the current directory.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workRoot}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
 
 ${message}
@@ -300,20 +314,21 @@ ${message}
 
 // One thunk per live track. codex and lens are existing repoPath-parameterized
 // workflows (built to run in separate worktrees), invoked as child workflows —
-// one level of nesting, which the runtime allows. police is inline (it's a
-// skill, not a workflow). Each thunk catches so one track's failure can't sink
-// the rest — consolidation just picks up whatever each track committed.
+// one level of nesting, which the runtime allows. They get the ABSOLUTE worktree
+// path as repoPath. police is inline (it's a skill, not a workflow). Each thunk
+// catches so one track's failure can't sink the rest — consolidation just picks
+// up whatever each track committed.
 const trackThunk = {
   codex: () =>
-    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtPath('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base, skillDir: CODEX_SKILLDIR, commit })
       .then((r) => ({ track: 'codex', ...r }))
       .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
   lens: () =>
-    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtPath('lens'), base, rationale, model, commit })
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base, rationale, model, commit })
       .then((r) => ({ track: 'lens', ...r }))
       .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
   police: () =>
-    policeTrack(wtPath('police'))
+    policeTrack(wtDir('police'))
       .then((r) => ({ track: 'police', ...r }))
       .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
 }
@@ -324,14 +339,104 @@ const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
 liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
 for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
+// ---------------------------------------------------------------------------
+// PR-comment builders + poster (used by the Report phase). Bodies are built
+// deterministically in JS from the structured track results; a thin mechanical
+// agent just writes each body to a scratch file and posts it with `gh pr comment`.
+// ---------------------------------------------------------------------------
+const sha9 = (s) => (s ? `\`${String(s).slice(0, 9)}\`` : '—')
+const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').trim()
+
+function codexComment(t) {
+  if (!t || t.status === 'track-error') return `## 🤖 Codex ⇄ Claude debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const rows = (t.transcript || [])
+    .map((r) => {
+      const v = r.codex || {}
+      const openBM = (v.findings || []).filter((f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major')).length
+      const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
+      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${openBM} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
+    })
+    .join('\n')
+  return `## 🤖 Codex ⇄ Claude debate
+
+**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
+
+${esc(t.finalVerdict?.summary)}
+
+| Round | codex approved | open blk/maj | claude dispositions | commit |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}`
+}
+
+function lensComment(t) {
+  if (!t || t.status === 'track-error') return `## ⚖️ Lowy ⇄ Hickey lens debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const appliedFor = (id) => (t.applied || []).find((x) => x.id === id)?.commit
+  const rows = (t.settled || [])
+    .map((s) => `| ${esc(s.origin)} | ${esc(s.title)} | ${esc(s.location)} | ${esc(s.disposition)} | ${s.disposition === 'fix' ? sha9(appliedFor(s.id)) : '—'} |`)
+    .join('\n')
+  const un = (t.unresolved || []).length
+    ? `\n\n**⚠️ ${t.unresolved.length} unresolved finding(s)** — needs a human:\n` + t.unresolved.map((u) => `- ${esc(u.title)} (${esc(u.location)})`).join('\n')
+    : ''
+  return `## ⚖️ Lowy ⇄ Hickey lens debate
+
+**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.
+
+| origin | finding | location | disposition | commit |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}${un}`
+}
+
+function policeComment(t) {
+  if (!t || t.status === 'track-error') return `## 👮 Code-police\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const rows = (t.applied || [])
+    .map((x) => `| ${esc(x.severity)} | ${esc(x.title)} | ${esc((x.files || []).join(', '))} | ${sha9(x.commit)} |`)
+    .join('\n')
+  return `## 👮 Code-police
+
+**${t.findings || 0} finding(s)** across the rules / fact-check / elegance passes${t.status === 'clean' ? ' — clean diff' : ''}.
+
+| severity | finding | files | commit |
+|---|---|---|---|
+${rows || '| — | — | — | — |'}`
+}
+
+function consolidationSection(c, order) {
+  const rows = (c?.picks || [])
+    .map((p) => `| ${esc(p.track)} | ${sha9(p.sourceCommit)} | \`${esc(p.outcome)}\` | ${sha9(p.newCommit)} | ${esc(p.note) || ''} |`)
+    .join('\n')
+  return `### Consolidation onto the branch (order: ${order.join(' → ')})
+
+| track | source | outcome | new commit | note |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}`
+}
+
+// Post one comment via a mechanical agent. Resolves the PR from the branch in the
+// MAIN worktree (gh uses cwd's repo; the agent runs `gh -C`-equivalent by cd-ing).
+async function postComment(slug, body) {
+  const file = `${SCRATCH}/comment-${slug}.md`
+  const prompt = `You are a MECHANICAL PR COMMENTER. Do exactly these steps and nothing else.
+
+1. \`mkdir -p ${SCRATCH}\`.
+2. Using the Write tool, create \`${file}\` with EXACTLY this markdown content:
+
+${body}
+
+3. Post it to THIS branch's PR: \`cd ${repoPath} && gh pr comment --body-file ${file}\`. (\`gh\` resolves the PR from the current branch.) If there is NO open PR for the branch, do nothing and report "no PR".
+4. Return the comment URL gh prints, or "no PR".`
+  return agent(prompt, { label: `comment:${slug}`, phase: 'Report', model })
+}
+
+// ---------------------------------------------------------------------------
 // `--no-commit` short-circuit. With commit=false the tracks deliberately leave
 // their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
 // (rev-list ${branchHead}..HEAD) and cleanup's `worktree remove --force` tears the
 // worktrees down — so running them now would silently discard every reviewer's edits.
 // Instead, stop here and hand the live worktrees to the user to inspect; nothing is
 // consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
+// ---------------------------------------------------------------------------
 if (!commit) {
-  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${WT_ROOT}/be-review-<track> diff\`).`)
   return {
     status: 'no-commit',
     branchHead,
@@ -341,8 +446,8 @@ if (!commit) {
     tracks,
     consolidation: null,
     conflicts: [],
-    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.be-review/wt-<track>` and re-run with commit enabled to consolidate.',
-    worktrees: liveTracks.map((t) => ({ track: t, path: wtPath(t) })),
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.worktrees/be-review-<track>` and re-run with commit enabled to consolidate.',
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
 
@@ -356,19 +461,19 @@ phase('Consolidate')
 
 // Skip tracks that errored or made no commits — the agent only picks real work.
 const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
-For each track, its worktree is \`${workRoot}/wt-<track>\`. Get that track's new commits oldest-first:
-  \`git -C ${workRoot}/wt-<track> rev-list --reverse ${branchHead}..HEAD\`
+For each track, its worktree is \`${WT_ROOT}/be-review-<track>\`. Get that track's new commits oldest-first:
+  \`git -C ${WT_ROOT}/be-review-<track> rev-list --reverse ${branchHead}..HEAD\`
 (An empty list means the track found nothing to change — skip it.)
 
-Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits onto the branch IN THAT ORDER:
+Then cherry-pick each of those commits onto the branch IN THAT ORDER:
   \`git -C ${repoPath} cherry-pick <sha>\`
 
 - **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
-- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides (ABSOLUTE paths under \`${repoPath}\`) and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
 
 Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
@@ -377,12 +482,37 @@ const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clea
 log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------
-// Phase 4 — tear down the per-track worktrees
+// Phase 4 — post a detailed PR comment for EVERY track + the consolidation
+// ledger. This is the review trail the whole gauntlet exists to leave; it runs
+// here (not in the caller) so it ALWAYS happens. `--no-comment` suppresses it.
+// ---------------------------------------------------------------------------
+phase('Report')
+
+const comments = {}
+if (postComments) {
+  const ledger = consolidationSection(consolidation, consolidateOrder)
+  const bodies = [
+    ['codex', `${codexComment(tracks.codex)}\n\n${ledger}`],
+    ['lens', lensComment(tracks.lens)],
+    ['police', policeComment(tracks.police)],
+  ].filter(([t]) => tracks[t])
+  // Post sequentially so the comments land in a stable order (codex, lens, police).
+  for (const [slug, body] of bodies) {
+    const url = await postComment(slug, body)
+    comments[slug] = (url || '').trim()
+    log(`Report: posted ${slug} comment${comments[slug] ? ` → ${comments[slug]}` : ''}`)
+  }
+} else {
+  log('Report: --no-comment — skipping PR comments.')
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5 — tear down the per-track worktrees
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
 await agent(
-  `You are a MECHANICAL CLEANUP RUNNER. From \`${repoPath}\`, for each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${workRoot}\` directory itself (it holds commit-message scratch); do not delete the branch's commits. Return "done".`,
+  `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. For each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
   { label: 'cleanup:worktrees', phase: 'Cleanup', model },
 )
 
@@ -395,4 +525,5 @@ return {
   tracks,
   consolidation,
   conflicts,
+  comments,
 }

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -63,9 +63,17 @@ const rationaleBlock = rationale
 const SETUP_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['branchHead', 'worktrees'],
+  required: ['branchHead', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    cleanTree: {
+      type: 'boolean',
+      description: 'true iff the main worktree had NO uncommitted changes (outside .be-review/) when checked',
+    },
+    dirtyStatus: {
+      type: 'string',
+      description: 'the offending `git status --short` lines when cleanTree is false; empty otherwise',
+    },
     worktrees: {
       type: 'array',
       description: 'one entry per track worktree created',
@@ -168,24 +176,51 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-2. Ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
-3. For EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under \`.be-review/\` (the gitignored scratch root). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+3. Only if \`cleanTree\` is true — ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
    - Path: \`${workRoot}/wt-<track>\`.
    - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
    - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
-4. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
+5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\` and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
+
+// Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
+// worktree would be invisible to every reviewer — a /be-review run could then
+// approve an INCOMPLETE change set. Bail loudly instead (the caller commits or
+// stashes, then re-runs) rather than silently reviewing a subset.
+if (setup?.cleanTree === false) {
+  const dirty = (setup?.dirtyStatus || '').trim()
+  log(`Setup: ABORT — the main worktree at ${repoPath} has uncommitted changes; tracks fork from HEAD and would not see them.`)
+  return {
+    status: 'setup-failed',
+    branchHead,
+    base,
+    tracks: {},
+    consolidation: null,
+    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside .be-review/) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+  }
+}
+
+// Seed every requested track with an explicit `track-error` for setup failures, so
+// a dropped reviewer is a STRUCTURED signal the caller (/be §4 falls back per
+// track) — not just a log line that silently shrinks the set while status='done'.
+const tracks = {}
 const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
 const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
-if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — those tracks are skipped.`)
+for (const t of failedTracks) {
+  const note = (setup?.worktrees || []).find((w) => w.track === t)?.note || 'worktree creation failed'
+  tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
+}
+if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
 log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
 
 if (!branchHead || liveTracks.length === 0) {
-  return { status: 'setup-failed', branchHead, base, tracks: {}, consolidation: null, note: 'no track worktrees could be created' }
+  return { status: 'setup-failed', branchHead, base, tracks, consolidation: null, note: 'no track worktrees could be created' }
 }
 
 // ---------------------------------------------------------------------------
@@ -278,9 +313,32 @@ const trackThunk = {
 }
 
 const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
-const tracks = {}
+// `tracks` already carries a `track-error` entry for every setup failure; the live
+// tracks fill in alongside them, so the returned map covers EVERY requested track.
 liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
 for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+
+// `--no-commit` short-circuit. With commit=false the tracks deliberately leave
+// their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
+// (rev-list ${branchHead}..HEAD) and cleanup tears the worktrees down — so running
+// them now would discard every reviewer's edits. Instead, stop here and hand the
+// live worktrees to the user to inspect; nothing is consolidated and nothing is
+// cleaned up. (This is the documented single-track-debugging mode.)
+if (!commit) {
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
+  return {
+    status: 'no-commit',
+    branchHead,
+    finalHead: branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    conflicts: [],
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.be-review/wt-<track>` and re-run with commit enabled to consolidate.',
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtPath(t) })),
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Phase 3 — consolidate: cherry-pick each track's commits onto the branch in

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -790,6 +790,48 @@ for (const t of preservedTracks) {
   }
   log(`Consolidate: track ${t} not consolidated — worktree preserved at ${wtDir(t)}.`)
 }
+
+// PRECONDITION GATE. The consolidate prompt below asserts the branch is AT
+// `branchHead` (the tracks' shared fork point) and cherry-picks the track commits
+// onto it without re-checking. That holds for a normal single run — nothing
+// advances the main worktree between Setup and here. But on an ABNORMAL re-run
+// (e.g. /be-review invoked twice in the same worktree without resetting), the
+// branch HEAD has already moved PAST `branchHead` to the previously-consolidated
+// commits; the Setup clean-tree preflight only rejects an UNcommitted tree, so a
+// clean-but-advanced HEAD sails through. Cherry-picking again would stack the
+// track commits a second time, silently double-applying every fix. Verify the
+// precondition mechanically (`rev-parse HEAD` == `branchHead`) and abort with a
+// `consolidation-precondition-failed` status rather than picking onto a drifted
+// HEAD — the worktrees are PRESERVED for the human to inspect and re-run from a
+// clean fork point.
+const headCheck = await agent(
+  `You are a MECHANICAL PRECONDITION CHECKER. Run \`git -C ${repoPath} rev-parse HEAD\` and report the FULL SHA it prints, verbatim. Do not edit anything, do not cherry-pick, do not run any other command.`,
+  {
+    label: 'consolidate:precondition',
+    phase: 'Consolidate',
+    model,
+    schema: { type: 'object', additionalProperties: false, required: ['head'], properties: { head: { type: 'string', description: 'the full HEAD SHA from `git rev-parse HEAD`' } } },
+  },
+)
+const currentHead = (headCheck?.head || '').trim()
+if (currentHead !== branchHead) {
+  log(`Consolidate: ABORTING — branch HEAD is ${sha9(currentHead) || '(unknown)'} but the tracks forked from ${sha9(branchHead)}. The branch has drifted (likely an already-consolidated re-run); cherry-picking now would double-apply every fix. Worktrees PRESERVED.`)
+  return {
+    status: 'consolidation-precondition-failed',
+    branchHead,
+    finalHead: currentHead || branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    reconciled: [],
+    dropped: [],
+    conflicts: [],
+    note: `consolidation precondition failed: the branch in \`${repoPath}\` is at \`${currentHead || '(unknown)'}\` but the review tracks forked from \`${branchHead}\`. The HEAD has advanced past the shared fork point — likely a re-run in an already-consolidated worktree — so cherry-picking the track commits would stack them a SECOND time and double-apply every fix. Nothing was consolidated and the per-track worktrees are PRESERVED. Reset the branch to \`${branchHead}\` (\`git -C ${repoPath} reset --hard ${branchHead}\`) or start from a clean worktree, then re-run.`,
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
+  }
+}
+
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -355,28 +355,51 @@ for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 // deterministically in JS from the structured track results; a thin mechanical
 // agent just writes each body to a scratch file and posts it with `gh pr comment`.
 // ---------------------------------------------------------------------------
-const sha9 = (s) => (s ? `\`${String(s).slice(0, 9)}\`` : '—')
+// Plain (NOT code-fenced) short SHA so GitHub auto-links it to the commit — a
+// backtick-wrapped SHA renders as code and is NOT linkified.
+const sha9 = (s) => (s ? String(s).slice(0, 9) : '—')
 const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').trim()
+
+const SEV = { blocking: '🔴 blocking', major: '🟠 major', minor: '🟡 minor', nit: '⚪ nit' }
+
+// Full per-round detail: every codex finding (severity, id, issue, location,
+// suggestion, status) and Claude's disposition of each — the complete debate
+// transcript, not a count table.
+function codexRound(r) {
+  const v = r.codex || {}
+  const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
+  const findings = (v.findings || []).length
+    ? v.findings
+        .map(
+          (f) =>
+            `- **${SEV[f.severity] || f.severity} · ${f.id}** — ${esc(f.issue)}\n  at \`${esc(f.location)}\` · status: **${f.status}**\n  suggestion: ${esc(f.suggestion)}`,
+        )
+        .join('\n')
+    : '_no findings_'
+  const actions = (r.claude?.actions || []).length
+    ? r.claude.actions.map((act) => `- **${act.findingId}** → _${act.disposition}_: ${esc(act.detail)}`).join('\n')
+    : ''
+  return [
+    `### Round ${r.round} — codex approved ${v.approved ? '✅' : '❌'} · ${open} open${r.commit ? ` · ${sha9(r.commit)}` : ''}`,
+    v.summary ? esc(v.summary) : '',
+    v.responseToRebuttal ? `**Codex on Claude's rebuttal:** ${esc(v.responseToRebuttal)}` : '',
+    `**Codex findings:**\n${findings}`,
+    actions ? `**Claude's response:**\n${actions}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+}
 
 function codexComment(t) {
   if (!t || t.status === 'track-error') return `## 🤖 Codex ⇄ Claude debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
-  const rows = (t.transcript || [])
-    .map((r) => {
-      const v = r.codex || {}
-      const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
-      const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
-      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${open} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
-    })
-    .join('\n')
+  const rounds = (t.transcript || []).map(codexRound).join('\n\n---\n\n')
   return `## 🤖 Codex ⇄ Claude debate
 
 **Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
 
 ${esc(t.finalVerdict?.summary)}
 
-| Round | codex approved | findings open | claude dispositions | commit |
-|---|---|---|---|---|
-${rows || '| — | — | — | — | — |'}`
+${rounds}`
 }
 
 function lensComment(t) {

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -207,10 +207,11 @@ if (setup?.cleanTree === false) {
 // a dropped reviewer is a STRUCTURED signal the caller (/be §4 falls back per
 // track) — not just a log line that silently shrinks the set while status='done'.
 const tracks = {}
-const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
+const wts = setup?.worktrees ?? []
+const liveTracks = TRACKS.filter((t) => wts.find((w) => w.track === t && w.ok))
 const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
 for (const t of failedTracks) {
-  const note = (setup?.worktrees || []).find((w) => w.track === t)?.note || 'worktree creation failed'
+  const note = wts.find((w) => w.track === t)?.note || 'worktree creation failed'
   tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
 }
 if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
@@ -278,7 +279,7 @@ async function policeTrack(wt) {
     applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
   }
-  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
+  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -303,6 +304,7 @@ ${message}
   return agent(prompt, {
     label: `police-commit:${id}`,
     phase: 'Tracks',
+    model,
     schema: {
       type: 'object',
       additionalProperties: false,
@@ -393,7 +395,7 @@ function policeComment(t) {
     .join('\n')
   return `## 👮 Code-police
 
-**${t.findings || 0} finding(s)** across the rules / fact-check / elegance passes${t.status === 'clean' ? ' — clean diff' : ''}.
+**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes${t.status === 'clean' ? ' — clean diff' : ''}.
 
 | severity | finding | files | commit |
 |---|---|---|---|
@@ -490,13 +492,20 @@ phase('Report')
 
 const comments = {}
 if (postComments) {
-  const ledger = consolidationSection(consolidation, consolidateOrder)
+  // Data-drive Report over the SAME track set as every other phase: a per-track
+  // comment builder keyed by track name, iterated in the canonical
+  // `consolidateOrder`/`liveTracks` order. Adding/removing a reviewer costs Report
+  // nothing — no hardcoded track literal to keep in sync.
+  const builder = { codex: codexComment, lens: lensComment, police: policeComment }
+  // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
+  // it posts as its own comment — surviving any track subset instead of being
+  // string-stapled onto whichever track happens to be present.
   const bodies = [
-    ['codex', `${codexComment(tracks.codex)}\n\n${ledger}`],
-    ['lens', lensComment(tracks.lens)],
-    ['police', policeComment(tracks.police)],
-  ].filter(([t]) => tracks[t])
-  // Post sequentially so the comments land in a stable order (codex, lens, police).
+    ['consolidation', consolidationSection(consolidation, consolidateOrder)],
+    ...liveTracks.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+  ]
+  // Post sequentially so the comments land in a stable order (consolidation, then
+  // the tracks in canonical order).
   for (const [slug, body] of bodies) {
     const url = await postComment(slug, body)
     comments[slug] = (url || '').trim()

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -24,7 +24,26 @@ const MODEL = 'opus'
 // Inputs (passed via the Workflow tool's `args`)
 // ---------------------------------------------------------------------------
 const a = args || {}
-const repoPath = a.repoPath || '.'
+// repoPath is the worktree root and the spine of EVERY path below (`git -C`,
+// child `repoPath`s, scratch + worktree dirs). It MUST be absolute: the whole
+// "isolation is structural, not behavioral" guarantee rests on every git command
+// and file path being absolute, and the codex child `cd`s into its repoPath while
+// reading a scratch path derived from it — a relative repoPath would `cd` once and
+// then resolve that scratch path against the new cwd, writing the verdict to a
+// nested path and reading it back from a different one. Rather than silently
+// canonicalize against an unknowable session cwd, reject a non-absolute repoPath
+// loudly. (/be always passes an absolute root; the default `.` is rejected here.)
+const repoPath = (a.repoPath || '').trim()
+if (!repoPath.startsWith('/')) {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `repoPath must be an ABSOLUTE path (got ${repoPath ? `\`${repoPath}\`` : 'empty'}). Every git command and scratch/worktree path in this orchestrator is absolute and cwd-independent; a relative repoPath would break the codex child's cd-then-read-scratch step and let agents leak into the wrong tree. Pass the absolute worktree root.`,
+  }
+}
 const base = a.base || 'origin/master'
 // Optional author note on deliberate design decisions, threaded into the lens
 // debate so the lenses don't flag intentional choices.
@@ -51,11 +70,17 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the shared cwd is irrelevant — no agent can leak into the wrong tree by
 // forgetting to `cd`. The per-track worktrees live under the repo's conventional
 // `.worktrees/` (gitignored); commit-message + PR-comment scratch lives under
-// the gitignored `.be-review/`. Both are absolute and per-main-worktree, so
-// parallel /be-review runs in different worktrees never collide.
+// the gitignored `.be-review/`. Both are absolute, and a per-RUN id is woven into
+// the worktree name and the scratch subdir so two /be-review runs in the SAME
+// main worktree never clobber each other's live worktrees or scratch files (the
+// old fixed `be-review-<track>` / `.be-review/*` paths let a second run `rm -rf`
+// the first run's in-flight worktree). The id is the start-time epoch ms — unique
+// per invocation, and the actual paths are reported back in the result so manual
+// inspection doesn't need to guess them.
+const RUN_ID = String(Date.now())
 const WT_ROOT = `${repoPath}/.worktrees`
-const wtDir = (track) => `${WT_ROOT}/be-review-${track}`
-const SCRATCH = `${repoPath}/.be-review`
+const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
+const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -81,7 +106,11 @@ const SETUP_SCHEMA = {
   required: ['branchHead', 'mergeBase', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
-    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed' },
+    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed. Empty string iff the merge-base command FAILED (do NOT fall back to the raw base).' },
+    mergeBaseError: {
+      type: 'string',
+      description: 'the verbatim `git merge-base` error when mergeBase is empty; "" otherwise',
+    },
     cleanTree: {
       type: 'boolean',
       description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
@@ -177,13 +206,12 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command fails, fall back to \`mergeBase\` = the resolved \`${base}\` and say so in a worktree \`note\`.
+1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command FAILS (missing/typoed base, stale ref, or unrelated history), the review scope is untrustworthy — do NOT fall back to the raw \`${base}\`; instead set \`mergeBase\`: "" and put the exact git error in \`mergeBaseError\`, then STOP (skip worktree creation, return an empty \`worktrees\` array). (The orchestrator aborts the whole run when \`mergeBase\` is empty.)
 2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
-4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
-   - Path: \`${WT_ROOT}/be-review-<track>\` (absolute).
-   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if it's not registered), then \`rm -rf ${WT_ROOT}/be-review-<track>\`.
-   - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
+4. Only if \`cleanTree\` is true — create a fresh detached worktree at \`branchHead\` for each track, at these EXACT absolute paths (per-run unique, so they cannot belong to another in-flight run):
+${TRACKS.map((t) => `   - ${t}: \`git -C ${repoPath} worktree add --detach ${wtDir(t)} <branchHead>\``).join('\n')}
+   These paths are unique to THIS run, so they should not pre-exist. If \`worktree add\` reports the path already exists, that is an error — set \`ok\`: false and put the message in \`note\`; do NOT \`rm -rf\` or force-remove it (it may belong to a concurrent run).
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
 Return \`branchHead\`, \`mergeBase\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
@@ -192,8 +220,24 @@ const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup
 const branchHead = (setup?.branchHead || '').trim()
 // The diff base every reviewer uses: the merge-base of the branch and `${base}`,
 // so commits `${base}` gained since the branch forked aren't reviewed as ours.
-// Falls back to the raw base if Setup couldn't resolve it.
-const mergeBase = (setup?.mergeBase || base).trim()
+const mergeBase = (setup?.mergeBase || '').trim()
+
+// Merge-base gate. A failed `git merge-base` means the review scope can't be
+// trusted (missing/typoed base, stale ref, unrelated history). Falling back to the
+// raw `${base}` tip would silently review the base branch's drift as if this PR
+// made it — the exact noise the merge-base exists to remove. Fail loudly instead.
+if (!mergeBase) {
+  const err = (setup?.mergeBaseError || '').trim()
+  log(`Setup: ABORT — \`git merge-base ${base} HEAD\` failed; the review scope can't be trusted. Not falling back to the raw ${base} tip.`)
+  return {
+    status: 'setup-failed',
+    branchHead,
+    base,
+    tracks: {},
+    consolidation: null,
+    note: `merge-base of \`${base}\` and HEAD could not be resolved, so the diff scope is untrustworthy (missing/typoed base, stale ref, or unrelated history). Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
 
 // Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
 // worktree would be invisible to every reviewer — a /be-review run could then
@@ -470,7 +514,7 @@ ${body}
 // consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
 // ---------------------------------------------------------------------------
 if (!commit) {
-  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${WT_ROOT}/be-review-<track> diff\`).`)
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there: ${liveTracks.map((t) => `git -C ${wtDir(t)} diff`).join(' ; ')}`)
   return {
     status: 'no-commit',
     branchHead,
@@ -480,7 +524,7 @@ if (!commit) {
     tracks,
     consolidation: null,
     conflicts: [],
-    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.worktrees/be-review-<track>` and re-run with commit enabled to consolidate.',
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
@@ -493,14 +537,70 @@ if (!commit) {
 // ---------------------------------------------------------------------------
 phase('Consolidate')
 
-// Skip tracks that errored or made no commits — the agent only picks real work.
-const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+// CLEAN-WORKTREE GATE before consolidation. Consolidation replays only COMMITTED
+// commits (`rev-list branchHead..HEAD`), and Cleanup later force-removes every
+// worktree — so any edit a track left UNcommitted (an apply agent that produced
+// files but whose commit helper failed, a formatter that touched an unlisted
+// file, an untracked new file) would be invisible to cherry-pick and then deleted
+// for good. Mechanically check each candidate track's worktree is clean; a dirty
+// one is excluded from both consolidation AND cleanup (its worktree is preserved
+// for the human) and surfaced in the result, instead of silently discarded.
+const consolidateCandidates = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+const cleanCheck = consolidateCandidates.length
+  ? await agent(
+      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Do not edit anything. Tracks and their worktrees:
+${consolidateCandidates.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
+      {
+        label: 'consolidate:clean-check',
+        phase: 'Consolidate',
+        model,
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['tracks'],
+          properties: {
+            tracks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['track', 'clean'],
+                properties: {
+                  track: { type: 'string' },
+                  clean: { type: 'boolean' },
+                  dirtyStatus: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    )
+  : { tracks: [] }
+const dirtyTracks = consolidateCandidates.filter((t) => (cleanCheck?.tracks || []).find((c) => c.track === t && c.clean === false))
+for (const t of dirtyTracks) {
+  const ds = (cleanCheck?.tracks || []).find((c) => c.track === t)?.dirtyStatus || ''
+  tracks[t] = {
+    ...tracks[t],
+    consolidated: false,
+    dirtyStatus: ds,
+    note: `track left UNcommitted changes in its worktree (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so the edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+  }
+  log(`Consolidate: track ${t} has UNcommitted changes — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
+}
+
+// Only replay tracks that are clean (every agreed fix really is a commit) and made
+// real work — the agent only picks committed work.
+const consolidateOrder = consolidateCandidates.filter((t) => !dirtyTracks.includes(t))
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
-For each track, its worktree is \`${WT_ROOT}/be-review-<track>\`. Get that track's new commits oldest-first:
-  \`git -C ${WT_ROOT}/be-review-<track> rev-list --reverse ${branchHead}..HEAD\`
+Each track's worktree (use these EXACT absolute paths):
+${consolidateOrder.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+For each track, get its new commits oldest-first:
+  \`git -C <that track's worktree> rev-list --reverse ${branchHead}..HEAD\`
 (An empty list means the track found nothing to change — skip it.)
 
 Then cherry-pick each of those commits onto the branch IN THAT ORDER:
@@ -524,17 +624,20 @@ phase('Report')
 
 const comments = {}
 if (postComments) {
-  // Data-drive Report over the SAME track set as every other phase: a per-track
-  // comment builder keyed by track name, iterated in the canonical
-  // `consolidateOrder`/`liveTracks` order. Adding/removing a reviewer costs Report
-  // nothing — no hardcoded track literal to keep in sync.
+  // Data-drive Report over every REQUESTED track (the `TRACKS` set), not just the
+  // live ones: a track whose worktree failed in Setup is in `tracks` as
+  // `track-error`, and each builder renders that as a "Track error" comment — so
+  // setup failures get a PR comment too, keeping the documented one-comment-per-
+  // requested-track audit trail instead of silently omitting the dropped track. A
+  // per-track comment builder keyed by track name; adding/removing a reviewer costs
+  // Report nothing — no hardcoded track literal to keep in sync.
   const builder = { codex: codexComment, lens: lensComment, police: policeComment }
   // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
   // it posts as its own comment — surviving any track subset instead of being
   // string-stapled onto whichever track happens to be present.
   const bodies = [
     ['consolidation', consolidationSection(consolidation, consolidateOrder)],
-    ...liveTracks.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+    ...TRACKS.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
   ]
   // Post sequentially so the comments land in a stable order (consolidation, then
   // the tracks in canonical order).
@@ -548,14 +651,24 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees
+// Phase 5 — tear down the per-track worktrees. Dirty tracks (uncommitted edits
+// the clean-check caught) are PRESERVED, not removed — their worktree is the only
+// place those edits live, so force-removing it would discard them.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-await agent(
-  `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. For each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
-  { label: 'cleanup:worktrees', phase: 'Cleanup', model },
-)
+const teardownTracks = liveTracks.filter((t) => !dirtyTracks.includes(t))
+if (dirtyTracks.length) log(`Cleanup: preserving ${dirtyTracks.length} dirty worktree(s) (${dirtyTracks.join(', ')}) — they hold uncommitted edits.`)
+if (teardownTracks.length) {
+  await agent(
+    `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
+${teardownTracks.map((t) => `  - \`git -C ${repoPath} worktree remove --force ${wtDir(t)}\``).join('\n')}
+Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
+    { label: 'cleanup:worktrees', phase: 'Cleanup', model },
+  )
+} else {
+  log('Cleanup: no clean worktrees to tear down (all preserved or none live).')
+}
 
 return {
   status: 'done',

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -1,0 +1,334 @@
+// The Workflow runtime requires `export const meta` to be the FIRST statement
+// and a PURE LITERAL (no interpolation), so 'opus' is inlined per phase. The
+// single MODEL socket lives just after meta; every other model reference reads
+// it lazily, well after meta is evaluated.
+export const meta = {
+  name: 'be-review',
+  description:
+    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile)',
+  phases: [
+    { title: 'Setup', detail: 'fan out one detached worktree per review track off the branch HEAD', model: 'opus' },
+    { title: 'Tracks', detail: 'codex, lens, and police gauntlets each run to consensus, concurrently and isolated', model: 'opus' },
+    { title: 'Consolidate', detail: 'cherry-pick each track’s commits onto the branch in order; reconcile the rare overlap', model: 'opus' },
+    { title: 'Cleanup', detail: 'tear down the per-track worktrees', model: 'opus' },
+  ],
+}
+
+// The model every orchestrated agent runs on. Structural review on /be runs on
+// Opus (the lens debate forces it, overriding its sonnet frontmatter); keep the
+// override to one socket so a model bump is a one-liner.
+const MODEL = 'opus'
+
+// ---------------------------------------------------------------------------
+// Inputs (passed via the Workflow tool's `args`)
+// ---------------------------------------------------------------------------
+const a = args || {}
+const repoPath = a.repoPath || '.'
+const base = a.base || 'origin/master'
+// Optional author note on deliberate design decisions, threaded into the lens
+// debate so the lenses don't flag intentional choices.
+const rationale = (a.rationale || '').trim()
+// Commit each track's fixes (default on). Tracks always commit inside their own
+// worktree — this only gates whether the lens/police APPLY steps commit; the
+// per-track commits are what consolidation cherry-picks, so leaving it on is the
+// norm. (`--no-commit` is for debugging a single track in isolation.)
+const commit = a.commit !== false
+const model = a.model || MODEL
+// The review tracks to run AND the order they consolidate in. codex first (it
+// changes the most — bug fixes), then the structural lenses, then police, so an
+// overlap surfaces as a conflict picking the later, lighter-touch track.
+const TRACKS = a.tracks || ['codex', 'lens', 'police']
+
+// Per-track worktrees + commit-message scratch live here. Gitignored (`.be-review/`),
+// so they never pollute the diff the reviewers inspect, and a track's own
+// `.codex-debate/`/`.lens-debate/` scratch nests harmlessly inside its worktree.
+const workRoot = `${repoPath}/.be-review`
+const wtPath = (track) => `${workRoot}/wt-${track}`
+
+// Generated skill locations the child debate workflows live at.
+const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
+const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
+const CODEX_SKILLDIR = '.claude/skills/codex-debate'
+
+const DIFF = (wt) =>
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore any \`.be-review/\`, \`.codex-debate/\`, or \`.lens-debate/\` scratch dirs.`
+
+const rationaleBlock = rationale
+  ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
+  : ''
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+const SETUP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['branchHead', 'worktrees'],
+  properties: {
+    branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    worktrees: {
+      type: 'array',
+      description: 'one entry per track worktree created',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'path', 'ok'],
+        properties: {
+          track: { type: 'string' },
+          path: { type: 'string' },
+          ok: { type: 'boolean' },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// code-police review pass output (mirrors /code-police's finding shape).
+const POLICE_FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      description: 'high-confidence findings from this pass (≤6; empty is a fine verdict)',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'location', 'problem', 'fix', 'severity'],
+        properties: {
+          title: { type: 'string' },
+          location: { type: 'string', description: 'file:line' },
+          problem: { type: 'string' },
+          fix: { type: 'string', description: 'a concrete, implementable change' },
+          severity: { type: 'string', enum: ['blocking', 'major', 'minor', 'nit'] },
+        },
+      },
+    },
+  },
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['summary', 'filesChanged'],
+  properties: {
+    summary: { type: 'string', description: 'one line: what you changed' },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const CONSOLIDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['picks', 'conflicts'],
+  properties: {
+    finalHead: { type: 'string', description: 'branch HEAD SHA after all picks' },
+    picks: {
+      type: 'array',
+      description: 'one entry per source commit you processed, in the order you processed it',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'sourceCommit', 'outcome'],
+        properties: {
+          track: { type: 'string' },
+          sourceCommit: { type: 'string', description: 'the short SHA from the track worktree' },
+          newCommit: { type: 'string', description: 'the resulting SHA on the branch' },
+          outcome: { type: 'string', enum: ['clean', 'reconciled', 'dropped'] },
+          note: { type: 'string', description: 'for reconciled/dropped: how you resolved it and why' },
+        },
+      },
+    },
+    conflicts: {
+      type: 'array',
+      description: 'the overlaps you had to reconcile (subset of picks); empty in the common no-overlap case',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'sourceCommit', 'files', 'resolution'],
+        properties: {
+          track: { type: 'string' },
+          sourceCommit: { type: 'string' },
+          files: { type: 'array', items: { type: 'string' } },
+          resolution: { type: 'string', enum: ['merged', 'dropped'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — fan out one detached worktree per track off the branch HEAD
+// ---------------------------------------------------------------------------
+phase('Setup')
+
+const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
+
+1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
+2. Ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+3. For EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
+   - Path: \`${workRoot}/wt-<track>\`.
+   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
+   - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
+4. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
+
+Return \`branchHead\` and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+
+const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
+const branchHead = (setup?.branchHead || '').trim()
+const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
+const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
+if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — those tracks are skipped.`)
+log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
+
+if (!branchHead || liveTracks.length === 0) {
+  return { status: 'setup-failed', branchHead, base, tracks: {}, consolidation: null, note: 'no track worktrees could be created' }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — run every track's gauntlet to consensus, concurrently & isolated
+// ---------------------------------------------------------------------------
+phase('Tracks')
+
+// The police track. /code-police is a skill, not a workflow, so its three cold
+// passes (rules / fact-check / elegance) are reproduced here as parallel agents,
+// then each agreed fix is applied as its own commit — matching /be §4.3's
+// "each finding is its own commit". Per-finding `just check` is deferred to the
+// post-consolidation check + §5 CI rather than run 3× concurrently across the
+// parallel worktrees (it would thrash the toolchain); fmt-on-touched-files still
+// runs in each apply.
+async function policeTrack(wt) {
+  const passes = [
+    { key: 'rules', brief: 'the built-in code-police rule checklist (dry-rule-of-three, prefer-focused-library, invalid-states-unrepresentable, no-dead-code, no-silent-error-swallowing, and the rest) PLUS any project rules' },
+    { key: 'fact-check', brief: 'a CORRECTNESS audit: logic errors, silently swallowed errors, wishful thinking, unjustified fallbacks — not style' },
+    { key: 'elegance', brief: 'simplicity and idiom: hand-rolled code that a focused library or a simpler shape would replace' },
+  ]
+  const reviews = await parallel(
+    passes.map((p) => () =>
+      agent(
+        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`.claude/skills/code-police/SKILL.md\` (and \`.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+        { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
+      ),
+    ),
+  )
+  const findings = []
+  passes.forEach((p, i) => (reviews[i]?.findings ?? []).forEach((f, j) => findings.push({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })))
+  log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
+
+  // Apply each finding as its own commit, sequentially (same-file edits can't be
+  // parallel-applied). Mechanical committer stages only the touched files.
+  const applied = []
+  for (const f of findings) {
+    const impl = await agent(
+      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change in the working tree. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`,
+      { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+    )
+    const files = impl?.filesChanged ?? []
+    let sha = null
+    if (commit && files.length) {
+      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files) || '').trim()
+    }
+    applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
+    log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
+  }
+  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
+}
+
+// Mechanical committer shared by the police track: stages EXACTLY the listed
+// files in worktree `wt` and commits with the given message. The workflow can't
+// run git itself, so a thin agent does. (codex/lens commit via their own
+// workflows.)
+async function commitFix(wt, id, subject, body, files) {
+  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
+  const msgPath = `${workRoot}/commit-msg-${id}.txt`
+  const message = `${subject}\n\n${body}`
+  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workRoot}\`.
+2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
+
+${message}
+
+3. Run: \`git -C ${wt} add -- ${fileArgs} && git -C ${wt} commit -F ${msgPath}\`. Stage ONLY those files; do NOT use \`git add -A\`/\`git add .\`.
+4. Return the new commit SHA from \`git -C ${wt} rev-parse HEAD\`. Do NOT push.`
+  return agent(prompt, { label: `police-commit:${id}`, phase: 'Tracks' })
+}
+
+// One thunk per live track. codex and lens are existing repoPath-parameterized
+// workflows (built to run in separate worktrees), invoked as child workflows —
+// one level of nesting, which the runtime allows. police is inline (it's a
+// skill, not a workflow). Each thunk catches so one track's failure can't sink
+// the rest — consolidation just picks up whatever each track committed.
+const trackThunk = {
+  codex: () =>
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtPath('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+      .then((r) => ({ track: 'codex', ...r }))
+      .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
+  lens: () =>
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtPath('lens'), base, rationale, model, commit })
+      .then((r) => ({ track: 'lens', ...r }))
+      .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
+  police: () =>
+    policeTrack(wtPath('police'))
+      .then((r) => ({ track: 'police', ...r }))
+      .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
+}
+
+const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
+const tracks = {}
+liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
+for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+
+// ---------------------------------------------------------------------------
+// Phase 3 — consolidate: cherry-pick each track's commits onto the branch in
+// TRACKS order. The common case is no overlap (clean picks); the rare overlap
+// surfaces as a cherry-pick conflict the agent reconciles by honoring BOTH
+// changes (it has both commit messages = both debates' rationale).
+// ---------------------------------------------------------------------------
+phase('Consolidate')
+
+// Skip tracks that errored or made no commits — the agent only picks real work.
+const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Three review tracks each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+
+The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
+
+For each track, its worktree is \`${workRoot}/wt-<track>\`. Get that track's new commits oldest-first:
+  \`git -C ${workRoot}/wt-<track> rev-list --reverse ${branchHead}..HEAD\`
+(An empty list means the track found nothing to change — skip it.)
+
+Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits onto the branch IN THAT ORDER:
+  \`git -C ${repoPath} cherry-pick <sha>\`
+
+- **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — say so in \`note\`; never drop to avoid the work of merging.
+
+Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD, the per-commit \`picks\` ledger (in processing order), and the \`conflicts\` subset you had to reconcile.`
+
+const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
+const conflicts = consolidation?.conflicts ?? []
+log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
+
+// ---------------------------------------------------------------------------
+// Phase 4 — tear down the per-track worktrees
+// ---------------------------------------------------------------------------
+phase('Cleanup')
+
+await agent(
+  `You are a MECHANICAL CLEANUP RUNNER. From \`${repoPath}\`, for each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${workRoot}\` directory itself (it holds commit-message scratch); do not delete the branch's commits. Return "done".`,
+  { label: 'cleanup:worktrees', phase: 'Cleanup', model },
+)
+
+return {
+  status: 'done',
+  branchHead,
+  finalHead: consolidation?.finalHead || null,
+  base,
+  order: consolidateOrder,
+  tracks,
+  consolidation,
+  conflicts,
+}

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -363,9 +363,9 @@ function codexComment(t) {
   const rows = (t.transcript || [])
     .map((r) => {
       const v = r.codex || {}
-      const openBM = (v.findings || []).filter((f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major')).length
+      const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
       const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
-      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${openBM} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
+      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${open} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
     })
     .join('\n')
   return `## 🤖 Codex ⇄ Claude debate
@@ -374,7 +374,7 @@ function codexComment(t) {
 
 ${esc(t.finalVerdict?.summary)}
 
-| Round | codex approved | open blk/maj | claude dispositions | commit |
+| Round | codex approved | findings open | claude dispositions | commit |
 |---|---|---|---|---|
 ${rows || '| — | — | — | — | — |'}`
 }

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -312,8 +312,9 @@ async function policeTrack(wt) {
       ),
     ),
   )
-  const findings = []
-  passes.forEach((p, i) => (reviews[i]?.findings ?? []).forEach((f, j) => findings.push({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })))
+  const findings = passes.flatMap((p, i) =>
+    (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })),
+  )
   log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
   // Apply each finding as its own commit, sequentially (same-file edits can't be
@@ -388,11 +389,21 @@ const trackThunk = {
       .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
 }
 
-const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
-// `tracks` already carries a `track-error` entry for every setup failure; the live
-// tracks fill in alongside them, so the returned map covers EVERY requested track.
-liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
-for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+// A live track with no registered thunk (an unknown/typo'd TRACKS entry whose
+// worktree Setup still built) would make `parallel` invoke `undefined()`. Seed it
+// as a track-error — same shape as a setup failure — and drop it from dispatch so
+// the parallel call stays total.
+const dispatchable = liveTracks.filter((t) => trackThunk[t])
+for (const t of liveTracks.filter((t) => !trackThunk[t])) {
+  tracks[t] = { track: t, status: 'track-error', error: 'unknown track: no thunk registered' }
+  log(`Track ${t}: no thunk registered — recorded as track-error and excluded from dispatch.`)
+}
+const trackResults = await parallel(dispatchable.map((t) => trackThunk[t]))
+// `tracks` already carries a `track-error` entry for every setup failure (and any
+// unknown track above); the dispatchable tracks fill in alongside them, so the
+// returned map covers EVERY requested track.
+dispatchable.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
+for (const t of dispatchable) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
 // ---------------------------------------------------------------------------
 // PR-comment builders + poster (used by the Report phase). Bodies are built
@@ -523,6 +534,8 @@ if (!commit) {
     order: [],
     tracks,
     consolidation: null,
+    reconciled: [],
+    dropped: [],
     conflicts: [],
     note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
@@ -642,8 +655,10 @@ Then cherry-pick each of those commits onto the branch IN THAT ORDER:
 Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
 const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
-const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clean')
-log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
+const picks = consolidation?.picks ?? []
+const reconciled = picks.filter((p) => p.outcome === 'reconciled')
+const dropped = picks.filter((p) => p.outcome === 'dropped')
+log(`Consolidate: ${picks.length} commit(s) replayed, ${reconciled.length} reconciled, ${dropped.length} dropped. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------
 // Phase 4 — post a detailed PR comment for EVERY track + the consolidation
@@ -712,6 +727,10 @@ return {
   order: consolidateOrder,
   tracks,
   consolidation,
-  conflicts,
+  reconciled,
+  dropped,
+  // back-compat: the union of non-clean picks. Consumers keying on a discarded
+  // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
+  conflicts: [...reconciled, ...dropped],
   comments,
 }

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -356,8 +356,10 @@ async function policeTrack(wt) {
   const applied = []
   let totalFindings = 0
   let policeRound = 0
+  let sweepsRun = 0
   let lastRoundFindings = 0
   for (; policeRound < POLICE_MAX_ROUNDS; policeRound++) {
+    sweepsRun++ // one review pass per iteration, counted BEFORE any break/cap exit so the reported sweep count is exact (not derived from the loop index)
     const reviews = await parallel(
       passes.map((p) => () =>
         agent(
@@ -396,7 +398,7 @@ async function policeTrack(wt) {
   const reachedClean = lastRoundFindings === 0
   const status = !totalFindings ? 'clean' : reachedClean ? 'consensus' : 'incomplete'
   if (!reachedClean) log(`police: hit round cap (${POLICE_MAX_ROUNDS}) with findings still open — reporting incomplete.`)
-  return { status, findings: totalFindings, rounds: policeRound + (reachedClean ? 0 : 1), passes: passes.map((p) => p.key), applied }
+  return { status, findings: totalFindings, rounds: sweepsRun, passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -751,6 +753,23 @@ const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
 // is untrustworthy. The agent only picks committed work.
 const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
 
+// The terminal statuses that mean a track's review actually FINISHED — codex/lens
+// reached consensus (or had nothing to raise), police got a clean final sweep.
+// Anything else a consolidated track can carry (police `incomplete` after the
+// round cap, lens `unresolved` with findings still contested, codex
+// `reviewer-error`/`merge-base-error`) means the gauntlet did NOT fully complete
+// for that track, even though its committed fixes are real and DO get replayed.
+const COMPLETED_TRACK_STATUS = new Set(['clean', 'consensus'])
+// Consolidated tracks whose own review did not reach a completed terminus. Their
+// fixes still land (they're committed and clean), but the top-level result must
+// not read `done`, or /be would proceed as if the gauntlet fully passed when a
+// police/lens sweep was actually cut short. (A `track-error` track is never in
+// `consolidateOrder`, so it can't appear here.)
+const incompleteTracks = consolidateOrder.filter((t) => !COMPLETED_TRACK_STATUS.has(tracks[t]?.status))
+for (const t of incompleteTracks) {
+  log(`Consolidate: track ${t} consolidated but its review ended \`${tracks[t]?.status}\` (not a completed terminus) — top-level status will reflect that the gauntlet did not fully finish.`)
+}
+
 // Preserve every live track we did NOT consolidate, so neither uncommitted edits
 // nor committed-but-unreplayed commits are lost.
 const preservedTracks = liveTracks.filter((t) => !consolidateOrder.includes(t))
@@ -854,17 +873,25 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
   log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
-// Top-level status reflects whether EVERY requested track actually landed on the
-// branch. A preserved track (uncommitted edits, an unconfirmed worktree, or a
-// crashed `track-error` whose committed fixes were deliberately not replayed) means
-// at least one reviewer's fixes live ONLY in a side worktree — so `done` would
-// overstate the outcome and let /be continue as if the gauntlet fully consolidated.
-// Surface `consolidation-incomplete` (with the preserved tracks + recovery notes
-// already on each `tracks[t]`) so the caller can adjudicate instead of silently
-// shipping a partial consolidation.
-const status = preservedTracks.length ? 'consolidation-incomplete' : 'done'
+// Top-level status reflects whether EVERY requested track actually (a) landed on
+// the branch AND (b) ran its review to a completed terminus. Two ways it falls
+// short of `done`:
+//   - a PRESERVED track (uncommitted edits, an unconfirmed worktree, or a crashed
+//     `track-error` whose committed fixes were deliberately not replayed) means at
+//     least one reviewer's fixes live ONLY in a side worktree; or
+//   - an INCOMPLETE track (consolidated, but its review ended `incomplete`/
+//     `unresolved`/`reviewer-error` rather than `clean`/`consensus`) means the
+//     gauntlet was cut short for that track even though its fixes landed.
+// Either way `done` would overstate the outcome and let /be continue as if the
+// gauntlet fully passed. Surface `consolidation-incomplete` (the preserved tracks'
+// recovery notes are already on each `tracks[t]`; the incomplete tracks carry their
+// own non-terminal status) so the caller adjudicates instead of silently shipping.
+const status = preservedTracks.length || incompleteTracks.length ? 'consolidation-incomplete' : 'done'
 if (preservedTracks.length) {
   log(`Done: status=consolidation-incomplete — ${preservedTracks.length} track(s) preserved, not consolidated: ${preservedTracks.join(', ')}. Their worktrees hold the only copy of those fixes; see each track's note for the recovery cherry-pick.`)
+}
+if (incompleteTracks.length) {
+  log(`Done: status=consolidation-incomplete — ${incompleteTracks.length} track(s) consolidated but their review did not finish (${incompleteTracks.map((t) => `${t}=${tracks[t]?.status}`).join(', ')}); re-run the gauntlet (or that track) before treating the change as fully reviewed.`)
 }
 return {
   status,
@@ -879,6 +906,10 @@ return {
   // Tracks whose fixes were NOT consolidated onto the branch (preserved worktrees);
   // empty in the common case. Non-empty ⇒ status is 'consolidation-incomplete'.
   preservedTracks,
+  // Tracks that WERE consolidated but whose review ended on a non-terminal status
+  // (police `incomplete`, lens `unresolved`, codex `reviewer-error`); their fixes
+  // landed but the gauntlet didn't fully finish. Non-empty ⇒ 'consolidation-incomplete'.
+  incompleteTracks,
   // back-compat: the union of non-clean picks. Consumers keying on a discarded
   // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
   conflicts: [...reconciled, ...dropped],

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -62,8 +62,11 @@ const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
 const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
 const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 
+// The diff base reviewers actually use is the MERGE-BASE (resolved by Setup),
+// not the raw `${base}` tip — see SETUP_SCHEMA.mergeBase. DIFF is an arrow, so it
+// reads `mergeBase` lazily at call time (Tracks phase, after Setup has set it).
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
@@ -75,9 +78,10 @@ const rationaleBlock = rationale
 const SETUP_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['branchHead', 'cleanTree', 'worktrees'],
+  required: ['branchHead', 'mergeBase', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed' },
     cleanTree: {
       type: 'boolean',
       description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
@@ -173,6 +177,7 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
+1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command fails, fall back to \`mergeBase\` = the resolved \`${base}\` and say so in a worktree \`note\`.
 2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
@@ -181,10 +186,14 @@ const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktr
    - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`mergeBase\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
+// The diff base every reviewer uses: the merge-base of the branch and `${base}`,
+// so commits `${base}` gained since the branch forked aren't reviewed as ours.
+// Falls back to the raw base if Setup couldn't resolve it.
+const mergeBase = (setup?.mergeBase || base).trim()
 
 // Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
 // worktree would be invisible to every reviewer — a /be-review run could then
@@ -215,7 +224,7 @@ for (const t of failedTracks) {
   tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
 }
 if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
-log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
+log(`Setup: branchHead ${branchHead.slice(0, 9)}; diffing against merge-base ${mergeBase.slice(0, 9)} (not the raw ${base} tip); tracks live: ${liveTracks.join(', ') || '(none)'}`)
 
 if (!branchHead || liveTracks.length === 0) {
   return { status: 'setup-failed', branchHead, base, tracks, consolidation: null, note: 'no track worktrees could be created' }
@@ -242,7 +251,7 @@ async function policeTrack(wt) {
   // is gated on the tiny-diff heuristic the skill mandates (skip when the worktree
   // diff against base is <10 lines).
   const tinyDiff = await agent(
-    `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
+    `Run \`git -C ${wt} diff ${mergeBase} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
     { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
   )
   const passes = [
@@ -322,11 +331,11 @@ ${message}
 // up whatever each track committed.
 const trackThunk = {
   codex: () =>
-    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base: mergeBase, skillDir: CODEX_SKILLDIR, commit })
       .then((r) => ({ track: 'codex', ...r }))
       .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
   lens: () =>
-    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base, rationale, model, commit })
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base: mergeBase, rationale, model, commit })
       .then((r) => ({ track: 'lens', ...r }))
       .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
   police: () =>

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -61,6 +61,24 @@ const model = a.model || MODEL
 // changes the most — bug fixes), then the structural lenses, then police, so an
 // overlap surfaces as a conflict picking the later, lighter-touch track.
 const TRACKS = a.tracks || ['codex', 'lens', 'police']
+// Whitelist the track names. Each is woven into worktree paths and the agents'
+// shell snippets (just like RUN_ID above), and each must map to a registered
+// thunk. Reject an unknown track or a duplicate up front rather than building a
+// worktree at an unexpected path or invoking `undefined()` in `parallel` — a
+// typo'd/hostile track is an input error, not something to silently route around.
+const KNOWN_TRACKS = ['codex', 'lens', 'police']
+const badTracks = TRACKS.filter((t) => !KNOWN_TRACKS.includes(t))
+const dupTracks = TRACKS.filter((t, i) => TRACKS.indexOf(t) !== i)
+if (badTracks.length || dupTracks.length) {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `tracks must be a subset of ${KNOWN_TRACKS.join(', ')} with no duplicates.${badTracks.length ? ` Unknown: ${[...new Set(badTracks)].join(', ')}.` : ''}${dupTracks.length ? ` Duplicated: ${[...new Set(dupTracks)].join(', ')}.` : ''}`,
+  }
+}
 
 // SHARED-CWD NOTE. Every workflow agent inherits the SESSION cwd (the main
 // worktree) — the harness offers no per-agent cwd, and `isolation:'worktree'`
@@ -81,6 +99,24 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the same main worktree must pass distinct ids. The actual paths are reported in
 // the result so manual inspection doesn't need to guess them.
 const RUN_ID = String(a.runId || 'run')
+// `RUN_ID` and the track names below are woven directly into filesystem paths
+// (worktree dirs, scratch subdirs) and into the shell snippets the mechanical
+// agents run, so they MUST be conservative tokens. A value with `/`, `..`, or
+// shell metacharacters could place a worktree or scratch file OUTSIDE the
+// intended `.worktrees`/`.be-review` dirs, collide with another run, or inject a
+// command into an agent's `git -C`/`mkdir` snippet. Reject anything that isn't a
+// plain `[A-Za-z0-9._-]` token (which also excludes path separators and `..` as a
+// whole, since `.` alone is fine but `..` can't reach a parent without a `/`).
+if (!/^[A-Za-z0-9._-]+$/.test(RUN_ID) || RUN_ID === '..' || RUN_ID === '.') {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `runId must match ^[A-Za-z0-9._-]+$ (no slashes, no shell metacharacters) so it stays safe inside filesystem paths and shell snippets; got \`${RUN_ID}\`. Pass a plain token like the launch epoch ms.`,
+  }
+}
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
@@ -307,36 +343,60 @@ async function policeTrack(wt) {
     { key: 'elegance', brief: 'the **Elegance** pass exactly as defined in that skill\'s "Running the passes" section (Pass 3) — simplicity and idiom' },
   ].filter((p) => p.key !== 'elegance' || !tinyDiff?.tiny)
   if (tinyDiff?.tiny) log('police: skipping elegance pass (tiny diff <10 lines, per code-police SKILL.md)')
-  const reviews = await parallel(
-    passes.map((p) => () =>
-      agent(
-        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
-        { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
-      ),
-    ),
-  )
-  const findings = passes.flatMap((p, i) =>
-    (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })),
-  )
-  log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
-  // Apply each finding as its own commit, sequentially (same-file edits can't be
-  // parallel-applied). Every edit and git command targets the absolute worktree.
+  // /code-police runs its passes "until clean": applying a finding can introduce a
+  // NEW issue or leave one only partially fixed, so a single review+apply sweep is
+  // not equivalent. Loop the passes on the UPDATED worktree until a sweep returns
+  // no findings (clean) — applied fixes are re-reviewed, not assumed correct. A cap
+  // keeps a thrashing reviewer from spinning forever (the harness backstop is the
+  // hard ceiling); if we hit it with findings still open, the track reports
+  // `incomplete` rather than a false `consensus`. Each round's finding ids are
+  // round-scoped so commits stay unique across sweeps.
+  const POLICE_MAX_ROUNDS = 4
   const applied = []
-  for (const f of findings) {
-    const impl = await agent(
-      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
-      { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+  let totalFindings = 0
+  let policeRound = 0
+  let lastRoundFindings = 0
+  for (; policeRound < POLICE_MAX_ROUNDS; policeRound++) {
+    const reviews = await parallel(
+      passes.map((p) => () =>
+        agent(
+          `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+          { label: `police:${p.key}:r${policeRound + 1}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
+        ),
+      ),
     )
-    const files = impl?.filesChanged ?? []
-    let sha = null
-    if (commit && files.length) {
-      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
+    const findings = passes.flatMap((p, i) =>
+      (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-r${policeRound + 1}-${p.key}-${j + 1}`, pass: p.key, ...f })),
+    )
+    lastRoundFindings = findings.length
+    log(`police: round ${policeRound + 1} — ${findings.length} finding(s) across ${passes.length} passes`)
+    if (!findings.length) break // clean sweep on the updated worktree → done
+
+    // Apply each finding as its own commit, sequentially (same-file edits can't be
+    // parallel-applied). Every edit and git command targets the absolute worktree.
+    for (const f of findings) {
+      const impl = await agent(
+        `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change, fixing the issue COMPLETELY (a partial fix would resurface in the next review sweep). Do NOT git add / commit / push. You MUST run the project's formatter on every file you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
+        { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+      )
+      const files = impl?.filesChanged ?? []
+      let sha = null
+      if (commit && files.length) {
+        sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
+      }
+      applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
+      log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
     }
-    applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
-    log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
+    totalFindings += findings.length
   }
-  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, passes: passes.map((p) => p.key), applied }
+  // `clean` only if the FINAL sweep found nothing. If we exhausted the round cap
+  // with findings still open, the worktree isn't verified-clean — report
+  // `incomplete` so the caller (and the PR comment) doesn't read it as consensus.
+  const reachedClean = lastRoundFindings === 0
+  const status = !totalFindings ? 'clean' : reachedClean ? 'consensus' : 'incomplete'
+  if (!reachedClean) log(`police: hit round cap (${POLICE_MAX_ROUNDS}) with findings still open — reporting incomplete.`)
+  return { status, findings: totalFindings, rounds: policeRound + (reachedClean ? 0 : 1), passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -420,6 +480,15 @@ const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').tr
 
 const SEV = { blocking: '🔴 blocking', major: '🟠 major', minor: '🟡 minor', nit: '⚪ nit' }
 
+// A track that ran but was NOT consolidated (preserved worktree) carries
+// `consolidated:false` and a recovery `note`. Surface it as a banner at the top of
+// that track's comment so the PR audit trail never reads "reached consensus" while
+// the fixes silently live only in a side worktree.
+function preservedBanner(t) {
+  if (!t || t.consolidated !== false) return ''
+  return `\n\n> ⚠️ **Not consolidated onto the branch.** ${esc(t.note) || 'This track was preserved in its own worktree; its fixes are not on the branch.'}`
+}
+
 // Full per-round detail: every codex finding (severity, id, issue, location,
 // suggestion, status) and Claude's disposition of each — the complete debate
 // transcript, not a count table.
@@ -453,7 +522,7 @@ function codexComment(t) {
   const rounds = (t.transcript || []).map(codexRound).join('\n\n---\n\n')
   return `## 🤖 Codex ⇄ Claude debate
 
-**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
+**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.${preservedBanner(t)}
 
 ${esc(t.finalVerdict?.summary)}
 
@@ -471,7 +540,7 @@ function lensComment(t) {
     : ''
   return `## ⚖️ Lowy ⇄ Hickey lens debate
 
-**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.
+**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.${preservedBanner(t)}
 
 | origin | finding | location | disposition | commit |
 |---|---|---|---|---|
@@ -485,7 +554,7 @@ function policeComment(t) {
     .join('\n')
   return `## 👮 Code-police
 
-**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes${t.status === 'clean' ? ' — clean diff' : ''}.
+**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes over ${t.rounds || 1} review sweep(s)${t.status === 'clean' ? ' — clean diff' : ''}.${t.status === 'incomplete' ? ` ⚠️ **Did not reach a clean sweep within the round cap** — the worktree may still have open issues; re-run /code-police on it.` : ''}${preservedBanner(t)}
 
 | severity | finding | files | commit |
 |---|---|---|---|
@@ -552,6 +621,69 @@ if (!commit) {
 // changes (it has both commit messages = both debates' rationale).
 // ---------------------------------------------------------------------------
 phase('Consolidate')
+
+// BRANCH-DRIFT GATE. The Tracks phase can run for many minutes; the consolidator
+// below cherry-picks onto the branch in `${repoPath}` and its prompt asserts the
+// branch is still AT `branchHead` (the tracks' shared fork point). Setup's
+// clean-tree preflight ran BEFORE the tracks, so if the user, another workflow, or
+// a second /be-review advanced or dirtied the branch while the tracks ran, we'd
+// cherry-pick onto an unreviewed base while telling the agent it's at `branchHead`
+// — corrupting the review scope. Re-check HEAD and cleanliness NOW, just before the
+// picks. If the branch moved or is dirty, abort and PRESERVE every track worktree
+// (don't tear them down — their commits are the only copy of the reviewed fixes),
+// so the human can consolidate by hand after sorting out the drift.
+const driftCheck = await agent(
+  `You are a MECHANICAL DRIFT CHECKER. Do exactly this against the main worktree at \`${repoPath}\` (use \`git -C\`; do not edit anything):
+1. \`git -C ${repoPath} rev-parse HEAD\` — return as \`head\`.
+2. \`git -C ${repoPath} status --short\` — IGNORE only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged/unstaged/untracked entry remains, set \`clean\`: false and put those lines in \`dirtyStatus\`; otherwise \`clean\`: true and \`dirtyStatus\`: "".`,
+  {
+    label: 'consolidate:drift-check',
+    phase: 'Consolidate',
+    model,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['head', 'clean'],
+      properties: {
+        head: { type: 'string', description: 'current HEAD SHA of the main worktree' },
+        clean: { type: 'boolean' },
+        dirtyStatus: { type: 'string' },
+      },
+    },
+  },
+)
+const curHead = (driftCheck?.head || '').trim()
+const branchMoved = curHead && curHead !== branchHead
+const branchDirty = driftCheck?.clean === false
+if (branchMoved || branchDirty) {
+  const dirty = (driftCheck?.dirtyStatus || '').trim()
+  const why = branchMoved
+    ? `the branch HEAD moved from \`${branchHead.slice(0, 9)}\` (the tracks' fork point) to \`${curHead.slice(0, 9)}\` while the tracks ran`
+    : `the main worktree became dirty while the tracks ran`
+  log(`Consolidate: ABORT — ${why}. Cherry-picking onto a changed base would corrupt the review scope. Preserving all track worktrees for manual consolidation.`)
+  for (const t of liveTracks) {
+    tracks[t] = {
+      ...tracks[t],
+      consolidated: false,
+      note: `NOT consolidated — ${why}, so the consolidator's "branch is at ${branchHead.slice(0, 9)}" assumption no longer holds. The track's worktree was PRESERVED at ${wtDir(t)}; after resolving the drift, replay its commits with \`git -C ${repoPath} cherry-pick $(git -C ${wtDir(t)} rev-list --reverse ${branchHead}..HEAD)\`.`,
+    }
+  }
+  return {
+    status: 'consolidation-aborted',
+    branchHead,
+    finalHead: curHead || branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    reconciled: [],
+    dropped: [],
+    conflicts: [],
+    preservedTracks: liveTracks,
+    note: `consolidation aborted: ${why}. Cherry-picking onto the changed base would review against an untrustworthy scope, so nothing was consolidated and every track worktree was PRESERVED (see each track's note for the recovery cherry-pick).${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
+  }
+}
 
 // CLEAN-WORKTREE GATE before consolidation. Consolidation replays only COMMITTED
 // commits (`rev-list branchHead..HEAD`), and Cleanup later force-removes every
@@ -722,8 +854,20 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
   log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
+// Top-level status reflects whether EVERY requested track actually landed on the
+// branch. A preserved track (uncommitted edits, an unconfirmed worktree, or a
+// crashed `track-error` whose committed fixes were deliberately not replayed) means
+// at least one reviewer's fixes live ONLY in a side worktree — so `done` would
+// overstate the outcome and let /be continue as if the gauntlet fully consolidated.
+// Surface `consolidation-incomplete` (with the preserved tracks + recovery notes
+// already on each `tracks[t]`) so the caller can adjudicate instead of silently
+// shipping a partial consolidation.
+const status = preservedTracks.length ? 'consolidation-incomplete' : 'done'
+if (preservedTracks.length) {
+  log(`Done: status=consolidation-incomplete — ${preservedTracks.length} track(s) preserved, not consolidated: ${preservedTracks.join(', ')}. Their worktrees hold the only copy of those fixes; see each track's note for the recovery cherry-pick.`)
+}
 return {
-  status: 'done',
+  status,
   branchHead,
   finalHead: consolidation?.finalHead || null,
   base,
@@ -732,6 +876,9 @@ return {
   consolidation,
   reconciled,
   dropped,
+  // Tracks whose fixes were NOT consolidated onto the branch (preserved worktrees);
+  // empty in the common case. Non-empty ⇒ status is 'consolidation-incomplete'.
+  preservedTracks,
   // back-compat: the union of non-clean picks. Consumers keying on a discarded
   // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
   conflicts: [...reconciled, ...dropped],

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: be
-description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with an AI review gauntlet (codex debate → lens debate (lowy ⇄ hickey) → code-police → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a PARALLEL AI review gauntlet (codex debate ∥ lens debate (lowy ⇄ hickey) ∥ code-police, each in its own worktree, consolidated by cherry-pick → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
 argument-hint: "<issue-url | prompt>"
 ---
 
@@ -40,13 +40,32 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 
 **If there's a plan of record, finalize it now.** Once the PR URL exists, update `docs/plans/<slug>.html` to read as it will *after merge* — flip its status to implemented/done and **link the PR** (e.g. a header line `Implemented in #<n>`) — then commit (`docs(plan): link PR #<n>`) and push so the finalized plan is part of this PR. This applies equally to a freshly-written plan and one the user brought in.
 
-## 4. Review gauntlet
+## 4. Review gauntlet — parallel
 
-Run **in order** — each surfaces different defects, each posts its findings to the PR:
+Run all three reviewers **at once** via **`/be-review`** (Skill tool), which fans
+each out into its own detached git worktree off the branch HEAD, runs every
+reviewer's **full multi-round debate to consensus concurrently** (codex⇄claude,
+lowy⇄hickey, and code-police's rules→fact-check→elegance — no depth is dropped),
+then **consolidates** their per-track commits onto the branch with `git
+cherry-pick`. The common case is no overlap (clean picks); the rare overlap — two
+debates editing the same lines — is reconciled to honor both fixes.
 
-1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus, commits per round, and posts its summary as a PR comment by default. Let it finish before moving on.
-2. **`/lens-debate`** (Skill tool) on the diff, briefed with the change rationale only — do **not** seed findings. One call does the whole `/lowy` ⇄ `/hickey` structural pass: it reviews with both lenses **independently in parallel** (forcing both onto Opus, overriding their `model: sonnet` frontmatter), debates **every** finding to consensus, and applies each agreed `fix` as its own commit. **It MUST post the per-finding debate ledger (origin, finding, disposition, applied commit) to the PR as a comment — this is mandatory; confirm the comment landed** (it is `/lens-debate`'s default, so don't pass `--no-comment`). Pass the change rationale via its `rationale` arg so the lenses don't flag deliberate decisions. Deadlock is not possible; on the rare **unresolved** finding, adjudicate it yourself before moving on. Let it finish.
-3. **`/code-police`** (Skill tool) on the resulting diff — its rules → fact-check → elegance passes until clean. **Each finding is its own commit** — never batch: apply the narrow fix, re-run **check** and **fmt**, `git add` only the touched files, commit (`fix(police):` …) with the finding restated in one line, and `git push`. Then post its findings to the PR as a comment.
+- Preflight: a non-empty diff and (since codex runs) `codex login status`.
+- Invoke `/be-review` with `base`, the change **`rationale`** (so the lenses
+  don't flag deliberate decisions — same brief the old `/lens-debate` step got),
+  and the default `tracks: [codex, lens, police]` (also the consolidation order).
+- It posts **one** consolidated `## Review gauntlet (parallel)` PR comment
+  covering all three tracks plus the consolidation ledger — confirm it landed.
+  This replaces the three separate per-reviewer comments.
+- On the rare **unresolved** lens finding or a **dropped** overlap you disagree
+  with, adjudicate it yourself before moving on. On `setup-failed` or a per-track
+  `track-error`, fall back to the serial path below for the affected track.
+
+The serial path (`/codex-debate` → `/lens-debate` → `/code-police`, each seeing
+the prior's fixes fresh) remains available and is the right call for a small,
+correctness-critical change where cross-track staleness matters — and is the
+automatic fallback under codex/opencode runtimes, which lack the `Workflow`
+engine `/be-review` needs.
 
 ## 5. Ship
 
@@ -55,6 +74,6 @@ Run **in order** — each surfaces different defects, each posts its findings to
 
 ## Done
 
-Report the PR URL, the outcome of each review (codex consensus or reviewer-error, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+Report the PR URL, the parallel gauntlet outcome (per-track: codex consensus or reviewer-error, lens-debate consensus, police findings actioned) and the consolidation ledger (clean picks vs reconciled overlaps), and CI status. Never merge — the human reviews the per-track commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -54,9 +54,10 @@ debates editing the same lines — is reconciled to honor both fixes.
 - Invoke `/be-review` with `base`, the change **`rationale`** (so the lenses
   don't flag deliberate decisions — same brief the old `/lens-debate` step got),
   and the default `tracks: [codex, lens, police]` (also the consolidation order).
-- It posts **one** consolidated `## Review gauntlet (parallel)` PR comment
-  covering all three tracks plus the consolidation ledger — confirm it landed.
-  This replaces the three separate per-reviewer comments.
+- Its **Report** phase posts a **detailed PR comment per track** (codex debate
+  table, lens per-finding ledger, police findings) plus the consolidation ledger —
+  automatically, so the trail lands regardless of caller. Confirm the comments
+  landed (the workflow returns their URLs in `comments`).
 - On the rare **unresolved** lens finding or a **dropped** overlap you disagree
   with, adjudicate it yourself before moving on. On `setup-failed` or a per-track
   `track-error`, fall back to the serial path below for the affected track.

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -67,10 +67,24 @@ correctness-critical change where cross-track staleness matters — and is the
 automatic fallback under codex/opencode runtimes, which lack the `Workflow`
 engine `/be-review` needs.
 
-## 5. Ship
+## 5. Ship — CI and evidence in parallel
 
-1. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
-2. **`/evidence`** — follow the **`## PR evidence`** section of `.agency/do.md` for the capture procedure, then post the result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff. Skip only if that section says to (or is absent).
+`/ci` and `/evidence` are independent — one exercises the build/test pipeline, the
+other captures on-screen behavior — so **run them concurrently**; don't wait for
+green before capturing.
+
+1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
+   consume `--progress json`) so it churns while you capture evidence. React to
+   streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
+   on real failures, confirm green on the final `HEAD`.
+2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
+   evidence`** section of `.agency/do.md` for the capture procedure, then post the
+   result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior
+   even when there's no visual diff. Skip only if that section says to (or is
+   absent).
+3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
+   is posted. If a CI fix-commit changed visible behavior *after* capture,
+   re-capture so the evidence matches what actually merges.
 
 ## Done
 

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -106,9 +106,10 @@ collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
-- **consensus** — codex approved with no blocking/major findings open. This is
-  the *only* way the debate ends *normally*: it keeps running rounds until codex
-  and Claude agree, with no round cap and no deadlock exit. (The harness's own
+- **consensus** — every finding codex raised is resolved (any severity — Claude
+  fixed it or codex conceded the dispute). This is the *only* way the debate ends
+  *normally*: it keeps running rounds until codex and Claude agree on every point,
+  with no round cap and no deadlock exit. (The harness's own
   per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
   a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
@@ -143,7 +144,7 @@ the per-round commits sit on the local branch for the human to review):
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
-  (approved? open blocking/major count), Claude's dispositions, and the
+  (approved? open-findings count), Claude's dispositions, and the
   round's `commit` SHA — so the convergence reads round by round.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
@@ -152,7 +153,7 @@ the per-round commits sit on the local branch for the human to review):
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
   `gh pr comment`. Include: the **consensus** outcome badge and the round count;
   a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
-  table (codex approved? open blocking/major findings; Claude's dispositions; the
+  table (codex approved? open-findings count; Claude's dispositions; the
   round's commit SHA) showing how the two sides converged. Use a
   single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -113,7 +113,12 @@ collide** and the scratch never shows up in the diff codex reviews. It returns:
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
   **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
-  carries the failure detail. Do **not** treat it as consensus (see step 3).
+  carries the failure detail (including how many attempts were made). Do **not**
+  treat it as consensus (see step 3). **Transient failures are retried first:**
+  `codex-review.sh` retries the `codex exec` invocation with linear backoff
+  (default 3 attempts; tune via `CODEX_REVIEW_RETRIES` / `CODEX_REVIEW_BACKOFF`)
+  and only synthesizes the reviewer-error verdict once every attempt comes back
+  empty — so a single codex hiccup no longer sinks the round.
 
 ### 3. Present the result
 

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -47,7 +47,9 @@ Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
   the repo default branch as `git symbolic-ref --short refs/remotes/origin/HEAD`
   (e.g. `origin/master`) — used **as-is**, NOT stripped to local `master` (which
   can lag the remote). Fallback `origin/master`. Step 1 runs `git fetch origin`
-  first so the ref is current.
+  first so the ref is current. The workflow then resolves this to the **merge-base**
+  of `base` and HEAD and diffs against that, so commits `base` gained since the
+  branch forked aren't reviewed as part of this change.
 - **`--no-commit`**: don't commit per round — leave all agreed changes
   uncommitted in the working tree for you to commit yourself. Default is to
   **commit each round** (see below).

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -108,12 +108,12 @@ async function codexReviews(round, rebuttalJson) {
 
 ${rebuttalJson}
 
-2. Run, from the repo root \`${repoPath}\`:
-   \`bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
+2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
     : `1. (No prior rebuttal this round.)
 
-2. Run, from the repo root \`${repoPath}\`:
-   \`bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
+2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -133,7 +133,7 @@ ${rebuttalStep}
 }
 
 async function claudeResponds(round, verdict) {
-  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git diff ${base}\` and read surrounding code as needed.
+  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git -C ${repoPath} diff ${base}\` and read surrounding code as needed.
 
 CODEX's latest verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
@@ -194,10 +194,10 @@ async function commitRound(round, files, message) {
 
 ${message}
 
-3. Run, from the repo root \`${repoPath}\`:
-   \`git add -- ${fileArgs} && git commit -F ${msgPath}\`
+3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
+   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git rev-parse HEAD\`. Do NOT push.`
+4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:round${round}`, phase: 'Debate' })
 }
 

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -87,19 +87,10 @@ const CLAUDE_RESPONSE_SCHEMA = {
   required: ['summary', 'actions', 'filesChanged', 'done'],
 }
 
-// ---------------------------------------------------------------------------
-// Consensus helper
-// ---------------------------------------------------------------------------
-// A finding still "counts against" consensus only if it is open AND
-// blocking/major. Minor issues and nits never block agreement. Consensus is the
-// ONLY terminal state — there is no round cap and no deadlock exit, so the loop
-// runs until codex approves with nothing blocking/major open. The debate is
-// pointless if it bails to "deadlock"; the two sides must argue it out until
-// one concedes.
-function blockingOpen(verdict) {
-  return (verdict.findings || []).filter(
-    (f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major'),
-  )
+// Consensus = no finding left open, any severity. The loop runs until codex
+// resolves every one (CLAUDE fixed it, or codex conceded a dispute). No cap.
+function openFindings(verdict) {
+  return (verdict.findings || []).filter((f) => f.status !== 'resolved')
 }
 
 // ---------------------------------------------------------------------------
@@ -138,25 +129,21 @@ ${rebuttalStep}
 }
 
 async function claudeResponds(round, verdict) {
-  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git -C ${repoPath} diff ${base}\` and read surrounding code as needed.
+  const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
-CODEX's latest verdict (JSON):
+Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
+
+CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
-For EACH finding:
-  - If you AGREE: fix it now by editing the code in the working tree (use your editing tools). Record disposition "fixed".
-  - If you DISAGREE: do NOT change the code. Record disposition "disputed" with a specific, technical reason citing file:line or the actual behavior. Concede when codex is right — do not dispute merely to win.
-  - If PARTIALLY right: fix the valid part, explain the rest. Record "partial".
+Address EVERY finding, any severity (don't skip minors/nits):
+  - agree → fix it in the working tree; disposition "fixed".
+  - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
+  - partly → fix the valid part, explain the rest; disposition "partial".
 
-Constraints:
-  - Edit the WORKING TREE only. Do NOT git add / commit / push, and do NOT create or modify a PR.
-  - You may run a trivial formatter on files you changed if the project has one.
-  - Keep fixes tightly scoped to the findings.
+Edit the working tree only — do NOT git add/commit/push. You may run the formatter on files you touched.
 
-Then return your structured response:
-  - actions: one per finding you addressed (findingId, disposition, detail).
-  - filesChanged: every working-tree file you edited this round.
-  - done: true ONLY if nothing further should change — i.e. everything valid is fixed and you stand by any remaining disputes. If you fixed things and want codex to re-check, that is still done=true (codex re-reviews next round regardless).`
+Return: actions (one per finding — findingId, disposition, detail), filesChanged, and done (true once you've addressed every finding this round).`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -218,12 +205,10 @@ let lastClaude = null
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
 // ---------------------------------------------------------------------------
-// The debate continues, round after round, until codex approves with nothing
-// blocking/major open. There is deliberately no upper bound and no early
-// "deadlock" surrender: a debate that quits without agreement defeats the
-// purpose, so the two sides keep arguing until one concedes. (The harness's own
-// per-workflow agent backstop is the only hard ceiling; interrupt via
-// /workflows or TaskStop if you ever need to stop one by hand.)
+// The debate continues, round after round, until codex resolves every finding
+// (any severity). No upper bound, no "deadlock" surrender: the two sides argue
+// every point until one concedes. (The harness's per-workflow agent backstop is
+// the only hard ceiling; interrupt via /workflows or TaskStop by hand.)
 phase('Debate')
 
 // Resolve the diff base to the merge-base of (base, HEAD) so codex reviews only
@@ -255,12 +240,11 @@ for (let round = 1; ; round++) {
     break
   }
 
-  const blocking = blockingOpen(verdict)
-  log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
+  const open = openFindings(verdict)
+  log(`Round ${round}: codex approved=${verdict.approved}, findings open=${open.length}`)
 
-  // Consensus — the normal exit: codex is satisfied and nothing blocking/major
-  // remains open.
-  if (verdict.approved && blocking.length === 0) {
+  // Consensus: every finding resolved (any severity).
+  if (open.length === 0) {
     break
   }
 

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -216,7 +216,7 @@ phase('Debate')
 // forked (those would otherwise show up in `git diff base` — master's drift
 // reviewed as ours). A thin mechanical git agent; the workflow can't run git
 // itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
-const rawBase = a.base || 'origin/master'
+const rawBase = base
 const baseRes = await agent(
   `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
   { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -11,7 +11,12 @@ export const meta = {
 // ---------------------------------------------------------------------------
 const a = args || {}
 const repoPath = a.repoPath || '.'
-const base = a.base || 'origin/master'
+// The diff base. Resolved to the MERGE-BASE of (rawBase, HEAD) just before the
+// debate (see phase 'Debate') so commits rawBase gained since the branch forked
+// aren't reviewed as if this change made them. `let` because that resolution
+// reassigns it; every prompt reads the resolved value. (Idempotent when the
+// caller already passed a merge-base SHA, e.g. /be-review.)
+let base = a.base || 'origin/master'
 // Where the generated skill lives, so the codex runner can find codex-review.sh.
 const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // Per-worktree scratch dir for rebuttal/verdict files. Derived from repoPath
@@ -220,6 +225,18 @@ let lastClaude = null
 // per-workflow agent backstop is the only hard ceiling; interrupt via
 // /workflows or TaskStop if you ever need to stop one by hand.)
 phase('Debate')
+
+// Resolve the diff base to the merge-base of (base, HEAD) so codex reviews only
+// what THIS branch changed, not commits the base branch gained since the branch
+// forked (those would otherwise show up in `git diff base` — master's drift
+// reviewed as ours). A thin mechanical git agent; the workflow can't run git
+// itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const baseRes = await agent(
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+)
+if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
+log(`Diffing against ${base.slice(0, 12)} (merge-base of ${a.base || 'origin/master'} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -259,7 +259,20 @@ for (let round = 1; ; round++) {
   const open = openFindings(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, findings open=${open.length}`)
 
-  // Consensus: every finding resolved (any severity).
+  // Consensus requires BOTH no open finding AND codex's explicit approval. An
+  // inconsistent verdict — `approved:false` with nothing open — is not consensus:
+  // codex declined to approve while leaving us nothing to route to Claude, so
+  // treating it as agreement would ship an unapproved change. There's no finding
+  // to debate, so re-running codex would just replay the same inconsistency;
+  // surface it as a reviewer error (the terminal abnormal path) instead of
+  // looping forever or falsely converging.
+  if (open.length === 0 && verdict.approved !== true) {
+    status = 'reviewer-error'
+    log(`Round ${round}: inconsistent verdict — approved=false with no open findings; aborting as reviewer-error.`)
+    break
+  }
+
+  // Consensus: codex approved AND every finding resolved (any severity).
   if (open.length === 0) {
     break
   }

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -216,12 +216,28 @@ phase('Debate')
 // forked (those would otherwise show up in `git diff base` — master's drift
 // reviewed as ours). A thin mechanical git agent; the workflow can't run git
 // itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const rawBase = a.base || 'origin/master'
 const baseRes = await agent(
-  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
-  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },
 )
-if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
-log(`Diffing against ${base.slice(0, 12)} (merge-base of ${a.base || 'origin/master'} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
+// Fail loud on a bad base. Falling back to the raw `${base}` tip would review the
+// base branch's drift since the fork as if this change made it — the exact noise
+// the merge-base removes — so a missing/typoed/stale base must abort, not degrade.
+if (!baseRes?.sha?.trim()) {
+  const err = (baseRes?.error || '').trim()
+  log(`Aborting: \`git merge-base ${rawBase} HEAD\` failed; the diff scope can't be trusted. Not falling back to the raw ${rawBase} tip.`)
+  return {
+    status: 'merge-base-error',
+    base: rawBase,
+    rounds: 0,
+    transcript: [],
+    finalVerdict: null,
+    note: `merge-base of \`${rawBase}\` and HEAD could not be resolved (missing/typoed base, stale ref, or unrelated history), so the review scope is untrustworthy. Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
+base = baseRes.sha.trim()
+log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -115,14 +115,38 @@ EOF
 # model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
 # relying on the user's global ~/.codex/config.toml — review is the one place we
 # always want codex thinking at full depth, regardless of their default.
-if ! codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="xhigh" \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"</dev/null >"$log" 2>&1; then
-  echo "codex exec exited non-zero (see $log)" >&2
-fi
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
+# hiccups, a spurious internal error) and writes no verdict — which would
+# otherwise degrade the whole track to reviewer-error on a single bad roll.
+# Retry the invocation with linear backoff, accepting the first attempt that
+# writes a non-empty verdict to "$out". Tunable via env: CODEX_REVIEW_RETRIES
+# (total attempts, default 3), CODEX_REVIEW_BACKOFF (base seconds, default 5 —
+# attempt n waits n*base). Only after every attempt fails empty do we synthesize
+# the reviewerError verdict below.
+attempts="${CODEX_REVIEW_RETRIES:-3}"
+backoff="${CODEX_REVIEW_BACKOFF:-5}"
+n=1
+while :; do
+  rm -f "$out"
+  if ! codex exec \
+        --sandbox read-only \
+        -c model_reasoning_effort="xhigh" \
+        --output-schema "$schema" \
+        -o "$out" \
+        "$prompt"</dev/null >"$log" 2>&1; then
+    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+  fi
+  # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
+  # make a non-empty "$out" a real, schema-valid verdict, not a partial.
+  [ -s "$out" ] && break
+  # Out of attempts — fall through to the synthesized reviewerError verdict.
+  [ "$n" -ge "$attempts" ] && break
+  wait_s=$(( backoff * n ))
+  echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+  n=$(( n + 1 ))
+  sleep "$wait_s"
+done
 
 if [ ! -s "$out" ]; then
   # codex produced no verdict — synthesize a schema-valid error verdict so the
@@ -132,9 +156,9 @@ if [ ! -s "$out" ]; then
   # substantive disagreement, so it must NOT be routed to Claude (there are no
   # findings to act on) and must NOT spin the loop forever.
   tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" '{
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
     approved: false,
-    summary: ("codex produced no verdict this round. Tail of log: " + $log),
+    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
     findings: [],
     responseToRebuttal: "",
     reviewerError: true

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -78,37 +78,38 @@ fi
 # Unquoted heredoc: only $base and $rebuttal_block expand. No backticks and no
 # other $/$(...) appear in the body, so there is nothing else to interpret.
 prompt="$(cat <<EOF
-You are CODEX, a rigorous, fair senior code reviewer in an automated review
-debate with another AI engineer ("CLAUDE") who authored the changes.
+You are CODEX, a rigorous senior code reviewer. Review the changes in this branch
+and give your honest, thorough feedback — exactly as you would on a serious PR.
+You're in a debate with the author ("CLAUDE"), who will fix what they agree with
+and push back, with reasons, on what they don't.
 
-REVIEW SCOPE — the full current state of the working tree against the base
-branch '$base', which includes committed AND uncommitted changes. Run these
-yourself:
+Inspect the change yourself (READ-ONLY — do not modify, create, or delete anything,
+and run no git write command: add/commit/push/stash/checkout):
 
-    git diff $base       (committed + tracked-but-unstaged changes)
-    git status --short   (find untracked/new files)
+    git diff $base       (committed + unstaged changes on this branch)
+    git status --short   (untracked/new files — read those too; they aren't in the diff)
 
-Then read every new/changed file plus surrounding context and review the change
-as a whole. Untracked new files do NOT appear in 'git diff', so you MUST inspect
-'git status --short' and read those files explicitly.
+Read every changed file plus enough surrounding code to judge it in context.
+Ignore the debate's own scratch dir '.codex-debate/' if it appears.
 
-IGNORE the debate's own scratch dir '.codex-debate/' if it shows up — it holds
-this process's verdict/rebuttal files, not part of the change under review.
-
-THIS IS READ-ONLY. Do NOT modify, create, or delete any files. Do NOT run any
-git write command (add/commit/push/stash/checkout) or any other state-mutating
-command. You are only inspecting.
-
-Review for correctness bugs, logic errors, silent error-swallowing, unjustified
-fallbacks, security issues, and clear simplicity/efficiency problems. Be
-specific and concrete; cite file:line. Do NOT invent issues to look busy — if
-the change is sound, approve it.
+Give ALL your feedback in this pass — every issue worth raising, at EVERY severity
+(blocking, major, minor, nit): correctness bugs, logic errors, silently swallowed
+errors, unjustified fallbacks, security problems, and clear simplicity/efficiency
+issues. Don't hold issues back for a later round, and don't limit yourself to
+blockers — surface everything you see now. Cite file:line. (If the change is
+genuinely clean, approving with no findings is fine — just never stay quiet about
+a real issue to seem agreeable.)
 $rebuttal_block
-Return a verdict matching the provided JSON schema:
-  - approved: true ONLY when no blocking or major issues remain (minor/nits may remain).
-  - findings: reuse stable ids (F1, F2, ...) across rounds for the same issue; set
-    status=resolved once adequately addressed, else open.
-  - responseToRebuttal: address CLAUDE's disputes directly (empty on round 1).
+Return your review in the JSON schema:
+  - findings: one entry per issue, each with a severity and a stable id (F1, F2, …)
+    reused across rounds for the same issue. Set status=resolved once it is
+    adequately addressed (CLAUDE fixed it, OR you accept CLAUDE's reasoning); else open.
+  - approved: true ONLY when EVERY finding is resolved — all your feedback addressed
+    at every severity, not just blockers. The review is not done while any issue you
+    raised still stands open.
+  - responseToRebuttal: when CLAUDE disputes a finding, address each dispute
+    individually — concede (mark that finding resolved) or hold firm with specific,
+    technical reasoning. Leave no dispute unanswered. Empty on round 1.
 EOF
 )"
 

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -130,6 +130,19 @@ EOF
 # the reviewerError verdict below.
 attempts="${CODEX_REVIEW_RETRIES:-3}"
 backoff="${CODEX_REVIEW_BACKOFF:-5}"
+# Validate both as positive integers. Left unchecked, a non-numeric value makes
+# the arithmetic `[ "$n" -ge "$attempts" ]` test error every iteration, so the
+# loop would spin forever instead of giving up and synthesizing the reviewerError
+# verdict. Fall back to the documented defaults (and clamp attempts to >=1) loudly
+# rather than wedge the headless debate on a typo'd override.
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+  attempts=3
+fi
+if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+  backoff=5
+fi
 n=1
 while :; do
   rm -f "$out"

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -65,12 +65,15 @@ fi
 rebuttal_block=""
 if [ -n "$rebuttal" ]; then
   rebuttal_block="
-CLAUDE responded to your PREVIOUS review as follows. Take it seriously: where a
-fix landed in the working tree, verify it and mark that finding resolved; where
-CLAUDE disputes a finding, either concede (mark it resolved) or hold firm with
-specific reasoning in responseToRebuttal.
+This is a FOLLOW-UP round — you already gave your full review. Your job now is to
+CLOSE OUT the findings already on the table, not re-scan the whole diff for more.
+For each existing finding: verify CLAUDE's fix and mark it resolved, or address
+CLAUDE's dispute (concede and mark resolved, or hold firm with specific reasoning
+in responseToRebuttal). Raise a NEW finding ONLY if CLAUDE's changes this round
+introduced it (a regression). Do NOT keep surfacing pre-existing issues you didn't
+raise in round 1 — that prevents the debate from ever converging.
 
-CLAUDE's response (JSON):
+CLAUDE responded to your PREVIOUS review as follows:
 $rebuttal
 "
 fi

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -144,14 +144,19 @@ if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
   backoff=5
 fi
 n=1
+: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
 while :; do
   rm -f "$out"
+  # Append (not truncate): when every attempt fails, the synthesized reviewerError
+  # verdict's tail_log must reflect ALL attempts' diagnostics — surfacing the exact
+  # transient failures this retry loop exists to weather — not just the final one.
+  echo "=== attempt $n/$attempts ===" >>"$log"
   if ! codex exec \
         --sandbox read-only \
         -c model_reasoning_effort="xhigh" \
         --output-schema "$schema" \
         -o "$out" \
-        "$prompt"</dev/null >"$log" 2>&1; then
+        "$prompt"</dev/null >>"$log" 2>&1; then
     echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
   fi
   # Success the moment codex writes a verdict: the kernel sandbox + --output-schema

--- a/.agents/skills/codex-debate/scripts/codex-verdict.schema.json
+++ b/.agents/skills/codex-debate/scripts/codex-verdict.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "approved": {
       "type": "boolean",
-      "description": "true ONLY if no blocking or major issues remain. Minor issues and nits may remain."
+      "description": "true ONLY when every finding is resolved — all your feedback addressed at any severity (minor and nit included), not just blockers."
     },
     "summary": {
       "type": "string",

--- a/.agents/skills/lens-debate/SKILL.md
+++ b/.agents/skills/lens-debate/SKILL.md
@@ -94,6 +94,8 @@ Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-co
   given, else the repo default branch via
   `git symbolic-ref --short refs/remotes/origin/HEAD` (e.g. `origin/master`),
   used **as-is**. Fallback `origin/master`. Step 1 runs `git fetch origin` first.
+  The workflow resolves this to the **merge-base** of `base` and HEAD and diffs
+  against that, so the base branch's drift since the fork isn't reviewed as ours.
 - **`--max-rounds <n>`**: safety backstop on debate rounds. Default **12**. Not a
   deadlock cap (see above) — raise it freely.
 - **`--no-commit`**: still apply the agreed fixes to the working tree, but leave

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -120,7 +120,7 @@ const FINDINGS_SCHEMA = {
   properties: {
     findings: {
       type: 'array',
-      description: 'your INDEPENDENT findings (≤4, high-confidence; an empty list is a fine verdict for a clean diff)',
+      description: 'ALL your independent structural findings — every issue worth raising through your lens, no cap. An empty list is fine only for a genuinely clean diff.',
       items: {
         type: 'object',
         additionalProperties: false,
@@ -184,7 +184,7 @@ function reviewBrief(lens, framework, probe) {
 
 Review the change through the **${framework}** lens, INDEPENDENTLY — you are NOT seeing any other reviewer's findings. That independence is the whole point: being handed someone else's curated finding biases the verdict.
 ${rationaleBlock}${probeBlock}
-Emit your own findings (≤4, high-confidence). Each: a title, a file:line location, the problem in your lens's terms, a concrete suggestion, and a disposition — \`fix\` (worth changing in THIS PR) or \`drop\` (observation only). Do not invent issues to look thorough: an empty list, or all-drop, is a fine verdict for a clean diff.`
+Give ALL your findings — every structural issue you see through your lens, no cap, at every level (boundary, complecting, naming, duplication, …). Each: a title, a file:line location, the problem in your lens's terms, a concrete suggestion, and a disposition — \`fix\` (worth changing in THIS PR) or \`drop\` (observation only). Don't fabricate issues, but don't hold any back either; an empty list is fine only for a genuinely clean diff.`
 }
 
 function findingLine(f) {

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -69,7 +69,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing
 // lesson from #1109: curation biases the verdict).
-const DIFF = `Inspect the FULL change in the repo at \`${repoPath}\`: run \`git diff ${base}\` (committed + unstaged) and \`git status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore the debate's own scratch dir \`.lens-debate/\` if it appears.`
+const DIFF = `Inspect the FULL change in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so use \`git -C ${repoPath}\` and ABSOLUTE paths under \`${repoPath}\`: run \`git -C ${repoPath} diff ${base}\` (committed + unstaged) and \`git -C ${repoPath} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore the debate's own scratch dir \`.lens-debate/\` if it appears.`
 
 const rationaleBlock = rationale ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n` : ''
 
@@ -172,7 +172,7 @@ Round ${roundNum}. For EVERY contested finding id above, output a disposition (\
 }
 
 function implementBrief(fix) {
-  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\`.
+  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\`.
 
 Finding ${fix.id} (raised by ${fix.origin}) — ${fix.title}
   at ${fix.location}
@@ -205,10 +205,10 @@ Agreed by the lowy ⇄ hickey lens debate (finding ${fix.id}, raised by ${fix.or
 
 ${message}
 
-3. Run, from the repo root \`${repoPath}\`:
-   \`git add -- ${fileArgs} && git commit -F ${msgPath}\`
+3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
+   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git rev-parse HEAD\`. Do NOT push.`
+4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply' })
 }
 

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -77,11 +77,31 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // changed, not the base branch's drift since the fork. A thin mechanical git
 // agent (the workflow can't run git itself); grouped under the Review phase.
 // Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const rawBase = a.base || 'origin/master'
 const baseRes = await agent(
-  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
-  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },
 )
-if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
+// Fail loud on a bad base. Falling back to the raw `${base}` tip would make the
+// lenses review the base branch's drift since the fork as if this change made it —
+// the exact noise the merge-base removes — so a missing/typoed/stale base aborts.
+if (!baseRes?.sha?.trim()) {
+  const err = (baseRes?.error || '').trim()
+  log(`Aborting: \`git merge-base ${rawBase} HEAD\` failed; the diff scope can't be trusted. Not falling back to the raw ${rawBase} tip.`)
+  return {
+    status: 'merge-base-error',
+    base: rawBase,
+    rounds: 0,
+    withPolice,
+    settled: [],
+    unresolved: [],
+    applied: [],
+    reviews: {},
+    history: [],
+    note: `merge-base of \`${rawBase}\` and HEAD could not be resolved (missing/typoed base, stale ref, or unrelated history), so the review scope is untrustworthy. Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
+base = baseRes.sha.trim()
 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -77,7 +77,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // changed, not the base branch's drift since the fork. A thin mechanical git
 // agent (the workflow can't run git itself); grouped under the Review phase.
 // Idempotent when `base` is already a merge-base SHA (caller resolved it).
-const rawBase = a.base || 'origin/master'
+const rawBase = base
 const baseRes = await agent(
   `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
   { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -26,7 +26,13 @@ const MODEL = 'opus'
 // ---------------------------------------------------------------------------
 const a = args || {}
 const repoPath = a.repoPath || '.'
-const base = a.base || 'origin/master'
+// The diff base. Resolved to the MERGE-BASE of (rawBase, HEAD) just below, before
+// DIFF is built, so the lenses review only what THIS branch changed — not commits
+// the base branch gained since the branch forked (those would otherwise appear in
+// `git diff base` as the base branch's drift, reviewed as ours). `let` because the
+// resolution reassigns it. Idempotent when the caller already passed a merge-base
+// SHA (e.g. /be-review).
+let base = a.base || 'origin/master'
 // Safety backstop only — NOT a deadlock cap. The debate runs until consensus;
 // this just keeps a pathologically oscillating debate from running unbounded.
 // Hitting it is reported as `unresolved` (needs human), never `deadlock`, and
@@ -65,6 +71,17 @@ const REVIEWERS = [
   { lens: 'hickey', framework: 'structural simplicity — independent concerns complected, or one thing fragmented? (Simple Made Easy)' },
 ]
 if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, correctness, and common-mistake review' })
+
+// Resolve the diff base to the merge-base of (base, HEAD) BEFORE building DIFF
+// (which interpolates `base` eagerly), so the lenses review only what this branch
+// changed, not the base branch's drift since the fork. A thin mechanical git
+// agent (the workflow can't run git itself); grouped under the Review phase.
+// Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const baseRes = await agent(
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+)
+if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -62,9 +62,13 @@ to `cd`.
   its own commit. Pass the change rationale so deliberate decisions aren't flagged.
 - **police** — `/code-police`'s three cold passes (rule checklist, fact-check,
   elegance) reproduced as parallel agents, each finding applied as its own commit
-  (`fix(police):`). Per-finding `just check` is **deferred** to the
-  post-consolidation check + `/be` §5 CI rather than run 3× concurrently across
-  the parallel worktrees; `fmt`-on-touched-files still runs in each apply.
+  (`fix(police):`). The passes run **until a sweep is clean** (re-reviewing the
+  updated worktree after each apply, so a fix that introduces or only partially
+  resolves an issue is caught), capped at a few sweeps; hitting the cap with issues
+  still open reports `incomplete` rather than a false consensus.
+  `fmt`-on-touched-files runs in every apply. Per-finding `just check` is
+  **deferred** to the post-consolidation check + `/be` §5 CI rather than run 3×
+  concurrently across the parallel worktrees.
 
 ## Arguments
 
@@ -144,18 +148,31 @@ track + the consolidation ledger), **Cleanup** (tear down the worktrees). It
 returns:
 
 ```
-{ status,                  // 'done' | 'no-commit' | 'setup-failed'
+{ status,                  // 'done' | 'consolidation-incomplete' | 'consolidation-aborted' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'
   consolidation,           // { finalHead, picks[] }  (null when not consolidated)
+  preservedTracks,         // tracks NOT consolidated (worktrees kept); non-empty ⇒ status incomplete/aborted
   conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
   comments }               // { consolidation, codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
-  and re-run) or no worktree could be created. `tracks` carries the per-track
-  `track-error` detail.
+  and re-run), an unresolvable merge-base, a malformed `runId`/`tracks` argument,
+  or no worktree could be created. `tracks` carries the per-track `track-error`
+  detail.
+- `consolidation-incomplete` — the picks ran, but at least one requested track was
+  **preserved** (left uncommitted edits, couldn't be confirmed clean, or crashed
+  with committed-but-unreplayed work), so its fixes live only in its worktree.
+  `preservedTracks` names them and each `tracks[t].note` has the recovery
+  cherry-pick. `/be` should adjudicate these before continuing rather than treat
+  the gauntlet as fully landed.
+- `consolidation-aborted` — the branch HEAD moved or the main worktree went dirty
+  **during** the (long) parallel tracks phase, so the cherry-pick base is no longer
+  the reviewed `branchHead`. Nothing was consolidated and **all** track worktrees
+  are preserved (`preservedTracks` + per-track recovery cherry-picks). Resolve the
+  drift, then consolidate by hand or re-run.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
   **uncommitted in its preserved `.worktrees/be-review-<runId>-<track>` worktree**
   and nothing is consolidated, reported, or cleaned up. The result lists those

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: be-review
+description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled). Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
+argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit]"
+---
+
+# Parallel review gauntlet
+
+`/be`'s §4 gauntlet runs three reviewers **serially** today (`/codex-debate` →
+`/lens-debate` → `/code-police`) for one structural reason: each step **commits
+fixes**, so the next reviewer sees the mutated tree. That chaining is the *only*
+thing forcing order — the reviews themselves are independent and read-only.
+
+This skill removes the chaining by giving each reviewer its **own detached git
+worktree** forked from the branch HEAD. All three multi-round debates run **at
+once**, each mutating only its own worktree, each running to full consensus (no
+depth is lost — every reviewer keeps its complete loop). When they finish, the
+orchestrator **consolidates** by cherry-picking each track's commits onto the
+branch in order. The common case is no overlap (clean picks); the rare overlap —
+two tracks editing the same lines — surfaces as a cherry-pick conflict that is
+**reconciled to honor both fixes**.
+
+```
+            ┌─ wt-codex   ─ codex⇄claude debate ─→ commits ─┐
+branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick onto branch
+            └─ wt-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
+```
+
+## Why this shape
+
+- **The debates were built for it.** `/codex-debate` and `/lens-debate` are
+  already `repoPath`-parameterized workflows whose docs promise "parallel debates
+  in different worktrees never collide." This skill is the orchestrator that
+  finally drives them that way — invoking each as a **child workflow** (one level
+  of nesting, which the runtime allows) pointed at a different worktree.
+- **No depth is traded for the parallelism.** Each track runs its *full*
+  multi-round loop to consensus — codex re-reviews its own fixes round after
+  round, the lenses debate every finding, police runs all three cold passes. The
+  only thing that changed is that the three loops run concurrently instead of
+  end-to-end.
+- **Consolidation is git, not vibes.** Each track's conclusions are real commits;
+  replaying them with `git cherry-pick` preserves each debate's per-commit ledger
+  in history and makes overlap a *detectable* conflict (`--diff-filter=U`) rather
+  than a silent clobber.
+
+## What runs in each track
+
+- **codex** — the `/codex-debate` workflow: codex (read-only, `xhigh`) ⇄ claude
+  author, to consensus, committing per round.
+- **lens** — the `/lens-debate` workflow: lowy + hickey review independently in
+  parallel (on Opus), debate every finding to consensus, apply each agreed fix as
+  its own commit. Pass the change rationale so deliberate decisions aren't flagged.
+- **police** — `/code-police`'s three cold passes (rule checklist, fact-check,
+  elegance) reproduced as parallel agents, each finding applied as its own commit
+  (`fix(police):`). Per-finding `just check` is **deferred** to the
+  post-consolidation check + `/be` §5 CI rather than run 3× concurrently across
+  the parallel worktrees; `fmt`-on-touched-files still runs in each apply.
+
+## Arguments
+
+- **`--base <branch>`**: remote-tracking ref to diff against (e.g. `origin/master`).
+  Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
+- **`--tracks codex,lens,police`**: which tracks to run *and the order they
+  consolidate in*. Default all three; codex first (it changes the most), police
+  last (lightest touch), so an overlap surfaces picking the later track.
+- **`--no-commit`**: leave each track's fixes uncommitted (debugging a single
+  track); default is to commit, since consolidation cherry-picks those commits.
+
+## Steps
+
+### 1. Resolve context
+
+- Determine `repoPath` (the worktree root, normally the cwd).
+- `git fetch origin` so the base remote-tracking ref is current.
+- Resolve `base` (a remote-tracking ref like `origin/master`).
+- Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
+- **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
+  not logged in, tell the user to run `codex login` (suggest the `!` prefix).
+
+### 2. Run the orchestrator Workflow
+
+```
+Workflow({
+  scriptPath: ".claude/skills/be-review/be-review.workflow.js",
+  args: {
+    repoPath: "<worktree root>",
+    base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
+    rationale: "<optional author note on deliberate decisions>",
+    tracks: ["codex", "lens", "police"],   // also the consolidation order
+    commit: <false only if --no-commit>
+  }
+})
+```
+
+It runs four phases the user can watch via `/workflows`: **Setup** (fan out one
+detached worktree per track), **Tracks** (the three gauntlets run concurrently to
+consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
+reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
+
+```
+{ status,                  // 'done' | 'setup-failed'
+  branchHead, finalHead, base, order,
+  tracks,                  // per-track result (codex/lens consensus, police findings/applied)
+  consolidation,           // { finalHead, picks[], conflicts[] }
+  conflicts }              // the overlaps reconciled (empty in the common case)
+```
+
+### 3. Present the result
+
+Report in chat and post **one** consolidated PR comment (this replaces the three
+separate per-reviewer comments): a `## Review gauntlet (parallel)` section with,
+per track, its outcome (codex consensus + rounds, lens consensus + per-finding
+table, police findings actioned); then the **consolidation ledger** — each
+cherry-picked commit and its outcome (`clean`/`reconciled`/`dropped`), with any
+overlap reconciliation explained. Then `git log --oneline <base>..HEAD` and
+`git diff --stat <base>` so the user sees the combined result. Never push or
+merge — the human reviews the per-track commits and merges.
+
+## Safety & notes
+
+- **Reviewers are read-only; only their own worktree is written.** Each track's
+  fixes land in `.be-review/wt-<track>/`; the branch is touched only by the
+  consolidation cherry-picks, which never push or merge.
+- **Overlap is reconciled, never silently dropped.** A cherry-pick conflict means
+  two debates changed the same lines; the orchestrator merges both intents (it
+  has both commit messages) and only drops a commit if an earlier track fully
+  subsumes it, saying so in the ledger.
+- **Cross-track staleness is the known limitation.** Because all three review the
+  *same* pre-fix branch HEAD, a track can't see another track's fixes mid-run
+  (the price of parallelism). Textual collisions are caught by consolidation;
+  residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
+  change is small and correctness-critical, the serial `/codex-debate` →
+  `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
+- **Parallel-safe.** Worktrees + scratch live under the gitignored, per-worktree
+  `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
+  scratch nests inside its worktree.
+
+## Files
+
+- `be-review.workflow.js` — the orchestrator (worktree fan-out → parallel tracks
+  → cherry-pick consolidation → cleanup). It invokes
+  `.claude/skills/{codex-debate,lens-debate}/debate.workflow.js` as child
+  workflows and reads `.claude/skills/code-police/SKILL.md` at runtime.
+
+This is generated from `.apm/skills/be-review/`; edit the source there and run
+`just ai::apm` to regenerate.
+
+ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -63,8 +63,11 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.
-- **`--no-commit`**: leave each track's fixes uncommitted (debugging a single
-  track); default is to commit, since consolidation cherry-picks those commits.
+- **`--no-commit`**: leave each track's fixes uncommitted for inspection
+  (debugging a single track). Consolidation cherry-picks per-track *commits*, so
+  with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
+  worktrees** (status `no-commit`) rather than silently discarding the uncommitted
+  edits. Default is to commit, which is what actually ships fixes.
 
 ## Steps
 
@@ -74,6 +77,12 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - `git fetch origin` so the base remote-tracking ref is current.
 - Resolve `base` (a remote-tracking ref like `origin/master`).
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
+- **Commit the change first.** Every track forks a detached worktree from the
+  branch HEAD, so only *committed* work is reviewed. If the main worktree has
+  staged/unstaged/untracked changes (outside `.be-review/`), commit (or stash)
+  them before invoking — the orchestrator's Setup preflight aborts with
+  `status: 'setup-failed'` on a dirty tree rather than reviewing an incomplete set.
+  (In `/be` this is automatic: §2/§3 commit and push before §4.)
 - **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
   not logged in, tell the user to run `codex login` (suggest the `!` prefix).
 
@@ -98,12 +107,24 @@ consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
 reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
 
 ```
-{ status,                  // 'done' | 'setup-failed'
+{ status,                  // 'done' | 'setup-failed' | 'no-commit'
   branchHead, finalHead, base, order,
-  tracks,                  // per-track result (codex/lens consensus, police findings/applied)
-  consolidation,           // { finalHead, picks[], conflicts[] }
+  tracks,                  // per-track result; ALWAYS one entry per requested track —
+                           //   a track whose worktree setup failed is status:'track-error'
+  consolidation,           // { finalHead, picks[], conflicts[] }  (null when not consolidated)
   conflicts }              // the overlaps reconciled (empty in the common case)
 ```
+
+- `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
+  and re-run) or no worktree could be created. `tracks` carries the per-track
+  `track-error` detail.
+- `no-commit` — `--no-commit` was set, so each track's fixes are left
+  **uncommitted in its preserved `.be-review/wt-<track>` worktree** and nothing is
+  consolidated or cleaned up. The result lists those `worktrees` to inspect; re-run
+  with commit enabled to actually consolidate. (`--no-commit` is a
+  single-track-debugging mode, not a way to ship fixes.)
+- For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
+  to the serial path for that track.
 
 ### 3. Present the result
 

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -143,7 +143,7 @@ returns:
                            //   a track whose worktree setup failed is status:'track-error'
   consolidation,           // { finalHead, picks[] }  (null when not consolidated)
   conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
-  comments }               // { codex, lens, police } → posted comment URLs ({} under --no-comment)
+  comments }               // { consolidation, codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -66,8 +66,10 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - **`--no-commit`**: leave each track's fixes uncommitted for inspection
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
   with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
-  worktrees** (status `no-commit`) rather than silently discarding the uncommitted
-  edits. Default is to commit, which is what actually ships fixes.
+  worktrees** (status `no-commit`) — leaving every track's worktree in place under
+  `.be-review/wt-<track>/` (the branch is untouched) rather than silently discarding
+  the uncommitted edits; inspect and tear them down yourself. Default is to commit,
+  which is what actually ships fixes.
 
 ## Steps
 
@@ -107,7 +109,7 @@ consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
 reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
 
 ```
-{ status,                  // 'done' | 'setup-failed' | 'no-commit'
+{ status,                  // 'done' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
-description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled). Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
-argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit]"
+description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled) and post a detailed PR comment per track. Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
+argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit] [--no-comment]"
 ---
 
 # Parallel review gauntlet
@@ -21,10 +21,18 @@ two tracks editing the same lines — surfaces as a cherry-pick conflict that is
 **reconciled to honor both fixes**.
 
 ```
-            ┌─ wt-codex   ─ codex⇄claude debate ─→ commits ─┐
-branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick onto branch
-            └─ wt-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
+            ┌─ be-review-codex   ─ codex⇄claude debate ─→ commits ─┐
+branch HEAD ┼─ be-review-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick → PR comments
+            └─ be-review-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
 ```
+
+The per-track worktrees live under the repo's conventional `.worktrees/`
+(gitignored) — `.worktrees/be-review-<track>`. **Isolation is structural, not
+behavioral:** every workflow agent inherits the *session* cwd (the harness has no
+per-agent cwd, and `isolation:'worktree'` can't host a multi-round debate that
+accumulates commits in one tree), so every git command is `git -C <worktree>` and
+every file path is absolute — no agent can leak into the wrong tree by forgetting
+to `cd`.
 
 ## Why this shape
 
@@ -65,11 +73,15 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
   last (lightest touch), so an overlap surfaces picking the later track.
 - **`--no-commit`**: leave each track's fixes uncommitted for inspection
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
-  with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
-  worktrees** (status `no-commit`) — leaving every track's worktree in place under
-  `.be-review/wt-<track>/` (the branch is untouched) rather than silently discarding
-  the uncommitted edits; inspect and tear them down yourself. Default is to commit,
-  which is what actually ships fixes.
+  with this flag the orchestrator **skips Consolidate + Report + Cleanup and
+  preserves the worktrees** (status `no-commit`) — leaving every track's worktree
+  in place under `.worktrees/be-review-<track>/` (the branch is untouched) rather
+  than silently discarding the uncommitted edits; inspect and tear them down
+  yourself. Default is to commit, which is what actually ships fixes.
+- **`--no-comment`**: suppress the PR comments. By default the **Report** phase
+  posts a detailed PR comment per track (codex debate table, lens per-finding
+  ledger, police findings) plus the consolidation ledger — the review trail the
+  gauntlet exists to leave. This flag reports in chat only.
 
 ## Steps
 
@@ -81,10 +93,11 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
 - **Commit the change first.** Every track forks a detached worktree from the
   branch HEAD, so only *committed* work is reviewed. If the main worktree has
-  staged/unstaged/untracked changes (outside `.be-review/`), commit (or stash)
-  them before invoking — the orchestrator's Setup preflight aborts with
-  `status: 'setup-failed'` on a dirty tree rather than reviewing an incomplete set.
-  (In `/be` this is automatic: §2/§3 commit and push before §4.)
+  staged/unstaged/untracked changes (outside the gitignored `.worktrees/` and
+  `.be-review/` scratch), commit (or stash) them before invoking — the
+  orchestrator's Setup preflight aborts with `status: 'setup-failed'` on a dirty
+  tree rather than reviewing an incomplete set. (In `/be` this is automatic: §2/§3
+  commit and push before §4.)
 - **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
   not logged in, tell the user to run `codex login` (suggest the `!` prefix).
 
@@ -98,52 +111,61 @@ Workflow({
     base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
     rationale: "<optional author note on deliberate decisions>",
     tracks: ["codex", "lens", "police"],   // also the consolidation order
-    commit: <false only if --no-commit>
+    commit: <false only if --no-commit>,
+    comment: <false only if --no-comment>
   }
 })
 ```
 
-It runs four phases the user can watch via `/workflows`: **Setup** (fan out one
-detached worktree per track), **Tracks** (the three gauntlets run concurrently to
-consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
-reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
+It runs five phases the user can watch via `/workflows`: **Setup** (fan out one
+detached worktree per track under `.worktrees/`), **Tracks** (the three gauntlets
+run concurrently to consensus), **Consolidate** (cherry-pick each track's commits
+onto the branch, reconciling overlap), **Report** (post a detailed PR comment per
+track + the consolidation ledger), **Cleanup** (tear down the worktrees). It
+returns:
 
 ```
 { status,                  // 'done' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'
-  consolidation,           // { finalHead, picks[], conflicts[] }  (null when not consolidated)
-  conflicts }              // the overlaps reconciled (empty in the common case)
+  consolidation,           // { finalHead, picks[] }  (null when not consolidated)
+  conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
+  comments }               // { codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
   and re-run) or no worktree could be created. `tracks` carries the per-track
   `track-error` detail.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
-  **uncommitted in its preserved `.be-review/wt-<track>` worktree** and nothing is
-  consolidated or cleaned up. The result lists those `worktrees` to inspect; re-run
-  with commit enabled to actually consolidate. (`--no-commit` is a
-  single-track-debugging mode, not a way to ship fixes.)
+  **uncommitted in its preserved `.worktrees/be-review-<track>` worktree** and
+  nothing is consolidated, reported, or cleaned up. The result lists those
+  `worktrees` to inspect; re-run with commit enabled to actually consolidate.
+  (`--no-commit` is a single-track-debugging mode, not a way to ship fixes.)
 - For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
   to the serial path for that track.
 
 ### 3. Present the result
 
-Report in chat and post **one** consolidated PR comment (this replaces the three
-separate per-reviewer comments): a `## Review gauntlet (parallel)` section with,
-per track, its outcome (codex consensus + rounds, lens consensus + per-finding
-table, police findings actioned); then the **consolidation ledger** — each
-cherry-picked commit and its outcome (`clean`/`reconciled`/`dropped`), with any
-overlap reconciliation explained. Then `git log --oneline <base>..HEAD` and
-`git diff --stat <base>` so the user sees the combined result. Never push or
-merge — the human reviews the per-track commits and merges.
+**The workflow already posted the PR comments** — one detailed comment per track
+(codex debate table, lens per-finding ledger, police findings) plus the
+consolidation ledger — in its **Report** phase, so the trail is on the PR no
+matter who invoked it (the `comments` field carries the URLs). Confirm they landed
+(re-post any that returned "no PR" once the PR exists). Then summarize in chat:
+the per-track outcomes, the consolidation ledger (`clean`/`reconciled`/`dropped`),
+and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the user sees
+the combined result. Never push or merge — the human reviews the per-track commits
+and merges.
 
 ## Safety & notes
 
 - **Reviewers are read-only; only their own worktree is written.** Each track's
-  fixes land in `.be-review/wt-<track>/`; the branch is touched only by the
+  fixes land in `.worktrees/be-review-<track>/`; the branch is touched only by the
   consolidation cherry-picks, which never push or merge.
+- **Isolation is structural (cwd-independent).** Workflow agents share the session
+  cwd; the orchestrator and both child workflows (`/codex-debate`, `/lens-debate`)
+  therefore use `git -C <worktree>` and absolute paths throughout, so a forgotten
+  `cd` can't make an agent edit or commit into the wrong tree.
 - **Overlap is reconciled, never silently dropped.** A cherry-pick conflict means
   two debates changed the same lines; the orchestrator merges both intents (it
   has both commit messages) and only drops a commit if an earlier track fully
@@ -154,14 +176,16 @@ merge — the human reviews the per-track commits and merges.
   residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
   change is small and correctness-critical, the serial `/codex-debate` →
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
-- **Parallel-safe.** Worktrees + scratch live under the gitignored, per-worktree
+- **Parallel-safe.** Worktrees live under the gitignored `<repoPath>/.worktrees/`
+  and commit-message + PR-comment scratch under the gitignored
   `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
-  scratch nests inside its worktree.
+  scratch nests inside its worktree. All paths are absolute and
+  per-main-worktree, so parallel `/be-review` runs never collide.
 
 ## Files
 
 - `be-review.workflow.js` — the orchestrator (worktree fan-out → parallel tracks
-  → cherry-pick consolidation → cleanup). It invokes
+  → cherry-pick consolidation → per-track PR comments → cleanup). It invokes
   `.claude/skills/{codex-debate,lens-debate}/debate.workflow.js` as child
   workflows and reads `.claude/skills/code-police/SKILL.md` at runtime.
 

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -121,6 +121,7 @@ Workflow({
   args: {
     repoPath: "<worktree root>",
     base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
+    runId: "<unique id, e.g. current epoch ms>", // isolates this run's worktrees/scratch
     rationale: "<optional author note on deliberate decisions>",
     tracks: ["codex", "lens", "police"],   // also the consolidation order
     commit: <false only if --no-commit>,
@@ -128,6 +129,12 @@ Workflow({
   }
 })
 ```
+
+**Pass a unique `runId`** (the workflow can't call `Date.now()` itself — the runtime
+forbids it to keep resume deterministic). Stamp the current epoch ms (or any unique
+token) so two `/be-review` runs in the same main worktree don't clobber each other's
+worktrees/scratch. Omitting it defaults to `'run'` — safe for a single run, unsafe
+for concurrent ones.
 
 It runs five phases the user can watch via `/workflows`: **Setup** (fan out one
 detached worktree per track under `.worktrees/`), **Tracks** (the three gauntlets

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -70,7 +70,10 @@ to `cd`.
   Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
   Setup resolves this to the **merge-base** of the branch and `base`, and *that* is
   what every reviewer diffs against — so commits `base` gained since the branch
-  forked are NOT reviewed as if this PR made them (no master-drift noise).
+  forked are NOT reviewed as if this PR made them (no master-drift noise). If the
+  merge-base can't be resolved (missing/typoed/stale base ref), Setup aborts with
+  `status: 'setup-failed'` rather than falling back to the raw `base` tip and
+  reviewing an untrustworthy scope — fix the ref (`git fetch`) and re-run.
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.
@@ -90,7 +93,10 @@ to `cd`.
 
 ### 1. Resolve context
 
-- Determine `repoPath` (the worktree root, normally the cwd).
+- Determine `repoPath` — the **absolute** worktree root (normally the cwd; resolve
+  it with `git -C . rev-parse --show-toplevel`). The orchestrator rejects a
+  relative `repoPath` with `status: 'setup-failed'`, since every git command and
+  scratch/worktree path it builds is absolute and cwd-independent.
 - `git fetch origin` so the base remote-tracking ref is current.
 - Resolve `base` (a remote-tracking ref like `origin/master`).
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
@@ -179,11 +185,22 @@ and merges.
   residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
   change is small and correctness-critical, the serial `/codex-debate` →
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
-- **Parallel-safe.** Worktrees live under the gitignored `<repoPath>/.worktrees/`
-  and commit-message + PR-comment scratch under the gitignored
-  `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
-  scratch nests inside its worktree. All paths are absolute and
-  per-main-worktree, so parallel `/be-review` runs never collide.
+- **Uncommitted track edits are never silently dropped.** Consolidation replays
+  only *committed* commits and Cleanup force-removes the worktrees, so before
+  consolidating the orchestrator mechanically checks each track's worktree with
+  `git status --short`. A track that left uncommitted/untracked edits (a failed
+  commit helper, a formatter touching an unlisted file) is **excluded from
+  consolidation and its worktree is preserved** (not torn down), and surfaced in
+  the result so the human can recover it — rather than cherry-picked-around and
+  deleted.
+- **Parallel-safe — even in the same worktree.** Worktrees live under the
+  gitignored `<repoPath>/.worktrees/` as `be-review-<runId>-<track>` and the
+  commit-message + PR-comment scratch under the gitignored
+  `<repoPath>/.be-review/<runId>/`, where `<runId>` is unique per invocation; each
+  track's own `.codex-debate/`/`.lens-debate/` scratch nests inside its worktree.
+  All paths are absolute and per-run, so two `/be-review` runs — in different
+  worktrees *or the same one* — never clobber each other's live worktrees or
+  scratch. Setup never `rm -rf`s a path that could belong to a concurrent run.
 
 ## Files
 

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -68,6 +68,9 @@ to `cd`.
 
 - **`--base <branch>`**: remote-tracking ref to diff against (e.g. `origin/master`).
   Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
+  Setup resolves this to the **merge-base** of the branch and `base`, and *that* is
+  what every reviewer diffs against — so commits `base` gained since the branch
+  forked are NOT reviewed as if this PR made them (no master-drift noise).
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -27,7 +27,9 @@ branch HEAD ┼─ be-review-lens    ─ lowy⇄hickey debate  ─→ commits �
 ```
 
 The per-track worktrees live under the repo's conventional `.worktrees/`
-(gitignored) — `.worktrees/be-review-<track>`. **Isolation is structural, not
+(gitignored) — `.worktrees/be-review-<runId>-<track>`, where `<runId>` is unique
+per invocation (the returned `worktrees` field carries each track's exact path).
+**Isolation is structural, not
 behavioral:** every workflow agent inherits the *session* cwd (the harness has no
 per-agent cwd, and `isolation:'worktree'` can't host a multi-round debate that
 accumulates commits in one tree), so every git command is `git -C <worktree>` and
@@ -81,9 +83,10 @@ to `cd`.
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
   with this flag the orchestrator **skips Consolidate + Report + Cleanup and
   preserves the worktrees** (status `no-commit`) — leaving every track's worktree
-  in place under `.worktrees/be-review-<track>/` (the branch is untouched) rather
-  than silently discarding the uncommitted edits; inspect and tear them down
-  yourself. Default is to commit, which is what actually ships fixes.
+  in place under `.worktrees/be-review-<runId>-<track>/` (the branch is untouched;
+  the returned `worktrees` field carries each exact path) rather than silently
+  discarding the uncommitted edits; inspect and tear them down yourself. Default is
+  to commit, which is what actually ships fixes.
 - **`--no-comment`**: suppress the PR comments. By default the **Report** phase
   posts a detailed PR comment per track (codex debate table, lens per-finding
   ledger, police findings) plus the consolidation ledger — the review trail the
@@ -147,9 +150,10 @@ returns:
   and re-run) or no worktree could be created. `tracks` carries the per-track
   `track-error` detail.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
-  **uncommitted in its preserved `.worktrees/be-review-<track>` worktree** and
-  nothing is consolidated, reported, or cleaned up. The result lists those
-  `worktrees` to inspect; re-run with commit enabled to actually consolidate.
+  **uncommitted in its preserved `.worktrees/be-review-<runId>-<track>` worktree**
+  and nothing is consolidated, reported, or cleaned up. The result lists those
+  `worktrees` (with exact paths) to inspect; re-run with commit enabled to
+  actually consolidate.
   (`--no-commit` is a single-track-debugging mode, not a way to ship fixes.)
 - For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
   to the serial path for that track.
@@ -169,8 +173,8 @@ and merges.
 ## Safety & notes
 
 - **Reviewers are read-only; only their own worktree is written.** Each track's
-  fixes land in `.worktrees/be-review-<track>/`; the branch is touched only by the
-  consolidation cherry-picks, which never push or merge.
+  fixes land in `.worktrees/be-review-<runId>-<track>/`; the branch is touched only
+  by the consolidation cherry-picks, which never push or merge.
 - **Isolation is structural (cwd-independent).** Workflow agents share the session
   cwd; the orchestrator and both child workflows (`/codex-debate`, `/lens-debate`)
   therefore use `git -C <worktree>` and absolute paths throughout, so a forgotten
@@ -187,11 +191,15 @@ and merges.
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
 - **Uncommitted track edits are never silently dropped.** Consolidation replays
   only *committed* commits and Cleanup force-removes the worktrees, so before
-  consolidating the orchestrator mechanically checks each track's worktree with
-  `git status --short`. A track that left uncommitted/untracked edits (a failed
-  commit helper, a formatter touching an unlisted file) is **excluded from
-  consolidation and its worktree is preserved** (not torn down), and surfaced in
-  the result so the human can recover it — rather than cherry-picked-around and
+  consolidating the orchestrator mechanically checks **every live worktree** with
+  `git status --short` — including a track whose gauntlet *crashed*
+  (`track-error`), since a crash after edits-applied-but-before-commit is exactly
+  when uncommitted work is most likely. Cleanup **fails closed**: only a worktree
+  the checker reports *explicitly clean* is torn down; one that left
+  uncommitted/untracked edits (a failed commit helper, a formatter touching an
+  unlisted file, a mid-run crash) — or that the checker never reported on — is
+  **excluded from consolidation and its worktree is preserved**, and surfaced in
+  the result so the human can recover it, rather than cherry-picked-around and
   deleted.
 - **Parallel-safe — even in the same worktree.** Worktrees live under the
   gitignored `<repoPath>/.worktrees/` as `be-review-<runId>-<track>` and the

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -74,10 +74,13 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the worktree name and the scratch subdir so two /be-review runs in the SAME
 // main worktree never clobber each other's live worktrees or scratch files (the
 // old fixed `be-review-<track>` / `.be-review/*` paths let a second run `rm -rf`
-// the first run's in-flight worktree). The id is the start-time epoch ms — unique
-// per invocation, and the actual paths are reported back in the result so manual
-// inspection doesn't need to guess them.
-const RUN_ID = String(Date.now())
+// the first run's in-flight worktree). The id comes from `args.runId`: the
+// workflow runtime forbids `Date.now()`/`Math.random()` (they'd break resume), so
+// the CALLER stamps a unique value (the /be-review skill passes the launch epoch
+// ms). Defaults to 'run' when absent — fine for a single run; CONCURRENT runs in
+// the same main worktree must pass distinct ids. The actual paths are reported in
+// the result so manual inspection doesn't need to guess them.
+const RUN_ID = String(a.runId || 'run')
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -542,14 +542,18 @@ phase('Consolidate')
 // worktree — so any edit a track left UNcommitted (an apply agent that produced
 // files but whose commit helper failed, a formatter that touched an unlisted
 // file, an untracked new file) would be invisible to cherry-pick and then deleted
-// for good. Mechanically check each candidate track's worktree is clean; a dirty
-// one is excluded from both consolidation AND cleanup (its worktree is preserved
-// for the human) and surfaced in the result, instead of silently discarded.
-const consolidateCandidates = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const cleanCheck = consolidateCandidates.length
+// for good. The check runs for EVERY live worktree — including a track whose
+// gauntlet CRASHED (`track-error`): a crash after edits-applied-but-before-commit
+// is exactly when uncommitted work is most likely, so skipping crashed tracks
+// here would force-remove the very edits this gate exists to save. We only USE the
+// clean result to decide consolidation eligibility (a `track-error` track is never
+// cherry-picked regardless); for cleanup we FAIL CLOSED — any worktree that isn't
+// EXPLICITLY clean (dirty, or missing from the checker's response) is preserved,
+// never torn down. A dirty/unknown track is surfaced in the result for the human.
+const cleanCheck = liveTracks.length
   ? await agent(
-      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Do not edit anything. Tracks and their worktrees:
-${consolidateCandidates.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
+${liveTracks.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
 For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
       {
         label: 'consolidate:clean-check',
@@ -578,21 +582,31 @@ For each track return { track, clean (boolean), dirtyStatus (the offending \`sta
       },
     )
   : { tracks: [] }
-const dirtyTracks = consolidateCandidates.filter((t) => (cleanCheck?.tracks || []).find((c) => c.track === t && c.clean === false))
-for (const t of dirtyTracks) {
-  const ds = (cleanCheck?.tracks || []).find((c) => c.track === t)?.dirtyStatus || ''
+// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless the
+// checker EXPLICITLY reported it clean. So a missing row, or a row that says it's
+// dirty, both keep the worktree. `cleanTracks` is the allowlist of explicitly-clean
+// worktrees; everything else is preserved.
+const cleanResultFor = (t) => (cleanCheck?.tracks || []).find((c) => c.track === t)
+const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
+const preservedTracks = liveTracks.filter((t) => !cleanTracks.includes(t))
+for (const t of preservedTracks) {
+  const row = cleanResultFor(t)
+  const ds = row?.dirtyStatus || ''
+  const reason = row ? 'left UNcommitted changes in its worktree' : "could not be confirmed clean (no clean-check result — failing closed)"
   tracks[t] = {
     ...tracks[t],
     consolidated: false,
     dirtyStatus: ds,
-    note: `track left UNcommitted changes in its worktree (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so the edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
   }
-  log(`Consolidate: track ${t} has UNcommitted changes — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
+  log(`Consolidate: track ${t} not confirmed clean — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
 }
 
-// Only replay tracks that are clean (every agreed fix really is a commit) and made
-// real work — the agent only picks committed work.
-const consolidateOrder = consolidateCandidates.filter((t) => !dirtyTracks.includes(t))
+// Only replay tracks that are explicitly clean (every agreed fix really is a
+// commit) AND completed without crashing — a `track-error` track is never
+// cherry-picked even if its worktree happens to be clean, since its commit ledger
+// is untrustworthy. The agent only picks committed work.
+const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
@@ -651,14 +665,16 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees. Dirty tracks (uncommitted edits
-// the clean-check caught) are PRESERVED, not removed — their worktree is the only
-// place those edits live, so force-removing it would discard them.
+// Phase 5 — tear down the per-track worktrees. Only EXPLICITLY-clean worktrees are
+// torn down; anything not confirmed clean (uncommitted edits the clean-check
+// caught, OR a worktree the checker never reported on — including a crashed
+// `track-error` track) is PRESERVED, since its worktree may be the only place
+// those edits live and force-removing it would discard them. Fail closed.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-const teardownTracks = liveTracks.filter((t) => !dirtyTracks.includes(t))
-if (dirtyTracks.length) log(`Cleanup: preserving ${dirtyTracks.length} dirty worktree(s) (${dirtyTracks.join(', ')}) — they hold uncommitted edits.`)
+const teardownTracks = cleanTracks
+if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not confirmed clean (${preservedTracks.join(', ')}) — they may hold uncommitted edits.`)
 if (teardownTracks.length) {
   await agent(
     `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -362,7 +362,7 @@ phase('Consolidate')
 
 // Skip tracks that errored or made no commits — the agent only picks real work.
 const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Three review tracks each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -582,31 +582,47 @@ For each track return { track, clean (boolean), dirtyStatus (the offending \`sta
       },
     )
   : { tracks: [] }
-// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless the
-// checker EXPLICITLY reported it clean. So a missing row, or a row that says it's
-// dirty, both keep the worktree. `cleanTracks` is the allowlist of explicitly-clean
-// worktrees; everything else is preserved.
+// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless it is
+// safe to discard. A worktree is safe to discard ONLY if it was both (a) EXPLICITLY
+// reported clean by the checker AND (b) successfully replayed onto the branch — i.e.
+// it ends up in `consolidateOrder`. Everything else is preserved:
+//   - a missing clean-check row, or a row that says it's dirty → may hold UNcommitted
+//     edits (fail closed on the checker);
+//   - a `track-error` track, even one that `git status` calls clean → may hold
+//     COMMITTED-but-unreplayed work, since `consolidateOrder` deliberately excludes
+//     it (its commit ledger is untrustworthy, so the consolidator never cherry-picks
+//     it). Removing its detached worktree would make those commits unreachable.
+// `cleanTracks` is the allowlist of explicitly-clean worktrees; `consolidateOrder`
+// narrows that to the ones we actually replayed; teardown only touches the latter.
 const cleanResultFor = (t) => (cleanCheck?.tracks || []).find((c) => c.track === t)
 const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
-const preservedTracks = liveTracks.filter((t) => !cleanTracks.includes(t))
-for (const t of preservedTracks) {
-  const row = cleanResultFor(t)
-  const ds = row?.dirtyStatus || ''
-  const reason = row ? 'left UNcommitted changes in its worktree' : "could not be confirmed clean (no clean-check result — failing closed)"
-  tracks[t] = {
-    ...tracks[t],
-    consolidated: false,
-    dirtyStatus: ds,
-    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
-  }
-  log(`Consolidate: track ${t} not confirmed clean — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
-}
 
 // Only replay tracks that are explicitly clean (every agreed fix really is a
 // commit) AND completed without crashing — a `track-error` track is never
 // cherry-picked even if its worktree happens to be clean, since its commit ledger
 // is untrustworthy. The agent only picks committed work.
 const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
+
+// Preserve every live track we did NOT consolidate, so neither uncommitted edits
+// nor committed-but-unreplayed commits are lost.
+const preservedTracks = liveTracks.filter((t) => !consolidateOrder.includes(t))
+for (const t of preservedTracks) {
+  const row = cleanResultFor(t)
+  const ds = row?.dirtyStatus || ''
+  const reason =
+    tracks[t]?.status === 'track-error'
+      ? 'CRASHED (track-error) so its commit ledger is untrustworthy and it was never replayed — its worktree may hold committed-but-unconsolidated fixes'
+      : row
+        ? 'left UNcommitted changes in its worktree'
+        : 'could not be confirmed clean (no clean-check result — failing closed)'
+  tracks[t] = {
+    ...tracks[t],
+    consolidated: false,
+    dirtyStatus: ds,
+    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} log ${branchHead}..HEAD\` and \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+  }
+  log(`Consolidate: track ${t} not consolidated — worktree preserved at ${wtDir(t)}.`)
+}
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
@@ -665,16 +681,18 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees. Only EXPLICITLY-clean worktrees are
-// torn down; anything not confirmed clean (uncommitted edits the clean-check
-// caught, OR a worktree the checker never reported on — including a crashed
-// `track-error` track) is PRESERVED, since its worktree may be the only place
-// those edits live and force-removing it would discard them. Fail closed.
+// Phase 5 — tear down the per-track worktrees. Only worktrees we actually
+// CONSOLIDATED (explicitly clean AND replayed onto the branch — i.e.
+// `consolidateOrder`) are torn down. Everything else is PRESERVED, since its
+// worktree may be the only place its edits live and force-removing it would
+// discard them: uncommitted edits the clean-check caught, a worktree the checker
+// never reported on, OR a crashed `track-error` track whose committed-but-
+// unreplayed fixes were deliberately excluded from consolidation. Fail closed.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-const teardownTracks = cleanTracks
-if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not confirmed clean (${preservedTracks.join(', ')}) — they may hold uncommitted edits.`)
+const teardownTracks = consolidateOrder
+if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not consolidated (${preservedTracks.join(', ')}) — they may hold uncommitted or unreplayed committed edits.`)
 if (teardownTracks.length) {
   await agent(
     `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
@@ -683,7 +701,7 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
     { label: 'cleanup:worktrees', phase: 'Cleanup', model },
   )
 } else {
-  log('Cleanup: no clean worktrees to tear down (all preserved or none live).')
+  log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
 return {

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -207,10 +207,11 @@ if (setup?.cleanTree === false) {
 // a dropped reviewer is a STRUCTURED signal the caller (/be §4 falls back per
 // track) — not just a log line that silently shrinks the set while status='done'.
 const tracks = {}
-const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
+const wts = setup?.worktrees ?? []
+const liveTracks = TRACKS.filter((t) => wts.find((w) => w.track === t && w.ok))
 const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
 for (const t of failedTracks) {
-  const note = (setup?.worktrees || []).find((w) => w.track === t)?.note || 'worktree creation failed'
+  const note = wts.find((w) => w.track === t)?.note || 'worktree creation failed'
   tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
 }
 if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -120,6 +120,13 @@ if (!/^[A-Za-z0-9._-]+$/.test(RUN_ID) || RUN_ID === '..' || RUN_ID === '.') {
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
+// The two gitignored scratch dirs this orchestrator owns: live per-track
+// worktrees under `.worktrees/` and commit-message/PR-comment scratch under
+// `.be-review/`. Two prompts must name them in lockstep — the DIFF brief tells
+// reviewers to ignore them, and the Setup preflight excludes them from the
+// clean-tree check — so the list lives here once and both interpolate it.
+const ORCHESTRATOR_SCRATCH = ['.worktrees/', '.be-review/']
+const scratchList = ORCHESTRATOR_SCRATCH.map((d) => `\`${d}\``).join(' and ')
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -130,7 +137,7 @@ const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 // not the raw `${base}` tip — see SETUP_SCHEMA.mergeBase. DIFF is an arrow, so it
 // reads `mergeBase` lazily at call time (Tracks phase, after Setup has set it).
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored ${scratchList} scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
@@ -255,7 +262,7 @@ const setupPrompt = `${mechanicalPreamble('SETUP RUNNER')} You are preparing iso
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
 1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command FAILS (missing/typoed base, stale ref, or unrelated history), the review scope is untrustworthy — do NOT fall back to the raw \`${base}\`; instead set \`mergeBase\`: "" and put the exact git error in \`mergeBaseError\`, then STOP (skip worktree creation, return an empty \`worktrees\` array). (The orchestrator aborts the whole run when \`mergeBase\` is empty.)
-2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (${scratchList}). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — create a fresh detached worktree at \`branchHead\` for each track, at these EXACT absolute paths (per-run unique, so they cannot belong to another in-flight run):
 ${TRACKS.map((t) => `   - ${t}: \`git -C ${repoPath} worktree add --detach ${wtDir(t)} <branchHead>\``).join('\n')}

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -5,11 +5,12 @@
 export const meta = {
   name: 'be-review',
   description:
-    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile)',
+    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile) and post a detailed PR comment per track',
   phases: [
     { title: 'Setup', detail: 'fan out one detached worktree per review track off the branch HEAD', model: 'opus' },
     { title: 'Tracks', detail: 'codex, lens, and police gauntlets each run to consensus, concurrently and isolated', model: 'opus' },
     { title: 'Consolidate', detail: 'cherry-pick each track’s commits onto the branch in order; reconcile the rare overlap', model: 'opus' },
+    { title: 'Report', detail: 'post a detailed PR comment for each track plus the consolidation ledger', model: 'opus' },
     { title: 'Cleanup', detail: 'tear down the per-track worktrees', model: 'opus' },
   ],
 }
@@ -33,17 +34,28 @@ const rationale = (a.rationale || '').trim()
 // per-track commits are what consolidation cherry-picks, so leaving it on is the
 // norm. (`--no-commit` is for debugging a single track in isolation.)
 const commit = a.commit !== false
+// Post a detailed PR comment per track + the consolidation ledger (default on).
+// `--no-comment` (comment:false) suppresses the outward-facing write.
+const postComments = a.comment !== false
 const model = a.model || MODEL
 // The review tracks to run AND the order they consolidate in. codex first (it
 // changes the most — bug fixes), then the structural lenses, then police, so an
 // overlap surfaces as a conflict picking the later, lighter-touch track.
 const TRACKS = a.tracks || ['codex', 'lens', 'police']
 
-// Per-track worktrees + commit-message scratch live here. Gitignored (`.be-review/`),
-// so they never pollute the diff the reviewers inspect, and a track's own
-// `.codex-debate/`/`.lens-debate/` scratch nests harmlessly inside its worktree.
-const workRoot = `${repoPath}/.be-review`
-const wtPath = (track) => `${workRoot}/wt-${track}`
+// SHARED-CWD NOTE. Every workflow agent inherits the SESSION cwd (the main
+// worktree) — the harness offers no per-agent cwd, and `isolation:'worktree'`
+// can't host a multi-round debate (each agent would get a fresh tree and lose
+// the prior round's commits). So isolation here is STRUCTURAL, not behavioral:
+// every path below is ABSOLUTE and every git command is `git -C <worktree>`, so
+// the shared cwd is irrelevant — no agent can leak into the wrong tree by
+// forgetting to `cd`. The per-track worktrees live under the repo's conventional
+// `.worktrees/` (gitignored); commit-message + PR-comment scratch lives under
+// the gitignored `.be-review/`. Both are absolute and per-main-worktree, so
+// parallel /be-review runs in different worktrees never collide.
+const WT_ROOT = `${repoPath}/.worktrees`
+const wtDir = (track) => `${WT_ROOT}/be-review-${track}`
+const SCRATCH = `${repoPath}/.be-review`
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -51,7 +63,7 @@ const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
 const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore any \`.be-review/\`, \`.codex-debate/\`, or \`.lens-debate/\` scratch dirs.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
@@ -68,7 +80,7 @@ const SETUP_SCHEMA = {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
     cleanTree: {
       type: 'boolean',
-      description: 'true iff the main worktree had NO uncommitted changes (outside .be-review/) when checked',
+      description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
     },
     dirtyStatus: {
       type: 'string',
@@ -158,18 +170,18 @@ const CONSOLIDATE_SCHEMA = {
 // ---------------------------------------------------------------------------
 phase('Setup')
 
-const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
+const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under \`.be-review/\` (the gitignored scratch root). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
-3. Only if \`cleanTree\` is true — ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
-   - Path: \`${workRoot}/wt-<track>\`.
-   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
-   - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
+   - Path: \`${WT_ROOT}/be-review-<track>\` (absolute).
+   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if it's not registered), then \`rm -rf ${WT_ROOT}/be-review-<track>\`.
+   - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
@@ -187,7 +199,7 @@ if (setup?.cleanTree === false) {
     base,
     tracks: {},
     consolidation: null,
-    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside .be-review/) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside the scratch dirs) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
   }
 }
 
@@ -226,8 +238,8 @@ async function policeTrack(wt) {
   // Pass *definitions* are single-sourced to code-police's SKILL.md: each brief
   // names that pass's section so the agent (which Reads the skill below) reviews
   // it exactly as written there — no inline checklist to drift. The elegance pass
-  // is gated on the tiny-diff heuristic the skill mandates (SKILL.md:141 — skip
-  // when the worktree diff against base is <10 lines).
+  // is gated on the tiny-diff heuristic the skill mandates (skip when the worktree
+  // diff against base is <10 lines).
   const tinyDiff = await agent(
     `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
     { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
@@ -241,7 +253,7 @@ async function policeTrack(wt) {
   const reviews = await parallel(
     passes.map((p) => () =>
       agent(
-        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`.claude/skills/code-police/SKILL.md\` (and \`.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
         { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
       ),
     ),
@@ -251,11 +263,11 @@ async function policeTrack(wt) {
   log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
   // Apply each finding as its own commit, sequentially (same-file edits can't be
-  // parallel-applied). Mechanical committer stages only the touched files.
+  // parallel-applied). Every edit and git command targets the absolute worktree.
   const applied = []
   for (const f of findings) {
     const impl = await agent(
-      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change in the working tree. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`,
+      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
       { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
     )
     const files = impl?.filesChanged ?? []
@@ -263,23 +275,25 @@ async function policeTrack(wt) {
     if (commit && files.length) {
       sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
     }
-    applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
+    applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
   }
   return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
-// files in worktree `wt` and commits with the given message. The workflow can't
-// run git itself, so a thin agent does. (codex/lens commit via their own
-// workflows.)
+// files in worktree `wt` and commits with the given message — all via `git -C`
+// so it never depends on the shell cwd. The workflow can't run git itself, so a
+// thin agent does. (codex/lens commit via their own workflows.)
 async function commitFix(wt, id, subject, body, files) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workRoot}/commit-msg-${id}.txt`
+  // Files may arrive as absolute worktree paths; git -C wants them relative to wt.
+  const rel = files.map((f) => f.replace(`${wt}/`, '').replace(/^\/+/, ''))
+  const fileArgs = rel.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
+  const msgPath = `${SCRATCH}/commit-msg-${id}.txt`
   const message = `${subject}\n\n${body}`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
+  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files. Every path is absolute / \`git -C\`; do not rely on the current directory.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workRoot}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
 
 ${message}
@@ -300,20 +314,21 @@ ${message}
 
 // One thunk per live track. codex and lens are existing repoPath-parameterized
 // workflows (built to run in separate worktrees), invoked as child workflows —
-// one level of nesting, which the runtime allows. police is inline (it's a
-// skill, not a workflow). Each thunk catches so one track's failure can't sink
-// the rest — consolidation just picks up whatever each track committed.
+// one level of nesting, which the runtime allows. They get the ABSOLUTE worktree
+// path as repoPath. police is inline (it's a skill, not a workflow). Each thunk
+// catches so one track's failure can't sink the rest — consolidation just picks
+// up whatever each track committed.
 const trackThunk = {
   codex: () =>
-    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtPath('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base, skillDir: CODEX_SKILLDIR, commit })
       .then((r) => ({ track: 'codex', ...r }))
       .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
   lens: () =>
-    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtPath('lens'), base, rationale, model, commit })
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base, rationale, model, commit })
       .then((r) => ({ track: 'lens', ...r }))
       .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
   police: () =>
-    policeTrack(wtPath('police'))
+    policeTrack(wtDir('police'))
       .then((r) => ({ track: 'police', ...r }))
       .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
 }
@@ -324,14 +339,104 @@ const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
 liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
 for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
+// ---------------------------------------------------------------------------
+// PR-comment builders + poster (used by the Report phase). Bodies are built
+// deterministically in JS from the structured track results; a thin mechanical
+// agent just writes each body to a scratch file and posts it with `gh pr comment`.
+// ---------------------------------------------------------------------------
+const sha9 = (s) => (s ? `\`${String(s).slice(0, 9)}\`` : '—')
+const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').trim()
+
+function codexComment(t) {
+  if (!t || t.status === 'track-error') return `## 🤖 Codex ⇄ Claude debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const rows = (t.transcript || [])
+    .map((r) => {
+      const v = r.codex || {}
+      const openBM = (v.findings || []).filter((f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major')).length
+      const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
+      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${openBM} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
+    })
+    .join('\n')
+  return `## 🤖 Codex ⇄ Claude debate
+
+**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
+
+${esc(t.finalVerdict?.summary)}
+
+| Round | codex approved | open blk/maj | claude dispositions | commit |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}`
+}
+
+function lensComment(t) {
+  if (!t || t.status === 'track-error') return `## ⚖️ Lowy ⇄ Hickey lens debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const appliedFor = (id) => (t.applied || []).find((x) => x.id === id)?.commit
+  const rows = (t.settled || [])
+    .map((s) => `| ${esc(s.origin)} | ${esc(s.title)} | ${esc(s.location)} | ${esc(s.disposition)} | ${s.disposition === 'fix' ? sha9(appliedFor(s.id)) : '—'} |`)
+    .join('\n')
+  const un = (t.unresolved || []).length
+    ? `\n\n**⚠️ ${t.unresolved.length} unresolved finding(s)** — needs a human:\n` + t.unresolved.map((u) => `- ${esc(u.title)} (${esc(u.location)})`).join('\n')
+    : ''
+  return `## ⚖️ Lowy ⇄ Hickey lens debate
+
+**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.
+
+| origin | finding | location | disposition | commit |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}${un}`
+}
+
+function policeComment(t) {
+  if (!t || t.status === 'track-error') return `## 👮 Code-police\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const rows = (t.applied || [])
+    .map((x) => `| ${esc(x.severity)} | ${esc(x.title)} | ${esc((x.files || []).join(', '))} | ${sha9(x.commit)} |`)
+    .join('\n')
+  return `## 👮 Code-police
+
+**${t.findings || 0} finding(s)** across the rules / fact-check / elegance passes${t.status === 'clean' ? ' — clean diff' : ''}.
+
+| severity | finding | files | commit |
+|---|---|---|---|
+${rows || '| — | — | — | — |'}`
+}
+
+function consolidationSection(c, order) {
+  const rows = (c?.picks || [])
+    .map((p) => `| ${esc(p.track)} | ${sha9(p.sourceCommit)} | \`${esc(p.outcome)}\` | ${sha9(p.newCommit)} | ${esc(p.note) || ''} |`)
+    .join('\n')
+  return `### Consolidation onto the branch (order: ${order.join(' → ')})
+
+| track | source | outcome | new commit | note |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}`
+}
+
+// Post one comment via a mechanical agent. Resolves the PR from the branch in the
+// MAIN worktree (gh uses cwd's repo; the agent runs `gh -C`-equivalent by cd-ing).
+async function postComment(slug, body) {
+  const file = `${SCRATCH}/comment-${slug}.md`
+  const prompt = `You are a MECHANICAL PR COMMENTER. Do exactly these steps and nothing else.
+
+1. \`mkdir -p ${SCRATCH}\`.
+2. Using the Write tool, create \`${file}\` with EXACTLY this markdown content:
+
+${body}
+
+3. Post it to THIS branch's PR: \`cd ${repoPath} && gh pr comment --body-file ${file}\`. (\`gh\` resolves the PR from the current branch.) If there is NO open PR for the branch, do nothing and report "no PR".
+4. Return the comment URL gh prints, or "no PR".`
+  return agent(prompt, { label: `comment:${slug}`, phase: 'Report', model })
+}
+
+// ---------------------------------------------------------------------------
 // `--no-commit` short-circuit. With commit=false the tracks deliberately leave
 // their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
 // (rev-list ${branchHead}..HEAD) and cleanup's `worktree remove --force` tears the
 // worktrees down — so running them now would silently discard every reviewer's edits.
 // Instead, stop here and hand the live worktrees to the user to inspect; nothing is
 // consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
+// ---------------------------------------------------------------------------
 if (!commit) {
-  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${WT_ROOT}/be-review-<track> diff\`).`)
   return {
     status: 'no-commit',
     branchHead,
@@ -341,8 +446,8 @@ if (!commit) {
     tracks,
     consolidation: null,
     conflicts: [],
-    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.be-review/wt-<track>` and re-run with commit enabled to consolidate.',
-    worktrees: liveTracks.map((t) => ({ track: t, path: wtPath(t) })),
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.worktrees/be-review-<track>` and re-run with commit enabled to consolidate.',
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
 
@@ -356,19 +461,19 @@ phase('Consolidate')
 
 // Skip tracks that errored or made no commits — the agent only picks real work.
 const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
-For each track, its worktree is \`${workRoot}/wt-<track>\`. Get that track's new commits oldest-first:
-  \`git -C ${workRoot}/wt-<track> rev-list --reverse ${branchHead}..HEAD\`
+For each track, its worktree is \`${WT_ROOT}/be-review-<track>\`. Get that track's new commits oldest-first:
+  \`git -C ${WT_ROOT}/be-review-<track> rev-list --reverse ${branchHead}..HEAD\`
 (An empty list means the track found nothing to change — skip it.)
 
-Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits onto the branch IN THAT ORDER:
+Then cherry-pick each of those commits onto the branch IN THAT ORDER:
   \`git -C ${repoPath} cherry-pick <sha>\`
 
 - **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
-- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides (ABSOLUTE paths under \`${repoPath}\`) and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
 
 Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
@@ -377,12 +482,37 @@ const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clea
 log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------
-// Phase 4 — tear down the per-track worktrees
+// Phase 4 — post a detailed PR comment for EVERY track + the consolidation
+// ledger. This is the review trail the whole gauntlet exists to leave; it runs
+// here (not in the caller) so it ALWAYS happens. `--no-comment` suppresses it.
+// ---------------------------------------------------------------------------
+phase('Report')
+
+const comments = {}
+if (postComments) {
+  const ledger = consolidationSection(consolidation, consolidateOrder)
+  const bodies = [
+    ['codex', `${codexComment(tracks.codex)}\n\n${ledger}`],
+    ['lens', lensComment(tracks.lens)],
+    ['police', policeComment(tracks.police)],
+  ].filter(([t]) => tracks[t])
+  // Post sequentially so the comments land in a stable order (codex, lens, police).
+  for (const [slug, body] of bodies) {
+    const url = await postComment(slug, body)
+    comments[slug] = (url || '').trim()
+    log(`Report: posted ${slug} comment${comments[slug] ? ` → ${comments[slug]}` : ''}`)
+  }
+} else {
+  log('Report: --no-comment — skipping PR comments.')
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5 — tear down the per-track worktrees
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
 await agent(
-  `You are a MECHANICAL CLEANUP RUNNER. From \`${repoPath}\`, for each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${workRoot}\` directory itself (it holds commit-message scratch); do not delete the branch's commits. Return "done".`,
+  `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. For each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
   { label: 'cleanup:worktrees', phase: 'Cleanup', model },
 )
 
@@ -395,4 +525,5 @@ return {
   tracks,
   consolidation,
   conflicts,
+  comments,
 }

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -127,6 +127,11 @@ const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
 // clean-tree check — so the list lives here once and both interpolate it.
 const ORCHESTRATOR_SCRATCH = ['.worktrees/', '.be-review/']
 const scratchList = ORCHESTRATOR_SCRATCH.map((d) => `\`${d}\``).join(' and ')
+// The per-track debate scratch dirs the child workflows own (codex/lens write
+// their transcripts here). The consolidation clean-check must ignore these when
+// judging whether a track left uncommitted work, so the list lives here once.
+const TRACK_SCRATCH = ['.codex-debate/', '.lens-debate/']
+const trackScratchList = TRACK_SCRATCH.map((d) => `\`${d}\``).join(', ')
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -728,7 +733,7 @@ if (branchMoved || branchDirty) {
 // never torn down. A dirty/unknown track is surfaced in the result for the human.
 const cleanCheck = liveTracks.length
   ? await agent(
-      `${mechanicalPreamble('CLEANLINESS CHECKER')} For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
+      `${mechanicalPreamble('CLEANLINESS CHECKER')} For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (${trackScratchList}); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
 ${liveTracks.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
 For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
       {

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -63,9 +63,17 @@ const rationaleBlock = rationale
 const SETUP_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['branchHead', 'worktrees'],
+  required: ['branchHead', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    cleanTree: {
+      type: 'boolean',
+      description: 'true iff the main worktree had NO uncommitted changes (outside .be-review/) when checked',
+    },
+    dirtyStatus: {
+      type: 'string',
+      description: 'the offending `git status --short` lines when cleanTree is false; empty otherwise',
+    },
     worktrees: {
       type: 'array',
       description: 'one entry per track worktree created',
@@ -168,24 +176,51 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-2. Ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
-3. For EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under \`.be-review/\` (the gitignored scratch root). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+3. Only if \`cleanTree\` is true — ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
    - Path: \`${workRoot}/wt-<track>\`.
    - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
    - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
-4. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
+5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\` and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
+
+// Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
+// worktree would be invisible to every reviewer — a /be-review run could then
+// approve an INCOMPLETE change set. Bail loudly instead (the caller commits or
+// stashes, then re-runs) rather than silently reviewing a subset.
+if (setup?.cleanTree === false) {
+  const dirty = (setup?.dirtyStatus || '').trim()
+  log(`Setup: ABORT — the main worktree at ${repoPath} has uncommitted changes; tracks fork from HEAD and would not see them.`)
+  return {
+    status: 'setup-failed',
+    branchHead,
+    base,
+    tracks: {},
+    consolidation: null,
+    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside .be-review/) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+  }
+}
+
+// Seed every requested track with an explicit `track-error` for setup failures, so
+// a dropped reviewer is a STRUCTURED signal the caller (/be §4 falls back per
+// track) — not just a log line that silently shrinks the set while status='done'.
+const tracks = {}
 const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
 const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
-if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — those tracks are skipped.`)
+for (const t of failedTracks) {
+  const note = (setup?.worktrees || []).find((w) => w.track === t)?.note || 'worktree creation failed'
+  tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
+}
+if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
 log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
 
 if (!branchHead || liveTracks.length === 0) {
-  return { status: 'setup-failed', branchHead, base, tracks: {}, consolidation: null, note: 'no track worktrees could be created' }
+  return { status: 'setup-failed', branchHead, base, tracks, consolidation: null, note: 'no track worktrees could be created' }
 }
 
 // ---------------------------------------------------------------------------
@@ -278,9 +313,32 @@ const trackThunk = {
 }
 
 const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
-const tracks = {}
+// `tracks` already carries a `track-error` entry for every setup failure; the live
+// tracks fill in alongside them, so the returned map covers EVERY requested track.
 liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
 for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+
+// `--no-commit` short-circuit. With commit=false the tracks deliberately leave
+// their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
+// (rev-list ${branchHead}..HEAD) and cleanup tears the worktrees down — so running
+// them now would discard every reviewer's edits. Instead, stop here and hand the
+// live worktrees to the user to inspect; nothing is consolidated and nothing is
+// cleaned up. (This is the documented single-track-debugging mode.)
+if (!commit) {
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
+  return {
+    status: 'no-commit',
+    branchHead,
+    finalHead: branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    conflicts: [],
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.be-review/wt-<track>` and re-run with commit enabled to consolidate.',
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtPath(t) })),
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Phase 3 — consolidate: cherry-pick each track's commits onto the branch in

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -533,6 +533,8 @@ if (!commit) {
     order: [],
     tracks,
     consolidation: null,
+    reconciled: [],
+    dropped: [],
     conflicts: [],
     note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
@@ -652,8 +654,10 @@ Then cherry-pick each of those commits onto the branch IN THAT ORDER:
 Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
 const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
-const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clean')
-log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
+const picks = consolidation?.picks ?? []
+const reconciled = picks.filter((p) => p.outcome === 'reconciled')
+const dropped = picks.filter((p) => p.outcome === 'dropped')
+log(`Consolidate: ${picks.length} commit(s) replayed, ${reconciled.length} reconciled, ${dropped.length} dropped. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------
 // Phase 4 — post a detailed PR comment for EVERY track + the consolidation
@@ -722,6 +726,10 @@ return {
   order: consolidateOrder,
   tracks,
   consolidation,
-  conflicts,
+  reconciled,
+  dropped,
+  // back-compat: the union of non-clean picks. Consumers keying on a discarded
+  // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
+  conflicts: [...reconciled, ...dropped],
   comments,
 }

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -388,11 +388,21 @@ const trackThunk = {
       .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
 }
 
-const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
-// `tracks` already carries a `track-error` entry for every setup failure; the live
-// tracks fill in alongside them, so the returned map covers EVERY requested track.
-liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
-for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+// A live track with no registered thunk (an unknown/typo'd TRACKS entry whose
+// worktree Setup still built) would make `parallel` invoke `undefined()`. Seed it
+// as a track-error — same shape as a setup failure — and drop it from dispatch so
+// the parallel call stays total.
+const dispatchable = liveTracks.filter((t) => trackThunk[t])
+for (const t of liveTracks.filter((t) => !trackThunk[t])) {
+  tracks[t] = { track: t, status: 'track-error', error: 'unknown track: no thunk registered' }
+  log(`Track ${t}: no thunk registered — recorded as track-error and excluded from dispatch.`)
+}
+const trackResults = await parallel(dispatchable.map((t) => trackThunk[t]))
+// `tracks` already carries a `track-error` entry for every setup failure (and any
+// unknown track above); the dispatchable tracks fill in alongside them, so the
+// returned map covers EVERY requested track.
+dispatchable.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
+for (const t of dispatchable) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
 // ---------------------------------------------------------------------------
 // PR-comment builders + poster (used by the Report phase). Bodies are built

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -130,7 +130,7 @@ const IMPL_SCHEMA = {
 const CONSOLIDATE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['picks', 'conflicts'],
+  required: ['picks'],
   properties: {
     finalHead: { type: 'string', description: 'branch HEAD SHA after all picks' },
     picks: {
@@ -145,23 +145,8 @@ const CONSOLIDATE_SCHEMA = {
           sourceCommit: { type: 'string', description: 'the short SHA from the track worktree' },
           newCommit: { type: 'string', description: 'the resulting SHA on the branch' },
           outcome: { type: 'string', enum: ['clean', 'reconciled', 'dropped'] },
+          files: { type: 'array', items: { type: 'string' }, description: 'for reconciled/dropped: the overlapping files' },
           note: { type: 'string', description: 'for reconciled/dropped: how you resolved it and why' },
-        },
-      },
-    },
-    conflicts: {
-      type: 'array',
-      description: 'the overlaps you had to reconcile (subset of picks); empty in the common no-overlap case',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        required: ['track', 'sourceCommit', 'files', 'resolution'],
-        properties: {
-          track: { type: 'string' },
-          sourceCommit: { type: 'string' },
-          files: { type: 'array', items: { type: 'string' } },
-          resolution: { type: 'string', enum: ['merged', 'dropped'] },
-          note: { type: 'string' },
         },
       },
     },
@@ -383,12 +368,12 @@ Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits 
   \`git -C ${repoPath} cherry-pick <sha>\`
 
 - **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
-- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — say so in \`note\`; never drop to avoid the work of merging.
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
 
-Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD, the per-commit \`picks\` ledger (in processing order), and the \`conflicts\` subset you had to reconcile.`
+Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
 const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
-const conflicts = consolidation?.conflicts ?? []
+const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clean')
 log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -228,19 +228,31 @@ if (!branchHead || liveTracks.length === 0) {
 // ---------------------------------------------------------------------------
 phase('Tracks')
 
-// The police track. /code-police is a skill, not a workflow, so its three cold
-// passes (rules / fact-check / elegance) are reproduced here as parallel agents,
-// then each agreed fix is applied as its own commit — matching /be §4.3's
-// "each finding is its own commit". Per-finding `just check` is deferred to the
-// post-consolidation check + §5 CI rather than run 3× concurrently across the
-// parallel worktrees (it would thrash the toolchain); fmt-on-touched-files still
-// runs in each apply.
+// The police track. /code-police is a skill, not a workflow, so its cold passes
+// (rules / fact-check / elegance) are fanned out here as parallel agents — but
+// each pass's *definition* stays single-sourced to code-police's SKILL.md (the
+// agents Read it; the briefs only name which section/pass to apply), and the
+// elegance pass honors the skill's tiny-diff skip. Each agreed fix is then
+// applied as its own commit — matching /be §4.3's "each finding is its own
+// commit". Per-finding `just check` is deferred to the post-consolidation check
+// + §5 CI rather than run 3× concurrently across the parallel worktrees (it
+// would thrash the toolchain); fmt-on-touched-files still runs in each apply.
 async function policeTrack(wt) {
+  // Pass *definitions* are single-sourced to code-police's SKILL.md: each brief
+  // names that pass's section so the agent (which Reads the skill below) reviews
+  // it exactly as written there — no inline checklist to drift. The elegance pass
+  // is gated on the tiny-diff heuristic the skill mandates (SKILL.md:141 — skip
+  // when the worktree diff against base is <10 lines).
+  const tinyDiff = await agent(
+    `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
+    { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
+  )
   const passes = [
-    { key: 'rules', brief: 'the built-in code-police rule checklist (dry-rule-of-three, prefer-focused-library, invalid-states-unrepresentable, no-dead-code, no-silent-error-swallowing, and the rest) PLUS any project rules' },
-    { key: 'fact-check', brief: 'a CORRECTNESS audit: logic errors, silently swallowed errors, wishful thinking, unjustified fallbacks — not style' },
-    { key: 'elegance', brief: 'simplicity and idiom: hand-rolled code that a focused library or a simpler shape would replace' },
-  ]
+    { key: 'rules', brief: 'the **Rule checklist** pass exactly as defined in that skill\'s "Running the passes" section (Pass 1) — every built-in rule plus any project rules' },
+    { key: 'fact-check', brief: 'the **Fact-check** correctness audit exactly as defined in that skill\'s "Running the passes" section (Pass 2)' },
+    { key: 'elegance', brief: 'the **Elegance** pass exactly as defined in that skill\'s "Running the passes" section (Pass 3) — simplicity and idiom' },
+  ].filter((p) => p.key !== 'elegance' || !tinyDiff?.tiny)
+  if (tinyDiff?.tiny) log('police: skipping elegance pass (tiny diff <10 lines, per code-police SKILL.md)')
   const reviews = await parallel(
     passes.map((p) => () =>
       agent(

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -278,7 +278,7 @@ async function policeTrack(wt) {
     applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
   }
-  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
+  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -394,7 +394,7 @@ function policeComment(t) {
     .join('\n')
   return `## 👮 Code-police
 
-**${t.findings || 0} finding(s)** across the rules / fact-check / elegance passes${t.status === 'clean' ? ' — clean diff' : ''}.
+**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes${t.status === 'clean' ? ' — clean diff' : ''}.
 
 | severity | finding | files | commit |
 |---|---|---|---|

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -355,28 +355,51 @@ for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 // deterministically in JS from the structured track results; a thin mechanical
 // agent just writes each body to a scratch file and posts it with `gh pr comment`.
 // ---------------------------------------------------------------------------
-const sha9 = (s) => (s ? `\`${String(s).slice(0, 9)}\`` : '—')
+// Plain (NOT code-fenced) short SHA so GitHub auto-links it to the commit — a
+// backtick-wrapped SHA renders as code and is NOT linkified.
+const sha9 = (s) => (s ? String(s).slice(0, 9) : '—')
 const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').trim()
+
+const SEV = { blocking: '🔴 blocking', major: '🟠 major', minor: '🟡 minor', nit: '⚪ nit' }
+
+// Full per-round detail: every codex finding (severity, id, issue, location,
+// suggestion, status) and Claude's disposition of each — the complete debate
+// transcript, not a count table.
+function codexRound(r) {
+  const v = r.codex || {}
+  const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
+  const findings = (v.findings || []).length
+    ? v.findings
+        .map(
+          (f) =>
+            `- **${SEV[f.severity] || f.severity} · ${f.id}** — ${esc(f.issue)}\n  at \`${esc(f.location)}\` · status: **${f.status}**\n  suggestion: ${esc(f.suggestion)}`,
+        )
+        .join('\n')
+    : '_no findings_'
+  const actions = (r.claude?.actions || []).length
+    ? r.claude.actions.map((act) => `- **${act.findingId}** → _${act.disposition}_: ${esc(act.detail)}`).join('\n')
+    : ''
+  return [
+    `### Round ${r.round} — codex approved ${v.approved ? '✅' : '❌'} · ${open} open${r.commit ? ` · ${sha9(r.commit)}` : ''}`,
+    v.summary ? esc(v.summary) : '',
+    v.responseToRebuttal ? `**Codex on Claude's rebuttal:** ${esc(v.responseToRebuttal)}` : '',
+    `**Codex findings:**\n${findings}`,
+    actions ? `**Claude's response:**\n${actions}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+}
 
 function codexComment(t) {
   if (!t || t.status === 'track-error') return `## 🤖 Codex ⇄ Claude debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
-  const rows = (t.transcript || [])
-    .map((r) => {
-      const v = r.codex || {}
-      const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
-      const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
-      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${open} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
-    })
-    .join('\n')
+  const rounds = (t.transcript || []).map(codexRound).join('\n\n---\n\n')
   return `## 🤖 Codex ⇄ Claude debate
 
 **Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
 
 ${esc(t.finalVerdict?.summary)}
 
-| Round | codex approved | findings open | claude dispositions | commit |
-|---|---|---|---|---|
-${rows || '| — | — | — | — | — |'}`
+${rounds}`
 }
 
 function lensComment(t) {

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -490,13 +490,20 @@ phase('Report')
 
 const comments = {}
 if (postComments) {
-  const ledger = consolidationSection(consolidation, consolidateOrder)
+  // Data-drive Report over the SAME track set as every other phase: a per-track
+  // comment builder keyed by track name, iterated in the canonical
+  // `consolidateOrder`/`liveTracks` order. Adding/removing a reviewer costs Report
+  // nothing — no hardcoded track literal to keep in sync.
+  const builder = { codex: codexComment, lens: lensComment, police: policeComment }
+  // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
+  // it posts as its own comment — surviving any track subset instead of being
+  // string-stapled onto whichever track happens to be present.
   const bodies = [
-    ['codex', `${codexComment(tracks.codex)}\n\n${ledger}`],
-    ['lens', lensComment(tracks.lens)],
-    ['police', policeComment(tracks.police)],
-  ].filter(([t]) => tracks[t])
-  // Post sequentially so the comments land in a stable order (codex, lens, police).
+    ['consolidation', consolidationSection(consolidation, consolidateOrder)],
+    ...liveTracks.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+  ]
+  // Post sequentially so the comments land in a stable order (consolidation, then
+  // the tracks in canonical order).
   for (const [slug, body] of bodies) {
     const url = await postComment(slug, body)
     comments[slug] = (url || '').trim()

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -303,6 +303,7 @@ ${message}
   return agent(prompt, {
     label: `police-commit:${id}`,
     phase: 'Tracks',
+    model,
     schema: {
       type: 'object',
       additionalProperties: false,

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -24,7 +24,26 @@ const MODEL = 'opus'
 // Inputs (passed via the Workflow tool's `args`)
 // ---------------------------------------------------------------------------
 const a = args || {}
-const repoPath = a.repoPath || '.'
+// repoPath is the worktree root and the spine of EVERY path below (`git -C`,
+// child `repoPath`s, scratch + worktree dirs). It MUST be absolute: the whole
+// "isolation is structural, not behavioral" guarantee rests on every git command
+// and file path being absolute, and the codex child `cd`s into its repoPath while
+// reading a scratch path derived from it — a relative repoPath would `cd` once and
+// then resolve that scratch path against the new cwd, writing the verdict to a
+// nested path and reading it back from a different one. Rather than silently
+// canonicalize against an unknowable session cwd, reject a non-absolute repoPath
+// loudly. (/be always passes an absolute root; the default `.` is rejected here.)
+const repoPath = (a.repoPath || '').trim()
+if (!repoPath.startsWith('/')) {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `repoPath must be an ABSOLUTE path (got ${repoPath ? `\`${repoPath}\`` : 'empty'}). Every git command and scratch/worktree path in this orchestrator is absolute and cwd-independent; a relative repoPath would break the codex child's cd-then-read-scratch step and let agents leak into the wrong tree. Pass the absolute worktree root.`,
+  }
+}
 const base = a.base || 'origin/master'
 // Optional author note on deliberate design decisions, threaded into the lens
 // debate so the lenses don't flag intentional choices.
@@ -51,11 +70,17 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the shared cwd is irrelevant — no agent can leak into the wrong tree by
 // forgetting to `cd`. The per-track worktrees live under the repo's conventional
 // `.worktrees/` (gitignored); commit-message + PR-comment scratch lives under
-// the gitignored `.be-review/`. Both are absolute and per-main-worktree, so
-// parallel /be-review runs in different worktrees never collide.
+// the gitignored `.be-review/`. Both are absolute, and a per-RUN id is woven into
+// the worktree name and the scratch subdir so two /be-review runs in the SAME
+// main worktree never clobber each other's live worktrees or scratch files (the
+// old fixed `be-review-<track>` / `.be-review/*` paths let a second run `rm -rf`
+// the first run's in-flight worktree). The id is the start-time epoch ms — unique
+// per invocation, and the actual paths are reported back in the result so manual
+// inspection doesn't need to guess them.
+const RUN_ID = String(Date.now())
 const WT_ROOT = `${repoPath}/.worktrees`
-const wtDir = (track) => `${WT_ROOT}/be-review-${track}`
-const SCRATCH = `${repoPath}/.be-review`
+const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
+const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -81,7 +106,11 @@ const SETUP_SCHEMA = {
   required: ['branchHead', 'mergeBase', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
-    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed' },
+    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed. Empty string iff the merge-base command FAILED (do NOT fall back to the raw base).' },
+    mergeBaseError: {
+      type: 'string',
+      description: 'the verbatim `git merge-base` error when mergeBase is empty; "" otherwise',
+    },
     cleanTree: {
       type: 'boolean',
       description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
@@ -177,13 +206,12 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command fails, fall back to \`mergeBase\` = the resolved \`${base}\` and say so in a worktree \`note\`.
+1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command FAILS (missing/typoed base, stale ref, or unrelated history), the review scope is untrustworthy — do NOT fall back to the raw \`${base}\`; instead set \`mergeBase\`: "" and put the exact git error in \`mergeBaseError\`, then STOP (skip worktree creation, return an empty \`worktrees\` array). (The orchestrator aborts the whole run when \`mergeBase\` is empty.)
 2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
-4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
-   - Path: \`${WT_ROOT}/be-review-<track>\` (absolute).
-   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if it's not registered), then \`rm -rf ${WT_ROOT}/be-review-<track>\`.
-   - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
+4. Only if \`cleanTree\` is true — create a fresh detached worktree at \`branchHead\` for each track, at these EXACT absolute paths (per-run unique, so they cannot belong to another in-flight run):
+${TRACKS.map((t) => `   - ${t}: \`git -C ${repoPath} worktree add --detach ${wtDir(t)} <branchHead>\``).join('\n')}
+   These paths are unique to THIS run, so they should not pre-exist. If \`worktree add\` reports the path already exists, that is an error — set \`ok\`: false and put the message in \`note\`; do NOT \`rm -rf\` or force-remove it (it may belong to a concurrent run).
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
 Return \`branchHead\`, \`mergeBase\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
@@ -192,8 +220,24 @@ const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup
 const branchHead = (setup?.branchHead || '').trim()
 // The diff base every reviewer uses: the merge-base of the branch and `${base}`,
 // so commits `${base}` gained since the branch forked aren't reviewed as ours.
-// Falls back to the raw base if Setup couldn't resolve it.
-const mergeBase = (setup?.mergeBase || base).trim()
+const mergeBase = (setup?.mergeBase || '').trim()
+
+// Merge-base gate. A failed `git merge-base` means the review scope can't be
+// trusted (missing/typoed base, stale ref, unrelated history). Falling back to the
+// raw `${base}` tip would silently review the base branch's drift as if this PR
+// made it — the exact noise the merge-base exists to remove. Fail loudly instead.
+if (!mergeBase) {
+  const err = (setup?.mergeBaseError || '').trim()
+  log(`Setup: ABORT — \`git merge-base ${base} HEAD\` failed; the review scope can't be trusted. Not falling back to the raw ${base} tip.`)
+  return {
+    status: 'setup-failed',
+    branchHead,
+    base,
+    tracks: {},
+    consolidation: null,
+    note: `merge-base of \`${base}\` and HEAD could not be resolved, so the diff scope is untrustworthy (missing/typoed base, stale ref, or unrelated history). Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
 
 // Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
 // worktree would be invisible to every reviewer — a /be-review run could then
@@ -470,7 +514,7 @@ ${body}
 // consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
 // ---------------------------------------------------------------------------
 if (!commit) {
-  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${WT_ROOT}/be-review-<track> diff\`).`)
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there: ${liveTracks.map((t) => `git -C ${wtDir(t)} diff`).join(' ; ')}`)
   return {
     status: 'no-commit',
     branchHead,
@@ -480,7 +524,7 @@ if (!commit) {
     tracks,
     consolidation: null,
     conflicts: [],
-    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.worktrees/be-review-<track>` and re-run with commit enabled to consolidate.',
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
@@ -493,14 +537,70 @@ if (!commit) {
 // ---------------------------------------------------------------------------
 phase('Consolidate')
 
-// Skip tracks that errored or made no commits — the agent only picks real work.
-const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+// CLEAN-WORKTREE GATE before consolidation. Consolidation replays only COMMITTED
+// commits (`rev-list branchHead..HEAD`), and Cleanup later force-removes every
+// worktree — so any edit a track left UNcommitted (an apply agent that produced
+// files but whose commit helper failed, a formatter that touched an unlisted
+// file, an untracked new file) would be invisible to cherry-pick and then deleted
+// for good. Mechanically check each candidate track's worktree is clean; a dirty
+// one is excluded from both consolidation AND cleanup (its worktree is preserved
+// for the human) and surfaced in the result, instead of silently discarded.
+const consolidateCandidates = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+const cleanCheck = consolidateCandidates.length
+  ? await agent(
+      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Do not edit anything. Tracks and their worktrees:
+${consolidateCandidates.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
+      {
+        label: 'consolidate:clean-check',
+        phase: 'Consolidate',
+        model,
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['tracks'],
+          properties: {
+            tracks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['track', 'clean'],
+                properties: {
+                  track: { type: 'string' },
+                  clean: { type: 'boolean' },
+                  dirtyStatus: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    )
+  : { tracks: [] }
+const dirtyTracks = consolidateCandidates.filter((t) => (cleanCheck?.tracks || []).find((c) => c.track === t && c.clean === false))
+for (const t of dirtyTracks) {
+  const ds = (cleanCheck?.tracks || []).find((c) => c.track === t)?.dirtyStatus || ''
+  tracks[t] = {
+    ...tracks[t],
+    consolidated: false,
+    dirtyStatus: ds,
+    note: `track left UNcommitted changes in its worktree (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so the edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+  }
+  log(`Consolidate: track ${t} has UNcommitted changes — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
+}
+
+// Only replay tracks that are clean (every agreed fix really is a commit) and made
+// real work — the agent only picks committed work.
+const consolidateOrder = consolidateCandidates.filter((t) => !dirtyTracks.includes(t))
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
-For each track, its worktree is \`${WT_ROOT}/be-review-<track>\`. Get that track's new commits oldest-first:
-  \`git -C ${WT_ROOT}/be-review-<track> rev-list --reverse ${branchHead}..HEAD\`
+Each track's worktree (use these EXACT absolute paths):
+${consolidateOrder.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+For each track, get its new commits oldest-first:
+  \`git -C <that track's worktree> rev-list --reverse ${branchHead}..HEAD\`
 (An empty list means the track found nothing to change — skip it.)
 
 Then cherry-pick each of those commits onto the branch IN THAT ORDER:
@@ -524,17 +624,20 @@ phase('Report')
 
 const comments = {}
 if (postComments) {
-  // Data-drive Report over the SAME track set as every other phase: a per-track
-  // comment builder keyed by track name, iterated in the canonical
-  // `consolidateOrder`/`liveTracks` order. Adding/removing a reviewer costs Report
-  // nothing — no hardcoded track literal to keep in sync.
+  // Data-drive Report over every REQUESTED track (the `TRACKS` set), not just the
+  // live ones: a track whose worktree failed in Setup is in `tracks` as
+  // `track-error`, and each builder renders that as a "Track error" comment — so
+  // setup failures get a PR comment too, keeping the documented one-comment-per-
+  // requested-track audit trail instead of silently omitting the dropped track. A
+  // per-track comment builder keyed by track name; adding/removing a reviewer costs
+  // Report nothing — no hardcoded track literal to keep in sync.
   const builder = { codex: codexComment, lens: lensComment, police: policeComment }
   // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
   // it posts as its own comment — surviving any track subset instead of being
   // string-stapled onto whichever track happens to be present.
   const bodies = [
     ['consolidation', consolidationSection(consolidation, consolidateOrder)],
-    ...liveTracks.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+    ...TRACKS.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
   ]
   // Post sequentially so the comments land in a stable order (consolidation, then
   // the tracks in canonical order).
@@ -548,14 +651,24 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees
+// Phase 5 — tear down the per-track worktrees. Dirty tracks (uncommitted edits
+// the clean-check caught) are PRESERVED, not removed — their worktree is the only
+// place those edits live, so force-removing it would discard them.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-await agent(
-  `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. For each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
-  { label: 'cleanup:worktrees', phase: 'Cleanup', model },
-)
+const teardownTracks = liveTracks.filter((t) => !dirtyTracks.includes(t))
+if (dirtyTracks.length) log(`Cleanup: preserving ${dirtyTracks.length} dirty worktree(s) (${dirtyTracks.join(', ')}) — they hold uncommitted edits.`)
+if (teardownTracks.length) {
+  await agent(
+    `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
+${teardownTracks.map((t) => `  - \`git -C ${repoPath} worktree remove --force ${wtDir(t)}\``).join('\n')}
+Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
+    { label: 'cleanup:worktrees', phase: 'Cleanup', model },
+  )
+} else {
+  log('Cleanup: no clean worktrees to tear down (all preserved or none live).')
+}
 
 return {
   status: 'done',

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -1,0 +1,334 @@
+// The Workflow runtime requires `export const meta` to be the FIRST statement
+// and a PURE LITERAL (no interpolation), so 'opus' is inlined per phase. The
+// single MODEL socket lives just after meta; every other model reference reads
+// it lazily, well after meta is evaluated.
+export const meta = {
+  name: 'be-review',
+  description:
+    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile)',
+  phases: [
+    { title: 'Setup', detail: 'fan out one detached worktree per review track off the branch HEAD', model: 'opus' },
+    { title: 'Tracks', detail: 'codex, lens, and police gauntlets each run to consensus, concurrently and isolated', model: 'opus' },
+    { title: 'Consolidate', detail: 'cherry-pick each track’s commits onto the branch in order; reconcile the rare overlap', model: 'opus' },
+    { title: 'Cleanup', detail: 'tear down the per-track worktrees', model: 'opus' },
+  ],
+}
+
+// The model every orchestrated agent runs on. Structural review on /be runs on
+// Opus (the lens debate forces it, overriding its sonnet frontmatter); keep the
+// override to one socket so a model bump is a one-liner.
+const MODEL = 'opus'
+
+// ---------------------------------------------------------------------------
+// Inputs (passed via the Workflow tool's `args`)
+// ---------------------------------------------------------------------------
+const a = args || {}
+const repoPath = a.repoPath || '.'
+const base = a.base || 'origin/master'
+// Optional author note on deliberate design decisions, threaded into the lens
+// debate so the lenses don't flag intentional choices.
+const rationale = (a.rationale || '').trim()
+// Commit each track's fixes (default on). Tracks always commit inside their own
+// worktree — this only gates whether the lens/police APPLY steps commit; the
+// per-track commits are what consolidation cherry-picks, so leaving it on is the
+// norm. (`--no-commit` is for debugging a single track in isolation.)
+const commit = a.commit !== false
+const model = a.model || MODEL
+// The review tracks to run AND the order they consolidate in. codex first (it
+// changes the most — bug fixes), then the structural lenses, then police, so an
+// overlap surfaces as a conflict picking the later, lighter-touch track.
+const TRACKS = a.tracks || ['codex', 'lens', 'police']
+
+// Per-track worktrees + commit-message scratch live here. Gitignored (`.be-review/`),
+// so they never pollute the diff the reviewers inspect, and a track's own
+// `.codex-debate/`/`.lens-debate/` scratch nests harmlessly inside its worktree.
+const workRoot = `${repoPath}/.be-review`
+const wtPath = (track) => `${workRoot}/wt-${track}`
+
+// Generated skill locations the child debate workflows live at.
+const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
+const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
+const CODEX_SKILLDIR = '.claude/skills/codex-debate'
+
+const DIFF = (wt) =>
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore any \`.be-review/\`, \`.codex-debate/\`, or \`.lens-debate/\` scratch dirs.`
+
+const rationaleBlock = rationale
+  ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
+  : ''
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+const SETUP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['branchHead', 'worktrees'],
+  properties: {
+    branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    worktrees: {
+      type: 'array',
+      description: 'one entry per track worktree created',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'path', 'ok'],
+        properties: {
+          track: { type: 'string' },
+          path: { type: 'string' },
+          ok: { type: 'boolean' },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// code-police review pass output (mirrors /code-police's finding shape).
+const POLICE_FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      description: 'high-confidence findings from this pass (≤6; empty is a fine verdict)',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'location', 'problem', 'fix', 'severity'],
+        properties: {
+          title: { type: 'string' },
+          location: { type: 'string', description: 'file:line' },
+          problem: { type: 'string' },
+          fix: { type: 'string', description: 'a concrete, implementable change' },
+          severity: { type: 'string', enum: ['blocking', 'major', 'minor', 'nit'] },
+        },
+      },
+    },
+  },
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['summary', 'filesChanged'],
+  properties: {
+    summary: { type: 'string', description: 'one line: what you changed' },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const CONSOLIDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['picks', 'conflicts'],
+  properties: {
+    finalHead: { type: 'string', description: 'branch HEAD SHA after all picks' },
+    picks: {
+      type: 'array',
+      description: 'one entry per source commit you processed, in the order you processed it',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'sourceCommit', 'outcome'],
+        properties: {
+          track: { type: 'string' },
+          sourceCommit: { type: 'string', description: 'the short SHA from the track worktree' },
+          newCommit: { type: 'string', description: 'the resulting SHA on the branch' },
+          outcome: { type: 'string', enum: ['clean', 'reconciled', 'dropped'] },
+          note: { type: 'string', description: 'for reconciled/dropped: how you resolved it and why' },
+        },
+      },
+    },
+    conflicts: {
+      type: 'array',
+      description: 'the overlaps you had to reconcile (subset of picks); empty in the common no-overlap case',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'sourceCommit', 'files', 'resolution'],
+        properties: {
+          track: { type: 'string' },
+          sourceCommit: { type: 'string' },
+          files: { type: 'array', items: { type: 'string' } },
+          resolution: { type: 'string', enum: ['merged', 'dropped'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — fan out one detached worktree per track off the branch HEAD
+// ---------------------------------------------------------------------------
+phase('Setup')
+
+const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
+
+1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
+2. Ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+3. For EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
+   - Path: \`${workRoot}/wt-<track>\`.
+   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
+   - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
+4. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
+
+Return \`branchHead\` and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+
+const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
+const branchHead = (setup?.branchHead || '').trim()
+const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
+const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
+if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — those tracks are skipped.`)
+log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
+
+if (!branchHead || liveTracks.length === 0) {
+  return { status: 'setup-failed', branchHead, base, tracks: {}, consolidation: null, note: 'no track worktrees could be created' }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — run every track's gauntlet to consensus, concurrently & isolated
+// ---------------------------------------------------------------------------
+phase('Tracks')
+
+// The police track. /code-police is a skill, not a workflow, so its three cold
+// passes (rules / fact-check / elegance) are reproduced here as parallel agents,
+// then each agreed fix is applied as its own commit — matching /be §4.3's
+// "each finding is its own commit". Per-finding `just check` is deferred to the
+// post-consolidation check + §5 CI rather than run 3× concurrently across the
+// parallel worktrees (it would thrash the toolchain); fmt-on-touched-files still
+// runs in each apply.
+async function policeTrack(wt) {
+  const passes = [
+    { key: 'rules', brief: 'the built-in code-police rule checklist (dry-rule-of-three, prefer-focused-library, invalid-states-unrepresentable, no-dead-code, no-silent-error-swallowing, and the rest) PLUS any project rules' },
+    { key: 'fact-check', brief: 'a CORRECTNESS audit: logic errors, silently swallowed errors, wishful thinking, unjustified fallbacks — not style' },
+    { key: 'elegance', brief: 'simplicity and idiom: hand-rolled code that a focused library or a simpler shape would replace' },
+  ]
+  const reviews = await parallel(
+    passes.map((p) => () =>
+      agent(
+        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`.claude/skills/code-police/SKILL.md\` (and \`.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+        { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
+      ),
+    ),
+  )
+  const findings = []
+  passes.forEach((p, i) => (reviews[i]?.findings ?? []).forEach((f, j) => findings.push({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })))
+  log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
+
+  // Apply each finding as its own commit, sequentially (same-file edits can't be
+  // parallel-applied). Mechanical committer stages only the touched files.
+  const applied = []
+  for (const f of findings) {
+    const impl = await agent(
+      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change in the working tree. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`,
+      { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+    )
+    const files = impl?.filesChanged ?? []
+    let sha = null
+    if (commit && files.length) {
+      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files) || '').trim()
+    }
+    applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
+    log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
+  }
+  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
+}
+
+// Mechanical committer shared by the police track: stages EXACTLY the listed
+// files in worktree `wt` and commits with the given message. The workflow can't
+// run git itself, so a thin agent does. (codex/lens commit via their own
+// workflows.)
+async function commitFix(wt, id, subject, body, files) {
+  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
+  const msgPath = `${workRoot}/commit-msg-${id}.txt`
+  const message = `${subject}\n\n${body}`
+  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workRoot}\`.
+2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
+
+${message}
+
+3. Run: \`git -C ${wt} add -- ${fileArgs} && git -C ${wt} commit -F ${msgPath}\`. Stage ONLY those files; do NOT use \`git add -A\`/\`git add .\`.
+4. Return the new commit SHA from \`git -C ${wt} rev-parse HEAD\`. Do NOT push.`
+  return agent(prompt, { label: `police-commit:${id}`, phase: 'Tracks' })
+}
+
+// One thunk per live track. codex and lens are existing repoPath-parameterized
+// workflows (built to run in separate worktrees), invoked as child workflows —
+// one level of nesting, which the runtime allows. police is inline (it's a
+// skill, not a workflow). Each thunk catches so one track's failure can't sink
+// the rest — consolidation just picks up whatever each track committed.
+const trackThunk = {
+  codex: () =>
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtPath('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+      .then((r) => ({ track: 'codex', ...r }))
+      .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
+  lens: () =>
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtPath('lens'), base, rationale, model, commit })
+      .then((r) => ({ track: 'lens', ...r }))
+      .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
+  police: () =>
+    policeTrack(wtPath('police'))
+      .then((r) => ({ track: 'police', ...r }))
+      .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
+}
+
+const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
+const tracks = {}
+liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
+for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+
+// ---------------------------------------------------------------------------
+// Phase 3 — consolidate: cherry-pick each track's commits onto the branch in
+// TRACKS order. The common case is no overlap (clean picks); the rare overlap
+// surfaces as a cherry-pick conflict the agent reconciles by honoring BOTH
+// changes (it has both commit messages = both debates' rationale).
+// ---------------------------------------------------------------------------
+phase('Consolidate')
+
+// Skip tracks that errored or made no commits — the agent only picks real work.
+const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Three review tracks each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+
+The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
+
+For each track, its worktree is \`${workRoot}/wt-<track>\`. Get that track's new commits oldest-first:
+  \`git -C ${workRoot}/wt-<track> rev-list --reverse ${branchHead}..HEAD\`
+(An empty list means the track found nothing to change — skip it.)
+
+Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits onto the branch IN THAT ORDER:
+  \`git -C ${repoPath} cherry-pick <sha>\`
+
+- **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — say so in \`note\`; never drop to avoid the work of merging.
+
+Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD, the per-commit \`picks\` ledger (in processing order), and the \`conflicts\` subset you had to reconcile.`
+
+const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
+const conflicts = consolidation?.conflicts ?? []
+log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
+
+// ---------------------------------------------------------------------------
+// Phase 4 — tear down the per-track worktrees
+// ---------------------------------------------------------------------------
+phase('Cleanup')
+
+await agent(
+  `You are a MECHANICAL CLEANUP RUNNER. From \`${repoPath}\`, for each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${workRoot}\` directory itself (it holds commit-message scratch); do not delete the branch's commits. Return "done".`,
+  { label: 'cleanup:worktrees', phase: 'Cleanup', model },
+)
+
+return {
+  status: 'done',
+  branchHead,
+  finalHead: consolidation?.finalHead || null,
+  base,
+  order: consolidateOrder,
+  tracks,
+  consolidation,
+  conflicts,
+}

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -819,6 +819,47 @@ for (const t of preservedTracks) {
   }
   log(`Consolidate: track ${t} not consolidated — worktree preserved at ${wtDir(t)}.`)
 }
+
+// PRECONDITION GATE. The consolidate prompt below asserts the branch is AT
+// `branchHead` (the tracks' shared fork point) and cherry-picks the track commits
+// onto it without re-checking. That holds for a normal single run — nothing
+// advances the main worktree between Setup and here. But on an ABNORMAL re-run
+// (e.g. /be-review invoked twice in the same worktree without resetting), the
+// branch HEAD has already moved PAST `branchHead` to the previously-consolidated
+// commits; the Setup clean-tree preflight only rejects an UNcommitted tree, so a
+// clean-but-advanced HEAD sails through. Cherry-picking again would stack the
+// track commits a second time, silently double-applying every fix. Verify the
+// precondition mechanically (`rev-parse HEAD` == `branchHead`) and abort with a
+// `consolidation-precondition-failed` status rather than picking onto a drifted
+// HEAD — the worktrees are PRESERVED for the human to inspect and re-run from a
+// clean fork point.
+const headCheck = await agent(
+  `You are a MECHANICAL PRECONDITION CHECKER. Run \`git -C ${repoPath} rev-parse HEAD\` and report the FULL SHA it prints, verbatim. Do not edit anything, do not cherry-pick, do not run any other command.`,
+  {
+    label: 'consolidate:precondition',
+    phase: 'Consolidate',
+    model,
+    schema: { type: 'object', additionalProperties: false, required: ['head'], properties: { head: { type: 'string', description: 'the full HEAD SHA from `git rev-parse HEAD`' } } },
+  },
+)
+const currentHead = (headCheck?.head || '').trim()
+if (currentHead !== branchHead) {
+  log(`Consolidate: ABORTING — branch HEAD is ${sha9(currentHead) || '(unknown)'} but the tracks forked from ${sha9(branchHead)}. The branch has drifted (likely an already-consolidated re-run); cherry-picking now would double-apply every fix. Worktrees PRESERVED.`)
+  return {
+    status: 'consolidation-precondition-failed',
+    branchHead,
+    finalHead: currentHead || branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    reconciled: [],
+    dropped: [],
+    note: `consolidation precondition failed: the branch in \`${repoPath}\` is at \`${currentHead || '(unknown)'}\` but the review tracks forked from \`${branchHead}\`. The HEAD has advanced past the shared fork point — likely a re-run in an already-consolidated worktree — so cherry-picking the track commits would stack them a SECOND time and double-apply every fix. Nothing was consolidated and the per-track worktrees are PRESERVED. Reset the branch to \`${branchHead}\` (\`git -C ${repoPath} reset --hard ${branchHead}\`) or start from a clean worktree, then re-run.`,
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
+  }
+}
+
 const consolidatePrompt = `${mechanicalPreamble('CONSOLIDATOR')} You are consolidating the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -363,9 +363,9 @@ function codexComment(t) {
   const rows = (t.transcript || [])
     .map((r) => {
       const v = r.codex || {}
-      const openBM = (v.findings || []).filter((f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major')).length
+      const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
       const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
-      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${openBM} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
+      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${open} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
     })
     .join('\n')
   return `## 🤖 Codex ⇄ Claude debate
@@ -374,7 +374,7 @@ function codexComment(t) {
 
 ${esc(t.finalVerdict?.summary)}
 
-| Round | codex approved | open blk/maj | claude dispositions | commit |
+| Round | codex approved | findings open | claude dispositions | commit |
 |---|---|---|---|---|
 ${rows || '| — | — | — | — | — |'}`
 }

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -641,7 +641,6 @@ if (!commit) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
@@ -711,7 +710,6 @@ if (branchMoved || branchDirty) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     preservedTracks: liveTracks,
     note: `consolidation aborted: ${why}. Cherry-picking onto the changed base would review against an untrustworthy scope, so nothing was consolidated and every track worktree was PRESERVED (see each track's note for the recovery cherry-pick).${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
@@ -944,8 +942,5 @@ return {
   // (police `incomplete`, lens `unresolved`, codex `reviewer-error`); their fixes
   // landed but the gauntlet didn't fully finish. Non-empty ⇒ 'consolidation-incomplete'.
   incompleteTracks,
-  // back-compat: the union of non-clean picks. Consumers keying on a discarded
-  // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
-  conflicts: [...reconciled, ...dropped],
   comments,
 }

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -332,10 +332,10 @@ for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
 // `--no-commit` short-circuit. With commit=false the tracks deliberately leave
 // their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
-// (rev-list ${branchHead}..HEAD) and cleanup tears the worktrees down — so running
-// them now would discard every reviewer's edits. Instead, stop here and hand the
-// live worktrees to the user to inspect; nothing is consolidated and nothing is
-// cleaned up. (This is the documented single-track-debugging mode.)
+// (rev-list ${branchHead}..HEAD) and cleanup's `worktree remove --force` tears the
+// worktrees down — so running them now would silently discard every reviewer's edits.
+// Instead, stop here and hand the live worktrees to the user to inspect; nothing is
+// consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
 if (!commit) {
   log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
   return {

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -356,8 +356,10 @@ async function policeTrack(wt) {
   const applied = []
   let totalFindings = 0
   let policeRound = 0
+  let sweepsRun = 0
   let lastRoundFindings = 0
   for (; policeRound < POLICE_MAX_ROUNDS; policeRound++) {
+    sweepsRun++ // one review pass per iteration, counted BEFORE any break/cap exit so the reported sweep count is exact (not derived from the loop index)
     const reviews = await parallel(
       passes.map((p) => () =>
         agent(
@@ -396,7 +398,7 @@ async function policeTrack(wt) {
   const reachedClean = lastRoundFindings === 0
   const status = !totalFindings ? 'clean' : reachedClean ? 'consensus' : 'incomplete'
   if (!reachedClean) log(`police: hit round cap (${POLICE_MAX_ROUNDS}) with findings still open — reporting incomplete.`)
-  return { status, findings: totalFindings, rounds: policeRound + (reachedClean ? 0 : 1), passes: passes.map((p) => p.key), applied }
+  return { status, findings: totalFindings, rounds: sweepsRun, passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -751,6 +753,23 @@ const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
 // is untrustworthy. The agent only picks committed work.
 const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
 
+// The terminal statuses that mean a track's review actually FINISHED — codex/lens
+// reached consensus (or had nothing to raise), police got a clean final sweep.
+// Anything else a consolidated track can carry (police `incomplete` after the
+// round cap, lens `unresolved` with findings still contested, codex
+// `reviewer-error`/`merge-base-error`) means the gauntlet did NOT fully complete
+// for that track, even though its committed fixes are real and DO get replayed.
+const COMPLETED_TRACK_STATUS = new Set(['clean', 'consensus'])
+// Consolidated tracks whose own review did not reach a completed terminus. Their
+// fixes still land (they're committed and clean), but the top-level result must
+// not read `done`, or /be would proceed as if the gauntlet fully passed when a
+// police/lens sweep was actually cut short. (A `track-error` track is never in
+// `consolidateOrder`, so it can't appear here.)
+const incompleteTracks = consolidateOrder.filter((t) => !COMPLETED_TRACK_STATUS.has(tracks[t]?.status))
+for (const t of incompleteTracks) {
+  log(`Consolidate: track ${t} consolidated but its review ended \`${tracks[t]?.status}\` (not a completed terminus) — top-level status will reflect that the gauntlet did not fully finish.`)
+}
+
 // Preserve every live track we did NOT consolidate, so neither uncommitted edits
 // nor committed-but-unreplayed commits are lost.
 const preservedTracks = liveTracks.filter((t) => !consolidateOrder.includes(t))
@@ -854,17 +873,25 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
   log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
-// Top-level status reflects whether EVERY requested track actually landed on the
-// branch. A preserved track (uncommitted edits, an unconfirmed worktree, or a
-// crashed `track-error` whose committed fixes were deliberately not replayed) means
-// at least one reviewer's fixes live ONLY in a side worktree — so `done` would
-// overstate the outcome and let /be continue as if the gauntlet fully consolidated.
-// Surface `consolidation-incomplete` (with the preserved tracks + recovery notes
-// already on each `tracks[t]`) so the caller can adjudicate instead of silently
-// shipping a partial consolidation.
-const status = preservedTracks.length ? 'consolidation-incomplete' : 'done'
+// Top-level status reflects whether EVERY requested track actually (a) landed on
+// the branch AND (b) ran its review to a completed terminus. Two ways it falls
+// short of `done`:
+//   - a PRESERVED track (uncommitted edits, an unconfirmed worktree, or a crashed
+//     `track-error` whose committed fixes were deliberately not replayed) means at
+//     least one reviewer's fixes live ONLY in a side worktree; or
+//   - an INCOMPLETE track (consolidated, but its review ended `incomplete`/
+//     `unresolved`/`reviewer-error` rather than `clean`/`consensus`) means the
+//     gauntlet was cut short for that track even though its fixes landed.
+// Either way `done` would overstate the outcome and let /be continue as if the
+// gauntlet fully passed. Surface `consolidation-incomplete` (the preserved tracks'
+// recovery notes are already on each `tracks[t]`; the incomplete tracks carry their
+// own non-terminal status) so the caller adjudicates instead of silently shipping.
+const status = preservedTracks.length || incompleteTracks.length ? 'consolidation-incomplete' : 'done'
 if (preservedTracks.length) {
   log(`Done: status=consolidation-incomplete — ${preservedTracks.length} track(s) preserved, not consolidated: ${preservedTracks.join(', ')}. Their worktrees hold the only copy of those fixes; see each track's note for the recovery cherry-pick.`)
+}
+if (incompleteTracks.length) {
+  log(`Done: status=consolidation-incomplete — ${incompleteTracks.length} track(s) consolidated but their review did not finish (${incompleteTracks.map((t) => `${t}=${tracks[t]?.status}`).join(', ')}); re-run the gauntlet (or that track) before treating the change as fully reviewed.`)
 }
 return {
   status,
@@ -879,6 +906,10 @@ return {
   // Tracks whose fixes were NOT consolidated onto the branch (preserved worktrees);
   // empty in the common case. Non-empty ⇒ status is 'consolidation-incomplete'.
   preservedTracks,
+  // Tracks that WERE consolidated but whose review ended on a non-terminal status
+  // (police `incomplete`, lens `unresolved`, codex `reviewer-error`); their fixes
+  // landed but the gauntlet didn't fully finish. Non-empty ⇒ 'consolidation-incomplete'.
+  incompleteTracks,
   // back-compat: the union of non-clean picks. Consumers keying on a discarded
   // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
   conflicts: [...reconciled, ...dropped],

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -136,6 +136,15 @@ const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
   : ''
 
+// Single source of the cwd-safety contract every mechanical git agent runs under.
+// The Workflow runtime can't run git/gh itself, so a thin agent shells out — and
+// because all agents share the SESSION cwd (see SHARED-CWD NOTE), each MUST use
+// absolute paths + `git -C` and never rely on the current directory. This sentence
+// was copy-pasted across the six mechanical-agent prompts; hoisting it here means
+// the contract lives in ONE place if the shared-cwd guarantee ever changes.
+const mechanicalPreamble = (role) =>
+  `You are a MECHANICAL ${role}. Every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory.`
+
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
@@ -242,7 +251,7 @@ const CONSOLIDATE_SCHEMA = {
 // ---------------------------------------------------------------------------
 phase('Setup')
 
-const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
+const setupPrompt = `${mechanicalPreamble('SETUP RUNNER')} You are preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps; do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
 1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command FAILS (missing/typoed base, stale ref, or unrelated history), the review scope is untrustworthy — do NOT fall back to the raw \`${base}\`; instead set \`mergeBase\`: "" and put the exact git error in \`mergeBaseError\`, then STOP (skip worktree creation, return an empty \`worktrees\` array). (The orchestrator aborts the whole run when \`mergeBase\` is empty.)
@@ -411,7 +420,7 @@ async function commitFix(wt, id, subject, body, files) {
   const fileArgs = rel.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
   const msgPath = `${SCRATCH}/commit-msg-${id}.txt`
   const message = `${subject}\n\n${body}`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files. Every path is absolute / \`git -C\`; do not rely on the current directory.
+  const prompt = `${mechanicalPreamble('COMMITTER')} Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
@@ -588,7 +597,7 @@ ${rows || '| — | — | — | — | — |'}`
 // MAIN worktree (gh uses cwd's repo; the agent runs `gh -C`-equivalent by cd-ing).
 async function postComment(slug, body) {
   const file = `${SCRATCH}/comment-${slug}.md`
-  const prompt = `You are a MECHANICAL PR COMMENTER. Do exactly these steps and nothing else.
+  const prompt = `${mechanicalPreamble('PR COMMENTER')} Do exactly these steps and nothing else.
 
 1. \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${file}\` with EXACTLY this markdown content:
@@ -712,7 +721,7 @@ if (branchMoved || branchDirty) {
 // never torn down. A dirty/unknown track is surfaced in the result for the human.
 const cleanCheck = liveTracks.length
   ? await agent(
-      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
+      `${mechanicalPreamble('CLEANLINESS CHECKER')} For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
 ${liveTracks.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
 For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
       {
@@ -800,7 +809,7 @@ for (const t of preservedTracks) {
   }
   log(`Consolidate: track ${t} not consolidated — worktree preserved at ${wtDir(t)}.`)
 }
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `${mechanicalPreamble('CONSOLIDATOR')} You are consolidating the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
@@ -877,7 +886,7 @@ const teardownTracks = consolidateOrder
 if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not consolidated (${preservedTracks.join(', ')}) — they may hold uncommitted or unreplayed committed edits.`)
 if (teardownTracks.length) {
   await agent(
-    `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
+    `${mechanicalPreamble('CLEANUP RUNNER')} Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
 ${teardownTracks.map((t) => `  - \`git -C ${repoPath} worktree remove --force ${wtDir(t)}\``).join('\n')}
 Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
     { label: 'cleanup:worktrees', phase: 'Cleanup', model },

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -312,8 +312,9 @@ async function policeTrack(wt) {
       ),
     ),
   )
-  const findings = []
-  passes.forEach((p, i) => (reviews[i]?.findings ?? []).forEach((f, j) => findings.push({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })))
+  const findings = passes.flatMap((p, i) =>
+    (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })),
+  )
   log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
   // Apply each finding as its own commit, sequentially (same-file edits can't be

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -62,8 +62,11 @@ const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
 const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
 const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 
+// The diff base reviewers actually use is the MERGE-BASE (resolved by Setup),
+// not the raw `${base}` tip — see SETUP_SCHEMA.mergeBase. DIFF is an arrow, so it
+// reads `mergeBase` lazily at call time (Tracks phase, after Setup has set it).
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
@@ -75,9 +78,10 @@ const rationaleBlock = rationale
 const SETUP_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['branchHead', 'cleanTree', 'worktrees'],
+  required: ['branchHead', 'mergeBase', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed' },
     cleanTree: {
       type: 'boolean',
       description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
@@ -173,6 +177,7 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
+1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command fails, fall back to \`mergeBase\` = the resolved \`${base}\` and say so in a worktree \`note\`.
 2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
@@ -181,10 +186,14 @@ const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktr
    - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`mergeBase\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
+// The diff base every reviewer uses: the merge-base of the branch and `${base}`,
+// so commits `${base}` gained since the branch forked aren't reviewed as ours.
+// Falls back to the raw base if Setup couldn't resolve it.
+const mergeBase = (setup?.mergeBase || base).trim()
 
 // Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
 // worktree would be invisible to every reviewer — a /be-review run could then
@@ -215,7 +224,7 @@ for (const t of failedTracks) {
   tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
 }
 if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
-log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
+log(`Setup: branchHead ${branchHead.slice(0, 9)}; diffing against merge-base ${mergeBase.slice(0, 9)} (not the raw ${base} tip); tracks live: ${liveTracks.join(', ') || '(none)'}`)
 
 if (!branchHead || liveTracks.length === 0) {
   return { status: 'setup-failed', branchHead, base, tracks, consolidation: null, note: 'no track worktrees could be created' }
@@ -242,7 +251,7 @@ async function policeTrack(wt) {
   // is gated on the tiny-diff heuristic the skill mandates (skip when the worktree
   // diff against base is <10 lines).
   const tinyDiff = await agent(
-    `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
+    `Run \`git -C ${wt} diff ${mergeBase} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
     { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
   )
   const passes = [
@@ -322,11 +331,11 @@ ${message}
 // up whatever each track committed.
 const trackThunk = {
   codex: () =>
-    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base: mergeBase, skillDir: CODEX_SKILLDIR, commit })
       .then((r) => ({ track: 'codex', ...r }))
       .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
   lens: () =>
-    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base, rationale, model, commit })
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base: mergeBase, rationale, model, commit })
       .then((r) => ({ track: 'lens', ...r }))
       .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
   police: () =>

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -276,7 +276,7 @@ async function policeTrack(wt) {
     const files = impl?.filesChanged ?? []
     let sha = null
     if (commit && files.length) {
-      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files) || '').trim()
+      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
     }
     applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
@@ -301,7 +301,16 @@ ${message}
 
 3. Run: \`git -C ${wt} add -- ${fileArgs} && git -C ${wt} commit -F ${msgPath}\`. Stage ONLY those files; do NOT use \`git add -A\`/\`git add .\`.
 4. Return the new commit SHA from \`git -C ${wt} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `police-commit:${id}`, phase: 'Tracks' })
+  return agent(prompt, {
+    label: `police-commit:${id}`,
+    phase: 'Tracks',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['sha'],
+      properties: { sha: { type: 'string', description: 'the new HEAD commit SHA, hex only' } },
+    },
+  })
 }
 
 // One thunk per live track. codex and lens are existing repoPath-parameterized

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -563,6 +563,16 @@ function policeComment(t) {
 ${rows || '| — | — | — | — |'}`
 }
 
+// Fallback comment for any requested track that has NO bespoke builder. It leans
+// only on the always-present per-track fields (`track`, `status`, and `error`/
+// `note` when present), so a newly-added reviewer track gets a real PR comment
+// instead of being silently dropped — keeping Report total over `TRACKS`.
+function genericComment(t) {
+  return `## ${t?.track || 'unknown'} track
+
+**Outcome:** \`${t?.status || 'unknown'}\`.${t?.error ? ` Track error: ${esc(t.error)}.` : ''}${t?.note ? `\n\n${esc(t.note)}` : ''}`
+}
+
 function consolidationSection(c, order) {
   const rows = (c?.picks || [])
     .map((p) => `| ${esc(p.track)} | ${sha9(p.sourceCommit)} | \`${esc(p.outcome)}\` | ${sha9(p.newCommit)} | ${esc(p.note) || ''} |`)
@@ -830,13 +840,16 @@ if (postComments) {
   // requested-track audit trail instead of silently omitting the dropped track. A
   // per-track comment builder keyed by track name; adding/removing a reviewer costs
   // Report nothing — no hardcoded track literal to keep in sync.
+  // Bespoke per-track builders; any requested track without one falls back to
+  // `genericComment`, so the map below stays TOTAL over `TRACKS` — a new reviewer
+  // track gets a comment even before it grows a hand-written builder.
   const builder = { codex: codexComment, lens: lensComment, police: policeComment }
   // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
   // it posts as its own comment — surviving any track subset instead of being
   // string-stapled onto whichever track happens to be present.
   const bodies = [
     ['consolidation', consolidationSection(consolidation, consolidateOrder)],
-    ...TRACKS.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+    ...TRACKS.map((t) => [t, (builder[t] || genericComment)(tracks[t])]),
   ]
   // Post sequentially so the comments land in a stable order (consolidation, then
   // the tracks in canonical order).

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -61,6 +61,24 @@ const model = a.model || MODEL
 // changes the most — bug fixes), then the structural lenses, then police, so an
 // overlap surfaces as a conflict picking the later, lighter-touch track.
 const TRACKS = a.tracks || ['codex', 'lens', 'police']
+// Whitelist the track names. Each is woven into worktree paths and the agents'
+// shell snippets (just like RUN_ID above), and each must map to a registered
+// thunk. Reject an unknown track or a duplicate up front rather than building a
+// worktree at an unexpected path or invoking `undefined()` in `parallel` — a
+// typo'd/hostile track is an input error, not something to silently route around.
+const KNOWN_TRACKS = ['codex', 'lens', 'police']
+const badTracks = TRACKS.filter((t) => !KNOWN_TRACKS.includes(t))
+const dupTracks = TRACKS.filter((t, i) => TRACKS.indexOf(t) !== i)
+if (badTracks.length || dupTracks.length) {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `tracks must be a subset of ${KNOWN_TRACKS.join(', ')} with no duplicates.${badTracks.length ? ` Unknown: ${[...new Set(badTracks)].join(', ')}.` : ''}${dupTracks.length ? ` Duplicated: ${[...new Set(dupTracks)].join(', ')}.` : ''}`,
+  }
+}
 
 // SHARED-CWD NOTE. Every workflow agent inherits the SESSION cwd (the main
 // worktree) — the harness offers no per-agent cwd, and `isolation:'worktree'`
@@ -81,6 +99,24 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the same main worktree must pass distinct ids. The actual paths are reported in
 // the result so manual inspection doesn't need to guess them.
 const RUN_ID = String(a.runId || 'run')
+// `RUN_ID` and the track names below are woven directly into filesystem paths
+// (worktree dirs, scratch subdirs) and into the shell snippets the mechanical
+// agents run, so they MUST be conservative tokens. A value with `/`, `..`, or
+// shell metacharacters could place a worktree or scratch file OUTSIDE the
+// intended `.worktrees`/`.be-review` dirs, collide with another run, or inject a
+// command into an agent's `git -C`/`mkdir` snippet. Reject anything that isn't a
+// plain `[A-Za-z0-9._-]` token (which also excludes path separators and `..` as a
+// whole, since `.` alone is fine but `..` can't reach a parent without a `/`).
+if (!/^[A-Za-z0-9._-]+$/.test(RUN_ID) || RUN_ID === '..' || RUN_ID === '.') {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `runId must match ^[A-Za-z0-9._-]+$ (no slashes, no shell metacharacters) so it stays safe inside filesystem paths and shell snippets; got \`${RUN_ID}\`. Pass a plain token like the launch epoch ms.`,
+  }
+}
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
@@ -307,36 +343,60 @@ async function policeTrack(wt) {
     { key: 'elegance', brief: 'the **Elegance** pass exactly as defined in that skill\'s "Running the passes" section (Pass 3) — simplicity and idiom' },
   ].filter((p) => p.key !== 'elegance' || !tinyDiff?.tiny)
   if (tinyDiff?.tiny) log('police: skipping elegance pass (tiny diff <10 lines, per code-police SKILL.md)')
-  const reviews = await parallel(
-    passes.map((p) => () =>
-      agent(
-        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
-        { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
-      ),
-    ),
-  )
-  const findings = passes.flatMap((p, i) =>
-    (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })),
-  )
-  log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
-  // Apply each finding as its own commit, sequentially (same-file edits can't be
-  // parallel-applied). Every edit and git command targets the absolute worktree.
+  // /code-police runs its passes "until clean": applying a finding can introduce a
+  // NEW issue or leave one only partially fixed, so a single review+apply sweep is
+  // not equivalent. Loop the passes on the UPDATED worktree until a sweep returns
+  // no findings (clean) — applied fixes are re-reviewed, not assumed correct. A cap
+  // keeps a thrashing reviewer from spinning forever (the harness backstop is the
+  // hard ceiling); if we hit it with findings still open, the track reports
+  // `incomplete` rather than a false `consensus`. Each round's finding ids are
+  // round-scoped so commits stay unique across sweeps.
+  const POLICE_MAX_ROUNDS = 4
   const applied = []
-  for (const f of findings) {
-    const impl = await agent(
-      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
-      { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+  let totalFindings = 0
+  let policeRound = 0
+  let lastRoundFindings = 0
+  for (; policeRound < POLICE_MAX_ROUNDS; policeRound++) {
+    const reviews = await parallel(
+      passes.map((p) => () =>
+        agent(
+          `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+          { label: `police:${p.key}:r${policeRound + 1}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
+        ),
+      ),
     )
-    const files = impl?.filesChanged ?? []
-    let sha = null
-    if (commit && files.length) {
-      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
+    const findings = passes.flatMap((p, i) =>
+      (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-r${policeRound + 1}-${p.key}-${j + 1}`, pass: p.key, ...f })),
+    )
+    lastRoundFindings = findings.length
+    log(`police: round ${policeRound + 1} — ${findings.length} finding(s) across ${passes.length} passes`)
+    if (!findings.length) break // clean sweep on the updated worktree → done
+
+    // Apply each finding as its own commit, sequentially (same-file edits can't be
+    // parallel-applied). Every edit and git command targets the absolute worktree.
+    for (const f of findings) {
+      const impl = await agent(
+        `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change, fixing the issue COMPLETELY (a partial fix would resurface in the next review sweep). Do NOT git add / commit / push. You MUST run the project's formatter on every file you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
+        { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+      )
+      const files = impl?.filesChanged ?? []
+      let sha = null
+      if (commit && files.length) {
+        sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
+      }
+      applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
+      log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
     }
-    applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
-    log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
+    totalFindings += findings.length
   }
-  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, passes: passes.map((p) => p.key), applied }
+  // `clean` only if the FINAL sweep found nothing. If we exhausted the round cap
+  // with findings still open, the worktree isn't verified-clean — report
+  // `incomplete` so the caller (and the PR comment) doesn't read it as consensus.
+  const reachedClean = lastRoundFindings === 0
+  const status = !totalFindings ? 'clean' : reachedClean ? 'consensus' : 'incomplete'
+  if (!reachedClean) log(`police: hit round cap (${POLICE_MAX_ROUNDS}) with findings still open — reporting incomplete.`)
+  return { status, findings: totalFindings, rounds: policeRound + (reachedClean ? 0 : 1), passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -420,6 +480,15 @@ const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').tr
 
 const SEV = { blocking: '🔴 blocking', major: '🟠 major', minor: '🟡 minor', nit: '⚪ nit' }
 
+// A track that ran but was NOT consolidated (preserved worktree) carries
+// `consolidated:false` and a recovery `note`. Surface it as a banner at the top of
+// that track's comment so the PR audit trail never reads "reached consensus" while
+// the fixes silently live only in a side worktree.
+function preservedBanner(t) {
+  if (!t || t.consolidated !== false) return ''
+  return `\n\n> ⚠️ **Not consolidated onto the branch.** ${esc(t.note) || 'This track was preserved in its own worktree; its fixes are not on the branch.'}`
+}
+
 // Full per-round detail: every codex finding (severity, id, issue, location,
 // suggestion, status) and Claude's disposition of each — the complete debate
 // transcript, not a count table.
@@ -453,7 +522,7 @@ function codexComment(t) {
   const rounds = (t.transcript || []).map(codexRound).join('\n\n---\n\n')
   return `## 🤖 Codex ⇄ Claude debate
 
-**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
+**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.${preservedBanner(t)}
 
 ${esc(t.finalVerdict?.summary)}
 
@@ -471,7 +540,7 @@ function lensComment(t) {
     : ''
   return `## ⚖️ Lowy ⇄ Hickey lens debate
 
-**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.
+**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.${preservedBanner(t)}
 
 | origin | finding | location | disposition | commit |
 |---|---|---|---|---|
@@ -485,7 +554,7 @@ function policeComment(t) {
     .join('\n')
   return `## 👮 Code-police
 
-**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes${t.status === 'clean' ? ' — clean diff' : ''}.
+**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes over ${t.rounds || 1} review sweep(s)${t.status === 'clean' ? ' — clean diff' : ''}.${t.status === 'incomplete' ? ` ⚠️ **Did not reach a clean sweep within the round cap** — the worktree may still have open issues; re-run /code-police on it.` : ''}${preservedBanner(t)}
 
 | severity | finding | files | commit |
 |---|---|---|---|
@@ -552,6 +621,69 @@ if (!commit) {
 // changes (it has both commit messages = both debates' rationale).
 // ---------------------------------------------------------------------------
 phase('Consolidate')
+
+// BRANCH-DRIFT GATE. The Tracks phase can run for many minutes; the consolidator
+// below cherry-picks onto the branch in `${repoPath}` and its prompt asserts the
+// branch is still AT `branchHead` (the tracks' shared fork point). Setup's
+// clean-tree preflight ran BEFORE the tracks, so if the user, another workflow, or
+// a second /be-review advanced or dirtied the branch while the tracks ran, we'd
+// cherry-pick onto an unreviewed base while telling the agent it's at `branchHead`
+// — corrupting the review scope. Re-check HEAD and cleanliness NOW, just before the
+// picks. If the branch moved or is dirty, abort and PRESERVE every track worktree
+// (don't tear them down — their commits are the only copy of the reviewed fixes),
+// so the human can consolidate by hand after sorting out the drift.
+const driftCheck = await agent(
+  `You are a MECHANICAL DRIFT CHECKER. Do exactly this against the main worktree at \`${repoPath}\` (use \`git -C\`; do not edit anything):
+1. \`git -C ${repoPath} rev-parse HEAD\` — return as \`head\`.
+2. \`git -C ${repoPath} status --short\` — IGNORE only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged/unstaged/untracked entry remains, set \`clean\`: false and put those lines in \`dirtyStatus\`; otherwise \`clean\`: true and \`dirtyStatus\`: "".`,
+  {
+    label: 'consolidate:drift-check',
+    phase: 'Consolidate',
+    model,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['head', 'clean'],
+      properties: {
+        head: { type: 'string', description: 'current HEAD SHA of the main worktree' },
+        clean: { type: 'boolean' },
+        dirtyStatus: { type: 'string' },
+      },
+    },
+  },
+)
+const curHead = (driftCheck?.head || '').trim()
+const branchMoved = curHead && curHead !== branchHead
+const branchDirty = driftCheck?.clean === false
+if (branchMoved || branchDirty) {
+  const dirty = (driftCheck?.dirtyStatus || '').trim()
+  const why = branchMoved
+    ? `the branch HEAD moved from \`${branchHead.slice(0, 9)}\` (the tracks' fork point) to \`${curHead.slice(0, 9)}\` while the tracks ran`
+    : `the main worktree became dirty while the tracks ran`
+  log(`Consolidate: ABORT — ${why}. Cherry-picking onto a changed base would corrupt the review scope. Preserving all track worktrees for manual consolidation.`)
+  for (const t of liveTracks) {
+    tracks[t] = {
+      ...tracks[t],
+      consolidated: false,
+      note: `NOT consolidated — ${why}, so the consolidator's "branch is at ${branchHead.slice(0, 9)}" assumption no longer holds. The track's worktree was PRESERVED at ${wtDir(t)}; after resolving the drift, replay its commits with \`git -C ${repoPath} cherry-pick $(git -C ${wtDir(t)} rev-list --reverse ${branchHead}..HEAD)\`.`,
+    }
+  }
+  return {
+    status: 'consolidation-aborted',
+    branchHead,
+    finalHead: curHead || branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    reconciled: [],
+    dropped: [],
+    conflicts: [],
+    preservedTracks: liveTracks,
+    note: `consolidation aborted: ${why}. Cherry-picking onto the changed base would review against an untrustworthy scope, so nothing was consolidated and every track worktree was PRESERVED (see each track's note for the recovery cherry-pick).${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
+  }
+}
 
 // CLEAN-WORKTREE GATE before consolidation. Consolidation replays only COMMITTED
 // commits (`rev-list branchHead..HEAD`), and Cleanup later force-removes every
@@ -722,8 +854,20 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
   log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
+// Top-level status reflects whether EVERY requested track actually landed on the
+// branch. A preserved track (uncommitted edits, an unconfirmed worktree, or a
+// crashed `track-error` whose committed fixes were deliberately not replayed) means
+// at least one reviewer's fixes live ONLY in a side worktree — so `done` would
+// overstate the outcome and let /be continue as if the gauntlet fully consolidated.
+// Surface `consolidation-incomplete` (with the preserved tracks + recovery notes
+// already on each `tracks[t]`) so the caller can adjudicate instead of silently
+// shipping a partial consolidation.
+const status = preservedTracks.length ? 'consolidation-incomplete' : 'done'
+if (preservedTracks.length) {
+  log(`Done: status=consolidation-incomplete — ${preservedTracks.length} track(s) preserved, not consolidated: ${preservedTracks.join(', ')}. Their worktrees hold the only copy of those fixes; see each track's note for the recovery cherry-pick.`)
+}
 return {
-  status: 'done',
+  status,
   branchHead,
   finalHead: consolidation?.finalHead || null,
   base,
@@ -732,6 +876,9 @@ return {
   consolidation,
   reconciled,
   dropped,
+  // Tracks whose fixes were NOT consolidated onto the branch (preserved worktrees);
+  // empty in the common case. Non-empty ⇒ status is 'consolidation-incomplete'.
+  preservedTracks,
   // back-compat: the union of non-clean picks. Consumers keying on a discarded
   // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
   conflicts: [...reconciled, ...dropped],

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: be
-description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with an AI review gauntlet (codex debate → lens debate (lowy ⇄ hickey) → code-police → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a PARALLEL AI review gauntlet (codex debate ∥ lens debate (lowy ⇄ hickey) ∥ code-police, each in its own worktree, consolidated by cherry-pick → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
 argument-hint: "<issue-url | prompt>"
 ---
 
@@ -40,13 +40,32 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 
 **If there's a plan of record, finalize it now.** Once the PR URL exists, update `docs/plans/<slug>.html` to read as it will *after merge* — flip its status to implemented/done and **link the PR** (e.g. a header line `Implemented in #<n>`) — then commit (`docs(plan): link PR #<n>`) and push so the finalized plan is part of this PR. This applies equally to a freshly-written plan and one the user brought in.
 
-## 4. Review gauntlet
+## 4. Review gauntlet — parallel
 
-Run **in order** — each surfaces different defects, each posts its findings to the PR:
+Run all three reviewers **at once** via **`/be-review`** (Skill tool), which fans
+each out into its own detached git worktree off the branch HEAD, runs every
+reviewer's **full multi-round debate to consensus concurrently** (codex⇄claude,
+lowy⇄hickey, and code-police's rules→fact-check→elegance — no depth is dropped),
+then **consolidates** their per-track commits onto the branch with `git
+cherry-pick`. The common case is no overlap (clean picks); the rare overlap — two
+debates editing the same lines — is reconciled to honor both fixes.
 
-1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus, commits per round, and posts its summary as a PR comment by default. Let it finish before moving on.
-2. **`/lens-debate`** (Skill tool) on the diff, briefed with the change rationale only — do **not** seed findings. One call does the whole `/lowy` ⇄ `/hickey` structural pass: it reviews with both lenses **independently in parallel** (forcing both onto Opus, overriding their `model: sonnet` frontmatter), debates **every** finding to consensus, and applies each agreed `fix` as its own commit. **It MUST post the per-finding debate ledger (origin, finding, disposition, applied commit) to the PR as a comment — this is mandatory; confirm the comment landed** (it is `/lens-debate`'s default, so don't pass `--no-comment`). Pass the change rationale via its `rationale` arg so the lenses don't flag deliberate decisions. Deadlock is not possible; on the rare **unresolved** finding, adjudicate it yourself before moving on. Let it finish.
-3. **`/code-police`** (Skill tool) on the resulting diff — its rules → fact-check → elegance passes until clean. **Each finding is its own commit** — never batch: apply the narrow fix, re-run **check** and **fmt**, `git add` only the touched files, commit (`fix(police):` …) with the finding restated in one line, and `git push`. Then post its findings to the PR as a comment.
+- Preflight: a non-empty diff and (since codex runs) `codex login status`.
+- Invoke `/be-review` with `base`, the change **`rationale`** (so the lenses
+  don't flag deliberate decisions — same brief the old `/lens-debate` step got),
+  and the default `tracks: [codex, lens, police]` (also the consolidation order).
+- It posts **one** consolidated `## Review gauntlet (parallel)` PR comment
+  covering all three tracks plus the consolidation ledger — confirm it landed.
+  This replaces the three separate per-reviewer comments.
+- On the rare **unresolved** lens finding or a **dropped** overlap you disagree
+  with, adjudicate it yourself before moving on. On `setup-failed` or a per-track
+  `track-error`, fall back to the serial path below for the affected track.
+
+The serial path (`/codex-debate` → `/lens-debate` → `/code-police`, each seeing
+the prior's fixes fresh) remains available and is the right call for a small,
+correctness-critical change where cross-track staleness matters — and is the
+automatic fallback under codex/opencode runtimes, which lack the `Workflow`
+engine `/be-review` needs.
 
 ## 5. Ship
 
@@ -55,6 +74,6 @@ Run **in order** — each surfaces different defects, each posts its findings to
 
 ## Done
 
-Report the PR URL, the outcome of each review (codex consensus or reviewer-error, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+Report the PR URL, the parallel gauntlet outcome (per-track: codex consensus or reviewer-error, lens-debate consensus, police findings actioned) and the consolidation ledger (clean picks vs reconciled overlaps), and CI status. Never merge — the human reviews the per-track commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -54,9 +54,10 @@ debates editing the same lines — is reconciled to honor both fixes.
 - Invoke `/be-review` with `base`, the change **`rationale`** (so the lenses
   don't flag deliberate decisions — same brief the old `/lens-debate` step got),
   and the default `tracks: [codex, lens, police]` (also the consolidation order).
-- It posts **one** consolidated `## Review gauntlet (parallel)` PR comment
-  covering all three tracks plus the consolidation ledger — confirm it landed.
-  This replaces the three separate per-reviewer comments.
+- Its **Report** phase posts a **detailed PR comment per track** (codex debate
+  table, lens per-finding ledger, police findings) plus the consolidation ledger —
+  automatically, so the trail lands regardless of caller. Confirm the comments
+  landed (the workflow returns their URLs in `comments`).
 - On the rare **unresolved** lens finding or a **dropped** overlap you disagree
   with, adjudicate it yourself before moving on. On `setup-failed` or a per-track
   `track-error`, fall back to the serial path below for the affected track.

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -67,10 +67,24 @@ correctness-critical change where cross-track staleness matters — and is the
 automatic fallback under codex/opencode runtimes, which lack the `Workflow`
 engine `/be-review` needs.
 
-## 5. Ship
+## 5. Ship — CI and evidence in parallel
 
-1. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
-2. **`/evidence`** — follow the **`## PR evidence`** section of `.agency/do.md` for the capture procedure, then post the result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff. Skip only if that section says to (or is absent).
+`/ci` and `/evidence` are independent — one exercises the build/test pipeline, the
+other captures on-screen behavior — so **run them concurrently**; don't wait for
+green before capturing.
+
+1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
+   consume `--progress json`) so it churns while you capture evidence. React to
+   streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
+   on real failures, confirm green on the final `HEAD`.
+2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
+   evidence`** section of `.agency/do.md` for the capture procedure, then post the
+   result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior
+   even when there's no visual diff. Skip only if that section says to (or is
+   absent).
+3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
+   is posted. If a CI fix-commit changed visible behavior *after* capture,
+   re-capture so the evidence matches what actually merges.
 
 ## Done
 

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -106,9 +106,10 @@ collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
-- **consensus** — codex approved with no blocking/major findings open. This is
-  the *only* way the debate ends *normally*: it keeps running rounds until codex
-  and Claude agree, with no round cap and no deadlock exit. (The harness's own
+- **consensus** — every finding codex raised is resolved (any severity — Claude
+  fixed it or codex conceded the dispute). This is the *only* way the debate ends
+  *normally*: it keeps running rounds until codex and Claude agree on every point,
+  with no round cap and no deadlock exit. (The harness's own
   per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
   a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
@@ -143,7 +144,7 @@ the per-round commits sit on the local branch for the human to review):
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
-  (approved? open blocking/major count), Claude's dispositions, and the
+  (approved? open-findings count), Claude's dispositions, and the
   round's `commit` SHA — so the convergence reads round by round.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
@@ -152,7 +153,7 @@ the per-round commits sit on the local branch for the human to review):
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
   `gh pr comment`. Include: the **consensus** outcome badge and the round count;
   a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
-  table (codex approved? open blocking/major findings; Claude's dispositions; the
+  table (codex approved? open-findings count; Claude's dispositions; the
   round's commit SHA) showing how the two sides converged. Use a
   single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -113,7 +113,12 @@ collide** and the scratch never shows up in the diff codex reviews. It returns:
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
   **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
-  carries the failure detail. Do **not** treat it as consensus (see step 3).
+  carries the failure detail (including how many attempts were made). Do **not**
+  treat it as consensus (see step 3). **Transient failures are retried first:**
+  `codex-review.sh` retries the `codex exec` invocation with linear backoff
+  (default 3 attempts; tune via `CODEX_REVIEW_RETRIES` / `CODEX_REVIEW_BACKOFF`)
+  and only synthesizes the reviewer-error verdict once every attempt comes back
+  empty — so a single codex hiccup no longer sinks the round.
 
 ### 3. Present the result
 

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -47,7 +47,9 @@ Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
   the repo default branch as `git symbolic-ref --short refs/remotes/origin/HEAD`
   (e.g. `origin/master`) — used **as-is**, NOT stripped to local `master` (which
   can lag the remote). Fallback `origin/master`. Step 1 runs `git fetch origin`
-  first so the ref is current.
+  first so the ref is current. The workflow then resolves this to the **merge-base**
+  of `base` and HEAD and diffs against that, so commits `base` gained since the
+  branch forked aren't reviewed as part of this change.
 - **`--no-commit`**: don't commit per round — leave all agreed changes
   uncommitted in the working tree for you to commit yourself. Default is to
   **commit each round** (see below).

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -108,12 +108,12 @@ async function codexReviews(round, rebuttalJson) {
 
 ${rebuttalJson}
 
-2. Run, from the repo root \`${repoPath}\`:
-   \`bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
+2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
     : `1. (No prior rebuttal this round.)
 
-2. Run, from the repo root \`${repoPath}\`:
-   \`bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
+2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -133,7 +133,7 @@ ${rebuttalStep}
 }
 
 async function claudeResponds(round, verdict) {
-  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git diff ${base}\` and read surrounding code as needed.
+  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git -C ${repoPath} diff ${base}\` and read surrounding code as needed.
 
 CODEX's latest verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
@@ -194,10 +194,10 @@ async function commitRound(round, files, message) {
 
 ${message}
 
-3. Run, from the repo root \`${repoPath}\`:
-   \`git add -- ${fileArgs} && git commit -F ${msgPath}\`
+3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
+   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git rev-parse HEAD\`. Do NOT push.`
+4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:round${round}`, phase: 'Debate' })
 }
 

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -87,19 +87,10 @@ const CLAUDE_RESPONSE_SCHEMA = {
   required: ['summary', 'actions', 'filesChanged', 'done'],
 }
 
-// ---------------------------------------------------------------------------
-// Consensus helper
-// ---------------------------------------------------------------------------
-// A finding still "counts against" consensus only if it is open AND
-// blocking/major. Minor issues and nits never block agreement. Consensus is the
-// ONLY terminal state — there is no round cap and no deadlock exit, so the loop
-// runs until codex approves with nothing blocking/major open. The debate is
-// pointless if it bails to "deadlock"; the two sides must argue it out until
-// one concedes.
-function blockingOpen(verdict) {
-  return (verdict.findings || []).filter(
-    (f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major'),
-  )
+// Consensus = no finding left open, any severity. The loop runs until codex
+// resolves every one (CLAUDE fixed it, or codex conceded a dispute). No cap.
+function openFindings(verdict) {
+  return (verdict.findings || []).filter((f) => f.status !== 'resolved')
 }
 
 // ---------------------------------------------------------------------------
@@ -138,25 +129,21 @@ ${rebuttalStep}
 }
 
 async function claudeResponds(round, verdict) {
-  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git -C ${repoPath} diff ${base}\` and read surrounding code as needed.
+  const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
-CODEX's latest verdict (JSON):
+Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
+
+CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
-For EACH finding:
-  - If you AGREE: fix it now by editing the code in the working tree (use your editing tools). Record disposition "fixed".
-  - If you DISAGREE: do NOT change the code. Record disposition "disputed" with a specific, technical reason citing file:line or the actual behavior. Concede when codex is right — do not dispute merely to win.
-  - If PARTIALLY right: fix the valid part, explain the rest. Record "partial".
+Address EVERY finding, any severity (don't skip minors/nits):
+  - agree → fix it in the working tree; disposition "fixed".
+  - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
+  - partly → fix the valid part, explain the rest; disposition "partial".
 
-Constraints:
-  - Edit the WORKING TREE only. Do NOT git add / commit / push, and do NOT create or modify a PR.
-  - You may run a trivial formatter on files you changed if the project has one.
-  - Keep fixes tightly scoped to the findings.
+Edit the working tree only — do NOT git add/commit/push. You may run the formatter on files you touched.
 
-Then return your structured response:
-  - actions: one per finding you addressed (findingId, disposition, detail).
-  - filesChanged: every working-tree file you edited this round.
-  - done: true ONLY if nothing further should change — i.e. everything valid is fixed and you stand by any remaining disputes. If you fixed things and want codex to re-check, that is still done=true (codex re-reviews next round regardless).`
+Return: actions (one per finding — findingId, disposition, detail), filesChanged, and done (true once you've addressed every finding this round).`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -218,12 +205,10 @@ let lastClaude = null
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
 // ---------------------------------------------------------------------------
-// The debate continues, round after round, until codex approves with nothing
-// blocking/major open. There is deliberately no upper bound and no early
-// "deadlock" surrender: a debate that quits without agreement defeats the
-// purpose, so the two sides keep arguing until one concedes. (The harness's own
-// per-workflow agent backstop is the only hard ceiling; interrupt via
-// /workflows or TaskStop if you ever need to stop one by hand.)
+// The debate continues, round after round, until codex resolves every finding
+// (any severity). No upper bound, no "deadlock" surrender: the two sides argue
+// every point until one concedes. (The harness's per-workflow agent backstop is
+// the only hard ceiling; interrupt via /workflows or TaskStop by hand.)
 phase('Debate')
 
 // Resolve the diff base to the merge-base of (base, HEAD) so codex reviews only
@@ -255,12 +240,11 @@ for (let round = 1; ; round++) {
     break
   }
 
-  const blocking = blockingOpen(verdict)
-  log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
+  const open = openFindings(verdict)
+  log(`Round ${round}: codex approved=${verdict.approved}, findings open=${open.length}`)
 
-  // Consensus — the normal exit: codex is satisfied and nothing blocking/major
-  // remains open.
-  if (verdict.approved && blocking.length === 0) {
+  // Consensus: every finding resolved (any severity).
+  if (open.length === 0) {
     break
   }
 

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -216,7 +216,7 @@ phase('Debate')
 // forked (those would otherwise show up in `git diff base` — master's drift
 // reviewed as ours). A thin mechanical git agent; the workflow can't run git
 // itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
-const rawBase = a.base || 'origin/master'
+const rawBase = base
 const baseRes = await agent(
   `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
   { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -11,7 +11,12 @@ export const meta = {
 // ---------------------------------------------------------------------------
 const a = args || {}
 const repoPath = a.repoPath || '.'
-const base = a.base || 'origin/master'
+// The diff base. Resolved to the MERGE-BASE of (rawBase, HEAD) just before the
+// debate (see phase 'Debate') so commits rawBase gained since the branch forked
+// aren't reviewed as if this change made them. `let` because that resolution
+// reassigns it; every prompt reads the resolved value. (Idempotent when the
+// caller already passed a merge-base SHA, e.g. /be-review.)
+let base = a.base || 'origin/master'
 // Where the generated skill lives, so the codex runner can find codex-review.sh.
 const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // Per-worktree scratch dir for rebuttal/verdict files. Derived from repoPath
@@ -220,6 +225,18 @@ let lastClaude = null
 // per-workflow agent backstop is the only hard ceiling; interrupt via
 // /workflows or TaskStop if you ever need to stop one by hand.)
 phase('Debate')
+
+// Resolve the diff base to the merge-base of (base, HEAD) so codex reviews only
+// what THIS branch changed, not commits the base branch gained since the branch
+// forked (those would otherwise show up in `git diff base` — master's drift
+// reviewed as ours). A thin mechanical git agent; the workflow can't run git
+// itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const baseRes = await agent(
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+)
+if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
+log(`Diffing against ${base.slice(0, 12)} (merge-base of ${a.base || 'origin/master'} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -259,7 +259,20 @@ for (let round = 1; ; round++) {
   const open = openFindings(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, findings open=${open.length}`)
 
-  // Consensus: every finding resolved (any severity).
+  // Consensus requires BOTH no open finding AND codex's explicit approval. An
+  // inconsistent verdict — `approved:false` with nothing open — is not consensus:
+  // codex declined to approve while leaving us nothing to route to Claude, so
+  // treating it as agreement would ship an unapproved change. There's no finding
+  // to debate, so re-running codex would just replay the same inconsistency;
+  // surface it as a reviewer error (the terminal abnormal path) instead of
+  // looping forever or falsely converging.
+  if (open.length === 0 && verdict.approved !== true) {
+    status = 'reviewer-error'
+    log(`Round ${round}: inconsistent verdict — approved=false with no open findings; aborting as reviewer-error.`)
+    break
+  }
+
+  // Consensus: codex approved AND every finding resolved (any severity).
   if (open.length === 0) {
     break
   }

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -216,12 +216,28 @@ phase('Debate')
 // forked (those would otherwise show up in `git diff base` — master's drift
 // reviewed as ours). A thin mechanical git agent; the workflow can't run git
 // itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const rawBase = a.base || 'origin/master'
 const baseRes = await agent(
-  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
-  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },
 )
-if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
-log(`Diffing against ${base.slice(0, 12)} (merge-base of ${a.base || 'origin/master'} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
+// Fail loud on a bad base. Falling back to the raw `${base}` tip would review the
+// base branch's drift since the fork as if this change made it — the exact noise
+// the merge-base removes — so a missing/typoed/stale base must abort, not degrade.
+if (!baseRes?.sha?.trim()) {
+  const err = (baseRes?.error || '').trim()
+  log(`Aborting: \`git merge-base ${rawBase} HEAD\` failed; the diff scope can't be trusted. Not falling back to the raw ${rawBase} tip.`)
+  return {
+    status: 'merge-base-error',
+    base: rawBase,
+    rounds: 0,
+    transcript: [],
+    finalVerdict: null,
+    note: `merge-base of \`${rawBase}\` and HEAD could not be resolved (missing/typoed base, stale ref, or unrelated history), so the review scope is untrustworthy. Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
+base = baseRes.sha.trim()
+log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -115,14 +115,38 @@ EOF
 # model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
 # relying on the user's global ~/.codex/config.toml — review is the one place we
 # always want codex thinking at full depth, regardless of their default.
-if ! codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="xhigh" \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"</dev/null >"$log" 2>&1; then
-  echo "codex exec exited non-zero (see $log)" >&2
-fi
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
+# hiccups, a spurious internal error) and writes no verdict — which would
+# otherwise degrade the whole track to reviewer-error on a single bad roll.
+# Retry the invocation with linear backoff, accepting the first attempt that
+# writes a non-empty verdict to "$out". Tunable via env: CODEX_REVIEW_RETRIES
+# (total attempts, default 3), CODEX_REVIEW_BACKOFF (base seconds, default 5 —
+# attempt n waits n*base). Only after every attempt fails empty do we synthesize
+# the reviewerError verdict below.
+attempts="${CODEX_REVIEW_RETRIES:-3}"
+backoff="${CODEX_REVIEW_BACKOFF:-5}"
+n=1
+while :; do
+  rm -f "$out"
+  if ! codex exec \
+        --sandbox read-only \
+        -c model_reasoning_effort="xhigh" \
+        --output-schema "$schema" \
+        -o "$out" \
+        "$prompt"</dev/null >"$log" 2>&1; then
+    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+  fi
+  # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
+  # make a non-empty "$out" a real, schema-valid verdict, not a partial.
+  [ -s "$out" ] && break
+  # Out of attempts — fall through to the synthesized reviewerError verdict.
+  [ "$n" -ge "$attempts" ] && break
+  wait_s=$(( backoff * n ))
+  echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+  n=$(( n + 1 ))
+  sleep "$wait_s"
+done
 
 if [ ! -s "$out" ]; then
   # codex produced no verdict — synthesize a schema-valid error verdict so the
@@ -132,9 +156,9 @@ if [ ! -s "$out" ]; then
   # substantive disagreement, so it must NOT be routed to Claude (there are no
   # findings to act on) and must NOT spin the loop forever.
   tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" '{
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
     approved: false,
-    summary: ("codex produced no verdict this round. Tail of log: " + $log),
+    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
     findings: [],
     responseToRebuttal: "",
     reviewerError: true

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -78,37 +78,38 @@ fi
 # Unquoted heredoc: only $base and $rebuttal_block expand. No backticks and no
 # other $/$(...) appear in the body, so there is nothing else to interpret.
 prompt="$(cat <<EOF
-You are CODEX, a rigorous, fair senior code reviewer in an automated review
-debate with another AI engineer ("CLAUDE") who authored the changes.
+You are CODEX, a rigorous senior code reviewer. Review the changes in this branch
+and give your honest, thorough feedback — exactly as you would on a serious PR.
+You're in a debate with the author ("CLAUDE"), who will fix what they agree with
+and push back, with reasons, on what they don't.
 
-REVIEW SCOPE — the full current state of the working tree against the base
-branch '$base', which includes committed AND uncommitted changes. Run these
-yourself:
+Inspect the change yourself (READ-ONLY — do not modify, create, or delete anything,
+and run no git write command: add/commit/push/stash/checkout):
 
-    git diff $base       (committed + tracked-but-unstaged changes)
-    git status --short   (find untracked/new files)
+    git diff $base       (committed + unstaged changes on this branch)
+    git status --short   (untracked/new files — read those too; they aren't in the diff)
 
-Then read every new/changed file plus surrounding context and review the change
-as a whole. Untracked new files do NOT appear in 'git diff', so you MUST inspect
-'git status --short' and read those files explicitly.
+Read every changed file plus enough surrounding code to judge it in context.
+Ignore the debate's own scratch dir '.codex-debate/' if it appears.
 
-IGNORE the debate's own scratch dir '.codex-debate/' if it shows up — it holds
-this process's verdict/rebuttal files, not part of the change under review.
-
-THIS IS READ-ONLY. Do NOT modify, create, or delete any files. Do NOT run any
-git write command (add/commit/push/stash/checkout) or any other state-mutating
-command. You are only inspecting.
-
-Review for correctness bugs, logic errors, silent error-swallowing, unjustified
-fallbacks, security issues, and clear simplicity/efficiency problems. Be
-specific and concrete; cite file:line. Do NOT invent issues to look busy — if
-the change is sound, approve it.
+Give ALL your feedback in this pass — every issue worth raising, at EVERY severity
+(blocking, major, minor, nit): correctness bugs, logic errors, silently swallowed
+errors, unjustified fallbacks, security problems, and clear simplicity/efficiency
+issues. Don't hold issues back for a later round, and don't limit yourself to
+blockers — surface everything you see now. Cite file:line. (If the change is
+genuinely clean, approving with no findings is fine — just never stay quiet about
+a real issue to seem agreeable.)
 $rebuttal_block
-Return a verdict matching the provided JSON schema:
-  - approved: true ONLY when no blocking or major issues remain (minor/nits may remain).
-  - findings: reuse stable ids (F1, F2, ...) across rounds for the same issue; set
-    status=resolved once adequately addressed, else open.
-  - responseToRebuttal: address CLAUDE's disputes directly (empty on round 1).
+Return your review in the JSON schema:
+  - findings: one entry per issue, each with a severity and a stable id (F1, F2, …)
+    reused across rounds for the same issue. Set status=resolved once it is
+    adequately addressed (CLAUDE fixed it, OR you accept CLAUDE's reasoning); else open.
+  - approved: true ONLY when EVERY finding is resolved — all your feedback addressed
+    at every severity, not just blockers. The review is not done while any issue you
+    raised still stands open.
+  - responseToRebuttal: when CLAUDE disputes a finding, address each dispute
+    individually — concede (mark that finding resolved) or hold firm with specific,
+    technical reasoning. Leave no dispute unanswered. Empty on round 1.
 EOF
 )"
 

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -130,6 +130,19 @@ EOF
 # the reviewerError verdict below.
 attempts="${CODEX_REVIEW_RETRIES:-3}"
 backoff="${CODEX_REVIEW_BACKOFF:-5}"
+# Validate both as positive integers. Left unchecked, a non-numeric value makes
+# the arithmetic `[ "$n" -ge "$attempts" ]` test error every iteration, so the
+# loop would spin forever instead of giving up and synthesizing the reviewerError
+# verdict. Fall back to the documented defaults (and clamp attempts to >=1) loudly
+# rather than wedge the headless debate on a typo'd override.
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+  attempts=3
+fi
+if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+  backoff=5
+fi
 n=1
 while :; do
   rm -f "$out"

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -65,12 +65,15 @@ fi
 rebuttal_block=""
 if [ -n "$rebuttal" ]; then
   rebuttal_block="
-CLAUDE responded to your PREVIOUS review as follows. Take it seriously: where a
-fix landed in the working tree, verify it and mark that finding resolved; where
-CLAUDE disputes a finding, either concede (mark it resolved) or hold firm with
-specific reasoning in responseToRebuttal.
+This is a FOLLOW-UP round — you already gave your full review. Your job now is to
+CLOSE OUT the findings already on the table, not re-scan the whole diff for more.
+For each existing finding: verify CLAUDE's fix and mark it resolved, or address
+CLAUDE's dispute (concede and mark resolved, or hold firm with specific reasoning
+in responseToRebuttal). Raise a NEW finding ONLY if CLAUDE's changes this round
+introduced it (a regression). Do NOT keep surfacing pre-existing issues you didn't
+raise in round 1 — that prevents the debate from ever converging.
 
-CLAUDE's response (JSON):
+CLAUDE responded to your PREVIOUS review as follows:
 $rebuttal
 "
 fi

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -144,14 +144,19 @@ if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
   backoff=5
 fi
 n=1
+: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
 while :; do
   rm -f "$out"
+  # Append (not truncate): when every attempt fails, the synthesized reviewerError
+  # verdict's tail_log must reflect ALL attempts' diagnostics — surfacing the exact
+  # transient failures this retry loop exists to weather — not just the final one.
+  echo "=== attempt $n/$attempts ===" >>"$log"
   if ! codex exec \
         --sandbox read-only \
         -c model_reasoning_effort="xhigh" \
         --output-schema "$schema" \
         -o "$out" \
-        "$prompt"</dev/null >"$log" 2>&1; then
+        "$prompt"</dev/null >>"$log" 2>&1; then
     echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
   fi
   # Success the moment codex writes a verdict: the kernel sandbox + --output-schema

--- a/.apm/skills/codex-debate/scripts/codex-verdict.schema.json
+++ b/.apm/skills/codex-debate/scripts/codex-verdict.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "approved": {
       "type": "boolean",
-      "description": "true ONLY if no blocking or major issues remain. Minor issues and nits may remain."
+      "description": "true ONLY when every finding is resolved — all your feedback addressed at any severity (minor and nit included), not just blockers."
     },
     "summary": {
       "type": "string",

--- a/.apm/skills/lens-debate/SKILL.md
+++ b/.apm/skills/lens-debate/SKILL.md
@@ -94,6 +94,8 @@ Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-co
   given, else the repo default branch via
   `git symbolic-ref --short refs/remotes/origin/HEAD` (e.g. `origin/master`),
   used **as-is**. Fallback `origin/master`. Step 1 runs `git fetch origin` first.
+  The workflow resolves this to the **merge-base** of `base` and HEAD and diffs
+  against that, so the base branch's drift since the fork isn't reviewed as ours.
 - **`--max-rounds <n>`**: safety backstop on debate rounds. Default **12**. Not a
   deadlock cap (see above) — raise it freely.
 - **`--no-commit`**: still apply the agreed fixes to the working tree, but leave

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -120,7 +120,7 @@ const FINDINGS_SCHEMA = {
   properties: {
     findings: {
       type: 'array',
-      description: 'your INDEPENDENT findings (≤4, high-confidence; an empty list is a fine verdict for a clean diff)',
+      description: 'ALL your independent structural findings — every issue worth raising through your lens, no cap. An empty list is fine only for a genuinely clean diff.',
       items: {
         type: 'object',
         additionalProperties: false,
@@ -184,7 +184,7 @@ function reviewBrief(lens, framework, probe) {
 
 Review the change through the **${framework}** lens, INDEPENDENTLY — you are NOT seeing any other reviewer's findings. That independence is the whole point: being handed someone else's curated finding biases the verdict.
 ${rationaleBlock}${probeBlock}
-Emit your own findings (≤4, high-confidence). Each: a title, a file:line location, the problem in your lens's terms, a concrete suggestion, and a disposition — \`fix\` (worth changing in THIS PR) or \`drop\` (observation only). Do not invent issues to look thorough: an empty list, or all-drop, is a fine verdict for a clean diff.`
+Give ALL your findings — every structural issue you see through your lens, no cap, at every level (boundary, complecting, naming, duplication, …). Each: a title, a file:line location, the problem in your lens's terms, a concrete suggestion, and a disposition — \`fix\` (worth changing in THIS PR) or \`drop\` (observation only). Don't fabricate issues, but don't hold any back either; an empty list is fine only for a genuinely clean diff.`
 }
 
 function findingLine(f) {

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -69,7 +69,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing
 // lesson from #1109: curation biases the verdict).
-const DIFF = `Inspect the FULL change in the repo at \`${repoPath}\`: run \`git diff ${base}\` (committed + unstaged) and \`git status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore the debate's own scratch dir \`.lens-debate/\` if it appears.`
+const DIFF = `Inspect the FULL change in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so use \`git -C ${repoPath}\` and ABSOLUTE paths under \`${repoPath}\`: run \`git -C ${repoPath} diff ${base}\` (committed + unstaged) and \`git -C ${repoPath} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore the debate's own scratch dir \`.lens-debate/\` if it appears.`
 
 const rationaleBlock = rationale ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n` : ''
 
@@ -172,7 +172,7 @@ Round ${roundNum}. For EVERY contested finding id above, output a disposition (\
 }
 
 function implementBrief(fix) {
-  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\`.
+  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\`.
 
 Finding ${fix.id} (raised by ${fix.origin}) — ${fix.title}
   at ${fix.location}
@@ -205,10 +205,10 @@ Agreed by the lowy ⇄ hickey lens debate (finding ${fix.id}, raised by ${fix.or
 
 ${message}
 
-3. Run, from the repo root \`${repoPath}\`:
-   \`git add -- ${fileArgs} && git commit -F ${msgPath}\`
+3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
+   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git rev-parse HEAD\`. Do NOT push.`
+4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply' })
 }
 

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -77,11 +77,31 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // changed, not the base branch's drift since the fork. A thin mechanical git
 // agent (the workflow can't run git itself); grouped under the Review phase.
 // Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const rawBase = a.base || 'origin/master'
 const baseRes = await agent(
-  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
-  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },
 )
-if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
+// Fail loud on a bad base. Falling back to the raw `${base}` tip would make the
+// lenses review the base branch's drift since the fork as if this change made it —
+// the exact noise the merge-base removes — so a missing/typoed/stale base aborts.
+if (!baseRes?.sha?.trim()) {
+  const err = (baseRes?.error || '').trim()
+  log(`Aborting: \`git merge-base ${rawBase} HEAD\` failed; the diff scope can't be trusted. Not falling back to the raw ${rawBase} tip.`)
+  return {
+    status: 'merge-base-error',
+    base: rawBase,
+    rounds: 0,
+    withPolice,
+    settled: [],
+    unresolved: [],
+    applied: [],
+    reviews: {},
+    history: [],
+    note: `merge-base of \`${rawBase}\` and HEAD could not be resolved (missing/typoed base, stale ref, or unrelated history), so the review scope is untrustworthy. Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
+base = baseRes.sha.trim()
 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -77,7 +77,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // changed, not the base branch's drift since the fork. A thin mechanical git
 // agent (the workflow can't run git itself); grouped under the Review phase.
 // Idempotent when `base` is already a merge-base SHA (caller resolved it).
-const rawBase = a.base || 'origin/master'
+const rawBase = base
 const baseRes = await agent(
   `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
   { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -26,7 +26,13 @@ const MODEL = 'opus'
 // ---------------------------------------------------------------------------
 const a = args || {}
 const repoPath = a.repoPath || '.'
-const base = a.base || 'origin/master'
+// The diff base. Resolved to the MERGE-BASE of (rawBase, HEAD) just below, before
+// DIFF is built, so the lenses review only what THIS branch changed — not commits
+// the base branch gained since the branch forked (those would otherwise appear in
+// `git diff base` as the base branch's drift, reviewed as ours). `let` because the
+// resolution reassigns it. Idempotent when the caller already passed a merge-base
+// SHA (e.g. /be-review).
+let base = a.base || 'origin/master'
 // Safety backstop only — NOT a deadlock cap. The debate runs until consensus;
 // this just keeps a pathologically oscillating debate from running unbounded.
 // Hitting it is reported as `unresolved` (needs human), never `deadlock`, and
@@ -65,6 +71,17 @@ const REVIEWERS = [
   { lens: 'hickey', framework: 'structural simplicity — independent concerns complected, or one thing fragmented? (Simple Made Easy)' },
 ]
 if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, correctness, and common-mistake review' })
+
+// Resolve the diff base to the merge-base of (base, HEAD) BEFORE building DIFF
+// (which interpolates `base` eagerly), so the lenses review only what this branch
+// changed, not the base branch's drift since the fork. A thin mechanical git
+// agent (the workflow can't run git itself); grouped under the Review phase.
+// Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const baseRes = await agent(
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+)
+if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -62,9 +62,13 @@ to `cd`.
   its own commit. Pass the change rationale so deliberate decisions aren't flagged.
 - **police** — `/code-police`'s three cold passes (rule checklist, fact-check,
   elegance) reproduced as parallel agents, each finding applied as its own commit
-  (`fix(police):`). Per-finding `just check` is **deferred** to the
-  post-consolidation check + `/be` §5 CI rather than run 3× concurrently across
-  the parallel worktrees; `fmt`-on-touched-files still runs in each apply.
+  (`fix(police):`). The passes run **until a sweep is clean** (re-reviewing the
+  updated worktree after each apply, so a fix that introduces or only partially
+  resolves an issue is caught), capped at a few sweeps; hitting the cap with issues
+  still open reports `incomplete` rather than a false consensus.
+  `fmt`-on-touched-files runs in every apply. Per-finding `just check` is
+  **deferred** to the post-consolidation check + `/be` §5 CI rather than run 3×
+  concurrently across the parallel worktrees.
 
 ## Arguments
 
@@ -144,18 +148,31 @@ track + the consolidation ledger), **Cleanup** (tear down the worktrees). It
 returns:
 
 ```
-{ status,                  // 'done' | 'no-commit' | 'setup-failed'
+{ status,                  // 'done' | 'consolidation-incomplete' | 'consolidation-aborted' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'
   consolidation,           // { finalHead, picks[] }  (null when not consolidated)
+  preservedTracks,         // tracks NOT consolidated (worktrees kept); non-empty ⇒ status incomplete/aborted
   conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
   comments }               // { consolidation, codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
-  and re-run) or no worktree could be created. `tracks` carries the per-track
-  `track-error` detail.
+  and re-run), an unresolvable merge-base, a malformed `runId`/`tracks` argument,
+  or no worktree could be created. `tracks` carries the per-track `track-error`
+  detail.
+- `consolidation-incomplete` — the picks ran, but at least one requested track was
+  **preserved** (left uncommitted edits, couldn't be confirmed clean, or crashed
+  with committed-but-unreplayed work), so its fixes live only in its worktree.
+  `preservedTracks` names them and each `tracks[t].note` has the recovery
+  cherry-pick. `/be` should adjudicate these before continuing rather than treat
+  the gauntlet as fully landed.
+- `consolidation-aborted` — the branch HEAD moved or the main worktree went dirty
+  **during** the (long) parallel tracks phase, so the cherry-pick base is no longer
+  the reviewed `branchHead`. Nothing was consolidated and **all** track worktrees
+  are preserved (`preservedTracks` + per-track recovery cherry-picks). Resolve the
+  drift, then consolidate by hand or re-run.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
   **uncommitted in its preserved `.worktrees/be-review-<runId>-<track>` worktree**
   and nothing is consolidated, reported, or cleaned up. The result lists those

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: be-review
+description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled). Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
+argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit]"
+---
+
+# Parallel review gauntlet
+
+`/be`'s §4 gauntlet runs three reviewers **serially** today (`/codex-debate` →
+`/lens-debate` → `/code-police`) for one structural reason: each step **commits
+fixes**, so the next reviewer sees the mutated tree. That chaining is the *only*
+thing forcing order — the reviews themselves are independent and read-only.
+
+This skill removes the chaining by giving each reviewer its **own detached git
+worktree** forked from the branch HEAD. All three multi-round debates run **at
+once**, each mutating only its own worktree, each running to full consensus (no
+depth is lost — every reviewer keeps its complete loop). When they finish, the
+orchestrator **consolidates** by cherry-picking each track's commits onto the
+branch in order. The common case is no overlap (clean picks); the rare overlap —
+two tracks editing the same lines — surfaces as a cherry-pick conflict that is
+**reconciled to honor both fixes**.
+
+```
+            ┌─ wt-codex   ─ codex⇄claude debate ─→ commits ─┐
+branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick onto branch
+            └─ wt-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
+```
+
+## Why this shape
+
+- **The debates were built for it.** `/codex-debate` and `/lens-debate` are
+  already `repoPath`-parameterized workflows whose docs promise "parallel debates
+  in different worktrees never collide." This skill is the orchestrator that
+  finally drives them that way — invoking each as a **child workflow** (one level
+  of nesting, which the runtime allows) pointed at a different worktree.
+- **No depth is traded for the parallelism.** Each track runs its *full*
+  multi-round loop to consensus — codex re-reviews its own fixes round after
+  round, the lenses debate every finding, police runs all three cold passes. The
+  only thing that changed is that the three loops run concurrently instead of
+  end-to-end.
+- **Consolidation is git, not vibes.** Each track's conclusions are real commits;
+  replaying them with `git cherry-pick` preserves each debate's per-commit ledger
+  in history and makes overlap a *detectable* conflict (`--diff-filter=U`) rather
+  than a silent clobber.
+
+## What runs in each track
+
+- **codex** — the `/codex-debate` workflow: codex (read-only, `xhigh`) ⇄ claude
+  author, to consensus, committing per round.
+- **lens** — the `/lens-debate` workflow: lowy + hickey review independently in
+  parallel (on Opus), debate every finding to consensus, apply each agreed fix as
+  its own commit. Pass the change rationale so deliberate decisions aren't flagged.
+- **police** — `/code-police`'s three cold passes (rule checklist, fact-check,
+  elegance) reproduced as parallel agents, each finding applied as its own commit
+  (`fix(police):`). Per-finding `just check` is **deferred** to the
+  post-consolidation check + `/be` §5 CI rather than run 3× concurrently across
+  the parallel worktrees; `fmt`-on-touched-files still runs in each apply.
+
+## Arguments
+
+- **`--base <branch>`**: remote-tracking ref to diff against (e.g. `origin/master`).
+  Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
+- **`--tracks codex,lens,police`**: which tracks to run *and the order they
+  consolidate in*. Default all three; codex first (it changes the most), police
+  last (lightest touch), so an overlap surfaces picking the later track.
+- **`--no-commit`**: leave each track's fixes uncommitted (debugging a single
+  track); default is to commit, since consolidation cherry-picks those commits.
+
+## Steps
+
+### 1. Resolve context
+
+- Determine `repoPath` (the worktree root, normally the cwd).
+- `git fetch origin` so the base remote-tracking ref is current.
+- Resolve `base` (a remote-tracking ref like `origin/master`).
+- Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
+- **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
+  not logged in, tell the user to run `codex login` (suggest the `!` prefix).
+
+### 2. Run the orchestrator Workflow
+
+```
+Workflow({
+  scriptPath: ".claude/skills/be-review/be-review.workflow.js",
+  args: {
+    repoPath: "<worktree root>",
+    base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
+    rationale: "<optional author note on deliberate decisions>",
+    tracks: ["codex", "lens", "police"],   // also the consolidation order
+    commit: <false only if --no-commit>
+  }
+})
+```
+
+It runs four phases the user can watch via `/workflows`: **Setup** (fan out one
+detached worktree per track), **Tracks** (the three gauntlets run concurrently to
+consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
+reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
+
+```
+{ status,                  // 'done' | 'setup-failed'
+  branchHead, finalHead, base, order,
+  tracks,                  // per-track result (codex/lens consensus, police findings/applied)
+  consolidation,           // { finalHead, picks[], conflicts[] }
+  conflicts }              // the overlaps reconciled (empty in the common case)
+```
+
+### 3. Present the result
+
+Report in chat and post **one** consolidated PR comment (this replaces the three
+separate per-reviewer comments): a `## Review gauntlet (parallel)` section with,
+per track, its outcome (codex consensus + rounds, lens consensus + per-finding
+table, police findings actioned); then the **consolidation ledger** — each
+cherry-picked commit and its outcome (`clean`/`reconciled`/`dropped`), with any
+overlap reconciliation explained. Then `git log --oneline <base>..HEAD` and
+`git diff --stat <base>` so the user sees the combined result. Never push or
+merge — the human reviews the per-track commits and merges.
+
+## Safety & notes
+
+- **Reviewers are read-only; only their own worktree is written.** Each track's
+  fixes land in `.be-review/wt-<track>/`; the branch is touched only by the
+  consolidation cherry-picks, which never push or merge.
+- **Overlap is reconciled, never silently dropped.** A cherry-pick conflict means
+  two debates changed the same lines; the orchestrator merges both intents (it
+  has both commit messages) and only drops a commit if an earlier track fully
+  subsumes it, saying so in the ledger.
+- **Cross-track staleness is the known limitation.** Because all three review the
+  *same* pre-fix branch HEAD, a track can't see another track's fixes mid-run
+  (the price of parallelism). Textual collisions are caught by consolidation;
+  residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
+  change is small and correctness-critical, the serial `/codex-debate` →
+  `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
+- **Parallel-safe.** Worktrees + scratch live under the gitignored, per-worktree
+  `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
+  scratch nests inside its worktree.
+
+## Files
+
+- `be-review.workflow.js` — the orchestrator (worktree fan-out → parallel tracks
+  → cherry-pick consolidation → cleanup). It invokes
+  `.claude/skills/{codex-debate,lens-debate}/debate.workflow.js` as child
+  workflows and reads `.claude/skills/code-police/SKILL.md` at runtime.
+
+This is generated from `.apm/skills/be-review/`; edit the source there and run
+`just ai::apm` to regenerate.
+
+ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -63,8 +63,11 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.
-- **`--no-commit`**: leave each track's fixes uncommitted (debugging a single
-  track); default is to commit, since consolidation cherry-picks those commits.
+- **`--no-commit`**: leave each track's fixes uncommitted for inspection
+  (debugging a single track). Consolidation cherry-picks per-track *commits*, so
+  with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
+  worktrees** (status `no-commit`) rather than silently discarding the uncommitted
+  edits. Default is to commit, which is what actually ships fixes.
 
 ## Steps
 
@@ -74,6 +77,12 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - `git fetch origin` so the base remote-tracking ref is current.
 - Resolve `base` (a remote-tracking ref like `origin/master`).
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
+- **Commit the change first.** Every track forks a detached worktree from the
+  branch HEAD, so only *committed* work is reviewed. If the main worktree has
+  staged/unstaged/untracked changes (outside `.be-review/`), commit (or stash)
+  them before invoking — the orchestrator's Setup preflight aborts with
+  `status: 'setup-failed'` on a dirty tree rather than reviewing an incomplete set.
+  (In `/be` this is automatic: §2/§3 commit and push before §4.)
 - **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
   not logged in, tell the user to run `codex login` (suggest the `!` prefix).
 
@@ -98,12 +107,24 @@ consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
 reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
 
 ```
-{ status,                  // 'done' | 'setup-failed'
+{ status,                  // 'done' | 'setup-failed' | 'no-commit'
   branchHead, finalHead, base, order,
-  tracks,                  // per-track result (codex/lens consensus, police findings/applied)
-  consolidation,           // { finalHead, picks[], conflicts[] }
+  tracks,                  // per-track result; ALWAYS one entry per requested track —
+                           //   a track whose worktree setup failed is status:'track-error'
+  consolidation,           // { finalHead, picks[], conflicts[] }  (null when not consolidated)
   conflicts }              // the overlaps reconciled (empty in the common case)
 ```
+
+- `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
+  and re-run) or no worktree could be created. `tracks` carries the per-track
+  `track-error` detail.
+- `no-commit` — `--no-commit` was set, so each track's fixes are left
+  **uncommitted in its preserved `.be-review/wt-<track>` worktree** and nothing is
+  consolidated or cleaned up. The result lists those `worktrees` to inspect; re-run
+  with commit enabled to actually consolidate. (`--no-commit` is a
+  single-track-debugging mode, not a way to ship fixes.)
+- For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
+  to the serial path for that track.
 
 ### 3. Present the result
 

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -143,7 +143,7 @@ returns:
                            //   a track whose worktree setup failed is status:'track-error'
   consolidation,           // { finalHead, picks[] }  (null when not consolidated)
   conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
-  comments }               // { codex, lens, police } → posted comment URLs ({} under --no-comment)
+  comments }               // { consolidation, codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -66,8 +66,10 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - **`--no-commit`**: leave each track's fixes uncommitted for inspection
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
   with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
-  worktrees** (status `no-commit`) rather than silently discarding the uncommitted
-  edits. Default is to commit, which is what actually ships fixes.
+  worktrees** (status `no-commit`) — leaving every track's worktree in place under
+  `.be-review/wt-<track>/` (the branch is untouched) rather than silently discarding
+  the uncommitted edits; inspect and tear them down yourself. Default is to commit,
+  which is what actually ships fixes.
 
 ## Steps
 
@@ -107,7 +109,7 @@ consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
 reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
 
 ```
-{ status,                  // 'done' | 'setup-failed' | 'no-commit'
+{ status,                  // 'done' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
-description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled). Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
-argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit]"
+description: Run /be's review gauntlet in PARALLEL — codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own git worktree at the same time, then consolidate the per-track commits onto the branch (the rare overlap is reconciled) and post a detailed PR comment per track. Use from /be §4, or when the user asks to "run the review gauntlet in parallel". Requires Claude Code's Workflow tool.
+argument-hint: "[--base <branch>] [--tracks codex,lens,police] [--no-commit] [--no-comment]"
 ---
 
 # Parallel review gauntlet
@@ -21,10 +21,18 @@ two tracks editing the same lines — surfaces as a cherry-pick conflict that is
 **reconciled to honor both fixes**.
 
 ```
-            ┌─ wt-codex   ─ codex⇄claude debate ─→ commits ─┐
-branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick onto branch
-            └─ wt-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
+            ┌─ be-review-codex   ─ codex⇄claude debate ─→ commits ─┐
+branch HEAD ┼─ be-review-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick → PR comments
+            └─ be-review-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
 ```
+
+The per-track worktrees live under the repo's conventional `.worktrees/`
+(gitignored) — `.worktrees/be-review-<track>`. **Isolation is structural, not
+behavioral:** every workflow agent inherits the *session* cwd (the harness has no
+per-agent cwd, and `isolation:'worktree'` can't host a multi-round debate that
+accumulates commits in one tree), so every git command is `git -C <worktree>` and
+every file path is absolute — no agent can leak into the wrong tree by forgetting
+to `cd`.
 
 ## Why this shape
 
@@ -65,11 +73,15 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
   last (lightest touch), so an overlap surfaces picking the later track.
 - **`--no-commit`**: leave each track's fixes uncommitted for inspection
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
-  with this flag the orchestrator **skips Consolidate + Cleanup and preserves the
-  worktrees** (status `no-commit`) — leaving every track's worktree in place under
-  `.be-review/wt-<track>/` (the branch is untouched) rather than silently discarding
-  the uncommitted edits; inspect and tear them down yourself. Default is to commit,
-  which is what actually ships fixes.
+  with this flag the orchestrator **skips Consolidate + Report + Cleanup and
+  preserves the worktrees** (status `no-commit`) — leaving every track's worktree
+  in place under `.worktrees/be-review-<track>/` (the branch is untouched) rather
+  than silently discarding the uncommitted edits; inspect and tear them down
+  yourself. Default is to commit, which is what actually ships fixes.
+- **`--no-comment`**: suppress the PR comments. By default the **Report** phase
+  posts a detailed PR comment per track (codex debate table, lens per-finding
+  ledger, police findings) plus the consolidation ledger — the review trail the
+  gauntlet exists to leave. This flag reports in chat only.
 
 ## Steps
 
@@ -81,10 +93,11 @@ branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
 - **Commit the change first.** Every track forks a detached worktree from the
   branch HEAD, so only *committed* work is reviewed. If the main worktree has
-  staged/unstaged/untracked changes (outside `.be-review/`), commit (or stash)
-  them before invoking — the orchestrator's Setup preflight aborts with
-  `status: 'setup-failed'` on a dirty tree rather than reviewing an incomplete set.
-  (In `/be` this is automatic: §2/§3 commit and push before §4.)
+  staged/unstaged/untracked changes (outside the gitignored `.worktrees/` and
+  `.be-review/` scratch), commit (or stash) them before invoking — the
+  orchestrator's Setup preflight aborts with `status: 'setup-failed'` on a dirty
+  tree rather than reviewing an incomplete set. (In `/be` this is automatic: §2/§3
+  commit and push before §4.)
 - **Preflight codex** (unless `--tracks` excludes it): `codex login status`. If
   not logged in, tell the user to run `codex login` (suggest the `!` prefix).
 
@@ -98,52 +111,61 @@ Workflow({
     base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
     rationale: "<optional author note on deliberate decisions>",
     tracks: ["codex", "lens", "police"],   // also the consolidation order
-    commit: <false only if --no-commit>
+    commit: <false only if --no-commit>,
+    comment: <false only if --no-comment>
   }
 })
 ```
 
-It runs four phases the user can watch via `/workflows`: **Setup** (fan out one
-detached worktree per track), **Tracks** (the three gauntlets run concurrently to
-consensus), **Consolidate** (cherry-pick each track's commits onto the branch,
-reconciling overlap), **Cleanup** (tear down the worktrees). It returns:
+It runs five phases the user can watch via `/workflows`: **Setup** (fan out one
+detached worktree per track under `.worktrees/`), **Tracks** (the three gauntlets
+run concurrently to consensus), **Consolidate** (cherry-pick each track's commits
+onto the branch, reconciling overlap), **Report** (post a detailed PR comment per
+track + the consolidation ledger), **Cleanup** (tear down the worktrees). It
+returns:
 
 ```
 { status,                  // 'done' | 'no-commit' | 'setup-failed'
   branchHead, finalHead, base, order,
   tracks,                  // per-track result; ALWAYS one entry per requested track —
                            //   a track whose worktree setup failed is status:'track-error'
-  consolidation,           // { finalHead, picks[], conflicts[] }  (null when not consolidated)
-  conflicts }              // the overlaps reconciled (empty in the common case)
+  consolidation,           // { finalHead, picks[] }  (null when not consolidated)
+  conflicts,               // the reconciled overlaps (picks whose outcome ≠ clean; empty common case)
+  comments }               // { codex, lens, police } → posted comment URLs ({} under --no-comment)
 ```
 
 - `setup-failed` — no work was consolidated: a dirty main worktree (commit/stash
   and re-run) or no worktree could be created. `tracks` carries the per-track
   `track-error` detail.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
-  **uncommitted in its preserved `.be-review/wt-<track>` worktree** and nothing is
-  consolidated or cleaned up. The result lists those `worktrees` to inspect; re-run
-  with commit enabled to actually consolidate. (`--no-commit` is a
-  single-track-debugging mode, not a way to ship fixes.)
+  **uncommitted in its preserved `.worktrees/be-review-<track>` worktree** and
+  nothing is consolidated, reported, or cleaned up. The result lists those
+  `worktrees` to inspect; re-run with commit enabled to actually consolidate.
+  (`--no-commit` is a single-track-debugging mode, not a way to ship fixes.)
 - For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
   to the serial path for that track.
 
 ### 3. Present the result
 
-Report in chat and post **one** consolidated PR comment (this replaces the three
-separate per-reviewer comments): a `## Review gauntlet (parallel)` section with,
-per track, its outcome (codex consensus + rounds, lens consensus + per-finding
-table, police findings actioned); then the **consolidation ledger** — each
-cherry-picked commit and its outcome (`clean`/`reconciled`/`dropped`), with any
-overlap reconciliation explained. Then `git log --oneline <base>..HEAD` and
-`git diff --stat <base>` so the user sees the combined result. Never push or
-merge — the human reviews the per-track commits and merges.
+**The workflow already posted the PR comments** — one detailed comment per track
+(codex debate table, lens per-finding ledger, police findings) plus the
+consolidation ledger — in its **Report** phase, so the trail is on the PR no
+matter who invoked it (the `comments` field carries the URLs). Confirm they landed
+(re-post any that returned "no PR" once the PR exists). Then summarize in chat:
+the per-track outcomes, the consolidation ledger (`clean`/`reconciled`/`dropped`),
+and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the user sees
+the combined result. Never push or merge — the human reviews the per-track commits
+and merges.
 
 ## Safety & notes
 
 - **Reviewers are read-only; only their own worktree is written.** Each track's
-  fixes land in `.be-review/wt-<track>/`; the branch is touched only by the
+  fixes land in `.worktrees/be-review-<track>/`; the branch is touched only by the
   consolidation cherry-picks, which never push or merge.
+- **Isolation is structural (cwd-independent).** Workflow agents share the session
+  cwd; the orchestrator and both child workflows (`/codex-debate`, `/lens-debate`)
+  therefore use `git -C <worktree>` and absolute paths throughout, so a forgotten
+  `cd` can't make an agent edit or commit into the wrong tree.
 - **Overlap is reconciled, never silently dropped.** A cherry-pick conflict means
   two debates changed the same lines; the orchestrator merges both intents (it
   has both commit messages) and only drops a commit if an earlier track fully
@@ -154,14 +176,16 @@ merge — the human reviews the per-track commits and merges.
   residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
   change is small and correctness-critical, the serial `/codex-debate` →
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
-- **Parallel-safe.** Worktrees + scratch live under the gitignored, per-worktree
+- **Parallel-safe.** Worktrees live under the gitignored `<repoPath>/.worktrees/`
+  and commit-message + PR-comment scratch under the gitignored
   `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
-  scratch nests inside its worktree.
+  scratch nests inside its worktree. All paths are absolute and
+  per-main-worktree, so parallel `/be-review` runs never collide.
 
 ## Files
 
 - `be-review.workflow.js` — the orchestrator (worktree fan-out → parallel tracks
-  → cherry-pick consolidation → cleanup). It invokes
+  → cherry-pick consolidation → per-track PR comments → cleanup). It invokes
   `.claude/skills/{codex-debate,lens-debate}/debate.workflow.js` as child
   workflows and reads `.claude/skills/code-police/SKILL.md` at runtime.
 

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -121,6 +121,7 @@ Workflow({
   args: {
     repoPath: "<worktree root>",
     base: "<base branch>",                 // remote-tracking ref, e.g. origin/master
+    runId: "<unique id, e.g. current epoch ms>", // isolates this run's worktrees/scratch
     rationale: "<optional author note on deliberate decisions>",
     tracks: ["codex", "lens", "police"],   // also the consolidation order
     commit: <false only if --no-commit>,
@@ -128,6 +129,12 @@ Workflow({
   }
 })
 ```
+
+**Pass a unique `runId`** (the workflow can't call `Date.now()` itself — the runtime
+forbids it to keep resume deterministic). Stamp the current epoch ms (or any unique
+token) so two `/be-review` runs in the same main worktree don't clobber each other's
+worktrees/scratch. Omitting it defaults to `'run'` — safe for a single run, unsafe
+for concurrent ones.
 
 It runs five phases the user can watch via `/workflows`: **Setup** (fan out one
 detached worktree per track under `.worktrees/`), **Tracks** (the three gauntlets

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -70,7 +70,10 @@ to `cd`.
   Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
   Setup resolves this to the **merge-base** of the branch and `base`, and *that* is
   what every reviewer diffs against — so commits `base` gained since the branch
-  forked are NOT reviewed as if this PR made them (no master-drift noise).
+  forked are NOT reviewed as if this PR made them (no master-drift noise). If the
+  merge-base can't be resolved (missing/typoed/stale base ref), Setup aborts with
+  `status: 'setup-failed'` rather than falling back to the raw `base` tip and
+  reviewing an untrustworthy scope — fix the ref (`git fetch`) and re-run.
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.
@@ -90,7 +93,10 @@ to `cd`.
 
 ### 1. Resolve context
 
-- Determine `repoPath` (the worktree root, normally the cwd).
+- Determine `repoPath` — the **absolute** worktree root (normally the cwd; resolve
+  it with `git -C . rev-parse --show-toplevel`). The orchestrator rejects a
+  relative `repoPath` with `status: 'setup-failed'`, since every git command and
+  scratch/worktree path it builds is absolute and cwd-independent.
 - `git fetch origin` so the base remote-tracking ref is current.
 - Resolve `base` (a remote-tracking ref like `origin/master`).
 - Confirm a non-empty diff: `git diff --stat <base>`. If empty, stop.
@@ -179,11 +185,22 @@ and merges.
   residual semantic staleness is backstopped by `/be` §5 CI and human review. If a
   change is small and correctness-critical, the serial `/codex-debate` →
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
-- **Parallel-safe.** Worktrees live under the gitignored `<repoPath>/.worktrees/`
-  and commit-message + PR-comment scratch under the gitignored
-  `<repoPath>/.be-review/`; each track's own `.codex-debate/`/`.lens-debate/`
-  scratch nests inside its worktree. All paths are absolute and
-  per-main-worktree, so parallel `/be-review` runs never collide.
+- **Uncommitted track edits are never silently dropped.** Consolidation replays
+  only *committed* commits and Cleanup force-removes the worktrees, so before
+  consolidating the orchestrator mechanically checks each track's worktree with
+  `git status --short`. A track that left uncommitted/untracked edits (a failed
+  commit helper, a formatter touching an unlisted file) is **excluded from
+  consolidation and its worktree is preserved** (not torn down), and surfaced in
+  the result so the human can recover it — rather than cherry-picked-around and
+  deleted.
+- **Parallel-safe — even in the same worktree.** Worktrees live under the
+  gitignored `<repoPath>/.worktrees/` as `be-review-<runId>-<track>` and the
+  commit-message + PR-comment scratch under the gitignored
+  `<repoPath>/.be-review/<runId>/`, where `<runId>` is unique per invocation; each
+  track's own `.codex-debate/`/`.lens-debate/` scratch nests inside its worktree.
+  All paths are absolute and per-run, so two `/be-review` runs — in different
+  worktrees *or the same one* — never clobber each other's live worktrees or
+  scratch. Setup never `rm -rf`s a path that could belong to a concurrent run.
 
 ## Files
 

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -68,6 +68,9 @@ to `cd`.
 
 - **`--base <branch>`**: remote-tracking ref to diff against (e.g. `origin/master`).
   Default the repo default via `git symbolic-ref --short refs/remotes/origin/HEAD`.
+  Setup resolves this to the **merge-base** of the branch and `base`, and *that* is
+  what every reviewer diffs against — so commits `base` gained since the branch
+  forked are NOT reviewed as if this PR made them (no master-drift noise).
 - **`--tracks codex,lens,police`**: which tracks to run *and the order they
   consolidate in*. Default all three; codex first (it changes the most), police
   last (lightest touch), so an overlap surfaces picking the later track.

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -27,7 +27,9 @@ branch HEAD ┼─ be-review-lens    ─ lowy⇄hickey debate  ─→ commits �
 ```
 
 The per-track worktrees live under the repo's conventional `.worktrees/`
-(gitignored) — `.worktrees/be-review-<track>`. **Isolation is structural, not
+(gitignored) — `.worktrees/be-review-<runId>-<track>`, where `<runId>` is unique
+per invocation (the returned `worktrees` field carries each track's exact path).
+**Isolation is structural, not
 behavioral:** every workflow agent inherits the *session* cwd (the harness has no
 per-agent cwd, and `isolation:'worktree'` can't host a multi-round debate that
 accumulates commits in one tree), so every git command is `git -C <worktree>` and
@@ -81,9 +83,10 @@ to `cd`.
   (debugging a single track). Consolidation cherry-picks per-track *commits*, so
   with this flag the orchestrator **skips Consolidate + Report + Cleanup and
   preserves the worktrees** (status `no-commit`) — leaving every track's worktree
-  in place under `.worktrees/be-review-<track>/` (the branch is untouched) rather
-  than silently discarding the uncommitted edits; inspect and tear them down
-  yourself. Default is to commit, which is what actually ships fixes.
+  in place under `.worktrees/be-review-<runId>-<track>/` (the branch is untouched;
+  the returned `worktrees` field carries each exact path) rather than silently
+  discarding the uncommitted edits; inspect and tear them down yourself. Default is
+  to commit, which is what actually ships fixes.
 - **`--no-comment`**: suppress the PR comments. By default the **Report** phase
   posts a detailed PR comment per track (codex debate table, lens per-finding
   ledger, police findings) plus the consolidation ledger — the review trail the
@@ -147,9 +150,10 @@ returns:
   and re-run) or no worktree could be created. `tracks` carries the per-track
   `track-error` detail.
 - `no-commit` — `--no-commit` was set, so each track's fixes are left
-  **uncommitted in its preserved `.worktrees/be-review-<track>` worktree** and
-  nothing is consolidated, reported, or cleaned up. The result lists those
-  `worktrees` to inspect; re-run with commit enabled to actually consolidate.
+  **uncommitted in its preserved `.worktrees/be-review-<runId>-<track>` worktree**
+  and nothing is consolidated, reported, or cleaned up. The result lists those
+  `worktrees` (with exact paths) to inspect; re-run with commit enabled to
+  actually consolidate.
   (`--no-commit` is a single-track-debugging mode, not a way to ship fixes.)
 - For any per-track `track-error` (setup failure or a crashed gauntlet), fall back
   to the serial path for that track.
@@ -169,8 +173,8 @@ and merges.
 ## Safety & notes
 
 - **Reviewers are read-only; only their own worktree is written.** Each track's
-  fixes land in `.worktrees/be-review-<track>/`; the branch is touched only by the
-  consolidation cherry-picks, which never push or merge.
+  fixes land in `.worktrees/be-review-<runId>-<track>/`; the branch is touched only
+  by the consolidation cherry-picks, which never push or merge.
 - **Isolation is structural (cwd-independent).** Workflow agents share the session
   cwd; the orchestrator and both child workflows (`/codex-debate`, `/lens-debate`)
   therefore use `git -C <worktree>` and absolute paths throughout, so a forgotten
@@ -187,11 +191,15 @@ and merges.
   `/lens-debate` → `/code-police` path is still available and sees each fix fresh.
 - **Uncommitted track edits are never silently dropped.** Consolidation replays
   only *committed* commits and Cleanup force-removes the worktrees, so before
-  consolidating the orchestrator mechanically checks each track's worktree with
-  `git status --short`. A track that left uncommitted/untracked edits (a failed
-  commit helper, a formatter touching an unlisted file) is **excluded from
-  consolidation and its worktree is preserved** (not torn down), and surfaced in
-  the result so the human can recover it — rather than cherry-picked-around and
+  consolidating the orchestrator mechanically checks **every live worktree** with
+  `git status --short` — including a track whose gauntlet *crashed*
+  (`track-error`), since a crash after edits-applied-but-before-commit is exactly
+  when uncommitted work is most likely. Cleanup **fails closed**: only a worktree
+  the checker reports *explicitly clean* is torn down; one that left
+  uncommitted/untracked edits (a failed commit helper, a formatter touching an
+  unlisted file, a mid-run crash) — or that the checker never reported on — is
+  **excluded from consolidation and its worktree is preserved**, and surfaced in
+  the result so the human can recover it, rather than cherry-picked-around and
   deleted.
 - **Parallel-safe — even in the same worktree.** Worktrees live under the
   gitignored `<repoPath>/.worktrees/` as `be-review-<runId>-<track>` and the

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -74,10 +74,13 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the worktree name and the scratch subdir so two /be-review runs in the SAME
 // main worktree never clobber each other's live worktrees or scratch files (the
 // old fixed `be-review-<track>` / `.be-review/*` paths let a second run `rm -rf`
-// the first run's in-flight worktree). The id is the start-time epoch ms — unique
-// per invocation, and the actual paths are reported back in the result so manual
-// inspection doesn't need to guess them.
-const RUN_ID = String(Date.now())
+// the first run's in-flight worktree). The id comes from `args.runId`: the
+// workflow runtime forbids `Date.now()`/`Math.random()` (they'd break resume), so
+// the CALLER stamps a unique value (the /be-review skill passes the launch epoch
+// ms). Defaults to 'run' when absent — fine for a single run; CONCURRENT runs in
+// the same main worktree must pass distinct ids. The actual paths are reported in
+// the result so manual inspection doesn't need to guess them.
+const RUN_ID = String(a.runId || 'run')
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -542,14 +542,18 @@ phase('Consolidate')
 // worktree — so any edit a track left UNcommitted (an apply agent that produced
 // files but whose commit helper failed, a formatter that touched an unlisted
 // file, an untracked new file) would be invisible to cherry-pick and then deleted
-// for good. Mechanically check each candidate track's worktree is clean; a dirty
-// one is excluded from both consolidation AND cleanup (its worktree is preserved
-// for the human) and surfaced in the result, instead of silently discarded.
-const consolidateCandidates = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const cleanCheck = consolidateCandidates.length
+// for good. The check runs for EVERY live worktree — including a track whose
+// gauntlet CRASHED (`track-error`): a crash after edits-applied-but-before-commit
+// is exactly when uncommitted work is most likely, so skipping crashed tracks
+// here would force-remove the very edits this gate exists to save. We only USE the
+// clean result to decide consolidation eligibility (a `track-error` track is never
+// cherry-picked regardless); for cleanup we FAIL CLOSED — any worktree that isn't
+// EXPLICITLY clean (dirty, or missing from the checker's response) is preserved,
+// never torn down. A dirty/unknown track is surfaced in the result for the human.
+const cleanCheck = liveTracks.length
   ? await agent(
-      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Do not edit anything. Tracks and their worktrees:
-${consolidateCandidates.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
+${liveTracks.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
 For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
       {
         label: 'consolidate:clean-check',
@@ -578,21 +582,31 @@ For each track return { track, clean (boolean), dirtyStatus (the offending \`sta
       },
     )
   : { tracks: [] }
-const dirtyTracks = consolidateCandidates.filter((t) => (cleanCheck?.tracks || []).find((c) => c.track === t && c.clean === false))
-for (const t of dirtyTracks) {
-  const ds = (cleanCheck?.tracks || []).find((c) => c.track === t)?.dirtyStatus || ''
+// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless the
+// checker EXPLICITLY reported it clean. So a missing row, or a row that says it's
+// dirty, both keep the worktree. `cleanTracks` is the allowlist of explicitly-clean
+// worktrees; everything else is preserved.
+const cleanResultFor = (t) => (cleanCheck?.tracks || []).find((c) => c.track === t)
+const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
+const preservedTracks = liveTracks.filter((t) => !cleanTracks.includes(t))
+for (const t of preservedTracks) {
+  const row = cleanResultFor(t)
+  const ds = row?.dirtyStatus || ''
+  const reason = row ? 'left UNcommitted changes in its worktree' : "could not be confirmed clean (no clean-check result — failing closed)"
   tracks[t] = {
     ...tracks[t],
     consolidated: false,
     dirtyStatus: ds,
-    note: `track left UNcommitted changes in its worktree (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so the edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
   }
-  log(`Consolidate: track ${t} has UNcommitted changes — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
+  log(`Consolidate: track ${t} not confirmed clean — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
 }
 
-// Only replay tracks that are clean (every agreed fix really is a commit) and made
-// real work — the agent only picks committed work.
-const consolidateOrder = consolidateCandidates.filter((t) => !dirtyTracks.includes(t))
+// Only replay tracks that are explicitly clean (every agreed fix really is a
+// commit) AND completed without crashing — a `track-error` track is never
+// cherry-picked even if its worktree happens to be clean, since its commit ledger
+// is untrustworthy. The agent only picks committed work.
+const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
@@ -651,14 +665,16 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees. Dirty tracks (uncommitted edits
-// the clean-check caught) are PRESERVED, not removed — their worktree is the only
-// place those edits live, so force-removing it would discard them.
+// Phase 5 — tear down the per-track worktrees. Only EXPLICITLY-clean worktrees are
+// torn down; anything not confirmed clean (uncommitted edits the clean-check
+// caught, OR a worktree the checker never reported on — including a crashed
+// `track-error` track) is PRESERVED, since its worktree may be the only place
+// those edits live and force-removing it would discard them. Fail closed.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-const teardownTracks = liveTracks.filter((t) => !dirtyTracks.includes(t))
-if (dirtyTracks.length) log(`Cleanup: preserving ${dirtyTracks.length} dirty worktree(s) (${dirtyTracks.join(', ')}) — they hold uncommitted edits.`)
+const teardownTracks = cleanTracks
+if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not confirmed clean (${preservedTracks.join(', ')}) — they may hold uncommitted edits.`)
 if (teardownTracks.length) {
   await agent(
     `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -582,31 +582,47 @@ For each track return { track, clean (boolean), dirtyStatus (the offending \`sta
       },
     )
   : { tracks: [] }
-// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless the
-// checker EXPLICITLY reported it clean. So a missing row, or a row that says it's
-// dirty, both keep the worktree. `cleanTracks` is the allowlist of explicitly-clean
-// worktrees; everything else is preserved.
+// FAIL CLOSED for cleanup: a track is "preserved" (kept off teardown) unless it is
+// safe to discard. A worktree is safe to discard ONLY if it was both (a) EXPLICITLY
+// reported clean by the checker AND (b) successfully replayed onto the branch — i.e.
+// it ends up in `consolidateOrder`. Everything else is preserved:
+//   - a missing clean-check row, or a row that says it's dirty → may hold UNcommitted
+//     edits (fail closed on the checker);
+//   - a `track-error` track, even one that `git status` calls clean → may hold
+//     COMMITTED-but-unreplayed work, since `consolidateOrder` deliberately excludes
+//     it (its commit ledger is untrustworthy, so the consolidator never cherry-picks
+//     it). Removing its detached worktree would make those commits unreachable.
+// `cleanTracks` is the allowlist of explicitly-clean worktrees; `consolidateOrder`
+// narrows that to the ones we actually replayed; teardown only touches the latter.
 const cleanResultFor = (t) => (cleanCheck?.tracks || []).find((c) => c.track === t)
 const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
-const preservedTracks = liveTracks.filter((t) => !cleanTracks.includes(t))
-for (const t of preservedTracks) {
-  const row = cleanResultFor(t)
-  const ds = row?.dirtyStatus || ''
-  const reason = row ? 'left UNcommitted changes in its worktree' : "could not be confirmed clean (no clean-check result — failing closed)"
-  tracks[t] = {
-    ...tracks[t],
-    consolidated: false,
-    dirtyStatus: ds,
-    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
-  }
-  log(`Consolidate: track ${t} not confirmed clean — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
-}
 
 // Only replay tracks that are explicitly clean (every agreed fix really is a
 // commit) AND completed without crashing — a `track-error` track is never
 // cherry-picked even if its worktree happens to be clean, since its commit ledger
 // is untrustworthy. The agent only picks committed work.
 const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
+
+// Preserve every live track we did NOT consolidate, so neither uncommitted edits
+// nor committed-but-unreplayed commits are lost.
+const preservedTracks = liveTracks.filter((t) => !consolidateOrder.includes(t))
+for (const t of preservedTracks) {
+  const row = cleanResultFor(t)
+  const ds = row?.dirtyStatus || ''
+  const reason =
+    tracks[t]?.status === 'track-error'
+      ? 'CRASHED (track-error) so its commit ledger is untrustworthy and it was never replayed — its worktree may hold committed-but-unconsolidated fixes'
+      : row
+        ? 'left UNcommitted changes in its worktree'
+        : 'could not be confirmed clean (no clean-check result — failing closed)'
+  tracks[t] = {
+    ...tracks[t],
+    consolidated: false,
+    dirtyStatus: ds,
+    note: `track ${reason} (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so any edits aren't lost. Inspect with \`git -C ${wtDir(t)} log ${branchHead}..HEAD\` and \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+  }
+  log(`Consolidate: track ${t} not consolidated — worktree preserved at ${wtDir(t)}.`)
+}
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
@@ -665,16 +681,18 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees. Only EXPLICITLY-clean worktrees are
-// torn down; anything not confirmed clean (uncommitted edits the clean-check
-// caught, OR a worktree the checker never reported on — including a crashed
-// `track-error` track) is PRESERVED, since its worktree may be the only place
-// those edits live and force-removing it would discard them. Fail closed.
+// Phase 5 — tear down the per-track worktrees. Only worktrees we actually
+// CONSOLIDATED (explicitly clean AND replayed onto the branch — i.e.
+// `consolidateOrder`) are torn down. Everything else is PRESERVED, since its
+// worktree may be the only place its edits live and force-removing it would
+// discard them: uncommitted edits the clean-check caught, a worktree the checker
+// never reported on, OR a crashed `track-error` track whose committed-but-
+// unreplayed fixes were deliberately excluded from consolidation. Fail closed.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-const teardownTracks = cleanTracks
-if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not confirmed clean (${preservedTracks.join(', ')}) — they may hold uncommitted edits.`)
+const teardownTracks = consolidateOrder
+if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not consolidated (${preservedTracks.join(', ')}) — they may hold uncommitted or unreplayed committed edits.`)
 if (teardownTracks.length) {
   await agent(
     `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
@@ -683,7 +701,7 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
     { label: 'cleanup:worktrees', phase: 'Cleanup', model },
   )
 } else {
-  log('Cleanup: no clean worktrees to tear down (all preserved or none live).')
+  log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
 return {

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -130,7 +130,7 @@ const IMPL_SCHEMA = {
 const CONSOLIDATE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['picks', 'conflicts'],
+  required: ['picks'],
   properties: {
     finalHead: { type: 'string', description: 'branch HEAD SHA after all picks' },
     picks: {
@@ -145,23 +145,8 @@ const CONSOLIDATE_SCHEMA = {
           sourceCommit: { type: 'string', description: 'the short SHA from the track worktree' },
           newCommit: { type: 'string', description: 'the resulting SHA on the branch' },
           outcome: { type: 'string', enum: ['clean', 'reconciled', 'dropped'] },
+          files: { type: 'array', items: { type: 'string' }, description: 'for reconciled/dropped: the overlapping files' },
           note: { type: 'string', description: 'for reconciled/dropped: how you resolved it and why' },
-        },
-      },
-    },
-    conflicts: {
-      type: 'array',
-      description: 'the overlaps you had to reconcile (subset of picks); empty in the common no-overlap case',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        required: ['track', 'sourceCommit', 'files', 'resolution'],
-        properties: {
-          track: { type: 'string' },
-          sourceCommit: { type: 'string' },
-          files: { type: 'array', items: { type: 'string' } },
-          resolution: { type: 'string', enum: ['merged', 'dropped'] },
-          note: { type: 'string' },
         },
       },
     },
@@ -228,19 +213,31 @@ if (!branchHead || liveTracks.length === 0) {
 // ---------------------------------------------------------------------------
 phase('Tracks')
 
-// The police track. /code-police is a skill, not a workflow, so its three cold
-// passes (rules / fact-check / elegance) are reproduced here as parallel agents,
-// then each agreed fix is applied as its own commit — matching /be §4.3's
-// "each finding is its own commit". Per-finding `just check` is deferred to the
-// post-consolidation check + §5 CI rather than run 3× concurrently across the
-// parallel worktrees (it would thrash the toolchain); fmt-on-touched-files still
-// runs in each apply.
+// The police track. /code-police is a skill, not a workflow, so its cold passes
+// (rules / fact-check / elegance) are fanned out here as parallel agents — but
+// each pass's *definition* stays single-sourced to code-police's SKILL.md (the
+// agents Read it; the briefs only name which section/pass to apply), and the
+// elegance pass honors the skill's tiny-diff skip. Each agreed fix is then
+// applied as its own commit — matching /be §4.3's "each finding is its own
+// commit". Per-finding `just check` is deferred to the post-consolidation check
+// + §5 CI rather than run 3× concurrently across the parallel worktrees (it
+// would thrash the toolchain); fmt-on-touched-files still runs in each apply.
 async function policeTrack(wt) {
+  // Pass *definitions* are single-sourced to code-police's SKILL.md: each brief
+  // names that pass's section so the agent (which Reads the skill below) reviews
+  // it exactly as written there — no inline checklist to drift. The elegance pass
+  // is gated on the tiny-diff heuristic the skill mandates (SKILL.md:141 — skip
+  // when the worktree diff against base is <10 lines).
+  const tinyDiff = await agent(
+    `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
+    { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
+  )
   const passes = [
-    { key: 'rules', brief: 'the built-in code-police rule checklist (dry-rule-of-three, prefer-focused-library, invalid-states-unrepresentable, no-dead-code, no-silent-error-swallowing, and the rest) PLUS any project rules' },
-    { key: 'fact-check', brief: 'a CORRECTNESS audit: logic errors, silently swallowed errors, wishful thinking, unjustified fallbacks — not style' },
-    { key: 'elegance', brief: 'simplicity and idiom: hand-rolled code that a focused library or a simpler shape would replace' },
-  ]
+    { key: 'rules', brief: 'the **Rule checklist** pass exactly as defined in that skill\'s "Running the passes" section (Pass 1) — every built-in rule plus any project rules' },
+    { key: 'fact-check', brief: 'the **Fact-check** correctness audit exactly as defined in that skill\'s "Running the passes" section (Pass 2)' },
+    { key: 'elegance', brief: 'the **Elegance** pass exactly as defined in that skill\'s "Running the passes" section (Pass 3) — simplicity and idiom' },
+  ].filter((p) => p.key !== 'elegance' || !tinyDiff?.tiny)
+  if (tinyDiff?.tiny) log('police: skipping elegance pass (tiny diff <10 lines, per code-police SKILL.md)')
   const reviews = await parallel(
     passes.map((p) => () =>
       agent(
@@ -264,7 +261,7 @@ async function policeTrack(wt) {
     const files = impl?.filesChanged ?? []
     let sha = null
     if (commit && files.length) {
-      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files) || '').trim()
+      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
     }
     applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
@@ -289,7 +286,16 @@ ${message}
 
 3. Run: \`git -C ${wt} add -- ${fileArgs} && git -C ${wt} commit -F ${msgPath}\`. Stage ONLY those files; do NOT use \`git add -A\`/\`git add .\`.
 4. Return the new commit SHA from \`git -C ${wt} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `police-commit:${id}`, phase: 'Tracks' })
+  return agent(prompt, {
+    label: `police-commit:${id}`,
+    phase: 'Tracks',
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['sha'],
+      properties: { sha: { type: 'string', description: 'the new HEAD commit SHA, hex only' } },
+    },
+  })
 }
 
 // One thunk per live track. codex and lens are existing repoPath-parameterized
@@ -320,10 +326,10 @@ for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
 // `--no-commit` short-circuit. With commit=false the tracks deliberately leave
 // their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
-// (rev-list ${branchHead}..HEAD) and cleanup tears the worktrees down — so running
-// them now would discard every reviewer's edits. Instead, stop here and hand the
-// live worktrees to the user to inspect; nothing is consolidated and nothing is
-// cleaned up. (This is the documented single-track-debugging mode.)
+// (rev-list ${branchHead}..HEAD) and cleanup's `worktree remove --force` tears the
+// worktrees down — so running them now would silently discard every reviewer's edits.
+// Instead, stop here and hand the live worktrees to the user to inspect; nothing is
+// consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
 if (!commit) {
   log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
   return {
@@ -350,7 +356,7 @@ phase('Consolidate')
 
 // Skip tracks that errored or made no commits — the agent only picks real work.
 const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Three review tracks each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
@@ -362,12 +368,12 @@ Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits 
   \`git -C ${repoPath} cherry-pick <sha>\`
 
 - **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
-- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — say so in \`note\`; never drop to avoid the work of merging.
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
 
-Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD, the per-commit \`picks\` ledger (in processing order), and the \`conflicts\` subset you had to reconcile.`
+Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
 const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
-const conflicts = consolidation?.conflicts ?? []
+const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clean')
 log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -120,6 +120,18 @@ if (!/^[A-Za-z0-9._-]+$/.test(RUN_ID) || RUN_ID === '..' || RUN_ID === '.') {
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
+// The two gitignored scratch dirs this orchestrator owns: live per-track
+// worktrees under `.worktrees/` and commit-message/PR-comment scratch under
+// `.be-review/`. Two prompts must name them in lockstep — the DIFF brief tells
+// reviewers to ignore them, and the Setup preflight excludes them from the
+// clean-tree check — so the list lives here once and both interpolate it.
+const ORCHESTRATOR_SCRATCH = ['.worktrees/', '.be-review/']
+const scratchList = ORCHESTRATOR_SCRATCH.map((d) => `\`${d}\``).join(' and ')
+// The per-track debate scratch dirs the child workflows own (codex/lens write
+// their transcripts here). The consolidation clean-check must ignore these when
+// judging whether a track left uncommitted work, so the list lives here once.
+const TRACK_SCRATCH = ['.codex-debate/', '.lens-debate/']
+const trackScratchList = TRACK_SCRATCH.map((d) => `\`${d}\``).join(', ')
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -130,11 +142,20 @@ const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 // not the raw `${base}` tip — see SETUP_SCHEMA.mergeBase. DIFF is an arrow, so it
 // reads `mergeBase` lazily at call time (Tracks phase, after Setup has set it).
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored ${scratchList} scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
   : ''
+
+// Single source of the cwd-safety contract every mechanical git agent runs under.
+// The Workflow runtime can't run git/gh itself, so a thin agent shells out — and
+// because all agents share the SESSION cwd (see SHARED-CWD NOTE), each MUST use
+// absolute paths + `git -C` and never rely on the current directory. This sentence
+// was copy-pasted across the six mechanical-agent prompts; hoisting it here means
+// the contract lives in ONE place if the shared-cwd guarantee ever changes.
+const mechanicalPreamble = (role) =>
+  `You are a MECHANICAL ${role}. Every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory.`
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -242,11 +263,11 @@ const CONSOLIDATE_SCHEMA = {
 // ---------------------------------------------------------------------------
 phase('Setup')
 
-const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
+const setupPrompt = `${mechanicalPreamble('SETUP RUNNER')} You are preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps; do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
 1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command FAILS (missing/typoed base, stale ref, or unrelated history), the review scope is untrustworthy — do NOT fall back to the raw \`${base}\`; instead set \`mergeBase\`: "" and put the exact git error in \`mergeBaseError\`, then STOP (skip worktree creation, return an empty \`worktrees\` array). (The orchestrator aborts the whole run when \`mergeBase\` is empty.)
-2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (${scratchList}). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — create a fresh detached worktree at \`branchHead\` for each track, at these EXACT absolute paths (per-run unique, so they cannot belong to another in-flight run):
 ${TRACKS.map((t) => `   - ${t}: \`git -C ${repoPath} worktree add --detach ${wtDir(t)} <branchHead>\``).join('\n')}
@@ -411,7 +432,7 @@ async function commitFix(wt, id, subject, body, files) {
   const fileArgs = rel.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
   const msgPath = `${SCRATCH}/commit-msg-${id}.txt`
   const message = `${subject}\n\n${body}`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files. Every path is absolute / \`git -C\`; do not rely on the current directory.
+  const prompt = `${mechanicalPreamble('COMMITTER')} Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
@@ -563,6 +584,16 @@ function policeComment(t) {
 ${rows || '| — | — | — | — |'}`
 }
 
+// Fallback comment for any requested track that has NO bespoke builder. It leans
+// only on the always-present per-track fields (`track`, `status`, and `error`/
+// `note` when present), so a newly-added reviewer track gets a real PR comment
+// instead of being silently dropped — keeping Report total over `TRACKS`.
+function genericComment(t) {
+  return `## ${t?.track || 'unknown'} track
+
+**Outcome:** \`${t?.status || 'unknown'}\`.${t?.error ? ` Track error: ${esc(t.error)}.` : ''}${t?.note ? `\n\n${esc(t.note)}` : ''}`
+}
+
 function consolidationSection(c, order) {
   const rows = (c?.picks || [])
     .map((p) => `| ${esc(p.track)} | ${sha9(p.sourceCommit)} | \`${esc(p.outcome)}\` | ${sha9(p.newCommit)} | ${esc(p.note) || ''} |`)
@@ -578,7 +609,7 @@ ${rows || '| — | — | — | — | — |'}`
 // MAIN worktree (gh uses cwd's repo; the agent runs `gh -C`-equivalent by cd-ing).
 async function postComment(slug, body) {
   const file = `${SCRATCH}/comment-${slug}.md`
-  const prompt = `You are a MECHANICAL PR COMMENTER. Do exactly these steps and nothing else.
+  const prompt = `${mechanicalPreamble('PR COMMENTER')} Do exactly these steps and nothing else.
 
 1. \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${file}\` with EXACTLY this markdown content:
@@ -610,7 +641,6 @@ if (!commit) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
@@ -680,7 +710,6 @@ if (branchMoved || branchDirty) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     preservedTracks: liveTracks,
     note: `consolidation aborted: ${why}. Cherry-picking onto the changed base would review against an untrustworthy scope, so nothing was consolidated and every track worktree was PRESERVED (see each track's note for the recovery cherry-pick).${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
@@ -702,7 +731,7 @@ if (branchMoved || branchDirty) {
 // never torn down. A dirty/unknown track is surfaced in the result for the human.
 const cleanCheck = liveTracks.length
   ? await agent(
-      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
+      `${mechanicalPreamble('CLEANLINESS CHECKER')} For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (${trackScratchList}); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Report a row for EVERY track listed, even if its worktree looks empty or the command errors (if \`git status\` fails, set clean=false and put the error in dirtyStatus). Do not edit anything. Tracks and their worktrees:
 ${liveTracks.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
 For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
       {
@@ -826,13 +855,12 @@ if (currentHead !== branchHead) {
     consolidation: null,
     reconciled: [],
     dropped: [],
-    conflicts: [],
     note: `consolidation precondition failed: the branch in \`${repoPath}\` is at \`${currentHead || '(unknown)'}\` but the review tracks forked from \`${branchHead}\`. The HEAD has advanced past the shared fork point — likely a re-run in an already-consolidated worktree — so cherry-picking the track commits would stack them a SECOND time and double-apply every fix. Nothing was consolidated and the per-track worktrees are PRESERVED. Reset the branch to \`${branchHead}\` (\`git -C ${repoPath} reset --hard ${branchHead}\`) or start from a clean worktree, then re-run.`,
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
 
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `${mechanicalPreamble('CONSOLIDATOR')} You are consolidating the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
@@ -872,13 +900,16 @@ if (postComments) {
   // requested-track audit trail instead of silently omitting the dropped track. A
   // per-track comment builder keyed by track name; adding/removing a reviewer costs
   // Report nothing — no hardcoded track literal to keep in sync.
+  // Bespoke per-track builders; any requested track without one falls back to
+  // `genericComment`, so the map below stays TOTAL over `TRACKS` — a new reviewer
+  // track gets a comment even before it grows a hand-written builder.
   const builder = { codex: codexComment, lens: lensComment, police: policeComment }
   // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
   // it posts as its own comment — surviving any track subset instead of being
   // string-stapled onto whichever track happens to be present.
   const bodies = [
     ['consolidation', consolidationSection(consolidation, consolidateOrder)],
-    ...TRACKS.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+    ...TRACKS.map((t) => [t, (builder[t] || genericComment)(tracks[t])]),
   ]
   // Post sequentially so the comments land in a stable order (consolidation, then
   // the tracks in canonical order).
@@ -906,7 +937,7 @@ const teardownTracks = consolidateOrder
 if (preservedTracks.length) log(`Cleanup: preserving ${preservedTracks.length} worktree(s) not consolidated (${preservedTracks.join(', ')}) — they may hold uncommitted or unreplayed committed edits.`)
 if (teardownTracks.length) {
   await agent(
-    `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
+    `${mechanicalPreamble('CLEANUP RUNNER')} Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
 ${teardownTracks.map((t) => `  - \`git -C ${repoPath} worktree remove --force ${wtDir(t)}\``).join('\n')}
 Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
     { label: 'cleanup:worktrees', phase: 'Cleanup', model },
@@ -952,8 +983,5 @@ return {
   // (police `incomplete`, lens `unresolved`, codex `reviewer-error`); their fixes
   // landed but the gauntlet didn't fully finish. Non-empty ⇒ 'consolidation-incomplete'.
   incompleteTracks,
-  // back-compat: the union of non-clean picks. Consumers keying on a discarded
-  // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
-  conflicts: [...reconciled, ...dropped],
   comments,
 }

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -5,11 +5,12 @@
 export const meta = {
   name: 'be-review',
   description:
-    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile)',
+    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile) and post a detailed PR comment per track',
   phases: [
     { title: 'Setup', detail: 'fan out one detached worktree per review track off the branch HEAD', model: 'opus' },
     { title: 'Tracks', detail: 'codex, lens, and police gauntlets each run to consensus, concurrently and isolated', model: 'opus' },
     { title: 'Consolidate', detail: 'cherry-pick each track’s commits onto the branch in order; reconcile the rare overlap', model: 'opus' },
+    { title: 'Report', detail: 'post a detailed PR comment for each track plus the consolidation ledger', model: 'opus' },
     { title: 'Cleanup', detail: 'tear down the per-track worktrees', model: 'opus' },
   ],
 }
@@ -33,17 +34,28 @@ const rationale = (a.rationale || '').trim()
 // per-track commits are what consolidation cherry-picks, so leaving it on is the
 // norm. (`--no-commit` is for debugging a single track in isolation.)
 const commit = a.commit !== false
+// Post a detailed PR comment per track + the consolidation ledger (default on).
+// `--no-comment` (comment:false) suppresses the outward-facing write.
+const postComments = a.comment !== false
 const model = a.model || MODEL
 // The review tracks to run AND the order they consolidate in. codex first (it
 // changes the most — bug fixes), then the structural lenses, then police, so an
 // overlap surfaces as a conflict picking the later, lighter-touch track.
 const TRACKS = a.tracks || ['codex', 'lens', 'police']
 
-// Per-track worktrees + commit-message scratch live here. Gitignored (`.be-review/`),
-// so they never pollute the diff the reviewers inspect, and a track's own
-// `.codex-debate/`/`.lens-debate/` scratch nests harmlessly inside its worktree.
-const workRoot = `${repoPath}/.be-review`
-const wtPath = (track) => `${workRoot}/wt-${track}`
+// SHARED-CWD NOTE. Every workflow agent inherits the SESSION cwd (the main
+// worktree) — the harness offers no per-agent cwd, and `isolation:'worktree'`
+// can't host a multi-round debate (each agent would get a fresh tree and lose
+// the prior round's commits). So isolation here is STRUCTURAL, not behavioral:
+// every path below is ABSOLUTE and every git command is `git -C <worktree>`, so
+// the shared cwd is irrelevant — no agent can leak into the wrong tree by
+// forgetting to `cd`. The per-track worktrees live under the repo's conventional
+// `.worktrees/` (gitignored); commit-message + PR-comment scratch lives under
+// the gitignored `.be-review/`. Both are absolute and per-main-worktree, so
+// parallel /be-review runs in different worktrees never collide.
+const WT_ROOT = `${repoPath}/.worktrees`
+const wtDir = (track) => `${WT_ROOT}/be-review-${track}`
+const SCRATCH = `${repoPath}/.be-review`
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -51,7 +63,7 @@ const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
 const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore any \`.be-review/\`, \`.codex-debate/\`, or \`.lens-debate/\` scratch dirs.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
@@ -68,7 +80,7 @@ const SETUP_SCHEMA = {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
     cleanTree: {
       type: 'boolean',
-      description: 'true iff the main worktree had NO uncommitted changes (outside .be-review/) when checked',
+      description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
     },
     dirtyStatus: {
       type: 'string',
@@ -158,18 +170,18 @@ const CONSOLIDATE_SCHEMA = {
 // ---------------------------------------------------------------------------
 phase('Setup')
 
-const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
+const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under \`.be-review/\` (the gitignored scratch root). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
-3. Only if \`cleanTree\` is true — ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
-   - Path: \`${workRoot}/wt-<track>\`.
-   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
-   - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
+   - Path: \`${WT_ROOT}/be-review-<track>\` (absolute).
+   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if it's not registered), then \`rm -rf ${WT_ROOT}/be-review-<track>\`.
+   - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
@@ -187,7 +199,7 @@ if (setup?.cleanTree === false) {
     base,
     tracks: {},
     consolidation: null,
-    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside .be-review/) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside the scratch dirs) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
   }
 }
 
@@ -226,8 +238,8 @@ async function policeTrack(wt) {
   // Pass *definitions* are single-sourced to code-police's SKILL.md: each brief
   // names that pass's section so the agent (which Reads the skill below) reviews
   // it exactly as written there — no inline checklist to drift. The elegance pass
-  // is gated on the tiny-diff heuristic the skill mandates (SKILL.md:141 — skip
-  // when the worktree diff against base is <10 lines).
+  // is gated on the tiny-diff heuristic the skill mandates (skip when the worktree
+  // diff against base is <10 lines).
   const tinyDiff = await agent(
     `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
     { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
@@ -241,7 +253,7 @@ async function policeTrack(wt) {
   const reviews = await parallel(
     passes.map((p) => () =>
       agent(
-        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`.claude/skills/code-police/SKILL.md\` (and \`.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
         { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
       ),
     ),
@@ -251,11 +263,11 @@ async function policeTrack(wt) {
   log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
   // Apply each finding as its own commit, sequentially (same-file edits can't be
-  // parallel-applied). Mechanical committer stages only the touched files.
+  // parallel-applied). Every edit and git command targets the absolute worktree.
   const applied = []
   for (const f of findings) {
     const impl = await agent(
-      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change in the working tree. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`,
+      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
       { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
     )
     const files = impl?.filesChanged ?? []
@@ -263,23 +275,25 @@ async function policeTrack(wt) {
     if (commit && files.length) {
       sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
     }
-    applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
+    applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
   }
   return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
-// files in worktree `wt` and commits with the given message. The workflow can't
-// run git itself, so a thin agent does. (codex/lens commit via their own
-// workflows.)
+// files in worktree `wt` and commits with the given message — all via `git -C`
+// so it never depends on the shell cwd. The workflow can't run git itself, so a
+// thin agent does. (codex/lens commit via their own workflows.)
 async function commitFix(wt, id, subject, body, files) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workRoot}/commit-msg-${id}.txt`
+  // Files may arrive as absolute worktree paths; git -C wants them relative to wt.
+  const rel = files.map((f) => f.replace(`${wt}/`, '').replace(/^\/+/, ''))
+  const fileArgs = rel.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
+  const msgPath = `${SCRATCH}/commit-msg-${id}.txt`
   const message = `${subject}\n\n${body}`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
+  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files. Every path is absolute / \`git -C\`; do not rely on the current directory.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workRoot}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${SCRATCH}\`.
 2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
 
 ${message}
@@ -300,20 +314,21 @@ ${message}
 
 // One thunk per live track. codex and lens are existing repoPath-parameterized
 // workflows (built to run in separate worktrees), invoked as child workflows —
-// one level of nesting, which the runtime allows. police is inline (it's a
-// skill, not a workflow). Each thunk catches so one track's failure can't sink
-// the rest — consolidation just picks up whatever each track committed.
+// one level of nesting, which the runtime allows. They get the ABSOLUTE worktree
+// path as repoPath. police is inline (it's a skill, not a workflow). Each thunk
+// catches so one track's failure can't sink the rest — consolidation just picks
+// up whatever each track committed.
 const trackThunk = {
   codex: () =>
-    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtPath('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base, skillDir: CODEX_SKILLDIR, commit })
       .then((r) => ({ track: 'codex', ...r }))
       .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
   lens: () =>
-    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtPath('lens'), base, rationale, model, commit })
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base, rationale, model, commit })
       .then((r) => ({ track: 'lens', ...r }))
       .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
   police: () =>
-    policeTrack(wtPath('police'))
+    policeTrack(wtDir('police'))
       .then((r) => ({ track: 'police', ...r }))
       .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
 }
@@ -324,14 +339,104 @@ const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
 liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
 for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
+// ---------------------------------------------------------------------------
+// PR-comment builders + poster (used by the Report phase). Bodies are built
+// deterministically in JS from the structured track results; a thin mechanical
+// agent just writes each body to a scratch file and posts it with `gh pr comment`.
+// ---------------------------------------------------------------------------
+const sha9 = (s) => (s ? `\`${String(s).slice(0, 9)}\`` : '—')
+const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').trim()
+
+function codexComment(t) {
+  if (!t || t.status === 'track-error') return `## 🤖 Codex ⇄ Claude debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const rows = (t.transcript || [])
+    .map((r) => {
+      const v = r.codex || {}
+      const openBM = (v.findings || []).filter((f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major')).length
+      const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
+      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${openBM} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
+    })
+    .join('\n')
+  return `## 🤖 Codex ⇄ Claude debate
+
+**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
+
+${esc(t.finalVerdict?.summary)}
+
+| Round | codex approved | open blk/maj | claude dispositions | commit |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}`
+}
+
+function lensComment(t) {
+  if (!t || t.status === 'track-error') return `## ⚖️ Lowy ⇄ Hickey lens debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const appliedFor = (id) => (t.applied || []).find((x) => x.id === id)?.commit
+  const rows = (t.settled || [])
+    .map((s) => `| ${esc(s.origin)} | ${esc(s.title)} | ${esc(s.location)} | ${esc(s.disposition)} | ${s.disposition === 'fix' ? sha9(appliedFor(s.id)) : '—'} |`)
+    .join('\n')
+  const un = (t.unresolved || []).length
+    ? `\n\n**⚠️ ${t.unresolved.length} unresolved finding(s)** — needs a human:\n` + t.unresolved.map((u) => `- ${esc(u.title)} (${esc(u.location)})`).join('\n')
+    : ''
+  return `## ⚖️ Lowy ⇄ Hickey lens debate
+
+**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.
+
+| origin | finding | location | disposition | commit |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}${un}`
+}
+
+function policeComment(t) {
+  if (!t || t.status === 'track-error') return `## 👮 Code-police\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
+  const rows = (t.applied || [])
+    .map((x) => `| ${esc(x.severity)} | ${esc(x.title)} | ${esc((x.files || []).join(', '))} | ${sha9(x.commit)} |`)
+    .join('\n')
+  return `## 👮 Code-police
+
+**${t.findings || 0} finding(s)** across the rules / fact-check / elegance passes${t.status === 'clean' ? ' — clean diff' : ''}.
+
+| severity | finding | files | commit |
+|---|---|---|---|
+${rows || '| — | — | — | — |'}`
+}
+
+function consolidationSection(c, order) {
+  const rows = (c?.picks || [])
+    .map((p) => `| ${esc(p.track)} | ${sha9(p.sourceCommit)} | \`${esc(p.outcome)}\` | ${sha9(p.newCommit)} | ${esc(p.note) || ''} |`)
+    .join('\n')
+  return `### Consolidation onto the branch (order: ${order.join(' → ')})
+
+| track | source | outcome | new commit | note |
+|---|---|---|---|---|
+${rows || '| — | — | — | — | — |'}`
+}
+
+// Post one comment via a mechanical agent. Resolves the PR from the branch in the
+// MAIN worktree (gh uses cwd's repo; the agent runs `gh -C`-equivalent by cd-ing).
+async function postComment(slug, body) {
+  const file = `${SCRATCH}/comment-${slug}.md`
+  const prompt = `You are a MECHANICAL PR COMMENTER. Do exactly these steps and nothing else.
+
+1. \`mkdir -p ${SCRATCH}\`.
+2. Using the Write tool, create \`${file}\` with EXACTLY this markdown content:
+
+${body}
+
+3. Post it to THIS branch's PR: \`cd ${repoPath} && gh pr comment --body-file ${file}\`. (\`gh\` resolves the PR from the current branch.) If there is NO open PR for the branch, do nothing and report "no PR".
+4. Return the comment URL gh prints, or "no PR".`
+  return agent(prompt, { label: `comment:${slug}`, phase: 'Report', model })
+}
+
+// ---------------------------------------------------------------------------
 // `--no-commit` short-circuit. With commit=false the tracks deliberately leave
 // their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
 // (rev-list ${branchHead}..HEAD) and cleanup's `worktree remove --force` tears the
 // worktrees down — so running them now would silently discard every reviewer's edits.
 // Instead, stop here and hand the live worktrees to the user to inspect; nothing is
 // consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
+// ---------------------------------------------------------------------------
 if (!commit) {
-  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${WT_ROOT}/be-review-<track> diff\`).`)
   return {
     status: 'no-commit',
     branchHead,
@@ -341,8 +446,8 @@ if (!commit) {
     tracks,
     consolidation: null,
     conflicts: [],
-    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.be-review/wt-<track>` and re-run with commit enabled to consolidate.',
-    worktrees: liveTracks.map((t) => ({ track: t, path: wtPath(t) })),
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.worktrees/be-review-<track>` and re-run with commit enabled to consolidate.',
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
 
@@ -356,19 +461,19 @@ phase('Consolidate')
 
 // Skip tracks that errored or made no commits — the agent only picks real work.
 const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
-const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
-For each track, its worktree is \`${workRoot}/wt-<track>\`. Get that track's new commits oldest-first:
-  \`git -C ${workRoot}/wt-<track> rev-list --reverse ${branchHead}..HEAD\`
+For each track, its worktree is \`${WT_ROOT}/be-review-<track>\`. Get that track's new commits oldest-first:
+  \`git -C ${WT_ROOT}/be-review-<track> rev-list --reverse ${branchHead}..HEAD\`
 (An empty list means the track found nothing to change — skip it.)
 
-Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits onto the branch IN THAT ORDER:
+Then cherry-pick each of those commits onto the branch IN THAT ORDER:
   \`git -C ${repoPath} cherry-pick <sha>\`
 
 - **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
-- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides (ABSOLUTE paths under \`${repoPath}\`) and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files in \`files\`, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — record outcome \`dropped\` with the overlapping \`files\` and say so in \`note\`; never drop to avoid the work of merging.
 
 Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
@@ -377,12 +482,37 @@ const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clea
 log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------
-// Phase 4 — tear down the per-track worktrees
+// Phase 4 — post a detailed PR comment for EVERY track + the consolidation
+// ledger. This is the review trail the whole gauntlet exists to leave; it runs
+// here (not in the caller) so it ALWAYS happens. `--no-comment` suppresses it.
+// ---------------------------------------------------------------------------
+phase('Report')
+
+const comments = {}
+if (postComments) {
+  const ledger = consolidationSection(consolidation, consolidateOrder)
+  const bodies = [
+    ['codex', `${codexComment(tracks.codex)}\n\n${ledger}`],
+    ['lens', lensComment(tracks.lens)],
+    ['police', policeComment(tracks.police)],
+  ].filter(([t]) => tracks[t])
+  // Post sequentially so the comments land in a stable order (codex, lens, police).
+  for (const [slug, body] of bodies) {
+    const url = await postComment(slug, body)
+    comments[slug] = (url || '').trim()
+    log(`Report: posted ${slug} comment${comments[slug] ? ` → ${comments[slug]}` : ''}`)
+  }
+} else {
+  log('Report: --no-comment — skipping PR comments.')
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5 — tear down the per-track worktrees
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
 await agent(
-  `You are a MECHANICAL CLEANUP RUNNER. From \`${repoPath}\`, for each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${workRoot}\` directory itself (it holds commit-message scratch); do not delete the branch's commits. Return "done".`,
+  `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. For each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
   { label: 'cleanup:worktrees', phase: 'Cleanup', model },
 )
 
@@ -395,4 +525,5 @@ return {
   tracks,
   consolidation,
   conflicts,
+  comments,
 }

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -63,9 +63,17 @@ const rationaleBlock = rationale
 const SETUP_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['branchHead', 'worktrees'],
+  required: ['branchHead', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    cleanTree: {
+      type: 'boolean',
+      description: 'true iff the main worktree had NO uncommitted changes (outside .be-review/) when checked',
+    },
+    dirtyStatus: {
+      type: 'string',
+      description: 'the offending `git status --short` lines when cleanTree is false; empty otherwise',
+    },
     worktrees: {
       type: 'array',
       description: 'one entry per track worktree created',
@@ -168,24 +176,51 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-2. Ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
-3. For EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
+2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under \`.be-review/\` (the gitignored scratch root). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
+3. Only if \`cleanTree\` is true — ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
    - Path: \`${workRoot}/wt-<track>\`.
    - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
    - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
-4. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
+5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\` and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
+
+// Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
+// worktree would be invisible to every reviewer — a /be-review run could then
+// approve an INCOMPLETE change set. Bail loudly instead (the caller commits or
+// stashes, then re-runs) rather than silently reviewing a subset.
+if (setup?.cleanTree === false) {
+  const dirty = (setup?.dirtyStatus || '').trim()
+  log(`Setup: ABORT — the main worktree at ${repoPath} has uncommitted changes; tracks fork from HEAD and would not see them.`)
+  return {
+    status: 'setup-failed',
+    branchHead,
+    base,
+    tracks: {},
+    consolidation: null,
+    note: `dirty working tree: the tracks fork from HEAD \`${branchHead.slice(0, 9)}\`, so staged/unstaged/untracked changes (outside .be-review/) would be invisible to every reviewer. Commit or stash them, then re-run.${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+  }
+}
+
+// Seed every requested track with an explicit `track-error` for setup failures, so
+// a dropped reviewer is a STRUCTURED signal the caller (/be §4 falls back per
+// track) — not just a log line that silently shrinks the set while status='done'.
+const tracks = {}
 const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
 const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
-if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — those tracks are skipped.`)
+for (const t of failedTracks) {
+  const note = (setup?.worktrees || []).find((w) => w.track === t)?.note || 'worktree creation failed'
+  tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
+}
+if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
 log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
 
 if (!branchHead || liveTracks.length === 0) {
-  return { status: 'setup-failed', branchHead, base, tracks: {}, consolidation: null, note: 'no track worktrees could be created' }
+  return { status: 'setup-failed', branchHead, base, tracks, consolidation: null, note: 'no track worktrees could be created' }
 }
 
 // ---------------------------------------------------------------------------
@@ -278,9 +313,32 @@ const trackThunk = {
 }
 
 const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
-const tracks = {}
+// `tracks` already carries a `track-error` entry for every setup failure; the live
+// tracks fill in alongside them, so the returned map covers EVERY requested track.
 liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
 for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+
+// `--no-commit` short-circuit. With commit=false the tracks deliberately leave
+// their fixes UNCOMMITTED in their own worktrees. Consolidation replays commits
+// (rev-list ${branchHead}..HEAD) and cleanup tears the worktrees down — so running
+// them now would discard every reviewer's edits. Instead, stop here and hand the
+// live worktrees to the user to inspect; nothing is consolidated and nothing is
+// cleaned up. (This is the documented single-track-debugging mode.)
+if (!commit) {
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${workRoot}/wt-<track> diff\`).`)
+  return {
+    status: 'no-commit',
+    branchHead,
+    finalHead: branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    conflicts: [],
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.be-review/wt-<track>` and re-run with commit enabled to consolidate.',
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtPath(t) })),
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Phase 3 — consolidate: cherry-pick each track's commits onto the branch in

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -790,6 +790,48 @@ for (const t of preservedTracks) {
   }
   log(`Consolidate: track ${t} not consolidated — worktree preserved at ${wtDir(t)}.`)
 }
+
+// PRECONDITION GATE. The consolidate prompt below asserts the branch is AT
+// `branchHead` (the tracks' shared fork point) and cherry-picks the track commits
+// onto it without re-checking. That holds for a normal single run — nothing
+// advances the main worktree between Setup and here. But on an ABNORMAL re-run
+// (e.g. /be-review invoked twice in the same worktree without resetting), the
+// branch HEAD has already moved PAST `branchHead` to the previously-consolidated
+// commits; the Setup clean-tree preflight only rejects an UNcommitted tree, so a
+// clean-but-advanced HEAD sails through. Cherry-picking again would stack the
+// track commits a second time, silently double-applying every fix. Verify the
+// precondition mechanically (`rev-parse HEAD` == `branchHead`) and abort with a
+// `consolidation-precondition-failed` status rather than picking onto a drifted
+// HEAD — the worktrees are PRESERVED for the human to inspect and re-run from a
+// clean fork point.
+const headCheck = await agent(
+  `You are a MECHANICAL PRECONDITION CHECKER. Run \`git -C ${repoPath} rev-parse HEAD\` and report the FULL SHA it prints, verbatim. Do not edit anything, do not cherry-pick, do not run any other command.`,
+  {
+    label: 'consolidate:precondition',
+    phase: 'Consolidate',
+    model,
+    schema: { type: 'object', additionalProperties: false, required: ['head'], properties: { head: { type: 'string', description: 'the full HEAD SHA from `git rev-parse HEAD`' } } },
+  },
+)
+const currentHead = (headCheck?.head || '').trim()
+if (currentHead !== branchHead) {
+  log(`Consolidate: ABORTING — branch HEAD is ${sha9(currentHead) || '(unknown)'} but the tracks forked from ${sha9(branchHead)}. The branch has drifted (likely an already-consolidated re-run); cherry-picking now would double-apply every fix. Worktrees PRESERVED.`)
+  return {
+    status: 'consolidation-precondition-failed',
+    branchHead,
+    finalHead: currentHead || branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    reconciled: [],
+    dropped: [],
+    conflicts: [],
+    note: `consolidation precondition failed: the branch in \`${repoPath}\` is at \`${currentHead || '(unknown)'}\` but the review tracks forked from \`${branchHead}\`. The HEAD has advanced past the shared fork point — likely a re-run in an already-consolidated worktree — so cherry-picking the track commits would stack them a SECOND time and double-apply every fix. Nothing was consolidated and the per-track worktrees are PRESERVED. Reset the branch to \`${branchHead}\` (\`git -C ${repoPath} reset --hard ${branchHead}\`) or start from a clean worktree, then re-run.`,
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
+  }
+}
+
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -355,28 +355,51 @@ for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 // deterministically in JS from the structured track results; a thin mechanical
 // agent just writes each body to a scratch file and posts it with `gh pr comment`.
 // ---------------------------------------------------------------------------
-const sha9 = (s) => (s ? `\`${String(s).slice(0, 9)}\`` : '—')
+// Plain (NOT code-fenced) short SHA so GitHub auto-links it to the commit — a
+// backtick-wrapped SHA renders as code and is NOT linkified.
+const sha9 = (s) => (s ? String(s).slice(0, 9) : '—')
 const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').trim()
+
+const SEV = { blocking: '🔴 blocking', major: '🟠 major', minor: '🟡 minor', nit: '⚪ nit' }
+
+// Full per-round detail: every codex finding (severity, id, issue, location,
+// suggestion, status) and Claude's disposition of each — the complete debate
+// transcript, not a count table.
+function codexRound(r) {
+  const v = r.codex || {}
+  const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
+  const findings = (v.findings || []).length
+    ? v.findings
+        .map(
+          (f) =>
+            `- **${SEV[f.severity] || f.severity} · ${f.id}** — ${esc(f.issue)}\n  at \`${esc(f.location)}\` · status: **${f.status}**\n  suggestion: ${esc(f.suggestion)}`,
+        )
+        .join('\n')
+    : '_no findings_'
+  const actions = (r.claude?.actions || []).length
+    ? r.claude.actions.map((act) => `- **${act.findingId}** → _${act.disposition}_: ${esc(act.detail)}`).join('\n')
+    : ''
+  return [
+    `### Round ${r.round} — codex approved ${v.approved ? '✅' : '❌'} · ${open} open${r.commit ? ` · ${sha9(r.commit)}` : ''}`,
+    v.summary ? esc(v.summary) : '',
+    v.responseToRebuttal ? `**Codex on Claude's rebuttal:** ${esc(v.responseToRebuttal)}` : '',
+    `**Codex findings:**\n${findings}`,
+    actions ? `**Claude's response:**\n${actions}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n')
+}
 
 function codexComment(t) {
   if (!t || t.status === 'track-error') return `## 🤖 Codex ⇄ Claude debate\n\n**Track error:** ${esc(t?.error) || 'did not run'}.`
-  const rows = (t.transcript || [])
-    .map((r) => {
-      const v = r.codex || {}
-      const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
-      const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
-      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${open} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
-    })
-    .join('\n')
+  const rounds = (t.transcript || []).map(codexRound).join('\n\n---\n\n')
   return `## 🤖 Codex ⇄ Claude debate
 
 **Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
 
 ${esc(t.finalVerdict?.summary)}
 
-| Round | codex approved | findings open | claude dispositions | commit |
-|---|---|---|---|---|
-${rows || '| — | — | — | — | — |'}`
+${rounds}`
 }
 
 function lensComment(t) {

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -207,10 +207,11 @@ if (setup?.cleanTree === false) {
 // a dropped reviewer is a STRUCTURED signal the caller (/be §4 falls back per
 // track) — not just a log line that silently shrinks the set while status='done'.
 const tracks = {}
-const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
+const wts = setup?.worktrees ?? []
+const liveTracks = TRACKS.filter((t) => wts.find((w) => w.track === t && w.ok))
 const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
 for (const t of failedTracks) {
-  const note = (setup?.worktrees || []).find((w) => w.track === t)?.note || 'worktree creation failed'
+  const note = wts.find((w) => w.track === t)?.note || 'worktree creation failed'
   tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
 }
 if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
@@ -278,7 +279,7 @@ async function policeTrack(wt) {
     applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
     log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
   }
-  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
+  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -303,6 +304,7 @@ ${message}
   return agent(prompt, {
     label: `police-commit:${id}`,
     phase: 'Tracks',
+    model,
     schema: {
       type: 'object',
       additionalProperties: false,
@@ -393,7 +395,7 @@ function policeComment(t) {
     .join('\n')
   return `## 👮 Code-police
 
-**${t.findings || 0} finding(s)** across the rules / fact-check / elegance passes${t.status === 'clean' ? ' — clean diff' : ''}.
+**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes${t.status === 'clean' ? ' — clean diff' : ''}.
 
 | severity | finding | files | commit |
 |---|---|---|---|
@@ -490,13 +492,20 @@ phase('Report')
 
 const comments = {}
 if (postComments) {
-  const ledger = consolidationSection(consolidation, consolidateOrder)
+  // Data-drive Report over the SAME track set as every other phase: a per-track
+  // comment builder keyed by track name, iterated in the canonical
+  // `consolidateOrder`/`liveTracks` order. Adding/removing a reviewer costs Report
+  // nothing — no hardcoded track literal to keep in sync.
+  const builder = { codex: codexComment, lens: lensComment, police: policeComment }
+  // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
+  // it posts as its own comment — surviving any track subset instead of being
+  // string-stapled onto whichever track happens to be present.
   const bodies = [
-    ['codex', `${codexComment(tracks.codex)}\n\n${ledger}`],
-    ['lens', lensComment(tracks.lens)],
-    ['police', policeComment(tracks.police)],
-  ].filter(([t]) => tracks[t])
-  // Post sequentially so the comments land in a stable order (codex, lens, police).
+    ['consolidation', consolidationSection(consolidation, consolidateOrder)],
+    ...liveTracks.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+  ]
+  // Post sequentially so the comments land in a stable order (consolidation, then
+  // the tracks in canonical order).
   for (const [slug, body] of bodies) {
     const url = await postComment(slug, body)
     comments[slug] = (url || '').trim()

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -24,7 +24,26 @@ const MODEL = 'opus'
 // Inputs (passed via the Workflow tool's `args`)
 // ---------------------------------------------------------------------------
 const a = args || {}
-const repoPath = a.repoPath || '.'
+// repoPath is the worktree root and the spine of EVERY path below (`git -C`,
+// child `repoPath`s, scratch + worktree dirs). It MUST be absolute: the whole
+// "isolation is structural, not behavioral" guarantee rests on every git command
+// and file path being absolute, and the codex child `cd`s into its repoPath while
+// reading a scratch path derived from it — a relative repoPath would `cd` once and
+// then resolve that scratch path against the new cwd, writing the verdict to a
+// nested path and reading it back from a different one. Rather than silently
+// canonicalize against an unknowable session cwd, reject a non-absolute repoPath
+// loudly. (/be always passes an absolute root; the default `.` is rejected here.)
+const repoPath = (a.repoPath || '').trim()
+if (!repoPath.startsWith('/')) {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `repoPath must be an ABSOLUTE path (got ${repoPath ? `\`${repoPath}\`` : 'empty'}). Every git command and scratch/worktree path in this orchestrator is absolute and cwd-independent; a relative repoPath would break the codex child's cd-then-read-scratch step and let agents leak into the wrong tree. Pass the absolute worktree root.`,
+  }
+}
 const base = a.base || 'origin/master'
 // Optional author note on deliberate design decisions, threaded into the lens
 // debate so the lenses don't flag intentional choices.
@@ -51,11 +70,17 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the shared cwd is irrelevant — no agent can leak into the wrong tree by
 // forgetting to `cd`. The per-track worktrees live under the repo's conventional
 // `.worktrees/` (gitignored); commit-message + PR-comment scratch lives under
-// the gitignored `.be-review/`. Both are absolute and per-main-worktree, so
-// parallel /be-review runs in different worktrees never collide.
+// the gitignored `.be-review/`. Both are absolute, and a per-RUN id is woven into
+// the worktree name and the scratch subdir so two /be-review runs in the SAME
+// main worktree never clobber each other's live worktrees or scratch files (the
+// old fixed `be-review-<track>` / `.be-review/*` paths let a second run `rm -rf`
+// the first run's in-flight worktree). The id is the start-time epoch ms — unique
+// per invocation, and the actual paths are reported back in the result so manual
+// inspection doesn't need to guess them.
+const RUN_ID = String(Date.now())
 const WT_ROOT = `${repoPath}/.worktrees`
-const wtDir = (track) => `${WT_ROOT}/be-review-${track}`
-const SCRATCH = `${repoPath}/.be-review`
+const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
+const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
 
 // Generated skill locations the child debate workflows live at.
 const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
@@ -81,7 +106,11 @@ const SETUP_SCHEMA = {
   required: ['branchHead', 'mergeBase', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
-    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed' },
+    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed. Empty string iff the merge-base command FAILED (do NOT fall back to the raw base).' },
+    mergeBaseError: {
+      type: 'string',
+      description: 'the verbatim `git merge-base` error when mergeBase is empty; "" otherwise',
+    },
     cleanTree: {
       type: 'boolean',
       description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
@@ -177,13 +206,12 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
-1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command fails, fall back to \`mergeBase\` = the resolved \`${base}\` and say so in a worktree \`note\`.
+1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command FAILS (missing/typoed base, stale ref, or unrelated history), the review scope is untrustworthy — do NOT fall back to the raw \`${base}\`; instead set \`mergeBase\`: "" and put the exact git error in \`mergeBaseError\`, then STOP (skip worktree creation, return an empty \`worktrees\` array). (The orchestrator aborts the whole run when \`mergeBase\` is empty.)
 2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
-4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
-   - Path: \`${WT_ROOT}/be-review-<track>\` (absolute).
-   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if it's not registered), then \`rm -rf ${WT_ROOT}/be-review-<track>\`.
-   - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
+4. Only if \`cleanTree\` is true — create a fresh detached worktree at \`branchHead\` for each track, at these EXACT absolute paths (per-run unique, so they cannot belong to another in-flight run):
+${TRACKS.map((t) => `   - ${t}: \`git -C ${repoPath} worktree add --detach ${wtDir(t)} <branchHead>\``).join('\n')}
+   These paths are unique to THIS run, so they should not pre-exist. If \`worktree add\` reports the path already exists, that is an error — set \`ok\`: false and put the message in \`note\`; do NOT \`rm -rf\` or force-remove it (it may belong to a concurrent run).
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
 Return \`branchHead\`, \`mergeBase\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
@@ -192,8 +220,24 @@ const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup
 const branchHead = (setup?.branchHead || '').trim()
 // The diff base every reviewer uses: the merge-base of the branch and `${base}`,
 // so commits `${base}` gained since the branch forked aren't reviewed as ours.
-// Falls back to the raw base if Setup couldn't resolve it.
-const mergeBase = (setup?.mergeBase || base).trim()
+const mergeBase = (setup?.mergeBase || '').trim()
+
+// Merge-base gate. A failed `git merge-base` means the review scope can't be
+// trusted (missing/typoed base, stale ref, unrelated history). Falling back to the
+// raw `${base}` tip would silently review the base branch's drift as if this PR
+// made it — the exact noise the merge-base exists to remove. Fail loudly instead.
+if (!mergeBase) {
+  const err = (setup?.mergeBaseError || '').trim()
+  log(`Setup: ABORT — \`git merge-base ${base} HEAD\` failed; the review scope can't be trusted. Not falling back to the raw ${base} tip.`)
+  return {
+    status: 'setup-failed',
+    branchHead,
+    base,
+    tracks: {},
+    consolidation: null,
+    note: `merge-base of \`${base}\` and HEAD could not be resolved, so the diff scope is untrustworthy (missing/typoed base, stale ref, or unrelated history). Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
 
 // Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
 // worktree would be invisible to every reviewer — a /be-review run could then
@@ -470,7 +514,7 @@ ${body}
 // consolidated and nothing is cleaned up. (This is the documented single-track-debugging mode.)
 // ---------------------------------------------------------------------------
 if (!commit) {
-  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there (\`git -C ${WT_ROOT}/be-review-<track> diff\`).`)
+  log(`--no-commit: skipping Consolidate + Cleanup. Per-track fixes are UNCOMMITTED in their worktrees; inspect them there: ${liveTracks.map((t) => `git -C ${wtDir(t)} diff`).join(' ; ')}`)
   return {
     status: 'no-commit',
     branchHead,
@@ -480,7 +524,7 @@ if (!commit) {
     tracks,
     consolidation: null,
     conflicts: [],
-    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — review each `.worktrees/be-review-<track>` and re-run with commit enabled to consolidate.',
+    note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
   }
 }
@@ -493,14 +537,70 @@ if (!commit) {
 // ---------------------------------------------------------------------------
 phase('Consolidate')
 
-// Skip tracks that errored or made no commits — the agent only picks real work.
-const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+// CLEAN-WORKTREE GATE before consolidation. Consolidation replays only COMMITTED
+// commits (`rev-list branchHead..HEAD`), and Cleanup later force-removes every
+// worktree — so any edit a track left UNcommitted (an apply agent that produced
+// files but whose commit helper failed, a formatter that touched an unlisted
+// file, an untracked new file) would be invisible to cherry-pick and then deleted
+// for good. Mechanically check each candidate track's worktree is clean; a dirty
+// one is excluded from both consolidation AND cleanup (its worktree is preserved
+// for the human) and surfaced in the result, instead of silently discarded.
+const consolidateCandidates = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+const cleanCheck = consolidateCandidates.length
+  ? await agent(
+      `You are a MECHANICAL CLEANLINESS CHECKER. For EACH track below, run \`git -C <path> status --short\` against its worktree and report whether it is fully clean. IGNORE only lines under each track's own gitignored debate scratch dirs (\`.codex-debate/\`, \`.lens-debate/\`); ANY other staged, unstaged, or untracked entry means the track left uncommitted work — set clean=false and report those lines. Do not edit anything. Tracks and their worktrees:
+${consolidateCandidates.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+For each track return { track, clean (boolean), dirtyStatus (the offending \`status --short\` lines verbatim, or "" if clean) }.`,
+      {
+        label: 'consolidate:clean-check',
+        phase: 'Consolidate',
+        model,
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['tracks'],
+          properties: {
+            tracks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['track', 'clean'],
+                properties: {
+                  track: { type: 'string' },
+                  clean: { type: 'boolean' },
+                  dirtyStatus: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    )
+  : { tracks: [] }
+const dirtyTracks = consolidateCandidates.filter((t) => (cleanCheck?.tracks || []).find((c) => c.track === t && c.clean === false))
+for (const t of dirtyTracks) {
+  const ds = (cleanCheck?.tracks || []).find((c) => c.track === t)?.dirtyStatus || ''
+  tracks[t] = {
+    ...tracks[t],
+    consolidated: false,
+    dirtyStatus: ds,
+    note: `track left UNcommitted changes in its worktree (${wtDir(t)}); NOT consolidated and its worktree was PRESERVED so the edits aren't lost. Inspect with \`git -C ${wtDir(t)} status\`.${ds ? `\nOffending entries:\n${ds}` : ''}`,
+  }
+  log(`Consolidate: track ${t} has UNcommitted changes — excluded from consolidation, worktree preserved at ${wtDir(t)}.`)
+}
+
+// Only replay tracks that are clean (every agreed fix really is a commit) and made
+// real work — the agent only picks committed work.
+const consolidateOrder = consolidateCandidates.filter((t) => !dirtyTracks.includes(t))
 const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Every command below is \`git -C\` against an ABSOLUTE path — do not rely on the current directory. ${consolidateOrder.length} review track(s) (${consolidateOrder.join(', ')}) each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
 
 The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
 
-For each track, its worktree is \`${WT_ROOT}/be-review-<track>\`. Get that track's new commits oldest-first:
-  \`git -C ${WT_ROOT}/be-review-<track> rev-list --reverse ${branchHead}..HEAD\`
+Each track's worktree (use these EXACT absolute paths):
+${consolidateOrder.map((t) => `  - ${t}: ${wtDir(t)}`).join('\n')}
+For each track, get its new commits oldest-first:
+  \`git -C <that track's worktree> rev-list --reverse ${branchHead}..HEAD\`
 (An empty list means the track found nothing to change — skip it.)
 
 Then cherry-pick each of those commits onto the branch IN THAT ORDER:
@@ -524,17 +624,20 @@ phase('Report')
 
 const comments = {}
 if (postComments) {
-  // Data-drive Report over the SAME track set as every other phase: a per-track
-  // comment builder keyed by track name, iterated in the canonical
-  // `consolidateOrder`/`liveTracks` order. Adding/removing a reviewer costs Report
-  // nothing — no hardcoded track literal to keep in sync.
+  // Data-drive Report over every REQUESTED track (the `TRACKS` set), not just the
+  // live ones: a track whose worktree failed in Setup is in `tracks` as
+  // `track-error`, and each builder renders that as a "Track error" comment — so
+  // setup failures get a PR comment too, keeping the documented one-comment-per-
+  // requested-track audit trail instead of silently omitting the dropped track. A
+  // per-track comment builder keyed by track name; adding/removing a reviewer costs
+  // Report nothing — no hardcoded track literal to keep in sync.
   const builder = { codex: codexComment, lens: lensComment, police: policeComment }
   // The consolidation ledger is a WORKFLOW-level artifact, not a track artifact, so
   // it posts as its own comment — surviving any track subset instead of being
   // string-stapled onto whichever track happens to be present.
   const bodies = [
     ['consolidation', consolidationSection(consolidation, consolidateOrder)],
-    ...liveTracks.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
+    ...TRACKS.filter((t) => builder[t]).map((t) => [t, builder[t](tracks[t])]),
   ]
   // Post sequentially so the comments land in a stable order (consolidation, then
   // the tracks in canonical order).
@@ -548,14 +651,24 @@ if (postComments) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 5 — tear down the per-track worktrees
+// Phase 5 — tear down the per-track worktrees. Dirty tracks (uncommitted edits
+// the clean-check caught) are PRESERVED, not removed — their worktree is the only
+// place those edits live, so force-removing it would discard them.
 // ---------------------------------------------------------------------------
 phase('Cleanup')
 
-await agent(
-  `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. For each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${WT_ROOT}/be-review-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
-  { label: 'cleanup:worktrees', phase: 'Cleanup', model },
-)
+const teardownTracks = liveTracks.filter((t) => !dirtyTracks.includes(t))
+if (dirtyTracks.length) log(`Cleanup: preserving ${dirtyTracks.length} dirty worktree(s) (${dirtyTracks.join(', ')}) — they hold uncommitted edits.`)
+if (teardownTracks.length) {
+  await agent(
+    `You are a MECHANICAL CLEANUP RUNNER. Every path is absolute / \`git -C\`; do not rely on the current directory. Remove EACH of these worktrees, then prune; ignore errors if one is already gone. Do NOT touch any other path.
+${teardownTracks.map((t) => `  - \`git -C ${repoPath} worktree remove --force ${wtDir(t)}\``).join('\n')}
+Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\` directory (it holds commit-message + comment scratch); do not delete the branch's commits. Return "done".`,
+    { label: 'cleanup:worktrees', phase: 'Cleanup', model },
+  )
+} else {
+  log('Cleanup: no clean worktrees to tear down (all preserved or none live).')
+}
 
 return {
   status: 'done',

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -1,0 +1,334 @@
+// The Workflow runtime requires `export const meta` to be the FIRST statement
+// and a PURE LITERAL (no interpolation), so 'opus' is inlined per phase. The
+// single MODEL socket lives just after meta; every other model reference reads
+// it lazily, well after meta is evaluated.
+export const meta = {
+  name: 'be-review',
+  description:
+    'Run the /be review gauntlet in PARALLEL: codex⇄claude, lowy⇄hickey, and code-police each debate to consensus in their own worktree at once, then consolidate the per-track commits onto the branch (overlap → reconcile)',
+  phases: [
+    { title: 'Setup', detail: 'fan out one detached worktree per review track off the branch HEAD', model: 'opus' },
+    { title: 'Tracks', detail: 'codex, lens, and police gauntlets each run to consensus, concurrently and isolated', model: 'opus' },
+    { title: 'Consolidate', detail: 'cherry-pick each track’s commits onto the branch in order; reconcile the rare overlap', model: 'opus' },
+    { title: 'Cleanup', detail: 'tear down the per-track worktrees', model: 'opus' },
+  ],
+}
+
+// The model every orchestrated agent runs on. Structural review on /be runs on
+// Opus (the lens debate forces it, overriding its sonnet frontmatter); keep the
+// override to one socket so a model bump is a one-liner.
+const MODEL = 'opus'
+
+// ---------------------------------------------------------------------------
+// Inputs (passed via the Workflow tool's `args`)
+// ---------------------------------------------------------------------------
+const a = args || {}
+const repoPath = a.repoPath || '.'
+const base = a.base || 'origin/master'
+// Optional author note on deliberate design decisions, threaded into the lens
+// debate so the lenses don't flag intentional choices.
+const rationale = (a.rationale || '').trim()
+// Commit each track's fixes (default on). Tracks always commit inside their own
+// worktree — this only gates whether the lens/police APPLY steps commit; the
+// per-track commits are what consolidation cherry-picks, so leaving it on is the
+// norm. (`--no-commit` is for debugging a single track in isolation.)
+const commit = a.commit !== false
+const model = a.model || MODEL
+// The review tracks to run AND the order they consolidate in. codex first (it
+// changes the most — bug fixes), then the structural lenses, then police, so an
+// overlap surfaces as a conflict picking the later, lighter-touch track.
+const TRACKS = a.tracks || ['codex', 'lens', 'police']
+
+// Per-track worktrees + commit-message scratch live here. Gitignored (`.be-review/`),
+// so they never pollute the diff the reviewers inspect, and a track's own
+// `.codex-debate/`/`.lens-debate/` scratch nests harmlessly inside its worktree.
+const workRoot = `${repoPath}/.be-review`
+const wtPath = (track) => `${workRoot}/wt-${track}`
+
+// Generated skill locations the child debate workflows live at.
+const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
+const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
+const CODEX_SKILLDIR = '.claude/skills/codex-debate'
+
+const DIFF = (wt) =>
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore any \`.be-review/\`, \`.codex-debate/\`, or \`.lens-debate/\` scratch dirs.`
+
+const rationaleBlock = rationale
+  ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
+  : ''
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+const SETUP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['branchHead', 'worktrees'],
+  properties: {
+    branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    worktrees: {
+      type: 'array',
+      description: 'one entry per track worktree created',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'path', 'ok'],
+        properties: {
+          track: { type: 'string' },
+          path: { type: 'string' },
+          ok: { type: 'boolean' },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// code-police review pass output (mirrors /code-police's finding shape).
+const POLICE_FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      description: 'high-confidence findings from this pass (≤6; empty is a fine verdict)',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'location', 'problem', 'fix', 'severity'],
+        properties: {
+          title: { type: 'string' },
+          location: { type: 'string', description: 'file:line' },
+          problem: { type: 'string' },
+          fix: { type: 'string', description: 'a concrete, implementable change' },
+          severity: { type: 'string', enum: ['blocking', 'major', 'minor', 'nit'] },
+        },
+      },
+    },
+  },
+}
+
+const IMPL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['summary', 'filesChanged'],
+  properties: {
+    summary: { type: 'string', description: 'one line: what you changed' },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const CONSOLIDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['picks', 'conflicts'],
+  properties: {
+    finalHead: { type: 'string', description: 'branch HEAD SHA after all picks' },
+    picks: {
+      type: 'array',
+      description: 'one entry per source commit you processed, in the order you processed it',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'sourceCommit', 'outcome'],
+        properties: {
+          track: { type: 'string' },
+          sourceCommit: { type: 'string', description: 'the short SHA from the track worktree' },
+          newCommit: { type: 'string', description: 'the resulting SHA on the branch' },
+          outcome: { type: 'string', enum: ['clean', 'reconciled', 'dropped'] },
+          note: { type: 'string', description: 'for reconciled/dropped: how you resolved it and why' },
+        },
+      },
+    },
+    conflicts: {
+      type: 'array',
+      description: 'the overlaps you had to reconcile (subset of picks); empty in the common no-overlap case',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['track', 'sourceCommit', 'files', 'resolution'],
+        properties: {
+          track: { type: 'string' },
+          sourceCommit: { type: 'string' },
+          files: { type: 'array', items: { type: 'string' } },
+          resolution: { type: 'string', enum: ['merged', 'dropped'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — fan out one detached worktree per track off the branch HEAD
+// ---------------------------------------------------------------------------
+phase('Setup')
+
+const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps in the repo at \`${repoPath}\`; do not edit any source files.
+
+1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
+2. Ensure the scratch root exists: \`mkdir -p ${workRoot}\`.
+3. For EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
+   - Path: \`${workRoot}/wt-<track>\`.
+   - If that path already exists from a prior run, remove it first: \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if it's not registered), then \`rm -rf ${workRoot}/wt-<track>\`.
+   - Then: \`git -C ${repoPath} worktree add --detach ${workRoot}/wt-<track> <branchHead>\`.
+4. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
+
+Return \`branchHead\` and, for each track, its worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+
+const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
+const branchHead = (setup?.branchHead || '').trim()
+const liveTracks = TRACKS.filter((t) => (setup?.worktrees || []).find((w) => w.track === t && w.ok))
+const failedTracks = TRACKS.filter((t) => !liveTracks.includes(t))
+if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — those tracks are skipped.`)
+log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
+
+if (!branchHead || liveTracks.length === 0) {
+  return { status: 'setup-failed', branchHead, base, tracks: {}, consolidation: null, note: 'no track worktrees could be created' }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — run every track's gauntlet to consensus, concurrently & isolated
+// ---------------------------------------------------------------------------
+phase('Tracks')
+
+// The police track. /code-police is a skill, not a workflow, so its three cold
+// passes (rules / fact-check / elegance) are reproduced here as parallel agents,
+// then each agreed fix is applied as its own commit — matching /be §4.3's
+// "each finding is its own commit". Per-finding `just check` is deferred to the
+// post-consolidation check + §5 CI rather than run 3× concurrently across the
+// parallel worktrees (it would thrash the toolchain); fmt-on-touched-files still
+// runs in each apply.
+async function policeTrack(wt) {
+  const passes = [
+    { key: 'rules', brief: 'the built-in code-police rule checklist (dry-rule-of-three, prefer-focused-library, invalid-states-unrepresentable, no-dead-code, no-silent-error-swallowing, and the rest) PLUS any project rules' },
+    { key: 'fact-check', brief: 'a CORRECTNESS audit: logic errors, silently swallowed errors, wishful thinking, unjustified fallbacks — not style' },
+    { key: 'elegance', brief: 'simplicity and idiom: hand-rolled code that a focused library or a simpler shape would replace' },
+  ]
+  const reviews = await parallel(
+    passes.map((p) => () =>
+      agent(
+        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`.claude/skills/code-police/SKILL.md\` (and \`.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+        { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
+      ),
+    ),
+  )
+  const findings = []
+  passes.forEach((p, i) => (reviews[i]?.findings ?? []).forEach((f, j) => findings.push({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })))
+  log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
+
+  // Apply each finding as its own commit, sequentially (same-file edits can't be
+  // parallel-applied). Mechanical committer stages only the touched files.
+  const applied = []
+  for (const f of findings) {
+    const impl = await agent(
+      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change in the working tree. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`,
+      { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+    )
+    const files = impl?.filesChanged ?? []
+    let sha = null
+    if (commit && files.length) {
+      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files) || '').trim()
+    }
+    applied.push({ id: f.id, title: f.title, severity: f.severity, files, commit: sha })
+    log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
+  }
+  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, applied }
+}
+
+// Mechanical committer shared by the police track: stages EXACTLY the listed
+// files in worktree `wt` and commits with the given message. The workflow can't
+// run git itself, so a thin agent does. (codex/lens commit via their own
+// workflows.)
+async function commitFix(wt, id, subject, body, files) {
+  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
+  const msgPath = `${workRoot}/commit-msg-${id}.txt`
+  const message = `${subject}\n\n${body}`
+  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workRoot}\`.
+2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
+
+${message}
+
+3. Run: \`git -C ${wt} add -- ${fileArgs} && git -C ${wt} commit -F ${msgPath}\`. Stage ONLY those files; do NOT use \`git add -A\`/\`git add .\`.
+4. Return the new commit SHA from \`git -C ${wt} rev-parse HEAD\`. Do NOT push.`
+  return agent(prompt, { label: `police-commit:${id}`, phase: 'Tracks' })
+}
+
+// One thunk per live track. codex and lens are existing repoPath-parameterized
+// workflows (built to run in separate worktrees), invoked as child workflows —
+// one level of nesting, which the runtime allows. police is inline (it's a
+// skill, not a workflow). Each thunk catches so one track's failure can't sink
+// the rest — consolidation just picks up whatever each track committed.
+const trackThunk = {
+  codex: () =>
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtPath('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+      .then((r) => ({ track: 'codex', ...r }))
+      .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
+  lens: () =>
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtPath('lens'), base, rationale, model, commit })
+      .then((r) => ({ track: 'lens', ...r }))
+      .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
+  police: () =>
+    policeTrack(wtPath('police'))
+      .then((r) => ({ track: 'police', ...r }))
+      .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
+}
+
+const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
+const tracks = {}
+liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
+for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+
+// ---------------------------------------------------------------------------
+// Phase 3 — consolidate: cherry-pick each track's commits onto the branch in
+// TRACKS order. The common case is no overlap (clean picks); the rare overlap
+// surfaces as a cherry-pick conflict the agent reconciles by honoring BOTH
+// changes (it has both commit messages = both debates' rationale).
+// ---------------------------------------------------------------------------
+phase('Consolidate')
+
+// Skip tracks that errored or made no commits — the agent only picks real work.
+const consolidateOrder = liveTracks.filter((t) => tracks[t]?.status !== 'track-error')
+const consolidatePrompt = `You are CONSOLIDATING the results of a parallel code-review gauntlet onto the branch in the MAIN worktree at \`${repoPath}\`. Three review tracks each ran to consensus in their own detached worktree, all forked from branch HEAD \`${branchHead}\`, each committing its agreed fixes on top. Your job: replay every track's commits onto the branch, in the given order, reconciling the rare overlap.
+
+The branch in \`${repoPath}\` is currently AT \`${branchHead}\` (the tracks' shared fork point). Process tracks in THIS order: ${consolidateOrder.join(' → ')}.
+
+For each track, its worktree is \`${workRoot}/wt-<track>\`. Get that track's new commits oldest-first:
+  \`git -C ${workRoot}/wt-<track> rev-list --reverse ${branchHead}..HEAD\`
+(An empty list means the track found nothing to change — skip it.)
+
+Then, from the MAIN worktree \`${repoPath}\`, cherry-pick each of those commits onto the branch IN THAT ORDER:
+  \`git -C ${repoPath} cherry-pick <sha>\`
+
+- **Clean pick** → record outcome \`clean\` with the new SHA (\`git -C ${repoPath} rev-parse HEAD\`).
+- **Conflict** (\`git -C ${repoPath} status\` shows unmerged paths) → this is an OVERLAP: an earlier track already changed the same lines. Resolve by Reading both sides and producing a result that HONORS BOTH fixes (they each came from a review debate — neither is noise). Edit the conflicted files to the merged result, \`git -C ${repoPath} add\` them, then \`git -C ${repoPath} cherry-pick --continue\` (keep the original commit message). Record outcome \`reconciled\`, list the conflicted files, and explain the merge in \`note\`. Only \`drop\` a commit (\`git -C ${repoPath} cherry-pick --abort\`) if the earlier track's change already FULLY subsumes this one — say so in \`note\`; never drop to avoid the work of merging.
+
+Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD, the per-commit \`picks\` ledger (in processing order), and the \`conflicts\` subset you had to reconcile.`
+
+const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
+const conflicts = consolidation?.conflicts ?? []
+log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
+
+// ---------------------------------------------------------------------------
+// Phase 4 — tear down the per-track worktrees
+// ---------------------------------------------------------------------------
+phase('Cleanup')
+
+await agent(
+  `You are a MECHANICAL CLEANUP RUNNER. From \`${repoPath}\`, for each track in [${liveTracks.join(', ')}] run \`git -C ${repoPath} worktree remove --force ${workRoot}/wt-<track>\` (ignore errors if already gone), then \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${workRoot}\` directory itself (it holds commit-message scratch); do not delete the branch's commits. Return "done".`,
+  { label: 'cleanup:worktrees', phase: 'Cleanup', model },
+)
+
+return {
+  status: 'done',
+  branchHead,
+  finalHead: consolidation?.finalHead || null,
+  base,
+  order: consolidateOrder,
+  tracks,
+  consolidation,
+  conflicts,
+}

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -363,9 +363,9 @@ function codexComment(t) {
   const rows = (t.transcript || [])
     .map((r) => {
       const v = r.codex || {}
-      const openBM = (v.findings || []).filter((f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major')).length
+      const open = (v.findings || []).filter((f) => f.status !== 'resolved').length
       const disp = (r.claude?.actions || []).map((act) => `${act.findingId}:${act.disposition}`).join(', ')
-      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${openBM} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
+      return `| ${r.round} | ${v.approved ? '✅' : '❌'} | ${open} | ${esc(disp) || '—'} | ${sha9(r.commit)} |`
     })
     .join('\n')
   return `## 🤖 Codex ⇄ Claude debate
@@ -374,7 +374,7 @@ function codexComment(t) {
 
 ${esc(t.finalVerdict?.summary)}
 
-| Round | codex approved | open blk/maj | claude dispositions | commit |
+| Round | codex approved | findings open | claude dispositions | commit |
 |---|---|---|---|---|
 ${rows || '| — | — | — | — | — |'}`
 }

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -312,8 +312,9 @@ async function policeTrack(wt) {
       ),
     ),
   )
-  const findings = []
-  passes.forEach((p, i) => (reviews[i]?.findings ?? []).forEach((f, j) => findings.push({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })))
+  const findings = passes.flatMap((p, i) =>
+    (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })),
+  )
   log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
   // Apply each finding as its own commit, sequentially (same-file edits can't be
@@ -388,11 +389,21 @@ const trackThunk = {
       .catch((e) => ({ track: 'police', status: 'track-error', error: String(e) })),
 }
 
-const trackResults = await parallel(liveTracks.map((t) => trackThunk[t]))
-// `tracks` already carries a `track-error` entry for every setup failure; the live
-// tracks fill in alongside them, so the returned map covers EVERY requested track.
-liveTracks.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
-for (const t of liveTracks) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
+// A live track with no registered thunk (an unknown/typo'd TRACKS entry whose
+// worktree Setup still built) would make `parallel` invoke `undefined()`. Seed it
+// as a track-error — same shape as a setup failure — and drop it from dispatch so
+// the parallel call stays total.
+const dispatchable = liveTracks.filter((t) => trackThunk[t])
+for (const t of liveTracks.filter((t) => !trackThunk[t])) {
+  tracks[t] = { track: t, status: 'track-error', error: 'unknown track: no thunk registered' }
+  log(`Track ${t}: no thunk registered — recorded as track-error and excluded from dispatch.`)
+}
+const trackResults = await parallel(dispatchable.map((t) => trackThunk[t]))
+// `tracks` already carries a `track-error` entry for every setup failure (and any
+// unknown track above); the dispatchable tracks fill in alongside them, so the
+// returned map covers EVERY requested track.
+dispatchable.forEach((t, i) => (tracks[t] = trackResults[i] || { track: t, status: 'track-error', error: 'no result' }))
+for (const t of dispatchable) log(`Track ${t}: ${tracks[t].status || 'unknown'}`)
 
 // ---------------------------------------------------------------------------
 // PR-comment builders + poster (used by the Report phase). Bodies are built
@@ -523,6 +534,8 @@ if (!commit) {
     order: [],
     tracks,
     consolidation: null,
+    reconciled: [],
+    dropped: [],
     conflicts: [],
     note: 'commit=false: each track left its fixes uncommitted in its worktree and nothing was consolidated. The worktrees are PRESERVED for inspection — see the `worktrees` field below for each track’s path — and re-run with commit enabled to consolidate.',
     worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
@@ -642,8 +655,10 @@ Then cherry-pick each of those commits onto the branch IN THAT ORDER:
 Do NOT push and do NOT merge — leave the consolidated commits on the local branch for the human. Return the final branch HEAD and the per-commit \`picks\` ledger (in processing order); the overlaps you reconciled are just the picks whose outcome isn't \`clean\`.`
 
 const consolidation = await agent(consolidatePrompt, { label: 'consolidate:cherry-pick', phase: 'Consolidate', model, schema: CONSOLIDATE_SCHEMA })
-const conflicts = (consolidation?.picks ?? []).filter((p) => p.outcome !== 'clean')
-log(`Consolidate: ${(consolidation?.picks ?? []).length} commit(s) replayed, ${conflicts.length} overlap(s) reconciled. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
+const picks = consolidation?.picks ?? []
+const reconciled = picks.filter((p) => p.outcome === 'reconciled')
+const dropped = picks.filter((p) => p.outcome === 'dropped')
+log(`Consolidate: ${picks.length} commit(s) replayed, ${reconciled.length} reconciled, ${dropped.length} dropped. HEAD ${(consolidation?.finalHead || '').slice(0, 9)}`)
 
 // ---------------------------------------------------------------------------
 // Phase 4 — post a detailed PR comment for EVERY track + the consolidation
@@ -712,6 +727,10 @@ return {
   order: consolidateOrder,
   tracks,
   consolidation,
-  conflicts,
+  reconciled,
+  dropped,
+  // back-compat: the union of non-clean picks. Consumers keying on a discarded
+  // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
+  conflicts: [...reconciled, ...dropped],
   comments,
 }

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -356,8 +356,10 @@ async function policeTrack(wt) {
   const applied = []
   let totalFindings = 0
   let policeRound = 0
+  let sweepsRun = 0
   let lastRoundFindings = 0
   for (; policeRound < POLICE_MAX_ROUNDS; policeRound++) {
+    sweepsRun++ // one review pass per iteration, counted BEFORE any break/cap exit so the reported sweep count is exact (not derived from the loop index)
     const reviews = await parallel(
       passes.map((p) => () =>
         agent(
@@ -396,7 +398,7 @@ async function policeTrack(wt) {
   const reachedClean = lastRoundFindings === 0
   const status = !totalFindings ? 'clean' : reachedClean ? 'consensus' : 'incomplete'
   if (!reachedClean) log(`police: hit round cap (${POLICE_MAX_ROUNDS}) with findings still open — reporting incomplete.`)
-  return { status, findings: totalFindings, rounds: policeRound + (reachedClean ? 0 : 1), passes: passes.map((p) => p.key), applied }
+  return { status, findings: totalFindings, rounds: sweepsRun, passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -751,6 +753,23 @@ const cleanTracks = liveTracks.filter((t) => cleanResultFor(t)?.clean === true)
 // is untrustworthy. The agent only picks committed work.
 const consolidateOrder = cleanTracks.filter((t) => tracks[t]?.status !== 'track-error')
 
+// The terminal statuses that mean a track's review actually FINISHED — codex/lens
+// reached consensus (or had nothing to raise), police got a clean final sweep.
+// Anything else a consolidated track can carry (police `incomplete` after the
+// round cap, lens `unresolved` with findings still contested, codex
+// `reviewer-error`/`merge-base-error`) means the gauntlet did NOT fully complete
+// for that track, even though its committed fixes are real and DO get replayed.
+const COMPLETED_TRACK_STATUS = new Set(['clean', 'consensus'])
+// Consolidated tracks whose own review did not reach a completed terminus. Their
+// fixes still land (they're committed and clean), but the top-level result must
+// not read `done`, or /be would proceed as if the gauntlet fully passed when a
+// police/lens sweep was actually cut short. (A `track-error` track is never in
+// `consolidateOrder`, so it can't appear here.)
+const incompleteTracks = consolidateOrder.filter((t) => !COMPLETED_TRACK_STATUS.has(tracks[t]?.status))
+for (const t of incompleteTracks) {
+  log(`Consolidate: track ${t} consolidated but its review ended \`${tracks[t]?.status}\` (not a completed terminus) — top-level status will reflect that the gauntlet did not fully finish.`)
+}
+
 // Preserve every live track we did NOT consolidate, so neither uncommitted edits
 // nor committed-but-unreplayed commits are lost.
 const preservedTracks = liveTracks.filter((t) => !consolidateOrder.includes(t))
@@ -854,17 +873,25 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
   log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
-// Top-level status reflects whether EVERY requested track actually landed on the
-// branch. A preserved track (uncommitted edits, an unconfirmed worktree, or a
-// crashed `track-error` whose committed fixes were deliberately not replayed) means
-// at least one reviewer's fixes live ONLY in a side worktree — so `done` would
-// overstate the outcome and let /be continue as if the gauntlet fully consolidated.
-// Surface `consolidation-incomplete` (with the preserved tracks + recovery notes
-// already on each `tracks[t]`) so the caller can adjudicate instead of silently
-// shipping a partial consolidation.
-const status = preservedTracks.length ? 'consolidation-incomplete' : 'done'
+// Top-level status reflects whether EVERY requested track actually (a) landed on
+// the branch AND (b) ran its review to a completed terminus. Two ways it falls
+// short of `done`:
+//   - a PRESERVED track (uncommitted edits, an unconfirmed worktree, or a crashed
+//     `track-error` whose committed fixes were deliberately not replayed) means at
+//     least one reviewer's fixes live ONLY in a side worktree; or
+//   - an INCOMPLETE track (consolidated, but its review ended `incomplete`/
+//     `unresolved`/`reviewer-error` rather than `clean`/`consensus`) means the
+//     gauntlet was cut short for that track even though its fixes landed.
+// Either way `done` would overstate the outcome and let /be continue as if the
+// gauntlet fully passed. Surface `consolidation-incomplete` (the preserved tracks'
+// recovery notes are already on each `tracks[t]`; the incomplete tracks carry their
+// own non-terminal status) so the caller adjudicates instead of silently shipping.
+const status = preservedTracks.length || incompleteTracks.length ? 'consolidation-incomplete' : 'done'
 if (preservedTracks.length) {
   log(`Done: status=consolidation-incomplete — ${preservedTracks.length} track(s) preserved, not consolidated: ${preservedTracks.join(', ')}. Their worktrees hold the only copy of those fixes; see each track's note for the recovery cherry-pick.`)
+}
+if (incompleteTracks.length) {
+  log(`Done: status=consolidation-incomplete — ${incompleteTracks.length} track(s) consolidated but their review did not finish (${incompleteTracks.map((t) => `${t}=${tracks[t]?.status}`).join(', ')}); re-run the gauntlet (or that track) before treating the change as fully reviewed.`)
 }
 return {
   status,
@@ -879,6 +906,10 @@ return {
   // Tracks whose fixes were NOT consolidated onto the branch (preserved worktrees);
   // empty in the common case. Non-empty ⇒ status is 'consolidation-incomplete'.
   preservedTracks,
+  // Tracks that WERE consolidated but whose review ended on a non-terminal status
+  // (police `incomplete`, lens `unresolved`, codex `reviewer-error`); their fixes
+  // landed but the gauntlet didn't fully finish. Non-empty ⇒ 'consolidation-incomplete'.
+  incompleteTracks,
   // back-compat: the union of non-clean picks. Consumers keying on a discarded
   // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
   conflicts: [...reconciled, ...dropped],

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -62,8 +62,11 @@ const CODEX_SCRIPT = '.claude/skills/codex-debate/debate.workflow.js'
 const LENS_SCRIPT = '.claude/skills/lens-debate/debate.workflow.js'
 const CODEX_SKILLDIR = '.claude/skills/codex-debate'
 
+// The diff base reviewers actually use is the MERGE-BASE (resolved by Setup),
+// not the raw `${base}` tip — see SETUP_SCHEMA.mergeBase. DIFF is an arrow, so it
+// reads `mergeBase` lazily at call time (Tracks phase, after Setup has set it).
 const DIFF = (wt) =>
-  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${base}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
+  `Inspect the FULL change in the worktree at \`${wt}\`: run \`git -C ${wt} diff ${mergeBase}\` (committed + unstaged) and \`git -C ${wt} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file (use ABSOLUTE paths under \`${wt}\`) plus enough surrounding code to judge it in context. Ignore the gitignored \`.worktrees/\` and \`.be-review/\` scratch dirs if they appear.`
 
 const rationaleBlock = rationale
   ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n`
@@ -75,9 +78,10 @@ const rationaleBlock = rationale
 const SETUP_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['branchHead', 'cleanTree', 'worktrees'],
+  required: ['branchHead', 'mergeBase', 'cleanTree', 'worktrees'],
   properties: {
     branchHead: { type: 'string', description: 'SHA of the branch HEAD every track was forked from' },
+    mergeBase: { type: 'string', description: 'SHA of `git merge-base <base> HEAD` — the diff base reviewers actually use, so master’s drift past the fork point is NOT reviewed' },
     cleanTree: {
       type: 'boolean',
       description: 'true iff the main worktree had NO uncommitted changes (outside the scratch dirs) when checked',
@@ -173,6 +177,7 @@ phase('Setup')
 const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktrees for a parallel code-review gauntlet. Do exactly these steps (every path here is ABSOLUTE; use \`git -C\` and never rely on the current directory); do not edit any source files.
 
 1. Record the branch HEAD: \`git -C ${repoPath} rev-parse HEAD\` — this is \`branchHead\`, the commit every track forks from.
+1b. Record the MERGE-BASE: \`git -C ${repoPath} merge-base ${base} HEAD\` — this is \`mergeBase\`, the point the branch diverged from its base. Reviewers diff against THIS (not the raw \`${base}\` tip) so that commits \`${base}\` gained since the branch forked are NOT reviewed as if this PR made them. If the command fails, fall back to \`mergeBase\` = the resolved \`${base}\` and say so in a worktree \`note\`.
 2. CLEAN-TREE PREFLIGHT. The tracks fork detached worktrees from \`branchHead\`, so anything NOT committed to HEAD is invisible to every reviewer. Run \`git -C ${repoPath} status --short\` and ignore only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged, unstaged, or untracked entry remains, the working tree is dirty: set \`cleanTree\`: false, put those offending lines in \`dirtyStatus\`, SKIP worktree creation entirely (return an empty \`worktrees\` array), and stop. Otherwise set \`cleanTree\`: true and \`dirtyStatus\`: "".
 3. Only if \`cleanTree\` is true — ensure the scratch dirs exist: \`mkdir -p ${WT_ROOT} ${SCRATCH}\`.
 4. Only if \`cleanTree\` is true — for EACH track in [${TRACKS.join(', ')}], create a fresh detached worktree at \`branchHead\`:
@@ -181,10 +186,14 @@ const setupPrompt = `You are a MECHANICAL SETUP RUNNER preparing isolated worktr
    - Then: \`git -C ${repoPath} worktree add --detach ${WT_ROOT}/be-review-<track> <branchHead>\`.
 5. Run \`git -C ${repoPath} worktree prune\` to clear any stale entries.
 
-Return \`branchHead\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
+Return \`branchHead\`, \`mergeBase\`, \`cleanTree\`, \`dirtyStatus\`, and, for each track, its absolute worktree \`path\` and whether creation succeeded (\`ok\`). If a worktree failed, set \`ok\`: false and put the git error in \`note\` — do NOT invent success.`
 
 const setup = await agent(setupPrompt, { label: 'setup:worktrees', phase: 'Setup', model, schema: SETUP_SCHEMA })
 const branchHead = (setup?.branchHead || '').trim()
+// The diff base every reviewer uses: the merge-base of the branch and `${base}`,
+// so commits `${base}` gained since the branch forked aren't reviewed as ours.
+// Falls back to the raw base if Setup couldn't resolve it.
+const mergeBase = (setup?.mergeBase || base).trim()
 
 // Clean-tree gate. The tracks fork from HEAD, so uncommitted work in the main
 // worktree would be invisible to every reviewer — a /be-review run could then
@@ -215,7 +224,7 @@ for (const t of failedTracks) {
   tracks[t] = { track: t, status: 'track-error', error: `setup: ${note}` }
 }
 if (failedTracks.length) log(`Setup: worktree creation FAILED for ${failedTracks.join(', ')} — recorded as track-error so the caller falls back for those.`)
-log(`Setup: branchHead ${branchHead.slice(0, 9)}; tracks live: ${liveTracks.join(', ') || '(none)'}`)
+log(`Setup: branchHead ${branchHead.slice(0, 9)}; diffing against merge-base ${mergeBase.slice(0, 9)} (not the raw ${base} tip); tracks live: ${liveTracks.join(', ') || '(none)'}`)
 
 if (!branchHead || liveTracks.length === 0) {
   return { status: 'setup-failed', branchHead, base, tracks, consolidation: null, note: 'no track worktrees could be created' }
@@ -242,7 +251,7 @@ async function policeTrack(wt) {
   // is gated on the tiny-diff heuristic the skill mandates (skip when the worktree
   // diff against base is <10 lines).
   const tinyDiff = await agent(
-    `Run \`git -C ${wt} diff ${base} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
+    `Run \`git -C ${wt} diff ${mergeBase} --shortstat\` and report whether the changed-line total (insertions + deletions) is **under 10**. Return only that boolean.`,
     { label: 'police:diff-size', phase: 'Tracks', model, schema: { type: 'object', properties: { tiny: { type: 'boolean' } }, required: ['tiny'] } },
   )
   const passes = [
@@ -322,11 +331,11 @@ ${message}
 // up whatever each track committed.
 const trackThunk = {
   codex: () =>
-    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base, skillDir: CODEX_SKILLDIR, commit })
+    workflow({ scriptPath: CODEX_SCRIPT }, { repoPath: wtDir('codex'), base: mergeBase, skillDir: CODEX_SKILLDIR, commit })
       .then((r) => ({ track: 'codex', ...r }))
       .catch((e) => ({ track: 'codex', status: 'track-error', error: String(e) })),
   lens: () =>
-    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base, rationale, model, commit })
+    workflow({ scriptPath: LENS_SCRIPT }, { repoPath: wtDir('lens'), base: mergeBase, rationale, model, commit })
       .then((r) => ({ track: 'lens', ...r }))
       .catch((e) => ({ track: 'lens', status: 'track-error', error: String(e) })),
   police: () =>

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -61,6 +61,24 @@ const model = a.model || MODEL
 // changes the most — bug fixes), then the structural lenses, then police, so an
 // overlap surfaces as a conflict picking the later, lighter-touch track.
 const TRACKS = a.tracks || ['codex', 'lens', 'police']
+// Whitelist the track names. Each is woven into worktree paths and the agents'
+// shell snippets (just like RUN_ID above), and each must map to a registered
+// thunk. Reject an unknown track or a duplicate up front rather than building a
+// worktree at an unexpected path or invoking `undefined()` in `parallel` — a
+// typo'd/hostile track is an input error, not something to silently route around.
+const KNOWN_TRACKS = ['codex', 'lens', 'police']
+const badTracks = TRACKS.filter((t) => !KNOWN_TRACKS.includes(t))
+const dupTracks = TRACKS.filter((t, i) => TRACKS.indexOf(t) !== i)
+if (badTracks.length || dupTracks.length) {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `tracks must be a subset of ${KNOWN_TRACKS.join(', ')} with no duplicates.${badTracks.length ? ` Unknown: ${[...new Set(badTracks)].join(', ')}.` : ''}${dupTracks.length ? ` Duplicated: ${[...new Set(dupTracks)].join(', ')}.` : ''}`,
+  }
+}
 
 // SHARED-CWD NOTE. Every workflow agent inherits the SESSION cwd (the main
 // worktree) — the harness offers no per-agent cwd, and `isolation:'worktree'`
@@ -81,6 +99,24 @@ const TRACKS = a.tracks || ['codex', 'lens', 'police']
 // the same main worktree must pass distinct ids. The actual paths are reported in
 // the result so manual inspection doesn't need to guess them.
 const RUN_ID = String(a.runId || 'run')
+// `RUN_ID` and the track names below are woven directly into filesystem paths
+// (worktree dirs, scratch subdirs) and into the shell snippets the mechanical
+// agents run, so they MUST be conservative tokens. A value with `/`, `..`, or
+// shell metacharacters could place a worktree or scratch file OUTSIDE the
+// intended `.worktrees`/`.be-review` dirs, collide with another run, or inject a
+// command into an agent's `git -C`/`mkdir` snippet. Reject anything that isn't a
+// plain `[A-Za-z0-9._-]` token (which also excludes path separators and `..` as a
+// whole, since `.` alone is fine but `..` can't reach a parent without a `/`).
+if (!/^[A-Za-z0-9._-]+$/.test(RUN_ID) || RUN_ID === '..' || RUN_ID === '.') {
+  return {
+    status: 'setup-failed',
+    branchHead: '',
+    base: a.base || 'origin/master',
+    tracks: {},
+    consolidation: null,
+    note: `runId must match ^[A-Za-z0-9._-]+$ (no slashes, no shell metacharacters) so it stays safe inside filesystem paths and shell snippets; got \`${RUN_ID}\`. Pass a plain token like the launch epoch ms.`,
+  }
+}
 const WT_ROOT = `${repoPath}/.worktrees`
 const wtDir = (track) => `${WT_ROOT}/be-review-${RUN_ID}-${track}`
 const SCRATCH = `${repoPath}/.be-review/${RUN_ID}`
@@ -307,36 +343,60 @@ async function policeTrack(wt) {
     { key: 'elegance', brief: 'the **Elegance** pass exactly as defined in that skill\'s "Running the passes" section (Pass 3) — simplicity and idiom' },
   ].filter((p) => p.key !== 'elegance' || !tinyDiff?.tiny)
   if (tinyDiff?.tiny) log('police: skipping elegance pass (tiny diff <10 lines, per code-police SKILL.md)')
-  const reviews = await parallel(
-    passes.map((p) => () =>
-      agent(
-        `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
-        { label: `police:${p.key}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
-      ),
-    ),
-  )
-  const findings = passes.flatMap((p, i) =>
-    (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-${p.key}-${j + 1}`, pass: p.key, ...f })),
-  )
-  log(`police: ${findings.length} finding(s) across ${passes.length} passes`)
 
-  // Apply each finding as its own commit, sequentially (same-file edits can't be
-  // parallel-applied). Every edit and git command targets the absolute worktree.
+  // /code-police runs its passes "until clean": applying a finding can introduce a
+  // NEW issue or leave one only partially fixed, so a single review+apply sweep is
+  // not equivalent. Loop the passes on the UPDATED worktree until a sweep returns
+  // no findings (clean) — applied fixes are re-reviewed, not assumed correct. A cap
+  // keeps a thrashing reviewer from spinning forever (the harness backstop is the
+  // hard ceiling); if we hit it with findings still open, the track reports
+  // `incomplete` rather than a false `consensus`. Each round's finding ids are
+  // round-scoped so commits stay unique across sweeps.
+  const POLICE_MAX_ROUNDS = 4
   const applied = []
-  for (const f of findings) {
-    const impl = await agent(
-      `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change. Do NOT git add / commit / push. You MAY run the project's formatter on files you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
-      { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+  let totalFindings = 0
+  let policeRound = 0
+  let lastRoundFindings = 0
+  for (; policeRound < POLICE_MAX_ROUNDS; policeRound++) {
+    const reviews = await parallel(
+      passes.map((p) => () =>
+        agent(
+          `You are the **code-police ${p.key}** reviewer on a fresh, cold context — the implementer is biased to rationalize their own diff, so you start from "assume the code is wrong until proven right" and NEVER talk yourself out of a finding. First Read \`${wt}/.claude/skills/code-police/SKILL.md\` (and \`${wt}/.agency/code-police.md\` if it exists) for the rules and reviewing principles, then ${DIFF(wt)}\n${rationaleBlock}\nReview through ${p.brief}. Emit high-confidence findings only; an empty list is a fine verdict for a clean diff. Each finding: a title, a file:line location, the problem, a concrete implementable fix, and a severity.`,
+          { label: `police:${p.key}:r${policeRound + 1}`, phase: 'Tracks', model, schema: POLICE_FINDINGS_SCHEMA },
+        ),
+      ),
     )
-    const files = impl?.filesChanged ?? []
-    let sha = null
-    if (commit && files.length) {
-      sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
+    const findings = passes.flatMap((p, i) =>
+      (reviews[i]?.findings ?? []).map((f, j) => ({ id: `police-r${policeRound + 1}-${p.key}-${j + 1}`, pass: p.key, ...f })),
+    )
+    lastRoundFindings = findings.length
+    log(`police: round ${policeRound + 1} — ${findings.length} finding(s) across ${passes.length} passes`)
+    if (!findings.length) break // clean sweep on the updated worktree → done
+
+    // Apply each finding as its own commit, sequentially (same-file edits can't be
+    // parallel-applied). Every edit and git command targets the absolute worktree.
+    for (const f of findings) {
+      const impl = await agent(
+        `You are implementing ONE code-police finding in the worktree at \`${wt}\`. Work ONLY inside that worktree — every file you Read or Edit MUST be an ABSOLUTE path under \`${wt}\` (your shell cwd is a DIFFERENT worktree, so a relative path would edit the wrong tree). Read the surrounding code first so the edit fits the existing style; keep it tightly scoped.\n\nFinding ${f.id} [${f.severity}] — ${f.title}\n  at ${f.location}\n  problem: ${f.problem}\n  fix: ${f.fix}\n\nMake ONLY this change, fixing the issue COMPLETELY (a partial fix would resurface in the next review sweep). Do NOT git add / commit / push. You MUST run the project's formatter on every file you touched (\`cd ${wt} && <formatter>\`). Return a one-line summary and the exact list of files you changed (absolute paths).`,
+        { label: `police-apply:${f.id}`, phase: 'Tracks', model, schema: IMPL_SCHEMA },
+      )
+      const files = impl?.filesChanged ?? []
+      let sha = null
+      if (commit && files.length) {
+        sha = (await commitFix(wt, f.id, `fix(police): ${f.title}`, `${impl.summary}\n\ncode-police ${f.pass} finding ${f.id} [${f.severity}]. Applied by the /be parallel gauntlet; not pushed or merged.`, files))?.sha?.trim() || null
+      }
+      applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
+      log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
     }
-    applied.push({ id: f.id, title: f.title, severity: f.severity, problem: f.problem, files, commit: sha })
-    log(`police: applied ${f.id}${sha ? ` (${sha.slice(0, 9)})` : ' (uncommitted)'}`)
+    totalFindings += findings.length
   }
-  return { status: findings.length ? 'consensus' : 'clean', findings: findings.length, passes: passes.map((p) => p.key), applied }
+  // `clean` only if the FINAL sweep found nothing. If we exhausted the round cap
+  // with findings still open, the worktree isn't verified-clean — report
+  // `incomplete` so the caller (and the PR comment) doesn't read it as consensus.
+  const reachedClean = lastRoundFindings === 0
+  const status = !totalFindings ? 'clean' : reachedClean ? 'consensus' : 'incomplete'
+  if (!reachedClean) log(`police: hit round cap (${POLICE_MAX_ROUNDS}) with findings still open — reporting incomplete.`)
+  return { status, findings: totalFindings, rounds: policeRound + (reachedClean ? 0 : 1), passes: passes.map((p) => p.key), applied }
 }
 
 // Mechanical committer shared by the police track: stages EXACTLY the listed
@@ -420,6 +480,15 @@ const esc = (s) => String(s ?? '').replace(/\|/g, '\\|').replace(/\n+/g, ' ').tr
 
 const SEV = { blocking: '🔴 blocking', major: '🟠 major', minor: '🟡 minor', nit: '⚪ nit' }
 
+// A track that ran but was NOT consolidated (preserved worktree) carries
+// `consolidated:false` and a recovery `note`. Surface it as a banner at the top of
+// that track's comment so the PR audit trail never reads "reached consensus" while
+// the fixes silently live only in a side worktree.
+function preservedBanner(t) {
+  if (!t || t.consolidated !== false) return ''
+  return `\n\n> ⚠️ **Not consolidated onto the branch.** ${esc(t.note) || 'This track was preserved in its own worktree; its fixes are not on the branch.'}`
+}
+
 // Full per-round detail: every codex finding (severity, id, issue, location,
 // suggestion, status) and Claude's disposition of each — the complete debate
 // transcript, not a count table.
@@ -453,7 +522,7 @@ function codexComment(t) {
   const rounds = (t.transcript || []).map(codexRound).join('\n\n---\n\n')
   return `## 🤖 Codex ⇄ Claude debate
 
-**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.
+**Outcome:** \`${t.status}\` after ${t.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort.${preservedBanner(t)}
 
 ${esc(t.finalVerdict?.summary)}
 
@@ -471,7 +540,7 @@ function lensComment(t) {
     : ''
   return `## ⚖️ Lowy ⇄ Hickey lens debate
 
-**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.
+**Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${Object.entries(t.reviews || {}).map(([k, v]) => `${k}=${(v || []).length}`).join(', ') || 'n/a'}.${preservedBanner(t)}
 
 | origin | finding | location | disposition | commit |
 |---|---|---|---|---|
@@ -485,7 +554,7 @@ function policeComment(t) {
     .join('\n')
   return `## 👮 Code-police
 
-**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes${t.status === 'clean' ? ' — clean diff' : ''}.
+**${t.findings || 0} finding(s)** across the ${(t.passes || []).join(' / ') || 'code-police'} passes over ${t.rounds || 1} review sweep(s)${t.status === 'clean' ? ' — clean diff' : ''}.${t.status === 'incomplete' ? ` ⚠️ **Did not reach a clean sweep within the round cap** — the worktree may still have open issues; re-run /code-police on it.` : ''}${preservedBanner(t)}
 
 | severity | finding | files | commit |
 |---|---|---|---|
@@ -552,6 +621,69 @@ if (!commit) {
 // changes (it has both commit messages = both debates' rationale).
 // ---------------------------------------------------------------------------
 phase('Consolidate')
+
+// BRANCH-DRIFT GATE. The Tracks phase can run for many minutes; the consolidator
+// below cherry-picks onto the branch in `${repoPath}` and its prompt asserts the
+// branch is still AT `branchHead` (the tracks' shared fork point). Setup's
+// clean-tree preflight ran BEFORE the tracks, so if the user, another workflow, or
+// a second /be-review advanced or dirtied the branch while the tracks ran, we'd
+// cherry-pick onto an unreviewed base while telling the agent it's at `branchHead`
+// — corrupting the review scope. Re-check HEAD and cleanliness NOW, just before the
+// picks. If the branch moved or is dirty, abort and PRESERVE every track worktree
+// (don't tear them down — their commits are the only copy of the reviewed fixes),
+// so the human can consolidate by hand after sorting out the drift.
+const driftCheck = await agent(
+  `You are a MECHANICAL DRIFT CHECKER. Do exactly this against the main worktree at \`${repoPath}\` (use \`git -C\`; do not edit anything):
+1. \`git -C ${repoPath} rev-parse HEAD\` — return as \`head\`.
+2. \`git -C ${repoPath} status --short\` — IGNORE only lines under the gitignored scratch dirs (\`.worktrees/\` and \`.be-review/\`). If ANY other staged/unstaged/untracked entry remains, set \`clean\`: false and put those lines in \`dirtyStatus\`; otherwise \`clean\`: true and \`dirtyStatus\`: "".`,
+  {
+    label: 'consolidate:drift-check',
+    phase: 'Consolidate',
+    model,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['head', 'clean'],
+      properties: {
+        head: { type: 'string', description: 'current HEAD SHA of the main worktree' },
+        clean: { type: 'boolean' },
+        dirtyStatus: { type: 'string' },
+      },
+    },
+  },
+)
+const curHead = (driftCheck?.head || '').trim()
+const branchMoved = curHead && curHead !== branchHead
+const branchDirty = driftCheck?.clean === false
+if (branchMoved || branchDirty) {
+  const dirty = (driftCheck?.dirtyStatus || '').trim()
+  const why = branchMoved
+    ? `the branch HEAD moved from \`${branchHead.slice(0, 9)}\` (the tracks' fork point) to \`${curHead.slice(0, 9)}\` while the tracks ran`
+    : `the main worktree became dirty while the tracks ran`
+  log(`Consolidate: ABORT — ${why}. Cherry-picking onto a changed base would corrupt the review scope. Preserving all track worktrees for manual consolidation.`)
+  for (const t of liveTracks) {
+    tracks[t] = {
+      ...tracks[t],
+      consolidated: false,
+      note: `NOT consolidated — ${why}, so the consolidator's "branch is at ${branchHead.slice(0, 9)}" assumption no longer holds. The track's worktree was PRESERVED at ${wtDir(t)}; after resolving the drift, replay its commits with \`git -C ${repoPath} cherry-pick $(git -C ${wtDir(t)} rev-list --reverse ${branchHead}..HEAD)\`.`,
+    }
+  }
+  return {
+    status: 'consolidation-aborted',
+    branchHead,
+    finalHead: curHead || branchHead,
+    base,
+    order: [],
+    tracks,
+    consolidation: null,
+    reconciled: [],
+    dropped: [],
+    conflicts: [],
+    preservedTracks: liveTracks,
+    note: `consolidation aborted: ${why}. Cherry-picking onto the changed base would review against an untrustworthy scope, so nothing was consolidated and every track worktree was PRESERVED (see each track's note for the recovery cherry-pick).${dirty ? `\nOffending entries:\n${dirty}` : ''}`,
+    worktrees: liveTracks.map((t) => ({ track: t, path: wtDir(t) })),
+  }
+}
 
 // CLEAN-WORKTREE GATE before consolidation. Consolidation replays only COMMITTED
 // commits (`rev-list branchHead..HEAD`), and Cleanup later force-removes every
@@ -722,8 +854,20 @@ Then: \`git -C ${repoPath} worktree prune\`. Leave the gitignored \`${SCRATCH}\`
   log('Cleanup: no consolidated worktrees to tear down (all preserved or none live).')
 }
 
+// Top-level status reflects whether EVERY requested track actually landed on the
+// branch. A preserved track (uncommitted edits, an unconfirmed worktree, or a
+// crashed `track-error` whose committed fixes were deliberately not replayed) means
+// at least one reviewer's fixes live ONLY in a side worktree — so `done` would
+// overstate the outcome and let /be continue as if the gauntlet fully consolidated.
+// Surface `consolidation-incomplete` (with the preserved tracks + recovery notes
+// already on each `tracks[t]`) so the caller can adjudicate instead of silently
+// shipping a partial consolidation.
+const status = preservedTracks.length ? 'consolidation-incomplete' : 'done'
+if (preservedTracks.length) {
+  log(`Done: status=consolidation-incomplete — ${preservedTracks.length} track(s) preserved, not consolidated: ${preservedTracks.join(', ')}. Their worktrees hold the only copy of those fixes; see each track's note for the recovery cherry-pick.`)
+}
 return {
-  status: 'done',
+  status,
   branchHead,
   finalHead: consolidation?.finalHead || null,
   base,
@@ -732,6 +876,9 @@ return {
   consolidation,
   reconciled,
   dropped,
+  // Tracks whose fixes were NOT consolidated onto the branch (preserved worktrees);
+  // empty in the common case. Non-empty ⇒ status is 'consolidation-incomplete'.
+  preservedTracks,
   // back-compat: the union of non-clean picks. Consumers keying on a discarded
   // fix (e.g. /be §4's "dropped overlap" adjudication) should read `dropped`.
   conflicts: [...reconciled, ...dropped],

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: be
-description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with an AI review gauntlet (codex debate → lens debate (lowy ⇄ hickey) → code-police → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a PARALLEL AI review gauntlet (codex debate ∥ lens debate (lowy ⇄ hickey) ∥ code-police, each in its own worktree, consolidated by cherry-pick → CI → evidence). ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
 argument-hint: "<issue-url | prompt>"
 ---
 
@@ -40,13 +40,32 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 
 **If there's a plan of record, finalize it now.** Once the PR URL exists, update `docs/plans/<slug>.html` to read as it will *after merge* — flip its status to implemented/done and **link the PR** (e.g. a header line `Implemented in #<n>`) — then commit (`docs(plan): link PR #<n>`) and push so the finalized plan is part of this PR. This applies equally to a freshly-written plan and one the user brought in.
 
-## 4. Review gauntlet
+## 4. Review gauntlet — parallel
 
-Run **in order** — each surfaces different defects, each posts its findings to the PR:
+Run all three reviewers **at once** via **`/be-review`** (Skill tool), which fans
+each out into its own detached git worktree off the branch HEAD, runs every
+reviewer's **full multi-round debate to consensus concurrently** (codex⇄claude,
+lowy⇄hickey, and code-police's rules→fact-check→elegance — no depth is dropped),
+then **consolidates** their per-track commits onto the branch with `git
+cherry-pick`. The common case is no overlap (clean picks); the rare overlap — two
+debates editing the same lines — is reconciled to honor both fixes.
 
-1. **`/codex-debate`** (Skill tool) on the diff. It loops codex⇄claude to consensus, commits per round, and posts its summary as a PR comment by default. Let it finish before moving on.
-2. **`/lens-debate`** (Skill tool) on the diff, briefed with the change rationale only — do **not** seed findings. One call does the whole `/lowy` ⇄ `/hickey` structural pass: it reviews with both lenses **independently in parallel** (forcing both onto Opus, overriding their `model: sonnet` frontmatter), debates **every** finding to consensus, and applies each agreed `fix` as its own commit. **It MUST post the per-finding debate ledger (origin, finding, disposition, applied commit) to the PR as a comment — this is mandatory; confirm the comment landed** (it is `/lens-debate`'s default, so don't pass `--no-comment`). Pass the change rationale via its `rationale` arg so the lenses don't flag deliberate decisions. Deadlock is not possible; on the rare **unresolved** finding, adjudicate it yourself before moving on. Let it finish.
-3. **`/code-police`** (Skill tool) on the resulting diff — its rules → fact-check → elegance passes until clean. **Each finding is its own commit** — never batch: apply the narrow fix, re-run **check** and **fmt**, `git add` only the touched files, commit (`fix(police):` …) with the finding restated in one line, and `git push`. Then post its findings to the PR as a comment.
+- Preflight: a non-empty diff and (since codex runs) `codex login status`.
+- Invoke `/be-review` with `base`, the change **`rationale`** (so the lenses
+  don't flag deliberate decisions — same brief the old `/lens-debate` step got),
+  and the default `tracks: [codex, lens, police]` (also the consolidation order).
+- It posts **one** consolidated `## Review gauntlet (parallel)` PR comment
+  covering all three tracks plus the consolidation ledger — confirm it landed.
+  This replaces the three separate per-reviewer comments.
+- On the rare **unresolved** lens finding or a **dropped** overlap you disagree
+  with, adjudicate it yourself before moving on. On `setup-failed` or a per-track
+  `track-error`, fall back to the serial path below for the affected track.
+
+The serial path (`/codex-debate` → `/lens-debate` → `/code-police`, each seeing
+the prior's fixes fresh) remains available and is the right call for a small,
+correctness-critical change where cross-track staleness matters — and is the
+automatic fallback under codex/opencode runtimes, which lack the `Workflow`
+engine `/be-review` needs.
 
 ## 5. Ship
 
@@ -55,6 +74,6 @@ Run **in order** — each surfaces different defects, each posts its findings to
 
 ## Done
 
-Report the PR URL, the outcome of each review (codex consensus or reviewer-error, lens-debate consensus, findings actioned), and CI status. Never merge — the human reviews the per-step commits and merges when satisfied.
+Report the PR URL, the parallel gauntlet outcome (per-track: codex consensus or reviewer-error, lens-debate consensus, police findings actioned) and the consolidation ledger (clean picks vs reconciled overlaps), and CI status. Never merge — the human reviews the per-track commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -54,9 +54,10 @@ debates editing the same lines — is reconciled to honor both fixes.
 - Invoke `/be-review` with `base`, the change **`rationale`** (so the lenses
   don't flag deliberate decisions — same brief the old `/lens-debate` step got),
   and the default `tracks: [codex, lens, police]` (also the consolidation order).
-- It posts **one** consolidated `## Review gauntlet (parallel)` PR comment
-  covering all three tracks plus the consolidation ledger — confirm it landed.
-  This replaces the three separate per-reviewer comments.
+- Its **Report** phase posts a **detailed PR comment per track** (codex debate
+  table, lens per-finding ledger, police findings) plus the consolidation ledger —
+  automatically, so the trail lands regardless of caller. Confirm the comments
+  landed (the workflow returns their URLs in `comments`).
 - On the rare **unresolved** lens finding or a **dropped** overlap you disagree
   with, adjudicate it yourself before moving on. On `setup-failed` or a per-track
   `track-error`, fall back to the serial path below for the affected track.

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -67,10 +67,24 @@ correctness-critical change where cross-track staleness matters — and is the
 automatic fallback under codex/opencode runtimes, which lack the `Workflow`
 engine `/be-review` needs.
 
-## 5. Ship
+## 5. Ship — CI and evidence in parallel
 
-1. **`/ci`** — run the pipeline (background; consume `--progress json`), fix→fmt→commit→retry on real failures, confirm green on current `HEAD`.
-2. **`/evidence`** — follow the **`## PR evidence`** section of `.agency/do.md` for the capture procedure, then post the result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior even when there's no visual diff. Skip only if that section says to (or is absent).
+`/ci` and `/evidence` are independent — one exercises the build/test pipeline, the
+other captures on-screen behavior — so **run them concurrently**; don't wait for
+green before capturing.
+
+1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
+   consume `--progress json`) so it churns while you capture evidence. React to
+   streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
+   on real failures, confirm green on the final `HEAD`.
+2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
+   evidence`** section of `.agency/do.md` for the capture procedure, then post the
+   result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior
+   even when there's no visual diff. Skip only if that section says to (or is
+   absent).
+3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
+   is posted. If a CI fix-commit changed visible behavior *after* capture,
+   re-capture so the evidence matches what actually merges.
 
 ## Done
 

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -106,9 +106,10 @@ collide** and the scratch never shows up in the diff codex reviews. It returns:
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 
-- **consensus** — codex approved with no blocking/major findings open. This is
-  the *only* way the debate ends *normally*: it keeps running rounds until codex
-  and Claude agree, with no round cap and no deadlock exit. (The harness's own
+- **consensus** — every finding codex raised is resolved (any severity — Claude
+  fixed it or codex conceded the dispute). This is the *only* way the debate ends
+  *normally*: it keeps running rounds until codex and Claude agree on every point,
+  with no round cap and no deadlock exit. (The harness's own
   per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
   a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
@@ -143,7 +144,7 @@ the per-round commits sit on the local branch for the human to review):
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round table from `transcript` — each round's codex verdict
-  (approved? open blocking/major count), Claude's dispositions, and the
+  (approved? open-findings count), Claude's dispositions, and the
   round's `commit` SHA — so the convergence reads round by round.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
@@ -152,7 +153,7 @@ the per-round commits sit on the local branch for the human to review):
   `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
   `gh pr comment`. Include: the **consensus** outcome badge and the round count;
   a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
-  table (codex approved? open blocking/major findings; Claude's dispositions; the
+  table (codex approved? open-findings count; Claude's dispositions; the
   round's commit SHA) showing how the two sides converged. Use a
   single-quoted heredoc so backticks/`$` survive. This is an
   outward-facing write — it's on by default because the whole point is to leave

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -113,7 +113,12 @@ collide** and the scratch never shows up in the diff codex reviews. It returns:
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
   **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
-  carries the failure detail. Do **not** treat it as consensus (see step 3).
+  carries the failure detail (including how many attempts were made). Do **not**
+  treat it as consensus (see step 3). **Transient failures are retried first:**
+  `codex-review.sh` retries the `codex exec` invocation with linear backoff
+  (default 3 attempts; tune via `CODEX_REVIEW_RETRIES` / `CODEX_REVIEW_BACKOFF`)
+  and only synthesizes the reviewer-error verdict once every attempt comes back
+  empty — so a single codex hiccup no longer sinks the round.
 
 ### 3. Present the result
 

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -47,7 +47,9 @@ Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
   the repo default branch as `git symbolic-ref --short refs/remotes/origin/HEAD`
   (e.g. `origin/master`) — used **as-is**, NOT stripped to local `master` (which
   can lag the remote). Fallback `origin/master`. Step 1 runs `git fetch origin`
-  first so the ref is current.
+  first so the ref is current. The workflow then resolves this to the **merge-base**
+  of `base` and HEAD and diffs against that, so commits `base` gained since the
+  branch forked aren't reviewed as part of this change.
 - **`--no-commit`**: don't commit per round — leave all agreed changes
   uncommitted in the working tree for you to commit yourself. Default is to
   **commit each round** (see below).

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -108,12 +108,12 @@ async function codexReviews(round, rebuttalJson) {
 
 ${rebuttalJson}
 
-2. Run, from the repo root \`${repoPath}\`:
-   \`bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
+2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
     : `1. (No prior rebuttal this round.)
 
-2. Run, from the repo root \`${repoPath}\`:
-   \`bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
+2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -133,7 +133,7 @@ ${rebuttalStep}
 }
 
 async function claudeResponds(round, verdict) {
-  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git diff ${base}\` and read surrounding code as needed.
+  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git -C ${repoPath} diff ${base}\` and read surrounding code as needed.
 
 CODEX's latest verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
@@ -194,10 +194,10 @@ async function commitRound(round, files, message) {
 
 ${message}
 
-3. Run, from the repo root \`${repoPath}\`:
-   \`git add -- ${fileArgs} && git commit -F ${msgPath}\`
+3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
+   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git rev-parse HEAD\`. Do NOT push.`
+4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:round${round}`, phase: 'Debate' })
 }
 

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -87,19 +87,10 @@ const CLAUDE_RESPONSE_SCHEMA = {
   required: ['summary', 'actions', 'filesChanged', 'done'],
 }
 
-// ---------------------------------------------------------------------------
-// Consensus helper
-// ---------------------------------------------------------------------------
-// A finding still "counts against" consensus only if it is open AND
-// blocking/major. Minor issues and nits never block agreement. Consensus is the
-// ONLY terminal state — there is no round cap and no deadlock exit, so the loop
-// runs until codex approves with nothing blocking/major open. The debate is
-// pointless if it bails to "deadlock"; the two sides must argue it out until
-// one concedes.
-function blockingOpen(verdict) {
-  return (verdict.findings || []).filter(
-    (f) => f.status !== 'resolved' && (f.severity === 'blocking' || f.severity === 'major'),
-  )
+// Consensus = no finding left open, any severity. The loop runs until codex
+// resolves every one (CLAUDE fixed it, or codex conceded a dispute). No cap.
+function openFindings(verdict) {
+  return (verdict.findings || []).filter((f) => f.status !== 'resolved')
 }
 
 // ---------------------------------------------------------------------------
@@ -138,25 +129,21 @@ ${rebuttalStep}
 }
 
 async function claudeResponds(round, verdict) {
-  const prompt = `You are CLAUDE, the engineer who authored the changes now under review, in an automated review debate with CODEX (a rigorous senior reviewer). Work in the repository at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`. The change under review is the working-tree diff against \`${base}\` — inspect it with \`git -C ${repoPath} diff ${base}\` and read surrounding code as needed.
+  const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
-CODEX's latest verdict (JSON):
+Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
+
+CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
-For EACH finding:
-  - If you AGREE: fix it now by editing the code in the working tree (use your editing tools). Record disposition "fixed".
-  - If you DISAGREE: do NOT change the code. Record disposition "disputed" with a specific, technical reason citing file:line or the actual behavior. Concede when codex is right — do not dispute merely to win.
-  - If PARTIALLY right: fix the valid part, explain the rest. Record "partial".
+Address EVERY finding, any severity (don't skip minors/nits):
+  - agree → fix it in the working tree; disposition "fixed".
+  - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
+  - partly → fix the valid part, explain the rest; disposition "partial".
 
-Constraints:
-  - Edit the WORKING TREE only. Do NOT git add / commit / push, and do NOT create or modify a PR.
-  - You may run a trivial formatter on files you changed if the project has one.
-  - Keep fixes tightly scoped to the findings.
+Edit the working tree only — do NOT git add/commit/push. You may run the formatter on files you touched.
 
-Then return your structured response:
-  - actions: one per finding you addressed (findingId, disposition, detail).
-  - filesChanged: every working-tree file you edited this round.
-  - done: true ONLY if nothing further should change — i.e. everything valid is fixed and you stand by any remaining disputes. If you fixed things and want codex to re-check, that is still done=true (codex re-reviews next round regardless).`
+Return: actions (one per finding — findingId, disposition, detail), filesChanged, and done (true once you've addressed every finding this round).`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -218,12 +205,10 @@ let lastClaude = null
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
 // ---------------------------------------------------------------------------
-// The debate continues, round after round, until codex approves with nothing
-// blocking/major open. There is deliberately no upper bound and no early
-// "deadlock" surrender: a debate that quits without agreement defeats the
-// purpose, so the two sides keep arguing until one concedes. (The harness's own
-// per-workflow agent backstop is the only hard ceiling; interrupt via
-// /workflows or TaskStop if you ever need to stop one by hand.)
+// The debate continues, round after round, until codex resolves every finding
+// (any severity). No upper bound, no "deadlock" surrender: the two sides argue
+// every point until one concedes. (The harness's per-workflow agent backstop is
+// the only hard ceiling; interrupt via /workflows or TaskStop by hand.)
 phase('Debate')
 
 // Resolve the diff base to the merge-base of (base, HEAD) so codex reviews only
@@ -255,12 +240,11 @@ for (let round = 1; ; round++) {
     break
   }
 
-  const blocking = blockingOpen(verdict)
-  log(`Round ${round}: codex approved=${verdict.approved}, blocking/major open=${blocking.length}`)
+  const open = openFindings(verdict)
+  log(`Round ${round}: codex approved=${verdict.approved}, findings open=${open.length}`)
 
-  // Consensus — the normal exit: codex is satisfied and nothing blocking/major
-  // remains open.
-  if (verdict.approved && blocking.length === 0) {
+  // Consensus: every finding resolved (any severity).
+  if (open.length === 0) {
     break
   }
 

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -216,7 +216,7 @@ phase('Debate')
 // forked (those would otherwise show up in `git diff base` — master's drift
 // reviewed as ours). A thin mechanical git agent; the workflow can't run git
 // itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
-const rawBase = a.base || 'origin/master'
+const rawBase = base
 const baseRes = await agent(
   `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
   { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -11,7 +11,12 @@ export const meta = {
 // ---------------------------------------------------------------------------
 const a = args || {}
 const repoPath = a.repoPath || '.'
-const base = a.base || 'origin/master'
+// The diff base. Resolved to the MERGE-BASE of (rawBase, HEAD) just before the
+// debate (see phase 'Debate') so commits rawBase gained since the branch forked
+// aren't reviewed as if this change made them. `let` because that resolution
+// reassigns it; every prompt reads the resolved value. (Idempotent when the
+// caller already passed a merge-base SHA, e.g. /be-review.)
+let base = a.base || 'origin/master'
 // Where the generated skill lives, so the codex runner can find codex-review.sh.
 const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // Per-worktree scratch dir for rebuttal/verdict files. Derived from repoPath
@@ -220,6 +225,18 @@ let lastClaude = null
 // per-workflow agent backstop is the only hard ceiling; interrupt via
 // /workflows or TaskStop if you ever need to stop one by hand.)
 phase('Debate')
+
+// Resolve the diff base to the merge-base of (base, HEAD) so codex reviews only
+// what THIS branch changed, not commits the base branch gained since the branch
+// forked (those would otherwise show up in `git diff base` — master's drift
+// reviewed as ours). A thin mechanical git agent; the workflow can't run git
+// itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const baseRes = await agent(
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+)
+if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
+log(`Diffing against ${base.slice(0, 12)} (merge-base of ${a.base || 'origin/master'} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -259,7 +259,20 @@ for (let round = 1; ; round++) {
   const open = openFindings(verdict)
   log(`Round ${round}: codex approved=${verdict.approved}, findings open=${open.length}`)
 
-  // Consensus: every finding resolved (any severity).
+  // Consensus requires BOTH no open finding AND codex's explicit approval. An
+  // inconsistent verdict — `approved:false` with nothing open — is not consensus:
+  // codex declined to approve while leaving us nothing to route to Claude, so
+  // treating it as agreement would ship an unapproved change. There's no finding
+  // to debate, so re-running codex would just replay the same inconsistency;
+  // surface it as a reviewer error (the terminal abnormal path) instead of
+  // looping forever or falsely converging.
+  if (open.length === 0 && verdict.approved !== true) {
+    status = 'reviewer-error'
+    log(`Round ${round}: inconsistent verdict — approved=false with no open findings; aborting as reviewer-error.`)
+    break
+  }
+
+  // Consensus: codex approved AND every finding resolved (any severity).
   if (open.length === 0) {
     break
   }

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -216,12 +216,28 @@ phase('Debate')
 // forked (those would otherwise show up in `git diff base` — master's drift
 // reviewed as ours). A thin mechanical git agent; the workflow can't run git
 // itself. Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const rawBase = a.base || 'origin/master'
 const baseRes = await agent(
-  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
-  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Debate', schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },
 )
-if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
-log(`Diffing against ${base.slice(0, 12)} (merge-base of ${a.base || 'origin/master'} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
+// Fail loud on a bad base. Falling back to the raw `${base}` tip would review the
+// base branch's drift since the fork as if this change made it — the exact noise
+// the merge-base removes — so a missing/typoed/stale base must abort, not degrade.
+if (!baseRes?.sha?.trim()) {
+  const err = (baseRes?.error || '').trim()
+  log(`Aborting: \`git merge-base ${rawBase} HEAD\` failed; the diff scope can't be trusted. Not falling back to the raw ${rawBase} tip.`)
+  return {
+    status: 'merge-base-error',
+    base: rawBase,
+    rounds: 0,
+    transcript: [],
+    finalVerdict: null,
+    note: `merge-base of \`${rawBase}\` and HEAD could not be resolved (missing/typoed base, stale ref, or unrelated history), so the review scope is untrustworthy. Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
+base = baseRes.sha.trim()
+log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -115,14 +115,38 @@ EOF
 # model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
 # relying on the user's global ~/.codex/config.toml — review is the one place we
 # always want codex thinking at full depth, regardless of their default.
-if ! codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="xhigh" \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"</dev/null >"$log" 2>&1; then
-  echo "codex exec exited non-zero (see $log)" >&2
-fi
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
+# hiccups, a spurious internal error) and writes no verdict — which would
+# otherwise degrade the whole track to reviewer-error on a single bad roll.
+# Retry the invocation with linear backoff, accepting the first attempt that
+# writes a non-empty verdict to "$out". Tunable via env: CODEX_REVIEW_RETRIES
+# (total attempts, default 3), CODEX_REVIEW_BACKOFF (base seconds, default 5 —
+# attempt n waits n*base). Only after every attempt fails empty do we synthesize
+# the reviewerError verdict below.
+attempts="${CODEX_REVIEW_RETRIES:-3}"
+backoff="${CODEX_REVIEW_BACKOFF:-5}"
+n=1
+while :; do
+  rm -f "$out"
+  if ! codex exec \
+        --sandbox read-only \
+        -c model_reasoning_effort="xhigh" \
+        --output-schema "$schema" \
+        -o "$out" \
+        "$prompt"</dev/null >"$log" 2>&1; then
+    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+  fi
+  # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
+  # make a non-empty "$out" a real, schema-valid verdict, not a partial.
+  [ -s "$out" ] && break
+  # Out of attempts — fall through to the synthesized reviewerError verdict.
+  [ "$n" -ge "$attempts" ] && break
+  wait_s=$(( backoff * n ))
+  echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+  n=$(( n + 1 ))
+  sleep "$wait_s"
+done
 
 if [ ! -s "$out" ]; then
   # codex produced no verdict — synthesize a schema-valid error verdict so the
@@ -132,9 +156,9 @@ if [ ! -s "$out" ]; then
   # substantive disagreement, so it must NOT be routed to Claude (there are no
   # findings to act on) and must NOT spin the loop forever.
   tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" '{
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
     approved: false,
-    summary: ("codex produced no verdict this round. Tail of log: " + $log),
+    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
     findings: [],
     responseToRebuttal: "",
     reviewerError: true

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -78,37 +78,38 @@ fi
 # Unquoted heredoc: only $base and $rebuttal_block expand. No backticks and no
 # other $/$(...) appear in the body, so there is nothing else to interpret.
 prompt="$(cat <<EOF
-You are CODEX, a rigorous, fair senior code reviewer in an automated review
-debate with another AI engineer ("CLAUDE") who authored the changes.
+You are CODEX, a rigorous senior code reviewer. Review the changes in this branch
+and give your honest, thorough feedback — exactly as you would on a serious PR.
+You're in a debate with the author ("CLAUDE"), who will fix what they agree with
+and push back, with reasons, on what they don't.
 
-REVIEW SCOPE — the full current state of the working tree against the base
-branch '$base', which includes committed AND uncommitted changes. Run these
-yourself:
+Inspect the change yourself (READ-ONLY — do not modify, create, or delete anything,
+and run no git write command: add/commit/push/stash/checkout):
 
-    git diff $base       (committed + tracked-but-unstaged changes)
-    git status --short   (find untracked/new files)
+    git diff $base       (committed + unstaged changes on this branch)
+    git status --short   (untracked/new files — read those too; they aren't in the diff)
 
-Then read every new/changed file plus surrounding context and review the change
-as a whole. Untracked new files do NOT appear in 'git diff', so you MUST inspect
-'git status --short' and read those files explicitly.
+Read every changed file plus enough surrounding code to judge it in context.
+Ignore the debate's own scratch dir '.codex-debate/' if it appears.
 
-IGNORE the debate's own scratch dir '.codex-debate/' if it shows up — it holds
-this process's verdict/rebuttal files, not part of the change under review.
-
-THIS IS READ-ONLY. Do NOT modify, create, or delete any files. Do NOT run any
-git write command (add/commit/push/stash/checkout) or any other state-mutating
-command. You are only inspecting.
-
-Review for correctness bugs, logic errors, silent error-swallowing, unjustified
-fallbacks, security issues, and clear simplicity/efficiency problems. Be
-specific and concrete; cite file:line. Do NOT invent issues to look busy — if
-the change is sound, approve it.
+Give ALL your feedback in this pass — every issue worth raising, at EVERY severity
+(blocking, major, minor, nit): correctness bugs, logic errors, silently swallowed
+errors, unjustified fallbacks, security problems, and clear simplicity/efficiency
+issues. Don't hold issues back for a later round, and don't limit yourself to
+blockers — surface everything you see now. Cite file:line. (If the change is
+genuinely clean, approving with no findings is fine — just never stay quiet about
+a real issue to seem agreeable.)
 $rebuttal_block
-Return a verdict matching the provided JSON schema:
-  - approved: true ONLY when no blocking or major issues remain (minor/nits may remain).
-  - findings: reuse stable ids (F1, F2, ...) across rounds for the same issue; set
-    status=resolved once adequately addressed, else open.
-  - responseToRebuttal: address CLAUDE's disputes directly (empty on round 1).
+Return your review in the JSON schema:
+  - findings: one entry per issue, each with a severity and a stable id (F1, F2, …)
+    reused across rounds for the same issue. Set status=resolved once it is
+    adequately addressed (CLAUDE fixed it, OR you accept CLAUDE's reasoning); else open.
+  - approved: true ONLY when EVERY finding is resolved — all your feedback addressed
+    at every severity, not just blockers. The review is not done while any issue you
+    raised still stands open.
+  - responseToRebuttal: when CLAUDE disputes a finding, address each dispute
+    individually — concede (mark that finding resolved) or hold firm with specific,
+    technical reasoning. Leave no dispute unanswered. Empty on round 1.
 EOF
 )"
 

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -130,6 +130,19 @@ EOF
 # the reviewerError verdict below.
 attempts="${CODEX_REVIEW_RETRIES:-3}"
 backoff="${CODEX_REVIEW_BACKOFF:-5}"
+# Validate both as positive integers. Left unchecked, a non-numeric value makes
+# the arithmetic `[ "$n" -ge "$attempts" ]` test error every iteration, so the
+# loop would spin forever instead of giving up and synthesizing the reviewerError
+# verdict. Fall back to the documented defaults (and clamp attempts to >=1) loudly
+# rather than wedge the headless debate on a typo'd override.
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+  attempts=3
+fi
+if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+  backoff=5
+fi
 n=1
 while :; do
   rm -f "$out"

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -65,12 +65,15 @@ fi
 rebuttal_block=""
 if [ -n "$rebuttal" ]; then
   rebuttal_block="
-CLAUDE responded to your PREVIOUS review as follows. Take it seriously: where a
-fix landed in the working tree, verify it and mark that finding resolved; where
-CLAUDE disputes a finding, either concede (mark it resolved) or hold firm with
-specific reasoning in responseToRebuttal.
+This is a FOLLOW-UP round — you already gave your full review. Your job now is to
+CLOSE OUT the findings already on the table, not re-scan the whole diff for more.
+For each existing finding: verify CLAUDE's fix and mark it resolved, or address
+CLAUDE's dispute (concede and mark resolved, or hold firm with specific reasoning
+in responseToRebuttal). Raise a NEW finding ONLY if CLAUDE's changes this round
+introduced it (a regression). Do NOT keep surfacing pre-existing issues you didn't
+raise in round 1 — that prevents the debate from ever converging.
 
-CLAUDE's response (JSON):
+CLAUDE responded to your PREVIOUS review as follows:
 $rebuttal
 "
 fi

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -144,14 +144,19 @@ if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
   backoff=5
 fi
 n=1
+: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
 while :; do
   rm -f "$out"
+  # Append (not truncate): when every attempt fails, the synthesized reviewerError
+  # verdict's tail_log must reflect ALL attempts' diagnostics — surfacing the exact
+  # transient failures this retry loop exists to weather — not just the final one.
+  echo "=== attempt $n/$attempts ===" >>"$log"
   if ! codex exec \
         --sandbox read-only \
         -c model_reasoning_effort="xhigh" \
         --output-schema "$schema" \
         -o "$out" \
-        "$prompt"</dev/null >"$log" 2>&1; then
+        "$prompt"</dev/null >>"$log" 2>&1; then
     echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
   fi
   # Success the moment codex writes a verdict: the kernel sandbox + --output-schema

--- a/.claude/skills/codex-debate/scripts/codex-verdict.schema.json
+++ b/.claude/skills/codex-debate/scripts/codex-verdict.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "approved": {
       "type": "boolean",
-      "description": "true ONLY if no blocking or major issues remain. Minor issues and nits may remain."
+      "description": "true ONLY when every finding is resolved — all your feedback addressed at any severity (minor and nit included), not just blockers."
     },
     "summary": {
       "type": "string",

--- a/.claude/skills/lens-debate/SKILL.md
+++ b/.claude/skills/lens-debate/SKILL.md
@@ -94,6 +94,8 @@ Parse `[<pr-number>] [--base <branch>] [--max-rounds <n>] [--no-commit] [--no-co
   given, else the repo default branch via
   `git symbolic-ref --short refs/remotes/origin/HEAD` (e.g. `origin/master`),
   used **as-is**. Fallback `origin/master`. Step 1 runs `git fetch origin` first.
+  The workflow resolves this to the **merge-base** of `base` and HEAD and diffs
+  against that, so the base branch's drift since the fork isn't reviewed as ours.
 - **`--max-rounds <n>`**: safety backstop on debate rounds. Default **12**. Not a
   deadlock cap (see above) — raise it freely.
 - **`--no-commit`**: still apply the agreed fixes to the working tree, but leave

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -120,7 +120,7 @@ const FINDINGS_SCHEMA = {
   properties: {
     findings: {
       type: 'array',
-      description: 'your INDEPENDENT findings (≤4, high-confidence; an empty list is a fine verdict for a clean diff)',
+      description: 'ALL your independent structural findings — every issue worth raising through your lens, no cap. An empty list is fine only for a genuinely clean diff.',
       items: {
         type: 'object',
         additionalProperties: false,
@@ -184,7 +184,7 @@ function reviewBrief(lens, framework, probe) {
 
 Review the change through the **${framework}** lens, INDEPENDENTLY — you are NOT seeing any other reviewer's findings. That independence is the whole point: being handed someone else's curated finding biases the verdict.
 ${rationaleBlock}${probeBlock}
-Emit your own findings (≤4, high-confidence). Each: a title, a file:line location, the problem in your lens's terms, a concrete suggestion, and a disposition — \`fix\` (worth changing in THIS PR) or \`drop\` (observation only). Do not invent issues to look thorough: an empty list, or all-drop, is a fine verdict for a clean diff.`
+Give ALL your findings — every structural issue you see through your lens, no cap, at every level (boundary, complecting, naming, duplication, …). Each: a title, a file:line location, the problem in your lens's terms, a concrete suggestion, and a disposition — \`fix\` (worth changing in THIS PR) or \`drop\` (observation only). Don't fabricate issues, but don't hold any back either; an empty list is fine only for a genuinely clean diff.`
 }
 
 function findingLine(f) {

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -69,7 +69,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing
 // lesson from #1109: curation biases the verdict).
-const DIFF = `Inspect the FULL change in the repo at \`${repoPath}\`: run \`git diff ${base}\` (committed + unstaged) and \`git status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore the debate's own scratch dir \`.lens-debate/\` if it appears.`
+const DIFF = `Inspect the FULL change in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so use \`git -C ${repoPath}\` and ABSOLUTE paths under \`${repoPath}\`: run \`git -C ${repoPath} diff ${base}\` (committed + unstaged) and \`git -C ${repoPath} status --short\` (untracked/new files do NOT appear in the diff), then Read every new/changed file plus enough surrounding code to judge it in context. Ignore the debate's own scratch dir \`.lens-debate/\` if it appears.`
 
 const rationaleBlock = rationale ? `\nAuthor's note on deliberate decisions (do not flag these as defects unless the reasoning is itself wrong):\n${rationale}\n` : ''
 
@@ -172,7 +172,7 @@ Round ${roundNum}. For EVERY contested finding id above, output a disposition (\
 }
 
 function implementBrief(fix) {
-  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\`.
+  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\`.
 
 Finding ${fix.id} (raised by ${fix.origin}) — ${fix.title}
   at ${fix.location}
@@ -205,10 +205,10 @@ Agreed by the lowy ⇄ hickey lens debate (finding ${fix.id}, raised by ${fix.or
 
 ${message}
 
-3. Run, from the repo root \`${repoPath}\`:
-   \`git add -- ${fileArgs} && git commit -F ${msgPath}\`
+3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
+   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git rev-parse HEAD\`. Do NOT push.`
+4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply' })
 }
 

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -77,11 +77,31 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // changed, not the base branch's drift since the fork. A thin mechanical git
 // agent (the workflow can't run git itself); grouped under the Review phase.
 // Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const rawBase = a.base || 'origin/master'
 const baseRes = await agent(
-  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
-  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },
 )
-if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
+// Fail loud on a bad base. Falling back to the raw `${base}` tip would make the
+// lenses review the base branch's drift since the fork as if this change made it —
+// the exact noise the merge-base removes — so a missing/typoed/stale base aborts.
+if (!baseRes?.sha?.trim()) {
+  const err = (baseRes?.error || '').trim()
+  log(`Aborting: \`git merge-base ${rawBase} HEAD\` failed; the diff scope can't be trusted. Not falling back to the raw ${rawBase} tip.`)
+  return {
+    status: 'merge-base-error',
+    base: rawBase,
+    rounds: 0,
+    withPolice,
+    settled: [],
+    unresolved: [],
+    applied: [],
+    reviews: {},
+    history: [],
+    note: `merge-base of \`${rawBase}\` and HEAD could not be resolved (missing/typoed base, stale ref, or unrelated history), so the review scope is untrustworthy. Fix the base ref (e.g. \`git fetch\`) and re-run.${err ? `\ngit error:\n${err}` : ''}`,
+  }
+}
+base = baseRes.sha.trim()
 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -77,7 +77,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // changed, not the base branch's drift since the fork. A thin mechanical git
 // agent (the workflow can't run git itself); grouped under the Review phase.
 // Idempotent when `base` is already a merge-base SHA (caller resolved it).
-const rawBase = a.base || 'origin/master'
+const rawBase = base
 const baseRes = await agent(
   `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex) in \`sha\`. If the command FAILS (missing/typoed base, stale ref, unrelated history), return \`sha\`: "" and put the verbatim git error in \`error\` — do NOT fall back to the raw base ref. Do nothing else.`,
   { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA, or "" on failure' }, error: { type: 'string', description: 'the git error when sha is empty' } } } },

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -26,7 +26,13 @@ const MODEL = 'opus'
 // ---------------------------------------------------------------------------
 const a = args || {}
 const repoPath = a.repoPath || '.'
-const base = a.base || 'origin/master'
+// The diff base. Resolved to the MERGE-BASE of (rawBase, HEAD) just below, before
+// DIFF is built, so the lenses review only what THIS branch changed — not commits
+// the base branch gained since the branch forked (those would otherwise appear in
+// `git diff base` as the base branch's drift, reviewed as ours). `let` because the
+// resolution reassigns it. Idempotent when the caller already passed a merge-base
+// SHA (e.g. /be-review).
+let base = a.base || 'origin/master'
 // Safety backstop only — NOT a deadlock cap. The debate runs until consensus;
 // this just keeps a pathologically oscillating debate from running unbounded.
 // Hitting it is reported as `unresolved` (needs human), never `deadlock`, and
@@ -65,6 +71,17 @@ const REVIEWERS = [
   { lens: 'hickey', framework: 'structural simplicity — independent concerns complected, or one thing fragmented? (Simple Made Easy)' },
 ]
 if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, correctness, and common-mistake review' })
+
+// Resolve the diff base to the merge-base of (base, HEAD) BEFORE building DIFF
+// (which interpolates `base` eagerly), so the lenses review only what this branch
+// changed, not the base branch's drift since the fork. A thin mechanical git
+// agent (the workflow can't run git itself); grouped under the Review phase.
+// Idempotent when `base` is already a merge-base SHA (caller resolved it).
+const baseRes = await agent(
+  `You are a MECHANICAL RUNNER. Run \`git -C ${repoPath} merge-base ${base} HEAD\` and return ONLY the resulting commit SHA (hex). If the command fails, return the literal \`${base}\` unchanged. Do nothing else.`,
+  { label: 'resolve:merge-base', phase: 'Review', model, schema: { type: 'object', additionalProperties: false, required: ['sha'], properties: { sha: { type: 'string', description: 'the merge-base SHA (or the unchanged base ref on failure)' } } } },
+)
+if (baseRes?.sha?.trim()) base = baseRes.sha.trim()
 
 // How every agent is told to inspect the change. The lenses do NOT trust a
 // curated finding list — they read the source themselves (the load-bearing

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ packages/client/public/fonts
 .codex-debate/
 # /lens-debate skill: per-worktree scratch (commit-message files)
 .lens-debate/
-# /be-review orchestrator: per-track worktrees + scratch (commit-message files)
+# /be-review orchestrator: per-track scratch (commit-message + PR-comment files; worktrees live under .worktrees/ above)
 .be-review/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ packages/client/public/fonts
 .codex-debate/
 # /lens-debate skill: per-worktree scratch (commit-message files)
 .lens-debate/
+# /be-review orchestrator: per-track worktrees + scratch (commit-message files)
+.be-review/

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T23:44:46.564078+00:00'
+generated_at: '2026-06-02T23:47:52.415565+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T00:17:06.467790+00:00'
+generated_at: '2026-06-03T00:54:58.230622+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T22:58:59.082714+00:00'
+generated_at: '2026-06-02T23:18:22.880214+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T11:59:15.808197+00:00'
+generated_at: '2026-06-03T12:05:40.483759+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T02:56:12.325555+00:00'
+generated_at: '2026-06-03T11:59:15.808197+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T00:54:58.230622+00:00'
+generated_at: '2026-06-03T02:16:49.886707+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T12:05:40.483759+00:00'
+generated_at: '2026-06-03T12:31:51.596464+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T23:47:52.415565+00:00'
+generated_at: '2026-06-03T00:17:06.467790+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T12:31:51.596464+00:00'
+generated_at: '2026-06-03T12:57:29.526801+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T02:16:49.886707+00:00'
+generated_at: '2026-06-03T02:56:12.325555+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T23:18:22.880214+00:00'
+generated_at: '2026-06-02T23:31:03.493145+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T15:35:04.497372+00:00'
+generated_at: '2026-06-02T22:52:26.262281+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills
@@ -113,6 +113,7 @@ mcp_configs:
     command: .agents/skills/nix-chrome-devtools-mcp/bin/serve
 local_deployed_files:
 - .agents/skills/be
+- .agents/skills/be-review
 - .agents/skills/codex-debate
 - .agents/skills/evidence
 - .agents/skills/lens-debate
@@ -133,6 +134,7 @@ local_deployed_files:
 - .claude/rules/streaming.md
 - .claude/rules/toast-conventions.md
 - .claude/skills/be
+- .claude/skills/be-review
 - .claude/skills/codex-debate
 - .claude/skills/evidence
 - .claude/skills/lens-debate

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T22:52:26.262281+00:00'
+generated_at: '2026-06-02T22:58:59.082714+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T23:31:03.493145+00:00'
+generated_at: '2026-06-02T23:44:46.564078+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
## What

`/be`'s §4 review gauntlet ran three reviewers **serially** — `/codex-debate` → `/lens-debate` → `/code-police` — for one structural reason: each step *commits fixes*, so the next reviewer had to see the mutated tree. That chaining is the only thing that forced an order; the reviews themselves are independent and read-only.

This PR removes the chaining. Each reviewer gets its **own detached git worktree** forked from the branch HEAD, so all three **full multi-round debates run concurrently** — no review depth is dropped (codex still re-reviews its own fixes round after round, the lenses still debate every finding, police still runs all three cold passes). When they finish, the orchestrator **consolidates** by cherry-picking each track's commits onto the branch.

```
            ┌─ wt-codex   ─ codex⇄claude debate ─→ commits ─┐
branch HEAD ┼─ wt-lens    ─ lowy⇄hickey debate  ─→ commits ─┼─→ cherry-pick onto branch
            └─ wt-police  ─ rules/fact/elegance ─→ commits ─┘   (overlap → reconcile)
```

The common case is **no overlap** (clean picks). The rare overlap — two debates editing the same lines — surfaces as a `cherry-pick` conflict that a reconcile agent merges to **honor both fixes** (dropping a commit only when an earlier track fully subsumes it, and saying so in the ledger).

## How

New **`/be-review`** skill orchestrates the gauntlet in four phases — **Setup** (fan out one worktree per track) → **Tracks** (the three gauntlets run at once) → **Consolidate** (ordered cherry-pick + reconcile) → **Cleanup**. It drives `codex-debate` and `lens-debate` as **child workflows** (one nesting level, which the runtime allows — and both were already \`repoPath\`-parameterized precisely so they could run in separate worktrees) and inlines `/code-police`'s three passes as parallel agents. A single consolidated \`## Review gauntlet (parallel)\` PR comment replaces the three separate per-reviewer comments.

`/be` §4 now calls `/be-review`. The serial path remains available and is the documented fallback for small, correctness-critical changes (where seeing each fix fresh matters) and the automatic fallback under codex/opencode runtimes, which lack the `Workflow` engine.

## Files

- `.apm/skills/be-review/{SKILL.md,be-review.workflow.js}` — new orchestrator (+ generated `.claude`/`.agents` copies)
- `.apm/skills/be/SKILL.md` — §4 rewritten to the parallel path
- `.gitignore` — `.be-review/` (per-track worktrees + scratch)

## Verification

- ✅ Core mechanic tested in a throwaway repo: non-overlapping tracks cherry-pick cleanly; overlapping tracks produce a detectable \`--diff-filter=U\` conflict (not a silent clobber).
- ✅ New workflow's syntax is identical to the two shipping engines under \`node --check\` (only the runtime-wrapped top-level \`return\`).
- ⏳ **Not yet run end-to-end** — that needs \`codex login\` + a live diff. Planned next: dry-run `/be-review` against **this PR's own diff**.

## Known limitation

Because all three tracks review the *same* pre-fix branch HEAD, a track can't see another's fixes mid-run (the price of parallelism). Textual collisions are caught by consolidation; residual semantic staleness is backstopped by §5 CI + human review. The serial path stays for cases where that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)