### PR TITLE
refactor(website): make website/default.nix self-contained for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,23 +28,9 @@
       # Import default.nix / the website once per system; `packages` and
       # `checks` both consume these so each derivation set is evaluated once.
       koluBySystem = eachSystem (pkgs: import ./default.nix { inherit pkgs commitHash; });
-      websiteBySystem = eachSystem (pkgs:
-        # Synthesized website source tree: website/ with the canonical assets
-        # copied in where the working tree has symlinks pointing outside it
-        # (favicon → ../../packages/client/favicon.svg, kaval logo →
-        # ../../packages/kaval/logo.svg). One SVG each on disk; the Nix sandbox
-        # still sees a self-contained website/ with real bytes.
-        let
-          websiteSrc = pkgs.runCommand "kolu-website-src" { } ''
-            cp -r ${./website} $out
-            chmod -R u+w $out
-            rm -f $out/public/favicon.svg
-            cp ${./packages/client/favicon.svg} $out/public/favicon.svg
-            rm -f $out/public/kaval-logo.svg
-            cp ${./packages/kaval/logo.svg} $out/public/kaval-logo.svg
-          '';
-        in
-        import ./website { inherit pkgs; src = websiteSrc; });
+      # website/default.nix is self-contained — it resolves its own public/
+      # asset symlinks (favicon, kaval logo), so the flake just imports it.
+      websiteBySystem = eachSystem (pkgs: import ./website { inherit pkgs; });
     in
     {
       # The module proper is platform-agnostic; the flake closes over it to

--- a/website/default.nix
+++ b/website/default.nix
@@ -5,21 +5,33 @@
 #
 # Imported from the root flake.nix and exposed as packages.${system}.website.
 # Reuses the root's npins-pinned nixpkgs (via ../nix/nixpkgs.nix) so there's
-# no duplicate pin to keep in sync. `src` is optional — when omitted, a
-# self-contained fileset is built from ./; the root flake passes a
-# synthesized src that resolves the favicon symlink.
+# no duplicate pin to keep in sync. `src` is optional and self-contained — it
+# resolves the public/ asset symlinks (see below), so the root flake just does
+# `import ./website { inherit pkgs; }` with no synthesis of its own.
 { pkgs ? import ../nix/nixpkgs.nix { }
-, src ? pkgs.lib.fileset.toSource {
-    root = ./.;
-    fileset = pkgs.lib.fileset.unions [
-      ./package.json
-      ./pnpm-lock.yaml
-      ./tsconfig.json
-      ./astro.config.mjs
-      ./src
-      ./public
-    ];
-  }
+, src ? # Self-contained website source for the Nix sandbox. The working tree keeps
+  # public/{favicon,kaval-logo}.svg as symlinks into packages/ (one SVG each
+  # on disk, no duplicated bytes) — but those dangle once copied into the
+  # store, so resolve them to real bytes here. Astro/Vite then sees a
+  # complete tree. Add a line per new out-of-tree public/ asset.
+  pkgs.runCommand "kolu-website-src" { } ''
+    cp -r ${pkgs.lib.fileset.toSource {
+      root = ./.;
+      fileset = pkgs.lib.fileset.unions [
+        ./package.json
+        ./pnpm-lock.yaml
+        ./tsconfig.json
+        ./astro.config.mjs
+        ./src
+        ./public
+      ];
+    }} $out
+    chmod -R u+w $out
+    rm -f $out/public/favicon.svg
+    cp ${../packages/client/favicon.svg} $out/public/favicon.svg
+    rm -f $out/public/kaval-logo.svg
+    cp ${../packages/kaval/logo.svg} $out/public/kaval-logo.svg
+  ''
 }:
 let
   # Single source for the website version — its own package.json (no literal to


### PR DESCRIPTION
## Why

The website's Nix build was split across two files in a way that just bit us. The **synthesized website source** — copying `public/` asset symlinks (`favicon.svg`, `kaval-logo.svg`) into real bytes so the sandbox sees a complete tree — lived in the **root `flake.nix`**, while the actual build lived in **`website/default.nix`**.

That split means every new out-of-tree `public/` asset has to be registered in `flake.nix`, far from the rest of the website build. That's exactly the gap that broke #1314: it added `public/kaval-logo.svg` as a symlink but the flake's synthesis didn't know to resolve it, so `nix build .#website` went red on `master` (fixed in #1315).

## What

Move the source synthesis into `website/default.nix`'s default `src` parameter. Now:

- **`website/default.nix`** is self-contained — it resolves its own `public/` symlinks. Adding a new out-of-tree asset is one line, right next to the build that consumes it.
- **`flake.nix`** drops the `websiteSrc` `runCommand` entirely and just does `import ./website { inherit pkgs; }`.

Shared Nix (`nix/nixpkgs.nix`, `nix/pnpm-typecheck.nix`) stays in `nix/` — the workspace root imports those too, so they're not website-specific.

## Verification

- `nix build .#website` passes; `result/{favicon,kaval-logo}.svg` both present with real bytes.
- `checks.x86_64-linux.website-typecheck` still evaluates.
- `just fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)