### PR TITLE
feat(debate): warm codex author via section files + deterministic comments

### DIFF
--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -107,17 +107,21 @@ codex reviews. It returns:
 
 ```
 { status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript, ledgerPath }
+  rounds, base, finalVerdict, filesChanged, transcript,
+  workDir, ledgerPath, ledgerHeader }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
-`ledgerPath` points at `.codex-debate/debate-log.md` — the **shared debate
-ledger**, one durable Markdown record of every round (codex's findings, its reply
-to the rebuttal, Claude's dispositions, the commit) rewritten each round. It has
-two readers: the **Claude author** reads it as its cross-round memory (so each
-round builds on the last instead of re-deriving the diff), and **step 3 posts it
-verbatim as the PR comment**. codex is *not* a reader — it keeps its own warm
-session, so re-feeding it the ledger would just duplicate its context.
+The debate is recorded as **one small Markdown file per round** —
+`<workDir>/section-NNN.md` (zero-padded). Those section files have two readers:
+the **Claude author** reads them as its cross-round memory (so each round builds
+on the last instead of re-deriving the diff), and **step 3 assembles them into the
+PR comment** — `ledgerHeader` (the outcome header) followed by a `cat` of the
+sections, written to `ledgerPath` (`.codex-debate/debate-log.md`) and posted. The
+comment is therefore a **deterministic concatenation**, never re-rendered through
+an agent — nothing weak ever retypes a large blob. codex is *not* a reader — it
+keeps its own warm session, so re-feeding it the sections would just duplicate its
+context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -156,24 +160,30 @@ the per-round commits sit on the local branch for the human to review):
   on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
-- A compact per-round summary — read it straight from the ledger at `ledgerPath`
-  (each round's codex verdict, Claude's dispositions, and the commit SHA) so the
-  convergence reads round by round. No need to re-derive it from `transcript`; the
-  ledger already renders it.
+- A compact per-round summary — read it straight from the section files
+  (`cat <workDir>/section-*.md`: each round's codex verdict, Claude's
+  dispositions, and the commit SHA) so the convergence reads round by round. No
+  need to re-derive it from `transcript`; the sections already render it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post the **ledger file verbatim** as the PR
-  comment: `gh pr comment <pr> -F "$ledgerPath"` (or `--body-file`). The workflow
-  already wrote the final, headed render to `ledgerPath` — a `## Codex ⇄ Claude
-  debate` document carrying the **consensus** badge, the round count, the
-  **`xhigh` reasoning-effort** note, and a per-round breakdown of codex's findings
-  and Claude's dispositions. Posting the file directly (rather than re-improvising
-  a table) keeps the comment a **deterministic** render of the same record the
-  commit messages and the author drew on. This is an outward-facing write — on by
-  default because the whole point is to leave the review trail on the PR;
-  `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, **assemble the comment from the workflow's
+  output and post it** — no agent re-renders it:
+
+  ```bash
+  { printf '%s\n\n' "$ledgerHeader"; cat "$workDir"/section-*.md; } > "$ledgerPath"
+  gh pr comment <pr> -F "$ledgerPath"
+  ```
+
+  `ledgerHeader` is the `## Codex ⇄ Claude debate` header (consensus badge, round
+  count, the **`xhigh` reasoning-effort** note); the zero-padded `section-*.md`
+  files are the per-round breakdown of codex's findings and Claude's dispositions
+  that the author also read. So the comment is a **deterministic concatenation**
+  of the same record the commit messages and the author drew on — not an
+  LLM-improvised table. This is an outward-facing write — on by default because
+  the whole point is to leave the review trail on the PR; `--no-comment`
+  suppresses it.
 
 ## Safety & notes
 
@@ -198,15 +208,16 @@ the per-round commits sit on the local branch for the human to review):
 - **Warm author (context, not session).** The Claude author can't be resumed the
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
   so there's no session id to carry forward. The equivalent is context, not state:
-  each follow-up round the author **reads the shared debate ledger**
-  (`.codex-debate/debate-log.md`) — every prior round's findings and its own
+  each follow-up round the author **reads the per-round section files**
+  (`cat .codex-debate/section-*.md`) — every prior round's findings and its own
   dispositions — so it builds on its last round rather than re-deriving the whole
-  diff, and won't re-fix or re-litigate findings already settled. The ledger is
-  rewritten after each round, so round N>1 always sees rounds 1..N-1; round 1 has
-  no ledger yet, so it's byte-identical to a cold start (and if the file is ever
-  missing, the author falls back to the diff + verdict). The *same* ledger is what
-  step 3 posts as the PR comment, so the author's memory and the published summary
-  are one artifact. codex stays on its own warm session and never reads the ledger.
+  diff, and won't re-fix or re-litigate findings already settled. A small section
+  is written after each round, so round N>1 always sees rounds 1..N-1; round 1 has
+  none yet, so it's byte-identical to a cold start (and if no sections exist, the
+  author falls back to the diff + verdict). The *same* sections compose the PR
+  comment step 3 posts, so the author's memory and the published summary are one
+  record. The writes stay small (one round each), so the Haiku writer never
+  retypes a large blob. codex stays on its own warm session and never reads them.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
@@ -216,9 +227,9 @@ the per-round commits sit on the local branch for the human to review):
   on many worktrees run at once without clobbering each other — no shared `/tmp`
   paths, and each worktree's `debate-log.md` is its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  ledger file (`debate-log.md`) — is posted verbatim as a PR comment
-  (outward-facing write) unless `--no-comment` is passed — the point is to leave
-  the review trail on the PR.
+  header + per-round sections assembled into `debate-log.md` — is posted as a PR
+  comment (outward-facing write) unless `--no-comment` is passed — the point is to
+  leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -153,10 +153,12 @@ Otherwise (`status === "consensus"`) report in chat (do **not** push or merge �
 the per-round commits sit on the local branch for the human to review):
 
 - The outcome — **consensus** — and how many rounds it took to get there.
-- **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
-  debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
-  of the user's global codex default). State this so the depth of the review is
-  on the record.
+- **The reviewer's reasoning effort** — sourced from the workflow's single
+  `REASONING_EFFORT` constant (`xhigh` today), which is passed down to
+  `codex-review.sh`'s `-c model_reasoning_effort` and into the comment header, so
+  the published value and the config codex actually ran at share one home. Read
+  it off the header rather than asserting it independently. State it so the depth
+  of the review is on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round summary — read it straight from the section files
@@ -177,8 +179,9 @@ the per-round commits sit on the local branch for the human to review):
   ```
 
   The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
-  header (consensus badge, round count, the **`xhigh` reasoning-effort** note)
-  followed by the per-round breakdown of codex's findings and Claude's dispositions
+  header (consensus badge, round count, the **reasoning-effort** note from the
+  workflow's `REASONING_EFFORT` constant) followed by the per-round breakdown of
+  codex's findings and Claude's dispositions
   that the author also read. So the comment is a **deterministic** render of the
   same record the commit messages and the author drew on — not an LLM-improvised
   table. Posting the returned string mirrors `/lens-debate`. This is an

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -108,20 +108,19 @@ codex reviews. It returns:
 ```
 { status: "consensus" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, transcript,
-  workDir, ledgerPath, ledgerHeader }
+  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 The debate is recorded as **one small Markdown file per round** —
-`<workDir>/section-NNN.md` (zero-padded). Those section files have two readers:
-the **Claude author** reads them as its cross-round memory (so each round builds
-on the last instead of re-deriving the diff), and **step 3 assembles them into the
-PR comment** — `ledgerHeader` (the outcome header) followed by a `cat` of the
-sections, written to `ledgerPath` (`.codex-debate/debate-log.md`) and posted. The
-comment is therefore a **deterministic concatenation**, never re-rendered through
-an agent — nothing weak ever retypes a large blob. codex is *not* a reader — it
-keeps its own warm session, so re-feeding it the sections would just duplicate its
-context.
+`<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
+author's cross-round memory** (so each round builds on the last instead of
+re-deriving the diff). The workflow renders the **same** record into `comment` —
+the outcome header followed by every round's section — so **step 3 just posts that
+string** (`gh pr comment -F`), exactly the way `/lens-debate` does. The comment is
+therefore a **deterministic** render, never re-improvised through an agent —
+nothing weak ever retypes a large blob. codex is *not* a reader — it keeps its own
+warm session, so re-feeding it the sections would just duplicate its context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -168,22 +167,23 @@ the per-round commits sit on the local branch for the human to review):
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, **assemble the comment from the workflow's
-  output and post it** — no agent re-renders it:
+  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
+  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  { printf '%s\n\n' "$ledgerHeader"; cat "$workDir"/section-*.md; } > "$ledgerPath"
-  gh pr comment <pr> -F "$ledgerPath"
+  mkdir -p "$repoPath/.codex-debate"   # reviewer-error/--no-commit runs may not have created it
+  printf '%s' "$comment" > "$repoPath/.codex-debate/comment.md"
+  gh pr comment <pr> -F "$repoPath/.codex-debate/comment.md"
   ```
 
-  `ledgerHeader` is the `## Codex ⇄ Claude debate` header (consensus badge, round
-  count, the **`xhigh` reasoning-effort** note); the zero-padded `section-*.md`
-  files are the per-round breakdown of codex's findings and Claude's dispositions
-  that the author also read. So the comment is a **deterministic concatenation**
-  of the same record the commit messages and the author drew on — not an
-  LLM-improvised table. This is an outward-facing write — on by default because
-  the whole point is to leave the review trail on the PR; `--no-comment`
-  suppresses it.
+  The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
+  header (consensus badge, round count, the **`xhigh` reasoning-effort** note)
+  followed by the per-round breakdown of codex's findings and Claude's dispositions
+  that the author also read. So the comment is a **deterministic** render of the
+  same record the commit messages and the author drew on — not an LLM-improvised
+  table. Posting the returned string mirrors `/lens-debate`. This is an
+  outward-facing write — on by default because the whole point is to leave the
+  review trail on the PR; `--no-comment` suppresses it.
 
 ## Safety & notes
 
@@ -222,14 +222,14 @@ the per-round commits sit on the local branch for the human to review):
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the debate ledger)
-  lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates
-  on many worktrees run at once without clobbering each other — no shared `/tmp`
-  paths, and each worktree's `debate-log.md` is its own.
+- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the per-round
+  sections) lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`,
+  so debates on many worktrees run at once without clobbering each other — no
+  shared `/tmp` paths, and each worktree's section files are its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  header + per-round sections assembled into `debate-log.md` — is posted as a PR
-  comment (outward-facing write) unless `--no-comment` is passed — the point is to
-  leave the review trail on the PR.
+  workflow's deterministically rendered `comment` (header + per-round sections) —
+  is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
+  — the point is to leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -184,6 +184,13 @@ the per-round commits sit on the local branch for the human to review):
   other's sessions. If the id is ever missing (round-1 capture failed), a later
   round transparently cold-starts with the full prompt + rebuttal — graceful
   degradation, never a wedge.
+- **Warm author (context, not session).** The Claude author can't be resumed the
+  way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
+  so there's no session id to carry forward. The prompt-level equivalent is used
+  instead: each follow-up round's author prompt carries the author's OWN previous
+  dispositions (its prior summary + actions), so it builds on its last round
+  rather than re-deriving the whole diff, and won't re-fix or re-litigate findings
+  already settled. Round 1 has no prior, so it's byte-identical to a cold start.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -100,16 +100,24 @@ tree, then (unless `--no-commit`) a `commit:roundN` agent **commits exactly that
 round's changed files** with a message embedding the round's codex findings and
 Claude's dispositions — never pushing or merging.
 
-Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
-`<repoPath>/.codex-debate/`, so **parallel debates in different worktrees never
-collide** and the scratch never shows up in the diff codex reviews. It returns:
+Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
+gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in
+different worktrees never collide** and the scratch never shows up in the diff
+codex reviews. It returns:
 
 ```
 { status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript }
+  rounds, base, finalVerdict, filesChanged, transcript, ledgerPath }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
+`ledgerPath` points at `.codex-debate/debate-log.md` — the **shared debate
+ledger**, one durable Markdown record of every round (codex's findings, its reply
+to the rebuttal, Claude's dispositions, the commit) rewritten each round. It has
+two readers: the **Claude author** reads it as its cross-round memory (so each
+round builds on the last instead of re-deriving the diff), and **step 3 posts it
+verbatim as the PR comment**. codex is *not* a reader — it keeps its own warm
+session, so re-feeding it the ledger would just duplicate its context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -148,21 +156,24 @@ the per-round commits sit on the local branch for the human to review):
   on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
