### PR TITLE
fix(nix): drop kaval-build-id IFD; run `nix flake check` in CI

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -55,7 +55,7 @@ nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accep
 [macos]
 [parallel]
 [metadata("ci")]
-default: nix home-manager e2e smoke fmt biome unit surface-example-build surface-app-example-build pnpm-hash-fresh atlas-sync
+default: nix flake-check home-manager e2e smoke fmt biome unit surface-example-build surface-app-example-build pnpm-hash-fresh atlas-sync
 
 # Single per-platform `pnpm install`. The runner fans every recipe out into
 # its own process and starts them all in parallel as soon as setup completes,
@@ -89,6 +89,17 @@ pnpm-hash-fresh:
 # is content-addressed, so it only re-runs when a typechecked source changes.
 nix:
     nix build github:srid/devour-flake -L --no-link --print-out-paths --override-input flake .
+
+# `nix flake check`: evaluate every flake output and run the flake's `checks.*`.
+# Complements the `nix` node (devour-flake builds the output drvs) with the
+# flake-schema + whole-output *evaluation* gate — it forces every output to
+# evaluate, so an eval-time regression like an import-from-derivation that can't
+# be realised mid-eval (juspay/kolu#1317) fails here even when a plain build of
+# the affected drv would have succeeded. Store locking dedups its check builds
+# against the concurrent `nix` node, so it overlaps that build rather than
+# repeating it. No `nix` dep — it's an independent parallel leaf.
+flake-check:
+    nix flake check --accept-flake-config -L
 
 # Builds the home-manager example flake, which pulls kolu in via
 # `--override-input flake/kolu .` — so it builds kolu from source itself. No

--- a/default.nix
+++ b/default.nix
@@ -87,9 +87,10 @@ let
   # restart would load different daemon code. Scoped to the three roots that run
   # IN the daemon — kaval, terminal-protocol, and the surface-daemon spine — so
   # server-/client-only deploys leave it unchanged (no over-prompting). The .ts
-  # filter drops `.test.ts` AND `.testlib.ts` (shared test-only helpers), and
-  # LC_ALL=C sort makes the hash byte-identical across Darwin/Linux. The set
-  # hashed here is asserted to equal the daemon's reachable closure by
+  # filter drops `.test.ts` AND `.testlib.ts` (shared test-only helpers); the id
+  # (below) is taken over this fileset's content-addressed store path, whose NAR
+  # hash is byte-identical across Darwin/Linux. The set hashed here is asserted
+  # to equal the daemon's reachable closure by
   # packages/kaval/src/buildId.closure.test.ts — keep the fileFilter and that
   # test in lockstep.
   isHashedSource =
@@ -117,12 +118,13 @@ let
     ];
   };
 
-  kavalBuildId = builtins.readFile (pkgs.runCommand "kaval-build-id"
-    { src = kavalSrc; } ''
-    cd "$src"
-    find . -type f | LC_ALL=C sort | xargs cat | sha256sum | cut -c1-64 \
-      | tr -d '\n' > $out
-  '');
+  # A content digest of kaval's daemon source closure, baked into KAVAL_BUILD_ID.
+  # kavalSrc is content-addressed (fileset.toSource adds it to the store at eval
+  # time), so its store path already changes iff any hashed file changes — hash
+  # that path to a stable, platform-independent 64-char id. Computed PURELY in
+  # Nix: no import-from-derivation, so `nix flake check` can evaluate every
+  # output without realising a build mid-eval (juspay/kolu#1317).
+  kavalBuildId = builtins.hashString "sha256" "${kavalSrc}";
 
   kolu = pkgs.stdenv.mkDerivation {
     pname = "kolu";


### PR DESCRIPTION
Closes #1317.

## The bug

`nix flake check` failed during **evaluation** with:

```
error: path '…-kaval-build-id.drv' is not valid
```

`kavalBuildId` (`default.nix`) was an **import-from-derivation** — `builtins.readFile` of a `runCommand` that hashed kaval's daemon source closure (`find | sort | cat | sha256sum`). To *evaluate* the value, Nix had to realise that build mid-eval, which is exactly what eval-only (`--no-build`) `nix flake check` refuses to do.

## The fix

The id only needs to be a **stable function of `kavalSrc`** that changes iff a hashed daemon file changes:

- The runtime side just *reads* `KAVAL_BUILD_ID` (`packages/kaval/src/buildId.ts`) — nothing recomputes the digest.
- `buildId.closure.test.ts` pins the hashed **file set**, not the hash algorithm.

`kavalSrc` is already content-addressed (`fileset.toSource` adds it to the store at eval time), so its store path changes iff a hashed file changes. So hash that path **purely in Nix**:

```nix
kavalBuildId = builtins.hashString "sha256" "${kavalSrc}";
```

No IFD, faster eval, same guarantee — and byte-identical across Darwin/Linux for free (the NAR hash is platform-neutral, so the old `LC_ALL=C`-sort rationale retires with the shell pipeline).

## CI: `nix flake check` node

Adds a `flake-check` recipe to `ci/mod.just`, wired into the `default` DAG. It's the whole-output **evaluation** + flake-schema gate, complementing the existing devour-flake `nix` node (which builds the output drvs). Store locking dedups its `checks.*` builds against that node, so it overlaps rather than repeats the big build.

### Honest scoping

- **Full `nix flake check` already passed on `master`** (a full build is allowed to realise IFDs) — so the CI node is green today, and its value is guarding *future* eval regressions plus closing the specific IFD #1317 named. The IFD only broke the eval-only (`--no-build`) path.
- CI runs **full** `nix flake check`, not `--no-build`: `mini-ci-runner` deliberately bakes `${mini-ci-runner.drvPath}` into its wrapper (so `nix run .#mini-ci` can build the runner on demand), which `--no-build` can't satisfy by design. That's intentional, not a bug, so `--no-build` isn't a usable gate.

## Verification

- `nix flake check` → `all checks passed!`
- `nix build .#kaval` → ok (id evaluates and bakes into the wrapper)
- `vitest packages/kaval/src/buildId` → 4/4 (unit + closure)
- `just fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)