### PR TITLE
Teach the blog-post skill to be visual-first, with non-cryptic titles

### DIFF
--- a/.agents/skills/blog-post/SKILL.md
+++ b/.agents/skills/blog-post/SKILL.md
@@ -18,6 +18,13 @@ happened** when something was built — the dead-end, the load-bearing decision,
 the bug that taught the lesson. Its source of truth is the Claude Code session
 logs that produced the work, not invented marketing copy.
 
+**Show the story, don't only tell it.** A good post leans on figures over prose:
+a trajectory chart, before/after cards, a timeline, a flow diagram, a comparison
+bar, a real screenshot — visualization carrying more of the argument than text.
+Every figure is grounded in real data (status timestamps, `ps` output, measured
+durations); a chart is an argument, never decoration. This applies to every post,
+not just the obviously visual ones.
+
 ## Steps
 
 1. **Locate the work's sessions.** Find the Claude Code session logs behind the
@@ -37,6 +44,13 @@ logs that produced the work, not invented marketing copy.
 3. **Write it in the author's voice.** Use the `pg` skill (Paul Graham voice)
    unless told otherwise, and settle the inline house style up front. Match the
    register of the existing posts; a new post often pairs as a sequel to one.
+   **Give it a non-cryptic title.** The frontmatter `title` is a plain,
+   self-explanatory headline that states what happened and carries the payoff —
+   "Making Kolu's macOS e2e CI lane 14x faster", not a slug and not a clever
+   teaser the reader can't decode until they've finished. Let the `description`
+   tease the concrete hook (the 64 GB leak, the one-character typo). This is a
+   deliberate shift from the older evocative-title posts toward titles that tell
+   the reader up front what they'll learn — apply it to every new post.
 
 4. **Wire it into the site.** Posts live in `website/src/content/blog/` under a
    short, stable slug (the filename is the URL). Use the site's components for
@@ -59,6 +73,27 @@ logs that produced the work, not invented marketing copy.
    see `auto-demo.mdx` for the reference usage. Balance prose with screenshots and
    code — host images in the site, don't hotlink.
 
-5. **Verify and ship.** Build the site and confirm it renders, open the PR with
-   the `forge-pr` skill, and run only the CI lane a docs change can touch (the
-   website build plus formatting and lint — see the `ci` skill).
+   **Figures: hand-author inline SVG, theme-aware.** Draw charts directly as
+   inline `<svg>` in the MDX (no chart library) — see `macos-e2e-lane.mdx` for
+   five reference figures. Color every stroke and fill with the site's `--color-*`
+   CSS custom properties (`--color-ink`, `--color-ink-dim`, `--color-ink-muted`,
+   `--color-rule-strong`, `--color-amber`, `--color-live-alert`, `--color-live-lime`,
+   `--color-void`, …; the palette lives in `website/src/styles/global.css`) so a
+   figure tracks light/dark automatically — never hardcode a hex value. Give each
+   `<svg>` a `role="img"` and an `aria-label` describing the data it shows.
+
+   > **MDX/SVG gotcha (hard-won on the macOS-lane post).** Astro's MDX passes
+   > camelCase SVG presentation attributes (`textAnchor`, `fontSize`) through
+   > literally, and SVG silently ignores them — every label renders at the 16px
+   > left-anchored default. Use each attribute's real kebab-case SVG spelling:
+   > `text-anchor`, `font-size`, `font-weight`, `font-family`, `stroke-width`,
+   > `fill-opacity`. Genuinely camelCase SVG attributes like `viewBox` stay as-is.
+   > Eyeballing misses it — catch it by measuring `getBBox()` in a real browser
+   > against the **built** site.
+
+5. **Verify and ship.** Build the site and confirm it renders, then verify every
+   figure in **both light and dark themes** against the built output with the
+   chrome-devtools MCP — confirm labels are actually placed (`getBBox()`), not
+   merely present in the DOM — before opening the PR with the `forge-pr` skill.
+   Run only the CI lane a docs change can touch (the website build plus formatting
+   and lint — see the `ci` skill).

--- a/.apm/skills/blog-post/SKILL.md
+++ b/.apm/skills/blog-post/SKILL.md
@@ -18,6 +18,13 @@ happened** when something was built — the dead-end, the load-bearing decision,
 the bug that taught the lesson. Its source of truth is the Claude Code session
 logs that produced the work, not invented marketing copy.
 
+**Show the story, don't only tell it.** A good post leans on figures over prose:
+a trajectory chart, before/after cards, a timeline, a flow diagram, a comparison
+bar, a real screenshot — visualization carrying more of the argument than text.
+Every figure is grounded in real data (status timestamps, `ps` output, measured
+durations); a chart is an argument, never decoration. This applies to every post,
+not just the obviously visual ones.
+
 ## Steps
 
 1. **Locate the work's sessions.** Find the Claude Code session logs behind the
