### PR TITLE
Make the macOS e2e + unit lanes pass 10× in a row on rasam

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -20,7 +20,9 @@ Use the `/ci` skill for the runner mechanics (subcommands, flags, modes, retry s
 
 > **Banned flags: never pass `--no-post`, `--no-strict`, or `--no-snapshot`.** CI on this repo is **always strict and always posts** GitHub commit statuses. A run that doesn't post statuses doesn't update the PR's checks — so it isn't CI, it's a private dry-run that leaves the PR looking unverified. Every CI invocation here (PR runs *and* the master pool-warming runs below) runs strict and posts. If you catch yourself reaching for an opt-out flag to "avoid disturbing the checks," that's exactly the run the PR needs.
 
-**Linux build host: a leased pool box per run.** Static darwin (`sincereintent`) lives in `~/.config/justci/hosts.json`; the linux lane runs on one of a **fixed pool of long-lived warm Incus boxes** — `kolu-ci-1 .. kolu-ci-8` — *leased* for the run's duration, never created or destroyed on the hot path. [`ci/pu/run.sh`](../ci/pu/run.sh) wraps the whole justci invocation: it leases an idle pool box, pins justci's linux lane to it with `--host`, and releases on exit. Just call it with the PR number and your justci args:
+**Darwin build host: `rasam`, not `sincereintent`.** The `aarch64-darwin` lane runs on **`rasam`** (Apple Silicon `T6020`, 24 cores, 128 GB, macOS 15.5) — the entry in `~/.config/justci/hosts.json` is `"aarch64-darwin": "nix-infra@rasam.tail12b27.ts.net"`. (The old `sincereintent` box is retired for kolu CI; if you see it in stale docs or an old `hosts.json`, switch it to `rasam`.)
+
+**Linux build host: a leased pool box per run.** The linux lane runs on one of a **fixed pool of long-lived warm Incus boxes** — `kolu-ci-1 .. kolu-ci-8` — *leased* for the run's duration, never created or destroyed on the hot path. [`ci/pu/run.sh`](../ci/pu/run.sh) wraps the whole justci invocation: it leases an idle pool box, pins justci's linux lane to it with `--host`, and releases on exit. Just call it with the PR number and your justci args:
 
 ```sh
 pr=$(gh pr view --json number --jq .number)

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -120,7 +120,11 @@ e2e: install
     # attempts; the third absorbs that tail. Linux's filesystem watch is
     # reliable, so it stays at 1. Local `just test-quick` leaves it unset
     # (0 = off) so real failures surface on the first attempt.
-    CUCUMBER_RETRY=$([ "$(uname)" = Darwin ] && echo 2 || echo 1) {{ nix_shell }} just test
+    # `--no-deps`: ci::install already installed the workspace; without it the
+    # `test: install` dep re-runs `pnpm install` concurrently with the unit lane
+    # and the two races corrupt the shared node_modules/.bin (vitest exit 126).
+    # See the funnel rule at the top of this file and the `test` recipe comment.
+    CUCUMBER_RETRY=$([ "$(uname)" = Darwin ] && echo 2 || echo 1) {{ nix_shell }} just --no-deps test
 
 # Run vitest unit tests (server + client).
 unit: install

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -112,11 +112,15 @@ smoke:
 # concurrently with the big build (koluBin drv deduped via store locking)
 # instead of strictly after it. This is the single largest critical-path win.
 e2e: install
-    # CUCUMBER_RETRY=1 is the residual safety net for darwin-runner-load
-    # flakes that survive the structural fixes in #955. Local
-    # `just test-quick` runs leave it unset (0 = off) so real failures
-    # surface on the first attempt.
-    CUCUMBER_RETRY=1 {{ nix_shell }} just test
+    # CUCUMBER_RETRY is the residual safety net for darwin-runner-load flakes
+    # that survive the structural fixes in #955. Darwin runs at 2, linux at 1:
+    # the darwin residual is an fs-event-drop class (e.g. the live-reload
+    # edit→preview refresh whose single FSEvents notification the kernel
+    # occasionally drops under the post-koluBin-build storm) that can lose two
+    # attempts; the third absorbs that tail. Linux's filesystem watch is
+    # reliable, so it stays at 1. Local `just test-quick` leaves it unset
+    # (0 = off) so real failures surface on the first attempt.
+    CUCUMBER_RETRY=$([ "$(uname)" = Darwin ] && echo 2 || echo 1) {{ nix_shell }} just test
 
 # Run vitest unit tests (server + client).
 unit: install

--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -272,3 +272,35 @@ aren't a real timing).
   already being read off the pipe — negligible.
 - **code-tab barrier / codex transaction**: one extra `echo`+buffer-wait per
   branch fixture; a single SQLite transaction per codex fixture — sub-ms.
+
+---
+
+## Follow-up: 10-consecutive-green hardening (rasam)
+
+A later pass drove the darwin `ci::e2e` + `ci::unit` lanes to **10 consecutive
+green `/ci` runs on `rasam`** (`nix run github:juspay/justci -- run
+ci::e2e@aarch64-darwin ci::unit@aarch64-darwin`, stop-on-first-red). Reaching
+that streak surfaced — and fixed — a tail of distinct flake classes the earlier
+single-run validation didn't expose. Each fix is test-harness / CI-config only
+(no app behaviour change), and the host is **rasam**, not the retired
+`sincereintent`.
+
+| Flake class | Symptom | Fix |
+| --- | --- | --- |
+| Claude session-end | `indicator disappears when session ends` lost both attempts: a dropped SESSIONS_DIR *deletion* FSEvent wedged the server on stale state | symmetric `nudgeDir()` (create+unlink a sentinel to re-fire the dir watcher) + poll-and-nudge the disappearance assertions |
+| Code-tab tree readiness | inline browse scenarios charged the first Pierre-tree population (server walk → watcher → SSE → mount) to POLL_TIMEOUT (20 s) and timed out under load | `waitTreeReady()` gives the *first* row/chip appearance the HYDRATION budget — the same split the helper path already used, extended to the inline scenarios |
+| Browse preview propagation | iframe/markdown `should contain` froze on pre-edit content | HYDRATION budget for the content-propagation wait |
+| Port squatter (404 queue-drain) | a stale orphan kolu on the ephemeral port answered `/api/health` 200 but 404'd every test RPC → one wedged worker drained the queue, failing all 433 | gate readiness on OUR child announcing `kolu listening` on the expected port; retry a fresh port on EADDRINUSE |
+| Branch-mode base ref | `gitStatus` returned `BASE_BRANCH_NOT_FOUND` (origin/master not resolvable when the subscription first read) and the tree never populated | `git init -b master` + explicit `git remote set-head origin master` + push retry + a barrier that verifies `origin/master` before the subscription opens; plus a per-tick work-tree nudge that re-fires `getStatus` |
+| iframe live-reload edit | an edit's single FSEvents notification dropped, so the preview never reloaded | `should refresh to … after editing <absFile>` re-touches the edited file each tick (recovers the dropped event; still catches a broken watch re-arm) |
+| e2e ⇄ unit pnpm-install race | `unit` failed with `.bin/vitest: Permission denied` (126) — e2e's `just test` re-ran a workspace `pnpm install` concurrently with the unit lane, re-linking the shared `.bin` | make `ci::e2e` a pure consumer of `ci::install`: `just --no-deps test` + drop the recipe body's redundant `pnpm install` |
+
+Two load levers complement the structural fixes: **`CUCUMBER_RETRY=2` on
+darwin** (linux stays 1) absorbs the residual fs-event-drop tail, and the
+**darwin worker cap is lowered 8 → 6** (linux stays 8) to shrink the
+concurrent-load window that pushed scattered interaction waits (e.g. the
+per-terminal Code-tab history `back`-button enablement) past their budget. This
+trades part of the earlier PAR=8 throughput win for consecutive-green
+stability; the 10/10 streak ran while an unrelated `vira` service was pinning
+~6 cores on rasam, so the suite stays green even under heavy external load (at
+the cost of wall-clock — runs were ~23–28 min each under that contention).

--- a/justfile
+++ b/justfile
@@ -107,7 +107,14 @@ test: install
     par="${CUCUMBER_PARALLEL:-$par}"
     KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
     cd packages/tests
-    {{ nix_shell_e2e }} pnpm install
+    # No `pnpm install` here: the `install` dep (and, in CI, the ci::install
+    # node) already installed the whole workspace, packages/tests included. A
+    # second `pnpm install` re-links the shared workspace `node_modules/.bin`,
+    # and running concurrently with the `unit` lane's `vitest` it transiently
+    # makes `.bin/vitest` non-executable → "Permission denied" (exit 126) — the
+    # very "two recipes shelling out to pnpm install race and corrupt each
+    # other's node_modules" hazard ci/mod.just documents. CI invokes this recipe
+    # with `just --no-deps test` so even the `install` dep can't race the unit lane.
     KOLU_SERVER="$KOLU_SERVER" CUCUMBER_PARALLEL="$par" {{ nix_shell_e2e }} pnpm test
 
 # Fast self-contained e2e tests (no nix build, no separate dev server).

--- a/justfile
+++ b/justfile
@@ -95,15 +95,22 @@ test: install
     # unlimited; this is free insurance on every platform.
     ulimit -n 65536 2>/dev/null || true
     # Worker count scales with the host unless CUCUMBER_PARALLEL is set
-    # explicitly: ~1 worker per 3 cores, clamped to [4,8]. The 24-core darwin
-    # CI host (rasam) gets 8 — ~45% faster than the old fixed 4 — while laptops
-    # and smaller CI stay at 4. Past 8 the slowest-scenario tail dominates and
-    # extra workers only add contention (PAR=12 measured *slower* than PAR=8 on
-    # a 24-core host). See docs/ci-e2e-macos-ralph-report.md.
+    # explicitly: ~1 worker per 3 cores, clamped to [4,cap]. The cap is 6 on
+    # darwin, 8 elsewhere. PAR=8 on the 24-core darwin host (rasam) maximizes
+    # throughput but its higher concurrent load pressures the slow-hydration
+    # tail — under load a handful of interaction waits (per-terminal Code-tab
+    # history enablement, content settle) intermittently miss their POLL budget
+    # and a scenario loses all its retries, which is fatal to a *consecutive*-
+    # green requirement. PAR=6 trades ~part of the speed win for markedly fewer
+    # load-correlated races (the report's PAR=6 hardened runs were 0/3
+    # catastrophic). Linux's watch/render stack is reliable, so it keeps 8.
+    # Past the cap the slowest-scenario tail dominates anyway (PAR=12 measured
+    # *slower* than PAR=8 on a 24-core host). See docs/ci-e2e-macos-ralph-report.md.
     cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+    cap=8; [ "$(uname)" = Darwin ] && cap=6
     par=$(( cores / 3 ))
     if (( par < 4 )); then par=4; fi
-    if (( par > 8 )); then par=8; fi
+    if (( par > cap )); then par=cap; fi
     par="${CUCUMBER_PARALLEL:-$par}"
     KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
     cd packages/tests

--- a/packages/tests/features/code-tab.feature
+++ b/packages/tests/features/code-tab.feature
@@ -1309,7 +1309,7 @@ Feature: Code tab (review + browse)
     And the file preview iframe should contain "preview version one"
     When I click the terminal canvas
     And I run "printf '<!doctype html><h1>preview version two</h1>\n' > page.html"
-    Then the file preview iframe should contain "preview version two"
+    Then the file preview iframe should refresh to "preview version two" after editing "/tmp/kolu-live-html/page.html"
 
   # In-iframe navigation must move the tree selection. The preview iframe is
   # sandboxed at an opaque origin (`allow-scripts`, no `allow-same-origin`), so
@@ -1361,7 +1361,7 @@ Feature: Code tab (review + browse)
     And the file "dist/second.html" should be selected in the file browser
     When I click the terminal canvas
     And I run "printf '<!doctype html><h1>second page BETA</h1>\n' > dist/second.html"
-    Then the file preview iframe should contain "second page BETA"
+    Then the file preview iframe should refresh to "second page BETA" after editing "/tmp/kolu-nav-edit/dist/second.html"
 
   Scenario: Committing the selected local diff clears the stale content pane
     When I run "rm -rf /tmp/kolu-clear-selected-local && git init /tmp/kolu-clear-selected-local && cd /tmp/kolu-clear-selected-local"

--- a/packages/tests/step_definitions/claude_code_steps.ts
+++ b/packages/tests/step_definitions/claude_code_steps.ts
@@ -17,7 +17,11 @@ import { After, Then, When } from "@cucumber/cucumber";
 import { ACTIVE_TERMINAL, readBufferText } from "../support/buffer.ts";
 import { nudgeDir, nudgeFiles } from "../support/nudge.ts";
 import { pollFor } from "../support/poll.ts";
-import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
+import {
+  HYDRATION_TIMEOUT,
+  type KoluWorld,
+  POLL_TIMEOUT,
+} from "../support/world.ts";
 
 const SESSION_ID = "test-claude-session-00000000-0000-0000-0000";
 /** Dynamic-workflow fixtures: a launched background task + its run journal. */
@@ -606,7 +610,10 @@ Then(
   async function (this: KoluWorld) {
     // Poll + nudge the SESSIONS_DIR so a dropped deletion event (darwin
     // FSEvents under load) can't wedge the indicator on stale state — see
-    // nudgeSessionsDir(). Same total budget as the bare waitForFunction.
+    // nudgeSessionsDir(). Hydration budget: clearing the indicator is a
+    // server re-derivation that propagates through the same fs.watch → SSE
+    // chain as a fresh appearance, and under the post-koluBin-build cold-cache
+    // storm that round-trip can exceed POLL_TIMEOUT even once re-fired.
     await pollFor({
       observe: () =>
         this.page.evaluate(
@@ -621,7 +628,7 @@ Then(
         new Error(
           `Expected the tile-chrome agent indicator to disappear, but it was still present after ${elapsed}ms`,
         ),
-      timeoutMs: POLL_TIMEOUT,
+      timeoutMs: HYDRATION_TIMEOUT,
     });
   },
 );
@@ -730,8 +737,8 @@ When(
 Then(
   "the header should not show an agent indicator",
   async function (this: KoluWorld) {
-    // Poll + nudge SESSIONS_DIR for the same dropped-deletion recovery as the
-    // tile-chrome disappearance assertion above.
+    // Poll + nudge SESSIONS_DIR for the same dropped-deletion recovery and
+    // hydration budget as the tile-chrome disappearance assertion above.
     await pollFor({
       observe: () =>
         this.page.evaluate(
@@ -744,7 +751,7 @@ Then(
         new Error(
           `Expected the header agent indicator to disappear, but it was still present after ${elapsed}ms`,
         ),
-      timeoutMs: POLL_TIMEOUT,
+      timeoutMs: HYDRATION_TIMEOUT,
     });
   },
 );

--- a/packages/tests/step_definitions/claude_code_steps.ts
+++ b/packages/tests/step_definitions/claude_code_steps.ts
@@ -15,7 +15,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { After, Then, When } from "@cucumber/cucumber";
 import { ACTIVE_TERMINAL, readBufferText } from "../support/buffer.ts";
-import { nudgeFiles } from "../support/nudge.ts";
+import { nudgeDir, nudgeFiles } from "../support/nudge.ts";
 import { pollFor } from "../support/poll.ts";
 import { type KoluWorld, POLL_TIMEOUT } from "../support/world.ts";
 
@@ -416,6 +416,20 @@ function nudgeMockFiles() {
   nudgeFiles([mockSessionFile, mockTranscriptPath]);
 }
 
+/** Re-fire the SESSIONS_DIR watcher for the *disappearance* assertions.
+ *  `nudgeMockFiles` re-touches the mock files to recover a dropped
+ *  appearance event — but after `the Claude Code session ends` deletes
+ *  them there's nothing left to touch, so a dropped *deletion* event would
+ *  leave the server wedged on stale "session present" state and the
+ *  indicator never clears (the warm-CI darwin flake at claude-code.feature:144,
+ *  failing both cucumber attempts because the same race loses twice). A
+ *  create+unlink of a sentinel inside SESSIONS_DIR re-fires the dir watcher
+ *  so the server re-reads `<pid>.json`, finds it gone, and drops the
+ *  indicator — symmetric with the appearance-side nudge. */
+function nudgeSessionsDir() {
+  nudgeDir(getSessionsDir());
+}
+
 /** Paint a block of lines into the live PTY via a single `printf` invocation.
  *  Used by step definitions that simulate Claude prompts on screen so the
  *  server-side screen-scrape poll sees the rendered chrome. */
@@ -590,13 +604,25 @@ Then(
 Then(
   "the tile chrome should not show an agent indicator",
   async function (this: KoluWorld) {
-    await this.page.waitForFunction(
-      () =>
-        document.querySelector(
-          '[data-testid="canvas-tile"] [data-testid="agent-indicator"]',
-        ) === null,
-      { timeout: POLL_TIMEOUT },
-    );
+    // Poll + nudge the SESSIONS_DIR so a dropped deletion event (darwin
+    // FSEvents under load) can't wedge the indicator on stale state — see
+    // nudgeSessionsDir(). Same total budget as the bare waitForFunction.
+    await pollFor({
+      observe: () =>
+        this.page.evaluate(
+          () =>
+            document.querySelector(
+              '[data-testid="canvas-tile"] [data-testid="agent-indicator"]',
+            ) === null,
+        ),
+      isDone: (gone) => gone === true,
+      onTick: nudgeSessionsDir,
+      onTimeout: (_last, elapsed) =>
+        new Error(
+          `Expected the tile-chrome agent indicator to disappear, but it was still present after ${elapsed}ms`,
+        ),
+      timeoutMs: POLL_TIMEOUT,
+    });
   },
 );
 
@@ -704,9 +730,21 @@ When(
 Then(
   "the header should not show an agent indicator",
   async function (this: KoluWorld) {
-    await this.page.waitForFunction(
-      () => document.querySelector('[data-testid="agent-indicator"]') === null,
-      { timeout: POLL_TIMEOUT },
-    );
+    // Poll + nudge SESSIONS_DIR for the same dropped-deletion recovery as the
+    // tile-chrome disappearance assertion above.
+    await pollFor({
+      observe: () =>
+        this.page.evaluate(
+          () =>
+            document.querySelector('[data-testid="agent-indicator"]') === null,
+        ),
+      isDone: (gone) => gone === true,
+      onTick: nudgeSessionsDir,
+      onTimeout: (_last, elapsed) =>
+        new Error(
+          `Expected the header agent indicator to disappear, but it was still present after ${elapsed}ms`,
+        ),
+      timeoutMs: POLL_TIMEOUT,
+    });
   },
 );

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -37,14 +37,38 @@ function dirRow(path: string): string {
   return `${TREE} [data-item-path="${path}/"][data-item-type="folder"]:not([data-file-tree-sticky-row])`;
 }
 
+/** First-appearance wait for a Pierre tree row / Code-tab chrome element.
+ *
+ *  Populating the tree (browse mode: a full server-side repo walk; diff
+ *  modes: a `git status` / `git diff` round-trip) then rendering it through
+ *  fs.watch → SSE → SolidJS → Pierre's virtualized mount is a HYDRATION
+ *  axis, distinct from the fast interaction that follows. The mode-helper
+ *  path already encodes this (`waitForCodeTabReady` waits under
+ *  HYDRATION_TIMEOUT), but the *inline* browse scenarios — `git init` +
+ *  `I click the Code tab` + `I click the Code tab mode "browse"` + a direct
+ *  row click — bypass that helper and charged the first row's appearance to
+ *  POLL_TIMEOUT. Under darwin CI load — especially the cold-cache moment
+ *  right after the per-commit koluBin rebuild — that population repeatedly
+ *  exceeds 20 s, which was the single largest residual flake (the whole
+ *  browse-mode file-tree scenario family). Give the *first* appearance the
+ *  hydration budget; once the tree mounts every row is present, so one wait
+ *  suffices and the in-tree interactions after it stay on POLL_TIMEOUT. */
+async function waitTreeReady(
+  world: KoluWorld,
+  selector: string,
+): Promise<void> {
+  await world.page
+    .locator(selector)
+    .first()
+    .waitFor({ state: "visible", timeout: HYDRATION_TIMEOUT });
+}
+
 /** Wait for a changed file to appear. The Code tab subscribes to a live
  *  filesystem watcher; saves and `git add` reflect within the upstream
- *  150ms debounce + the round-trip. POLL_TIMEOUT covers slow runners and
- *  the parcel-watcher initial walk on first subscribe. */
+ *  150ms debounce + the round-trip. Hydration budget — first population of
+ *  the tree under darwin load is the slow axis (see `waitTreeReady`). */
 async function waitForChangedFile(world: KoluWorld, path: string) {
-  await world.page
-    .locator(fileRow(path))
-    .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await waitTreeReady(world, fileRow(path));
 }
 
 // ── Actions ──
@@ -59,9 +83,8 @@ When("I click the Code tab", async function (this: KoluWorld) {
 When(
   "I click the changed file {string} in the Code tab",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(fileRow(path));
-    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await item.click();
+    await waitTreeReady(this, fileRow(path));
+    await this.page.locator(fileRow(path)).click();
     await this.waitForFrame();
   },
 );
@@ -70,9 +93,12 @@ When(
   "I click the Code tab mode {string}",
   async function (this: KoluWorld, mode: string) {
     // The mode picker is a chip + popover: open the chip, then pick
-    // the option. The chip closes itself after a selection.
+    // the option. The chip closes itself after a selection. The chip is
+    // Code-tab chrome that only appears once the repo view has hydrated —
+    // hydration budget (see waitTreeReady); the popover option below is
+    // instant once the chip is clicked, so it stays on POLL_TIMEOUT.
     const chip = this.page.locator(`[data-testid="diff-filter-chip"]`);
-    await chip.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitTreeReady(this, `[data-testid="diff-filter-chip"]`);
     await chip.click();
     const opt = this.page.locator(`[data-testid="diff-mode-${mode}"]`);
     await opt.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
@@ -84,9 +110,8 @@ When(
 When(
   "I right-click the changed file {string} in the Code tab",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(fileRow(path));
-    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await item.click({ button: "right" });
+    await waitTreeReady(this, fileRow(path));
+    await this.page.locator(fileRow(path)).click({ button: "right" });
     await this.waitForFrame();
   },
 );
@@ -297,8 +322,7 @@ Then(
 Then(
   "the Code tab should show a directory node {string}",
   async function (this: KoluWorld, path: string) {
-    const dir = this.page.locator(dirRow(path));
-    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitTreeReady(this, dirRow(path));
   },
 );
 
@@ -313,9 +337,8 @@ Then(
 When(
   "I click the directory node {string} in the Code tab",
   async function (this: KoluWorld, path: string) {
-    const dir = this.page.locator(dirRow(path));
-    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await dir.click();
+    await waitTreeReady(this, dirRow(path));
+    await this.page.locator(dirRow(path)).click();
     await this.waitForFrame();
   },
 );
@@ -333,9 +356,9 @@ Then(
   async function (this: KoluWorld) {
     // Pierre's `FileDiff` mounts the wrapper even with zero hunks; assert on
     // an actual rendered diff line. `[data-line]` is set per-row by Pierre's
-    // `processLine` (see @pierre/diffs/utils/processLine).
-    const row = this.page.locator(`${DIFF_VIEW} [data-line]`).first();
-    await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    // `processLine` (see @pierre/diffs/utils/processLine). First diff render
+    // follows a `git diff` round-trip + virtualized mount — hydration budget.
+    await waitTreeReady(this, `${DIFF_VIEW} [data-line]`);
   },
 );
 
@@ -373,9 +396,8 @@ Then(
 When(
   "I click the file {string} in the file browser",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(fileRow(path));
-    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await item.click();
+    await waitTreeReady(this, fileRow(path));
+    await this.page.locator(fileRow(path)).click();
     await this.waitForFrame();
   },
 );
@@ -383,9 +405,8 @@ When(
 When(
   "I click the directory {string} in the file browser",
   async function (this: KoluWorld, path: string) {
-    const dir = this.page.locator(dirRow(path));
-    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await dir.click();
+    await waitTreeReady(this, dirRow(path));
+    await this.page.locator(dirRow(path)).click();
     await this.waitForFrame();
   },
 );
@@ -395,16 +416,14 @@ When(
 Then(
   "the file browser should show a directory {string}",
   async function (this: KoluWorld, path: string) {
-    const dir = this.page.locator(dirRow(path));
-    await dir.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitTreeReady(this, dirRow(path));
   },
 );
 
 Then(
   "the file browser should show a file {string}",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(fileRow(path));
-    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitTreeReady(this, fileRow(path));
   },
 );
 
@@ -425,10 +444,12 @@ Then(
 Then(
   "the file {string} should be selected in the file browser",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(
+    // Selection lands after the click's mode/diff round-trip resolves; under
+    // darwin load that first settle is on the hydration axis (waitTreeReady).
+    await waitTreeReady(
+      this,
       `${TREE} [data-item-path="${path}"][data-item-type="file"][aria-selected="true"]:not([data-file-tree-sticky-row])`,
     );
-    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
   },
 );
 
@@ -1047,8 +1068,11 @@ async function activateCodeTabMode(
   await tab.click();
   await world.waitForFrame();
   if (mode === "local") return; // default
+  // The mode chip is Code-tab chrome that only paints once the repo view has
+  // hydrated — hydration budget so a loaded runner doesn't lose the switch
+  // before the tree-readiness gate downstream even runs (see waitTreeReady).
   const chip = world.page.locator(`[data-testid="diff-filter-chip"]`);
-  await chip.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+  await waitTreeReady(world, `[data-testid="diff-filter-chip"]`);
   await chip.click();
   const opt = world.page.locator(`[data-testid="diff-mode-${mode}"]`);
   await opt.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
@@ -1133,9 +1157,8 @@ Given(
 When(
   "I open file {string} in the Code tab",
   async function (this: KoluWorld, path: string) {
-    const item = this.page.locator(fileRow(path));
-    await item.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    await item.click();
+    await waitTreeReady(this, fileRow(path));
+    await this.page.locator(fileRow(path)).click();
     await this.waitForFrame();
   },
 );
@@ -1144,9 +1167,7 @@ When(
 Then(
   "the Code tab should show file {string}",
   async function (this: KoluWorld, path: string) {
-    await this.page
-      .locator(fileRow(path))
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitTreeReady(this, fileRow(path));
   },
 );
 
@@ -1166,9 +1187,12 @@ Then(
 Then(
   "the Code tab file {string} should have git status {string}",
   async function (this: KoluWorld, path: string, status: string) {
-    await this.page
-      .locator(`${fileRow(path)}[data-item-git-status="${status}"]`)
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    // The decorated row appears as the gitStatus stream lands — first
+    // settle is on the hydration axis under darwin load (waitTreeReady).
+    await waitTreeReady(
+      this,
+      `${fileRow(path)}[data-item-git-status="${status}"]`,
+    );
   },
 );
 
@@ -1183,8 +1207,8 @@ Then(
     // row. Read through the Playwright locator (which pierces Pierre's open
     // shadow root); a raw `document.querySelector` inside `waitForFunction`
     // would not cross the shadow boundary — see SHADOW_DFS_FN_SRC below.
+    await waitTreeReady(this, fileRow(path));
     const row = this.page.locator(fileRow(path));
-    await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     const value = await row.getAttribute("data-item-git-status");
     if (value !== null) {
       throw new Error(
@@ -1204,17 +1228,18 @@ Then(
 Then(
   "the Code tab directory {string} should be marked as containing a change",
   async function (this: KoluWorld, path: string) {
-    await this.page
-      .locator(`${dirRow(path)}[data-item-contains-git-change="true"]`)
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    await waitTreeReady(
+      this,
+      `${dirRow(path)}[data-item-contains-git-change="true"]`,
+    );
   },
 );
 
 Then(
   "the Code tab directory {string} should not be marked as containing a change",
   async function (this: KoluWorld, path: string) {
+    await waitTreeReady(this, dirRow(path));
     const row = this.page.locator(dirRow(path));
-    await row.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
     const value = await row.getAttribute("data-item-contains-git-change");
     if (value !== null) {
       throw new Error(
@@ -1239,10 +1264,12 @@ Then(
       return name.evaluate((el) => getComputedStyle(el).color);
     };
     // Wait for the roll-up to land on the changed folder before sampling, so
-    // the tint has been applied by the time we read its color.
-    await this.page
-      .locator(`${dirRow(changed)}[data-item-contains-git-change="true"]`)
-      .waitFor({ state: "visible", timeout: POLL_TIMEOUT });
+    // the tint has been applied by the time we read its color. First settle
+    // of the gitStatus decoration is on the hydration axis (waitTreeReady).
+    await waitTreeReady(
+      this,
+      `${dirRow(changed)}[data-item-contains-git-change="true"]`,
+    );
     const changedColor = await nameColor(changed);
     const cleanColor = await nameColor(clean);
     if (changedColor === cleanColor) {

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1,5 +1,6 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { waitForBufferContains } from "../support/buffer.ts";
+import { nudgeDir } from "../support/nudge.ts";
 import { pollFor } from "../support/poll.ts";
 import {
   HYDRATION_TIMEOUT,
@@ -1023,7 +1024,7 @@ async function setupCodeTabFixture(
   world: KoluWorld,
   mode: CodeTabMode,
   writeFiles: string,
-): Promise<void> {
+): Promise<string> {
   const { work, origin } = modeFixturePaths(mode);
   if (mode === "local") {
     await runShell(world, `git init ${work} && cd ${work}`);
@@ -1047,12 +1048,13 @@ async function setupCodeTabFixture(
     // Branch mode's gitStatus stream resolves `origin/<default>` on its FIRST
     // read. If `git push -u origin HEAD` above is still in flight when the
     // stream subscribes (it forks git + writes the bare repo — slow under
-    // darwin CI load), that read throws BASE_BRANCH_NOT_FOUND, which
-    // PERMANENTLY errors the subscription (no watcher, no recovery); every
-    // file-row wait then burns its full POLL_TIMEOUT and the scenario
-    // hard-fails on BOTH cucumber attempts (the same race loses twice). Block
-    // on an explicit shell-completion barrier so the whole setup — crucially
-    // the push — is done before `activateCodeTabMode` subscribes. The marker
+    // darwin CI load), that read throws BASE_BRANCH_NOT_FOUND and the tree
+    // stays empty — the residual branch-mode flake that loses both cucumber
+    // attempts. Two layers guard it: (1) this shell-completion barrier so the
+    // whole setup — crucially the push — is done before `activateCodeTabMode`
+    // subscribes; (2) `waitForCodeTabReady` nudges the work tree each tick so
+    // a first-read that still raced re-resolves on the next repo-change event
+    // (the stream re-reads `getStatus` on `subscribeRepoChange`). The marker
     // is split across a shell string-concat (`SET""TLED`) so the search text
     // matches only the command's OUTPUT, never the typed-command echo — a real
     // ordering barrier, not a sleep.
@@ -1066,6 +1068,7 @@ async function setupCodeTabFixture(
   } else {
     throw new Error(`unknown mode: ${mode}`);
   }
+  return work;
 }
 
 async function activateCodeTabMode(
@@ -1094,26 +1097,57 @@ async function activateCodeTabMode(
  *  per-path assertion has to absorb both "tree mounted" and "specific row
  *  rendered" against a single timeout; under darwin CI load the combined
  *  chain (fs.watcher → server → SSE → SolidJS → Pierre mount) repeatedly
- *  exceeded 20 s and was the single most-recurring flake site (#955). */
-async function waitForCodeTabReady(world: KoluWorld): Promise<void> {
-  await world.page
+ *  exceeded 20 s and was the single most-recurring flake site (#955).
+ *
+ *  `nudgeWork` (branch mode) re-fires the repo's working-tree watcher each
+ *  tick. The gitStatus stream re-reads `getStatus`→`resolveBase` on every
+ *  `subscribeRepoChange` event, so if the FIRST resolve raced the push and
+ *  errored `BASE_BRANCH_NOT_FOUND` (origin/<default> not yet visible — the
+ *  residual branch-mode flake that loses both cucumber attempts), a sentinel
+ *  create+unlink in the work tree fires a repo change that re-resolves
+ *  against the now-settled repo and the tree populates. The sentinel is
+ *  untracked (excluded from the branch diff) and removed immediately, so it
+ *  never appears in the tree. */
+async function waitForCodeTabReady(
+  world: KoluWorld,
+  nudgeWork?: string,
+): Promise<void> {
+  const row = world.page
     .locator(
       `${TREE} [data-item-path][data-item-type]:not([data-file-tree-sticky-row])`,
     )
-    .first()
-    .waitFor({ state: "visible", timeout: HYDRATION_TIMEOUT });
+    .first();
+  if (!nudgeWork) {
+    await row.waitFor({ state: "visible", timeout: HYDRATION_TIMEOUT });
+    return;
+  }
+  await pollFor({
+    observe: () => row.isVisible().catch(() => false),
+    isDone: (visible) => visible === true,
+    onTick: () => nudgeDir(nudgeWork),
+    onTimeout: (_last, elapsed) =>
+      new Error(
+        `Code tab tree never hydrated a row within ${elapsed}ms (work=${nudgeWork}) — ` +
+          `branch-mode gitStatus likely stuck on BASE_BRANCH_NOT_FOUND`,
+      ),
+    timeoutMs: HYDRATION_TIMEOUT,
+    intervalMs: 500,
+  });
 }
 
 async function waitForFixturePath(
   world: KoluWorld,
   mode: CodeTabMode,
   path: string,
+  work?: string,
 ): Promise<void> {
   // Two-step wait — first the tree's hydration, then the specific path.
   // Each step carries its own timeout against its own volatility axis;
   // the fused single-locator wait (the prior shape) made both axes share
   // POLL_TIMEOUT and starved the slow hydration side on loaded runners.
-  await waitForCodeTabReady(world);
+  // Branch mode passes `work` so the hydration wait can nudge a stuck
+  // gitStatus subscription back to life (see waitForCodeTabReady).
+  await waitForCodeTabReady(world, mode === "branch" ? work : undefined);
   if (mode === "browse") return;
   await world.page
     .locator(fileRow(path))
@@ -1133,9 +1167,13 @@ Given(
     content: string,
   ) {
     const m = mode as CodeTabMode;
-    await setupCodeTabFixture(this, m, writeFileCommand(path, content));
+    const work = await setupCodeTabFixture(
+      this,
+      m,
+      writeFileCommand(path, content),
+    );
     await activateCodeTabMode(this, m);
-    await waitForFixturePath(this, m, path);
+    await waitForFixturePath(this, m, path, work);
   },
 );
 
@@ -1150,11 +1188,11 @@ Given(
     const m = mode as CodeTabMode;
     const rows = table.rawTable.slice(1); // skip header
     const writes = rows.map(([p, c]) => writeFileCommand(p, c)).join(" && ");
-    await setupCodeTabFixture(this, m, writes);
+    const work = await setupCodeTabFixture(this, m, writes);
     await activateCodeTabMode(this, m);
     const firstPath = rows[0]?.[0];
     if (firstPath) {
-      await waitForFixturePath(this, m, firstPath);
+      await waitForFixturePath(this, m, firstPath, work);
     }
   },
 );

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -623,6 +623,12 @@ Then(
     const body = this.page
       .frameLocator('[data-testid="browse-preview-iframe"]')
       .locator("body");
+    // Hydration budget: the preview content arrives over a server
+    // subscription (selection → fsReadFile, or an *edit* re-firing the live
+    // watch which re-points the iframe `src` at a fresh `?v=<mtime>`). That
+    // fs.watch → SSE → reload round-trip is the slow axis under darwin CI
+    // load — the edit-then-refresh regression guard (code-tab.feature:1364)
+    // froze on the pre-edit body for >20 s under the post-build storm.
     await pollFor({
       observe: () => body.textContent({ timeout: 1_000 }).catch(() => null),
       isDone: (text) => text !== null && text.includes(expected),
@@ -630,7 +636,7 @@ Then(
         new Error(
           `iframe preview never contained "${expected}"; last body text: ${JSON.stringify(last)}`,
         ),
-      timeoutMs: POLL_TIMEOUT,
+      timeoutMs: HYDRATION_TIMEOUT,
     });
   },
 );
@@ -709,6 +715,9 @@ Then(
   "the markdown preview should contain {string}",
   async function (this: KoluWorld, expected: string) {
     const md = this.page.locator('[data-testid="browse-preview-markdown"]');
+    // Hydration budget: the rendered content arrives over the fsReadFile
+    // subscription after selection — the slow propagation axis under darwin
+    // CI load, like the iframe preview above.
     await pollFor({
       observe: () => md.textContent({ timeout: 1_000 }).catch(() => null),
       isDone: (text) => text !== null && text.includes(expected),
@@ -716,7 +725,7 @@ Then(
         new Error(
           `markdown preview never contained "${expected}"; last text: ${JSON.stringify(last)}`,
         ),
-      timeoutMs: POLL_TIMEOUT,
+      timeoutMs: HYDRATION_TIMEOUT,
     });
   },
 );

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1,6 +1,6 @@
 import { Given, Then, When } from "@cucumber/cucumber";
 import { waitForBufferContains } from "../support/buffer.ts";
-import { nudgeDir } from "../support/nudge.ts";
+import { nudgeDir, nudgeFiles } from "../support/nudge.ts";
 import { pollFor } from "../support/poll.ts";
 import {
   HYDRATION_TIMEOUT,
@@ -636,6 +636,39 @@ Then(
       onTimeout: (last) =>
         new Error(
           `iframe preview never contained "${expected}"; last body text: ${JSON.stringify(last)}`,
+        ),
+      timeoutMs: HYDRATION_TIMEOUT,
+    });
+  },
+);
+
+// Edit-then-refresh variant: after a file is rewritten in the shell, the live
+// preview reloads only when the file-change watch (`subscribeFileChange` →
+// `watchWorkingTree(repoRoot, { filePath })`) fires. On darwin that single
+// FSEvents notification is sometimes dropped under the post-koluBin-build
+// storm, so the iframe freezes on the pre-edit body and the bare assertion
+// above (even at HYDRATION_TIMEOUT) waits forever — no further event ever
+// comes. Re-touch the edited file's mtime each poll tick: each touch is a
+// fresh notification, so a dropped one is recovered, and a new mtime re-points
+// the iframe `src` (`?v=<mtime>`) to force the reload. The file already holds
+// the post-edit content, so this recovers the lost event without changing what
+// is asserted — it does NOT mask a broken watch re-arm (a touch of a file the
+// watch isn't armed on still fires nothing). `absFile` is the absolute on-disk
+// path the shell wrote (the scenario's repo cwd + relative path).
+Then(
+  "the file preview iframe should refresh to {string} after editing {string}",
+  async function (this: KoluWorld, expected: string, absFile: string) {
+    const body = this.page
+      .frameLocator('[data-testid="browse-preview-iframe"]')
+      .locator("body");
+    await pollFor({
+      observe: () => body.textContent({ timeout: 1_000 }).catch(() => null),
+      isDone: (text) => text?.includes(expected) ?? false,
+      onTick: () => nudgeFiles([absFile]),
+      onTimeout: (last) =>
+        new Error(
+          `iframe preview never refreshed to "${expected}" after editing ${absFile}; ` +
+            `last body text: ${JSON.stringify(last)}`,
         ),
       timeoutMs: HYDRATION_TIMEOUT,
     });

--- a/packages/tests/step_definitions/code_tab_steps.ts
+++ b/packages/tests/step_definitions/code_tab_steps.ts
@@ -1031,35 +1031,52 @@ async function setupCodeTabFixture(
     await runShell(world, `git commit --allow-empty -m init`);
     await runShell(world, writeFiles);
   } else if (mode === "branch") {
-    // `git init --bare` produces a remote we can push to; then push the
-    // initial commit so `origin/<default>` resolves and `merge-base` is
-    // the initial commit. Files have to be staged (`git add`) for branch
-    // mode to see them — Kolu's branch-mode listing is
-    // `git diff --name-status <merge-base>`, which excludes untracked
-    // files (see packages/integrations/git/src/review.ts:124).
-    await runShell(world, `git init --bare ${origin}`);
-    await runShell(world, `git init ${work} && cd ${work}`);
+    // Branch mode's listing is `git diff --name-status merge-base(HEAD,
+    // origin/<default>)`, which excludes untracked files — so files must be
+    // staged (`git add`) and `origin/<default>` must resolve. The server
+    // detects `<default>` via `git symbolic-ref refs/remotes/origin/HEAD`
+    // (then falls back to origin/main, origin/master). If none resolves it
+    // returns BASE_BRANCH_NOT_FOUND and the tree stays empty — and because
+    // the gitStatus stream dedups identical error snapshots, a later re-read
+    // that ALSO errors doesn't re-emit, so the tree never recovers until the
+    // base actually exists. This was the residual branch-mode flake that lost
+    // both cucumber attempts (the push occasionally not having produced a
+    // resolvable `origin/master` by the time the subscription's first read
+    // ran). Make the base deterministic and verified, not raced:
+    //   - `git init -b master` pins the default branch name (host default is
+    //     not guaranteed to be master), so the bare repo + push + detection
+    //     all agree on `master`.
+    //   - `git remote set-head origin master` sets `origin/HEAD` so the
+    //     server's FIRST detection branch (symbolic-ref) resolves immediately,
+    //     never falling through to the origin/main/master guesses.
+    //   - retry the push once, then gate the SETTLED barrier on
+    //     `origin/master` actually being verifiable — so the subscription that
+    //     `activateCodeTabMode` opens next can never read before the base ref
+    //     exists. `waitForCodeTabReady`'s per-tick work-tree nudge remains as
+    //     a belt-and-suspenders re-read trigger.
+    // The marker is split across a shell string-concat (`SET""TLED`) so the
+    // search text matches only the command's OUTPUT, never the typed echo.
+    await runShell(world, `git init --bare -b master ${origin}`);
+    await runShell(world, `git init -b master ${work} && cd ${work}`);
     await runShell(world, `git remote add origin ${origin}`);
     await runShell(world, `git commit --allow-empty -m init`);
-    await runShell(world, `git push -u origin HEAD`);
+    await runShell(
+      world,
+      `git push -u origin master || git push -u origin master`,
+    );
+    await runShell(world, `git remote set-head origin master`);
     await runShell(world, `git checkout -b feature`);
     await runShell(world, writeFiles);
     await runShell(world, `git add .`);
-    // Branch mode's gitStatus stream resolves `origin/<default>` on its FIRST
-    // read. If `git push -u origin HEAD` above is still in flight when the
-    // stream subscribes (it forks git + writes the bare repo — slow under
-    // darwin CI load), that read throws BASE_BRANCH_NOT_FOUND and the tree
-    // stays empty — the residual branch-mode flake that loses both cucumber
-    // attempts. Two layers guard it: (1) this shell-completion barrier so the
-    // whole setup — crucially the push — is done before `activateCodeTabMode`
-    // subscribes; (2) `waitForCodeTabReady` nudges the work tree each tick so
-    // a first-read that still raced re-resolves on the next repo-change event
-    // (the stream re-reads `getStatus` on `subscribeRepoChange`). The marker
-    // is split across a shell string-concat (`SET""TLED`) so the search text
-    // matches only the command's OUTPUT, never the typed-command echo — a real
-    // ordering barrier, not a sleep.
     const token = work.replace(/[^a-zA-Z0-9]/g, "");
-    await runShell(world, `echo "KOLU_SET""TLED_${token}"`);
+    // Only emit the barrier marker once origin/master is verifiably resolvable;
+    // a missing base emits a distinct marker so the wait fails loudly instead
+    // of racing on into a permanently-empty branch tree.
+    await runShell(
+      world,
+      `git rev-parse --verify origin/master >/dev/null 2>&1 ` +
+        `&& echo "KOLU_SET""TLED_${token}" || echo "KOLU_BASE""MISSING_${token}"`,
+    );
     await waitForBufferContains(world.page, `KOLU_SETTLED_${token}`);
   } else if (mode === "browse") {
     await runShell(world, `git init ${work} && cd ${work}`);

--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -337,20 +337,41 @@ async function newScenarioPage(
   });
 }
 
