### PR TITLE
fix(kaval-tui): drop stale biome-ignore in render.ts

### DIFF
--- a/packages/kaval-tui/src/render.ts
+++ b/packages/kaval-tui/src/render.ts
@@ -34,7 +34,6 @@ export function commandName(processPath: string | undefined): string {
  *  output stays raw (`JSON.stringify` escapes controls), this is only the
  *  human-rendered path. */
 export function sanitizeCell(value: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching C0 (\x00-\x1f) + DEL (\x7f) to neutralize them.
   return value.replace(/[\x00-\x1f\x7f]+/g, " ").trim();
 }
 


### PR DESCRIPTION
**`just check` / `ci::biome` was red on `master`** — independent of any open PR. Under the **biome 2.4.7** pinned in the devshell, `noControlCharactersInRegex` no longer fires on the C0+DEL sanitize pattern in `sanitizeCell`, so the `biome-ignore` above it suppressed nothing and `suppressions/unused` (error severity) tripped.

The fix is to delete the now-dead suppression comment — the regex itself is *not* flagged, so the file lints clean afterward:

```diff
 export function sanitizeCell(value: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching C0 (\x00-\x1f) + DEL (\x7f) to neutralize them.
   return value.replace(/[\x00-\x1f\x7f]+/g, " ").trim();
 }
```

The sanitize behavior is unchanged; only the suppression comment goes. `just check` now exits clean (the remaining output is the repo's pre-existing `noExplicitAny` *warnings*, not errors).

Closes #1318

_Generated by [`/do`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._