### PR TITLE
Push /be-review's commits when a PR exists

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -77,13 +77,24 @@ depend on codex. The built-in `codex exec` retries inside `codex-review.sh` are 
 *lower* layer (one flaky invocation); this is the *outer* layer (the whole debate
 came back without a verdict) — both apply.
 
+## Push the fixes
+
+The reviewers commit straight to the branch — so if they committed anything,
+those fixes must reach the remote, or the open PR shows none of the review work.
+
+After the gauntlet, **if any reviewer committed** (`git log --oneline
+<base>..HEAD` is non-empty vs. the start) **and a PR exists for this branch**
+(`gh pr view --json number -q .number`), **push**: `git push`. No PR → nothing to
+push to, so skip (the local commits are still there for the human). **Never
+merge** — pushing updates the open PR; the human reviews the commits and merges
+when satisfied.
+
 ## Report
 
 Confirm the three PR comments landed, then summarize in chat: each reviewer's
 outcome (codex consensus / reviewer-error — note how many attempts codex took if
-it was retried, lens consensus, police findings actioned) and
-`git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
-result is visible. **Never push or merge** — the human reviews the commits and
-merges when satisfied.
+it was retried, lens consensus, police findings actioned), whether the fixes were
+pushed, and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the
+combined result is visible.
 
 ARGUMENTS:

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -77,13 +77,24 @@ depend on codex. The built-in `codex exec` retries inside `codex-review.sh` are 
 *lower* layer (one flaky invocation); this is the *outer* layer (the whole debate
 came back without a verdict) — both apply.
 
+## Push the fixes
+
+The reviewers commit straight to the branch — so if they committed anything,
+those fixes must reach the remote, or the open PR shows none of the review work.
+
+After the gauntlet, **if any reviewer committed** (`git log --oneline
+<base>..HEAD` is non-empty vs. the start) **and a PR exists for this branch**
+(`gh pr view --json number -q .number`), **push**: `git push`. No PR → nothing to
+push to, so skip (the local commits are still there for the human). **Never
+merge** — pushing updates the open PR; the human reviews the commits and merges
+when satisfied.
+
 ## Report
 
 Confirm the three PR comments landed, then summarize in chat: each reviewer's
 outcome (codex consensus / reviewer-error — note how many attempts codex took if
-it was retried, lens consensus, police findings actioned) and
-`git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
-result is visible. **Never push or merge** — the human reviews the commits and
-merges when satisfied.
+it was retried, lens consensus, police findings actioned), whether the fixes were
+pushed, and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the
+combined result is visible.
 
 ARGUMENTS:

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -77,13 +77,24 @@ depend on codex. The built-in `codex exec` retries inside `codex-review.sh` are 
 *lower* layer (one flaky invocation); this is the *outer* layer (the whole debate
 came back without a verdict) — both apply.
 
+## Push the fixes
+
+The reviewers commit straight to the branch — so if they committed anything,
+those fixes must reach the remote, or the open PR shows none of the review work.
+
+After the gauntlet, **if any reviewer committed** (`git log --oneline
+<base>..HEAD` is non-empty vs. the start) **and a PR exists for this branch**
+(`gh pr view --json number -q .number`), **push**: `git push`. No PR → nothing to
+push to, so skip (the local commits are still there for the human). **Never
+merge** — pushing updates the open PR; the human reviews the commits and merges
+when satisfied.
+
 ## Report
 
 Confirm the three PR comments landed, then summarize in chat: each reviewer's
 outcome (codex consensus / reviewer-error — note how many attempts codex took if
-it was retried, lens consensus, police findings actioned) and
-`git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
-result is visible. **Never push or merge** — the human reviews the commits and
-merges when satisfied.
+it was retried, lens consensus, police findings actioned), whether the fixes were
+pushed, and `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the
+combined result is visible.
 
 ARGUMENTS:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-07T20:32:34.590590+00:00'
+generated_at: '2026-06-08T18:32:10.617799+00:00'
 apm_version: 0.18.0
 dependencies:
 - repo_url: anthropics/skills


### PR DESCRIPTION
**`/be-review` now pushes the fixes its reviewers commit** — so an open PR actually shows the review work instead of nothing. The gauntlet (codex-debate → lens-debate → code-police) commits `fix(…)` / `fix(police):` straight to the branch, but the skill's Report step ended with a flat *"Never push or merge"* — which stranded every one of those commits locally while the PR sat unchanged.

The new **Push the fixes** step is guarded so it only acts when there's somewhere to push and something to push:

| Condition | Action |
| --- | --- |
| Reviewers committed **and** a PR exists for the branch | `git push` — updates the open PR |
| No commits, or no PR | Skip — local commits stay put for the human |
| Any case | **Never merge** — the human still reviews and merges |

Edited the `.apm/` source of truth and regenerated the `.claude/` + `.agents/` runtime copies via `just ai::apm` (hence the `apm.lock.yaml` bump). The Report step now also notes whether the fixes were pushed.

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._