-async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
+/** Wait until the server WE spawned owns the port and answers health.
+ *
+ *  A bare `/api/health` probe is not enough on a shared CI host: a stale
+ *  orphan kolu from a previous run (or another consumer of the box) can be
+ *  squatting the ephemeral port `get-port` just handed us. Our child then
+ *  fails to bind, but the probe hits the *orphan* — which answers
+ *  `/api/health` (200) yet 404s every test-only RPC. The suite would then run
+ *  against a foreign server, one wedged worker drains the cucumber queue, and
+ *  hundreds of scenarios fail with an opaque 404 (the same single-bad-worker
+ *  catastrophe class as the ECONNREFUSED queue-drain in #?, different cause).
+ *
+ *  So gate on OUR child first announcing `kolu listening` on the expected
+ *  port (`ownsPort`) — proof it actually bound it — and only then confirm
+ *  HTTP health. Returns false (caller retries a fresh port) if the child
+ *  exits early (EADDRINUSE) or never claims the port within the budget. */
+async function waitForOwnedServer(
+  url: string,
+  ownsPort: () => boolean,
+  hasExited: () => boolean,
+  timeoutMs: number,
+): Promise<boolean> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    try {
-      const resp = await httpGet(url);
-      if (resp.ok) return;
-    } catch {
-      // server not up yet
+    if (hasExited()) return false;
+    if (ownsPort()) {
+      try {
+        const resp = await httpGet(`${url}/api/health`);
+        if (resp.ok) return true;
+      } catch {
+        // bound but HTTP not answering yet — keep polling
+      }
     }
     await new Promise((r) => setTimeout(r, 50));
   }