@@ -37,6 +44,13 @@ logs that produced the work, not invented marketing copy.
 3. **Write it in the author's voice.** Use the `pg` skill (Paul Graham voice)
    unless told otherwise, and settle the inline house style up front. Match the
    register of the existing posts; a new post often pairs as a sequel to one.
+   **Give it a non-cryptic title.** The frontmatter `title` is a plain,
+   self-explanatory headline that states what happened and carries the payoff —
+   "Making Kolu's macOS e2e CI lane 14x faster", not a slug and not a clever
+   teaser the reader can't decode until they've finished. Let the `description`
+   tease the concrete hook (the 64 GB leak, the one-character typo). This is a
+   deliberate shift from the older evocative-title posts toward titles that tell
+   the reader up front what they'll learn — apply it to every new post.
 
 4. **Wire it into the site.** Posts live in `website/src/content/blog/` under a
    short, stable slug (the filename is the URL). Use the site's components for
@@ -59,6 +73,27 @@ logs that produced the work, not invented marketing copy.
    see `auto-demo.mdx` for the reference usage. Balance prose with screenshots and
    code — host images in the site, don't hotlink.
 
-5. **Verify and ship.** Build the site and confirm it renders, open the PR with
-   the `forge-pr` skill, and run only the CI lane a docs change can touch (the
-   website build plus formatting and lint — see the `ci` skill).
+   **Figures: hand-author inline SVG, theme-aware.** Draw charts directly as
+   inline `<svg>` in the MDX (no chart library) — see `macos-e2e-lane.mdx` for
+   five reference figures. Color every stroke and fill with the site's `--color-*`
+   CSS custom properties (`--color-ink`, `--color-ink-dim`, `--color-ink-muted`,
+   `--color-rule-strong`, `--color-amber`, `--color-live-alert`, `--color-live-lime`,
+   `--color-void`, …; the palette lives in `website/src/styles/global.css`) so a
+   figure tracks light/dark automatically — never hardcode a hex value. Give each
+   `<svg>` a `role="img"` and an `aria-label` describing the data it shows.
+
+   > **MDX/SVG gotcha (hard-won on the macOS-lane post).** Astro's MDX passes
+   > camelCase SVG presentation attributes (`textAnchor`, `fontSize`) through
+   > literally, and SVG silently ignores them — every label renders at the 16px
+   > left-anchored default. Use each attribute's real kebab-case SVG spelling:
+   > `text-anchor`, `font-size`, `font-weight`, `font-family`, `stroke-width`,
+   > `fill-opacity`. Genuinely camelCase SVG attributes like `viewBox` stay as-is.
+   > Eyeballing misses it — catch it by measuring `getBBox()` in a real browser
+   > against the **built** site.
+
+5. **Verify and ship.** Build the site and confirm it renders, then verify every
+   figure in **both light and dark themes** against the built output with the
+   chrome-devtools MCP — confirm labels are actually placed (`getBBox()`), not
+   merely present in the DOM — before opening the PR with the `forge-pr` skill.
+   Run only the CI lane a docs change can touch (the website build plus formatting
+   and lint — see the `ci` skill).

--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -18,6 +18,13 @@ happened** when something was built — the dead-end, the load-bearing decision,
 the bug that taught the lesson. Its source of truth is the Claude Code session
 logs that produced the work, not invented marketing copy.
 
+**Show the story, don't only tell it.** A good post leans on figures over prose:
+a trajectory chart, before/after cards, a timeline, a flow diagram, a comparison
+bar, a real screenshot — visualization carrying more of the argument than text.
+Every figure is grounded in real data (status timestamps, `ps` output, measured
+durations); a chart is an argument, never decoration. This applies to every post,
+not just the obviously visual ones.
+
 ## Steps
 
 1. **Locate the work's sessions.** Find the Claude Code session logs behind the
@@ -37,6 +44,13 @@ logs that produced the work, not invented marketing copy.
 3. **Write it in the author's voice.** Use the `pg` skill (Paul Graham voice)
    unless told otherwise, and settle the inline house style up front. Match the
    register of the existing posts; a new post often pairs as a sequel to one.
