### PR TITLE
Add visual figures + clarifying subtitles to three older blog posts

### DIFF
--- a/.agents/skills/blog-post/SKILL.md
+++ b/.agents/skills/blog-post/SKILL.md
@@ -50,7 +50,10 @@ not just the obviously visual ones.
    teaser the reader can't decode until they've finished. Let the `description`
    tease the concrete hook (the 64 GB leak, the one-character typo). This is a
    deliberate shift from the older evocative-title posts toward titles that tell
-   the reader up front what they'll learn — apply it to every new post.
+   the reader up front what they'll learn — apply it to every new post. When a
+   title stays deliberately evocative ("The spacetime of code"), give it an
+   optional `subtitle` in the frontmatter — one plain line that decrypts the
+   metaphor into what the reader will learn; it renders as a deck under the title.
 
 4. **Wire it into the site.** Posts live in `website/src/content/blog/` under a
    short, stable slug (the filename is the URL). Use the site's components for

--- a/.apm/skills/blog-post/SKILL.md
+++ b/.apm/skills/blog-post/SKILL.md
@@ -50,7 +50,10 @@ not just the obviously visual ones.
    teaser the reader can't decode until they've finished. Let the `description`
    tease the concrete hook (the 64 GB leak, the one-character typo). This is a
    deliberate shift from the older evocative-title posts toward titles that tell
-   the reader up front what they'll learn — apply it to every new post.
+   the reader up front what they'll learn — apply it to every new post. When a
+   title stays deliberately evocative ("The spacetime of code"), give it an
+   optional `subtitle` in the frontmatter — one plain line that decrypts the
+   metaphor into what the reader will learn; it renders as a deck under the title.
 
 4. **Wire it into the site.** Posts live in `website/src/content/blog/` under a
    short, stable slug (the filename is the URL). Use the site's components for

--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -50,7 +50,10 @@ not just the obviously visual ones.
    teaser the reader can't decode until they've finished. Let the `description`
    tease the concrete hook (the 64 GB leak, the one-character typo). This is a
    deliberate shift from the older evocative-title posts toward titles that tell
