### PR TITLE
Rewrite all four blog posts in Paul Graham's voice

### DIFF
--- a/.agents/skills/pg/SKILL.md
+++ b/.agents/skills/pg/SKILL.md
@@ -12,7 +12,18 @@ argument-hint: "<topic, or a draft to rewrite in PG's style>"
 
 # Write Like Paul Graham
 
-Use this when someone asks for an essay, article, or blog post "like Paul Graham" or "in PG's style." Write the piece in that voice, then revise out the AI tells using the checks below.
+Use this when someone asks for an essay, article, or blog post "like Paul Graham" or "in PG's style." First settle the inline-format house style (below), write the piece in that voice, then revise out the AI tells using the checks further down.
+
+## First, pick an inline-format
+
+PG's own prose uses almost no inline emphasis — but a blog post usually wants a few scan anchors, and how heavy to go is the reader's call, not yours. So before you write (or before a rewrite pass), ask the user with the **AskUserQuestion** tool which house style to apply. Offer these four, in this order, and attach a `preview` of the same short snippet rendered under each so they can compare:
+
+1. **Bold takeaway + italic terms** _(recommended default)_ — one bold punchline per section, the single line the eye should catch, plus `_italic_` on a coined or key term's _first_ mention only. About one bold per section. Stays mostly PG-plain.
+2. **Bold lead-ins (definition style)** — open key sentences and list items with a bold label, so concepts scan down the left edge. Most skimmable, least PG; reads like docs.
+3. **Italics only (PG-light)** — `_italic_` for term-introduction and contrast, no bold at all. Closest to PG's own habit.
+4. **Code spans + structure only** — no bold or italic. Scannability comes from `##` headers, `>` blockquotes, and `` `identifier` `` code spans. Purest PG, lowest skim-ability.
+
+If the user doesn't care, default to option 1. Whichever they pick, apply it consistently and keep it sparing: emphasis on every line is emphasis on none. Never bold a whole paragraph — bold at most one sentence, and make it the takeaway. Italicize a term only on its first use.
 
 ## The voice
 
@@ -129,6 +140,7 @@ An essay is something you write to figure something out, so build it as live rea
 - [ ] Is there at least one blunt or crude word landing against the plain backdrop?
 - [ ] Did I argue from named, first-hand evidence rather than "studies show"?
 - [ ] Did I state a real, falsifiable claim, or did I fence-sit?
+- [ ] Did I apply the agreed inline-format consistently — bold only the section takeaway, italics only on a term's first use, and nothing on every line?
 
 ## Calibration — real PG cadences
 

--- a/.apm/skills/pg/SKILL.md
+++ b/.apm/skills/pg/SKILL.md
@@ -12,7 +12,18 @@ argument-hint: "<topic, or a draft to rewrite in PG's style>"
 
 # Write Like Paul Graham
 
-Use this when someone asks for an essay, article, or blog post "like Paul Graham" or "in PG's style." Write the piece in that voice, then revise out the AI tells using the checks below.
+Use this when someone asks for an essay, article, or blog post "like Paul Graham" or "in PG's style." First settle the inline-format house style (below), write the piece in that voice, then revise out the AI tells using the checks further down.
+
+## First, pick an inline-format
+
+PG's own prose uses almost no inline emphasis — but a blog post usually wants a few scan anchors, and how heavy to go is the reader's call, not yours. So before you write (or before a rewrite pass), ask the user with the **AskUserQuestion** tool which house style to apply. Offer these four, in this order, and attach a `preview` of the same short snippet rendered under each so they can compare:
+
+1. **Bold takeaway + italic terms** _(recommended default)_ — one bold punchline per section, the single line the eye should catch, plus `_italic_` on a coined or key term's _first_ mention only. About one bold per section. Stays mostly PG-plain.
+2. **Bold lead-ins (definition style)** — open key sentences and list items with a bold label, so concepts scan down the left edge. Most skimmable, least PG; reads like docs.
+3. **Italics only (PG-light)** — `_italic_` for term-introduction and contrast, no bold at all. Closest to PG's own habit.
+4. **Code spans + structure only** — no bold or italic. Scannability comes from `##` headers, `>` blockquotes, and `` `identifier` `` code spans. Purest PG, lowest skim-ability.
+
+If the user doesn't care, default to option 1. Whichever they pick, apply it consistently and keep it sparing: emphasis on every line is emphasis on none. Never bold a whole paragraph — bold at most one sentence, and make it the takeaway. Italicize a term only on its first use.
 
 ## The voice
 
@@ -129,6 +140,7 @@ An essay is something you write to figure something out, so build it as live rea
 - [ ] Is there at least one blunt or crude word landing against the plain backdrop?
 - [ ] Did I argue from named, first-hand evidence rather than "studies show"?
 - [ ] Did I state a real, falsifiable claim, or did I fence-sit?
+- [ ] Did I apply the agreed inline-format consistently — bold only the section takeaway, italics only on a term's first use, and nothing on every line?
 
 ## Calibration — real PG cadences
 

--- a/.claude/skills/pg/SKILL.md
+++ b/.claude/skills/pg/SKILL.md
@@ -12,7 +12,18 @@ argument-hint: "<topic, or a draft to rewrite in PG's style>"
 
 # Write Like Paul Graham
 
-Use this when someone asks for an essay, article, or blog post "like Paul Graham" or "in PG's style." Write the piece in that voice, then revise out the AI tells using the checks below.
+Use this when someone asks for an essay, article, or blog post "like Paul Graham" or "in PG's style." First settle the inline-format house style (below), write the piece in that voice, then revise out the AI tells using the checks further down.
+
+## First, pick an inline-format
+
+PG's own prose uses almost no inline emphasis — but a blog post usually wants a few scan anchors, and how heavy to go is the reader's call, not yours. So before you write (or before a rewrite pass), ask the user with the **AskUserQuestion** tool which house style to apply. Offer these four, in this order, and attach a `preview` of the same short snippet rendered under each so they can compare:
+
+1. **Bold takeaway + italic terms** _(recommended default)_ — one bold punchline per section, the single line the eye should catch, plus `_italic_` on a coined or key term's _first_ mention only. About one bold per section. Stays mostly PG-plain.
+2. **Bold lead-ins (definition style)** — open key sentences and list items with a bold label, so concepts scan down the left edge. Most skimmable, least PG; reads like docs.
+3. **Italics only (PG-light)** — `_italic_` for term-introduction and contrast, no bold at all. Closest to PG's own habit.
+4. **Code spans + structure only** — no bold or italic. Scannability comes from `##` headers, `>` blockquotes, and `` `identifier` `` code spans. Purest PG, lowest skim-ability.
+
+If the user doesn't care, default to option 1. Whichever they pick, apply it consistently and keep it sparing: emphasis on every line is emphasis on none. Never bold a whole paragraph — bold at most one sentence, and make it the takeaway. Italicize a term only on its first use.
 
 ## The voice
 
@@ -129,6 +140,7 @@ An essay is something you write to figure something out, so build it as live rea
 - [ ] Is there at least one blunt or crude word landing against the plain backdrop?
 - [ ] Did I argue from named, first-hand evidence rather than "studies show"?
 - [ ] Did I state a real, falsifiable claim, or did I fence-sit?
+- [ ] Did I apply the agreed inline-format consistently — bold only the section takeaway, italics only on a term's first use, and nothing on every line?
 
 ## Calibration — real PG cadences
 

--- a/website/src/content/blog/hickey-lowy.mdx
+++ b/website/src/content/blog/hickey-lowy.mdx
@@ -7,68 +7,30 @@ author: "Sridhar Ratnakumar"
 
 import Tip from "../../components/Tip.astro";
 
