### PR TITLE
refactor(be-review): run the lens debate before codex debate

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
-description: Run /be's review gauntlet SERIALLY — /codex-debate, then /lens-debate (lowy ⇄ hickey), then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
-argument-hint: "[--base <branch>] [--rationale <note>] [--tracks codex,lens,simplify,police]"
+description: Run /be's review gauntlet SERIALLY — /lens-debate (lowy ⇄ hickey), then /codex-debate, then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
+argument-hint: "[--base <branch>] [--rationale <note>] [--tracks lens,codex,simplify,police]"
 ---
 
 # Review gauntlet (serial)
@@ -13,11 +13,11 @@ that impossible without any snapshot machinery — when a step starts, the previ
 step has already committed, so every reviewer reads a clean, settled tree and
 applies its own fixes directly:
 
-1. **`/codex-debate`** — codex (`xhigh`) ⇄ claude author, debating to consensus.
-   Its author rounds edit and each round auto-commits `fix(…)` on the branch.
-2. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,
+1. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,
    then **apply** the agreed fixes (each its own commit). Pass the change
    **`rationale`** so the lenses don't flag deliberate decisions.
+2. **`/codex-debate`** — codex (`xhigh`) ⇄ claude author, debating to consensus.
+   Its author rounds edit and each round auto-commits `fix(…)` on the branch.
 3. **`/simplify`** — the self-applying reuse / simplification / efficiency pass
    over the changed code. Now that nothing runs concurrently, it runs as itself
    (it could not against the old read-only snapshot).
@@ -25,7 +25,7 @@ applies its own fixes directly:
    their fixes (the elegance pass re-runs `/simplify`, harmless after step 3).
 
 Each step runs to completion before the next begins. Wall-clock is
-`codex + lens + simplify + police` — slower than the old parallel form, but with
+`lens + codex + simplify + police` — slower than the old parallel form, but with
 no snapshot, no change-request handoff, and no separate apply pass: every step is
 its own editor and commits its own work.
 
@@ -35,7 +35,7 @@ a commit SHA must never be posted while that SHA is local-only — if a later st
 failed or the run were interrupted, the PR would advertise commits that were
 never pushed. So the debate skills run with their self-commenting **suppressed**
 (`--no-comment`); be-review captures the comment body each returns, pushes once at
-the end, and only then posts the codex comment, the lens comment, and its own
+the end, and only then posts the lens comment, the codex comment, and its own
 police summary. No PR comment can reference a local-only commit.
 
 ## Preflight
@@ -57,36 +57,19 @@ police summary. No PR comment can reference a local-only commit.
 
 ## Run the steps in order
 
-`--tracks codex,lens,simplify,police` selects which steps run (default all four),
+`--tracks lens,codex,simplify,police` selects which steps run (default all four),
 in the listed order. Run each to completion, then move to the next. Preflight
 already ran `git fetch origin` and resolved the base, so pass `MB` straight into
 each step and **skip the per-skill step-1 fetch / base resolution** — don't redo
 it once per step.
 
-1. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
-   worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
-   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
-   in the background; **wait for it to finish** before starting the lens step. It
-   commits its rounds and **returns** its rendered comment body — hold onto it to
-   post after the final push. (On persistent `reviewer-error` there is **no
-   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
-   consensus to report; skip the codex comment in that case.)
-
-   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   either in `consensus` or in `reviewer-error` — the latter meaning codex never
-   produced a structured verdict even after `codex-review.sh`'s built-in
-   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
-   outcome*: re-launch it immediately with the same args. Stop the moment an
-   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
-   you give up on codex — report the persistent reviewer-error honestly (no false
-   consensus comment) and move on to the lens step.
-
-2. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
+1. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
    `base` = `MB`, **apply mode** (the default — do *not* pass `--no-apply`),
