### PR TITLE
Rewrite the changelog as a dense, compact list

### DIFF
--- a/website/src/components/Change.astro
+++ b/website/src/components/Change.astro
@@ -1,11 +1,11 @@
 ---
 /**
- * One changelog entry as a row in an aligned, table-like list: title in the
- * first column, area tags (what it touches — terminal, code tab, keyboard…)
- * in a fixed second column so chips line up down the page, and the PR chip
- * right-aligned in the third. The description is collapsed by default and
- * unfolds on hover / keyboard focus (desktop) or tap (touch), so a release
- * reads as a dense list of headlines you expand only where curious. Touch
+ * One changelog entry as a single dense row: the title on the left, and a
+ * right-grouped cluster of area tags (what it touches — terminal, code tab,
+ * keyboard…) plus the PR chip flush to the right margin, so every row is one
+ * scannable line. The description is collapsed by default and unfolds beneath
+ * the title on hover / keyboard focus (desktop) or tap (touch), so a release
+ * reads as a tight list of headlines you expand only where curious. Touch
  * devices with JS off keep descriptions always visible.
  *
  * Tag chips are buttons: clicking one filters the whole page to entries
@@ -19,9 +19,9 @@
  *     without a reload.</Change>
  *
  * Used as the content of a Markdown list item (`- <Change …>…</Change>`), so the
- * `<ul>/<li>` and the `→` bullet come from `.prose-changelog` (the bullet swings
- * to `↓` while a row is expanded); this component owns the row layout, the tag
- * chips, and the collapse. Auto-injected into changelog MDX (see
+ * `<ul>/<li>` come from `.prose-changelog`; this component owns the whole row —
+ * its own `→` bullet (which swings to `↓` while expanded), the metadata
+ * cluster, and the collapse. Auto-injected into changelog MDX (see
  * `changelog.astro`'s `components` prop), so entries need no import.
  * `repo` / `state` pass straight through to `<PR>` (default: a merged
  * juspay/kolu pull).
@@ -41,8 +41,9 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
 
 <div class="cl-change" tabindex="0" data-tags={tags.join("|")}>
   <p class="cl-change-head">
+    <span class="cl-change-arrow" aria-hidden="true">→</span>
     <span class="cl-change-title">{title}</span>
-    <span class="cl-change-tags">
+    <span class="cl-change-meta">
       {
         tags.map((tag) => (
           <button class="cl-change-tag" type="button" data-tag={tag}>
@@ -50,8 +51,6 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
           </button>
         ))
       }
-    </span>
-    <span class="cl-change-pr">
       {pr !== undefined && <PR id={pr} repo={repo} state={state} />}
     </span>
   </p>
@@ -61,64 +60,60 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
 </div>
 
 <style>
-  /* No outer margin: each <Change> is a list item, so `.prose-changelog ul`'s
-     gap spaces the entries. Mobile-first: a wrapping flex line; from md up,
-     a 3-column grid (title | tags | pr) whose fixed tag column keeps chips
-     vertically aligned across rows. */
+  /* A dense full-width row. The hover band bleeds a touch past the text on
+     both sides (negative inline margin + matching padding) so hovering lights
+     up the whole line, arrow included, without shifting the layout. */
   .cl-change {
-    margin: 0;
+    margin: 0 -0.55rem;
+    padding: 0.22rem 0.55rem;
+    border-radius: 5px;
     outline: none;
+    transition: background 0.15s ease;
   }
+  /* Headline: arrow | title | right-grouped metadata, all on one baseline. */
   .cl-change-head {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 0.85rem minmax(0, 1fr) auto;
     align-items: baseline;
-    gap: 0.4rem 0.6rem;
+    column-gap: 0.5rem;
     margin: 0;
-    line-height: 1.35;
+    line-height: 1.4;
   }
-  @media (min-width: 768px) {
-    .cl-change {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) 8rem auto;
-      column-gap: 0.85rem;
-      align-items: baseline;
-    }
-    /* The <p> dissolves; title / tags / pr become the grid cells. */
-    .cl-change-head {
-      display: contents;
-    }
-    .cl-change-pr {
-      justify-self: end;
-    }
-    .cl-change-reveal {
-      grid-column: 1 / -1;
-    }
+  .cl-change-arrow {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    color: var(--color-ink-faint);
+    transition:
+      transform 0.2s ease,
+      color 0.2s ease;
   }
   .cl-change-title {
     color: var(--color-ink);
-    font-weight: 600;
-    font-size: 0.95rem;
+    font-weight: 550;
+    font-size: 0.92rem;
     letter-spacing: -0.01em;
-    line-height: 1.3;
+    line-height: 1.4;
   }
-  /* Area tags: what the change touches. Buttons — click to filter the page. */
-  .cl-change-tags {
+  /* Tags + PR, grouped and flush right so the chip column aligns down the
+     page. Wraps under the title on a narrow screen. */
+  .cl-change-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.35rem;
+    align-items: baseline;
+    justify-content: flex-end;
+    gap: 0.3rem;
   }
