### PR TITLE
feat(be-review): retry codex debate up to 3× on reviewer-error

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -61,12 +61,29 @@ finish before starting the next** — never in parallel. Thread `--base` and the
 `rationale` through. `--tracks codex,lens,police` selects/reorders which run
 (default all three, in the order above).
 
+**Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
+either in `consensus` or in `reviewer-error` — the latter meaning codex itself
+never produced a structured verdict (it emitted reasoning prose, or the CLI was
+broken/unavailable) even after `codex-review.sh`'s built-in per-`codex exec`
+retries. That is an *infrastructure hiccup, not a debate outcome*, and in
+practice the next whole-debate attempt usually produces a real verdict. So when
+`/codex-debate` returns `reviewer-error`, **re-invoke it** — same `--base` /
+`rationale` — and keep retrying **up to 3 total attempts**. Stop early the moment
+an attempt reaches `consensus` (that result wins, proceed to lens-debate). Only
+if **all 3** attempts come back `reviewer-error` do you give up on codex: report
+the persistent reviewer-error honestly (no false `## Codex ⇄ Claude debate`
+consensus comment), then continue with lens-debate and code-police, which don't
+depend on codex. The built-in `codex exec` retries inside `codex-review.sh` are a
+*lower* layer (one flaky invocation); this is the *outer* layer (the whole debate
+came back without a verdict) — both apply.
+
 ## Report
 
 Confirm the three PR comments landed, then summarize in chat: each reviewer's
-outcome (codex consensus / reviewer-error, lens consensus, police findings
-actioned) and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the
-combined result is visible. **Never push or merge** — the human reviews the commits
-and merges when satisfied.
+outcome (codex consensus / reviewer-error — note how many attempts codex took if
+it was retried, lens consensus, police findings actioned) and
+`git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
+result is visible. **Never push or merge** — the human reviews the commits and
+merges when satisfied.
 
 ARGUMENTS:

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -61,12 +61,29 @@ finish before starting the next** — never in parallel. Thread `--base` and the
 `rationale` through. `--tracks codex,lens,police` selects/reorders which run
 (default all three, in the order above).
 
+**Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
+either in `consensus` or in `reviewer-error` — the latter meaning codex itself
+never produced a structured verdict (it emitted reasoning prose, or the CLI was
+broken/unavailable) even after `codex-review.sh`'s built-in per-`codex exec`
+retries. That is an *infrastructure hiccup, not a debate outcome*, and in
+practice the next whole-debate attempt usually produces a real verdict. So when
+`/codex-debate` returns `reviewer-error`, **re-invoke it** — same `--base` /
+`rationale` — and keep retrying **up to 3 total attempts**. Stop early the moment
+an attempt reaches `consensus` (that result wins, proceed to lens-debate). Only
+if **all 3** attempts come back `reviewer-error` do you give up on codex: report
+the persistent reviewer-error honestly (no false `## Codex ⇄ Claude debate`
+consensus comment), then continue with lens-debate and code-police, which don't
+depend on codex. The built-in `codex exec` retries inside `codex-review.sh` are a
+*lower* layer (one flaky invocation); this is the *outer* layer (the whole debate
+came back without a verdict) — both apply.
+
 ## Report
 
 Confirm the three PR comments landed, then summarize in chat: each reviewer's
-outcome (codex consensus / reviewer-error, lens consensus, police findings
-actioned) and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the
-combined result is visible. **Never push or merge** — the human reviews the commits
-and merges when satisfied.
+outcome (codex consensus / reviewer-error — note how many attempts codex took if
+it was retried, lens consensus, police findings actioned) and
+`git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
+result is visible. **Never push or merge** — the human reviews the commits and
+merges when satisfied.
 
 ARGUMENTS:

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -61,12 +61,29 @@ finish before starting the next** — never in parallel. Thread `--base` and the
 `rationale` through. `--tracks codex,lens,police` selects/reorders which run
 (default all three, in the order above).
 
+**Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
+either in `consensus` or in `reviewer-error` — the latter meaning codex itself
+never produced a structured verdict (it emitted reasoning prose, or the CLI was
+broken/unavailable) even after `codex-review.sh`'s built-in per-`codex exec`
+retries. That is an *infrastructure hiccup, not a debate outcome*, and in
+practice the next whole-debate attempt usually produces a real verdict. So when
+`/codex-debate` returns `reviewer-error`, **re-invoke it** — same `--base` /
+`rationale` — and keep retrying **up to 3 total attempts**. Stop early the moment
+an attempt reaches `consensus` (that result wins, proceed to lens-debate). Only
+if **all 3** attempts come back `reviewer-error` do you give up on codex: report
+the persistent reviewer-error honestly (no false `## Codex ⇄ Claude debate`
+consensus comment), then continue with lens-debate and code-police, which don't
+depend on codex. The built-in `codex exec` retries inside `codex-review.sh` are a
+*lower* layer (one flaky invocation); this is the *outer* layer (the whole debate
+came back without a verdict) — both apply.
+
 ## Report
 
 Confirm the three PR comments landed, then summarize in chat: each reviewer's
-outcome (codex consensus / reviewer-error, lens consensus, police findings
-actioned) and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the
-combined result is visible. **Never push or merge** — the human reviews the commits
-and merges when satisfied.
+outcome (codex consensus / reviewer-error — note how many attempts codex took if
+it was retried, lens consensus, police findings actioned) and
+`git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
+result is visible. **Never push or merge** — the human reviews the commits and
+merges when satisfied.
 
 ARGUMENTS:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-04T21:35:39.552519+00:00'
+generated_at: '2026-06-04T22:01:53.784617+00:00'
 apm_version: 0.18.0
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
## What

When `/codex-debate` returns `reviewer-error` — codex never produced a structured verdict (it emitted reasoning prose, or the CLI was broken/unavailable) even after `codex-review.sh`'s built-in per-`codex exec` retries — the `be-review` gauntlet now **re-invokes the whole debate, up to 3 total attempts**, before giving up on codex. It stops early the moment an attempt reaches `consensus`. Only if all 3 attempts come back `reviewer-error` does it report the persistent failure honestly (no false consensus comment) and continue with lens-debate + code-police, which don't depend on codex.

## Why

In a recent `/be` run (worktree `all-files-changed`, PR #1185), codex came back `reviewer-error` on the first attempt — a transient hiccup where it returned reasoning text instead of the schema-constrained verdict. The gauntlet moved on, and the **human had to manually ask for codex retries** afterward to get a real pass on the record. The retry attempt then succeeded. Baking the retry into the skill removes that manual step.

This is the *outer* retry layer (the whole debate came back without a verdict); the existing `codex exec` retries inside `codex-review.sh` are the *lower* layer (one flaky invocation). Both apply.

## Changes

- `.apm/skills/be-review/SKILL.md` — source: added the retry-on-`reviewer-error` policy to the **Run** section and a note in **Report** to surface how many attempts codex took.
- Regenerated runtime copies (`.claude/`, `.agents/`) and `apm.lock.yaml` via `just ai::apm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)