-   **`--no-comment`** (same reason as codex — defer the comment until after the
-   push), and thread the `rationale` through. It applies the agreed fixes as
-   commits and **returns** its rendered comment body for be-review to post after
-   the push. Wait for its `Workflow` to finish.
+   **`--no-comment`** (so it doesn't advertise its local-only commits before
+   be-review pushes — defer the comment until after the push), and thread the
+   `rationale` through. It applies the agreed fixes as commits and **returns** its
+   rendered comment body for be-review to post after the push. Wait for its
+   `Workflow` to finish before starting the codex step.
 
    `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
    `merge-base-error`:
@@ -99,6 +82,24 @@ it once per step.
      skill ran `--no-comment`, so there is no self-posted comment to follow up
      on). Never report "lens consensus" for an `unresolved` run.
    - `merge-base-error` — the scope couldn't be trusted; report it and move on.
+
+2. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
+   worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
+   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
+   in the background; **wait for it to finish** before starting the simplify step.
+   It commits its rounds and **returns** its rendered comment body — hold onto it
+   to post after the final push. (On persistent `reviewer-error` there is **no
+   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
+   consensus to report; skip the codex comment in that case.)
+
+   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
+   either in `consensus` or in `reviewer-error` — the latter meaning codex never
+   produced a structured verdict even after `codex-review.sh`'s built-in
+   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
+   outcome*: re-launch it immediately with the same args. Stop the moment an
+   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
+   you give up on codex — report the persistent reviewer-error honestly (no false
+   consensus comment) and move on to the simplify step.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it
@@ -125,7 +126,7 @@ First settle whether there is anything to push: `git log --oneline $START..HEAD`
 
 - **New commits exist** and **a PR exists for this branch**
   (`gh pr view --json number -q .number`) → **`git push`**. **Only after the push
-  succeeds** do you post the deferred comments — the codex and lens bodies from
+  succeeds** do you post the deferred comments — the lens and codex bodies from
   steps 1–2 are now safe to publish because the SHAs they name are on the remote.
 - **No new commits** (every step was clean or applied nothing) but **a PR
   exists** → there is nothing to push, and HEAD is already remote-visible, so
@@ -143,8 +144,8 @@ merges when satisfied.
 
 When you do post, post **one comment per track that produced a body** — skip any
 track `--tracks` excluded, and skip a track that ran but yielded no postable
-comment (codex on persistent `reviewer-error`, lens on `merge-base-error`): the
-codex body and the lens body verbatim (`gh pr comment -F`), and the police
+comment (lens on `merge-base-error`, codex on persistent `reviewer-error`): the
+lens body and the codex body verbatim (`gh pr comment -F`), and the police
 summary (the `## [👮 Code-police](https://agency.srid.ca/)` comment described in
 Report).
 
@@ -153,17 +154,17 @@ Report).
 Summarize in chat — reporting **only the selected tracks**, and naming any track
 `--tracks` **skipped** so the absence is explicit, not silent:
 