-- A compact per-round table from `transcript` — each round's codex verdict
-  (approved? open-findings count), Claude's dispositions, and the
-  round's `commit` SHA — so the convergence reads round by round.
+- A compact per-round summary — read it straight from the ledger at `ledgerPath`
+  (each round's codex verdict, Claude's dispositions, and the commit SHA) so the
+  convergence reads round by round. No need to re-derive it from `transcript`; the
+  ledger already renders it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
-  `gh pr comment`. Include: the **consensus** outcome badge and the round count;
-  a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
-  table (codex approved? open-findings count; Claude's dispositions; the
-  round's commit SHA) showing how the two sides converged. Use a
-  single-quoted heredoc so backticks/`$` survive. This is an
-  outward-facing write — it's on by default because the whole point is to leave
-  the review trail on the PR; `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, post the **ledger file verbatim** as the PR
+  comment: `gh pr comment <pr> -F "$ledgerPath"` (or `--body-file`). The workflow
+  already wrote the final, headed render to `ledgerPath` — a `## Codex ⇄ Claude
+  debate` document carrying the **consensus** badge, the round count, the
+  **`xhigh` reasoning-effort** note, and a per-round breakdown of codex's findings
+  and Claude's dispositions. Posting the file directly (rather than re-improvising
+  a table) keeps the comment a **deterministic** render of the same record the
+  commit messages and the author drew on. This is an outward-facing write — on by
+  default because the whole point is to leave the review trail on the PR;
+  `--no-comment` suppresses it.
 
 ## Safety & notes
 
@@ -186,21 +197,28 @@ the per-round commits sit on the local branch for the human to review):
   degradation, never a wedge.
 - **Warm author (context, not session).** The Claude author can't be resumed the
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
-  so there's no session id to carry forward. The prompt-level equivalent is used
-  instead: each follow-up round's author prompt carries the author's OWN previous
-  dispositions (its prior summary + actions), so it builds on its last round
-  rather than re-deriving the whole diff, and won't re-fix or re-litigate findings
-  already settled. Round 1 has no prior, so it's byte-identical to a cold start.
+  so there's no session id to carry forward. The equivalent is context, not state:
+  each follow-up round the author **reads the shared debate ledger**
+  (`.codex-debate/debate-log.md`) — every prior round's findings and its own
+  dispositions — so it builds on its last round rather than re-deriving the whole
+  diff, and won't re-fix or re-litigate findings already settled. The ledger is
+  rewritten after each round, so round N>1 always sees rounds 1..N-1; round 1 has
+  no ledger yet, so it's byte-identical to a cold start (and if the file is ever
+  missing, the author falls back to the diff + verdict). The *same* ledger is what
+  step 3 posts as the PR comment, so the author's memory and the published summary
+  are one artifact. codex stays on its own warm session and never reads the ledger.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals) lives under the
-  gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates on many
-  worktrees run at once without clobbering each other — no shared `/tmp` paths.
-- **Posts to the PR by default.** When a PR exists, the debate summary is posted
-  as a PR comment (outward-facing write) unless `--no-comment` is passed — the
-  point is to leave the review trail on the PR.
+- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the debate ledger)
+  lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates
+  on many worktrees run at once without clobbering each other — no shared `/tmp`
+  paths, and each worktree's `debate-log.md` is its own.
+- **Posts to the PR by default.** When a PR exists, the debate summary — the
+  ledger file (`debate-log.md`) — is posted verbatim as a PR comment
+  (outward-facing write) unless `--no-comment` is passed — the point is to leave
+  the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -355,6 +355,21 @@ if (!baseRes?.sha?.trim()) {
 base = baseRes.sha.trim()
 log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
+// Clear any stale ledger from a PRIOR debate in this worktree. The scratch dir
+// is persistent (per-worktree, not per-run) and the section files use a flat,
+// stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
+// sections would otherwise survive into this run — the author cats `section-*.md`
+// as its memory and step 3 cats the same glob into the posted comment, so stale
+// sections would pollute BOTH the author's context and the published trail. A
+// thin mechanical agent (the workflow can't run shell itself); deleting the whole
+// dir is safe because nothing in THIS run has written to it yet. This script has
+// no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
+// so a fresh start owns a fresh ledger.
+await agent(
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf ${workDir} && mkdir -p ${workDir}\`. Do not edit any other file. Do not run git.`,
+  { label: 'ledger:reset', phase: 'Debate', model: mechModel },
+)
+
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
   finalVerdict = verdict

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -136,12 +136,31 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict) {
+async function claudeResponds(round, verdict, priorClaude) {
+  // WARM AUTHOR. On follow-up rounds, thread the author's OWN previous
+  // dispositions back into the prompt so it builds on its prior round instead
+  // of re-deriving everything from the diff — the prompt-level analog of codex's
+  // warm session. (We can't truly resume the Claude author: agent() is one-shot,
+  // and Claude isn't headless under Max auth, so there's no session to resume the
+  // way `codex exec resume` carries codex's reasoning forward. This is the
+  // achievable equivalent — context, not state.) codex's responseToRebuttal in
+  // the verdict already says which of the author's disputes it conceded vs still
+  // holds, so the author knows exactly what to revisit. Empty on round 1, so the
+  // first round is byte-identical to the pre-warm-author prompt.
+  const priorBlock = priorClaude
+    ? `This is a FOLLOW-UP round — you already worked this diff last round. Here is what YOU did then (your own dispositions); build on it, don't re-derive it from scratch, and don't re-fix or re-litigate anything already settled:
+
+${JSON.stringify({ summary: priorClaude.summary, actions: priorClaude.actions }, null, 2)}
+
+For any finding you DISPUTED last round, read codex's \`responseToRebuttal\` below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+
+`
+    : ''
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
 
-CODEX's verdict (JSON):
+${priorBlock}CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
 Address EVERY finding, any severity (don't skip minors/nits):
@@ -286,8 +305,11 @@ for (let round = 1; ; round++) {
     break
   }
 
-  // Claude responds: fixes what it agrees with (editing the tree), disputes the rest.
-  const response = await claudeResponds(round, verdict)
+  // Claude responds: fixes what it agrees with (editing the tree), disputes the
+  // rest. `lastClaude` still holds the PREVIOUS round's response here (it's
+  // reassigned just below), so the author gets its own prior dispositions — the
+  // warm-author context — and on round 1 it's null (cold start, unchanged).
+  const response = await claudeResponds(round, verdict, lastClaude)
   entry.claude = response
   lastClaude = response
   log(

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -30,16 +30,14 @@ const workDir = `${repoPath}/.codex-debate`
 // DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
 // elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
-// The assembled PR comment. The debate is recorded as one small Markdown file
-// PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
-// section files serve TWO readers: the claude author reads them as its cross-round
-// memory (full history, no inline blob), and the orchestrator concatenates the
-// outcome header + every section into THIS file and posts it (`gh pr comment -F`).
-// So the published summary and the author's context are one record — assembled by
-// deterministic `cat`, never re-rendered through an agent (nothing weak ever
-// retypes a large blob). codex is NOT a reader: it keeps its own warm session, so
-// re-feeding it the ledger would just duplicate what it already remembers.
-const ledgerPath = `${workDir}/debate-log.md`
+// The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
+// written under the gitignored scratch dir) — the claude author reads them as its
+// cross-round memory (full history, no inline blob). The PR comment is rendered
+// from the SAME per-round sections in-process (see renderLedger) and returned as
+// `comment`, so the published summary and the author's context are one record —
+// deterministic, never re-rendered through an agent (nothing weak ever retypes a
+// large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
+// it the ledger would just duplicate what it already remembers.
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
 // pushes or merges — that stays the human's call.
@@ -286,12 +284,22 @@ function roundLedgerSection(entry) {
 }
 
 // The comment header (small). The full comment is this header followed by the
-// per-round section files, assembled by the orchestrator at post time (SKILL
-// step 3) with a deterministic `cat`. The workflow never renders the whole ledger
-// through an agent, so nothing weak ever retypes a large blob.
+// per-round section files (see renderLedger). The workflow renders the whole
+// comment deterministically from the transcript — no agent ever retypes the blob.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+}
+
+// The whole PR comment, rendered deterministically in-process from the transcript:
+// the outcome header followed by each round's Markdown section. The per-round
+// section files on disk remain the author's cross-round memory (see writeSection);
+// this re-uses the SAME `roundLedgerSection` renderer to assemble the published
+// comment, so the orchestrator posts a ready string (`gh pr comment -F`) exactly
+// the way lens-debate does — no bespoke `cat` glob at the consumer, and nothing
+// weak ever retypes a large blob (the workflow builds the string itself).
+function renderLedger(transcript, meta) {
+  return [ledgerHeader(meta), ...transcript.map(roundLedgerSection)].join('\n\n')
 }
 
 // Zero-pad the round so the section glob (`section-*.md`) sorts in round order
@@ -450,9 +458,11 @@ log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged
 // reached before the author got a turn) would be missing from the comment.
 if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
-// Hand the orchestrator the header and the paths; it assembles the comment
-// (header + section-*.md → ledgerPath) with a deterministic cat and posts it —
-// no agent ever retypes the whole ledger. See SKILL step 3.
+// Hand the orchestrator the ready-to-post comment, rendered deterministically
+// in-process (header + per-round sections) — it just writes the string to a file
+// and posts it (`gh pr comment -F`), the same shape lens-debate uses. The section
+// files on disk stay the author's cross-round memory; this is the published view
+// of that same record, so no agent ever retypes the whole ledger. See SKILL step 3.
 return {
   status,
   rounds: transcript.length,
@@ -460,7 +470,5 @@ return {
   finalVerdict,
   filesChanged,
   transcript,
-  workDir,
-  ledgerPath,
-  ledgerHeader: ledgerHeader({ status, rounds: transcript.length, base }),
+  comment: renderLedger(transcript, { status, rounds: transcript.length, base }),
 }

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -58,6 +58,14 @@ const mechModel = a.mechModel || 'haiku'
 // agent's. The small per-round section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
+// The reasoning effort codex runs at, scoped to the debate. This JS constant is
+// the SINGLE home for the value: it is passed script-ward (a 4th positional arg
+// to codex-review.sh, which sets `-c model_reasoning_effort`) and read by
+// ledgerHeader for the published comment, so the `-c` flag and the header both
+// derive from here via the one-directional invocation channel — no literal
+// repeated across files held together by "remember to update all of them".
+const REASONING_EFFORT = 'xhigh'
+
 // ---------------------------------------------------------------------------
 // Schemas — the codex verdict schema mirrors scripts/codex-verdict.schema.json
 // so the runner agent returns the same shape codex was constrained to.
@@ -134,11 +142,11 @@ async function codexReviews(round, rebuttalJson) {
 ${rebuttalJson}
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT}\``
     : `1. (No prior rebuttal this round.)
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -201,13 +209,16 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
 }
 
 // Commit message for one debate round, carrying the debate context: what codex
-// raised and how claude dispositioned each finding.
+// raised and how claude dispositioned each finding. It reuses the same per-bullet
+// projection as the ledger section (findingBullet/actionBullet), in `plain` chrome
+// — no backticks/bold and no `status` field — so the round summary derives from a
+// single rendering rather than two parallel ones.
 function roundCommitMessage(round, verdict, response) {
   const findings = (verdict.findings || [])
-    .map((f) => `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`)
+    .map((f) => findingBullet(f, { plain: true }))
     .join('\n')
   const actions = (response.actions || [])
-    .map((act) => `- ${act.findingId} ${act.disposition}: ${act.detail}`)
+    .map((a) => actionBullet(a, { plain: true }))
     .join('\n')
   return `fix: codex review — debate round ${round}
 
@@ -244,11 +255,28 @@ ${message}
 // ---------------------------------------------------------------------------
 // The shared ledger — rendered from the transcript, deterministically
 // ---------------------------------------------------------------------------
+// One codex finding as a Markdown bullet. The single projection of a finding's
+// fields, shared by the ledger section and the round commit message. `plain` drops
+// the ledger chrome (backticks + the `status` field) for the commit message, which
+// wants plainer text; the field access stays in one place either way.
+function findingBullet(f, { plain = false } = {}) {
+  return plain
+    ? `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`
+    : `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
+}
+
+// One author disposition as a Markdown bullet. The single projection of an action's
+// fields, shared by the ledger section and the round commit message. `plain` drops
+// the ledger chrome (backticks + bold) for the commit message.
+function actionBullet(a, { plain = false } = {}) {
+  return plain
+    ? `- ${a.findingId} ${a.disposition}: ${a.detail}`
+    : `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
+}
+
 // One round's findings, as a Markdown list. Shared by the section renderer below.
 function renderFindings(verdict) {
-  const list = (verdict.findings || [])
-    .map((f) => `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`)
-    .join('\n')
+  const list = (verdict.findings || []).map((f) => findingBullet(f)).join('\n')
   return list || '- _(none)_'
 }
 
@@ -256,9 +284,7 @@ function renderFindings(verdict) {
 // (codex approved or errored before the author got a turn).
 function renderActions(response) {
   if (!response) return '_(no author turn — the debate ended this round)_'
-  const list = (response.actions || [])
-    .map((a) => `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`)
-    .join('\n')
+  const list = (response.actions || []).map((a) => actionBullet(a)).join('\n')
   return list || '- _(no actions)_'
 }
 
@@ -296,7 +322,7 @@ function roundLedgerSection(entry) {
 // the runtime ever admits a shared helper file, lift this common chrome there.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
-  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`${meta.reasoningEffort}\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
 // The whole PR comment, rendered deterministically in-process from the transcript:
@@ -480,5 +506,5 @@ return {
   finalVerdict,
   filesChanged,
   transcript,
-  comment: renderLedger(transcript, { status, rounds: transcript.length, base }),
+  comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
 }

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -24,6 +24,15 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
+// The shared debate ledger: one durable Markdown record of the whole debate
+// (every round's codex findings + claude dispositions + commit), rewritten each
+// round under the gitignored scratch dir. It serves TWO readers — the claude
+// author reads it as its cross-round memory (replacing an inline blob), and the
+// orchestrator posts it verbatim as the PR comment (`gh pr comment -F`), so the
+// summary is a deterministic render of the same record, not an LLM re-improvisation.
+// codex is NOT a reader: it keeps its own warm session, so re-feeding it the
+// ledger would just duplicate what it already remembers (and bloat its context).
+const ledgerPath = `${workDir}/debate-log.md`
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
 // pushes or merges — that stays the human's call.
@@ -136,26 +145,24 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict, priorClaude) {
-  // WARM AUTHOR. On follow-up rounds, thread the author's OWN previous
-  // dispositions back into the prompt so it builds on its prior round instead
-  // of re-deriving everything from the diff — the prompt-level analog of codex's
-  // warm session. (We can't truly resume the Claude author: agent() is one-shot,
+async function claudeResponds(round, verdict) {
+  // WARM AUTHOR. We can't truly resume the Claude author (agent() is one-shot,
   // and Claude isn't headless under Max auth, so there's no session to resume the
-  // way `codex exec resume` carries codex's reasoning forward. This is the
-  // achievable equivalent — context, not state.) codex's responseToRebuttal in
-  // the verdict already says which of the author's disputes it conceded vs still
-  // holds, so the author knows exactly what to revisit. Empty on round 1, so the
-  // first round is byte-identical to the pre-warm-author prompt.
-  const priorBlock = priorClaude
-    ? `This is a FOLLOW-UP round — you already worked this diff last round. Here is what YOU did then (your own dispositions); build on it, don't re-derive it from scratch, and don't re-fix or re-litigate anything already settled:
-
-${JSON.stringify({ summary: priorClaude.summary, actions: priorClaude.actions }, null, 2)}
-
-For any finding you DISPUTED last round, read codex's \`responseToRebuttal\` below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+  // way `codex exec resume` carries codex's reasoning forward). The achievable
+  // equivalent is context, not state: every follow-up round the author reads the
+  // shared debate ledger — the durable record of every prior round's findings and
+  // its OWN dispositions — and builds on it instead of re-deriving the diff. The
+  // ledger is written after each round (see the loop), so on round N>1 it already
+  // holds rounds 1..N-1. Round 1 has no ledger yet, so its prompt is byte-identical
+  // to a cold start.
+  const priorBlock =
+    round > 1
+      ? `This is a FOLLOW-UP round. The debate so far — every prior round's codex findings and YOUR own dispositions — is recorded in this file:
+  \`${ledgerPath}\`
+Read it FIRST (if it's somehow missing, fall back to the diff + the verdict below). Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
 
 `
-    : ''
+      : ''
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
@@ -219,6 +226,79 @@ ${message}
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
 4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:round${round}`, phase: 'Debate', model: mechModel })
+}
+
+// ---------------------------------------------------------------------------
+// The shared ledger — rendered from the transcript, deterministically
+// ---------------------------------------------------------------------------
+// One round's findings, as a Markdown list. Shared by the section renderer below.
+function renderFindings(verdict) {
+  const list = (verdict.findings || [])
+    .map((f) => `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`)
+    .join('\n')
+  return list || '- _(none)_'
+}
+
+// One round's author dispositions, as a Markdown list. `null` on a terminal round
+// (codex approved or errored before the author got a turn).
+function renderActions(response) {
+  if (!response) return '_(no author turn — the debate ended this round)_'
+  const list = (response.actions || [])
+    .map((a) => `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`)
+    .join('\n')
+  return list || '- _(no actions)_'
+}
+
+// One round as a Markdown section: codex's verdict, its response to the rebuttal,
+// and the author's dispositions + commit. The single per-round renderer — the
+// author reads these as its memory and they compose into the posted comment.
+function roundLedgerSection(entry) {
+  const { round, codex, claude, commit } = entry
+  const lines = [
+    `### Round ${round}`,
+    '',
+    `**codex** — approved: \`${codex.approved}\``,
+    '',
+    codex.summary,
+    '',
+    'Findings:',
+    renderFindings(codex),
+  ]
+  if (codex.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${codex.responseToRebuttal}`)
+  lines.push('', `**claude** — ${claude ? claude.summary : '_(no author turn this round)_'}`, '', renderActions(claude))
+  if (commit) lines.push('', `commit: \`${commit}\``)
+  return lines.join('\n')
+}
+
+// The whole ledger. With `meta` (final write) it gets the consensus header that
+// makes the file directly postable as the PR comment; without it (the provisional
+// mid-debate writes that feed the author) it's just the round sections.
+function renderLedger(rounds, meta) {
+  const sections = rounds.map(roundLedgerSection).join('\n\n')
+  if (!meta) return sections
+  const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
+  const header = `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+  return `${header}\n\n${sections}`
+}
+
+// Write the ledger to disk. A thin mechanical agent: the workflow can't do file
+// I/O itself, so (like commitRound) it hands an agent the exact bytes to write.
+// Always overwrites with the full current render, so there's no fragile append
+// and the file is consistent whenever the author reads it. `meta` only on the
+// final write (the postable comment); omitted mid-debate.
+async function writeLedger(meta) {
+  const text = renderLedger(transcript, meta)
+  const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool (NOT a shell heredoc — the content has Markdown/special characters), create \`${ledgerPath}\` with EXACTLY this content, overwriting any existing file:
+
+${text}`
+  return agent(prompt, {
+    label: meta ? 'ledger:final' : `ledger:round${transcript.length}`,
+    phase: 'Debate',
+    model: mechModel,
+  })
 }
 
 const transcript = []
@@ -306,10 +386,10 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. `lastClaude` still holds the PREVIOUS round's response here (it's
-  // reassigned just below), so the author gets its own prior dispositions — the
-  // warm-author context — and on round 1 it's null (cold start, unchanged).
-  const response = await claudeResponds(round, verdict, lastClaude)
+  // rest. It reads the shared ledger (written at the end of each round below) for
+  // its cross-round memory. `lastClaude` is kept only to feed codex's rebuttal
+  // next round (see codexReviews) — it is no longer the author's memory.
+  const response = await claudeResponds(round, verdict)
   entry.claude = response
   lastClaude = response
   log(
@@ -324,6 +404,11 @@ for (let round = 1; ; round++) {
     entry.commit = (sha || '').trim()
     log(`Round ${round}: committed ${entry.commit}`)
   }
+
+  // Record the round in the shared ledger so the NEXT round's author can read its
+  // own history. Provisional (no header) — the final, postable render with the
+  // consensus header is written at the terminus.
+  await writeLedger()
 }
 
 const filesChanged = Array.from(
@@ -331,4 +416,10 @@ const filesChanged = Array.from(
 )
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript }
+// Final ledger render — full history plus the outcome header — the canonical,
+// directly-postable PR comment. The terminal round is already in `transcript`
+// (pushed before every break), so this single write covers every exit path,
+// including a consensus or error reached before the author got a turn.
+await writeLedger({ status, rounds: transcript.length, base })
+
+return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript, ledgerPath }

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -24,6 +24,12 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
+// POSIX single-quote a path for safe interpolation into a shell command. Wraps
+// in single quotes (so spaces, globs, and shell metacharacters are inert) and
+// escapes any embedded single quote via the '\'' idiom. Used for the one
+// DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
+// elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
+const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // The assembled PR comment. The debate is recorded as one small Markdown file
 // PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
 // section files serve TWO readers: the claude author reads them as its cross-round
@@ -366,7 +372,7 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
 // so a fresh start owns a fresh ledger.
 await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf ${workDir} && mkdir -p ${workDir}\`. Do not edit any other file. Do not run git.`,
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf -- ${shq(workDir)} && mkdir -p -- ${shq(workDir)}\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
 

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -27,8 +27,8 @@ const workDir = `${repoPath}/.codex-debate`
 // POSIX single-quote a path for safe interpolation into a shell command. Wraps
 // in single quotes (so spaces, globs, and shell metacharacters are inert) and
 // escapes any embedded single quote via the '\'' idiom. Used for the one
-// DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
-// elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
+// DESTRUCTIVE command (the ledger `rm -f` below); the benign `mkdir -p` prompts
+// elsewhere can tolerate an unquoted path, but a mistargeted `rm -f` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
 // written under the gitignored scratch dir) — the claude author reads them as its
@@ -407,7 +407,7 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // is persistent (per-worktree, not per-run) and the section files use a flat,
 // stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
 // sections would otherwise survive into this run — the author cats `section-*.md`
-// as its memory and step 3 cats the same glob into the posted comment, so stale
+// as its memory (and they compose into the `comment` renderLedger returns), so stale
 // sections would pollute BOTH the author's context and the published trail. A
 // thin mechanical agent (the workflow can't run shell itself). The reset is
 // section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
@@ -491,7 +491,9 @@ log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged
 
 // Section the terminal round — it broke out of the loop before the in-loop
 // writeSection, so without this its section (a consensus approval, or an error
-// reached before the author got a turn) would be missing from the comment.
+// reached before the author got a turn) would be missing from the disk record
+// the orchestrator reads for the chat summary (cat section-*.md) and the
+// author would read as memory if the debate somehow continued.
 if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
 // Hand the orchestrator the ready-to-post comment, rendered deterministically

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -286,6 +286,14 @@ function roundLedgerSection(entry) {
 // The comment header (small). The full comment is this header followed by the
 // per-round section files (see renderLedger). The workflow renders the whole
 // comment deterministically from the transcript — no agent ever retypes the blob.
+//
+// This header's chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
+// deliberately kept STRUCTURALLY PARALLEL to lens-debate's renderComment header
+// chrome. The no-module workflow runtime has no imports, so a truly shared
+// renderer isn't available; the two are instead siblings that move together. A
+// house-style change (badge emoji, base-slice length, a new metadata row) is a
+// mechanical mirror edit — make it here and in lens-debate's renderComment. If
+// the runtime ever admits a shared helper file, lift this common chrome there.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
@@ -375,12 +383,14 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // sections would otherwise survive into this run — the author cats `section-*.md`
 // as its memory and step 3 cats the same glob into the posted comment, so stale
 // sections would pollute BOTH the author's context and the published trail. A
-// thin mechanical agent (the workflow can't run shell itself); deleting the whole
-// dir is safe because nothing in THIS run has written to it yet. This script has
-// no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
-// so a fresh start owns a fresh ledger.
+// thin mechanical agent (the workflow can't run shell itself). The reset is
+// section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
+// whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
+// commit-msg-N.txt) keep their own lifecycle and a future pre-loop writer won't
+// be silently wiped. This script has no true resume (agent() is one-shot, the
+// whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
 await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf -- ${shq(workDir)} && mkdir -p -- ${shq(workDir)}\`. Do not edit any other file. Do not run git.`,
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
 

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -24,14 +24,15 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
-// The shared debate ledger: one durable Markdown record of the whole debate
-// (every round's codex findings + claude dispositions + commit), rewritten each
-// round under the gitignored scratch dir. It serves TWO readers — the claude
-// author reads it as its cross-round memory (replacing an inline blob), and the
-// orchestrator posts it verbatim as the PR comment (`gh pr comment -F`), so the
-// summary is a deterministic render of the same record, not an LLM re-improvisation.
-// codex is NOT a reader: it keeps its own warm session, so re-feeding it the
-// ledger would just duplicate what it already remembers (and bloat its context).
+// The assembled PR comment. The debate is recorded as one small Markdown file
+// PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
+// section files serve TWO readers: the claude author reads them as its cross-round
+// memory (full history, no inline blob), and the orchestrator concatenates the
+// outcome header + every section into THIS file and posts it (`gh pr comment -F`).
+// So the published summary and the author's context are one record — assembled by
+// deterministic `cat`, never re-rendered through an agent (nothing weak ever
+// retypes a large blob). codex is NOT a reader: it keeps its own warm session, so
+// re-feeding it the ledger would just duplicate what it already remembers.
 const ledgerPath = `${workDir}/debate-log.md`
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
@@ -44,6 +45,14 @@ const commit = a.commit !== false
 // (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
+// Fidelity tier (Sonnet). One "mechanical" job isn't a trivial command but a
+// faithful COPY: the codex runner reads codex's verdict JSON off disk and must
+// return it byte-for-byte. A paraphrase silently corrupts the debate (and schema
+// validation checks the verdict's SHAPE, not its wording), and Haiku is the
+// weakest tier for verbatim reproduction — so the verdict relay runs a notch up.
+// Still far cheaper/faster than Opus; the real reviewing is codex's, not this
+// agent's. The small per-round section writes stay on Haiku (tiny payloads).
+const copyModel = a.copyModel || 'sonnet'
 
 // ---------------------------------------------------------------------------
 // Schemas — the codex verdict schema mirrors scripts/codex-verdict.schema.json
@@ -140,7 +149,7 @@ ${rebuttalStep}
   return agent(prompt, {
     label: `codex:round${round}`,
     phase: 'Debate',
-    model: mechModel, // mechanical: runs codex-review.sh + copies the verdict
+    model: copyModel, // not trivial: must relay codex's verdict JSON faithfully
     schema: CODEX_VERDICT_SCHEMA,
   })
 }
@@ -150,16 +159,16 @@ async function claudeResponds(round, verdict) {
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
   // equivalent is context, not state: every follow-up round the author reads the
-  // shared debate ledger — the durable record of every prior round's findings and
-  // its OWN dispositions — and builds on it instead of re-deriving the diff. The
-  // ledger is written after each round (see the loop), so on round N>1 it already
-  // holds rounds 1..N-1. Round 1 has no ledger yet, so its prompt is byte-identical
-  // to a cold start.
+  // per-round section files — the record of every prior round's findings and its
+  // OWN dispositions — and builds on them instead of re-deriving the diff. A
+  // section is written after each round (see the loop), so on round N>1 the files
+  // already hold rounds 1..N-1. Round 1 has none yet, so its prompt is
+  // byte-identical to a cold start.
   const priorBlock =
     round > 1
-      ? `This is a FOLLOW-UP round. The debate so far — every prior round's codex findings and YOUR own dispositions — is recorded in this file:
-  \`${ledgerPath}\`
-Read it FIRST (if it's somehow missing, fall back to the diff + the verdict below). Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+      ? `This is a FOLLOW-UP round. Every prior round is recorded as a small Markdown file under the debate's scratch dir — read them FIRST for the full history (codex's past findings and YOUR own dispositions):
+  \`cat ${workDir}/section-*.md\`   (or Read them individually; if none exist, fall back to the diff + the verdict below)
+Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
 
 `
       : ''
@@ -270,35 +279,34 @@ function roundLedgerSection(entry) {
   return lines.join('\n')
 }
 
-// The whole ledger. With `meta` (final write) it gets the consensus header that
-// makes the file directly postable as the PR comment; without it (the provisional
-// mid-debate writes that feed the author) it's just the round sections.
-function renderLedger(rounds, meta) {
-  const sections = rounds.map(roundLedgerSection).join('\n\n')
-  if (!meta) return sections
+// The comment header (small). The full comment is this header followed by the
+// per-round section files, assembled by the orchestrator at post time (SKILL
+// step 3) with a deterministic `cat`. The workflow never renders the whole ledger
+// through an agent, so nothing weak ever retypes a large blob.
+function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
-  const header = `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
-  return `${header}\n\n${sections}`
+  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
-// Write the ledger to disk. A thin mechanical agent: the workflow can't do file
-// I/O itself, so (like commitRound) it hands an agent the exact bytes to write.
-// Always overwrites with the full current render, so there's no fragile append
-// and the file is consistent whenever the author reads it. `meta` only on the
-// final write (the postable comment); omitted mid-debate.
-async function writeLedger(meta) {
-  const text = renderLedger(transcript, meta)
+// Zero-pad the round so the section glob (`section-*.md`) sorts in round order
+// (section-002 before section-010) for both the author's read and the assembly.
+const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
+
+// Write ONE round's section to its own small file — the author reads these as its
+// cross-round memory, and the orchestrator cats them into the posted comment. A
+// thin mechanical agent (the workflow can't do file I/O), but the payload is just
+// this round, so it stays small and Haiku-safe — no whole-ledger retype, and
+// rewriting a round's own file is idempotent (safe on a resume).
+async function writeSection(entry) {
+  const text = roundLedgerSection(entry)
+  const path = sectionFile(entry.round)
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool (NOT a shell heredoc — the content has Markdown/special characters), create \`${ledgerPath}\` with EXACTLY this content, overwriting any existing file:
+2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
 ${text}`
-  return agent(prompt, {
-    label: meta ? 'ledger:final' : `ledger:round${transcript.length}`,
-    phase: 'Debate',
-    model: mechModel,
-  })
+  return agent(prompt, { label: `ledger:round${entry.round}`, phase: 'Debate', model: mechModel })
 }
 
 const transcript = []
@@ -386,9 +394,9 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. It reads the shared ledger (written at the end of each round below) for
-  // its cross-round memory. `lastClaude` is kept only to feed codex's rebuttal
-  // next round (see codexReviews) — it is no longer the author's memory.
+  // rest. It reads the per-round section files (written at the end of each round
+  // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
+  // rebuttal next round (see codexReviews) — it is no longer the author's memory.
   const response = await claudeResponds(round, verdict)
   entry.claude = response
   lastClaude = response
@@ -405,10 +413,10 @@ for (let round = 1; ; round++) {
     log(`Round ${round}: committed ${entry.commit}`)
   }
 
-  // Record the round in the shared ledger so the NEXT round's author can read its
-  // own history. Provisional (no header) — the final, postable render with the
-  // consensus header is written at the terminus.
-  await writeLedger()
+  // Write this round's section so the NEXT round's author can read the full
+  // history. Terminal rounds break above before reaching here, so they're
+  // sectioned just after the loop.
+  await writeSection(entry)
 }
 
 const filesChanged = Array.from(
@@ -416,10 +424,22 @@ const filesChanged = Array.from(
 )
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-// Final ledger render — full history plus the outcome header — the canonical,
-// directly-postable PR comment. The terminal round is already in `transcript`
-// (pushed before every break), so this single write covers every exit path,
-// including a consensus or error reached before the author got a turn.
-await writeLedger({ status, rounds: transcript.length, base })
+// Section the terminal round — it broke out of the loop before the in-loop
+// writeSection, so without this its section (a consensus approval, or an error
+// reached before the author got a turn) would be missing from the comment.
+if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
-return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript, ledgerPath }
+// Hand the orchestrator the header and the paths; it assembles the comment
+// (header + section-*.md → ledgerPath) with a deterministic cat and posts it —
+// no agent ever retypes the whole ledger. See SKILL step 3.
+return {
+  status,
+  rounds: transcript.length,
+  base,
+  finalVerdict,
+  filesChanged,
+  transcript,
+  workDir,
+  ledgerPath,
+  ledgerHeader: ledgerHeader({ status, rounds: transcript.length, base }),
+}

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -6,12 +6,15 @@
 # codex-verdict.schema.json, and writes the JSON verdict to <out-json>.
 #
 # Usage:
-#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json>
+#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
 #
 #   <base-branch>    branch to diff against (e.g. master)
 #   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
 #                    or "-" on the first round (no rebuttal yet)
 #   <out-json>       path the JSON verdict is written to (also echoed to stdout)
+#   <reasoning-effort> codex model_reasoning_effort for this run; the debate
+#                    workflow passes its REASONING_EFFORT constant here so the
+#                    value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only`, which enforces read-only at the
@@ -34,9 +37,12 @@
 #     was never captured, a later round cleanly falls back to a cold start.
 set -uo pipefail
 
-base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json>}"
+base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
 rebuttal_file="${2:?missing rebuttal-file (use - for none)}"
 out="${3:?missing out-json path}"
+# The debate workflow owns this value (its REASONING_EFFORT constant) and passes
+# it down; "xhigh" is only the default for a standalone invocation of this script.
+effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
@@ -194,7 +200,7 @@ run_codex() {
   if [ -n "$resume_id" ]; then
     codex exec resume \
       -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="xhigh" \
+      -c model_reasoning_effort="$effort" \
       --json \
       --output-schema "$schema" \
       -o "$out" \
@@ -202,7 +208,7 @@ run_codex() {
   else
     codex exec \
       --sandbox read-only \
-      -c model_reasoning_effort="xhigh" \
+      -c model_reasoning_effort="$effort" \
       --json \
       --output-schema "$schema" \
       -o "$out" \
@@ -210,9 +216,10 @@ run_codex() {
   fi
 }
 
-# model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
-# relying on the user's global ~/.codex/config.toml — review is the one place we
-# always want codex thinking at full depth, regardless of their default.
+# model_reasoning_effort is scoped to the debate here (via -c, from the $effort
+# the workflow passes down — default "xhigh") rather than relying on the user's
+# global ~/.codex/config.toml — review is the one place we always want codex
+# thinking at full depth, regardless of their default.
 #
 # RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
 # hiccups, a spurious internal error) and writes no verdict — which would

--- a/.agents/skills/lens-debate/SKILL.md
+++ b/.agents/skills/lens-debate/SKILL.md
@@ -168,7 +168,8 @@ collide and the scratch never shows up in the diff the lenses review. It returns
   unresolved,  // findings still contested at the backstop (empty on consensus)
   applied,     // [{ id, title, files, commit }]
   reviews,     // each lens's independent findings
-  history }    // per-round dispositions
+  history,     // per-round dispositions
+  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
 - **consensus** — every finding settled (the normal outcome).
@@ -194,6 +195,7 @@ branch for the human to review):
   `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
+  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never hit commitFix, so the dir may not exist yet
   printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
   gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
   ```

--- a/.agents/skills/lens-debate/SKILL.md
+++ b/.agents/skills/lens-debate/SKILL.md
@@ -190,12 +190,21 @@ branch for the human to review):
 - On any **unresolved** finding, surface both lenses' final positions plainly so
   the human can adjudicate — do not pick a winner yourself.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post a `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)` comment via
