### PR TITLE
fix(be-review): pure-JS base64 in Report — TextEncoder crashes the workflow runtime

### DIFF
--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -1029,15 +1029,37 @@ async function authorBody(slug, data, baseline, guidance) {
 // UTF-8-safe base64. The Workflow runtime has NEITHER `Buffer` NOR `TextEncoder`
 // NOR `btoa` (the old `new TextEncoder()` fallback threw `ReferenceError:
 // TextEncoder is not defined` and crashed the whole Report phase), so the fallback
-// is a self-contained pure-JS encoder using only `encodeURIComponent` (always
-// present) for UTF-8 and a hand-rolled base64 alphabet — no runtime globals. The
-// `Buffer` fast-path is kept behind a `typeof` guard (which never throws) for
-// runtimes that do have it; the pure path is byte-for-byte identical output.
+// is a self-contained pure-JS encoder that hand-rolls UTF-8 byte emission and a
+// base64 alphabet — no runtime globals. The `Buffer` fast-path is kept behind a
+// `typeof` guard (which never throws) for runtimes that do have it; the pure path
+// is byte-for-byte identical output. UTF-8 is computed manually rather than via
+// `encodeURIComponent`, which throws `URIError` on lone surrogate halves; here, as
+// in Buffer/TextEncoder, an unpaired surrogate is replaced with U+FFFD so the
+// encoder is total over every JS string and never crashes the Report phase.
 function toBase64(s) {
   const str = String(s)
   if (typeof Buffer !== 'undefined') return Buffer.from(str, 'utf8').toString('base64')
-  // UTF-8 bytes as a binary string, without TextEncoder: %XX escape each byte.
-  const bin = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+  // UTF-8 bytes as a binary string, decoding surrogate pairs and substituting
+  // U+FFFD for any unpaired surrogate (matching Buffer/TextEncoder semantics).
+  let bin = ''
+  const emit = (cp) => {
+    if (cp < 0x80) bin += String.fromCharCode(cp)
+    else if (cp < 0x800) bin += String.fromCharCode(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f))
+    else if (cp < 0x10000) bin += String.fromCharCode(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f))
+    else bin += String.fromCharCode(0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 0x3f), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f))
+  }
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i)
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = str.charCodeAt(i + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        emit(0x10000 + ((c - 0xd800) << 10) + (next - 0xdc00))
+        i++
+      } else emit(0xfffd) // unpaired high surrogate
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      emit(0xfffd) // unpaired low surrogate
+    } else emit(c)
+  }
   const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let out = ''
   for (let i = 0; i < bin.length; i += 3) {

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -1063,10 +1063,11 @@ function toBase64(s) {
   const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let out = ''
   for (let i = 0; i < bin.length; i += 3) {
+    const n = Math.min(3, bin.length - i)
     const a = bin.charCodeAt(i)
-    const b = i + 1 < bin.length ? bin.charCodeAt(i + 1) : 0
-    const c = i + 2 < bin.length ? bin.charCodeAt(i + 2) : 0
-    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (i + 1 < bin.length ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (i + 2 < bin.length ? CH[c & 63] : '=')
+    const b = n > 1 ? bin.charCodeAt(i + 1) : 0
+    const c = n > 2 ? bin.charCodeAt(i + 2) : 0
+    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (n > 1 ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (n > 2 ? CH[c & 63] : '=')
   }
   return out
 }

--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -1026,15 +1026,27 @@ async function authorBody(slug, data, baseline, guidance) {
 // decodes it to the file mechanically and never sees it as prose, so no body content
 // can be confused with a workflow instruction. The deterministic baseline is itself a
 // valid body and rides the same opaque path (it's the fallback when authoring fails).
-// UTF-8-safe base64, runtime-agnostic: Node's Buffer if present, else TextEncoder +
-// btoa (handles multi-byte chars, which a bare btoa(string) would corrupt).
+// UTF-8-safe base64. The Workflow runtime has NEITHER `Buffer` NOR `TextEncoder`
+// NOR `btoa` (the old `new TextEncoder()` fallback threw `ReferenceError:
+// TextEncoder is not defined` and crashed the whole Report phase), so the fallback
+// is a self-contained pure-JS encoder using only `encodeURIComponent` (always
+// present) for UTF-8 and a hand-rolled base64 alphabet — no runtime globals. The
+// `Buffer` fast-path is kept behind a `typeof` guard (which never throws) for
+// runtimes that do have it; the pure path is byte-for-byte identical output.
 function toBase64(s) {
   const str = String(s)
   if (typeof Buffer !== 'undefined') return Buffer.from(str, 'utf8').toString('base64')
-  const bytes = new TextEncoder().encode(str)
-  let bin = ''
-  for (const b of bytes) bin += String.fromCharCode(b)
-  return btoa(bin)
+  // UTF-8 bytes as a binary string, without TextEncoder: %XX escape each byte.
+  const bin = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+  const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  let out = ''
+  for (let i = 0; i < bin.length; i += 3) {
+    const a = bin.charCodeAt(i)
+    const b = i + 1 < bin.length ? bin.charCodeAt(i + 1) : 0
+    const c = i + 2 < bin.length ? bin.charCodeAt(i + 2) : 0
+    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (i + 1 < bin.length ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (i + 2 < bin.length ? CH[c & 63] : '=')
+  }
+  return out
 }
 
 async function postComment(slug, body) {

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -1029,15 +1029,37 @@ async function authorBody(slug, data, baseline, guidance) {
 // UTF-8-safe base64. The Workflow runtime has NEITHER `Buffer` NOR `TextEncoder`
 // NOR `btoa` (the old `new TextEncoder()` fallback threw `ReferenceError:
 // TextEncoder is not defined` and crashed the whole Report phase), so the fallback
-// is a self-contained pure-JS encoder using only `encodeURIComponent` (always
-// present) for UTF-8 and a hand-rolled base64 alphabet — no runtime globals. The
-// `Buffer` fast-path is kept behind a `typeof` guard (which never throws) for
-// runtimes that do have it; the pure path is byte-for-byte identical output.
+// is a self-contained pure-JS encoder that hand-rolls UTF-8 byte emission and a
+// base64 alphabet — no runtime globals. The `Buffer` fast-path is kept behind a
+// `typeof` guard (which never throws) for runtimes that do have it; the pure path
+// is byte-for-byte identical output. UTF-8 is computed manually rather than via
+// `encodeURIComponent`, which throws `URIError` on lone surrogate halves; here, as
+// in Buffer/TextEncoder, an unpaired surrogate is replaced with U+FFFD so the
+// encoder is total over every JS string and never crashes the Report phase.
 function toBase64(s) {
   const str = String(s)
   if (typeof Buffer !== 'undefined') return Buffer.from(str, 'utf8').toString('base64')
-  // UTF-8 bytes as a binary string, without TextEncoder: %XX escape each byte.
-  const bin = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+  // UTF-8 bytes as a binary string, decoding surrogate pairs and substituting
+  // U+FFFD for any unpaired surrogate (matching Buffer/TextEncoder semantics).
+  let bin = ''
+  const emit = (cp) => {
+    if (cp < 0x80) bin += String.fromCharCode(cp)
+    else if (cp < 0x800) bin += String.fromCharCode(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f))
+    else if (cp < 0x10000) bin += String.fromCharCode(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f))
+    else bin += String.fromCharCode(0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 0x3f), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f))
+  }
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i)
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = str.charCodeAt(i + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        emit(0x10000 + ((c - 0xd800) << 10) + (next - 0xdc00))
+        i++
+      } else emit(0xfffd) // unpaired high surrogate
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      emit(0xfffd) // unpaired low surrogate
+    } else emit(c)
+  }
   const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let out = ''
   for (let i = 0; i < bin.length; i += 3) {

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -1063,10 +1063,11 @@ function toBase64(s) {
   const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let out = ''
   for (let i = 0; i < bin.length; i += 3) {
+    const n = Math.min(3, bin.length - i)
     const a = bin.charCodeAt(i)
-    const b = i + 1 < bin.length ? bin.charCodeAt(i + 1) : 0
-    const c = i + 2 < bin.length ? bin.charCodeAt(i + 2) : 0
-    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (i + 1 < bin.length ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (i + 2 < bin.length ? CH[c & 63] : '=')
+    const b = n > 1 ? bin.charCodeAt(i + 1) : 0
+    const c = n > 2 ? bin.charCodeAt(i + 2) : 0
+    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (n > 1 ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (n > 2 ? CH[c & 63] : '=')
   }
   return out
 }

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -1026,15 +1026,27 @@ async function authorBody(slug, data, baseline, guidance) {
 // decodes it to the file mechanically and never sees it as prose, so no body content
 // can be confused with a workflow instruction. The deterministic baseline is itself a
 // valid body and rides the same opaque path (it's the fallback when authoring fails).
-// UTF-8-safe base64, runtime-agnostic: Node's Buffer if present, else TextEncoder +
-// btoa (handles multi-byte chars, which a bare btoa(string) would corrupt).
+// UTF-8-safe base64. The Workflow runtime has NEITHER `Buffer` NOR `TextEncoder`
+// NOR `btoa` (the old `new TextEncoder()` fallback threw `ReferenceError:
+// TextEncoder is not defined` and crashed the whole Report phase), so the fallback
+// is a self-contained pure-JS encoder using only `encodeURIComponent` (always
+// present) for UTF-8 and a hand-rolled base64 alphabet — no runtime globals. The
+// `Buffer` fast-path is kept behind a `typeof` guard (which never throws) for
+// runtimes that do have it; the pure path is byte-for-byte identical output.
 function toBase64(s) {
   const str = String(s)
   if (typeof Buffer !== 'undefined') return Buffer.from(str, 'utf8').toString('base64')
-  const bytes = new TextEncoder().encode(str)
-  let bin = ''
-  for (const b of bytes) bin += String.fromCharCode(b)
-  return btoa(bin)
+  // UTF-8 bytes as a binary string, without TextEncoder: %XX escape each byte.
+  const bin = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+  const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  let out = ''
+  for (let i = 0; i < bin.length; i += 3) {
+    const a = bin.charCodeAt(i)
+    const b = i + 1 < bin.length ? bin.charCodeAt(i + 1) : 0
+    const c = i + 2 < bin.length ? bin.charCodeAt(i + 2) : 0
+    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (i + 1 < bin.length ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (i + 2 < bin.length ? CH[c & 63] : '=')
+  }
+  return out
 }
 
 async function postComment(slug, body) {

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -1029,15 +1029,37 @@ async function authorBody(slug, data, baseline, guidance) {
 // UTF-8-safe base64. The Workflow runtime has NEITHER `Buffer` NOR `TextEncoder`
 // NOR `btoa` (the old `new TextEncoder()` fallback threw `ReferenceError:
 // TextEncoder is not defined` and crashed the whole Report phase), so the fallback
-// is a self-contained pure-JS encoder using only `encodeURIComponent` (always
-// present) for UTF-8 and a hand-rolled base64 alphabet — no runtime globals. The
-// `Buffer` fast-path is kept behind a `typeof` guard (which never throws) for
-// runtimes that do have it; the pure path is byte-for-byte identical output.
+// is a self-contained pure-JS encoder that hand-rolls UTF-8 byte emission and a
+// base64 alphabet — no runtime globals. The `Buffer` fast-path is kept behind a
+// `typeof` guard (which never throws) for runtimes that do have it; the pure path
+// is byte-for-byte identical output. UTF-8 is computed manually rather than via
+// `encodeURIComponent`, which throws `URIError` on lone surrogate halves; here, as
+// in Buffer/TextEncoder, an unpaired surrogate is replaced with U+FFFD so the
+// encoder is total over every JS string and never crashes the Report phase.
 function toBase64(s) {
   const str = String(s)
   if (typeof Buffer !== 'undefined') return Buffer.from(str, 'utf8').toString('base64')
-  // UTF-8 bytes as a binary string, without TextEncoder: %XX escape each byte.
-  const bin = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+  // UTF-8 bytes as a binary string, decoding surrogate pairs and substituting
+  // U+FFFD for any unpaired surrogate (matching Buffer/TextEncoder semantics).
+  let bin = ''
+  const emit = (cp) => {
+    if (cp < 0x80) bin += String.fromCharCode(cp)
+    else if (cp < 0x800) bin += String.fromCharCode(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f))
+    else if (cp < 0x10000) bin += String.fromCharCode(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f))
+    else bin += String.fromCharCode(0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 0x3f), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f))
+  }
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i)
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = str.charCodeAt(i + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        emit(0x10000 + ((c - 0xd800) << 10) + (next - 0xdc00))
+        i++
+      } else emit(0xfffd) // unpaired high surrogate
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      emit(0xfffd) // unpaired low surrogate
+    } else emit(c)
+  }
   const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let out = ''
   for (let i = 0; i < bin.length; i += 3) {

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -1063,10 +1063,11 @@ function toBase64(s) {
   const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   let out = ''
   for (let i = 0; i < bin.length; i += 3) {
+    const n = Math.min(3, bin.length - i)
     const a = bin.charCodeAt(i)
-    const b = i + 1 < bin.length ? bin.charCodeAt(i + 1) : 0
-    const c = i + 2 < bin.length ? bin.charCodeAt(i + 2) : 0
-    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (i + 1 < bin.length ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (i + 2 < bin.length ? CH[c & 63] : '=')
+    const b = n > 1 ? bin.charCodeAt(i + 1) : 0
+    const c = n > 2 ? bin.charCodeAt(i + 2) : 0
+    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (n > 1 ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (n > 2 ? CH[c & 63] : '=')
   }
   return out
 }

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -1026,15 +1026,27 @@ async function authorBody(slug, data, baseline, guidance) {
 // decodes it to the file mechanically and never sees it as prose, so no body content
 // can be confused with a workflow instruction. The deterministic baseline is itself a
 // valid body and rides the same opaque path (it's the fallback when authoring fails).
-// UTF-8-safe base64, runtime-agnostic: Node's Buffer if present, else TextEncoder +
-// btoa (handles multi-byte chars, which a bare btoa(string) would corrupt).
+// UTF-8-safe base64. The Workflow runtime has NEITHER `Buffer` NOR `TextEncoder`
+// NOR `btoa` (the old `new TextEncoder()` fallback threw `ReferenceError:
+// TextEncoder is not defined` and crashed the whole Report phase), so the fallback
+// is a self-contained pure-JS encoder using only `encodeURIComponent` (always
+// present) for UTF-8 and a hand-rolled base64 alphabet — no runtime globals. The
+// `Buffer` fast-path is kept behind a `typeof` guard (which never throws) for
+// runtimes that do have it; the pure path is byte-for-byte identical output.
 function toBase64(s) {
   const str = String(s)
   if (typeof Buffer !== 'undefined') return Buffer.from(str, 'utf8').toString('base64')
-  const bytes = new TextEncoder().encode(str)
-  let bin = ''
-  for (const b of bytes) bin += String.fromCharCode(b)
-  return btoa(bin)
+  // UTF-8 bytes as a binary string, without TextEncoder: %XX escape each byte.
+  const bin = encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+  const CH = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  let out = ''
+  for (let i = 0; i < bin.length; i += 3) {
+    const a = bin.charCodeAt(i)
+    const b = i + 1 < bin.length ? bin.charCodeAt(i + 1) : 0
+    const c = i + 2 < bin.length ? bin.charCodeAt(i + 2) : 0
+    out += CH[a >> 2] + CH[((a & 3) << 4) | (b >> 4)] + (i + 1 < bin.length ? CH[((b & 15) << 2) | (c >> 6)] : '=') + (i + 2 < bin.length ? CH[c & 63] : '=')
+  }
+  return out
 }
 
 async function postComment(slug, body) {

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T14:41:22.091378+00:00'
+generated_at: '2026-06-03T17:37:29.922832+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T17:37:29.922832+00:00'
+generated_at: '2026-06-03T18:07:53.480067+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
## The bug

A `/be-review` run on #1155 crashed in its **Report** phase with `ReferenceError: TextEncoder is not defined`, so no per-track comments were posted and the report had to be reconstructed by hand — **with no commit links** ([example](https://github.com/juspay/kolu/pull/1155#issuecomment-4615086060)).

Root cause: the Report phase base64-encodes each comment body so the mechanical commenter agent treats it as **opaque data**, not prompt instructions (the F3 prompt-injection fix from #1153). `toBase64` fell back to `new TextEncoder()` when `Buffer` was undefined — but the **Workflow runtime has none of `Buffer`, `TextEncoder`, or `btoa`** (the same class of restriction as `Date.now()`/`Math.random()`). So the fallback threw and took down the whole Report phase.

## The fix

Replace the fallback with a **self-contained pure-JS UTF-8→base64 encoder** that uses only `encodeURIComponent` (always present) + a hand-rolled base64 alphabet — no runtime globals. The `Buffer` fast-path stays behind a safe `typeof` guard for runtimes that have it.

## Verification

- Byte-for-byte **identical to `Buffer.from(s,'utf8').toString('base64')`** across ASCII, multibyte (`café`, `résumé`), emoji (`🤖🔴`), markdown special chars (`| \n \` $`), and empty string.
- **Round-trips** cleanly through `base64 -d` (the decode side `postComment` runs).
- Full-file syntax check passes; `.apm`→generated in sync; `just fmt` clean.

This is the bug that blocks reporter-authored comments (incl. the `remapCommits` SHA-resolution from #1153) from ever reaching the PR — once Report stops crashing, those land with resolving commit links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)