-_Complexity creeps along two axes — space and time. Hickey catches
-one; Löwy catches the other. A single-lens review only audits half
-the code._
+Code can be wrong in two different ways, and for a long time I only checked for one of them.
+
+The first way you can see by looking. Two ideas braided into one thing, a name that means two things, a seam that isn't really a seam. The code, sitting there right now, is tangled. The second way you can't see by looking, because it isn't there yet. Two parts that will come apart later, on clocks you could name if you stopped to think — one revs when the UI changes, the other when a schema changes — bound together today as if they moved as one. The first defect is _spatial_. The second is _temporal_. They aren't the same defect, they don't show up at the same time, and a review that checks for one is blind to the other.
+
+So I run two reviewers, one for each. Rich Hickey's structural-simplicity lens catches the spatial kind. Juval Löwy's volatility lens catches the temporal kind. And the thing that surprised me, the thing this post is about, is how often a finding from one of them is invisible to the other. A review running only Hickey would have looked at the diff and been happy. So would a review running only Löwy. **Different code each time.**
 
 <Tip title="Quick start">
   The reviewer agents in this post are available as `/hickey` and `/lowy` skills from [agency.srid.ca](https://agency.srid.ca/).
 </Tip>
 
-Code goes wrong along two axes, not one. The code as it stands
-right now can be _spatially_ wrong — concepts braided together,
-names that mean two things, seams that aren't really seams. The same code can
-be _temporally_ wrong — parts that will rev on different clocks,
-decisions that will be revisited, volatilities that got bound when
-they should have stayed apart. Two different defects. Two different
-lenses. Most code review runs one.
-
-I run two. Rich Hickey's structural-simplicity lens catches defects
-on the spatial axis. Juval Löwy's volatility-decomposition lens
-catches defects on the temporal one. Each lens sees things the
-other is blind to. A review that only ran one of them would have
-been perfectly satisfied with the diff.
-
-That's the practice this post is arguing for. The framing I'll use
-to justify it is that code has a _spacetime_ — two orthogonal axes
-of complexity creep, not one. **Measure both, or miss half.**
+This matters more than it used to, because I'm not the one typing most of the code anymore. [Claude Code](https://claude.com/claude-code) writes it, from high-level intent, faster than I can read it line by line. So reading it line by line stopped being the useful thing for me to do during review. Reading the structure is the useful thing now. And reading the structure is exactly what two narrow, opinionated reviewers, aimed at a finished diff and run side by side, are good at. My job shrank to three steps: pick the lenses, read what they found, decide.
 
 <div class="tweet-embed">
 <blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">I think the biggest productivity boost from AI will come when we can nearly automate the software architect out of existence.<br/><br/>I&#39;m refining both /hickey and /lowy toward that end — so I don&#39;t have to babysit the AI after every PR.</p>&mdash; Sridhar Ratnakumar (@sridca) <a href="https://twitter.com/sridca/status/2044792589119832082?ref_src=twsrc%5Etfw">April 16, 2026</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
-I posted that two days ago. This post is where the refinement
-stands today — not the finish line, a snapshot mid-process.
+I posted that two days ago. This is where the refinement stands now — not the finish line, just a snapshot mid-process.
 
-This matters more than it used to. Most of the code I ship is no
-longer typed by hand — [Claude Code](https://claude.com/claude-code)
-writes it from high-level intent, faster than line-by-line human
-review can keep up with. Diff-inspection has quietly stopped being
-the highest-leverage human activity during review; **structural
-review** has. And structural review is exactly what two orthogonal
-agent reviewers, aimed at a finished diff and run in parallel, are
-good at. The human's remaining job is to pick the lenses, read the
-findings, and decide.
-
-I ran both reviewers on [PR #623](https://github.com/juspay/kolu/pull/623)[^1]
-of [Kolu](https://github.com/juspay/kolu), a canvas-only UX redesign.
-I drove the iterations; Claude Code wrote every line piecemeal,
-and the two reviewers are themselves Claude Code subagents spawned
-from the same session. The reviewers
-ran [once before any code was written](https://github.com/juspay/kolu/pull/623#issuecomment-4272457685)
-and then [twice against the committed diff](https://github.com/juspay/kolu/pull/623#issuecomment-4274952616)
-as revisions went in. Across the post-implementation passes, most
-findings hit one axis — with a handful of cases where both lenses
-agreed on a piece of code that would have shipped otherwise. The
-one-axis findings are the story this post is built around.
+I ran both reviewers on [PR #623](https://github.com/juspay/kolu/pull/623)[^1] of [Kolu](https://github.com/juspay/kolu), a redesign of the whole UI down to a single canvas. I drove the iterations; Claude Code wrote every line; the two reviewers are themselves Claude Code subagents spawned from the same session. They ran [once before any code existed](https://github.com/juspay/kolu/pull/623#issuecomment-4272457685) and then [twice against the committed diff](https://github.com/juspay/kolu/pull/623#issuecomment-4274952616) as I revised. Most of what they found sat on one axis or the other. A few times both landed on the same code — code that would have shipped otherwise. The one-axis findings are the story.
 
 ## What the two lenses are
 
-Rich Hickey's _Simple Made Easy_ gives you one question: **is this
-complected?** Are two ideas braided together in one thing, so that
-to touch one you have to touch the other? Hickey is literal about
-the word:
+Hickey's _Simple Made Easy_ hands you one question: is this _complected_? Are two ideas braided together in one thing, so that to touch one you have to touch the other? He's literal about the word:
 
 > Okay. So there's this really cool word called _complect_. I found
 > it. I love it. It means to interleave or entwine or braid. Okay?
@@ -77,15 +39,9 @@ the word:
 >
 > — Rich Hickey, [_Simple Made Easy_](https://www.infoq.com/presentations/Simple-Made-Easy/) (Strange Loop, 2011)
 
-A [Hickey reviewer](https://github.com/srid/agency/blob/master/.apm/skills/hickey/SKILL.md)
-reads code the way a lockpicker reads a tumbler[^2] — looking for
-concepts that shouldn't be in the same position. The output is
-always "split these apart."
+A [Hickey reviewer](https://github.com/srid/agency/blob/master/.apm/skills/hickey/SKILL.md) reads code the way a lockpicker reads a lock[^2]: hunting for concepts sitting in the same position that shouldn't be. The output is always the same shape — split these apart.
 
-Juval Löwy's _Righting Software_ (2019) gives you a different
-question: **what changes at a different rate than its neighbors?**
-Löwy builds on David Parnas, who had the rule fifty-four years
-ago:
+Löwy's _Righting Software_ hands you a different question: what changes at a different rate than the things around it? He's building on David Parnas, who wrote the rule down fifty-four years ago:
 
 > We propose instead that one begins with a list of difficult design
 > decisions or design decisions which are likely to change. Each
@@ -94,43 +50,17 @@ ago:
 > — David Parnas, [_On the Criteria To Be Used in Decomposing
 > Systems into Modules_](https://www.win.tue.nl/~wstomv/edu/2ip30/references/criteria_for_modularization.pdf) (1972)
 
-A [Löwy reviewer](https://github.com/srid/agency/blob/master/.apm/skills/lowy/SKILL.md)
-reads code the way an actuary reads a portfolio[^3] — looking for
-things coupled to unrelated schedules. The output is always "draw
-a boundary that encapsulates this volatility."
+A [Löwy reviewer](https://github.com/srid/agency/blob/master/.apm/skills/lowy/SKILL.md) reads code the way an actuary reads a portfolio[^3]: hunting for things tied to schedules that have nothing to do with each other. The output is always the same shape too — draw a boundary around this _volatility_.
 
-These sound adjacent. They aren't. Hickey is a _spatial_ question:
-the code, as a static snapshot, has a concept-duplication problem
-or it doesn't. Löwy is a _temporal_
-question: these two things will drift in the future on clocks you
-can name, and the code doesn't know that yet. Defects live on one
-axis, the other, or — rarely — both. A module can be perfectly
-uncomplected and still be a volatility time-bomb. A module can be
-volatility-safe and still be complected. The lenses don't overlap.
-They aren't meant to.
+These sound like the same question asked twice. They aren't. Hickey is asking about the code as it sits still: is there concept-duplication in this snapshot, or isn't there? Löwy is asking about the code as it moves: these two things will drift apart later, on clocks you can name, and the code doesn't know it yet. A module can be perfectly uncomplected and still be a time-bomb. A module can be safe against every future drift and still be a tangle right now. **The lenses don't overlap. They were never meant to.**
 
 ## The spacetime of code
 
-In physics, space and time are not independent. They're two
-projections of one four-dimensional manifold — different observers,
-depending on how they're moving, measure different mixes of the
-two. What looks like pure space from one frame is a blend of space
-_and_ time from another. But the interval between events is the
-same in every frame. The structure is real, prior to any observer's
-view of it.
+Here's the analogy I keep coming back to, and I'll admit up front it's the kind that can stretch too far. In physics, space and time aren't separate things. They're two views of one four-dimensional whole, and two observers moving differently slice it into different amounts of each. What's pure space to me is part space and part time to you. The thing that's actually real is the whole, sitting underneath both our views.
 
-Code has a spacetime too. A module's current shape (what's braided
-with what, what shares a name, what occupies the same scope) is
-one projection. Its evolution (what will rev on what clock, which
-decisions will be revisited, how fast each part drifts) is
-another. A defect can live in one projection without registering
-in the other — and usually does.
+Code has a whole like that too. A module's shape right now — what's braided with what, what shares a name, what sits in the same scope — is one view of it. How it changes over time — what revs on which clock, which decisions get reopened, how fast each part drifts — is another. A defect can sit in one view and leave no trace in the other. Usually it does.
 
-Hickey's lens is a space-like observer. It reads the code as a
-snapshot: what's tangled right now? Löwy's lens is a time-like
-observer. It reads the same code as a world-line: what will pull
-apart, and when? They are measuring different axes. Each is blind
-to what lives only in the other.
+Hickey's lens is the space-like observer. It reads the snapshot: what's tangled right now? Löwy's lens is the time-like observer. It reads the world-line: what's going to pull apart, and when? Same code, different axis, and each is blind to whatever lives only in the other's.
 
 Löwy says as much himself, in an appendix on complexity:
 
@@ -141,23 +71,11 @@ Löwy says as much himself, in an appendix on complexity:
 >
 > — Juval Löwy, _Righting Software_ (Appendix B)
 
-The complexity Löwy warns about is temporal in origin — _diversity
-across customers and points in time_ — but spatial in eventual
-manifestation. Mis-scoped volatilities eventually become complected
-code. Still, the two usually arrive out of phase. The spatial
-defect shows up now; the temporal defect only reveals itself later,
-when the clock it rides changes. That's why a review that runs one
-lens is blind to roughly half of what's actually wrong.
+The complexity he's warning about starts as a temporal thing — variety across customers and across time — and only later turns into tangled code. So the two do meet eventually: a mis-scoped volatility, left alone long enough, becomes a complected mess. But they meet late. The spatial defect is visible today; the temporal one stays hidden until the clock it's riding finally ticks. Which is the whole reason a one-lens review misses half of what's wrong. **It's reading one frame of a two-frame picture.**
 
 ## A spatial defect: `borderClass`
 
-Kolu's UI is an infinite 2D canvas — terminals live as tiles you
-can pan and zoom around, like desktop windows in a workspace with
-no edges. Floating above it is a pill tree: one pill per
-terminal, grouped by repo. Each pill's border carries two concerns: _activity_ (is
-an agent thinking, using tools, waiting?) and _focus_ (is this the
-active terminal?). The first implementation fused them into one
-Cartesian `ts-pattern` match:
+Kolu's screen is one infinite canvas. Terminals are tiles you pan and zoom around, like windows on a desk with no edges. Floating over them is a row of pills, one per terminal, grouped by repo. Each pill's border has to say two things at once: what the agent is doing (thinking, using a tool, waiting) and whether this is the terminal you're looking at. The first version fused them into one match:
 
 ```ts
 const borderClass = () =>
@@ -177,22 +95,11 @@ const borderClass = () =>
     .exhaustive();
 ```
 
-The comment above it, in the committed code, said: _"Single border
-channel: encodes BOTH active-ness and agent state."_ The code was
-honest about what it was doing. It was a single pattern match
-returning a single class string, with two concepts braided into
-every arm.
+The comment above it, in the shipped code, said so out loud: _"Single border channel: encodes BOTH active-ness and agent state."_ The code was honest about what it was doing. One pattern match, returning one string, with two ideas in every arm.
 
-The Hickey pass flagged it. Two concepts — _what the agent is
-doing_ and _whether this terminal is focused_ — were in the same
-pattern match, sharing arms, concatenated into one string. Adding a
-new agent variant (say, `streaming`) forced you to write both an
-active-and-streaming arm and an inactive-and-streaming arm. The
-`active` dimension intruded into every change that had nothing to
-do with focus.
+Hickey's pass flagged it on sight. Two concepts — what the agent is doing, and whether this pill is focused — were sharing arms in one match, concatenated into a single class string. Want to add a new agent state, say `streaming`? Now you write it twice, once for the focused case and once for the unfocused one. The focus dimension had crawled into every change that had nothing to do with focus.
 
-[Commit `fd6f802`](https://github.com/juspay/kolu/commit/fd6f802)
-split them:
+[Commit `fd6f802`](https://github.com/juspay/kolu/commit/fd6f802) split them:
 
 ```ts
 const agentBorderClass = () =>
@@ -208,43 +115,21 @@ const agentBorderClass = () =>
 />
 ```
 
-Two composers, two concerns. Agent state drives the animation;
-`classList` composes the active glow on top. Adding `streaming` now
-touches exactly the agent-state match. The new comment reads:
-_"Two orthogonal border concerns, composed via classList."_ The
-code's own vocabulary flipped from _BOTH_ to _orthogonal_.
+Two composers, two concerns. Agent state picks the animation; `classList` lays the focus glow on top. Adding `streaming` now touches the agent-state match and nothing else. The new comment reads _"Two orthogonal border concerns, composed via classList."_ The code's own vocabulary flipped, from BOTH to orthogonal.
 
-Löwy had nothing to say here. Active-ness and agent state rev on
-the same clock — they're both user-driven UI state that changes at
-interaction speed. No temporal mis-scope, no volatility boundary
-to draw. The defect was purely spatial: two concepts in one match,
-splittable by rewriting, end of story.
+And Löwy? Nothing to say here. Active-ness and agent state rev on the same clock — they're both UI state that changes when you click things. No mismatched schedule, no boundary to draw. The defect was purely spatial: two concepts in one match, fixable by rewriting, and that's the end of it.
 
-Every codebase has a `borderClass`. It's the kind of code that
-gets merged because it works. The Löwy lens is blind to it.
-Without Hickey in rotation, it stays.
+Every codebase has a `borderClass`. It's the code that gets merged because it works. Löwy's lens looks straight at it and sees nothing wrong. **Without Hickey in the rotation, it stays.**
 
 ## A temporal defect: `displaySuffix`
 
-Two terminals can land on the same identity — same git
-`repoName + branch`, or same `cwd` for non-git terminals. The UI
-has to disambiguate them. Kolu does it with a short
-collision-suffix on the label: `main #a3f2`. Cute problem; obvious
-solution.
+Two terminals can end up with the same name — same `repoName + branch` in git, or same `cwd` when there's no git. The UI has to tell them apart, so Kolu tacks a short collision-suffix onto the label: `main #a3f2`. Cute problem, obvious fix.
 
-The first implementation computed the suffix client-side, in
-`terminalDisplay.ts`. Every render, every pill-tree redraw, every
-tile chrome update, the client walked the terminal list, built an
-identity map, counted collisions, and emitted the suffix for any
-id whose identity had duplicates. It worked. Tests passed. The
-suffix showed up.
+The first version computed the suffix on the client, in `terminalDisplay.ts`. Every render, every time the pill tree redrew, every time a tile's chrome updated, the client walked the whole terminal list, built a map of identities, counted the collisions, and emitted a suffix for any id that had a twin. It worked. Tests passed. The suffix showed up.
 
-The Hickey pass had nothing to say. Structurally, the logic was
-cleanly encapsulated in one file, read by two or three consumers,
-using well-named helpers (`identityKey`, `idSuffix`,
-`identityCounts`). Nothing was braided. The snapshot looked fine.
+Hickey's pass had nothing to say. The logic sat cleanly in one file, read by two or three consumers, with well-named helpers (`identityKey`, `idSuffix`, `identityCounts`). Nothing braided. The snapshot was fine.
 
-The Löwy pass said:
+Löwy's pass said this:
 
 > Identity-collision is a business rule about the live terminal
 > set, not a per-render display preference. The volatility — "which
@@ -252,17 +137,9 @@ The Löwy pass said:
 > terminal set lives. The display layer is recomputing what the
 > server already knows.
 
-That's a volatility argument, not a structural one. The collision
-set changes on a specific clock: terminal lifecycle events (create,
-kill, cwd change, git metadata update). Not on render. Not on
-display preferences. Not on anything else. Putting the derivation
-in the display layer means every client, every tab, every render
-independently re-derives what is, in fact, a global property of a
-single set owned by a single service.
+That's a volatility argument, not a structural one. The set of colliding terminals changes on exactly one clock: terminal lifecycle — create, kill, cwd change, git metadata update. Not on render. Not on display preferences. Not on anything else. Computing it in the display layer means every client, every tab, every render independently re-derives what is, in fact, one global property of one set owned by one service.
 
-[Commit `5ac5fe2`](https://github.com/juspay/kolu/commit/5ac5fe2)
-moved it. `recomputeDisplaySuffixes()` runs in
-`packages/server/src/terminals.ts` on every metadata mutation:
+[Commit `5ac5fe2`](https://github.com/juspay/kolu/commit/5ac5fe2) moved it. `recomputeDisplaySuffixes()` now runs in `packages/server/src/terminals.ts`, once, on every metadata mutation:
 
 ```ts
 export function recomputeDisplaySuffixes(): TerminalId[] {
@@ -285,158 +162,55 @@ export function recomputeDisplaySuffixes(): TerminalId[] {
 }
 ```
 
-O(N) sweep, delta gate, fan-out republish for the sibling whose
-collision status flipped. `TerminalMetadata` carries
-`displaySuffix?: string` directly. Clients render `meta.displaySuffix`
-and delete the identity-tracking module entirely.
+One O(N) sweep, a gate so it only republishes the sibling whose collision status actually flipped, and the suffix rides along on `TerminalMetadata` as `displaySuffix?: string`. The client renders `meta.displaySuffix` and deletes its identity-tracking module outright.
 
-Hickey had nothing to say. Structurally, the before-and-after
-diffs look equivalent — a function in one file either way. What
-changed was _where the volatility lives_: with the concern that
-causes it. The Löwy lens is the only one that could see it.
+Hickey, this time, had nothing to say. To a snapshot the before and after look about the same — a function in a file either way. What moved was _where the volatility lives_: next to the thing that causes it. Only Löwy's lens could see that.
 
-Every codebase has a `displaySuffix`. Something derived in the
-wrong layer, because the wrong layer is the easiest place to write
-it. Without Löwy in rotation, it stays — and every future change
-to collision rules has to walk the client layer to find it.
+Every codebase has a `displaySuffix` too. Something computed in the wrong layer, because the wrong layer was the easiest place to type it. **Without Löwy in the rotation, it stays** — and every future change to the collision rule has to go hunting for it in the client.
 
-## When both lenses fire: an aside
+## When both fire
 
-The one case in PR #623 where the two lenses converged on the same
-line was `canvasMaximized` — a piece of state tracking "which tile,
-if any, is currently filling the viewport." The first
-implementation treated it the way every other user preference is
-treated in Kolu: a `Preferences` field, synced through the server,
-persisted in `SavedSession`, hydrated on mount with a careful
-`maxHydrated` sequencing flag to avoid a first-render flash.
+Once in PR #623 the two lenses landed on the same line. The state was `canvasMaximized` — which tile, if any, is currently filling the screen. The first version treated it like every other preference in Kolu: a `Preferences` field, synced through the server, saved into `SavedSession`, hydrated on mount behind a careful `maxHydrated` flag so the first paint wouldn't flash.
 
-Hickey's pass flagged it as three concepts braided into one
-propagation chain: _what's maximized_, _when is the client caught
-up to the server_, _how do we avoid a flash on first paint_. Löwy's
-pass, running independently, flagged it as three volatilities with
-no shared consumer: a client UI signal that revs at interaction
-speed, a server module field that revs on schema changes, and a
-`SavedSession` entry with its own versioning concerns.
+Hickey saw three concepts braided into one chain: what's maximized, whether the client has caught up to the server yet, and how to dodge a flash on first paint. Löwy, running on its own, saw three volatilities with no shared consumer: a client UI signal that revs when you click, a server field that revs on schema changes, and a `SavedSession` entry with its own versioning to worry about.
 
-Different diagnoses. Same line. Same fix. [Commit `99c1c44`](https://github.com/juspay/kolu/commit/99c1c44)
-deleted the server field, the `SavedSession` entry, the hydration
-flag, and the oRPC mutation, and moved the signal to
-`makePersisted` on `localStorage`. Across nine files: 14 insertions,
-90 deletions.
+**Different diagnoses. Same line. Same fix.** [Commit `99c1c44`](https://github.com/juspay/kolu/commit/99c1c44) deleted the server field, the `SavedSession` entry, the hydration flag, and the oRPC mutation, and moved the signal to `makePersisted` over `localStorage`. Nine files: 14 insertions, 90 deletions.
 
-When both lenses fire at the same coordinate, it's because the
-defect registers in both projections of the invariant — the
-factoring is wrong at a level that shows up both spatially (right
-now, in the propagation chain) and temporally (in the mismatched
-clocks the fields were bound to). Call it **binocular agreement**.
-It's a particularly sharp signal when it happens. It's also the
-minority. In PR #623, binocular findings were outnumbered several-
-to-one by single-axis ones across three review passes — and the
-binocular cases that did surface tended to come from later passes,
-because revisions keep introducing the defects both lenses catch
-together. Most findings, including the two centerpieces of this
-post, were single-axis. That's the common shape.
+When both lenses fire on the same spot, it's because the factoring is wrong deep enough to show up in both views at once — tangled right now, and bound to mismatched clocks for later. Call it _binocular agreement_. It's a sharp signal when you get it. It's also the minority. In PR #623 the binocular findings were outnumbered several-to-one by single-axis ones across three passes, and the few that did turn up came mostly from later passes — because revising the code keeps reintroducing the kind of defect both lenses catch together. Most findings, including the two I built this post around, sat on a single axis. That's the normal shape.
 
-## Why the two passes catch different things
+## Why the passes differ
 
-The pre-implementation reviews ran before any code was written,
-against a design sketch. They caught the obvious structural risks
-— terminal identity scattered across `PillTree`, `CanvasTile` and
-`CanvasMinimap`; the mobile-vs-desktop split turning into scattered
-conditionals. All of them got designed around before the first
-line of code.
+The reviews that ran before any code existed, against a design sketch, caught the obvious structural risks: terminal identity smeared across `PillTree`, `CanvasTile`, and `CanvasMinimap`; the mobile-versus-desktop split threatening to become scattered conditionals. We designed around all of it before the first line went in.
 
-The post-implementation reviews ran against the committed diff,
-then again after revisions. They found a completely different set
-of issues — the ones that only emerge after implementation has
-taste-decided its way through twenty design micro-choices. Pre-implementation review is cheap; it
-catches categories. Post-implementation review is expensive; it
-catches what specific design iterations did to the architecture
-while nobody was looking. Both the `borderClass` braid and the
-`displaySuffix` mis-location emerged during implementation.
-Neither existed in the design sketch.
+The reviews that ran against the committed diff, and again after revisions, caught a completely different set of things — the ones that only appear after the implementation has taste-decided its way through twenty little design choices. The early review is cheap and catches categories. The late review is expensive and catches what the design iterations did to the architecture while nobody was watching. Both `borderClass` and `displaySuffix` were born during implementation. Neither was in the sketch.
 
-If you only run these reviewers once, run them at the end. Not the
-beginning.
+So if you only run these reviewers once, **run them at the end. Not the beginning.**
 
-## When to trust a single-lens finding
+## Trusting one lens
 
-Most findings are single-lens. The practical question is how to
-evaluate them.
+Most findings come from one lens alone, so the real question is how to weigh one.
 
-If only Hickey fires, ask: _is this structural duplication actually
-going to hurt, or am I about to DRY up two things that happen to
-look alike but rev independently?_ The `repoColor` helper
-duplicated in `PillTree.tsx` and `MobileChromeSheet.tsx` was a safe
-DRY — one semantic concept ("the canonical color for this repo")
-that happened to have two call sites. Move it to `pillTreeOrder.ts`,
-done. But I've seen Hickey-lens deduplications that collapsed two
-things that _should_ rev on different clocks, and the subsequent
-"now I need to parameterize the helper" spiral is exactly what
-Löwy exists to prevent.
+If only Hickey fires, ask yourself: is this duplication actually going to hurt, or am I about to merge two things that only look alike and will rev apart later? The `repoColor` helper, duplicated in `PillTree.tsx` and `MobileChromeSheet.tsx`, was a safe merge — one idea ("the canonical color for this repo") that happened to have two call sites. Move it to `pillTreeOrder.ts`, done. But I've watched Hickey-style deduplications fuse two things that should have revved on different clocks, and the "well, now I have to parameterize the helper" spiral that follows is exactly what Löwy is there to head off.
 
-If only Löwy fires, ask: _am I drawing a boundary around a real
-volatility, or around something that currently happens to look
-bounded?_ `displaySuffix` was a real Löwy catch — collision
-detection genuinely revs on terminal lifecycle, not display
-preferences. But Löwy-lens module splits drawn for volatility that
-never actually revs are premature abstractions, and that's its own
-failure mode.
+If only Löwy fires, ask: am I drawing a boundary around a real volatility, or around something that just happens to look bounded today? `displaySuffix` was the real thing — collision detection genuinely revs on terminal lifecycle, not display preferences. But a Löwy split drawn for a volatility that never actually revs is a premature abstraction in a nicer hat, and that's its own way of being wrong.
 
-The Hickey failure mode is over-merging: collapsing things that
-should be separate. The Löwy failure mode is over-splitting:
-carving up things that don't need boundaries. Each lens has its
-own way of being wrong. Running the other lens as a counterweight
-helps, but only if you let it — not as a veto, as a second
-opinion.
+Hickey's failure mode is _over-merging_: gluing together things that should be apart. Löwy's is _over-splitting_: carving up things that didn't need a boundary. Each lens has its own way of being wrong. Running the other as a counterweight helps — but only if you treat it as **a second opinion, not a veto.**
 
 ## How to run them
 
-Run them as _independent_ reviewers, not as one pass. If you ask a
-single reader to "check for structural simplicity and volatility,"
-you get a blended answer. Blended answers bias toward whichever
-axis the reader already cares about. Separate the passes. Hickey
-agent reads the diff, writes findings. Löwy agent reads the same
-diff, writes findings. You read both. (Both agents ship in
-[srid/agency](https://github.com/srid/agency) as subagents your
-main Claude Code session can spawn in parallel.)
+Run them as two _separate_ reviewers, not one pass. Ask a single reader to "check for structural simplicity and volatility" and you get a blended answer, and a blended answer leans toward whichever axis that reader already cares about. So split the passes. Hickey reads the diff and writes its findings. Löwy reads the same diff and writes its own. You read both. (Both ship in [srid/agency](https://github.com/srid/agency) as subagents your main Claude Code session can spawn in parallel.)
 
-Don't expect the reviewers to agree on _fixes_. They agree on
-_locations_, occasionally — and on those occasions, they're
-rarely prescribing the same edit. Hickey wants you to decouple
-the concepts. Löwy wants you to encapsulate the volatilities.
-Sometimes those are the same edit. Sometimes Hickey says "split
-the function" and Löwy says "move the boundary," and both are
-right in a way that only the third, synthesizing read — yours —
-can land. The fix you ship is rarely either agent's literal
-proposal.
+Don't expect them to agree on the _fix_. They sometimes agree on the _location_ — and even then they're rarely prescribing the same edit. Hickey wants the concepts decoupled. Löwy wants the volatilities encapsulated. Sometimes that's one edit. Sometimes Hickey says "split the function" and Löwy says "move the boundary," and both are right in a way that only the third read — yours — can resolve. The fix you ship is rarely either agent's literal proposal.
 
-When the passes disagree, don't split the difference. Pick the
-one whose reasoning held under your own pushback, and drop the
-other. Splitting the difference gives you the worst of both —
-neither a clean concept nor a clean volatility boundary, just a
-compromise that fails both tests six months later.
+And when they disagree, **don't split the difference.** Take the one whose reasoning survived your own pushback, and drop the other. Splitting the difference hands you the worst of both: not a clean concept, not a clean boundary, just a compromise that fails both tests six months later.
 
-## In a line
+## Half a review
 
-_A single-lens review is a half-review. Code has a spacetime;
-complexity creeps along both axes._
+**A single-lens review is half a review.** Code has a spacetime, and complexity creeps in along both axes.
 
-Everything above is existence proof for that sentence: the
-`borderClass` braid that Löwy couldn't see, the `displaySuffix`
-mis-location that Hickey couldn't see, the `canvasMaximized` chain
-where both lenses happened to land on the same line. Most findings
-on one axis. A handful on both. A team that had run only Hickey
-would have shipped with `displaySuffix` recomputed per render on
-every client forever. A team that had run only Löwy would have
-shipped with a `borderClass` pattern match that intruded on every
-future agent-state variant.
+Everything above is the existence proof for that one sentence: the `borderClass` braid Löwy couldn't see, the `displaySuffix` in the wrong layer that Hickey couldn't see, the `canvasMaximized` chain where they happened to land together. Run only Hickey and you'd have shipped `displaySuffix` recomputing on every client on every render, forever. Run only Löwy and you'd have shipped a `borderClass` match that taxes every future agent-state variant you ever add.
 
-PR #623 shipped seven refactor commits past the point I would have
-merged on taste. Every one of them made the diff smaller. That's
-the other thing this practice does — the fix removes code, it
-doesn't add it. If a "simplification" is making your diff bigger,
-one of your lenses is broken. Probably both.
+One more thing, and it's the part I trust most. PR #623 shipped seven refactor commits past the point I'd have merged on taste, and every one of them made the diff smaller. That's the tell. The fix removes code, it doesn't add it. If your "simplification" is growing the diff, one of your lenses is broken. Probably both.
 
 **Ship when both lenses go quiet. Not before.**
 

--- a/website/src/content/blog/nix-chrome-devtools-mcp.mdx
+++ b/website/src/content/blog/nix-chrome-devtools-mcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Give your coding agent a browser, on Nix"
+title: "Eyes for the Agent"
 description: "A practical setup guide: install Nix, add one dep to apm.yml, your AI agent (Claude Code / Codex / OpenCode) gets DOM inspection, screenshots, network traces, and heap snapshots."
 pubDate: 2026-05-12
 author: "Sridhar Ratnakumar"
@@ -7,13 +7,11 @@ author: "Sridhar Ratnakumar"
 
 import Tip from "../../components/Tip.astro";
 
-_Install Nix, add one APM dep, and your agent — Claude Code, Codex, or OpenCode — gets a real Chrome to drive: DOM inspection, screenshots, network traces, heap snapshots._
+If you've ever wanted your coding agent to actually see your app running — take a screenshot, dump the DOM, read the network panel, snapshot the JS heap — Google ships an MCP server that does exactly that: [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp). It speaks the [Model Context Protocol](https://modelcontextprotocol.io/), so any agent that speaks it can plug in.
 
-If you've ever wanted your AI coding agent to actually **see your app running** — take a screenshot, dump the DOM, check the network panel, snapshot the JS heap — Google ships an MCP server for exactly that: [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp). It speaks the [Model Context Protocol](https://modelcontextprotocol.io/), so any compliant agent harness can plug into it.
+Wiring it into a project used to be a chore. You needed a Chrome binary, a launcher script, and a separate config block for each runtime — one for Claude Code, another for Codex, another for OpenCode. This guide skips all of that by leaning on two tools you may not be using together yet: Nix and APM.
 
-Wiring it into your project used to be irritating — you needed a Chrome binary, a launcher script, and a per-runtime config block (one for Claude Code, another for Codex, another for OpenCode). This guide gets you to a working setup by leaning on two tools you may not yet be using together: **Nix** and **APM**.
-
-> One-sentence pitches: **[Nix](https://nixos.org/)** gives you reproducible binaries — Chrome, Node, anything — without manual installers. **[APM](https://microsoft.github.io/apm/)** is the package manager for AI agent context: like `npm`, but the things you install are skills and MCP servers rather than libraries.
+> One-sentence pitches: **[Nix](https://nixos.org/)** gives you reproducible binaries — Chrome, Node, anything — with no manual installers. **[APM](https://microsoft.github.io/apm/)** is a package manager for AI-agent context: like `npm`, except the things you install are skills and MCP servers instead of libraries.
 
 ## Step 1 — Install Nix
 
@@ -31,7 +29,7 @@ experimental-features = nix-command flakes
 
 ## Step 2 — Drop one dep into apm.yml
 
-APM is a Python tool. You don't need to install it — Nix can pull [`uvx`](https://docs.astral.sh/uv/) on demand, and `uvx` in turn fetches APM from its Python package on first run:
+APM is a Python tool, but you don't have to install it. Nix can pull [`uvx`](https://docs.astral.sh/uv/) on demand, and `uvx` in turn fetches APM from its Python package on first run:
 
 ```sh
 nix shell nixpkgs#uv -c uvx --from apm-cli apm --version
@@ -58,7 +56,7 @@ Keep only the `targets` you actually use. Then install:
 nix shell nixpkgs#uv -c uvx --from apm-cli apm install --target claude,codex,opencode
 ```
 
-APM clones [`juspay/nix-chrome-devtools-mcp`](https://github.com/juspay/nix-chrome-devtools-mcp), deploys its launcher into `.agents/skills/nix-chrome-devtools-mcp/bin/serve`, and writes a per-runtime MCP config for each target — `.mcp.json` for Claude Code, `.codex/config.toml` for Codex, `opencode.json` for OpenCode.
+APM clones [`juspay/nix-chrome-devtools-mcp`](https://github.com/juspay/nix-chrome-devtools-mcp), drops its launcher into `.agents/skills/nix-chrome-devtools-mcp/bin/serve`, and writes a per-runtime MCP config for each target — `.mcp.json` for Claude Code, `.codex/config.toml` for Codex, `opencode.json` for OpenCode.
 
 ## Step 3 — Verify
 
@@ -80,7 +78,7 @@ Launch your agent and ask:
 
 > Open https://kolu.dev in a fresh page and tell me what's in the H1.
 
-Under the hood the agent calls `mcp__chrome-devtools__new_page`, then `mcp__chrome-devtools__take_snapshot`, and inspects the DOM tree. A non-exhaustive shopping list of what's now available:
+Under the hood the agent calls `mcp__chrome-devtools__new_page`, then `mcp__chrome-devtools__take_snapshot`, and reads the DOM tree. A partial list of what you now have:
 
 - `new_page`, `navigate_page`, `close_page` — page lifecycle
 - `take_snapshot`, `take_screenshot` — DOM + image capture
@@ -94,19 +92,21 @@ Under the hood the agent calls `mcp__chrome-devtools__new_page`, then `mcp__chro
 
 ## What we actually use it for
 
-The first use is **iteration**. The agent opens the page it just changed, takes a snapshot or screenshot, sees whether the output matches what it intended, and adjusts before moving on. It pulls console errors with `list_console_messages`, runs assertions through `evaluate_script`, checks network behavior with `list_network_requests` — the same DevTools panels a human would reach for, the agent reaches for too, on its own work. The feedback loop closes inside the agent's own turn.
+Two things, mostly.
 
-The second use is **PR evidence**. Our [`/do`](https://agency.srid.ca/) workflow (from [`srid/agency`](https://github.com/srid/agency)) ends with an `evidence` step: spawn a dev server on a free port, point `chrome-devtools-mcp` at the relevant routes, run `take_screenshot`, upload to a long-lived [`evidence-assets`](https://github.com/juspay/kolu/releases/tag/evidence-assets) GitHub release, embed the URLs in the PR comment. The reviewer sees exactly what changed without checking out the branch.
+The first is iteration. The agent opens the page it just changed, takes a snapshot or a screenshot, and checks whether the output matches what it meant to do — before it moves on. It pulls console errors with `list_console_messages`, runs assertions through `evaluate_script`, watches the network with `list_network_requests`. The same panels a human would open, the agent opens on its own work. **The loop closes inside the agent's own turn** — which is the whole point. An agent that can't see what it built is working blind.
 
-Here's what an evidence comment looks like, lifted from [Kolu PR #835](https://github.com/juspay/kolu/pull/835#issuecomment-4393613826):
+The second is PR evidence. Our [`/do`](https://agency.srid.ca/) workflow (from [`srid/agency`](https://github.com/srid/agency)) ends with an `evidence` step: spin up a dev server on a free port, point `chrome-devtools-mcp` at the routes that changed, run `take_screenshot`, upload to a long-lived [`evidence-assets`](https://github.com/juspay/kolu/releases/tag/evidence-assets) GitHub release, and drop the URLs into the PR comment. **The reviewer sees exactly what changed without checking out the branch.**
+
+Here's what one of those evidence comments looks like, lifted from [Kolu PR #835](https://github.com/juspay/kolu/pull/835#issuecomment-4393613826):
 
 ![Worktree-naming leaf with prefilled `peaked-rank` suggestion](/blog/kolu-evidence-worktree-name-leaf.png)
 
-(See also [#866](https://github.com/juspay/kolu/pull/866#issuecomment-4430710269) for a cross-palette icon check, and [#867](https://github.com/juspay/kolu/pull/867#issuecomment-4432265073) for a three-step diagnostic table comparing `master` vs the fix.)
+(See also [#866](https://github.com/juspay/kolu/pull/866#issuecomment-4430710269) for a cross-palette icon check, and [#867](https://github.com/juspay/kolu/pull/867#issuecomment-4432265073) for a three-step diagnostic table comparing `master` against the fix.)
 
 ## Overrides (optional)
 
-The launcher honours two env vars, set before you launch the agent:
+The launcher honors two env vars, set before you launch the agent:
 
 | Var | Default | Effect |
 |---|---|---|
@@ -115,7 +115,7 @@ The launcher honours two env vars, set before you launch the agent:
 
 ## What's actually happening
 
-`bin/serve` is twenty lines of bash. It runs `nix build nixpkgs#playwright-driver.browsers` to materialise Chrome-for-Testing (the same Chrome binary the Playwright project bundles), then `nix shell nixpkgs#nodejs --command npx -y chrome-devtools-mcp@latest --executable-path=$chrome` to start the server. All inputs are resolved through Nix; nothing gets dropped into your project tree as a side-effect.
+`bin/serve` is twenty lines of bash. It runs `nix build nixpkgs#playwright-driver.browsers` to materialise Chrome-for-Testing — the same Chrome binary the Playwright project bundles — then `nix shell nixpkgs#nodejs --command npx -y chrome-devtools-mcp@latest --executable-path=$chrome` to start the server. Every input is resolved through Nix, and nothing gets dropped into your project tree as a side-effect.
 
 <Tip title="Provenance">
   This package was extracted from [Kolu](https://kolu.dev)'s own `/perf-diagnose` skill — see [the WebGL-leak debugging post](/blog/xtermjs-perf/) for what we use it for. After iterating on the shape inside Kolu, we lifted it into its own repo under Apache 2.0 ([juspay/nix-chrome-devtools-mcp#1](https://github.com/juspay/nix-chrome-devtools-mcp/pull/1)) so any Nix-using AI-agent project can drop it in.

--- a/website/src/content/blog/surface-framework.md
+++ b/website/src/content/blog/surface-framework.md
@@ -1,62 +1,35 @@
 ---
 title: "Announcing @kolu/surface: typed reactive state for SolidJS + oRPC"
-description: "A small framework that owns the snapshot+deltas wire protocol so your Solid client and oRPC server stop hand-rolling it. Five primitives, one declaration, contract derived end-to-end."
+description: "I'd written the same dozen lines of subscribe-reconcile-retry code so many times I stopped seeing them. @kolu/surface is what happened when I finally asked what I'd extract before accepting one more copy."
 pubDate: 2026-05-04
 author: "Sridhar Ratnakumar"
 ---
 
-[`@kolu/surface`](https://github.com/juspay/kolu/tree/master/packages/surface) is a small framework for SolidJS clients backed by an oRPC streaming server. **Declare the reactive surface of your app once; the framework derives the typed contract, the server router, and the client hooks from a single spec.** It owns the wire protocol — snapshot+deltas, retry-on-reconnect, per-channel pub/sub — so your domain code stops referencing channel names, store keys, retry contexts, or oRPC procedure refs.
+For a few weeks I kept writing the same code. Not similar code. The same code. On the client: subscribe to a streaming RPC, lift the stream of values into something [Solid](https://www.solidjs.com/) can react to, fold each new value into a local store, and send the errors to a toast. On the server, the mirror image — yield the current value, then sit in a `for await` loop yielding the changes, and somewhere else, on every mutation, remember to publish the change so that loop has something to yield. I wrote it for the terminal list. Then for preferences. Then for git status. By the fifth time I could type it without thinking, **which is exactly the problem.**
 
-It was extracted from [Kolu](https://kolu.dev) and now ships as a workspace-private package alongside it. This post walks through why the framework exists, the five primitives it offers, the API for defining and implementing a surface, the runnable example, and how Kolu itself uses it.
+Because here's the thing I was slow to see: none of it was about [Kolu](https://kolu.dev). The schema changed each time. The name of the procedure changed. The pair of channel and payload type changed. And that was all that changed. The order of the frames — full snapshot first, then deltas — was always the same. The retry behavior was the same. The publish-then-subscribe symmetry was the same. The little branch in the store write, reconcile if it's an object and assign if it's a scalar, was the same. I was hand-copying the wiring of a house and changing nothing but which appliance I plugged in.
 
-## Why: electricity
+## Electricity
 
-In [_Righting Software_](https://www.amazon.com/Righting-Software-Method-Engineering-Architecture/dp/0136524036), Juval Löwy argues that infrastructure should feel like the **electricity** in a building: invisible, ubiquitous, plugged into via simple sockets. Domain code is the appliance you swap. The wiring stays put. **Volatility-based decomposition** is the discipline of deciding which is which. (The analogy is also developed in the [InformIT excerpt](https://www.informit.com/articles/article.aspx?p=2995357&seqNum=2) of Chapter 2 if you want a free read.)
+Juval Löwy has a good way of putting this. In [_Righting Software_](https://www.amazon.com/Righting-Software-Method-Engineering-Architecture/dp/0136524036) he says infrastructure should be like the [electricity](https://www.informit.com/articles/article.aspx?p=2995357&seqNum=2) in a building. You don't run a new wire every time you buy a toaster. The wiring is in the walls, you plug into a socket, and the toaster is the part you swap. His name for the discipline of sorting the wiring from the toaster is _volatility-based decomposition_, which is a mouthful, but the idea under it is plain. Find the parts that don't vary and bury them in the wall. My subscribe-reconcile-retry dance was wiring. I'd been stapling it to the outside of every wall in the house.
 
-Kolu's client had a dozen call sites doing the same thing: subscribe to an oRPC streaming RPC, lift the AsyncIterable into a Solid `Accessor`, reconcile new values into a local store, dispatch errors to a toast. Its server had the mirror image: hand-rolled `yield current; for await (ev of subscribeSystem(...)) yield ev` loops in every streaming handler, plus the parallel `publishSystem("X:changed", value)` write path threaded through every domain mutation.
+There's a test I've started using for whether something should be pulled out. Not "is this snippet clean?" That question has a bottomless number of yeses. The better question is: what would I be willing to extract as a utility before I'd accept one more per-call-site fix? When I asked it here the answer was everything. All of it. And when the answer is all of it, you're not looking at a snippet that needs tidying. You're looking at a snippet at the wrong _altitude_. **The framework is just the same code, moved up to where it stops repeating.**
 
-The pattern was obvious enough that I'd been writing it for weeks. It also turned out to have **no Kolu-specific decision in any of it.** The schema varied. The procedure name varied. The `(channel, payload type)` pair varied. Everything else — the snapshot-then-deltas frame ordering, the retry context, the publish-then-subscribe symmetry, the reconcile-vs-assign branch on the store write — was electricity.
+## Five shapes
 
-That's the bar for extraction: **what would I extract as utility before I'd accept any of these per-call-site fixes?** When the answer is "all of it," the question stops being _is this snippet clean?_ and becomes _is the snippet at the right altitude?_ The framework is the answer to the second question.
+So I pulled it out into a package, [`@kolu/surface`](https://github.com/juspay/kolu/tree/master/packages/surface), and the question became how many kinds of thing it had to know about. The answer turned out to be five, and the five are worth naming, because each one bites you at runtime if you pretend it's one of the others.
 
-## The surface package
+A `Cell` is a single current value. What's the theme right now? One of them, you can read it, you can set it. A `Collection` is the same idea but keyed: what's the current value for each id? Many of them, you set any one by key. A `Stream` is read-only and derived from something the server doesn't own — git, the filesystem, the network. What's the live output for this input? You can read it. You can't set it. An `Event` has no current value at all. Has the thing happened yet? You don't render it; you handle it when it fires. And a `Procedure` is the boring one: run a side-effect on the server, get an answer back. A plain RPC, living in the same namespace as the rest.
 
-`@kolu/surface` exposes **five primitives**. Each captures a structurally distinct shape that bites at runtime if collapsed into a single primitive:
+You might reasonably ask why these aren't one primitive with some flags. I tried that first. It collapses badly. The distinction that finally convinced me is the one between a Cell and a Stream, and it's older than this framework — it comes from [reflex-frp](https://github.com/reflex-frp/reflex), where the shapes are called `Dynamic` and `Incremental` and `Event`. A Cell is an identity over time: the same logical thing, whose value evolves, like your preferences. You can set it because you own it. A Stream isn't a thing at all; it's a function being re-run. The list of files that changed in your repo isn't a value Kolu owns — git owns it, and Kolu is watching. You can't `set` that without quietly becoming the cache, and the moment you're the cache you've signed up to be wrong. So a Stream is read-only, and the type system won't let you forget. Each of the five carries an invariant like that. Collapse them and you move the invariant from something the compiler checks to something you have to remember. **And you will not remember.**
 
-| Primitive | The question it answers | Cardinality | Persistable | Mutable from client | Has current value |
-|-----------|-------------------------|-------------|-------------|---------------------|-------------------|
-| `Cell<T>` | "What's the current X?" | One singleton | Optional | Yes | Yes |
-| `Collection<K,T>` | "What's the current X for each key K?" | Many, keyed | Optional | Yes | Yes (per key) |
-| `Stream<I,T>` | "What's the live output for input I?" | One per input combo | Never | No (read-only) | Yes |
-| `Event<I,T>` | "Has X happened yet?" | Occurrences over time | Never | No (read-only) | **No** — handler-based |
-| `Procedure` | "Run this side-effect on the server" | Per call | n/a | Yes (RPC) | n/a |
+Anything that fits none of the five stays raw [oRPC](https://orpc.unnoq.com/). There's a one-line escape hatch, `streamCall(client.X.Y, input, opts)`, that threads the same retry context the rest of the framework uses, so dropping to the metal doesn't cost you the plumbing you actually wanted. A bidirectional binary stream isn't a Cell. Don't make it one.
 
-Cell, Collection, and Stream are *state* — there's a current value the consumer renders. Event is *occurrence* — a handler fires per yield, no current value to read. Procedure is *imperative* — a request/response RPC bound to the same surface namespace as the reactive primitives.
+## One spec, three places
 
-The vocabulary borrows from [reflex-frp](https://github.com/reflex-frp/reflex)'s `Dynamic` / `Incremental` / `Event` lattice, translated to an oRPC wire boundary. The structural difference between Cell and Stream comes from there directly: **Cells are identities over time** (same logical entity, value evolves; you can `set` one), while **Streams are functions being re-evaluated** (server-derived from external state — git, fs, network — that the framework doesn't own; you can't `set` one without becoming the cache).
+The whole thing is declared once and read from three places. You write a spec — the cells, collections, streams, events, and procedures, each with its [Zod](https://zod.dev/) schema. From that one spec the framework derives the typed contract, the server router, and the client hooks. There's no parallel list to keep in sync, which matters, because the parallel list is the thing that always drifts.
 
-Anything genuinely outside these shapes — bidirectional binary streams, custom retry plumbing — stays as raw oRPC, accessed via a one-line `streamCall(client.X.Y, input, opts)` escape hatch that threads the same retry context the hooks use.
-
-## The API
-
-A surface is declared in three places — common, server, client — each layer derived from the same spec.
-
-```
-common/  defineSurface({ cells, collections, streams, events, procedures })  ─┐
-                                  │                                           │ contract
-                                  ▼                                           │ derived
-server/  implementSurface(surface, { channel, cells, collections, … })  ◀────┘
-                                  │
-                                  ▼
-client/  surfaceClient(surface, { transport })
-                ├─ rpc            (raw oRPC client, retry-wired)
-                ├─ cells          (.use, .upsert, .patch)
-                ├─ collections    (.use, .upsert, .remove)
-                ├─ streams        (.use)
-                └─ events         (.use)
-```
-
-### Define (`common/surface.ts`)
+Here's the spec for a little notes app:
 
 ```ts
 import { defineSurface } from "@kolu/surface/define";
@@ -106,16 +79,11 @@ export const surface = defineSurface({
     },
   },
 });
-
-// `surface.contract` is a typed oRPC router built statically from the
-// spec — no parallel literal to maintain. Use it on both sides:
-//   server: const t = implement(surface.contract);
-//   client: websocketLink<typeof surface.contract>(ws);
 ```
 
-A single mapped helper `SurfaceTypes<typeof surface.spec>` lifts the runtime types out of the spec, so consumers reach for `SF["cells"]["prefs"]["Value"]` instead of maintaining a parallel set of `z.infer` aliases. The spec is the single source of truth for schemas, defaults, and types.
+There's no second copy of the types. `surface.contract` is a real oRPC router built from the spec at compile time, and a mapped helper lifts the runtime types straight out, so on both sides you reach into `SF["cells"]["prefs"]["Value"]` instead of maintaining your own `z.infer` aliases. The spec is the only source of truth for the schemas, the defaults, and the types. **One place.**
 
-### Implement (`server/surface.ts`)
+The server side fills the spec in — how to read all the notes, how to upsert one, how to watch for changes:
 
 ```ts
 import {
@@ -166,19 +134,13 @@ export const { router, ctx } = implementSurface(surface, {
     },
   },
 });
-
-// Spread `router` into a host `t.router({...})` alongside any hand-written
-// raw-oRPC blocks; import `ctx` from domain modules for typed mutations:
-//   ctx.cells.prefs.set(next)
-//   ctx.collections.notes.upsert(id, value)
-//   ctx.events.autosave.publish(noteId, payload)
 ```
 
-`implementSurface` returns `{ router, ctx }`. The `ctx` is the typed mutation surface domain code uses to write through the framework — every mutation flows through one apply+publish chain, so there's no parallel `store.set + bus.publish` path that can drift.
+`implementSurface` hands back `{ router, ctx }`. The `ctx` is the part your domain code writes through — `ctx.cells.prefs.set(next)`, `ctx.collections.notes.upsert(id, value)`. Every mutation goes through one apply-then-publish chain. There's no second path: no place where someone sets the store but forgets to publish, or publishes a value that never made it into the store. That second path was the source of half my reconnect bugs. **Now it doesn't exist.**
 
-For Streams, the framework absorbs two common shapes. The poll-on-event form (above) is for state the server doesn't own — files, git refs, anything that fires "something changed" without telling you what. Provide `read` + `install` + `isEqual` and the framework handles snapshot-then-deltas, equality-suppression, and reconnect. Or provide a raw `source: (input, signal) => AsyncIterable<T>` for cases that don't fit poll-on-event.
+Streams come in two shapes and the framework absorbs both. Most of the time you're watching something you don't own — a file, a git ref — and all you get is a "something changed" nudge with no payload. For that you hand over three functions: how to read the current value, how to install a listener, and how to tell whether two values are equal. The framework does the rest, snapshot then deltas, suppressing the no-op changes, re-reading on reconnect. When that shape doesn't fit, you give it a raw `source` that yields, and it gets out of your way.
 
-### Consume (`client/wire.ts`)
+On the client, each primitive is pre-bound to its wire identity, so the call site never mentions it:
 
 ```ts
 import { surfaceClient } from "@kolu/surface/solid";
@@ -217,76 +179,15 @@ app.events.autosave.use(
 const note = await app.rpc.surface.notes.create({ title: "Untitled" });
 ```
 
-The bound `.use()` shape is the headline ergonomic win. Compared to passing procedure refs at every call site, the surface client pre-binds each primitive to its oRPC entry, drops the wire-identity args, and threads `STREAM_RETRY` context internally. The hooks **own the snapshot+deltas reconcile path**, the per-key reactive lifecycle (via `mapArray`), the local-authority optimistic merge (for cells with `authority: "local"`), and the resubscribe-on-reconnect cleanup.
+The bound `.use()` is the part I'm happiest with. Instead of passing a procedure reference at every call site, the client has already wired each primitive to its oRPC entry, dropped the identity arguments, and threaded the retry context inside. The hooks own the snapshot-and-deltas reconcile, the per-key reactive lifecycle, the optimistic local merge for the cells you mark `authority: "local"`, and the resubscribe-on-reconnect cleanup. You ask for `app.cells.prefs.use(...)` and you get a value that's still correct after a dropped connection, without your having typed the word "reconnect."
 
-## What the framework absorbs
+## What it deleted
 
-So you don't write any of these per call site:
+The easiest way to say what the framework does is to count what it removed. About 800 lines of plumbing across the client and server. But the number that tells the story better is the set of things that now appear zero times in Kolu's code. Zero hand-written `yield current; for await (…) yield ev` loops in the router. Zero `publishSystem("X:changed", value)` calls — every publish goes through a typed channel whose name is derived from the key, so nobody writes the string `"X:changed"` and nobody typos it. Zero hand-threaded retry contexts in client code. Zero `pollOnEvent` wrappers. Zero `AbortController` plumbing in the providers.
 
-- **Snapshot+deltas wire protocol** — every server handler yields a fresh full snapshot first, then deltas; the streaming retry plugin re-invokes the source on every reconnect, so the new iterator's first yield replaces stale client state. Get this wrong and reconnects silently lose state.
-- **Retry context** — `ClientRetryPlugin` parameterized at both `RPCLink` and `ContractRouterClient` so per-call `{ context }` options type-check; the hooks thread `STREAM_RETRY` (infinite retry on transport, propagate `ORPCError`) automatically.
-- **Per-key channels** — `Channel<T>.publish(v)` / `.subscribe(signal)` / `.consume({ onEvent, onError })`. Channel names derive from the surface key; domain code never types `"X:changed"`.
-- **Reconcile vs assign** — primitives get plain assignment; objects/arrays go through Solid's `reconcile` for fine-grained reactivity.
-- **Per-collection lifecycle** — `useCollection` runs `mapArray` over the live key set; each key gets its own reactive owner, automatically disposed when the key leaves.
-- **Local authority's "ignore subsequent echoes"** — `useCell` with `authority: "local"` reconciles the first server yield, then ignores the subscription so an unrelated event piggybacking on the same channel doesn't stomp a just-made client write whose RPC hasn't round-tripped yet.
+And the number I care about most: **adding a new cell to Kolu now touches two files.** The descriptor in one, the wiring in the other. The client gets it for free.
 
-## The runnable example
-
-`packages/surface/example/` is a minimal in-memory notes app demonstrating all five primitives end-to-end. ~500 LOC across server + client + common; single-file `App.tsx` with every hook visible; SolidJS + Tailwind v4. Self-contained — no Kolu-internal imports, just `@kolu/surface/{*}` plus the standard oRPC + Hono + Vite stack.
-
-```sh
-just surface-example
-```
-
-Enters the Nix devshell and starts the Hono server (port 7700) plus Vite dev server (port 5174) in parallel.
-
-| Primitive | What the example demonstrates |
-|---|---|
-| `Cell<EditorPrefs>` | Editor preferences (font size, theme). `authority: "local"` for instant-UI mutation; `applyPatch` defaulted from the spec's `patch` so server and client merge with the same function. |
-| `Collection<NoteId, Note>` | Notes keyed by id. Sidebar list with per-key reactive lifecycle. `notes.upsert` / `notes.delete` are framework-bound; `notes.create` is an imperative procedure that mints the id server-side. |
-| `Stream<{query}, SearchResult>` | Full-text search, one-shot per query. `useStream` re-subscribes on input change; the server runs the source once and closes. Demonstrates the raw `source` shape. |
-| `Event<NoteId, AutosaveEvent>` | "Saved" flash beside the active note title. Per-id channel; the autosave debounce in the server publishes to it; the client's `useEvent` handler triggers the flash. |
-| `Procedure` | `notes.create` — the imperative escape hatch for verbs the primitives can't model (id minting, cross-primitive coordination). |
-
-The example existed first as a tractable substrate for iterating on the framework itself. **The discipline is that any framework change has to land on the example before it touches Kolu.** That keeps the API decisions visible end-to-end at 500 LOC instead of buried in Kolu's hundred-file consumer codebase.
-
-## How Kolu uses it
-
-Kolu has 10 typed primitives plus a handful of imperative procedures and raw streaming shapes. Every server-pushed reactive surface in Kolu maps to one entry in `packages/common/src/surface.ts`.
-
-### Cells
-
-| Descriptor | Backs | Authority | Persistence |
-|---|---|---|---|
-| `preferences` | User preferences (theme, scrollLock, sound, right-panel state, …) | `local` | `confStore("preferences")` |
-| `terminalList` | Live terminal list — drives the pill tree, canvas tile set, mobile swipe order | `server` | `inMemoryStore` (registry is canonical) |
-| `activityFeed` | Recent repos cd'd into + recent agent CLIs spotted via OSC 633;E | `server` | `confStore("activityFeed")` |
-| `session` | Last-persisted snapshot of terminals + active id (drives session restore) | `server` | `confStore("session")` |
-
-### Collections
-
-| Descriptor | Backs |
-|---|---|
-| `terminalMetadata` | Per-terminal metadata (cwd, git, PR, agent state, foreground process) — each terminal's tile chrome and inspector reads its own key |
-
-### Streams
-
-| Descriptor | Backs |
-|---|---|
-| `gitStatus` | Code-view's Local/Branch mode file list (changed files) |
-| `gitDiff` | Code-view's unified diff for the selected file |
-| `fsListAll` | Code-view's All-mode tree (full repo path list) |
-| `fsReadFile` | Code-view's All-mode body (file content) |
-
-### Events
-
-| Descriptor | Backs |
-|---|---|
-| `terminalExit` | Per-terminal one-shot exit notification — drives the exit toast and the active-terminal auto-switch |
-
-### Raw oRPC (everything else)
-
-Shapes that don't fit a primitive stay imperative — terminal lifecycle (`create`/`kill`/`resize`/`sendInput`/...), git mutations (`worktreeCreate`/`worktreeRemove`), screen queries, and the bidirectional binary `terminal.attach` stream. They live in a hand-written `oc.router({...})` alongside `surface.contract`. The composition is one spread:
+In Kolu itself there are four cells — user preferences, the live terminal list, an activity feed of recent repos and agents, and the session snapshot that drives restore. One collection, for the per-terminal metadata each tile reads off its own key. Four streams behind the code view: the changed-file list, the diff for the selected file, the full repo tree, and the contents of one file. One event, for a terminal exiting, which fires the exit toast and the auto-switch. Everything that doesn't fit a shape stays imperative — terminal create, kill, resize, the git worktree mutations, the bidirectional binary attach stream — and lives in a hand-written router right next to the generated one. The two compose with a single spread:
 
 ```ts
 export const contract = oc.router({
@@ -295,39 +196,18 @@ export const contract = oc.router({
 });
 ```
 
-### What disappeared from Kolu
+## What it won't do
 
-The framework absorbed roughly 800 lines of plumbing across client and server:
+Now the part where I tell you what it can't do, which is usually more honest than the feature list. Kolu has one client per session, and the framework is built for exactly that. It doesn't carry the machinery you'd need for a hundred clients watching the same key — no refcounting, no query-cropping, none of the cross-network sharing that reflex-frp grows for that case. That machinery is real and it's good, and Kolu doesn't have the problem it solves, so paying for it would be plumbing with no payback. It also doesn't try to compose primitives into bigger primitives. Solid already has `createMemo` and `on` for that, and the framework's job ends at the wire. I kept wanting to make it cleverer and kept stopping, because every time I looked, **the clever version was solving a problem I didn't have.**
 
-- **Zero** call sites of `createSubscription` / `createReactiveSubscription` outside `@kolu/surface/solid`.
-- **Zero** hand-rolled `yield X; for await (ev of subscribeSystem_(...)) yield ev` loops in `router.ts`.
-- **Zero** `publishSystem("X:changed", value)` or `publishForTerminal(channel, id, v)` calls — every server-side publish flows through a typed `Channel<T>`.
-- **Zero** `import { stream }` or hand-threaded `STREAM_RETRY` in client code — the bound layer threads context internally.
-- **Zero** `pollOnEvent` wrappers per stream — declarative `{ read, install, isEqual }` synthesizes inside the framework.
-- **Zero** `AbortController + consumeChannel` plumbing in meta providers — `Channel.consume` owns the controller and returns the cleanup.
+There's a runnable example in the repo — a tiny in-memory notes app, about 500 lines, with all five primitives visible in a single `App.tsx`. `just surface-example` starts it. I built the example before I built any of the framework, and I keep one rule: a change has to land in the example before it touches Kolu. The example is 500 lines and Kolu is a hundred files, and you can see an API mistake in the first long before you'd find it in the second.
 
-Adding a new cell in Kolu now touches **two files**: the descriptor in `packages/common/src/surface.ts`, the wiring in `packages/server/src/surface.ts`. The client gets it for free via `app.cells.X.use(...)`.
+## Subtraction
 
-## What the framework deliberately doesn't do
+**The work from here is subtraction, not addition.** That sounds like a pose, so here's what's already gone. A consumer escape hatch called `mergeIntoStore`, deleted once the schema shape made it unnecessary. A per-stream `pollOnEvent` wrapper, folded into the three-function declaration. A `consumeChannel` helper, folded into the channel itself. Each one was a thing the framework was half-doing, and the fix in every case was to do it the rest of the way and delete the seam. There's a list of more: some type-oracle helpers that exist only to be `ReturnType`'d and might collapse; a generic parameter that's uglier than it should be because the type checker runs out of patience expanding two big types in one pass; a few schema field names I'd pick differently now and can still change cheaply, because there's exactly one consumer — and the day there are two, the names are frozen.
 
-Kolu is single-client per session. The framework doesn't carry plumbing it doesn't need:
+It's internal-only, by the way. `@kolu/surface` ships inside Kolu, not as its own package, and the API is still moving. Don't reach for it from outside yet.
 
-- **No `Behavior`-style pull-only sampling.** Reflex's `Behavior t a` is a function `t -> a` you sample without subscribing. In a Solid client we have closures and `createMemo`; nothing the framework ships needs to model "value at time t" as a separate concept.
-- **No cross-network query machinery.** Reflex's `Group q` / `crop` / `SelectedCount` story (used in Obelisk / Focus) pays off when 100 clients are watching the same key. Single-client kolu doesn't have that problem; refcounting + crop projections would be plumbing without payback.
-- **No monadic Dynamic composition.** Reflex composes `Dynamic`s into bigger `Dynamic`s monadically (`bind`, `joinDyn`, `holdDyn`). We expose Solid's primitives (`createMemo`, `on`, `derive`) for that — the framework's job stops at the wire boundary.
-- **No one-primitive-fits-all.** Cell/Collection/Stream/Event are split because the type-level distinctions encode domain invariants the type system enforces. A `Stream` is read-only and never persisted; an `Event` has no current value to render; `Cell.default` is one canonical seed shared across consumers. Collapsing those would move invariants from compile-time enforcement to runtime convention.
-
-## Where it goes from here
-
-> **Status: internal-use only.** `@kolu/surface` is workspace-private and shipped alongside Kolu, not as a standalone package. The API is still settling — the recent passes already deleted `mergeIntoStore` (consumer escape hatch absorbed into a flat-shape schema), absorbed `pollOnEvent` (per-stream wrapper became a declarative `{ read, install, isEqual }`), and folded `consumeChannel` into `Channel<T>.consume`. Each was a "thing the framework was half-providing"; expect more of the same. Don't reach for it from outside Kolu yet.
-
-The frame for ongoing work is **subtraction, not addition**. Each iteration tries to remove a concept the consumer needs to know about. The remaining axes:
-
-- **Further simplification.** The `build*` type-oracle helpers in `define.ts` (eight runtime-dead functions kept only for `ReturnType<typeof X>` inference) are still a pattern that could collapse if mapped types could derive from runtime entry-builders directly. The `surfaceClient` generic awkwardness (`Rpc` parameter defaulted because TS's union-resolution budget can't expand both `SurfaceContractFor<S>` and `ContractRouterClient<...>` in the same pass) is another smell that wants resolution. Schema suffix naming (`CellSpec.schema`, `CollectionSpec.keySchema`) survived from the first pass and is cheap to fix in-flight, expensive once a second consumer arrives.
-- **Schema-walking for discriminated-union reconciliation.** Solid's `setStore` deep-merge can't preserve DU variant invariants without a per-path `reconcile` call, which forces consumers to pass a `mergeIntoStore` escape hatch. The framework could walk the cell's Zod schema once at registration, find every `z.discriminatedUnion` subtree, and reconcile those automatically. Kolu's only DU-shaped storage was already flattened (the right-panel `tab` field is now `activeTab` + `codeMode`), so the walker doesn't earn its keep yet.
-- **Derived streams** (`{ from, compute }` over a graph dep) — designed and built once, then deleted because neither Kolu nor the example needed it. The shape is genuinely the right design for server-derived primitives; it just doesn't have a use case yet. A second consumer with a server-side derivation requirement would resurrect it.
-- **Implicit dep tracking via Solid server-side.** The most ambitious axis: run Solid's reactive runtime on the server too, so a stream's `compute` body declares its inputs by reading them — same `createMemo` semantics, no `from:` prelude. That collapses the framework's surface area further but adds a runtime dep both sides have to agree on.
-
-For now: Cell, Collection, Stream, Event, Procedure. Five shapes the framework type-system-enforces, derived from one spec, snapshot+deltas on the wire, retry-resilient. Kolu's domain code stops referencing channel names, store keys, retry contexts, or oRPC procedure refs. The framework's job is to keep shrinking the consumer's API surface, not to grow into a general-purpose library.
+Five shapes, then. Cell, Collection, Stream, Event, Procedure. One spec, derived three ways, snapshot-and-deltas on the wire, and a domain layer that no longer knows the name of a single channel. The job was never to grow a library. It was to get the wiring back into the walls — and then to keep finding the wires I'd left stapled to the outside.
 
 [`@kolu/surface` source](https://github.com/juspay/kolu/tree/master/packages/surface) · [the runnable example](https://github.com/juspay/kolu/tree/master/packages/surface/example) · [Kolu's surface declaration](https://github.com/juspay/kolu/blob/master/packages/common/src/surface.ts)

--- a/website/src/content/blog/xtermjs-perf.md
+++ b/website/src/content/blog/xtermjs-perf.md
@@ -1,130 +1,55 @@
 ---
-title: "The leak that wasn't in any Context"
+title: "Measuring the Wrong Thing"
 description: "One afternoon, two xterm.js contributions, and a reminder that proxy metrics can be wrong by three orders of magnitude."
 pubDate: 2026-04-18
 author: "Sridhar Ratnakumar"
 ---
 
-_One afternoon, two xterm.js contributions, and a reminder that proxy
-metrics can be wrong by three orders of magnitude._
+[Kolu](https://github.com/juspay/kolu) is a terminal-native cockpit for coding agents — `claude`, `opencode`, whatever ships next week. The terminal is the universal interface: every pane is a real [xterm.js](https://xtermjs.org/) in the browser, wired over a WebSocket to a PTY on the server, and Kolu just watches what you already do — the repos you `cd` into, the agents you run — to build its UI. No agent adapters, no preferences pane. Run a new agent once and it shows up in the command palette the next time you want it.
 
-[Kolu](https://github.com/juspay/kolu) is a terminal-native cockpit for
-coding agents — `claude`, `opencode`, whatever ships next week.
-The terminal is the universal interface: every pane is a real
-[xterm.js](https://xtermjs.org/) in the browser, connected over
-WebSocket to a PTY on the server, and Kolu watches what you already
-do (the repos you `cd` into, the agents you run) to populate its
-UI. No agent adapters, no preferences pane. Run a new agent once
-and it appears in the command palette the next time you need it.
+Yesterday I shipped [canvas mode](https://x.com/sridca/status/2044953014100726221): instead of stacking terminals in a sidebar, you drag them around a freeform 2D canvas, like windows on a desk. Cute demo, people liked it, and — within hours of it going live on the always-on Kolu instance on my headless dev box — the thing that drove the tab to 1.2 GB.
 
-Yesterday I shipped [canvas mode](https://x.com/sridca/status/2044953014100726221):
-instead of stacking terminals in a sidebar, you drag them around a
-freeform 2D canvas like desktop windows. Cute demo, popular feature,
-and — within hours of me updating the always-on Kolu instance on my
-headless dev box — the thing that made the tab footprint climb to
-1.2 GB.
+Toggle canvas on, toggle it off, thirty times. Chrome's Task Manager kept climbing. Stop, leave the tab alone, come back an hour later: still 1.2 GB. Close the tab, reopen it: 300 MB. Toggle thirty times: 1.2 GB again.
 
-Toggle canvas-on, toggle canvas-off, repeat thirty times. Chrome Task
-Manager kept climbing. Stop toggling, leave the tab alone, come back
-in an hour: still 1.2 GB. Close the tab. Reopen. 300 MB again.
-Toggle thirty times. 1.2 GB.
+This is the story of finding that leak, told honestly — the two wrong hours, the one good diff, the one-line fix, and the two small patches I sent upstream to xterm.js on the way. I drove; [Claude Code](https://claude.com/claude-code) did the agent-side work.
 
-This is the story of finding the leak, told honestly: the two
-wrong hours, the one good diff, the one-line fix, and the two small
-patches I upstreamed to xterm.js along the way. I drove; [Claude
-Code](https://claude.com/claude-code) did the agent-side work.
-
-## First pass: the bus-stop fix
+## The bus-stop fix
 
 <div class="tweet-embed">
 <blockquote class="twitter-tweet" data-dnt="true" data-theme="dark"><p lang="en" dir="ltr">Debugging Kolu memory leak in Kolu itself on iPhone whilst waiting at the bus stop. <a href="https://t.co/ysFvgmHZoS">pic.twitter.com/ysFvgmHZoS</a></p>&mdash; Sridhar Ratnakumar (@sridca) <a href="https://twitter.com/sridca/status/2045164268341895434?ref_src=twsrc%5Etfw">April 17, 2026</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </div>
 
-The first pass at the leak happened earlier that day on the bus to
-the swimming pool, then again checking it on the way back,
-typing instructions to Claude Code on my phone and watching retainer
-walks come back between stops. That pass found a
-dispose-registration gap inside xterm itself: two `MutableDisposable`
-fields in `RenderService` and `WebglRenderer` were declared with `=
-new MutableDisposable()` but never wrapped in `this._register(...)`.
-Without that registration, xterm's `Disposable` base class never
-disposed them on teardown, so a `setInterval` for the cursor blink
-and a debounced resize task kept ticking past `terminal.dispose()`.
-Six lines of source. [xtermjs/xterm.js#5817](https://github.com/xtermjs/xterm.js/pull/5817).
+The first crack at it happened on the bus to the swimming pool, and again on the way back — typing instructions to Claude Code on my phone and watching retainer walks come back between stops. That pass found a real bug, just not the one I was chasing. Two `MutableDisposable` fields in xterm — one in `RenderService`, one in `WebglRenderer` — were created with `= new MutableDisposable()` but never wrapped in `this._register(...)`. Without that registration, xterm's `Disposable` base class never tore them down, so a `setInterval` for the cursor blink and a debounced resize task kept ticking long after `terminal.dispose()`. Six lines of source: [xtermjs/xterm.js#5817](https://github.com/xtermjs/xterm.js/pull/5817).
 
-Deploy. Chrome Task Manager, GPU Memory column: dropped from steady-
-climbing to flat. Memory Footprint column: unchanged. GPU was a
-symptom of its own leak, not the big one.
+Deploy. Chrome's Task Manager, GPU Memory column: the steady climb went flat. Memory Footprint column: unchanged. So the GPU thing was a leak — its own small leak — but not the one eating the gigabyte. **I'd fixed a symptom.**
 
 ## The wrong turn
 
-Kolu uses [SolidJS](https://www.solidjs.com/), which tracks
-reactivity through [`system/Context`](https://developer.chrome.com/docs/devtools/memory-problems/heap-snapshots#system-context)
-objects — V8's name for the block of memory that holds a closure's
-captured variables. If a component's scope fails to clean up on
-unmount, its `Context` lingers, and everything that scope closes
-over lingers with it. Classic retention.
+Kolu uses [SolidJS](https://www.solidjs.com/), which tracks reactivity through [`system/Context`](https://developer.chrome.com/docs/devtools/memory-problems/heap-snapshots#system-context) objects — V8's name for the block of memory that holds a closure's captured variables. If a component's scope doesn't clean up on unmount, its `Context` hangs around, and everything that scope closed over hangs around with it. _Retention_, the textbook kind.
 
-Claude took the usual first steps. Open Chrome DevTools → Memory tab.
-Take a [heap snapshot](https://developer.chrome.com/docs/devtools/memory-problems/heap-snapshots)
-before, thirty toggles, snapshot after. Look at instance count growth
-per class. Tens of thousands of new `system/Context` and `closure`
-objects between the two snapshots. Chase the retainer chains. Find
-the usual SolidJS-shaped culprits:
+So Claude took the obvious first steps. Chrome DevTools, Memory tab. [Heap snapshot](https://developer.chrome.com/docs/devtools/memory-problems/heap-snapshots) before, thirty toggles, snapshot after. Diff the instance counts per class. Tens of thousands of new `system/Context` and `closure` objects between the two. Chase the retainer chains. Find exactly the SolidJS-shaped culprits you'd expect:
 
-- Inline JSX event handlers (`<div onClick={() => terminal.focus()}>`)
-  that share a V8 lexical scope with everything else in the component
-  body. One closure in that scope captures something heavy; the whole
-  scope gets pinned.
-- Third-party component libraries (`@corvu/resizable`,
-  `@thisbeyond/solid-dnd`) that register internal contexts and don't
-  always tear them down cleanly.
+- Inline JSX handlers (`<div onClick={() => terminal.focus()}>`) that share one V8 lexical scope with the whole component body. One closure in that scope captures something heavy, and the entire scope gets pinned.
+- Component libraries (`@corvu/resizable`, `@thisbeyond/solid-dnd`) that register internal contexts and don't always tear them down cleanly.
 
-Six commits landed on [a branch](https://github.com/juspay/kolu/pull/614)
-over the afternoon. Claude replaced the two libraries with 200 lines
-of custom code. Delegated every inline handler to the parent.
-`Context` count per 30-toggle run went from +11,025 down to +1,208.
-An 89% reduction. Claude wrote the PR, drew a mermaid graph of the
-staircase. I deployed to my dev box.
+Six commits landed on [a branch](https://github.com/juspay/kolu/pull/614) over the afternoon. Claude swapped both libraries for 200 lines of our own code, delegated every inline handler to the parent, and got the `Context` count per 30-toggle run from +11,025 down to +1,208. An 89% cut. It wrote the PR and drew a tidy mermaid graph of the staircase coming down. I deployed.
 
-Chrome Task Manager showed no change. Zero. Identical to before.
+Chrome's Task Manager showed no change. None. **The number I'd spent the afternoon cutting wasn't the number that mattered.**
 
 ## What I was actually measuring
 
-Chrome's [Task Manager](https://developer.chrome.com/docs/devtools/memory-problems#monitor_memory_use_in_realtime_with_the_chrome_task_manager)
-has three columns that matter for a tab: `JavaScript Memory`,
-`GPU Memory`, and `Memory Footprint`. The first two are what they
-sound like. `Memory Footprint` is the one that matters: the total
-resident size the operating system assigns to the tab's renderer
-process. It's an aggregate — it rolls up the JS heap, the GPU
-textures, Chrome's per-renderer baseline (~100-150 MB), V8's code
-cache, and a category that isn't called out as its own column but
-turned out to be the big one here:
+Chrome's [Task Manager](https://developer.chrome.com/docs/devtools/memory-problems#monitor_memory_use_in_realtime_with_the_chrome_task_manager) shows three columns for a tab: `JavaScript Memory`, `GPU Memory`, and `Memory Footprint`. The first two are what they sound like. `Memory Footprint` is the one that counts — the total resident size the operating system hands the tab's renderer process. It rolls everything up: the JS heap, the GPU textures, Chrome's per-renderer baseline (~100–150 MB), V8's code cache, and one more thing that gets no column of its own and turned out to be the whole story.
 
-**Native-side state backing the DOM and typed-array objects.** SVG
-element attributes, detached canvases, and — the one that mattered —
-[`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)
-backing stores. An `ArrayBuffer` is the raw byte block that a typed
-array (a `Uint32Array` etc.) is a typed view of; it lives outside
-what [`performance.memory`](https://web.dev/articles/monitor-total-page-memory-usage)
-can see. Kilobytes of typed-array object metadata in the JS heap can
-correspond to megabytes of `ArrayBuffer` bytes in the native heap.
-The JS-side instance count tells you how many arrays exist; the
-aggregate `Memory Footprint` tells you how much memory they actually
-cost.
+_Native-side state backing the DOM and typed-array objects._ SVG attributes, detached canvases, and — the one that mattered — [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) backing stores. An `ArrayBuffer` is the raw block of bytes a typed array (a `Uint32Array`, say) is a view onto, and it lives outside what [`performance.memory`](https://web.dev/articles/monitor-total-page-memory-usage) can see. A few kilobytes of typed-array metadata in the JS heap can stand for megabytes of `ArrayBuffer` bytes in the native heap. The JS-side count tells you how many arrays exist. The aggregate footprint tells you what they cost.
 
-`system/Context` count is a JS-heap metric. Reducing it by 89% is
-meaningful if the leak is there. It's invisible if the leak is in
-native-side `ArrayBuffer` bytes.
+`system/Context` count is a JS-heap number. Cutting it by 89% means something if that's where the leak is. It means nothing if the leak is in native `ArrayBuffer` bytes.
 
-The leak was in native-side `ArrayBuffer` bytes.
+**The leak was in native `ArrayBuffer` bytes.**
 
 ## The one-line fix that took hours to find
 
-I told Claude to throw the PR away and start over with a different
-analyzer: aggregate `self_size` bytes per class across a snapshot
-pair, sort by byte growth. Five minutes of code, one line of output:
+I told Claude to throw the PR away and start over, this time with a different analyzer: sum `self_size` bytes per class across a snapshot pair, sort by byte growth. Five minutes of code, one line of output worth reading:
 
 ```
   dBytes        dCount    Class
@@ -132,18 +57,11 @@ pair, sort by byte growth. Five minutes of code, one line of output:
    10,535,640   175,594   object:Uint32Array
 ```
 
-220 megabytes. 175,594 retained [`Uint32Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array)s
-per 30 toggles.
+220 megabytes. 175,594 retained [`Uint32Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array)s per thirty toggles.
 
-The number factored obviously: 30 toggles × 7 terminals × ~830
-scrollback lines per terminal = 174,300. Every `xterm.js BufferLine`
-of every `Terminal` instance that had ever existed during those
-thirty toggles was still in memory. `terminal.dispose()` had fired
-for every one. The buffers were supposed to be gone.
+The number factored on sight: 30 toggles × 7 terminals × ~830 scrollback lines each = 174,300. Every `xterm.js BufferLine` of every `Terminal` that had existed during those thirty toggles was still in memory. `terminal.dispose()` had fired on every one of them. The buffers were supposed to be gone.
 
-Claude then walked BFS from the GC root to every retained
-`Uint32Array`. Every one of the 175,594 instances came back with the
-same retainer chain:
+So Claude walked BFS from the GC root out to each retained `Uint32Array`. All 175,594 came back with the same chain:
 
 ```
 Window.IntersectionObserver   (native browser registry)
@@ -154,25 +72,11 @@ Window.IntersectionObserver   (native browser registry)
   → Uint32Array
 ```
 
-xterm's [`RenderService`](https://github.com/xtermjs/xterm.js/blob/master/src/browser/services/RenderService.ts)
-wires an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
-(a browser API for "tell me when this element scrolls into or out of
-view") to the terminal's DOM element so it can pause rendering when
-the terminal isn't visible. Perfectly reasonable. The callback is an
-arrow function — it closes over `this` (the `RenderService` with its
-whole service graph). On dispose, xterm calls `observer.disconnect()`.
-In a clean environment, that releases the callback and the service
-graph can GC.
+xterm's [`RenderService`](https://github.com/xtermjs/xterm.js/blob/master/src/browser/services/RenderService.ts) hangs an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) — the browser API for "tell me when this element scrolls into or out of view" — on the terminal's DOM node, so it can stop rendering when the terminal isn't visible. Perfectly reasonable. But the callback is an arrow function, so it closes over `this`: the whole `RenderService` with its entire service graph. On dispose, xterm calls `observer.disconnect()`, and in a clean browser that frees the callback and the graph can be collected.
 
-In my environment, the callback stayed alive. Maybe a Chrome
-extension monkey-patched `window.IntersectionObserver`. Maybe DevTools
-was instrumenting it. I don't know. I spent some time trying to find
-out and gave up. The heap snapshot told me one thing that mattered:
-the callback was still in the native registry, holding `this`.
+In my browser it didn't. Maybe an extension had monkey-patched `window.IntersectionObserver`. Maybe DevTools was instrumenting it. I spent a while trying to find out and gave up, because the snapshot had already told me the one thing I needed: the callback was still sitting in the native registry, holding `this`.
 
-You can break this chain defensively without knowing who's holding
-what. `WeakRef` a reference that tells the GC "hold this only if
-someone else is":
+And you can cut that chain without ever learning who's holding it. `WeakRef` the back-reference — tell the GC to keep `this` only if someone else is already keeping it:
 
 ```diff
  if ('IntersectionObserver' in w) {
@@ -190,41 +94,20 @@ someone else is":
  }
 ```
 
-While the `RenderService` has live strong references (which it does,
-as long as the terminal is on screen), `weakSelf.deref()` returns it
-and the handler runs exactly as before. When `terminal.dispose()`
-drops the strong references, `deref()` starts returning `undefined`
-and the entire `BufferService → BufferLine → Uint32Array` graph
-becomes collectable — which is what `disconnect()` was supposed to
-guarantee but doesn't, in practice.
+While the `RenderService` has live strong references — which it does the whole time the terminal is on screen — `weakSelf.deref()` hands it back and the handler runs exactly as before. When `terminal.dispose()` drops those references, `deref()` starts returning `undefined`, and the whole `BufferService → BufferLine → Uint32Array` graph becomes collectable. Which is what `disconnect()` was supposed to guarantee, and didn't.
 
-Deploy. Fresh tab, thirty toggles, quiet session: **Task Manager
-footprint flat.** The original +367 MB/30-toggles regression dropped
-to zero.
+Deploy. Fresh tab, thirty toggles, quiet session: **the footprint stayed flat.** The +367 MB-per-30-toggles regression went to zero.
 
 ## The xterm.js side
 
-Two upstream contributions fell out of the day's work:
+Two upstream patches fell out of the day:
 
-- [xtermjs/xterm.js#5817](https://github.com/xtermjs/xterm.js/pull/5817)
-  — the bus-stop patch above. Register the two `MutableDisposable`
-  fields. Six lines of source. Dropped the GPU-memory leak.
-- [xtermjs/xterm.js#5821](https://github.com/xtermjs/xterm.js/pull/5821)
-  — the `WeakRef` patch. One line of real code plus a comment
-  explaining why. Dropped the Memory-Footprint leak.
+- [xtermjs/xterm.js#5817](https://github.com/xtermjs/xterm.js/pull/5817) — the bus-stop patch. Register the two `MutableDisposable` fields. Six lines of source. Killed the GPU-memory leak.
+- [xtermjs/xterm.js#5821](https://github.com/xtermjs/xterm.js/pull/5821) — the `WeakRef` patch. One line of real code plus a comment saying why. Killed the Memory-Footprint leak.
 
-Both patches look laughably small. Both took hours of measurement,
-retainer-walking, and wrong turns to find. That's the shape of this
-kind of work; the ratio of code-volume to investigation-time is
-always roughly zero.
+Both look laughably small. Both took hours of measuring, retainer-walking, and wrong turns to find. **That's the shape of this work: the ratio of code written to time spent is about zero.**
 
-While these were unreleased, I consumed them via a `juspay/xterm.js`
-fork pinned in `pnpm.overrides`. #5817 has since merged upstream, and
-#5821 was closed in favour of the equivalent
-[#5831](https://github.com/xtermjs/xterm.js/pull/5831) (clear the
-observer reference on dispose); both shipped in the upstream
-`6.1.0-beta` line, so the override is now a plain version pin against
-the auto-published betas built from `xtermjs/xterm.js@master`:
+While they were unreleased I pulled them in through a `juspay/xterm.js` fork pinned in `pnpm.overrides`. #5817 has since merged upstream, and #5821 was closed in favor of the equivalent [#5831](https://github.com/xtermjs/xterm.js/pull/5831) (clear the observer reference on dispose); both shipped in the upstream `6.1.0-beta` line, so the override is now a plain version pin against the auto-published betas built from `xtermjs/xterm.js@master`:
 
 ```json
 "@xterm/xterm": "6.1.0-beta.225",
@@ -233,48 +116,18 @@ the auto-published betas built from `xtermjs/xterm.js@master`:
 
 ## What I'd tell past-me
 
-Three things to internalise if you came here from a backend or
-systems-programming background and web-frontend memory tooling feels
-murky:
+Three things, if you came to web-frontend memory work from a backend or systems background and the tooling feels murky.
 
-**The browser's Task Manager is the only ground truth.** Everything
-else — `performance.memory.usedJSHeapSize`, heap snapshot class
-counts, anything derived from the JS-side heap alone — is a proxy for
-what the tab actually uses. Proxies can drift from the truth by
-orders of magnitude, because the truth includes native DOM state,
-GPU buffers, and compositor layers that JS introspection can't reach.
-Before claiming a fix works: fresh tab, Task Manager baseline,
-reproducer, Task Manager after. No exceptions.
+The browser's Task Manager is the only ground truth. Everything else — `performance.memory.usedJSHeapSize`, heap-snapshot class counts, anything read off the JS heap alone — is a proxy for what the tab actually uses, and a proxy can be wrong by orders of magnitude, because the truth includes native DOM state, GPU buffers, and compositor layers that JS introspection can't reach. Before you claim a fix works: fresh tab, Task Manager baseline, reproducer, Task Manager after. **No exceptions.**
 
-**Sort heap diffs by bytes, not by instance count.** A 220 MB leak
-across 175,594 `Uint32Array` instances dominates any amount of churn
-in `system/Context` or `closure` counts. The biggest class by bytes
-almost always holds everything else via its closure chain; fixing
-something smaller first gets you zero footprint improvement.
+Sort heap diffs by bytes, not by instance count. A 220 MB leak across 175,594 `Uint32Array`s drowns out any amount of churn in `system/Context` or `closure` counts. The biggest class by bytes is almost always holding everything else through its closure chain, so fix it first. **Fix something smaller and you get zero footprint back.**
 
-**`.disconnect()`, `.dispose()`, and `removeEventListener()` are
-best-effort in the presence of browser extensions, DevTools, and
-native registries.** If a callback closes over heavy state and lives
-past its owner, the graph stays alive. `WeakRef` is cheap insurance:
-one `.deref()?.` in the callback path, zero behavioural change when
-the reference is live, clean GC when it isn't. Use it defensively on
-any callback you hand to `IntersectionObserver`, `MutationObserver`,
-`ResizeObserver`, or `EventTarget.addEventListener`.
+`.disconnect()`, `.dispose()`, and `removeEventListener()` are best-effort. In the presence of browser extensions, DevTools, and native registries, a callback that closes over heavy state and outlives its owner keeps the whole graph alive. `WeakRef` is cheap insurance: one `.deref()?.` in the callback path, no behavior change while the reference is live, clean collection when it isn't. **Use it on anything you hand to `IntersectionObserver`, `MutationObserver`, `ResizeObserver`, or `EventTarget.addEventListener`.**
 
-The commit hash is
-[c9794db](https://github.com/juspay/kolu/pull/617). My always-on Kolu
-tab sits at 300 MB now, and stays there.
+The fix is [c9794db](https://github.com/juspay/kolu/pull/617). My always-on Kolu tab sits at 300 MB now, and stays there.
 
-The full investigation history — including the wrong turns I glossed
-over here — lives in Kolu's repo alongside the tools that did the
-work:
+The full investigation history — including the wrong turns I glossed over here — lives in Kolu's repo alongside the tools that did the work:
 
-- [`docs/perf-investigations/memory-learnings.md`](https://github.com/juspay/kolu/blob/master/docs/perf-investigations/memory-learnings.md)
-  — three chapters of leak-hunts, with all the failed theories
-  preserved.
-- [`.apm/skills/perf-diagnose/SKILL.md`](https://github.com/juspay/kolu/blob/master/.apm/skills/perf-diagnose/SKILL.md)
-  — the runbook future Claude Code sessions will read before they
-  re-tread the proxy-metric path I spent the afternoon on.
-- [`docs/perf-investigations/scripts/`](https://github.com/juspay/kolu/tree/master/docs/perf-investigations/scripts)
-  — the heap-snapshot analyzers, including the byte-delta diff that
-  named the leak in one line.
+- [`docs/perf-investigations/memory-learnings.md`](https://github.com/juspay/kolu/blob/master/docs/perf-investigations/memory-learnings.md) — three chapters of leak-hunts, with all the failed theories preserved.
+- [`.apm/skills/perf-diagnose/SKILL.md`](https://github.com/juspay/kolu/blob/master/.apm/skills/perf-diagnose/SKILL.md) — the runbook future Claude Code sessions read before they re-tread the proxy-metric path I spent the afternoon on.
+- [`docs/perf-investigations/scripts/`](https://github.com/juspay/kolu/tree/master/docs/perf-investigations/scripts) — the heap-snapshot analyzers, including the byte-delta diff that named the leak in one line.


### PR DESCRIPTION
**Every post on the kolu blog is now rewritten in Paul Graham's voice** — plain, spoken prose that reasons out loud and lands a surprising true claim, instead of the smooth, signpost-laden register that reads as AI-generated. Each was run through the [`/pg`](https://github.com/juspay/kolu/pull/1152) skill: open on a concrete observation, let the thesis emerge, ground every abstraction in a named thing, scrub the AI tells, end on a swerve. Technical content, code blocks, MDX components, footnotes, quotes, and tweet embeds are all preserved.

### The four posts

| Post | Title | What changed |
| --- | --- | --- |
| `surface-framework` | _Announcing @kolu/surface…_ (kept) | Body + description recast; tech links added on first mention (Solid, oRPC, Zod, Kolu, and _electricity_ → the InformIT excerpt) |
| `hickey-lowy` | _The spacetime of code_ (kept) | Prose recast to plainer reasoning; grandiose physics passage trimmed. All MDX preserved — `<Tip>`, tweet embed, the Hickey/Parnas/Löwy blockquotes, three footnotes |
| `xtermjs-perf` | **Measuring the Wrong Thing** | Retitled from _"The leak that wasn't in any Context"_ to lead with the lesson (the proxy metric lied) |
| `nix-chrome-devtools-mcp` | **Eyes for the Agent** | Retitled from _"Give your coding agent a browser, on Nix"_; **tutorial shape kept** (steps, code, config, table, both `<Tip>`s) — only the connecting prose is PG-ified |

### House style

A short interview decided the emphasis: **bold the one takeaway per section, italicize a term only on first use** — sparing, so the prose stays close to PG-plain. _The companion commit teaches the `/pg` skill to ask this up front via `AskUserQuestion` (with a preview per option), so future runs offer the same four house styles rather than guessing._

### Notable

> The `/pg` skill's banned-word list was enforced across all four posts (scan is clean) — including reworking a stray _"agent harness"_ into plainer phrasing. Two posts kept their titles because they were already in voice; only the two that buried their point got retitled.

### Try it locally

```sh
nix build github:juspay/kolu/pg-rewrite-surface-post#website
```

_Generated by Claude Code (model `claude-opus-4-8`)._