### PR TITLE
be-review: stop running /simplify twice per gauntlet

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -21,8 +21,9 @@ applies its own fixes directly:
 3. **`/simplify`** — the self-applying reuse / simplification / efficiency pass
    over the changed code. Now that nothing runs concurrently, it runs as itself
    (it could not against the old read-only snapshot).
-4. **code-police** — its rule-checklist, fact-check, and elegance passes, applying
-   their fixes (the elegance pass re-runs `/simplify`, harmless after step 3).
+4. **code-police** — its rule-checklist and fact-check passes, applying their
+   fixes. Run with `--no-elegance` so its elegance pass is skipped: that pass
+   re-invokes `/simplify`, which step 3 already ran over this same tree.
 
 Each step runs to completion before the next begins. Wall-clock is
 `lens + codex + simplify + police` — slower than the old parallel form, but with
@@ -106,18 +107,20 @@ it once per step.
    changed (`refactor: simplify <area>`, staging only the files it touched). If it
    changed nothing, note that and move on.
 
-4. **police** — invoke `/code-police` (Skill tool). It runs all three of its
-   passes — rule checklist, fact-check, and the elegance pass (which itself
-   re-invokes `/simplify`). Its embedded pass prompts diff against
+4. **police** — invoke `/code-police` (Skill tool), passing **`--no-elegance`
+   whenever the simplify track (step 3) ran this gauntlet**. That flag skips
+   Pass 3 (elegance), which would otherwise re-invoke `/simplify` over the tree
+   step 3 already simplified — a full skill invocation to re-derive a
+   near-guaranteed no-op. Pass 1 (rules) and Pass 2 (fact-check) still run.
+   _Only omit the flag when `--tracks` excluded `simplify`_ — then no standalone
+   simplify ran, and the elegance pass is the run's one simplify, not redundant.
+   Its embedded pass prompts diff against
    `origin/HEAD...HEAD` by default, which is *wrong* whenever `--base` isn't the
    repo default: before invoking, **tell the police passes to scope to `MB`** —
    pass the merge-base explicitly so every pass runs `git diff <MB>...HEAD`, not
    the default ref. **Apply** the fixes it surfaces, committing each
    `fix(police): <title>` with the finding in the message (stage only the files
-   changed). Its elegance pass re-running `/simplify` over an already-simplified
-   tree (step 3) is harmless — on a settled tree `/simplify` typically reports no
-   changes — so let it run rather than ask code-police to skip a
-   pass its contract has no flag for.
+   changed).
 
 ## Push, then comment
 

--- a/.agents/skills/code-police/SKILL.md
+++ b/.agents/skills/code-police/SKILL.md
@@ -3,11 +3,16 @@ name: code-police
 description: Review code for quality, simplicity, and common mistakes before declaring work complete.
 context: fork
 model: sonnet
+argument-hint: "[--no-elegance]"
 ---
 
 # Code Police
 
 Review the current changes (scoped to the current branch/PR) against the rules below **plus any additional rules from the project**. The three passes — rule checklist, fact-check, elegance — run as parallel sub-agents on fresh contexts; the implementer's main context just wrote the diff and is biased to rationalize it, so reviewing inline laundered violations through. Sub-agents start cold, which is the point. After they return, the orchestrator stitches their findings into a single summary.
+
+## Arguments
+
+`--no-elegance` — skip Pass 3 (elegance) entirely. Pass 1 (rules) and Pass 2 (fact-check) still run. Use this when the elegance pass would be redundant because `/simplify` already ran over this same tree — e.g. a caller that invokes `/simplify` standalone and then `/code-police`. Without it, Pass 3 re-invokes `/simplify` on an already-simplified tree, paying a full skill invocation (agent spawn, diff re-read, model tokens) to re-derive a near-guaranteed no-op. When the flag is set, report Pass 3 as `Elegance | – | Skipped (--no-elegance)` in the summary.
 
 ## Project rules
 
