### PR TITLE
Hide the right panel on an empty workspace (no more ghost panel)

### DIFF
--- a/packages/client/src/ChromeBar.tsx
+++ b/packages/client/src/ChromeBar.tsx
@@ -108,9 +108,13 @@ const ChromeBar: Component<{
               // sibling outside the Resizable ever shrinks the
               // container, switch to a measured pixel offset or a
               // host-published CSS custom property.
-              right: rightPanel.collapsed()
-                ? 0
-                : `${rightPanel.panelSize() * 100}vw`,
+              // `panelOpen()` (not raw `collapsed()`) so an empty workspace —
+              // where the panel host isn't even mounted (App's `showEmpty`)
+              // — reserves no width here. Otherwise the cluster floats 25vw
+              // shy of the right edge with nothing filling the gap.
+              right: rightPanel.panelOpen()
+                ? `${rightPanel.panelSize() * 100}vw`
+                : 0,
             }
       }
     >
@@ -191,15 +195,20 @@ const ChromeBar: Component<{
             data-testid="inspector-toggle"
             class={toggleBtnClass}
             classList={{
-              "bg-surface-2 text-fg": !rightPanel.collapsed(),
+              "bg-surface-2 text-fg": rightPanel.panelOpen(),
               "text-fg-3 hover:bg-surface-2 hover:text-fg":
-                rightPanel.collapsed(),
+                rightPanel.hasTerminals() && !rightPanel.panelOpen(),
+              "text-fg-3/40 cursor-not-allowed": !rightPanel.hasTerminals(),
             }}
-            data-active={!rightPanel.collapsed() ? "" : undefined}
+            data-active={rightPanel.panelOpen() ? "" : undefined}
+            // Dead on an empty workspace: there's no panel to reveal, so the
+            // toggle joins the maximize button in being disabled until a
+            // terminal exists (the keybind/palette no-op via togglePanel too).
+            disabled={!rightPanel.hasTerminals()}
             onClick={() => rightPanel.togglePanel()}
             aria-label="Toggle right panel"
           >
-            <InspectorToggleIcon active={!rightPanel.collapsed()} />
+            <InspectorToggleIcon active={rightPanel.panelOpen()} />
           </button>
         </Tip>
         <div class="pointer-events-auto">

--- a/packages/client/src/commands.tsx
+++ b/packages/client/src/commands.tsx
@@ -342,7 +342,15 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
       : []),
 
     // --- UI (panel/dock visibility — global UI chrome, not per-terminal) ---
-    actionPaletteCommand("toggleRightPanel", deps, { section: "ui" }),
+    // Hide "Toggle right panel" on an empty workspace: with no terminals the
+    // panel host is unmounted (App's `showEmpty`) and `togglePanel()`
+    // early-returns, so the command would close the palette and do nothing —
+    // exactly the "offering a command that does nothing surfaces as broken"
+    // case the canvas-arrange gate above avoids. The header button is disabled
+    // for the same reason.
+    ...(deps.terminalIds().length > 0
+      ? [actionPaletteCommand("toggleRightPanel", deps, { section: "ui" })]
+      : []),
     actionPaletteCommand("toggleDock", deps, { section: "ui" }),
 
     // --- Help (reference + advanced) ---

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -217,6 +217,17 @@ export function useRightPanel() {
     reportToServer(id);
   }
 
