### PR TITLE
Detect the multi-select AskUserQuestion prompt (screen scrape)

### DIFF
--- a/packages/integrations/claude-code/src/screen.test.ts
+++ b/packages/integrations/claude-code/src/screen.test.ts
@@ -30,6 +30,29 @@ Which database do you prefer?
 
 Enter to select · ↑/↓ to navigate · Esc to cancel`;
 
+/** AskUserQuestion — the multi-select (tabbed form) variant, captured live. Its
+ *  nav hint is `Tab/Arrow keys to navigate`, not `↑/↓ to navigate`, so a marker
+ *  keyed on the arrow glyphs alone would miss it; the trailing
+ *  `… to navigate · Esc to cancel` is what both shapes share. */
+const ASK_USER_QUESTION_MULTISELECT = `←  □ xterm title   □ Nix title   □ Nix depth   ✔ Submit  →
+
+Title for the xterm.js memory-leak post? It's a war story: I optimized the
+Chrome heap-count proxy; the real 220MB leak was in native ArrayBuffers.
+
+❯ 1. Measuring the Wrong Thing
+     Leads with the actual lesson — the proxy metric lied. Plain PG-ish.
+  2. Keep: The leak that wasn't in any Context
+     Current title. Already PG-ish — a plain, slightly mysterious phrase.
+  3. Off by Three Orders of Magnitude
+     Uses the concrete number (PG likes a surprising figure).
+  4. The Proxy Lies
+     Short and punchy; names the villain directly.
+  5. Type something.
+
+  6. Chat about this
+
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel`;
+
 /** Adversarial NEGATIVE — Claude's own `/fork` background-agent list (captured
  *  live from a real session). Its footer is `↑/↓ to select` — "to select", NOT
  *  "to navigate" — so the marker must NOT fire while a user browses it. This is
@@ -86,8 +109,12 @@ const PLAIN_ASSISTANT_TEXT = `● The function returns null when the file is
   missing, so the caller treats it as "retry".`;
 
 describe("screenHasClaudePrompt — AskUserQuestion", () => {
-  it("detects the live '↑/↓ to navigate' select footer", () => {
+  it("detects the single-select '↑/↓ to navigate' footer", () => {
     expect(screenHasClaudePrompt(ASK_USER_QUESTION)).toBe(true);
+  });
+
+  it("detects the multi-select 'Tab/Arrow keys to navigate' footer", () => {
+    expect(screenHasClaudePrompt(ASK_USER_QUESTION_MULTISELECT)).toBe(true);
   });
 });
 

--- a/packages/integrations/claude-code/src/screen.ts
+++ b/packages/integrations/claude-code/src/screen.ts
@@ -18,15 +18,19 @@
  *  `schemas.ts`.
  *
  *  ## Signature — one framework-rendered marker (claude-code v2.1.162, captured live)
- *  `AskUserQuestion`'s select footer `↑/↓ to navigate` — framework chrome, not
- *  the model-supplied question/option text, so it survives option-label churn.
- *  Captured ONLY on this prompt; the look-alikes a user might have on screen at
- *  `waiting` all use a *different* footer, so none collide:
+ *  `AskUserQuestion`'s footer, anchored on its trailing `… to navigate · Esc to
+ *  cancel` — framework chrome, not the model-supplied question/option text, so it
+ *  survives option-label churn. Keying on the trailing structure (not the nav
+ *  glyphs) covers both prompt shapes: a single-select renders `↑/↓ to navigate`,
+ *  a multi-select (tabbed form) renders `Tab/Arrow keys to navigate`. The
+ *  look-alikes a user might have on screen at `waiting`/`thinking` all end
+ *  differently, so none collide:
  *   - Claude's own `/fork` agent list → `↑/↓ to select · Enter to view` — "to
  *     select", NOT "to navigate";
- *   - `/model` picker → "Enter to set as default · s to use this session only";
+ *   - `/model` picker → "… s to use this session only · Esc to cancel" — ends in
+ *     "Esc to cancel" but not via "to navigate";
  *   - folder-trust prompt → "Enter to confirm · Esc to cancel";
- *   - slash / `@` menus → no arrow footer at all.
+ *   - slash / `@` menus → no footer of this shape at all.
  *
  *  Deliberately a *single* marker. `ExitPlanMode` is NOT detected in this cut —
  *  its dialog has no arrow footer (`Ready to code?` + `shift+tab to approve…`),
@@ -52,12 +56,18 @@ import type { ClaudeCodeInfo } from "./schemas.ts";
  *  prompt-like words. */
 export const TAIL_REGION_LINES = 40;
 
-/** The one awaiting-user marker: `AskUserQuestion`'s select footer
- *  `↑/↓ to navigate` (whitespace around the slash kept flexible against minor VT
- *  spacing). See the file header for why this single marker, and why the
- *  look-alike footers (`↑/↓ to select` on Claude's `/fork` agent list, the
- *  `/model` and trust pickers) deliberately don't match. */
-const NAV_FOOTER_RE = /↑\s*\/\s*↓\s+to navigate/;
+/** The one awaiting-user marker: `AskUserQuestion`'s footer, anchored on its
+ *  trailing `… to navigate · Esc to cancel`. Keying on the trailing structure
+ *  rather than the nav-hint glyphs makes it cover both observed variants without
+ *  enumerating them — single-select renders `↑/↓ to navigate`, multi-select (a
+ *  tabbed form) renders `Tab/Arrow keys to navigate`. The `· Esc to cancel`
+ *  suffix is what keeps it from colliding with prose ("…arrow keys to navigate
+ *  the file tree") or the look-alike menus that also end in "Esc to cancel" but
+ *  not via "to navigate" (`/model` → "session only · Esc to cancel"; the trust
+ *  prompt → "Enter to confirm · Esc to cancel"; the `/fork` agent list →
+ *  "↑/↓ to select · Enter to view"). The `·` separator is optional so a VT that
+ *  drops the middot still matches. */
+const NAV_FOOTER_RE = /to navigate\s*·?\s*Esc to cancel/;
 
 /** The last block of rendered lines, trailing blank rows trimmed so the "tail"
  *  is the last *painted* content, not the empty rows below a short prompt. */
@@ -69,7 +79,7 @@ function tailRegion(screenText: string): string[] {
 }
 
 /** Whether a Claude `AskUserQuestion` prompt is painted on the rendered screen —
- *  its `↑/↓ to navigate` select footer present in the screen tail. */
+ *  its `… to navigate · Esc to cancel` footer present in the screen tail. */
 export function screenHasClaudePrompt(screenText: string): boolean {
   return NAV_FOOTER_RE.test(tailRegion(screenText).join("\n"));
 }


### PR DESCRIPTION
**The screen-scrape `awaiting_user` detection (#1160) missed the multi-select AskUserQuestion prompt** — the tabbed form. It keyed on the footer `↑/↓ to navigate`, which only the single-select prompt renders; the multi-select variant renders **`Tab/Arrow keys to navigate`** instead, so the dock stayed on *Thinking* with the prompt clearly on screen.

Re-anchor the marker on the footer's **trailing `… to navigate · Esc to cancel`** structure — the part both shapes share — instead of the nav-hint glyphs:

| Prompt shape | Footer |
| --- | --- |
| single-select | `Enter to select · ↑/↓ to navigate · Esc to cancel` |
| multi-select (tabbed) | `Enter to select · Tab/Arrow keys to navigate · Esc to cancel` |

The `· Esc to cancel` suffix is what keeps it from colliding with prose (*"…arrow keys to navigate the file tree"*) or the look-alike menus that also end in "Esc to cancel" but **not** via "to navigate" — `/model` (`… session only · Esc to cancel`), the folder-trust prompt, the `/fork` agent list (`↑/↓ to select`). All of those stay green as negatives, and the captured multi-select prompt is added as a positive fixture.

Verified against the live capture from the screenshot that surfaced this. Unit suite green (16 tests); `just check` clean.

Follow-up to #1160 / #905.

_Generated by Claude Code (model `claude-opus-4-8`)._