@@ -82,7 +87,7 @@ Spawn Pass 1 and Pass 2 as **two parallel sub-agents** via the harness's agent t
 
 Each sub-agent inherits no context from the implementer's main thread; the prompts below are self-contained and reference the rules-of-record by file path so a single source of truth stays in this skill.
 
-Pass 3 runs **after** Pass 1 and Pass 2 return. It applies fixes (via `/simplify`) and would race against Pass 1/2's grep-and-read work if run in parallel; sequential is the safer ordering. See "Pass 3: Elegance" below.
+Pass 3 runs **after** Pass 1 and Pass 2 return. It applies fixes (via `/simplify`) and would race against Pass 1/2's grep-and-read work if run in parallel; sequential is the safer ordering. See "Pass 3: Elegance" below. If `--no-elegance` was passed, skip Pass 3 — only Pass 1 and Pass 2 run.
 
 Once all three pass outputs are in hand, stitch them into the summary table in the **Output** section.
 
@@ -137,6 +142,8 @@ Sub-agent prompt:
 > For each finding: file, line, one-line risk, concrete fix. If no issues, say so — don't invent problems. Do not apply fixes; the orchestrator will route them.
 
 ### Pass 3: Elegance
+
+**Skip if `--no-elegance` was passed.** Do not run this pass and do not invoke `/simplify`; report `Elegance | – | Skipped (--no-elegance)` in the summary. The caller asserted `/simplify` already ran over this tree, so a second run is redundant. Pass 1 and Pass 2 are unaffected.
 
 **Skip on tiny diffs.** Run `git diff origin/HEAD...HEAD --shortstat` (or the appropriate base-branch ref). If the diff is **under 10 lines**, skip this pass and report `Elegance | 0 | Skipped (tiny diff)` in the summary. The elegance pass's three-lens fan-out has overhead that's disproportionate to a few-line change; Pass 1 and Pass 2 still run. If the diff exceeds the threshold, proceed below.
 

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -21,8 +21,9 @@ applies its own fixes directly:
 3. **`/simplify`** — the self-applying reuse / simplification / efficiency pass
    over the changed code. Now that nothing runs concurrently, it runs as itself
    (it could not against the old read-only snapshot).
-4. **code-police** — its rule-checklist, fact-check, and elegance passes, applying
-   their fixes (the elegance pass re-runs `/simplify`, harmless after step 3).
+4. **code-police** — its rule-checklist and fact-check passes, applying their
+   fixes. Run with `--no-elegance` so its elegance pass is skipped: that pass
+   re-invokes `/simplify`, which step 3 already ran over this same tree.
 
 Each step runs to completion before the next begins. Wall-clock is
 `lens + codex + simplify + police` — slower than the old parallel form, but with
@@ -106,18 +107,20 @@ it once per step.
    changed (`refactor: simplify <area>`, staging only the files it touched). If it
    changed nothing, note that and move on.
 
-4. **police** — invoke `/code-police` (Skill tool). It runs all three of its
-   passes — rule checklist, fact-check, and the elegance pass (which itself
-   re-invokes `/simplify`). Its embedded pass prompts diff against
+4. **police** — invoke `/code-police` (Skill tool), passing **`--no-elegance`
+   whenever the simplify track (step 3) ran this gauntlet**. That flag skips
+   Pass 3 (elegance), which would otherwise re-invoke `/simplify` over the tree
+   step 3 already simplified — a full skill invocation to re-derive a
+   near-guaranteed no-op. Pass 1 (rules) and Pass 2 (fact-check) still run.
+   _Only omit the flag when `--tracks` excluded `simplify`_ — then no standalone
+   simplify ran, and the elegance pass is the run's one simplify, not redundant.
+   Its embedded pass prompts diff against
    `origin/HEAD...HEAD` by default, which is *wrong* whenever `--base` isn't the
    repo default: before invoking, **tell the police passes to scope to `MB`** —
    pass the merge-base explicitly so every pass runs `git diff <MB>...HEAD`, not
    the default ref. **Apply** the fixes it surfaces, committing each
    `fix(police): <title>` with the finding in the message (stage only the files
-   changed). Its elegance pass re-running `/simplify` over an already-simplified
-   tree (step 3) is harmless — on a settled tree `/simplify` typically reports no
-   changes — so let it run rather than ask code-police to skip a
-   pass its contract has no flag for.
+   changed).
 
 ## Push, then comment
 

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -21,8 +21,9 @@ applies its own fixes directly:
 3. **`/simplify`** — the self-applying reuse / simplification / efficiency pass
    over the changed code. Now that nothing runs concurrently, it runs as itself
    (it could not against the old read-only snapshot).