-  `gh pr comment`. Include: the outcome badge and round count; the independent
-  per-lens finding counts; the per-finding table (origin, title, location, agreed
-  disposition, applied commit); and, for any unresolved finding, both lenses'
-  positions. Use a single-quoted heredoc so backticks/`$` survive. This mirrors
-  `/codex-debate`; `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
+  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
+
+  ```bash
+  printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
+  gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
+  ```
+
+  The workflow returns `comment` already rendered — the
+  `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)` header
+  with the outcome badge and round count, the independent per-lens finding counts,
+  the applied fixes (with commit SHAs), the agreed no-change observations, and any
+  unresolved findings with both lenses' positions. Posting the returned string
+  (rather than re-improvising a table) keeps the comment a **deterministic** render
+  of the debate outcome. This mirrors `/codex-debate`; `--no-comment` suppresses it.
 
 ## Safety & notes
 

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -260,15 +260,23 @@ ${message}
 // re-improvises a table. Unlike codex-debate there are NO per-round files to
 // assemble: the lenses don't read a ledger (feeding them prior reasoning would
 // invite entrenchment against conceding), so the comment is the only artifact.
-function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }) {
-  const badge = unresolved.length === 0 ? '✅ **Consensus**' : `⚠️ **${unresolved.length} unresolved**`
+function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base, clean }) {
+  const badge = clean
+    ? '✅ **Clean** — every lens found nothing worth raising'
+    : unresolved.length === 0
+      ? '✅ **Consensus**'
+      : `⚠️ **${unresolved.length} unresolved**`
   const counts = Object.entries(reviewByLens)
     .map(([lens, fs]) => `${lens}=${fs.length}`)
     .join(', ')
+  // A clean diff never debated, so the "after N round(s)" clause is omitted; the
+  // base, the lens roster, and the (all-zero) per-lens counts still ride along so
+  // the comment carries the same audit metadata as a debated run.
+  const meta = `lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``
   const lines = [
     '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)',
     '',
-    `${badge} after ${rounds} round(s) · lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``,
+    clean ? `${badge} · ${meta}` : `${badge} after ${rounds} round(s) · ${meta}`,
     '',
     `Independent findings: ${counts}`,
   ]
@@ -283,7 +291,19 @@ function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, 
   }
   if (unresolved.length) {
     lines.push('', `### Unresolved — needs human (${unresolved.length})`)
-    unresolved.forEach((u) => lines.push(`- \`${u.id}\` ${u.title} (${u.location}) — lowy: ${u.lowy?.disposition ?? '?'}, hickey: ${u.hickey?.disposition ?? '?'}`))
+    // Surface BOTH lenses' full final positions (disposition + reasoning + any
+    // plan), not just the bare verdict — a human adjudicating needs the actual
+    // disagreement, which lives in each side's reasoning/plan text.
+    unresolved.forEach((u) => {
+      lines.push('', `- \`${u.id}\` ${u.title} (${u.location})`)
+      for (const lens of ['lowy', 'hickey']) {
+        const p = u[lens]
+        const verdict = p?.disposition ?? '?'
+        const reasoning = p?.reasoning ? ` — ${p.reasoning}` : ''
+        lines.push(`  - **${lens}**: ${verdict}${reasoning}`)
+        if (p?.plan?.trim()) lines.push(`    - plan: ${p.plan}`)
+      }
+    })
   }
   return lines.join('\n')
 }
@@ -309,7 +329,11 @@ REVIEWERS.forEach((r, idx) => {
 log(`Independent findings: ${REVIEWERS.map((r) => `${r.lens}=${reviewByLens[r.lens].length}`).join(', ')}`)
 
 if (combined.length === 0) {
-  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment: '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n✅ Every lens found nothing worth raising.' }
+  // Route the clean outcome through the SAME renderer as a debated run so the
+  // comment carries the same audit metadata (base, lens roster, per-lens counts,
+  // whether code-police ran) instead of a bare one-liner.
+  const comment = renderComment({ rounds: 0, settledOut: [], unresolved: [], applied: [], reviewByLens, withPolice, base, clean: true })
+  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment }
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -255,6 +255,39 @@ ${message}
   return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply', model: mechModel })
 }
 
+// Render the PR comment deterministically from the debate outcome, returned as a
+// string so the ORCHESTRATOR posts it verbatim (`gh pr comment -F`) — no agent
+// re-improvises a table. Unlike codex-debate there are NO per-round files to
+// assemble: the lenses don't read a ledger (feeding them prior reasoning would
+// invite entrenchment against conceding), so the comment is the only artifact.
+function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }) {
+  const badge = unresolved.length === 0 ? '✅ **Consensus**' : `⚠️ **${unresolved.length} unresolved**`
+  const counts = Object.entries(reviewByLens)
+    .map(([lens, fs]) => `${lens}=${fs.length}`)
+    .join(', ')
+  const lines = [
+    '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)',
+    '',
+    `${badge} after ${rounds} round(s) · lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``,
+    '',
+    `Independent findings: ${counts}`,
+  ]
+  const drops = settledOut.filter((s) => s.agreed && s.disposition === 'drop')
+  if (applied.length) {
+    lines.push('', `### Applied (${applied.length})`)
+    applied.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+  }
+  if (drops.length) {
+    lines.push('', `### Agreed — no change (${drops.length})`)
+    drops.forEach((d) => lines.push(`- \`${d.id}\` ${d.title} (${d.location})`))
+  }
+  if (unresolved.length) {
+    lines.push('', `### Unresolved — needs human (${unresolved.length})`)
+    unresolved.forEach((u) => lines.push(`- \`${u.id}\` ${u.title} (${u.location}) — lowy: ${u.lowy?.disposition ?? '?'}, hickey: ${u.hickey?.disposition ?? '?'}`))
+  }
+  return lines.join('\n')
+}
+
 // ---------------------------------------------------------------------------
 // Phase 1 — independent parallel review
 // ---------------------------------------------------------------------------
@@ -276,7 +309,7 @@ REVIEWERS.forEach((r, idx) => {
 log(`Independent findings: ${REVIEWERS.map((r) => `${r.lens}=${reviewByLens[r.lens].length}`).join(', ')}`)
 
 if (combined.length === 0) {
-  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [] }
+  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment: '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n✅ Every lens found nothing worth raising.' }
 }
 
 // ---------------------------------------------------------------------------
@@ -384,4 +417,15 @@ for (const fix of fixes) {
   log(`Applied ${fix.id}: ${files.length} file(s)${sha ? `, committed ${sha.slice(0, 9)}` : ' (uncommitted)'}`)
 }
 
-return { status, rounds, base, withPolice, settled: settledOut, unresolved, applied, reviews: reviewByLens, history }
+return {
+  status,
+  rounds,
+  base,
+  withPolice,
+  settled: settledOut,
+  unresolved,
+  applied,
+  reviews: reviewByLens,
+  history,
+  comment: renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }),
+}

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -260,6 +260,14 @@ ${message}
 // re-improvises a table. Unlike codex-debate there are NO per-round files to
 // assemble: the lenses don't read a ledger (feeding them prior reasoning would
 // invite entrenchment against conceding), so the comment is the only artifact.
+//
+// The header chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
+// deliberately kept STRUCTURALLY PARALLEL to codex-debate's ledgerHeader chrome.
+// The no-module workflow runtime has no imports, so a truly shared renderer isn't
+// available; the two are instead siblings that move together. A house-style change
+// (badge emoji, base-slice length, a new metadata row) is a mechanical mirror edit
+// — make it here and in codex-debate's ledgerHeader. If the runtime ever admits a
+// shared helper file, lift this common chrome there.
 function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base, clean }) {
   const badge = clean
     ? '✅ **Clean** — every lens found nothing worth raising'

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -107,17 +107,21 @@ codex reviews. It returns:
 
 ```
 { status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript, ledgerPath }
+  rounds, base, finalVerdict, filesChanged, transcript,
+  workDir, ledgerPath, ledgerHeader }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
-`ledgerPath` points at `.codex-debate/debate-log.md` — the **shared debate
-ledger**, one durable Markdown record of every round (codex's findings, its reply
-to the rebuttal, Claude's dispositions, the commit) rewritten each round. It has
-two readers: the **Claude author** reads it as its cross-round memory (so each
-round builds on the last instead of re-deriving the diff), and **step 3 posts it
-verbatim as the PR comment**. codex is *not* a reader — it keeps its own warm
-session, so re-feeding it the ledger would just duplicate its context.
+The debate is recorded as **one small Markdown file per round** —
+`<workDir>/section-NNN.md` (zero-padded). Those section files have two readers:
+the **Claude author** reads them as its cross-round memory (so each round builds
+on the last instead of re-deriving the diff), and **step 3 assembles them into the
+PR comment** — `ledgerHeader` (the outcome header) followed by a `cat` of the
+sections, written to `ledgerPath` (`.codex-debate/debate-log.md`) and posted. The
+comment is therefore a **deterministic concatenation**, never re-rendered through
+an agent — nothing weak ever retypes a large blob. codex is *not* a reader — it
+keeps its own warm session, so re-feeding it the sections would just duplicate its
+context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -156,24 +160,30 @@ the per-round commits sit on the local branch for the human to review):
   on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
-- A compact per-round summary — read it straight from the ledger at `ledgerPath`
-  (each round's codex verdict, Claude's dispositions, and the commit SHA) so the
-  convergence reads round by round. No need to re-derive it from `transcript`; the
-  ledger already renders it.
+- A compact per-round summary — read it straight from the section files
+  (`cat <workDir>/section-*.md`: each round's codex verdict, Claude's
+  dispositions, and the commit SHA) so the convergence reads round by round. No
+  need to re-derive it from `transcript`; the sections already render it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post the **ledger file verbatim** as the PR
-  comment: `gh pr comment <pr> -F "$ledgerPath"` (or `--body-file`). The workflow
-  already wrote the final, headed render to `ledgerPath` — a `## Codex ⇄ Claude
-  debate` document carrying the **consensus** badge, the round count, the
-  **`xhigh` reasoning-effort** note, and a per-round breakdown of codex's findings
-  and Claude's dispositions. Posting the file directly (rather than re-improvising
-  a table) keeps the comment a **deterministic** render of the same record the
-  commit messages and the author drew on. This is an outward-facing write — on by
-  default because the whole point is to leave the review trail on the PR;
-  `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, **assemble the comment from the workflow's
+  output and post it** — no agent re-renders it:
+
+  ```bash
+  { printf '%s\n\n' "$ledgerHeader"; cat "$workDir"/section-*.md; } > "$ledgerPath"
+  gh pr comment <pr> -F "$ledgerPath"
+  ```
+
+  `ledgerHeader` is the `## Codex ⇄ Claude debate` header (consensus badge, round
+  count, the **`xhigh` reasoning-effort** note); the zero-padded `section-*.md`
+  files are the per-round breakdown of codex's findings and Claude's dispositions
+  that the author also read. So the comment is a **deterministic concatenation**
+  of the same record the commit messages and the author drew on — not an
+  LLM-improvised table. This is an outward-facing write — on by default because
+  the whole point is to leave the review trail on the PR; `--no-comment`
+  suppresses it.
 
 ## Safety & notes
 
@@ -198,15 +208,16 @@ the per-round commits sit on the local branch for the human to review):
 - **Warm author (context, not session).** The Claude author can't be resumed the
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
   so there's no session id to carry forward. The equivalent is context, not state:
-  each follow-up round the author **reads the shared debate ledger**
-  (`.codex-debate/debate-log.md`) — every prior round's findings and its own
+  each follow-up round the author **reads the per-round section files**
+  (`cat .codex-debate/section-*.md`) — every prior round's findings and its own
   dispositions — so it builds on its last round rather than re-deriving the whole
-  diff, and won't re-fix or re-litigate findings already settled. The ledger is
-  rewritten after each round, so round N>1 always sees rounds 1..N-1; round 1 has
-  no ledger yet, so it's byte-identical to a cold start (and if the file is ever
-  missing, the author falls back to the diff + verdict). The *same* ledger is what
-  step 3 posts as the PR comment, so the author's memory and the published summary
-  are one artifact. codex stays on its own warm session and never reads the ledger.
+  diff, and won't re-fix or re-litigate findings already settled. A small section
+  is written after each round, so round N>1 always sees rounds 1..N-1; round 1 has
+  none yet, so it's byte-identical to a cold start (and if no sections exist, the
+  author falls back to the diff + verdict). The *same* sections compose the PR
+  comment step 3 posts, so the author's memory and the published summary are one
+  record. The writes stay small (one round each), so the Haiku writer never
+  retypes a large blob. codex stays on its own warm session and never reads them.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
@@ -216,9 +227,9 @@ the per-round commits sit on the local branch for the human to review):
   on many worktrees run at once without clobbering each other — no shared `/tmp`
   paths, and each worktree's `debate-log.md` is its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  ledger file (`debate-log.md`) — is posted verbatim as a PR comment
-  (outward-facing write) unless `--no-comment` is passed — the point is to leave
-  the review trail on the PR.
+  header + per-round sections assembled into `debate-log.md` — is posted as a PR
+  comment (outward-facing write) unless `--no-comment` is passed — the point is to
+  leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -153,10 +153,12 @@ Otherwise (`status === "consensus"`) report in chat (do **not** push or merge �
 the per-round commits sit on the local branch for the human to review):
 
 - The outcome — **consensus** — and how many rounds it took to get there.
-- **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
-  debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
-  of the user's global codex default). State this so the depth of the review is
-  on the record.
+- **The reviewer's reasoning effort** — sourced from the workflow's single
+  `REASONING_EFFORT` constant (`xhigh` today), which is passed down to
+  `codex-review.sh`'s `-c model_reasoning_effort` and into the comment header, so
+  the published value and the config codex actually ran at share one home. Read
+  it off the header rather than asserting it independently. State it so the depth
+  of the review is on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round summary — read it straight from the section files
@@ -177,8 +179,9 @@ the per-round commits sit on the local branch for the human to review):
   ```
 
   The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
-  header (consensus badge, round count, the **`xhigh` reasoning-effort** note)
-  followed by the per-round breakdown of codex's findings and Claude's dispositions
+  header (consensus badge, round count, the **reasoning-effort** note from the
+  workflow's `REASONING_EFFORT` constant) followed by the per-round breakdown of
+  codex's findings and Claude's dispositions
   that the author also read. So the comment is a **deterministic** render of the
   same record the commit messages and the author drew on — not an LLM-improvised
   table. Posting the returned string mirrors `/lens-debate`. This is an

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -108,20 +108,19 @@ codex reviews. It returns:
 ```
 { status: "consensus" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, transcript,
-  workDir, ledgerPath, ledgerHeader }
+  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 The debate is recorded as **one small Markdown file per round** —
-`<workDir>/section-NNN.md` (zero-padded). Those section files have two readers:
-the **Claude author** reads them as its cross-round memory (so each round builds
-on the last instead of re-deriving the diff), and **step 3 assembles them into the
-PR comment** — `ledgerHeader` (the outcome header) followed by a `cat` of the
-sections, written to `ledgerPath` (`.codex-debate/debate-log.md`) and posted. The
-comment is therefore a **deterministic concatenation**, never re-rendered through
-an agent — nothing weak ever retypes a large blob. codex is *not* a reader — it
-keeps its own warm session, so re-feeding it the sections would just duplicate its
-context.
+`<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
+author's cross-round memory** (so each round builds on the last instead of
+re-deriving the diff). The workflow renders the **same** record into `comment` —
+the outcome header followed by every round's section — so **step 3 just posts that
+string** (`gh pr comment -F`), exactly the way `/lens-debate` does. The comment is
+therefore a **deterministic** render, never re-improvised through an agent —
+nothing weak ever retypes a large blob. codex is *not* a reader — it keeps its own
+warm session, so re-feeding it the sections would just duplicate its context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -168,22 +167,23 @@ the per-round commits sit on the local branch for the human to review):
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, **assemble the comment from the workflow's
-  output and post it** — no agent re-renders it:
+  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
+  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  { printf '%s\n\n' "$ledgerHeader"; cat "$workDir"/section-*.md; } > "$ledgerPath"
-  gh pr comment <pr> -F "$ledgerPath"
+  mkdir -p "$repoPath/.codex-debate"   # reviewer-error/--no-commit runs may not have created it
+  printf '%s' "$comment" > "$repoPath/.codex-debate/comment.md"
+  gh pr comment <pr> -F "$repoPath/.codex-debate/comment.md"
   ```
 
