### PR TITLE
fix(deps): patch shell-quote, qs, and devalue Dependabot alerts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -69,7 +69,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-CL9BUWyv7HY2jhDeDxU1X+jELrUJ9NNMGEk0ASof5i8=";
+    hash = "sha256-XnYnIyYCJPkEzWLFIVlWMLXmv6u/WQKelgTfbIY0ChY=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
       "postcss": "^8.5.10",
       "fast-uri": "3.1.2",
       "ip-address": "10.1.1",
+      "shell-quote": "^1.8.4",
+      "qs": "^6.15.2",
       "@anthropic-ai/sdk": "^0.91.1",
       "@xterm/xterm": "6.1.0-beta.225",
       "@xterm/addon-webgl": "0.20.0-beta.224"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   postcss: ^8.5.10
   fast-uri: 3.1.2
   ip-address: 10.1.1
+  shell-quote: ^1.8.4
+  qs: ^6.15.2
   '@anthropic-ai/sdk': ^0.91.1
   '@xterm/xterm': 6.1.0-beta.225
   '@xterm/addon-webgl': 0.20.0-beta.224
@@ -3619,8 +3621,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -3755,8 +3757,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@3.23.0:
@@ -5564,7 +5566,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -5668,7 +5670,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -5898,7 +5900,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -6462,7 +6464,7 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -6625,7 +6627,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@3.23.0:
     dependencies:

--- a/website/default.nix
+++ b/website/default.nix
@@ -54,7 +54,7 @@ let
         libc: ["glibc", "musl"]
       }' package.json | sponge package.json
     '';
-    hash = "sha256-EgCvlKgSv86ecZR7aL1J2uGFWnaCMyQjkvUlpqXjaTo=";
+    hash = "sha256-S9yueSAXBP21UTsNu/ZidyCWBSf9FKdvGckQF4soEx8=";
     fetcherVersion = 3;
   };
 

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,8 @@
   },
   "pnpm": {
     "overrides": {
-      "fast-uri": "3.1.2"
+      "fast-uri": "3.1.2",
+      "devalue": "^5.8.1"
     }
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   fast-uri: 3.1.2
+  devalue: ^5.8.1
 
 importers:
 
@@ -1041,8 +1042,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.8.0:
-    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -3001,7 +3002,7 @@ snapshots:
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      devalue: 5.8.0
+      devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
       es-module-lexer: 2.1.0
@@ -3186,7 +3187,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.8.0: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
Closes all three open [Dependabot alerts](https://github.com/juspay/kolu/security/dependabot). Each is a transitive dependency pulled in through the lockfiles, so the fix is a pinned `pnpm.overrides` minimum-version bump plus regenerated lockfiles and refreshed `fetchPnpmDeps` hashes.

| Alert | Package | Severity | Was → Now | Brought in by | Manifest |
|-------|---------|----------|-----------|---------------|----------|
| [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) | `shell-quote` | Critical | 1.8.3 → 1.8.4 | `concurrently` | root |
| [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) | `qs` | Medium | 6.15.0 → 6.15.2 | `express` | root |
| [GHSA-77vg-94rm-hx3p](https://github.com/advisories/GHSA-77vg-94rm-hx3p) | `devalue` | High | 5.8.0 → 5.8.1 | `website` | website |

## Changes

- **`package.json`** — add `shell-quote: ^1.8.4` and `qs: ^6.15.2` to the existing `pnpm.overrides` block.
- **`website/package.json`** — add `devalue: ^5.8.1` to its overrides.
- **`pnpm-lock.yaml` / `website/pnpm-lock.yaml`** — regenerated (`pnpm install`, website with `--ignore-workspace`).
- **`default.nix` / `website/default.nix`** — refreshed the `fetchPnpmDeps` hashes to match the new lockfiles. Both pnpmDeps derivations build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)