+  /** Write the persisted desktop `collapsed` bit. No-op on an empty
+   *  workspace — the EmptyState owns the screen and there's no panel host,
+   *  so flipping the bit would just persist a ghost state. Every
+   *  collapsed-mutating path (toggle/collapse/expand and `reveal`'s desktop
+   *  branch) routes through here so the empty-workspace rule lives in one
+   *  place rather than per-caller. */
+  const setCollapsed = (collapsed: boolean) => {
+    if (!hasTerminals()) return;
+    updatePreferences({ rightPanel: { collapsed } });
+  };
+
   return {
     // ── Workspace chrome (global) ────────────────────────────────────
     collapsed: () => rp().collapsed,
@@ -231,16 +242,9 @@ export function useRightPanel() {
      *  width offset and toggle state off this (not raw `collapsed`) so an
      *  empty workspace shows no ghost panel. */
     panelOpen: () => hasTerminals() && !rp().collapsed,
-    togglePanel: () => {
-      // Nothing to toggle on an empty workspace — the EmptyState owns the
-      // screen and there's no panel to reveal. Guarding here means the
-      // button, the keybind, and the palette command (all routed through
-      // this one function) share the rule.
-      if (!hasTerminals()) return;
-      updatePreferences({ rightPanel: { collapsed: !rp().collapsed } });
-    },
-    collapsePanel: () => updatePreferences({ rightPanel: { collapsed: true } }),
-    expandPanel: () => updatePreferences({ rightPanel: { collapsed: false } }),
+    togglePanel: () => setCollapsed(!rp().collapsed),
+    collapsePanel: () => setCollapsed(true),
+    expandPanel: () => setCollapsed(false),
     setPanelSize: (size: number) => {
       if (size > MIN_PANEL_SIZE && Math.abs(size - rp().size) > SIZE_EPSILON)
         updatePreferences({ rightPanel: { size } }, { coalesce: true });
@@ -274,8 +278,7 @@ export function useRightPanel() {
      *  `collapsed`) stay separate and are resolved here in one place. */
     reveal: () => {
       if (isMobile()) setDrawerOpen(true);
-      else if (rp().collapsed)
-        updatePreferences({ rightPanel: { collapsed: false } });
+      else if (rp().collapsed) setCollapsed(false);
     },
 
     // ── Per-terminal task state ──────────────────────────────────────

--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -175,6 +175,14 @@ export function useRightPanel() {
   const store = useTerminalStore();
   const rp = () => preferences().rightPanel;
 
+  /** Whether there's anything for the panel to show — at least one terminal
+   *  exists. An empty workspace renders the `EmptyState` in place of the
+   *  panel host (App.tsx's `showEmpty`), so the desktop chrome must treat the
+   *  panel as absent regardless of the persisted `collapsed` preference —
+   *  otherwise the ChromeBar reserves panel-width it never fills (a "ghost"
+   *  gap) and the toggle reads as open with nothing behind it. */
+  const hasTerminals = () => store.terminalIds().length > 0;
+
   /** Read the per-terminal record for the active terminal, falling back
    *  to defaults when no terminal is active or the terminal has no record
    *  yet. The returned object is read-only — write through the mutators. */
@@ -213,8 +221,24 @@ export function useRightPanel() {
     // ── Workspace chrome (global) ────────────────────────────────────
     collapsed: () => rp().collapsed,
     panelSize: () => rp().size,
-    togglePanel: () =>
-      updatePreferences({ rightPanel: { collapsed: !rp().collapsed } }),
+    /** At least one terminal exists, so the desktop panel host is mounted
+     *  (rather than the EmptyState). Desktop chrome gates its panel
+     *  affordances on this — the toggle is dead and the offset zero when
+     *  there's nothing to inspect. */
+    hasTerminals,
+    /** Effective desktop visibility: the panel only occupies canvas space
+     *  when it isn't collapsed AND a terminal exists. ChromeBar keys its
+     *  width offset and toggle state off this (not raw `collapsed`) so an
+     *  empty workspace shows no ghost panel. */
+    panelOpen: () => hasTerminals() && !rp().collapsed,
+    togglePanel: () => {
+      // Nothing to toggle on an empty workspace — the EmptyState owns the
+      // screen and there's no panel to reveal. Guarding here means the
+      // button, the keybind, and the palette command (all routed through
+      // this one function) share the rule.
+      if (!hasTerminals()) return;
+      updatePreferences({ rightPanel: { collapsed: !rp().collapsed } });
+    },
     collapsePanel: () => updatePreferences({ rightPanel: { collapsed: true } }),
     expandPanel: () => updatePreferences({ rightPanel: { collapsed: false } }),
     setPanelSize: (size: number) => {

--- a/packages/tests/features/right-panel.feature
+++ b/packages/tests/features/right-panel.feature
@@ -121,6 +121,21 @@ Feature: Right panel (Code + Inspector)
     And the Code tab should be active
     And there should be no page errors
 
+  Scenario: No ghost right panel once the last terminal closes
+    # With the panel open (collapsed=false), closing the last terminal drops
+    # to the EmptyState — which doesn't mount the panel host. The desktop
+    # chrome must follow: the toggle goes dead and the ChromeBar reserves no
+    # panel-width, instead of floating its controls 25vw shy of the edge with
+    # an empty "ghost" gap behind them.
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I close the active terminal via command palette
+    Then the empty state tip should be visible
+    And the inspector toggle should not be active
+    And the inspector toggle should be disabled
+    And the chrome bar should reserve no right-panel space
+    And there should be no page errors
+
   Scenario: Active tab is per-terminal (each terminal remembers its own)
     # Terminal 1 (from Background) — switch to Inspector, leaving terminal 2 untouched
     When I press the toggle inspector shortcut

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -134,12 +134,16 @@ Then(
 Then(
   "the inspector toggle should be disabled",
   async function (this: KoluWorld) {
-    const toggle = this.page.locator('header [data-testid="inspector-toggle"]');
-    await toggle.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
-    assert.ok(
-      await toggle.isDisabled(),
-      "Expected the inspector toggle to be disabled on an empty workspace",
+    // Use the `:disabled` selector with waitFor so the assertion polls until
+    // SolidJS reactivity has flushed the `disabled` attribute onto the button —
+    // the same idiom as "the Code tab back/forward button should be disabled".
+    // A bare isDisabled() snapshot after waitFor(attached) is a race: the
+    // element can exist in the DOM before the reactive flush propagates
+    // `disabled={true}`.
+    const toggle = this.page.locator(
+      'header [data-testid="inspector-toggle"]:disabled',
     );
+    await toggle.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
   },
 );
 

--- a/packages/tests/step_definitions/right_panel_steps.ts
+++ b/packages/tests/step_definitions/right_panel_steps.ts
@@ -113,6 +113,55 @@ Then(
 );
 
 Then(
+  "the inspector toggle should not be active",
+  async function (this: KoluWorld) {
+    // The header toggle drops its `data-active` marker when the panel isn't
+    // effectively open — which an empty workspace forces regardless of the
+    // collapsed preference.
+    await this.page.waitForFunction(
+      () => {
+        const btn = document.querySelector(
+          'header [data-testid="inspector-toggle"]',
+        );
+        return !!btn && !btn.hasAttribute("data-active");
+      },
+      null,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+Then(
+  "the inspector toggle should be disabled",
+  async function (this: KoluWorld) {
+    const toggle = this.page.locator('header [data-testid="inspector-toggle"]');
+    await toggle.waitFor({ state: "attached", timeout: POLL_TIMEOUT });
+    assert.ok(
+      await toggle.isDisabled(),
+      "Expected the inspector toggle to be disabled on an empty workspace",
+    );
+  },
+);
+
+Then(
+  "the chrome bar should reserve no right-panel space",
+  async function (this: KoluWorld) {
+    // The ghost: the floating chrome's inline `right` offset reserves the
+    // panel's width. With no panel mounted it must collapse to 0 so the
+    // control cluster sits flush against the viewport's right edge.
+    await this.page.waitForFunction(
+      () => {
+        const bar = document.querySelector('[data-testid="chrome-bar"]');
+        if (!bar) return false;
+        return getComputedStyle(bar).right === "0px";
+      },
+      null,
+      { timeout: POLL_TIMEOUT },
+    );
+  },
+);
+
+Then(
   "the right panel resize handle should be visible",
   async function (this: KoluWorld) {
     // Handle uses w-0 with ::before pseudo-element — check attached, not visible


### PR DESCRIPTION
**An empty workspace no longer shows a "ghost" right panel.** With no terminals open, the canvas renders the `EmptyState`, not the right-panel host — but the `ChromeBar` still reserved the panel's width through its inline `right: 25vw` offset, and the inspector toggle still read as *open*. The control cluster floated 25vw shy of the right edge with nothing behind the gap.

The fix gives the desktop chrome the same knowledge the panel host already had — *is there anything to inspect?* — instead of keying off the raw `collapsed` preference alone.

### The seam

`useRightPanel` now exposes two derived accessors the chrome reads instead of `collapsed()`:

- **`hasTerminals()`** — at least one terminal exists, so the panel host is actually mounted (vs. the EmptyState).
- **`panelOpen()`** — `hasTerminals() && !collapsed`: the panel genuinely occupies canvas space.

`togglePanel()` no-ops on an empty workspace, so the button, the keybind, and the palette command all share one rule rather than each re-deriving it.

| Surface | Before (empty workspace) | After |
| --- | --- | --- |
| ChromeBar `right` offset | `25vw` — reserved width, empty gap | `0` — controls flush to the edge |
| Inspector toggle | reads *active*, clickable | inactive **and** disabled (joins maximize) |
| Toggle keybind / palette | flips a hidden preference | no-op until a terminal exists |

The panel re-opens per the persisted preference the moment the first tile appears — *the user's open/collapsed choice is never mutated, just gated.*

A reproducing e2e scenario in `right-panel.feature` opens the panel, closes the last terminal, and asserts the toggle goes dead and the chrome reserves no panel-width.

### Try it locally

```sh
nix run github:juspay/kolu/ill-boot
```

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._