### PR TITLE
Add blog-post skill for session-grounded essays

### DIFF
--- a/.agents/skills/blog-post/SKILL.md
+++ b/.agents/skills/blog-post/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: blog-post
+description: >-
+  Write a kolu blog post grounded in the real build history — mine the Claude
+  Code session logs behind a feature for the actual story (for large efforts,
+  fan out over the transcripts with an ultracode workflow), draft it in the
+  author's voice, and wire it into the Astro site. Use when asked to write a
+  blog post or engineering essay about something that was built, especially one
+  that should read as a narrative of what actually happened rather than invented
+  marketing copy.
+argument-hint: "<feature/topic to write about, or a PR/package whose story to tell>"
+---
+
+# Writing a kolu blog post
+
+A kolu blog post is a first-person engineering essay grounded in **what actually
+happened** when something was built — the dead-end, the load-bearing decision,
+the bug that taught the lesson. Its source of truth is the Claude Code session
+logs that produced the work, not invented marketing copy.
+
+## Steps
+
+1. **Locate the work's sessions.** Find the Claude Code session logs behind the
+   feature (they live under `~/.claude/projects/`, one directory per working
+   directory). Map them deterministically by tracing PRs → branches → logs, not
+   by keyword hits.
+
+2. **Mine them for the story.** Read the human/assistant narrative out of the
+   logs and pull out the why behind decisions, the hard-won lessons and
+   dead-ends, the concrete mechanisms, and vivid verbatim quotes. When the effort
+   spans more than a handful of sessions, fan out with an **ultracode workflow** —
+   one agent per transcript returning structured notes — then synthesize the
+   notes into a single digest, draft from it, and run an adversarial editor pass.
+   The digest is the fact-checked spine; never fabricate numbers, dates, quotes,
+   or PRs.
+
+3. **Write it in the author's voice.** Use the `pg` skill (Paul Graham voice)
+   unless told otherwise, and settle the inline house style up front. Match the
+   register of the existing posts; a new post often pairs as a sequel to one.
+
+4. **Wire it into the site.** Posts live in `website/src/content/blog/`. Use the
+   site's components for callouts, GitHub PR/issue references, and the table of
+   contents; cite the real PRs behind each claim, and give the post a two-level
+   heading outline so the TOC nests. Balance prose with screenshots and code —
+   host images in the site, don't hotlink.
+
+5. **Verify and ship.** Build the site and confirm it renders, open the PR with
+   the `forge-pr` skill, and run only the CI lane a docs change can touch (the
+   website build plus formatting and lint — see the `ci` skill).

--- a/.apm/skills/blog-post/SKILL.md
+++ b/.apm/skills/blog-post/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: blog-post
+description: >-
+  Write a kolu blog post grounded in the real build history — mine the Claude
+  Code session logs behind a feature for the actual story (for large efforts,
+  fan out over the transcripts with an ultracode workflow), draft it in the
+  author's voice, and wire it into the Astro site. Use when asked to write a
+  blog post or engineering essay about something that was built, especially one
+  that should read as a narrative of what actually happened rather than invented
+  marketing copy.
+argument-hint: "<feature/topic to write about, or a PR/package whose story to tell>"
+---
+
+# Writing a kolu blog post
+
+A kolu blog post is a first-person engineering essay grounded in **what actually
+happened** when something was built — the dead-end, the load-bearing decision,
+the bug that taught the lesson. Its source of truth is the Claude Code session
+logs that produced the work, not invented marketing copy.
+
+## Steps
+
+1. **Locate the work's sessions.** Find the Claude Code session logs behind the
+   feature (they live under `~/.claude/projects/`, one directory per working
+   directory). Map them deterministically by tracing PRs → branches → logs, not
+   by keyword hits.
+
+2. **Mine them for the story.** Read the human/assistant narrative out of the
+   logs and pull out the why behind decisions, the hard-won lessons and
+   dead-ends, the concrete mechanisms, and vivid verbatim quotes. When the effort
+   spans more than a handful of sessions, fan out with an **ultracode workflow** —
+   one agent per transcript returning structured notes — then synthesize the
+   notes into a single digest, draft from it, and run an adversarial editor pass.
+   The digest is the fact-checked spine; never fabricate numbers, dates, quotes,
+   or PRs.
+
+3. **Write it in the author's voice.** Use the `pg` skill (Paul Graham voice)
+   unless told otherwise, and settle the inline house style up front. Match the
+   register of the existing posts; a new post often pairs as a sequel to one.
+
+4. **Wire it into the site.** Posts live in `website/src/content/blog/`. Use the
+   site's components for callouts, GitHub PR/issue references, and the table of
+   contents; cite the real PRs behind each claim, and give the post a two-level
+   heading outline so the TOC nests. Balance prose with screenshots and code —
+   host images in the site, don't hotlink.
+
+5. **Verify and ship.** Build the site and confirm it renders, open the PR with
+   the `forge-pr` skill, and run only the CI lane a docs change can touch (the
+   website build plus formatting and lint — see the `ci` skill).