-4. **code-police** — its rule-checklist, fact-check, and elegance passes, applying
-   their fixes (the elegance pass re-runs `/simplify`, harmless after step 3).
+4. **code-police** — its rule-checklist and fact-check passes, applying their
+   fixes. Run with `--no-elegance` so its elegance pass is skipped: that pass
+   re-invokes `/simplify`, which step 3 already ran over this same tree.
 
 Each step runs to completion before the next begins. Wall-clock is
 `lens + codex + simplify + police` — slower than the old parallel form, but with
@@ -106,18 +107,20 @@ it once per step.
    changed (`refactor: simplify <area>`, staging only the files it touched). If it
    changed nothing, note that and move on.
 
-4. **police** — invoke `/code-police` (Skill tool). It runs all three of its
-   passes — rule checklist, fact-check, and the elegance pass (which itself
-   re-invokes `/simplify`). Its embedded pass prompts diff against
+4. **police** — invoke `/code-police` (Skill tool), passing **`--no-elegance`
+   whenever the simplify track (step 3) ran this gauntlet**. That flag skips
+   Pass 3 (elegance), which would otherwise re-invoke `/simplify` over the tree
+   step 3 already simplified — a full skill invocation to re-derive a
+   near-guaranteed no-op. Pass 1 (rules) and Pass 2 (fact-check) still run.
+   _Only omit the flag when `--tracks` excluded `simplify`_ — then no standalone
+   simplify ran, and the elegance pass is the run's one simplify, not redundant.
+   Its embedded pass prompts diff against
    `origin/HEAD...HEAD` by default, which is *wrong* whenever `--base` isn't the
    repo default: before invoking, **tell the police passes to scope to `MB`** —
    pass the merge-base explicitly so every pass runs `git diff <MB>...HEAD`, not
    the default ref. **Apply** the fixes it surfaces, committing each
    `fix(police): <title>` with the finding in the message (stage only the files
-   changed). Its elegance pass re-running `/simplify` over an already-simplified
-   tree (step 3) is harmless — on a settled tree `/simplify` typically reports no
-   changes — so let it run rather than ask code-police to skip a
-   pass its contract has no flag for.
+   changed).
 
 ## Push, then comment
 

--- a/.claude/skills/code-police/SKILL.md
+++ b/.claude/skills/code-police/SKILL.md
@@ -3,11 +3,16 @@ name: code-police
 description: Review code for quality, simplicity, and common mistakes before declaring work complete.
 context: fork
 model: sonnet
+argument-hint: "[--no-elegance]"
 ---
 
 # Code Police
 
 Review the current changes (scoped to the current branch/PR) against the rules below **plus any additional rules from the project**. The three passes — rule checklist, fact-check, elegance — run as parallel sub-agents on fresh contexts; the implementer's main context just wrote the diff and is biased to rationalize it, so reviewing inline laundered violations through. Sub-agents start cold, which is the point. After they return, the orchestrator stitches their findings into a single summary.
+
+## Arguments
+
+`--no-elegance` — skip Pass 3 (elegance) entirely. Pass 1 (rules) and Pass 2 (fact-check) still run. Use this when the elegance pass would be redundant because `/simplify` already ran over this same tree — e.g. a caller that invokes `/simplify` standalone and then `/code-police`. Without it, Pass 3 re-invokes `/simplify` on an already-simplified tree, paying a full skill invocation (agent spawn, diff re-read, model tokens) to re-derive a near-guaranteed no-op. When the flag is set, report Pass 3 as `Elegance | – | Skipped (--no-elegance)` in the summary.
 
 ## Project rules
 