-  `ledgerHeader` is the `## Codex ⇄ Claude debate` header (consensus badge, round
-  count, the **`xhigh` reasoning-effort** note); the zero-padded `section-*.md`
-  files are the per-round breakdown of codex's findings and Claude's dispositions
-  that the author also read. So the comment is a **deterministic concatenation**
-  of the same record the commit messages and the author drew on — not an
-  LLM-improvised table. This is an outward-facing write — on by default because
-  the whole point is to leave the review trail on the PR; `--no-comment`
-  suppresses it.
+  The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
+  header (consensus badge, round count, the **`xhigh` reasoning-effort** note)
+  followed by the per-round breakdown of codex's findings and Claude's dispositions
+  that the author also read. So the comment is a **deterministic** render of the
+  same record the commit messages and the author drew on — not an LLM-improvised
+  table. Posting the returned string mirrors `/lens-debate`. This is an
+  outward-facing write — on by default because the whole point is to leave the
+  review trail on the PR; `--no-comment` suppresses it.
 
 ## Safety & notes
 
@@ -222,14 +222,14 @@ the per-round commits sit on the local branch for the human to review):
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the debate ledger)
-  lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates
-  on many worktrees run at once without clobbering each other — no shared `/tmp`
-  paths, and each worktree's `debate-log.md` is its own.
+- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the per-round
+  sections) lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`,
+  so debates on many worktrees run at once without clobbering each other — no
+  shared `/tmp` paths, and each worktree's section files are its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  header + per-round sections assembled into `debate-log.md` — is posted as a PR
-  comment (outward-facing write) unless `--no-comment` is passed — the point is to
-  leave the review trail on the PR.
+  workflow's deterministically rendered `comment` (header + per-round sections) —
+  is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
+  — the point is to leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -184,6 +184,13 @@ the per-round commits sit on the local branch for the human to review):
   other's sessions. If the id is ever missing (round-1 capture failed), a later
   round transparently cold-starts with the full prompt + rebuttal — graceful
   degradation, never a wedge.
+- **Warm author (context, not session).** The Claude author can't be resumed the
+  way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
+  so there's no session id to carry forward. The prompt-level equivalent is used
+  instead: each follow-up round's author prompt carries the author's OWN previous
+  dispositions (its prior summary + actions), so it builds on its last round
+  rather than re-deriving the whole diff, and won't re-fix or re-litigate findings
+  already settled. Round 1 has no prior, so it's byte-identical to a cold start.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -100,16 +100,24 @@ tree, then (unless `--no-commit`) a `commit:roundN` agent **commits exactly that
 round's changed files** with a message embedding the round's codex findings and
 Claude's dispositions — never pushing or merging.
 
-Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
-`<repoPath>/.codex-debate/`, so **parallel debates in different worktrees never
-collide** and the scratch never shows up in the diff codex reviews. It returns:
+Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
+gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in
+different worktrees never collide** and the scratch never shows up in the diff
+codex reviews. It returns:
 
 ```
 { status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript }
+  rounds, base, finalVerdict, filesChanged, transcript, ledgerPath }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
+`ledgerPath` points at `.codex-debate/debate-log.md` — the **shared debate
+ledger**, one durable Markdown record of every round (codex's findings, its reply
+to the rebuttal, Claude's dispositions, the commit) rewritten each round. It has
+two readers: the **Claude author** reads it as its cross-round memory (so each
+round builds on the last instead of re-deriving the diff), and **step 3 posts it
+verbatim as the PR comment**. codex is *not* a reader — it keeps its own warm
+session, so re-feeding it the ledger would just duplicate its context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -148,21 +156,24 @@ the per-round commits sit on the local branch for the human to review):
   on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
-- A compact per-round table from `transcript` — each round's codex verdict
-  (approved? open-findings count), Claude's dispositions, and the
-  round's `commit` SHA — so the convergence reads round by round.
+- A compact per-round summary — read it straight from the ledger at `ledgerPath`
+  (each round's codex verdict, Claude's dispositions, and the commit SHA) so the
+  convergence reads round by round. No need to re-derive it from `transcript`; the
+  ledger already renders it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
-  `gh pr comment`. Include: the **consensus** outcome badge and the round count;
-  a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
-  table (codex approved? open-findings count; Claude's dispositions; the
-  round's commit SHA) showing how the two sides converged. Use a
-  single-quoted heredoc so backticks/`$` survive. This is an
-  outward-facing write — it's on by default because the whole point is to leave
-  the review trail on the PR; `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, post the **ledger file verbatim** as the PR
+  comment: `gh pr comment <pr> -F "$ledgerPath"` (or `--body-file`). The workflow
+  already wrote the final, headed render to `ledgerPath` — a `## Codex ⇄ Claude
+  debate` document carrying the **consensus** badge, the round count, the
+  **`xhigh` reasoning-effort** note, and a per-round breakdown of codex's findings
+  and Claude's dispositions. Posting the file directly (rather than re-improvising
+  a table) keeps the comment a **deterministic** render of the same record the
+  commit messages and the author drew on. This is an outward-facing write — on by
+  default because the whole point is to leave the review trail on the PR;
+  `--no-comment` suppresses it.
 
 ## Safety & notes
 
@@ -186,21 +197,28 @@ the per-round commits sit on the local branch for the human to review):
   degradation, never a wedge.
 - **Warm author (context, not session).** The Claude author can't be resumed the
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
-  so there's no session id to carry forward. The prompt-level equivalent is used
-  instead: each follow-up round's author prompt carries the author's OWN previous
-  dispositions (its prior summary + actions), so it builds on its last round
-  rather than re-deriving the whole diff, and won't re-fix or re-litigate findings
-  already settled. Round 1 has no prior, so it's byte-identical to a cold start.
+  so there's no session id to carry forward. The equivalent is context, not state:
+  each follow-up round the author **reads the shared debate ledger**
+  (`.codex-debate/debate-log.md`) — every prior round's findings and its own
+  dispositions — so it builds on its last round rather than re-deriving the whole
+  diff, and won't re-fix or re-litigate findings already settled. The ledger is
+  rewritten after each round, so round N>1 always sees rounds 1..N-1; round 1 has
+  no ledger yet, so it's byte-identical to a cold start (and if the file is ever
+  missing, the author falls back to the diff + verdict). The *same* ledger is what
+  step 3 posts as the PR comment, so the author's memory and the published summary
+  are one artifact. codex stays on its own warm session and never reads the ledger.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals) lives under the
-  gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates on many
-  worktrees run at once without clobbering each other — no shared `/tmp` paths.
-- **Posts to the PR by default.** When a PR exists, the debate summary is posted
-  as a PR comment (outward-facing write) unless `--no-comment` is passed — the
-  point is to leave the review trail on the PR.
+- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the debate ledger)
+  lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates
+  on many worktrees run at once without clobbering each other — no shared `/tmp`
+  paths, and each worktree's `debate-log.md` is its own.
+- **Posts to the PR by default.** When a PR exists, the debate summary — the
+  ledger file (`debate-log.md`) — is posted verbatim as a PR comment
+  (outward-facing write) unless `--no-comment` is passed — the point is to leave
+  the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -286,6 +286,14 @@ function roundLedgerSection(entry) {
 // The comment header (small). The full comment is this header followed by the
 // per-round section files (see renderLedger). The workflow renders the whole
 // comment deterministically from the transcript — no agent ever retypes the blob.
+//
+// This header's chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
+// deliberately kept STRUCTURALLY PARALLEL to lens-debate's renderComment header
+// chrome. The no-module workflow runtime has no imports, so a truly shared
+// renderer isn't available; the two are instead siblings that move together. A
+// house-style change (badge emoji, base-slice length, a new metadata row) is a
+// mechanical mirror edit — make it here and in lens-debate's renderComment. If
+// the runtime ever admits a shared helper file, lift this common chrome there.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -355,6 +355,21 @@ if (!baseRes?.sha?.trim()) {
 base = baseRes.sha.trim()
 log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
+// Clear any stale ledger from a PRIOR debate in this worktree. The scratch dir
+// is persistent (per-worktree, not per-run) and the section files use a flat,
+// stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
+// sections would otherwise survive into this run — the author cats `section-*.md`
+// as its memory and step 3 cats the same glob into the posted comment, so stale
+// sections would pollute BOTH the author's context and the published trail. A
+// thin mechanical agent (the workflow can't run shell itself); deleting the whole
+// dir is safe because nothing in THIS run has written to it yet. This script has
+// no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
+// so a fresh start owns a fresh ledger.
+await agent(
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf ${workDir} && mkdir -p ${workDir}\`. Do not edit any other file. Do not run git.`,
+  { label: 'ledger:reset', phase: 'Debate', model: mechModel },
+)
+
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
   finalVerdict = verdict

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -136,12 +136,31 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict) {
+async function claudeResponds(round, verdict, priorClaude) {
+  // WARM AUTHOR. On follow-up rounds, thread the author's OWN previous
+  // dispositions back into the prompt so it builds on its prior round instead
+  // of re-deriving everything from the diff — the prompt-level analog of codex's
+  // warm session. (We can't truly resume the Claude author: agent() is one-shot,
+  // and Claude isn't headless under Max auth, so there's no session to resume the
+  // way `codex exec resume` carries codex's reasoning forward. This is the
+  // achievable equivalent — context, not state.) codex's responseToRebuttal in
+  // the verdict already says which of the author's disputes it conceded vs still
+  // holds, so the author knows exactly what to revisit. Empty on round 1, so the
+  // first round is byte-identical to the pre-warm-author prompt.
+  const priorBlock = priorClaude
+    ? `This is a FOLLOW-UP round — you already worked this diff last round. Here is what YOU did then (your own dispositions); build on it, don't re-derive it from scratch, and don't re-fix or re-litigate anything already settled:
+
+${JSON.stringify({ summary: priorClaude.summary, actions: priorClaude.actions }, null, 2)}
+
+For any finding you DISPUTED last round, read codex's \`responseToRebuttal\` below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+
+`
+    : ''
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
 
-CODEX's verdict (JSON):
+${priorBlock}CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
 Address EVERY finding, any severity (don't skip minors/nits):
@@ -286,8 +305,11 @@ for (let round = 1; ; round++) {
     break
   }
 
-  // Claude responds: fixes what it agrees with (editing the tree), disputes the rest.
-  const response = await claudeResponds(round, verdict)
+  // Claude responds: fixes what it agrees with (editing the tree), disputes the
+  // rest. `lastClaude` still holds the PREVIOUS round's response here (it's
+  // reassigned just below), so the author gets its own prior dispositions — the
+  // warm-author context — and on round 1 it's null (cold start, unchanged).
+  const response = await claudeResponds(round, verdict, lastClaude)
   entry.claude = response
   lastClaude = response
   log(

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -30,16 +30,14 @@ const workDir = `${repoPath}/.codex-debate`
 // DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
 // elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
-// The assembled PR comment. The debate is recorded as one small Markdown file
-// PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
-// section files serve TWO readers: the claude author reads them as its cross-round
-// memory (full history, no inline blob), and the orchestrator concatenates the
-// outcome header + every section into THIS file and posts it (`gh pr comment -F`).
-// So the published summary and the author's context are one record — assembled by
-// deterministic `cat`, never re-rendered through an agent (nothing weak ever
-// retypes a large blob). codex is NOT a reader: it keeps its own warm session, so
-// re-feeding it the ledger would just duplicate what it already remembers.
-const ledgerPath = `${workDir}/debate-log.md`
+// The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
+// written under the gitignored scratch dir) — the claude author reads them as its
+// cross-round memory (full history, no inline blob). The PR comment is rendered
+// from the SAME per-round sections in-process (see renderLedger) and returned as
+// `comment`, so the published summary and the author's context are one record —
+// deterministic, never re-rendered through an agent (nothing weak ever retypes a
+// large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
+// it the ledger would just duplicate what it already remembers.
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
 // pushes or merges — that stays the human's call.
@@ -286,12 +284,22 @@ function roundLedgerSection(entry) {
 }
 
 // The comment header (small). The full comment is this header followed by the
-// per-round section files, assembled by the orchestrator at post time (SKILL
-// step 3) with a deterministic `cat`. The workflow never renders the whole ledger
-// through an agent, so nothing weak ever retypes a large blob.
+// per-round section files (see renderLedger). The workflow renders the whole
+// comment deterministically from the transcript — no agent ever retypes the blob.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+}
+
+// The whole PR comment, rendered deterministically in-process from the transcript:
+// the outcome header followed by each round's Markdown section. The per-round
+// section files on disk remain the author's cross-round memory (see writeSection);
+// this re-uses the SAME `roundLedgerSection` renderer to assemble the published
+// comment, so the orchestrator posts a ready string (`gh pr comment -F`) exactly
+// the way lens-debate does — no bespoke `cat` glob at the consumer, and nothing
+// weak ever retypes a large blob (the workflow builds the string itself).
+function renderLedger(transcript, meta) {
+  return [ledgerHeader(meta), ...transcript.map(roundLedgerSection)].join('\n\n')
 }
 
 // Zero-pad the round so the section glob (`section-*.md`) sorts in round order
@@ -450,9 +458,11 @@ log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged
 // reached before the author got a turn) would be missing from the comment.
 if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
-// Hand the orchestrator the header and the paths; it assembles the comment
-// (header + section-*.md → ledgerPath) with a deterministic cat and posts it —
-// no agent ever retypes the whole ledger. See SKILL step 3.
+// Hand the orchestrator the ready-to-post comment, rendered deterministically
+// in-process (header + per-round sections) — it just writes the string to a file
+// and posts it (`gh pr comment -F`), the same shape lens-debate uses. The section
+// files on disk stay the author's cross-round memory; this is the published view
+// of that same record, so no agent ever retypes the whole ledger. See SKILL step 3.
 return {
   status,
   rounds: transcript.length,
@@ -460,7 +470,5 @@ return {
   finalVerdict,
   filesChanged,
   transcript,
-  workDir,
-  ledgerPath,
-  ledgerHeader: ledgerHeader({ status, rounds: transcript.length, base }),
+  comment: renderLedger(transcript, { status, rounds: transcript.length, base }),
 }

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -383,12 +383,14 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // sections would otherwise survive into this run — the author cats `section-*.md`
 // as its memory and step 3 cats the same glob into the posted comment, so stale
 // sections would pollute BOTH the author's context and the published trail. A
-// thin mechanical agent (the workflow can't run shell itself); deleting the whole
-// dir is safe because nothing in THIS run has written to it yet. This script has
-// no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
-// so a fresh start owns a fresh ledger.
+// thin mechanical agent (the workflow can't run shell itself). The reset is
+// section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
+// whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
+// commit-msg-N.txt) keep their own lifecycle and a future pre-loop writer won't
+// be silently wiped. This script has no true resume (agent() is one-shot, the
+// whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
 await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf -- ${shq(workDir)} && mkdir -p -- ${shq(workDir)}\`. Do not edit any other file. Do not run git.`,
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
 

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -24,6 +24,15 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
+// The shared debate ledger: one durable Markdown record of the whole debate
+// (every round's codex findings + claude dispositions + commit), rewritten each
+// round under the gitignored scratch dir. It serves TWO readers — the claude
+// author reads it as its cross-round memory (replacing an inline blob), and the
+// orchestrator posts it verbatim as the PR comment (`gh pr comment -F`), so the
+// summary is a deterministic render of the same record, not an LLM re-improvisation.
+// codex is NOT a reader: it keeps its own warm session, so re-feeding it the
+// ledger would just duplicate what it already remembers (and bloat its context).
+const ledgerPath = `${workDir}/debate-log.md`
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
 // pushes or merges — that stays the human's call.
@@ -136,26 +145,24 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict, priorClaude) {
-  // WARM AUTHOR. On follow-up rounds, thread the author's OWN previous
-  // dispositions back into the prompt so it builds on its prior round instead
-  // of re-deriving everything from the diff — the prompt-level analog of codex's
-  // warm session. (We can't truly resume the Claude author: agent() is one-shot,
+async function claudeResponds(round, verdict) {
+  // WARM AUTHOR. We can't truly resume the Claude author (agent() is one-shot,
   // and Claude isn't headless under Max auth, so there's no session to resume the
-  // way `codex exec resume` carries codex's reasoning forward. This is the
-  // achievable equivalent — context, not state.) codex's responseToRebuttal in
-  // the verdict already says which of the author's disputes it conceded vs still
-  // holds, so the author knows exactly what to revisit. Empty on round 1, so the
-  // first round is byte-identical to the pre-warm-author prompt.
-  const priorBlock = priorClaude
-    ? `This is a FOLLOW-UP round — you already worked this diff last round. Here is what YOU did then (your own dispositions); build on it, don't re-derive it from scratch, and don't re-fix or re-litigate anything already settled:
-
-${JSON.stringify({ summary: priorClaude.summary, actions: priorClaude.actions }, null, 2)}
-
-For any finding you DISPUTED last round, read codex's \`responseToRebuttal\` below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+  // way `codex exec resume` carries codex's reasoning forward). The achievable
+  // equivalent is context, not state: every follow-up round the author reads the
+  // shared debate ledger — the durable record of every prior round's findings and
+  // its OWN dispositions — and builds on it instead of re-deriving the diff. The
+  // ledger is written after each round (see the loop), so on round N>1 it already
+  // holds rounds 1..N-1. Round 1 has no ledger yet, so its prompt is byte-identical
+  // to a cold start.
+  const priorBlock =
+    round > 1
+      ? `This is a FOLLOW-UP round. The debate so far — every prior round's codex findings and YOUR own dispositions — is recorded in this file:
+  \`${ledgerPath}\`
+Read it FIRST (if it's somehow missing, fall back to the diff + the verdict below). Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
 
 `
-    : ''
+      : ''
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
@@ -219,6 +226,79 @@ ${message}
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
 4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:round${round}`, phase: 'Debate', model: mechModel })
+}
+
+// ---------------------------------------------------------------------------
+// The shared ledger — rendered from the transcript, deterministically
+// ---------------------------------------------------------------------------
+// One round's findings, as a Markdown list. Shared by the section renderer below.
+function renderFindings(verdict) {
+  const list = (verdict.findings || [])
+    .map((f) => `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`)
+    .join('\n')
+  return list || '- _(none)_'
+}
+
+// One round's author dispositions, as a Markdown list. `null` on a terminal round
+// (codex approved or errored before the author got a turn).
+function renderActions(response) {
+  if (!response) return '_(no author turn — the debate ended this round)_'
+  const list = (response.actions || [])
+    .map((a) => `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`)
+    .join('\n')
+  return list || '- _(no actions)_'
+}
+
+// One round as a Markdown section: codex's verdict, its response to the rebuttal,
+// and the author's dispositions + commit. The single per-round renderer — the
+// author reads these as its memory and they compose into the posted comment.
+function roundLedgerSection(entry) {
+  const { round, codex, claude, commit } = entry
+  const lines = [
+    `### Round ${round}`,
+    '',
+    `**codex** — approved: \`${codex.approved}\``,
+    '',
+    codex.summary,
+    '',
+    'Findings:',
+    renderFindings(codex),
+  ]
+  if (codex.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${codex.responseToRebuttal}`)
+  lines.push('', `**claude** — ${claude ? claude.summary : '_(no author turn this round)_'}`, '', renderActions(claude))
+  if (commit) lines.push('', `commit: \`${commit}\``)
+  return lines.join('\n')
+}
+
+// The whole ledger. With `meta` (final write) it gets the consensus header that
+// makes the file directly postable as the PR comment; without it (the provisional
+// mid-debate writes that feed the author) it's just the round sections.
+function renderLedger(rounds, meta) {
+  const sections = rounds.map(roundLedgerSection).join('\n\n')
+  if (!meta) return sections
+  const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
+  const header = `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+  return `${header}\n\n${sections}`
+}
+
+// Write the ledger to disk. A thin mechanical agent: the workflow can't do file
+// I/O itself, so (like commitRound) it hands an agent the exact bytes to write.
+// Always overwrites with the full current render, so there's no fragile append
+// and the file is consistent whenever the author reads it. `meta` only on the
+// final write (the postable comment); omitted mid-debate.
+async function writeLedger(meta) {
+  const text = renderLedger(transcript, meta)
+  const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool (NOT a shell heredoc — the content has Markdown/special characters), create \`${ledgerPath}\` with EXACTLY this content, overwriting any existing file:
+
+${text}`
+  return agent(prompt, {
+    label: meta ? 'ledger:final' : `ledger:round${transcript.length}`,
+    phase: 'Debate',
+    model: mechModel,
+  })
 }
 
 const transcript = []
@@ -306,10 +386,10 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. `lastClaude` still holds the PREVIOUS round's response here (it's
-  // reassigned just below), so the author gets its own prior dispositions — the
-  // warm-author context — and on round 1 it's null (cold start, unchanged).
-  const response = await claudeResponds(round, verdict, lastClaude)
+  // rest. It reads the shared ledger (written at the end of each round below) for
+  // its cross-round memory. `lastClaude` is kept only to feed codex's rebuttal
+  // next round (see codexReviews) — it is no longer the author's memory.
+  const response = await claudeResponds(round, verdict)
   entry.claude = response
   lastClaude = response
   log(
@@ -324,6 +404,11 @@ for (let round = 1; ; round++) {
     entry.commit = (sha || '').trim()
     log(`Round ${round}: committed ${entry.commit}`)
   }
+
+  // Record the round in the shared ledger so the NEXT round's author can read its
+  // own history. Provisional (no header) — the final, postable render with the
+  // consensus header is written at the terminus.
+  await writeLedger()
 }
 
 const filesChanged = Array.from(
@@ -331,4 +416,10 @@ const filesChanged = Array.from(
 )
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript }
+// Final ledger render — full history plus the outcome header — the canonical,
+// directly-postable PR comment. The terminal round is already in `transcript`
+// (pushed before every break), so this single write covers every exit path,
+// including a consensus or error reached before the author got a turn.
+await writeLedger({ status, rounds: transcript.length, base })
+
+return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript, ledgerPath }

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -24,6 +24,12 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
+// POSIX single-quote a path for safe interpolation into a shell command. Wraps
+// in single quotes (so spaces, globs, and shell metacharacters are inert) and
+// escapes any embedded single quote via the '\'' idiom. Used for the one
+// DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
+// elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
+const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // The assembled PR comment. The debate is recorded as one small Markdown file
 // PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
 // section files serve TWO readers: the claude author reads them as its cross-round
@@ -366,7 +372,7 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
 // so a fresh start owns a fresh ledger.
 await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf ${workDir} && mkdir -p ${workDir}\`. Do not edit any other file. Do not run git.`,
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf -- ${shq(workDir)} && mkdir -p -- ${shq(workDir)}\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
 

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -27,8 +27,8 @@ const workDir = `${repoPath}/.codex-debate`
 // POSIX single-quote a path for safe interpolation into a shell command. Wraps
 // in single quotes (so spaces, globs, and shell metacharacters are inert) and
 // escapes any embedded single quote via the '\'' idiom. Used for the one
-// DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
-// elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
+// DESTRUCTIVE command (the ledger `rm -f` below); the benign `mkdir -p` prompts
+// elsewhere can tolerate an unquoted path, but a mistargeted `rm -f` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
 // written under the gitignored scratch dir) — the claude author reads them as its
@@ -407,7 +407,7 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // is persistent (per-worktree, not per-run) and the section files use a flat,
 // stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
 // sections would otherwise survive into this run — the author cats `section-*.md`
-// as its memory and step 3 cats the same glob into the posted comment, so stale
+// as its memory (and they compose into the `comment` renderLedger returns), so stale
 // sections would pollute BOTH the author's context and the published trail. A
 // thin mechanical agent (the workflow can't run shell itself). The reset is
 // section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
@@ -491,7 +491,9 @@ log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged
 
 // Section the terminal round — it broke out of the loop before the in-loop
 // writeSection, so without this its section (a consensus approval, or an error
-// reached before the author got a turn) would be missing from the comment.
+// reached before the author got a turn) would be missing from the disk record
+// the orchestrator reads for the chat summary (cat section-*.md) and the
+// author would read as memory if the debate somehow continued.
 if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
 // Hand the orchestrator the ready-to-post comment, rendered deterministically

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -58,6 +58,14 @@ const mechModel = a.mechModel || 'haiku'
 // agent's. The small per-round section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
+// The reasoning effort codex runs at, scoped to the debate. This JS constant is
+// the SINGLE home for the value: it is passed script-ward (a 4th positional arg
+// to codex-review.sh, which sets `-c model_reasoning_effort`) and read by
+// ledgerHeader for the published comment, so the `-c` flag and the header both
+// derive from here via the one-directional invocation channel — no literal
+// repeated across files held together by "remember to update all of them".
+const REASONING_EFFORT = 'xhigh'
+
 // ---------------------------------------------------------------------------
 // Schemas — the codex verdict schema mirrors scripts/codex-verdict.schema.json
 // so the runner agent returns the same shape codex was constrained to.
@@ -134,11 +142,11 @@ async function codexReviews(round, rebuttalJson) {
 ${rebuttalJson}
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT}\``
     : `1. (No prior rebuttal this round.)
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -314,7 +322,7 @@ function roundLedgerSection(entry) {
 // the runtime ever admits a shared helper file, lift this common chrome there.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
-  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`${meta.reasoningEffort}\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
 // The whole PR comment, rendered deterministically in-process from the transcript:
@@ -498,5 +506,5 @@ return {
   finalVerdict,
   filesChanged,
   transcript,
-  comment: renderLedger(transcript, { status, rounds: transcript.length, base }),
+  comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
 }

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -24,14 +24,15 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
-// The shared debate ledger: one durable Markdown record of the whole debate
-// (every round's codex findings + claude dispositions + commit), rewritten each
-// round under the gitignored scratch dir. It serves TWO readers — the claude
-// author reads it as its cross-round memory (replacing an inline blob), and the
-// orchestrator posts it verbatim as the PR comment (`gh pr comment -F`), so the
-// summary is a deterministic render of the same record, not an LLM re-improvisation.
-// codex is NOT a reader: it keeps its own warm session, so re-feeding it the
-// ledger would just duplicate what it already remembers (and bloat its context).
+// The assembled PR comment. The debate is recorded as one small Markdown file
+// PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
+// section files serve TWO readers: the claude author reads them as its cross-round
+// memory (full history, no inline blob), and the orchestrator concatenates the
+// outcome header + every section into THIS file and posts it (`gh pr comment -F`).
+// So the published summary and the author's context are one record — assembled by
+// deterministic `cat`, never re-rendered through an agent (nothing weak ever
+// retypes a large blob). codex is NOT a reader: it keeps its own warm session, so
+// re-feeding it the ledger would just duplicate what it already remembers.
 const ledgerPath = `${workDir}/debate-log.md`
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
@@ -44,6 +45,14 @@ const commit = a.commit !== false
 // (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
+// Fidelity tier (Sonnet). One "mechanical" job isn't a trivial command but a
+// faithful COPY: the codex runner reads codex's verdict JSON off disk and must
+// return it byte-for-byte. A paraphrase silently corrupts the debate (and schema
+// validation checks the verdict's SHAPE, not its wording), and Haiku is the
+// weakest tier for verbatim reproduction — so the verdict relay runs a notch up.
+// Still far cheaper/faster than Opus; the real reviewing is codex's, not this
+// agent's. The small per-round section writes stay on Haiku (tiny payloads).
+const copyModel = a.copyModel || 'sonnet'
 
 // ---------------------------------------------------------------------------
 // Schemas — the codex verdict schema mirrors scripts/codex-verdict.schema.json
@@ -140,7 +149,7 @@ ${rebuttalStep}
   return agent(prompt, {
     label: `codex:round${round}`,
     phase: 'Debate',
-    model: mechModel, // mechanical: runs codex-review.sh + copies the verdict
+    model: copyModel, // not trivial: must relay codex's verdict JSON faithfully
     schema: CODEX_VERDICT_SCHEMA,
   })
 }
@@ -150,16 +159,16 @@ async function claudeResponds(round, verdict) {
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
   // equivalent is context, not state: every follow-up round the author reads the
-  // shared debate ledger — the durable record of every prior round's findings and
-  // its OWN dispositions — and builds on it instead of re-deriving the diff. The
-  // ledger is written after each round (see the loop), so on round N>1 it already
-  // holds rounds 1..N-1. Round 1 has no ledger yet, so its prompt is byte-identical
-  // to a cold start.
+  // per-round section files — the record of every prior round's findings and its
+  // OWN dispositions — and builds on them instead of re-deriving the diff. A
+  // section is written after each round (see the loop), so on round N>1 the files
+  // already hold rounds 1..N-1. Round 1 has none yet, so its prompt is
+  // byte-identical to a cold start.
   const priorBlock =
     round > 1
-      ? `This is a FOLLOW-UP round. The debate so far — every prior round's codex findings and YOUR own dispositions — is recorded in this file:
-  \`${ledgerPath}\`
-Read it FIRST (if it's somehow missing, fall back to the diff + the verdict below). Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+      ? `This is a FOLLOW-UP round. Every prior round is recorded as a small Markdown file under the debate's scratch dir — read them FIRST for the full history (codex's past findings and YOUR own dispositions):
+  \`cat ${workDir}/section-*.md\`   (or Read them individually; if none exist, fall back to the diff + the verdict below)
+Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
 
 `
       : ''
@@ -270,35 +279,34 @@ function roundLedgerSection(entry) {
   return lines.join('\n')
 }
 
-// The whole ledger. With `meta` (final write) it gets the consensus header that
-// makes the file directly postable as the PR comment; without it (the provisional
-// mid-debate writes that feed the author) it's just the round sections.
-function renderLedger(rounds, meta) {
-  const sections = rounds.map(roundLedgerSection).join('\n\n')
-  if (!meta) return sections
+// The comment header (small). The full comment is this header followed by the
+// per-round section files, assembled by the orchestrator at post time (SKILL
+// step 3) with a deterministic `cat`. The workflow never renders the whole ledger
+// through an agent, so nothing weak ever retypes a large blob.
+function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
-  const header = `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
-  return `${header}\n\n${sections}`
+  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
-// Write the ledger to disk. A thin mechanical agent: the workflow can't do file
-// I/O itself, so (like commitRound) it hands an agent the exact bytes to write.
-// Always overwrites with the full current render, so there's no fragile append
-// and the file is consistent whenever the author reads it. `meta` only on the
-// final write (the postable comment); omitted mid-debate.
-async function writeLedger(meta) {
-  const text = renderLedger(transcript, meta)
+// Zero-pad the round so the section glob (`section-*.md`) sorts in round order
+// (section-002 before section-010) for both the author's read and the assembly.
+const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
+
+// Write ONE round's section to its own small file — the author reads these as its
+// cross-round memory, and the orchestrator cats them into the posted comment. A
+// thin mechanical agent (the workflow can't do file I/O), but the payload is just
+// this round, so it stays small and Haiku-safe — no whole-ledger retype, and
+// rewriting a round's own file is idempotent (safe on a resume).
+async function writeSection(entry) {
+  const text = roundLedgerSection(entry)
+  const path = sectionFile(entry.round)
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool (NOT a shell heredoc — the content has Markdown/special characters), create \`${ledgerPath}\` with EXACTLY this content, overwriting any existing file:
+2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
 ${text}`
-  return agent(prompt, {
-    label: meta ? 'ledger:final' : `ledger:round${transcript.length}`,
-    phase: 'Debate',
-    model: mechModel,
-  })
+  return agent(prompt, { label: `ledger:round${entry.round}`, phase: 'Debate', model: mechModel })
 }
 
 const transcript = []
@@ -386,9 +394,9 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. It reads the shared ledger (written at the end of each round below) for
-  // its cross-round memory. `lastClaude` is kept only to feed codex's rebuttal
-  // next round (see codexReviews) — it is no longer the author's memory.
+  // rest. It reads the per-round section files (written at the end of each round
+  // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
+  // rebuttal next round (see codexReviews) — it is no longer the author's memory.
   const response = await claudeResponds(round, verdict)
   entry.claude = response
   lastClaude = response
@@ -405,10 +413,10 @@ for (let round = 1; ; round++) {
     log(`Round ${round}: committed ${entry.commit}`)
   }
 
-  // Record the round in the shared ledger so the NEXT round's author can read its
-  // own history. Provisional (no header) — the final, postable render with the
-  // consensus header is written at the terminus.
-  await writeLedger()
+  // Write this round's section so the NEXT round's author can read the full
+  // history. Terminal rounds break above before reaching here, so they're
+  // sectioned just after the loop.
+  await writeSection(entry)
 }
 
 const filesChanged = Array.from(
@@ -416,10 +424,22 @@ const filesChanged = Array.from(
 )
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-// Final ledger render — full history plus the outcome header — the canonical,
-// directly-postable PR comment. The terminal round is already in `transcript`
-// (pushed before every break), so this single write covers every exit path,
-// including a consensus or error reached before the author got a turn.
-await writeLedger({ status, rounds: transcript.length, base })
+// Section the terminal round — it broke out of the loop before the in-loop
+// writeSection, so without this its section (a consensus approval, or an error
+// reached before the author got a turn) would be missing from the comment.
+if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
-return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript, ledgerPath }
+// Hand the orchestrator the header and the paths; it assembles the comment
+// (header + section-*.md → ledgerPath) with a deterministic cat and posts it —
+// no agent ever retypes the whole ledger. See SKILL step 3.
+return {
+  status,
+  rounds: transcript.length,
+  base,
+  finalVerdict,
+  filesChanged,
+  transcript,
+  workDir,
+  ledgerPath,
+  ledgerHeader: ledgerHeader({ status, rounds: transcript.length, base }),
+}

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -201,13 +201,16 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
 }
 
 // Commit message for one debate round, carrying the debate context: what codex
