### PR TITLE
feat(be): sync docs as part of /be's implementation step

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -32,6 +32,8 @@ Add a question only when something material is genuinely unclear — don't pad. 
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 
+**Sync the docs.** Read `.agency/do.md` for its **`## Documentation`** section — the list of files to keep in lockstep with code (README and the like). Compare each against this change and update any that the diff makes stale, so the docs commit rides the same review gauntlet as the code. Skip only when that section is absent or the change is genuinely doc-neutral.
+
 Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
 
 ## 3. Open the PR

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -32,6 +32,8 @@ Add a question only when something material is genuinely unclear — don't pad. 
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 
+**Sync the docs.** Read `.agency/do.md` for its **`## Documentation`** section — the list of files to keep in lockstep with code (README and the like). Compare each against this change and update any that the diff makes stale, so the docs commit rides the same review gauntlet as the code. Skip only when that section is absent or the change is genuinely doc-neutral.
+
 Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
 
 ## 3. Open the PR

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -32,6 +32,8 @@ Add a question only when something material is genuinely unclear — don't pad. 
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 
+**Sync the docs.** Read `.agency/do.md` for its **`## Documentation`** section — the list of files to keep in lockstep with code (README and the like). Compare each against this change and update any that the diff makes stale, so the docs commit rides the same review gauntlet as the code. Skip only when that section is absent or the change is genuinely doc-neutral.
+
 Run **check** and **fmt**, then commit (conventional message) and push the feature branch.
 
 ## 3. Open the PR

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-05T21:47:12.345038+00:00'
+generated_at: '2026-06-06T13:36:55.352896+00:00'
 apm_version: 0.18.0
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
## Why

`/be` is billed as the modern alternative to `/do`, but it was **not** a strict superset — it had no equivalent to `/do`'s `docs` step. So a user-facing change shipped through `/be` skipped the README/docs sync that this repo's `.claude/rules/workflow.md` mandates (*"Keep `README.md` in sync with user-facing changes."*). Under `/do` that's enforced by a dedicated step; under `/be` the only safety net was a gauntlet reviewer happening to notice — not guaranteed.

This came up while comparing the two skills: `/be` actually has the *heavier* review (codex debate → lens debate → code-police, serial), but docs sync was the one real gap.

## What

Add a **docs-sync instruction to §2 (Implement)** of the `be` skill, mirroring `/do`'s `docs` step:

> Read `.agency/do.md` for its `## Documentation` section, compare each listed file against the change, and update any the diff makes stale — before the commit, so the docs change rides the same review gauntlet as the code. Skip only when the section is absent or the change is doc-neutral.

Placing it inside §2 (rather than as a late standalone step) means the docs commit is reviewed by the gauntlet alongside the code, which is stronger than `/do`'s ordering.

## How

Edited the source at `.apm/skills/be/SKILL.md` and regenerated the runtime copies (`.claude/`, `.agents/`) with `just ai::apm`, per `.claude/rules/apm-sources.md` (those dirs are generated — never hand-edited). The `apm.lock.yaml` change is just the regeneration timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)