-- **codex** — consensus / reviewer-error (note how many attempts if retried); on
-  consensus its PR comment landed (posted after the push, per "Push, then
-  comment") — on persistent reviewer-error there is no comment to post.
 - **lens** — status (**consensus** + fixes applied, or **unresolved** + how many
   findings still need human adjudication and how you adjudicated each, or
   `merge-base-error`); its PR comment landed (posted after the push) — except on
   `merge-base-error`, which has no comment body to post.
+- **codex** — consensus / reviewer-error (note how many attempts if retried); on
+  consensus its PR comment landed (posted after the push, per "Push, then
+  comment") — on persistent reviewer-error there is no comment to post.
 - **simplify** — whether it changed anything and what it committed.
 - **police** — findings and how each was actioned; the
   `## [👮 Code-police](https://agency.srid.ca/)` summary comment landed (posted
-  after the push, alongside the codex and lens comments).
+  after the push, alongside the lens and codex comments).
 - whether the fixes were pushed;
 - `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
   result is visible.

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: be
-description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a serial AI review gauntlet (codex debate → lens debate (lowy ⇄ hickey) → simplify → code-police, each editing the branch in turn) → CI → evidence. ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a serial AI review gauntlet (lens debate (lowy ⇄ hickey) → codex debate → simplify → code-police, each editing the branch in turn) → CI → evidence. ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
 argument-hint: "<issue-url | prompt>"
 ---
 
@@ -49,19 +49,19 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 ## 4. Review gauntlet
 
 Run **`/be-review`** (Skill tool) — it runs four reviewers **serially**, each the
-sole editor while it runs: `/codex-debate` (its per-round commits are the debate),
-then `/lens-debate` applying the agreed fixes, then `/simplify`, then code-police.
-Each step reads a clean tree (the previous step has committed) and applies its own
-fixes directly — no snapshot, no apply pass. be-review pushes once at the end and
-*then* posts the PR comments (codex, lens, and a code-police summary), so no
-comment advertises a local-only commit.
+sole editor while it runs: `/lens-debate` applying the agreed fixes, then
+`/codex-debate` (its per-round commits are the debate), then `/simplify`, then
+code-police. Each step reads a clean tree (the previous step has committed) and
+applies its own fixes directly — no snapshot, no apply pass. be-review pushes once
+at the end and *then* posts the PR comments (lens, codex, and a code-police
+summary), so no comment advertises a local-only commit.
 
 - Pass `base` and the change **`rationale`** (so the lenses don't flag deliberate
   decisions). Preflight is a non-empty diff and (since codex runs) `codex login
   status`.
-- Codex's rounds commit `fix(…)`; lens-debate commits its agreed fixes; simplify
+- Lens-debate commits its agreed fixes; codex's rounds commit `fix(…)`; simplify
   and code-police commit `refactor:` / `fix(police):`. Confirm the post-push PR
-  comments landed: codex, lens, and — when the police track ran — the code-police
+  comments landed: lens, codex, and — when the police track ran — the code-police
   summary.
 - On an **unresolved** lens finding, adjudicate it yourself before moving on.
 
@@ -86,6 +86,6 @@ green before capturing.
 
 ## Done
 
-Report the PR URL, the gauntlet outcome (codex consensus or reviewer-error, lens-debate consensus + fixes applied, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
+Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
-description: Run /be's review gauntlet SERIALLY — /codex-debate, then /lens-debate (lowy ⇄ hickey), then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
-argument-hint: "[--base <branch>] [--rationale <note>] [--tracks codex,lens,simplify,police]"
+description: Run /be's review gauntlet SERIALLY — /lens-debate (lowy ⇄ hickey), then /codex-debate, then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
+argument-hint: "[--base <branch>] [--rationale <note>] [--tracks lens,codex,simplify,police]"
 ---
 
 # Review gauntlet (serial)
@@ -13,11 +13,11 @@ that impossible without any snapshot machinery — when a step starts, the previ
 step has already committed, so every reviewer reads a clean, settled tree and
 applies its own fixes directly:
 
-1. **`/codex-debate`** — codex (`xhigh`) ⇄ claude author, debating to consensus.
-   Its author rounds edit and each round auto-commits `fix(…)` on the branch.
-2. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,
+1. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,
    then **apply** the agreed fixes (each its own commit). Pass the change
    **`rationale`** so the lenses don't flag deliberate decisions.
+2. **`/codex-debate`** — codex (`xhigh`) ⇄ claude author, debating to consensus.
+   Its author rounds edit and each round auto-commits `fix(…)` on the branch.
 3. **`/simplify`** — the self-applying reuse / simplification / efficiency pass
    over the changed code. Now that nothing runs concurrently, it runs as itself
    (it could not against the old read-only snapshot).
@@ -25,7 +25,7 @@ applies its own fixes directly:
    their fixes (the elegance pass re-runs `/simplify`, harmless after step 3).
 
 Each step runs to completion before the next begins. Wall-clock is
-`codex + lens + simplify + police` — slower than the old parallel form, but with
+`lens + codex + simplify + police` — slower than the old parallel form, but with
 no snapshot, no change-request handoff, and no separate apply pass: every step is
 its own editor and commits its own work.
 
@@ -35,7 +35,7 @@ a commit SHA must never be posted while that SHA is local-only — if a later st
 failed or the run were interrupted, the PR would advertise commits that were
 never pushed. So the debate skills run with their self-commenting **suppressed**
 (`--no-comment`); be-review captures the comment body each returns, pushes once at
-the end, and only then posts the codex comment, the lens comment, and its own
+the end, and only then posts the lens comment, the codex comment, and its own
 police summary. No PR comment can reference a local-only commit.
 
 ## Preflight
@@ -57,36 +57,19 @@ police summary. No PR comment can reference a local-only commit.
 
 ## Run the steps in order
 
-`--tracks codex,lens,simplify,police` selects which steps run (default all four),
+`--tracks lens,codex,simplify,police` selects which steps run (default all four),
 in the listed order. Run each to completion, then move to the next. Preflight
 already ran `git fetch origin` and resolved the base, so pass `MB` straight into
 each step and **skip the per-skill step-1 fetch / base resolution** — don't redo
 it once per step.
 
-1. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
-   worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
-   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
-   in the background; **wait for it to finish** before starting the lens step. It
-   commits its rounds and **returns** its rendered comment body — hold onto it to
-   post after the final push. (On persistent `reviewer-error` there is **no
-   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
-   consensus to report; skip the codex comment in that case.)
-
-   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   either in `consensus` or in `reviewer-error` — the latter meaning codex never
-   produced a structured verdict even after `codex-review.sh`'s built-in
-   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
-   outcome*: re-launch it immediately with the same args. Stop the moment an
-   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
-   you give up on codex — report the persistent reviewer-error honestly (no false
-   consensus comment) and move on to the lens step.
-
-2. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
+1. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
    `base` = `MB`, **apply mode** (the default — do *not* pass `--no-apply`),
-   **`--no-comment`** (same reason as codex — defer the comment until after the
-   push), and thread the `rationale` through. It applies the agreed fixes as
-   commits and **returns** its rendered comment body for be-review to post after
-   the push. Wait for its `Workflow` to finish.
+   **`--no-comment`** (so it doesn't advertise its local-only commits before
+   be-review pushes — defer the comment until after the push), and thread the
+   `rationale` through. It applies the agreed fixes as commits and **returns** its
+   rendered comment body for be-review to post after the push. Wait for its
+   `Workflow` to finish before starting the codex step.
 
    `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
    `merge-base-error`:
@@ -99,6 +82,24 @@ it once per step.
      skill ran `--no-comment`, so there is no self-posted comment to follow up
      on). Never report "lens consensus" for an `unresolved` run.
    - `merge-base-error` — the scope couldn't be trusted; report it and move on.