-// raised and how claude dispositioned each finding.
+// raised and how claude dispositioned each finding. It reuses the same per-bullet
+// projection as the ledger section (findingBullet/actionBullet), in `plain` chrome
+// — no backticks/bold and no `status` field — so the round summary derives from a
+// single rendering rather than two parallel ones.
 function roundCommitMessage(round, verdict, response) {
   const findings = (verdict.findings || [])
-    .map((f) => `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`)
+    .map((f) => findingBullet(f, { plain: true }))
     .join('\n')
   const actions = (response.actions || [])
-    .map((act) => `- ${act.findingId} ${act.disposition}: ${act.detail}`)
+    .map((a) => actionBullet(a, { plain: true }))
     .join('\n')
   return `fix: codex review — debate round ${round}
 
@@ -244,11 +247,28 @@ ${message}
 // ---------------------------------------------------------------------------
 // The shared ledger — rendered from the transcript, deterministically
 // ---------------------------------------------------------------------------
+// One codex finding as a Markdown bullet. The single projection of a finding's
+// fields, shared by the ledger section and the round commit message. `plain` drops
+// the ledger chrome (backticks + the `status` field) for the commit message, which
+// wants plainer text; the field access stays in one place either way.
+function findingBullet(f, { plain = false } = {}) {
+  return plain
+    ? `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`
+    : `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
+}
+
+// One author disposition as a Markdown bullet. The single projection of an action's
+// fields, shared by the ledger section and the round commit message. `plain` drops
+// the ledger chrome (backticks + bold) for the commit message.
+function actionBullet(a, { plain = false } = {}) {
+  return plain
+    ? `- ${a.findingId} ${a.disposition}: ${a.detail}`
+    : `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
+}
+
 // One round's findings, as a Markdown list. Shared by the section renderer below.
 function renderFindings(verdict) {
-  const list = (verdict.findings || [])
-    .map((f) => `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`)
-    .join('\n')
+  const list = (verdict.findings || []).map((f) => findingBullet(f)).join('\n')
   return list || '- _(none)_'
 }
 
@@ -256,9 +276,7 @@ function renderFindings(verdict) {
 // (codex approved or errored before the author got a turn).
 function renderActions(response) {
   if (!response) return '_(no author turn — the debate ended this round)_'
-  const list = (response.actions || [])
-    .map((a) => `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`)
-    .join('\n')
+  const list = (response.actions || []).map((a) => actionBullet(a)).join('\n')
   return list || '- _(no actions)_'
 }
 

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -6,12 +6,15 @@
 # codex-verdict.schema.json, and writes the JSON verdict to <out-json>.
 #
 # Usage:
-#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json>
+#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
 #
 #   <base-branch>    branch to diff against (e.g. master)
 #   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
 #                    or "-" on the first round (no rebuttal yet)
 #   <out-json>       path the JSON verdict is written to (also echoed to stdout)
+#   <reasoning-effort> codex model_reasoning_effort for this run; the debate
+#                    workflow passes its REASONING_EFFORT constant here so the
+#                    value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only`, which enforces read-only at the
@@ -34,9 +37,12 @@
 #     was never captured, a later round cleanly falls back to a cold start.
 set -uo pipefail
 
-base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json>}"
+base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
 rebuttal_file="${2:?missing rebuttal-file (use - for none)}"
 out="${3:?missing out-json path}"
+# The debate workflow owns this value (its REASONING_EFFORT constant) and passes
+# it down; "xhigh" is only the default for a standalone invocation of this script.
+effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
@@ -194,7 +200,7 @@ run_codex() {
   if [ -n "$resume_id" ]; then
     codex exec resume \
       -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="xhigh" \
+      -c model_reasoning_effort="$effort" \
       --json \
       --output-schema "$schema" \
       -o "$out" \
@@ -202,7 +208,7 @@ run_codex() {
   else
     codex exec \
       --sandbox read-only \
-      -c model_reasoning_effort="xhigh" \
+      -c model_reasoning_effort="$effort" \
       --json \
       --output-schema "$schema" \
       -o "$out" \
@@ -210,9 +216,10 @@ run_codex() {
   fi
 }
 
-# model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
-# relying on the user's global ~/.codex/config.toml — review is the one place we
-# always want codex thinking at full depth, regardless of their default.
+# model_reasoning_effort is scoped to the debate here (via -c, from the $effort
+# the workflow passes down — default "xhigh") rather than relying on the user's
+# global ~/.codex/config.toml — review is the one place we always want codex
+# thinking at full depth, regardless of their default.
 #
 # RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
 # hiccups, a spurious internal error) and writes no verdict — which would

--- a/.apm/skills/lens-debate/SKILL.md
+++ b/.apm/skills/lens-debate/SKILL.md
@@ -168,7 +168,8 @@ collide and the scratch never shows up in the diff the lenses review. It returns
   unresolved,  // findings still contested at the backstop (empty on consensus)
   applied,     // [{ id, title, files, commit }]
   reviews,     // each lens's independent findings
-  history }    // per-round dispositions
+  history,     // per-round dispositions
+  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
 - **consensus** — every finding settled (the normal outcome).
@@ -194,6 +195,7 @@ branch for the human to review):
   `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
+  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never hit commitFix, so the dir may not exist yet
   printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
   gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
   ```

--- a/.apm/skills/lens-debate/SKILL.md
+++ b/.apm/skills/lens-debate/SKILL.md
@@ -190,12 +190,21 @@ branch for the human to review):
 - On any **unresolved** finding, surface both lenses' final positions plainly so
   the human can adjudicate — do not pick a winner yourself.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post a `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)` comment via
-  `gh pr comment`. Include: the outcome badge and round count; the independent
-  per-lens finding counts; the per-finding table (origin, title, location, agreed
-  disposition, applied commit); and, for any unresolved finding, both lenses'
-  positions. Use a single-quoted heredoc so backticks/`$` survive. This mirrors
-  `/codex-debate`; `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
+  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
+
+  ```bash
+  printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
+  gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
+  ```
+
+  The workflow returns `comment` already rendered — the
+  `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)` header
+  with the outcome badge and round count, the independent per-lens finding counts,
+  the applied fixes (with commit SHAs), the agreed no-change observations, and any
+  unresolved findings with both lenses' positions. Posting the returned string
+  (rather than re-improvising a table) keeps the comment a **deterministic** render
+  of the debate outcome. This mirrors `/codex-debate`; `--no-comment` suppresses it.
 
 ## Safety & notes
 

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -260,15 +260,23 @@ ${message}
 // re-improvises a table. Unlike codex-debate there are NO per-round files to
 // assemble: the lenses don't read a ledger (feeding them prior reasoning would
 // invite entrenchment against conceding), so the comment is the only artifact.
-function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }) {
-  const badge = unresolved.length === 0 ? '✅ **Consensus**' : `⚠️ **${unresolved.length} unresolved**`
+function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base, clean }) {
+  const badge = clean
+    ? '✅ **Clean** — every lens found nothing worth raising'
+    : unresolved.length === 0
+      ? '✅ **Consensus**'
+      : `⚠️ **${unresolved.length} unresolved**`
   const counts = Object.entries(reviewByLens)
     .map(([lens, fs]) => `${lens}=${fs.length}`)
     .join(', ')
+  // A clean diff never debated, so the "after N round(s)" clause is omitted; the
+  // base, the lens roster, and the (all-zero) per-lens counts still ride along so
+  // the comment carries the same audit metadata as a debated run.
+  const meta = `lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``
   const lines = [
     '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)',
     '',
-    `${badge} after ${rounds} round(s) · lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``,
+    clean ? `${badge} · ${meta}` : `${badge} after ${rounds} round(s) · ${meta}`,
     '',
     `Independent findings: ${counts}`,
   ]
@@ -283,7 +291,19 @@ function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, 
   }
   if (unresolved.length) {
     lines.push('', `### Unresolved — needs human (${unresolved.length})`)
-    unresolved.forEach((u) => lines.push(`- \`${u.id}\` ${u.title} (${u.location}) — lowy: ${u.lowy?.disposition ?? '?'}, hickey: ${u.hickey?.disposition ?? '?'}`))
+    // Surface BOTH lenses' full final positions (disposition + reasoning + any
+    // plan), not just the bare verdict — a human adjudicating needs the actual
+    // disagreement, which lives in each side's reasoning/plan text.
+    unresolved.forEach((u) => {
+      lines.push('', `- \`${u.id}\` ${u.title} (${u.location})`)
+      for (const lens of ['lowy', 'hickey']) {
+        const p = u[lens]
+        const verdict = p?.disposition ?? '?'
+        const reasoning = p?.reasoning ? ` — ${p.reasoning}` : ''
+        lines.push(`  - **${lens}**: ${verdict}${reasoning}`)
+        if (p?.plan?.trim()) lines.push(`    - plan: ${p.plan}`)
+      }
+    })
   }
   return lines.join('\n')
 }
@@ -309,7 +329,11 @@ REVIEWERS.forEach((r, idx) => {
 log(`Independent findings: ${REVIEWERS.map((r) => `${r.lens}=${reviewByLens[r.lens].length}`).join(', ')}`)
 
 if (combined.length === 0) {
-  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment: '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n✅ Every lens found nothing worth raising.' }
+  // Route the clean outcome through the SAME renderer as a debated run so the
+  // comment carries the same audit metadata (base, lens roster, per-lens counts,
+  // whether code-police ran) instead of a bare one-liner.
+  const comment = renderComment({ rounds: 0, settledOut: [], unresolved: [], applied: [], reviewByLens, withPolice, base, clean: true })
+  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment }
 }
 
 // ---------------------------------------------------------------------------

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -255,6 +255,39 @@ ${message}
   return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply', model: mechModel })
 }
 
