### PR TITLE
fix(canvas): drop redundant aria-hidden on covered tiles

### DIFF
--- a/packages/client/src/canvas/CanvasTile.tsx
+++ b/packages/client/src/canvas/CanvasTile.tsx
@@ -165,8 +165,15 @@ const CanvasTile: Component<{
       // the pre-#988 `visibility: hidden` wrapper without re-introducing
       // it. xterm.js writes still land in the buffer (no render dependency
       // on inert), so the dock's buffer previews stay populated.
+      //
+      // Deliberately NOT pairing this with `aria-hidden="true"`: `inert`
+      // already drops the subtree from the accessibility tree, so the
+      // attribute is redundant — and the browser blocks `aria-hidden` on an
+      // ancestor of a focused element (the xterm helper textarea can retain
+      // DOM focus the instant a tile is covered), logging a WAI-ARIA console
+      // warning. `inert` is the spec's recommended replacement precisely
+      // because it hides *and* prevents focus without that conflict.
       inert={isCovered()}
-      aria-hidden={isCovered() ? "true" : undefined}
       class="flex flex-col overflow-hidden border transition-shadow duration-200"
       classList={{
         // Maximized uses `absolute inset-0 z-40` to cover the canvas

--- a/packages/client/src/right-panel/RightPanel.tsx
+++ b/packages/client/src/right-panel/RightPanel.tsx
@@ -7,9 +7,10 @@
  *  for the horizontal split + drag-to-resize; the mobile host wraps
  *  this in a `@corvu/drawer` (`RightPanelDrawer.tsx`). Both hosts thread
  *  the same `visible` accessor — desktop reads `collapsed()`, mobile
- *  reads `drawerOpen()` — so `aria-hidden` reflects actual visibility on
- *  both surfaces. `data-collapsed` is emitted when `!visible` so e2e
- *  selectors can assert collapse state without inspecting widths. */
+ *  reads `drawerOpen()` — so `inert` (and the `data-collapsed` marker)
+ *  reflect actual visibility on both surfaces. `data-collapsed` is emitted
+ *  when `!visible` so e2e selectors can assert collapse state without
+ *  inspecting widths. */
 
 import type {
   RightPanelTabKind,
@@ -61,12 +62,14 @@ const RightPanel: Component<{
       class="flex flex-col h-full min-w-0 overflow-hidden bg-surface-0"
       // Panel stays mounted across collapse on desktop so CodeTab's local
       // state survives (#818); the desktop Resizable shrinks it to ~0 width
-      // via `sizes=[1, 0]`. `aria-hidden` keeps the subtree out of the
-      // screen-reader tree; `inert` keeps it out of the Tab focus order
-      // (aria-hidden alone leaves the Collapse button and tab buttons
-      // Tab-reachable at zero width — invisible focus trap). Together
-      // they make "not visible" mean "not interactive."
-      aria-hidden={!props.visible}
+      // via `sizes=[1, 0]`. `inert` alone makes "not visible" mean "not
+      // interactive": it both drops the subtree from the accessibility tree
+      // and removes the Collapse button, tab buttons, and CodeTab inputs
+      // from the Tab focus order (an invisible focus trap otherwise). We
+      // deliberately omit a paired `aria-hidden`: the browser blocks
+      // `aria-hidden` on an ancestor of a focused element (a focused
+      // Collapse/tab button or CodeTab input when the panel collapses) and
+      // logs a WAI-ARIA console warning — `inert` covers both concerns.
       inert={!props.visible}
     >
       {/* Tab bar */}


### PR DESCRIPTION
**Covered canvas tiles no longer emit a WAI-ARIA console warning on every maximize.** A covered tile carried both `inert` and `aria-hidden="true"`, but the xterm helper textarea inside it can retain DOM focus the instant the tile is covered — and the browser *blocks* `aria-hidden` on an ancestor of a focused element, logging:

> Blocked aria-hidden on an element because its descendant retained focus… Consider using the `inert` attribute instead, which will also prevent focus.

`inert` already removes the subtree from the accessibility tree *and* prevents focus, so `aria-hidden` was pure redundancy — and the sole source of the warning. Dropping it leaves `inert` doing the hiding alone, exactly as the WAI-ARIA spec recommends.

### Why this is safe

| Concern | Outcome |
| --- | --- |
| Hidden from assistive tech | Still hidden — `inert` removes the subtree from the a11y tree |
| Intrinsic visual hide | Unchanged — covered tiles still set `visibility: hidden` |
| e2e coverage | `canvas.feature` asserts `visibility: hidden`, not `aria-hidden` — untouched |

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._