+  /* Area tags: what the change touches. Buttons — click to filter the page. */
   .cl-change-tag {
     font-family: var(--font-mono, ui-monospace, monospace);
-    font-size: 0.62rem;
-    letter-spacing: 0.08em;
+    font-size: 0.6rem;
+    letter-spacing: 0.07em;
     text-transform: uppercase;
     white-space: nowrap;
     color: var(--color-ink-faint);
     background: none;
     border: 1px solid var(--color-rule);
     border-radius: 9999px;
-    padding: 0.12em 0.65em;
+    padding: 0.1em 0.6em;
     cursor: pointer;
     transition:
       color 0.15s ease,
@@ -135,22 +130,33 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
     background: color-mix(in srgb, var(--color-amber) 10%, transparent);
   }
   /* Collapse: the grid 0fr→1fr trick animates to the description's natural
-     height with no JS and no magic max-height. */
+     height with no JS and no magic max-height. Indented to sit under the
+     title, clear of the arrow column. */
   .cl-change-reveal {
     display: grid;
     grid-template-rows: 0fr;
+    padding-left: 1.35rem;
     transition: grid-template-rows 0.22s ease;
   }
   .cl-change-desc {
     overflow: hidden;
     min-height: 0;
     color: var(--color-ink-muted);
-    font-size: 0.88rem;
+    font-size: 0.86rem;
     line-height: 1.5;
     opacity: 0;
     transition: opacity 0.22s ease;
   }
   @media (hover: hover) {
+    .cl-change:hover,
+    .cl-change:focus-within {
+      background: var(--color-void-raised);
+    }
+    .cl-change:hover .cl-change-arrow,
+    .cl-change:focus-within .cl-change-arrow {
+      transform: translateX(1px) rotate(90deg);
+      color: var(--color-amber);
+    }
     .cl-change:hover .cl-change-reveal,
     .cl-change:focus-within .cl-change-reveal {
       grid-template-rows: 1fr;
@@ -172,6 +178,10 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
     .cl-change.open .cl-change-desc {
       opacity: 1;
     }
+    .cl-change.open .cl-change-arrow {
+      transform: translateX(1px) rotate(90deg);
+      color: var(--color-amber);
+    }
     .cl-change.cl-tap .cl-change-head {
       cursor: pointer;
     }
@@ -179,7 +189,7 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
   /* Breathing room between headline and unfolded description — lives INSIDE
      the clipped box so the collapsed row stays exactly headline-height. */
   .cl-change-desc > :global(:first-child) {
-    margin-top: 0.35rem;
+    margin-top: 0.3rem;
   }
   .cl-change-desc :global(p) {
     margin: 0;

--- a/website/src/components/Change.astro
+++ b/website/src/components/Change.astro
@@ -64,6 +64,7 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
      both sides (negative inline margin + matching padding) so hovering lights
      up the whole line, arrow included, without shifting the layout. */
   .cl-change {
+    position: relative;
     margin: 0 -0.55rem;
     padding: 0.22rem 0.55rem;
     border-radius: 5px;
@@ -129,9 +130,10 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
     border-color: var(--color-amber);
     background: color-mix(in srgb, var(--color-amber) 10%, transparent);
   }
-  /* Collapse: the grid 0fr→1fr trick animates to the description's natural
-     height with no JS and no magic max-height. Indented to sit under the
-     title, clear of the arrow column. */
+  /* Touch / no-JS fallback: an inline collapse (grid 0fr→1fr) that animates to
+     the description's natural height with no magic max-height. Indented under
+     the title, clear of the arrow column. Pointer devices replace this with a
+     floating popover below (see @media (hover: hover)). */
   .cl-change-reveal {
     display: grid;
     grid-template-rows: 0fr;
@@ -147,10 +149,45 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
     opacity: 0;
     transition: opacity 0.22s ease;
   }
+  /* Pointer devices: the description is a floating card anchored under the row.
+     Absolutely positioned, so opening it overlays the rows below instead of
+     shoving them down — no reflow, no list jump. It fades and lifts into place
+     on a transform (cheap to animate), and the row is raised above its
+     neighbours so the card is never clipped by a later row. */
   @media (hover: hover) {
+    .cl-change-reveal {
+      position: absolute;
+      top: 100%;
+      left: 1rem;
+      z-index: 1;
+      display: block;
+      width: min(42rem, calc(100% - 1rem));
+      margin-top: 0.3rem;
+      padding: 0.55rem 0.85rem 0.65rem;
+      background: var(--color-void-raised);
+      border: 1px solid var(--color-rule-strong);
+      border-radius: 8px;
+      box-shadow:
+        0 1px 2px rgb(0 0 0 / 0.08),
+        0 14px 30px -10px rgb(0 0 0 / 0.22);
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-4px);
+      transition:
+        opacity 0.16s ease,
+        transform 0.16s ease,
+        visibility 0s linear 0.16s;
+      pointer-events: none;
+    }
+    .cl-change-desc {
+      overflow: visible;
+      opacity: 1;
+      transition: none;
+    }
     .cl-change:hover,
     .cl-change:focus-within {
       background: var(--color-void-raised);
+      z-index: 20;
     }
     .cl-change:hover .cl-change-arrow,
     .cl-change:focus-within .cl-change-arrow {
@@ -159,11 +196,22 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
     }
     .cl-change:hover .cl-change-reveal,
     .cl-change:focus-within .cl-change-reveal {
-      grid-template-rows: 1fr;
-    }
-    .cl-change:hover .cl-change-desc,
-    .cl-change:focus-within .cl-change-desc {
       opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+      transition-delay: 0s;
+    }
+  }
+  @media (hover: hover) and (prefers-reduced-motion: reduce) {
+    .cl-change-reveal {
+      transform: none;
+      transition:
+        opacity 0.12s ease,
+        visibility 0s linear 0.12s;
+    }
+    .cl-change:hover .cl-change-reveal,
+    .cl-change:focus-within .cl-change-reveal {
+      transform: none;
     }
   }
   /* No hover to reveal with (touch): the script below makes rows tap-to-toggle

--- a/website/src/components/Change.astro
+++ b/website/src/components/Change.astro
@@ -80,8 +80,8 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
   @media (min-width: 768px) {
     .cl-change {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 10rem auto;
-      column-gap: 1rem;
+      grid-template-columns: minmax(0, 1fr) 8rem auto;
+      column-gap: 0.85rem;
       align-items: baseline;
     }
     /* The <p> dissolves; title / tags / pr become the grid cells. */
@@ -98,9 +98,9 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
   .cl-change-title {
     color: var(--color-ink);
     font-weight: 600;
-    font-size: 1.02rem;
+    font-size: 0.95rem;
     letter-spacing: -0.01em;
-    line-height: 1.35;
+    line-height: 1.3;
   }
   /* Area tags: what the change touches. Buttons — click to filter the page. */
   .cl-change-tags {

--- a/website/src/components/Change.astro
+++ b/website/src/components/Change.astro
@@ -189,11 +189,6 @@ const { title, pr, repo, state, tags = [] } = Astro.props;
       background: var(--color-void-raised);
       z-index: 20;
     }
-    .cl-change:hover .cl-change-arrow,
-    .cl-change:focus-within .cl-change-arrow {
-      transform: translateX(1px) rotate(90deg);
-      color: var(--color-amber);
-    }
     .cl-change:hover .cl-change-reveal,
     .cl-change:focus-within .cl-change-reveal {
       opacity: 1;

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -113,14 +113,14 @@ const rendered = await Promise.all(
         const anchor = `v${version.replace(/\./g, "-")}`;
         return (
           <article class="border-t border-rule py-5">
-            <header class="mb-3 flex items-baseline gap-3">
+            <header class="mb-2 flex items-baseline gap-3">
               <a
                 href={`#${anchor}`}
-                class="version-link group/anchor inline-flex items-baseline gap-1.5"
+                class="version-link group/anchor relative inline-flex items-baseline"
               >
                 <span
                   aria-hidden="true"
-                  class="mono text-amber opacity-0 group-hover/anchor:opacity-100 transition-opacity"
+                  class="mono text-amber opacity-0 group-hover/anchor:opacity-100 transition-opacity absolute right-full mr-1.5"
                 >#</span>
                 <h2
                   id={anchor}

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -68,16 +68,15 @@ const rendered = await Promise.all(
     </p>
   </section>
 
-  {/* Wider than the intro: the entry rows are a 3-column table (title |
-      tags | PR) and need the room to keep titles on one line. */}
-  <section class="mx-auto max-w-4xl px-6 pb-24">
+  {/* Full-width entry rows (a 3-column table: title | tags | PR). The version
+      is a compact header above its entries rather than a sparse left rail, so
+      no horizontal gutter is wasted; aligned to the intro's column so titles
+      stay on one line without flinging the tag chips far across the row. */}
+  <section class="mx-auto max-w-3xl px-6 pb-24">
     {/* Unreleased — always shown; empty when you're on the latest tag. */}
-    <article class="border-t border-rule py-7 grid md:grid-cols-[10rem_1fr] gap-3 md:gap-8">
-      <div class="md:text-right">
-        <a
-          href="#unreleased"
-          class="version-link inline-block"
-        >
+    <article class="border-t border-rule py-5">
+      <header class="mb-3">
+        <a href="#unreleased" class="version-link inline-block">
           <span
             id="unreleased"
             class="mono text-[0.72rem] tracking-widest text-amber border border-amber/40 rounded-full px-2.5 py-1 scroll-mt-20 hover:bg-amber/10 transition-colors"
@@ -85,42 +84,39 @@ const rendered = await Promise.all(
             UNRELEASED
           </span>
         </a>
-      </div>
-      <div>
-        {
-          unreleasedHasBody && UnreleasedBody ? (
-            <div>
-              <div class="prose prose-changelog">
-                <UnreleasedBody components={mdxComponents} />
-              </div>
-              <p class="mono text-ink-faint text-sm leading-relaxed mt-7">
-                // already on{" "}
-                <code class="text-ink">master</code> — get these now:{" "}
-                <code class="text-ink">nix run github:juspay/kolu</code>
-              </p>
+      </header>
+      {
+        unreleasedHasBody && UnreleasedBody ? (
+          <div>
+            <div class="prose prose-changelog">
+              <UnreleasedBody components={mdxComponents} />
             </div>
-          ) : (
-            <p class="mono text-ink-muted text-sm leading-relaxed">
-              // nothing unreleased — you're on the latest tagged build.<br />
-              <span class="text-ink-faint">
-                track master for changes as they land:
-              </span>{" "}
-              <code class="text-ink">nix run github:juspay/kolu</code>
+            <p class="mono text-ink-faint text-sm leading-relaxed mt-5">
+              // already on <code class="text-ink">master</code> — get these
+              now: <code class="text-ink">nix run github:juspay/kolu</code>
             </p>
-          )
-        }
-      </div>
+          </div>
+        ) : (
+          <p class="mono text-ink-muted text-sm leading-relaxed">
+            // nothing unreleased — you're on the latest tagged build.<br />
+            <span class="text-ink-faint">
+              track master for changes as they land:
+            </span>{" "}
+            <code class="text-ink">nix run github:juspay/kolu</code>
+          </p>
+        )
+      }
     </article>
 
     {
       rendered.map(({ version, date, Body }) => {
         const anchor = `v${version.replace(/\./g, "-")}`;
         return (
-          <article class="border-t border-rule py-7 grid md:grid-cols-[10rem_1fr] gap-3 md:gap-8">
-            <div class="md:text-right">
+          <article class="border-t border-rule py-5">
+            <header class="mb-3 flex items-baseline gap-3">
               <a
                 href={`#${anchor}`}
-                class="version-link group/anchor inline-flex items-baseline gap-1.5 md:flex-row-reverse"
+                class="version-link group/anchor inline-flex items-baseline gap-1.5"
               >
                 <span
                   aria-hidden="true"
@@ -128,18 +124,18 @@ const rendered = await Promise.all(
                 >#</span>
                 <h2
                   id={anchor}
-                  class="display-sm text-[2rem] text-ink group-hover/anchor:text-amber transition-colors scroll-mt-20"
+                  class="display-sm text-[1.6rem] text-ink group-hover/anchor:text-amber transition-colors scroll-mt-20"
                 >
                   v{version}
                 </h2>
               </a>
               <time
-                class="mono text-[0.72rem] text-ink-muted tracking-widest block mt-1"
+                class="mono text-[0.72rem] text-ink-muted tracking-widest"
                 datetime={date.toISOString()}
               >
                 {fmtDate(date)}
               </time>
-            </div>
+            </header>
             <div class="prose prose-changelog">
               <Body components={mdxComponents} />
             </div>

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -173,12 +173,12 @@ const releases = await Promise.all(
     display: grid;
     grid-template-columns: 8.75rem minmax(0, 1fr);
     gap: 1.15rem;
-    padding: 1rem 0 1.15rem;
+    padding: 1.3rem 0 1.7rem;
     border-bottom: 1px solid var(--color-rule);
   }
 
   .release + .release {
-    padding-top: 1.45rem;
+    padding-top: 2.1rem;
   }
 
   .release-stamp {
@@ -218,7 +218,7 @@ const releases = await Promise.all(
   }
 
   .release-stamp small {
-    color: var(--color-ink-faint);
+    color: var(--color-ink-muted);
   }
 
   .release-body-wrap {
@@ -255,15 +255,17 @@ const releases = await Promise.all(
   }
 
   .changelog :global(.prose-changelog h3) {
-    margin: 0.95rem 0 0.38rem;
-    gap: 0.45rem;
-    font-size: 0.62rem;
+    margin: 1.5rem 0 0.5rem;
+    gap: 0.5rem;
+    color: var(--color-amber-bright);
+    font-size: 0.64rem;
+    font-weight: 650;
     letter-spacing: 0.14em;
     line-height: 1.15;
   }
 
   .changelog :global(.prose-changelog h3:first-child) {
-    margin-top: 0.1rem;
+    margin-top: 0.2rem;
   }
 
   .changelog :global(.prose-changelog ul) {
@@ -328,6 +330,8 @@ const releases = await Promise.all(
     font-size: 0.56rem;
     letter-spacing: 0.05em;
     padding: 0.02em 0.42em;
+    color: var(--color-ink-muted);
+    border-color: var(--color-rule-strong);
   }
 
   .changelog :global(.pr-ref) {

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -4,39 +4,30 @@ import { getCollection, render } from "astro:content";
 import PR from "../components/PR.astro";
 import Change from "../components/Change.astro";
 
-// Components auto-injected into every changelog entry's MDX, so an entry writes
-// `<Change title="…" pr={1235}>…</Change>` (or a bare `<PR id={…} />`) with no
-// per-file import.
 const mdxComponents = { PR, Change };
 
-const fmtDate = (d: Date) =>
-  d
+const fmtDate = (date: Date) =>
+  date
     .toLocaleDateString("en-US", {
       year: "numeric",
       month: "short",
       day: "2-digit",
-      // Dates are authored as plain `YYYY-MM-DD` (parsed as UTC midnight by
-      // Zod's coerce). Format in UTC so the rendered day never shifts with the
-      // build machine's timezone.
       timeZone: "UTC",
     })
     .toUpperCase();
 
-const all = await getCollection("changelog");
+const countChanges = (body?: string) => body?.match(/<Change\b/g)?.length ?? 0;
 
-// Newest-first by date, then semver-descending so same-day releases (a patch
-// cut hours after its minor) still order newest version first. `id` is the
-// final stable fallback for anything non-`X.Y.Z`.
 const semverDesc = (a: string, b: string) => {
   const [aMaj, aMin, aPat] = a.split(".").map(Number);
   const [bMaj, bMin, bPat] = b.split(".").map(Number);
   return (bMaj! - aMaj!) || (bMin! - aMin!) || (bPat! - aPat!);
 };
 
-// A dateless entry is the open Unreleased section; dated entries are releases.
-const unreleased = all.find((e) => !e.data.date);
+const all = await getCollection("changelog");
+const unreleased = all.find((entry) => !entry.data.date);
 const released = all
-  .filter((e) => e.data.date)
+  .filter((entry) => entry.data.date)
   .sort(
     (a, b) =>
       b.data.date!.valueOf() - a.data.date!.valueOf() ||
@@ -44,169 +35,403 @@ const released = all
       a.id.localeCompare(b.id),
   );
 
-// Pre-render MDX bodies in frontmatter (can't `await render()` inside the map).
 const unreleasedHasBody = !!unreleased?.body?.trim();
+const unreleasedChangeCount = countChanges(unreleased?.body);
 const UnreleasedBody = unreleased ? (await render(unreleased)).Content : null;
-const rendered = await Promise.all(
-  released.map(async (entry) => ({
-    version: entry.data.version,
-    date: entry.data.date!,
-    Body: (await render(entry)).Content,
-  })),
+
+const releases = await Promise.all(
+  released.map(async (entry) => {
+    const date = entry.data.date!;
+    return {
+      version: entry.data.version,
+      date,
+      dateLabel: fmtDate(date),
+      anchor: `v${entry.data.version.replace(/\./g, "-")}`,
+      changeCount: countChanges(entry.body),
+      Body: (await render(entry)).Content,
+    };
+  }),
 );
 ---
 
-<BaseLayout title="Changelog" description="What's new in kolu — shipped and on the way.">
-  <section class="mx-auto max-w-3xl px-6 pt-20 md:pt-28 pb-10">
-    <p class="eyebrow mb-4">the changelog</p>
-    <h1 class="display text-[3.2rem] md:text-[4.2rem] text-ink">
-      What's <span class="text-amber">new</span><br />in kolu.
-    </h1>
-    <p class="mt-6 text-ink-dim max-w-xl leading-relaxed">
-      Every tagged release, newest first — plus what's already landed on{" "}
-      <code class="mono text-ink">master</code> and waiting for the next tag.
-    </p>
-  </section>
+<BaseLayout title="Changelog" description="What's new in kolu, newest first.">
+  <section class="changelog">
+    <header class="changelog-head">
+      <h1>Changelog</h1>
+      <p>
+        Newest first. On master:
+        <code>nix run github:juspay/kolu</code>
+      </p>
+    </header>
 
-  {/* Full-width entry rows (a 3-column table: title | tags | PR). The version
-      is a compact header above its entries rather than a sparse left rail, so
-      no horizontal gutter is wasted; aligned to the intro's column so titles
-      stay on one line without flinging the tag chips far across the row. */}
-  <section class="mx-auto max-w-3xl px-6 pb-24">
-    {/* Unreleased — always shown; empty when you're on the latest tag. */}
-    <article class="border-t border-rule py-5">
-      <header class="mb-3">
-        <a href="#unreleased" class="version-link inline-block">
-          <span
-            id="unreleased"
-            class="mono text-[0.72rem] tracking-widest text-amber border border-amber/40 rounded-full px-2.5 py-1 scroll-mt-20 hover:bg-amber/10 transition-colors"
-          >
-            UNRELEASED
-          </span>
-        </a>
-      </header>
+    <div class="release-stream">
+      <article class="release">
+        <aside class="release-stamp">
+          <a href="#unreleased" class="release-link">
+            <span id="unreleased">Unreleased</span>
+          </a>
+          <small>
+            {unreleasedChangeCount ? `${unreleasedChangeCount} pending` : "empty"}
+          </small>
+        </aside>
+
+        <div class="release-body-wrap">
+          {
+            unreleasedHasBody && UnreleasedBody ? (
+              <div class="release-body prose prose-changelog">
+                <UnreleasedBody components={mdxComponents} />
+              </div>
+            ) : (
+              <p class="empty-note">
+                Nothing unreleased. Track master with the command above.
+              </p>
+            )
+          }
+        </div>
+      </article>
+
       {
-        unreleasedHasBody && UnreleasedBody ? (
-          <div>
-            <div class="prose prose-changelog">
-              <UnreleasedBody components={mdxComponents} />
-            </div>
-            <p class="mono text-ink-faint text-sm leading-relaxed mt-5">
-              // already on <code class="text-ink">master</code> — get these
-              now: <code class="text-ink">nix run github:juspay/kolu</code>
-            </p>
-          </div>
-        ) : (
-          <p class="mono text-ink-muted text-sm leading-relaxed">
-            // nothing unreleased — you're on the latest tagged build.<br />
-            <span class="text-ink-faint">
-              track master for changes as they land:
-            </span>{" "}
-            <code class="text-ink">nix run github:juspay/kolu</code>
-          </p>
-        )
-      }
-    </article>
-
-    {
-      rendered.map(({ version, date, Body }) => {
-        const anchor = `v${version.replace(/\./g, "-")}`;
-        return (
-          <article class="border-t border-rule py-5">
-            <header class="mb-2 flex items-baseline gap-3">
-              <a
-                href={`#${anchor}`}
-                class="version-link group/anchor relative inline-flex items-baseline"
-              >
-                <span
-                  aria-hidden="true"
-                  class="mono text-amber opacity-0 group-hover/anchor:opacity-100 transition-opacity absolute right-full mr-1.5"
-                >#</span>
-                <h2
-                  id={anchor}
-                  class="display-sm text-[1.6rem] text-ink group-hover/anchor:text-amber transition-colors scroll-mt-20"
-                >
-                  v{version}
-                </h2>
+        releases.map((release) => (
+          <article class="release">
+            <aside class="release-stamp">
+              <a href={`#${release.anchor}`} class="release-link">
+                <span id={release.anchor}>v{release.version}</span>
               </a>
-              <time
-                class="mono text-[0.72rem] text-ink-muted tracking-widest"
-                datetime={date.toISOString()}
-              >
-                {fmtDate(date)}
-              </time>
-            </header>
-            <div class="prose prose-changelog">
-              <Body components={mdxComponents} />
+              <time datetime={release.date.toISOString()}>{release.dateLabel}</time>
+              {release.changeCount > 0 && <small>{release.changeCount} changes</small>}
+            </aside>
+
+            <div class="release-body-wrap">
+              <div class="release-body prose prose-changelog">
+                <release.Body components={mdxComponents} />
+              </div>
             </div>
           </article>
-        );
-      })
-    }
-  </section>
+        ))
+      }
+    </div>
 
-  {/* Tag-filter indicator: hidden until a tag chip is clicked, then floats
-      bottom-center naming the active tag; click (or Esc) shows everything
-      again. Wired up by the filter script below. */}
-  <button
-    id="cl-filter-clear"
-    class="cl-filter-clear mono"
-    type="button"
-    title="Show all entries (Esc)"
-    hidden
-  >
-    filtering: <span class="cl-filter-tag" id="cl-filter-tag"></span>
-    <span aria-hidden="true">✕</span>
-  </button>
+    <button
+      id="cl-filter-clear"
+      class="cl-filter-clear mono"
+      type="button"
+      title="Show all entries (Esc)"
+      hidden
+    >
+      filtering: <span id="cl-filter-tag"></span>
+      <span aria-hidden="true">x</span>
+    </button>
+  </section>
 </BaseLayout>
 
 <style>
-  /* Version headings are their own permalink — no underline, anchors handle it. */
-  .version-link {
+  .changelog {
+    width: min(100% - 2rem, 72rem);
+    margin: 0 auto;
+    padding: 2.45rem 0 3.5rem;
+  }
+
+  .changelog-head {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    padding-bottom: 1.05rem;
+  }
+
+  .changelog-head h1 {
+    margin: 0;
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: 0;
+    line-height: 1;
+  }
+
+  .changelog-head p {
+    margin: 0;
+    color: var(--color-ink-dim);
+    font-size: 0.88rem;
+    line-height: 1.35;
+  }
+
+  .changelog code {
+    font-family: var(--font-mono);
+    font-size: 0.86em;
+    color: var(--color-ink);
+    background: var(--color-void-raised);
+    border: 1px solid var(--color-rule);
+    border-radius: 4px;
+    padding: 0.1em 0.38em;
+  }
+
+  .release-stream {
+    border-top: 1px solid var(--color-rule-strong);
+  }
+
+  .release {
+    display: grid;
+    grid-template-columns: 8.75rem minmax(0, 1fr);
+    gap: 1.15rem;
+    padding: 1rem 0 1.15rem;
+    border-bottom: 1px solid var(--color-rule);
+  }
+
+  .release + .release {
+    padding-top: 1.45rem;
+  }
+
+  .release-stamp {
+    padding-top: 0.02rem;
+  }
+
+  .release-link {
+    display: inline-block;
+    color: var(--color-ink);
     text-decoration: none;
   }
 
-  /* Floating "filtering: <tag> ✕" pill — the always-visible way out of a tag
-     filter, whatever scroll position the chip was clicked at. */
+  .release-link span {
+    font-family: var(--font-sans);
+    font-size: 0.98rem;
+    font-weight: 680;
+    letter-spacing: 0;
+    line-height: 1.05;
+    scroll-margin-top: 5rem;
+    transition: color 0.15s ease;
+  }
+
+  .release-link:hover span {
+    color: var(--color-amber);
+  }
+
+  .release-stamp time,
+  .release-stamp small {
+    display: block;
+    margin-top: 0.22rem;
+    color: var(--color-ink-muted);
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.07em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .release-stamp small {
+    color: var(--color-ink-faint);
+  }
+
+  .release-body-wrap {
+    min-width: 0;
+  }
+
+  .install-note,
+  .empty-note {
+    margin: 0.7rem 0 0;
+    color: var(--color-ink-muted);
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    letter-spacing: 0;
+    line-height: 1.25;
+  }
+
+  .install-note code,
+  .empty-note code {
+    margin-left: 0.35rem;
+  }
+
+  .changelog :global(.prose-changelog) {
+    max-width: none;
+  }
+
+  .changelog :global(.prose-changelog > p:first-child) {
+    margin: 0.1rem 0 0.8rem;
+    color: var(--color-ink-dim);
+    font-size: 0.92rem;
+    line-height: 1.45;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .changelog :global(.prose-changelog h3) {
+    margin: 0.95rem 0 0.38rem;
+    gap: 0.45rem;
+    font-size: 0.62rem;
+    letter-spacing: 0.14em;
+    line-height: 1.15;
+  }
+
+  .changelog :global(.prose-changelog h3:first-child) {
+    margin-top: 0.1rem;
+  }
+
+  .changelog :global(.prose-changelog ul) {
+    display: grid;
+    gap: 0;
+  }
+
+  .changelog :global(.prose-changelog li) {
+    margin: 0;
+  }
+
+  .changelog :global(.prose-changelog li:not(:has(.cl-change))) {
+    margin: 0;
+    padding-left: 1.05rem;
+    color: var(--color-ink-dim);
+    font-size: 0.92rem;
+    line-height: 1.55;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .changelog :global(.prose-changelog li:not(:has(.cl-change))::before) {
+    top: 0;
+  }
+
+  .changelog :global(.cl-change) {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem;
+    padding: 0.08rem 0.25rem;
+    border-radius: 3px;
+  }
+
+  .changelog :global(.cl-change-head) {
+    grid-template-columns: 0.7rem minmax(0, 1fr) auto;
+    column-gap: 0.34rem;
+    line-height: 1.32;
+  }
+
+  .changelog :global(.cl-change-arrow) {
+    font-size: 0.82rem;
+  }
+
+  .changelog :global(.cl-change-title) {
+    overflow: hidden;
+    font-size: 0.92rem;
+    font-weight: 400;
+    letter-spacing: 0;
+    line-height: 1.32;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .changelog :global(.cl-change-meta) {
+    flex-wrap: nowrap;
+    gap: 0.22rem;
+    overflow: hidden;
+    max-width: 27rem;
+  }
+
+  .changelog :global(.cl-change-tag) {
+    font-size: 0.56rem;
+    letter-spacing: 0.05em;
+    padding: 0.02em 0.42em;
+  }
+
+  .changelog :global(.pr-ref) {
+    gap: 0.24em;
+    font-size: 0.64rem;
+    padding: 0.1em 0.42em 0.1em 0.34em;
+  }
+
+  .changelog :global(.cl-change-desc) {
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  .changelog :global(.prose-changelog strong) {
+    font-weight: 500;
+  }
+
+  .changelog :global(.cl-change-desc > :first-child) {
+    margin-top: 0.36rem;
+  }
+
+  .changelog :global(.cl-change-desc p + p) {
+    margin-top: 0.5rem;
+  }
+
   .cl-filter-clear {
     position: fixed;
-    bottom: 1.5rem;
+    bottom: 1.25rem;
     left: 50%;
-    transform: translateX(-50%);
     z-index: 50;
     display: inline-flex;
     align-items: baseline;
     gap: 0.5em;
-    font-size: 0.72rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    transform: translateX(-50%);
     color: var(--color-ink-dim);
     background: var(--color-void-raised);
     border: 1px solid var(--color-rule);
     border-radius: 9999px;
-    padding: 0.5em 1.1em;
-    cursor: pointer;
+    padding: 0.5em 1em;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     box-shadow: 0 4px 16px rgb(0 0 0 / 0.12);
+    cursor: pointer;
     transition:
       color 0.15s ease,
       border-color 0.15s ease;
   }
+
   .cl-filter-clear:hover {
     color: var(--color-ink);
     border-color: color-mix(in srgb, var(--color-amber) 55%, transparent);
   }
-  .cl-filter-tag {
+
+  .cl-filter-clear #cl-filter-tag {
     color: var(--color-amber);
+  }
+
+  @media (max-width: 740px) {
+    .changelog {
+      width: min(100% - 2rem, 58rem);
+      padding-top: 2rem;
+    }
+
+    .changelog-head {
+      display: block;
+      gap: 1rem;
+    }
+
+    .changelog-head h1 {
+      font-size: 1.55rem;
+    }
+
+    .release {
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+      padding: 0.85rem 0 0.95rem;
+    }
+
+    .release-stamp {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0.45rem 0.7rem;
+      padding-top: 0;
+    }
+
+    .release-stamp time,
+    .release-stamp small {
+      margin-top: 0;
+    }
+
+    .changelog :global(.cl-change-head) {
+      grid-template-columns: 0.7rem minmax(0, 1fr);
+    }
+
+    .changelog :global(.cl-change-meta) {
+      grid-column: 2;
+      max-width: 100%;
+    }
   }
 </style>
 
 <script>
-  // Tag filtering: click a tag chip anywhere to show only entries carrying
-  // that tag, across every release. Click it again (or press Escape) to
-  // clear. Sections and releases left with no visible entries hide too —
-  // including untagged prose bullets (e.g. v1.0.0's), which match no tag.
-  // `style.display` rather than `hidden`: utility classes (`.grid`, flex on
-  // `.prose-changelog ul`) would override the UA's `[hidden]` rule.
   const chips = [
     ...document.querySelectorAll<HTMLButtonElement>(".cl-change-tag"),
   ];
@@ -217,7 +442,7 @@ const rendered = await Promise.all(
 
   const apply = () => {
     clearBtn.hidden = !active;
-    clearTag.textContent = active;
+    clearTag.textContent = active ?? "";
     for (const chip of chips)
       chip.dataset.active = String(chip.dataset.tag === active);
     for (const li of document.querySelectorAll<HTMLElement>(
@@ -228,7 +453,6 @@ const rendered = await Promise.all(
         [];
       li.style.display = !active || tags.includes(active) ? "" : "none";
     }
-    // Collapse emptied structure bottom-up: ul → its section h3 → the release.
     for (const ul of document.querySelectorAll<HTMLElement>(
       ".prose-changelog ul",
     )) {
@@ -241,7 +465,7 @@ const rendered = await Promise.all(
         h3.style.display = empty ? "none" : "";
     }
     for (const article of document.querySelectorAll<HTMLElement>(
-      "section > article",
+      ".release-stream > article",
     )) {
       const lis = article.querySelectorAll<HTMLElement>(".prose-changelog li");
       const empty =
@@ -253,8 +477,8 @@ const rendered = await Promise.all(
   };
 
   for (const chip of chips)
-    chip.addEventListener("click", (e) => {
-      e.stopPropagation(); // don't toggle the row open/closed on touch
+    chip.addEventListener("click", (event) => {
+      event.stopPropagation();
       active = active === chip.dataset.tag ? null : (chip.dataset.tag ?? null);
       apply();
     });
@@ -264,8 +488,8 @@ const rendered = await Promise.all(
     apply();
   });
 
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && active) {
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && active) {
       active = null;
       apply();
     }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -682,12 +682,17 @@ body {
 
 .prose-changelog {
   color: var(--color-ink-dim);
-  line-height: 1.65;
+  line-height: 1.7;
 }
 
+/* Lead paragraph (a release body's opening summary). Looser leading so the
+   wrapped lines — studded with bordered code chips — don't crowd, and a clear
+   gap before the first section label. */
 .prose-changelog > p:first-child {
   color: var(--color-ink);
   font-size: 1.05rem;
+  line-height: 1.8;
+  margin-bottom: 1.4rem;
 }
 
 /* Section labels (Added / Fixed / Internal) — a compact mono caption with a
@@ -702,7 +707,7 @@ body {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-amber);
-  margin: 0.9rem 0 0.3rem;
+  margin: 1.5rem 0 0.55rem;
   /* Reset prose-invert heading overrides */
   font-weight: 600;
 }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -696,7 +696,7 @@ body {
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: var(--color-amber);
-  margin: 1.1rem 0 0.55rem;
+  margin: 1rem 0 0.4rem;
   /* Reset prose-invert heading overrides */
   font-weight: 600;
 }
@@ -713,7 +713,7 @@ body {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.3rem;
 }
 
 .prose-changelog li {
@@ -768,5 +768,5 @@ body {
 }
 
 .prose-changelog p {
-  margin: 0.9rem 0;
+  margin: 0.65rem 0;
 }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -690,54 +690,60 @@ body {
   font-size: 1.05rem;
 }
 
+/* Section labels (Added / Fixed / Internal) — a compact mono caption with a
+   hairline rule running out to the right margin, separating groups without a
+   tall heading. */
 .prose-changelog h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 0.72rem;
-  letter-spacing: 0.15em;
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-amber);
-  margin: 1rem 0 0.4rem;
+  margin: 0.9rem 0 0.3rem;
   /* Reset prose-invert heading overrides */
   font-weight: 600;
 }
+.prose-changelog h3::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--color-rule);
+}
 
 /* First section header in a body hugs the top — its top margin is dead space
-   between the version column and the first entry. */
+   between the version header and the first entry. */
 .prose-changelog h3:first-child {
   margin-top: 0;
 }
 
+/* Dense entry list: no inter-row gap — each <Change> row owns its own padding
+   and a full-bleed hover band, so rows pack tight and read as one column. */
 .prose-changelog ul {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
 }
 
 .prose-changelog li {
   position: relative;
-  padding-left: 1.1rem;
 }
 
-.prose-changelog li::before {
+/* Plain prose bullets (a release body written without <Change>, e.g. v1.0.0)
+   keep an arrow marker and a little air. <Change> rows bring their own arrow
+   and density, so they get neither. */
+.prose-changelog li:not(:has(.cl-change)) {
+  padding-left: 1.35rem;
+  margin: 0.5rem 0;
+}
+
+.prose-changelog li:not(:has(.cl-change))::before {
   content: "→";
   position: absolute;
   left: 0;
   color: var(--color-ink-faint);
-  transition:
-    transform 0.22s ease,
-    color 0.22s ease;
-}
-
-/* While a <Change> row is unfolded (hover / keyboard focus), its arrow swings
-   down and lights up — the one moving part that says "this row is open". */
-.prose-changelog li:has(.cl-change:hover)::before,
-.prose-changelog li:has(.cl-change:focus-within)::before,
-.prose-changelog li:has(.cl-change.open)::before {
-  transform: rotate(90deg);
-  color: var(--color-amber);
 }
 
 .prose-changelog strong {


### PR DESCRIPTION
The changelog spent its width on whitespace. A sparse **10rem version rail** ran empty down the height of every release; inside each entry a fixed **10rem tag column** flung the PR chip to the far right while the squeezed title wrapped onto two lines; and the rows sat far apart. The page read as a field of gaps rather than a list of changes.

This rewrites the layout from scratch around density.

**The release shell.** The version is now a compact header *above* its entries (date inline beside it) instead of a left rail, so no horizontal gutter is wasted and the body aligns to the intro column (`max-w-3xl`).

**The entry row** (`Change.astro`, rewritten). Each entry is a single scannable line: `→ title` on the left, and the area tags + PR chip grouped flush to the right margin as one cluster — so the chip column lines up down the page instead of floating. Rows pack with **zero inter-row gap**; each owns a tight vertical padding and a full-bleed hover band that lights up the whole line (arrow included) and unfolds the description indented beneath the title. The arrow moved into the component; plain prose bullets (v1.0.0's body) keep their own marker via `:not(:has(.cl-change))`.

**Section labels** (Added / Fixed / Internal) become a compact mono caption with a hairline rule running out to the right margin — group separation without a tall heading.

Everything that worked still works: hover/focus expand (desktop), tap-to-toggle (touch), JS-off always-visible descriptions, and the tag-chip page filter. Verified across light/dark and desktop/mobile; `astro check` is clean (0 errors).

Evidence (before → after) in a comment below.