@@ -82,7 +87,7 @@ Spawn Pass 1 and Pass 2 as **two parallel sub-agents** via the harness's agent t
 
 Each sub-agent inherits no context from the implementer's main thread; the prompts below are self-contained and reference the rules-of-record by file path so a single source of truth stays in this skill.
 
-Pass 3 runs **after** Pass 1 and Pass 2 return. It applies fixes (via `/simplify`) and would race against Pass 1/2's grep-and-read work if run in parallel; sequential is the safer ordering. See "Pass 3: Elegance" below.
+Pass 3 runs **after** Pass 1 and Pass 2 return. It applies fixes (via `/simplify`) and would race against Pass 1/2's grep-and-read work if run in parallel; sequential is the safer ordering. See "Pass 3: Elegance" below. If `--no-elegance` was passed, skip Pass 3 — only Pass 1 and Pass 2 run.
 
 Once all three pass outputs are in hand, stitch them into the summary table in the **Output** section.
 
@@ -137,6 +142,8 @@ Sub-agent prompt:
 > For each finding: file, line, one-line risk, concrete fix. If no issues, say so — don't invent problems. Do not apply fixes; the orchestrator will route them.
 
 ### Pass 3: Elegance
+
+**Skip if `--no-elegance` was passed.** Do not run this pass and do not invoke `/simplify`; report `Elegance | – | Skipped (--no-elegance)` in the summary. The caller asserted `/simplify` already ran over this tree, so a second run is redundant. Pass 1 and Pass 2 are unaffected.
 
 **Skip on tiny diffs.** Run `git diff origin/HEAD...HEAD --shortstat` (or the appropriate base-branch ref). If the diff is **under 10 lines**, skip this pass and report `Elegance | 0 | Skipped (tiny diff)` in the summary. The elegance pass's three-lens fan-out has overhead that's disproportionate to a few-line change; Pass 1 and Pass 2 still run. If the diff exceeds the threshold, proceed below.
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -125,7 +125,7 @@ dependencies:
   content_hash: sha256:55aa91acea2f65028147786dffec979d5c2f1b18f402ee441353dada10ffbb2a
 - repo_url: srid/agency
   host: github.com
-  resolved_commit: 6d53751b5fb42cc2c55b9072b314f3cdd0449ecb
+  resolved_commit: 81455051ccca654c57ad6088838c85e7248ac159
   resolved_ref: master
   package_type: apm_package
   deployed_files:
@@ -181,7 +181,7 @@ dependencies:
   - .opencode/agents/hickey.md
   - .opencode/agents/lowy.md
   deployed_file_hashes:
-    .agents/skills/code-police/SKILL.md: sha256:5a9f4ec8c2c2c44aaf7305561ee44884fbf551d45b27f94373eec49a18e5ad1f
+    .agents/skills/code-police/SKILL.md: sha256:8d188754eaf56063de720a0c02fa927db3b56ff5fa30d0e612893ca8798da899
     .agents/skills/do/SKILL.md: sha256:24e77e783759e1f2d20c1600f2f9fc800d950efd19b9ea23f8e232d29d6ae84d
     .agents/skills/do/scripts/do-results: sha256:2684dfce9cc7e4314d56c39edd5495628ac65d0631860e27e11f17fdcc0c7d49
     .agents/skills/do/scripts/steps/done: sha256:03513d90bea1357eef3379c5b4fee5e46fe2d67b41fe8cf8b52d4beba4c73c72
@@ -198,7 +198,7 @@ dependencies:
     .claude/agents/lowy.md: sha256:05aff7f6a91149a42c1fb9a3ca382a6f77bc39ac8a8d45436d443dd3349fb11e
     .claude/hooks/agency/scripts/do-stop-guard.sh: sha256:cb033f86c15ffd3d09d8e4b74a61f55a70def4cc4131cc013b7368a2d23f3f33
     .claude/rules/apm-sources.md: sha256:90626875e2a63e5658f0b5e77524c9c4f949f4ce890bd1f1ce9a2663d4fc8ea7