+// Render the PR comment deterministically from the debate outcome, returned as a
+// string so the ORCHESTRATOR posts it verbatim (`gh pr comment -F`) — no agent
+// re-improvises a table. Unlike codex-debate there are NO per-round files to
+// assemble: the lenses don't read a ledger (feeding them prior reasoning would
+// invite entrenchment against conceding), so the comment is the only artifact.
+function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }) {
+  const badge = unresolved.length === 0 ? '✅ **Consensus**' : `⚠️ **${unresolved.length} unresolved**`
+  const counts = Object.entries(reviewByLens)
+    .map(([lens, fs]) => `${lens}=${fs.length}`)
+    .join(', ')
+  const lines = [
+    '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)',
+    '',
+    `${badge} after ${rounds} round(s) · lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``,
+    '',
+    `Independent findings: ${counts}`,
+  ]
+  const drops = settledOut.filter((s) => s.agreed && s.disposition === 'drop')
+  if (applied.length) {
+    lines.push('', `### Applied (${applied.length})`)
+    applied.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+  }
+  if (drops.length) {
+    lines.push('', `### Agreed — no change (${drops.length})`)
+    drops.forEach((d) => lines.push(`- \`${d.id}\` ${d.title} (${d.location})`))
+  }
+  if (unresolved.length) {
+    lines.push('', `### Unresolved — needs human (${unresolved.length})`)
+    unresolved.forEach((u) => lines.push(`- \`${u.id}\` ${u.title} (${u.location}) — lowy: ${u.lowy?.disposition ?? '?'}, hickey: ${u.hickey?.disposition ?? '?'}`))
+  }
+  return lines.join('\n')
+}
+
 // ---------------------------------------------------------------------------
 // Phase 1 — independent parallel review
 // ---------------------------------------------------------------------------
@@ -276,7 +309,7 @@ REVIEWERS.forEach((r, idx) => {
 log(`Independent findings: ${REVIEWERS.map((r) => `${r.lens}=${reviewByLens[r.lens].length}`).join(', ')}`)
 
 if (combined.length === 0) {
-  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [] }
+  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment: '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n✅ Every lens found nothing worth raising.' }
 }
 
 // ---------------------------------------------------------------------------
@@ -384,4 +417,15 @@ for (const fix of fixes) {
   log(`Applied ${fix.id}: ${files.length} file(s)${sha ? `, committed ${sha.slice(0, 9)}` : ' (uncommitted)'}`)
 }
 
-return { status, rounds, base, withPolice, settled: settledOut, unresolved, applied, reviews: reviewByLens, history }
+return {
+  status,
+  rounds,
+  base,
+  withPolice,
+  settled: settledOut,
+  unresolved,
+  applied,
+  reviews: reviewByLens,
+  history,
+  comment: renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }),
+}

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -260,6 +260,14 @@ ${message}
 // re-improvises a table. Unlike codex-debate there are NO per-round files to
 // assemble: the lenses don't read a ledger (feeding them prior reasoning would
 // invite entrenchment against conceding), so the comment is the only artifact.
+//
+// The header chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
+// deliberately kept STRUCTURALLY PARALLEL to codex-debate's ledgerHeader chrome.
+// The no-module workflow runtime has no imports, so a truly shared renderer isn't
+// available; the two are instead siblings that move together. A house-style change
+// (badge emoji, base-slice length, a new metadata row) is a mechanical mirror edit
+// — make it here and in codex-debate's ledgerHeader. If the runtime ever admits a
+// shared helper file, lift this common chrome there.
 function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base, clean }) {
   const badge = clean
     ? '✅ **Clean** — every lens found nothing worth raising'

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -107,17 +107,21 @@ codex reviews. It returns:
 
 ```
 { status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript, ledgerPath }
+  rounds, base, finalVerdict, filesChanged, transcript,
+  workDir, ledgerPath, ledgerHeader }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
-`ledgerPath` points at `.codex-debate/debate-log.md` — the **shared debate
-ledger**, one durable Markdown record of every round (codex's findings, its reply
-to the rebuttal, Claude's dispositions, the commit) rewritten each round. It has
-two readers: the **Claude author** reads it as its cross-round memory (so each
-round builds on the last instead of re-deriving the diff), and **step 3 posts it
-verbatim as the PR comment**. codex is *not* a reader — it keeps its own warm
-session, so re-feeding it the ledger would just duplicate its context.
+The debate is recorded as **one small Markdown file per round** —
+`<workDir>/section-NNN.md` (zero-padded). Those section files have two readers:
+the **Claude author** reads them as its cross-round memory (so each round builds
+on the last instead of re-deriving the diff), and **step 3 assembles them into the
+PR comment** — `ledgerHeader` (the outcome header) followed by a `cat` of the
+sections, written to `ledgerPath` (`.codex-debate/debate-log.md`) and posted. The
+comment is therefore a **deterministic concatenation**, never re-rendered through
+an agent — nothing weak ever retypes a large blob. codex is *not* a reader — it
+keeps its own warm session, so re-feeding it the sections would just duplicate its
+context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -156,24 +160,30 @@ the per-round commits sit on the local branch for the human to review):
   on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
-- A compact per-round summary — read it straight from the ledger at `ledgerPath`
-  (each round's codex verdict, Claude's dispositions, and the commit SHA) so the
-  convergence reads round by round. No need to re-derive it from `transcript`; the
-  ledger already renders it.
+- A compact per-round summary — read it straight from the section files
+  (`cat <workDir>/section-*.md`: each round's codex verdict, Claude's
+  dispositions, and the commit SHA) so the convergence reads round by round. No
+  need to re-derive it from `transcript`; the sections already render it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post the **ledger file verbatim** as the PR
-  comment: `gh pr comment <pr> -F "$ledgerPath"` (or `--body-file`). The workflow
-  already wrote the final, headed render to `ledgerPath` — a `## Codex ⇄ Claude
-  debate` document carrying the **consensus** badge, the round count, the
-  **`xhigh` reasoning-effort** note, and a per-round breakdown of codex's findings
-  and Claude's dispositions. Posting the file directly (rather than re-improvising
-  a table) keeps the comment a **deterministic** render of the same record the
-  commit messages and the author drew on. This is an outward-facing write — on by
-  default because the whole point is to leave the review trail on the PR;
-  `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, **assemble the comment from the workflow's
+  output and post it** — no agent re-renders it:
+
+  ```bash
+  { printf '%s\n\n' "$ledgerHeader"; cat "$workDir"/section-*.md; } > "$ledgerPath"
+  gh pr comment <pr> -F "$ledgerPath"
+  ```
+
+  `ledgerHeader` is the `## Codex ⇄ Claude debate` header (consensus badge, round
+  count, the **`xhigh` reasoning-effort** note); the zero-padded `section-*.md`
+  files are the per-round breakdown of codex's findings and Claude's dispositions
+  that the author also read. So the comment is a **deterministic concatenation**
+  of the same record the commit messages and the author drew on — not an
+  LLM-improvised table. This is an outward-facing write — on by default because
+  the whole point is to leave the review trail on the PR; `--no-comment`
+  suppresses it.
 
 ## Safety & notes
 
@@ -198,15 +208,16 @@ the per-round commits sit on the local branch for the human to review):
 - **Warm author (context, not session).** The Claude author can't be resumed the
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
   so there's no session id to carry forward. The equivalent is context, not state:
-  each follow-up round the author **reads the shared debate ledger**
-  (`.codex-debate/debate-log.md`) — every prior round's findings and its own
+  each follow-up round the author **reads the per-round section files**
+  (`cat .codex-debate/section-*.md`) — every prior round's findings and its own
   dispositions — so it builds on its last round rather than re-deriving the whole
-  diff, and won't re-fix or re-litigate findings already settled. The ledger is
-  rewritten after each round, so round N>1 always sees rounds 1..N-1; round 1 has
-  no ledger yet, so it's byte-identical to a cold start (and if the file is ever
-  missing, the author falls back to the diff + verdict). The *same* ledger is what
-  step 3 posts as the PR comment, so the author's memory and the published summary
-  are one artifact. codex stays on its own warm session and never reads the ledger.
+  diff, and won't re-fix or re-litigate findings already settled. A small section
+  is written after each round, so round N>1 always sees rounds 1..N-1; round 1 has
+  none yet, so it's byte-identical to a cold start (and if no sections exist, the
+  author falls back to the diff + verdict). The *same* sections compose the PR
+  comment step 3 posts, so the author's memory and the published summary are one
+  record. The writes stay small (one round each), so the Haiku writer never
+  retypes a large blob. codex stays on its own warm session and never reads them.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
@@ -216,9 +227,9 @@ the per-round commits sit on the local branch for the human to review):
   on many worktrees run at once without clobbering each other — no shared `/tmp`
   paths, and each worktree's `debate-log.md` is its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  ledger file (`debate-log.md`) — is posted verbatim as a PR comment
-  (outward-facing write) unless `--no-comment` is passed — the point is to leave
-  the review trail on the PR.
+  header + per-round sections assembled into `debate-log.md` — is posted as a PR
+  comment (outward-facing write) unless `--no-comment` is passed — the point is to
+  leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -153,10 +153,12 @@ Otherwise (`status === "consensus"`) report in chat (do **not** push or merge �
 the per-round commits sit on the local branch for the human to review):
 
 - The outcome — **consensus** — and how many rounds it took to get there.
-- **The reviewer's reasoning effort: codex runs at `xhigh`** (scoped to the
-  debate via `-c model_reasoning_effort=xhigh` in `codex-review.sh`, regardless
-  of the user's global codex default). State this so the depth of the review is
-  on the record.
+- **The reviewer's reasoning effort** — sourced from the workflow's single
+  `REASONING_EFFORT` constant (`xhigh` today), which is passed down to
+  `codex-review.sh`'s `-c model_reasoning_effort` and into the comment header, so
+  the published value and the config codex actually ran at share one home. Read
+  it off the header rather than asserting it independently. State it so the depth
+  of the review is on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round summary — read it straight from the section files
@@ -177,8 +179,9 @@ the per-round commits sit on the local branch for the human to review):
   ```
 
   The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
-  header (consensus badge, round count, the **`xhigh` reasoning-effort** note)
-  followed by the per-round breakdown of codex's findings and Claude's dispositions
+  header (consensus badge, round count, the **reasoning-effort** note from the
+  workflow's `REASONING_EFFORT` constant) followed by the per-round breakdown of
+  codex's findings and Claude's dispositions
   that the author also read. So the comment is a **deterministic** render of the
   same record the commit messages and the author drew on — not an LLM-improvised
   table. Posting the returned string mirrors `/lens-debate`. This is an

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -108,20 +108,19 @@ codex reviews. It returns:
 ```
 { status: "consensus" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, transcript,
-  workDir, ledgerPath, ledgerHeader }
+  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
 The debate is recorded as **one small Markdown file per round** —
-`<workDir>/section-NNN.md` (zero-padded). Those section files have two readers:
-the **Claude author** reads them as its cross-round memory (so each round builds
-on the last instead of re-deriving the diff), and **step 3 assembles them into the
-PR comment** — `ledgerHeader` (the outcome header) followed by a `cat` of the
-sections, written to `ledgerPath` (`.codex-debate/debate-log.md`) and posted. The
-comment is therefore a **deterministic concatenation**, never re-rendered through
-an agent — nothing weak ever retypes a large blob. codex is *not* a reader — it
-keeps its own warm session, so re-feeding it the sections would just duplicate its
-context.
+`<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
+author's cross-round memory** (so each round builds on the last instead of
+re-deriving the diff). The workflow renders the **same** record into `comment` —
+the outcome header followed by every round's section — so **step 3 just posts that
+string** (`gh pr comment -F`), exactly the way `/lens-debate` does. The comment is
+therefore a **deterministic** render, never re-improvised through an agent —
+nothing weak ever retypes a large blob. codex is *not* a reader — it keeps its own
+warm session, so re-feeding it the sections would just duplicate its context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -168,22 +167,23 @@ the per-round commits sit on the local branch for the human to review):
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, **assemble the comment from the workflow's
-  output and post it** — no agent re-renders it:
+  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
+  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  { printf '%s\n\n' "$ledgerHeader"; cat "$workDir"/section-*.md; } > "$ledgerPath"
-  gh pr comment <pr> -F "$ledgerPath"
+  mkdir -p "$repoPath/.codex-debate"   # reviewer-error/--no-commit runs may not have created it
+  printf '%s' "$comment" > "$repoPath/.codex-debate/comment.md"
+  gh pr comment <pr> -F "$repoPath/.codex-debate/comment.md"
   ```
 
-  `ledgerHeader` is the `## Codex ⇄ Claude debate` header (consensus badge, round
-  count, the **`xhigh` reasoning-effort** note); the zero-padded `section-*.md`
-  files are the per-round breakdown of codex's findings and Claude's dispositions
-  that the author also read. So the comment is a **deterministic concatenation**
-  of the same record the commit messages and the author drew on — not an
-  LLM-improvised table. This is an outward-facing write — on by default because
-  the whole point is to leave the review trail on the PR; `--no-comment`
-  suppresses it.
+  The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
+  header (consensus badge, round count, the **`xhigh` reasoning-effort** note)
+  followed by the per-round breakdown of codex's findings and Claude's dispositions
+  that the author also read. So the comment is a **deterministic** render of the
+  same record the commit messages and the author drew on — not an LLM-improvised
+  table. Posting the returned string mirrors `/lens-debate`. This is an
+  outward-facing write — on by default because the whole point is to leave the
+  review trail on the PR; `--no-comment` suppresses it.
 
 ## Safety & notes
 
@@ -222,14 +222,14 @@ the per-round commits sit on the local branch for the human to review):
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the debate ledger)
-  lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates
-  on many worktrees run at once without clobbering each other — no shared `/tmp`
-  paths, and each worktree's `debate-log.md` is its own.
+- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the per-round
+  sections) lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`,
+  so debates on many worktrees run at once without clobbering each other — no
+  shared `/tmp` paths, and each worktree's section files are its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  header + per-round sections assembled into `debate-log.md` — is posted as a PR
-  comment (outward-facing write) unless `--no-comment` is passed — the point is to
-  leave the review trail on the PR.
+  workflow's deterministically rendered `comment` (header + per-round sections) —
+  is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
+  — the point is to leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -184,6 +184,13 @@ the per-round commits sit on the local branch for the human to review):
   other's sessions. If the id is ever missing (round-1 capture failed), a later
   round transparently cold-starts with the full prompt + rebuttal — graceful
   degradation, never a wedge.
+- **Warm author (context, not session).** The Claude author can't be resumed the
+  way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
+  so there's no session id to carry forward. The prompt-level equivalent is used
+  instead: each follow-up round's author prompt carries the author's OWN previous
+  dispositions (its prior summary + actions), so it builds on its last round
+  rather than re-deriving the whole diff, and won't re-fix or re-litigate findings
+  already settled. Round 1 has no prior, so it's byte-identical to a cold start.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -100,16 +100,24 @@ tree, then (unless `--no-commit`) a `commit:roundN` agent **commits exactly that
 round's changed files** with a message embedding the round's codex findings and
 Claude's dispositions — never pushing or merging.
 
-Ephemeral scratch (verdicts, rebuttals) lives under the gitignored, per-worktree
-`<repoPath>/.codex-debate/`, so **parallel debates in different worktrees never
-collide** and the scratch never shows up in the diff codex reviews. It returns:
+Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
+gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in
+different worktrees never collide** and the scratch never shows up in the diff
+codex reviews. It returns:
 
 ```
 { status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript }
+  rounds, base, finalVerdict, filesChanged, transcript, ledgerPath }
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed.)
+`ledgerPath` points at `.codex-debate/debate-log.md` — the **shared debate
+ledger**, one durable Markdown record of every round (codex's findings, its reply
+to the rebuttal, Claude's dispositions, the commit) rewritten each round. It has
+two readers: the **Claude author** reads it as its cross-round memory (so each
+round builds on the last instead of re-deriving the diff), and **step 3 posts it
+verbatim as the PR comment**. codex is *not* a reader — it keeps its own warm
+session, so re-feeding it the ledger would just duplicate its context.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -148,21 +156,24 @@ the per-round commits sit on the local branch for the human to review):
   on the record.
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
-- A compact per-round table from `transcript` — each round's codex verdict
-  (approved? open-findings count), Claude's dispositions, and the
-  round's `commit` SHA — so the convergence reads round by round.
+- A compact per-round summary — read it straight from the ledger at `ledgerPath`
+  (each round's codex verdict, Claude's dispositions, and the commit SHA) so the
+  convergence reads round by round. No need to re-derive it from `transcript`; the
+  ledger already renders it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post a `## Codex ⇄ Claude debate` comment via
-  `gh pr comment`. Include: the **consensus** outcome badge and the round count;
-  a note that **codex reviewed at `xhigh` reasoning effort**; and a per-round
-  table (codex approved? open-findings count; Claude's dispositions; the
-  round's commit SHA) showing how the two sides converged. Use a
-  single-quoted heredoc so backticks/`$` survive. This is an
-  outward-facing write — it's on by default because the whole point is to leave
-  the review trail on the PR; `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, post the **ledger file verbatim** as the PR
+  comment: `gh pr comment <pr> -F "$ledgerPath"` (or `--body-file`). The workflow
+  already wrote the final, headed render to `ledgerPath` — a `## Codex ⇄ Claude
+  debate` document carrying the **consensus** badge, the round count, the
+  **`xhigh` reasoning-effort** note, and a per-round breakdown of codex's findings
+  and Claude's dispositions. Posting the file directly (rather than re-improvising
+  a table) keeps the comment a **deterministic** render of the same record the
+  commit messages and the author drew on. This is an outward-facing write — on by
+  default because the whole point is to leave the review trail on the PR;
+  `--no-comment` suppresses it.
 
 ## Safety & notes
 
@@ -186,21 +197,28 @@ the per-round commits sit on the local branch for the human to review):
   degradation, never a wedge.
 - **Warm author (context, not session).** The Claude author can't be resumed the
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
-  so there's no session id to carry forward. The prompt-level equivalent is used
-  instead: each follow-up round's author prompt carries the author's OWN previous
-  dispositions (its prior summary + actions), so it builds on its last round
-  rather than re-deriving the whole diff, and won't re-fix or re-litigate findings
-  already settled. Round 1 has no prior, so it's byte-identical to a cold start.
+  so there's no session id to carry forward. The equivalent is context, not state:
+  each follow-up round the author **reads the shared debate ledger**
+  (`.codex-debate/debate-log.md`) — every prior round's findings and its own
+  dispositions — so it builds on its last round rather than re-deriving the whole
+  diff, and won't re-fix or re-litigate findings already settled. The ledger is
+  rewritten after each round, so round N>1 always sees rounds 1..N-1; round 1 has
+  no ledger yet, so it's byte-identical to a cold start (and if the file is ever
+  missing, the author falls back to the diff + verdict). The *same* ledger is what
+  step 3 posts as the PR comment, so the author's memory and the published summary
+  are one artifact. codex stays on its own warm session and never reads the ledger.
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals) lives under the
-  gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates on many
-  worktrees run at once without clobbering each other — no shared `/tmp` paths.
-- **Posts to the PR by default.** When a PR exists, the debate summary is posted
-  as a PR comment (outward-facing write) unless `--no-comment` is passed — the
-  point is to leave the review trail on the PR.
+- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the debate ledger)
+  lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`, so debates
+  on many worktrees run at once without clobbering each other — no shared `/tmp`
+  paths, and each worktree's `debate-log.md` is its own.
+- **Posts to the PR by default.** When a PR exists, the debate summary — the
+  ledger file (`debate-log.md`) — is posted verbatim as a PR comment
+  (outward-facing write) unless `--no-comment` is passed — the point is to leave
+  the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because
   a debate that quits without agreement is pointless. The two sides keep arguing

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -355,6 +355,21 @@ if (!baseRes?.sha?.trim()) {
 base = baseRes.sha.trim()
 log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), so the base branch's drift since the fork isn't reviewed.`)
 
+// Clear any stale ledger from a PRIOR debate in this worktree. The scratch dir
+// is persistent (per-worktree, not per-run) and the section files use a flat,
+// stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
+// sections would otherwise survive into this run — the author cats `section-*.md`
+// as its memory and step 3 cats the same glob into the posted comment, so stale
+// sections would pollute BOTH the author's context and the published trail. A
+// thin mechanical agent (the workflow can't run shell itself); deleting the whole
+// dir is safe because nothing in THIS run has written to it yet. This script has
+// no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
+// so a fresh start owns a fresh ledger.
+await agent(
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf ${workDir} && mkdir -p ${workDir}\`. Do not edit any other file. Do not run git.`,
+  { label: 'ledger:reset', phase: 'Debate', model: mechModel },
+)
+
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
   finalVerdict = verdict

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -136,12 +136,31 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict) {
+async function claudeResponds(round, verdict, priorClaude) {
+  // WARM AUTHOR. On follow-up rounds, thread the author's OWN previous
+  // dispositions back into the prompt so it builds on its prior round instead
+  // of re-deriving everything from the diff — the prompt-level analog of codex's
+  // warm session. (We can't truly resume the Claude author: agent() is one-shot,
+  // and Claude isn't headless under Max auth, so there's no session to resume the
+  // way `codex exec resume` carries codex's reasoning forward. This is the
+  // achievable equivalent — context, not state.) codex's responseToRebuttal in
+  // the verdict already says which of the author's disputes it conceded vs still
+  // holds, so the author knows exactly what to revisit. Empty on round 1, so the
+  // first round is byte-identical to the pre-warm-author prompt.
+  const priorBlock = priorClaude
+    ? `This is a FOLLOW-UP round — you already worked this diff last round. Here is what YOU did then (your own dispositions); build on it, don't re-derive it from scratch, and don't re-fix or re-litigate anything already settled:
+
+${JSON.stringify({ summary: priorClaude.summary, actions: priorClaude.actions }, null, 2)}
+
+For any finding you DISPUTED last round, read codex's \`responseToRebuttal\` below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+
+`
+    : ''
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
 
-CODEX's verdict (JSON):
+${priorBlock}CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
 Address EVERY finding, any severity (don't skip minors/nits):
@@ -286,8 +305,11 @@ for (let round = 1; ; round++) {
     break
   }
 
-  // Claude responds: fixes what it agrees with (editing the tree), disputes the rest.
-  const response = await claudeResponds(round, verdict)
+  // Claude responds: fixes what it agrees with (editing the tree), disputes the
+  // rest. `lastClaude` still holds the PREVIOUS round's response here (it's
+  // reassigned just below), so the author gets its own prior dispositions — the
+  // warm-author context — and on round 1 it's null (cold start, unchanged).
+  const response = await claudeResponds(round, verdict, lastClaude)
   entry.claude = response
   lastClaude = response
   log(

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -30,16 +30,14 @@ const workDir = `${repoPath}/.codex-debate`
 // DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
 // elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
-// The assembled PR comment. The debate is recorded as one small Markdown file
-// PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
-// section files serve TWO readers: the claude author reads them as its cross-round
-// memory (full history, no inline blob), and the orchestrator concatenates the
-// outcome header + every section into THIS file and posts it (`gh pr comment -F`).
-// So the published summary and the author's context are one record — assembled by
-// deterministic `cat`, never re-rendered through an agent (nothing weak ever
-// retypes a large blob). codex is NOT a reader: it keeps its own warm session, so
-// re-feeding it the ledger would just duplicate what it already remembers.
-const ledgerPath = `${workDir}/debate-log.md`
+// The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
+// written under the gitignored scratch dir) — the claude author reads them as its
+// cross-round memory (full history, no inline blob). The PR comment is rendered
+// from the SAME per-round sections in-process (see renderLedger) and returned as
+// `comment`, so the published summary and the author's context are one record —
+// deterministic, never re-rendered through an agent (nothing weak ever retypes a
+// large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
+// it the ledger would just duplicate what it already remembers.
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
 // pushes or merges — that stays the human's call.
@@ -286,12 +284,22 @@ function roundLedgerSection(entry) {
 }
 
 // The comment header (small). The full comment is this header followed by the
-// per-round section files, assembled by the orchestrator at post time (SKILL
-// step 3) with a deterministic `cat`. The workflow never renders the whole ledger
-// through an agent, so nothing weak ever retypes a large blob.
+// per-round section files (see renderLedger). The workflow renders the whole
+// comment deterministically from the transcript — no agent ever retypes the blob.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+}
+
+// The whole PR comment, rendered deterministically in-process from the transcript:
+// the outcome header followed by each round's Markdown section. The per-round
+// section files on disk remain the author's cross-round memory (see writeSection);
+// this re-uses the SAME `roundLedgerSection` renderer to assemble the published
+// comment, so the orchestrator posts a ready string (`gh pr comment -F`) exactly
+// the way lens-debate does — no bespoke `cat` glob at the consumer, and nothing
+// weak ever retypes a large blob (the workflow builds the string itself).
+function renderLedger(transcript, meta) {
+  return [ledgerHeader(meta), ...transcript.map(roundLedgerSection)].join('\n\n')
 }
 
 // Zero-pad the round so the section glob (`section-*.md`) sorts in round order
@@ -450,9 +458,11 @@ log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged
 // reached before the author got a turn) would be missing from the comment.
 if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
-// Hand the orchestrator the header and the paths; it assembles the comment
-// (header + section-*.md → ledgerPath) with a deterministic cat and posts it —
-// no agent ever retypes the whole ledger. See SKILL step 3.
+// Hand the orchestrator the ready-to-post comment, rendered deterministically
+// in-process (header + per-round sections) — it just writes the string to a file
+// and posts it (`gh pr comment -F`), the same shape lens-debate uses. The section
+// files on disk stay the author's cross-round memory; this is the published view
+// of that same record, so no agent ever retypes the whole ledger. See SKILL step 3.
 return {
   status,
   rounds: transcript.length,
@@ -460,7 +470,5 @@ return {
   finalVerdict,
   filesChanged,
   transcript,
-  workDir,
-  ledgerPath,
-  ledgerHeader: ledgerHeader({ status, rounds: transcript.length, base }),
+  comment: renderLedger(transcript, { status, rounds: transcript.length, base }),
 }

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -58,6 +58,14 @@ const mechModel = a.mechModel || 'haiku'
 // agent's. The small per-round section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
+// The reasoning effort codex runs at, scoped to the debate. This JS constant is
+// the SINGLE home for the value: it is passed script-ward (a 4th positional arg
+// to codex-review.sh, which sets `-c model_reasoning_effort`) and read by
+// ledgerHeader for the published comment, so the `-c` flag and the header both
+// derive from here via the one-directional invocation channel — no literal
+// repeated across files held together by "remember to update all of them".
+const REASONING_EFFORT = 'xhigh'
+
 // ---------------------------------------------------------------------------
 // Schemas — the codex verdict schema mirrors scripts/codex-verdict.schema.json
 // so the runner agent returns the same shape codex was constrained to.
@@ -134,11 +142,11 @@ async function codexReviews(round, rebuttalJson) {
 ${rebuttalJson}
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT}\``
     : `1. (No prior rebuttal this round.)
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -201,13 +209,16 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
 }
 
 // Commit message for one debate round, carrying the debate context: what codex
-// raised and how claude dispositioned each finding.
+// raised and how claude dispositioned each finding. It reuses the same per-bullet
+// projection as the ledger section (findingBullet/actionBullet), in `plain` chrome
+// — no backticks/bold and no `status` field — so the round summary derives from a
+// single rendering rather than two parallel ones.
 function roundCommitMessage(round, verdict, response) {
   const findings = (verdict.findings || [])
-    .map((f) => `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`)
+    .map((f) => findingBullet(f, { plain: true }))
     .join('\n')
   const actions = (response.actions || [])
-    .map((act) => `- ${act.findingId} ${act.disposition}: ${act.detail}`)
+    .map((a) => actionBullet(a, { plain: true }))
     .join('\n')
   return `fix: codex review — debate round ${round}
 
@@ -244,11 +255,28 @@ ${message}
 // ---------------------------------------------------------------------------
 // The shared ledger — rendered from the transcript, deterministically
 // ---------------------------------------------------------------------------
+// One codex finding as a Markdown bullet. The single projection of a finding's
+// fields, shared by the ledger section and the round commit message. `plain` drops
+// the ledger chrome (backticks + the `status` field) for the commit message, which
+// wants plainer text; the field access stays in one place either way.
+function findingBullet(f, { plain = false } = {}) {
+  return plain
+    ? `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`
+    : `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
+}
+
+// One author disposition as a Markdown bullet. The single projection of an action's
+// fields, shared by the ledger section and the round commit message. `plain` drops
+// the ledger chrome (backticks + bold) for the commit message.
+function actionBullet(a, { plain = false } = {}) {
+  return plain
+    ? `- ${a.findingId} ${a.disposition}: ${a.detail}`
+    : `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
+}
+
 // One round's findings, as a Markdown list. Shared by the section renderer below.
 function renderFindings(verdict) {
-  const list = (verdict.findings || [])
-    .map((f) => `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`)
-    .join('\n')
+  const list = (verdict.findings || []).map((f) => findingBullet(f)).join('\n')
   return list || '- _(none)_'
 }
 
@@ -256,9 +284,7 @@ function renderFindings(verdict) {
 // (codex approved or errored before the author got a turn).
 function renderActions(response) {
   if (!response) return '_(no author turn — the debate ended this round)_'
-  const list = (response.actions || [])
-    .map((a) => `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`)
-    .join('\n')
+  const list = (response.actions || []).map((a) => actionBullet(a)).join('\n')
   return list || '- _(no actions)_'
 }
 
@@ -296,7 +322,7 @@ function roundLedgerSection(entry) {
 // the runtime ever admits a shared helper file, lift this common chrome there.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
-  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`${meta.reasoningEffort}\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
 // The whole PR comment, rendered deterministically in-process from the transcript:
@@ -480,5 +506,5 @@ return {
   finalVerdict,
   filesChanged,
   transcript,
-  comment: renderLedger(transcript, { status, rounds: transcript.length, base }),
+  comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
 }

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -24,6 +24,15 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
+// The shared debate ledger: one durable Markdown record of the whole debate
+// (every round's codex findings + claude dispositions + commit), rewritten each
+// round under the gitignored scratch dir. It serves TWO readers — the claude
+// author reads it as its cross-round memory (replacing an inline blob), and the
+// orchestrator posts it verbatim as the PR comment (`gh pr comment -F`), so the
+// summary is a deterministic render of the same record, not an LLM re-improvisation.
+// codex is NOT a reader: it keeps its own warm session, so re-feeding it the
+// ledger would just duplicate what it already remembers (and bloat its context).
+const ledgerPath = `${workDir}/debate-log.md`
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
 // pushes or merges — that stays the human's call.
@@ -136,26 +145,24 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict, priorClaude) {
-  // WARM AUTHOR. On follow-up rounds, thread the author's OWN previous
-  // dispositions back into the prompt so it builds on its prior round instead
-  // of re-deriving everything from the diff — the prompt-level analog of codex's
-  // warm session. (We can't truly resume the Claude author: agent() is one-shot,
+async function claudeResponds(round, verdict) {
+  // WARM AUTHOR. We can't truly resume the Claude author (agent() is one-shot,
   // and Claude isn't headless under Max auth, so there's no session to resume the
-  // way `codex exec resume` carries codex's reasoning forward. This is the
-  // achievable equivalent — context, not state.) codex's responseToRebuttal in
-  // the verdict already says which of the author's disputes it conceded vs still
-  // holds, so the author knows exactly what to revisit. Empty on round 1, so the
-  // first round is byte-identical to the pre-warm-author prompt.
-  const priorBlock = priorClaude
-    ? `This is a FOLLOW-UP round — you already worked this diff last round. Here is what YOU did then (your own dispositions); build on it, don't re-derive it from scratch, and don't re-fix or re-litigate anything already settled:
-
-${JSON.stringify({ summary: priorClaude.summary, actions: priorClaude.actions }, null, 2)}
-
-For any finding you DISPUTED last round, read codex's \`responseToRebuttal\` below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+  // way `codex exec resume` carries codex's reasoning forward). The achievable
+  // equivalent is context, not state: every follow-up round the author reads the
+  // shared debate ledger — the durable record of every prior round's findings and
+  // its OWN dispositions — and builds on it instead of re-deriving the diff. The
+  // ledger is written after each round (see the loop), so on round N>1 it already
+  // holds rounds 1..N-1. Round 1 has no ledger yet, so its prompt is byte-identical
+  // to a cold start.
+  const priorBlock =
+    round > 1
+      ? `This is a FOLLOW-UP round. The debate so far — every prior round's codex findings and YOUR own dispositions — is recorded in this file:
+  \`${ledgerPath}\`
+Read it FIRST (if it's somehow missing, fall back to the diff + the verdict below). Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
 
 `
-    : ''
+      : ''
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
@@ -219,6 +226,79 @@ ${message}
    Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
 4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
   return agent(prompt, { label: `commit:round${round}`, phase: 'Debate', model: mechModel })
+}
+
+// ---------------------------------------------------------------------------
+// The shared ledger — rendered from the transcript, deterministically
+// ---------------------------------------------------------------------------
+// One round's findings, as a Markdown list. Shared by the section renderer below.
+function renderFindings(verdict) {
+  const list = (verdict.findings || [])
+    .map((f) => `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`)
+    .join('\n')
+  return list || '- _(none)_'
+}
+
+// One round's author dispositions, as a Markdown list. `null` on a terminal round
+// (codex approved or errored before the author got a turn).
+function renderActions(response) {
+  if (!response) return '_(no author turn — the debate ended this round)_'
+  const list = (response.actions || [])
+    .map((a) => `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`)
+    .join('\n')
+  return list || '- _(no actions)_'
+}
+
+// One round as a Markdown section: codex's verdict, its response to the rebuttal,
+// and the author's dispositions + commit. The single per-round renderer — the
+// author reads these as its memory and they compose into the posted comment.
+function roundLedgerSection(entry) {
+  const { round, codex, claude, commit } = entry
+  const lines = [
+    `### Round ${round}`,
+    '',
+    `**codex** — approved: \`${codex.approved}\``,
+    '',
+    codex.summary,
+    '',
+    'Findings:',
+    renderFindings(codex),
+  ]
+  if (codex.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${codex.responseToRebuttal}`)
+  lines.push('', `**claude** — ${claude ? claude.summary : '_(no author turn this round)_'}`, '', renderActions(claude))
+  if (commit) lines.push('', `commit: \`${commit}\``)
+  return lines.join('\n')
+}
+
+// The whole ledger. With `meta` (final write) it gets the consensus header that
+// makes the file directly postable as the PR comment; without it (the provisional
+// mid-debate writes that feed the author) it's just the round sections.
+function renderLedger(rounds, meta) {
+  const sections = rounds.map(roundLedgerSection).join('\n\n')
+  if (!meta) return sections
+  const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
+  const header = `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
+  return `${header}\n\n${sections}`
+}
+
+// Write the ledger to disk. A thin mechanical agent: the workflow can't do file
+// I/O itself, so (like commitRound) it hands an agent the exact bytes to write.
+// Always overwrites with the full current render, so there's no fragile append
+// and the file is consistent whenever the author reads it. `meta` only on the
+// final write (the postable comment); omitted mid-debate.
+async function writeLedger(meta) {
+  const text = renderLedger(transcript, meta)
+  const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool (NOT a shell heredoc — the content has Markdown/special characters), create \`${ledgerPath}\` with EXACTLY this content, overwriting any existing file:
+
+${text}`
+  return agent(prompt, {
+    label: meta ? 'ledger:final' : `ledger:round${transcript.length}`,
+    phase: 'Debate',
+    model: mechModel,
+  })
 }
 
 const transcript = []
@@ -306,10 +386,10 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. `lastClaude` still holds the PREVIOUS round's response here (it's
-  // reassigned just below), so the author gets its own prior dispositions — the
-  // warm-author context — and on round 1 it's null (cold start, unchanged).
-  const response = await claudeResponds(round, verdict, lastClaude)
+  // rest. It reads the shared ledger (written at the end of each round below) for
+  // its cross-round memory. `lastClaude` is kept only to feed codex's rebuttal
+  // next round (see codexReviews) — it is no longer the author's memory.
+  const response = await claudeResponds(round, verdict)
   entry.claude = response
   lastClaude = response
   log(
@@ -324,6 +404,11 @@ for (let round = 1; ; round++) {
     entry.commit = (sha || '').trim()
     log(`Round ${round}: committed ${entry.commit}`)
   }
+
+  // Record the round in the shared ledger so the NEXT round's author can read its
+  // own history. Provisional (no header) — the final, postable render with the
+  // consensus header is written at the terminus.
+  await writeLedger()
 }
 
 const filesChanged = Array.from(
@@ -331,4 +416,10 @@ const filesChanged = Array.from(
 )
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript }
+// Final ledger render — full history plus the outcome header — the canonical,
+// directly-postable PR comment. The terminal round is already in `transcript`
+// (pushed before every break), so this single write covers every exit path,
+// including a consensus or error reached before the author got a turn.
+await writeLedger({ status, rounds: transcript.length, base })
+
+return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript, ledgerPath }

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -24,6 +24,12 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
+// POSIX single-quote a path for safe interpolation into a shell command. Wraps
+// in single quotes (so spaces, globs, and shell metacharacters are inert) and
+// escapes any embedded single quote via the '\'' idiom. Used for the one
+// DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
+// elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
+const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // The assembled PR comment. The debate is recorded as one small Markdown file
 // PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
 // section files serve TWO readers: the claude author reads them as its cross-round
@@ -366,7 +372,7 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
 // so a fresh start owns a fresh ledger.
 await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf ${workDir} && mkdir -p ${workDir}\`. Do not edit any other file. Do not run git.`,
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf -- ${shq(workDir)} && mkdir -p -- ${shq(workDir)}\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
 

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -27,8 +27,8 @@ const workDir = `${repoPath}/.codex-debate`
 // POSIX single-quote a path for safe interpolation into a shell command. Wraps
 // in single quotes (so spaces, globs, and shell metacharacters are inert) and
 // escapes any embedded single quote via the '\'' idiom. Used for the one
-// DESTRUCTIVE command (the ledger `rm -rf` below); the benign `mkdir -p` prompts
-// elsewhere can tolerate an unquoted path, but a mistargeted `rm -rf` cannot.
+// DESTRUCTIVE command (the ledger `rm -f` below); the benign `mkdir -p` prompts
+// elsewhere can tolerate an unquoted path, but a mistargeted `rm -f` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
 // written under the gitignored scratch dir) — the claude author reads them as its
@@ -407,7 +407,7 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // is persistent (per-worktree, not per-run) and the section files use a flat,
 // stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
 // sections would otherwise survive into this run — the author cats `section-*.md`
-// as its memory and step 3 cats the same glob into the posted comment, so stale
+// as its memory (and they compose into the `comment` renderLedger returns), so stale
 // sections would pollute BOTH the author's context and the published trail. A
 // thin mechanical agent (the workflow can't run shell itself). The reset is
 // section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
@@ -491,7 +491,9 @@ log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged
 
 // Section the terminal round — it broke out of the loop before the in-loop
 // writeSection, so without this its section (a consensus approval, or an error
-// reached before the author got a turn) would be missing from the comment.
+// reached before the author got a turn) would be missing from the disk record
+// the orchestrator reads for the chat summary (cat section-*.md) and the
+// author would read as memory if the debate somehow continued.
 if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
 // Hand the orchestrator the ready-to-post comment, rendered deterministically

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -286,6 +286,14 @@ function roundLedgerSection(entry) {
 // The comment header (small). The full comment is this header followed by the
 // per-round section files (see renderLedger). The workflow renders the whole
 // comment deterministically from the transcript — no agent ever retypes the blob.
+//
+// This header's chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
+// deliberately kept STRUCTURALLY PARALLEL to lens-debate's renderComment header
+// chrome. The no-module workflow runtime has no imports, so a truly shared
+// renderer isn't available; the two are instead siblings that move together. A
+// house-style change (badge emoji, base-slice length, a new metadata row) is a
+// mechanical mirror edit — make it here and in lens-debate's renderComment. If
+// the runtime ever admits a shared helper file, lift this common chrome there.
 function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
@@ -375,12 +383,14 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // sections would otherwise survive into this run — the author cats `section-*.md`
 // as its memory and step 3 cats the same glob into the posted comment, so stale
 // sections would pollute BOTH the author's context and the published trail. A
-// thin mechanical agent (the workflow can't run shell itself); deleting the whole
-// dir is safe because nothing in THIS run has written to it yet. This script has
-// no true resume (agent() is one-shot, the whole workflow re-runs from scratch),
-// so a fresh start owns a fresh ledger.
+// thin mechanical agent (the workflow can't run shell itself). The reset is
+// section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
+// whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
+// commit-msg-N.txt) keep their own lifecycle and a future pre-loop writer won't
+// be silently wiped. This script has no true resume (agent() is one-shot, the
+// whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
 await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`rm -rf -- ${shq(workDir)} && mkdir -p -- ${shq(workDir)}\`. Do not edit any other file. Do not run git.`,
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
 

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -24,14 +24,15 @@ const skillDir = a.skillDir || '.claude/skills/codex-debate'
 // collide on shared /tmp paths, and `.codex-debate/` is gitignored so these
 // files never pollute the diff codex reviews.
 const workDir = `${repoPath}/.codex-debate`
-// The shared debate ledger: one durable Markdown record of the whole debate
-// (every round's codex findings + claude dispositions + commit), rewritten each
-// round under the gitignored scratch dir. It serves TWO readers — the claude
-// author reads it as its cross-round memory (replacing an inline blob), and the
-// orchestrator posts it verbatim as the PR comment (`gh pr comment -F`), so the
-// summary is a deterministic render of the same record, not an LLM re-improvisation.
-// codex is NOT a reader: it keeps its own warm session, so re-feeding it the
-// ledger would just duplicate what it already remembers (and bloat its context).
+// The assembled PR comment. The debate is recorded as one small Markdown file
+// PER ROUND (`section-NNN.md`, written under the gitignored scratch dir). Those
+// section files serve TWO readers: the claude author reads them as its cross-round
+// memory (full history, no inline blob), and the orchestrator concatenates the
+// outcome header + every section into THIS file and posts it (`gh pr comment -F`).
+// So the published summary and the author's context are one record — assembled by
+// deterministic `cat`, never re-rendered through an agent (nothing weak ever
+// retypes a large blob). codex is NOT a reader: it keeps its own warm session, so
+// re-feeding it the ledger would just duplicate what it already remembers.
 const ledgerPath = `${workDir}/debate-log.md`
 // Commit each round's changes individually (default on). The commit message
 // carries the debate context (codex's findings + claude's dispositions). Never
@@ -44,6 +45,14 @@ const commit = a.commit !== false
 // (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
+// Fidelity tier (Sonnet). One "mechanical" job isn't a trivial command but a
+// faithful COPY: the codex runner reads codex's verdict JSON off disk and must
+// return it byte-for-byte. A paraphrase silently corrupts the debate (and schema
+// validation checks the verdict's SHAPE, not its wording), and Haiku is the
+// weakest tier for verbatim reproduction — so the verdict relay runs a notch up.
+// Still far cheaper/faster than Opus; the real reviewing is codex's, not this
+// agent's. The small per-round section writes stay on Haiku (tiny payloads).
+const copyModel = a.copyModel || 'sonnet'
 
 // ---------------------------------------------------------------------------
 // Schemas — the codex verdict schema mirrors scripts/codex-verdict.schema.json
@@ -140,7 +149,7 @@ ${rebuttalStep}
   return agent(prompt, {
     label: `codex:round${round}`,
     phase: 'Debate',
-    model: mechModel, // mechanical: runs codex-review.sh + copies the verdict
+    model: copyModel, // not trivial: must relay codex's verdict JSON faithfully
     schema: CODEX_VERDICT_SCHEMA,
   })
 }
@@ -150,16 +159,16 @@ async function claudeResponds(round, verdict) {
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
   // equivalent is context, not state: every follow-up round the author reads the
-  // shared debate ledger — the durable record of every prior round's findings and
-  // its OWN dispositions — and builds on it instead of re-deriving the diff. The
-  // ledger is written after each round (see the loop), so on round N>1 it already
-  // holds rounds 1..N-1. Round 1 has no ledger yet, so its prompt is byte-identical
-  // to a cold start.
+  // per-round section files — the record of every prior round's findings and its
+  // OWN dispositions — and builds on them instead of re-deriving the diff. A
+  // section is written after each round (see the loop), so on round N>1 the files
+  // already hold rounds 1..N-1. Round 1 has none yet, so its prompt is
+  // byte-identical to a cold start.
   const priorBlock =
     round > 1
-      ? `This is a FOLLOW-UP round. The debate so far — every prior round's codex findings and YOUR own dispositions — is recorded in this file:
-  \`${ledgerPath}\`
-Read it FIRST (if it's somehow missing, fall back to the diff + the verdict below). Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
+      ? `This is a FOLLOW-UP round. Every prior round is recorded as a small Markdown file under the debate's scratch dir — read them FIRST for the full history (codex's past findings and YOUR own dispositions):
+  \`cat ${workDir}/section-*.md\`   (or Read them individually; if none exist, fall back to the diff + the verdict below)
+Build on what you already did; don't re-derive the diff from scratch, and don't re-fix or re-litigate anything already settled. For any finding you DISPUTED, check codex's \`responseToRebuttal\` in the verdict below: if codex conceded, you're done with it; if codex held firm, weigh its reasoning and either fix it or hold with a sharper argument. Spend this round on findings still \`open\` plus any new ones.
 
 `
       : ''
@@ -270,35 +279,34 @@ function roundLedgerSection(entry) {
   return lines.join('\n')
 }
 
-// The whole ledger. With `meta` (final write) it gets the consensus header that
-// makes the file directly postable as the PR comment; without it (the provisional
-// mid-debate writes that feed the author) it's just the round sections.
-function renderLedger(rounds, meta) {
-  const sections = rounds.map(roundLedgerSection).join('\n\n')
-  if (!meta) return sections
+// The comment header (small). The full comment is this header followed by the
+// per-round section files, assembled by the orchestrator at post time (SKILL
+// step 3) with a deterministic `cat`. The workflow never renders the whole ledger
+// through an agent, so nothing weak ever retypes a large blob.
+function ledgerHeader(meta) {
   const badge = meta.status === 'consensus' ? '✅ **Consensus**' : `⚠️ **${meta.status}**`
-  const header = `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
-  return `${header}\n\n${sections}`
+  return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`xhigh\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
-// Write the ledger to disk. A thin mechanical agent: the workflow can't do file
-// I/O itself, so (like commitRound) it hands an agent the exact bytes to write.
-// Always overwrites with the full current render, so there's no fragile append
-// and the file is consistent whenever the author reads it. `meta` only on the
-// final write (the postable comment); omitted mid-debate.
-async function writeLedger(meta) {
-  const text = renderLedger(transcript, meta)
+// Zero-pad the round so the section glob (`section-*.md`) sorts in round order
+// (section-002 before section-010) for both the author's read and the assembly.
+const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
+
+// Write ONE round's section to its own small file — the author reads these as its
+// cross-round memory, and the orchestrator cats them into the posted comment. A
+// thin mechanical agent (the workflow can't do file I/O), but the payload is just
+// this round, so it stays small and Haiku-safe — no whole-ledger retype, and
+// rewriting a round's own file is idempotent (safe on a resume).
+async function writeSection(entry) {
+  const text = roundLedgerSection(entry)
+  const path = sectionFile(entry.round)
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool (NOT a shell heredoc — the content has Markdown/special characters), create \`${ledgerPath}\` with EXACTLY this content, overwriting any existing file:
+2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
 ${text}`
-  return agent(prompt, {
-    label: meta ? 'ledger:final' : `ledger:round${transcript.length}`,
-    phase: 'Debate',
-    model: mechModel,
-  })
+  return agent(prompt, { label: `ledger:round${entry.round}`, phase: 'Debate', model: mechModel })
 }
 
 const transcript = []
@@ -386,9 +394,9 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. It reads the shared ledger (written at the end of each round below) for
-  // its cross-round memory. `lastClaude` is kept only to feed codex's rebuttal
-  // next round (see codexReviews) — it is no longer the author's memory.
+  // rest. It reads the per-round section files (written at the end of each round
+  // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
+  // rebuttal next round (see codexReviews) — it is no longer the author's memory.
   const response = await claudeResponds(round, verdict)
   entry.claude = response
   lastClaude = response
@@ -405,10 +413,10 @@ for (let round = 1; ; round++) {
     log(`Round ${round}: committed ${entry.commit}`)
   }
 
-  // Record the round in the shared ledger so the NEXT round's author can read its
-  // own history. Provisional (no header) — the final, postable render with the
-  // consensus header is written at the terminus.
-  await writeLedger()
+  // Write this round's section so the NEXT round's author can read the full
+  // history. Terminal rounds break above before reaching here, so they're
+  // sectioned just after the loop.
+  await writeSection(entry)
 }
 
 const filesChanged = Array.from(
@@ -416,10 +424,22 @@ const filesChanged = Array.from(
 )
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-// Final ledger render — full history plus the outcome header — the canonical,
-// directly-postable PR comment. The terminal round is already in `transcript`
-// (pushed before every break), so this single write covers every exit path,
-// including a consensus or error reached before the author got a turn.
-await writeLedger({ status, rounds: transcript.length, base })
+// Section the terminal round — it broke out of the loop before the in-loop
+// writeSection, so without this its section (a consensus approval, or an error
+// reached before the author got a turn) would be missing from the comment.
+if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
 
-return { status, rounds: transcript.length, base, finalVerdict, filesChanged, transcript, ledgerPath }
+// Hand the orchestrator the header and the paths; it assembles the comment
+// (header + section-*.md → ledgerPath) with a deterministic cat and posts it —
+// no agent ever retypes the whole ledger. See SKILL step 3.
+return {
+  status,
+  rounds: transcript.length,
+  base,
+  finalVerdict,
+  filesChanged,
+  transcript,
+  workDir,
+  ledgerPath,
+  ledgerHeader: ledgerHeader({ status, rounds: transcript.length, base }),
+}

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -6,12 +6,15 @@
 # codex-verdict.schema.json, and writes the JSON verdict to <out-json>.
 #
 # Usage:
-#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json>
+#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
 #
 #   <base-branch>    branch to diff against (e.g. master)
 #   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
 #                    or "-" on the first round (no rebuttal yet)
 #   <out-json>       path the JSON verdict is written to (also echoed to stdout)
+#   <reasoning-effort> codex model_reasoning_effort for this run; the debate
+#                    workflow passes its REASONING_EFFORT constant here so the
+#                    value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only`, which enforces read-only at the
@@ -34,9 +37,12 @@
 #     was never captured, a later round cleanly falls back to a cold start.
 set -uo pipefail
 
-base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json>}"
+base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
 rebuttal_file="${2:?missing rebuttal-file (use - for none)}"
 out="${3:?missing out-json path}"
+# The debate workflow owns this value (its REASONING_EFFORT constant) and passes
+# it down; "xhigh" is only the default for a standalone invocation of this script.
+effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
@@ -194,7 +200,7 @@ run_codex() {
   if [ -n "$resume_id" ]; then
     codex exec resume \
       -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="xhigh" \
+      -c model_reasoning_effort="$effort" \
       --json \
       --output-schema "$schema" \
       -o "$out" \
@@ -202,7 +208,7 @@ run_codex() {
   else
     codex exec \
       --sandbox read-only \
-      -c model_reasoning_effort="xhigh" \
+      -c model_reasoning_effort="$effort" \
       --json \
       --output-schema "$schema" \
       -o "$out" \
@@ -210,9 +216,10 @@ run_codex() {
   fi
 }
 
-# model_reasoning_effort=xhigh is scoped to the debate here (via -c) rather than
-# relying on the user's global ~/.codex/config.toml — review is the one place we
-# always want codex thinking at full depth, regardless of their default.
+# model_reasoning_effort is scoped to the debate here (via -c, from the $effort
+# the workflow passes down — default "xhigh") rather than relying on the user's
+# global ~/.codex/config.toml — review is the one place we always want codex
+# thinking at full depth, regardless of their default.
 #
 # RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
 # hiccups, a spurious internal error) and writes no verdict — which would

--- a/.claude/skills/lens-debate/SKILL.md
+++ b/.claude/skills/lens-debate/SKILL.md
@@ -168,7 +168,8 @@ collide and the scratch never shows up in the diff the lenses review. It returns
   unresolved,  // findings still contested at the backstop (empty on consensus)
   applied,     // [{ id, title, files, commit }]
   reviews,     // each lens's independent findings
-  history }    // per-round dispositions
+  history,     // per-round dispositions
+  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
 - **consensus** — every finding settled (the normal outcome).
@@ -194,6 +195,7 @@ branch for the human to review):
   `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
+  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never hit commitFix, so the dir may not exist yet
   printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
   gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
   ```

--- a/.claude/skills/lens-debate/SKILL.md
+++ b/.claude/skills/lens-debate/SKILL.md
@@ -190,12 +190,21 @@ branch for the human to review):
 - On any **unresolved** finding, surface both lenses' final positions plainly so
   the human can adjudicate — do not pick a winner yourself.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post a `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)` comment via
-  `gh pr comment`. Include: the outcome badge and round count; the independent
-  per-lens finding counts; the per-finding table (origin, title, location, agreed
-  disposition, applied commit); and, for any unresolved finding, both lenses'
-  positions. Use a single-quoted heredoc so backticks/`$` survive. This mirrors
-  `/codex-debate`; `--no-comment` suppresses it.
+  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
+  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
+
+  ```bash
+  printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
+  gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
+  ```
+
+  The workflow returns `comment` already rendered — the
+  `## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)` header
+  with the outcome badge and round count, the independent per-lens finding counts,
+  the applied fixes (with commit SHAs), the agreed no-change observations, and any
+  unresolved findings with both lenses' positions. Posting the returned string
+  (rather than re-improvising a table) keeps the comment a **deterministic** render
+  of the debate outcome. This mirrors `/codex-debate`; `--no-comment` suppresses it.
 
 ## Safety & notes
 

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -260,15 +260,23 @@ ${message}
 // re-improvises a table. Unlike codex-debate there are NO per-round files to
 // assemble: the lenses don't read a ledger (feeding them prior reasoning would
 // invite entrenchment against conceding), so the comment is the only artifact.
-function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }) {
-  const badge = unresolved.length === 0 ? '✅ **Consensus**' : `⚠️ **${unresolved.length} unresolved**`
+function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base, clean }) {
+  const badge = clean
+    ? '✅ **Clean** — every lens found nothing worth raising'
+    : unresolved.length === 0
+      ? '✅ **Consensus**'
+      : `⚠️ **${unresolved.length} unresolved**`
   const counts = Object.entries(reviewByLens)
     .map(([lens, fs]) => `${lens}=${fs.length}`)
     .join(', ')
+  // A clean diff never debated, so the "after N round(s)" clause is omitted; the
+  // base, the lens roster, and the (all-zero) per-lens counts still ride along so
+  // the comment carries the same audit metadata as a debated run.
+  const meta = `lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``
   const lines = [
     '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)',
     '',
-    `${badge} after ${rounds} round(s) · lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``,
+    clean ? `${badge} · ${meta}` : `${badge} after ${rounds} round(s) · ${meta}`,
     '',
     `Independent findings: ${counts}`,
   ]
@@ -283,7 +291,19 @@ function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, 
   }
   if (unresolved.length) {
     lines.push('', `### Unresolved — needs human (${unresolved.length})`)
-    unresolved.forEach((u) => lines.push(`- \`${u.id}\` ${u.title} (${u.location}) — lowy: ${u.lowy?.disposition ?? '?'}, hickey: ${u.hickey?.disposition ?? '?'}`))
+    // Surface BOTH lenses' full final positions (disposition + reasoning + any
+    // plan), not just the bare verdict — a human adjudicating needs the actual
+    // disagreement, which lives in each side's reasoning/plan text.
+    unresolved.forEach((u) => {
+      lines.push('', `- \`${u.id}\` ${u.title} (${u.location})`)
+      for (const lens of ['lowy', 'hickey']) {
+        const p = u[lens]
+        const verdict = p?.disposition ?? '?'
+        const reasoning = p?.reasoning ? ` — ${p.reasoning}` : ''
+        lines.push(`  - **${lens}**: ${verdict}${reasoning}`)
+        if (p?.plan?.trim()) lines.push(`    - plan: ${p.plan}`)
+      }
+    })
   }
   return lines.join('\n')
 }
