### PR TITLE
feat(pty): assert COLORTERM=truecolor for PTY shells

### DIFF
--- a/packages/integrations/pty/src/shell.test.ts
+++ b/packages/integrations/pty/src/shell.test.ts
@@ -37,13 +37,22 @@ function runZsh(script: string, cwd = "/tmp"): string | null {
 }
 
 describe("koluIdentityEnv", () => {
-  it("returns Kolu's identity vars: TERM_PROGRAM, TERM_PROGRAM_VERSION, VTE_VERSION", () => {
+  it("returns Kolu's identity vars: TERM_PROGRAM, TERM_PROGRAM_VERSION, VTE_VERSION, COLORTERM", () => {
     const env = koluIdentityEnv("9.9.9");
     expect(env).toEqual({
       TERM_PROGRAM: "kolu",
       TERM_PROGRAM_VERSION: "9.9.9",
       VTE_VERSION: "7603",
+      COLORTERM: "truecolor",
     });
+  });
+
+  it("asserts COLORTERM=truecolor so PTY tools emit 24-bit color escapes", () => {
+    // kolu's xterm.js WebGL renderer displays 24-bit color, so the
+    // assertion is honest. Unconditional (not passthrough) because a
+    // GUI/launchd launch carries no parent COLORTERM to forward, yet the
+    // renderer is just as capable — see koluIdentityEnv's doc comment.
+    expect(koluIdentityEnv("9.9.9").COLORTERM).toBe("truecolor");
   });
 
   it("VTE_VERSION stomps a parent value when layered via Object.assign", () => {

--- a/packages/integrations/pty/src/shell.ts
+++ b/packages/integrations/pty/src/shell.ts
@@ -28,12 +28,12 @@ import { join } from "node:path";
  * Exported so callers can pass it as the default whitelist value.
  *
  * Kolu's own identity vars (TERM_PROGRAM, TERM_PROGRAM_VERSION,
- * VTE_VERSION) live in `koluIdentityEnv()` and are layered on top of
- * cleanEnv's output by the PTY spawn caller — they don't belong in the
- * parent-forward whitelist.
+ * VTE_VERSION, COLORTERM) live in `koluIdentityEnv()` and are layered on
+ * top of cleanEnv's output by the PTY spawn caller — they don't belong in
+ * the parent-forward whitelist.
  */
 export const NIX_ENV_WHITELIST =
-  "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY,COLORTERM";
+  "HOME,USER,PATH,TERM,LANG,LC_ALL,LOGNAME,DISPLAY";
 
 /** Whitelist set once at startup; undefined means passthrough mode (production). */
 let envWhitelist: Set<string> | undefined;
@@ -110,6 +110,14 @@ export function cleanEnv(): Record<string, string> {
  * the same shape as the identity assertions. The value `7603` encodes VTE
  * 0.76.3 using VTE's scheme: major×10000 + minor×100 + micro.
  *
+ * `COLORTERM=truecolor` advertises 24-bit color so tools gate their
+ * truecolor escapes on it (Claude Code, vim, bat, delta). Our xterm.js
+ * WebGL renderer displays 24-bit color faithfully, so the assertion is
+ * honest. It belongs here, not in cleanEnv's passthrough whitelist: the
+ * capability is a property of kolu's renderer, not of whatever env the
+ * parent process happened to inherit — a GUI/launchd launch carries no
+ * COLORTERM to forward, yet the renderer is just as capable.
+ *
  * Per-PTY identity vars (anything that depends on terminalId) belong in
  * `SpawnInit.env` returned by `prepareShellInit`, not here.
  */
@@ -118,6 +126,7 @@ export function koluIdentityEnv(version: string): Record<string, string> {
     TERM_PROGRAM: "kolu",
     TERM_PROGRAM_VERSION: version,
     VTE_VERSION: "7603",
+    COLORTERM: "truecolor",
   };
 }
 


### PR DESCRIPTION
## What

Spawned PTY shells advertised `TERM=xterm-256color` but never got `COLORTERM`. Tools that gate 24-bit truecolor escapes on `COLORTERM` — Claude Code, vim, bat, delta — therefore fell back to the 256-color palette. (Claude Code even nags about it: *"Try setting environment variable COLORTERM=truecolor for richer colors."*)

`COLORTERM` was only ever *forwarded* from the parent kolu process (it sat in the nix dev whitelist), so it reached the shell only if kolu itself was launched from a terminal that happened to carry it. A GUI / launchd launch carries no `COLORTERM`, so those sessions never got truecolor.

## Change

Assert `COLORTERM=truecolor` in `koluIdentityEnv()`, alongside `TERM_PROGRAM` / `VTE_VERSION`. That's the documented home for "what kolu asserts about itself" and, like the others, it stomps any stale parent value unconditionally — so every PTY gets it regardless of how kolu was started.

The assertion is honest: kolu's xterm.js WebGL renderer displays 24-bit color faithfully. `TERM`/`COLORTERM` are signals *to the programs inside the PTY* that truecolor output will render correctly — which it does. Truecolor support is a property of the renderer, not of the launch environment, which is exactly why it belongs in the identity layer and not the parent-passthrough whitelist.

Dropped the now-redundant `COLORTERM` from `NIX_ENV_WHITELIST` — layer 2 stomps any passthrough value anyway, and the whitelist's own doc comment says identity vars don't belong there.

## Test

Updated `koluIdentityEnv` unit tests (exact-shape + dedicated truecolor assertion). All 21 `kolu-pty` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)