--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: blog-post
+description: >-
+  Write a kolu blog post grounded in the real build history — mine the Claude
+  Code session logs behind a feature for the actual story (for large efforts,
+  fan out over the transcripts with an ultracode workflow), draft it in the
+  author's voice, and wire it into the Astro site. Use when asked to write a
+  blog post or engineering essay about something that was built, especially one
+  that should read as a narrative of what actually happened rather than invented
+  marketing copy.
+argument-hint: "<feature/topic to write about, or a PR/package whose story to tell>"
+---
+
+# Writing a kolu blog post
+
+A kolu blog post is a first-person engineering essay grounded in **what actually
+happened** when something was built — the dead-end, the load-bearing decision,
+the bug that taught the lesson. Its source of truth is the Claude Code session
+logs that produced the work, not invented marketing copy.
+
+## Steps
+
+1. **Locate the work's sessions.** Find the Claude Code session logs behind the
+   feature (they live under `~/.claude/projects/`, one directory per working
+   directory). Map them deterministically by tracing PRs → branches → logs, not
+   by keyword hits.
+
+2. **Mine them for the story.** Read the human/assistant narrative out of the
+   logs and pull out the why behind decisions, the hard-won lessons and
+   dead-ends, the concrete mechanisms, and vivid verbatim quotes. When the effort
+   spans more than a handful of sessions, fan out with an **ultracode workflow** —
+   one agent per transcript returning structured notes — then synthesize the
+   notes into a single digest, draft from it, and run an adversarial editor pass.
+   The digest is the fact-checked spine; never fabricate numbers, dates, quotes,
+   or PRs.
+
+3. **Write it in the author's voice.** Use the `pg` skill (Paul Graham voice)
+   unless told otherwise, and settle the inline house style up front. Match the
+   register of the existing posts; a new post often pairs as a sequel to one.
+
+4. **Wire it into the site.** Posts live in `website/src/content/blog/`. Use the
+   site's components for callouts, GitHub PR/issue references, and the table of
+   contents; cite the real PRs behind each claim, and give the post a two-level
+   heading outline so the TOC nests. Balance prose with screenshots and code —
+   host images in the site, don't hotlink.
+
+5. **Verify and ship.** Build the site and confirm it renders, open the PR with
+   the `forge-pr` skill, and run only the CI lane a docs change can touch (the
+   website build plus formatting and lint — see the `ci` skill).


### PR DESCRIPTION
**A `blog-post` skill that turns the way we wrote [_Apps that ship themselves over ssh_](https://kolu.dev/blog/orpc-over-ssh/) (#1215) into a repeatable path.** A kolu blog post is a first-person engineering essay grounded in what *actually* happened when something was built — so the skill's core move is mining the Claude Code session logs behind a feature for the real story (fanning an **ultracode** workflow over the transcripts when the effort is large), then drafting in the author's voice and wiring it into the Astro site.

Deliberately concise — it states the *what* of each step (locate the sessions → mine them for the story → write in voice via `/pg` → wire into the site → verify and ship the relevant CI lane) and leaves the *how* to the agent and the skills it points at (`pg`, `forge-pr`, `ci`).

Authored in `.apm/skills/blog-post/SKILL.md` (the source of truth) and distributed to `.claude/` and `.agents/` per the project-local skill convention. Branched off latest `master`.

_Generated by Claude Code (model `claude-opus-4-8`)._