+
+2. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
+   worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
+   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
+   in the background; **wait for it to finish** before starting the simplify step.
+   It commits its rounds and **returns** its rendered comment body — hold onto it
+   to post after the final push. (On persistent `reviewer-error` there is **no
+   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
+   consensus to report; skip the codex comment in that case.)
+
+   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
+   either in `consensus` or in `reviewer-error` — the latter meaning codex never
+   produced a structured verdict even after `codex-review.sh`'s built-in
+   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
+   outcome*: re-launch it immediately with the same args. Stop the moment an
+   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
+   you give up on codex — report the persistent reviewer-error honestly (no false
+   consensus comment) and move on to the simplify step.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it
@@ -125,7 +126,7 @@ First settle whether there is anything to push: `git log --oneline $START..HEAD`
 
 - **New commits exist** and **a PR exists for this branch**
   (`gh pr view --json number -q .number`) → **`git push`**. **Only after the push
-  succeeds** do you post the deferred comments — the codex and lens bodies from
+  succeeds** do you post the deferred comments — the lens and codex bodies from
   steps 1–2 are now safe to publish because the SHAs they name are on the remote.
 - **No new commits** (every step was clean or applied nothing) but **a PR
   exists** → there is nothing to push, and HEAD is already remote-visible, so
@@ -143,8 +144,8 @@ merges when satisfied.
 
 When you do post, post **one comment per track that produced a body** — skip any
 track `--tracks` excluded, and skip a track that ran but yielded no postable
