### PR TITLE
fix(website): resolve kaval-logo.svg symlink in nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,9 +29,10 @@
       # `checks` both consume these so each derivation set is evaluated once.
       koluBySystem = eachSystem (pkgs: import ./default.nix { inherit pkgs commitHash; });
       websiteBySystem = eachSystem (pkgs:
-        # Synthesized website source tree: website/ with the canonical favicon
-        # copied in where the working tree has a symlink to
-        # ../../packages/client/favicon.svg. One SVG on disk; the Nix sandbox
+        # Synthesized website source tree: website/ with the canonical assets
+        # copied in where the working tree has symlinks pointing outside it
+        # (favicon → ../../packages/client/favicon.svg, kaval logo →
+        # ../../packages/kaval/logo.svg). One SVG each on disk; the Nix sandbox
         # still sees a self-contained website/ with real bytes.
         let
           websiteSrc = pkgs.runCommand "kolu-website-src" { } ''
@@ -39,6 +40,8 @@
             chmod -R u+w $out
             rm -f $out/public/favicon.svg
             cp ${./packages/client/favicon.svg} $out/public/favicon.svg
+            rm -f $out/public/kaval-logo.svg
+            cp ${./packages/kaval/logo.svg} $out/public/kaval-logo.svg
           '';
         in
         import ./website { inherit pkgs; src = websiteSrc; });


### PR DESCRIPTION
## Problem

PR #1314 (Move /tui to /kaval) added `website/public/kaval-logo.svg` as a symlink to `../../packages/kaval/logo.svg` — mirroring how `favicon.svg` symlinks to the canonical SVG in `packages/client/`. But it missed the other half of that pattern: the flake's **synthesized website source** only resolves the `favicon.svg` symlink into real bytes for the Nix sandbox.

So inside the sandbox `public/kaval-logo.svg` was a dangling symlink, and the Astro/vite build failed:

```
[vite:prepare-out-dir] ENOENT: no such file or directory, stat '/build/kolu-website-src/public/kaval-logo.svg'
```

`nix build .#website` was red on `master`.

## Fix

Resolve the `kaval-logo.svg` symlink in `flake.nix`'s `websiteSrc` exactly as `favicon.svg` is already resolved — copy the real bytes from `packages/kaval/logo.svg` into `public/`. One SVG on disk, a self-contained website tree in the sandbox.

## Verification

`nix build .#website` now passes, and `result/kaval-logo.svg` is present (2445 bytes) in the static output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)