+   **Give it a non-cryptic title.** The frontmatter `title` is a plain,
+   self-explanatory headline that states what happened and carries the payoff —
+   "Making Kolu's macOS e2e CI lane 14x faster", not a slug and not a clever
+   teaser the reader can't decode until they've finished. Let the `description`
+   tease the concrete hook (the 64 GB leak, the one-character typo). This is a
+   deliberate shift from the older evocative-title posts toward titles that tell
+   the reader up front what they'll learn — apply it to every new post.
 
 4. **Wire it into the site.** Posts live in `website/src/content/blog/` under a
    short, stable slug (the filename is the URL). Use the site's components for
@@ -59,6 +73,27 @@ logs that produced the work, not invented marketing copy.
    see `auto-demo.mdx` for the reference usage. Balance prose with screenshots and
    code — host images in the site, don't hotlink.
 
-5. **Verify and ship.** Build the site and confirm it renders, open the PR with
-   the `forge-pr` skill, and run only the CI lane a docs change can touch (the
-   website build plus formatting and lint — see the `ci` skill).
+   **Figures: hand-author inline SVG, theme-aware.** Draw charts directly as
+   inline `<svg>` in the MDX (no chart library) — see `macos-e2e-lane.mdx` for
+   five reference figures. Color every stroke and fill with the site's `--color-*`
+   CSS custom properties (`--color-ink`, `--color-ink-dim`, `--color-ink-muted`,
+   `--color-rule-strong`, `--color-amber`, `--color-live-alert`, `--color-live-lime`,
+   `--color-void`, …; the palette lives in `website/src/styles/global.css`) so a
+   figure tracks light/dark automatically — never hardcode a hex value. Give each
+   `<svg>` a `role="img"` and an `aria-label` describing the data it shows.
+
+   > **MDX/SVG gotcha (hard-won on the macOS-lane post).** Astro's MDX passes
+   > camelCase SVG presentation attributes (`textAnchor`, `fontSize`) through
+   > literally, and SVG silently ignores them — every label renders at the 16px
+   > left-anchored default. Use each attribute's real kebab-case SVG spelling:
+   > `text-anchor`, `font-size`, `font-weight`, `font-family`, `stroke-width`,
+   > `fill-opacity`. Genuinely camelCase SVG attributes like `viewBox` stay as-is.
+   > Eyeballing misses it — catch it by measuring `getBBox()` in a real browser
+   > against the **built** site.
+
+5. **Verify and ship.** Build the site and confirm it renders, then verify every
+   figure in **both light and dark themes** against the built output with the
+   chrome-devtools MCP — confirm labels are actually placed (`getBBox()`), not
+   merely present in the DOM — before opening the PR with the `forge-pr` skill.
+   Run only the CI lane a docs change can touch (the website build plus formatting
+   and lint — see the `ci` skill).


### PR DESCRIPTION
The macOS-lane post ([#1263](https://github.com/juspay/kolu/pull/1263)) was written to a brief — *"graphs, screenshots, visualization more than text"* — and it discovered a real MDX rendering trap along the way. None of that was written down where the next post would find it. This mines the JSONL session behind that post and folds the lessons back into the `blog-post` skill, so they become the house default rather than a one-off.

## What's new in the skill

| Lesson | Where it came from |
| --- | --- |
| **Visual-first** — lead with figures grounded in real data (timestamps, `ps` output, measured durations); a chart is an argument, not decoration | the brief at U14/U17 of the writing session; the post shipped five inline SVG charts + a screenshot |
| **Non-cryptic title** — the frontmatter `title` states what happened and carries the payoff ("Making Kolu's macOS e2e CI lane 14x faster"), not a clever teaser. A deliberate shift from the older evocative-title posts ("Measuring the Wrong Thing", "Eyes for the Agent") | the explicit ask: *non-cryptic title and headings* |
| **Theme-aware inline SVG** — hand-author charts as `<svg>`, color them with the site's `--color-*` tokens (`global.css`) so they track light/dark; never hardcode hex; `role="img"` + `aria-label` | the post's figures |
| **The MDX/SVG gotcha** — Astro passes camelCase SVG attrs (`textAnchor`, `fontSize`) through literally, so SVG ignores them and labels render 16px left-anchored. Use kebab-case (`text-anchor`, `font-size`…); `viewBox` stays. Catch it with `getBBox()` against the **built** site | the lesson encoded in #1263's own diff |
| **Verify in both themes** via chrome-devtools before shipping | the post's verification step |

> "We should do that for all posts" — so this is written as standing guidance in the skill (intro + every step), not advice scoped to one post.

## Mechanics

The skill ships in three runtime trees, all generated by APM from one source. I edited the source (`.apm/skills/blog-post/SKILL.md`) and ran `just ai::apm` to regenerate `.claude/` and `.agents/`; the diff is the same content in all three. The `apm.lock.yaml` timestamp bump was reverted as noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)