### PR TITLE
Fix e2e worker clamp: literal 'cap' string silently serialized the suite

### DIFF
--- a/docs/ci-e2e-macos-ralph-report.md
+++ b/docs/ci-e2e-macos-ralph-report.md
@@ -375,8 +375,24 @@ Neither change touches coverage (same 440 scenarios) or app behaviour.
 | recent-PR baseline | degraded + pile-up | 6 | **41–60 min** | green (retry-absorbed) |
 | post-fix, quiet | mediaanalysisd dead, no vira build | 6 | **9m18s** | 440/440, first attempt |
 | post-fix, contended | live vira GHC build (load 8–11) | 5 (auto) | **11m24s** | 440/440, first attempt |
+| post-fix + host healed | fseventsd restarted, Spotlight off, mediaanalysisd contained | 6 | **3m28s** | 440/440, first attempt |
 
 The contended run is the telling one: under the same external load class that
 used to produce 33-min cucumber phases, the load-aware sizing held the lane to
-~11 min. fseventsd was still wedged during both runs — the admin runbook above
-is unrealized upside.
+~11 min.
+
+The admin runbook was then executed with sudo (same day): Spotlight disabled
+(`mdutil -a -i off`), the wedged fseventsd killed (fresh instance: 18 MB RSS /
+0% CPU vs 64 GB / 100%; ~90 GB RAM returned to the system), and — since SIP
+blocks `bootout` and FileVault rules out a remote reboot (the host would park
+at the unlock screen) — mediaanalysisd contained by a root LaunchDaemon
+(`/Library/LaunchDaemons/net.kolu.ci.kill-mediaanalysisd.plist`, pkill every
+300 s; delete it after the next console login makes the per-user
+`launchctl disable` stick). The healed-host lane time, **3m28s**, matches the
+original report's clean-host numbers scaled to today's 440 scenarios.
+
+One regression shipped in the first PR and is fixed here: the cap clamp wrote
+`par=cap` (literal string) instead of `par=$cap`, and `cucumber.js`
+`parseInt`→`NaN` silently *dropped* the `parallel` option — a serial suite that
+still looks green (the linux lane's `wall ≈ executing-steps` signature gave it
+away). The recipe now fails loud on any non-numeric worker count.

--- a/justfile
+++ b/justfile
@@ -157,8 +157,12 @@ test: install
     free=$(( cores - ${load:-0} ))
     par=$(( free / 3 ))
     if (( par < 4 )); then par=4; fi
-    if (( par > cap )); then par=cap; fi
+    if (( par > cap )); then par=$cap; fi
     par="${CUCUMBER_PARALLEL:-$par}"
+    # Fail loud on a non-numeric worker count: cucumber.js drops a NaN
+    # `parallel` silently and runs the whole suite SERIAL — a ~5x slowdown
+    # that looks green (this exact bug shipped as the literal string "cap").
+    case "$par" in *[!0-9]*|'') echo "e2e: invalid worker count '$par'" >&2; exit 1;; esac
     echo "e2e: workers=$par (cores=$cores load=$load cap=$cap)"
     # No `pnpm install` here: the `install` dep (and, in CI, the ci::install
     # node) already installed the whole workspace, packages/tests included. A


### PR DESCRIPTION
**Follow-up bug in #1259's load-aware worker sizing: the cap clamp wrote `par=cap` instead of `par=$cap`**, assigning the literal string `"cap"` whenever the free-core formula exceeded the platform cap — i.e. on any *idle* host, the common case the formula was supposed to leave untouched.

The failure is silent by construction: `cucumber.js` does `parseInt(process.env.CUCUMBER_PARALLEL)` → `NaN`, and `...(parallel > 1 && { parallel })` quietly omits the option, so **the whole suite runs serial while everything stays green**. The full-pipeline run on #1259's head shows it: the linux e2e lane logged `7m35s wall ≈ 7m33s executing steps` (the serial signature) instead of its usual ~2 min; an idle darwin lane would regress to ~45 min — worse than the problem #1259 fixed.

Two lines:

- `par=$cap` — the actual fix.
- A numeric guard on the resolved worker count that **fails loud** (`e2e: invalid worker count`) instead of letting any future non-numeric value degrade to a silent serial run. _Contended-load paths (`workers=5`, `workers=4`) were always numeric and validated green in #1259 — only the idle-host clamp path was broken._

> Validation: `odu run e2e@aarch64-darwin` on this branch, on the now-healed rasam (fseventsd restarted, Spotlight off, mediaanalysisd contained) — result posted below once the lane completes.

_Generated by Claude Code (model `claude-opus-4-8`)._