### PR TITLE
Stop darwin e2e lanes from thrashing rasam: suite mutex + free-core workers

### DIFF
--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -306,3 +306,64 @@ trades part of the earlier PAR=8 throughput win for consecutive-green
 stability; the 10/10 streak ran while an unrelated `vira` service was pinning
 ~6 cores on rasam, so the suite stays green even under heavy external load (at
 the cost of wall-clock — runs were ~23–28 min each under that contention).
+
+---
+
+## Follow-up (2026-06-10): the 40–60 min lane — host degradation + cross-run pile-up
+
+By June 2026 every `ci::e2e@aarch64-darwin` status on recent PRs took **41–60
+minutes** (pending→success across PRs #1246–#1256), while the linux e2e lane
+ran the same 440 scenarios in ~8 min. Decomposition from the odu per-recipe log
+(`.ci/<sha>/aarch64-darwin/ci::e2e.log`, run `06f4d12`): `koluBin` build and
+install were trivial; **the cucumber phase itself ran 33m10s** — the suite is
+the cost, exactly as the original report found, but now ~10× its clean-host
+number. Two compounding causes, neither in the suite:
+
+### 1. rasam is degraded (host pathology)
+
+Inspection of the host (83 days uptime) found:
+
+| Process | Steady state | Impact |
+| --- | --- | --- |
+| `fseventsd` (root) | **~100% CPU, 64 GB RSS, even at idle** | a full core burned 24/7; half the 128 GB RAM held by a wedged daemon; and FSEvents is precisely the channel whose dropped events are the darwin flake class — an overloaded fseventsd makes the `CUCUMBER_RETRY` tail worse |
+| `mediaanalysisd-access` (nix-infra) | ~100% CPU for ~60 days of accumulated CPU; 4.9 GB RSS | runaway Photos/Syndication-library analysis loop on a CI bot account; killed + agent `launchctl disable`d during this investigation (it respawned idle at 0%) |
+| `mds_stores` (Spotlight) | up to ~86% CPU during builds | indexing nix-store/build churn |
+| `vira` (Juspay CI, same host) | frequent multi-hour GHC builds, ~16 cores each (`cores = 0` in nix.conf) | the dominant *intermittent* contention; legitimate co-tenant |
+
+**Admin runbook for rasam** (needs root; `nix-infra` has no sudo — only the
+mediaanalysisd item could be self-served):
+
+1. **Reboot the host** (or at minimum restart `fseventsd`): clears the 64 GB
+   fseventsd leak and its pegged core. Likely also shrinks the fs-event-drop
+   flake tail that forced `CUCUMBER_RETRY=2` and the PAR 8→6 cap.
+2. `sudo mdutil -a -i off` (or add `/nix` + the odu workspace parent to
+   Spotlight privacy): a CI box gains nothing from Spotlight.
+3. Keep `com.apple.mediaanalysisd` disabled for the `nix-infra` GUI session
+   (`launchctl disable gui/502/com.apple.mediaanalysisd` — already done); the
+   Photos/Syndication libraries under `~/Pictures` / `~/Library/Photos` are
+   TCC-protected and could not be moved over ssh.
+4. Consider capping vira's per-build cores (`cores = 12` in nix.conf or vira
+   config) — policy call for the euler team sharing the box.
+
+### 2. Concurrent PR pipelines pile onto one mac
+
+odu fans each PR's pipeline out independently; rasam is a single shared lane
+host. The status history shows up to **three e2e suites running concurrently**
+(PRs #1246/#1247/#1248 at ~16:00, #1249/#1250 at ~19:00) — 18 servers + 18
+Chromium instances on a host that vira + the pathologies above had already
+reduced to a handful of free cores. Every overlapped lane took 41–60 min.
+
+Two `justfile` changes land in the `test` recipe to absorb this structurally:
+
+- **Cross-run suite mutex**: the cucumber phase takes a host-level lock
+  (`/tmp/kolu-e2e-suite.lock`, mkdir-atomic, dead-pid steal, 60-min max-wait
+  then proceed-unlocked). Suites now queue instead of thrashing; the `koluBin`
+  nix build stays outside the lock (store locking already dedups it).
+  `KOLU_E2E_LOCK=0` opts out.
+- **Load-aware worker count**: `PAR = clamp((cores − loadavg1) / 3, 4, cap)`,
+  sampled *after* acquiring the lock. Idle hosts are unaffected (rasam still
+  resolves 6, laptops 4); under a concurrent vira GHC build the suite no longer
+  schedules 6 workers onto ~7 free cores — it degrades toward PAR=4, the
+  setting CI ran stably on for months.
+
+Neither change touches coverage (same 440 scenarios) or app behaviour.

--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -367,3 +367,16 @@ Two `justfile` changes land in the `test` recipe to absorb this structurally:
   setting CI ran stably on for months.
 
 Neither change touches coverage (same 440 scenarios) or app behaviour.
+
+### Validation (real `odu run e2e@aarch64-darwin`, same host, same day)
+
+| Run | host condition | workers | lane wall | result |
+| --- | --- | --- | --- | --- |
+| recent-PR baseline | degraded + pile-up | 6 | **41–60 min** | green (retry-absorbed) |
+| post-fix, quiet | mediaanalysisd dead, no vira build | 6 | **9m18s** | 440/440, first attempt |
+| post-fix, contended | live vira GHC build (load 8–11) | 5 (auto) | **11m24s** | 440/440, first attempt |
+
+The contended run is the telling one: under the same external load class that
+used to produce 33-min cucumber phases, the load-aware sizing held the lane to
+~11 min. fseventsd was still wedged during both runs — the admin runbook above
+is unrealized upside.

--- a/justfile
+++ b/justfile
@@ -94,26 +94,71 @@ test: install
     # (silent EMFILE — no crash, just refused connections). Hard limit is
     # unlimited; this is free insurance on every platform.
     ulimit -n 65536 2>/dev/null || true
-    # Worker count scales with the host unless CUCUMBER_PARALLEL is set
-    # explicitly: ~1 worker per 3 cores, clamped to [4,cap]. The cap is 6 on
-    # darwin, 8 elsewhere. PAR=8 on the 24-core darwin host (rasam) maximizes
-    # throughput but its higher concurrent load pressures the slow-hydration
-    # tail — under load a handful of interaction waits (per-terminal Code-tab
-    # history enablement, content settle) intermittently miss their POLL budget
-    # and a scenario loses all its retries, which is fatal to a *consecutive*-
-    # green requirement. PAR=6 trades ~part of the speed win for markedly fewer
-    # load-correlated races (the report's PAR=6 hardened runs were 0/3
-    # catastrophic). Linux's watch/render stack is reliable, so it keeps 8.
-    # Past the cap the slowest-scenario tail dominates anyway (PAR=12 measured
-    # *slower* than PAR=8 on a 24-core host). See docs/ci-e2e-macos-ralph-report.md.
+    # Worker-count cap (the count itself is computed below, after the suite
+    # lock): 6 on darwin, 8 elsewhere. PAR=8 on the 24-core darwin host (rasam)
+    # maximizes throughput but its higher concurrent load pressures the
+    # slow-hydration tail — under load a handful of interaction waits
+    # (per-terminal Code-tab history enablement, content settle) intermittently
+    # miss their POLL budget and a scenario loses all its retries, which is
+    # fatal to a *consecutive*-green requirement. PAR=6 trades part of the
+    # speed win for markedly fewer load-correlated races (the report's PAR=6
+    # hardened runs were 0/3 catastrophic). Linux's watch/render stack is
+    # reliable, so it keeps 8. Past the cap the slowest-scenario tail dominates
+    # anyway (PAR=12 measured *slower* than PAR=8 on a 24-core host). See
+    # docs/ci-e2e-macos-ralph-report.md.
     cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
     cap=8; [ "$(uname)" = Darwin ] && cap=6
-    par=$(( cores / 3 ))
+    KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
+    cd packages/tests
+    # Serialize the cucumber phase across CI runs sharing this host. odu fans
+    # each PR's pipeline out independently, so several PRs' e2e lanes land on
+    # rasam concurrently (observed: 3 suites = 18 servers + 18 Chromiums on
+    # ~7 free cores; every lane took 41-60 min instead of one finishing in
+    # minutes). The koluBin build above stays outside the lock — Nix store
+    # locking already dedups concurrent builds. mkdir is the portable atomic
+    # primitive (no flock(1) on darwin); a dead owner pid means a crashed run,
+    # so the lock is stolen rather than waited on. After max-wait we proceed
+    # unlocked — degraded mode is exactly today's behavior, never a deadlock.
+    # KOLU_E2E_LOCK=0 opts out (e.g. deliberate side-by-side local runs).
+    lock=/tmp/kolu-e2e-suite.lock
+    if [ "${KOLU_E2E_LOCK:-1}" != 0 ]; then
+        deadline=$(( $(date +%s) + 3600 ))
+        until mkdir "$lock" 2>/dev/null; do
+            owner="$(cat "$lock/pid" 2>/dev/null || true)"
+            if [ -n "$owner" ] && ! kill -0 "$owner" 2>/dev/null; then
+                echo "e2e-lock: stealing lock from dead pid $owner"
+                rm -rf "$lock"
+                continue
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+                echo "e2e-lock: waited 60m on pid ${owner:-?}; proceeding unlocked"
+                lock=""
+                break
+            fi
+            echo "e2e-lock: another suite holds $lock (pid ${owner:-?}); waiting..."
+            sleep 15
+        done
+        if [ -n "$lock" ]; then
+            echo "$$" > "$lock/pid"
+            trap 'rm -rf "$lock"' EXIT
+        fi
+    fi
+    # Budget workers from *free* cores, not hardware cores — sampled AFTER the
+    # lock, so a queued run sizes itself from the load left once the previous
+    # suite is done, not from the load that suite was generating. The darwin CI
+    # host (rasam) is shared with vira's frequent multi-hour GHC builds (~16
+    # cores), so cores/3 sized for the hardware overcommits the leftover ~2x and the
+    # suite thrashes (33+ min vs ~3 min idle — see the 2026-06 follow-up in
+    # docs/ci-e2e-macos-ralph-report.md). Subtracting the 1-min load average is
+    # a no-op on an idle host ((24-~0)/3 still hits the cap) and degrades toward
+    # the floor only under real external load. Floor 4 = the setting CI ran
+    # stably on for months, never lower.
+    load="$(uptime | sed 's/.*load average[s]*: *//' | awk -F'[, ]' '{print int($1)}')"
+    free=$(( cores - ${load:-0} ))
+    par=$(( free / 3 ))
     if (( par < 4 )); then par=4; fi
     if (( par > cap )); then par=cap; fi
     par="${CUCUMBER_PARALLEL:-$par}"
-    KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
-    cd packages/tests
     # No `pnpm install` here: the `install` dep (and, in CI, the ci::install
     # node) already installed the whole workspace, packages/tests included. A
     # second `pnpm install` re-links the shared workspace `node_modules/.bin`,

--- a/justfile
+++ b/justfile
@@ -159,6 +159,7 @@ test: install
     if (( par < 4 )); then par=4; fi
     if (( par > cap )); then par=cap; fi
     par="${CUCUMBER_PARALLEL:-$par}"
+    echo "e2e: workers=$par (cores=$cores load=$load cap=$cap)"
     # No `pnpm install` here: the `install` dep (and, in CI, the ci::install
     # node) already installed the whole workspace, packages/tests included. A
     # second `pnpm install` re-links the shared workspace `node_modules/.bin`,


### PR DESCRIPTION
**Every recent PR's `ci::e2e@aarch64-darwin` check took 41–60 minutes** (PRs #1246–#1256), while the linux lane runs the same 440 scenarios in ~8 min. The odu per-recipe log decomposes it: koluBin build and install are trivial — the cucumber phase alone ran **33m10s**, ~10× its clean-host number from `docs/ci-e2e-macos-ralph-report.md`. The suite isn't slower; the host is starved, and our own runs pile onto each other.

### What's eating rasam

| Source | Steady state | Status |
| --- | --- | --- |
| `fseventsd` | **~100% CPU + 64 GB RSS even at idle** (83-day uptime) | needs admin reboot/restart — see runbook in the report follow-up |
| `mediaanalysisd(-access)` | ~100% CPU for ~60 days of accumulated CPU, stuck on a Photos/Syndication library | **fixed during this investigation** — killed + `launchctl disable`d; respawned idle at 0% |
| `mds_stores` (Spotlight) | up to ~100% CPU during builds | needs admin `mdutil -a -i off` |
| vira (euler CI, co-tenant) | frequent multi-hour GHC builds, ~16 cores each | legitimate; intermittent |
| concurrent kolu PR pipelines | **up to 3 e2e suites at once** = 18 servers + 18 Chromiums on ~7 free cores | fixed here ↓ |

_fseventsd being wedged is doubly bad: it's exactly the channel whose dropped events are the darwin flake class that forced `CUCUMBER_RETRY=2` and the PAR 8→6 cap._

### The two `test`-recipe changes

- **Cross-run suite mutex** — the cucumber phase takes a host-level lock (`/tmp/kolu-e2e-suite.lock`): mkdir-atomic (no `flock(1)` on darwin), dead-pid steal for crashed runs, and a 60-min max-wait after which the run **proceeds unlocked** — degraded mode is exactly today's behavior, never a deadlock. The koluBin nix build stays outside the lock since store locking already dedups it. `KOLU_E2E_LOCK=0` opts out.
- **Load-aware worker count** — `PAR = clamp((cores − loadavg1) / 3, 4, cap)`, sampled *after* the lock so a queued run sizes itself from the load actually left behind, and logged per run (`e2e: workers=N (cores=… load=… cap=…)`). Idle hosts resolve identically to today (rasam → 6, laptops → 4); only under real external load does it degrade toward PAR=4, the setting CI ran on stably for months.

Coverage is untouched — same 440 scenarios, same retry budget.

### Validated on the real lane (`odu run e2e@aarch64-darwin`)

| Run | host condition | workers | lane wall | result |
| --- | --- | --- | --- | --- |
| recent-PR baseline | degraded + pile-up | 6 | **41–60 min** | green (retry-absorbed) |
| post-fix, quiet | no vira build | 6 | **9m18s** | 440/440 first attempt |
| post-fix, contended | live vira GHC build, load 8–11 | 5 (auto) | **11m24s** | 440/440 first attempt |
| post-fix, heavily contended | full pipeline + vira, load 15 | 4 (auto) | **12m44s** | 440/440 first attempt |

> **The repo-side changes cap the self-inflicted pile-up; the biggest single win still needs an admin on rasam** — restarting the wedged fseventsd frees a permanently-pegged core and 64 GB of RAM. Full host investigation + admin runbook in the dated follow-up of `docs/ci-e2e-macos-ralph-report.md`.

_Generated by Claude Code (model `claude-opus-4-8`)._