-comment (codex on persistent `reviewer-error`, lens on `merge-base-error`): the
-codex body and the lens body verbatim (`gh pr comment -F`), and the police
+comment (lens on `merge-base-error`, codex on persistent `reviewer-error`): the
+lens body and the codex body verbatim (`gh pr comment -F`), and the police
 summary (the `## [👮 Code-police](https://agency.srid.ca/)` comment described in
 Report).
 
@@ -153,17 +154,17 @@ Report).
 Summarize in chat — reporting **only the selected tracks**, and naming any track
 `--tracks` **skipped** so the absence is explicit, not silent:
 
-- **codex** — consensus / reviewer-error (note how many attempts if retried); on
-  consensus its PR comment landed (posted after the push, per "Push, then
-  comment") — on persistent reviewer-error there is no comment to post.
 - **lens** — status (**consensus** + fixes applied, or **unresolved** + how many
   findings still need human adjudication and how you adjudicated each, or
   `merge-base-error`); its PR comment landed (posted after the push) — except on
   `merge-base-error`, which has no comment body to post.
+- **codex** — consensus / reviewer-error (note how many attempts if retried); on
+  consensus its PR comment landed (posted after the push, per "Push, then
+  comment") — on persistent reviewer-error there is no comment to post.
 - **simplify** — whether it changed anything and what it committed.
 - **police** — findings and how each was actioned; the
   `## [👮 Code-police](https://agency.srid.ca/)` summary comment landed (posted
-  after the push, alongside the codex and lens comments).
+  after the push, alongside the lens and codex comments).
 - whether the fixes were pushed;
 - `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
   result is visible.

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: be
-description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a serial AI review gauntlet (codex debate → lens debate (lowy ⇄ hickey) → simplify → code-police, each editing the branch in turn) → CI → evidence. ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a serial AI review gauntlet (lens debate (lowy ⇄ hickey) → codex debate → simplify → code-police, each editing the branch in turn) → CI → evidence. ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
 argument-hint: "<issue-url | prompt>"
 ---
 
@@ -49,19 +49,19 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 ## 4. Review gauntlet
 
 Run **`/be-review`** (Skill tool) — it runs four reviewers **serially**, each the
-sole editor while it runs: `/codex-debate` (its per-round commits are the debate),
-then `/lens-debate` applying the agreed fixes, then `/simplify`, then code-police.
-Each step reads a clean tree (the previous step has committed) and applies its own
-fixes directly — no snapshot, no apply pass. be-review pushes once at the end and
-*then* posts the PR comments (codex, lens, and a code-police summary), so no
-comment advertises a local-only commit.
+sole editor while it runs: `/lens-debate` applying the agreed fixes, then
+`/codex-debate` (its per-round commits are the debate), then `/simplify`, then
+code-police. Each step reads a clean tree (the previous step has committed) and
+applies its own fixes directly — no snapshot, no apply pass. be-review pushes once
+at the end and *then* posts the PR comments (lens, codex, and a code-police
+summary), so no comment advertises a local-only commit.
 
 - Pass `base` and the change **`rationale`** (so the lenses don't flag deliberate
   decisions). Preflight is a non-empty diff and (since codex runs) `codex login
   status`.
-- Codex's rounds commit `fix(…)`; lens-debate commits its agreed fixes; simplify
+- Lens-debate commits its agreed fixes; codex's rounds commit `fix(…)`; simplify
   and code-police commit `refactor:` / `fix(police):`. Confirm the post-push PR
-  comments landed: codex, lens, and — when the police track ran — the code-police
+  comments landed: lens, codex, and — when the police track ran — the code-police
   summary.
 - On an **unresolved** lens finding, adjudicate it yourself before moving on.
 
@@ -86,6 +86,6 @@ green before capturing.
 
 ## Done
 
-Report the PR URL, the gauntlet outcome (codex consensus or reviewer-error, lens-debate consensus + fixes applied, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
+Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
-description: Run /be's review gauntlet SERIALLY — /codex-debate, then /lens-debate (lowy ⇄ hickey), then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
-argument-hint: "[--base <branch>] [--rationale <note>] [--tracks codex,lens,simplify,police]"
+description: Run /be's review gauntlet SERIALLY — /lens-debate (lowy ⇄ hickey), then /codex-debate, then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
+argument-hint: "[--base <branch>] [--rationale <note>] [--tracks lens,codex,simplify,police]"
 ---
 
 # Review gauntlet (serial)
@@ -13,11 +13,11 @@ that impossible without any snapshot machinery — when a step starts, the previ
 step has already committed, so every reviewer reads a clean, settled tree and
 applies its own fixes directly:
 
-1. **`/codex-debate`** — codex (`xhigh`) ⇄ claude author, debating to consensus.
-   Its author rounds edit and each round auto-commits `fix(…)` on the branch.
-2. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,
+1. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,
    then **apply** the agreed fixes (each its own commit). Pass the change
    **`rationale`** so the lenses don't flag deliberate decisions.
+2. **`/codex-debate`** — codex (`xhigh`) ⇄ claude author, debating to consensus.
+   Its author rounds edit and each round auto-commits `fix(…)` on the branch.
 3. **`/simplify`** — the self-applying reuse / simplification / efficiency pass
    over the changed code. Now that nothing runs concurrently, it runs as itself
    (it could not against the old read-only snapshot).
@@ -25,7 +25,7 @@ applies its own fixes directly:
    their fixes (the elegance pass re-runs `/simplify`, harmless after step 3).
 
 Each step runs to completion before the next begins. Wall-clock is
-`codex + lens + simplify + police` — slower than the old parallel form, but with
+`lens + codex + simplify + police` — slower than the old parallel form, but with
 no snapshot, no change-request handoff, and no separate apply pass: every step is
 its own editor and commits its own work.
 
@@ -35,7 +35,7 @@ a commit SHA must never be posted while that SHA is local-only — if a later st
 failed or the run were interrupted, the PR would advertise commits that were
 never pushed. So the debate skills run with their self-commenting **suppressed**
 (`--no-comment`); be-review captures the comment body each returns, pushes once at
-the end, and only then posts the codex comment, the lens comment, and its own
+the end, and only then posts the lens comment, the codex comment, and its own
 police summary. No PR comment can reference a local-only commit.
 
 ## Preflight
@@ -57,36 +57,19 @@ police summary. No PR comment can reference a local-only commit.
 
 ## Run the steps in order
 
-`--tracks codex,lens,simplify,police` selects which steps run (default all four),
+`--tracks lens,codex,simplify,police` selects which steps run (default all four),
 in the listed order. Run each to completion, then move to the next. Preflight
 already ran `git fetch origin` and resolved the base, so pass `MB` straight into
 each step and **skip the per-skill step-1 fetch / base resolution** — don't redo
 it once per step.
 
-1. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
-   worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
-   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
-   in the background; **wait for it to finish** before starting the lens step. It
-   commits its rounds and **returns** its rendered comment body — hold onto it to
-   post after the final push. (On persistent `reviewer-error` there is **no
-   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
-   consensus to report; skip the codex comment in that case.)
-
-   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   either in `consensus` or in `reviewer-error` — the latter meaning codex never
-   produced a structured verdict even after `codex-review.sh`'s built-in
-   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
-   outcome*: re-launch it immediately with the same args. Stop the moment an
-   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
-   you give up on codex — report the persistent reviewer-error honestly (no false
-   consensus comment) and move on to the lens step.
-
-2. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
+1. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
    `base` = `MB`, **apply mode** (the default — do *not* pass `--no-apply`),
-   **`--no-comment`** (same reason as codex — defer the comment until after the
-   push), and thread the `rationale` through. It applies the agreed fixes as
-   commits and **returns** its rendered comment body for be-review to post after
-   the push. Wait for its `Workflow` to finish.
+   **`--no-comment`** (so it doesn't advertise its local-only commits before
+   be-review pushes — defer the comment until after the push), and thread the
+   `rationale` through. It applies the agreed fixes as commits and **returns** its
+   rendered comment body for be-review to post after the push. Wait for its
+   `Workflow` to finish before starting the codex step.
 
    `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
    `merge-base-error`:
@@ -99,6 +82,24 @@ it once per step.
      skill ran `--no-comment`, so there is no self-posted comment to follow up
      on). Never report "lens consensus" for an `unresolved` run.
    - `merge-base-error` — the scope couldn't be trusted; report it and move on.
