### PR TITLE
add x86_64-darwin to supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
   outputs = { self, ... }:
     let
-      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       eachSystem = f: builtins.listToAttrs (map
         (system: {
           name = system;


### PR DESCRIPTION
x86_64-darwin was missing from the systems list. one-liner fix.

built and ran fine on my old intel macbook. since this is a web project, there's basically zero arch-specific maintenance burden — js/ts doesn't care.