### PR TITLE
feat(codex-debate): add answer mode — Claude ⇄ codex debate to a unified answer

### DIFF
--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -1,34 +1,47 @@
 ---
 name: codex-debate
-description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, for code review) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg) — Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
-argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
+description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two explicit subcommands. `review` (also the bare/back-compat default) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. `answer` — Claude and codex each answer a freeform prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
+argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  answer \"<prompt>\""
 ---
 
 # Codex ⇄ Claude debate
 
 This skill runs an automated debate between **codex** and **Claude** that loops to
-consensus with no round cap and no deadlock exit. It has **two modes**, chosen by
-the argument:
+consensus with no round cap and no deadlock exit. It has **two modes**, selected by
+an **explicit leading subcommand** — never by guessing from the argument's shape:
 
-- **Review mode** (default) — the original behavior. codex reviews the current
-  diff, a Claude author fixes/disputes, round after round until they agree, and the
-  trail is committed + posted to the PR. This is everything from
+- **`review`** — codex reviews the current diff, a Claude author fixes/disputes,
+  round after round until they agree, and the trail is **committed + posted to the
+  PR** (a mutating, outward-facing mode). This is everything from
   [Review mode](#review-mode) down.
-- **Answer mode** — triggered when you pass a **freeform prompt** instead of a PR
-  number/flags. Claude and codex **each answer the prompt in parallel**, then
-  **cross-check each other** until both agree, and a **unified answer** is returned
-  to you (plus a saved transcript). See [Answer mode](#answer-mode).
+- **`answer`** — Claude and codex **each answer a freeform prompt in parallel**,
+  then **cross-check each other** until both agree, and a **unified answer** is
+  returned to you (read-only; plus a saved transcript). See
+  [Answer mode](#answer-mode).
+
+The two modes have **different side-effect contracts** (review mutates + writes to
+the PR; answer is read-only), so the mode is chosen **explicitly**, not inferred
+from whether the argument looks like a PR number or like prose. Inferring a
+mutating action from prose shape is exactly the coupling this design avoids.
 
 ## Mode detection (do this first)
 
-Parse `$ARGUMENTS`:
+Look at the **first whitespace-delimited token** of `$ARGUMENTS`:
 
-- **No args, OR the first non-flag token is a number** (a PR number), OR the only
-  args are the review flags (`--base`, `--no-commit`, `--no-comment`) → **review
-  mode**. Continue with [Review mode](#review-mode) below.
-- **The args are a freeform prompt** (any quoted string, a question, or prose that
-  isn't a bare PR number) → **answer mode**. Jump to [Answer mode](#answer-mode);
-  the review-mode steps do not apply.
+- **`answer`** → **answer mode**. The prompt is everything after the `answer`
+  token. Jump to [Answer mode](#answer-mode); the review-mode steps do not apply.
+- **`review`** → **review mode**. The remaining args are the review grammar
+  (`[<pr-number>] [--base …] [--no-commit] [--no-comment]`). Continue with
+  [Review mode](#review-mode).
+- **No args, OR the first token is a number (a PR number) or a `--flag`** →
+  **review mode** (the backward-compatible bare alias for the original
+  `/codex-debate [<pr>] [flags]`, so existing callers like `/be-review` keep
+  working). Continue with [Review mode](#review-mode).
+- **Anything else** (freeform prose with no recognized subcommand) → **ambiguous**.
+  Do **not** guess — ask the user to pick an explicit mode and stop, e.g.: "Did you
+  mean `/codex-debate answer \"<your prompt>\"` (read-only) or `/codex-debate review
+  [<pr>] [flags]` (mutating)?" Only the safe, backward-compatible review grammar
+  auto-routes; prose never silently triggers a mode.
 
 Both modes require Claude Code's **`Workflow` tool** (the engine). Under
 codex/opencode runtimes the skill is inert.
@@ -72,7 +85,9 @@ codex/opencode runtimes the skill is inert.
 
 ## Arguments
 
-Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
+A leading `review` subcommand token, if present, is consumed by mode detection;
+what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]` (the
+bare alias passes the whole argument string through unchanged). Parse:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -243,8 +258,8 @@ the loop ends only when **both** sides report no remaining disagreement. There i
 ### A1. Resolve context
 
 - Determine `repoPath` (the worktree root, normally the cwd).
-- Capture the **prompt**: everything in `$ARGUMENTS` (strip surrounding quotes). If
-  it's empty, ask the user what they want answered and stop.
+- Capture the **prompt**: everything **after the `answer` subcommand token** (strip
+  surrounding quotes). If it's empty, ask the user what they want answered and stop.
 - **Preflight codex**: `codex login status`. If not logged in, stop and tell the
   user to run `codex login` (suggest the `!` prefix to do it in-session).
 - No `git fetch` / base resolution / `gh pr checkout` here — answer mode doesn't
@@ -380,19 +395,26 @@ returns:
 
 ## Files
 
+Shared:
+
+- `scripts/codex-exec-lib.sh` — the sourced core both modes share: the read-only
+  `codex exec`/`resume` invocation, warm-session resolve/persist, retry/backoff,
+  thread-id capture, and the synthesized error-verdict fallback (via a caller hook).
+  The two mode scripts source this and add only their own prompts + verdict shape.
+
 Review mode:
 
 - `debate.workflow.js` — the Workflow script (the loop + consensus logic).
-- `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation
-  (cold-starts round 1, `codex exec resume`s the warm session thereafter).
+- `scripts/codex-review.sh` — the review-specific invocation (arg parsing, the
+  review prompts, the verdict schema/session file, the verdict-shaped error).
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
 
 Answer mode:
 
 - `answer.workflow.js` — the Workflow script for the symmetric answer-debate
   (parallel answers → cross-check loop to agreement → synthesis).
-- `scripts/codex-answer.sh` — the canonical, deterministic `codex exec` invocation
-  for answering a prompt as a read-only peer (warm session across cross-check rounds).
+- `scripts/codex-answer.sh` — the answer-specific invocation (arg parsing, the
+  answer prompts, the answer schema/session file, the answer-shaped error).
 - `scripts/codex-answer.schema.json` — the JSON Schema codex's answer is constrained to.
 
 These are generated from `.apm/skills/codex-debate/`; edit the source there and

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-debate
-description: Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, code-review): codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg): Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".
+description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, for code review) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg) — Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
 argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
 ---
 

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -291,17 +291,21 @@ per-worktree `<repoPath>/.codex-debate/`, so parallel debates never collide. It
 returns:
 
 ```
-{ status: "consensus" | "reviewer-error" | "agent-error" | "no-prompt",
+{ status: "consensus" | "reviewer-error" | "agent-error" | "synthesis-error" | "no-prompt",
   rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
 ```
 
-- **consensus** — the only normal terminus: both sides agreed, and `finalAnswer`
-  is the synthesized unified answer. `transcriptPath` points at the saved
-  Markdown transcript (`.codex-debate/answer-<slug>.md`).
+- **consensus** — the only normal terminus: both sides agreed (for two consecutive
+  rounds — see the convergence note), and `finalAnswer` is the synthesized unified
+  answer. `transcriptPath` points at the saved Markdown transcript
+  (`.codex-debate/answer-<slug>.md`).
 - **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
   CLI) after retries; `codexError` carries the failure detail. Infrastructure
   failure, not a debate outcome.
 - **agent-error** — one side died on a terminal API error after retries.
+- **synthesis-error** — both sides DID agree, but the final synthesis pass produced
+  no answer (the synthesis agent died or returned empty). Not a successful answer —
+  report it as a failure (there is agreement on record, only the merge failed).
 - **no-prompt** — the prompt was empty (shouldn't happen if A1 guarded it).
 
 ### A3. Present the result
@@ -321,10 +325,17 @@ returns:
 
 ## Answer-mode safety & notes
 
-- **Both peers read-only.** codex runs under `--sandbox read-only` (kernel-
-  enforced, belt-and-suspenders with the prompt text — it reads arbitrary repo
-  files and could be prompt-injected); the Claude peer is instructed to read but
-  never edit. No mode of this debate writes to the repo.
+- **Both peers read-only — but enforced ASYMMETRICALLY.** codex runs under
+  `--sandbox read-only` (kernel-enforced, belt-and-suspenders with the prompt text —
+  it reads arbitrary repo files and could be prompt-injected). The **Claude peer is
+  only prompt-enforced**: the harness's `agent()` exposes no sandbox/tool restriction
+  (the same is true of every Claude reviewer in `/lens-debate` and review mode), so
+  Claude's read-only behaviour rests on instruction, not a kernel guard. A
+  prompt-injected or mistaken Claude agent *could* in principle edit files or run a
+  git write — answer mode does not, and cannot here, harden against that the way it
+  does for codex. If that risk matters for a given prompt, run the debate in a
+  disposable/read-only worktree. Treat the read-only guarantee as **hard for codex,
+  best-effort for Claude.**
 - **Warm codex session.** Round 1 cold-starts `codex exec`; every later round
   resumes the same session (`codex exec resume`) so codex cross-checks from its own
   prior answer rather than reconstructing it. The session id lives in the
@@ -332,10 +343,18 @@ returns:
   so it never collides with review mode's session), degrading gracefully to a cold
   start if capture ever fails.
 - **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
-  `objections`; the loop ends only when both sides agree, with no round cap and no
-  deadlock exit. Because the two run in parallel each round, agreement is on the
-  prior round's answers — safe (it only ever ends on real agreement), at worst one
-  round later than a serial handoff.
+  `objections`; a side counts as agreeing only when it sets `agreesWithOther:true`
+  AND leaves no objection, so a stray objection can't be papered over by an
+  over-eager boolean. The loop ends only when both sides agree, with no round cap and
+  no deadlock exit. Because the two run in parallel each round, a single
+  mutually-agreeing round can be a **swap false positive** (Claude adopts codex's
+  prior answer while codex adopts Claude's — both report agreement, but their current
+  outputs are swapped and may still differ). So convergence requires **two
+  consecutive** mutually-agreeing rounds: after the first, each side cross-checks the
+  other's just-agreed answer, and only if both still agree — having now seen each
+  other's current answers — does the loop stop. A real swap surfaces a fresh
+  objection in that confirmation round. Convergence is thus on answers both sides
+  have actually seen — safe, at worst two rounds later than a serial handoff.
 - **Chat + saved transcript, no outward writes.** The unified answer is presented
   in chat and the full transcript is saved to the gitignored
   `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -295,10 +295,10 @@ returns:
   rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
 ```
 
-- **consensus** — the only normal terminus: both sides agreed (for two consecutive
-  rounds — see the convergence note), and `finalAnswer` is the synthesized unified
-  answer. `transcriptPath` points at the saved Markdown transcript
-  (`.codex-debate/answer-<slug>.md`).
+- **consensus** — the only normal terminus: both sides agreed and then both
+  **approved the synthesized candidate** (see the convergence note), and
+  `finalAnswer` is that approved unified answer. `transcriptPath` points at the saved
+  Markdown transcript (`.codex-debate/answer-<slug>.md`).
 - **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
   CLI) after retries; `codexError` carries the failure detail. Infrastructure
   failure, not a debate outcome.
@@ -342,19 +342,23 @@ returns:
   gitignored per-worktree `.codex-debate/` (a distinct `codex-answer-session.id`,
   so it never collides with review mode's session), degrading gracefully to a cold
   start if capture ever fails.
-- **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
-  `objections`; a side counts as agreeing only when it sets `agreesWithOther:true`
-  AND leaves no objection, so a stray objection can't be papered over by an
-  over-eager boolean. The loop ends only when both sides agree, with no round cap and
-  no deadlock exit. Because the two run in parallel each round, a single
-  mutually-agreeing round can be a **swap false positive** (Claude adopts codex's
-  prior answer while codex adopts Claude's — both report agreement, but their current
-  outputs are swapped and may still differ). So convergence requires **two
-  consecutive** mutually-agreeing rounds: after the first, each side cross-checks the
-  other's just-agreed answer, and only if both still agree — having now seen each
-  other's current answers — does the loop stop. A real swap surfaces a fresh
-  objection in that confirmation round. Convergence is thus on answers both sides
-  have actually seen — safe, at worst two rounds later than a serial handoff.
+- **Symmetric convergence, schema-detected, candidate-confirmed.** Each side emits
+  `agreesWithOther` + `objections`; a side counts as agreeing only when it sets
+  `agreesWithOther:true` AND leaves no objection, so a stray objection can't be
+  papered over by an over-eager boolean. Because the two run in parallel each round,
+  a single mutually-agreeing round can be a **swap false positive** (Claude adopts
+  codex's prior answer while codex adopts Claude's — both report agreement, but their
+  current outputs are swapped and still differ), and they can keep swapping back and
+  forth, so counting consecutive parallel agreements does **not** prove the current
+  outputs match. The only sound test is to make both sides judge **one shared piece
+  of text**. So when a round shows mutual agreement, the workflow synthesizes a single
+  **candidate** from the two agreed answers and runs a **confirmation phase**: both
+  sides review that *identical* candidate (without rewriting their own answer) and
+  either approve it or object. Approval is on one fixed text both actually saw, so no
+  swap is possible; if both approve, that candidate is the converged answer — already
+  signed off by both debaters (which is also why `finalAnswer` is never unapproved
+  synthesized text). If either objects, the candidate is dropped and the cross-check
+  loop resumes with the objections folded in. No round cap, no deadlock exit.
 - **Chat + saved transcript, no outward writes.** The unified answer is presented
   in chat and the full transcript is saved to the gitignored
   `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -1,10 +1,40 @@
 ---
 name: codex-debate
-description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus — no round cap, no deadlock exit. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
-argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]"
+description: Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, code-review): codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg): Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".
+argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
 ---
 
-# Codex ⇄ Claude review debate
+# Codex ⇄ Claude debate
+
+This skill runs an automated debate between **codex** and **Claude** that loops to
+consensus with no round cap and no deadlock exit. It has **two modes**, chosen by
+the argument:
+
+- **Review mode** (default) — the original behavior. codex reviews the current
+  diff, a Claude author fixes/disputes, round after round until they agree, and the
+  trail is committed + posted to the PR. This is everything from
+  [Review mode](#review-mode) down.
+- **Answer mode** — triggered when you pass a **freeform prompt** instead of a PR
+  number/flags. Claude and codex **each answer the prompt in parallel**, then
+  **cross-check each other** until both agree, and a **unified answer** is returned
+  to you (plus a saved transcript). See [Answer mode](#answer-mode).
+
+## Mode detection (do this first)
+
+Parse `$ARGUMENTS`:
+
+- **No args, OR the first non-flag token is a number** (a PR number), OR the only
+  args are the review flags (`--base`, `--no-commit`, `--no-comment`) → **review
+  mode**. Continue with [Review mode](#review-mode) below.
+- **The args are a freeform prompt** (any quoted string, a question, or prose that
+  isn't a bare PR number) → **answer mode**. Jump to [Answer mode](#answer-mode);
+  the review-mode steps do not apply.
+
+Both modes require Claude Code's **`Workflow` tool** (the engine). Under
+codex/opencode runtimes the skill is inert.
+
+<a id="review-mode"></a>
+# Review mode — Codex ⇄ Claude review debate
 
 Automate the back-and-forth you'd otherwise courier by hand: **codex** (the
 reviewer) critiques the current change, a **Claude subagent** (the author)
@@ -188,7 +218,115 @@ the per-round commits sit on the local branch for the human to review):
   outward-facing write — on by default because the whole point is to leave the
   review trail on the PR; `--no-comment` suppresses it.
 
-## Safety & notes
+<a id="answer-mode"></a>
+# Answer mode — Codex ⇄ Claude answer debate
+
+When the argument is a **freeform prompt** (not a PR number/flags), the skill
+generalizes the same debate machinery from *reviewing a diff* to *answering a
+question*. The shape is **symmetric**, not author⇄reviewer: **Claude and codex are
+two equal peers**. They each answer the prompt **independently and in parallel**,
+then **cross-check each other's answer** round after round — conceding where the
+other is right, holding firm (with evidence) where it isn't — **until both agree**.
+A final pass **synthesizes their two converged answers into one unified reply**,
+which you present to the user along with a saved transcript.
+
+Both peers are **codebase-aware but read-only**: each may read this repo (`git
+diff/log`, read files, grep) to ground its answer, but neither edits anything —
+codex stays under `--sandbox read-only` (kernel-enforced), and the Claude peer is
+instructed not to write. Consensus is **schema-detected in code**: each side emits
+a structured answer with an `agreesWithOther` boolean and an `objections` list, and
+the loop ends only when **both** sides report no remaining disagreement. There is
+**no round cap and no deadlock exit** — same as review mode.
+
+## Steps
+
+### A1. Resolve context
+
+- Determine `repoPath` (the worktree root, normally the cwd).
+- Capture the **prompt**: everything in `$ARGUMENTS` (strip surrounding quotes). If
+  it's empty, ask the user what they want answered and stop.
+- **Preflight codex**: `codex login status`. If not logged in, stop and tell the
+  user to run `codex login` (suggest the `!` prefix to do it in-session).
+- No `git fetch` / base resolution / `gh pr checkout` here — answer mode doesn't
+  diff a branch.
+
+### A2. Run the answer Workflow
+
+Invoke the **`Workflow` tool** pointing at this skill's committed answer script,
+passing the prompt through `args`:
+
+```
+Workflow({
+  scriptPath: ".claude/skills/codex-debate/answer.workflow.js",
+  args: {
+    repoPath: "<worktree root>",   // also the per-worktree scratch dir root
+    prompt: "<the user's freeform prompt, verbatim>",
+    skillDir: ".claude/skills/codex-debate"
+  }
+})
+```
+
+The workflow runs in the background and notifies you when it completes. It runs an
+**Answer** phase (round 1: `claude:round1` and `codex:round1` in parallel), a
+**Reconcile** phase (rounds 2+: each side cross-checks the other, in parallel,
+round after round), and a **Synthesis** phase that merges the two agreed answers.
+Watch live via `/workflows`. Ephemeral scratch (per-side answers, cross-check
+files, per-round sections, the saved transcript) lives under the gitignored,
+per-worktree `<repoPath>/.codex-debate/`, so parallel debates never collide. It
+returns:
+
+```
+{ status: "consensus" | "reviewer-error" | "agent-error" | "no-prompt",
+  rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
+```
+
+- **consensus** — the only normal terminus: both sides agreed, and `finalAnswer`
+  is the synthesized unified answer. `transcriptPath` points at the saved
+  Markdown transcript (`.codex-debate/answer-<slug>.md`).
+- **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
+  CLI) after retries; `codexError` carries the failure detail. Infrastructure
+  failure, not a debate outcome.
+- **agent-error** — one side died on a terminal API error after retries.
+- **no-prompt** — the prompt was empty (shouldn't happen if A1 guarded it).
+
+### A3. Present the result
+
+- If `status === "consensus"`: present **`finalAnswer`** to the user as the answer
+  — this is the unified reply both Claude and codex agreed on. State **how many
+  rounds** it took to converge and that **codex answered at `reasoningEffort`**
+  (read it off the return value). Point the user at the saved transcript
+  (`transcriptPath`) for the full convergence trail; optionally `cat` the
+  `.codex-debate/answer-section-*.md` files to show a compact per-round summary
+  (each side's answer, what changed, remaining objections). This mode makes **no
+  outward-facing writes** — no PR comment, no commits — it just answers.
+- If `status !== "consensus"`: report it as a **failure**, not an answer. Surface
+  `codexError` (for `reviewer-error`) or the workflow log so the user sees what
+  broke, and tell them how to fix it (e.g. `codex login`) and re-run. Do **not**
+  present a half-debate as if it were an agreed answer.
+
+## Answer-mode safety & notes
+
+- **Both peers read-only.** codex runs under `--sandbox read-only` (kernel-
+  enforced, belt-and-suspenders with the prompt text — it reads arbitrary repo
+  files and could be prompt-injected); the Claude peer is instructed to read but
+  never edit. No mode of this debate writes to the repo.
+- **Warm codex session.** Round 1 cold-starts `codex exec`; every later round
+  resumes the same session (`codex exec resume`) so codex cross-checks from its own
+  prior answer rather than reconstructing it. The session id lives in the
+  gitignored per-worktree `.codex-debate/` (a distinct `codex-answer-session.id`,
+  so it never collides with review mode's session), degrading gracefully to a cold
+  start if capture ever fails.
+- **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
+  `objections`; the loop ends only when both sides agree, with no round cap and no
+  deadlock exit. Because the two run in parallel each round, agreement is on the
+  prior round's answers — safe (it only ever ends on real agreement), at worst one
+  round later than a serial handoff.
+- **Chat + saved transcript, no outward writes.** The unified answer is presented
+  in chat and the full transcript is saved to the gitignored
+  `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits
+  or posts to a PR.
+
+## Safety & notes (review mode)
 
 - **codex runs read-only — enforced, not just asked.** codex is invoked with
   `--sandbox read-only`, so the kernel sandbox blocks file writes and other
@@ -242,10 +380,20 @@ the per-round commits sit on the local branch for the human to review):
 
 ## Files
 
+Review mode:
+
 - `debate.workflow.js` — the Workflow script (the loop + consensus logic).
 - `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation
   (cold-starts round 1, `codex exec resume`s the warm session thereafter).
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
+
+Answer mode:
+
+- `answer.workflow.js` — the Workflow script for the symmetric answer-debate
+  (parallel answers → cross-check loop to agreement → synthesis).
+- `scripts/codex-answer.sh` — the canonical, deterministic `codex exec` invocation
+  for answering a prompt as a read-only peer (warm session across cross-check rounds).
+- `scripts/codex-answer.schema.json` — the JSON Schema codex's answer is constrained to.
 
 These are generated from `.apm/skills/codex-debate/`; edit the source there and
 run `just ai apm` to regenerate.

--- a/.agents/skills/codex-debate/answer.workflow.js
+++ b/.agents/skills/codex-debate/answer.workflow.js
@@ -153,16 +153,20 @@ async function codexAnswers(round, other) {
       : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
 
 ${JSON.stringify(other, null, 2)}`
+  // Every path below is spliced into a shell command the runner agent executes, so
+  // POSIX-quote each one (worktrees or skill dirs with spaces/metacharacters would
+  // otherwise break the command or misdirect it). The Write-tool file CONTENTS
+  // (${prompt}, ${JSON.stringify(other)}) are not shell-parsed and stay verbatim.
   const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
 
 ${prompt}
 
 ${crossStep}
 
 3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-answer.sh ${promptPath} ${crossArg} ${answerPath} ${REASONING_EFFORT}\`
+   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}\`
 
    This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
 
@@ -254,17 +258,32 @@ let status = 'consensus'
 let claudeAns = null
 let codexAns = null
 
+// A side "agrees" only when it BOTH set agreesWithOther AND left no objection. The
+// boolean and the objections list must be consistent (the schema says so), but a
+// model can set the flag while still listing a disagreement; honour the objections
+// too so a leftover objection can't be papered over by an over-eager boolean.
+const sideAgrees = (a) => a.agreesWithOther === true && (a.objections || []).length === 0
+
 // ---------------------------------------------------------------------------
 // The loop — round 1 is the independent answer (parallel); rounds 2+ are
-// cross-checks. Runs until BOTH sides agree. No round cap, no deadlock exit:
-// each side keeps cross-checking until they converge (the harness's per-workflow
-// agent backstop is the only hard ceiling — interrupt via /workflows or TaskStop).
+// cross-checks. Runs until BOTH sides agree, then ONE confirmation round. No round
+// cap, no deadlock exit: each side keeps cross-checking until they converge (the
+// harness's per-workflow agent backstop is the only hard ceiling — interrupt via
+// /workflows or TaskStop).
 //
-// Both sides run in PARALLEL each round, so in round N each cross-checks the
-// OTHER's round-(N-1) answer. Convergence is thus mutual agreement on the prior
-// round's answers — safe (it can only end on real agreement, never prematurely),
-// at worst one round later than a strictly-serial handoff would.
+// Both sides run in PARALLEL each round, so in round N each cross-checks the OTHER's
+// round-(N-1) answer. That parallelism creates a SWAP hazard: if Claude adopts
+// codex's prior answer while codex simultaneously adopts Claude's prior answer, both
+// can report agreesWithOther:true in the SAME round even though their CURRENT outputs
+// are swapped and may still differ. So a single mutually-agreeing round is NOT
+// sufficient. We require TWO CONSECUTIVE mutually-agreeing rounds: after the first,
+// each side runs once more and now cross-checks the OTHER's just-agreed answer; only
+// if both still agree (having seen each other's current answers) do we converge. A
+// real swap surfaces a fresh objection in that confirmation round; genuine agreement
+// holds. Convergence is therefore on answers both sides have actually seen — safe,
+// at worst two rounds later than a strictly-serial handoff would be.
 // ---------------------------------------------------------------------------
+let agreedStreak = 0
 for (let round = 1; ; round++) {
   const prevClaude = claudeAns
   const prevCodex = codexAns
@@ -299,14 +318,23 @@ for (let round = 1; ; round++) {
   await writeSection(entry)
 
   // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
-  // remaining disagreement with the other's latest answer.
-  if (round >= 2 && claude.agreesWithOther === true && codex.agreesWithOther === true) {
-    log(`Round ${round}: both sides agree — converged.`)
+  // remaining disagreement — agreesWithOther:true AND no objections. One such round
+  // can be a parallel-swap false positive (see the loop header), so require TWO in a
+  // row: the second round has each side cross-check the other's just-agreed answer,
+  // confirming on outputs both have actually seen.
+  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
+  agreedStreak = bothAgree ? agreedStreak + 1 : 0
+  if (agreedStreak >= 2) {
+    log(`Round ${round}: both sides agree for a second consecutive round — converged.`)
     break
   }
-  log(
-    `Round ${round}: claude agrees=${!!claude.agreesWithOther} (objections=${(claude.objections || []).length}), codex agrees=${!!codex.agreesWithOther} (objections=${(codex.objections || []).length})`,
-  )
+  if (bothAgree) {
+    log(`Round ${round}: both sides agree — running one confirmation round before converging.`)
+  } else {
+    log(
+      `Round ${round}: claude agrees=${sideAgrees(claude)} (objections=${(claude.objections || []).length}), codex agrees=${sideAgrees(codex)} (objections=${(codex.objections || []).length})`,
+    )
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -331,7 +359,16 @@ ${JSON.stringify(codexAns, null, 2)}
 Return the unified answer in \`answer\`.`,
     { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
   )
-  finalAnswer = synth ? synth.answer : null
+  finalAnswer = synth && synth.answer ? synth.answer : null
+  // Synthesis is the user-facing payload of a consensus run. If the synthesis agent
+  // died (null) or returned an empty answer, there is no answer to present — do NOT
+  // keep reporting "consensus" with finalAnswer:null, which A3 would mis-handle as a
+  // successful answer. Demote to an explicit failure terminus so the skill surfaces
+  // it as broken (the sides DID agree; only the final merge failed).
+  if (!finalAnswer) {
+    status = 'synthesis-error'
+    log('Synthesis produced no answer — both sides agreed but the merge failed; reporting synthesis-error.')
+  }
 }
 
 log(`Answer-debate ended: ${status} after ${transcript.length} round(s).`)

--- a/.agents/skills/codex-debate/answer.workflow.js
+++ b/.agents/skills/codex-debate/answer.workflow.js
@@ -362,6 +362,12 @@ return {
   transcriptPath: answerDocPath,
   finalAnswer,
   reasoningEffort: REASONING_EFFORT,
-  // The error terminus carries codex's failure detail in its answer text.
-  codexError: status === 'reviewer-error' ? (codexAns && codexAns.answer) || null : null,
+  // The error terminus carries codex's failure detail in the synthesized verdict's
+  // answer text. Sourced from the transcript (not codexAns) because the
+  // reviewer-error branch breaks BEFORE assigning codexAns — the failing round is
+  // recorded in the transcript, so read the detail back from there.
+  codexError:
+    status === 'reviewer-error'
+      ? transcript.find((e) => e.codex && e.codex.reviewerError)?.codex.answer || null
+      : null,
 }

--- a/.agents/skills/codex-debate/answer.workflow.js
+++ b/.agents/skills/codex-debate/answer.workflow.js
@@ -25,12 +25,10 @@ const workDir = `${repoPath}/.codex-debate`
 
 // Model tiers. The claude-answer round does real reasoning (answering, then
 // cross-checking codex) → `model` (Opus). The final synthesis is also user-facing
-// prose, so it runs on `model` too. The codex RUNNER must relay codex's answer
-// JSON faithfully (a verbatim copy, not a paraphrase — the weakest tier corrupts
-// it silently) → `copyModel` (Sonnet). The file writers/assemblers are mechanical
-// → `mechModel` (Haiku). Defaults match a direct invocation.
+// prose, so it runs on `model` too. The codex RUNNER and the transcript writer must
+// relay text faithfully (a verbatim copy, not a paraphrase — the weakest tier
+// corrupts it silently) → `copyModel` (Sonnet). Defaults match a direct invocation.
 const model = a.model || 'opus'
-const mechModel = a.mechModel || 'haiku'
 const copyModel = a.copyModel || 'sonnet'
 
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
@@ -296,33 +294,7 @@ function renderTranscript(transcript, meta, finalAnswer) {
   return parts.join('\n\n')
 }
 
-// Zero-pad the round so the section glob sorts in round order for the assembly.
-const sectionFile = (round) => `${workDir}/answer-section-${String(round).padStart(3, '0')}.md`
-
-// Write ONE round's section to its own small file (Haiku-safe — just this round).
-async function writeSection(entry) {
-  const text = roundSection(entry)
-  const path = sectionFile(entry.round)
-  const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
-2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
-
-${text}`
-  return agent(p, { label: `section:round${entry.round}`, phase: 'Reconcile', model: mechModel })
-}
-
-// ---------------------------------------------------------------------------
-// Set up scratch — clear any stale per-round sections from a PRIOR debate in this
-// worktree so they don't leak into the assembled transcript. Scoped to the
-// answer-section files; the review mode's section-NNN.md and the verdict/answer
-// JSONs keep their own lifecycle.
-// ---------------------------------------------------------------------------
 phase('Answer')
-await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/answer-section-*.md\`. Do not edit any other file. Do not run git.`,
-  { label: 'sections:reset', phase: 'Answer', model: mechModel },
-)
 
 const transcript = []
 let status = 'consensus'
@@ -431,7 +403,6 @@ for (let round = 1; ; round++) {
     ? { round, claude, codex, confirming: true, candidate: pendingCandidate }
     : { round, claude, codex }
   transcript.push(entry)
-  await writeSection(entry)
 
   // CONFIRMATION phase: both sides judged the SAME synthesized candidate. If both
   // approve it (agreesWithOther:true + no objections), that candidate is the agreed,

--- a/.agents/skills/codex-debate/answer.workflow.js
+++ b/.agents/skills/codex-debate/answer.workflow.js
@@ -135,11 +135,45 @@ Return the schema:
   })
 }
 
+// A confirmation/approval turn for ONE side, judging a SINGLE shared candidate
+// answer (the synthesized merge) WITHOUT rewriting its own. Both sides judge the
+// IDENTICAL text, so no swap/oscillation is possible (the swap hazard exists only
+// because each parallel round adopts the OTHER's separate answer). Returns
+// `agreesWithOther` + `objections` against that candidate. Claude runs it directly
+// (it's read-only reasoning); codex runs it through the same cross-check machinery
+// (the candidate is handed to it as "CLAUDE's latest answer" to approve).
+async function claudeConfirms(round, candidate) {
+  const prompt_ = `You and CODEX were asked the SAME question, debated, and AGREED. A unified candidate answer has been synthesized from your two agreed answers. Your ONLY job now is to APPROVE it or object — do NOT rewrite it, do NOT produce a new answer of your own.
+
+You may inspect the repo at \`${repoPath}\` to verify (READ-ONLY — \`git -C ${repoPath} diff/log\`, read files, grep; do NOT edit/create/delete or run any git write).
+
+The question:
+${prompt}
+
+The candidate unified answer to approve:
+${candidate}
+
+Return the schema:
+  - answer: echo the candidate VERBATIM (you are approving it, not rewriting it).
+  - keyPoints: the core claims the candidate rests on.
+  - objections: anything the candidate gets wrong, drops, or overstates relative to what you agreed — empty if you approve it as-is. Be specific (file:line for repo claims).
+  - changedMind: empty (you are confirming, not revising).
+  - agreesWithOther: true ONLY if you approve the candidate as a correct, complete unified answer with NO objection left.`
+  return agent(prompt_, {
+    label: `claude:confirm${round}`,
+    phase: 'Synthesis',
+    model,
+    schema: ANSWER_SCHEMA,
+  })
+}
+
 // CODEX answers/cross-checks via codex-answer.sh (warm session across rounds). The
 // agent here is a MECHANICAL RUNNER: it writes the prompt + cross-check files,
 // shells out to the script, and relays codex's JSON answer verbatim — it does NOT
 // answer the question itself. The user's prompt and CLAUDE's latest answer carry
 // arbitrary characters, so they're written with the Write tool, never a heredoc.
+// On a confirmation turn (`confirm`), the cross-check input is the SINGLE shared
+// candidate, and the runner relays codex's approval/objections to it.
 async function codexAnswers(round, other) {
   const answerPath = `${workDir}/answer-codex-${round}.json`
   const promptPath = `${workDir}/answer-prompt.txt`
@@ -234,7 +268,7 @@ async function writeSection(entry) {
   const path = sectionFile(entry.round)
   const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
 2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
 ${text}`
@@ -264,32 +298,70 @@ let codexAns = null
 // too so a leftover objection can't be papered over by an over-eager boolean.
 const sideAgrees = (a) => a.agreesWithOther === true && (a.objections || []).length === 0
 
+// Synthesize a SINGLE candidate answer from the two agreed answers. This is the
+// user-facing unified reply, but it is NOT returned until BOTH sides approve it (the
+// confirmation phase below), so the synthesized text is never reported as consensus
+// without both debaters having signed off on it. Returns the candidate string, or
+// null if the synthesis agent died / returned empty.
+async function synthesize(claudeFinal, codexFinal) {
+  const synth = await agent(
+    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
+
+The question:
+${prompt}
+
+Claude's final answer (JSON):
+${JSON.stringify(claudeFinal, null, 2)}
+
+Codex's final answer (JSON):
+${JSON.stringify(codexFinal, null, 2)}
+
+Return the unified answer in \`answer\`.`,
+    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
+  )
+  return synth && synth.answer ? synth.answer : null
+}
+
 // ---------------------------------------------------------------------------
 // The loop — round 1 is the independent answer (parallel); rounds 2+ are
-// cross-checks. Runs until BOTH sides agree, then ONE confirmation round. No round
-// cap, no deadlock exit: each side keeps cross-checking until they converge (the
-// harness's per-workflow agent backstop is the only hard ceiling — interrupt via
-// /workflows or TaskStop).
+// cross-checks. Runs until BOTH sides agree, then a CONFIRMATION phase on a single
+// synthesized candidate. No round cap, no deadlock exit: each side keeps
+// cross-checking until they converge (the harness's per-workflow agent backstop is
+// the only hard ceiling — interrupt via /workflows or TaskStop).
 //
 // Both sides run in PARALLEL each round, so in round N each cross-checks the OTHER's
-// round-(N-1) answer. That parallelism creates a SWAP hazard: if Claude adopts
-// codex's prior answer while codex simultaneously adopts Claude's prior answer, both
-// can report agreesWithOther:true in the SAME round even though their CURRENT outputs
-// are swapped and may still differ. So a single mutually-agreeing round is NOT
-// sufficient. We require TWO CONSECUTIVE mutually-agreeing rounds: after the first,
-// each side runs once more and now cross-checks the OTHER's just-agreed answer; only
-// if both still agree (having seen each other's current answers) do we converge. A
-// real swap surfaces a fresh objection in that confirmation round; genuine agreement
-// holds. Convergence is therefore on answers both sides have actually seen — safe,
-// at worst two rounds later than a strictly-serial handoff would be.
+// round-(N-1) answer. That parallelism creates a SWAP/OSCILLATION hazard: if Claude
+// adopts codex's prior answer while codex simultaneously adopts Claude's prior
+// answer, both can report agreesWithOther:true in the SAME round even though their
+// CURRENT outputs are swapped and still differ — and they can keep swapping back and
+// forth, so counting consecutive parallel agreements does NOT prove the current
+// outputs match. The only sound test is to make BOTH sides judge ONE shared piece of
+// text. So when a round shows mutual agreement, we synthesize a single candidate
+// from the two agreed answers and run a CONFIRMATION phase: both sides review that
+// IDENTICAL candidate (without rewriting their own answer) and either approve it or
+// object. Approval is on one fixed text both actually saw, so no swap is possible. If
+// both approve, that candidate IS the converged answer (already debater-approved). If
+// either objects, its objections fold back into the cross-check loop and we continue.
 // ---------------------------------------------------------------------------
-let agreedStreak = 0
+let finalAnswer = null
+// On a confirmation turn, each side's "other" input is the synthesized candidate
+// (wrapped in the answer shape so the existing cross-check machinery accepts it).
+// Carried across iterations so a rejected confirmation feeds the candidate + the
+// objector's complaints back into the next ordinary cross-check round.
+let pendingCandidate = null
 for (let round = 1; ; round++) {
+  const confirming = pendingCandidate !== null
+  const candidateAns = confirming
+    ? { answer: pendingCandidate, keyPoints: [], agreesWithOther: true, objections: [], changedMind: '' }
+    : null
   const prevClaude = claudeAns
   const prevCodex = codexAns
   const [claude, codex] = await parallel([
-    () => claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
-    () => codexAnswers(round, round === 1 ? null : prevClaude),
+    () =>
+      confirming
+        ? claudeConfirms(round, pendingCandidate)
+        : claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
+    () => codexAnswers(round, round === 1 ? null : confirming ? candidateAns : prevClaude),
   ])
 
   // codex infrastructure failure — terminal. The runner could not get an answer
@@ -317,57 +389,43 @@ for (let round = 1; ; round++) {
   transcript.push(entry)
   await writeSection(entry)
 
-  // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
-  // remaining disagreement — agreesWithOther:true AND no objections. One such round
-  // can be a parallel-swap false positive (see the loop header), so require TWO in a
-  // row: the second round has each side cross-check the other's just-agreed answer,
-  // confirming on outputs both have actually seen.
-  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
-  agreedStreak = bothAgree ? agreedStreak + 1 : 0
-  if (agreedStreak >= 2) {
-    log(`Round ${round}: both sides agree for a second consecutive round — converged.`)
-    break
+  // CONFIRMATION phase: both sides judged the SAME synthesized candidate. If both
+  // approve it (agreesWithOther:true + no objections), that candidate is the agreed,
+  // debater-approved unified answer — converge. If either objects, drop the candidate
+  // and continue the cross-check loop (their objections are already in `claudeAns` /
+  // `codexAns` and feed the next round).
+  if (confirming) {
+    if (sideAgrees(claude) && sideAgrees(codex)) {
+      finalAnswer = pendingCandidate
+      log(`Round ${round}: both sides approved the synthesized candidate — converged.`)
+      break
+    }
+    log(`Round ${round}: candidate rejected (claude agrees=${sideAgrees(claude)}, codex agrees=${sideAgrees(codex)}) — resuming cross-check.`)
+    pendingCandidate = null
+    continue
   }
+
+  // From round 2 on (round 1 has no cross-check), if BOTH sides report no remaining
+  // disagreement, synthesize one candidate and enter the confirmation phase next
+  // round. A single parallel-agreeing round can be a swap false positive, so we do
+  // NOT converge here — we converge only after both sides approve the SAME candidate.
+  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
   if (bothAgree) {
-    log(`Round ${round}: both sides agree — running one confirmation round before converging.`)
+    phase('Synthesis')
+    pendingCandidate = await synthesize(claude, codex)
+    if (!pendingCandidate) {
+      // The merge itself failed (synthesis agent died / returned empty). The sides
+      // DID agree; only the merge broke — surface that explicitly rather than spin.
+      status = 'synthesis-error'
+      log('Synthesis produced no candidate — both sides agreed but the merge failed; reporting synthesis-error.')
+      break
+    }
+    log(`Round ${round}: both sides agree — synthesized a candidate; confirming it next round.`)
+    phase('Reconcile')
   } else {
     log(
       `Round ${round}: claude agrees=${sideAgrees(claude)} (objections=${(claude.objections || []).length}), codex agrees=${sideAgrees(codex)} (objections=${(codex.objections || []).length})`,
     )
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Synthesis — merge the two AGREED answers into one unified reply for the user.
-// Only on consensus: on a failure terminus there's no agreement to synthesize.
-// ---------------------------------------------------------------------------
-let finalAnswer = null
-if (status === 'consensus' && claudeAns && codexAns) {
-  phase('Synthesis')
-  const synth = await agent(
-    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
-
-The question:
-${prompt}
-
-Claude's final answer (JSON):
-${JSON.stringify(claudeAns, null, 2)}
-
-Codex's final answer (JSON):
-${JSON.stringify(codexAns, null, 2)}
-
-Return the unified answer in \`answer\`.`,
-    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
-  )
-  finalAnswer = synth && synth.answer ? synth.answer : null
-  // Synthesis is the user-facing payload of a consensus run. If the synthesis agent
-  // died (null) or returned an empty answer, there is no answer to present — do NOT
-  // keep reporting "consensus" with finalAnswer:null, which A3 would mis-handle as a
-  // successful answer. Demote to an explicit failure terminus so the skill surfaces
-  // it as broken (the sides DID agree; only the final merge failed).
-  if (!finalAnswer) {
-    status = 'synthesis-error'
-    log('Synthesis produced no answer — both sides agreed but the merge failed; reporting synthesis-error.')
   }
 }
 
@@ -385,7 +443,7 @@ const transcriptText = renderTranscript(
 await agent(
   `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
 2. Using the Write tool, create \`${answerDocPath}\` with EXACTLY this content, overwriting any existing file:
 
 ${transcriptText}`,

--- a/.agents/skills/codex-debate/answer.workflow.js
+++ b/.agents/skills/codex-debate/answer.workflow.js
@@ -1,0 +1,367 @@
+export const meta = {
+  name: 'codex-answer-debate',
+  description: 'Have Claude and codex each answer a prompt in parallel, then cross-check until they agree, and synthesize one unified answer (no round cap, no deadlock exit)',
+  phases: [
+    { title: 'Answer', detail: 'claude + codex answer the prompt independently, in parallel' },
+    { title: 'Reconcile', detail: 'each cross-checks the other, round after round, until both agree' },
+    { title: 'Synthesis', detail: 'merge the two agreed answers into one unified reply' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Inputs (passed via the Workflow tool's `args`)
+// ---------------------------------------------------------------------------
+const a = args || {}
+const repoPath = a.repoPath || '.'
+// The user's freeform prompt — the question both assistants answer and then
+// cross-check toward one agreed reply. Required; the orchestrator passes it.
+const prompt = (a.prompt || '').trim()
+// Where the generated skill lives, so the codex runner can find codex-answer.sh.
+const skillDir = a.skillDir || '.claude/skills/codex-debate'
+// Per-worktree scratch dir, shared with the review mode. Gitignored, derived from
+// repoPath (the worktree root === $PWD) so parallel debates in DIFFERENT worktrees
+// never collide on shared /tmp paths and these files never pollute the repo.
+const workDir = `${repoPath}/.codex-debate`
+
+// Model tiers. The claude-answer round does real reasoning (answering, then
+// cross-checking codex) → `model` (Opus). The final synthesis is also user-facing
+// prose, so it runs on `model` too. The codex RUNNER must relay codex's answer
+// JSON faithfully (a verbatim copy, not a paraphrase — the weakest tier corrupts
+// it silently) → `copyModel` (Sonnet). The file writers/assemblers are mechanical
+// → `mechModel` (Haiku). Defaults match a direct invocation.
+const model = a.model || 'opus'
+const mechModel = a.mechModel || 'haiku'
+const copyModel = a.copyModel || 'sonnet'
+
+// The reasoning effort codex runs at, scoped to the debate. This JS constant is
+// the SINGLE home for the value: it is passed script-ward (a 4th positional arg to
+// codex-answer.sh, which sets `-c model_reasoning_effort`) and read by the
+// transcript header, so the `-c` flag and the header both derive from here.
+const REASONING_EFFORT = 'xhigh'
+
+// POSIX single-quote a path for safe interpolation into a shell command (spaces,
+// globs, metacharacters inert; embedded single quotes escaped via '\'' ). Used for
+// the destructive scratch reset (`rm -f`) below.
+const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
+
+// A filesystem-safe slug for this prompt, so the saved transcript has a readable,
+// deterministic name (Date.now()/Math.random() are unavailable in workflow scripts,
+// so the name is derived purely from the prompt text). Falls back to 'answer'.
+const slug =
+  (prompt.toLowerCase().match(/[a-z0-9]+/g) || []).slice(0, 8).join('-').slice(0, 60) || 'answer'
+const answerDocPath = `${workDir}/answer-${slug}.md`
+
+// ---------------------------------------------------------------------------
+// Schema — shared by both debaters (codex's runner mirrors
+// scripts/codex-answer.schema.json). `reviewerError` is set ONLY by the codex
+// runner script when codex itself failed; the claude side never sets it.
+// ---------------------------------------------------------------------------
+const OBJECTION = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { point: { type: 'string' }, reason: { type: 'string' } },
+  required: ['point', 'reason'],
+}
+const ANSWER_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    answer: { type: 'string' },
+    keyPoints: { type: 'array', items: { type: 'string' } },
+    agreesWithOther: { type: 'boolean' },
+    objections: { type: 'array', items: OBJECTION },
+    changedMind: { type: 'string' },
+    reviewerError: { type: 'boolean' },
+  },
+  required: ['answer', 'keyPoints', 'agreesWithOther', 'objections', 'changedMind'],
+}
+const FINAL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { answer: { type: 'string' } },
+  required: ['answer'],
+}
+
+if (!prompt) {
+  return {
+    status: 'no-prompt',
+    rounds: 0,
+    prompt,
+    transcriptPath: null,
+    finalAnswer: null,
+    note: 'No prompt was passed to the answer-debate workflow; nothing to answer.',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The two debaters (symmetric: each answers, then cross-checks the other)
+// ---------------------------------------------------------------------------
+// CLAUDE answers/cross-checks via a harness subagent (Claude isn't headless under
+// Max auth, so agent() is the only way to run it). Read-only: it may inspect the
+// repo to ground its answer but must not edit anything.
+async function claudeAnswers(round, other, myPrev) {
+  const block =
+    round === 1
+      ? `Answer the question below thoroughly and honestly — your best, most defensible answer. You are in a debate with another assistant ("CODEX") answering the SAME question independently; you'll cross-check each other afterward, so make this strong.`
+      : `This is a CROSS-CHECK round. You and CODEX each answered the question; now reconcile toward ONE agreed answer.
+
+Your OWN previous answer (build on it — don't re-derive from scratch):
+${JSON.stringify(myPrev, null, 2)}
+
+CODEX's LATEST answer (and its objections to your previous answer) (JSON):
+${JSON.stringify(other, null, 2)}
+
+Weigh CODEX's answer against yours:
+  - Where CODEX is right and you were wrong or incomplete, UPDATE your answer to match and say what you changed in changedMind.
+  - Where CODEX is wrong or has a gap, hold your position and record it under objections with a specific, evidence-backed reason.`
+  const prompt_ = `You and CODEX were asked the SAME question. ${block}
+
+You may inspect the repo at \`${repoPath}\` to ground your answer — your shell cwd may be a different worktree, so use \`git -C ${repoPath}\` and absolute paths under it. READ-ONLY: read files, \`git -C ${repoPath} diff/log\`, grep; do NOT edit, create, delete, or run any git write command. Cite file:line for claims about this codebase. If the question isn't about this repo, answer from your own knowledge.
+
+The question:
+${prompt}
+
+Return the schema:
+  - answer: your complete, self-contained answer as it stands now (on a cross-check round, your UPDATED unified answer).
+  - keyPoints: the core claims your answer rests on, one per item.
+  - objections: your remaining disagreements with CODEX's latest answer (empty on round 1, and empty once you fully agree).
+  - changedMind: what CODEX convinced you to change this round (empty on round 1 or if nothing changed).
+  - agreesWithOther: true ONLY when CODEX's latest answer is correct and complete and you have NO objection left — your two answers say the same thing. false on round 1.`
+  return agent(prompt_, {
+    label: `claude:round${round}`,
+    phase: round === 1 ? 'Answer' : 'Reconcile',
+    model,
+    schema: ANSWER_SCHEMA,
+  })
+}
+
+// CODEX answers/cross-checks via codex-answer.sh (warm session across rounds). The
+// agent here is a MECHANICAL RUNNER: it writes the prompt + cross-check files,
+// shells out to the script, and relays codex's JSON answer verbatim — it does NOT
+// answer the question itself. The user's prompt and CLAUDE's latest answer carry
+// arbitrary characters, so they're written with the Write tool, never a heredoc.
+async function codexAnswers(round, other) {
+  const answerPath = `${workDir}/answer-codex-${round}.json`
+  const promptPath = `${workDir}/answer-prompt.txt`
+  const crossPath = `${workDir}/answer-crosscheck.json`
+  // The cross-check argument to the script: `-` on round 1 (codex answers
+  // independently), else the file holding CLAUDE's latest answer.
+  const crossArg = round === 1 ? '-' : crossPath
+  const crossStep =
+    round === 1
+      ? `2. (No cross-check this round — codex answers independently.)`
+      : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
+
+${JSON.stringify(other, null, 2)}`
+  const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
+
+${prompt}
+
+${crossStep}
+
+3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-answer.sh ${promptPath} ${crossArg} ${answerPath} ${REASONING_EFFORT}\`
+
+   This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
+
+4. Read \`${answerPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
+  return agent(runnerPrompt, {
+    label: `codex:round${round}`,
+    phase: round === 1 ? 'Answer' : 'Reconcile',
+    model: copyModel, // must relay codex's answer JSON faithfully
+    schema: ANSWER_SCHEMA,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Transcript rendering — deterministic, in-process (no agent retypes the blob)
+// ---------------------------------------------------------------------------
+function renderObjections(objs) {
+  if (!objs || objs.length === 0) return '  - _(none)_'
+  return objs.map((o) => `  - **${o.point}** — ${o.reason}`).join('\n')
+}
+
+function renderSide(name, ans) {
+  if (!ans) return `**${name}** — _(no turn this round)_`
+  const lines = [
+    `**${name}** — agrees with other: \`${!!ans.agreesWithOther}\``,
+    '',
+    ans.answer,
+  ]
+  if (ans.changedMind && ans.changedMind.trim()) lines.push('', `_changed mind:_ ${ans.changedMind}`)
+  lines.push('', 'Objections to the other side:', renderObjections(ans.objections))
+  return lines.join('\n')
+}
+
+function roundSection(entry) {
+  return [
+    `### Round ${entry.round}`,
+    '',
+    renderSide('claude', entry.claude),
+    '',
+    renderSide('codex', entry.codex),
+  ].join('\n')
+}
+
+function transcriptHeader(meta) {
+  const badge = meta.status === 'consensus' ? '✅ **Agreed**' : `⚠️ **${meta.status}**`
+  return `# Codex ⇄ Claude answer-debate
+
+> **Prompt:** ${meta.prompt}
+
+${badge} after ${meta.rounds} round(s) · codex answered at \`${meta.reasoningEffort}\` reasoning effort`
+}
+
+function renderTranscript(transcript, meta, finalAnswer) {
+  const parts = [transcriptHeader(meta)]
+  if (finalAnswer) parts.push('## Final unified answer', '', finalAnswer)
+  parts.push('## Convergence trail', ...transcript.map(roundSection))
+  return parts.join('\n\n')
+}
+
+// Zero-pad the round so the section glob sorts in round order for the assembly.
+const sectionFile = (round) => `${workDir}/answer-section-${String(round).padStart(3, '0')}.md`
+
+// Write ONE round's section to its own small file (Haiku-safe — just this round).
+async function writeSection(entry) {
+  const text = roundSection(entry)
+  const path = sectionFile(entry.round)
+  const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
+
+${text}`
+  return agent(p, { label: `section:round${entry.round}`, phase: 'Reconcile', model: mechModel })
+}
+
+// ---------------------------------------------------------------------------
+// Set up scratch — clear any stale per-round sections from a PRIOR debate in this
+// worktree so they don't leak into the assembled transcript. Scoped to the
+// answer-section files; the review mode's section-NNN.md and the verdict/answer
+// JSONs keep their own lifecycle.
+// ---------------------------------------------------------------------------
+phase('Answer')
+await agent(
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/answer-section-*.md\`. Do not edit any other file. Do not run git.`,
+  { label: 'sections:reset', phase: 'Answer', model: mechModel },
+)
+
+const transcript = []
+let status = 'consensus'
+let claudeAns = null
+let codexAns = null
+
+// ---------------------------------------------------------------------------
+// The loop — round 1 is the independent answer (parallel); rounds 2+ are
+// cross-checks. Runs until BOTH sides agree. No round cap, no deadlock exit:
+// each side keeps cross-checking until they converge (the harness's per-workflow
+// agent backstop is the only hard ceiling — interrupt via /workflows or TaskStop).
+//
+// Both sides run in PARALLEL each round, so in round N each cross-checks the
+// OTHER's round-(N-1) answer. Convergence is thus mutual agreement on the prior
+// round's answers — safe (it can only end on real agreement, never prematurely),
+// at worst one round later than a strictly-serial handoff would.
+// ---------------------------------------------------------------------------
+for (let round = 1; ; round++) {
+  const prevClaude = claudeAns
+  const prevCodex = codexAns
+  const [claude, codex] = await parallel([
+    () => claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
+    () => codexAnswers(round, round === 1 ? null : prevClaude),
+  ])
+
+  // codex infrastructure failure — terminal. The runner could not get an answer
+  // out of codex (broken/unavailable CLI), so it synthesized reviewerError:true.
+  // Retrying a dead reviewer just spins, so abort and surface the failure. This is
+  // deliberately separate from the "no deadlock exit" rule for real disagreement.
+  if (codex && codex.reviewerError) {
+    status = 'reviewer-error'
+    log(`Round ${round}: codex error — aborting. ${codex.answer}`)
+    transcript.push({ round, claude, codex })
+    break
+  }
+  // A side died on a terminal API error after retries (agent() returned null).
+  // We can't reconcile half a debate, so abort loudly rather than loop on nulls.
+  if (!claude || !codex) {
+    status = 'agent-error'
+    log(`Round ${round}: ${!claude ? 'claude' : 'codex'} produced no answer (agent error) — aborting.`)
+    transcript.push({ round, claude, codex })
+    break
+  }
+
+  claudeAns = claude
+  codexAns = codex
+  const entry = { round, claude, codex }
+  transcript.push(entry)
+  await writeSection(entry)
+
+  // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
+  // remaining disagreement with the other's latest answer.
+  if (round >= 2 && claude.agreesWithOther === true && codex.agreesWithOther === true) {
+    log(`Round ${round}: both sides agree — converged.`)
+    break
+  }
+  log(
+    `Round ${round}: claude agrees=${!!claude.agreesWithOther} (objections=${(claude.objections || []).length}), codex agrees=${!!codex.agreesWithOther} (objections=${(codex.objections || []).length})`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis — merge the two AGREED answers into one unified reply for the user.
+// Only on consensus: on a failure terminus there's no agreement to synthesize.
+// ---------------------------------------------------------------------------
+let finalAnswer = null
+if (status === 'consensus' && claudeAns && codexAns) {
+  phase('Synthesis')
+  const synth = await agent(
+    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
+
+The question:
+${prompt}
+
+Claude's final answer (JSON):
+${JSON.stringify(claudeAns, null, 2)}
+
+Codex's final answer (JSON):
+${JSON.stringify(codexAns, null, 2)}
+
+Return the unified answer in \`answer\`.`,
+    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
+  )
+  finalAnswer = synth ? synth.answer : null
+}
+
+log(`Answer-debate ended: ${status} after ${transcript.length} round(s).`)
+
+// Persist the full transcript to a single readable file the user can revisit
+// (chat + saved transcript). Rendered deterministically in-process, then handed to
+// one mechanical writer — the payload can be large, so use copyModel for faithful
+// reproduction (the same tier the codex relay uses).
+const transcriptText = renderTranscript(
+  transcript,
+  { status, rounds: transcript.length, prompt, reasoningEffort: REASONING_EFFORT },
+  finalAnswer,
+)
+await agent(
+  `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${answerDocPath}\` with EXACTLY this content, overwriting any existing file:
+
+${transcriptText}`,
+  { label: 'transcript:write', phase: 'Synthesis', model: copyModel },
+)
+
+return {
+  status,
+  rounds: transcript.length,
+  prompt,
+  transcriptPath: answerDocPath,
+  finalAnswer,
+  reasoningEffort: REASONING_EFFORT,
+  // The error terminus carries codex's failure detail in its answer text.
+  codexError: status === 'reviewer-error' ? (codexAns && codexAns.answer) || null : null,
+}

--- a/.agents/skills/codex-debate/answer.workflow.js
+++ b/.agents/skills/codex-debate/answer.workflow.js
@@ -243,7 +243,34 @@ function renderSide(name, ans) {
   return lines.join('\n')
 }
 
+// A confirm round is not a normal answer round: both sides judged ONE shared
+// synthesized candidate (approve-or-object), so rendering each side's `answer`
+// would misleadingly show two texts for a round whose whole point was that both
+// judged the IDENTICAL one. Show the candidate ONCE, then each side's verdict
+// (agrees + objections) against it.
+function renderConfirmVerdict(name, ans) {
+  if (!ans) return `**${name}** — _(no turn this round)_`
+  return [
+    `**${name}** — approved: \`${!!ans.agreesWithOther}\``,
+    'Objections to the candidate:',
+    renderObjections(ans.objections),
+  ].join('\n')
+}
+
 function roundSection(entry) {
+  if (entry.confirming) {
+    return [
+      `### Round ${entry.round} — confirmation`,
+      '',
+      'Both sides judged this single synthesized candidate (approve or object):',
+      '',
+      entry.candidate,
+      '',
+      renderConfirmVerdict('claude', entry.claude),
+      '',
+      renderConfirmVerdict('codex', entry.codex),
+    ].join('\n')
+  }
   return [
     `### Round ${entry.round}`,
     '',
@@ -397,7 +424,12 @@ for (let round = 1; ; round++) {
 
   claudeAns = claude
   codexAns = codex
-  const entry = { round, claude, codex }
+  // On a confirm round both sides judged the ONE shared candidate; tag the entry
+  // (with the candidate itself) so the transcript renders it as an approve/object
+  // verdict on a single text rather than as two separate answer rounds.
+  const entry = confirming
+    ? { round, claude, codex, confirming: true, candidate: pendingCandidate }
+    : { round, claude, codex }
   transcript.push(entry)
   await writeSection(entry)
 

--- a/.agents/skills/codex-debate/answer.workflow.js
+++ b/.agents/skills/codex-debate/answer.workflow.js
@@ -172,25 +172,35 @@ Return the schema:
 // shells out to the script, and relays codex's JSON answer verbatim — it does NOT
 // answer the question itself. The user's prompt and CLAUDE's latest answer carry
 // arbitrary characters, so they're written with the Write tool, never a heredoc.
-// On a confirmation turn (`confirm`), the cross-check input is the SINGLE shared
-// candidate, and the runner relays codex's approval/objections to it.
-async function codexAnswers(round, other) {
+// On a CONFIRM turn (`confirming`), `other` is the SINGLE shared synthesized
+// candidate STRING; the runner writes it to the cross-check file and passes the
+// script's `confirm` token so codex plugs into the same verbatim/approve-or-object
+// contract as the workflow's claudeConfirms turn (NOT the ordinary cross-check
+// contract, which would tell codex to UPDATE its own answer instead of approving).
+async function codexAnswers(round, other, confirming) {
   const answerPath = `${workDir}/answer-codex-${round}.json`
   const promptPath = `${workDir}/answer-prompt.txt`
   const crossPath = `${workDir}/answer-crosscheck.json`
   // The cross-check argument to the script: `-` on round 1 (codex answers
-  // independently), else the file holding CLAUDE's latest answer.
+  // independently), else the file holding either CLAUDE's latest answer (ordinary
+  // cross-check) or the synthesized candidate to approve (confirm turn).
   const crossArg = round === 1 ? '-' : crossPath
+  // On a confirm turn the cross-check file holds the candidate VERBATIM (a plain
+  // string); on an ordinary cross-check it holds CLAUDE's answer JSON.
+  const crossContent = confirming ? other : JSON.stringify(other, null, 2)
   const crossStep =
     round === 1
       ? `2. (No cross-check this round — codex answers independently.)`
       : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
 
-${JSON.stringify(other, null, 2)}`
+${crossContent}`
+  // Pass the script's `confirm` token on a confirm turn so it selects the
+  // approve-the-candidate prompt shape rather than the cross-check shape.
+  const confirmArg = confirming ? ` ${shq('confirm')}` : ''
   // Every path below is spliced into a shell command the runner agent executes, so
   // POSIX-quote each one (worktrees or skill dirs with spaces/metacharacters would
   // otherwise break the command or misdirect it). The Write-tool file CONTENTS
-  // (${prompt}, ${JSON.stringify(other)}) are not shell-parsed and stay verbatim.
+  // (${prompt}, ${crossContent}) are not shell-parsed and stay verbatim.
   const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
@@ -200,14 +210,14 @@ ${prompt}
 ${crossStep}
 
 3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}\`
+   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}${confirmArg}\`
 
    This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
 
 4. Read \`${answerPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
   return agent(runnerPrompt, {
-    label: `codex:round${round}`,
-    phase: round === 1 ? 'Answer' : 'Reconcile',
+    label: confirming ? `codex:confirm${round}` : `codex:round${round}`,
+    phase: confirming ? 'Synthesis' : round === 1 ? 'Answer' : 'Reconcile',
     model: copyModel, // must relay codex's answer JSON faithfully
     schema: ANSWER_SCHEMA,
   })
@@ -344,24 +354,26 @@ Return the unified answer in \`answer\`.`,
 // either objects, its objections fold back into the cross-check loop and we continue.
 // ---------------------------------------------------------------------------
 let finalAnswer = null
-// On a confirmation turn, each side's "other" input is the synthesized candidate
-// (wrapped in the answer shape so the existing cross-check machinery accepts it).
+// On a confirmation turn, each side judges the SAME synthesized candidate STRING.
 // Carried across iterations so a rejected confirmation feeds the candidate + the
 // objector's complaints back into the next ordinary cross-check round.
 let pendingCandidate = null
 for (let round = 1; ; round++) {
   const confirming = pendingCandidate !== null
-  const candidateAns = confirming
-    ? { answer: pendingCandidate, keyPoints: [], agreesWithOther: true, objections: [], changedMind: '' }
-    : null
   const prevClaude = claudeAns
   const prevCodex = codexAns
+  // On a confirm turn BOTH sides run their dedicated approve-a-fixed-candidate
+  // interface (claudeConfirms / codexAnswers(..., confirming)), so both plug into
+  // one verbatim/approve-or-object contract instead of the ordinary cross-check.
   const [claude, codex] = await parallel([
     () =>
       confirming
         ? claudeConfirms(round, pendingCandidate)
         : claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
-    () => codexAnswers(round, round === 1 ? null : confirming ? candidateAns : prevClaude),
+    () =>
+      confirming
+        ? codexAnswers(round, pendingCandidate, true)
+        : codexAnswers(round, round === 1 ? null : prevClaude, false),
   ])
 
   // codex infrastructure failure — terminal. The runner could not get an answer

--- a/.agents/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.agents/skills/codex-debate/scripts/codex-answer.schema.json
@@ -39,5 +39,11 @@
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
     }
   },
-  "required": ["answer", "keyPoints", "agreesWithOther", "objections", "changedMind"]
+  "required": [
+    "answer",
+    "keyPoints",
+    "agreesWithOther",
+    "objections",
+    "changedMind"
+  ]
 }

--- a/.agents/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.agents/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,10 +37,6 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
-    },
-    "reviewerError": {
-      "type": "boolean",
-      "description": "Set to true ONLY by the codex-answer.sh runner when codex itself failed to produce an answer after every retry (a synthesized infrastructure-error verdict the workflow aborts on). codex never sets this in a real answer; it is declared here so the script's synthesized error answer validates against this schema under additionalProperties:false."
     }
   },
   "required": [

--- a/.agents/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.agents/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,17 +37,7 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
-    },
-    "reviewerError": {
-      "type": "boolean",
-      "description": "Set by the runner script ONLY when codex itself failed to produce an answer (broken/unavailable CLI). Not part of a real answer."
     }
   },
-  "required": [
-    "answer",
-    "keyPoints",
-    "agreesWithOther",
-    "objections",
-    "changedMind"
-  ]
+  "required": ["answer", "keyPoints", "agreesWithOther", "objections", "changedMind"]
 }

--- a/.agents/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.agents/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,6 +37,10 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
+    },
+    "reviewerError": {
+      "type": "boolean",
+      "description": "Set to true ONLY by the codex-answer.sh runner when codex itself failed to produce an answer after every retry (a synthesized infrastructure-error verdict the workflow aborts on). codex never sets this in a real answer; it is declared here so the script's synthesized error answer validates against this schema under additionalProperties:false."
     }
   },
   "required": [

--- a/.agents/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.agents/skills/codex-debate/scripts/codex-answer.schema.json
@@ -1,0 +1,53 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "answer": {
+      "type": "string",
+      "description": "Your complete, self-contained answer to the user's prompt as it stands THIS round. On a cross-check round this is your UPDATED unified answer, revised in light of the other assistant's answer."
+    },
+    "keyPoints": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "The core claims your answer rests on, one per item — the things the other side must agree with for there to be consensus."
+    },
+    "agreesWithOther": {
+      "type": "boolean",
+      "description": "true ONLY when the other assistant's latest answer is correct and complete and you have NO substantive disagreement left — your answers say the same thing. false on the first round (you haven't seen theirs yet) and whenever any objection below remains."
+    },
+    "objections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "point": {
+            "type": "string",
+            "description": "The specific claim in the OTHER assistant's answer you disagree with, or the gap you think it leaves."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why it's wrong or incomplete — cite file:line or concrete evidence when the prompt is about this repo."
+          }
+        },
+        "required": ["point", "reason"]
+      },
+      "description": "Your remaining disagreements with the other assistant's latest answer. Empty when you fully agree (agreesWithOther:true) and on round 1."
+    },
+    "changedMind": {
+      "type": "string",
+      "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
+    },
+    "reviewerError": {
+      "type": "boolean",
+      "description": "Set by the runner script ONLY when codex itself failed to produce an answer (broken/unavailable CLI). Not part of a real answer."
+    }
+  },
+  "required": [
+    "answer",
+    "keyPoints",
+    "agreesWithOther",
+    "objections",
+    "changedMind"
+  ]
+}

--- a/.agents/skills/codex-debate/scripts/codex-answer.sh
+++ b/.agents/skills/codex-debate/scripts/codex-answer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # codex-answer.sh — the canonical, deterministic codex invocation for the
-# SYMMETRIC answer-debate (the prompt-mode of /codex-debate). codex answers a
+# SYMMETRIC answer-debate (the `answer` mode of /codex-debate). codex answers a
 # freeform user prompt as one of two equal debaters; on follow-up rounds it
 # CROSS-CHECKS the other assistant's ("CLAUDE") latest answer against its own and
 # either concedes (revising its answer) or holds firm (recording objections),
@@ -9,6 +9,11 @@
 # this repo to ground its answer (git diff/log, read files, grep) but cannot
 # modify anything. The output is constrained to codex-answer.schema.json and
 # written to <out-json>.
+#
+# This script owns only what is SPECIFIC to answering a prompt: arg parsing, the
+# warm/cold prompt text, the answer schema + session file, and the answer-shaped
+# error verdict. The shared codex-driving core (read-only exec/resume, retry/
+# backoff, thread-id capture, session persistence) lives in codex-exec-lib.sh.
 #
 # Usage:
 #   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
@@ -23,23 +28,14 @@
 #                     value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
-#   * codex runs under `--sandbox read-only`, which enforces read-only at the
-#     execution boundary (the kernel sandbox blocks file writes and other
-#     state-mutating syscalls), NOT merely by prompt text. codex reads arbitrary
-#     repo files to ground its answer and could be prompt-injected by file
-#     contents, so the read-only promise must be enforced, not advertised. codex
-#     auto-falls-back to its bundled bubblewrap when the system one is absent, so
-#     this works in containers; read-only permits read commands (git diff/status,
-#     grep, reading files) but denies writes. `codex exec` is already
-#     non-interactive (approval policy "never"), so a blocked command is denied
-#     outright rather than escalating to a prompt that would wedge the loop.
+#   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
+#     read-only at the kernel boundary, NOT merely by prompt text. codex reads
+#     arbitrary repo files to ground its answer and could be prompt-injected by file
+#     contents, so the read-only promise must be enforced, not advertised.
 #   * Always emits a schema-valid answer on stdout, even if codex errors — a
 #     synthesized error answer (reviewerError:true) so the loop never wedges.
-#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
-#     scratch dir; every later round resumes that same session (`codex exec
-#     resume <id>`) so codex retains its OWN prior answer + reasoning across rounds
-#     instead of reconstructing it each time. If the id was never captured, a later
-#     round cleanly falls back to a cold start.
+#   * WARM SESSION: round 1 cold-starts codex; every later round resumes that same
+#     session so codex retains its OWN prior answer + reasoning across rounds.
 set -uo pipefail
 
 prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
@@ -51,11 +47,8 @@ effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-answer.schema.json"
-log="$out.log"
-
-# The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
-# it exists before codex tries to write the answer there.
-mkdir -p "$(dirname "$out")"
+# shellcheck source=codex-exec-lib.sh
+source "$here/codex-exec-lib.sh"
 
 # The user's prompt. Required and must be non-empty — an empty prompt would make
 # codex answer nothing and silently degrade the debate, so fail loud instead.
@@ -64,11 +57,6 @@ if [ ! -s "$prompt_file" ]; then
   exit 2
 fi
 prompt_text="$(cat "$prompt_file")"
-
-# Never let a stale answer from a previous run survive: if the current codex
-# invocation fails to write one, the empty-check below must catch it and
-# synthesize an error answer (otherwise a leftover file reads as a fresh answer).
-rm -f "$out" "$log"
 
 # Pull CLAUDE's latest answer, if any (the cross-check input). Built as a plain
 # string and injected below via a simple variable reference so any special
@@ -85,26 +73,27 @@ if [ "$crosscheck_file" != "-" ]; then
   fi
 fi
 
-# WARM SESSION. codex keeps its OWN answer + reasoning across rounds by resuming
-# the same codex session instead of cold-starting `codex exec` each round. The
-# session id (codex's thread_id) is persisted in the scratch dir after round 1
-# and reused on every follow-up round, so when it cross-checks CLAUDE it argues
-# from its original rationale rather than reconstructing it.
-#
-#   * Round 1 (crosscheck_file == "-"): fresh `codex exec`; capture thread_id below.
-#   * Later rounds: `codex exec resume <id>` with just the cross-check follow-up,
-#     relying on codex's retained context.
-#   * Fallback: if no id was captured (round-1 capture failed), a later round
-#     cold-starts with the FULL prompt + cross-check — graceful, never a wedge.
+# WARM SESSION. Round 1 (crosscheck_file == "-") cold-starts and resets any stale
+# id; later rounds resume codex's own answer session. Resolve the id first so the
+# prompt below can lean on codex's retained context when warm.
 session_id_file="$(dirname "$out")/codex-answer-session.id"
-resume_id=""
-if [ "$crosscheck_file" = "-" ]; then
-  # Round 1 of a fresh debate: start a NEW session and drop any session id left
-  # behind by a previous debate in this worktree, so we never resume a stale one.
-  rm -f "$session_id_file"
-elif [ -s "$session_id_file" ]; then
-  resume_id="$(cat "$session_id_file")"
-fi
+[ "$crosscheck_file" = "-" ] && is_round1=1 || is_round1=
+resume_id="$(codex_resolve_session "$session_id_file" "$is_round1")"
+
+# Synthesize codex-answer's error verdict shape when codex produces nothing after
+# every attempt (called by codex_exec_round). reviewerError:true is the signal the
+# workflow aborts the debate on.
+synthesize_error_verdict() {
+  local out="$1" tail_log="$2" attempts="$3"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    keyPoints: [],
+    agreesWithOther: false,
+    objections: [],
+    changedMind: "",
+    reviewerError: true
+  }' >"$out"
+}
 
 # Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
 # on codex's retained answer, and the full answer prompt for the COLD path (round
@@ -169,105 +158,6 @@ EOF
 )"
 fi
 
-# One codex invocation: warm-resume when we have a session id (carries codex's own
-# prior answer), else a cold start. `--json` emits a `thread.started` event
-# carrying codex's thread_id, captured below to resume next round; it does NOT
-# change the answer, which `--output-schema`/`-o` still write to "$out". `resume`
-# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
-# the same kernel-enforced policy, set through config instead of the flag.
-run_codex() {
-  if [ -n "$resume_id" ]; then
-    codex exec resume \
-      -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$resume_id" "$prompt"
-  else
-    codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"
-  fi
-}
-
-# model_reasoning_effort is scoped to the debate here (via -c, from the $effort the
-# workflow passes down — default "xhigh") rather than relying on the user's global
-# ~/.codex/config.toml — we always want codex thinking at full depth here.
-#
-# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
-# hiccups, a spurious internal error) and writes no answer — which would otherwise
-# degrade the round to reviewer-error on a single bad roll. Retry with linear
-# backoff, accepting the first attempt that writes a non-empty answer to "$out".
-# Tunable via env: CODEX_REVIEW_RETRIES (total attempts, default 3),
-# CODEX_REVIEW_BACKOFF (base seconds, default 5 — attempt n waits n*base). Only
-# after every attempt fails empty do we synthesize the reviewerError answer below.
-attempts="${CODEX_REVIEW_RETRIES:-3}"
-backoff="${CODEX_REVIEW_BACKOFF:-5}"
-# Validate both as positive integers. Left unchecked, a non-numeric value makes the
-# arithmetic test error every iteration, so the loop would spin forever instead of
-# giving up. Fall back to the documented defaults (and clamp attempts to >=1)
-# loudly rather than wedge the headless debate on a typo'd override.
-if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
-  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
-  attempts=3
-fi
-if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
-  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
-  backoff=5
-fi
-n=1
-: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
-while :; do
-  rm -f "$out"
-  # Append (not truncate): when every attempt fails, the synthesized reviewerError
-  # answer's tail_log must reflect ALL attempts' diagnostics, not just the last.
-  echo "=== attempt $n/$attempts ===" >>"$log"
-  if ! run_codex </dev/null >>"$log" 2>&1; then
-    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
-  fi
-  # Success the moment codex writes an answer: the kernel sandbox + --output-schema
-  # make a non-empty "$out" a real, schema-valid answer, not a partial.
-  [ -s "$out" ] && break
-  # Out of attempts — fall through to the synthesized reviewerError answer.
-  [ "$n" -ge "$attempts" ] && break
-  wait_s=$(( backoff * n ))
-  echo "codex produced no answer (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
-  n=$(( n + 1 ))
-  sleep "$wait_s"
-done
-
-if [ -s "$out" ]; then
-  # Persist codex's session id so NEXT round can resume this same warm session
-  # (carrying codex's own prior answer + reasoning). The successful attempt's
-  # `thread.started` is the last one appended to the log; on a resume round it
-  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
-  # an id just means next round cold-starts via the fallback above — not fatal.
-  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
-  if [ -n "$sid" ]; then
-    printf '%s\n' "$sid" >"$session_id_file"
-  fi
-fi
-
-if [ ! -s "$out" ]; then
-  # codex produced no answer — synthesize a schema-valid error answer so the debate
-  # loop can surface the failure instead of hanging. The reviewerError flag is the
-  # machine-detectable signal the workflow uses to abort with a terminal failure: a
-  # broken/unavailable codex is INFRASTRUCTURE failure, not substantive
-  # disagreement, so it must NOT spin the loop forever.
-  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
-    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
-    keyPoints: [],
-    agreesWithOther: false,
-    objections: [],
-    changedMind: "",
-    reviewerError: true
-  }' >"$out"
-fi
-
-cat "$out"
+# Drive codex for this round (retry/backoff, thread capture, error fallback) — the
+# shared core does the work; this script supplied the prompt, schema, and shapes.
+codex_exec_round "$schema" "$out" "$session_id_file" "$effort" "$resume_id" "$prompt"

--- a/.agents/skills/codex-debate/scripts/codex-answer.sh
+++ b/.agents/skills/codex-debate/scripts/codex-answer.sh
@@ -59,6 +59,13 @@ is_confirm=
 [ "${5:-}" = "confirm" ] && is_confirm=1
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The codex-FACING output schema. Do NOT add a `reviewerError` property to it:
+# codex's `--output-schema` (OpenAI structured outputs) requires every declared
+# property to be in `required` with additionalProperties:false, so an optional
+# `reviewerError` 400s the request. codex never emits reviewerError; the error
+# answer synthesize_error_verdict writes carries it but is validated by the
+# workflow's in-JS ANSWER_SCHEMA, not by this file. (This has been re-added in
+# error twice — review mode's codex-verdict.schema.json omits it for the same reason.)
 schema="$here/codex-answer.schema.json"
 # shellcheck source=codex-exec-lib.sh
 source "$here/codex-exec-lib.sh"

--- a/.agents/skills/codex-debate/scripts/codex-answer.sh
+++ b/.agents/skills/codex-debate/scripts/codex-answer.sh
@@ -95,12 +95,46 @@ synthesize_error_verdict() {
   }' >"$out"
 }
 
-# Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
-# on codex's retained answer, and the full answer prompt for the COLD path (round
-# 1, or the fallback when no session id was captured). Unquoted heredocs: only
-# $prompt_text and $crosscheck expand; their expansions are inserted literally
-# (heredoc results aren't re-scanned), so special chars stay inert.
-if [ -n "$resume_id" ] && [ -n "$crosscheck" ]; then
+# Whether this is a cross-check round: a cross-check file was provided (not "-") AND
+# it actually held CLAUDE's answer. A follow-up round MUST cross-check even when the
+# warm session id is missing — dropping the cross-check would tell codex to answer
+# independently again (agreesWithOther:false, no objections) and the debate could
+# never converge. So the cross-check, not the resume id, gates which prompt we use.
+is_crosscheck=
+[ -n "$crosscheck" ] && is_crosscheck=1
+
+# A reusable block carrying CLAUDE's latest answer + the cross-check instructions,
+# spliced into BOTH the warm and cold follow-up prompts (mirrors codex-review.sh's
+# $rebuttal_block) so a missing resume id degrades to a COLD CROSS-CHECK, never to a
+# fresh independent answer. Empty on round 1.
+crosscheck_block=""
+if [ -n "$is_crosscheck" ]; then
+  crosscheck_block="$(cat <<EOF
+
+CLAUDE's LATEST answer (JSON) is:
+$crosscheck
+
+Cross-check CLAUDE's answer against your own. Then:
+  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
+    match and note what you changed in changedMind.
+  - Where CLAUDE is wrong or has a gap, keep your position and record it under
+    objections with a specific, evidence-backed reason (cite file:line for repo
+    questions).
+EOF
+)"
+fi
+
+# Three prompt shapes, chosen by (resume id × cross-check):
+#   * WARM follow-up   (resume id + cross-check): lean prompt leaning on codex's
+#     retained answer.
+#   * COLD follow-up   (no resume id + cross-check): the full answer prompt PLUS the
+#     cross-check block — codex re-derives its own answer from scratch but still
+#     reconciles against CLAUDE's, so the debate keeps converging.
+#   * COLD first round (no cross-check): the independent answer prompt.
+# Unquoted heredocs: only $prompt_text, $crosscheck, and $crosscheck_block expand;
+# their expansions are inserted literally (heredoc results aren't re-scanned), so
+# special chars stay inert.
+if [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME answer session you started earlier — you still
 have your own previous answer and reasoning in context. You and another assistant
@@ -110,18 +144,10 @@ to reach ONE agreed answer.
 The original question was:
 $prompt_text
 
-CLAUDE's LATEST answer (JSON) is:
-$crosscheck
-
 Cross-check CLAUDE's answer against your own (READ-ONLY — you may read repo files,
 git diff/log, grep to verify, but do NOT modify, create, or delete anything, and
-run no git write command: add/commit/push/stash/checkout). Then:
-  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
-    match and note what you changed in changedMind.
-  - Where CLAUDE is wrong or has a gap, keep your position and record it under
-    objections with a specific, evidence-backed reason (cite file:line for repo
-    questions).
-
+run no git write command: add/commit/push/stash/checkout).
+$crosscheck_block
 Return the JSON schema:
   - answer: your UPDATED, self-contained unified answer as it stands now.
   - keyPoints: the core claims your answer rests on.
@@ -137,8 +163,8 @@ else
 You are CODEX, a rigorous, truthful expert. Answer the user's question below
 thoroughly and honestly — exactly as you would for a careful colleague. You are in
 a debate with another assistant ("CLAUDE") who is answering the SAME question
-independently; afterward you'll cross-check each other until you agree, so give
-your best, most defensible answer now.
+independently; you cross-check each other until you agree, so give your best, most
+defensible answer.
 
 You may inspect this repository to ground your answer (READ-ONLY — read files, run
 git diff/log/grep; do NOT modify, create, or delete anything, and run no git write
@@ -147,13 +173,17 @@ codebase. If the question isn't about this repo, answer from your own knowledge.
 
 The question:
 $prompt_text
-
+$crosscheck_block
 Return the JSON schema:
-  - answer: your complete, self-contained answer.
+  - answer: your complete, self-contained answer (on a cross-check round, your
+    UPDATED unified answer revised in light of CLAUDE's).
   - keyPoints: the core claims your answer rests on, one per item.
-  - objections: leave empty this round (you haven't seen CLAUDE's answer yet).
-  - changedMind: empty string this round.
-  - agreesWithOther: false this round (you haven't seen CLAUDE's answer yet).
+  - objections: your remaining disagreements with CLAUDE's latest answer — empty
+    when you fully agree, and empty on the first round (no cross-check yet).
+  - changedMind: what CLAUDE convinced you to change this round (empty if nothing,
+    and empty on the first round).
+  - agreesWithOther: true ONLY when CLAUDE's latest answer is correct and complete
+    and you have NO objection left. false on the first round (no cross-check yet).
 EOF
 )"
 fi

--- a/.agents/skills/codex-debate/scripts/codex-answer.sh
+++ b/.agents/skills/codex-debate/scripts/codex-answer.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# codex-answer.sh — the canonical, deterministic codex invocation for the
+# SYMMETRIC answer-debate (the prompt-mode of /codex-debate). codex answers a
+# freeform user prompt as one of two equal debaters; on follow-up rounds it
+# CROSS-CHECKS the other assistant's ("CLAUDE") latest answer against its own and
+# either concedes (revising its answer) or holds firm (recording objections),
+# looping until both sides agree. codex runs as a READ-ONLY peer — it may read
+# this repo to ground its answer (git diff/log, read files, grep) but cannot
+# modify anything. The output is constrained to codex-answer.schema.json and
+# written to <out-json>.
+#
+# Usage:
+#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
+#
+#   <prompt-file>     path to a file holding the user's prompt/question
+#   <crosscheck-file> path to a file holding CLAUDE's latest answer (JSON) for
+#                     codex to cross-check, or "-" on the first round (codex
+#                     hasn't seen CLAUDE's answer yet — it answers independently)
+#   <out-json>        path the JSON answer is written to (also echoed to stdout)
+#   <reasoning-effort> codex model_reasoning_effort for this run; the answer
+#                     workflow passes its REASONING_EFFORT constant here so the
+#                     value has one home. Defaults to "xhigh" for standalone runs.
+#
+# Notes:
+#   * codex runs under `--sandbox read-only`, which enforces read-only at the
+#     execution boundary (the kernel sandbox blocks file writes and other
+#     state-mutating syscalls), NOT merely by prompt text. codex reads arbitrary
+#     repo files to ground its answer and could be prompt-injected by file
+#     contents, so the read-only promise must be enforced, not advertised. codex
+#     auto-falls-back to its bundled bubblewrap when the system one is absent, so
+#     this works in containers; read-only permits read commands (git diff/status,
+#     grep, reading files) but denies writes. `codex exec` is already
+#     non-interactive (approval policy "never"), so a blocked command is denied
+#     outright rather than escalating to a prompt that would wedge the loop.
+#   * Always emits a schema-valid answer on stdout, even if codex errors — a
+#     synthesized error answer (reviewerError:true) so the loop never wedges.
+#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
+#     scratch dir; every later round resumes that same session (`codex exec
+#     resume <id>`) so codex retains its OWN prior answer + reasoning across rounds
+#     instead of reconstructing it each time. If the id was never captured, a later
+#     round cleanly falls back to a cold start.
+set -uo pipefail
+
+prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
+crosscheck_file="${2:?missing crosscheck-file (use - for none)}"
+out="${3:?missing out-json path}"
+# The answer workflow owns this value (its REASONING_EFFORT constant) and passes
+# it down; "xhigh" is only the default for a standalone invocation of this script.
+effort="${4:-xhigh}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+schema="$here/codex-answer.schema.json"
+log="$out.log"
+
+# The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
+# it exists before codex tries to write the answer there.
+mkdir -p "$(dirname "$out")"
+
+# The user's prompt. Required and must be non-empty — an empty prompt would make
+# codex answer nothing and silently degrade the debate, so fail loud instead.
+if [ ! -s "$prompt_file" ]; then
+  echo "ERROR: prompt file '$prompt_file' is missing or empty." >&2
+  exit 2
+fi
+prompt_text="$(cat "$prompt_file")"
+
+# Never let a stale answer from a previous run survive: if the current codex
+# invocation fails to write one, the empty-check below must catch it and
+# synthesize an error answer (otherwise a leftover file reads as a fresh answer).
+rm -f "$out" "$log"
+
+# Pull CLAUDE's latest answer, if any (the cross-check input). Built as a plain
+# string and injected below via a simple variable reference so any special
+# characters in the JSON (backticks, $, ...) stay literal.
+crosscheck=""
+if [ "$crosscheck_file" != "-" ]; then
+  if [ -s "$crosscheck_file" ]; then
+    crosscheck="$(cat "$crosscheck_file")"
+  else
+    # A cross-check was expected (path given, not "-") but the file is missing or
+    # empty — the handoff broke. Proceed without it, but make the failure loud so
+    # codex's cross-check isn't silently skipped.
+    echo "WARNING: expected cross-check file '$crosscheck_file' is missing or empty; proceeding with no cross-check this round." >&2
+  fi
+fi
+
+# WARM SESSION. codex keeps its OWN answer + reasoning across rounds by resuming
+# the same codex session instead of cold-starting `codex exec` each round. The
+# session id (codex's thread_id) is persisted in the scratch dir after round 1
+# and reused on every follow-up round, so when it cross-checks CLAUDE it argues
+# from its original rationale rather than reconstructing it.
+#
+#   * Round 1 (crosscheck_file == "-"): fresh `codex exec`; capture thread_id below.
+#   * Later rounds: `codex exec resume <id>` with just the cross-check follow-up,
+#     relying on codex's retained context.
+#   * Fallback: if no id was captured (round-1 capture failed), a later round
+#     cold-starts with the FULL prompt + cross-check — graceful, never a wedge.
+session_id_file="$(dirname "$out")/codex-answer-session.id"
+resume_id=""
+if [ "$crosscheck_file" = "-" ]; then
+  # Round 1 of a fresh debate: start a NEW session and drop any session id left
+  # behind by a previous debate in this worktree, so we never resume a stale one.
+  rm -f "$session_id_file"
+elif [ -s "$session_id_file" ]; then
+  resume_id="$(cat "$session_id_file")"
+fi
+
+# Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
+# on codex's retained answer, and the full answer prompt for the COLD path (round
+# 1, or the fallback when no session id was captured). Unquoted heredocs: only
+# $prompt_text and $crosscheck expand; their expansions are inserted literally
+# (heredoc results aren't re-scanned), so special chars stay inert.
+if [ -n "$resume_id" ] && [ -n "$crosscheck" ]; then
+  prompt="$(cat <<EOF
+You are CODEX, continuing the SAME answer session you started earlier — you still
+have your own previous answer and reasoning in context. You and another assistant
+("CLAUDE") were each asked the SAME question and are now cross-checking each other
+to reach ONE agreed answer.
+
+The original question was:
+$prompt_text
+
+CLAUDE's LATEST answer (JSON) is:
+$crosscheck
+
+Cross-check CLAUDE's answer against your own (READ-ONLY — you may read repo files,
+git diff/log, grep to verify, but do NOT modify, create, or delete anything, and
+run no git write command: add/commit/push/stash/checkout). Then:
+  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
+    match and note what you changed in changedMind.
+  - Where CLAUDE is wrong or has a gap, keep your position and record it under
+    objections with a specific, evidence-backed reason (cite file:line for repo
+    questions).
+
+Return the JSON schema:
+  - answer: your UPDATED, self-contained unified answer as it stands now.
+  - keyPoints: the core claims your answer rests on.
+  - objections: your remaining disagreements with CLAUDE's latest answer (empty
+    when you fully agree).
+  - changedMind: what CLAUDE convinced you to change this round (empty if nothing).
+  - agreesWithOther: true ONLY when CLAUDE's latest answer is correct and complete
+    and you have NO objection left — your two answers say the same thing.
+EOF
+)"
+else
+  prompt="$(cat <<EOF
+You are CODEX, a rigorous, truthful expert. Answer the user's question below
+thoroughly and honestly — exactly as you would for a careful colleague. You are in
+a debate with another assistant ("CLAUDE") who is answering the SAME question
+independently; afterward you'll cross-check each other until you agree, so give
+your best, most defensible answer now.
+
+You may inspect this repository to ground your answer (READ-ONLY — read files, run
+git diff/log/grep; do NOT modify, create, or delete anything, and run no git write
+command: add/commit/push/stash/checkout). Cite file:line for claims about this
+codebase. If the question isn't about this repo, answer from your own knowledge.
+
+The question:
+$prompt_text
+
+Return the JSON schema:
+  - answer: your complete, self-contained answer.
+  - keyPoints: the core claims your answer rests on, one per item.
+  - objections: leave empty this round (you haven't seen CLAUDE's answer yet).
+  - changedMind: empty string this round.
+  - agreesWithOther: false this round (you haven't seen CLAUDE's answer yet).
+EOF
+)"
+fi
+
+# One codex invocation: warm-resume when we have a session id (carries codex's own
+# prior answer), else a cold start. `--json` emits a `thread.started` event
+# carrying codex's thread_id, captured below to resume next round; it does NOT
+# change the answer, which `--output-schema`/`-o` still write to "$out". `resume`
+# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
+# the same kernel-enforced policy, set through config instead of the flag.
+run_codex() {
+  if [ -n "$resume_id" ]; then
+    codex exec resume \
+      -c sandbox_mode="read-only" \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$resume_id" "$prompt"
+  else
+    codex exec \
+      --sandbox read-only \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$prompt"
+  fi
+}
+
+# model_reasoning_effort is scoped to the debate here (via -c, from the $effort the
+# workflow passes down — default "xhigh") rather than relying on the user's global
+# ~/.codex/config.toml — we always want codex thinking at full depth here.
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
+# hiccups, a spurious internal error) and writes no answer — which would otherwise
+# degrade the round to reviewer-error on a single bad roll. Retry with linear
+# backoff, accepting the first attempt that writes a non-empty answer to "$out".
+# Tunable via env: CODEX_REVIEW_RETRIES (total attempts, default 3),
+# CODEX_REVIEW_BACKOFF (base seconds, default 5 — attempt n waits n*base). Only
+# after every attempt fails empty do we synthesize the reviewerError answer below.
+attempts="${CODEX_REVIEW_RETRIES:-3}"
+backoff="${CODEX_REVIEW_BACKOFF:-5}"
+# Validate both as positive integers. Left unchecked, a non-numeric value makes the
+# arithmetic test error every iteration, so the loop would spin forever instead of
+# giving up. Fall back to the documented defaults (and clamp attempts to >=1)
+# loudly rather than wedge the headless debate on a typo'd override.
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+  attempts=3
+fi
+if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+  backoff=5
+fi
+n=1
+: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
+while :; do
+  rm -f "$out"
+  # Append (not truncate): when every attempt fails, the synthesized reviewerError
+  # answer's tail_log must reflect ALL attempts' diagnostics, not just the last.
+  echo "=== attempt $n/$attempts ===" >>"$log"
+  if ! run_codex </dev/null >>"$log" 2>&1; then
+    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+  fi
+  # Success the moment codex writes an answer: the kernel sandbox + --output-schema
+  # make a non-empty "$out" a real, schema-valid answer, not a partial.
+  [ -s "$out" ] && break
+  # Out of attempts — fall through to the synthesized reviewerError answer.
+  [ "$n" -ge "$attempts" ] && break
+  wait_s=$(( backoff * n ))
+  echo "codex produced no answer (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+  n=$(( n + 1 ))
+  sleep "$wait_s"
+done
+
+if [ -s "$out" ]; then
+  # Persist codex's session id so NEXT round can resume this same warm session
+  # (carrying codex's own prior answer + reasoning). The successful attempt's
+  # `thread.started` is the last one appended to the log; on a resume round it
+  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
+  # an id just means next round cold-starts via the fallback above — not fatal.
+  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+  if [ -n "$sid" ]; then
+    printf '%s\n' "$sid" >"$session_id_file"
+  fi
+fi
+
+if [ ! -s "$out" ]; then
+  # codex produced no answer — synthesize a schema-valid error answer so the debate
+  # loop can surface the failure instead of hanging. The reviewerError flag is the
+  # machine-detectable signal the workflow uses to abort with a terminal failure: a
+  # broken/unavailable codex is INFRASTRUCTURE failure, not substantive
+  # disagreement, so it must NOT spin the loop forever.
+  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    keyPoints: [],
+    agreesWithOther: false,
+    objections: [],
+    changedMind: "",
+    reviewerError: true
+  }' >"$out"
+fi
+
+cat "$out"

--- a/.agents/skills/codex-debate/scripts/codex-answer.sh
+++ b/.agents/skills/codex-debate/scripts/codex-answer.sh
@@ -16,16 +16,23 @@
 # backoff, thread-id capture, session persistence) lives in codex-exec-lib.sh.
 #
 # Usage:
-#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
+#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort] [confirm]
 #
 #   <prompt-file>     path to a file holding the user's prompt/question
 #   <crosscheck-file> path to a file holding CLAUDE's latest answer (JSON) for
 #                     codex to cross-check, or "-" on the first round (codex
-#                     hasn't seen CLAUDE's answer yet — it answers independently)
+#                     hasn't seen CLAUDE's answer yet — it answers independently).
+#                     On a CONFIRM turn this file instead holds the synthesized
+#                     unified CANDIDATE answer codex is asked to approve verbatim.
 #   <out-json>        path the JSON answer is written to (also echoed to stdout)
 #   <reasoning-effort> codex model_reasoning_effort for this run; the answer
 #                     workflow passes its REASONING_EFFORT constant here so the
 #                     value has one home. Defaults to "xhigh" for standalone runs.
+#   [confirm]         the literal token "confirm" selects the CONFIRM prompt shape:
+#                     codex judges ONE shared synthesized candidate (held in the
+#                     crosscheck-file) and approves it VERBATIM or objects — it does
+#                     NOT rewrite its own answer. Mirrors the workflow's
+#                     claudeConfirms turn so both peers plug into one confirm contract.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
@@ -38,12 +45,18 @@
 #     session so codex retains its OWN prior answer + reasoning across rounds.
 set -uo pipefail
 
-prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
+prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort] [confirm]}"
 crosscheck_file="${2:?missing crosscheck-file (use - for none)}"
 out="${3:?missing out-json path}"
 # The answer workflow owns this value (its REASONING_EFFORT constant) and passes
 # it down; "xhigh" is only the default for a standalone invocation of this script.
 effort="${4:-xhigh}"
+# CONFIRM mode: the 5th arg is the literal "confirm" when codex is judging ONE
+# synthesized candidate (held in crosscheck_file) rather than cross-checking
+# CLAUDE's separate answer. This swaps in the confirm prompt shape below — a
+# verbatim/approve-or-object contract symmetric to the workflow's claudeConfirms.
+is_confirm=
+[ "${5:-}" = "confirm" ] && is_confirm=1
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-answer.schema.json"
@@ -124,7 +137,13 @@ EOF
 )"
 fi
 
-# Three prompt shapes, chosen by (resume id × cross-check):
+# Prompt shapes, chosen by (confirm × resume id × cross-check):
+#   * CONFIRM           (confirm token): codex judges ONE synthesized candidate
+#     (in $crosscheck) and approves it VERBATIM or objects — it does NOT rewrite its
+#     own answer. One contract symmetric to the workflow's claudeConfirms turn, so
+#     both peers plug into the same approve-a-fixed-candidate interface. Takes
+#     precedence over warm/cold below (the session is warm here, but the activity is
+#     approval, not cross-check).
 #   * WARM follow-up   (resume id + cross-check): lean prompt leaning on codex's
 #     retained answer.
 #   * COLD follow-up   (no resume id + cross-check): the full answer prompt PLUS the
@@ -134,7 +153,35 @@ fi
 # Unquoted heredocs: only $prompt_text, $crosscheck, and $crosscheck_block expand;
 # their expansions are inserted literally (heredoc results aren't re-scanned), so
 # special chars stay inert.
-if [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
+if [ -n "$is_confirm" ]; then
+  prompt="$(cat <<EOF
+You are CODEX. You and another assistant ("CLAUDE") were each asked the SAME
+question, debated, and AGREED. A unified candidate answer has been synthesized from
+your two agreed answers. Your ONLY job now is to APPROVE it or object — do NOT
+rewrite it, do NOT produce a new answer of your own.
+
+You may inspect this repository to verify (READ-ONLY — read files, run git
+diff/log/grep; do NOT modify, create, or delete anything, and run no git write
+command: add/commit/push/stash/checkout). Cite file:line for repo claims.
+
+The original question was:
+$prompt_text
+
+The candidate unified answer to approve is:
+$crosscheck
+
+Return the JSON schema:
+  - answer: echo the candidate VERBATIM (you are approving it, not rewriting it).
+  - keyPoints: the core claims the candidate rests on.
+  - objections: anything the candidate gets wrong, drops, or overstates relative to
+    what you agreed — empty if you approve it as-is. Be specific (file:line for repo
+    claims).
+  - changedMind: empty (you are confirming, not revising).
+  - agreesWithOther: true ONLY if you approve the candidate as a correct, complete
+    unified answer with NO objection left.
+EOF
+)"
+elif [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME answer session you started earlier — you still
 have your own previous answer and reasoning in context. You and another assistant

--- a/.agents/skills/codex-debate/scripts/codex-exec-lib.sh
+++ b/.agents/skills/codex-debate/scripts/codex-exec-lib.sh
@@ -142,7 +142,11 @@ codex_exec_round() {
     # so overwriting is a harmless refresh. Failure to capture an id just means next
     # round cold-starts via the caller's fallback — not fatal.
     local sid
-    sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+    # Extract the LAST thread_id in the log (one awk, no grep|tail|cut pipeline).
+    # Splitting on '"', the value sits two fields AFTER the "thread_id" key field
+    # (key, then ":", then value) — NOT a fixed column, since other quoted keys
+    # (e.g. "type":"thread.started") precede it on the same JSON event line.
+    sid="$(awk -F'"' '{for (i = 1; i < NF; i++) if ($i == "thread_id") sid = $(i + 2)} END {print sid}' "$log")"
     if [ -n "$sid" ]; then
       printf '%s\n' "$sid" >"$session_id_file"
     fi

--- a/.agents/skills/codex-debate/scripts/codex-exec-lib.sh
+++ b/.agents/skills/codex-debate/scripts/codex-exec-lib.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# codex-exec-lib.sh — the shared, SOURCED core of the codex⇄claude debate scripts.
+#
+# Both modes of /codex-debate drive codex the same way; only WHAT they ask and the
+# verdict SHAPE differ. This file is the single home for the part that is identical
+# (and the part most volatile to codex CLI changes): driving codex headless and
+# READ-ONLY, resuming its warm session, retrying transient failures with backoff,
+# capturing the thread id, and — when codex produces nothing after every attempt —
+# synthesizing a schema-valid error verdict so the debate loop never wedges.
+#
+# It is `source`d, not executed. The two callers (codex-review.sh, codex-answer.sh)
+# own the parts that DIFFER: parsing their own args, building the prompt, choosing
+# the schema + per-mode session-id file, and defining the verdict shape.
+#
+# Contract — a caller must:
+#   1. source this file;
+#   2. define a function  synthesize_error_verdict <out> <tail_log> <attempts>
+#      that writes its own schema-valid error verdict (reviewerError:true) to <out>;
+#   3. resolve the warm-session resume id with  codex_resolve_session <id-file> <round1?>
+#      (so it can pick the warm vs cold prompt), then build $prompt;
+#   4. run one round with  codex_exec_round <schema> <out> <id-file> <effort> <resume-id> <prompt>.
+#
+# Tunables (shared by both modes; names kept for back-compat):
+#   CODEX_REVIEW_RETRIES  total attempts per round (default 3)
+#   CODEX_REVIEW_BACKOFF  base seconds; attempt n waits n*base (default 5)
+
+# Resolve the warm-session resume id for this round, and reset it on round 1.
+#
+#   * Round 1 (is_round1 == "1"): start a NEW session — drop any id left behind by
+#     a previous debate in this worktree so we never resume a stale one. Echoes "".
+#   * Later rounds: echo the persisted id (empty if none was captured — the caller
+#     then cleanly cold-starts with the full prompt, never a wedge).
+#
+# Echoing (rather than setting a global) keeps the caller explicit: it captures the
+# id, uses it to choose the warm vs cold prompt, and passes it back to
+# codex_exec_round. Usage: resume_id="$(codex_resolve_session "$id_file" "$round1")"
+codex_resolve_session() {
+  local session_id_file="$1" is_round1="$2"
+  if [ "$is_round1" = "1" ]; then
+    rm -f "$session_id_file"
+    return 0
+  fi
+  if [ -s "$session_id_file" ]; then
+    cat "$session_id_file"
+  fi
+}
+
+# One codex invocation: warm-resume when we have a session id (carries codex's own
+# prior turn), else a cold start. `--json` emits a `thread.started` event carrying
+# codex's thread_id (captured by codex_exec_round to resume next round); it does NOT
+# change the verdict, which `--output-schema`/`-o` still write to "$out". `resume`
+# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
+# the same kernel-enforced policy, set through config instead of the flag.
+#
+# Reads $resume_id, $schema, $out, $effort, $prompt from the enclosing
+# codex_exec_round via bash's dynamic scope (they're `local` there).
+_codex_run_once() {
+  if [ -n "$resume_id" ]; then
+    codex exec resume \
+      -c sandbox_mode="read-only" \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$resume_id" "$prompt"
+  else
+    codex exec \
+      --sandbox read-only \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$prompt"
+  fi
+}
+
+# Run ONE debate round against codex and leave a schema-valid verdict in <out>
+# (also echoed to stdout). Owns the out/log lifecycle, the retry/backoff loop, the
+# thread-id capture, and the error-verdict fallback.
+#
+#   codex_exec_round <schema> <out> <session_id_file> <effort> <resume_id> <prompt>
+#
+# model_reasoning_effort is scoped to the debate here (via -c, from <effort>) rather
+# than the user's global ~/.codex/config.toml — review/answer is the one place we
+# always want codex thinking at full depth, regardless of their default.
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API hiccups,
+# a spurious internal error) and writes no verdict — which would otherwise degrade
+# the round to reviewer-error on a single bad roll. Retry with linear backoff,
+# accepting the first attempt that writes a non-empty verdict to <out>. Only after
+# every attempt fails empty do we synthesize the reviewerError verdict (via the
+# caller's synthesize_error_verdict hook).
+codex_exec_round() {
+  local schema="$1" out="$2" session_id_file="$3" effort="$4" resume_id="$5" prompt="$6"
+  local log="$out.log"
+
+  # The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
+  # it exists before codex tries to write the verdict there.
+  mkdir -p "$(dirname "$out")"
+
+  local attempts="${CODEX_REVIEW_RETRIES:-3}"
+  local backoff="${CODEX_REVIEW_BACKOFF:-5}"
+  # Validate both as positive integers. Left unchecked, a non-numeric value makes the
+  # arithmetic test error every iteration, so the loop would spin forever instead of
+  # giving up. Fall back to the documented defaults (and clamp attempts to >=1)
+  # loudly rather than wedge the headless debate on a typo'd override.
+  if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+    echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+    attempts=3
+  fi
+  if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+    echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+    backoff=5
+  fi
+
+  local n=1 wait_s
+  : >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
+  while :; do
+    rm -f "$out"
+    # Append (not truncate): when every attempt fails, the synthesized error
+    # verdict's tail_log must reflect ALL attempts' diagnostics, not just the last.
+    echo "=== attempt $n/$attempts ===" >>"$log"
+    if ! _codex_run_once </dev/null >>"$log" 2>&1; then
+      echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+    fi
+    # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
+    # make a non-empty "$out" a real, schema-valid verdict, not a partial.
+    [ -s "$out" ] && break
+    # Out of attempts — fall through to the synthesized error verdict.
+    [ "$n" -ge "$attempts" ] && break
+    wait_s=$(( backoff * n ))
+    echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+    n=$(( n + 1 ))
+    sleep "$wait_s"
+  done
+
+  if [ -s "$out" ]; then
+    # Persist codex's session id so the NEXT round can resume this same warm session
+    # (carrying codex's own prior turn). The successful attempt's `thread.started`
+    # is the last one appended to the log; on a resume round it echoes the same id,
+    # so overwriting is a harmless refresh. Failure to capture an id just means next
+    # round cold-starts via the caller's fallback — not fatal.
+    local sid
+    sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+    if [ -n "$sid" ]; then
+      printf '%s\n' "$sid" >"$session_id_file"
+    fi
+  fi
+
+  if [ ! -s "$out" ]; then
+    # codex produced no verdict — hand off to the caller's shape-specific synthesizer
+    # so the debate loop can surface the failure instead of hanging. reviewerError is
+    # the machine-detectable signal the workflow aborts on: a broken/unavailable codex
+    # is INFRASTRUCTURE failure, not substantive disagreement, so it must NOT spin the
+    # loop forever.
+    local tail_log
+    tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
+    synthesize_error_verdict "$out" "$tail_log" "$attempts"
+  fi
+
+  cat "$out"
+}

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 #
 # codex-review.sh — the canonical, deterministic codex invocation for the
-# codex<->claude review debate. Runs the codex CLI as a READ-ONLY reviewer of
-# the current working-tree state against a base branch, constrained to
-# codex-verdict.schema.json, and writes the JSON verdict to <out-json>.
+# codex<->claude review debate (the `review` mode of /codex-debate). Runs the
+# codex CLI as a READ-ONLY reviewer of the current working-tree state against a
+# base branch, constrained to codex-verdict.schema.json, and writes the JSON
+# verdict to <out-json>.
+#
+# This script owns only what is SPECIFIC to reviewing a diff: arg parsing, the
+# warm/cold review prompt text, the verdict schema + session file, and the
+# verdict-shaped error fallback. The shared codex-driving core (read-only exec/
+# resume, retry/backoff, thread-id capture, session persistence) lives in
+# codex-exec-lib.sh.
 #
 # Usage:
 #   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
@@ -17,24 +24,16 @@
 #                    value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
-#   * codex runs under `--sandbox read-only`, which enforces read-only at the
-#     execution boundary (the kernel sandbox blocks file writes and other
-#     state-mutating syscalls), NOT merely by prompt text. codex reviews
-#     arbitrary diffs and could be prompt-injected by file contents, so the
-#     read-only promise must be enforced, not advertised. codex auto-falls-back
-#     to its bundled bubblewrap when the system one is absent, so this works in
-#     containers; `--sandbox read-only` permits read-only command execution
-#     (git diff/status, reading files) but denies writes. `codex exec` is already
-#     non-interactive (approval policy "never"), so a command the sandbox blocks
-#     is denied outright rather than escalating to a prompt that would wedge the
-#     headless loop.
+#   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
+#     read-only at the kernel boundary (file writes and other state-mutating
+#     syscalls denied), NOT merely by prompt text. codex reviews arbitrary diffs and
+#     could be prompt-injected by file contents, so the read-only promise must be
+#     enforced, not advertised.
 #   * Always emits a schema-valid verdict on stdout, even if codex errors — a
 #     synthesized error verdict (approved:false) so the loop never wedges.
-#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
-#     scratch dir; every later round resumes that same session (`codex exec
-#     resume <id>`) so codex retains its OWN prior review + reasoning across rounds
-#     instead of reconstructing it from the diff + rebuttal each time. If the id
-#     was never captured, a later round cleanly falls back to a cold start.
+#   * WARM SESSION: round 1 cold-starts codex and records its session id; every later
+#     round resumes that same session (`codex exec resume <id>`) so codex retains its
+#     OWN prior review + reasoning across rounds.
 set -uo pipefail
 
 base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
@@ -46,21 +45,12 @@ effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
-log="$out.log"
-
-# The out path lives under a per-worktree scratch dir (e.g. .codex-debate/);
-# make sure it exists before codex tries to write the verdict there.
-mkdir -p "$(dirname "$out")"
+# shellcheck source=codex-exec-lib.sh
+source "$here/codex-exec-lib.sh"
 
 # Pull CLAUDE's previous response, if any. Built as a plain string and injected
 # below via a simple variable reference so any special characters in the JSON
-# (backticks, $, ...) stay literal — heredoc expansion results are not re-scanned.
-# Never let a stale verdict from a previous run survive: if the current codex
-# invocation fails to write one, the empty-check below must catch it and
-# synthesize an error verdict (otherwise a leftover /tmp file reads as a fresh
-# pass — a false consensus).
-rm -f "$out" "$log"
-
+# (backticks, $, ...) stay literal (heredoc expansion results are not re-scanned).
 rebuttal=""
 if [ "$rebuttal_file" != "-" ]; then
   if [ -s "$rebuttal_file" ]; then
@@ -89,28 +79,26 @@ $rebuttal
 "
 fi
 
-# WARM SESSION. codex keeps its OWN review + reasoning across rounds by resuming
-# the same codex session instead of cold-starting `codex exec` each round. The
-# session id (codex's thread_id) is persisted in the scratch dir after round 1
-# and reused on every follow-up round, so when CLAUDE disputes a finding codex
-# re-engages with its original rationale rather than reconstructing it from the
-# diff + rebuttal alone.
-#
-#   * Round 1 (rebuttal_file == "-"): fresh `codex exec`; capture thread_id below.
-#   * Later rounds: `codex exec resume <id>` with just the follow-up (rebuttal +
-#     close-out), relying on codex's retained context.
-#   * Fallback: if no id was captured (round-1 capture failed), a later round
-#     cold-starts with the FULL prompt + rebuttal_block — same as before warm
-#     sessions existed — so a missing id degrades gracefully, never wedges.
+# WARM SESSION. Round 1 (rebuttal_file == "-") cold-starts and resets any stale id;
+# later rounds resume codex's own review session. Resolve the id first so the prompt
+# below can lean on codex's retained context when warm.
 session_id_file="$(dirname "$out")/codex-session.id"
-resume_id=""
-if [ "$rebuttal_file" = "-" ]; then
-  # Round 1 of a fresh debate: start a NEW session and drop any session id left
-  # behind by a previous debate in this worktree, so we never resume a stale one.
-  rm -f "$session_id_file"
-elif [ -s "$session_id_file" ]; then
-  resume_id="$(cat "$session_id_file")"
-fi
+[ "$rebuttal_file" = "-" ] && is_round1=1 || is_round1=
+resume_id="$(codex_resolve_session "$session_id_file" "$is_round1")"
+
+# Synthesize codex-review's error verdict shape when codex produces nothing after
+# every attempt (called by codex_exec_round). reviewerError:true is the signal the
+# workflow aborts the debate on.
+synthesize_error_verdict() {
+  local out="$1" tail_log="$2" attempts="$3"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    approved: false,
+    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    findings: [],
+    responseToRebuttal: "",
+    reviewerError: true
+  }' >"$out"
+}
 
 # Two prompts: a lean follow-up for the WARM (resume) path that leans on codex's
 # retained context, and the full review prompt for the COLD path (round 1, or the
@@ -189,110 +177,6 @@ EOF
 )"
 fi
 
-# One codex invocation: warm-resume when we have a session id (carries codex's own
-# prior review), else a cold start. `--json` is added so the run emits a
-# `thread.started` event carrying codex's thread_id, which we capture below to
-# resume next round; it does NOT change the verdict, which `--output-schema`/`-o`
-# still write to "$out". `resume` has no `--sandbox` flag, so read-only is enforced
-# there via `-c sandbox_mode` — the same kernel-enforced policy, set through config
-# instead of the flag.
-run_codex() {
-  if [ -n "$resume_id" ]; then
-    codex exec resume \
-      -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$resume_id" "$prompt"
-  else
-    codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"
-  fi
-}
-
-# model_reasoning_effort is scoped to the debate here (via -c, from the $effort
-# the workflow passes down — default "xhigh") rather than relying on the user's
-# global ~/.codex/config.toml — review is the one place we always want codex
-# thinking at full depth, regardless of their default.
-#
-# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
-# hiccups, a spurious internal error) and writes no verdict — which would
-# otherwise degrade the whole track to reviewer-error on a single bad roll.
-# Retry the invocation with linear backoff, accepting the first attempt that
-# writes a non-empty verdict to "$out". Tunable via env: CODEX_REVIEW_RETRIES
-# (total attempts, default 3), CODEX_REVIEW_BACKOFF (base seconds, default 5 —
-# attempt n waits n*base). Only after every attempt fails empty do we synthesize
-# the reviewerError verdict below.
-attempts="${CODEX_REVIEW_RETRIES:-3}"
-backoff="${CODEX_REVIEW_BACKOFF:-5}"
-# Validate both as positive integers. Left unchecked, a non-numeric value makes
-# the arithmetic `[ "$n" -ge "$attempts" ]` test error every iteration, so the
-# loop would spin forever instead of giving up and synthesizing the reviewerError
-# verdict. Fall back to the documented defaults (and clamp attempts to >=1) loudly
-# rather than wedge the headless debate on a typo'd override.
-if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
-  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
-  attempts=3
-fi
-if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
-  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
-  backoff=5
-fi
-n=1
-: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
-while :; do
-  rm -f "$out"
-  # Append (not truncate): when every attempt fails, the synthesized reviewerError
-  # verdict's tail_log must reflect ALL attempts' diagnostics — surfacing the exact
-  # transient failures this retry loop exists to weather — not just the final one.
-  echo "=== attempt $n/$attempts ===" >>"$log"
-  if ! run_codex </dev/null >>"$log" 2>&1; then
-    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
-  fi
-  # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
-  # make a non-empty "$out" a real, schema-valid verdict, not a partial.
-  [ -s "$out" ] && break
-  # Out of attempts — fall through to the synthesized reviewerError verdict.
-  [ "$n" -ge "$attempts" ] && break
-  wait_s=$(( backoff * n ))
-  echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
-  n=$(( n + 1 ))
-  sleep "$wait_s"
-done
-
-if [ -s "$out" ]; then
-  # Persist codex's session id so NEXT round can resume this same warm session
-  # (carrying codex's own prior review + reasoning). The successful attempt's
-  # `thread.started` is the last one appended to the log; on a resume round it
-  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
-  # an id just means next round cold-starts via the fallback above — not fatal.
-  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
-  if [ -n "$sid" ]; then
-    printf '%s\n' "$sid" >"$session_id_file"
-  fi
-fi
-
-if [ ! -s "$out" ]; then
-  # codex produced no verdict — synthesize a schema-valid error verdict so the
-  # debate loop can surface the failure instead of hanging. The reviewerError
-  # flag is the machine-detectable signal the workflow uses to abort with a
-  # terminal failure: a broken/unavailable codex is INFRASTRUCTURE failure, not
-  # substantive disagreement, so it must NOT be routed to Claude (there are no
-  # findings to act on) and must NOT spin the loop forever.
-  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
-    approved: false,
-    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
-    findings: [],
-    responseToRebuttal: "",
-    reviewerError: true
-  }' >"$out"
-fi
-
-cat "$out"
+# Drive codex for this round (retry/backoff, thread capture, error fallback) — the
+# shared core does the work; this script supplied the prompt, schema, and shapes.
+codex_exec_round "$schema" "$out" "$session_id_file" "$effort" "$resume_id" "$prompt"

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -1,34 +1,47 @@
 ---
 name: codex-debate
-description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, for code review) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg) — Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
-argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
+description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two explicit subcommands. `review` (also the bare/back-compat default) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. `answer` — Claude and codex each answer a freeform prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
+argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  answer \"<prompt>\""
 ---
 
 # Codex ⇄ Claude debate
 
 This skill runs an automated debate between **codex** and **Claude** that loops to
-consensus with no round cap and no deadlock exit. It has **two modes**, chosen by
-the argument:
+consensus with no round cap and no deadlock exit. It has **two modes**, selected by
+an **explicit leading subcommand** — never by guessing from the argument's shape:
 
-- **Review mode** (default) — the original behavior. codex reviews the current
-  diff, a Claude author fixes/disputes, round after round until they agree, and the
-  trail is committed + posted to the PR. This is everything from
+- **`review`** — codex reviews the current diff, a Claude author fixes/disputes,
+  round after round until they agree, and the trail is **committed + posted to the
+  PR** (a mutating, outward-facing mode). This is everything from
   [Review mode](#review-mode) down.
-- **Answer mode** — triggered when you pass a **freeform prompt** instead of a PR
-  number/flags. Claude and codex **each answer the prompt in parallel**, then
-  **cross-check each other** until both agree, and a **unified answer** is returned
-  to you (plus a saved transcript). See [Answer mode](#answer-mode).
+- **`answer`** — Claude and codex **each answer a freeform prompt in parallel**,
+  then **cross-check each other** until both agree, and a **unified answer** is
+  returned to you (read-only; plus a saved transcript). See
+  [Answer mode](#answer-mode).
+
+The two modes have **different side-effect contracts** (review mutates + writes to
+the PR; answer is read-only), so the mode is chosen **explicitly**, not inferred
+from whether the argument looks like a PR number or like prose. Inferring a
+mutating action from prose shape is exactly the coupling this design avoids.
 
 ## Mode detection (do this first)
 
-Parse `$ARGUMENTS`:
+Look at the **first whitespace-delimited token** of `$ARGUMENTS`:
 
-- **No args, OR the first non-flag token is a number** (a PR number), OR the only
-  args are the review flags (`--base`, `--no-commit`, `--no-comment`) → **review
-  mode**. Continue with [Review mode](#review-mode) below.
-- **The args are a freeform prompt** (any quoted string, a question, or prose that
-  isn't a bare PR number) → **answer mode**. Jump to [Answer mode](#answer-mode);
-  the review-mode steps do not apply.
+- **`answer`** → **answer mode**. The prompt is everything after the `answer`
+  token. Jump to [Answer mode](#answer-mode); the review-mode steps do not apply.
+- **`review`** → **review mode**. The remaining args are the review grammar
+  (`[<pr-number>] [--base …] [--no-commit] [--no-comment]`). Continue with
+  [Review mode](#review-mode).
+- **No args, OR the first token is a number (a PR number) or a `--flag`** →
+  **review mode** (the backward-compatible bare alias for the original
+  `/codex-debate [<pr>] [flags]`, so existing callers like `/be-review` keep
+  working). Continue with [Review mode](#review-mode).
+- **Anything else** (freeform prose with no recognized subcommand) → **ambiguous**.
+  Do **not** guess — ask the user to pick an explicit mode and stop, e.g.: "Did you
+  mean `/codex-debate answer \"<your prompt>\"` (read-only) or `/codex-debate review
+  [<pr>] [flags]` (mutating)?" Only the safe, backward-compatible review grammar
+  auto-routes; prose never silently triggers a mode.
 
 Both modes require Claude Code's **`Workflow` tool** (the engine). Under
 codex/opencode runtimes the skill is inert.
@@ -72,7 +85,9 @@ codex/opencode runtimes the skill is inert.
 
 ## Arguments
 
-Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
+A leading `review` subcommand token, if present, is consumed by mode detection;
+what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]` (the
+bare alias passes the whole argument string through unchanged). Parse:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -243,8 +258,8 @@ the loop ends only when **both** sides report no remaining disagreement. There i
 ### A1. Resolve context
 
 - Determine `repoPath` (the worktree root, normally the cwd).
-- Capture the **prompt**: everything in `$ARGUMENTS` (strip surrounding quotes). If
-  it's empty, ask the user what they want answered and stop.
+- Capture the **prompt**: everything **after the `answer` subcommand token** (strip
+  surrounding quotes). If it's empty, ask the user what they want answered and stop.
 - **Preflight codex**: `codex login status`. If not logged in, stop and tell the
   user to run `codex login` (suggest the `!` prefix to do it in-session).
 - No `git fetch` / base resolution / `gh pr checkout` here — answer mode doesn't
@@ -380,19 +395,26 @@ returns:
 
 ## Files
 
+Shared:
+
+- `scripts/codex-exec-lib.sh` — the sourced core both modes share: the read-only
+  `codex exec`/`resume` invocation, warm-session resolve/persist, retry/backoff,
+  thread-id capture, and the synthesized error-verdict fallback (via a caller hook).
+  The two mode scripts source this and add only their own prompts + verdict shape.
+
 Review mode:
 
 - `debate.workflow.js` — the Workflow script (the loop + consensus logic).
-- `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation
-  (cold-starts round 1, `codex exec resume`s the warm session thereafter).
+- `scripts/codex-review.sh` — the review-specific invocation (arg parsing, the
+  review prompts, the verdict schema/session file, the verdict-shaped error).
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
 
 Answer mode:
 
 - `answer.workflow.js` — the Workflow script for the symmetric answer-debate
   (parallel answers → cross-check loop to agreement → synthesis).
-- `scripts/codex-answer.sh` — the canonical, deterministic `codex exec` invocation
-  for answering a prompt as a read-only peer (warm session across cross-check rounds).
+- `scripts/codex-answer.sh` — the answer-specific invocation (arg parsing, the
+  answer prompts, the answer schema/session file, the answer-shaped error).
 - `scripts/codex-answer.schema.json` — the JSON Schema codex's answer is constrained to.
 
 These are generated from `.apm/skills/codex-debate/`; edit the source there and

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-debate
-description: Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, code-review): codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg): Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".
+description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, for code review) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg) — Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
 argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
 ---
 

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -291,17 +291,21 @@ per-worktree `<repoPath>/.codex-debate/`, so parallel debates never collide. It
 returns:
 
 ```
-{ status: "consensus" | "reviewer-error" | "agent-error" | "no-prompt",
+{ status: "consensus" | "reviewer-error" | "agent-error" | "synthesis-error" | "no-prompt",
   rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
 ```
 
-- **consensus** — the only normal terminus: both sides agreed, and `finalAnswer`
-  is the synthesized unified answer. `transcriptPath` points at the saved
-  Markdown transcript (`.codex-debate/answer-<slug>.md`).
+- **consensus** — the only normal terminus: both sides agreed (for two consecutive
+  rounds — see the convergence note), and `finalAnswer` is the synthesized unified
+  answer. `transcriptPath` points at the saved Markdown transcript
+  (`.codex-debate/answer-<slug>.md`).
 - **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
   CLI) after retries; `codexError` carries the failure detail. Infrastructure
   failure, not a debate outcome.
 - **agent-error** — one side died on a terminal API error after retries.
+- **synthesis-error** — both sides DID agree, but the final synthesis pass produced
+  no answer (the synthesis agent died or returned empty). Not a successful answer —
+  report it as a failure (there is agreement on record, only the merge failed).
 - **no-prompt** — the prompt was empty (shouldn't happen if A1 guarded it).
 
 ### A3. Present the result
@@ -321,10 +325,17 @@ returns:
 
 ## Answer-mode safety & notes
 
-- **Both peers read-only.** codex runs under `--sandbox read-only` (kernel-
-  enforced, belt-and-suspenders with the prompt text — it reads arbitrary repo
-  files and could be prompt-injected); the Claude peer is instructed to read but
-  never edit. No mode of this debate writes to the repo.
+- **Both peers read-only — but enforced ASYMMETRICALLY.** codex runs under
+  `--sandbox read-only` (kernel-enforced, belt-and-suspenders with the prompt text —
+  it reads arbitrary repo files and could be prompt-injected). The **Claude peer is
+  only prompt-enforced**: the harness's `agent()` exposes no sandbox/tool restriction
+  (the same is true of every Claude reviewer in `/lens-debate` and review mode), so
+  Claude's read-only behaviour rests on instruction, not a kernel guard. A
+  prompt-injected or mistaken Claude agent *could* in principle edit files or run a
+  git write — answer mode does not, and cannot here, harden against that the way it
+  does for codex. If that risk matters for a given prompt, run the debate in a
+  disposable/read-only worktree. Treat the read-only guarantee as **hard for codex,
+  best-effort for Claude.**
 - **Warm codex session.** Round 1 cold-starts `codex exec`; every later round
   resumes the same session (`codex exec resume`) so codex cross-checks from its own
   prior answer rather than reconstructing it. The session id lives in the
@@ -332,10 +343,18 @@ returns:
   so it never collides with review mode's session), degrading gracefully to a cold
   start if capture ever fails.
 - **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
-  `objections`; the loop ends only when both sides agree, with no round cap and no
-  deadlock exit. Because the two run in parallel each round, agreement is on the
-  prior round's answers — safe (it only ever ends on real agreement), at worst one
-  round later than a serial handoff.
+  `objections`; a side counts as agreeing only when it sets `agreesWithOther:true`
+  AND leaves no objection, so a stray objection can't be papered over by an
+  over-eager boolean. The loop ends only when both sides agree, with no round cap and
+  no deadlock exit. Because the two run in parallel each round, a single
+  mutually-agreeing round can be a **swap false positive** (Claude adopts codex's
+  prior answer while codex adopts Claude's — both report agreement, but their current
+  outputs are swapped and may still differ). So convergence requires **two
+  consecutive** mutually-agreeing rounds: after the first, each side cross-checks the
+  other's just-agreed answer, and only if both still agree — having now seen each
+  other's current answers — does the loop stop. A real swap surfaces a fresh
+  objection in that confirmation round. Convergence is thus on answers both sides
+  have actually seen — safe, at worst two rounds later than a serial handoff.
 - **Chat + saved transcript, no outward writes.** The unified answer is presented
   in chat and the full transcript is saved to the gitignored
   `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -295,10 +295,10 @@ returns:
   rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
 ```
 
-- **consensus** — the only normal terminus: both sides agreed (for two consecutive
-  rounds — see the convergence note), and `finalAnswer` is the synthesized unified
-  answer. `transcriptPath` points at the saved Markdown transcript
-  (`.codex-debate/answer-<slug>.md`).
+- **consensus** — the only normal terminus: both sides agreed and then both
+  **approved the synthesized candidate** (see the convergence note), and
+  `finalAnswer` is that approved unified answer. `transcriptPath` points at the saved
+  Markdown transcript (`.codex-debate/answer-<slug>.md`).
 - **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
   CLI) after retries; `codexError` carries the failure detail. Infrastructure
   failure, not a debate outcome.
@@ -342,19 +342,23 @@ returns:
   gitignored per-worktree `.codex-debate/` (a distinct `codex-answer-session.id`,
   so it never collides with review mode's session), degrading gracefully to a cold
   start if capture ever fails.
-- **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
-  `objections`; a side counts as agreeing only when it sets `agreesWithOther:true`
-  AND leaves no objection, so a stray objection can't be papered over by an
-  over-eager boolean. The loop ends only when both sides agree, with no round cap and
-  no deadlock exit. Because the two run in parallel each round, a single
-  mutually-agreeing round can be a **swap false positive** (Claude adopts codex's
-  prior answer while codex adopts Claude's — both report agreement, but their current
-  outputs are swapped and may still differ). So convergence requires **two
-  consecutive** mutually-agreeing rounds: after the first, each side cross-checks the
-  other's just-agreed answer, and only if both still agree — having now seen each
-  other's current answers — does the loop stop. A real swap surfaces a fresh
-  objection in that confirmation round. Convergence is thus on answers both sides
-  have actually seen — safe, at worst two rounds later than a serial handoff.
+- **Symmetric convergence, schema-detected, candidate-confirmed.** Each side emits
+  `agreesWithOther` + `objections`; a side counts as agreeing only when it sets
+  `agreesWithOther:true` AND leaves no objection, so a stray objection can't be
+  papered over by an over-eager boolean. Because the two run in parallel each round,
+  a single mutually-agreeing round can be a **swap false positive** (Claude adopts
+  codex's prior answer while codex adopts Claude's — both report agreement, but their
+  current outputs are swapped and still differ), and they can keep swapping back and
+  forth, so counting consecutive parallel agreements does **not** prove the current
+  outputs match. The only sound test is to make both sides judge **one shared piece
+  of text**. So when a round shows mutual agreement, the workflow synthesizes a single
+  **candidate** from the two agreed answers and runs a **confirmation phase**: both
+  sides review that *identical* candidate (without rewriting their own answer) and
+  either approve it or object. Approval is on one fixed text both actually saw, so no
+  swap is possible; if both approve, that candidate is the converged answer — already
+  signed off by both debaters (which is also why `finalAnswer` is never unapproved
+  synthesized text). If either objects, the candidate is dropped and the cross-check
+  loop resumes with the objections folded in. No round cap, no deadlock exit.
 - **Chat + saved transcript, no outward writes.** The unified answer is presented
   in chat and the full transcript is saved to the gitignored
   `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -1,10 +1,40 @@
 ---
 name: codex-debate
-description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus — no round cap, no deadlock exit. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
-argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]"
+description: Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, code-review): codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg): Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".
+argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
 ---
 
-# Codex ⇄ Claude review debate
+# Codex ⇄ Claude debate
+
+This skill runs an automated debate between **codex** and **Claude** that loops to
+consensus with no round cap and no deadlock exit. It has **two modes**, chosen by
+the argument:
+
+- **Review mode** (default) — the original behavior. codex reviews the current
+  diff, a Claude author fixes/disputes, round after round until they agree, and the
+  trail is committed + posted to the PR. This is everything from
+  [Review mode](#review-mode) down.
+- **Answer mode** — triggered when you pass a **freeform prompt** instead of a PR
+  number/flags. Claude and codex **each answer the prompt in parallel**, then
+  **cross-check each other** until both agree, and a **unified answer** is returned
+  to you (plus a saved transcript). See [Answer mode](#answer-mode).
+
+## Mode detection (do this first)
+
+Parse `$ARGUMENTS`:
+
+- **No args, OR the first non-flag token is a number** (a PR number), OR the only
+  args are the review flags (`--base`, `--no-commit`, `--no-comment`) → **review
+  mode**. Continue with [Review mode](#review-mode) below.
+- **The args are a freeform prompt** (any quoted string, a question, or prose that
+  isn't a bare PR number) → **answer mode**. Jump to [Answer mode](#answer-mode);
+  the review-mode steps do not apply.
+
+Both modes require Claude Code's **`Workflow` tool** (the engine). Under
+codex/opencode runtimes the skill is inert.
+
+<a id="review-mode"></a>
+# Review mode — Codex ⇄ Claude review debate
 
 Automate the back-and-forth you'd otherwise courier by hand: **codex** (the
 reviewer) critiques the current change, a **Claude subagent** (the author)
@@ -188,7 +218,115 @@ the per-round commits sit on the local branch for the human to review):
   outward-facing write — on by default because the whole point is to leave the
   review trail on the PR; `--no-comment` suppresses it.
 
-## Safety & notes
+<a id="answer-mode"></a>
+# Answer mode — Codex ⇄ Claude answer debate
+
+When the argument is a **freeform prompt** (not a PR number/flags), the skill
+generalizes the same debate machinery from *reviewing a diff* to *answering a
+question*. The shape is **symmetric**, not author⇄reviewer: **Claude and codex are
+two equal peers**. They each answer the prompt **independently and in parallel**,
+then **cross-check each other's answer** round after round — conceding where the
+other is right, holding firm (with evidence) where it isn't — **until both agree**.
+A final pass **synthesizes their two converged answers into one unified reply**,
+which you present to the user along with a saved transcript.
+
+Both peers are **codebase-aware but read-only**: each may read this repo (`git
+diff/log`, read files, grep) to ground its answer, but neither edits anything —
+codex stays under `--sandbox read-only` (kernel-enforced), and the Claude peer is
+instructed not to write. Consensus is **schema-detected in code**: each side emits
+a structured answer with an `agreesWithOther` boolean and an `objections` list, and
+the loop ends only when **both** sides report no remaining disagreement. There is
+**no round cap and no deadlock exit** — same as review mode.
+
+## Steps
+
+### A1. Resolve context
+
+- Determine `repoPath` (the worktree root, normally the cwd).
+- Capture the **prompt**: everything in `$ARGUMENTS` (strip surrounding quotes). If
+  it's empty, ask the user what they want answered and stop.
+- **Preflight codex**: `codex login status`. If not logged in, stop and tell the
+  user to run `codex login` (suggest the `!` prefix to do it in-session).
+- No `git fetch` / base resolution / `gh pr checkout` here — answer mode doesn't
+  diff a branch.
+
+### A2. Run the answer Workflow
+
+Invoke the **`Workflow` tool** pointing at this skill's committed answer script,
+passing the prompt through `args`:
+
+```
+Workflow({
+  scriptPath: ".claude/skills/codex-debate/answer.workflow.js",
+  args: {
+    repoPath: "<worktree root>",   // also the per-worktree scratch dir root
+    prompt: "<the user's freeform prompt, verbatim>",
+    skillDir: ".claude/skills/codex-debate"
+  }
+})
+```
+
+The workflow runs in the background and notifies you when it completes. It runs an
+**Answer** phase (round 1: `claude:round1` and `codex:round1` in parallel), a
+**Reconcile** phase (rounds 2+: each side cross-checks the other, in parallel,
+round after round), and a **Synthesis** phase that merges the two agreed answers.
+Watch live via `/workflows`. Ephemeral scratch (per-side answers, cross-check
+files, per-round sections, the saved transcript) lives under the gitignored,
+per-worktree `<repoPath>/.codex-debate/`, so parallel debates never collide. It
+returns:
+
+```
+{ status: "consensus" | "reviewer-error" | "agent-error" | "no-prompt",
+  rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
+```
+
+- **consensus** — the only normal terminus: both sides agreed, and `finalAnswer`
+  is the synthesized unified answer. `transcriptPath` points at the saved
+  Markdown transcript (`.codex-debate/answer-<slug>.md`).
+- **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
+  CLI) after retries; `codexError` carries the failure detail. Infrastructure
+  failure, not a debate outcome.
+- **agent-error** — one side died on a terminal API error after retries.
+- **no-prompt** — the prompt was empty (shouldn't happen if A1 guarded it).
+
+### A3. Present the result
+
+- If `status === "consensus"`: present **`finalAnswer`** to the user as the answer
+  — this is the unified reply both Claude and codex agreed on. State **how many
+  rounds** it took to converge and that **codex answered at `reasoningEffort`**
+  (read it off the return value). Point the user at the saved transcript
+  (`transcriptPath`) for the full convergence trail; optionally `cat` the
+  `.codex-debate/answer-section-*.md` files to show a compact per-round summary
+  (each side's answer, what changed, remaining objections). This mode makes **no
+  outward-facing writes** — no PR comment, no commits — it just answers.
+- If `status !== "consensus"`: report it as a **failure**, not an answer. Surface
+  `codexError` (for `reviewer-error`) or the workflow log so the user sees what
+  broke, and tell them how to fix it (e.g. `codex login`) and re-run. Do **not**
+  present a half-debate as if it were an agreed answer.
+
+## Answer-mode safety & notes
+
+- **Both peers read-only.** codex runs under `--sandbox read-only` (kernel-
+  enforced, belt-and-suspenders with the prompt text — it reads arbitrary repo
+  files and could be prompt-injected); the Claude peer is instructed to read but
+  never edit. No mode of this debate writes to the repo.
+- **Warm codex session.** Round 1 cold-starts `codex exec`; every later round
+  resumes the same session (`codex exec resume`) so codex cross-checks from its own
+  prior answer rather than reconstructing it. The session id lives in the
+  gitignored per-worktree `.codex-debate/` (a distinct `codex-answer-session.id`,
+  so it never collides with review mode's session), degrading gracefully to a cold
+  start if capture ever fails.
+- **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
+  `objections`; the loop ends only when both sides agree, with no round cap and no
+  deadlock exit. Because the two run in parallel each round, agreement is on the
+  prior round's answers — safe (it only ever ends on real agreement), at worst one
+  round later than a serial handoff.
+- **Chat + saved transcript, no outward writes.** The unified answer is presented
+  in chat and the full transcript is saved to the gitignored
+  `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits
+  or posts to a PR.
+
+## Safety & notes (review mode)
 
 - **codex runs read-only — enforced, not just asked.** codex is invoked with
   `--sandbox read-only`, so the kernel sandbox blocks file writes and other
@@ -242,10 +380,20 @@ the per-round commits sit on the local branch for the human to review):
 
 ## Files
 
+Review mode:
+
 - `debate.workflow.js` — the Workflow script (the loop + consensus logic).
 - `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation
   (cold-starts round 1, `codex exec resume`s the warm session thereafter).
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
+
+Answer mode:
+
+- `answer.workflow.js` — the Workflow script for the symmetric answer-debate
+  (parallel answers → cross-check loop to agreement → synthesis).
+- `scripts/codex-answer.sh` — the canonical, deterministic `codex exec` invocation
+  for answering a prompt as a read-only peer (warm session across cross-check rounds).
+- `scripts/codex-answer.schema.json` — the JSON Schema codex's answer is constrained to.
 
 These are generated from `.apm/skills/codex-debate/`; edit the source there and
 run `just ai apm` to regenerate.

--- a/.apm/skills/codex-debate/answer.workflow.js
+++ b/.apm/skills/codex-debate/answer.workflow.js
@@ -153,16 +153,20 @@ async function codexAnswers(round, other) {
       : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
 
 ${JSON.stringify(other, null, 2)}`
+  // Every path below is spliced into a shell command the runner agent executes, so
+  // POSIX-quote each one (worktrees or skill dirs with spaces/metacharacters would
+  // otherwise break the command or misdirect it). The Write-tool file CONTENTS
+  // (${prompt}, ${JSON.stringify(other)}) are not shell-parsed and stay verbatim.
   const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
 
 ${prompt}
 
 ${crossStep}
 
 3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-answer.sh ${promptPath} ${crossArg} ${answerPath} ${REASONING_EFFORT}\`
+   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}\`
 
    This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
 
@@ -254,17 +258,32 @@ let status = 'consensus'
 let claudeAns = null
 let codexAns = null
 
+// A side "agrees" only when it BOTH set agreesWithOther AND left no objection. The
+// boolean and the objections list must be consistent (the schema says so), but a
+// model can set the flag while still listing a disagreement; honour the objections
+// too so a leftover objection can't be papered over by an over-eager boolean.
+const sideAgrees = (a) => a.agreesWithOther === true && (a.objections || []).length === 0
+
 // ---------------------------------------------------------------------------
 // The loop — round 1 is the independent answer (parallel); rounds 2+ are
-// cross-checks. Runs until BOTH sides agree. No round cap, no deadlock exit:
-// each side keeps cross-checking until they converge (the harness's per-workflow
-// agent backstop is the only hard ceiling — interrupt via /workflows or TaskStop).
+// cross-checks. Runs until BOTH sides agree, then ONE confirmation round. No round
+// cap, no deadlock exit: each side keeps cross-checking until they converge (the
+// harness's per-workflow agent backstop is the only hard ceiling — interrupt via
+// /workflows or TaskStop).
 //
-// Both sides run in PARALLEL each round, so in round N each cross-checks the
-// OTHER's round-(N-1) answer. Convergence is thus mutual agreement on the prior
-// round's answers — safe (it can only end on real agreement, never prematurely),
-// at worst one round later than a strictly-serial handoff would.
+// Both sides run in PARALLEL each round, so in round N each cross-checks the OTHER's
+// round-(N-1) answer. That parallelism creates a SWAP hazard: if Claude adopts
+// codex's prior answer while codex simultaneously adopts Claude's prior answer, both
+// can report agreesWithOther:true in the SAME round even though their CURRENT outputs
+// are swapped and may still differ. So a single mutually-agreeing round is NOT
+// sufficient. We require TWO CONSECUTIVE mutually-agreeing rounds: after the first,
+// each side runs once more and now cross-checks the OTHER's just-agreed answer; only
+// if both still agree (having seen each other's current answers) do we converge. A
+// real swap surfaces a fresh objection in that confirmation round; genuine agreement
+// holds. Convergence is therefore on answers both sides have actually seen — safe,
+// at worst two rounds later than a strictly-serial handoff would be.
 // ---------------------------------------------------------------------------
+let agreedStreak = 0
 for (let round = 1; ; round++) {
   const prevClaude = claudeAns
   const prevCodex = codexAns
@@ -299,14 +318,23 @@ for (let round = 1; ; round++) {
   await writeSection(entry)
 
   // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
-  // remaining disagreement with the other's latest answer.
-  if (round >= 2 && claude.agreesWithOther === true && codex.agreesWithOther === true) {
-    log(`Round ${round}: both sides agree — converged.`)
+  // remaining disagreement — agreesWithOther:true AND no objections. One such round
+  // can be a parallel-swap false positive (see the loop header), so require TWO in a
+  // row: the second round has each side cross-check the other's just-agreed answer,
+  // confirming on outputs both have actually seen.
+  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
+  agreedStreak = bothAgree ? agreedStreak + 1 : 0
+  if (agreedStreak >= 2) {
+    log(`Round ${round}: both sides agree for a second consecutive round — converged.`)
     break
   }
-  log(
-    `Round ${round}: claude agrees=${!!claude.agreesWithOther} (objections=${(claude.objections || []).length}), codex agrees=${!!codex.agreesWithOther} (objections=${(codex.objections || []).length})`,
-  )
+  if (bothAgree) {
+    log(`Round ${round}: both sides agree — running one confirmation round before converging.`)
+  } else {
+    log(
+      `Round ${round}: claude agrees=${sideAgrees(claude)} (objections=${(claude.objections || []).length}), codex agrees=${sideAgrees(codex)} (objections=${(codex.objections || []).length})`,
+    )
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -331,7 +359,16 @@ ${JSON.stringify(codexAns, null, 2)}
 Return the unified answer in \`answer\`.`,
     { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
   )
-  finalAnswer = synth ? synth.answer : null
+  finalAnswer = synth && synth.answer ? synth.answer : null
+  // Synthesis is the user-facing payload of a consensus run. If the synthesis agent
+  // died (null) or returned an empty answer, there is no answer to present — do NOT
+  // keep reporting "consensus" with finalAnswer:null, which A3 would mis-handle as a
+  // successful answer. Demote to an explicit failure terminus so the skill surfaces
+  // it as broken (the sides DID agree; only the final merge failed).
+  if (!finalAnswer) {
+    status = 'synthesis-error'
+    log('Synthesis produced no answer — both sides agreed but the merge failed; reporting synthesis-error.')
+  }
 }
 
 log(`Answer-debate ended: ${status} after ${transcript.length} round(s).`)

--- a/.apm/skills/codex-debate/answer.workflow.js
+++ b/.apm/skills/codex-debate/answer.workflow.js
@@ -362,6 +362,12 @@ return {
   transcriptPath: answerDocPath,
   finalAnswer,
   reasoningEffort: REASONING_EFFORT,
-  // The error terminus carries codex's failure detail in its answer text.
-  codexError: status === 'reviewer-error' ? (codexAns && codexAns.answer) || null : null,
+  // The error terminus carries codex's failure detail in the synthesized verdict's
+  // answer text. Sourced from the transcript (not codexAns) because the
+  // reviewer-error branch breaks BEFORE assigning codexAns — the failing round is
+  // recorded in the transcript, so read the detail back from there.
+  codexError:
+    status === 'reviewer-error'
+      ? transcript.find((e) => e.codex && e.codex.reviewerError)?.codex.answer || null
+      : null,
 }

--- a/.apm/skills/codex-debate/answer.workflow.js
+++ b/.apm/skills/codex-debate/answer.workflow.js
@@ -25,12 +25,10 @@ const workDir = `${repoPath}/.codex-debate`
 
 // Model tiers. The claude-answer round does real reasoning (answering, then
 // cross-checking codex) → `model` (Opus). The final synthesis is also user-facing
-// prose, so it runs on `model` too. The codex RUNNER must relay codex's answer
-// JSON faithfully (a verbatim copy, not a paraphrase — the weakest tier corrupts
-// it silently) → `copyModel` (Sonnet). The file writers/assemblers are mechanical
-// → `mechModel` (Haiku). Defaults match a direct invocation.
+// prose, so it runs on `model` too. The codex RUNNER and the transcript writer must
+// relay text faithfully (a verbatim copy, not a paraphrase — the weakest tier
+// corrupts it silently) → `copyModel` (Sonnet). Defaults match a direct invocation.
 const model = a.model || 'opus'
-const mechModel = a.mechModel || 'haiku'
 const copyModel = a.copyModel || 'sonnet'
 
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
@@ -296,33 +294,7 @@ function renderTranscript(transcript, meta, finalAnswer) {
   return parts.join('\n\n')
 }
 
-// Zero-pad the round so the section glob sorts in round order for the assembly.
-const sectionFile = (round) => `${workDir}/answer-section-${String(round).padStart(3, '0')}.md`
-
-// Write ONE round's section to its own small file (Haiku-safe — just this round).
-async function writeSection(entry) {
-  const text = roundSection(entry)
-  const path = sectionFile(entry.round)
-  const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
-2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
-
-${text}`
-  return agent(p, { label: `section:round${entry.round}`, phase: 'Reconcile', model: mechModel })
-}
-
-// ---------------------------------------------------------------------------
-// Set up scratch — clear any stale per-round sections from a PRIOR debate in this
-// worktree so they don't leak into the assembled transcript. Scoped to the
-// answer-section files; the review mode's section-NNN.md and the verdict/answer
-// JSONs keep their own lifecycle.
-// ---------------------------------------------------------------------------
 phase('Answer')
-await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/answer-section-*.md\`. Do not edit any other file. Do not run git.`,
-  { label: 'sections:reset', phase: 'Answer', model: mechModel },
-)
 
 const transcript = []
 let status = 'consensus'
@@ -431,7 +403,6 @@ for (let round = 1; ; round++) {
     ? { round, claude, codex, confirming: true, candidate: pendingCandidate }
     : { round, claude, codex }
   transcript.push(entry)
-  await writeSection(entry)
 
   // CONFIRMATION phase: both sides judged the SAME synthesized candidate. If both
   // approve it (agreesWithOther:true + no objections), that candidate is the agreed,

--- a/.apm/skills/codex-debate/answer.workflow.js
+++ b/.apm/skills/codex-debate/answer.workflow.js
@@ -135,11 +135,45 @@ Return the schema:
   })
 }
 
+// A confirmation/approval turn for ONE side, judging a SINGLE shared candidate
+// answer (the synthesized merge) WITHOUT rewriting its own. Both sides judge the
+// IDENTICAL text, so no swap/oscillation is possible (the swap hazard exists only
+// because each parallel round adopts the OTHER's separate answer). Returns
+// `agreesWithOther` + `objections` against that candidate. Claude runs it directly
+// (it's read-only reasoning); codex runs it through the same cross-check machinery
+// (the candidate is handed to it as "CLAUDE's latest answer" to approve).
+async function claudeConfirms(round, candidate) {
+  const prompt_ = `You and CODEX were asked the SAME question, debated, and AGREED. A unified candidate answer has been synthesized from your two agreed answers. Your ONLY job now is to APPROVE it or object — do NOT rewrite it, do NOT produce a new answer of your own.
+
+You may inspect the repo at \`${repoPath}\` to verify (READ-ONLY — \`git -C ${repoPath} diff/log\`, read files, grep; do NOT edit/create/delete or run any git write).
+
+The question:
+${prompt}
+
+The candidate unified answer to approve:
+${candidate}
+
+Return the schema:
+  - answer: echo the candidate VERBATIM (you are approving it, not rewriting it).
+  - keyPoints: the core claims the candidate rests on.
+  - objections: anything the candidate gets wrong, drops, or overstates relative to what you agreed — empty if you approve it as-is. Be specific (file:line for repo claims).
+  - changedMind: empty (you are confirming, not revising).
+  - agreesWithOther: true ONLY if you approve the candidate as a correct, complete unified answer with NO objection left.`
+  return agent(prompt_, {
+    label: `claude:confirm${round}`,
+    phase: 'Synthesis',
+    model,
+    schema: ANSWER_SCHEMA,
+  })
+}
+
 // CODEX answers/cross-checks via codex-answer.sh (warm session across rounds). The
 // agent here is a MECHANICAL RUNNER: it writes the prompt + cross-check files,
 // shells out to the script, and relays codex's JSON answer verbatim — it does NOT
 // answer the question itself. The user's prompt and CLAUDE's latest answer carry
 // arbitrary characters, so they're written with the Write tool, never a heredoc.
+// On a confirmation turn (`confirm`), the cross-check input is the SINGLE shared
+// candidate, and the runner relays codex's approval/objections to it.
 async function codexAnswers(round, other) {
   const answerPath = `${workDir}/answer-codex-${round}.json`
   const promptPath = `${workDir}/answer-prompt.txt`
@@ -234,7 +268,7 @@ async function writeSection(entry) {
   const path = sectionFile(entry.round)
   const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
 2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
 ${text}`
@@ -264,32 +298,70 @@ let codexAns = null
 // too so a leftover objection can't be papered over by an over-eager boolean.
 const sideAgrees = (a) => a.agreesWithOther === true && (a.objections || []).length === 0
 
+// Synthesize a SINGLE candidate answer from the two agreed answers. This is the
+// user-facing unified reply, but it is NOT returned until BOTH sides approve it (the
+// confirmation phase below), so the synthesized text is never reported as consensus
+// without both debaters having signed off on it. Returns the candidate string, or
+// null if the synthesis agent died / returned empty.
+async function synthesize(claudeFinal, codexFinal) {
+  const synth = await agent(
+    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
+
+The question:
+${prompt}
+
+Claude's final answer (JSON):
+${JSON.stringify(claudeFinal, null, 2)}
+
+Codex's final answer (JSON):
+${JSON.stringify(codexFinal, null, 2)}
+
+Return the unified answer in \`answer\`.`,
+    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
+  )
+  return synth && synth.answer ? synth.answer : null
+}
+
 // ---------------------------------------------------------------------------
 // The loop — round 1 is the independent answer (parallel); rounds 2+ are
-// cross-checks. Runs until BOTH sides agree, then ONE confirmation round. No round
-// cap, no deadlock exit: each side keeps cross-checking until they converge (the
-// harness's per-workflow agent backstop is the only hard ceiling — interrupt via
-// /workflows or TaskStop).
+// cross-checks. Runs until BOTH sides agree, then a CONFIRMATION phase on a single
+// synthesized candidate. No round cap, no deadlock exit: each side keeps
+// cross-checking until they converge (the harness's per-workflow agent backstop is
+// the only hard ceiling — interrupt via /workflows or TaskStop).
 //
 // Both sides run in PARALLEL each round, so in round N each cross-checks the OTHER's
-// round-(N-1) answer. That parallelism creates a SWAP hazard: if Claude adopts
-// codex's prior answer while codex simultaneously adopts Claude's prior answer, both
-// can report agreesWithOther:true in the SAME round even though their CURRENT outputs
-// are swapped and may still differ. So a single mutually-agreeing round is NOT
-// sufficient. We require TWO CONSECUTIVE mutually-agreeing rounds: after the first,
-// each side runs once more and now cross-checks the OTHER's just-agreed answer; only
-// if both still agree (having seen each other's current answers) do we converge. A
-// real swap surfaces a fresh objection in that confirmation round; genuine agreement
-// holds. Convergence is therefore on answers both sides have actually seen — safe,
-// at worst two rounds later than a strictly-serial handoff would be.
+// round-(N-1) answer. That parallelism creates a SWAP/OSCILLATION hazard: if Claude
+// adopts codex's prior answer while codex simultaneously adopts Claude's prior
+// answer, both can report agreesWithOther:true in the SAME round even though their
+// CURRENT outputs are swapped and still differ — and they can keep swapping back and
+// forth, so counting consecutive parallel agreements does NOT prove the current
+// outputs match. The only sound test is to make BOTH sides judge ONE shared piece of
+// text. So when a round shows mutual agreement, we synthesize a single candidate
+// from the two agreed answers and run a CONFIRMATION phase: both sides review that
+// IDENTICAL candidate (without rewriting their own answer) and either approve it or
+// object. Approval is on one fixed text both actually saw, so no swap is possible. If
+// both approve, that candidate IS the converged answer (already debater-approved). If
+// either objects, its objections fold back into the cross-check loop and we continue.
 // ---------------------------------------------------------------------------
-let agreedStreak = 0
+let finalAnswer = null
+// On a confirmation turn, each side's "other" input is the synthesized candidate
+// (wrapped in the answer shape so the existing cross-check machinery accepts it).
+// Carried across iterations so a rejected confirmation feeds the candidate + the
+// objector's complaints back into the next ordinary cross-check round.
+let pendingCandidate = null
 for (let round = 1; ; round++) {
+  const confirming = pendingCandidate !== null
+  const candidateAns = confirming
+    ? { answer: pendingCandidate, keyPoints: [], agreesWithOther: true, objections: [], changedMind: '' }
+    : null
   const prevClaude = claudeAns
   const prevCodex = codexAns
   const [claude, codex] = await parallel([
-    () => claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
-    () => codexAnswers(round, round === 1 ? null : prevClaude),
+    () =>
+      confirming
+        ? claudeConfirms(round, pendingCandidate)
+        : claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
+    () => codexAnswers(round, round === 1 ? null : confirming ? candidateAns : prevClaude),
   ])
 
   // codex infrastructure failure — terminal. The runner could not get an answer
@@ -317,57 +389,43 @@ for (let round = 1; ; round++) {
   transcript.push(entry)
   await writeSection(entry)
 
-  // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
-  // remaining disagreement — agreesWithOther:true AND no objections. One such round
-  // can be a parallel-swap false positive (see the loop header), so require TWO in a
-  // row: the second round has each side cross-check the other's just-agreed answer,
-  // confirming on outputs both have actually seen.
-  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
-  agreedStreak = bothAgree ? agreedStreak + 1 : 0
-  if (agreedStreak >= 2) {
-    log(`Round ${round}: both sides agree for a second consecutive round — converged.`)
-    break
+  // CONFIRMATION phase: both sides judged the SAME synthesized candidate. If both
+  // approve it (agreesWithOther:true + no objections), that candidate is the agreed,
+  // debater-approved unified answer — converge. If either objects, drop the candidate
+  // and continue the cross-check loop (their objections are already in `claudeAns` /
+  // `codexAns` and feed the next round).
+  if (confirming) {
+    if (sideAgrees(claude) && sideAgrees(codex)) {
+      finalAnswer = pendingCandidate
+      log(`Round ${round}: both sides approved the synthesized candidate — converged.`)
+      break
+    }
+    log(`Round ${round}: candidate rejected (claude agrees=${sideAgrees(claude)}, codex agrees=${sideAgrees(codex)}) — resuming cross-check.`)
+    pendingCandidate = null
+    continue
   }
+
+  // From round 2 on (round 1 has no cross-check), if BOTH sides report no remaining
+  // disagreement, synthesize one candidate and enter the confirmation phase next
+  // round. A single parallel-agreeing round can be a swap false positive, so we do
+  // NOT converge here — we converge only after both sides approve the SAME candidate.
+  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
   if (bothAgree) {
-    log(`Round ${round}: both sides agree — running one confirmation round before converging.`)
+    phase('Synthesis')
+    pendingCandidate = await synthesize(claude, codex)
+    if (!pendingCandidate) {
+      // The merge itself failed (synthesis agent died / returned empty). The sides
+      // DID agree; only the merge broke — surface that explicitly rather than spin.
+      status = 'synthesis-error'
+      log('Synthesis produced no candidate — both sides agreed but the merge failed; reporting synthesis-error.')
+      break
+    }
+    log(`Round ${round}: both sides agree — synthesized a candidate; confirming it next round.`)
+    phase('Reconcile')
   } else {
     log(
       `Round ${round}: claude agrees=${sideAgrees(claude)} (objections=${(claude.objections || []).length}), codex agrees=${sideAgrees(codex)} (objections=${(codex.objections || []).length})`,
     )
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Synthesis — merge the two AGREED answers into one unified reply for the user.
-// Only on consensus: on a failure terminus there's no agreement to synthesize.
-// ---------------------------------------------------------------------------
-let finalAnswer = null
-if (status === 'consensus' && claudeAns && codexAns) {
-  phase('Synthesis')
-  const synth = await agent(
-    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
-
-The question:
-${prompt}
-
-Claude's final answer (JSON):
-${JSON.stringify(claudeAns, null, 2)}
-
-Codex's final answer (JSON):
-${JSON.stringify(codexAns, null, 2)}
-
-Return the unified answer in \`answer\`.`,
-    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
-  )
-  finalAnswer = synth && synth.answer ? synth.answer : null
-  // Synthesis is the user-facing payload of a consensus run. If the synthesis agent
-  // died (null) or returned an empty answer, there is no answer to present — do NOT
-  // keep reporting "consensus" with finalAnswer:null, which A3 would mis-handle as a
-  // successful answer. Demote to an explicit failure terminus so the skill surfaces
-  // it as broken (the sides DID agree; only the final merge failed).
-  if (!finalAnswer) {
-    status = 'synthesis-error'
-    log('Synthesis produced no answer — both sides agreed but the merge failed; reporting synthesis-error.')
   }
 }
 
@@ -385,7 +443,7 @@ const transcriptText = renderTranscript(
 await agent(
   `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
 2. Using the Write tool, create \`${answerDocPath}\` with EXACTLY this content, overwriting any existing file:
 
 ${transcriptText}`,

--- a/.apm/skills/codex-debate/answer.workflow.js
+++ b/.apm/skills/codex-debate/answer.workflow.js
@@ -1,0 +1,367 @@
+export const meta = {
+  name: 'codex-answer-debate',
+  description: 'Have Claude and codex each answer a prompt in parallel, then cross-check until they agree, and synthesize one unified answer (no round cap, no deadlock exit)',
+  phases: [
+    { title: 'Answer', detail: 'claude + codex answer the prompt independently, in parallel' },
+    { title: 'Reconcile', detail: 'each cross-checks the other, round after round, until both agree' },
+    { title: 'Synthesis', detail: 'merge the two agreed answers into one unified reply' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Inputs (passed via the Workflow tool's `args`)
+// ---------------------------------------------------------------------------
+const a = args || {}
+const repoPath = a.repoPath || '.'
+// The user's freeform prompt — the question both assistants answer and then
+// cross-check toward one agreed reply. Required; the orchestrator passes it.
+const prompt = (a.prompt || '').trim()
+// Where the generated skill lives, so the codex runner can find codex-answer.sh.
+const skillDir = a.skillDir || '.claude/skills/codex-debate'
+// Per-worktree scratch dir, shared with the review mode. Gitignored, derived from
+// repoPath (the worktree root === $PWD) so parallel debates in DIFFERENT worktrees
+// never collide on shared /tmp paths and these files never pollute the repo.
+const workDir = `${repoPath}/.codex-debate`
+
+// Model tiers. The claude-answer round does real reasoning (answering, then
+// cross-checking codex) → `model` (Opus). The final synthesis is also user-facing
+// prose, so it runs on `model` too. The codex RUNNER must relay codex's answer
+// JSON faithfully (a verbatim copy, not a paraphrase — the weakest tier corrupts
+// it silently) → `copyModel` (Sonnet). The file writers/assemblers are mechanical
+// → `mechModel` (Haiku). Defaults match a direct invocation.
+const model = a.model || 'opus'
+const mechModel = a.mechModel || 'haiku'
+const copyModel = a.copyModel || 'sonnet'
+
+// The reasoning effort codex runs at, scoped to the debate. This JS constant is
+// the SINGLE home for the value: it is passed script-ward (a 4th positional arg to
+// codex-answer.sh, which sets `-c model_reasoning_effort`) and read by the
+// transcript header, so the `-c` flag and the header both derive from here.
+const REASONING_EFFORT = 'xhigh'
+
+// POSIX single-quote a path for safe interpolation into a shell command (spaces,
+// globs, metacharacters inert; embedded single quotes escaped via '\'' ). Used for
+// the destructive scratch reset (`rm -f`) below.
+const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
+
+// A filesystem-safe slug for this prompt, so the saved transcript has a readable,
+// deterministic name (Date.now()/Math.random() are unavailable in workflow scripts,
+// so the name is derived purely from the prompt text). Falls back to 'answer'.
+const slug =
+  (prompt.toLowerCase().match(/[a-z0-9]+/g) || []).slice(0, 8).join('-').slice(0, 60) || 'answer'
+const answerDocPath = `${workDir}/answer-${slug}.md`
+
+// ---------------------------------------------------------------------------
+// Schema — shared by both debaters (codex's runner mirrors
+// scripts/codex-answer.schema.json). `reviewerError` is set ONLY by the codex
+// runner script when codex itself failed; the claude side never sets it.
+// ---------------------------------------------------------------------------
+const OBJECTION = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { point: { type: 'string' }, reason: { type: 'string' } },
+  required: ['point', 'reason'],
+}
+const ANSWER_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    answer: { type: 'string' },
+    keyPoints: { type: 'array', items: { type: 'string' } },
+    agreesWithOther: { type: 'boolean' },
+    objections: { type: 'array', items: OBJECTION },
+    changedMind: { type: 'string' },
+    reviewerError: { type: 'boolean' },
+  },
+  required: ['answer', 'keyPoints', 'agreesWithOther', 'objections', 'changedMind'],
+}
+const FINAL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { answer: { type: 'string' } },
+  required: ['answer'],
+}
+
+if (!prompt) {
+  return {
+    status: 'no-prompt',
+    rounds: 0,
+    prompt,
+    transcriptPath: null,
+    finalAnswer: null,
+    note: 'No prompt was passed to the answer-debate workflow; nothing to answer.',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The two debaters (symmetric: each answers, then cross-checks the other)
+// ---------------------------------------------------------------------------
+// CLAUDE answers/cross-checks via a harness subagent (Claude isn't headless under
+// Max auth, so agent() is the only way to run it). Read-only: it may inspect the
+// repo to ground its answer but must not edit anything.
+async function claudeAnswers(round, other, myPrev) {
+  const block =
+    round === 1
+      ? `Answer the question below thoroughly and honestly — your best, most defensible answer. You are in a debate with another assistant ("CODEX") answering the SAME question independently; you'll cross-check each other afterward, so make this strong.`
+      : `This is a CROSS-CHECK round. You and CODEX each answered the question; now reconcile toward ONE agreed answer.
+
+Your OWN previous answer (build on it — don't re-derive from scratch):
+${JSON.stringify(myPrev, null, 2)}
+
+CODEX's LATEST answer (and its objections to your previous answer) (JSON):
+${JSON.stringify(other, null, 2)}
+
+Weigh CODEX's answer against yours:
+  - Where CODEX is right and you were wrong or incomplete, UPDATE your answer to match and say what you changed in changedMind.
+  - Where CODEX is wrong or has a gap, hold your position and record it under objections with a specific, evidence-backed reason.`
+  const prompt_ = `You and CODEX were asked the SAME question. ${block}
+
+You may inspect the repo at \`${repoPath}\` to ground your answer — your shell cwd may be a different worktree, so use \`git -C ${repoPath}\` and absolute paths under it. READ-ONLY: read files, \`git -C ${repoPath} diff/log\`, grep; do NOT edit, create, delete, or run any git write command. Cite file:line for claims about this codebase. If the question isn't about this repo, answer from your own knowledge.
+
+The question:
+${prompt}
+
+Return the schema:
+  - answer: your complete, self-contained answer as it stands now (on a cross-check round, your UPDATED unified answer).
+  - keyPoints: the core claims your answer rests on, one per item.
+  - objections: your remaining disagreements with CODEX's latest answer (empty on round 1, and empty once you fully agree).
+  - changedMind: what CODEX convinced you to change this round (empty on round 1 or if nothing changed).
+  - agreesWithOther: true ONLY when CODEX's latest answer is correct and complete and you have NO objection left — your two answers say the same thing. false on round 1.`
+  return agent(prompt_, {
+    label: `claude:round${round}`,
+    phase: round === 1 ? 'Answer' : 'Reconcile',
+    model,
+    schema: ANSWER_SCHEMA,
+  })
+}
+
+// CODEX answers/cross-checks via codex-answer.sh (warm session across rounds). The
+// agent here is a MECHANICAL RUNNER: it writes the prompt + cross-check files,
+// shells out to the script, and relays codex's JSON answer verbatim — it does NOT
+// answer the question itself. The user's prompt and CLAUDE's latest answer carry
+// arbitrary characters, so they're written with the Write tool, never a heredoc.
+async function codexAnswers(round, other) {
+  const answerPath = `${workDir}/answer-codex-${round}.json`
+  const promptPath = `${workDir}/answer-prompt.txt`
+  const crossPath = `${workDir}/answer-crosscheck.json`
+  // The cross-check argument to the script: `-` on round 1 (codex answers
+  // independently), else the file holding CLAUDE's latest answer.
+  const crossArg = round === 1 ? '-' : crossPath
+  const crossStep =
+    round === 1
+      ? `2. (No cross-check this round — codex answers independently.)`
+      : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
+
+${JSON.stringify(other, null, 2)}`
+  const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
+
+${prompt}
+
+${crossStep}
+
+3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-answer.sh ${promptPath} ${crossArg} ${answerPath} ${REASONING_EFFORT}\`
+
+   This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
+
+4. Read \`${answerPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
+  return agent(runnerPrompt, {
+    label: `codex:round${round}`,
+    phase: round === 1 ? 'Answer' : 'Reconcile',
+    model: copyModel, // must relay codex's answer JSON faithfully
+    schema: ANSWER_SCHEMA,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Transcript rendering — deterministic, in-process (no agent retypes the blob)
+// ---------------------------------------------------------------------------
+function renderObjections(objs) {
+  if (!objs || objs.length === 0) return '  - _(none)_'
+  return objs.map((o) => `  - **${o.point}** — ${o.reason}`).join('\n')
+}
+
+function renderSide(name, ans) {
+  if (!ans) return `**${name}** — _(no turn this round)_`
+  const lines = [
+    `**${name}** — agrees with other: \`${!!ans.agreesWithOther}\``,
+    '',
+    ans.answer,
+  ]
+  if (ans.changedMind && ans.changedMind.trim()) lines.push('', `_changed mind:_ ${ans.changedMind}`)
+  lines.push('', 'Objections to the other side:', renderObjections(ans.objections))
+  return lines.join('\n')
+}
+
+function roundSection(entry) {
+  return [
+    `### Round ${entry.round}`,
+    '',
+    renderSide('claude', entry.claude),
+    '',
+    renderSide('codex', entry.codex),
+  ].join('\n')
+}
+
+function transcriptHeader(meta) {
+  const badge = meta.status === 'consensus' ? '✅ **Agreed**' : `⚠️ **${meta.status}**`
+  return `# Codex ⇄ Claude answer-debate
+
+> **Prompt:** ${meta.prompt}
+
+${badge} after ${meta.rounds} round(s) · codex answered at \`${meta.reasoningEffort}\` reasoning effort`
+}
+
+function renderTranscript(transcript, meta, finalAnswer) {
+  const parts = [transcriptHeader(meta)]
+  if (finalAnswer) parts.push('## Final unified answer', '', finalAnswer)
+  parts.push('## Convergence trail', ...transcript.map(roundSection))
+  return parts.join('\n\n')
+}
+
+// Zero-pad the round so the section glob sorts in round order for the assembly.
+const sectionFile = (round) => `${workDir}/answer-section-${String(round).padStart(3, '0')}.md`
+
+// Write ONE round's section to its own small file (Haiku-safe — just this round).
+async function writeSection(entry) {
+  const text = roundSection(entry)
+  const path = sectionFile(entry.round)
+  const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
+
+${text}`
+  return agent(p, { label: `section:round${entry.round}`, phase: 'Reconcile', model: mechModel })
+}
+
+// ---------------------------------------------------------------------------
+// Set up scratch — clear any stale per-round sections from a PRIOR debate in this
+// worktree so they don't leak into the assembled transcript. Scoped to the
+// answer-section files; the review mode's section-NNN.md and the verdict/answer
+// JSONs keep their own lifecycle.
+// ---------------------------------------------------------------------------
+phase('Answer')
+await agent(
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/answer-section-*.md\`. Do not edit any other file. Do not run git.`,
+  { label: 'sections:reset', phase: 'Answer', model: mechModel },
+)
+
+const transcript = []
+let status = 'consensus'
+let claudeAns = null
+let codexAns = null
+
+// ---------------------------------------------------------------------------
+// The loop — round 1 is the independent answer (parallel); rounds 2+ are
+// cross-checks. Runs until BOTH sides agree. No round cap, no deadlock exit:
+// each side keeps cross-checking until they converge (the harness's per-workflow
+// agent backstop is the only hard ceiling — interrupt via /workflows or TaskStop).
+//
+// Both sides run in PARALLEL each round, so in round N each cross-checks the
+// OTHER's round-(N-1) answer. Convergence is thus mutual agreement on the prior
+// round's answers — safe (it can only end on real agreement, never prematurely),
+// at worst one round later than a strictly-serial handoff would.
+// ---------------------------------------------------------------------------
+for (let round = 1; ; round++) {
+  const prevClaude = claudeAns
+  const prevCodex = codexAns
+  const [claude, codex] = await parallel([
+    () => claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
+    () => codexAnswers(round, round === 1 ? null : prevClaude),
+  ])
+
+  // codex infrastructure failure — terminal. The runner could not get an answer
+  // out of codex (broken/unavailable CLI), so it synthesized reviewerError:true.
+  // Retrying a dead reviewer just spins, so abort and surface the failure. This is
+  // deliberately separate from the "no deadlock exit" rule for real disagreement.
+  if (codex && codex.reviewerError) {
+    status = 'reviewer-error'
+    log(`Round ${round}: codex error — aborting. ${codex.answer}`)
+    transcript.push({ round, claude, codex })
+    break
+  }
+  // A side died on a terminal API error after retries (agent() returned null).
+  // We can't reconcile half a debate, so abort loudly rather than loop on nulls.
+  if (!claude || !codex) {
+    status = 'agent-error'
+    log(`Round ${round}: ${!claude ? 'claude' : 'codex'} produced no answer (agent error) — aborting.`)
+    transcript.push({ round, claude, codex })
+    break
+  }
+
+  claudeAns = claude
+  codexAns = codex
+  const entry = { round, claude, codex }
+  transcript.push(entry)
+  await writeSection(entry)
+
+  // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
+  // remaining disagreement with the other's latest answer.
+  if (round >= 2 && claude.agreesWithOther === true && codex.agreesWithOther === true) {
+    log(`Round ${round}: both sides agree — converged.`)
+    break
+  }
+  log(
+    `Round ${round}: claude agrees=${!!claude.agreesWithOther} (objections=${(claude.objections || []).length}), codex agrees=${!!codex.agreesWithOther} (objections=${(codex.objections || []).length})`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis — merge the two AGREED answers into one unified reply for the user.
+// Only on consensus: on a failure terminus there's no agreement to synthesize.
+// ---------------------------------------------------------------------------
+let finalAnswer = null
+if (status === 'consensus' && claudeAns && codexAns) {
+  phase('Synthesis')
+  const synth = await agent(
+    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
+
+The question:
+${prompt}
+
+Claude's final answer (JSON):
+${JSON.stringify(claudeAns, null, 2)}
+
+Codex's final answer (JSON):
+${JSON.stringify(codexAns, null, 2)}
+
+Return the unified answer in \`answer\`.`,
+    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
+  )
+  finalAnswer = synth ? synth.answer : null
+}
+
+log(`Answer-debate ended: ${status} after ${transcript.length} round(s).`)
+
+// Persist the full transcript to a single readable file the user can revisit
+// (chat + saved transcript). Rendered deterministically in-process, then handed to
+// one mechanical writer — the payload can be large, so use copyModel for faithful
+// reproduction (the same tier the codex relay uses).
+const transcriptText = renderTranscript(
+  transcript,
+  { status, rounds: transcript.length, prompt, reasoningEffort: REASONING_EFFORT },
+  finalAnswer,
+)
+await agent(
+  `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${answerDocPath}\` with EXACTLY this content, overwriting any existing file:
+
+${transcriptText}`,
+  { label: 'transcript:write', phase: 'Synthesis', model: copyModel },
+)
+
+return {
+  status,
+  rounds: transcript.length,
+  prompt,
+  transcriptPath: answerDocPath,
+  finalAnswer,
+  reasoningEffort: REASONING_EFFORT,
+  // The error terminus carries codex's failure detail in its answer text.
+  codexError: status === 'reviewer-error' ? (codexAns && codexAns.answer) || null : null,
+}

--- a/.apm/skills/codex-debate/answer.workflow.js
+++ b/.apm/skills/codex-debate/answer.workflow.js
@@ -243,7 +243,34 @@ function renderSide(name, ans) {
   return lines.join('\n')
 }
 
+// A confirm round is not a normal answer round: both sides judged ONE shared
+// synthesized candidate (approve-or-object), so rendering each side's `answer`
+// would misleadingly show two texts for a round whose whole point was that both
+// judged the IDENTICAL one. Show the candidate ONCE, then each side's verdict
+// (agrees + objections) against it.
+function renderConfirmVerdict(name, ans) {
+  if (!ans) return `**${name}** — _(no turn this round)_`
+  return [
+    `**${name}** — approved: \`${!!ans.agreesWithOther}\``,
+    'Objections to the candidate:',
+    renderObjections(ans.objections),
+  ].join('\n')
+}
+
 function roundSection(entry) {
+  if (entry.confirming) {
+    return [
+      `### Round ${entry.round} — confirmation`,
+      '',
+      'Both sides judged this single synthesized candidate (approve or object):',
+      '',
+      entry.candidate,
+      '',
+      renderConfirmVerdict('claude', entry.claude),
+      '',
+      renderConfirmVerdict('codex', entry.codex),
+    ].join('\n')
+  }
   return [
     `### Round ${entry.round}`,
     '',
@@ -397,7 +424,12 @@ for (let round = 1; ; round++) {
 
   claudeAns = claude
   codexAns = codex
-  const entry = { round, claude, codex }
+  // On a confirm round both sides judged the ONE shared candidate; tag the entry
+  // (with the candidate itself) so the transcript renders it as an approve/object
+  // verdict on a single text rather than as two separate answer rounds.
+  const entry = confirming
+    ? { round, claude, codex, confirming: true, candidate: pendingCandidate }
+    : { round, claude, codex }
   transcript.push(entry)
   await writeSection(entry)
 

--- a/.apm/skills/codex-debate/answer.workflow.js
+++ b/.apm/skills/codex-debate/answer.workflow.js
@@ -172,25 +172,35 @@ Return the schema:
 // shells out to the script, and relays codex's JSON answer verbatim — it does NOT
 // answer the question itself. The user's prompt and CLAUDE's latest answer carry
 // arbitrary characters, so they're written with the Write tool, never a heredoc.
-// On a confirmation turn (`confirm`), the cross-check input is the SINGLE shared
-// candidate, and the runner relays codex's approval/objections to it.
-async function codexAnswers(round, other) {
+// On a CONFIRM turn (`confirming`), `other` is the SINGLE shared synthesized
+// candidate STRING; the runner writes it to the cross-check file and passes the
+// script's `confirm` token so codex plugs into the same verbatim/approve-or-object
+// contract as the workflow's claudeConfirms turn (NOT the ordinary cross-check
+// contract, which would tell codex to UPDATE its own answer instead of approving).
+async function codexAnswers(round, other, confirming) {
   const answerPath = `${workDir}/answer-codex-${round}.json`
   const promptPath = `${workDir}/answer-prompt.txt`
   const crossPath = `${workDir}/answer-crosscheck.json`
   // The cross-check argument to the script: `-` on round 1 (codex answers
-  // independently), else the file holding CLAUDE's latest answer.
+  // independently), else the file holding either CLAUDE's latest answer (ordinary
+  // cross-check) or the synthesized candidate to approve (confirm turn).
   const crossArg = round === 1 ? '-' : crossPath
+  // On a confirm turn the cross-check file holds the candidate VERBATIM (a plain
+  // string); on an ordinary cross-check it holds CLAUDE's answer JSON.
+  const crossContent = confirming ? other : JSON.stringify(other, null, 2)
   const crossStep =
     round === 1
       ? `2. (No cross-check this round — codex answers independently.)`
       : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
 
-${JSON.stringify(other, null, 2)}`
+${crossContent}`
+  // Pass the script's `confirm` token on a confirm turn so it selects the
+  // approve-the-candidate prompt shape rather than the cross-check shape.
+  const confirmArg = confirming ? ` ${shq('confirm')}` : ''
   // Every path below is spliced into a shell command the runner agent executes, so
   // POSIX-quote each one (worktrees or skill dirs with spaces/metacharacters would
   // otherwise break the command or misdirect it). The Write-tool file CONTENTS
-  // (${prompt}, ${JSON.stringify(other)}) are not shell-parsed and stay verbatim.
+  // (${prompt}, ${crossContent}) are not shell-parsed and stay verbatim.
   const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
@@ -200,14 +210,14 @@ ${prompt}
 ${crossStep}
 
 3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}\`
+   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}${confirmArg}\`
 
    This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
 
 4. Read \`${answerPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
   return agent(runnerPrompt, {
-    label: `codex:round${round}`,
-    phase: round === 1 ? 'Answer' : 'Reconcile',
+    label: confirming ? `codex:confirm${round}` : `codex:round${round}`,
+    phase: confirming ? 'Synthesis' : round === 1 ? 'Answer' : 'Reconcile',
     model: copyModel, // must relay codex's answer JSON faithfully
     schema: ANSWER_SCHEMA,
   })
@@ -344,24 +354,26 @@ Return the unified answer in \`answer\`.`,
 // either objects, its objections fold back into the cross-check loop and we continue.
 // ---------------------------------------------------------------------------
 let finalAnswer = null
-// On a confirmation turn, each side's "other" input is the synthesized candidate
-// (wrapped in the answer shape so the existing cross-check machinery accepts it).
+// On a confirmation turn, each side judges the SAME synthesized candidate STRING.
 // Carried across iterations so a rejected confirmation feeds the candidate + the
 // objector's complaints back into the next ordinary cross-check round.
 let pendingCandidate = null
 for (let round = 1; ; round++) {
   const confirming = pendingCandidate !== null
-  const candidateAns = confirming
-    ? { answer: pendingCandidate, keyPoints: [], agreesWithOther: true, objections: [], changedMind: '' }
-    : null
   const prevClaude = claudeAns
   const prevCodex = codexAns
+  // On a confirm turn BOTH sides run their dedicated approve-a-fixed-candidate
+  // interface (claudeConfirms / codexAnswers(..., confirming)), so both plug into
+  // one verbatim/approve-or-object contract instead of the ordinary cross-check.
   const [claude, codex] = await parallel([
     () =>
       confirming
         ? claudeConfirms(round, pendingCandidate)
         : claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
-    () => codexAnswers(round, round === 1 ? null : confirming ? candidateAns : prevClaude),
+    () =>
+      confirming
+        ? codexAnswers(round, pendingCandidate, true)
+        : codexAnswers(round, round === 1 ? null : prevClaude, false),
   ])
 
   // codex infrastructure failure — terminal. The runner could not get an answer

--- a/.apm/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.apm/skills/codex-debate/scripts/codex-answer.schema.json
@@ -39,5 +39,11 @@
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
     }
   },
-  "required": ["answer", "keyPoints", "agreesWithOther", "objections", "changedMind"]
+  "required": [
+    "answer",
+    "keyPoints",
+    "agreesWithOther",
+    "objections",
+    "changedMind"
+  ]
 }

--- a/.apm/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.apm/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,10 +37,6 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
-    },
-    "reviewerError": {
-      "type": "boolean",
-      "description": "Set to true ONLY by the codex-answer.sh runner when codex itself failed to produce an answer after every retry (a synthesized infrastructure-error verdict the workflow aborts on). codex never sets this in a real answer; it is declared here so the script's synthesized error answer validates against this schema under additionalProperties:false."
     }
   },
   "required": [

--- a/.apm/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.apm/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,17 +37,7 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
-    },
-    "reviewerError": {
-      "type": "boolean",
-      "description": "Set by the runner script ONLY when codex itself failed to produce an answer (broken/unavailable CLI). Not part of a real answer."
     }
   },
-  "required": [
-    "answer",
-    "keyPoints",
-    "agreesWithOther",
-    "objections",
-    "changedMind"
-  ]
+  "required": ["answer", "keyPoints", "agreesWithOther", "objections", "changedMind"]
 }

--- a/.apm/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.apm/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,6 +37,10 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
+    },
+    "reviewerError": {
+      "type": "boolean",
+      "description": "Set to true ONLY by the codex-answer.sh runner when codex itself failed to produce an answer after every retry (a synthesized infrastructure-error verdict the workflow aborts on). codex never sets this in a real answer; it is declared here so the script's synthesized error answer validates against this schema under additionalProperties:false."
     }
   },
   "required": [

--- a/.apm/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.apm/skills/codex-debate/scripts/codex-answer.schema.json
@@ -1,0 +1,53 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "answer": {
+      "type": "string",
+      "description": "Your complete, self-contained answer to the user's prompt as it stands THIS round. On a cross-check round this is your UPDATED unified answer, revised in light of the other assistant's answer."
+    },
+    "keyPoints": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "The core claims your answer rests on, one per item — the things the other side must agree with for there to be consensus."
+    },
+    "agreesWithOther": {
+      "type": "boolean",
+      "description": "true ONLY when the other assistant's latest answer is correct and complete and you have NO substantive disagreement left — your answers say the same thing. false on the first round (you haven't seen theirs yet) and whenever any objection below remains."
+    },
+    "objections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "point": {
+            "type": "string",
+            "description": "The specific claim in the OTHER assistant's answer you disagree with, or the gap you think it leaves."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why it's wrong or incomplete — cite file:line or concrete evidence when the prompt is about this repo."
+          }
+        },
+        "required": ["point", "reason"]
+      },
+      "description": "Your remaining disagreements with the other assistant's latest answer. Empty when you fully agree (agreesWithOther:true) and on round 1."
+    },
+    "changedMind": {
+      "type": "string",
+      "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
+    },
+    "reviewerError": {
+      "type": "boolean",
+      "description": "Set by the runner script ONLY when codex itself failed to produce an answer (broken/unavailable CLI). Not part of a real answer."
+    }
+  },
+  "required": [
+    "answer",
+    "keyPoints",
+    "agreesWithOther",
+    "objections",
+    "changedMind"
+  ]
+}

--- a/.apm/skills/codex-debate/scripts/codex-answer.sh
+++ b/.apm/skills/codex-debate/scripts/codex-answer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # codex-answer.sh — the canonical, deterministic codex invocation for the
-# SYMMETRIC answer-debate (the prompt-mode of /codex-debate). codex answers a
+# SYMMETRIC answer-debate (the `answer` mode of /codex-debate). codex answers a
 # freeform user prompt as one of two equal debaters; on follow-up rounds it
 # CROSS-CHECKS the other assistant's ("CLAUDE") latest answer against its own and
 # either concedes (revising its answer) or holds firm (recording objections),
@@ -9,6 +9,11 @@
 # this repo to ground its answer (git diff/log, read files, grep) but cannot
 # modify anything. The output is constrained to codex-answer.schema.json and
 # written to <out-json>.
+#
+# This script owns only what is SPECIFIC to answering a prompt: arg parsing, the
+# warm/cold prompt text, the answer schema + session file, and the answer-shaped
+# error verdict. The shared codex-driving core (read-only exec/resume, retry/
+# backoff, thread-id capture, session persistence) lives in codex-exec-lib.sh.
 #
 # Usage:
 #   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
@@ -23,23 +28,14 @@
 #                     value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
-#   * codex runs under `--sandbox read-only`, which enforces read-only at the
-#     execution boundary (the kernel sandbox blocks file writes and other
-#     state-mutating syscalls), NOT merely by prompt text. codex reads arbitrary
-#     repo files to ground its answer and could be prompt-injected by file
-#     contents, so the read-only promise must be enforced, not advertised. codex
-#     auto-falls-back to its bundled bubblewrap when the system one is absent, so
-#     this works in containers; read-only permits read commands (git diff/status,
-#     grep, reading files) but denies writes. `codex exec` is already
-#     non-interactive (approval policy "never"), so a blocked command is denied
-#     outright rather than escalating to a prompt that would wedge the loop.
+#   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
+#     read-only at the kernel boundary, NOT merely by prompt text. codex reads
+#     arbitrary repo files to ground its answer and could be prompt-injected by file
+#     contents, so the read-only promise must be enforced, not advertised.
 #   * Always emits a schema-valid answer on stdout, even if codex errors — a
 #     synthesized error answer (reviewerError:true) so the loop never wedges.
-#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
-#     scratch dir; every later round resumes that same session (`codex exec
-#     resume <id>`) so codex retains its OWN prior answer + reasoning across rounds
-#     instead of reconstructing it each time. If the id was never captured, a later
-#     round cleanly falls back to a cold start.
+#   * WARM SESSION: round 1 cold-starts codex; every later round resumes that same
+#     session so codex retains its OWN prior answer + reasoning across rounds.
 set -uo pipefail
 
 prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
@@ -51,11 +47,8 @@ effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-answer.schema.json"
-log="$out.log"
-
-# The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
-# it exists before codex tries to write the answer there.
-mkdir -p "$(dirname "$out")"
+# shellcheck source=codex-exec-lib.sh
+source "$here/codex-exec-lib.sh"
 
 # The user's prompt. Required and must be non-empty — an empty prompt would make
 # codex answer nothing and silently degrade the debate, so fail loud instead.
@@ -64,11 +57,6 @@ if [ ! -s "$prompt_file" ]; then
   exit 2
 fi
 prompt_text="$(cat "$prompt_file")"
-
-# Never let a stale answer from a previous run survive: if the current codex
-# invocation fails to write one, the empty-check below must catch it and
-# synthesize an error answer (otherwise a leftover file reads as a fresh answer).
-rm -f "$out" "$log"
 
 # Pull CLAUDE's latest answer, if any (the cross-check input). Built as a plain
 # string and injected below via a simple variable reference so any special
@@ -85,26 +73,27 @@ if [ "$crosscheck_file" != "-" ]; then
   fi
 fi
 
-# WARM SESSION. codex keeps its OWN answer + reasoning across rounds by resuming
-# the same codex session instead of cold-starting `codex exec` each round. The
-# session id (codex's thread_id) is persisted in the scratch dir after round 1
-# and reused on every follow-up round, so when it cross-checks CLAUDE it argues
-# from its original rationale rather than reconstructing it.
-#
-#   * Round 1 (crosscheck_file == "-"): fresh `codex exec`; capture thread_id below.
-#   * Later rounds: `codex exec resume <id>` with just the cross-check follow-up,
-#     relying on codex's retained context.
-#   * Fallback: if no id was captured (round-1 capture failed), a later round
-#     cold-starts with the FULL prompt + cross-check — graceful, never a wedge.
+# WARM SESSION. Round 1 (crosscheck_file == "-") cold-starts and resets any stale
+# id; later rounds resume codex's own answer session. Resolve the id first so the
+# prompt below can lean on codex's retained context when warm.
 session_id_file="$(dirname "$out")/codex-answer-session.id"
-resume_id=""
-if [ "$crosscheck_file" = "-" ]; then
-  # Round 1 of a fresh debate: start a NEW session and drop any session id left
-  # behind by a previous debate in this worktree, so we never resume a stale one.
-  rm -f "$session_id_file"
-elif [ -s "$session_id_file" ]; then
-  resume_id="$(cat "$session_id_file")"
-fi
+[ "$crosscheck_file" = "-" ] && is_round1=1 || is_round1=
+resume_id="$(codex_resolve_session "$session_id_file" "$is_round1")"
+
+# Synthesize codex-answer's error verdict shape when codex produces nothing after
+# every attempt (called by codex_exec_round). reviewerError:true is the signal the
+# workflow aborts the debate on.
+synthesize_error_verdict() {
+  local out="$1" tail_log="$2" attempts="$3"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    keyPoints: [],
+    agreesWithOther: false,
+    objections: [],
+    changedMind: "",
+    reviewerError: true
+  }' >"$out"
+}
 
 # Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
 # on codex's retained answer, and the full answer prompt for the COLD path (round
@@ -169,105 +158,6 @@ EOF
 )"
 fi
 
-# One codex invocation: warm-resume when we have a session id (carries codex's own
-# prior answer), else a cold start. `--json` emits a `thread.started` event
-# carrying codex's thread_id, captured below to resume next round; it does NOT
-# change the answer, which `--output-schema`/`-o` still write to "$out". `resume`
-# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
-# the same kernel-enforced policy, set through config instead of the flag.
-run_codex() {
-  if [ -n "$resume_id" ]; then
-    codex exec resume \
-      -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$resume_id" "$prompt"
-  else
-    codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"
-  fi
-}
-
-# model_reasoning_effort is scoped to the debate here (via -c, from the $effort the
-# workflow passes down — default "xhigh") rather than relying on the user's global
-# ~/.codex/config.toml — we always want codex thinking at full depth here.
-#
-# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
-# hiccups, a spurious internal error) and writes no answer — which would otherwise
-# degrade the round to reviewer-error on a single bad roll. Retry with linear
-# backoff, accepting the first attempt that writes a non-empty answer to "$out".
-# Tunable via env: CODEX_REVIEW_RETRIES (total attempts, default 3),
-# CODEX_REVIEW_BACKOFF (base seconds, default 5 — attempt n waits n*base). Only
-# after every attempt fails empty do we synthesize the reviewerError answer below.
-attempts="${CODEX_REVIEW_RETRIES:-3}"
-backoff="${CODEX_REVIEW_BACKOFF:-5}"
-# Validate both as positive integers. Left unchecked, a non-numeric value makes the
-# arithmetic test error every iteration, so the loop would spin forever instead of
-# giving up. Fall back to the documented defaults (and clamp attempts to >=1)
-# loudly rather than wedge the headless debate on a typo'd override.
-if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
-  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
-  attempts=3
-fi
-if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
-  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
-  backoff=5
-fi
-n=1
-: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
-while :; do
-  rm -f "$out"
-  # Append (not truncate): when every attempt fails, the synthesized reviewerError
-  # answer's tail_log must reflect ALL attempts' diagnostics, not just the last.
-  echo "=== attempt $n/$attempts ===" >>"$log"
-  if ! run_codex </dev/null >>"$log" 2>&1; then
-    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
-  fi
-  # Success the moment codex writes an answer: the kernel sandbox + --output-schema
-  # make a non-empty "$out" a real, schema-valid answer, not a partial.
-  [ -s "$out" ] && break
-  # Out of attempts — fall through to the synthesized reviewerError answer.
-  [ "$n" -ge "$attempts" ] && break
-  wait_s=$(( backoff * n ))
-  echo "codex produced no answer (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
-  n=$(( n + 1 ))
-  sleep "$wait_s"
-done
-
-if [ -s "$out" ]; then
-  # Persist codex's session id so NEXT round can resume this same warm session
-  # (carrying codex's own prior answer + reasoning). The successful attempt's
-  # `thread.started` is the last one appended to the log; on a resume round it
-  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
-  # an id just means next round cold-starts via the fallback above — not fatal.
-  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
-  if [ -n "$sid" ]; then
-    printf '%s\n' "$sid" >"$session_id_file"
-  fi
-fi
-
-if [ ! -s "$out" ]; then
-  # codex produced no answer — synthesize a schema-valid error answer so the debate
-  # loop can surface the failure instead of hanging. The reviewerError flag is the
-  # machine-detectable signal the workflow uses to abort with a terminal failure: a
-  # broken/unavailable codex is INFRASTRUCTURE failure, not substantive
-  # disagreement, so it must NOT spin the loop forever.
-  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
-    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
-    keyPoints: [],
-    agreesWithOther: false,
-    objections: [],
-    changedMind: "",
-    reviewerError: true
-  }' >"$out"
-fi
-
-cat "$out"
+# Drive codex for this round (retry/backoff, thread capture, error fallback) — the
+# shared core does the work; this script supplied the prompt, schema, and shapes.
+codex_exec_round "$schema" "$out" "$session_id_file" "$effort" "$resume_id" "$prompt"

--- a/.apm/skills/codex-debate/scripts/codex-answer.sh
+++ b/.apm/skills/codex-debate/scripts/codex-answer.sh
@@ -59,6 +59,13 @@ is_confirm=
 [ "${5:-}" = "confirm" ] && is_confirm=1
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The codex-FACING output schema. Do NOT add a `reviewerError` property to it:
+# codex's `--output-schema` (OpenAI structured outputs) requires every declared
+# property to be in `required` with additionalProperties:false, so an optional
+# `reviewerError` 400s the request. codex never emits reviewerError; the error
+# answer synthesize_error_verdict writes carries it but is validated by the
+# workflow's in-JS ANSWER_SCHEMA, not by this file. (This has been re-added in
+# error twice — review mode's codex-verdict.schema.json omits it for the same reason.)
 schema="$here/codex-answer.schema.json"
 # shellcheck source=codex-exec-lib.sh
 source "$here/codex-exec-lib.sh"

--- a/.apm/skills/codex-debate/scripts/codex-answer.sh
+++ b/.apm/skills/codex-debate/scripts/codex-answer.sh
@@ -95,12 +95,46 @@ synthesize_error_verdict() {
   }' >"$out"
 }
 
-# Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
-# on codex's retained answer, and the full answer prompt for the COLD path (round
-# 1, or the fallback when no session id was captured). Unquoted heredocs: only
-# $prompt_text and $crosscheck expand; their expansions are inserted literally
-# (heredoc results aren't re-scanned), so special chars stay inert.
-if [ -n "$resume_id" ] && [ -n "$crosscheck" ]; then
+# Whether this is a cross-check round: a cross-check file was provided (not "-") AND
+# it actually held CLAUDE's answer. A follow-up round MUST cross-check even when the
+# warm session id is missing — dropping the cross-check would tell codex to answer
+# independently again (agreesWithOther:false, no objections) and the debate could
+# never converge. So the cross-check, not the resume id, gates which prompt we use.
+is_crosscheck=
+[ -n "$crosscheck" ] && is_crosscheck=1
+
+# A reusable block carrying CLAUDE's latest answer + the cross-check instructions,
+# spliced into BOTH the warm and cold follow-up prompts (mirrors codex-review.sh's
+# $rebuttal_block) so a missing resume id degrades to a COLD CROSS-CHECK, never to a
+# fresh independent answer. Empty on round 1.
+crosscheck_block=""
+if [ -n "$is_crosscheck" ]; then
+  crosscheck_block="$(cat <<EOF
+
+CLAUDE's LATEST answer (JSON) is:
+$crosscheck
+
+Cross-check CLAUDE's answer against your own. Then:
+  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
+    match and note what you changed in changedMind.
+  - Where CLAUDE is wrong or has a gap, keep your position and record it under
+    objections with a specific, evidence-backed reason (cite file:line for repo
+    questions).
+EOF
+)"
+fi
+
+# Three prompt shapes, chosen by (resume id × cross-check):
+#   * WARM follow-up   (resume id + cross-check): lean prompt leaning on codex's
+#     retained answer.
+#   * COLD follow-up   (no resume id + cross-check): the full answer prompt PLUS the
+#     cross-check block — codex re-derives its own answer from scratch but still
+#     reconciles against CLAUDE's, so the debate keeps converging.
+#   * COLD first round (no cross-check): the independent answer prompt.
+# Unquoted heredocs: only $prompt_text, $crosscheck, and $crosscheck_block expand;
+# their expansions are inserted literally (heredoc results aren't re-scanned), so
+# special chars stay inert.
+if [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME answer session you started earlier — you still
 have your own previous answer and reasoning in context. You and another assistant
@@ -110,18 +144,10 @@ to reach ONE agreed answer.
 The original question was:
 $prompt_text
 
-CLAUDE's LATEST answer (JSON) is:
-$crosscheck
-
 Cross-check CLAUDE's answer against your own (READ-ONLY — you may read repo files,
 git diff/log, grep to verify, but do NOT modify, create, or delete anything, and
-run no git write command: add/commit/push/stash/checkout). Then:
-  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
-    match and note what you changed in changedMind.
-  - Where CLAUDE is wrong or has a gap, keep your position and record it under
-    objections with a specific, evidence-backed reason (cite file:line for repo
-    questions).
-
+run no git write command: add/commit/push/stash/checkout).
+$crosscheck_block
 Return the JSON schema:
   - answer: your UPDATED, self-contained unified answer as it stands now.
   - keyPoints: the core claims your answer rests on.
@@ -137,8 +163,8 @@ else
 You are CODEX, a rigorous, truthful expert. Answer the user's question below
 thoroughly and honestly — exactly as you would for a careful colleague. You are in
 a debate with another assistant ("CLAUDE") who is answering the SAME question
-independently; afterward you'll cross-check each other until you agree, so give
-your best, most defensible answer now.
+independently; you cross-check each other until you agree, so give your best, most
+defensible answer.
 
 You may inspect this repository to ground your answer (READ-ONLY — read files, run
 git diff/log/grep; do NOT modify, create, or delete anything, and run no git write
@@ -147,13 +173,17 @@ codebase. If the question isn't about this repo, answer from your own knowledge.
 
 The question:
 $prompt_text
-
+$crosscheck_block
 Return the JSON schema:
-  - answer: your complete, self-contained answer.
+  - answer: your complete, self-contained answer (on a cross-check round, your
+    UPDATED unified answer revised in light of CLAUDE's).
   - keyPoints: the core claims your answer rests on, one per item.
-  - objections: leave empty this round (you haven't seen CLAUDE's answer yet).
-  - changedMind: empty string this round.
-  - agreesWithOther: false this round (you haven't seen CLAUDE's answer yet).
+  - objections: your remaining disagreements with CLAUDE's latest answer — empty
+    when you fully agree, and empty on the first round (no cross-check yet).
+  - changedMind: what CLAUDE convinced you to change this round (empty if nothing,
+    and empty on the first round).
+  - agreesWithOther: true ONLY when CLAUDE's latest answer is correct and complete
+    and you have NO objection left. false on the first round (no cross-check yet).
 EOF
 )"
 fi

--- a/.apm/skills/codex-debate/scripts/codex-answer.sh
+++ b/.apm/skills/codex-debate/scripts/codex-answer.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# codex-answer.sh — the canonical, deterministic codex invocation for the
+# SYMMETRIC answer-debate (the prompt-mode of /codex-debate). codex answers a
+# freeform user prompt as one of two equal debaters; on follow-up rounds it
+# CROSS-CHECKS the other assistant's ("CLAUDE") latest answer against its own and
+# either concedes (revising its answer) or holds firm (recording objections),
+# looping until both sides agree. codex runs as a READ-ONLY peer — it may read
+# this repo to ground its answer (git diff/log, read files, grep) but cannot
+# modify anything. The output is constrained to codex-answer.schema.json and
+# written to <out-json>.
+#
+# Usage:
+#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
+#
+#   <prompt-file>     path to a file holding the user's prompt/question
+#   <crosscheck-file> path to a file holding CLAUDE's latest answer (JSON) for
+#                     codex to cross-check, or "-" on the first round (codex
+#                     hasn't seen CLAUDE's answer yet — it answers independently)
+#   <out-json>        path the JSON answer is written to (also echoed to stdout)
+#   <reasoning-effort> codex model_reasoning_effort for this run; the answer
+#                     workflow passes its REASONING_EFFORT constant here so the
+#                     value has one home. Defaults to "xhigh" for standalone runs.
+#
+# Notes:
+#   * codex runs under `--sandbox read-only`, which enforces read-only at the
+#     execution boundary (the kernel sandbox blocks file writes and other
+#     state-mutating syscalls), NOT merely by prompt text. codex reads arbitrary
+#     repo files to ground its answer and could be prompt-injected by file
+#     contents, so the read-only promise must be enforced, not advertised. codex
+#     auto-falls-back to its bundled bubblewrap when the system one is absent, so
+#     this works in containers; read-only permits read commands (git diff/status,
+#     grep, reading files) but denies writes. `codex exec` is already
+#     non-interactive (approval policy "never"), so a blocked command is denied
+#     outright rather than escalating to a prompt that would wedge the loop.
+#   * Always emits a schema-valid answer on stdout, even if codex errors — a
+#     synthesized error answer (reviewerError:true) so the loop never wedges.
+#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
+#     scratch dir; every later round resumes that same session (`codex exec
+#     resume <id>`) so codex retains its OWN prior answer + reasoning across rounds
+#     instead of reconstructing it each time. If the id was never captured, a later
+#     round cleanly falls back to a cold start.
+set -uo pipefail
+
+prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
+crosscheck_file="${2:?missing crosscheck-file (use - for none)}"
+out="${3:?missing out-json path}"
+# The answer workflow owns this value (its REASONING_EFFORT constant) and passes
+# it down; "xhigh" is only the default for a standalone invocation of this script.
+effort="${4:-xhigh}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+schema="$here/codex-answer.schema.json"
+log="$out.log"
+
+# The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
+# it exists before codex tries to write the answer there.
+mkdir -p "$(dirname "$out")"
+
+# The user's prompt. Required and must be non-empty — an empty prompt would make
+# codex answer nothing and silently degrade the debate, so fail loud instead.
+if [ ! -s "$prompt_file" ]; then
+  echo "ERROR: prompt file '$prompt_file' is missing or empty." >&2
+  exit 2
+fi
+prompt_text="$(cat "$prompt_file")"
+
+# Never let a stale answer from a previous run survive: if the current codex
+# invocation fails to write one, the empty-check below must catch it and
+# synthesize an error answer (otherwise a leftover file reads as a fresh answer).
+rm -f "$out" "$log"
+
+# Pull CLAUDE's latest answer, if any (the cross-check input). Built as a plain
+# string and injected below via a simple variable reference so any special
+# characters in the JSON (backticks, $, ...) stay literal.
+crosscheck=""
+if [ "$crosscheck_file" != "-" ]; then
+  if [ -s "$crosscheck_file" ]; then
+    crosscheck="$(cat "$crosscheck_file")"
+  else
+    # A cross-check was expected (path given, not "-") but the file is missing or
+    # empty — the handoff broke. Proceed without it, but make the failure loud so
+    # codex's cross-check isn't silently skipped.
+    echo "WARNING: expected cross-check file '$crosscheck_file' is missing or empty; proceeding with no cross-check this round." >&2
+  fi
+fi
+
+# WARM SESSION. codex keeps its OWN answer + reasoning across rounds by resuming
+# the same codex session instead of cold-starting `codex exec` each round. The
+# session id (codex's thread_id) is persisted in the scratch dir after round 1
+# and reused on every follow-up round, so when it cross-checks CLAUDE it argues
+# from its original rationale rather than reconstructing it.
+#
+#   * Round 1 (crosscheck_file == "-"): fresh `codex exec`; capture thread_id below.
+#   * Later rounds: `codex exec resume <id>` with just the cross-check follow-up,
+#     relying on codex's retained context.
+#   * Fallback: if no id was captured (round-1 capture failed), a later round
+#     cold-starts with the FULL prompt + cross-check — graceful, never a wedge.
+session_id_file="$(dirname "$out")/codex-answer-session.id"
+resume_id=""
+if [ "$crosscheck_file" = "-" ]; then
+  # Round 1 of a fresh debate: start a NEW session and drop any session id left
+  # behind by a previous debate in this worktree, so we never resume a stale one.
+  rm -f "$session_id_file"
+elif [ -s "$session_id_file" ]; then
+  resume_id="$(cat "$session_id_file")"
+fi
+
+# Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
+# on codex's retained answer, and the full answer prompt for the COLD path (round
+# 1, or the fallback when no session id was captured). Unquoted heredocs: only
+# $prompt_text and $crosscheck expand; their expansions are inserted literally
+# (heredoc results aren't re-scanned), so special chars stay inert.
+if [ -n "$resume_id" ] && [ -n "$crosscheck" ]; then
+  prompt="$(cat <<EOF
+You are CODEX, continuing the SAME answer session you started earlier — you still
+have your own previous answer and reasoning in context. You and another assistant
+("CLAUDE") were each asked the SAME question and are now cross-checking each other
+to reach ONE agreed answer.
+
+The original question was:
+$prompt_text
+
+CLAUDE's LATEST answer (JSON) is:
+$crosscheck
+
+Cross-check CLAUDE's answer against your own (READ-ONLY — you may read repo files,
+git diff/log, grep to verify, but do NOT modify, create, or delete anything, and
+run no git write command: add/commit/push/stash/checkout). Then:
+  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
+    match and note what you changed in changedMind.
+  - Where CLAUDE is wrong or has a gap, keep your position and record it under
+    objections with a specific, evidence-backed reason (cite file:line for repo
+    questions).
+
+Return the JSON schema:
+  - answer: your UPDATED, self-contained unified answer as it stands now.
+  - keyPoints: the core claims your answer rests on.
+  - objections: your remaining disagreements with CLAUDE's latest answer (empty
+    when you fully agree).
+  - changedMind: what CLAUDE convinced you to change this round (empty if nothing).
+  - agreesWithOther: true ONLY when CLAUDE's latest answer is correct and complete
+    and you have NO objection left — your two answers say the same thing.
+EOF
+)"
+else
+  prompt="$(cat <<EOF
+You are CODEX, a rigorous, truthful expert. Answer the user's question below
+thoroughly and honestly — exactly as you would for a careful colleague. You are in
+a debate with another assistant ("CLAUDE") who is answering the SAME question
+independently; afterward you'll cross-check each other until you agree, so give
+your best, most defensible answer now.
+
+You may inspect this repository to ground your answer (READ-ONLY — read files, run
+git diff/log/grep; do NOT modify, create, or delete anything, and run no git write
+command: add/commit/push/stash/checkout). Cite file:line for claims about this
+codebase. If the question isn't about this repo, answer from your own knowledge.
+
+The question:
+$prompt_text
+
+Return the JSON schema:
+  - answer: your complete, self-contained answer.
+  - keyPoints: the core claims your answer rests on, one per item.
+  - objections: leave empty this round (you haven't seen CLAUDE's answer yet).
+  - changedMind: empty string this round.
+  - agreesWithOther: false this round (you haven't seen CLAUDE's answer yet).
+EOF
+)"
+fi
+
+# One codex invocation: warm-resume when we have a session id (carries codex's own
+# prior answer), else a cold start. `--json` emits a `thread.started` event
+# carrying codex's thread_id, captured below to resume next round; it does NOT
+# change the answer, which `--output-schema`/`-o` still write to "$out". `resume`
+# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
+# the same kernel-enforced policy, set through config instead of the flag.
+run_codex() {
+  if [ -n "$resume_id" ]; then
+    codex exec resume \
+      -c sandbox_mode="read-only" \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$resume_id" "$prompt"
+  else
+    codex exec \
+      --sandbox read-only \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$prompt"
+  fi
+}
+
+# model_reasoning_effort is scoped to the debate here (via -c, from the $effort the
+# workflow passes down — default "xhigh") rather than relying on the user's global
+# ~/.codex/config.toml — we always want codex thinking at full depth here.
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
+# hiccups, a spurious internal error) and writes no answer — which would otherwise
+# degrade the round to reviewer-error on a single bad roll. Retry with linear
+# backoff, accepting the first attempt that writes a non-empty answer to "$out".
+# Tunable via env: CODEX_REVIEW_RETRIES (total attempts, default 3),
+# CODEX_REVIEW_BACKOFF (base seconds, default 5 — attempt n waits n*base). Only
+# after every attempt fails empty do we synthesize the reviewerError answer below.
+attempts="${CODEX_REVIEW_RETRIES:-3}"
+backoff="${CODEX_REVIEW_BACKOFF:-5}"
+# Validate both as positive integers. Left unchecked, a non-numeric value makes the
+# arithmetic test error every iteration, so the loop would spin forever instead of
+# giving up. Fall back to the documented defaults (and clamp attempts to >=1)
+# loudly rather than wedge the headless debate on a typo'd override.
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+  attempts=3
+fi
+if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+  backoff=5
+fi
+n=1
+: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
+while :; do
+  rm -f "$out"
+  # Append (not truncate): when every attempt fails, the synthesized reviewerError
+  # answer's tail_log must reflect ALL attempts' diagnostics, not just the last.
+  echo "=== attempt $n/$attempts ===" >>"$log"
+  if ! run_codex </dev/null >>"$log" 2>&1; then
+    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+  fi
+  # Success the moment codex writes an answer: the kernel sandbox + --output-schema
+  # make a non-empty "$out" a real, schema-valid answer, not a partial.
+  [ -s "$out" ] && break
+  # Out of attempts — fall through to the synthesized reviewerError answer.
+  [ "$n" -ge "$attempts" ] && break
+  wait_s=$(( backoff * n ))
+  echo "codex produced no answer (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+  n=$(( n + 1 ))
+  sleep "$wait_s"
+done
+
+if [ -s "$out" ]; then
+  # Persist codex's session id so NEXT round can resume this same warm session
+  # (carrying codex's own prior answer + reasoning). The successful attempt's
+  # `thread.started` is the last one appended to the log; on a resume round it
+  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
+  # an id just means next round cold-starts via the fallback above — not fatal.
+  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+  if [ -n "$sid" ]; then
+    printf '%s\n' "$sid" >"$session_id_file"
+  fi
+fi
+
+if [ ! -s "$out" ]; then
+  # codex produced no answer — synthesize a schema-valid error answer so the debate
+  # loop can surface the failure instead of hanging. The reviewerError flag is the
+  # machine-detectable signal the workflow uses to abort with a terminal failure: a
+  # broken/unavailable codex is INFRASTRUCTURE failure, not substantive
+  # disagreement, so it must NOT spin the loop forever.
+  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    keyPoints: [],
+    agreesWithOther: false,
+    objections: [],
+    changedMind: "",
+    reviewerError: true
+  }' >"$out"
+fi
+
+cat "$out"

--- a/.apm/skills/codex-debate/scripts/codex-answer.sh
+++ b/.apm/skills/codex-debate/scripts/codex-answer.sh
@@ -16,16 +16,23 @@
 # backoff, thread-id capture, session persistence) lives in codex-exec-lib.sh.
 #
 # Usage:
-#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
+#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort] [confirm]
 #
 #   <prompt-file>     path to a file holding the user's prompt/question
 #   <crosscheck-file> path to a file holding CLAUDE's latest answer (JSON) for
 #                     codex to cross-check, or "-" on the first round (codex
-#                     hasn't seen CLAUDE's answer yet — it answers independently)
+#                     hasn't seen CLAUDE's answer yet — it answers independently).
+#                     On a CONFIRM turn this file instead holds the synthesized
+#                     unified CANDIDATE answer codex is asked to approve verbatim.
 #   <out-json>        path the JSON answer is written to (also echoed to stdout)
 #   <reasoning-effort> codex model_reasoning_effort for this run; the answer
 #                     workflow passes its REASONING_EFFORT constant here so the
 #                     value has one home. Defaults to "xhigh" for standalone runs.
+#   [confirm]         the literal token "confirm" selects the CONFIRM prompt shape:
+#                     codex judges ONE shared synthesized candidate (held in the
+#                     crosscheck-file) and approves it VERBATIM or objects — it does
+#                     NOT rewrite its own answer. Mirrors the workflow's
+#                     claudeConfirms turn so both peers plug into one confirm contract.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
@@ -38,12 +45,18 @@
 #     session so codex retains its OWN prior answer + reasoning across rounds.
 set -uo pipefail
 
-prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
+prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort] [confirm]}"
 crosscheck_file="${2:?missing crosscheck-file (use - for none)}"
 out="${3:?missing out-json path}"
 # The answer workflow owns this value (its REASONING_EFFORT constant) and passes
 # it down; "xhigh" is only the default for a standalone invocation of this script.
 effort="${4:-xhigh}"
+# CONFIRM mode: the 5th arg is the literal "confirm" when codex is judging ONE
+# synthesized candidate (held in crosscheck_file) rather than cross-checking
+# CLAUDE's separate answer. This swaps in the confirm prompt shape below — a
+# verbatim/approve-or-object contract symmetric to the workflow's claudeConfirms.
+is_confirm=
+[ "${5:-}" = "confirm" ] && is_confirm=1
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-answer.schema.json"
@@ -124,7 +137,13 @@ EOF
 )"
 fi
 
-# Three prompt shapes, chosen by (resume id × cross-check):
+# Prompt shapes, chosen by (confirm × resume id × cross-check):
+#   * CONFIRM           (confirm token): codex judges ONE synthesized candidate
+#     (in $crosscheck) and approves it VERBATIM or objects — it does NOT rewrite its
+#     own answer. One contract symmetric to the workflow's claudeConfirms turn, so
+#     both peers plug into the same approve-a-fixed-candidate interface. Takes
+#     precedence over warm/cold below (the session is warm here, but the activity is
+#     approval, not cross-check).
 #   * WARM follow-up   (resume id + cross-check): lean prompt leaning on codex's
 #     retained answer.
 #   * COLD follow-up   (no resume id + cross-check): the full answer prompt PLUS the
@@ -134,7 +153,35 @@ fi
 # Unquoted heredocs: only $prompt_text, $crosscheck, and $crosscheck_block expand;
 # their expansions are inserted literally (heredoc results aren't re-scanned), so
 # special chars stay inert.
-if [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
+if [ -n "$is_confirm" ]; then
+  prompt="$(cat <<EOF
+You are CODEX. You and another assistant ("CLAUDE") were each asked the SAME
+question, debated, and AGREED. A unified candidate answer has been synthesized from
+your two agreed answers. Your ONLY job now is to APPROVE it or object — do NOT
+rewrite it, do NOT produce a new answer of your own.
+
+You may inspect this repository to verify (READ-ONLY — read files, run git
+diff/log/grep; do NOT modify, create, or delete anything, and run no git write
+command: add/commit/push/stash/checkout). Cite file:line for repo claims.
+
+The original question was:
+$prompt_text
+
+The candidate unified answer to approve is:
+$crosscheck
+
+Return the JSON schema:
+  - answer: echo the candidate VERBATIM (you are approving it, not rewriting it).
+  - keyPoints: the core claims the candidate rests on.
+  - objections: anything the candidate gets wrong, drops, or overstates relative to
+    what you agreed — empty if you approve it as-is. Be specific (file:line for repo
+    claims).
+  - changedMind: empty (you are confirming, not revising).
+  - agreesWithOther: true ONLY if you approve the candidate as a correct, complete
+    unified answer with NO objection left.
+EOF
+)"
+elif [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME answer session you started earlier — you still
 have your own previous answer and reasoning in context. You and another assistant

--- a/.apm/skills/codex-debate/scripts/codex-exec-lib.sh
+++ b/.apm/skills/codex-debate/scripts/codex-exec-lib.sh
@@ -142,7 +142,11 @@ codex_exec_round() {
     # so overwriting is a harmless refresh. Failure to capture an id just means next
     # round cold-starts via the caller's fallback — not fatal.
     local sid
-    sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+    # Extract the LAST thread_id in the log (one awk, no grep|tail|cut pipeline).
+    # Splitting on '"', the value sits two fields AFTER the "thread_id" key field
+    # (key, then ":", then value) — NOT a fixed column, since other quoted keys
+    # (e.g. "type":"thread.started") precede it on the same JSON event line.
+    sid="$(awk -F'"' '{for (i = 1; i < NF; i++) if ($i == "thread_id") sid = $(i + 2)} END {print sid}' "$log")"
     if [ -n "$sid" ]; then
       printf '%s\n' "$sid" >"$session_id_file"
     fi

--- a/.apm/skills/codex-debate/scripts/codex-exec-lib.sh
+++ b/.apm/skills/codex-debate/scripts/codex-exec-lib.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# codex-exec-lib.sh — the shared, SOURCED core of the codex⇄claude debate scripts.
+#
+# Both modes of /codex-debate drive codex the same way; only WHAT they ask and the
+# verdict SHAPE differ. This file is the single home for the part that is identical
+# (and the part most volatile to codex CLI changes): driving codex headless and
+# READ-ONLY, resuming its warm session, retrying transient failures with backoff,
+# capturing the thread id, and — when codex produces nothing after every attempt —
+# synthesizing a schema-valid error verdict so the debate loop never wedges.
+#
+# It is `source`d, not executed. The two callers (codex-review.sh, codex-answer.sh)
+# own the parts that DIFFER: parsing their own args, building the prompt, choosing
+# the schema + per-mode session-id file, and defining the verdict shape.
+#
+# Contract — a caller must:
+#   1. source this file;
+#   2. define a function  synthesize_error_verdict <out> <tail_log> <attempts>
+#      that writes its own schema-valid error verdict (reviewerError:true) to <out>;
+#   3. resolve the warm-session resume id with  codex_resolve_session <id-file> <round1?>
+#      (so it can pick the warm vs cold prompt), then build $prompt;
+#   4. run one round with  codex_exec_round <schema> <out> <id-file> <effort> <resume-id> <prompt>.
+#
+# Tunables (shared by both modes; names kept for back-compat):
+#   CODEX_REVIEW_RETRIES  total attempts per round (default 3)
+#   CODEX_REVIEW_BACKOFF  base seconds; attempt n waits n*base (default 5)
+
+# Resolve the warm-session resume id for this round, and reset it on round 1.
+#
+#   * Round 1 (is_round1 == "1"): start a NEW session — drop any id left behind by
+#     a previous debate in this worktree so we never resume a stale one. Echoes "".
+#   * Later rounds: echo the persisted id (empty if none was captured — the caller
+#     then cleanly cold-starts with the full prompt, never a wedge).
+#
+# Echoing (rather than setting a global) keeps the caller explicit: it captures the
+# id, uses it to choose the warm vs cold prompt, and passes it back to
+# codex_exec_round. Usage: resume_id="$(codex_resolve_session "$id_file" "$round1")"
+codex_resolve_session() {
+  local session_id_file="$1" is_round1="$2"
+  if [ "$is_round1" = "1" ]; then
+    rm -f "$session_id_file"
+    return 0
+  fi
+  if [ -s "$session_id_file" ]; then
+    cat "$session_id_file"
+  fi
+}
+
+# One codex invocation: warm-resume when we have a session id (carries codex's own
+# prior turn), else a cold start. `--json` emits a `thread.started` event carrying
+# codex's thread_id (captured by codex_exec_round to resume next round); it does NOT
+# change the verdict, which `--output-schema`/`-o` still write to "$out". `resume`
+# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
+# the same kernel-enforced policy, set through config instead of the flag.
+#
+# Reads $resume_id, $schema, $out, $effort, $prompt from the enclosing
+# codex_exec_round via bash's dynamic scope (they're `local` there).
+_codex_run_once() {
+  if [ -n "$resume_id" ]; then
+    codex exec resume \
+      -c sandbox_mode="read-only" \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$resume_id" "$prompt"
+  else
+    codex exec \
+      --sandbox read-only \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$prompt"
+  fi
+}
+
+# Run ONE debate round against codex and leave a schema-valid verdict in <out>
+# (also echoed to stdout). Owns the out/log lifecycle, the retry/backoff loop, the
+# thread-id capture, and the error-verdict fallback.
+#
+#   codex_exec_round <schema> <out> <session_id_file> <effort> <resume_id> <prompt>
+#
+# model_reasoning_effort is scoped to the debate here (via -c, from <effort>) rather
+# than the user's global ~/.codex/config.toml — review/answer is the one place we
+# always want codex thinking at full depth, regardless of their default.
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API hiccups,
+# a spurious internal error) and writes no verdict — which would otherwise degrade
+# the round to reviewer-error on a single bad roll. Retry with linear backoff,
+# accepting the first attempt that writes a non-empty verdict to <out>. Only after
+# every attempt fails empty do we synthesize the reviewerError verdict (via the
+# caller's synthesize_error_verdict hook).
+codex_exec_round() {
+  local schema="$1" out="$2" session_id_file="$3" effort="$4" resume_id="$5" prompt="$6"
+  local log="$out.log"
+
+  # The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
+  # it exists before codex tries to write the verdict there.
+  mkdir -p "$(dirname "$out")"
+
+  local attempts="${CODEX_REVIEW_RETRIES:-3}"
+  local backoff="${CODEX_REVIEW_BACKOFF:-5}"
+  # Validate both as positive integers. Left unchecked, a non-numeric value makes the
+  # arithmetic test error every iteration, so the loop would spin forever instead of
+  # giving up. Fall back to the documented defaults (and clamp attempts to >=1)
+  # loudly rather than wedge the headless debate on a typo'd override.
+  if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+    echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+    attempts=3
+  fi
+  if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+    echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+    backoff=5
+  fi
+
+  local n=1 wait_s
+  : >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
+  while :; do
+    rm -f "$out"
+    # Append (not truncate): when every attempt fails, the synthesized error
+    # verdict's tail_log must reflect ALL attempts' diagnostics, not just the last.
+    echo "=== attempt $n/$attempts ===" >>"$log"
+    if ! _codex_run_once </dev/null >>"$log" 2>&1; then
+      echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+    fi
+    # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
+    # make a non-empty "$out" a real, schema-valid verdict, not a partial.
+    [ -s "$out" ] && break
+    # Out of attempts — fall through to the synthesized error verdict.
+    [ "$n" -ge "$attempts" ] && break
+    wait_s=$(( backoff * n ))
+    echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+    n=$(( n + 1 ))
+    sleep "$wait_s"
+  done
+
+  if [ -s "$out" ]; then
+    # Persist codex's session id so the NEXT round can resume this same warm session
+    # (carrying codex's own prior turn). The successful attempt's `thread.started`
+    # is the last one appended to the log; on a resume round it echoes the same id,
+    # so overwriting is a harmless refresh. Failure to capture an id just means next
+    # round cold-starts via the caller's fallback — not fatal.
+    local sid
+    sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+    if [ -n "$sid" ]; then
+      printf '%s\n' "$sid" >"$session_id_file"
+    fi
+  fi
+
+  if [ ! -s "$out" ]; then
+    # codex produced no verdict — hand off to the caller's shape-specific synthesizer
+    # so the debate loop can surface the failure instead of hanging. reviewerError is
+    # the machine-detectable signal the workflow aborts on: a broken/unavailable codex
+    # is INFRASTRUCTURE failure, not substantive disagreement, so it must NOT spin the
+    # loop forever.
+    local tail_log
+    tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
+    synthesize_error_verdict "$out" "$tail_log" "$attempts"
+  fi
+
+  cat "$out"
+}

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 #
 # codex-review.sh — the canonical, deterministic codex invocation for the
-# codex<->claude review debate. Runs the codex CLI as a READ-ONLY reviewer of
-# the current working-tree state against a base branch, constrained to
-# codex-verdict.schema.json, and writes the JSON verdict to <out-json>.
+# codex<->claude review debate (the `review` mode of /codex-debate). Runs the
+# codex CLI as a READ-ONLY reviewer of the current working-tree state against a
+# base branch, constrained to codex-verdict.schema.json, and writes the JSON
+# verdict to <out-json>.
+#
+# This script owns only what is SPECIFIC to reviewing a diff: arg parsing, the
+# warm/cold review prompt text, the verdict schema + session file, and the
+# verdict-shaped error fallback. The shared codex-driving core (read-only exec/
+# resume, retry/backoff, thread-id capture, session persistence) lives in
+# codex-exec-lib.sh.
 #
 # Usage:
 #   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
@@ -17,24 +24,16 @@
 #                    value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
-#   * codex runs under `--sandbox read-only`, which enforces read-only at the
-#     execution boundary (the kernel sandbox blocks file writes and other
-#     state-mutating syscalls), NOT merely by prompt text. codex reviews
-#     arbitrary diffs and could be prompt-injected by file contents, so the
-#     read-only promise must be enforced, not advertised. codex auto-falls-back
-#     to its bundled bubblewrap when the system one is absent, so this works in
-#     containers; `--sandbox read-only` permits read-only command execution
-#     (git diff/status, reading files) but denies writes. `codex exec` is already
-#     non-interactive (approval policy "never"), so a command the sandbox blocks
-#     is denied outright rather than escalating to a prompt that would wedge the
-#     headless loop.
+#   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
+#     read-only at the kernel boundary (file writes and other state-mutating
+#     syscalls denied), NOT merely by prompt text. codex reviews arbitrary diffs and
+#     could be prompt-injected by file contents, so the read-only promise must be
+#     enforced, not advertised.
 #   * Always emits a schema-valid verdict on stdout, even if codex errors — a
 #     synthesized error verdict (approved:false) so the loop never wedges.
-#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
-#     scratch dir; every later round resumes that same session (`codex exec
-#     resume <id>`) so codex retains its OWN prior review + reasoning across rounds
-#     instead of reconstructing it from the diff + rebuttal each time. If the id
-#     was never captured, a later round cleanly falls back to a cold start.
+#   * WARM SESSION: round 1 cold-starts codex and records its session id; every later
+#     round resumes that same session (`codex exec resume <id>`) so codex retains its
+#     OWN prior review + reasoning across rounds.
 set -uo pipefail
 
 base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
@@ -46,21 +45,12 @@ effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
-log="$out.log"
-
-# The out path lives under a per-worktree scratch dir (e.g. .codex-debate/);
-# make sure it exists before codex tries to write the verdict there.
-mkdir -p "$(dirname "$out")"
+# shellcheck source=codex-exec-lib.sh
+source "$here/codex-exec-lib.sh"
 
 # Pull CLAUDE's previous response, if any. Built as a plain string and injected
 # below via a simple variable reference so any special characters in the JSON
-# (backticks, $, ...) stay literal — heredoc expansion results are not re-scanned.
-# Never let a stale verdict from a previous run survive: if the current codex
-# invocation fails to write one, the empty-check below must catch it and
-# synthesize an error verdict (otherwise a leftover /tmp file reads as a fresh
-# pass — a false consensus).
-rm -f "$out" "$log"
-
+# (backticks, $, ...) stay literal (heredoc expansion results are not re-scanned).
 rebuttal=""
 if [ "$rebuttal_file" != "-" ]; then
   if [ -s "$rebuttal_file" ]; then
@@ -89,28 +79,26 @@ $rebuttal
 "
 fi
 
-# WARM SESSION. codex keeps its OWN review + reasoning across rounds by resuming
-# the same codex session instead of cold-starting `codex exec` each round. The
-# session id (codex's thread_id) is persisted in the scratch dir after round 1
-# and reused on every follow-up round, so when CLAUDE disputes a finding codex
-# re-engages with its original rationale rather than reconstructing it from the
-# diff + rebuttal alone.
-#
-#   * Round 1 (rebuttal_file == "-"): fresh `codex exec`; capture thread_id below.
-#   * Later rounds: `codex exec resume <id>` with just the follow-up (rebuttal +
-#     close-out), relying on codex's retained context.
-#   * Fallback: if no id was captured (round-1 capture failed), a later round
-#     cold-starts with the FULL prompt + rebuttal_block — same as before warm
-#     sessions existed — so a missing id degrades gracefully, never wedges.
+# WARM SESSION. Round 1 (rebuttal_file == "-") cold-starts and resets any stale id;
+# later rounds resume codex's own review session. Resolve the id first so the prompt
+# below can lean on codex's retained context when warm.
 session_id_file="$(dirname "$out")/codex-session.id"
-resume_id=""
-if [ "$rebuttal_file" = "-" ]; then
-  # Round 1 of a fresh debate: start a NEW session and drop any session id left
-  # behind by a previous debate in this worktree, so we never resume a stale one.
-  rm -f "$session_id_file"
-elif [ -s "$session_id_file" ]; then
-  resume_id="$(cat "$session_id_file")"
-fi
+[ "$rebuttal_file" = "-" ] && is_round1=1 || is_round1=
+resume_id="$(codex_resolve_session "$session_id_file" "$is_round1")"
+
+# Synthesize codex-review's error verdict shape when codex produces nothing after
+# every attempt (called by codex_exec_round). reviewerError:true is the signal the
+# workflow aborts the debate on.
+synthesize_error_verdict() {
+  local out="$1" tail_log="$2" attempts="$3"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    approved: false,
+    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    findings: [],
+    responseToRebuttal: "",
+    reviewerError: true
+  }' >"$out"
+}
 
 # Two prompts: a lean follow-up for the WARM (resume) path that leans on codex's
 # retained context, and the full review prompt for the COLD path (round 1, or the
@@ -189,110 +177,6 @@ EOF
 )"
 fi
 
-# One codex invocation: warm-resume when we have a session id (carries codex's own
-# prior review), else a cold start. `--json` is added so the run emits a
-# `thread.started` event carrying codex's thread_id, which we capture below to
-# resume next round; it does NOT change the verdict, which `--output-schema`/`-o`
-# still write to "$out". `resume` has no `--sandbox` flag, so read-only is enforced
-# there via `-c sandbox_mode` — the same kernel-enforced policy, set through config
-# instead of the flag.
-run_codex() {
-  if [ -n "$resume_id" ]; then
-    codex exec resume \
-      -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$resume_id" "$prompt"
-  else
-    codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"
-  fi
-}
-
-# model_reasoning_effort is scoped to the debate here (via -c, from the $effort
-# the workflow passes down — default "xhigh") rather than relying on the user's
-# global ~/.codex/config.toml — review is the one place we always want codex
-# thinking at full depth, regardless of their default.
-#
-# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
-# hiccups, a spurious internal error) and writes no verdict — which would
-# otherwise degrade the whole track to reviewer-error on a single bad roll.
-# Retry the invocation with linear backoff, accepting the first attempt that
-# writes a non-empty verdict to "$out". Tunable via env: CODEX_REVIEW_RETRIES
-# (total attempts, default 3), CODEX_REVIEW_BACKOFF (base seconds, default 5 —
-# attempt n waits n*base). Only after every attempt fails empty do we synthesize
-# the reviewerError verdict below.
-attempts="${CODEX_REVIEW_RETRIES:-3}"
-backoff="${CODEX_REVIEW_BACKOFF:-5}"
-# Validate both as positive integers. Left unchecked, a non-numeric value makes
-# the arithmetic `[ "$n" -ge "$attempts" ]` test error every iteration, so the
-# loop would spin forever instead of giving up and synthesizing the reviewerError
-# verdict. Fall back to the documented defaults (and clamp attempts to >=1) loudly
-# rather than wedge the headless debate on a typo'd override.
-if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
-  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
-  attempts=3
-fi
-if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
-  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
-  backoff=5
-fi
-n=1
-: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
-while :; do
-  rm -f "$out"
-  # Append (not truncate): when every attempt fails, the synthesized reviewerError
-  # verdict's tail_log must reflect ALL attempts' diagnostics — surfacing the exact
-  # transient failures this retry loop exists to weather — not just the final one.
-  echo "=== attempt $n/$attempts ===" >>"$log"
-  if ! run_codex </dev/null >>"$log" 2>&1; then
-    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
-  fi
-  # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
-  # make a non-empty "$out" a real, schema-valid verdict, not a partial.
-  [ -s "$out" ] && break
-  # Out of attempts — fall through to the synthesized reviewerError verdict.
-  [ "$n" -ge "$attempts" ] && break
-  wait_s=$(( backoff * n ))
-  echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
-  n=$(( n + 1 ))
-  sleep "$wait_s"
-done
-
-if [ -s "$out" ]; then
-  # Persist codex's session id so NEXT round can resume this same warm session
-  # (carrying codex's own prior review + reasoning). The successful attempt's
-  # `thread.started` is the last one appended to the log; on a resume round it
-  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
-  # an id just means next round cold-starts via the fallback above — not fatal.
-  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
-  if [ -n "$sid" ]; then
-    printf '%s\n' "$sid" >"$session_id_file"
-  fi
-fi
-
-if [ ! -s "$out" ]; then
-  # codex produced no verdict — synthesize a schema-valid error verdict so the
-  # debate loop can surface the failure instead of hanging. The reviewerError
-  # flag is the machine-detectable signal the workflow uses to abort with a
-  # terminal failure: a broken/unavailable codex is INFRASTRUCTURE failure, not
-  # substantive disagreement, so it must NOT be routed to Claude (there are no
-  # findings to act on) and must NOT spin the loop forever.
-  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
-    approved: false,
-    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
-    findings: [],
-    responseToRebuttal: "",
-    reviewerError: true
-  }' >"$out"
-fi
-
-cat "$out"
+# Drive codex for this round (retry/backoff, thread capture, error fallback) — the
+# shared core does the work; this script supplied the prompt, schema, and shapes.
+codex_exec_round "$schema" "$out" "$session_id_file" "$effort" "$resume_id" "$prompt"

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -1,34 +1,47 @@
 ---
 name: codex-debate
-description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, for code review) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg) — Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
-argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
+description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two explicit subcommands. `review` (also the bare/back-compat default) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. `answer` — Claude and codex each answer a freeform prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
+argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  answer \"<prompt>\""
 ---
 
 # Codex ⇄ Claude debate
 
 This skill runs an automated debate between **codex** and **Claude** that loops to
-consensus with no round cap and no deadlock exit. It has **two modes**, chosen by
-the argument:
+consensus with no round cap and no deadlock exit. It has **two modes**, selected by
+an **explicit leading subcommand** — never by guessing from the argument's shape:
 
-- **Review mode** (default) — the original behavior. codex reviews the current
-  diff, a Claude author fixes/disputes, round after round until they agree, and the
-  trail is committed + posted to the PR. This is everything from
+- **`review`** — codex reviews the current diff, a Claude author fixes/disputes,
+  round after round until they agree, and the trail is **committed + posted to the
+  PR** (a mutating, outward-facing mode). This is everything from
   [Review mode](#review-mode) down.
-- **Answer mode** — triggered when you pass a **freeform prompt** instead of a PR
-  number/flags. Claude and codex **each answer the prompt in parallel**, then
-  **cross-check each other** until both agree, and a **unified answer** is returned
-  to you (plus a saved transcript). See [Answer mode](#answer-mode).
+- **`answer`** — Claude and codex **each answer a freeform prompt in parallel**,
+  then **cross-check each other** until both agree, and a **unified answer** is
+  returned to you (read-only; plus a saved transcript). See
+  [Answer mode](#answer-mode).
+
+The two modes have **different side-effect contracts** (review mutates + writes to
+the PR; answer is read-only), so the mode is chosen **explicitly**, not inferred
+from whether the argument looks like a PR number or like prose. Inferring a
+mutating action from prose shape is exactly the coupling this design avoids.
 
 ## Mode detection (do this first)
 
-Parse `$ARGUMENTS`:
+Look at the **first whitespace-delimited token** of `$ARGUMENTS`:
 
-- **No args, OR the first non-flag token is a number** (a PR number), OR the only
-  args are the review flags (`--base`, `--no-commit`, `--no-comment`) → **review
-  mode**. Continue with [Review mode](#review-mode) below.
-- **The args are a freeform prompt** (any quoted string, a question, or prose that
-  isn't a bare PR number) → **answer mode**. Jump to [Answer mode](#answer-mode);
-  the review-mode steps do not apply.
+- **`answer`** → **answer mode**. The prompt is everything after the `answer`
+  token. Jump to [Answer mode](#answer-mode); the review-mode steps do not apply.
+- **`review`** → **review mode**. The remaining args are the review grammar
+  (`[<pr-number>] [--base …] [--no-commit] [--no-comment]`). Continue with
+  [Review mode](#review-mode).
+- **No args, OR the first token is a number (a PR number) or a `--flag`** →
+  **review mode** (the backward-compatible bare alias for the original
+  `/codex-debate [<pr>] [flags]`, so existing callers like `/be-review` keep
+  working). Continue with [Review mode](#review-mode).
+- **Anything else** (freeform prose with no recognized subcommand) → **ambiguous**.
+  Do **not** guess — ask the user to pick an explicit mode and stop, e.g.: "Did you
+  mean `/codex-debate answer \"<your prompt>\"` (read-only) or `/codex-debate review
+  [<pr>] [flags]` (mutating)?" Only the safe, backward-compatible review grammar
+  auto-routes; prose never silently triggers a mode.
 
 Both modes require Claude Code's **`Workflow` tool** (the engine). Under
 codex/opencode runtimes the skill is inert.
@@ -72,7 +85,9 @@ codex/opencode runtimes the skill is inert.
 
 ## Arguments
 
-Parse `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]`:
+A leading `review` subcommand token, if present, is consumed by mode detection;
+what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]` (the
+bare alias passes the whole argument string through unchanged). Parse:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -243,8 +258,8 @@ the loop ends only when **both** sides report no remaining disagreement. There i
 ### A1. Resolve context
 
 - Determine `repoPath` (the worktree root, normally the cwd).
-- Capture the **prompt**: everything in `$ARGUMENTS` (strip surrounding quotes). If
-  it's empty, ask the user what they want answered and stop.
+- Capture the **prompt**: everything **after the `answer` subcommand token** (strip
+  surrounding quotes). If it's empty, ask the user what they want answered and stop.
 - **Preflight codex**: `codex login status`. If not logged in, stop and tell the
   user to run `codex login` (suggest the `!` prefix to do it in-session).
 - No `git fetch` / base resolution / `gh pr checkout` here — answer mode doesn't
@@ -380,19 +395,26 @@ returns:
 
 ## Files
 
+Shared:
+
+- `scripts/codex-exec-lib.sh` — the sourced core both modes share: the read-only
+  `codex exec`/`resume` invocation, warm-session resolve/persist, retry/backoff,
+  thread-id capture, and the synthesized error-verdict fallback (via a caller hook).
+  The two mode scripts source this and add only their own prompts + verdict shape.
+
 Review mode:
 
 - `debate.workflow.js` — the Workflow script (the loop + consensus logic).
-- `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation
-  (cold-starts round 1, `codex exec resume`s the warm session thereafter).
+- `scripts/codex-review.sh` — the review-specific invocation (arg parsing, the
+  review prompts, the verdict schema/session file, the verdict-shaped error).
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
 
 Answer mode:
 
 - `answer.workflow.js` — the Workflow script for the symmetric answer-debate
   (parallel answers → cross-check loop to agreement → synthesis).
-- `scripts/codex-answer.sh` — the canonical, deterministic `codex exec` invocation
-  for answering a prompt as a read-only peer (warm session across cross-check rounds).
+- `scripts/codex-answer.sh` — the answer-specific invocation (arg parsing, the
+  answer prompts, the answer schema/session file, the answer-shaped error).
 - `scripts/codex-answer.schema.json` — the JSON Schema codex's answer is constrained to.
 
 These are generated from `.apm/skills/codex-debate/`; edit the source there and

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-debate
-description: Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, code-review): codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg): Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".
+description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, for code review) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg) — Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
 argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
 ---
 

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -291,17 +291,21 @@ per-worktree `<repoPath>/.codex-debate/`, so parallel debates never collide. It
 returns:
 
 ```
-{ status: "consensus" | "reviewer-error" | "agent-error" | "no-prompt",
+{ status: "consensus" | "reviewer-error" | "agent-error" | "synthesis-error" | "no-prompt",
   rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
 ```
 
-- **consensus** — the only normal terminus: both sides agreed, and `finalAnswer`
-  is the synthesized unified answer. `transcriptPath` points at the saved
-  Markdown transcript (`.codex-debate/answer-<slug>.md`).
+- **consensus** — the only normal terminus: both sides agreed (for two consecutive
+  rounds — see the convergence note), and `finalAnswer` is the synthesized unified
+  answer. `transcriptPath` points at the saved Markdown transcript
+  (`.codex-debate/answer-<slug>.md`).
 - **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
   CLI) after retries; `codexError` carries the failure detail. Infrastructure
   failure, not a debate outcome.
 - **agent-error** — one side died on a terminal API error after retries.
+- **synthesis-error** — both sides DID agree, but the final synthesis pass produced
+  no answer (the synthesis agent died or returned empty). Not a successful answer —
+  report it as a failure (there is agreement on record, only the merge failed).
 - **no-prompt** — the prompt was empty (shouldn't happen if A1 guarded it).
 
 ### A3. Present the result
@@ -321,10 +325,17 @@ returns:
 
 ## Answer-mode safety & notes
 
-- **Both peers read-only.** codex runs under `--sandbox read-only` (kernel-
-  enforced, belt-and-suspenders with the prompt text — it reads arbitrary repo
-  files and could be prompt-injected); the Claude peer is instructed to read but
-  never edit. No mode of this debate writes to the repo.
+- **Both peers read-only — but enforced ASYMMETRICALLY.** codex runs under
+  `--sandbox read-only` (kernel-enforced, belt-and-suspenders with the prompt text —
+  it reads arbitrary repo files and could be prompt-injected). The **Claude peer is
+  only prompt-enforced**: the harness's `agent()` exposes no sandbox/tool restriction
+  (the same is true of every Claude reviewer in `/lens-debate` and review mode), so
+  Claude's read-only behaviour rests on instruction, not a kernel guard. A
+  prompt-injected or mistaken Claude agent *could* in principle edit files or run a
+  git write — answer mode does not, and cannot here, harden against that the way it
+  does for codex. If that risk matters for a given prompt, run the debate in a
+  disposable/read-only worktree. Treat the read-only guarantee as **hard for codex,
+  best-effort for Claude.**
 - **Warm codex session.** Round 1 cold-starts `codex exec`; every later round
   resumes the same session (`codex exec resume`) so codex cross-checks from its own
   prior answer rather than reconstructing it. The session id lives in the
@@ -332,10 +343,18 @@ returns:
   so it never collides with review mode's session), degrading gracefully to a cold
   start if capture ever fails.
 - **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
-  `objections`; the loop ends only when both sides agree, with no round cap and no
-  deadlock exit. Because the two run in parallel each round, agreement is on the
-  prior round's answers — safe (it only ever ends on real agreement), at worst one
-  round later than a serial handoff.
+  `objections`; a side counts as agreeing only when it sets `agreesWithOther:true`
+  AND leaves no objection, so a stray objection can't be papered over by an
+  over-eager boolean. The loop ends only when both sides agree, with no round cap and
+  no deadlock exit. Because the two run in parallel each round, a single
+  mutually-agreeing round can be a **swap false positive** (Claude adopts codex's
+  prior answer while codex adopts Claude's — both report agreement, but their current
+  outputs are swapped and may still differ). So convergence requires **two
+  consecutive** mutually-agreeing rounds: after the first, each side cross-checks the
+  other's just-agreed answer, and only if both still agree — having now seen each
+  other's current answers — does the loop stop. A real swap surfaces a fresh
+  objection in that confirmation round. Convergence is thus on answers both sides
+  have actually seen — safe, at worst two rounds later than a serial handoff.
 - **Chat + saved transcript, no outward writes.** The unified answer is presented
   in chat and the full transcript is saved to the gitignored
   `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -295,10 +295,10 @@ returns:
   rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
 ```
 
-- **consensus** — the only normal terminus: both sides agreed (for two consecutive
-  rounds — see the convergence note), and `finalAnswer` is the synthesized unified
-  answer. `transcriptPath` points at the saved Markdown transcript
-  (`.codex-debate/answer-<slug>.md`).
+- **consensus** — the only normal terminus: both sides agreed and then both
+  **approved the synthesized candidate** (see the convergence note), and
+  `finalAnswer` is that approved unified answer. `transcriptPath` points at the saved
+  Markdown transcript (`.codex-debate/answer-<slug>.md`).
 - **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
   CLI) after retries; `codexError` carries the failure detail. Infrastructure
   failure, not a debate outcome.
@@ -342,19 +342,23 @@ returns:
   gitignored per-worktree `.codex-debate/` (a distinct `codex-answer-session.id`,
   so it never collides with review mode's session), degrading gracefully to a cold
   start if capture ever fails.
-- **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
-  `objections`; a side counts as agreeing only when it sets `agreesWithOther:true`
-  AND leaves no objection, so a stray objection can't be papered over by an
-  over-eager boolean. The loop ends only when both sides agree, with no round cap and
-  no deadlock exit. Because the two run in parallel each round, a single
-  mutually-agreeing round can be a **swap false positive** (Claude adopts codex's
-  prior answer while codex adopts Claude's — both report agreement, but their current
-  outputs are swapped and may still differ). So convergence requires **two
-  consecutive** mutually-agreeing rounds: after the first, each side cross-checks the
-  other's just-agreed answer, and only if both still agree — having now seen each
-  other's current answers — does the loop stop. A real swap surfaces a fresh
-  objection in that confirmation round. Convergence is thus on answers both sides
-  have actually seen — safe, at worst two rounds later than a serial handoff.
+- **Symmetric convergence, schema-detected, candidate-confirmed.** Each side emits
+  `agreesWithOther` + `objections`; a side counts as agreeing only when it sets
+  `agreesWithOther:true` AND leaves no objection, so a stray objection can't be
+  papered over by an over-eager boolean. Because the two run in parallel each round,
+  a single mutually-agreeing round can be a **swap false positive** (Claude adopts
+  codex's prior answer while codex adopts Claude's — both report agreement, but their
+  current outputs are swapped and still differ), and they can keep swapping back and
+  forth, so counting consecutive parallel agreements does **not** prove the current
+  outputs match. The only sound test is to make both sides judge **one shared piece
+  of text**. So when a round shows mutual agreement, the workflow synthesizes a single
+  **candidate** from the two agreed answers and runs a **confirmation phase**: both
+  sides review that *identical* candidate (without rewriting their own answer) and
+  either approve it or object. Approval is on one fixed text both actually saw, so no
+  swap is possible; if both approve, that candidate is the converged answer — already
+  signed off by both debaters (which is also why `finalAnswer` is never unapproved
+  synthesized text). If either objects, the candidate is dropped and the cross-check
+  loop resumes with the objections folded in. No round cap, no deadlock exit.
 - **Chat + saved transcript, no outward writes.** The unified answer is presented
   in chat and the full transcript is saved to the gitignored
   `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -1,10 +1,40 @@
 ---
 name: codex-debate
-description: Run an automated code-review debate between the codex CLI (reviewer) and a Claude subagent (author) on the current diff, looping until they reach consensus — no round cap, no deadlock exit. Use when the user types `/codex-debate`, or asks to "have codex review this", "run the codex debate", "review this PR with codex", or "argue this with codex until you agree".
-argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]"
+description: Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two modes. REVIEW mode (default, code-review): codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. ANSWER mode (a freeform prompt arg): Claude and codex each answer the prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".
+argument-hint: "[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  \"<prompt to answer>\""
 ---
 
-# Codex ⇄ Claude review debate
+# Codex ⇄ Claude debate
+
+This skill runs an automated debate between **codex** and **Claude** that loops to
+consensus with no round cap and no deadlock exit. It has **two modes**, chosen by
+the argument:
+
+- **Review mode** (default) — the original behavior. codex reviews the current
+  diff, a Claude author fixes/disputes, round after round until they agree, and the
+  trail is committed + posted to the PR. This is everything from
+  [Review mode](#review-mode) down.
+- **Answer mode** — triggered when you pass a **freeform prompt** instead of a PR
+  number/flags. Claude and codex **each answer the prompt in parallel**, then
+  **cross-check each other** until both agree, and a **unified answer** is returned
+  to you (plus a saved transcript). See [Answer mode](#answer-mode).
+
+## Mode detection (do this first)
+
+Parse `$ARGUMENTS`:
+
+- **No args, OR the first non-flag token is a number** (a PR number), OR the only
+  args are the review flags (`--base`, `--no-commit`, `--no-comment`) → **review
+  mode**. Continue with [Review mode](#review-mode) below.
+- **The args are a freeform prompt** (any quoted string, a question, or prose that
+  isn't a bare PR number) → **answer mode**. Jump to [Answer mode](#answer-mode);
+  the review-mode steps do not apply.
+
+Both modes require Claude Code's **`Workflow` tool** (the engine). Under
+codex/opencode runtimes the skill is inert.
+
+<a id="review-mode"></a>
+# Review mode — Codex ⇄ Claude review debate
 
 Automate the back-and-forth you'd otherwise courier by hand: **codex** (the
 reviewer) critiques the current change, a **Claude subagent** (the author)
@@ -188,7 +218,115 @@ the per-round commits sit on the local branch for the human to review):
   outward-facing write — on by default because the whole point is to leave the
   review trail on the PR; `--no-comment` suppresses it.
 
-## Safety & notes
+<a id="answer-mode"></a>
+# Answer mode — Codex ⇄ Claude answer debate
+
+When the argument is a **freeform prompt** (not a PR number/flags), the skill
+generalizes the same debate machinery from *reviewing a diff* to *answering a
+question*. The shape is **symmetric**, not author⇄reviewer: **Claude and codex are
+two equal peers**. They each answer the prompt **independently and in parallel**,
+then **cross-check each other's answer** round after round — conceding where the
+other is right, holding firm (with evidence) where it isn't — **until both agree**.
+A final pass **synthesizes their two converged answers into one unified reply**,
+which you present to the user along with a saved transcript.
+
+Both peers are **codebase-aware but read-only**: each may read this repo (`git
+diff/log`, read files, grep) to ground its answer, but neither edits anything —
+codex stays under `--sandbox read-only` (kernel-enforced), and the Claude peer is
+instructed not to write. Consensus is **schema-detected in code**: each side emits
+a structured answer with an `agreesWithOther` boolean and an `objections` list, and
+the loop ends only when **both** sides report no remaining disagreement. There is
+**no round cap and no deadlock exit** — same as review mode.
+
+## Steps
+
+### A1. Resolve context
+
+- Determine `repoPath` (the worktree root, normally the cwd).
+- Capture the **prompt**: everything in `$ARGUMENTS` (strip surrounding quotes). If
+  it's empty, ask the user what they want answered and stop.
+- **Preflight codex**: `codex login status`. If not logged in, stop and tell the
+  user to run `codex login` (suggest the `!` prefix to do it in-session).
+- No `git fetch` / base resolution / `gh pr checkout` here — answer mode doesn't
+  diff a branch.
+
+### A2. Run the answer Workflow
+
+Invoke the **`Workflow` tool** pointing at this skill's committed answer script,
+passing the prompt through `args`:
+
+```
+Workflow({
+  scriptPath: ".claude/skills/codex-debate/answer.workflow.js",
+  args: {
+    repoPath: "<worktree root>",   // also the per-worktree scratch dir root
+    prompt: "<the user's freeform prompt, verbatim>",
+    skillDir: ".claude/skills/codex-debate"
+  }
+})
+```
+
+The workflow runs in the background and notifies you when it completes. It runs an
+**Answer** phase (round 1: `claude:round1` and `codex:round1` in parallel), a
+**Reconcile** phase (rounds 2+: each side cross-checks the other, in parallel,
+round after round), and a **Synthesis** phase that merges the two agreed answers.
+Watch live via `/workflows`. Ephemeral scratch (per-side answers, cross-check
+files, per-round sections, the saved transcript) lives under the gitignored,
+per-worktree `<repoPath>/.codex-debate/`, so parallel debates never collide. It
+returns:
+
+```
+{ status: "consensus" | "reviewer-error" | "agent-error" | "no-prompt",
+  rounds, prompt, finalAnswer, transcriptPath, reasoningEffort, codexError }
+```
+
+- **consensus** — the only normal terminus: both sides agreed, and `finalAnswer`
+  is the synthesized unified answer. `transcriptPath` points at the saved
+  Markdown transcript (`.codex-debate/answer-<slug>.md`).
+- **reviewer-error** — codex itself failed to produce an answer (broken/unavailable
+  CLI) after retries; `codexError` carries the failure detail. Infrastructure
+  failure, not a debate outcome.
+- **agent-error** — one side died on a terminal API error after retries.
+- **no-prompt** — the prompt was empty (shouldn't happen if A1 guarded it).
+
+### A3. Present the result
+
+- If `status === "consensus"`: present **`finalAnswer`** to the user as the answer
+  — this is the unified reply both Claude and codex agreed on. State **how many
+  rounds** it took to converge and that **codex answered at `reasoningEffort`**
+  (read it off the return value). Point the user at the saved transcript
+  (`transcriptPath`) for the full convergence trail; optionally `cat` the
+  `.codex-debate/answer-section-*.md` files to show a compact per-round summary
+  (each side's answer, what changed, remaining objections). This mode makes **no
+  outward-facing writes** — no PR comment, no commits — it just answers.
+- If `status !== "consensus"`: report it as a **failure**, not an answer. Surface
+  `codexError` (for `reviewer-error`) or the workflow log so the user sees what
+  broke, and tell them how to fix it (e.g. `codex login`) and re-run. Do **not**
+  present a half-debate as if it were an agreed answer.
+
+## Answer-mode safety & notes
+
+- **Both peers read-only.** codex runs under `--sandbox read-only` (kernel-
+  enforced, belt-and-suspenders with the prompt text — it reads arbitrary repo
+  files and could be prompt-injected); the Claude peer is instructed to read but
+  never edit. No mode of this debate writes to the repo.
+- **Warm codex session.** Round 1 cold-starts `codex exec`; every later round
+  resumes the same session (`codex exec resume`) so codex cross-checks from its own
+  prior answer rather than reconstructing it. The session id lives in the
+  gitignored per-worktree `.codex-debate/` (a distinct `codex-answer-session.id`,
+  so it never collides with review mode's session), degrading gracefully to a cold
+  start if capture ever fails.
+- **Symmetric convergence, schema-detected.** Each side emits `agreesWithOther` +
+  `objections`; the loop ends only when both sides agree, with no round cap and no
+  deadlock exit. Because the two run in parallel each round, agreement is on the
+  prior round's answers — safe (it only ever ends on real agreement), at worst one
+  round later than a serial handoff.
+- **Chat + saved transcript, no outward writes.** The unified answer is presented
+  in chat and the full transcript is saved to the gitignored
+  `.codex-debate/answer-<slug>.md`. Unlike review mode, answer mode never commits
+  or posts to a PR.
+
+## Safety & notes (review mode)
 
 - **codex runs read-only — enforced, not just asked.** codex is invoked with
   `--sandbox read-only`, so the kernel sandbox blocks file writes and other
@@ -242,10 +380,20 @@ the per-round commits sit on the local branch for the human to review):
 
 ## Files
 
+Review mode:
+
 - `debate.workflow.js` — the Workflow script (the loop + consensus logic).
 - `scripts/codex-review.sh` — the canonical, deterministic `codex exec` invocation
   (cold-starts round 1, `codex exec resume`s the warm session thereafter).
 - `scripts/codex-verdict.schema.json` — the JSON Schema codex's verdict is constrained to.
+
+Answer mode:
+
+- `answer.workflow.js` — the Workflow script for the symmetric answer-debate
+  (parallel answers → cross-check loop to agreement → synthesis).
+- `scripts/codex-answer.sh` — the canonical, deterministic `codex exec` invocation
+  for answering a prompt as a read-only peer (warm session across cross-check rounds).
+- `scripts/codex-answer.schema.json` — the JSON Schema codex's answer is constrained to.
 
 These are generated from `.apm/skills/codex-debate/`; edit the source there and
 run `just ai apm` to regenerate.

--- a/.claude/skills/codex-debate/answer.workflow.js
+++ b/.claude/skills/codex-debate/answer.workflow.js
@@ -153,16 +153,20 @@ async function codexAnswers(round, other) {
       : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
 
 ${JSON.stringify(other, null, 2)}`
+  // Every path below is spliced into a shell command the runner agent executes, so
+  // POSIX-quote each one (worktrees or skill dirs with spaces/metacharacters would
+  // otherwise break the command or misdirect it). The Write-tool file CONTENTS
+  // (${prompt}, ${JSON.stringify(other)}) are not shell-parsed and stay verbatim.
   const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
 
 ${prompt}
 
 ${crossStep}
 
 3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-answer.sh ${promptPath} ${crossArg} ${answerPath} ${REASONING_EFFORT}\`
+   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}\`
 
    This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
 
@@ -254,17 +258,32 @@ let status = 'consensus'
 let claudeAns = null
 let codexAns = null
 
+// A side "agrees" only when it BOTH set agreesWithOther AND left no objection. The
+// boolean and the objections list must be consistent (the schema says so), but a
+// model can set the flag while still listing a disagreement; honour the objections
+// too so a leftover objection can't be papered over by an over-eager boolean.
+const sideAgrees = (a) => a.agreesWithOther === true && (a.objections || []).length === 0
+
 // ---------------------------------------------------------------------------
 // The loop — round 1 is the independent answer (parallel); rounds 2+ are
-// cross-checks. Runs until BOTH sides agree. No round cap, no deadlock exit:
-// each side keeps cross-checking until they converge (the harness's per-workflow
-// agent backstop is the only hard ceiling — interrupt via /workflows or TaskStop).
+// cross-checks. Runs until BOTH sides agree, then ONE confirmation round. No round
+// cap, no deadlock exit: each side keeps cross-checking until they converge (the
+// harness's per-workflow agent backstop is the only hard ceiling — interrupt via
+// /workflows or TaskStop).
 //
-// Both sides run in PARALLEL each round, so in round N each cross-checks the
-// OTHER's round-(N-1) answer. Convergence is thus mutual agreement on the prior
-// round's answers — safe (it can only end on real agreement, never prematurely),
-// at worst one round later than a strictly-serial handoff would.
+// Both sides run in PARALLEL each round, so in round N each cross-checks the OTHER's
+// round-(N-1) answer. That parallelism creates a SWAP hazard: if Claude adopts
+// codex's prior answer while codex simultaneously adopts Claude's prior answer, both
+// can report agreesWithOther:true in the SAME round even though their CURRENT outputs
+// are swapped and may still differ. So a single mutually-agreeing round is NOT
+// sufficient. We require TWO CONSECUTIVE mutually-agreeing rounds: after the first,
+// each side runs once more and now cross-checks the OTHER's just-agreed answer; only
+// if both still agree (having seen each other's current answers) do we converge. A
+// real swap surfaces a fresh objection in that confirmation round; genuine agreement
+// holds. Convergence is therefore on answers both sides have actually seen — safe,
+// at worst two rounds later than a strictly-serial handoff would be.
 // ---------------------------------------------------------------------------
+let agreedStreak = 0
 for (let round = 1; ; round++) {
   const prevClaude = claudeAns
   const prevCodex = codexAns
@@ -299,14 +318,23 @@ for (let round = 1; ; round++) {
   await writeSection(entry)
 
   // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
-  // remaining disagreement with the other's latest answer.
-  if (round >= 2 && claude.agreesWithOther === true && codex.agreesWithOther === true) {
-    log(`Round ${round}: both sides agree — converged.`)
+  // remaining disagreement — agreesWithOther:true AND no objections. One such round
+  // can be a parallel-swap false positive (see the loop header), so require TWO in a
+  // row: the second round has each side cross-check the other's just-agreed answer,
+  // confirming on outputs both have actually seen.
+  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
+  agreedStreak = bothAgree ? agreedStreak + 1 : 0
+  if (agreedStreak >= 2) {
+    log(`Round ${round}: both sides agree for a second consecutive round — converged.`)
     break
   }
-  log(
-    `Round ${round}: claude agrees=${!!claude.agreesWithOther} (objections=${(claude.objections || []).length}), codex agrees=${!!codex.agreesWithOther} (objections=${(codex.objections || []).length})`,
-  )
+  if (bothAgree) {
+    log(`Round ${round}: both sides agree — running one confirmation round before converging.`)
+  } else {
+    log(
+      `Round ${round}: claude agrees=${sideAgrees(claude)} (objections=${(claude.objections || []).length}), codex agrees=${sideAgrees(codex)} (objections=${(codex.objections || []).length})`,
+    )
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -331,7 +359,16 @@ ${JSON.stringify(codexAns, null, 2)}
 Return the unified answer in \`answer\`.`,
     { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
   )
-  finalAnswer = synth ? synth.answer : null
+  finalAnswer = synth && synth.answer ? synth.answer : null
+  // Synthesis is the user-facing payload of a consensus run. If the synthesis agent
+  // died (null) or returned an empty answer, there is no answer to present — do NOT
+  // keep reporting "consensus" with finalAnswer:null, which A3 would mis-handle as a
+  // successful answer. Demote to an explicit failure terminus so the skill surfaces
+  // it as broken (the sides DID agree; only the final merge failed).
+  if (!finalAnswer) {
+    status = 'synthesis-error'
+    log('Synthesis produced no answer — both sides agreed but the merge failed; reporting synthesis-error.')
+  }
 }
 
 log(`Answer-debate ended: ${status} after ${transcript.length} round(s).`)

--- a/.claude/skills/codex-debate/answer.workflow.js
+++ b/.claude/skills/codex-debate/answer.workflow.js
@@ -362,6 +362,12 @@ return {
   transcriptPath: answerDocPath,
   finalAnswer,
   reasoningEffort: REASONING_EFFORT,
-  // The error terminus carries codex's failure detail in its answer text.
-  codexError: status === 'reviewer-error' ? (codexAns && codexAns.answer) || null : null,
+  // The error terminus carries codex's failure detail in the synthesized verdict's
+  // answer text. Sourced from the transcript (not codexAns) because the
+  // reviewer-error branch breaks BEFORE assigning codexAns — the failing round is
+  // recorded in the transcript, so read the detail back from there.
+  codexError:
+    status === 'reviewer-error'
+      ? transcript.find((e) => e.codex && e.codex.reviewerError)?.codex.answer || null
+      : null,
 }

--- a/.claude/skills/codex-debate/answer.workflow.js
+++ b/.claude/skills/codex-debate/answer.workflow.js
@@ -25,12 +25,10 @@ const workDir = `${repoPath}/.codex-debate`
 
 // Model tiers. The claude-answer round does real reasoning (answering, then
 // cross-checking codex) → `model` (Opus). The final synthesis is also user-facing
-// prose, so it runs on `model` too. The codex RUNNER must relay codex's answer
-// JSON faithfully (a verbatim copy, not a paraphrase — the weakest tier corrupts
-// it silently) → `copyModel` (Sonnet). The file writers/assemblers are mechanical
-// → `mechModel` (Haiku). Defaults match a direct invocation.
+// prose, so it runs on `model` too. The codex RUNNER and the transcript writer must
+// relay text faithfully (a verbatim copy, not a paraphrase — the weakest tier
+// corrupts it silently) → `copyModel` (Sonnet). Defaults match a direct invocation.
 const model = a.model || 'opus'
-const mechModel = a.mechModel || 'haiku'
 const copyModel = a.copyModel || 'sonnet'
 
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
@@ -296,33 +294,7 @@ function renderTranscript(transcript, meta, finalAnswer) {
   return parts.join('\n\n')
 }
 
-// Zero-pad the round so the section glob sorts in round order for the assembly.
-const sectionFile = (round) => `${workDir}/answer-section-${String(round).padStart(3, '0')}.md`
-
-// Write ONE round's section to its own small file (Haiku-safe — just this round).
-async function writeSection(entry) {
-  const text = roundSection(entry)
-  const path = sectionFile(entry.round)
-  const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
-2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
-
-${text}`
-  return agent(p, { label: `section:round${entry.round}`, phase: 'Reconcile', model: mechModel })
-}
-
-// ---------------------------------------------------------------------------
-// Set up scratch — clear any stale per-round sections from a PRIOR debate in this
-// worktree so they don't leak into the assembled transcript. Scoped to the
-// answer-section files; the review mode's section-NNN.md and the verdict/answer
-// JSONs keep their own lifecycle.
-// ---------------------------------------------------------------------------
 phase('Answer')
-await agent(
-  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/answer-section-*.md\`. Do not edit any other file. Do not run git.`,
-  { label: 'sections:reset', phase: 'Answer', model: mechModel },
-)
 
 const transcript = []
 let status = 'consensus'
@@ -431,7 +403,6 @@ for (let round = 1; ; round++) {
     ? { round, claude, codex, confirming: true, candidate: pendingCandidate }
     : { round, claude, codex }
   transcript.push(entry)
-  await writeSection(entry)
 
   // CONFIRMATION phase: both sides judged the SAME synthesized candidate. If both
   // approve it (agreesWithOther:true + no objections), that candidate is the agreed,

--- a/.claude/skills/codex-debate/answer.workflow.js
+++ b/.claude/skills/codex-debate/answer.workflow.js
@@ -135,11 +135,45 @@ Return the schema:
   })
 }
 
+// A confirmation/approval turn for ONE side, judging a SINGLE shared candidate
+// answer (the synthesized merge) WITHOUT rewriting its own. Both sides judge the
+// IDENTICAL text, so no swap/oscillation is possible (the swap hazard exists only
+// because each parallel round adopts the OTHER's separate answer). Returns
+// `agreesWithOther` + `objections` against that candidate. Claude runs it directly
+// (it's read-only reasoning); codex runs it through the same cross-check machinery
+// (the candidate is handed to it as "CLAUDE's latest answer" to approve).
+async function claudeConfirms(round, candidate) {
+  const prompt_ = `You and CODEX were asked the SAME question, debated, and AGREED. A unified candidate answer has been synthesized from your two agreed answers. Your ONLY job now is to APPROVE it or object — do NOT rewrite it, do NOT produce a new answer of your own.
+
+You may inspect the repo at \`${repoPath}\` to verify (READ-ONLY — \`git -C ${repoPath} diff/log\`, read files, grep; do NOT edit/create/delete or run any git write).
+
+The question:
+${prompt}
+
+The candidate unified answer to approve:
+${candidate}
+
+Return the schema:
+  - answer: echo the candidate VERBATIM (you are approving it, not rewriting it).
+  - keyPoints: the core claims the candidate rests on.
+  - objections: anything the candidate gets wrong, drops, or overstates relative to what you agreed — empty if you approve it as-is. Be specific (file:line for repo claims).
+  - changedMind: empty (you are confirming, not revising).
+  - agreesWithOther: true ONLY if you approve the candidate as a correct, complete unified answer with NO objection left.`
+  return agent(prompt_, {
+    label: `claude:confirm${round}`,
+    phase: 'Synthesis',
+    model,
+    schema: ANSWER_SCHEMA,
+  })
+}
+
 // CODEX answers/cross-checks via codex-answer.sh (warm session across rounds). The
 // agent here is a MECHANICAL RUNNER: it writes the prompt + cross-check files,
 // shells out to the script, and relays codex's JSON answer verbatim — it does NOT
 // answer the question itself. The user's prompt and CLAUDE's latest answer carry
 // arbitrary characters, so they're written with the Write tool, never a heredoc.
+// On a confirmation turn (`confirm`), the cross-check input is the SINGLE shared
+// candidate, and the runner relays codex's approval/objections to it.
 async function codexAnswers(round, other) {
   const answerPath = `${workDir}/answer-codex-${round}.json`
   const promptPath = `${workDir}/answer-prompt.txt`
@@ -234,7 +268,7 @@ async function writeSection(entry) {
   const path = sectionFile(entry.round)
   const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
 2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
 ${text}`
@@ -264,32 +298,70 @@ let codexAns = null
 // too so a leftover objection can't be papered over by an over-eager boolean.
 const sideAgrees = (a) => a.agreesWithOther === true && (a.objections || []).length === 0
 
+// Synthesize a SINGLE candidate answer from the two agreed answers. This is the
+// user-facing unified reply, but it is NOT returned until BOTH sides approve it (the
+// confirmation phase below), so the synthesized text is never reported as consensus
+// without both debaters having signed off on it. Returns the candidate string, or
+// null if the synthesis agent died / returned empty.
+async function synthesize(claudeFinal, codexFinal) {
+  const synth = await agent(
+    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
+
+The question:
+${prompt}
+
+Claude's final answer (JSON):
+${JSON.stringify(claudeFinal, null, 2)}
+
+Codex's final answer (JSON):
+${JSON.stringify(codexFinal, null, 2)}
+
+Return the unified answer in \`answer\`.`,
+    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
+  )
+  return synth && synth.answer ? synth.answer : null
+}
+
 // ---------------------------------------------------------------------------
 // The loop — round 1 is the independent answer (parallel); rounds 2+ are
-// cross-checks. Runs until BOTH sides agree, then ONE confirmation round. No round
-// cap, no deadlock exit: each side keeps cross-checking until they converge (the
-// harness's per-workflow agent backstop is the only hard ceiling — interrupt via
-// /workflows or TaskStop).
+// cross-checks. Runs until BOTH sides agree, then a CONFIRMATION phase on a single
+// synthesized candidate. No round cap, no deadlock exit: each side keeps
+// cross-checking until they converge (the harness's per-workflow agent backstop is
+// the only hard ceiling — interrupt via /workflows or TaskStop).
 //
 // Both sides run in PARALLEL each round, so in round N each cross-checks the OTHER's
-// round-(N-1) answer. That parallelism creates a SWAP hazard: if Claude adopts
-// codex's prior answer while codex simultaneously adopts Claude's prior answer, both
-// can report agreesWithOther:true in the SAME round even though their CURRENT outputs
-// are swapped and may still differ. So a single mutually-agreeing round is NOT
-// sufficient. We require TWO CONSECUTIVE mutually-agreeing rounds: after the first,
-// each side runs once more and now cross-checks the OTHER's just-agreed answer; only
-// if both still agree (having seen each other's current answers) do we converge. A
-// real swap surfaces a fresh objection in that confirmation round; genuine agreement
-// holds. Convergence is therefore on answers both sides have actually seen — safe,
-// at worst two rounds later than a strictly-serial handoff would be.
+// round-(N-1) answer. That parallelism creates a SWAP/OSCILLATION hazard: if Claude
+// adopts codex's prior answer while codex simultaneously adopts Claude's prior
+// answer, both can report agreesWithOther:true in the SAME round even though their
+// CURRENT outputs are swapped and still differ — and they can keep swapping back and
+// forth, so counting consecutive parallel agreements does NOT prove the current
+// outputs match. The only sound test is to make BOTH sides judge ONE shared piece of
+// text. So when a round shows mutual agreement, we synthesize a single candidate
+// from the two agreed answers and run a CONFIRMATION phase: both sides review that
+// IDENTICAL candidate (without rewriting their own answer) and either approve it or
+// object. Approval is on one fixed text both actually saw, so no swap is possible. If
+// both approve, that candidate IS the converged answer (already debater-approved). If
+// either objects, its objections fold back into the cross-check loop and we continue.
 // ---------------------------------------------------------------------------
-let agreedStreak = 0
+let finalAnswer = null
+// On a confirmation turn, each side's "other" input is the synthesized candidate
+// (wrapped in the answer shape so the existing cross-check machinery accepts it).
+// Carried across iterations so a rejected confirmation feeds the candidate + the
+// objector's complaints back into the next ordinary cross-check round.
+let pendingCandidate = null
 for (let round = 1; ; round++) {
+  const confirming = pendingCandidate !== null
+  const candidateAns = confirming
+    ? { answer: pendingCandidate, keyPoints: [], agreesWithOther: true, objections: [], changedMind: '' }
+    : null
   const prevClaude = claudeAns
   const prevCodex = codexAns
   const [claude, codex] = await parallel([
-    () => claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
-    () => codexAnswers(round, round === 1 ? null : prevClaude),
+    () =>
+      confirming
+        ? claudeConfirms(round, pendingCandidate)
+        : claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
+    () => codexAnswers(round, round === 1 ? null : confirming ? candidateAns : prevClaude),
   ])
 
   // codex infrastructure failure — terminal. The runner could not get an answer
@@ -317,57 +389,43 @@ for (let round = 1; ; round++) {
   transcript.push(entry)
   await writeSection(entry)
 
-  // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
-  // remaining disagreement — agreesWithOther:true AND no objections. One such round
-  // can be a parallel-swap false positive (see the loop header), so require TWO in a
-  // row: the second round has each side cross-check the other's just-agreed answer,
-  // confirming on outputs both have actually seen.
-  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
-  agreedStreak = bothAgree ? agreedStreak + 1 : 0
-  if (agreedStreak >= 2) {
-    log(`Round ${round}: both sides agree for a second consecutive round — converged.`)
-    break
+  // CONFIRMATION phase: both sides judged the SAME synthesized candidate. If both
+  // approve it (agreesWithOther:true + no objections), that candidate is the agreed,
+  // debater-approved unified answer — converge. If either objects, drop the candidate
+  // and continue the cross-check loop (their objections are already in `claudeAns` /
+  // `codexAns` and feed the next round).
+  if (confirming) {
+    if (sideAgrees(claude) && sideAgrees(codex)) {
+      finalAnswer = pendingCandidate
+      log(`Round ${round}: both sides approved the synthesized candidate — converged.`)
+      break
+    }
+    log(`Round ${round}: candidate rejected (claude agrees=${sideAgrees(claude)}, codex agrees=${sideAgrees(codex)}) — resuming cross-check.`)
+    pendingCandidate = null
+    continue
   }
+
+  // From round 2 on (round 1 has no cross-check), if BOTH sides report no remaining
+  // disagreement, synthesize one candidate and enter the confirmation phase next
+  // round. A single parallel-agreeing round can be a swap false positive, so we do
+  // NOT converge here — we converge only after both sides approve the SAME candidate.
+  const bothAgree = round >= 2 && sideAgrees(claude) && sideAgrees(codex)
   if (bothAgree) {
-    log(`Round ${round}: both sides agree — running one confirmation round before converging.`)
+    phase('Synthesis')
+    pendingCandidate = await synthesize(claude, codex)
+    if (!pendingCandidate) {
+      // The merge itself failed (synthesis agent died / returned empty). The sides
+      // DID agree; only the merge broke — surface that explicitly rather than spin.
+      status = 'synthesis-error'
+      log('Synthesis produced no candidate — both sides agreed but the merge failed; reporting synthesis-error.')
+      break
+    }
+    log(`Round ${round}: both sides agree — synthesized a candidate; confirming it next round.`)
+    phase('Reconcile')
   } else {
     log(
       `Round ${round}: claude agrees=${sideAgrees(claude)} (objections=${(claude.objections || []).length}), codex agrees=${sideAgrees(codex)} (objections=${(codex.objections || []).length})`,
     )
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Synthesis — merge the two AGREED answers into one unified reply for the user.
-// Only on consensus: on a failure terminus there's no agreement to synthesize.
-// ---------------------------------------------------------------------------
-let finalAnswer = null
-if (status === 'consensus' && claudeAns && codexAns) {
-  phase('Synthesis')
-  const synth = await agent(
-    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
-
-The question:
-${prompt}
-
-Claude's final answer (JSON):
-${JSON.stringify(claudeAns, null, 2)}
-
-Codex's final answer (JSON):
-${JSON.stringify(codexAns, null, 2)}
-
-Return the unified answer in \`answer\`.`,
-    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
-  )
-  finalAnswer = synth && synth.answer ? synth.answer : null
-  // Synthesis is the user-facing payload of a consensus run. If the synthesis agent
-  // died (null) or returned an empty answer, there is no answer to present — do NOT
-  // keep reporting "consensus" with finalAnswer:null, which A3 would mis-handle as a
-  // successful answer. Demote to an explicit failure terminus so the skill surfaces
-  // it as broken (the sides DID agree; only the final merge failed).
-  if (!finalAnswer) {
-    status = 'synthesis-error'
-    log('Synthesis produced no answer — both sides agreed but the merge failed; reporting synthesis-error.')
   }
 }
 
@@ -385,7 +443,7 @@ const transcriptText = renderTranscript(
 await agent(
   `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`.
 2. Using the Write tool, create \`${answerDocPath}\` with EXACTLY this content, overwriting any existing file:
 
 ${transcriptText}`,

--- a/.claude/skills/codex-debate/answer.workflow.js
+++ b/.claude/skills/codex-debate/answer.workflow.js
@@ -1,0 +1,367 @@
+export const meta = {
+  name: 'codex-answer-debate',
+  description: 'Have Claude and codex each answer a prompt in parallel, then cross-check until they agree, and synthesize one unified answer (no round cap, no deadlock exit)',
+  phases: [
+    { title: 'Answer', detail: 'claude + codex answer the prompt independently, in parallel' },
+    { title: 'Reconcile', detail: 'each cross-checks the other, round after round, until both agree' },
+    { title: 'Synthesis', detail: 'merge the two agreed answers into one unified reply' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Inputs (passed via the Workflow tool's `args`)
+// ---------------------------------------------------------------------------
+const a = args || {}
+const repoPath = a.repoPath || '.'
+// The user's freeform prompt — the question both assistants answer and then
+// cross-check toward one agreed reply. Required; the orchestrator passes it.
+const prompt = (a.prompt || '').trim()
+// Where the generated skill lives, so the codex runner can find codex-answer.sh.
+const skillDir = a.skillDir || '.claude/skills/codex-debate'
+// Per-worktree scratch dir, shared with the review mode. Gitignored, derived from
+// repoPath (the worktree root === $PWD) so parallel debates in DIFFERENT worktrees
+// never collide on shared /tmp paths and these files never pollute the repo.
+const workDir = `${repoPath}/.codex-debate`
+
+// Model tiers. The claude-answer round does real reasoning (answering, then
+// cross-checking codex) → `model` (Opus). The final synthesis is also user-facing
+// prose, so it runs on `model` too. The codex RUNNER must relay codex's answer
+// JSON faithfully (a verbatim copy, not a paraphrase — the weakest tier corrupts
+// it silently) → `copyModel` (Sonnet). The file writers/assemblers are mechanical
+// → `mechModel` (Haiku). Defaults match a direct invocation.
+const model = a.model || 'opus'
+const mechModel = a.mechModel || 'haiku'
+const copyModel = a.copyModel || 'sonnet'
+
+// The reasoning effort codex runs at, scoped to the debate. This JS constant is
+// the SINGLE home for the value: it is passed script-ward (a 4th positional arg to
+// codex-answer.sh, which sets `-c model_reasoning_effort`) and read by the
+// transcript header, so the `-c` flag and the header both derive from here.
+const REASONING_EFFORT = 'xhigh'
+
+// POSIX single-quote a path for safe interpolation into a shell command (spaces,
+// globs, metacharacters inert; embedded single quotes escaped via '\'' ). Used for
+// the destructive scratch reset (`rm -f`) below.
+const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
+
+// A filesystem-safe slug for this prompt, so the saved transcript has a readable,
+// deterministic name (Date.now()/Math.random() are unavailable in workflow scripts,
+// so the name is derived purely from the prompt text). Falls back to 'answer'.
+const slug =
+  (prompt.toLowerCase().match(/[a-z0-9]+/g) || []).slice(0, 8).join('-').slice(0, 60) || 'answer'
+const answerDocPath = `${workDir}/answer-${slug}.md`
+
+// ---------------------------------------------------------------------------
+// Schema — shared by both debaters (codex's runner mirrors
+// scripts/codex-answer.schema.json). `reviewerError` is set ONLY by the codex
+// runner script when codex itself failed; the claude side never sets it.
+// ---------------------------------------------------------------------------
+const OBJECTION = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { point: { type: 'string' }, reason: { type: 'string' } },
+  required: ['point', 'reason'],
+}
+const ANSWER_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    answer: { type: 'string' },
+    keyPoints: { type: 'array', items: { type: 'string' } },
+    agreesWithOther: { type: 'boolean' },
+    objections: { type: 'array', items: OBJECTION },
+    changedMind: { type: 'string' },
+    reviewerError: { type: 'boolean' },
+  },
+  required: ['answer', 'keyPoints', 'agreesWithOther', 'objections', 'changedMind'],
+}
+const FINAL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { answer: { type: 'string' } },
+  required: ['answer'],
+}
+
+if (!prompt) {
+  return {
+    status: 'no-prompt',
+    rounds: 0,
+    prompt,
+    transcriptPath: null,
+    finalAnswer: null,
+    note: 'No prompt was passed to the answer-debate workflow; nothing to answer.',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The two debaters (symmetric: each answers, then cross-checks the other)
+// ---------------------------------------------------------------------------
+// CLAUDE answers/cross-checks via a harness subagent (Claude isn't headless under
+// Max auth, so agent() is the only way to run it). Read-only: it may inspect the
+// repo to ground its answer but must not edit anything.
+async function claudeAnswers(round, other, myPrev) {
+  const block =
+    round === 1
+      ? `Answer the question below thoroughly and honestly — your best, most defensible answer. You are in a debate with another assistant ("CODEX") answering the SAME question independently; you'll cross-check each other afterward, so make this strong.`
+      : `This is a CROSS-CHECK round. You and CODEX each answered the question; now reconcile toward ONE agreed answer.
+
+Your OWN previous answer (build on it — don't re-derive from scratch):
+${JSON.stringify(myPrev, null, 2)}
+
+CODEX's LATEST answer (and its objections to your previous answer) (JSON):
+${JSON.stringify(other, null, 2)}
+
+Weigh CODEX's answer against yours:
+  - Where CODEX is right and you were wrong or incomplete, UPDATE your answer to match and say what you changed in changedMind.
+  - Where CODEX is wrong or has a gap, hold your position and record it under objections with a specific, evidence-backed reason.`
+  const prompt_ = `You and CODEX were asked the SAME question. ${block}
+
+You may inspect the repo at \`${repoPath}\` to ground your answer — your shell cwd may be a different worktree, so use \`git -C ${repoPath}\` and absolute paths under it. READ-ONLY: read files, \`git -C ${repoPath} diff/log\`, grep; do NOT edit, create, delete, or run any git write command. Cite file:line for claims about this codebase. If the question isn't about this repo, answer from your own knowledge.
+
+The question:
+${prompt}
+
+Return the schema:
+  - answer: your complete, self-contained answer as it stands now (on a cross-check round, your UPDATED unified answer).
+  - keyPoints: the core claims your answer rests on, one per item.
+  - objections: your remaining disagreements with CODEX's latest answer (empty on round 1, and empty once you fully agree).
+  - changedMind: what CODEX convinced you to change this round (empty on round 1 or if nothing changed).
+  - agreesWithOther: true ONLY when CODEX's latest answer is correct and complete and you have NO objection left — your two answers say the same thing. false on round 1.`
+  return agent(prompt_, {
+    label: `claude:round${round}`,
+    phase: round === 1 ? 'Answer' : 'Reconcile',
+    model,
+    schema: ANSWER_SCHEMA,
+  })
+}
+
+// CODEX answers/cross-checks via codex-answer.sh (warm session across rounds). The
+// agent here is a MECHANICAL RUNNER: it writes the prompt + cross-check files,
+// shells out to the script, and relays codex's JSON answer verbatim — it does NOT
+// answer the question itself. The user's prompt and CLAUDE's latest answer carry
+// arbitrary characters, so they're written with the Write tool, never a heredoc.
+async function codexAnswers(round, other) {
+  const answerPath = `${workDir}/answer-codex-${round}.json`
+  const promptPath = `${workDir}/answer-prompt.txt`
+  const crossPath = `${workDir}/answer-crosscheck.json`
+  // The cross-check argument to the script: `-` on round 1 (codex answers
+  // independently), else the file holding CLAUDE's latest answer.
+  const crossArg = round === 1 ? '-' : crossPath
+  const crossStep =
+    round === 1
+      ? `2. (No cross-check this round — codex answers independently.)`
+      : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
+
+${JSON.stringify(other, null, 2)}`
+  const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
+
+${prompt}
+
+${crossStep}
+
+3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-answer.sh ${promptPath} ${crossArg} ${answerPath} ${REASONING_EFFORT}\`
+
+   This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
+
+4. Read \`${answerPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
+  return agent(runnerPrompt, {
+    label: `codex:round${round}`,
+    phase: round === 1 ? 'Answer' : 'Reconcile',
+    model: copyModel, // must relay codex's answer JSON faithfully
+    schema: ANSWER_SCHEMA,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Transcript rendering — deterministic, in-process (no agent retypes the blob)
+// ---------------------------------------------------------------------------
+function renderObjections(objs) {
+  if (!objs || objs.length === 0) return '  - _(none)_'
+  return objs.map((o) => `  - **${o.point}** — ${o.reason}`).join('\n')
+}
+
+function renderSide(name, ans) {
+  if (!ans) return `**${name}** — _(no turn this round)_`
+  const lines = [
+    `**${name}** — agrees with other: \`${!!ans.agreesWithOther}\``,
+    '',
+    ans.answer,
+  ]
+  if (ans.changedMind && ans.changedMind.trim()) lines.push('', `_changed mind:_ ${ans.changedMind}`)
+  lines.push('', 'Objections to the other side:', renderObjections(ans.objections))
+  return lines.join('\n')
+}
+
+function roundSection(entry) {
+  return [
+    `### Round ${entry.round}`,
+    '',
+    renderSide('claude', entry.claude),
+    '',
+    renderSide('codex', entry.codex),
+  ].join('\n')
+}
+
+function transcriptHeader(meta) {
+  const badge = meta.status === 'consensus' ? '✅ **Agreed**' : `⚠️ **${meta.status}**`
+  return `# Codex ⇄ Claude answer-debate
+
+> **Prompt:** ${meta.prompt}
+
+${badge} after ${meta.rounds} round(s) · codex answered at \`${meta.reasoningEffort}\` reasoning effort`
+}
+
+function renderTranscript(transcript, meta, finalAnswer) {
+  const parts = [transcriptHeader(meta)]
+  if (finalAnswer) parts.push('## Final unified answer', '', finalAnswer)
+  parts.push('## Convergence trail', ...transcript.map(roundSection))
+  return parts.join('\n\n')
+}
+
+// Zero-pad the round so the section glob sorts in round order for the assembly.
+const sectionFile = (round) => `${workDir}/answer-section-${String(round).padStart(3, '0')}.md`
+
+// Write ONE round's section to its own small file (Haiku-safe — just this round).
+async function writeSection(entry) {
+  const text = roundSection(entry)
+  const path = sectionFile(entry.round)
+  const p = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
+
+${text}`
+  return agent(p, { label: `section:round${entry.round}`, phase: 'Reconcile', model: mechModel })
+}
+
+// ---------------------------------------------------------------------------
+// Set up scratch — clear any stale per-round sections from a PRIOR debate in this
+// worktree so they don't leak into the assembled transcript. Scoped to the
+// answer-section files; the review mode's section-NNN.md and the verdict/answer
+// JSONs keep their own lifecycle.
+// ---------------------------------------------------------------------------
+phase('Answer')
+await agent(
+  `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/answer-section-*.md\`. Do not edit any other file. Do not run git.`,
+  { label: 'sections:reset', phase: 'Answer', model: mechModel },
+)
+
+const transcript = []
+let status = 'consensus'
+let claudeAns = null
+let codexAns = null
+
+// ---------------------------------------------------------------------------
+// The loop — round 1 is the independent answer (parallel); rounds 2+ are
+// cross-checks. Runs until BOTH sides agree. No round cap, no deadlock exit:
+// each side keeps cross-checking until they converge (the harness's per-workflow
+// agent backstop is the only hard ceiling — interrupt via /workflows or TaskStop).
+//
+// Both sides run in PARALLEL each round, so in round N each cross-checks the
+// OTHER's round-(N-1) answer. Convergence is thus mutual agreement on the prior
+// round's answers — safe (it can only end on real agreement, never prematurely),
+// at worst one round later than a strictly-serial handoff would.
+// ---------------------------------------------------------------------------
+for (let round = 1; ; round++) {
+  const prevClaude = claudeAns
+  const prevCodex = codexAns
+  const [claude, codex] = await parallel([
+    () => claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
+    () => codexAnswers(round, round === 1 ? null : prevClaude),
+  ])
+
+  // codex infrastructure failure — terminal. The runner could not get an answer
+  // out of codex (broken/unavailable CLI), so it synthesized reviewerError:true.
+  // Retrying a dead reviewer just spins, so abort and surface the failure. This is
+  // deliberately separate from the "no deadlock exit" rule for real disagreement.
+  if (codex && codex.reviewerError) {
+    status = 'reviewer-error'
+    log(`Round ${round}: codex error — aborting. ${codex.answer}`)
+    transcript.push({ round, claude, codex })
+    break
+  }
+  // A side died on a terminal API error after retries (agent() returned null).
+  // We can't reconcile half a debate, so abort loudly rather than loop on nulls.
+  if (!claude || !codex) {
+    status = 'agent-error'
+    log(`Round ${round}: ${!claude ? 'claude' : 'codex'} produced no answer (agent error) — aborting.`)
+    transcript.push({ round, claude, codex })
+    break
+  }
+
+  claudeAns = claude
+  codexAns = codex
+  const entry = { round, claude, codex }
+  transcript.push(entry)
+  await writeSection(entry)
+
+  // Consensus: from round 2 on (round 1 has no cross-check), BOTH sides report no
+  // remaining disagreement with the other's latest answer.
+  if (round >= 2 && claude.agreesWithOther === true && codex.agreesWithOther === true) {
+    log(`Round ${round}: both sides agree — converged.`)
+    break
+  }
+  log(
+    `Round ${round}: claude agrees=${!!claude.agreesWithOther} (objections=${(claude.objections || []).length}), codex agrees=${!!codex.agreesWithOther} (objections=${(codex.objections || []).length})`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis — merge the two AGREED answers into one unified reply for the user.
+// Only on consensus: on a failure terminus there's no agreement to synthesize.
+// ---------------------------------------------------------------------------
+let finalAnswer = null
+if (status === 'consensus' && claudeAns && codexAns) {
+  phase('Synthesis')
+  const synth = await agent(
+    `Claude and codex were each asked the question below and, after cross-checking, AGREED. Merge their two (now-equivalent) answers into ONE clean, unified, self-contained answer for the user — no "Claude said / codex said" framing, no meta-commentary about the debate, just the best single answer. Preserve every substantive point both kept; where they used different wording for the same idea, pick the clearest. Keep any file:line citations.
+
+The question:
+${prompt}
+
+Claude's final answer (JSON):
+${JSON.stringify(claudeAns, null, 2)}
+
+Codex's final answer (JSON):
+${JSON.stringify(codexAns, null, 2)}
+
+Return the unified answer in \`answer\`.`,
+    { label: 'synthesis', phase: 'Synthesis', model, schema: FINAL_SCHEMA },
+  )
+  finalAnswer = synth ? synth.answer : null
+}
+
+log(`Answer-debate ended: ${status} after ${transcript.length} round(s).`)
+
+// Persist the full transcript to a single readable file the user can revisit
+// (chat + saved transcript). Rendered deterministically in-process, then handed to
+// one mechanical writer — the payload can be large, so use copyModel for faithful
+// reproduction (the same tier the codex relay uses).
+const transcriptText = renderTranscript(
+  transcript,
+  { status, rounds: transcript.length, prompt, reasoningEffort: REASONING_EFFORT },
+  finalAnswer,
+)
+await agent(
+  `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${answerDocPath}\` with EXACTLY this content, overwriting any existing file:
+
+${transcriptText}`,
+  { label: 'transcript:write', phase: 'Synthesis', model: copyModel },
+)
+
+return {
+  status,
+  rounds: transcript.length,
+  prompt,
+  transcriptPath: answerDocPath,
+  finalAnswer,
+  reasoningEffort: REASONING_EFFORT,
+  // The error terminus carries codex's failure detail in its answer text.
+  codexError: status === 'reviewer-error' ? (codexAns && codexAns.answer) || null : null,
+}

--- a/.claude/skills/codex-debate/answer.workflow.js
+++ b/.claude/skills/codex-debate/answer.workflow.js
@@ -243,7 +243,34 @@ function renderSide(name, ans) {
   return lines.join('\n')
 }
 
+// A confirm round is not a normal answer round: both sides judged ONE shared
+// synthesized candidate (approve-or-object), so rendering each side's `answer`
+// would misleadingly show two texts for a round whose whole point was that both
+// judged the IDENTICAL one. Show the candidate ONCE, then each side's verdict
+// (agrees + objections) against it.
+function renderConfirmVerdict(name, ans) {
+  if (!ans) return `**${name}** — _(no turn this round)_`
+  return [
+    `**${name}** — approved: \`${!!ans.agreesWithOther}\``,
+    'Objections to the candidate:',
+    renderObjections(ans.objections),
+  ].join('\n')
+}
+
 function roundSection(entry) {
+  if (entry.confirming) {
+    return [
+      `### Round ${entry.round} — confirmation`,
+      '',
+      'Both sides judged this single synthesized candidate (approve or object):',
+      '',
+      entry.candidate,
+      '',
+      renderConfirmVerdict('claude', entry.claude),
+      '',
+      renderConfirmVerdict('codex', entry.codex),
+    ].join('\n')
+  }
   return [
     `### Round ${entry.round}`,
     '',
@@ -397,7 +424,12 @@ for (let round = 1; ; round++) {
 
   claudeAns = claude
   codexAns = codex
-  const entry = { round, claude, codex }
+  // On a confirm round both sides judged the ONE shared candidate; tag the entry
+  // (with the candidate itself) so the transcript renders it as an approve/object
+  // verdict on a single text rather than as two separate answer rounds.
+  const entry = confirming
+    ? { round, claude, codex, confirming: true, candidate: pendingCandidate }
+    : { round, claude, codex }
   transcript.push(entry)
   await writeSection(entry)
 

--- a/.claude/skills/codex-debate/answer.workflow.js
+++ b/.claude/skills/codex-debate/answer.workflow.js
@@ -172,25 +172,35 @@ Return the schema:
 // shells out to the script, and relays codex's JSON answer verbatim — it does NOT
 // answer the question itself. The user's prompt and CLAUDE's latest answer carry
 // arbitrary characters, so they're written with the Write tool, never a heredoc.
-// On a confirmation turn (`confirm`), the cross-check input is the SINGLE shared
-// candidate, and the runner relays codex's approval/objections to it.
-async function codexAnswers(round, other) {
+// On a CONFIRM turn (`confirming`), `other` is the SINGLE shared synthesized
+// candidate STRING; the runner writes it to the cross-check file and passes the
+// script's `confirm` token so codex plugs into the same verbatim/approve-or-object
+// contract as the workflow's claudeConfirms turn (NOT the ordinary cross-check
+// contract, which would tell codex to UPDATE its own answer instead of approving).
+async function codexAnswers(round, other, confirming) {
   const answerPath = `${workDir}/answer-codex-${round}.json`
   const promptPath = `${workDir}/answer-prompt.txt`
   const crossPath = `${workDir}/answer-crosscheck.json`
   // The cross-check argument to the script: `-` on round 1 (codex answers
-  // independently), else the file holding CLAUDE's latest answer.
+  // independently), else the file holding either CLAUDE's latest answer (ordinary
+  // cross-check) or the synthesized candidate to approve (confirm turn).
   const crossArg = round === 1 ? '-' : crossPath
+  // On a confirm turn the cross-check file holds the candidate VERBATIM (a plain
+  // string); on an ordinary cross-check it holds CLAUDE's answer JSON.
+  const crossContent = confirming ? other : JSON.stringify(other, null, 2)
   const crossStep =
     round === 1
       ? `2. (No cross-check this round — codex answers independently.)`
       : `2. Using the Write tool (NOT a shell heredoc — the content has special characters), create \`${crossPath}\` with EXACTLY this content (overwriting any existing file):
 
-${JSON.stringify(other, null, 2)}`
+${crossContent}`
+  // Pass the script's `confirm` token on a confirm turn so it selects the
+  // approve-the-candidate prompt shape rather than the cross-check shape.
+  const confirmArg = confirming ? ` ${shq('confirm')}` : ''
   // Every path below is spliced into a shell command the runner agent executes, so
   // POSIX-quote each one (worktrees or skill dirs with spaces/metacharacters would
   // otherwise break the command or misdirect it). The Write-tool file CONTENTS
-  // (${prompt}, ${JSON.stringify(other)}) are not shell-parsed and stay verbatim.
+  // (${prompt}, ${crossContent}) are not shell-parsed and stay verbatim.
   const runnerPrompt = `You are a MECHANICAL RUNNER for one round of an automated answer-debate. Do exactly the steps below and nothing else. Do NOT answer the question yourself, do NOT edit repository files, do NOT add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${shq(workDir)}\`. Using the Write tool (NOT a heredoc), create \`${promptPath}\` with EXACTLY this content (overwriting any existing file):
@@ -200,14 +210,14 @@ ${prompt}
 ${crossStep}
 
 3. Run (cd into the repo root so the script's internal \`git\` targets THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}\`
+   \`cd ${shq(repoPath)} && bash ${shq(`${skillDir}/scripts/codex-answer.sh`)} ${shq(promptPath)} ${crossArg === '-' ? '-' : shq(crossArg)} ${shq(answerPath)} ${shq(REASONING_EFFORT)}${confirmArg}\`
 
    This shells out to the codex CLI as a read-only peer; it can take 1-3 minutes. It prints a JSON answer as its final stdout and also writes it to \`${answerPath}\`.
 
 4. Read \`${answerPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
   return agent(runnerPrompt, {
-    label: `codex:round${round}`,
-    phase: round === 1 ? 'Answer' : 'Reconcile',
+    label: confirming ? `codex:confirm${round}` : `codex:round${round}`,
+    phase: confirming ? 'Synthesis' : round === 1 ? 'Answer' : 'Reconcile',
     model: copyModel, // must relay codex's answer JSON faithfully
     schema: ANSWER_SCHEMA,
   })
@@ -344,24 +354,26 @@ Return the unified answer in \`answer\`.`,
 // either objects, its objections fold back into the cross-check loop and we continue.
 // ---------------------------------------------------------------------------
 let finalAnswer = null
-// On a confirmation turn, each side's "other" input is the synthesized candidate
-// (wrapped in the answer shape so the existing cross-check machinery accepts it).
+// On a confirmation turn, each side judges the SAME synthesized candidate STRING.
 // Carried across iterations so a rejected confirmation feeds the candidate + the
 // objector's complaints back into the next ordinary cross-check round.
 let pendingCandidate = null
 for (let round = 1; ; round++) {
   const confirming = pendingCandidate !== null
-  const candidateAns = confirming
-    ? { answer: pendingCandidate, keyPoints: [], agreesWithOther: true, objections: [], changedMind: '' }
-    : null
   const prevClaude = claudeAns
   const prevCodex = codexAns
+  // On a confirm turn BOTH sides run their dedicated approve-a-fixed-candidate
+  // interface (claudeConfirms / codexAnswers(..., confirming)), so both plug into
+  // one verbatim/approve-or-object contract instead of the ordinary cross-check.
   const [claude, codex] = await parallel([
     () =>
       confirming
         ? claudeConfirms(round, pendingCandidate)
         : claudeAnswers(round, round === 1 ? null : prevCodex, prevClaude),
-    () => codexAnswers(round, round === 1 ? null : confirming ? candidateAns : prevClaude),
+    () =>
+      confirming
+        ? codexAnswers(round, pendingCandidate, true)
+        : codexAnswers(round, round === 1 ? null : prevClaude, false),
   ])
 
   // codex infrastructure failure — terminal. The runner could not get an answer

--- a/.claude/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.claude/skills/codex-debate/scripts/codex-answer.schema.json
@@ -39,5 +39,11 @@
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
     }
   },
-  "required": ["answer", "keyPoints", "agreesWithOther", "objections", "changedMind"]
+  "required": [
+    "answer",
+    "keyPoints",
+    "agreesWithOther",
+    "objections",
+    "changedMind"
+  ]
 }

--- a/.claude/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.claude/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,10 +37,6 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
-    },
-    "reviewerError": {
-      "type": "boolean",
-      "description": "Set to true ONLY by the codex-answer.sh runner when codex itself failed to produce an answer after every retry (a synthesized infrastructure-error verdict the workflow aborts on). codex never sets this in a real answer; it is declared here so the script's synthesized error answer validates against this schema under additionalProperties:false."
     }
   },
   "required": [

--- a/.claude/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.claude/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,17 +37,7 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
-    },
-    "reviewerError": {
-      "type": "boolean",
-      "description": "Set by the runner script ONLY when codex itself failed to produce an answer (broken/unavailable CLI). Not part of a real answer."
     }
   },
-  "required": [
-    "answer",
-    "keyPoints",
-    "agreesWithOther",
-    "objections",
-    "changedMind"
-  ]
+  "required": ["answer", "keyPoints", "agreesWithOther", "objections", "changedMind"]
 }

--- a/.claude/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.claude/skills/codex-debate/scripts/codex-answer.schema.json
@@ -37,6 +37,10 @@
     "changedMind": {
       "type": "string",
       "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
+    },
+    "reviewerError": {
+      "type": "boolean",
+      "description": "Set to true ONLY by the codex-answer.sh runner when codex itself failed to produce an answer after every retry (a synthesized infrastructure-error verdict the workflow aborts on). codex never sets this in a real answer; it is declared here so the script's synthesized error answer validates against this schema under additionalProperties:false."
     }
   },
   "required": [

--- a/.claude/skills/codex-debate/scripts/codex-answer.schema.json
+++ b/.claude/skills/codex-debate/scripts/codex-answer.schema.json
@@ -1,0 +1,53 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "answer": {
+      "type": "string",
+      "description": "Your complete, self-contained answer to the user's prompt as it stands THIS round. On a cross-check round this is your UPDATED unified answer, revised in light of the other assistant's answer."
+    },
+    "keyPoints": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "The core claims your answer rests on, one per item — the things the other side must agree with for there to be consensus."
+    },
+    "agreesWithOther": {
+      "type": "boolean",
+      "description": "true ONLY when the other assistant's latest answer is correct and complete and you have NO substantive disagreement left — your answers say the same thing. false on the first round (you haven't seen theirs yet) and whenever any objection below remains."
+    },
+    "objections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "point": {
+            "type": "string",
+            "description": "The specific claim in the OTHER assistant's answer you disagree with, or the gap you think it leaves."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why it's wrong or incomplete — cite file:line or concrete evidence when the prompt is about this repo."
+          }
+        },
+        "required": ["point", "reason"]
+      },
+      "description": "Your remaining disagreements with the other assistant's latest answer. Empty when you fully agree (agreesWithOther:true) and on round 1."
+    },
+    "changedMind": {
+      "type": "string",
+      "description": "What you revised this round because the other assistant convinced you, and why. Empty string on round 1 or when nothing changed."
+    },
+    "reviewerError": {
+      "type": "boolean",
+      "description": "Set by the runner script ONLY when codex itself failed to produce an answer (broken/unavailable CLI). Not part of a real answer."
+    }
+  },
+  "required": [
+    "answer",
+    "keyPoints",
+    "agreesWithOther",
+    "objections",
+    "changedMind"
+  ]
+}

--- a/.claude/skills/codex-debate/scripts/codex-answer.sh
+++ b/.claude/skills/codex-debate/scripts/codex-answer.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # codex-answer.sh — the canonical, deterministic codex invocation for the
-# SYMMETRIC answer-debate (the prompt-mode of /codex-debate). codex answers a
+# SYMMETRIC answer-debate (the `answer` mode of /codex-debate). codex answers a
 # freeform user prompt as one of two equal debaters; on follow-up rounds it
 # CROSS-CHECKS the other assistant's ("CLAUDE") latest answer against its own and
 # either concedes (revising its answer) or holds firm (recording objections),
@@ -9,6 +9,11 @@
 # this repo to ground its answer (git diff/log, read files, grep) but cannot
 # modify anything. The output is constrained to codex-answer.schema.json and
 # written to <out-json>.
+#
+# This script owns only what is SPECIFIC to answering a prompt: arg parsing, the
+# warm/cold prompt text, the answer schema + session file, and the answer-shaped
+# error verdict. The shared codex-driving core (read-only exec/resume, retry/
+# backoff, thread-id capture, session persistence) lives in codex-exec-lib.sh.
 #
 # Usage:
 #   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
@@ -23,23 +28,14 @@
 #                     value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
-#   * codex runs under `--sandbox read-only`, which enforces read-only at the
-#     execution boundary (the kernel sandbox blocks file writes and other
-#     state-mutating syscalls), NOT merely by prompt text. codex reads arbitrary
-#     repo files to ground its answer and could be prompt-injected by file
-#     contents, so the read-only promise must be enforced, not advertised. codex
-#     auto-falls-back to its bundled bubblewrap when the system one is absent, so
-#     this works in containers; read-only permits read commands (git diff/status,
-#     grep, reading files) but denies writes. `codex exec` is already
-#     non-interactive (approval policy "never"), so a blocked command is denied
-#     outright rather than escalating to a prompt that would wedge the loop.
+#   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
+#     read-only at the kernel boundary, NOT merely by prompt text. codex reads
+#     arbitrary repo files to ground its answer and could be prompt-injected by file
+#     contents, so the read-only promise must be enforced, not advertised.
 #   * Always emits a schema-valid answer on stdout, even if codex errors — a
 #     synthesized error answer (reviewerError:true) so the loop never wedges.
-#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
-#     scratch dir; every later round resumes that same session (`codex exec
-#     resume <id>`) so codex retains its OWN prior answer + reasoning across rounds
-#     instead of reconstructing it each time. If the id was never captured, a later
-#     round cleanly falls back to a cold start.
+#   * WARM SESSION: round 1 cold-starts codex; every later round resumes that same
+#     session so codex retains its OWN prior answer + reasoning across rounds.
 set -uo pipefail
 
 prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
@@ -51,11 +47,8 @@ effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-answer.schema.json"
-log="$out.log"
-
-# The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
-# it exists before codex tries to write the answer there.
-mkdir -p "$(dirname "$out")"
+# shellcheck source=codex-exec-lib.sh
+source "$here/codex-exec-lib.sh"
 
 # The user's prompt. Required and must be non-empty — an empty prompt would make
 # codex answer nothing and silently degrade the debate, so fail loud instead.
@@ -64,11 +57,6 @@ if [ ! -s "$prompt_file" ]; then
   exit 2
 fi
 prompt_text="$(cat "$prompt_file")"
-
-# Never let a stale answer from a previous run survive: if the current codex
-# invocation fails to write one, the empty-check below must catch it and
-# synthesize an error answer (otherwise a leftover file reads as a fresh answer).
-rm -f "$out" "$log"
 
 # Pull CLAUDE's latest answer, if any (the cross-check input). Built as a plain
 # string and injected below via a simple variable reference so any special
@@ -85,26 +73,27 @@ if [ "$crosscheck_file" != "-" ]; then
   fi
 fi
 
-# WARM SESSION. codex keeps its OWN answer + reasoning across rounds by resuming
-# the same codex session instead of cold-starting `codex exec` each round. The
-# session id (codex's thread_id) is persisted in the scratch dir after round 1
-# and reused on every follow-up round, so when it cross-checks CLAUDE it argues
-# from its original rationale rather than reconstructing it.
-#
-#   * Round 1 (crosscheck_file == "-"): fresh `codex exec`; capture thread_id below.
-#   * Later rounds: `codex exec resume <id>` with just the cross-check follow-up,
-#     relying on codex's retained context.
-#   * Fallback: if no id was captured (round-1 capture failed), a later round
-#     cold-starts with the FULL prompt + cross-check — graceful, never a wedge.
+# WARM SESSION. Round 1 (crosscheck_file == "-") cold-starts and resets any stale
+# id; later rounds resume codex's own answer session. Resolve the id first so the
+# prompt below can lean on codex's retained context when warm.
 session_id_file="$(dirname "$out")/codex-answer-session.id"
-resume_id=""
-if [ "$crosscheck_file" = "-" ]; then
-  # Round 1 of a fresh debate: start a NEW session and drop any session id left
-  # behind by a previous debate in this worktree, so we never resume a stale one.
-  rm -f "$session_id_file"
-elif [ -s "$session_id_file" ]; then
-  resume_id="$(cat "$session_id_file")"
-fi
+[ "$crosscheck_file" = "-" ] && is_round1=1 || is_round1=
+resume_id="$(codex_resolve_session "$session_id_file" "$is_round1")"
+
+# Synthesize codex-answer's error verdict shape when codex produces nothing after
+# every attempt (called by codex_exec_round). reviewerError:true is the signal the
+# workflow aborts the debate on.
+synthesize_error_verdict() {
+  local out="$1" tail_log="$2" attempts="$3"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    keyPoints: [],
+    agreesWithOther: false,
+    objections: [],
+    changedMind: "",
+    reviewerError: true
+  }' >"$out"
+}
 
 # Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
 # on codex's retained answer, and the full answer prompt for the COLD path (round
@@ -169,105 +158,6 @@ EOF
 )"
 fi
 
-# One codex invocation: warm-resume when we have a session id (carries codex's own
-# prior answer), else a cold start. `--json` emits a `thread.started` event
-# carrying codex's thread_id, captured below to resume next round; it does NOT
-# change the answer, which `--output-schema`/`-o` still write to "$out". `resume`
-# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
-# the same kernel-enforced policy, set through config instead of the flag.
-run_codex() {
-  if [ -n "$resume_id" ]; then
-    codex exec resume \
-      -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$resume_id" "$prompt"
-  else
-    codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"
-  fi
-}
-
-# model_reasoning_effort is scoped to the debate here (via -c, from the $effort the
-# workflow passes down — default "xhigh") rather than relying on the user's global
-# ~/.codex/config.toml — we always want codex thinking at full depth here.
-#
-# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
-# hiccups, a spurious internal error) and writes no answer — which would otherwise
-# degrade the round to reviewer-error on a single bad roll. Retry with linear
-# backoff, accepting the first attempt that writes a non-empty answer to "$out".
-# Tunable via env: CODEX_REVIEW_RETRIES (total attempts, default 3),
-# CODEX_REVIEW_BACKOFF (base seconds, default 5 — attempt n waits n*base). Only
-# after every attempt fails empty do we synthesize the reviewerError answer below.
-attempts="${CODEX_REVIEW_RETRIES:-3}"
-backoff="${CODEX_REVIEW_BACKOFF:-5}"
-# Validate both as positive integers. Left unchecked, a non-numeric value makes the
-# arithmetic test error every iteration, so the loop would spin forever instead of
-# giving up. Fall back to the documented defaults (and clamp attempts to >=1)
-# loudly rather than wedge the headless debate on a typo'd override.
-if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
-  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
-  attempts=3
-fi
-if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
-  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
-  backoff=5
-fi
-n=1
-: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
-while :; do
-  rm -f "$out"
-  # Append (not truncate): when every attempt fails, the synthesized reviewerError
-  # answer's tail_log must reflect ALL attempts' diagnostics, not just the last.
-  echo "=== attempt $n/$attempts ===" >>"$log"
-  if ! run_codex </dev/null >>"$log" 2>&1; then
-    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
-  fi
-  # Success the moment codex writes an answer: the kernel sandbox + --output-schema
-  # make a non-empty "$out" a real, schema-valid answer, not a partial.
-  [ -s "$out" ] && break
-  # Out of attempts — fall through to the synthesized reviewerError answer.
-  [ "$n" -ge "$attempts" ] && break
-  wait_s=$(( backoff * n ))
-  echo "codex produced no answer (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
-  n=$(( n + 1 ))
-  sleep "$wait_s"
-done
-
-if [ -s "$out" ]; then
-  # Persist codex's session id so NEXT round can resume this same warm session
-  # (carrying codex's own prior answer + reasoning). The successful attempt's
-  # `thread.started` is the last one appended to the log; on a resume round it
-  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
-  # an id just means next round cold-starts via the fallback above — not fatal.
-  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
-  if [ -n "$sid" ]; then
-    printf '%s\n' "$sid" >"$session_id_file"
-  fi
-fi
-
-if [ ! -s "$out" ]; then
-  # codex produced no answer — synthesize a schema-valid error answer so the debate
-  # loop can surface the failure instead of hanging. The reviewerError flag is the
-  # machine-detectable signal the workflow uses to abort with a terminal failure: a
-  # broken/unavailable codex is INFRASTRUCTURE failure, not substantive
-  # disagreement, so it must NOT spin the loop forever.
-  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
-    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
-    keyPoints: [],
-    agreesWithOther: false,
-    objections: [],
-    changedMind: "",
-    reviewerError: true
-  }' >"$out"
-fi
-
-cat "$out"
+# Drive codex for this round (retry/backoff, thread capture, error fallback) — the
+# shared core does the work; this script supplied the prompt, schema, and shapes.
+codex_exec_round "$schema" "$out" "$session_id_file" "$effort" "$resume_id" "$prompt"

--- a/.claude/skills/codex-debate/scripts/codex-answer.sh
+++ b/.claude/skills/codex-debate/scripts/codex-answer.sh
@@ -59,6 +59,13 @@ is_confirm=
 [ "${5:-}" = "confirm" ] && is_confirm=1
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The codex-FACING output schema. Do NOT add a `reviewerError` property to it:
+# codex's `--output-schema` (OpenAI structured outputs) requires every declared
+# property to be in `required` with additionalProperties:false, so an optional
+# `reviewerError` 400s the request. codex never emits reviewerError; the error
+# answer synthesize_error_verdict writes carries it but is validated by the
+# workflow's in-JS ANSWER_SCHEMA, not by this file. (This has been re-added in
+# error twice — review mode's codex-verdict.schema.json omits it for the same reason.)
 schema="$here/codex-answer.schema.json"
 # shellcheck source=codex-exec-lib.sh
 source "$here/codex-exec-lib.sh"

--- a/.claude/skills/codex-debate/scripts/codex-answer.sh
+++ b/.claude/skills/codex-debate/scripts/codex-answer.sh
@@ -95,12 +95,46 @@ synthesize_error_verdict() {
   }' >"$out"
 }
 
-# Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
-# on codex's retained answer, and the full answer prompt for the COLD path (round
-# 1, or the fallback when no session id was captured). Unquoted heredocs: only
-# $prompt_text and $crosscheck expand; their expansions are inserted literally
-# (heredoc results aren't re-scanned), so special chars stay inert.
-if [ -n "$resume_id" ] && [ -n "$crosscheck" ]; then
+# Whether this is a cross-check round: a cross-check file was provided (not "-") AND
+# it actually held CLAUDE's answer. A follow-up round MUST cross-check even when the
+# warm session id is missing — dropping the cross-check would tell codex to answer
+# independently again (agreesWithOther:false, no objections) and the debate could
+# never converge. So the cross-check, not the resume id, gates which prompt we use.
+is_crosscheck=
+[ -n "$crosscheck" ] && is_crosscheck=1
+
+# A reusable block carrying CLAUDE's latest answer + the cross-check instructions,
+# spliced into BOTH the warm and cold follow-up prompts (mirrors codex-review.sh's
+# $rebuttal_block) so a missing resume id degrades to a COLD CROSS-CHECK, never to a
+# fresh independent answer. Empty on round 1.
+crosscheck_block=""
+if [ -n "$is_crosscheck" ]; then
+  crosscheck_block="$(cat <<EOF
+
+CLAUDE's LATEST answer (JSON) is:
+$crosscheck
+
+Cross-check CLAUDE's answer against your own. Then:
+  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
+    match and note what you changed in changedMind.
+  - Where CLAUDE is wrong or has a gap, keep your position and record it under
+    objections with a specific, evidence-backed reason (cite file:line for repo
+    questions).
+EOF
+)"
+fi
+
+# Three prompt shapes, chosen by (resume id × cross-check):
+#   * WARM follow-up   (resume id + cross-check): lean prompt leaning on codex's
+#     retained answer.
+#   * COLD follow-up   (no resume id + cross-check): the full answer prompt PLUS the
+#     cross-check block — codex re-derives its own answer from scratch but still
+#     reconciles against CLAUDE's, so the debate keeps converging.
+#   * COLD first round (no cross-check): the independent answer prompt.
+# Unquoted heredocs: only $prompt_text, $crosscheck, and $crosscheck_block expand;
+# their expansions are inserted literally (heredoc results aren't re-scanned), so
+# special chars stay inert.
+if [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME answer session you started earlier — you still
 have your own previous answer and reasoning in context. You and another assistant
@@ -110,18 +144,10 @@ to reach ONE agreed answer.
 The original question was:
 $prompt_text
 
-CLAUDE's LATEST answer (JSON) is:
-$crosscheck
-
 Cross-check CLAUDE's answer against your own (READ-ONLY — you may read repo files,
 git diff/log, grep to verify, but do NOT modify, create, or delete anything, and
-run no git write command: add/commit/push/stash/checkout). Then:
-  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
-    match and note what you changed in changedMind.
-  - Where CLAUDE is wrong or has a gap, keep your position and record it under
-    objections with a specific, evidence-backed reason (cite file:line for repo
-    questions).
-
+run no git write command: add/commit/push/stash/checkout).
+$crosscheck_block
 Return the JSON schema:
   - answer: your UPDATED, self-contained unified answer as it stands now.
   - keyPoints: the core claims your answer rests on.
@@ -137,8 +163,8 @@ else
 You are CODEX, a rigorous, truthful expert. Answer the user's question below
 thoroughly and honestly — exactly as you would for a careful colleague. You are in
 a debate with another assistant ("CLAUDE") who is answering the SAME question
-independently; afterward you'll cross-check each other until you agree, so give
-your best, most defensible answer now.
+independently; you cross-check each other until you agree, so give your best, most
+defensible answer.
 
 You may inspect this repository to ground your answer (READ-ONLY — read files, run
 git diff/log/grep; do NOT modify, create, or delete anything, and run no git write
@@ -147,13 +173,17 @@ codebase. If the question isn't about this repo, answer from your own knowledge.
 
 The question:
 $prompt_text
-
+$crosscheck_block
 Return the JSON schema:
-  - answer: your complete, self-contained answer.
+  - answer: your complete, self-contained answer (on a cross-check round, your
+    UPDATED unified answer revised in light of CLAUDE's).
   - keyPoints: the core claims your answer rests on, one per item.
-  - objections: leave empty this round (you haven't seen CLAUDE's answer yet).
-  - changedMind: empty string this round.
-  - agreesWithOther: false this round (you haven't seen CLAUDE's answer yet).
+  - objections: your remaining disagreements with CLAUDE's latest answer — empty
+    when you fully agree, and empty on the first round (no cross-check yet).
+  - changedMind: what CLAUDE convinced you to change this round (empty if nothing,
+    and empty on the first round).
+  - agreesWithOther: true ONLY when CLAUDE's latest answer is correct and complete
+    and you have NO objection left. false on the first round (no cross-check yet).
 EOF
 )"
 fi

--- a/.claude/skills/codex-debate/scripts/codex-answer.sh
+++ b/.claude/skills/codex-debate/scripts/codex-answer.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# codex-answer.sh — the canonical, deterministic codex invocation for the
+# SYMMETRIC answer-debate (the prompt-mode of /codex-debate). codex answers a
+# freeform user prompt as one of two equal debaters; on follow-up rounds it
+# CROSS-CHECKS the other assistant's ("CLAUDE") latest answer against its own and
+# either concedes (revising its answer) or holds firm (recording objections),
+# looping until both sides agree. codex runs as a READ-ONLY peer — it may read
+# this repo to ground its answer (git diff/log, read files, grep) but cannot
+# modify anything. The output is constrained to codex-answer.schema.json and
+# written to <out-json>.
+#
+# Usage:
+#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
+#
+#   <prompt-file>     path to a file holding the user's prompt/question
+#   <crosscheck-file> path to a file holding CLAUDE's latest answer (JSON) for
+#                     codex to cross-check, or "-" on the first round (codex
+#                     hasn't seen CLAUDE's answer yet — it answers independently)
+#   <out-json>        path the JSON answer is written to (also echoed to stdout)
+#   <reasoning-effort> codex model_reasoning_effort for this run; the answer
+#                     workflow passes its REASONING_EFFORT constant here so the
+#                     value has one home. Defaults to "xhigh" for standalone runs.
+#
+# Notes:
+#   * codex runs under `--sandbox read-only`, which enforces read-only at the
+#     execution boundary (the kernel sandbox blocks file writes and other
+#     state-mutating syscalls), NOT merely by prompt text. codex reads arbitrary
+#     repo files to ground its answer and could be prompt-injected by file
+#     contents, so the read-only promise must be enforced, not advertised. codex
+#     auto-falls-back to its bundled bubblewrap when the system one is absent, so
+#     this works in containers; read-only permits read commands (git diff/status,
+#     grep, reading files) but denies writes. `codex exec` is already
+#     non-interactive (approval policy "never"), so a blocked command is denied
+#     outright rather than escalating to a prompt that would wedge the loop.
+#   * Always emits a schema-valid answer on stdout, even if codex errors — a
+#     synthesized error answer (reviewerError:true) so the loop never wedges.
+#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
+#     scratch dir; every later round resumes that same session (`codex exec
+#     resume <id>`) so codex retains its OWN prior answer + reasoning across rounds
+#     instead of reconstructing it each time. If the id was never captured, a later
+#     round cleanly falls back to a cold start.
+set -uo pipefail
+
+prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
+crosscheck_file="${2:?missing crosscheck-file (use - for none)}"
+out="${3:?missing out-json path}"
+# The answer workflow owns this value (its REASONING_EFFORT constant) and passes
+# it down; "xhigh" is only the default for a standalone invocation of this script.
+effort="${4:-xhigh}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+schema="$here/codex-answer.schema.json"
+log="$out.log"
+
+# The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
+# it exists before codex tries to write the answer there.
+mkdir -p "$(dirname "$out")"
+
+# The user's prompt. Required and must be non-empty — an empty prompt would make
+# codex answer nothing and silently degrade the debate, so fail loud instead.
+if [ ! -s "$prompt_file" ]; then
+  echo "ERROR: prompt file '$prompt_file' is missing or empty." >&2
+  exit 2
+fi
+prompt_text="$(cat "$prompt_file")"
+
+# Never let a stale answer from a previous run survive: if the current codex
+# invocation fails to write one, the empty-check below must catch it and
+# synthesize an error answer (otherwise a leftover file reads as a fresh answer).
+rm -f "$out" "$log"
+
+# Pull CLAUDE's latest answer, if any (the cross-check input). Built as a plain
+# string and injected below via a simple variable reference so any special
+# characters in the JSON (backticks, $, ...) stay literal.
+crosscheck=""
+if [ "$crosscheck_file" != "-" ]; then
+  if [ -s "$crosscheck_file" ]; then
+    crosscheck="$(cat "$crosscheck_file")"
+  else
+    # A cross-check was expected (path given, not "-") but the file is missing or
+    # empty — the handoff broke. Proceed without it, but make the failure loud so
+    # codex's cross-check isn't silently skipped.
+    echo "WARNING: expected cross-check file '$crosscheck_file' is missing or empty; proceeding with no cross-check this round." >&2
+  fi
+fi
+
+# WARM SESSION. codex keeps its OWN answer + reasoning across rounds by resuming
+# the same codex session instead of cold-starting `codex exec` each round. The
+# session id (codex's thread_id) is persisted in the scratch dir after round 1
+# and reused on every follow-up round, so when it cross-checks CLAUDE it argues
+# from its original rationale rather than reconstructing it.
+#
+#   * Round 1 (crosscheck_file == "-"): fresh `codex exec`; capture thread_id below.
+#   * Later rounds: `codex exec resume <id>` with just the cross-check follow-up,
+#     relying on codex's retained context.
+#   * Fallback: if no id was captured (round-1 capture failed), a later round
+#     cold-starts with the FULL prompt + cross-check — graceful, never a wedge.
+session_id_file="$(dirname "$out")/codex-answer-session.id"
+resume_id=""
+if [ "$crosscheck_file" = "-" ]; then
+  # Round 1 of a fresh debate: start a NEW session and drop any session id left
+  # behind by a previous debate in this worktree, so we never resume a stale one.
+  rm -f "$session_id_file"
+elif [ -s "$session_id_file" ]; then
+  resume_id="$(cat "$session_id_file")"
+fi
+
+# Two prompts: a lean cross-check follow-up for the WARM (resume) path that leans
+# on codex's retained answer, and the full answer prompt for the COLD path (round
+# 1, or the fallback when no session id was captured). Unquoted heredocs: only
+# $prompt_text and $crosscheck expand; their expansions are inserted literally
+# (heredoc results aren't re-scanned), so special chars stay inert.
+if [ -n "$resume_id" ] && [ -n "$crosscheck" ]; then
+  prompt="$(cat <<EOF
+You are CODEX, continuing the SAME answer session you started earlier — you still
+have your own previous answer and reasoning in context. You and another assistant
+("CLAUDE") were each asked the SAME question and are now cross-checking each other
+to reach ONE agreed answer.
+
+The original question was:
+$prompt_text
+
+CLAUDE's LATEST answer (JSON) is:
+$crosscheck
+
+Cross-check CLAUDE's answer against your own (READ-ONLY — you may read repo files,
+git diff/log, grep to verify, but do NOT modify, create, or delete anything, and
+run no git write command: add/commit/push/stash/checkout). Then:
+  - Where CLAUDE is right and you were wrong or incomplete, UPDATE your answer to
+    match and note what you changed in changedMind.
+  - Where CLAUDE is wrong or has a gap, keep your position and record it under
+    objections with a specific, evidence-backed reason (cite file:line for repo
+    questions).
+
+Return the JSON schema:
+  - answer: your UPDATED, self-contained unified answer as it stands now.
+  - keyPoints: the core claims your answer rests on.
+  - objections: your remaining disagreements with CLAUDE's latest answer (empty
+    when you fully agree).
+  - changedMind: what CLAUDE convinced you to change this round (empty if nothing).
+  - agreesWithOther: true ONLY when CLAUDE's latest answer is correct and complete
+    and you have NO objection left — your two answers say the same thing.
+EOF
+)"
+else
+  prompt="$(cat <<EOF
+You are CODEX, a rigorous, truthful expert. Answer the user's question below
+thoroughly and honestly — exactly as you would for a careful colleague. You are in
+a debate with another assistant ("CLAUDE") who is answering the SAME question
+independently; afterward you'll cross-check each other until you agree, so give
+your best, most defensible answer now.
+
+You may inspect this repository to ground your answer (READ-ONLY — read files, run
+git diff/log/grep; do NOT modify, create, or delete anything, and run no git write
+command: add/commit/push/stash/checkout). Cite file:line for claims about this
+codebase. If the question isn't about this repo, answer from your own knowledge.
+
+The question:
+$prompt_text
+
+Return the JSON schema:
+  - answer: your complete, self-contained answer.
+  - keyPoints: the core claims your answer rests on, one per item.
+  - objections: leave empty this round (you haven't seen CLAUDE's answer yet).
+  - changedMind: empty string this round.
+  - agreesWithOther: false this round (you haven't seen CLAUDE's answer yet).
+EOF
+)"
+fi
+
+# One codex invocation: warm-resume when we have a session id (carries codex's own
+# prior answer), else a cold start. `--json` emits a `thread.started` event
+# carrying codex's thread_id, captured below to resume next round; it does NOT
+# change the answer, which `--output-schema`/`-o` still write to "$out". `resume`
+# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
+# the same kernel-enforced policy, set through config instead of the flag.
+run_codex() {
+  if [ -n "$resume_id" ]; then
+    codex exec resume \
+      -c sandbox_mode="read-only" \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$resume_id" "$prompt"
+  else
+    codex exec \
+      --sandbox read-only \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$prompt"
+  fi
+}
+
+# model_reasoning_effort is scoped to the debate here (via -c, from the $effort the
+# workflow passes down — default "xhigh") rather than relying on the user's global
+# ~/.codex/config.toml — we always want codex thinking at full depth here.
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
+# hiccups, a spurious internal error) and writes no answer — which would otherwise
+# degrade the round to reviewer-error on a single bad roll. Retry with linear
+# backoff, accepting the first attempt that writes a non-empty answer to "$out".
+# Tunable via env: CODEX_REVIEW_RETRIES (total attempts, default 3),
+# CODEX_REVIEW_BACKOFF (base seconds, default 5 — attempt n waits n*base). Only
+# after every attempt fails empty do we synthesize the reviewerError answer below.
+attempts="${CODEX_REVIEW_RETRIES:-3}"
+backoff="${CODEX_REVIEW_BACKOFF:-5}"
+# Validate both as positive integers. Left unchecked, a non-numeric value makes the
+# arithmetic test error every iteration, so the loop would spin forever instead of
+# giving up. Fall back to the documented defaults (and clamp attempts to >=1)
+# loudly rather than wedge the headless debate on a typo'd override.
+if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+  attempts=3
+fi
+if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+  backoff=5
+fi
+n=1
+: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
+while :; do
+  rm -f "$out"
+  # Append (not truncate): when every attempt fails, the synthesized reviewerError
+  # answer's tail_log must reflect ALL attempts' diagnostics, not just the last.
+  echo "=== attempt $n/$attempts ===" >>"$log"
+  if ! run_codex </dev/null >>"$log" 2>&1; then
+    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+  fi
+  # Success the moment codex writes an answer: the kernel sandbox + --output-schema
+  # make a non-empty "$out" a real, schema-valid answer, not a partial.
+  [ -s "$out" ] && break
+  # Out of attempts — fall through to the synthesized reviewerError answer.
+  [ "$n" -ge "$attempts" ] && break
+  wait_s=$(( backoff * n ))
+  echo "codex produced no answer (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+  n=$(( n + 1 ))
+  sleep "$wait_s"
+done
+
+if [ -s "$out" ]; then
+  # Persist codex's session id so NEXT round can resume this same warm session
+  # (carrying codex's own prior answer + reasoning). The successful attempt's
+  # `thread.started` is the last one appended to the log; on a resume round it
+  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
+  # an id just means next round cold-starts via the fallback above — not fatal.
+  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+  if [ -n "$sid" ]; then
+    printf '%s\n' "$sid" >"$session_id_file"
+  fi
+fi
+
+if [ ! -s "$out" ]; then
+  # codex produced no answer — synthesize a schema-valid error answer so the debate
+  # loop can surface the failure instead of hanging. The reviewerError flag is the
+  # machine-detectable signal the workflow uses to abort with a terminal failure: a
+  # broken/unavailable codex is INFRASTRUCTURE failure, not substantive
+  # disagreement, so it must NOT spin the loop forever.
+  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    answer: ("codex produced no answer this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    keyPoints: [],
+    agreesWithOther: false,
+    objections: [],
+    changedMind: "",
+    reviewerError: true
+  }' >"$out"
+fi
+
+cat "$out"

--- a/.claude/skills/codex-debate/scripts/codex-answer.sh
+++ b/.claude/skills/codex-debate/scripts/codex-answer.sh
@@ -16,16 +16,23 @@
 # backoff, thread-id capture, session persistence) lives in codex-exec-lib.sh.
 #
 # Usage:
-#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]
+#   codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort] [confirm]
 #
 #   <prompt-file>     path to a file holding the user's prompt/question
 #   <crosscheck-file> path to a file holding CLAUDE's latest answer (JSON) for
 #                     codex to cross-check, or "-" on the first round (codex
-#                     hasn't seen CLAUDE's answer yet — it answers independently)
+#                     hasn't seen CLAUDE's answer yet — it answers independently).
+#                     On a CONFIRM turn this file instead holds the synthesized
+#                     unified CANDIDATE answer codex is asked to approve verbatim.
 #   <out-json>        path the JSON answer is written to (also echoed to stdout)
 #   <reasoning-effort> codex model_reasoning_effort for this run; the answer
 #                     workflow passes its REASONING_EFFORT constant here so the
 #                     value has one home. Defaults to "xhigh" for standalone runs.
+#   [confirm]         the literal token "confirm" selects the CONFIRM prompt shape:
+#                     codex judges ONE shared synthesized candidate (held in the
+#                     crosscheck-file) and approves it VERBATIM or objects — it does
+#                     NOT rewrite its own answer. Mirrors the workflow's
+#                     claudeConfirms turn so both peers plug into one confirm contract.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
@@ -38,12 +45,18 @@
 #     session so codex retains its OWN prior answer + reasoning across rounds.
 set -uo pipefail
 
-prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort]}"
+prompt_file="${1:?usage: codex-answer.sh <prompt-file> <crosscheck-file|-> <out-json> [reasoning-effort] [confirm]}"
 crosscheck_file="${2:?missing crosscheck-file (use - for none)}"
 out="${3:?missing out-json path}"
 # The answer workflow owns this value (its REASONING_EFFORT constant) and passes
 # it down; "xhigh" is only the default for a standalone invocation of this script.
 effort="${4:-xhigh}"
+# CONFIRM mode: the 5th arg is the literal "confirm" when codex is judging ONE
+# synthesized candidate (held in crosscheck_file) rather than cross-checking
+# CLAUDE's separate answer. This swaps in the confirm prompt shape below — a
+# verbatim/approve-or-object contract symmetric to the workflow's claudeConfirms.
+is_confirm=
+[ "${5:-}" = "confirm" ] && is_confirm=1
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-answer.schema.json"
@@ -124,7 +137,13 @@ EOF
 )"
 fi
 
-# Three prompt shapes, chosen by (resume id × cross-check):
+# Prompt shapes, chosen by (confirm × resume id × cross-check):
+#   * CONFIRM           (confirm token): codex judges ONE synthesized candidate
+#     (in $crosscheck) and approves it VERBATIM or objects — it does NOT rewrite its
+#     own answer. One contract symmetric to the workflow's claudeConfirms turn, so
+#     both peers plug into the same approve-a-fixed-candidate interface. Takes
+#     precedence over warm/cold below (the session is warm here, but the activity is
+#     approval, not cross-check).
 #   * WARM follow-up   (resume id + cross-check): lean prompt leaning on codex's
 #     retained answer.
 #   * COLD follow-up   (no resume id + cross-check): the full answer prompt PLUS the
@@ -134,7 +153,35 @@ fi
 # Unquoted heredocs: only $prompt_text, $crosscheck, and $crosscheck_block expand;
 # their expansions are inserted literally (heredoc results aren't re-scanned), so
 # special chars stay inert.
-if [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
+if [ -n "$is_confirm" ]; then
+  prompt="$(cat <<EOF
+You are CODEX. You and another assistant ("CLAUDE") were each asked the SAME
+question, debated, and AGREED. A unified candidate answer has been synthesized from
+your two agreed answers. Your ONLY job now is to APPROVE it or object — do NOT
+rewrite it, do NOT produce a new answer of your own.
+
+You may inspect this repository to verify (READ-ONLY — read files, run git
+diff/log/grep; do NOT modify, create, or delete anything, and run no git write
+command: add/commit/push/stash/checkout). Cite file:line for repo claims.
+
+The original question was:
+$prompt_text
+
+The candidate unified answer to approve is:
+$crosscheck
+
+Return the JSON schema:
+  - answer: echo the candidate VERBATIM (you are approving it, not rewriting it).
+  - keyPoints: the core claims the candidate rests on.
+  - objections: anything the candidate gets wrong, drops, or overstates relative to
+    what you agreed — empty if you approve it as-is. Be specific (file:line for repo
+    claims).
+  - changedMind: empty (you are confirming, not revising).
+  - agreesWithOther: true ONLY if you approve the candidate as a correct, complete
+    unified answer with NO objection left.
+EOF
+)"
+elif [ -n "$resume_id" ] && [ -n "$is_crosscheck" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME answer session you started earlier — you still
 have your own previous answer and reasoning in context. You and another assistant

--- a/.claude/skills/codex-debate/scripts/codex-exec-lib.sh
+++ b/.claude/skills/codex-debate/scripts/codex-exec-lib.sh
@@ -142,7 +142,11 @@ codex_exec_round() {
     # so overwriting is a harmless refresh. Failure to capture an id just means next
     # round cold-starts via the caller's fallback — not fatal.
     local sid
-    sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+    # Extract the LAST thread_id in the log (one awk, no grep|tail|cut pipeline).
+    # Splitting on '"', the value sits two fields AFTER the "thread_id" key field
+    # (key, then ":", then value) — NOT a fixed column, since other quoted keys
+    # (e.g. "type":"thread.started") precede it on the same JSON event line.
+    sid="$(awk -F'"' '{for (i = 1; i < NF; i++) if ($i == "thread_id") sid = $(i + 2)} END {print sid}' "$log")"
     if [ -n "$sid" ]; then
       printf '%s\n' "$sid" >"$session_id_file"
     fi

--- a/.claude/skills/codex-debate/scripts/codex-exec-lib.sh
+++ b/.claude/skills/codex-debate/scripts/codex-exec-lib.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# codex-exec-lib.sh — the shared, SOURCED core of the codex⇄claude debate scripts.
+#
+# Both modes of /codex-debate drive codex the same way; only WHAT they ask and the
+# verdict SHAPE differ. This file is the single home for the part that is identical
+# (and the part most volatile to codex CLI changes): driving codex headless and
+# READ-ONLY, resuming its warm session, retrying transient failures with backoff,
+# capturing the thread id, and — when codex produces nothing after every attempt —
+# synthesizing a schema-valid error verdict so the debate loop never wedges.
+#
+# It is `source`d, not executed. The two callers (codex-review.sh, codex-answer.sh)
+# own the parts that DIFFER: parsing their own args, building the prompt, choosing
+# the schema + per-mode session-id file, and defining the verdict shape.
+#
+# Contract — a caller must:
+#   1. source this file;
+#   2. define a function  synthesize_error_verdict <out> <tail_log> <attempts>
+#      that writes its own schema-valid error verdict (reviewerError:true) to <out>;
+#   3. resolve the warm-session resume id with  codex_resolve_session <id-file> <round1?>
+#      (so it can pick the warm vs cold prompt), then build $prompt;
+#   4. run one round with  codex_exec_round <schema> <out> <id-file> <effort> <resume-id> <prompt>.
+#
+# Tunables (shared by both modes; names kept for back-compat):
+#   CODEX_REVIEW_RETRIES  total attempts per round (default 3)
+#   CODEX_REVIEW_BACKOFF  base seconds; attempt n waits n*base (default 5)
+
+# Resolve the warm-session resume id for this round, and reset it on round 1.
+#
+#   * Round 1 (is_round1 == "1"): start a NEW session — drop any id left behind by
+#     a previous debate in this worktree so we never resume a stale one. Echoes "".
+#   * Later rounds: echo the persisted id (empty if none was captured — the caller
+#     then cleanly cold-starts with the full prompt, never a wedge).
+#
+# Echoing (rather than setting a global) keeps the caller explicit: it captures the
+# id, uses it to choose the warm vs cold prompt, and passes it back to
+# codex_exec_round. Usage: resume_id="$(codex_resolve_session "$id_file" "$round1")"
+codex_resolve_session() {
+  local session_id_file="$1" is_round1="$2"
+  if [ "$is_round1" = "1" ]; then
+    rm -f "$session_id_file"
+    return 0
+  fi
+  if [ -s "$session_id_file" ]; then
+    cat "$session_id_file"
+  fi
+}
+
+# One codex invocation: warm-resume when we have a session id (carries codex's own
+# prior turn), else a cold start. `--json` emits a `thread.started` event carrying
+# codex's thread_id (captured by codex_exec_round to resume next round); it does NOT
+# change the verdict, which `--output-schema`/`-o` still write to "$out". `resume`
+# has no `--sandbox` flag, so read-only is enforced there via `-c sandbox_mode` —
+# the same kernel-enforced policy, set through config instead of the flag.
+#
+# Reads $resume_id, $schema, $out, $effort, $prompt from the enclosing
+# codex_exec_round via bash's dynamic scope (they're `local` there).
+_codex_run_once() {
+  if [ -n "$resume_id" ]; then
+    codex exec resume \
+      -c sandbox_mode="read-only" \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$resume_id" "$prompt"
+  else
+    codex exec \
+      --sandbox read-only \
+      -c model_reasoning_effort="$effort" \
+      --json \
+      --output-schema "$schema" \
+      -o "$out" \
+      "$prompt"
+  fi
+}
+
+# Run ONE debate round against codex and leave a schema-valid verdict in <out>
+# (also echoed to stdout). Owns the out/log lifecycle, the retry/backoff loop, the
+# thread-id capture, and the error-verdict fallback.
+#
+#   codex_exec_round <schema> <out> <session_id_file> <effort> <resume_id> <prompt>
+#
+# model_reasoning_effort is scoped to the debate here (via -c, from <effort>) rather
+# than the user's global ~/.codex/config.toml — review/answer is the one place we
+# always want codex thinking at full depth, regardless of their default.
+#
+# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API hiccups,
+# a spurious internal error) and writes no verdict — which would otherwise degrade
+# the round to reviewer-error on a single bad roll. Retry with linear backoff,
+# accepting the first attempt that writes a non-empty verdict to <out>. Only after
+# every attempt fails empty do we synthesize the reviewerError verdict (via the
+# caller's synthesize_error_verdict hook).
+codex_exec_round() {
+  local schema="$1" out="$2" session_id_file="$3" effort="$4" resume_id="$5" prompt="$6"
+  local log="$out.log"
+
+  # The out path lives under a per-worktree scratch dir (.codex-debate/); make sure
+  # it exists before codex tries to write the verdict there.
+  mkdir -p "$(dirname "$out")"
+
+  local attempts="${CODEX_REVIEW_RETRIES:-3}"
+  local backoff="${CODEX_REVIEW_BACKOFF:-5}"
+  # Validate both as positive integers. Left unchecked, a non-numeric value makes the
+  # arithmetic test error every iteration, so the loop would spin forever instead of
+  # giving up. Fall back to the documented defaults (and clamp attempts to >=1)
+  # loudly rather than wedge the headless debate on a typo'd override.
+  if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
+    echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
+    attempts=3
+  fi
+  if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
+    echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
+    backoff=5
+  fi
+
+  local n=1 wait_s
+  : >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
+  while :; do
+    rm -f "$out"
+    # Append (not truncate): when every attempt fails, the synthesized error
+    # verdict's tail_log must reflect ALL attempts' diagnostics, not just the last.
+    echo "=== attempt $n/$attempts ===" >>"$log"
+    if ! _codex_run_once </dev/null >>"$log" 2>&1; then
+      echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
+    fi
+    # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
+    # make a non-empty "$out" a real, schema-valid verdict, not a partial.
+    [ -s "$out" ] && break
+    # Out of attempts — fall through to the synthesized error verdict.
+    [ "$n" -ge "$attempts" ] && break
+    wait_s=$(( backoff * n ))
+    echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
+    n=$(( n + 1 ))
+    sleep "$wait_s"
+  done
+
+  if [ -s "$out" ]; then
+    # Persist codex's session id so the NEXT round can resume this same warm session
+    # (carrying codex's own prior turn). The successful attempt's `thread.started`
+    # is the last one appended to the log; on a resume round it echoes the same id,
+    # so overwriting is a harmless refresh. Failure to capture an id just means next
+    # round cold-starts via the caller's fallback — not fatal.
+    local sid
+    sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
+    if [ -n "$sid" ]; then
+      printf '%s\n' "$sid" >"$session_id_file"
+    fi
+  fi
+
+  if [ ! -s "$out" ]; then
+    # codex produced no verdict — hand off to the caller's shape-specific synthesizer
+    # so the debate loop can surface the failure instead of hanging. reviewerError is
+    # the machine-detectable signal the workflow aborts on: a broken/unavailable codex
+    # is INFRASTRUCTURE failure, not substantive disagreement, so it must NOT spin the
+    # loop forever.
+    local tail_log
+    tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
+    synthesize_error_verdict "$out" "$tail_log" "$attempts"
+  fi
+
+  cat "$out"
+}

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 #
 # codex-review.sh — the canonical, deterministic codex invocation for the
-# codex<->claude review debate. Runs the codex CLI as a READ-ONLY reviewer of
-# the current working-tree state against a base branch, constrained to
-# codex-verdict.schema.json, and writes the JSON verdict to <out-json>.
+# codex<->claude review debate (the `review` mode of /codex-debate). Runs the
+# codex CLI as a READ-ONLY reviewer of the current working-tree state against a
+# base branch, constrained to codex-verdict.schema.json, and writes the JSON
+# verdict to <out-json>.
+#
+# This script owns only what is SPECIFIC to reviewing a diff: arg parsing, the
+# warm/cold review prompt text, the verdict schema + session file, and the
+# verdict-shaped error fallback. The shared codex-driving core (read-only exec/
+# resume, retry/backoff, thread-id capture, session persistence) lives in
+# codex-exec-lib.sh.
 #
 # Usage:
 #   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
@@ -17,24 +24,16 @@
 #                    value has one home. Defaults to "xhigh" for standalone runs.
 #
 # Notes:
-#   * codex runs under `--sandbox read-only`, which enforces read-only at the
-#     execution boundary (the kernel sandbox blocks file writes and other
-#     state-mutating syscalls), NOT merely by prompt text. codex reviews
-#     arbitrary diffs and could be prompt-injected by file contents, so the
-#     read-only promise must be enforced, not advertised. codex auto-falls-back
-#     to its bundled bubblewrap when the system one is absent, so this works in
-#     containers; `--sandbox read-only` permits read-only command execution
-#     (git diff/status, reading files) but denies writes. `codex exec` is already
-#     non-interactive (approval policy "never"), so a command the sandbox blocks
-#     is denied outright rather than escalating to a prompt that would wedge the
-#     headless loop.
+#   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
+#     read-only at the kernel boundary (file writes and other state-mutating
+#     syscalls denied), NOT merely by prompt text. codex reviews arbitrary diffs and
+#     could be prompt-injected by file contents, so the read-only promise must be
+#     enforced, not advertised.
 #   * Always emits a schema-valid verdict on stdout, even if codex errors — a
 #     synthesized error verdict (approved:false) so the loop never wedges.
-#   * WARM SESSION: round 1 cold-starts codex and records its session id under the
-#     scratch dir; every later round resumes that same session (`codex exec
-#     resume <id>`) so codex retains its OWN prior review + reasoning across rounds
-#     instead of reconstructing it from the diff + rebuttal each time. If the id
-#     was never captured, a later round cleanly falls back to a cold start.
+#   * WARM SESSION: round 1 cold-starts codex and records its session id; every later
+#     round resumes that same session (`codex exec resume <id>`) so codex retains its
+#     OWN prior review + reasoning across rounds.
 set -uo pipefail
 
 base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
@@ -46,21 +45,12 @@ effort="${4:-xhigh}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
-log="$out.log"
-
-# The out path lives under a per-worktree scratch dir (e.g. .codex-debate/);
-# make sure it exists before codex tries to write the verdict there.
-mkdir -p "$(dirname "$out")"
+# shellcheck source=codex-exec-lib.sh
+source "$here/codex-exec-lib.sh"
 
 # Pull CLAUDE's previous response, if any. Built as a plain string and injected
 # below via a simple variable reference so any special characters in the JSON
-# (backticks, $, ...) stay literal — heredoc expansion results are not re-scanned.
-# Never let a stale verdict from a previous run survive: if the current codex
-# invocation fails to write one, the empty-check below must catch it and
-# synthesize an error verdict (otherwise a leftover /tmp file reads as a fresh
-# pass — a false consensus).
-rm -f "$out" "$log"
-
+# (backticks, $, ...) stay literal (heredoc expansion results are not re-scanned).
 rebuttal=""
 if [ "$rebuttal_file" != "-" ]; then
   if [ -s "$rebuttal_file" ]; then
@@ -89,28 +79,26 @@ $rebuttal
 "
 fi
 
-# WARM SESSION. codex keeps its OWN review + reasoning across rounds by resuming
-# the same codex session instead of cold-starting `codex exec` each round. The
-# session id (codex's thread_id) is persisted in the scratch dir after round 1
-# and reused on every follow-up round, so when CLAUDE disputes a finding codex
-# re-engages with its original rationale rather than reconstructing it from the
-# diff + rebuttal alone.
-#
-#   * Round 1 (rebuttal_file == "-"): fresh `codex exec`; capture thread_id below.
-#   * Later rounds: `codex exec resume <id>` with just the follow-up (rebuttal +
-#     close-out), relying on codex's retained context.
-#   * Fallback: if no id was captured (round-1 capture failed), a later round
-#     cold-starts with the FULL prompt + rebuttal_block — same as before warm
-#     sessions existed — so a missing id degrades gracefully, never wedges.
+# WARM SESSION. Round 1 (rebuttal_file == "-") cold-starts and resets any stale id;
+# later rounds resume codex's own review session. Resolve the id first so the prompt
+# below can lean on codex's retained context when warm.
 session_id_file="$(dirname "$out")/codex-session.id"
-resume_id=""
-if [ "$rebuttal_file" = "-" ]; then
-  # Round 1 of a fresh debate: start a NEW session and drop any session id left
-  # behind by a previous debate in this worktree, so we never resume a stale one.
-  rm -f "$session_id_file"
-elif [ -s "$session_id_file" ]; then
-  resume_id="$(cat "$session_id_file")"
-fi
+[ "$rebuttal_file" = "-" ] && is_round1=1 || is_round1=
+resume_id="$(codex_resolve_session "$session_id_file" "$is_round1")"
+
+# Synthesize codex-review's error verdict shape when codex produces nothing after
+# every attempt (called by codex_exec_round). reviewerError:true is the signal the
+# workflow aborts the debate on.
+synthesize_error_verdict() {
+  local out="$1" tail_log="$2" attempts="$3"
+  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
+    approved: false,
+    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
+    findings: [],
+    responseToRebuttal: "",
+    reviewerError: true
+  }' >"$out"
+}
 
 # Two prompts: a lean follow-up for the WARM (resume) path that leans on codex's
 # retained context, and the full review prompt for the COLD path (round 1, or the
@@ -189,110 +177,6 @@ EOF
 )"
 fi
 
-# One codex invocation: warm-resume when we have a session id (carries codex's own
-# prior review), else a cold start. `--json` is added so the run emits a
-# `thread.started` event carrying codex's thread_id, which we capture below to
-# resume next round; it does NOT change the verdict, which `--output-schema`/`-o`
-# still write to "$out". `resume` has no `--sandbox` flag, so read-only is enforced
-# there via `-c sandbox_mode` — the same kernel-enforced policy, set through config
-# instead of the flag.
-run_codex() {
-  if [ -n "$resume_id" ]; then
-    codex exec resume \
-      -c sandbox_mode="read-only" \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$resume_id" "$prompt"
-  else
-    codex exec \
-      --sandbox read-only \
-      -c model_reasoning_effort="$effort" \
-      --json \
-      --output-schema "$schema" \
-      -o "$out" \
-      "$prompt"
-  fi
-}
-
-# model_reasoning_effort is scoped to the debate here (via -c, from the $effort
-# the workflow passes down — default "xhigh") rather than relying on the user's
-# global ~/.codex/config.toml — review is the one place we always want codex
-# thinking at full depth, regardless of their default.
-#
-# RETRY/BACKOFF. codex's CLI fails transiently often enough to matter (API
-# hiccups, a spurious internal error) and writes no verdict — which would
-# otherwise degrade the whole track to reviewer-error on a single bad roll.
-# Retry the invocation with linear backoff, accepting the first attempt that
-# writes a non-empty verdict to "$out". Tunable via env: CODEX_REVIEW_RETRIES
-# (total attempts, default 3), CODEX_REVIEW_BACKOFF (base seconds, default 5 —
-# attempt n waits n*base). Only after every attempt fails empty do we synthesize
-# the reviewerError verdict below.
-attempts="${CODEX_REVIEW_RETRIES:-3}"
-backoff="${CODEX_REVIEW_BACKOFF:-5}"
-# Validate both as positive integers. Left unchecked, a non-numeric value makes
-# the arithmetic `[ "$n" -ge "$attempts" ]` test error every iteration, so the
-# loop would spin forever instead of giving up and synthesizing the reviewerError
-# verdict. Fall back to the documented defaults (and clamp attempts to >=1) loudly
-# rather than wedge the headless debate on a typo'd override.
-if ! [[ "$attempts" =~ ^[0-9]+$ ]] || [ "$attempts" -lt 1 ]; then
-  echo "WARNING: CODEX_REVIEW_RETRIES='$attempts' is not a positive integer; using 3." >&2
-  attempts=3
-fi
-if ! [[ "$backoff" =~ ^[0-9]+$ ]]; then
-  echo "WARNING: CODEX_REVIEW_BACKOFF='$backoff' is not a non-negative integer; using 5." >&2
-  backoff=5
-fi
-n=1
-: >"$log"  # start each round fresh; attempts below APPEND so no failure's diagnostics are lost
-while :; do
-  rm -f "$out"
-  # Append (not truncate): when every attempt fails, the synthesized reviewerError
-  # verdict's tail_log must reflect ALL attempts' diagnostics — surfacing the exact
-  # transient failures this retry loop exists to weather — not just the final one.
-  echo "=== attempt $n/$attempts ===" >>"$log"
-  if ! run_codex </dev/null >>"$log" 2>&1; then
-    echo "codex exec exited non-zero (attempt $n/$attempts; see $log)" >&2
-  fi
-  # Success the moment codex writes a verdict: the kernel sandbox + --output-schema
-  # make a non-empty "$out" a real, schema-valid verdict, not a partial.
-  [ -s "$out" ] && break
-  # Out of attempts — fall through to the synthesized reviewerError verdict.
-  [ "$n" -ge "$attempts" ] && break
-  wait_s=$(( backoff * n ))
-  echo "codex produced no verdict (attempt $n/$attempts); retrying in ${wait_s}s..." >&2
-  n=$(( n + 1 ))
-  sleep "$wait_s"
-done
-
-if [ -s "$out" ]; then
-  # Persist codex's session id so NEXT round can resume this same warm session
-  # (carrying codex's own prior review + reasoning). The successful attempt's
-  # `thread.started` is the last one appended to the log; on a resume round it
-  # echoes the same id, so overwriting is a harmless refresh. Failure to capture
-  # an id just means next round cold-starts via the fallback above — not fatal.
-  sid="$(grep -o '"thread_id":"[^"]*"' "$log" | tail -1 | cut -d'"' -f4)"
-  if [ -n "$sid" ]; then
-    printf '%s\n' "$sid" >"$session_id_file"
-  fi
-fi
-
-if [ ! -s "$out" ]; then
-  # codex produced no verdict — synthesize a schema-valid error verdict so the
-  # debate loop can surface the failure instead of hanging. The reviewerError
-  # flag is the machine-detectable signal the workflow uses to abort with a
-  # terminal failure: a broken/unavailable codex is INFRASTRUCTURE failure, not
-  # substantive disagreement, so it must NOT be routed to Claude (there are no
-  # findings to act on) and must NOT spin the loop forever.
-  tail_log="$(tail -c 2000 "$log" 2>/dev/null || true)"
-  jq -n --arg log "$tail_log" --arg attempts "$attempts" '{
-    approved: false,
-    summary: ("codex produced no verdict this round after " + $attempts + " attempt(s). Tail of log: " + $log),
-    findings: [],
-    responseToRebuttal: "",
-    reviewerError: true
-  }' >"$out"
-fi
-
-cat "$out"
+# Drive codex for this round (retry/backoff, thread capture, error fallback) — the
+# shared core does the work; this script supplied the prompt, schema, and shapes.
+codex_exec_round "$schema" "$out" "$session_id_file" "$effort" "$resume_id" "$prompt"


### PR DESCRIPTION
## What

`/codex-debate` has always been a **code-review** debate: codex critiques the diff, a Claude author fixes or disputes, looping to consensus. This PR generalizes it. When you pass a **freeform prompt** instead of a PR number, the skill runs a **symmetric answer-debate**:

```
/codex-debate 12 --base origin/master         -> review debate (unchanged)
/codex-debate "Is our retry backoff correct?"  -> answer debate (new)
```

Claude and codex **each answer the prompt independently and in parallel**, then **cross-check each other** — round after round, conceding where the other is right and holding firm (with evidence) where it isn't — **until both agree**. A final synthesis pass merges the two converged answers into **one unified reply**, presented in chat and saved as a transcript.

## How it works

```mermaid
flowchart TD
    P["freeform prompt"] --> A["Answer (round 1, parallel)"]
    A --> C1["claude answers"]
    A --> X1["codex answers (read-only)"]
    C1 & X1 --> R{"both agree?"}
    R -- no --> RC["Reconcile (round N, parallel):<br/>each cross-checks the other's latest answer"]
    RC --> R
    R -- yes --> S["Synthesis: merge into one unified answer"]
    S --> O["chat reply + .codex-debate/answer-&lt;slug&gt;.md"]
```

- **Symmetric, not author⇄reviewer.** Both sides are equal peers. Each emits a structured answer with `agreesWithOther` + `objections`, so **consensus is detected in code**, not by vibes. **No round cap, no deadlock exit** — same contract as review mode.
- **Codebase-aware, read-only.** Each peer may read the repo to ground its answer (`git diff/log`, files, grep). codex stays under kernel-enforced `--sandbox read-only`; the Claude peer is instructed never to write. **No mode of this debate touches the repo.**
- **Warm codex session.** Round 1 cold-starts `codex exec`; later rounds `codex exec resume` so codex cross-checks from its own prior answer. Its session id lives in a distinct `codex-answer-session.id` so it never collides with review mode's.
- **Chat + saved transcript, no outward writes.** Unlike review mode, answer mode never commits or posts to a PR — it just answers. The full convergence trail is saved to the gitignored `.codex-debate/answer-<slug>.md`.

## Files

| File | Role |
|------|------|
| `answer.workflow.js` | The symmetric loop: parallel answers → cross-check to agreement → synthesis. Mirrors `debate.workflow.js`. |
| `scripts/codex-answer.sh` | Deterministic `codex exec` invocation to answer a prompt as a read-only peer — warm resume, retry/backoff, synthesized `reviewerError` on failure. |
| `scripts/codex-answer.schema.json` | The JSON Schema codex's answer is constrained to. |
| `SKILL.md` | Mode-detection routing (PR-number/flags → review; freeform prompt → answer) + Answer-mode steps and safety notes. |

Sources live in `.apm/`; `.claude/` and `.agents/` are regenerated via `just ai apm`.

## Notes

- Both sides run in **parallel** each round, so agreement is on the prior round's answers — safe (it only ever ends on real agreement), at worst one round later than a strictly-serial handoff.
- Terminal failure paths (`reviewer-error` for a broken codex, `agent-error` for a dead side) are reported as failures, never presented as an agreed answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)