+
+2. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
+   worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
+   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
+   in the background; **wait for it to finish** before starting the simplify step.
+   It commits its rounds and **returns** its rendered comment body — hold onto it
+   to post after the final push. (On persistent `reviewer-error` there is **no
+   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
+   consensus to report; skip the codex comment in that case.)
+
+   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
+   either in `consensus` or in `reviewer-error` — the latter meaning codex never
+   produced a structured verdict even after `codex-review.sh`'s built-in
+   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
+   outcome*: re-launch it immediately with the same args. Stop the moment an
+   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
+   you give up on codex — report the persistent reviewer-error honestly (no false
+   consensus comment) and move on to the simplify step.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it
@@ -125,7 +126,7 @@ First settle whether there is anything to push: `git log --oneline $START..HEAD`
 
 - **New commits exist** and **a PR exists for this branch**
   (`gh pr view --json number -q .number`) → **`git push`**. **Only after the push
-  succeeds** do you post the deferred comments — the codex and lens bodies from
+  succeeds** do you post the deferred comments — the lens and codex bodies from
   steps 1–2 are now safe to publish because the SHAs they name are on the remote.
 - **No new commits** (every step was clean or applied nothing) but **a PR
   exists** → there is nothing to push, and HEAD is already remote-visible, so
@@ -143,8 +144,8 @@ merges when satisfied.
 
 When you do post, post **one comment per track that produced a body** — skip any
 track `--tracks` excluded, and skip a track that ran but yielded no postable
