### PR TITLE
feat(be-review): link lens + police PR comment headers to their references

### DIFF
--- a/.agents/skills/be-review/be-review.workflow.js
+++ b/.agents/skills/be-review/be-review.workflow.js
@@ -823,7 +823,7 @@ ${rounds}`;
 
 function lensComment(t) {
   if (!t || t.status === "track-error")
-    return `## ⚖️ Lowy ⇄ Hickey lens debate\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
+    return `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
   const appliedFor = (id) => (t.applied || []).find((x) => x.id === id)?.commit;
   const rows = (t.settled || [])
     .map(
@@ -837,7 +837,7 @@ function lensComment(t) {
         .map((u) => `- ${esc(u.title)} (${esc(u.location)})`)
         .join("\n")
     : "";
-  return `## ⚖️ Lowy ⇄ Hickey lens debate
+  return `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)
 
 **Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${
     Object.entries(t.reviews || {})
@@ -852,14 +852,14 @@ ${rows || "| — | — | — | — | — |"}${un}`;
 
 function policeComment(t) {
   if (!t || t.status === "track-error")
-    return `## 👮 Code-police\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
+    return `## [👮 Code-police](https://agency.srid.ca/)\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
   const rows = (t.applied || [])
     .map(
       (x) =>
         `| ${esc(x.severity)} | ${esc(x.title)} | ${esc((x.files || []).join(", "))} | ${sha9(x.commit)} |`,
     )
     .join("\n");
-  return `## 👮 Code-police
+  return `## [👮 Code-police](https://agency.srid.ca/)
 
 **${t.findings || 0} finding(s)** across the ${(t.passes || []).join(" / ") || "code-police"} passes over ${t.rounds || 1} review sweep(s)${t.status === "clean" ? " — clean diff" : ""}.${t.status === "incomplete" ? ` ⚠️ **Did not reach a clean sweep within the round cap** — the worktree may still have open issues; re-run /code-police on it.` : ""}${preservedBanner(t)}
 

--- a/.apm/skills/be-review/be-review.workflow.js
+++ b/.apm/skills/be-review/be-review.workflow.js
@@ -823,7 +823,7 @@ ${rounds}`;
 
 function lensComment(t) {
   if (!t || t.status === "track-error")
-    return `## ⚖️ Lowy ⇄ Hickey lens debate\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
+    return `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
   const appliedFor = (id) => (t.applied || []).find((x) => x.id === id)?.commit;
   const rows = (t.settled || [])
     .map(
@@ -837,7 +837,7 @@ function lensComment(t) {
         .map((u) => `- ${esc(u.title)} (${esc(u.location)})`)
         .join("\n")
     : "";
-  return `## ⚖️ Lowy ⇄ Hickey lens debate
+  return `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)
 
 **Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${
     Object.entries(t.reviews || {})
@@ -852,14 +852,14 @@ ${rows || "| — | — | — | — | — |"}${un}`;
 
 function policeComment(t) {
   if (!t || t.status === "track-error")
-    return `## 👮 Code-police\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
+    return `## [👮 Code-police](https://agency.srid.ca/)\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
   const rows = (t.applied || [])
     .map(
       (x) =>
         `| ${esc(x.severity)} | ${esc(x.title)} | ${esc((x.files || []).join(", "))} | ${sha9(x.commit)} |`,
     )
     .join("\n");
-  return `## 👮 Code-police
+  return `## [👮 Code-police](https://agency.srid.ca/)
 
 **${t.findings || 0} finding(s)** across the ${(t.passes || []).join(" / ") || "code-police"} passes over ${t.rounds || 1} review sweep(s)${t.status === "clean" ? " — clean diff" : ""}.${t.status === "incomplete" ? ` ⚠️ **Did not reach a clean sweep within the round cap** — the worktree may still have open issues; re-run /code-police on it.` : ""}${preservedBanner(t)}
 

--- a/.claude/skills/be-review/be-review.workflow.js
+++ b/.claude/skills/be-review/be-review.workflow.js
@@ -823,7 +823,7 @@ ${rounds}`;
 
 function lensComment(t) {
   if (!t || t.status === "track-error")
-    return `## ⚖️ Lowy ⇄ Hickey lens debate\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
+    return `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
   const appliedFor = (id) => (t.applied || []).find((x) => x.id === id)?.commit;
   const rows = (t.settled || [])
     .map(
@@ -837,7 +837,7 @@ function lensComment(t) {
         .map((u) => `- ${esc(u.title)} (${esc(u.location)})`)
         .join("\n")
     : "";
-  return `## ⚖️ Lowy ⇄ Hickey lens debate
+  return `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)
 
 **Outcome:** \`${t.status}\` after ${t.rounds || 0} round(s). Independent review: ${
     Object.entries(t.reviews || {})
@@ -852,14 +852,14 @@ ${rows || "| — | — | — | — | — |"}${un}`;
 
 function policeComment(t) {
   if (!t || t.status === "track-error")
-    return `## 👮 Code-police\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
+    return `## [👮 Code-police](https://agency.srid.ca/)\n\n**Track error:** ${esc(t?.error) || "did not run"}.`;
   const rows = (t.applied || [])
     .map(
       (x) =>
         `| ${esc(x.severity)} | ${esc(x.title)} | ${esc((x.files || []).join(", "))} | ${sha9(x.commit)} |`,
     )
     .join("\n");
-  return `## 👮 Code-police
+  return `## [👮 Code-police](https://agency.srid.ca/)
 
 **${t.findings || 0} finding(s)** across the ${(t.passes || []).join(" / ") || "code-police"} passes over ${t.rounds || 1} review sweep(s)${t.status === "clean" ? " — clean diff" : ""}.${t.status === "incomplete" ? ` ⚠️ **Did not reach a clean sweep within the round cap** — the worktree may still have open issues; re-run /code-police on it.` : ""}${preservedBanner(t)}
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-03T23:21:35.820072+00:00'
+generated_at: '2026-06-04T00:37:52.553780+00:00'
 apm_version: 0.16.1
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
Small touch: the per-track PR comment headers now link to the methodology behind each reviewer.

- **`## ⚖️ Lowy ⇄ Hickey lens debate`** → https://kolu.dev/blog/hickey-lowy/
- **`## 👮 Code-police`** → https://agency.srid.ca/

Changed in the deterministic comment builders (`lensComment` / `policeComment`, both the main and track-error returns). Because the reporter agents are told to *keep the baseline's exact top-level header line* (and the F2 anchor validation enforces it), the link carries into the agent-authored rich comments too — no separate change needed there.

Syntax-checked; `.apm`→generated in sync; `just fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)