-   the reader up front what they'll learn — apply it to every new post.
+   the reader up front what they'll learn — apply it to every new post. When a
+   title stays deliberately evocative ("The spacetime of code"), give it an
+   optional `subtitle` in the frontmatter — one plain line that decrypts the
+   metaphor into what the reader will learn; it renders as a deck under the title.
 
 4. **Wire it into the site.** Posts live in `website/src/content/blog/` under a
    short, stable slug (the filename is the URL). Use the site's components for

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -5,6 +5,9 @@ const blog = defineCollection({
   loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/blog" }),
   schema: z.object({
     title: z.string(),
+    // An optional deck: one plain line under the title that decrypts an
+    // evocative headline into what the reader will actually learn.
+    subtitle: z.string().optional(),
     description: z.string(),
     pubDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),

--- a/website/src/content/blog/hickey-lowy.mdx
+++ b/website/src/content/blog/hickey-lowy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The spacetime of code"
+subtitle: "A code review needs two lenses — one for the tangles you can see today, one for the drift you can't. Running just one audits half the code."
 description: "Complexity creeps along two axes — space and time. Hickey catches one; Löwy catches the other. A single-lens review only audits half the code."
 pubDate: 2026-04-19
 author: "Sridhar Ratnakumar"
@@ -62,6 +63,29 @@ Here's the analogy I keep coming back to, and I'll admit up front it's the kind 
 Code has a whole like that too. A module's shape right now — what's braided with what, what shares a name, what sits in the same scope — is one view of it. How it changes over time — what revs on which clock, which decisions get reopened, how fast each part drifts — is another. A defect can sit in one view and leave no trace in the other. Usually it does.
 
 Hickey's lens is the space-like observer. It reads the snapshot: what's tangled right now? Löwy's lens is the time-like observer. It reads the world-line: what's going to pull apart, and when? Same code, different axis, and each is blind to whatever lives only in the other's.
+
+<svg viewBox="0 0 680 440" role="img" aria-label="A plane with two axes: the horizontal axis is Hickey's spatial lens (tangled right now), the vertical axis is Löwy's temporal lens (drifts on its own clock). borderClass sits in the spatial-only quadrant, displaySuffix in the temporal-only quadrant, and canvasMaximized in the top-right where both lenses fire." style="width:100%;max-width:680px;display:block;margin:1.75rem auto;">
+  <text x="14" y="22" fill="var(--color-ink)" font-size="13" font-weight="600" font-family="monospace">where each finding lands on the plane of code</text>
+  <line x1="96" y1="64" x2="96" y2="352" stroke="var(--color-rule-strong)" stroke-width="1.2" />
+  <line x1="96" y1="352" x2="640" y2="352" stroke="var(--color-rule-strong)" stroke-width="1.2" />
+  <line x1="368" y1="80" x2="368" y2="352" stroke="var(--color-rule)" stroke-width="1" stroke-dasharray="3 4" />
+  <line x1="96" y1="212" x2="640" y2="212" stroke="var(--color-rule)" stroke-width="1" stroke-dasharray="3 4" />
+  <text x="232" y="300" fill="var(--color-ink-faint)" font-size="10.5" text-anchor="middle" font-family="monospace">clean · ship</text>
+  <text x="232" y="150" fill="var(--color-ink-faint)" font-size="10.5" text-anchor="middle" font-family="monospace">temporal only</text>
+  <text x="504" y="300" fill="var(--color-ink-faint)" font-size="10.5" text-anchor="middle" font-family="monospace">spatial only</text>
+  <text x="504" y="100" fill="var(--color-ink-faint)" font-size="10.5" text-anchor="middle" font-family="monospace">both fire</text>
+  <circle cx="500" cy="288" r="7" fill="var(--color-amber)" />
+  <text x="500" y="274" fill="var(--color-ink)" font-size="12.5" text-anchor="middle" font-family="monospace">borderClass</text>
+  <text x="500" y="312" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">Löwy: nothing to say</text>
+  <circle cx="232" cy="170" r="7" fill="var(--color-live-teal)" />
+  <text x="232" y="194" fill="var(--color-ink)" font-size="12.5" text-anchor="middle" font-family="monospace">displaySuffix</text>
+  <text x="232" y="129" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">Hickey: nothing to say</text>
+  <circle cx="508" cy="168" r="7" fill="var(--color-live-lime)" />
+  <text x="508" y="154" fill="var(--color-ink)" font-size="12.5" text-anchor="middle" font-family="monospace">canvasMaximized</text>
+  <text x="508" y="192" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">binocular agreement</text>
+  <text x="368" y="384" fill="var(--color-ink-dim)" font-size="11.5" text-anchor="middle" font-family="monospace">Hickey · tangled right now — the spatial axis →</text>
+  <text x="30" y="208" fill="var(--color-ink-dim)" font-size="11.5" text-anchor="middle" font-family="monospace" transform="rotate(-90 30 208)">Löwy · drifts on its own clock — the temporal axis →</text>
+</svg>
 
 Löwy says as much himself, in an appendix on complexity:
 

--- a/website/src/content/blog/orpc-over-ssh.mdx
+++ b/website/src/content/blog/orpc-over-ssh.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Apps that ship themselves over ssh"
+subtitle: "Moving a typed, reactive app's source of truth onto another machine — with nothing between you and it but ssh, and nothing installed on the far end."
 description: "@kolu/surface gave me typed reactive state over a WebSocket. This is what happened when the source of truth moved to another machine and the only thing between me and it was ssh — no install, no open port, no daemon."
 pubDate: 2026-05-29
 author: "Sridhar Ratnakumar"
@@ -38,6 +39,47 @@ client.system.get({}); // identical oRPC the browser calls over a WebSocket
 ```
 
 That's the property the whole previous post was secretly setting up. An in-process contract is a network protocol in disguise. Shape the in-process direct link the way it would have to look riding ssh — full snapshot first, then deltas, typed framing, race-free attach — and the day you put a socket under it, the consumer code doesn't notice. I'd been building the toaster to fit a socket that wasn't in the wall yet.
+
+<svg viewBox="0 0 680 330" role="img" aria-label="The same app on both ends of an ssh pipe. The near end (parent) runs useCell and useCollection over an oRPC client; the far end (host) runs kolu --stdio, the same binary. Only the ssh pipe crosses the boundary, carrying typed oRPC where stdout is the wire. Below, the Nix bootstrap: the parent evaluates a derivation once, nix copy --derivation ships it, the remote realises its own target-architecture binary, then the parent spawns it over stdio." style="width:100%;max-width:680px;display:block;margin:1.75rem auto;">
+  <text x="14" y="22" fill="var(--color-ink)" font-size="13" font-weight="600" font-family="monospace">one boundary — the same binary on both ends of an ssh pipe</text>
+  <line x1="340" y1="48" x2="340" y2="300" stroke="var(--color-rule)" stroke-width="1" stroke-dasharray="3 4" />
+  <text x="340" y="44" fill="var(--color-ink-muted)" font-size="10.5" text-anchor="middle" font-family="monospace">ssh boundary · the only thing that crosses</text>
+  <rect x="24" y="58" width="212" height="86" rx="6" fill="none" stroke="var(--color-ink-muted)" stroke-width="1.2" />
+  <text x="34" y="78" fill="var(--color-ink-dim)" font-size="11" font-family="monospace">near end · parent</text>
+  <text x="34" y="104" fill="var(--color-ink)" font-size="12" font-family="monospace">useCell · useCollection</text>
+  <text x="34" y="126" fill="var(--color-ink)" font-size="12" font-family="monospace">oRPC client</text>
+  <rect x="444" y="58" width="212" height="86" rx="6" fill="none" stroke="var(--color-live-lime)" stroke-width="1.2" />
+  <text x="454" y="78" fill="var(--color-ink-dim)" font-size="11" font-family="monospace">far end · host</text>
+  <text x="454" y="104" fill="var(--color-ink)" font-size="12" font-family="monospace">kolu --stdio</text>
+  <text x="454" y="126" fill="var(--color-ink)" font-size="11" font-family="monospace">same binary · one Backend</text>
+  <line x1="240" y1="88" x2="438" y2="88" stroke="var(--color-ink-dim)" stroke-width="1.2" />
+  <polygon points="444,88 436,84 436,92" fill="var(--color-ink-dim)" />
+  <text x="340" y="80" fill="var(--color-ink-dim)" font-size="10.5" text-anchor="middle" font-family="monospace">oRPC calls →</text>
+  <line x1="438" y1="116" x2="240" y2="116" stroke="var(--color-ink-dim)" stroke-width="1.2" />
+  <polygon points="234,116 242,112 242,120" fill="var(--color-ink-dim)" />
+  <text x="340" y="134" fill="var(--color-ink-dim)" font-size="10.5" text-anchor="middle" font-family="monospace">← snapshot, then deltas · stdout is the wire</text>
+  <text x="14" y="186" fill="var(--color-ink-dim)" font-size="11" font-family="monospace">provisioning the far end (Nix) — once per host</text>
+  <rect x="20" y="200" width="148" height="46" rx="6" fill="none" stroke="var(--color-amber)" stroke-width="1.2" />
+  <text x="94" y="220" fill="var(--color-ink)" font-size="11.5" text-anchor="middle" font-family="monospace">eval .drv</text>
+  <text x="94" y="236" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">parent · once</text>
+  <line x1="168" y1="223" x2="180" y2="223" stroke="var(--color-ink-dim)" stroke-width="1.2" />
+  <polygon points="186,223 178,219 178,227" fill="var(--color-ink-dim)" />
+  <rect x="188" y="200" width="148" height="46" rx="6" fill="none" stroke="var(--color-amber)" stroke-width="1.2" />
+  <text x="262" y="220" fill="var(--color-ink)" font-size="11.5" text-anchor="middle" font-family="monospace">nix copy</text>
+  <text x="262" y="236" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">--derivation</text>
+  <line x1="336" y1="223" x2="350" y2="223" stroke="var(--color-ink-dim)" stroke-width="1.2" />
+  <polygon points="356,223 348,219 348,227" fill="var(--color-ink-dim)" />
+  <rect x="356" y="200" width="158" height="46" rx="6" fill="none" stroke="var(--color-live-lime)" stroke-width="1.2" />
+  <text x="435" y="220" fill="var(--color-ink)" font-size="11.5" text-anchor="middle" font-family="monospace">realise</text>
+  <text x="435" y="236" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">target-arch · remote</text>
+  <line x1="514" y1="223" x2="526" y2="223" stroke="var(--color-ink-dim)" stroke-width="1.2" />
+  <polygon points="532,223 524,219 524,227" fill="var(--color-ink-dim)" />
+  <rect x="532" y="200" width="124" height="46" rx="6" fill="none" stroke="var(--color-live-lime)" stroke-width="1.2" />
+  <text x="594" y="220" fill="var(--color-ink)" font-size="11.5" text-anchor="middle" font-family="monospace">spawn</text>
+  <text x="594" y="236" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">--stdio</text>
+  <text x="14" y="284" fill="var(--color-ink-muted)" font-size="11" font-family="monospace">Ship build instructions, not binaries — each host realises its own architecture.</text>
+  <text x="14" y="300" fill="var(--color-ink-muted)" font-size="11" font-family="monospace">Nothing installed for good · no inbound port · no daemon.</text>
+</svg>
 
 ### The transport is the ssh pipe
 

--- a/website/src/content/blog/xtermjs-perf.mdx
+++ b/website/src/content/blog/xtermjs-perf.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Measuring the Wrong Thing"
+subtitle: "Hunting a 1.2 GB browser leak in xterm.js — and the afternoon I wasted cutting a metric that turned out not to matter."
 description: "One afternoon, two xterm.js contributions, and a reminder that proxy metrics can be wrong by three orders of magnitude."
 pubDate: 2026-04-18
 author: "Sridhar Ratnakumar"
@@ -52,6 +53,26 @@ _Native-side state backing the DOM and typed-array objects._ SVG attributes, det
 `system/Context` count is a JS-heap number. Cutting it by 89% means something if that's where the leak is. It means nothing if the leak is in native `ArrayBuffer` bytes.
 
 **The leak was in native `ArrayBuffer` bytes.**
+
+<svg viewBox="0 0 680 250" role="img" aria-label="Memory Footprint per 30 toggles. The baseline regression is 367 megabytes. After six commits that cut the system/Context count by 89 percent, the footprint is unchanged at 367 megabytes. After a one-line WeakRef fix, the footprint regression drops to roughly zero." style="width:100%;max-width:680px;display:block;margin:1.75rem auto;">
+  <text x="14" y="22" fill="var(--color-ink)" font-size="13" font-weight="600" font-family="monospace">Memory Footprint regression — per 30 toggles, the only number that mattered</text>
+  <text x="190" y="58" fill="var(--color-ink-dim)" font-size="11.5" text-anchor="end" font-family="monospace">baseline</text>
+  <rect x="200" y="46" width="386" height="20" rx="2" fill="var(--color-live-alert)" fill-opacity="0.85" />
+  <text x="594" y="61" fill="var(--color-live-alert)" font-size="11.5" font-family="monospace">+367 MB</text>
+  <text x="190" y="100" fill="var(--color-ink-dim)" font-size="11.5" text-anchor="end" font-family="monospace">after −89% to system/Context</text>
+  <rect x="200" y="88" width="386" height="20" rx="2" fill="var(--color-live-alert)" fill-opacity="0.85" />
+  <text x="594" y="103" fill="var(--color-live-alert)" font-size="11.5" font-family="monospace">unmoved</text>
+  <text x="190" y="142" fill="var(--color-ink-dim)" font-size="11.5" text-anchor="end" font-family="monospace">after WeakRef · 1 line</text>
+  <rect x="200" y="130" width="5" height="20" rx="2" fill="var(--color-live-lime)" />
+  <text x="213" y="145" fill="var(--color-live-lime)" font-size="11.5" font-family="monospace">≈ 0 MB</text>
+  <line x1="200" y1="164" x2="600" y2="164" stroke="var(--color-rule-strong)" stroke-width="1" />
+  <text x="200" y="182" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">0</text>
+  <text x="305" y="182" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">100</text>
+  <text x="411" y="182" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">200</text>
+  <text x="516" y="182" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">300 MB</text>
+  <text x="14" y="218" fill="var(--color-ink-muted)" font-size="11" font-family="monospace">Six commits cut a JS-heap proxy 89%. The gigabyte lived in 175,594 native Uint32Arrays — 220 MB</text>
+  <text x="14" y="234" fill="var(--color-ink-muted)" font-size="11" font-family="monospace">of ArrayBuffer the system/Context count couldn't see. One WeakRef cut the chain.</text>
+</svg>
 
 ### The one-line fix that took hours to find
 

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -45,6 +45,14 @@ const showToc = tocHeadings.length >= 4;
         {post.data.title}
       </h1>
 
+      {
+        post.data.subtitle && (
+          <p class="mt-5 text-[1.15rem] md:text-[1.3rem] leading-snug text-ink-dim">
+            {post.data.subtitle}
+          </p>
+        )
+      }
+
       <div class="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 mono text-[0.72rem] text-ink-muted tracking-widest">
         <time datetime={post.data.pubDate.toISOString()}>
           {


### PR DESCRIPTION
Last PR taught the `blog-post` skill to be visual-first and to give posts non-cryptic titles. This applies that guidance to the existing posts that most needed it — the prose-heavy ones with no figures — without rewriting a word of their argument.

The pick was deliberate: of the seven posts, only the macОS-lane one had any charts. The three here are the ones where a single figure carries the thesis. The other four (already-visual or short) are left alone.

## The figures

Each is hand-authored inline SVG, grounded in numbers already in the post, colored entirely with the site's `--color-*` tokens so it tracks light/dark.

| Post | Figure | What it shows |
| --- | --- | --- |
| **The spacetime of code** | the Hickey×Löwy plane | the post's three real findings plotted — `borderClass` (spatial only), `displaySuffix` (temporal only), `canvasMaximized` (both fire). The figure *is* the title. |
| **Measuring the Wrong Thing** | Memory Footprint, per 30 toggles | the 89% cut to the JS-heap proxy moved the footprint **zero**; one `WeakRef` line zeroed it. The whole essay in one chart. |
| **Apps that ship themselves over ssh** | the ssh-boundary data flow | same binary both ends, stdout is the wire, over the Nix bootstrap rail (eval `.drv` once → `nix copy --derivation` → realise target-arch → spawn `--stdio`). |

## Subtitles, not title rewrites

Per the earlier discussion, the evocative titles stay. Each gains an optional `subtitle` deck — a new schema field rendered under the `<h1>` — that decrypts the metaphor into a plain line of what the reader will learn. The skill records the convention.

## Verification

`pnpm build` clean (10 pages). Every figure was checked **rendering and label placement via `getBBox()` in both light and dark** against the built site with chrome-devtools — which caught the exact MDX/SVG trap the skill warns about (one label overrunning the viewBox, since trimmed). No camelCase-attribute leakage, no label collisions, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)