-comment (codex on persistent `reviewer-error`, lens on `merge-base-error`): the
-codex body and the lens body verbatim (`gh pr comment -F`), and the police
+comment (lens on `merge-base-error`, codex on persistent `reviewer-error`): the
+lens body and the codex body verbatim (`gh pr comment -F`), and the police
 summary (the `## [👮 Code-police](https://agency.srid.ca/)` comment described in
 Report).
 
@@ -153,17 +154,17 @@ Report).
 Summarize in chat — reporting **only the selected tracks**, and naming any track
 `--tracks` **skipped** so the absence is explicit, not silent:
 
-- **codex** — consensus / reviewer-error (note how many attempts if retried); on
-  consensus its PR comment landed (posted after the push, per "Push, then
-  comment") — on persistent reviewer-error there is no comment to post.
 - **lens** — status (**consensus** + fixes applied, or **unresolved** + how many
   findings still need human adjudication and how you adjudicated each, or
   `merge-base-error`); its PR comment landed (posted after the push) — except on
   `merge-base-error`, which has no comment body to post.
+- **codex** — consensus / reviewer-error (note how many attempts if retried); on
+  consensus its PR comment landed (posted after the push, per "Push, then
+  comment") — on persistent reviewer-error there is no comment to post.
 - **simplify** — whether it changed anything and what it committed.
 - **police** — findings and how each was actioned; the
   `## [👮 Code-police](https://agency.srid.ca/)` summary comment landed (posted
-  after the push, alongside the codex and lens comments).
+  after the push, alongside the lens and codex comments).
 - whether the fixes were pushed;
 - `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
   result is visible.

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: be
-description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a serial AI review gauntlet (codex debate → lens debate (lowy ⇄ hickey) → simplify → code-police, each editing the branch in turn) → CI → evidence. ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
+description: Modern, interactive alternative to `/do` — clarify intent up front, then take a task end-to-end with a serial AI review gauntlet (lens debate (lowy ⇄ hickey) → codex debate → simplify → code-police, each editing the branch in turn) → CI → evidence. ONLY invoke when the user explicitly types `/be` or `$be`; never auto-select from a natural-language request.
 argument-hint: "<issue-url | prompt>"
 ---
 
@@ -49,19 +49,19 @@ Run **check** and **fmt**, then commit (conventional message) and push the featu
 ## 4. Review gauntlet
 
 Run **`/be-review`** (Skill tool) — it runs four reviewers **serially**, each the
-sole editor while it runs: `/codex-debate` (its per-round commits are the debate),
-then `/lens-debate` applying the agreed fixes, then `/simplify`, then code-police.
-Each step reads a clean tree (the previous step has committed) and applies its own
-fixes directly — no snapshot, no apply pass. be-review pushes once at the end and
-*then* posts the PR comments (codex, lens, and a code-police summary), so no
-comment advertises a local-only commit.
+sole editor while it runs: `/lens-debate` applying the agreed fixes, then
+`/codex-debate` (its per-round commits are the debate), then `/simplify`, then
+code-police. Each step reads a clean tree (the previous step has committed) and
+applies its own fixes directly — no snapshot, no apply pass. be-review pushes once
+at the end and *then* posts the PR comments (lens, codex, and a code-police
+summary), so no comment advertises a local-only commit.
 
 - Pass `base` and the change **`rationale`** (so the lenses don't flag deliberate
   decisions). Preflight is a non-empty diff and (since codex runs) `codex login
   status`.
-- Codex's rounds commit `fix(…)`; lens-debate commits its agreed fixes; simplify
+- Lens-debate commits its agreed fixes; codex's rounds commit `fix(…)`; simplify
   and code-police commit `refactor:` / `fix(police):`. Confirm the post-push PR
-  comments landed: codex, lens, and — when the police track ran — the code-police
+  comments landed: lens, codex, and — when the police track ran — the code-police
   summary.
 - On an **unresolved** lens finding, adjudicate it yourself before moving on.
 
@@ -86,6 +86,6 @@ green before capturing.
 
 ## Done
 
-Report the PR URL, the gauntlet outcome (codex consensus or reviewer-error, lens-debate consensus + fixes applied, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
+Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## What

Reorder `/be-review`'s serial review gauntlet so the **lens debate runs before the codex debate**:

| before | after |
| --- | --- |
| codex → lens → simplify → police | **lens → codex** → simplify → police |

The lens debate (lowy ⇄ hickey, structural/boundary review) now goes first; `/codex-debate` follows, then `/simplify`, then code-police — each still the sole editor while it runs, each reading the previous step's committed tree.

## Why

Structural/boundary findings are cheapest to act on before the line-level codex debate churns the diff — running the lenses first means codex reviews an already-restructured change rather than the lenses re-litigating boundaries codex just touched.

## Scope of edits

The order is described in several places, all updated to stay consistent:

- `be-review` skill — frontmatter description + `--tracks` hint, the intro gauntlet list, the wall-clock formula, the numbered "Run the steps in order" section (renumbered, cross-references retargeted), and the push/comment + report ordering.
- `be` skill §4 + its description — the gauntlet summary it shows for `/be`.

Edited the `.apm/` sources and regenerated the `.claude/` and `.agents/` runtime copies via `just ai::apm` (per the repo's generated-files rule). The lockfile's timestamp-only bump was reverted to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
