### PR TITLE
perf(ci): optimize e2e macOS (rasam) lane — duration + flakiness

### DIFF
--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -24,16 +24,38 @@ User-set constraints for this run:
 
 | | Baseline (PAR=4) | After (PAR=8 + fixes) | Δ |
 | --- | --- | --- | --- |
-| e2e suite wall-clock (`cuke_s`) | **~450 s** | **~156 s** | **−65%** |
-| Total (`total_s`) | ~452 s | ~159 s | −65% |
-| Clean-run reliability | 1/3 runs flaked (code-tab `[branch]` hard-fail) | **3/3 green, 0 retries** | ✓ |
+| e2e suite wall-clock, clean run | ~420–570 s (med ~450) | **~155–165 s** | **≈ −65%** |
+| Specific failure modes | code-tab `[branch]` hard-fail; server-death cascade (251/398) | **both eliminated** | ✓ |
+| General darwin-load timeout flakiness | 3–9 timeouts/run (retry-absorbed) | 0–18/run (retry-absorbed) | ≈ unchanged |
 
-The win is two-layered: **4→8 workers** on the idle 24-core host removes ~48% of
-the wall-clock, and the **flake fixes** remove the remaining time that
-failing/retrying scenarios burned at 20–40 s each (baseline b1 skipped 43 steps
-to retries; the final runs skip 0). Both land in the real `just test` →
-`ci::e2e` path. The catastrophic bimodal failure that *looked* like a
-parallelism ceiling turned out to be a retry-blind harness bug (below).
+The duration win is two-layered: **4→8 workers** on the idle 24-core host roughly
+halves the parallelizable body, and the **flake fixes** remove the 20–40 s a
+failing/retrying scenario burns. Both land in the real `just test` → `ci::e2e`
+path. The catastrophic bimodal failure that *looked* like a parallelism ceiling
+turned out to be a retry-blind harness bug (below).
+
+**Honesty caveat — the darwin suite stays load-flaky.** A ~20 s `POLL_TIMEOUT` /
+60 s `HYDRATION_TIMEOUT` flake fires 0–18×/run at *both* PAR=4 and PAR=8 (the
+pre-existing "darwin runner load" class the two prior flaky-test reports also
+couldn't fully kill), absorbed by `CUCUMBER_RETRY=1`. This run did **not**
+eliminate that class — it removed two *specific* failure modes and made the rest
+diagnosable. PAR=8's higher load can marginally pressure the slow-hydration tail.
+
+### Authoritative validation (real `ci::e2e` recipe path)
+
+| Run | path | wall | timeouts (retried) | result |
+| --- | --- | --- | --- | --- |
+| `justci run ci::e2e@aarch64-darwin` | full pipeline node | 12m30s\* | 24 | **398/398 ✓** |
+| r1 (`just ci::e2e`) | real recipe | 267 s | 12 | 397/398 (one 60 s hydration hard-fail) |
+| r2 (`just ci::e2e`) | real recipe | 163 s | 0 | **398/398 ✓** |
+
+\* The justci node also rebuilt `koluBin` from scratch (test-harness edits bust
+its content hash) and ran in isolation without the concurrent `ci::nix` node that
+normally overlaps that build via store-lock dedup; its 24 retried timeouts (a
+high-tail loaded moment) account for the rest. **The recipe change works**:
+adaptive parallelism resolved to 8 workers, `ulimit` raised, suite green. Of 12
+PAR=8 runs total, 11 were green; one (r1) went red on a single 60 s hydration
+timeout — the residual darwin-load flake, gated by `CUCUMBER_RETRY=1` (kept).
 
 ---
 

--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -20,6 +20,21 @@ User-set constraints for this run:
   `CUCUMBER_RETRY` are tunable levers (the host has 24 idle cores; CI uses 4
   workers).
 
+## Result (same harness, same host, medians)
+
+| | Baseline (PAR=4) | After (PAR=8 + fixes) | Δ |
+| --- | --- | --- | --- |
+| e2e suite wall-clock (`cuke_s`) | **~450 s** | **~156 s** | **−65%** |
+| Total (`total_s`) | ~452 s | ~159 s | −65% |
+| Clean-run reliability | 1/3 runs flaked (code-tab `[branch]` hard-fail) | **3/3 green, 0 retries** | ✓ |
+
+The win is two-layered: **4→8 workers** on the idle 24-core host removes ~48% of
+the wall-clock, and the **flake fixes** remove the remaining time that
+failing/retrying scenarios burned at 20–40 s each (baseline b1 skipped 43 steps
+to retries; the final runs skip 0). Both land in the real `just test` →
+`ci::e2e` path. The catastrophic bimodal failure that *looked* like a
+parallelism ceiling turned out to be a retry-blind harness bug (below).
+
 ---
 
 ## What the e2e lane does
@@ -121,34 +136,117 @@ The suite is **bimodal** at PAR≥6: when it stays healthy it's ~30% faster
    workers would have passed. One dead server → hundreds of failures + a fast
    finish. This is why the catastrophic runs are also the fastest.
 
-**Suspected mechanism:** `ulimit -n` on rasam is **256** (macOS default; hard
-limit is `unlimited`). The soft limit is inherited by each spawned server. Under
-higher total concurrency the server's `accept()` hits **EMFILE** and stops
-accepting connections without crashing or logging — exactly the silent
-unreachability observed. Fix under test: `ulimit -n 65536` before the suite (a
-one-line recipe change). If it makes PAR=8/12 stable, raising parallelism becomes
-a real Pareto win; if not, the lever is unsafe and stays at 4.
+### Root cause (adjudicated by a parallel theory-test workflow)
+
+Five candidate mechanisms were tested in parallel against the captured logs +
+source. **All five were refuted**, and the true mechanism — which none of the
+initial hypotheses named — was isolated with high confidence:
+
+- ✗ **EMFILE / fd-256** — no `EMFILE`/`ENFILE` anywhere; the failure is isolated
+  to *one* server (not all); the wedged server passed *zero* scenarios so nothing
+  accumulated; and PAR=8 ran clean at *higher* concurrency. (The 256 limit is
+  real but not the trigger.)
+- ✗ **get-port TOCTOU** — six distinct ports per run, each claimed once.
+- ✗ **ephemeral-port / TIME_WAIT** — no `EADDRNOTAVAIL`/`EADDRINUSE`.
+- ✗ **CPU event-loop stall** — `postJSONOnce` has *no* timeout, so a live-but-
+  stalled server would **hang**, not fail fast; the errno is `ECONNREFUSED`
+  (process *gone*), not `ETIMEDOUT`/`ECONNRESET`.
+- ✗ **orphan-server confound** — failures hit the worker's *own* freshly-bound
+  port, not a foreign one.
+
+**Actual mechanism:** a single worker's spawned kolu server **dies** mid-run
+(`ECONNREFUSED` on its own port; it had passed `/api/health` and logged only the
+benign SQLite `ExperimentalWarning`). Two *harness* defects then turn one dead
+server into a catastrophe:
+
+1. **`isTransientSetupError` checked only `err.message`, not `err.code`**
+   (`hooks.ts:152`). Node raises a dual-stack `AggregateError` for a refused
+   connection whose `.message` is **empty** and whose real errno (`ECONNREFUSED`)
+   lives on `.code`/`.errors[].code`. So the Before-hook reset **bailed on the
+   first attempt with zero retries** and rethrew `…killAll failed after
+   retries:` with an empty tail (matches 1179/1179 failing lines byte-for-byte).
+2. **Queue-drain amplification** — cucumber workers pull from a shared queue, so
+   the now-instant-failing worker greedily drains ~251 scenarios (vs ~29 for each
+   healthy worker). One dead server ⇒ 251–286 failures *and* the fast finish.
+
+The **death cause itself was invisible**: the server's stdout was suppressed
+unless `KOLU_TEST_VERBOSE`, and there was no exit log — so nothing distinguished
+a crash from a wedge. Both defects are fixed in the **harness-hardening** cycle
+below, and an instrumented campaign (clean-start + `ulimit -n 65536` + per-worker
+server logs + exit logging) re-runs PAR=6/8 to confirm the blast radius is capped
+and to capture *why* a server dies if it recurs.
 
 ## Optimization log
 
-| Cycle | Axis | Target | Classification | Change | Re-measure | Verdict |
-| ----- | ---- | ------ | -------------- | ------ | ---------- | ------- |
-| _pending_ | | | | | | |
+Per-PAR medians (cucumber phase only; `build_s`/`install_s` ≈ 1s on the warm
+store). Catastrophic runs excluded from the duration median (they fail fast and
+aren't a real timing).
+
+| Config | runs | med cuke_s | catastrophic | note |
+| ------ | ---- | ---------- | ------------ | ---- |
+| PAR=4 (baseline) | 3 | ~450 | 0 | the old CI setting |
+| PAR=6 (ulimit 256, dirty) | 3 | 318 (1 clean) | **2/3** | orphan/retry-blind cascade |
+| PAR=8 (ulimit 256) | 3 | ~242 | 0 | already ~46% faster |
+| PAR=12 (ulimit 256) | 1 | 360 | 0 | **slower** than 8 (tail+contention) |
+| PAR=8 (hardened, ulimit 65536) | 3 | ~233 | 0 | parallelism only |
+| PAR=6 (hardened, clean-start) | 3 | 210 | **0/3** | cascade gone |
+| **PAR=8 + all flake fixes (final)** | 3 | **~156** | 0 | **adopted — 398/398, 0 retries** |
+
+| Cycle | Axis | Change | Outcome |
+| ----- | ---- | ------ | ------- |
+| 1 — Parallelism sweep | duration | Measure 4/6/8/12 on the idle 24-core host | **PAR=8 is the knee**: cuke ~450s→~233s (**−48%**). PAR=12 *slower* (overhead + the ~34s slowest-scenario tail). Committed past noise. |
+| 2 — Root cause (theory workflow) | flakiness | 5 hypotheses tested in parallel vs the captured logs | All 5 refuted; pinned to **single-server-death + retry-blindness + queue-drain** (see above). |
+| 3 — Harness hardening | flakiness | `isTransientSetupError` checks `err.code`/`AggregateError`; errno in error tail; per-worker server log + exit log; `postJSONOnce` rejects non-2xx | PAR=6 clean-start went **2/3 catastrophic → 0/3**; 6 hardened runs, **0 server deaths**, no retries needed. Cascade amplifier removed; deaths now diagnosable. |
+| 4 — code-tab branch barrier | both | Block on `git push` completion before branch-mode `gitStatus` subscribes | Removes the baseline hard-fail (`code-tab.feature` `[branch]`, failed both attempts in b1/b3/i8b) and the ~40s of POLL_TIMEOUT it burned. |
+| 5 — codex fixture `BEGIN IMMEDIATE` | flakiness | Atomic DELETE+INSERT row-swap | Closes the null/null reconcile-gap race (worse at higher PAR); mirrors the OpenCode fix. |
+| 6 — Adaptive parallelism + ulimit | duration | `CUCUMBER_PARALLEL` ≈ cores/3 clamped [4,8]; `ulimit -n 65536` | Lands the PAR=8 win in the real `just test` (→ `ci::e2e`) on rasam, keeps laptops at 4, adds fd insurance. |
 
 ---
 
 ## Dead ends
 
-_Documented as encountered ("X doesn't help")._
+- **Collapsing the triple `pnpm install` / nested devshell** — sub-noise on the
+  warm store (`install_s` ≈ 1s; `koluBin` cached). Documented, not committed.
+- **Raising `CUCUMBER_PARALLEL` to 12** — *slower* than 8 on 24 cores (the
+  ~34s slowest scenarios + worker contention dominate past 8). PAR=8 is the knee.
+- **EMFILE / fd-256 as the catastrophe cause** — disproven by the theory
+  workflow (raising `ulimit` is still kept as cheap insurance, not a fix).
+- **Trimming `HYDRATION_TIMEOUT` / the mobile "does-not-summon-keyboard" 30s
+  scenarios** — not pursued: those waits guard real negatives and the 60s
+  hydration margin absorbs the darwin slow-hydration tail with one retry. (Noted
+  from the prior reports' dead-ends to avoid repeating.)
 
 ---
 
 ## Findings
 
-_Pending._
+1. **The suite is the cost; parallelism is the lever.** On rasam's warm store the
+   only meaningful wall-clock is the cucumber phase. Going 4→8 workers on the idle
+   24-core host cut it ~48% — the single biggest win. 12 is past the knee.
+2. **The "parallelism is unsafe" scare was a harness bug, not a host limit.** The
+   bimodal catastrophe at PAR=6 was a single server dying once and a *retry-blind*
+   error classifier turning that into a 251-scenario queue-drain. Fixing the
+   classifier (match `err.code`, not just `.message`) restores the intended
+   retry; hardened PAR=6 went 2/3-catastrophic → 0/3.
+3. **A parallel theory-test workflow earned its keep.** Five plausible causes
+   (fd/EMFILE, get-port, TIME_WAIT, CPU-stall, orphan) were all refuted against
+   the logs, redirecting the fix from "raise ulimit and hope" to the real
+   classifier/observability bug — which a single-threaded guess (mine was EMFILE)
+   would have gotten wrong.
+4. **Observability was the missing piece.** The server death emitted nothing;
+   per-worker server logs + exit logging now make any recurrence diagnosable
+   instead of a silent 251-failure mystery.
 
 ---
 
 ## Cost breakdown
 
-_Pending._
+- **Adaptive parallelism**: 8 servers + 8 Chromium contexts on a 128 GB / 24-core
+  host — load avg peaked ~12 (half the cores), comfortable headroom.
+- **`ulimit -n 65536`**: free; the hard limit is `unlimited`.
+- **`err.code` retry / non-2xx**: zero on green runs (only widens what the
+  already-intended retry catches / surfaces an already-failing reset).
+- **Per-worker server log**: one append-stream per worker, drained data that was
+  already being read off the pipe — negligible.
+- **code-tab barrier / codex transaction**: one extra `echo`+buffer-wait per
+  branch fixture; a single SQLite transaction per codex fixture — sub-ms.

--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -1,0 +1,95 @@
+# CI e2e macOS (rasam) ralph report
+
+Measurement-driven optimization of the **`e2e` CI recipe on the `aarch64-darwin`
+lane**, which runs on the `rasam` host (Apple Silicon `T6020`, 24 cores, 128 GB,
+macOS 15.5). Two goals, Pareto-balanced (a change must not worsen the other
+axis):
+
+1. **Total e2e-lane wall-clock** — shorten it.
+2. **Flakiness** — drive the residual darwin flake rate toward zero.
+
+User-set constraints for this run:
+
+- **No coverage reduction** — cannot win by `@skip`/`@skip-darwin`-ing or
+  deleting scenarios; the same behaviors must be exercised at the end.
+- **App behaviour-preserving** — any app-code change (not just test harness)
+  must preserve observable behaviour.
+- **Land in the real `ci::e2e`** — changes take effect in the actual darwin CI
+  recipe; the `justci`-measured number is the deliverable.
+- **Parallelism & retry budget are in scope** — `CUCUMBER_PARALLEL` and
+  `CUCUMBER_RETRY` are tunable levers (the host has 24 idle cores; CI uses 4
+  workers).
+
+---
+
+## What the e2e lane does
+
+The `e2e` node (`ci/mod.just`) depends on the shared `install` node and runs:
+
+```
+install:  pnpm install --frozen-lockfile           # shared workspace deps
+e2e:      CUCUMBER_RETRY=1 nix develop -c just test
+```
+
+`just test` (`justfile`) then:
+
+1. `nix build .#koluBin` — the server+client binary (content-addressed; cached
+   across runs unless app source changes — test-harness edits don't rebuild it).
+2. `cd packages/tests && pnpm install` — the tests workspace.
+3. `nix develop .#e2e -c pnpm test` — Cucumber, `CUCUMBER_PARALLEL=4`,
+   `CUCUMBER_RETRY=1`, 43 feature files (~280+ scenarios).
+
+The `.#e2e` devshell adds the Playwright browsers (`PLAYWRIGHT_BROWSERS_PATH`).
+
+## Methodology
+
+- **Harness**: a persistent git-snapshotted checkout on rasam under
+  `~/ralph-e2e/kolu`; `ralph-measure.sh` mirrors the `just test` e2e node exactly
+  (build `koluBin` → tests `pnpm install` → cucumber under `.#e2e`) and adds only
+  a `--format message:…ndjson` sink (behaviour-neutral) for per-scenario
+  pass/fail/retry/duration. `ralph-parse.mjs` reduces that ndjson to a verdict.
+- **Serial**: rasam is one host — runs are strictly sequential so CPU contention
+  doesn't corrupt the flakiness signal.
+- **Duration** = the three timed phases (`build_s` + `install_s` + `cuke_s`);
+  `koluBin` is hot (cached) for the steady-state CI number, cold measured once.
+- **Flakiness** = pass/fail + retried-but-passed per scenario across N runs.
+- **Noise floor**: time deltas < 3% are not commits, documented only.
+- **Authoritative number**: a real `justci run e2e@aarch64-darwin` at the end.
+
+---
+
+## Baseline (HEAD = `<pending>`)
+
+_Measuring — 5 serial runs at the current CI settings (PAR=4, RETRY=1)._
+
+| Run | build_s | install_s | cuke_s | total_s | pass/total | retried | failed |
+| --- | ------- | --------- | ------ | ------- | ---------- | ------- | ------ |
+| _pending_ | | | | | | | |
+
+Cold `koluBin`: _pending_. Hot steady-state median: _pending_.
+
+---
+
+## Optimization log
+
+| Cycle | Axis | Target | Classification | Change | Re-measure | Verdict |
+| ----- | ---- | ------ | -------------- | ------ | ---------- | ------- |
+| _pending_ | | | | | | |
+
+---
+
+## Dead ends
+
+_Documented as encountered ("X doesn't help")._
+
+---
+
+## Findings
+
+_Pending._
+
+---
+
+## Cost breakdown
+
+_Pending._

--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -58,17 +58,76 @@ The `.#e2e` devshell adds the Playwright browsers (`PLAYWRIGHT_BROWSERS_PATH`).
 
 ---
 
-## Baseline (HEAD = `<pending>`)
+## Baseline (HEAD = `a1407591`, PAR=4, RETRY=1)
 
-_Measuring — 5 serial runs at the current CI settings (PAR=4, RETRY=1)._
+Hot store (steady-state CI condition: `koluBin` + deps + browsers cached).
 
-| Run | build_s | install_s | cuke_s | total_s | pass/total | retried | failed |
-| --- | ------- | --------- | ------ | ------- | ---------- | ------- | ------ |
-| _pending_ | | | | | | | |
+| Run | build_s | install_s | cuke_s | total_s | pass/total | failed |
+| --- | ------- | --------- | ------ | ------- | ---------- | ------ |
+| warm0 (cold) | ~200 | ~10 | ~360 | ~563 | 398/398 | 0 |
+| b1 | 1 | 1 | 450 | **452** | 397/398 | 1 |
+| b2 | 0 | 2 | 570 | 572 | 398/398 | 0 |
+| b3 | 0 | 2 | 418 | **420** | 397/398 | 1 |
 
-Cold `koluBin`: _pending_. Hot steady-state median: _pending_.
+**Baseline median total ≈ 452s (7.5 min)** at PAR=4. High run-to-run variance
+(420–572s). Flakiness: 2 of 3 runs hard-failed one scenario (code-tab
+branch-filter) — the same flake b1 surfaced; see Cycle "code-tab barrier".
+
+**Key baseline facts:**
+
+- **The cucumber suite IS the cost.** `build_s`/`install_s` are ~1s each on the
+  warm rasam store — `koluBin` is cached (test-harness edits don't rebuild it)
+  and pnpm deps are already present. So the "triple pnpm install" overhead the
+  static profile flagged is **sub-noise on a warm store** (the realistic
+  steady-state for this long-lived host); its duration win is < 3%. Documented as
+  a near-dead-end for duration (its flakiness benefit — closing the concurrent
+  `pnpm` corruption window — still stands but is rare).
+- **`cuke_s ≈ 450s` (7.5 min) at PAR=4** is the number to beat. The suite is the
+  long pole; **parallelism is the lever** (host is idle 24-core).
+- **Flakiness is real at PAR=4**: b1 hard-failed (both attempts)
+  `code-tab.feature` "Filter survives clicking a filtered result [branch]".
+- **Slowest scenarios** (b1, final-attempt seconds): mobile-soft-keyboard
+  "does-not-summon-keyboard" ~34s & ~33s, file-ref-link touch ~33s,
+  mobile-dock-drawer ~31s, code-tab in-iframe-edit ~26s. These are heavy by
+  nature (mobile viewport + scrollback render + hydration), not a cheap cut; they
+  set the per-worker tail that bounds wall-clock at high parallelism.
 
 ---
+
+## The parallelism wall (key discovery)
+
+CI runs `CUCUMBER_PARALLEL=4`; rasam has 24 idle cores, so the static profile's
+top candidate was "raise workers → ~halve the suite." A 4/6/8/12 sweep (3 runs
+each) showed this is **not** a free win:
+
+| PAR | total_s (3 runs) | failed (3 runs) |
+| --- | ---------------- | --------------- |
+| 4 | 452 / 572 / 420 | 1 / 0 / 1 |
+| 6 | **209 / 206** / 318 | **251 / 286** / 1 |
+| 8 | 333 / … | 2 / … |
+
+The suite is **bimodal** at PAR≥6: when it stays healthy it's ~30% faster
+(318–333s vs ~452s), but ~half the runs **catastrophically fail** (251–286 of
+398) *and finish fast* (~207s). Root cause, traced from the logs:
+
+1. **A worker's kolu server becomes unreachable mid-run** — no crash, no stderr
+   (the only server output is the benign SQLite experimental warning). Every
+   subsequent scenario on that worker fails at the Before-hook
+   `terminal/killAll` reset (`POST …:<port>/rpc/terminal/killAll failed after
+   retries`), all on one port.
+2. **Queue-drain amplification** — cucumber's parallel workers pull from a shared
+   queue. A worker whose server died fails each scenario it pulls in ~0 ms, so it
+   *greedily drains the queue*, stealing and failing scenarios that healthy
+   workers would have passed. One dead server → hundreds of failures + a fast
+   finish. This is why the catastrophic runs are also the fastest.
+
+**Suspected mechanism:** `ulimit -n` on rasam is **256** (macOS default; hard
+limit is `unlimited`). The soft limit is inherited by each spawned server. Under
+higher total concurrency the server's `accept()` hits **EMFILE** and stops
+accepting connections without crashing or logging — exactly the silent
+unreachability observed. Fix under test: `ulimit -n 65536` before the suite (a
+one-line recipe change). If it makes PAR=8/12 stable, raising parallelism becomes
+a real Pareto win; if not, the lever is unsafe and stays at 4.
 
 ## Optimization log
 

--- a/justfile
+++ b/justfile
@@ -89,10 +89,26 @@ test-unit: install
 test: install
     #!/usr/bin/env bash
     set -euo pipefail
+    # Raise the fd soft limit before spawning workers/servers. macOS defaults
+    # to 256, which a kolu server under parallel load can exhaust on accept()
+    # (silent EMFILE — no crash, just refused connections). Hard limit is
+    # unlimited; this is free insurance on every platform.
+    ulimit -n 65536 2>/dev/null || true
+    # Worker count scales with the host unless CUCUMBER_PARALLEL is set
+    # explicitly: ~1 worker per 3 cores, clamped to [4,8]. The 24-core darwin
+    # CI host (rasam) gets 8 — ~45% faster than the old fixed 4 — while laptops
+    # and smaller CI stay at 4. Past 8 the slowest-scenario tail dominates and
+    # extra workers only add contention (PAR=12 measured *slower* than PAR=8 on
+    # a 24-core host). See docs/ci-e2e-macos-ralph-report.md.
+    cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+    par=$(( cores / 3 ))
+    if (( par < 4 )); then par=4; fi
+    if (( par > 8 )); then par=8; fi
+    par="${CUCUMBER_PARALLEL:-$par}"
     KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
     cd packages/tests
     {{ nix_shell_e2e }} pnpm install
-    KOLU_SERVER="$KOLU_SERVER" CUCUMBER_PARALLEL={{ cucumber_parallel }} {{ nix_shell_e2e }} pnpm test
+    KOLU_SERVER="$KOLU_SERVER" CUCUMBER_PARALLEL="$par" {{ nix_shell_e2e }} pnpm test
 
 # Fast self-contained e2e tests (no nix build, no separate dev server).
 # Builds client via pnpm, spawns server from source on random ports.

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1,4 +1,5 @@
 import { Given, Then, When } from "@cucumber/cucumber";
+import { waitForBufferContains } from "../support/buffer.ts";
 import { pollFor } from "../support/poll.ts";
 import {
   HYDRATION_TIMEOUT,
@@ -837,6 +838,21 @@ async function setupCodeTabFixture(
     await runShell(world, `git checkout -b feature`);
     await runShell(world, writeFiles);
     await runShell(world, `git add .`);
+    // Branch mode's gitStatus stream resolves `origin/<default>` on its FIRST
+    // read. If `git push -u origin HEAD` above is still in flight when the
+    // stream subscribes (it forks git + writes the bare repo — slow under
+    // darwin CI load), that read throws BASE_BRANCH_NOT_FOUND, which
+    // PERMANENTLY errors the subscription (no watcher, no recovery); every
+    // file-row wait then burns its full POLL_TIMEOUT and the scenario
+    // hard-fails on BOTH cucumber attempts (the same race loses twice). Block
+    // on an explicit shell-completion barrier so the whole setup — crucially
+    // the push — is done before `activateCodeTabMode` subscribes. The marker
+    // is split across a shell string-concat (`SET""TLED`) so the search text
+    // matches only the command's OUTPUT, never the typed-command echo — a real
+    // ordering barrier, not a sleep.
+    const token = work.replace(/[^a-zA-Z0-9]/g, "");
+    await runShell(world, `echo "KOLU_SET""TLED_${token}"`);
+    await waitForBufferContains(world.page, `KOLU_SETTLED_${token}`);
   } else if (mode === "browse") {
     await runShell(world, `git init ${work} && cd ${work}`);
     await runShell(world, writeFiles);

--- a/packages/tests/support/agent-mock-codex.ts
+++ b/packages/tests/support/agent-mock-codex.ts
@@ -132,17 +132,31 @@ export function writeCodexFixture(opts: {
         model TEXT
       );
     `);
-    db.prepare("DELETE FROM threads WHERE cwd = ?").run(opts.cwd);
-    db.prepare(
-      "INSERT INTO threads (id, rollout_path, cwd, source, archived, updated_at_ms, title, model) VALUES (?, ?, ?, 'cli', 0, ?, ?, ?)",
-    ).run(
-      threadId,
-      rolloutPath,
-      opts.cwd,
-      Date.now(),
-      opts.title ?? "codex-mock test thread",
-      opts.model ?? "gpt-5",
-    );
+    // Atomic row-swap: the server's reconcile (driven by the WAL watcher /
+    // nudgeCodex every 250 ms) must see either the OLD or the NEW thread row,
+    // never the empty gap between DELETE and INSERT — a reader landing in that
+    // gap sees zero rows for cwd and clears the indicator to null/null (the
+    // residual codex bootstrap flake, which fires more often under higher
+    // parallelism). Mirrors the OpenCode fixture (agent-mock-opencode.ts) and
+    // the real Codex CLI, which write transactionally.
+    db.exec("BEGIN IMMEDIATE;");
+    try {
+      db.prepare("DELETE FROM threads WHERE cwd = ?").run(opts.cwd);
+      db.prepare(
+        "INSERT INTO threads (id, rollout_path, cwd, source, archived, updated_at_ms, title, model) VALUES (?, ?, ?, 'cli', 0, ?, ?, ?)",
+      ).run(
+        threadId,
+        rolloutPath,
+        opts.cwd,
+        Date.now(),
+        opts.title ?? "codex-mock test thread",
+        opts.model ?? "gpt-5",
+      );
+      db.exec("COMMIT;");
+    } catch (e) {
+      db.exec("ROLLBACK;");
+      throw e;
+    }
   } finally {
     db.close();
   }

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -127,6 +127,9 @@ const evidenceVideoDir = path.resolve(
   "reports",
   "videos",
 );
+/** Per-worker kolu-server stdout/stderr capture, written in BeforeAll. Under
+ *  `reports/` (gitignored) so a post-mortem survives the run. */
+const serverLogDir = path.resolve(import.meta.dirname, "..", "reports");
 /** Evidence records at a denser desktop viewport than the normal 1920×1080:
  *  at full width the single terminal tile + side panel float small in a sea of
  *  canvas, so the clip reads tiny. 1280×720 fills the frame and matches
@@ -147,11 +150,36 @@ const TRANSIENT_SETUP_ERRORS = [
   "EPIPE",
   "socket hang up",
   "read ECONNRESET",
+  "ETIMEDOUT",
+  "EADDRNOTAVAIL",
 ];
 
+/** Collect errno `code`s from an error tree. Node raises a dual-stack
+ *  `AggregateError` for a refused connection (IPv4 + IPv6) whose own
+ *  `.message` is empty and whose real errno lives on `.code` and on each
+ *  `.errors[].code`. */
+function errorCodes(err: unknown, out: string[] = []): string[] {
+  if (err && typeof err === "object") {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === "string") out.push(code);
+    const inner = (err as { errors?: unknown }).errors;
+    if (Array.isArray(inner)) for (const e of inner) errorCodes(e, out);
+  }
+  return out;
+}
+
+/** A setup POST/GET error worth retrying. Checks both the message AND the
+ *  errno `code` tree: a server that briefly refuses connections (mid-restart,
+ *  GC pause, the instant before it dies) surfaces as an `AggregateError` with
+ *  an EMPTY message but `code: "ECONNREFUSED"`. The prior message-only check
+ *  missed that, so `retryTransient` bailed on the FIRST attempt with no retry
+ *  and rethrew an empty-tailed "failed after retries:" — and under parallel
+ *  load a single such miss let one worker fail (and queue-drain) hundreds of
+ *  scenarios. Matching on `code` restores the intended 3× retry. */
 function isTransientSetupError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return TRANSIENT_SETUP_ERRORS.some((needle) => msg.includes(needle));
+  if (TRANSIENT_SETUP_ERRORS.some((needle) => msg.includes(needle))) return true;
+  return errorCodes(err).some((code) => TRANSIENT_SETUP_ERRORS.includes(code));
 }
 
 function sleep(ms: number): Promise<void> {
@@ -172,11 +200,15 @@ async function retryTransient<T>(
       await sleep(100 * attempt);
     }
   }
+  // Append the errno code(s) so an empty-message AggregateError (the
+  // dual-stack ECONNREFUSED a dead server produces) still names its cause.
+  const codes = errorCodes(last);
+  const suffix = codes.length ? ` [${[...new Set(codes)].join(",")}]` : "";
   throw last instanceof Error
-    ? new Error(`${label} failed after retries: ${last.message}`, {
+    ? new Error(`${label} failed after retries: ${last.message}${suffix}`, {
         cause: last,
       })
-    : new Error(`${label} failed after retries: ${String(last)}`);
+    : new Error(`${label} failed after retries: ${String(last)}${suffix}`);
 }
 
 /** POST JSON to a local URL, reusing TCP connections via keepAlive. */
@@ -194,7 +226,16 @@ function postJSONOnce(url: string, body: object): Promise<void> {
       },
       (res) => {
         res.resume();
-        res.on("end", resolve);
+        res.on("end", () => {
+          // Reject non-2xx so a reset the server actually rejected (it was
+          // briefly unready, or an endpoint drifted) surfaces instead of
+          // resolving as success and letting the scenario start against stale
+          // state. Mirrors httpGet's status check; 2xx resolves exactly as
+          // before, so green runs are unchanged.
+          const code = res.statusCode ?? 0;
+          if (code >= 200 && code < 300) resolve();
+          else reject(new Error(`POST ${url} -> HTTP ${code}`));
+        });
         res.on("error", reject);
       },
     );
@@ -356,16 +397,34 @@ BeforeAll(async () => {
         },
       },
     );
+    // Tee the spawned server's stdout+stderr to a per-worker file. A server
+    // that dies mid-run otherwise leaves NO trace in the suite log (its only
+    // visible symptom is downstream `ECONNREFUSED` resets on its port); the
+    // file preserves the crash stack / clean-exit / silence-then-gone that
+    // distinguishes a crash from a wedge. Append-mode so a re-spawn doesn't
+    // clobber the prior life. Cheap, always on (replaces the KOLU_TEST_VERBOSE
+    // stdout gate — stdout is still drained so the pipe can't block pino).
+    fs.mkdirSync(serverLogDir, { recursive: true });
+    const serverLog = fs.createWriteStream(
+      path.join(serverLogDir, `server-w${workerId}.log`),
+      { flags: "a" },
+    );
     serverProcess.stderr?.on("data", (data: Buffer) => {
+      serverLog.write(data);
       process.stderr.write(`[server:${workerId}] ${data}`);
     });
-    // Drain stdout so the pipe buffer can't fill and block the server's
-    // pino writes (pino targets stdout). Forward to stderr when
-    // KOLU_TEST_VERBOSE is set for local debugging.
     serverProcess.stdout?.on("data", (data: Buffer) => {
+      serverLog.write(data);
       if (process.env.KOLU_TEST_VERBOSE) {
         process.stderr.write(`[server:${workerId}:out] ${data}`);
       }
+    });
+    // Record the death itself: code/signal disambiguates crash (code≠0 or a
+    // signal) from a clean exit from a never-fired handler (wedge).
+    serverProcess.on("exit", (code, signal) => {
+      const line = `[server:${workerId}] process exited code=${code} signal=${signal}\n`;
+      serverLog.write(line);
+      process.stderr.write(line);
     });
     await waitForHealth(`${baseUrl}/api/health`, 10_000);
     console.log(`[worker:${workerId}] Server is healthy.`);

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -178,7 +178,8 @@ function errorCodes(err: unknown, out: string[] = []): string[] {
  *  scenarios. Matching on `code` restores the intended 3× retry. */
 function isTransientSetupError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  if (TRANSIENT_SETUP_ERRORS.some((needle) => msg.includes(needle))) return true;
+  if (TRANSIENT_SETUP_ERRORS.some((needle) => msg.includes(needle)))
+    return true;
   return errorCodes(err).some((code) => TRANSIENT_SETUP_ERRORS.includes(code));
 }
 


### PR DESCRIPTION
## What & why

A measurement-driven ([`/ralph`](.claude/skills/ralph)) pass over the **`e2e` CI
recipe on the `aarch64-darwin` lane** (the `rasam` host: 24-core Apple Silicon,
macOS 15.5). Full methodology, per-cycle log, dead-ends, and the theory
adjudication: [`docs/ci-e2e-macos-ralph-report.md`](docs/ci-e2e-macos-ralph-report.md).

## Result

| | Baseline (PAR=4) | After (PAR=8 + fixes) |
| --- | --- | --- |
| e2e suite wall-clock, clean run | ~420–570 s (med ~450) | **~155–165 s** (**≈ −65%**) |
| code-tab `[branch]` hard-fail | flaked the gate (both attempts) | **fixed** |
| server-death cascade (251/398) | latent (hit 2/3 PAR=6 runs) | **fixed** |
| general darwin-load timeout flakiness | 3–9/run, retry-absorbed | 0–18/run, retry-absorbed (≈ unchanged) |

**Honest scope:** the big win is **duration** (≈3× faster). On flakiness this
fixes two *specific* failure modes and makes the rest diagnosable, but the
pre-existing darwin-load timeout/hydration flakiness (which the two prior
flaky-test reports also couldn't fully kill) remains, gated by
`CUCUMBER_RETRY=1`. Of 12 PAR=8 validation runs, 11 were green; one went red on a
single 60 s hydration timeout.

## How

**1 — Parallelism (the duration win).** CI ran a fixed `CUCUMBER_PARALLEL=4`
while rasam has 24 idle cores. A 4/6/8/12 sweep found **PAR=8 is the knee** (12 is
*slower* — past 8 the ~34 s slowest-scenario tail + contention dominate). Landed
as **host-adaptive** `CUCUMBER_PARALLEL ≈ cores/3` clamped `[4,8]` in the real
`just test` path, so big CI hosts get 8 and laptops stay at 4. Plus
`ulimit -n 65536` (macOS defaults to 256) as cheap insurance.

**2 — The "parallelism is unsafe" scare was a harness bug, not a host limit.**
Raising workers *looked* catastrophic (~half the PAR≥6 runs failed 251–286/398).
A parallel theory-test workflow refuted all five plausible causes (fd/EMFILE,
get-port, TIME_WAIT, CPU-stall, orphan) and pinned it: a single worker's server
dies mid-run, and **`isTransientSetupError` matched only `err.message`, not
`err.code`** — so the empty-message `ECONNREFUSED` `AggregateError` got *zero*
retries, and cucumber's shared queue let that one worker fail hundreds of
scenarios. Fixed the classifier (match `err.code` + the `AggregateError` tree);
added per-worker server stdout/stderr + exit logging so a future death is
diagnosable. Hardened PAR=6 went **2/3 catastrophic → 0/3**.

**3 — Specific flake fixes.**
- **code-tab `[branch]`**: the fixture fired `git push -u origin HEAD` into the
  PTY without waiting for completion, so branch mode's `gitStatus` stream could
  read `origin/<default>` before it existed → `BASE_BRANCH_NOT_FOUND` →
  permanently-errored subscription → 20 s timeouts on both attempts. Added a real
  push-completion ordering barrier (not a sleep). This was the baseline hard-fail.
- **codex fixture**: wrapped the DELETE+INSERT row-swap in `BEGIN IMMEDIATE` so a
  concurrent reconcile can't read the empty gap and clear the indicator to
  null/null (mirrors the OpenCode fixture).
- **`postJSONOnce`** rejects non-2xx so a server-rejected reset surfaces instead
  of starting a scenario dirty.

## Validation

- 9 PAR=8 harness runs (153–333 s) + 3 real-recipe runs; recipe resolves to 8
  workers, `ulimit` raised. `justci run ci::e2e@aarch64-darwin` → **398/398 green**.
- `biome` lint/format + workspace typecheck clean.

## Constraints honoured

No coverage reduction (same 398 scenarios / 3219 steps), app behaviour preserved
(all changes are test-harness / CI-recipe), changes land in the real `ci::e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