-    .claude/skills/code-police/SKILL.md: sha256:5a9f4ec8c2c2c44aaf7305561ee44884fbf551d45b27f94373eec49a18e5ad1f
+    .claude/skills/code-police/SKILL.md: sha256:8d188754eaf56063de720a0c02fa927db3b56ff5fa30d0e612893ca8798da899
     .claude/skills/do/SKILL.md: sha256:24e77e783759e1f2d20c1600f2f9fc800d950efd19b9ea23f8e232d29d6ae84d
     .claude/skills/do/scripts/do-results: sha256:2684dfce9cc7e4314d56c39edd5495628ac65d0631860e27e11f17fdcc0c7d49
     .claude/skills/do/scripts/steps/done: sha256:03513d90bea1357eef3379c5b4fee5e46fe2d67b41fe8cf8b52d4beba4c73c72
@@ -214,7 +214,7 @@ dependencies:
     .codex/hooks/agency/scripts/do-stop-guard.sh: sha256:cb033f86c15ffd3d09d8e4b74a61f55a70def4cc4131cc013b7368a2d23f3f33
     .opencode/agents/hickey.md: sha256:10d9a4350a85752dc6658af8e0efb3d8be41803a2b6c73464e3d5b7a840435ad
     .opencode/agents/lowy.md: sha256:05aff7f6a91149a42c1fb9a3ca382a6f77bc39ac8a8d45436d443dd3349fb11e
-  content_hash: sha256:703dc7eb1a510ab80f5daa4cd7d9997ed1c748cb0942ff3ced88ac7bd062944b
+  content_hash: sha256:e2144eca9c2932044bde96b74db5a546a2cec052f747be926abfc638ab684db9
 mcp_servers:
 - chrome-devtools
 - odu
@@ -313,7 +313,7 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .agents/skills/be-review/SKILL.md: sha256:89e7e1d6d5ab4832bb5015f0b5d6c2baccf04ed22130b606042d178af54217d4
+  .agents/skills/be-review/SKILL.md: sha256:9869bfec8241f0d03e54db1a673a932d0169c570f9ffd3d9144ab81f9011aabc
   .agents/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:595c607447a68fcade0983d8a411bec326be9cd1eb0fe06da05e83e9b6858ab7
@@ -347,7 +347,7 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .claude/skills/be-review/SKILL.md: sha256:89e7e1d6d5ab4832bb5015f0b5d6c2baccf04ed22130b606042d178af54217d4
+  .claude/skills/be-review/SKILL.md: sha256:9869bfec8241f0d03e54db1a673a932d0169c570f9ffd3d9144ab81f9011aabc
   .claude/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:595c607447a68fcade0983d8a411bec326be9cd1eb0fe06da05e83e9b6858ab7


### PR DESCRIPTION
A full `/be-review` gauntlet ran `/simplify` **twice** over the same tree — once as its own standalone step 3, then again inside `code-police`'s elegance pass (Pass 3), which re-invokes `/simplify` per its contract. On a settled tree the second run is a near-guaranteed no-op, yet it still pays a full skill invocation (agent spawn, diff re-read, model tokens) to re-derive what step 3 just concluded. **This wires up the fix so the gauntlet's police step skips that redundant pass.**

The flag itself shipped on the agency side in [srid/agency#203](https://github.com/srid/agency/pull/203); this is the kolu consumer half:

- **Bump the agency pin** (`6d53751` → `8145505`) so kolu's vendored `code-police` gains the `--no-elegance` flag.
- **be-review's police step passes `--no-elegance`** — but _only when the simplify track actually ran_. If `--tracks` excluded `simplify`, the elegance pass is the run's *one and only* simplify, so the flag is omitted and Pass 3 runs as before.

Pass 1 (rules) and Pass 2 (fact-check) are untouched and always run. `/do`'s police step has no standalone `/simplify`, so it keeps invoking `code-police` without the flag — default behavior is unchanged everywhere outside the be-review gauntlet.

Closes [srid/agency#202](https://github.com/srid/agency/issues/202).

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._