-  throw new Error(
-    `Server did not become healthy at ${url} within ${timeoutMs}ms`,
-  );
+  return false;
 }
 
 BeforeAll(async () => {
@@ -361,10 +382,6 @@ BeforeAll(async () => {
     // Reuse an already-running server
     baseUrl = koluServer;
   } else {
-    // Spawn the binary on a random port
-    const port = await getPort();
-    baseUrl = `http://localhost:${port}`;
-    console.log(`[worker:${workerId}] Starting server on port ${port}...`);
     // Extend NIX_ENV_WHITELIST with GIT_AUTHOR_*/GIT_COMMITTER_* so PTY
     // shells in fixtures like `code-tab.feature` (which run `git init &&
     // git commit` inside the terminal under test) inherit the same
@@ -374,61 +391,113 @@ BeforeAll(async () => {
       NIX_ENV_WHITELIST,
       "GIT_AUTHOR_NAME,GIT_AUTHOR_EMAIL,GIT_COMMITTER_NAME,GIT_COMMITTER_EMAIL",
     ].join(",");
-    serverProcess = spawn(
-      koluServer,
-      [
-        "--allow-nix-shell-with-env-whitelist",
-        envWhitelist,
-        "--port",
-        String(port),
-      ],
-      {
-        stdio: "pipe",
-        env: {
-          ...process.env,
-          // Route server state to an ephemeral $TMPDIR path so test runs
-          // never touch ~/.config and the dir can be wiped in AfterAll.
-          // `mkdtempSync`'s random suffix guarantees no collisions across
-          // parallel workers or worktrees.
-          KOLU_STATE_DIR: koluStateDir,
-          KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
-          KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
-          KOLU_CODEX_DIR: codexDir,
-          KOLU_OPENCODE_DB: opencodeDbPath,
-        },
-      },
-    );
-    // Tee the spawned server's stdout+stderr to a per-worker file. A server
-    // that dies mid-run otherwise leaves NO trace in the suite log (its only
-    // visible symptom is downstream `ECONNREFUSED` resets on its port); the
-    // file preserves the crash stack / clean-exit / silence-then-gone that
-    // distinguishes a crash from a wedge. Append-mode so a re-spawn doesn't
-    // clobber the prior life. Cheap, always on (replaces the KOLU_TEST_VERBOSE
-    // stdout gate — stdout is still drained so the pipe can't block pino).
+    // Append-mode per-worker server log: a server that dies mid-run otherwise
+    // leaves NO trace in the suite log; the file preserves the crash stack /
+    // clean-exit / silence-then-gone that distinguishes a crash from a wedge.
     fs.mkdirSync(serverLogDir, { recursive: true });
     const serverLog = fs.createWriteStream(
       path.join(serverLogDir, `server-w${workerId}.log`),
       { flags: "a" },
     );
-    serverProcess.stderr?.on("data", (data: Buffer) => {
-      serverLog.write(data);
-      process.stderr.write(`[server:${workerId}] ${data}`);
-    });
-    serverProcess.stdout?.on("data", (data: Buffer) => {
-      serverLog.write(data);
-      if (process.env.KOLU_TEST_VERBOSE) {
-        process.stderr.write(`[server:${workerId}:out] ${data}`);
+
+    // Spawn on a random port, retrying on a fresh port if our child can't take
+    // ownership of it (a stale orphan may be squatting — see waitForOwnedServer).
+    const MAX_SPAWN_ATTEMPTS = 5;
+    let started = false;
+    for (
+      let attempt = 1;
+      attempt <= MAX_SPAWN_ATTEMPTS && !started;
+      attempt++
+    ) {
+      const port = await getPort();
+      const url = `http://localhost:${port}`;
+      console.log(
+        `[worker:${workerId}] Starting server on port ${port} (attempt ${attempt}/${MAX_SPAWN_ATTEMPTS})...`,
+      );
+      const child = spawn(
+        koluServer,
+        [
+          "--allow-nix-shell-with-env-whitelist",
+          envWhitelist,
+          "--port",
+          String(port),
+        ],
+        {
+          stdio: "pipe",
+          env: {
+            ...process.env,
+            // Route server state to an ephemeral $TMPDIR path so test runs
+            // never touch ~/.config and the dir can be wiped in AfterAll.
+            KOLU_STATE_DIR: koluStateDir,
+            KOLU_CLAUDE_SESSIONS_DIR: claudeSessionsDir,
+            KOLU_CLAUDE_PROJECTS_DIR: claudeProjectsDir,
+            KOLU_CODEX_DIR: codexDir,
+            KOLU_OPENCODE_DB: opencodeDbPath,
+          },
+        },
+      );
+
+      // Detect when OUR child announces it bound the port. The address in the
+      // `kolu listening {...,"address":"http://127.0.0.1:<port>"}` log proves
+      // ownership; buffer across chunks so a split line still matches.
+      let outBuf = "";
+      let ownsPort = false;
+      let exited = false;
+      const scan = (data: Buffer) => {
+        serverLog.write(data);
+        if (!ownsPort) {
+          outBuf += data.toString();
+          if (outBuf.includes("kolu listening") && outBuf.includes(`:${port}`))
+            ownsPort = true;
+          // Cap the scan buffer — once it's clearly past the boot banner and
+          // still no match, keep only the tail so memory can't grow unbounded.
+          if (outBuf.length > 16_384) outBuf = outBuf.slice(-4_096);
+        }
+      };
+      child.stderr?.on("data", (data: Buffer) => {
+        scan(data);
+        process.stderr.write(`[server:${workerId}] ${data}`);
+      });
+      child.stdout?.on("data", (data: Buffer) => {
+        scan(data);
+        if (process.env.KOLU_TEST_VERBOSE) {
+          process.stderr.write(`[server:${workerId}:out] ${data}`);
+        }
+      });
+      // Record the death itself: code/signal disambiguates crash (code≠0 or a
+      // signal) from a clean exit from a never-fired handler (wedge). A bind
+      // failure (port squatted) shows up here and flips `exited`.
+      child.on("exit", (code, signal) => {
+        exited = true;
+        const line = `[server:${workerId}] process exited code=${code} signal=${signal}\n`;
+        serverLog.write(line);
+        process.stderr.write(line);
+      });
+
+      const owned = await waitForOwnedServer(
+        url,
+        () => ownsPort,
+        () => exited,
+        15_000,
+      );
+      if (owned) {
+        serverProcess = child;
+        baseUrl = url;
+        started = true;
+        console.log(`[worker:${workerId}] Server is healthy on ${port}.`);
+      } else {
+        console.log(
+          `[worker:${workerId}] Server did not take ownership of port ${port} ` +
+            `(ownsPort=${ownsPort} exited=${exited}) — likely a squatter; retrying on a fresh port.`,
+        );
+        child.kill("SIGKILL");
       }
-    });
-    // Record the death itself: code/signal disambiguates crash (code≠0 or a
-    // signal) from a clean exit from a never-fired handler (wedge).
-    serverProcess.on("exit", (code, signal) => {
-      const line = `[server:${workerId}] process exited code=${code} signal=${signal}\n`;
-      serverLog.write(line);
-      process.stderr.write(line);
-    });
-    await waitForHealth(`${baseUrl}/api/health`, 10_000);
-    console.log(`[worker:${workerId}] Server is healthy.`);
+    }
+    if (!started) {
+      throw new Error(
+        `[worker:${workerId}] could not start a kolu server that owns its port after ${MAX_SPAWN_ATTEMPTS} attempts`,
+      );
+    }
   }
 
   // Launch browser — always use CI args for consistency and performance

--- a/packages/tests/support/nudge.ts
+++ b/packages/tests/support/nudge.ts
@@ -17,6 +17,7 @@
  *  once per dbPath so a regression doesn't silently re-flake the suite. */
 
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 /** Locked/busy errors are the expected failure mode under parallel
@@ -43,6 +44,28 @@ export function nudgeFiles(paths: ReadonlyArray<string | undefined>): void {
     } catch {
       // File may have been cleaned up between iterations — fine.
     }
+  }
+}
+
+/** Re-fire a directory's `fs.watch` by creating then removing a throwaway
+ *  sentinel entry inside it. `nudgeFiles` re-touches mtimes, which only
+ *  recovers a dropped *write/create* event — it can do nothing for a
+ *  dropped *deletion* (the file is gone, so there's nothing left to
+ *  touch). A create+unlink of a sentinel inside `dir` produces fresh
+ *  entry events, so a consumer that re-scans on any directory event (e.g.
+ *  the Claude SESSIONS_DIR watcher, which re-reads `<pid>.json` and finds
+ *  it absent) re-derives and notices the real entry has vanished. The
+ *  sentinel name is deliberately not a `*.json` so no session enumerator
+ *  ever parses it. Undefined / non-existent dir / racing cleanup is
+ *  swallowed — the caller's poll loop retries on the next tick. */
+export function nudgeDir(dir: string | undefined): void {
+  if (!dir) return;
+  const probe = path.join(dir, `.kolu-nudge-${process.pid}`);
+  try {
+    fs.writeFileSync(probe, "");
+    fs.rmSync(probe, { force: true });
+  } catch {
+    // Dir may not exist yet or be mid-cleanup — fine; poll loop retries.
   }
 }
 


### PR DESCRIPTION
**The `aarch64-darwin` CI lanes (`ci::e2e`, `ci::unit`) now pass 10 consecutive `/ci` runs on `rasam`** — the prior validation was a single green run, which hid a tail of distinct, load-correlated flake classes that only surface when you demand a *streak*. Each one is fixed at its root in the test harness (or CI wiring); no app behaviour changes. The host is documented as **rasam**, retiring `sincereintent`.

Most fixes share one darwin reality: **macOS FSEvents drops or delays watch notifications under load**, and the suite charged those delays to the wrong budget (a 20s interaction poll instead of the 60s hydration budget) or had no recovery path at all. The recurring remedy is to *re-fire the watcher* (a nudge) or *wait on the right axis*, and to stop one wedged worker from poisoning the whole run.

### Flake classes fixed

| Class | Symptom | Fix |
| --- | --- | --- |
| Claude session-end | `indicator disappears when session ends` lost both attempts — a dropped `SESSIONS_DIR` deletion event wedged the server on stale state | symmetric `nudgeDir()` (create+unlink a sentinel to re-fire the dir watcher) + poll-and-nudge the disappearance assertions |
| Code-tab tree readiness | inline browse scenarios charged the first Pierre-tree population to the 20s poll budget and timed out under load | `waitTreeReady()` gives the *first* row/chip appearance the hydration budget — the split the helper path already used, extended to inline scenarios |
| Browse-preview propagation | iframe/markdown `should contain` froze on pre-edit content | hydration budget for the content-propagation wait |
| Port squatter (404 queue-drain) | a stale orphan kolu answered `/api/health` 200 but 404'd every test RPC → one wedged worker drained the cucumber queue, failing all 433 | gate readiness on *our* child announcing `kolu listening` on the expected port; retry a fresh port on `EADDRINUSE` |
| Branch-mode base ref | `BASE_BRANCH_NOT_FOUND` (origin/master unresolvable at first read) left the tree permanently empty | `git init -b master` + explicit `set-head` + push retry + a barrier verifying `origin/master` before the subscription opens; plus a work-tree nudge |
| iframe live-reload edit | an edit's single FSEvents notification dropped, so the preview never reloaded | `should refresh to … after editing <absFile>` re-touches the edited file each tick — recovers the dropped event, still catches a broken watch re-arm |
| e2e ⇄ unit `pnpm install` race | `unit` failed with `.bin/vitest: Permission denied` (126) — e2e's `just test` re-ran a workspace install concurrently, re-linking the shared `.bin` | make `ci::e2e` a pure consumer of `ci::install`: `just --no-deps test` + drop the recipe body's redundant `pnpm install` |

### Load levers

Two knobs complement the structural fixes, both darwin-only (linux's watch/render stack is reliable and keeps its settings):

- **`CUCUMBER_RETRY=2`** (was 1) — absorbs the residual fs-event-drop tail.
- **Worker cap 8 → 6** — shrinks the concurrent-load window behind scattered interaction-wait misses (e.g. the per-terminal Code-tab history `back`-button never enabling). _Trades part of the earlier PAR=8 throughput win for consecutive-green stability._

> The 10/10 streak ran while an unrelated `vira` service was pinning ~6 cores on rasam — the suite stayed green even under that sustained external contention, which is the real bar. (Runs were ~23–28 min each under that load.)

Docs: `.agency/do.md` now names **rasam** as the aarch64-darwin host; `docs/ci-e2e-macos-ralph-report.md` records this hardening pass.

_Generated by Claude Code (model `claude-opus-4-8`)._