@@ -309,7 +329,11 @@ REVIEWERS.forEach((r, idx) => {
 log(`Independent findings: ${REVIEWERS.map((r) => `${r.lens}=${reviewByLens[r.lens].length}`).join(', ')}`)
 
 if (combined.length === 0) {
-  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment: '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n✅ Every lens found nothing worth raising.' }
+  // Route the clean outcome through the SAME renderer as a debated run so the
+  // comment carries the same audit metadata (base, lens roster, per-lens counts,
+  // whether code-police ran) instead of a bare one-liner.
+  const comment = renderComment({ rounds: 0, settledOut: [], unresolved: [], applied: [], reviewByLens, withPolice, base, clean: true })
+  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment }
 }
 
 // ---------------------------------------------------------------------------

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -255,6 +255,39 @@ ${message}
   return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply', model: mechModel })
 }
 
+// Render the PR comment deterministically from the debate outcome, returned as a
+// string so the ORCHESTRATOR posts it verbatim (`gh pr comment -F`) — no agent
+// re-improvises a table. Unlike codex-debate there are NO per-round files to
+// assemble: the lenses don't read a ledger (feeding them prior reasoning would
+// invite entrenchment against conceding), so the comment is the only artifact.
+function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }) {
+  const badge = unresolved.length === 0 ? '✅ **Consensus**' : `⚠️ **${unresolved.length} unresolved**`
+  const counts = Object.entries(reviewByLens)
+    .map(([lens, fs]) => `${lens}=${fs.length}`)
+    .join(', ')
+  const lines = [
+    '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)',
+    '',
+    `${badge} after ${rounds} round(s) · lowy + hickey${withPolice ? ' + code-police' : ''} · base \`${(base || '').slice(0, 12)}\``,
+    '',
+    `Independent findings: ${counts}`,
+  ]
+  const drops = settledOut.filter((s) => s.agreed && s.disposition === 'drop')
+  if (applied.length) {
+    lines.push('', `### Applied (${applied.length})`)
+    applied.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+  }
+  if (drops.length) {
+    lines.push('', `### Agreed — no change (${drops.length})`)
+    drops.forEach((d) => lines.push(`- \`${d.id}\` ${d.title} (${d.location})`))
+  }
+  if (unresolved.length) {
+    lines.push('', `### Unresolved — needs human (${unresolved.length})`)
+    unresolved.forEach((u) => lines.push(`- \`${u.id}\` ${u.title} (${u.location}) — lowy: ${u.lowy?.disposition ?? '?'}, hickey: ${u.hickey?.disposition ?? '?'}`))
+  }
+  return lines.join('\n')
+}
+
 // ---------------------------------------------------------------------------
 // Phase 1 — independent parallel review
 // ---------------------------------------------------------------------------
@@ -276,7 +309,7 @@ REVIEWERS.forEach((r, idx) => {
 log(`Independent findings: ${REVIEWERS.map((r) => `${r.lens}=${reviewByLens[r.lens].length}`).join(', ')}`)
 
 if (combined.length === 0) {
-  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [] }
+  return { status: 'clean', rounds: 0, base, withPolice, note: 'every lens found nothing worth raising', settled: [], unresolved: [], applied: [], reviews: reviewByLens, history: [], comment: '## [⚖️ Lowy ⇄ Hickey lens debate](https://kolu.dev/blog/hickey-lowy/)\n\n✅ Every lens found nothing worth raising.' }
 }
 
 // ---------------------------------------------------------------------------
@@ -384,4 +417,15 @@ for (const fix of fixes) {
   log(`Applied ${fix.id}: ${files.length} file(s)${sha ? `, committed ${sha.slice(0, 9)}` : ' (uncommitted)'}`)
 }
 
-return { status, rounds, base, withPolice, settled: settledOut, unresolved, applied, reviews: reviewByLens, history }
+return {
+  status,
+  rounds,
+  base,
+  withPolice,
+  settled: settledOut,
+  unresolved,
+  applied,
+  reviews: reviewByLens,
+  history,
+  comment: renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base }),
+}

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -260,6 +260,14 @@ ${message}
 // re-improvises a table. Unlike codex-debate there are NO per-round files to
 // assemble: the lenses don't read a ledger (feeding them prior reasoning would
 // invite entrenchment against conceding), so the comment is the only artifact.
+//
+// The header chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
+// deliberately kept STRUCTURALLY PARALLEL to codex-debate's ledgerHeader chrome.
+// The no-module workflow runtime has no imports, so a truly shared renderer isn't
+// available; the two are instead siblings that move together. A house-style change
+// (badge emoji, base-slice length, a new metadata row) is a mechanical mirror edit
+// — make it here and in codex-debate's ledgerHeader. If the runtime ever admits a
+// shared helper file, lift this common chrome there.
 function renderComment({ rounds, settledOut, unresolved, applied, reviewByLens, withPolice, base, clean }) {
   const badge = clean
     ? '✅ **Clean** — every lens found nothing worth raising'

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-04T23:08:01.502568+00:00'
+generated_at: '2026-06-05T21:43:04.206649+00:00'
 apm_version: 0.18.0
 dependencies:
 - repo_url: anthropics/skills

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-05T21:43:04.206649+00:00'
+generated_at: '2026-06-05T21:47:12.345038+00:00'
 apm_version: 0.18.0
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
## What

Two improvements to the review-debate skills, plus the design fixes from review:

1. **Warm Claude author** in `/codex-debate` — the author carries cross-round memory instead of cold-starting every round (codex already had this via its warm session; the author didn't).
2. **Deterministic PR comments** for *both* `/codex-debate` and `/lens-debate` — the published summary is now a deterministic render, not an LLM-improvised table.

## Why not a real session resume?

`agent()` (the Workflow primitive) is **one-shot** — no `fork`, no resume, no `SendMessage` — and Claude isn't headless under Max auth, so there's no session id to carry forward the way codex has one. So the author's memory is **context, not state**.

## How it works (after review hardening)

The debate is recorded as **one small `section-NNN.md` per round** under the gitignored scratch dir:

- **Author memory** — each follow-up round reads `section-*.md` for the full history (its own prior dispositions + codex's findings), so it builds on the last round instead of re-deriving the diff. Round 1 has no sections → **byte-identical to a cold start**.
- **The PR comment** — the workflow returns `ledgerHeader` + the section paths; the **orchestrator assembles the comment with a deterministic `cat`** (header + `section-*.md`) and posts it (`gh pr comment -F`). **No agent ever re-renders the ledger.**
- **codex** stays on its own warm session and is *not* fed the sections (that would just duplicate its context).

`/lens-debate` gets the **comment artifact only**: the workflow returns a deterministically-rendered `comment`; the orchestrator posts it verbatim. The **lenses are deliberately not fed a ledger** — they have no warm-session gap, already carry inline memory (opponent positions + settled set + a shrinking active set), and feeding a debater its own prior positions would invite entrenchment against the skill's explicit "concede, don't win" goal.

## Design fixes from review (the reason this isn't one commit)

Two smells were caught and corrected mid-PR:

- **A haiku re-rendering the *whole* growing ledger every round** → replaced with **small per-round section writes** (haiku-safe; payload is one round, never the whole file).
- **The comment routed through a writer agent** it never needed → the workflow **returns the string/paths** and the **orchestrator** (which already has `Write` + `gh`) assembles and posts. Nothing weak retypes a large blob.
- **The codex verdict relay** — a faithful *copy*, not a "run a command" task — moved off **haiku** onto a **`copyModel` (sonnet)**: a paraphrase silently corrupts the debate, and schema validation checks shape, not wording. The genuinely trivial agents (merge-base, commit, section writes) stay on haiku; nothing jumps to Opus.

## Commits

1. `warm Claude author` — first cut (inline blob).
2. `shared debate ledger` — file-based memory + the comment.
3. `per-round section files; de-risk the haiku copies` — the review-hardened mechanism above.
4. `lens-debate: deterministic PR comment artifact` — the sibling fix.

## Invariants / scope

- Round 1 byte-identical to a cold start; missing-sections fallback to diff+verdict.
- `/be-review` unchanged — it delegates posting to the two skills; comment titles are the same.
- Honest cost: the wall-clock win is **modest** (the big fixed costs — codex's `xhigh` review, the author's Opus reasoning — are untouched). The value is less re-derivation, no large verbatim copies on the weakest tier, and durable/deterministic published summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)