### PR TITLE
Stop spawning a subagent per commit in the lens & codex debates

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -72,8 +72,8 @@ it once per step.
    rendered comment body for be-review to post after the push. Wait for its
    `Workflow` to finish before starting the codex step.
 
-   `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
-   `merge-base-error`:
+   `/lens-debate` returns a `status` of `clean`, `consensus`,
+   `apply-incomplete`, `unresolved`, or `merge-base-error`:
    - `clean` / `consensus` — the lenses agreed per-finding and applied the fixes.
    - `apply-incomplete` — the lenses agreed, but the Apply phase didn't land every
      fix cleanly (see `applyGaps`: a fix was missing from the apply output or
@@ -100,7 +100,8 @@ it once per step.
    consensus to report; skip the codex comment in that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   either in `consensus` or in `reviewer-error` — the latter meaning codex never
+   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
+   last meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
    per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
    outcome*: re-launch it immediately with the same args. Stop the moment an

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -75,6 +75,12 @@ it once per step.
    `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
    `merge-base-error`:
    - `clean` / `consensus` — the lenses agreed per-finding and applied the fixes.
+   - `apply-incomplete` — the lenses agreed, but the Apply phase didn't land every
+     fix cleanly (see `applyGaps`: a fix was missing from the apply output or
+     changed-but-uncommitted). **Reconcile before moving on:** for each gap, apply
+     or commit the outstanding fix yourself (staging only its files), then fold the
+     reconciliation into the deferred lens comment. Never report "lens consensus"
+     for an `apply-incomplete` run.
    - `unresolved` — the debate hit its round backstop with findings still
      contested. `/be` §4 requires you to **adjudicate every unresolved lens
      finding yourself before moving on**: surface them in the report, decide drop
@@ -101,6 +107,14 @@ it once per step.
    attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
    you give up on codex — report the persistent reviewer-error honestly (no false
    consensus comment) and move on to the simplify step.
+
+   **On `commit-incomplete`,** the debate converged but a round's author left its
+   edits uncommitted (round numbers in `commitGaps`). The edits are still in the
+   tree, but the per-round commit didn't land — **commit the outstanding tree
+   yourself** (staging only the files that round changed, message
+   `fix: codex review — debate round N`) before the simplify step, and note the
+   reconciliation in the deferred codex comment. Don't report it as a clean
+   consensus.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -153,12 +153,14 @@ different worktrees never collide** and the scratch never shows up in the diff
 codex reviews. It returns:
 
 ```
-{ status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript,
+{ status: "consensus" | "commit-incomplete" | "reviewer-error",
+  rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
   comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
-(each `transcript[]` round also carries a `commit` SHA when that round committed.)
+(each `transcript[]` round also carries a `commit` SHA when that round committed;
+`commitGaps` lists the round numbers whose author edited files but returned no
+commit SHA — empty unless `status === "commit-incomplete"`.)
 The debate is recorded as **one small Markdown file per round** —
 `<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
 author's cross-round memory** (so each round builds on the last instead of
@@ -175,6 +177,14 @@ warm session, so re-feeding it the sections would just duplicate its context.
   with no round cap and no deadlock exit. (The harness's own
   per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
   a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
+- **commit-incomplete** — the debate *converged* (codex approved, nothing open),
+  but a round's author edited files yet returned **no commit SHA**, so its
+  in-session commit didn't land and the "one commit per round" contract broke for
+  the round(s) in `commitGaps`. The edits are **not lost** — they stay in the
+  working tree and the next reviewer diffs them against the base — but this is
+  **not** a clean consensus: a human must reconcile the uncommitted round(s)
+  (e.g. commit the outstanding tree) before relying on the per-round history. Do
+  **not** report it as a plain consensus (see step 3).
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
@@ -195,6 +205,13 @@ so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
 `codex login`, check the CLI) and re-run. Do **not** post a consensus badge or a
 `## Codex ⇄ Claude debate` PR comment for this path — there is no agreement to
 report. Skip the rest of this section.
+
+If `status === "commit-incomplete"`, the debate converged but at least one round
+left its edits **uncommitted** (the round numbers are in `commitGaps`). Report it
+as **converged-but-not-clean**: post the `comment` (its header already shows a
+`⚠️` badge, not the consensus check), then tell the user which round(s) are
+uncommitted and that the outstanding tree must be committed before the per-round
+history can be trusted. Do **not** call it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -141,9 +141,11 @@ Workflow({
 The workflow runs in the background and notifies you when it completes. It
 alternates `codex:roundN` and `claude:roundN` agents under a **Debate** phase —
 the user can watch live via `/workflows`. Each Claude round edits the working
-tree, then (unless `--no-commit`) a `commit:roundN` agent **commits exactly that
-round's changed files** with a message embedding the round's codex findings and
-Claude's dispositions — never pushing or merging.
+tree and (unless `--no-commit`) **commits exactly that round's changed files in
+the same session** — one commit per round, with a message embedding the round's
+codex findings and Claude's dispositions — never pushing or merging. (The commit
+is no longer a separate `commit:roundN` agent: the author already has the tree
+open, so it commits its own round.)
 
 Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
 gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -38,14 +38,16 @@ const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // deterministic, never re-rendered through an agent (nothing weak ever retypes a
 // large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
 // it the ledger would just duplicate what it already remembers.
-// Commit each round's changes individually (default on). The commit message
-// carries the debate context (codex's findings + claude's dispositions). Never
-// pushes or merges — that stays the human's call.
+// Commit each round's changes individually (default on). The author commits its
+// OWN round in-session — it already edits the tree, so it stages exactly what it
+// changed and writes a message carrying the debate context (codex's findings +
+// its dispositions). Never pushes or merges — that stays the human's call.
 const commit = a.commit !== false
 // Model tiers. The claude-author round does real reasoning (fixing/disputing
-// codex's findings) → `model` (Opus). Everything else here is mechanical — the
-// codex runner just shells out to codex-review.sh and copies the verdict, the
-// committer stages files, the merge-base resolver runs one git command → `mechModel`
+// codex's findings, and committing its own round) → `model` (Opus). Everything
+// else here is mechanical — the codex runner just shells out to codex-review.sh
+// and copies the verdict, the ledger writer dumps a section file, the merge-base
+// resolver runs one git command → `mechModel`
 // (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
@@ -119,6 +121,9 @@ const CLAUDE_RESPONSE_SCHEMA = {
       },
     },
     filesChanged: { type: 'array', items: { type: 'string' } },
+    // The author commits its own round (it already edits the tree), so it returns
+    // the resulting SHA here. "" when it changed nothing or ran under --no-commit.
+    commitSha: { type: 'string' },
     done: { type: 'boolean' },
   },
   required: ['summary', 'actions', 'filesChanged', 'done'],
@@ -166,7 +171,7 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict) {
+async function claudeResponds(round, verdict, doCommit) {
   // WARM AUTHOR. We can't truly resume the Claude author (agent() is one-shot,
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
@@ -196,9 +201,13 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-Edit the working tree only — do NOT git add/commit/push. You may run the formatter on files you touched.
+You may run the formatter on files you touched. ${
+    doCommit
+      ? `Once you've addressed every finding AND you actually changed files, COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
+      : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
+  }
 
-Return: actions (one per finding — findingId, disposition, detail), filesChanged, and done (true once you've addressed every finding this round).`
+Return: actions (one per finding — findingId, disposition, detail), filesChanged, commitSha, and done (true once you've addressed every finding this round).`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -208,70 +217,20 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
   })
 }
 
-// Commit message for one debate round, carrying the debate context: what codex
-// raised and how claude dispositioned each finding. It reuses the same per-bullet
-// projection as the ledger section (findingBullet/actionBullet), in `plain` chrome
-// — no backticks/bold and no `status` field — so the round summary derives from a
-// single rendering rather than two parallel ones.
-function roundCommitMessage(round, verdict, response) {
-  const findings = (verdict.findings || [])
-    .map((f) => findingBullet(f, { plain: true }))
-    .join('\n')
-  const actions = (response.actions || [])
-    .map((a) => actionBullet(a, { plain: true }))
-    .join('\n')
-  return `fix: codex review — debate round ${round}
-
-${response.summary}
-
-codex (round ${round}) findings:
-${findings || '- (none)'}
-
-claude:
-${actions || '- (no actions)'}
-
-Committed by the codex<->claude debate (round ${round}); not pushed or merged.`
-}
-
-// Commit exactly the files claude changed this round, with the debate-context
-// message. A thin mechanical agent: the workflow can't run git itself.
-async function commitRound(round, files, message) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workDir}/commit-msg-${round}.txt`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
-
-${message}
-
-3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
-   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
-   Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `commit:round${round}`, phase: 'Debate', model: mechModel })
-}
-
 // ---------------------------------------------------------------------------
 // The shared ledger — rendered from the transcript, deterministically
 // ---------------------------------------------------------------------------
-// One codex finding as a Markdown bullet. The single projection of a finding's
-// fields, shared by the ledger section and the round commit message. `plain` drops
-// the ledger chrome (backticks + the `status` field) for the commit message, which
-// wants plainer text; the field access stays in one place either way.
-function findingBullet(f, { plain = false } = {}) {
-  return plain
-    ? `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`
-    : `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
+// One codex finding as a Markdown bullet — the single projection of a finding's
+// fields for the ledger section. (The per-round commit message is now written by
+// the author itself, in its own session, so this no longer feeds it.)
+function findingBullet(f) {
+  return `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
 }
 
-// One author disposition as a Markdown bullet. The single projection of an action's
-// fields, shared by the ledger section and the round commit message. `plain` drops
-// the ledger chrome (backticks + bold) for the commit message.
-function actionBullet(a, { plain = false } = {}) {
-  return plain
-    ? `- ${a.findingId} ${a.disposition}: ${a.detail}`
-    : `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
+// One author disposition as a Markdown bullet — the single projection of an
+// action's fields for the ledger section.
+function actionBullet(a) {
+  return `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
 }
 
 // One round's findings, as a Markdown list. Shared by the section renderer below.
@@ -412,8 +371,8 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // thin mechanical agent (the workflow can't run shell itself). The reset is
 // section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
 // whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
-// commit-msg-N.txt) keep their own lifecycle and a future pre-loop writer won't
-// be silently wiped. This script has no true resume (agent() is one-shot, the
+// and any commit-message file the author writes) keep their own lifecycle and a
+// future pre-loop writer won't be silently wiped. This script has no true resume (agent() is one-shot, the
 // whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
 await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
@@ -462,20 +421,21 @@ for (let round = 1; ; round++) {
   // rest. It reads the per-round section files (written at the end of each round
   // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
   // rebuttal next round (see codexReviews) — it is no longer the author's memory.
-  const response = await claudeResponds(round, verdict)
+  const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
   lastClaude = response
   log(
     `Round ${round}: claude done=${response.done}, actions=${(response.actions || []).length}, files=${(response.filesChanged || []).length}`,
   )
 
-  // Commit this round individually so the PR history reads as the debate
-  // itself — one commit per round, message carrying codex's findings and
-  // claude's dispositions. Only when claude actually changed files.
+  // The author commits its own round in-session (one commit per round, message
+  // carrying codex's findings and its dispositions), so here we just record the
+  // SHA it returned. Only when it actually changed files; flag the inconsistency
+  // if it reported changes but no commit rather than silently dropping it.
   if (commit && (response.filesChanged || []).length > 0) {
-    const sha = await commitRound(round, response.filesChanged, roundCommitMessage(round, verdict, response))
-    entry.commit = (sha || '').trim()
-    log(`Round ${round}: committed ${entry.commit}`)
+    entry.commit = (response.commitSha || '').trim()
+    if (entry.commit) log(`Round ${round}: committed ${entry.commit}`)
+    else log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA`)
   }
 
   // Write this round's section so the NEXT round's author can read the full

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -324,6 +324,14 @@ const transcript = []
 let status = 'consensus'
 let finalVerdict = null
 let lastClaude = null
+// Rounds where the author edited files (commit mode on) but returned no SHA —
+// the in-session commit it was told to make didn't land. The edits aren't lost
+// (they stay in the tree and the next reviewer still diffs them against base),
+// but the "one commit per round" contract was broken for that round, so the run
+// is NOT a clean consensus: we downgrade the terminal status below rather than
+// report success over a missed commit. Not a hard abort: a transient SHA omission
+// shouldn't nuke a multi-round debate whose edits are all present in the tree.
+const commitGaps = []
 
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
@@ -434,8 +442,16 @@ for (let round = 1; ; round++) {
   // if it reported changes but no commit rather than silently dropping it.
   if (commit && (response.filesChanged || []).length > 0) {
     entry.commit = (response.commitSha || '').trim()
-    if (entry.commit) log(`Round ${round}: committed ${entry.commit}`)
-    else log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA`)
+    if (entry.commit) {
+      log(`Round ${round}: committed ${entry.commit}`)
+    } else {
+      // The author edited the tree but didn't return a SHA: its in-session commit
+      // didn't land. Record the gap so the terminal status reflects it instead of
+      // reporting a clean consensus over a round that broke the one-commit-per-round
+      // contract. The edits themselves remain in the tree for the next reviewer.
+      commitGaps.push(round)
+      log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA — round left uncommitted`)
+    }
   }
 
   // Write this round's section so the NEXT round's author can read the full
@@ -447,6 +463,20 @@ for (let round = 1; ; round++) {
 const filesChanged = Array.from(
   new Set(transcript.flatMap((e) => (e.claude && e.claude.filesChanged) || [])),
 )
+
+// Downgrade a would-be consensus when any round's in-session commit didn't land.
+// The debate may have converged (codex approved, nothing open), but with the
+// "one commit per round" contract broken we must NOT advertise a clean consensus:
+// /be-review keys off this status (and the SKILL's status table) to decide whether
+// the step settled cleanly. 'commit-incomplete' is a distinct, non-consensus
+// terminus — the edits are all in the tree (the next reviewer diffs them), but a
+// human/caller must reconcile the uncommitted round(s). We don't touch a status
+// that's already abnormal (reviewer-error), which is strictly more severe.
+if (status === 'consensus' && commitGaps.length) {
+  status = 'commit-incomplete'
+  log(`Round(s) ${commitGaps.join(', ')} left uncommitted despite changing files — downgrading consensus to commit-incomplete.`)
+}
+
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
 // Section the terminal round — it broke out of the loop before the in-loop
@@ -467,6 +497,9 @@ return {
   base,
   finalVerdict,
   filesChanged,
+  // Rounds whose author-side commit didn't land (empty unless status is
+  // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
+  commitGaps,
   transcript,
   comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
 }

--- a/.agents/skills/lens-debate/SKILL.md
+++ b/.agents/skills/lens-debate/SKILL.md
@@ -207,7 +207,7 @@ branch for the human to review):
   `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never hit commitFix, so the dir may not exist yet
+  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never run the Apply commit step, so the dir may not exist yet
   printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
   gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
   ```

--- a/.agents/skills/lens-debate/SKILL.md
+++ b/.agents/skills/lens-debate/SKILL.md
@@ -157,10 +157,12 @@ three phases the user can watch via `/workflows`:
   means both lenses agree on the disposition *and* the plan — if they both say
   `fix` but propose different changes, the finding stays open until the plans
   converge too (so Apply never picks one lens's plan arbitrarily).
-- **Apply** — one `apply:<finding-id>` per agreed `fix`, each followed (unless
-  `--no-commit`) by a `commit:<finding-id>` that commits **exactly** that fix's
-  changed files with a message carrying the debate context. Skipped wholesale
-  under `--no-apply` — the plans come back in `fixes` for the caller to apply.
+- **Apply** — a single `apply:all` agent implements **every** agreed `fix` in one
+  session and (unless `--no-commit`) commits each one individually, staging
+  **exactly** that fix's changed files with a message carrying the debate context.
+  One orientation for all fixes instead of a fresh implement+commit agent per
+  finding. Skipped wholesale under `--no-apply` — the plans come back in `fixes`
+  for the caller to apply.
 
 When `rationale` is set, pull it from the PR/issue description (the deliberate
 design decisions the author wants the lenses to respect, e.g. a deliberate
@@ -222,7 +224,8 @@ branch for the human to review):
 
 - **The lenses are read-only reviewers; only the Apply phase writes.** lowy and
   hickey never edit code — they only emit dispositions. The sole writes to the
-  tree come from the `apply:` agents implementing the *agreed* fixes.
+  tree come from the single `apply:all` agent implementing the *agreed* fixes
+  (one session, one commit per finding) — not one agent per fix.
 - **Commits, but never pushes or merges.** Each agreed fix is committed locally
   (unless `--no-commit`) so the PR history reads as the debate's conclusions, but
   the skill never pushes or merges. Consensus means "both lenses agree on the

--- a/.agents/skills/lens-debate/SKILL.md
+++ b/.agents/skills/lens-debate/SKILL.md
@@ -173,11 +173,12 @@ Ephemeral scratch (commit-message files) lives under the gitignored, per-worktre
 collide and the scratch never shows up in the diff the lenses review. It returns:
 
 ```
-{ status: "consensus" | "unresolved" | "clean",
+{ status: "consensus" | "apply-incomplete" | "unresolved" | "clean",
   rounds, base, withPolice,
   settled,     // per-finding: id, origin, title, location, agreed disposition, plan, both reasonings
   unresolved,  // findings still contested at the backstop (empty on consensus)
   applied,     // [{ id, title, files, commit }] (empty under --no-apply)
+  applyGaps,   // [{ id, reason }] agreed fixes that didn't cleanly land — empty unless status is "apply-incomplete"
   fixes,       // the agreed `fix` findings with converged plans — the caller's change requests under --no-apply
   reviews,     // each lens's independent findings
   history,     // per-round dispositions
@@ -186,6 +187,14 @@ collide and the scratch never shows up in the diff the lenses review. It returns
 
 - **consensus** — every finding settled (the normal outcome).
 - **clean** — every lens found nothing worth raising.
+- **apply-incomplete** — the lenses *converged*, but the Apply phase didn't land
+  every agreed fix cleanly: a fix was **missing from the apply agent's output**
+  (so we can't confirm it was applied) or, in commit mode, was **changed but
+  returned no commit SHA** (its per-fix commit didn't land). The offending fixes
+  are in `applyGaps`. Any edits present stay in the working tree, but this is
+  **not** a clean consensus — surface the gap and reconcile it (re-apply or commit
+  the outstanding fix) before relying on the per-fix history. Do **not** report it
+  as a plain consensus.
 - **unresolved** — the backstop was hit with findings still contested. Rare;
   needs a human. This is NOT a deadlock — the lenses simply didn't converge in
   the round budget; raise `--max-rounds` or adjudicate the listed findings.

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -492,6 +492,11 @@ if (apply && fixes.length) {
   applied = fixes.map((f) => {
     const a = byId[f.id] || {}
     const sha = (a.commit || '').trim()
+    // Mirror codex-debate's mismatch log: surface a fix the agent reported as
+    // changed-but-uncommitted instead of silently recording commit: null.
+    if (!sha && (a.filesChanged ?? []).length > 0) {
+      log(`Apply ${f.id}: agent changed ${a.filesChanged.length} file(s) but returned no commit SHA`)
+    }
     return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
   })
   applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -179,13 +179,30 @@ const POSITION_SCHEMA = {
   },
 }
 
-const IMPL_SCHEMA = {
+// One Apply agent implements every agreed fix and commits each in a single
+// session, so it returns the full per-fix outcome (not one impl per agent). One
+// entry per fix it was handed; `commit` is "" under `--no-commit` or when a fix
+// turned out to need no change.
+const APPLY_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['summary', 'filesChanged'],
+  required: ['applied'],
   properties: {
-    summary: { type: 'string', description: 'one line: what you changed' },
-    filesChanged: { type: 'array', items: { type: 'string' } },
+    applied: {
+      type: 'array',
+      description: 'one entry for EVERY agreed fix you were given, in the same order',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'summary', 'filesChanged'],
+        properties: {
+          id: { type: 'string' },
+          summary: { type: 'string', description: 'one line: what you changed for this fix' },
+          filesChanged: { type: 'array', items: { type: 'string' } },
+          commit: { type: 'string', description: 'this fix\'s commit SHA, or "" if nothing was committed' },
+        },
+      },
+    },
   },
 }
 
@@ -222,47 +239,48 @@ ${oppBlock}
 Round ${roundNum}. For EVERY contested finding id above, output a disposition (\`fix\` = worth changing in THIS PR / \`drop\` = leave as-is, observation only), a concrete implementable plan if \`fix\`, and reasoning grounded in the code. **The goal is the correct answer for THIS PR, not winning** — concede explicitly ("conceding: …") when ${opp}'s code-grounded argument is right. A \`fix\` is worth it only if it genuinely improves the PR.`
 }
 
-function implementBrief(fix) {
-  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\`.
+// ONE brief for ALL agreed fixes — implemented and committed in a single Apply
+// session, so the agent orients on the repo once instead of paying that cost per
+// fix (the old form spawned an implement agent AND a commit agent per finding,
+// serially). The fixes are independent and their plans already converged in the
+// debate, so there's no cross-fix reasoning to isolate; what we keep is one
+// commit PER finding so the history still reads finding-by-finding.
+function applyAllBrief(fixes, doCommit) {
+  const list = fixes
+    .map(
+      (f) => `### ${f.id} (raised by ${f.origin}) — ${f.title}
+  at ${f.location}
+  problem: ${f.problem}
+  original suggestion (context, not the agreed plan): ${f.suggestion}
+  agreed plan: ${f.plan}`,
+    )
+    .join('\n\n')
+  const commitStep = doCommit
+    ? `After a fix's edits are done, COMMIT that fix on its own before moving to the next, so each finding maps to one commit and the history reads finding-by-finding. Stage ONLY the files you changed for that fix — never \`git add -A\` or \`git add .\`. Write the message to a file under \`${workDir}\` (run \`mkdir -p ${workDir}\` first) and commit with \`git -C ${repoPath} add -- <files> && git -C ${repoPath} commit -F <msgfile>\`, using EXACTLY this message shape:
 
-Finding ${fix.id} (raised by ${fix.origin}) — ${fix.title}
-  at ${fix.location}
-  problem: ${fix.problem}
-  original suggestion (context, not the agreed plan): ${fix.suggestion}
-  agreed plan: ${fix.plan}
+  fix(lens): <the fix's title>
 
-Make ONLY this change in the working tree, following the agreed plan above. Keep it tightly scoped to the finding; read the surrounding code first so the edit fits the existing style. Do NOT git add / commit / push. You may run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`
+  <your one-line summary of the change>
+
+  Agreed by the lowy ⇄ hickey lens debate (finding <id>, raised by <origin>). Not pushed or merged.
+
+Do NOT push. Record each fix's resulting commit SHA (\`git -C ${repoPath} rev-parse HEAD\`) in its \`commit\` field. If a fix turns out to need no change, leave its \`filesChanged\` empty and its \`commit\` "".`
+    : `Do NOT git add / commit / push — leave every change in the working tree and set each fix's \`commit\` to "".`
+  return `You are implementing the changes that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`.
+
+Apply each agreed fix below, IN ORDER. The fixes are independent — keep each one tightly scoped to its finding and don't let one bleed into another. Read the surrounding code first so each edit fits the existing style. You may run the project's formatter on files you touched.
+
+${list}
+
+${commitStep}
+
+Return one \`applied\` entry per fix (same order): its id, a one-line summary, the exact files you changed, and the commit SHA (or "").`
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 const posMap = (res) => Object.fromEntries((res?.positions ?? []).map((p) => [p.id, p]))
-
-// Commit exactly the files one fix changed, with a message carrying the debate
-// context. A thin mechanical agent: the workflow can't run git itself.
-async function commitFix(fix, files, summary) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workDir}/commit-msg-${fix.id}.txt`
-  // `fix(lens):` — the conventional prefix for lens-originated commits.
-  const message = `fix(lens): ${fix.title}
-
-${summary}
-
-Agreed by the lowy ⇄ hickey lens debate (finding ${fix.id}, raised by ${fix.origin}). Not pushed or merged.`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
-
-${message}
-
-3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
-   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
-   Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply', model: mechModel })
-}
 
 // Render the PR comment deterministically from the debate outcome, returned as a
 // string so the ORCHESTRATOR posts it verbatim (`gh pr comment -F`) — no agent
@@ -452,25 +470,29 @@ const unresolved = settledOut.filter((s) => !s.agreed)
 log(`Debate ended: ${status} after ${rounds} round(s); ${settledOut.length - unresolved.length}/${settledOut.length} settled, ${unresolved.length} unresolved.`)
 
 // ---------------------------------------------------------------------------
-// Phase 3 — apply the agreed `fix` findings, each as its own commit. Skipped
-// wholesale under `apply: false`: the agreed plans are returned in `fixes` for
-// the caller to implement against whatever tree it chooses.
+// Phase 3 — apply every agreed `fix` finding in a SINGLE session, one commit
+// per finding. One agent orients on the repo once and applies all the fixes,
+// rather than paying a fresh implement+commit agent (and its re-orientation
+// cost) per finding; the fixes are independent and their plans already
+// converged, so there's no cross-fix reasoning to isolate. Skipped wholesale
+// under `apply: false`: the agreed plans are returned in `fixes` for the caller
+// to implement against whatever tree it chooses.
 // ---------------------------------------------------------------------------
 const fixes = settledOut.filter((s) => s.agreed && s.disposition === 'fix')
-const applied = []
-if (apply) {
+let applied = []
+if (apply && fixes.length) {
   phase('Apply')
-  for (const fix of fixes) {
-    const impl = await agent(implementBrief(fix), { label: `apply:${fix.id}`, phase: 'Apply', model, schema: IMPL_SCHEMA })
-    const files = impl?.filesChanged ?? []
-    let sha = null
-    if (commit && files.length > 0) {
-      const out = await commitFix(fix, files, impl.summary)
-      sha = (out || '').trim()
-    }
-    applied.push({ id: fix.id, title: fix.title, files, commit: sha })
-    log(`Applied ${fix.id}: ${files.length} file(s)${sha ? `, committed ${sha.slice(0, 9)}` : ' (uncommitted)'}`)
-  }
+  const res = await agent(applyAllBrief(fixes, commit), { label: 'apply:all', phase: 'Apply', model, schema: APPLY_SCHEMA })
+  const byId = Object.fromEntries((res?.applied ?? []).map((a) => [a.id, a]))
+  // Re-key off the agreed `fixes` (not the agent's array) so a fix the agent
+  // dropped from its output still surfaces — as 0 files / uncommitted — instead
+  // of vanishing from `applied` and the PR comment.
+  applied = fixes.map((f) => {
+    const a = byId[f.id] || {}
+    const sha = (a.commit || '').trim()
+    return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
+  })
+  applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))
 } else if (fixes.length) {
   log(`Apply skipped (apply: false) — returning ${fixes.length} agreed fix plan(s) to the caller.`)
 }

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -302,12 +302,20 @@ const posMap = (res) => Object.fromEntries((res?.positions ?? []).map((p) => [p.
 // { kind: 'handed-off', items } when apply:false returned the plans to the
 // caller — one param, so "at most one of applied/handed-off" holds by
 // construction instead of by convention.
-function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, withPolice, base, clean }) {
-  const badge = clean
-    ? '✅ **Clean** — every lens found nothing worth raising'
-    : unresolved.length === 0
-      ? '✅ **Consensus**'
-      : `⚠️ **${unresolved.length} unresolved**`
+// `applyGaps` (agreed fixes the Apply phase did not cleanly land) is rendered
+// HERE, not just in the machine `status`: the SKILL posts this comment verbatim,
+// so an apply-incomplete run must surface a warning badge and a dedicated gap
+// section instead of advertising `✅ Consensus` and listing the gapped fix as
+// `Applied`. Keep this consistent with the status downgrade in Phase 3.
+function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, withPolice, base, clean, applyGaps = [] }) {
+  const gapIds = new Set(applyGaps.map((g) => g.id))
+  const badge = applyGaps.length
+    ? `⚠️ **Apply incomplete** — ${applyGaps.length} agreed fix(es) not cleanly applied`
+    : clean
+      ? '✅ **Clean** — every lens found nothing worth raising'
+      : unresolved.length === 0
+        ? '✅ **Consensus**'
+        : `⚠️ **${unresolved.length} unresolved**`
   const counts = Object.entries(reviewByLens)
     .map(([lens, fs]) => `${lens}=${fs.length}`)
     .join(', ')
@@ -323,9 +331,25 @@ function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, 
     `Independent findings: ${counts}`,
   ]
   const drops = settledOut.filter((s) => s.agreed && s.disposition === 'drop')
-  if (outcome.kind === 'applied' && outcome.items.length) {
-    lines.push('', `### Applied (${outcome.items.length})`)
-    outcome.items.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+  if (outcome.kind === 'applied') {
+    // Only CLEANLY-landed fixes go under `Applied`; a fix in `applyGaps` (missing
+    // from the apply output, or changed-but-uncommitted) is NOT applied work and
+    // must not be advertised as such under what would otherwise be a consensus
+    // badge — it gets its own gap section below.
+    const cleanlyApplied = outcome.items.filter((a) => !gapIds.has(a.id))
+    if (cleanlyApplied.length) {
+      lines.push('', `### Applied (${cleanlyApplied.length})`)
+      cleanlyApplied.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+    }
+    if (applyGaps.length) {
+      lines.push('', `### Apply incomplete — needs reconcile (${applyGaps.length})`)
+      const reasonText = { 'missing-from-output': 'not confirmed applied (absent from apply output)', uncommitted: 'changed but not committed (per-fix commit missing)' }
+      applyGaps.forEach((g) => {
+        const item = outcome.items.find((a) => a.id === g.id)
+        const title = item?.title ? ` ${item.title}` : ''
+        lines.push(`- \`${g.id}\`${title} — ${reasonText[g.reason] ?? g.reason}`)
+      })
+    }
   }
   // apply:false runs hand the agreed plans to the caller instead of implementing
   // them; the comment records the handoff so the trail still shows what was agreed
@@ -549,5 +573,5 @@ return {
   fixes,
   reviews: reviewByLens,
   history,
-  comment: renderComment({ rounds, settledOut, unresolved, outcome: apply ? { kind: 'applied', items: applied } : { kind: 'handed-off', items: fixes }, reviewByLens, withPolice, base }),
+  comment: renderComment({ rounds, settledOut, unresolved, outcome: apply ? { kind: 'applied', items: applied } : { kind: 'handed-off', items: fixes }, reviewByLens, withPolice, base, applyGaps }),
 }

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -90,7 +90,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // The result shape's empty collections, shared by the two EARLY returns
 // (merge-base-error, clean) so adding a result field is one edit, not a mirror
 // edit per return site. The final return carries real values and stays literal.
-const EMPTY_RESULT = { settled: [], unresolved: [], applied: [], fixes: [], reviews: {}, history: [] }
+const EMPTY_RESULT = { settled: [], unresolved: [], applied: [], applyGaps: [], fixes: [], reviews: {}, history: [] }
 
 // Resolve the diff base to the merge-base of (base, HEAD) BEFORE building DIFF
 // (which interpolates `base` eagerly), so the lenses review only what this branch
@@ -482,6 +482,15 @@ log(`Debate ended: ${status} after ${rounds} round(s); ${settledOut.length - unr
 // ---------------------------------------------------------------------------
 const fixes = settledOut.filter((s) => s.agreed && s.disposition === 'fix')
 let applied = []
+// Agreed fixes the Apply phase did not cleanly land. Two failure shapes, both of
+// which would otherwise be rendered as "applied" and reported under a consensus:
+//  - missing: the agent dropped the fix from its output entirely (no entry, no
+//    files) — we can't tell if it was applied, so it must not be reported as done.
+//  - uncommitted: in commit mode the agent changed files for the fix but returned
+//    no SHA — its per-fix commit didn't land, breaking "one commit per fix".
+// The edits (when present) stay in the tree, so this is a status downgrade, not a
+// hard abort: the caller reconciles the gap rather than losing a converged debate.
+const applyGaps = []
 if (apply && fixes.length) {
   phase('Apply')
   const res = await agent(applyAllBrief(fixes, commit), { label: 'apply:all', phase: 'Apply', model, schema: APPLY_SCHEMA })
@@ -490,16 +499,34 @@ if (apply && fixes.length) {
   // dropped from its output still surfaces — as 0 files / uncommitted — instead
   // of vanishing from `applied` and the PR comment.
   applied = fixes.map((f) => {
-    const a = byId[f.id] || {}
+    const entry = byId[f.id]
+    const a = entry || {}
     const sha = (a.commit || '').trim()
-    // Mirror codex-debate's mismatch log: surface a fix the agent reported as
-    // changed-but-uncommitted instead of silently recording commit: null.
-    if (!sha && (a.filesChanged ?? []).length > 0) {
-      log(`Apply ${f.id}: agent changed ${a.filesChanged.length} file(s) but returned no commit SHA`)
+    const files = a.filesChanged ?? []
+    if (!entry) {
+      // The agent never reported this agreed fix. We can't confirm it was applied,
+      // so flag it rather than render a phantom 0-file "applied" row as success.
+      applyGaps.push({ id: f.id, reason: 'missing-from-output' })
+      log(`Apply ${f.id}: agreed fix absent from apply-agent output — not confirmed applied`)
+    } else if (commit && !sha && files.length > 0) {
+      // Reported changed-but-uncommitted in commit mode: the per-fix commit the
+      // agent was told to make didn't land. Surface it as a gap, not a clean apply.
+      applyGaps.push({ id: f.id, reason: 'uncommitted' })
+      log(`Apply ${f.id}: agent changed ${files.length} file(s) but returned no commit SHA`)
     }
-    return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
+    return { id: f.id, title: f.title, files, commit: sha || null }
   })
   applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))
+  // A converged debate whose fixes didn't cleanly land is NOT a clean consensus:
+  // downgrade so /be-review (which keys off this status) and the comment don't
+  // advertise success over an unconfirmed/uncommitted fix. Only touch a status
+  // that was otherwise clean ('consensus'/'clean'); 'unresolved' already signals
+  // the human must act.
+  if (applyGaps.length && (status === 'consensus' || status === 'clean')) {
+    const prior = status
+    status = 'apply-incomplete'
+    log(`Apply incomplete: ${applyGaps.map((g) => `${g.id} (${g.reason})`).join(', ')} — downgrading ${prior} to apply-incomplete.`)
+  }
 } else if (fixes.length) {
   log(`Apply skipped (apply: false) — returning ${fixes.length} agreed fix plan(s) to the caller.`)
 }
@@ -512,6 +539,10 @@ return {
   settled: settledOut,
   unresolved,
   applied,
+  // Agreed fixes that didn't cleanly land (missing from the apply output, or
+  // changed-but-uncommitted). Empty unless status is 'apply-incomplete'; lets the
+  // caller pinpoint which fix to reconcile.
+  applyGaps,
   // The agreed `fix` findings with their converged plans — the caller's
   // change-request payload under `apply: false` (redundant with `settled` when
   // the Apply phase ran, but always present so consumers need not re-filter).

--- a/.agents/skills/lens-debate/debate.workflow.js
+++ b/.agents/skills/lens-debate/debate.workflow.js
@@ -1,9 +1,11 @@
 // The Workflow runtime requires `export const meta` to be the FIRST statement
 // and a PURE LITERAL (no variable interpolation), so the primary model is
-// inlined as 'opus' in the phase entries below; commit agents within Apply run
-// on mechModel (haiku). The single `const MODEL` socket lives just after meta —
-// every other model reference in this script reads it lazily at
-// input-resolution time, well after meta is evaluated.
+// inlined as 'opus' in the phase entries below. The only Apply-phase agent is a
+// single `apply:all` on `model` (Opus) that implements and commits each agreed
+// fix in-session. Those inlined 'opus' phase entries plus the `const MODEL`
+// socket just after meta are the model bindings — every other model reference in
+// this script reads MODEL lazily at input-resolution time, well after meta is
+// evaluated.
 export const meta = {
   name: 'lens-debate',
   description:
@@ -60,8 +62,8 @@ const rationale = (a.rationale || '').trim()
 const model = a.model || MODEL
 // Mechanical tier (Haiku). The lenses' reviews + the per-finding debate + applying
 // an agreed fix all do real reasoning → `model` (Opus, load-bearing for the
-// lenses). The merge-base resolver and the per-fix committer are pure git → run
-// them on `mechModel`. Defaults match a direct invocation; /be-review passes it.
+// lenses). The merge-base resolver is pure git → run it on `mechModel`.
+// Defaults match a direct invocation; /be-review passes it.
 const mechModel = a.mechModel || 'haiku'
 // Per-worktree scratch for commit-message files; gitignored so it never shows up
 // in the diff the lenses review, and parallel debates in different worktrees

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -72,8 +72,8 @@ it once per step.
    rendered comment body for be-review to post after the push. Wait for its
    `Workflow` to finish before starting the codex step.
 
-   `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
-   `merge-base-error`:
+   `/lens-debate` returns a `status` of `clean`, `consensus`,
+   `apply-incomplete`, `unresolved`, or `merge-base-error`:
    - `clean` / `consensus` — the lenses agreed per-finding and applied the fixes.
    - `apply-incomplete` — the lenses agreed, but the Apply phase didn't land every
      fix cleanly (see `applyGaps`: a fix was missing from the apply output or
@@ -100,7 +100,8 @@ it once per step.
    consensus to report; skip the codex comment in that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   either in `consensus` or in `reviewer-error` — the latter meaning codex never
+   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
+   last meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
    per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
    outcome*: re-launch it immediately with the same args. Stop the moment an

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -75,6 +75,12 @@ it once per step.
    `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
    `merge-base-error`:
    - `clean` / `consensus` — the lenses agreed per-finding and applied the fixes.
+   - `apply-incomplete` — the lenses agreed, but the Apply phase didn't land every
+     fix cleanly (see `applyGaps`: a fix was missing from the apply output or
+     changed-but-uncommitted). **Reconcile before moving on:** for each gap, apply
+     or commit the outstanding fix yourself (staging only its files), then fold the
+     reconciliation into the deferred lens comment. Never report "lens consensus"
+     for an `apply-incomplete` run.
    - `unresolved` — the debate hit its round backstop with findings still
      contested. `/be` §4 requires you to **adjudicate every unresolved lens
      finding yourself before moving on**: surface them in the report, decide drop
@@ -101,6 +107,14 @@ it once per step.
    attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
    you give up on codex — report the persistent reviewer-error honestly (no false
    consensus comment) and move on to the simplify step.
+
+   **On `commit-incomplete`,** the debate converged but a round's author left its
+   edits uncommitted (round numbers in `commitGaps`). The edits are still in the
+   tree, but the per-round commit didn't land — **commit the outstanding tree
+   yourself** (staging only the files that round changed, message
+   `fix: codex review — debate round N`) before the simplify step, and note the
+   reconciliation in the deferred codex comment. Don't report it as a clean
+   consensus.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -153,12 +153,14 @@ different worktrees never collide** and the scratch never shows up in the diff
 codex reviews. It returns:
 
 ```
-{ status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript,
+{ status: "consensus" | "commit-incomplete" | "reviewer-error",
+  rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
   comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
-(each `transcript[]` round also carries a `commit` SHA when that round committed.)
+(each `transcript[]` round also carries a `commit` SHA when that round committed;
+`commitGaps` lists the round numbers whose author edited files but returned no
+commit SHA — empty unless `status === "commit-incomplete"`.)
 The debate is recorded as **one small Markdown file per round** —
 `<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
 author's cross-round memory** (so each round builds on the last instead of
@@ -175,6 +177,14 @@ warm session, so re-feeding it the sections would just duplicate its context.
   with no round cap and no deadlock exit. (The harness's own
   per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
   a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
+- **commit-incomplete** — the debate *converged* (codex approved, nothing open),
+  but a round's author edited files yet returned **no commit SHA**, so its
+  in-session commit didn't land and the "one commit per round" contract broke for
+  the round(s) in `commitGaps`. The edits are **not lost** — they stay in the
+  working tree and the next reviewer diffs them against the base — but this is
+  **not** a clean consensus: a human must reconcile the uncommitted round(s)
+  (e.g. commit the outstanding tree) before relying on the per-round history. Do
+  **not** report it as a plain consensus (see step 3).
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
@@ -195,6 +205,13 @@ so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
 `codex login`, check the CLI) and re-run. Do **not** post a consensus badge or a
 `## Codex ⇄ Claude debate` PR comment for this path — there is no agreement to
 report. Skip the rest of this section.
+
+If `status === "commit-incomplete"`, the debate converged but at least one round
+left its edits **uncommitted** (the round numbers are in `commitGaps`). Report it
+as **converged-but-not-clean**: post the `comment` (its header already shows a
+`⚠️` badge, not the consensus check), then tell the user which round(s) are
+uncommitted and that the outstanding tree must be committed before the per-round
+history can be trusted. Do **not** call it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -141,9 +141,11 @@ Workflow({
 The workflow runs in the background and notifies you when it completes. It
 alternates `codex:roundN` and `claude:roundN` agents under a **Debate** phase —
 the user can watch live via `/workflows`. Each Claude round edits the working
-tree, then (unless `--no-commit`) a `commit:roundN` agent **commits exactly that
-round's changed files** with a message embedding the round's codex findings and
-Claude's dispositions — never pushing or merging.
+tree and (unless `--no-commit`) **commits exactly that round's changed files in
+the same session** — one commit per round, with a message embedding the round's
+codex findings and Claude's dispositions — never pushing or merging. (The commit
+is no longer a separate `commit:roundN` agent: the author already has the tree
+open, so it commits its own round.)
 
 Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
 gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -38,14 +38,16 @@ const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // deterministic, never re-rendered through an agent (nothing weak ever retypes a
 // large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
 // it the ledger would just duplicate what it already remembers.
-// Commit each round's changes individually (default on). The commit message
-// carries the debate context (codex's findings + claude's dispositions). Never
-// pushes or merges — that stays the human's call.
+// Commit each round's changes individually (default on). The author commits its
+// OWN round in-session — it already edits the tree, so it stages exactly what it
+// changed and writes a message carrying the debate context (codex's findings +
+// its dispositions). Never pushes or merges — that stays the human's call.
 const commit = a.commit !== false
 // Model tiers. The claude-author round does real reasoning (fixing/disputing
-// codex's findings) → `model` (Opus). Everything else here is mechanical — the
-// codex runner just shells out to codex-review.sh and copies the verdict, the
-// committer stages files, the merge-base resolver runs one git command → `mechModel`
+// codex's findings, and committing its own round) → `model` (Opus). Everything
+// else here is mechanical — the codex runner just shells out to codex-review.sh
+// and copies the verdict, the ledger writer dumps a section file, the merge-base
+// resolver runs one git command → `mechModel`
 // (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
@@ -119,6 +121,9 @@ const CLAUDE_RESPONSE_SCHEMA = {
       },
     },
     filesChanged: { type: 'array', items: { type: 'string' } },
+    // The author commits its own round (it already edits the tree), so it returns
+    // the resulting SHA here. "" when it changed nothing or ran under --no-commit.
+    commitSha: { type: 'string' },
     done: { type: 'boolean' },
   },
   required: ['summary', 'actions', 'filesChanged', 'done'],
@@ -166,7 +171,7 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict) {
+async function claudeResponds(round, verdict, doCommit) {
   // WARM AUTHOR. We can't truly resume the Claude author (agent() is one-shot,
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
@@ -196,9 +201,13 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-Edit the working tree only — do NOT git add/commit/push. You may run the formatter on files you touched.
+You may run the formatter on files you touched. ${
+    doCommit
+      ? `Once you've addressed every finding AND you actually changed files, COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
+      : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
+  }
 
-Return: actions (one per finding — findingId, disposition, detail), filesChanged, and done (true once you've addressed every finding this round).`
+Return: actions (one per finding — findingId, disposition, detail), filesChanged, commitSha, and done (true once you've addressed every finding this round).`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -208,70 +217,20 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
   })
 }
 
-// Commit message for one debate round, carrying the debate context: what codex
-// raised and how claude dispositioned each finding. It reuses the same per-bullet
-// projection as the ledger section (findingBullet/actionBullet), in `plain` chrome
-// — no backticks/bold and no `status` field — so the round summary derives from a
-// single rendering rather than two parallel ones.
-function roundCommitMessage(round, verdict, response) {
-  const findings = (verdict.findings || [])
-    .map((f) => findingBullet(f, { plain: true }))
-    .join('\n')
-  const actions = (response.actions || [])
-    .map((a) => actionBullet(a, { plain: true }))
-    .join('\n')
-  return `fix: codex review — debate round ${round}
-
-${response.summary}
-
-codex (round ${round}) findings:
-${findings || '- (none)'}
-
-claude:
-${actions || '- (no actions)'}
-
-Committed by the codex<->claude debate (round ${round}); not pushed or merged.`
-}
-
-// Commit exactly the files claude changed this round, with the debate-context
-// message. A thin mechanical agent: the workflow can't run git itself.
-async function commitRound(round, files, message) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workDir}/commit-msg-${round}.txt`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
-
-${message}
-
-3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
-   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
-   Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `commit:round${round}`, phase: 'Debate', model: mechModel })
-}
-
 // ---------------------------------------------------------------------------
 // The shared ledger — rendered from the transcript, deterministically
 // ---------------------------------------------------------------------------
-// One codex finding as a Markdown bullet. The single projection of a finding's
-// fields, shared by the ledger section and the round commit message. `plain` drops
-// the ledger chrome (backticks + the `status` field) for the commit message, which
-// wants plainer text; the field access stays in one place either way.
-function findingBullet(f, { plain = false } = {}) {
-  return plain
-    ? `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`
-    : `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
+// One codex finding as a Markdown bullet — the single projection of a finding's
+// fields for the ledger section. (The per-round commit message is now written by
+// the author itself, in its own session, so this no longer feeds it.)
+function findingBullet(f) {
+  return `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
 }
 
-// One author disposition as a Markdown bullet. The single projection of an action's
-// fields, shared by the ledger section and the round commit message. `plain` drops
-// the ledger chrome (backticks + bold) for the commit message.
-function actionBullet(a, { plain = false } = {}) {
-  return plain
-    ? `- ${a.findingId} ${a.disposition}: ${a.detail}`
-    : `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
+// One author disposition as a Markdown bullet — the single projection of an
+// action's fields for the ledger section.
+function actionBullet(a) {
+  return `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
 }
 
 // One round's findings, as a Markdown list. Shared by the section renderer below.
@@ -412,8 +371,8 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // thin mechanical agent (the workflow can't run shell itself). The reset is
 // section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
 // whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
-// commit-msg-N.txt) keep their own lifecycle and a future pre-loop writer won't
-// be silently wiped. This script has no true resume (agent() is one-shot, the
+// and any commit-message file the author writes) keep their own lifecycle and a
+// future pre-loop writer won't be silently wiped. This script has no true resume (agent() is one-shot, the
 // whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
 await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
@@ -462,20 +421,21 @@ for (let round = 1; ; round++) {
   // rest. It reads the per-round section files (written at the end of each round
   // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
   // rebuttal next round (see codexReviews) — it is no longer the author's memory.
-  const response = await claudeResponds(round, verdict)
+  const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
   lastClaude = response
   log(
     `Round ${round}: claude done=${response.done}, actions=${(response.actions || []).length}, files=${(response.filesChanged || []).length}`,
   )
 
-  // Commit this round individually so the PR history reads as the debate
-  // itself — one commit per round, message carrying codex's findings and
-  // claude's dispositions. Only when claude actually changed files.
+  // The author commits its own round in-session (one commit per round, message
+  // carrying codex's findings and its dispositions), so here we just record the
+  // SHA it returned. Only when it actually changed files; flag the inconsistency
+  // if it reported changes but no commit rather than silently dropping it.
   if (commit && (response.filesChanged || []).length > 0) {
-    const sha = await commitRound(round, response.filesChanged, roundCommitMessage(round, verdict, response))
-    entry.commit = (sha || '').trim()
-    log(`Round ${round}: committed ${entry.commit}`)
+    entry.commit = (response.commitSha || '').trim()
+    if (entry.commit) log(`Round ${round}: committed ${entry.commit}`)
+    else log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA`)
   }
 
   // Write this round's section so the NEXT round's author can read the full

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -324,6 +324,14 @@ const transcript = []
 let status = 'consensus'
 let finalVerdict = null
 let lastClaude = null
+// Rounds where the author edited files (commit mode on) but returned no SHA —
+// the in-session commit it was told to make didn't land. The edits aren't lost
+// (they stay in the tree and the next reviewer still diffs them against base),
+// but the "one commit per round" contract was broken for that round, so the run
+// is NOT a clean consensus: we downgrade the terminal status below rather than
+// report success over a missed commit. Not a hard abort: a transient SHA omission
+// shouldn't nuke a multi-round debate whose edits are all present in the tree.
+const commitGaps = []
 
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
@@ -434,8 +442,16 @@ for (let round = 1; ; round++) {
   // if it reported changes but no commit rather than silently dropping it.
   if (commit && (response.filesChanged || []).length > 0) {
     entry.commit = (response.commitSha || '').trim()
-    if (entry.commit) log(`Round ${round}: committed ${entry.commit}`)
-    else log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA`)
+    if (entry.commit) {
+      log(`Round ${round}: committed ${entry.commit}`)
+    } else {
+      // The author edited the tree but didn't return a SHA: its in-session commit
+      // didn't land. Record the gap so the terminal status reflects it instead of
+      // reporting a clean consensus over a round that broke the one-commit-per-round
+      // contract. The edits themselves remain in the tree for the next reviewer.
+      commitGaps.push(round)
+      log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA — round left uncommitted`)
+    }
   }
 
   // Write this round's section so the NEXT round's author can read the full
@@ -447,6 +463,20 @@ for (let round = 1; ; round++) {
 const filesChanged = Array.from(
   new Set(transcript.flatMap((e) => (e.claude && e.claude.filesChanged) || [])),
 )
+
+// Downgrade a would-be consensus when any round's in-session commit didn't land.
+// The debate may have converged (codex approved, nothing open), but with the
+// "one commit per round" contract broken we must NOT advertise a clean consensus:
+// /be-review keys off this status (and the SKILL's status table) to decide whether
+// the step settled cleanly. 'commit-incomplete' is a distinct, non-consensus
+// terminus — the edits are all in the tree (the next reviewer diffs them), but a
+// human/caller must reconcile the uncommitted round(s). We don't touch a status
+// that's already abnormal (reviewer-error), which is strictly more severe.
+if (status === 'consensus' && commitGaps.length) {
+  status = 'commit-incomplete'
+  log(`Round(s) ${commitGaps.join(', ')} left uncommitted despite changing files — downgrading consensus to commit-incomplete.`)
+}
+
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
 // Section the terminal round — it broke out of the loop before the in-loop
@@ -467,6 +497,9 @@ return {
   base,
   finalVerdict,
   filesChanged,
+  // Rounds whose author-side commit didn't land (empty unless status is
+  // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
+  commitGaps,
   transcript,
   comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
 }

--- a/.apm/skills/lens-debate/SKILL.md
+++ b/.apm/skills/lens-debate/SKILL.md
@@ -207,7 +207,7 @@ branch for the human to review):
   `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never hit commitFix, so the dir may not exist yet
+  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never run the Apply commit step, so the dir may not exist yet
   printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
   gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
   ```

--- a/.apm/skills/lens-debate/SKILL.md
+++ b/.apm/skills/lens-debate/SKILL.md
@@ -157,10 +157,12 @@ three phases the user can watch via `/workflows`:
   means both lenses agree on the disposition *and* the plan — if they both say
   `fix` but propose different changes, the finding stays open until the plans
   converge too (so Apply never picks one lens's plan arbitrarily).
-- **Apply** — one `apply:<finding-id>` per agreed `fix`, each followed (unless
-  `--no-commit`) by a `commit:<finding-id>` that commits **exactly** that fix's
-  changed files with a message carrying the debate context. Skipped wholesale
-  under `--no-apply` — the plans come back in `fixes` for the caller to apply.
+- **Apply** — a single `apply:all` agent implements **every** agreed `fix` in one
+  session and (unless `--no-commit`) commits each one individually, staging
+  **exactly** that fix's changed files with a message carrying the debate context.
+  One orientation for all fixes instead of a fresh implement+commit agent per
+  finding. Skipped wholesale under `--no-apply` — the plans come back in `fixes`
+  for the caller to apply.
 
 When `rationale` is set, pull it from the PR/issue description (the deliberate
 design decisions the author wants the lenses to respect, e.g. a deliberate
@@ -222,7 +224,8 @@ branch for the human to review):
 
 - **The lenses are read-only reviewers; only the Apply phase writes.** lowy and
   hickey never edit code — they only emit dispositions. The sole writes to the
-  tree come from the `apply:` agents implementing the *agreed* fixes.
+  tree come from the single `apply:all` agent implementing the *agreed* fixes
+  (one session, one commit per finding) — not one agent per fix.
 - **Commits, but never pushes or merges.** Each agreed fix is committed locally
   (unless `--no-commit`) so the PR history reads as the debate's conclusions, but
   the skill never pushes or merges. Consensus means "both lenses agree on the

--- a/.apm/skills/lens-debate/SKILL.md
+++ b/.apm/skills/lens-debate/SKILL.md
@@ -173,11 +173,12 @@ Ephemeral scratch (commit-message files) lives under the gitignored, per-worktre
 collide and the scratch never shows up in the diff the lenses review. It returns:
 
 ```
-{ status: "consensus" | "unresolved" | "clean",
+{ status: "consensus" | "apply-incomplete" | "unresolved" | "clean",
   rounds, base, withPolice,
   settled,     // per-finding: id, origin, title, location, agreed disposition, plan, both reasonings
   unresolved,  // findings still contested at the backstop (empty on consensus)
   applied,     // [{ id, title, files, commit }] (empty under --no-apply)
+  applyGaps,   // [{ id, reason }] agreed fixes that didn't cleanly land — empty unless status is "apply-incomplete"
   fixes,       // the agreed `fix` findings with converged plans — the caller's change requests under --no-apply
   reviews,     // each lens's independent findings
   history,     // per-round dispositions
@@ -186,6 +187,14 @@ collide and the scratch never shows up in the diff the lenses review. It returns
 
 - **consensus** — every finding settled (the normal outcome).
 - **clean** — every lens found nothing worth raising.
+- **apply-incomplete** — the lenses *converged*, but the Apply phase didn't land
+  every agreed fix cleanly: a fix was **missing from the apply agent's output**
+  (so we can't confirm it was applied) or, in commit mode, was **changed but
+  returned no commit SHA** (its per-fix commit didn't land). The offending fixes
+  are in `applyGaps`. Any edits present stay in the working tree, but this is
+  **not** a clean consensus — surface the gap and reconcile it (re-apply or commit
+  the outstanding fix) before relying on the per-fix history. Do **not** report it
+  as a plain consensus.
 - **unresolved** — the backstop was hit with findings still contested. Rare;
   needs a human. This is NOT a deadlock — the lenses simply didn't converge in
   the round budget; raise `--max-rounds` or adjudicate the listed findings.

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -492,6 +492,11 @@ if (apply && fixes.length) {
   applied = fixes.map((f) => {
     const a = byId[f.id] || {}
     const sha = (a.commit || '').trim()
+    // Mirror codex-debate's mismatch log: surface a fix the agent reported as
+    // changed-but-uncommitted instead of silently recording commit: null.
+    if (!sha && (a.filesChanged ?? []).length > 0) {
+      log(`Apply ${f.id}: agent changed ${a.filesChanged.length} file(s) but returned no commit SHA`)
+    }
     return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
   })
   applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -179,13 +179,30 @@ const POSITION_SCHEMA = {
   },
 }
 
-const IMPL_SCHEMA = {
+// One Apply agent implements every agreed fix and commits each in a single
+// session, so it returns the full per-fix outcome (not one impl per agent). One
+// entry per fix it was handed; `commit` is "" under `--no-commit` or when a fix
+// turned out to need no change.
+const APPLY_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['summary', 'filesChanged'],
+  required: ['applied'],
   properties: {
-    summary: { type: 'string', description: 'one line: what you changed' },
-    filesChanged: { type: 'array', items: { type: 'string' } },
+    applied: {
+      type: 'array',
+      description: 'one entry for EVERY agreed fix you were given, in the same order',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'summary', 'filesChanged'],
+        properties: {
+          id: { type: 'string' },
+          summary: { type: 'string', description: 'one line: what you changed for this fix' },
+          filesChanged: { type: 'array', items: { type: 'string' } },
+          commit: { type: 'string', description: 'this fix\'s commit SHA, or "" if nothing was committed' },
+        },
+      },
+    },
   },
 }
 
@@ -222,47 +239,48 @@ ${oppBlock}
 Round ${roundNum}. For EVERY contested finding id above, output a disposition (\`fix\` = worth changing in THIS PR / \`drop\` = leave as-is, observation only), a concrete implementable plan if \`fix\`, and reasoning grounded in the code. **The goal is the correct answer for THIS PR, not winning** — concede explicitly ("conceding: …") when ${opp}'s code-grounded argument is right. A \`fix\` is worth it only if it genuinely improves the PR.`
 }
 
-function implementBrief(fix) {
-  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\`.
+// ONE brief for ALL agreed fixes — implemented and committed in a single Apply
+// session, so the agent orients on the repo once instead of paying that cost per
+// fix (the old form spawned an implement agent AND a commit agent per finding,
+// serially). The fixes are independent and their plans already converged in the
+// debate, so there's no cross-fix reasoning to isolate; what we keep is one
+// commit PER finding so the history still reads finding-by-finding.
+function applyAllBrief(fixes, doCommit) {
+  const list = fixes
+    .map(
+      (f) => `### ${f.id} (raised by ${f.origin}) — ${f.title}
+  at ${f.location}
+  problem: ${f.problem}
+  original suggestion (context, not the agreed plan): ${f.suggestion}
+  agreed plan: ${f.plan}`,
+    )
+    .join('\n\n')
+  const commitStep = doCommit
+    ? `After a fix's edits are done, COMMIT that fix on its own before moving to the next, so each finding maps to one commit and the history reads finding-by-finding. Stage ONLY the files you changed for that fix — never \`git add -A\` or \`git add .\`. Write the message to a file under \`${workDir}\` (run \`mkdir -p ${workDir}\` first) and commit with \`git -C ${repoPath} add -- <files> && git -C ${repoPath} commit -F <msgfile>\`, using EXACTLY this message shape:
 
-Finding ${fix.id} (raised by ${fix.origin}) — ${fix.title}
-  at ${fix.location}
-  problem: ${fix.problem}
-  original suggestion (context, not the agreed plan): ${fix.suggestion}
-  agreed plan: ${fix.plan}
+  fix(lens): <the fix's title>
 
-Make ONLY this change in the working tree, following the agreed plan above. Keep it tightly scoped to the finding; read the surrounding code first so the edit fits the existing style. Do NOT git add / commit / push. You may run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`
+  <your one-line summary of the change>
+
+  Agreed by the lowy ⇄ hickey lens debate (finding <id>, raised by <origin>). Not pushed or merged.
+
+Do NOT push. Record each fix's resulting commit SHA (\`git -C ${repoPath} rev-parse HEAD\`) in its \`commit\` field. If a fix turns out to need no change, leave its \`filesChanged\` empty and its \`commit\` "".`
+    : `Do NOT git add / commit / push — leave every change in the working tree and set each fix's \`commit\` to "".`
+  return `You are implementing the changes that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`.
+
+Apply each agreed fix below, IN ORDER. The fixes are independent — keep each one tightly scoped to its finding and don't let one bleed into another. Read the surrounding code first so each edit fits the existing style. You may run the project's formatter on files you touched.
+
+${list}
+
+${commitStep}
+
+Return one \`applied\` entry per fix (same order): its id, a one-line summary, the exact files you changed, and the commit SHA (or "").`
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 const posMap = (res) => Object.fromEntries((res?.positions ?? []).map((p) => [p.id, p]))
-
-// Commit exactly the files one fix changed, with a message carrying the debate
-// context. A thin mechanical agent: the workflow can't run git itself.
-async function commitFix(fix, files, summary) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workDir}/commit-msg-${fix.id}.txt`
-  // `fix(lens):` — the conventional prefix for lens-originated commits.
-  const message = `fix(lens): ${fix.title}
-
-${summary}
-
-Agreed by the lowy ⇄ hickey lens debate (finding ${fix.id}, raised by ${fix.origin}). Not pushed or merged.`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
-
-${message}
-
-3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
-   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
-   Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply', model: mechModel })
-}
 
 // Render the PR comment deterministically from the debate outcome, returned as a
 // string so the ORCHESTRATOR posts it verbatim (`gh pr comment -F`) — no agent
@@ -452,25 +470,29 @@ const unresolved = settledOut.filter((s) => !s.agreed)
 log(`Debate ended: ${status} after ${rounds} round(s); ${settledOut.length - unresolved.length}/${settledOut.length} settled, ${unresolved.length} unresolved.`)
 
 // ---------------------------------------------------------------------------
-// Phase 3 — apply the agreed `fix` findings, each as its own commit. Skipped
-// wholesale under `apply: false`: the agreed plans are returned in `fixes` for
-// the caller to implement against whatever tree it chooses.
+// Phase 3 — apply every agreed `fix` finding in a SINGLE session, one commit
+// per finding. One agent orients on the repo once and applies all the fixes,
+// rather than paying a fresh implement+commit agent (and its re-orientation
+// cost) per finding; the fixes are independent and their plans already
+// converged, so there's no cross-fix reasoning to isolate. Skipped wholesale
+// under `apply: false`: the agreed plans are returned in `fixes` for the caller
+// to implement against whatever tree it chooses.
 // ---------------------------------------------------------------------------
 const fixes = settledOut.filter((s) => s.agreed && s.disposition === 'fix')
-const applied = []
-if (apply) {
+let applied = []
+if (apply && fixes.length) {
   phase('Apply')
-  for (const fix of fixes) {
-    const impl = await agent(implementBrief(fix), { label: `apply:${fix.id}`, phase: 'Apply', model, schema: IMPL_SCHEMA })
-    const files = impl?.filesChanged ?? []
-    let sha = null
-    if (commit && files.length > 0) {
-      const out = await commitFix(fix, files, impl.summary)
-      sha = (out || '').trim()
-    }
-    applied.push({ id: fix.id, title: fix.title, files, commit: sha })
-    log(`Applied ${fix.id}: ${files.length} file(s)${sha ? `, committed ${sha.slice(0, 9)}` : ' (uncommitted)'}`)
-  }
+  const res = await agent(applyAllBrief(fixes, commit), { label: 'apply:all', phase: 'Apply', model, schema: APPLY_SCHEMA })
+  const byId = Object.fromEntries((res?.applied ?? []).map((a) => [a.id, a]))
+  // Re-key off the agreed `fixes` (not the agent's array) so a fix the agent
+  // dropped from its output still surfaces — as 0 files / uncommitted — instead
+  // of vanishing from `applied` and the PR comment.
+  applied = fixes.map((f) => {
+    const a = byId[f.id] || {}
+    const sha = (a.commit || '').trim()
+    return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
+  })
+  applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))
 } else if (fixes.length) {
   log(`Apply skipped (apply: false) — returning ${fixes.length} agreed fix plan(s) to the caller.`)
 }

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -302,12 +302,20 @@ const posMap = (res) => Object.fromEntries((res?.positions ?? []).map((p) => [p.
 // { kind: 'handed-off', items } when apply:false returned the plans to the
 // caller — one param, so "at most one of applied/handed-off" holds by
 // construction instead of by convention.
-function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, withPolice, base, clean }) {
-  const badge = clean
-    ? '✅ **Clean** — every lens found nothing worth raising'
-    : unresolved.length === 0
-      ? '✅ **Consensus**'
-      : `⚠️ **${unresolved.length} unresolved**`
+// `applyGaps` (agreed fixes the Apply phase did not cleanly land) is rendered
+// HERE, not just in the machine `status`: the SKILL posts this comment verbatim,
+// so an apply-incomplete run must surface a warning badge and a dedicated gap
+// section instead of advertising `✅ Consensus` and listing the gapped fix as
+// `Applied`. Keep this consistent with the status downgrade in Phase 3.
+function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, withPolice, base, clean, applyGaps = [] }) {
+  const gapIds = new Set(applyGaps.map((g) => g.id))
+  const badge = applyGaps.length
+    ? `⚠️ **Apply incomplete** — ${applyGaps.length} agreed fix(es) not cleanly applied`
+    : clean
+      ? '✅ **Clean** — every lens found nothing worth raising'
+      : unresolved.length === 0
+        ? '✅ **Consensus**'
+        : `⚠️ **${unresolved.length} unresolved**`
   const counts = Object.entries(reviewByLens)
     .map(([lens, fs]) => `${lens}=${fs.length}`)
     .join(', ')
@@ -323,9 +331,25 @@ function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, 
     `Independent findings: ${counts}`,
   ]
   const drops = settledOut.filter((s) => s.agreed && s.disposition === 'drop')
-  if (outcome.kind === 'applied' && outcome.items.length) {
-    lines.push('', `### Applied (${outcome.items.length})`)
-    outcome.items.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+  if (outcome.kind === 'applied') {
+    // Only CLEANLY-landed fixes go under `Applied`; a fix in `applyGaps` (missing
+    // from the apply output, or changed-but-uncommitted) is NOT applied work and
+    // must not be advertised as such under what would otherwise be a consensus
+    // badge — it gets its own gap section below.
+    const cleanlyApplied = outcome.items.filter((a) => !gapIds.has(a.id))
+    if (cleanlyApplied.length) {
+      lines.push('', `### Applied (${cleanlyApplied.length})`)
+      cleanlyApplied.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+    }
+    if (applyGaps.length) {
+      lines.push('', `### Apply incomplete — needs reconcile (${applyGaps.length})`)
+      const reasonText = { 'missing-from-output': 'not confirmed applied (absent from apply output)', uncommitted: 'changed but not committed (per-fix commit missing)' }
+      applyGaps.forEach((g) => {
+        const item = outcome.items.find((a) => a.id === g.id)
+        const title = item?.title ? ` ${item.title}` : ''
+        lines.push(`- \`${g.id}\`${title} — ${reasonText[g.reason] ?? g.reason}`)
+      })
+    }
   }
   // apply:false runs hand the agreed plans to the caller instead of implementing
   // them; the comment records the handoff so the trail still shows what was agreed
@@ -549,5 +573,5 @@ return {
   fixes,
   reviews: reviewByLens,
   history,
-  comment: renderComment({ rounds, settledOut, unresolved, outcome: apply ? { kind: 'applied', items: applied } : { kind: 'handed-off', items: fixes }, reviewByLens, withPolice, base }),
+  comment: renderComment({ rounds, settledOut, unresolved, outcome: apply ? { kind: 'applied', items: applied } : { kind: 'handed-off', items: fixes }, reviewByLens, withPolice, base, applyGaps }),
 }

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -90,7 +90,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // The result shape's empty collections, shared by the two EARLY returns
 // (merge-base-error, clean) so adding a result field is one edit, not a mirror
 // edit per return site. The final return carries real values and stays literal.
-const EMPTY_RESULT = { settled: [], unresolved: [], applied: [], fixes: [], reviews: {}, history: [] }
+const EMPTY_RESULT = { settled: [], unresolved: [], applied: [], applyGaps: [], fixes: [], reviews: {}, history: [] }
 
 // Resolve the diff base to the merge-base of (base, HEAD) BEFORE building DIFF
 // (which interpolates `base` eagerly), so the lenses review only what this branch
@@ -482,6 +482,15 @@ log(`Debate ended: ${status} after ${rounds} round(s); ${settledOut.length - unr
 // ---------------------------------------------------------------------------
 const fixes = settledOut.filter((s) => s.agreed && s.disposition === 'fix')
 let applied = []
+// Agreed fixes the Apply phase did not cleanly land. Two failure shapes, both of
+// which would otherwise be rendered as "applied" and reported under a consensus:
+//  - missing: the agent dropped the fix from its output entirely (no entry, no
+//    files) — we can't tell if it was applied, so it must not be reported as done.
+//  - uncommitted: in commit mode the agent changed files for the fix but returned
+//    no SHA — its per-fix commit didn't land, breaking "one commit per fix".
+// The edits (when present) stay in the tree, so this is a status downgrade, not a
+// hard abort: the caller reconciles the gap rather than losing a converged debate.
+const applyGaps = []
 if (apply && fixes.length) {
   phase('Apply')
   const res = await agent(applyAllBrief(fixes, commit), { label: 'apply:all', phase: 'Apply', model, schema: APPLY_SCHEMA })
@@ -490,16 +499,34 @@ if (apply && fixes.length) {
   // dropped from its output still surfaces — as 0 files / uncommitted — instead
   // of vanishing from `applied` and the PR comment.
   applied = fixes.map((f) => {
-    const a = byId[f.id] || {}
+    const entry = byId[f.id]
+    const a = entry || {}
     const sha = (a.commit || '').trim()
-    // Mirror codex-debate's mismatch log: surface a fix the agent reported as
-    // changed-but-uncommitted instead of silently recording commit: null.
-    if (!sha && (a.filesChanged ?? []).length > 0) {
-      log(`Apply ${f.id}: agent changed ${a.filesChanged.length} file(s) but returned no commit SHA`)
+    const files = a.filesChanged ?? []
+    if (!entry) {
+      // The agent never reported this agreed fix. We can't confirm it was applied,
+      // so flag it rather than render a phantom 0-file "applied" row as success.
+      applyGaps.push({ id: f.id, reason: 'missing-from-output' })
+      log(`Apply ${f.id}: agreed fix absent from apply-agent output — not confirmed applied`)
+    } else if (commit && !sha && files.length > 0) {
+      // Reported changed-but-uncommitted in commit mode: the per-fix commit the
+      // agent was told to make didn't land. Surface it as a gap, not a clean apply.
+      applyGaps.push({ id: f.id, reason: 'uncommitted' })
+      log(`Apply ${f.id}: agent changed ${files.length} file(s) but returned no commit SHA`)
     }
-    return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
+    return { id: f.id, title: f.title, files, commit: sha || null }
   })
   applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))
+  // A converged debate whose fixes didn't cleanly land is NOT a clean consensus:
+  // downgrade so /be-review (which keys off this status) and the comment don't
+  // advertise success over an unconfirmed/uncommitted fix. Only touch a status
+  // that was otherwise clean ('consensus'/'clean'); 'unresolved' already signals
+  // the human must act.
+  if (applyGaps.length && (status === 'consensus' || status === 'clean')) {
+    const prior = status
+    status = 'apply-incomplete'
+    log(`Apply incomplete: ${applyGaps.map((g) => `${g.id} (${g.reason})`).join(', ')} — downgrading ${prior} to apply-incomplete.`)
+  }
 } else if (fixes.length) {
   log(`Apply skipped (apply: false) — returning ${fixes.length} agreed fix plan(s) to the caller.`)
 }
@@ -512,6 +539,10 @@ return {
   settled: settledOut,
   unresolved,
   applied,
+  // Agreed fixes that didn't cleanly land (missing from the apply output, or
+  // changed-but-uncommitted). Empty unless status is 'apply-incomplete'; lets the
+  // caller pinpoint which fix to reconcile.
+  applyGaps,
   // The agreed `fix` findings with their converged plans — the caller's
   // change-request payload under `apply: false` (redundant with `settled` when
   // the Apply phase ran, but always present so consumers need not re-filter).

--- a/.apm/skills/lens-debate/debate.workflow.js
+++ b/.apm/skills/lens-debate/debate.workflow.js
@@ -1,9 +1,11 @@
 // The Workflow runtime requires `export const meta` to be the FIRST statement
 // and a PURE LITERAL (no variable interpolation), so the primary model is
-// inlined as 'opus' in the phase entries below; commit agents within Apply run
-// on mechModel (haiku). The single `const MODEL` socket lives just after meta —
-// every other model reference in this script reads it lazily at
-// input-resolution time, well after meta is evaluated.
+// inlined as 'opus' in the phase entries below. The only Apply-phase agent is a
+// single `apply:all` on `model` (Opus) that implements and commits each agreed
+// fix in-session. Those inlined 'opus' phase entries plus the `const MODEL`
+// socket just after meta are the model bindings — every other model reference in
+// this script reads MODEL lazily at input-resolution time, well after meta is
+// evaluated.
 export const meta = {
   name: 'lens-debate',
   description:
@@ -60,8 +62,8 @@ const rationale = (a.rationale || '').trim()
 const model = a.model || MODEL
 // Mechanical tier (Haiku). The lenses' reviews + the per-finding debate + applying
 // an agreed fix all do real reasoning → `model` (Opus, load-bearing for the
-// lenses). The merge-base resolver and the per-fix committer are pure git → run
-// them on `mechModel`. Defaults match a direct invocation; /be-review passes it.
+// lenses). The merge-base resolver is pure git → run it on `mechModel`.
+// Defaults match a direct invocation; /be-review passes it.
 const mechModel = a.mechModel || 'haiku'
 // Per-worktree scratch for commit-message files; gitignored so it never shows up
 // in the diff the lenses review, and parallel debates in different worktrees

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -72,8 +72,8 @@ it once per step.
    rendered comment body for be-review to post after the push. Wait for its
    `Workflow` to finish before starting the codex step.
 
-   `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
-   `merge-base-error`:
+   `/lens-debate` returns a `status` of `clean`, `consensus`,
+   `apply-incomplete`, `unresolved`, or `merge-base-error`:
    - `clean` / `consensus` — the lenses agreed per-finding and applied the fixes.
    - `apply-incomplete` — the lenses agreed, but the Apply phase didn't land every
      fix cleanly (see `applyGaps`: a fix was missing from the apply output or
@@ -100,7 +100,8 @@ it once per step.
    consensus to report; skip the codex comment in that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   either in `consensus` or in `reviewer-error` — the latter meaning codex never
+   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
+   last meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
    per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
    outcome*: re-launch it immediately with the same args. Stop the moment an

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -75,6 +75,12 @@ it once per step.
    `/lens-debate` returns a `status` of `clean`, `consensus`, `unresolved`, or
    `merge-base-error`:
    - `clean` / `consensus` — the lenses agreed per-finding and applied the fixes.
+   - `apply-incomplete` — the lenses agreed, but the Apply phase didn't land every
+     fix cleanly (see `applyGaps`: a fix was missing from the apply output or
+     changed-but-uncommitted). **Reconcile before moving on:** for each gap, apply
+     or commit the outstanding fix yourself (staging only its files), then fold the
+     reconciliation into the deferred lens comment. Never report "lens consensus"
+     for an `apply-incomplete` run.
    - `unresolved` — the debate hit its round backstop with findings still
      contested. `/be` §4 requires you to **adjudicate every unresolved lens
      finding yourself before moving on**: surface them in the report, decide drop
@@ -101,6 +107,14 @@ it once per step.
    attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
    you give up on codex — report the persistent reviewer-error honestly (no false
    consensus comment) and move on to the simplify step.
+
+   **On `commit-incomplete`,** the debate converged but a round's author left its
+   edits uncommitted (round numbers in `commitGaps`). The edits are still in the
+   tree, but the per-round commit didn't land — **commit the outstanding tree
+   yourself** (staging only the files that round changed, message
+   `fix: codex review — debate round N`) before the simplify step, and note the
+   reconciliation in the deferred codex comment. Don't report it as a clean
+   consensus.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -153,12 +153,14 @@ different worktrees never collide** and the scratch never shows up in the diff
 codex reviews. It returns:
 
 ```
-{ status: "consensus" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, transcript,
+{ status: "consensus" | "commit-incomplete" | "reviewer-error",
+  rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
   comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
 ```
 
-(each `transcript[]` round also carries a `commit` SHA when that round committed.)
+(each `transcript[]` round also carries a `commit` SHA when that round committed;
+`commitGaps` lists the round numbers whose author edited files but returned no
+commit SHA — empty unless `status === "commit-incomplete"`.)
 The debate is recorded as **one small Markdown file per round** —
 `<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
 author's cross-round memory** (so each round builds on the last instead of
@@ -175,6 +177,14 @@ warm session, so re-feeding it the sections would just duplicate its context.
   with no round cap and no deadlock exit. (The harness's own
   per-workflow agent backstop is the sole hard ceiling; if you ever need to stop
   a debate by hand, interrupt it via `/workflows` or `TaskStop`.)
+- **commit-incomplete** — the debate *converged* (codex approved, nothing open),
+  but a round's author edited files yet returned **no commit SHA**, so its
+  in-session commit didn't land and the "one commit per round" contract broke for
+  the round(s) in `commitGaps`. The edits are **not lost** — they stay in the
+  working tree and the next reviewer diffs them against the base — but this is
+  **not** a clean consensus: a human must reconcile the uncommitted round(s)
+  (e.g. commit the outstanding tree) before relying on the per-round history. Do
+  **not** report it as a plain consensus (see step 3).
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
@@ -195,6 +205,13 @@ so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
 `codex login`, check the CLI) and re-run. Do **not** post a consensus badge or a
 `## Codex ⇄ Claude debate` PR comment for this path — there is no agreement to
 report. Skip the rest of this section.
+
+If `status === "commit-incomplete"`, the debate converged but at least one round
+left its edits **uncommitted** (the round numbers are in `commitGaps`). Report it
+as **converged-but-not-clean**: post the `comment` (its header already shows a
+`⚠️` badge, not the consensus check), then tell the user which round(s) are
+uncommitted and that the outstanding tree must be committed before the per-round
+history can be trusted. Do **not** call it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -141,9 +141,11 @@ Workflow({
 The workflow runs in the background and notifies you when it completes. It
 alternates `codex:roundN` and `claude:roundN` agents under a **Debate** phase —
 the user can watch live via `/workflows`. Each Claude round edits the working
-tree, then (unless `--no-commit`) a `commit:roundN` agent **commits exactly that
-round's changed files** with a message embedding the round's codex findings and
-Claude's dispositions — never pushing or merging.
+tree and (unless `--no-commit`) **commits exactly that round's changed files in
+the same session** — one commit per round, with a message embedding the round's
+codex findings and Claude's dispositions — never pushing or merging. (The commit
+is no longer a separate `commit:roundN` agent: the author already has the tree
+open, so it commits its own round.)
 
 Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
 gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -38,14 +38,16 @@ const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
 // deterministic, never re-rendered through an agent (nothing weak ever retypes a
 // large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
 // it the ledger would just duplicate what it already remembers.
-// Commit each round's changes individually (default on). The commit message
-// carries the debate context (codex's findings + claude's dispositions). Never
-// pushes or merges — that stays the human's call.
+// Commit each round's changes individually (default on). The author commits its
+// OWN round in-session — it already edits the tree, so it stages exactly what it
+// changed and writes a message carrying the debate context (codex's findings +
+// its dispositions). Never pushes or merges — that stays the human's call.
 const commit = a.commit !== false
 // Model tiers. The claude-author round does real reasoning (fixing/disputing
-// codex's findings) → `model` (Opus). Everything else here is mechanical — the
-// codex runner just shells out to codex-review.sh and copies the verdict, the
-// committer stages files, the merge-base resolver runs one git command → `mechModel`
+// codex's findings, and committing its own round) → `model` (Opus). Everything
+// else here is mechanical — the codex runner just shells out to codex-review.sh
+// and copies the verdict, the ledger writer dumps a section file, the merge-base
+// resolver runs one git command → `mechModel`
 // (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
@@ -119,6 +121,9 @@ const CLAUDE_RESPONSE_SCHEMA = {
       },
     },
     filesChanged: { type: 'array', items: { type: 'string' } },
+    // The author commits its own round (it already edits the tree), so it returns
+    // the resulting SHA here. "" when it changed nothing or ran under --no-commit.
+    commitSha: { type: 'string' },
     done: { type: 'boolean' },
   },
   required: ['summary', 'actions', 'filesChanged', 'done'],
@@ -166,7 +171,7 @@ ${rebuttalStep}
   })
 }
 
-async function claudeResponds(round, verdict) {
+async function claudeResponds(round, verdict, doCommit) {
   // WARM AUTHOR. We can't truly resume the Claude author (agent() is one-shot,
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
@@ -196,9 +201,13 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-Edit the working tree only — do NOT git add/commit/push. You may run the formatter on files you touched.
+You may run the formatter on files you touched. ${
+    doCommit
+      ? `Once you've addressed every finding AND you actually changed files, COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
+      : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
+  }
 
-Return: actions (one per finding — findingId, disposition, detail), filesChanged, and done (true once you've addressed every finding this round).`
+Return: actions (one per finding — findingId, disposition, detail), filesChanged, commitSha, and done (true once you've addressed every finding this round).`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -208,70 +217,20 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
   })
 }
 
-// Commit message for one debate round, carrying the debate context: what codex
-// raised and how claude dispositioned each finding. It reuses the same per-bullet
-// projection as the ledger section (findingBullet/actionBullet), in `plain` chrome
-// — no backticks/bold and no `status` field — so the round summary derives from a
-// single rendering rather than two parallel ones.
-function roundCommitMessage(round, verdict, response) {
-  const findings = (verdict.findings || [])
-    .map((f) => findingBullet(f, { plain: true }))
-    .join('\n')
-  const actions = (response.actions || [])
-    .map((a) => actionBullet(a, { plain: true }))
-    .join('\n')
-  return `fix: codex review — debate round ${round}
-
-${response.summary}
-
-codex (round ${round}) findings:
-${findings || '- (none)'}
-
-claude:
-${actions || '- (no actions)'}
-
-Committed by the codex<->claude debate (round ${round}); not pushed or merged.`
-}
-
-// Commit exactly the files claude changed this round, with the debate-context
-// message. A thin mechanical agent: the workflow can't run git itself.
-async function commitRound(round, files, message) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workDir}/commit-msg-${round}.txt`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
-
-${message}
-
-3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
-   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
-   Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `commit:round${round}`, phase: 'Debate', model: mechModel })
-}
-
 // ---------------------------------------------------------------------------
 // The shared ledger — rendered from the transcript, deterministically
 // ---------------------------------------------------------------------------
-// One codex finding as a Markdown bullet. The single projection of a finding's
-// fields, shared by the ledger section and the round commit message. `plain` drops
-// the ledger chrome (backticks + the `status` field) for the commit message, which
-// wants plainer text; the field access stays in one place either way.
-function findingBullet(f, { plain = false } = {}) {
-  return plain
-    ? `- [${f.id} · ${f.severity}] ${f.issue} (${f.location})`
-    : `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
+// One codex finding as a Markdown bullet — the single projection of a finding's
+// fields for the ledger section. (The per-round commit message is now written by
+// the author itself, in its own session, so this no longer feeds it.)
+function findingBullet(f) {
+  return `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
 }
 
-// One author disposition as a Markdown bullet. The single projection of an action's
-// fields, shared by the ledger section and the round commit message. `plain` drops
-// the ledger chrome (backticks + bold) for the commit message.
-function actionBullet(a, { plain = false } = {}) {
-  return plain
-    ? `- ${a.findingId} ${a.disposition}: ${a.detail}`
-    : `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
+// One author disposition as a Markdown bullet — the single projection of an
+// action's fields for the ledger section.
+function actionBullet(a) {
+  return `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
 }
 
 // One round's findings, as a Markdown list. Shared by the section renderer below.
@@ -412,8 +371,8 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 // thin mechanical agent (the workflow can't run shell itself). The reset is
 // section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
 // whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
-// commit-msg-N.txt) keep their own lifecycle and a future pre-loop writer won't
-// be silently wiped. This script has no true resume (agent() is one-shot, the
+// and any commit-message file the author writes) keep their own lifecycle and a
+// future pre-loop writer won't be silently wiped. This script has no true resume (agent() is one-shot, the
 // whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
 await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
@@ -462,20 +421,21 @@ for (let round = 1; ; round++) {
   // rest. It reads the per-round section files (written at the end of each round
   // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
   // rebuttal next round (see codexReviews) — it is no longer the author's memory.
-  const response = await claudeResponds(round, verdict)
+  const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
   lastClaude = response
   log(
     `Round ${round}: claude done=${response.done}, actions=${(response.actions || []).length}, files=${(response.filesChanged || []).length}`,
   )
 
-  // Commit this round individually so the PR history reads as the debate
-  // itself — one commit per round, message carrying codex's findings and
-  // claude's dispositions. Only when claude actually changed files.
+  // The author commits its own round in-session (one commit per round, message
+  // carrying codex's findings and its dispositions), so here we just record the
+  // SHA it returned. Only when it actually changed files; flag the inconsistency
+  // if it reported changes but no commit rather than silently dropping it.
   if (commit && (response.filesChanged || []).length > 0) {
-    const sha = await commitRound(round, response.filesChanged, roundCommitMessage(round, verdict, response))
-    entry.commit = (sha || '').trim()
-    log(`Round ${round}: committed ${entry.commit}`)
+    entry.commit = (response.commitSha || '').trim()
+    if (entry.commit) log(`Round ${round}: committed ${entry.commit}`)
+    else log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA`)
   }
 
   // Write this round's section so the NEXT round's author can read the full

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -324,6 +324,14 @@ const transcript = []
 let status = 'consensus'
 let finalVerdict = null
 let lastClaude = null
+// Rounds where the author edited files (commit mode on) but returned no SHA —
+// the in-session commit it was told to make didn't land. The edits aren't lost
+// (they stay in the tree and the next reviewer still diffs them against base),
+// but the "one commit per round" contract was broken for that round, so the run
+// is NOT a clean consensus: we downgrade the terminal status below rather than
+// report success over a missed commit. Not a hard abort: a transient SHA omission
+// shouldn't nuke a multi-round debate whose edits are all present in the tree.
+const commitGaps = []
 
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
@@ -434,8 +442,16 @@ for (let round = 1; ; round++) {
   // if it reported changes but no commit rather than silently dropping it.
   if (commit && (response.filesChanged || []).length > 0) {
     entry.commit = (response.commitSha || '').trim()
-    if (entry.commit) log(`Round ${round}: committed ${entry.commit}`)
-    else log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA`)
+    if (entry.commit) {
+      log(`Round ${round}: committed ${entry.commit}`)
+    } else {
+      // The author edited the tree but didn't return a SHA: its in-session commit
+      // didn't land. Record the gap so the terminal status reflects it instead of
+      // reporting a clean consensus over a round that broke the one-commit-per-round
+      // contract. The edits themselves remain in the tree for the next reviewer.
+      commitGaps.push(round)
+      log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA — round left uncommitted`)
+    }
   }
 
   // Write this round's section so the NEXT round's author can read the full
@@ -447,6 +463,20 @@ for (let round = 1; ; round++) {
 const filesChanged = Array.from(
   new Set(transcript.flatMap((e) => (e.claude && e.claude.filesChanged) || [])),
 )
+
+// Downgrade a would-be consensus when any round's in-session commit didn't land.
+// The debate may have converged (codex approved, nothing open), but with the
+// "one commit per round" contract broken we must NOT advertise a clean consensus:
+// /be-review keys off this status (and the SKILL's status table) to decide whether
+// the step settled cleanly. 'commit-incomplete' is a distinct, non-consensus
+// terminus — the edits are all in the tree (the next reviewer diffs them), but a
+// human/caller must reconcile the uncommitted round(s). We don't touch a status
+// that's already abnormal (reviewer-error), which is strictly more severe.
+if (status === 'consensus' && commitGaps.length) {
+  status = 'commit-incomplete'
+  log(`Round(s) ${commitGaps.join(', ')} left uncommitted despite changing files — downgrading consensus to commit-incomplete.`)
+}
+
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
 // Section the terminal round — it broke out of the loop before the in-loop
@@ -467,6 +497,9 @@ return {
   base,
   finalVerdict,
   filesChanged,
+  // Rounds whose author-side commit didn't land (empty unless status is
+  // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
+  commitGaps,
   transcript,
   comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
 }

--- a/.claude/skills/lens-debate/SKILL.md
+++ b/.claude/skills/lens-debate/SKILL.md
@@ -207,7 +207,7 @@ branch for the human to review):
   `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never hit commitFix, so the dir may not exist yet
+  mkdir -p "$repoPath/.lens-debate"   # clean/all-drop/--no-commit runs never run the Apply commit step, so the dir may not exist yet
   printf '%s' "$comment" > "$repoPath/.lens-debate/comment.md"
   gh pr comment <pr> -F "$repoPath/.lens-debate/comment.md"
   ```

--- a/.claude/skills/lens-debate/SKILL.md
+++ b/.claude/skills/lens-debate/SKILL.md
@@ -157,10 +157,12 @@ three phases the user can watch via `/workflows`:
   means both lenses agree on the disposition *and* the plan — if they both say
   `fix` but propose different changes, the finding stays open until the plans
   converge too (so Apply never picks one lens's plan arbitrarily).
-- **Apply** — one `apply:<finding-id>` per agreed `fix`, each followed (unless
-  `--no-commit`) by a `commit:<finding-id>` that commits **exactly** that fix's
-  changed files with a message carrying the debate context. Skipped wholesale
-  under `--no-apply` — the plans come back in `fixes` for the caller to apply.
+- **Apply** — a single `apply:all` agent implements **every** agreed `fix` in one
+  session and (unless `--no-commit`) commits each one individually, staging
+  **exactly** that fix's changed files with a message carrying the debate context.
+  One orientation for all fixes instead of a fresh implement+commit agent per
+  finding. Skipped wholesale under `--no-apply` — the plans come back in `fixes`
+  for the caller to apply.
 
 When `rationale` is set, pull it from the PR/issue description (the deliberate
 design decisions the author wants the lenses to respect, e.g. a deliberate
@@ -222,7 +224,8 @@ branch for the human to review):
 
 - **The lenses are read-only reviewers; only the Apply phase writes.** lowy and
   hickey never edit code — they only emit dispositions. The sole writes to the
-  tree come from the `apply:` agents implementing the *agreed* fixes.
+  tree come from the single `apply:all` agent implementing the *agreed* fixes
+  (one session, one commit per finding) — not one agent per fix.
 - **Commits, but never pushes or merges.** Each agreed fix is committed locally
   (unless `--no-commit`) so the PR history reads as the debate's conclusions, but
   the skill never pushes or merges. Consensus means "both lenses agree on the

--- a/.claude/skills/lens-debate/SKILL.md
+++ b/.claude/skills/lens-debate/SKILL.md
@@ -173,11 +173,12 @@ Ephemeral scratch (commit-message files) lives under the gitignored, per-worktre
 collide and the scratch never shows up in the diff the lenses review. It returns:
 
 ```
-{ status: "consensus" | "unresolved" | "clean",
+{ status: "consensus" | "apply-incomplete" | "unresolved" | "clean",
   rounds, base, withPolice,
   settled,     // per-finding: id, origin, title, location, agreed disposition, plan, both reasonings
   unresolved,  // findings still contested at the backstop (empty on consensus)
   applied,     // [{ id, title, files, commit }] (empty under --no-apply)
+  applyGaps,   // [{ id, reason }] agreed fixes that didn't cleanly land — empty unless status is "apply-incomplete"
   fixes,       // the agreed `fix` findings with converged plans — the caller's change requests under --no-apply
   reviews,     // each lens's independent findings
   history,     // per-round dispositions
@@ -186,6 +187,14 @@ collide and the scratch never shows up in the diff the lenses review. It returns
 
 - **consensus** — every finding settled (the normal outcome).
 - **clean** — every lens found nothing worth raising.
+- **apply-incomplete** — the lenses *converged*, but the Apply phase didn't land
+  every agreed fix cleanly: a fix was **missing from the apply agent's output**
+  (so we can't confirm it was applied) or, in commit mode, was **changed but
+  returned no commit SHA** (its per-fix commit didn't land). The offending fixes
+  are in `applyGaps`. Any edits present stay in the working tree, but this is
+  **not** a clean consensus — surface the gap and reconcile it (re-apply or commit
+  the outstanding fix) before relying on the per-fix history. Do **not** report it
+  as a plain consensus.
 - **unresolved** — the backstop was hit with findings still contested. Rare;
   needs a human. This is NOT a deadlock — the lenses simply didn't converge in
   the round budget; raise `--max-rounds` or adjudicate the listed findings.

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -492,6 +492,11 @@ if (apply && fixes.length) {
   applied = fixes.map((f) => {
     const a = byId[f.id] || {}
     const sha = (a.commit || '').trim()
+    // Mirror codex-debate's mismatch log: surface a fix the agent reported as
+    // changed-but-uncommitted instead of silently recording commit: null.
+    if (!sha && (a.filesChanged ?? []).length > 0) {
+      log(`Apply ${f.id}: agent changed ${a.filesChanged.length} file(s) but returned no commit SHA`)
+    }
     return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
   })
   applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -179,13 +179,30 @@ const POSITION_SCHEMA = {
   },
 }
 
-const IMPL_SCHEMA = {
+// One Apply agent implements every agreed fix and commits each in a single
+// session, so it returns the full per-fix outcome (not one impl per agent). One
+// entry per fix it was handed; `commit` is "" under `--no-commit` or when a fix
+// turned out to need no change.
+const APPLY_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['summary', 'filesChanged'],
+  required: ['applied'],
   properties: {
-    summary: { type: 'string', description: 'one line: what you changed' },
-    filesChanged: { type: 'array', items: { type: 'string' } },
+    applied: {
+      type: 'array',
+      description: 'one entry for EVERY agreed fix you were given, in the same order',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'summary', 'filesChanged'],
+        properties: {
+          id: { type: 'string' },
+          summary: { type: 'string', description: 'one line: what you changed for this fix' },
+          filesChanged: { type: 'array', items: { type: 'string' } },
+          commit: { type: 'string', description: 'this fix\'s commit SHA, or "" if nothing was committed' },
+        },
+      },
+    },
   },
 }
 
@@ -222,47 +239,48 @@ ${oppBlock}
 Round ${roundNum}. For EVERY contested finding id above, output a disposition (\`fix\` = worth changing in THIS PR / \`drop\` = leave as-is, observation only), a concrete implementable plan if \`fix\`, and reasoning grounded in the code. **The goal is the correct answer for THIS PR, not winning** — concede explicitly ("conceding: …") when ${opp}'s code-grounded argument is right. A \`fix\` is worth it only if it genuinely improves the PR.`
 }
 
-function implementBrief(fix) {
-  return `You are implementing ONE change that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\`.
+// ONE brief for ALL agreed fixes — implemented and committed in a single Apply
+// session, so the agent orients on the repo once instead of paying that cost per
+// fix (the old form spawned an implement agent AND a commit agent per finding,
+// serially). The fixes are independent and their plans already converged in the
+// debate, so there's no cross-fix reasoning to isolate; what we keep is one
+// commit PER finding so the history still reads finding-by-finding.
+function applyAllBrief(fixes, doCommit) {
+  const list = fixes
+    .map(
+      (f) => `### ${f.id} (raised by ${f.origin}) — ${f.title}
+  at ${f.location}
+  problem: ${f.problem}
+  original suggestion (context, not the agreed plan): ${f.suggestion}
+  agreed plan: ${f.plan}`,
+    )
+    .join('\n\n')
+  const commitStep = doCommit
+    ? `After a fix's edits are done, COMMIT that fix on its own before moving to the next, so each finding maps to one commit and the history reads finding-by-finding. Stage ONLY the files you changed for that fix — never \`git add -A\` or \`git add .\`. Write the message to a file under \`${workDir}\` (run \`mkdir -p ${workDir}\` first) and commit with \`git -C ${repoPath} add -- <files> && git -C ${repoPath} commit -F <msgfile>\`, using EXACTLY this message shape:
 
-Finding ${fix.id} (raised by ${fix.origin}) — ${fix.title}
-  at ${fix.location}
-  problem: ${fix.problem}
-  original suggestion (context, not the agreed plan): ${fix.suggestion}
-  agreed plan: ${fix.plan}
+  fix(lens): <the fix's title>
 
-Make ONLY this change in the working tree, following the agreed plan above. Keep it tightly scoped to the finding; read the surrounding code first so the edit fits the existing style. Do NOT git add / commit / push. You may run the project's formatter on files you touched. Return a one-line summary and the exact list of files you changed.`
+  <your one-line summary of the change>
+
+  Agreed by the lowy ⇄ hickey lens debate (finding <id>, raised by <origin>). Not pushed or merged.
+
+Do NOT push. Record each fix's resulting commit SHA (\`git -C ${repoPath} rev-parse HEAD\`) in its \`commit\` field. If a fix turns out to need no change, leave its \`filesChanged\` empty and its \`commit\` "".`
+    : `Do NOT git add / commit / push — leave every change in the working tree and set each fix's \`commit\` to "".`
+  return `You are implementing the changes that two structural-review lenses (lowy and hickey) independently agreed should be fixed in THIS PR. Work in the repo at \`${repoPath}\` — your shell cwd may be a DIFFERENT worktree, so every file you Read/Edit MUST be an ABSOLUTE path under \`${repoPath}\` and every git command MUST use \`git -C ${repoPath}\`.
+
+Apply each agreed fix below, IN ORDER. The fixes are independent — keep each one tightly scoped to its finding and don't let one bleed into another. Read the surrounding code first so each edit fits the existing style. You may run the project's formatter on files you touched.
+
+${list}
+
+${commitStep}
+
+Return one \`applied\` entry per fix (same order): its id, a one-line summary, the exact files you changed, and the commit SHA (or "").`
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 const posMap = (res) => Object.fromEntries((res?.positions ?? []).map((p) => [p.id, p]))
-
-// Commit exactly the files one fix changed, with a message carrying the debate
-// context. A thin mechanical agent: the workflow can't run git itself.
-async function commitFix(fix, files, summary) {
-  const fileArgs = files.map((f) => `'${f.replace(/'/g, `'\\''`)}'`).join(' ')
-  const msgPath = `${workDir}/commit-msg-${fix.id}.txt`
-  // `fix(lens):` — the conventional prefix for lens-originated commits.
-  const message = `fix(lens): ${fix.title}
-
-${summary}
-
-Agreed by the lowy ⇄ hickey lens debate (finding ${fix.id}, raised by ${fix.origin}). Not pushed or merged.`
-  const prompt = `You are a MECHANICAL COMMITTER. Do exactly these steps and nothing else — do not edit files, do not push, do not stage anything beyond the listed files.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${msgPath}\` with EXACTLY this content:
-
-${message}
-
-3. Run (every git command uses \`git -C ${repoPath}\`, so it targets THIS worktree regardless of your shell cwd):
-   \`git -C ${repoPath} add -- ${fileArgs} && git -C ${repoPath} commit -F ${msgPath}\`
-   Stage ONLY those files. Do NOT use \`git add -A\` or \`git add .\`.
-4. Return the new commit SHA from \`git -C ${repoPath} rev-parse HEAD\`. Do NOT push.`
-  return agent(prompt, { label: `commit:${fix.id}`, phase: 'Apply', model: mechModel })
-}
 
 // Render the PR comment deterministically from the debate outcome, returned as a
 // string so the ORCHESTRATOR posts it verbatim (`gh pr comment -F`) — no agent
@@ -452,25 +470,29 @@ const unresolved = settledOut.filter((s) => !s.agreed)
 log(`Debate ended: ${status} after ${rounds} round(s); ${settledOut.length - unresolved.length}/${settledOut.length} settled, ${unresolved.length} unresolved.`)
 
 // ---------------------------------------------------------------------------
-// Phase 3 — apply the agreed `fix` findings, each as its own commit. Skipped
-// wholesale under `apply: false`: the agreed plans are returned in `fixes` for
-// the caller to implement against whatever tree it chooses.
+// Phase 3 — apply every agreed `fix` finding in a SINGLE session, one commit
+// per finding. One agent orients on the repo once and applies all the fixes,
+// rather than paying a fresh implement+commit agent (and its re-orientation
+// cost) per finding; the fixes are independent and their plans already
+// converged, so there's no cross-fix reasoning to isolate. Skipped wholesale
+// under `apply: false`: the agreed plans are returned in `fixes` for the caller
+// to implement against whatever tree it chooses.
 // ---------------------------------------------------------------------------
 const fixes = settledOut.filter((s) => s.agreed && s.disposition === 'fix')
-const applied = []
-if (apply) {
+let applied = []
+if (apply && fixes.length) {
   phase('Apply')
-  for (const fix of fixes) {
-    const impl = await agent(implementBrief(fix), { label: `apply:${fix.id}`, phase: 'Apply', model, schema: IMPL_SCHEMA })
-    const files = impl?.filesChanged ?? []
-    let sha = null
-    if (commit && files.length > 0) {
-      const out = await commitFix(fix, files, impl.summary)
-      sha = (out || '').trim()
-    }
-    applied.push({ id: fix.id, title: fix.title, files, commit: sha })
-    log(`Applied ${fix.id}: ${files.length} file(s)${sha ? `, committed ${sha.slice(0, 9)}` : ' (uncommitted)'}`)
-  }
+  const res = await agent(applyAllBrief(fixes, commit), { label: 'apply:all', phase: 'Apply', model, schema: APPLY_SCHEMA })
+  const byId = Object.fromEntries((res?.applied ?? []).map((a) => [a.id, a]))
+  // Re-key off the agreed `fixes` (not the agent's array) so a fix the agent
+  // dropped from its output still surfaces — as 0 files / uncommitted — instead
+  // of vanishing from `applied` and the PR comment.
+  applied = fixes.map((f) => {
+    const a = byId[f.id] || {}
+    const sha = (a.commit || '').trim()
+    return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
+  })
+  applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))
 } else if (fixes.length) {
   log(`Apply skipped (apply: false) — returning ${fixes.length} agreed fix plan(s) to the caller.`)
 }

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -302,12 +302,20 @@ const posMap = (res) => Object.fromEntries((res?.positions ?? []).map((p) => [p.
 // { kind: 'handed-off', items } when apply:false returned the plans to the
 // caller — one param, so "at most one of applied/handed-off" holds by
 // construction instead of by convention.
-function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, withPolice, base, clean }) {
-  const badge = clean
-    ? '✅ **Clean** — every lens found nothing worth raising'
-    : unresolved.length === 0
-      ? '✅ **Consensus**'
-      : `⚠️ **${unresolved.length} unresolved**`
+// `applyGaps` (agreed fixes the Apply phase did not cleanly land) is rendered
+// HERE, not just in the machine `status`: the SKILL posts this comment verbatim,
+// so an apply-incomplete run must surface a warning badge and a dedicated gap
+// section instead of advertising `✅ Consensus` and listing the gapped fix as
+// `Applied`. Keep this consistent with the status downgrade in Phase 3.
+function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, withPolice, base, clean, applyGaps = [] }) {
+  const gapIds = new Set(applyGaps.map((g) => g.id))
+  const badge = applyGaps.length
+    ? `⚠️ **Apply incomplete** — ${applyGaps.length} agreed fix(es) not cleanly applied`
+    : clean
+      ? '✅ **Clean** — every lens found nothing worth raising'
+      : unresolved.length === 0
+        ? '✅ **Consensus**'
+        : `⚠️ **${unresolved.length} unresolved**`
   const counts = Object.entries(reviewByLens)
     .map(([lens, fs]) => `${lens}=${fs.length}`)
     .join(', ')
@@ -323,9 +331,25 @@ function renderComment({ rounds, settledOut, unresolved, outcome, reviewByLens, 
     `Independent findings: ${counts}`,
   ]
   const drops = settledOut.filter((s) => s.agreed && s.disposition === 'drop')
-  if (outcome.kind === 'applied' && outcome.items.length) {
-    lines.push('', `### Applied (${outcome.items.length})`)
-    outcome.items.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+  if (outcome.kind === 'applied') {
+    // Only CLEANLY-landed fixes go under `Applied`; a fix in `applyGaps` (missing
+    // from the apply output, or changed-but-uncommitted) is NOT applied work and
+    // must not be advertised as such under what would otherwise be a consensus
+    // badge — it gets its own gap section below.
+    const cleanlyApplied = outcome.items.filter((a) => !gapIds.has(a.id))
+    if (cleanlyApplied.length) {
+      lines.push('', `### Applied (${cleanlyApplied.length})`)
+      cleanlyApplied.forEach((a) => lines.push(`- \`${a.id}\` ${a.title}${a.commit ? ` — commit \`${a.commit.slice(0, 9)}\`` : ' — (uncommitted)'}`))
+    }
+    if (applyGaps.length) {
+      lines.push('', `### Apply incomplete — needs reconcile (${applyGaps.length})`)
+      const reasonText = { 'missing-from-output': 'not confirmed applied (absent from apply output)', uncommitted: 'changed but not committed (per-fix commit missing)' }
+      applyGaps.forEach((g) => {
+        const item = outcome.items.find((a) => a.id === g.id)
+        const title = item?.title ? ` ${item.title}` : ''
+        lines.push(`- \`${g.id}\`${title} — ${reasonText[g.reason] ?? g.reason}`)
+      })
+    }
   }
   // apply:false runs hand the agreed plans to the caller instead of implementing
   // them; the comment records the handoff so the trail still shows what was agreed
@@ -549,5 +573,5 @@ return {
   fixes,
   reviews: reviewByLens,
   history,
-  comment: renderComment({ rounds, settledOut, unresolved, outcome: apply ? { kind: 'applied', items: applied } : { kind: 'handed-off', items: fixes }, reviewByLens, withPolice, base }),
+  comment: renderComment({ rounds, settledOut, unresolved, outcome: apply ? { kind: 'applied', items: applied } : { kind: 'handed-off', items: fixes }, reviewByLens, withPolice, base, applyGaps }),
 }

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -90,7 +90,7 @@ if (withPolice) REVIEWERS.push({ lens: 'code-police', framework: 'code quality, 
 // The result shape's empty collections, shared by the two EARLY returns
 // (merge-base-error, clean) so adding a result field is one edit, not a mirror
 // edit per return site. The final return carries real values and stays literal.
-const EMPTY_RESULT = { settled: [], unresolved: [], applied: [], fixes: [], reviews: {}, history: [] }
+const EMPTY_RESULT = { settled: [], unresolved: [], applied: [], applyGaps: [], fixes: [], reviews: {}, history: [] }
 
 // Resolve the diff base to the merge-base of (base, HEAD) BEFORE building DIFF
 // (which interpolates `base` eagerly), so the lenses review only what this branch
@@ -482,6 +482,15 @@ log(`Debate ended: ${status} after ${rounds} round(s); ${settledOut.length - unr
 // ---------------------------------------------------------------------------
 const fixes = settledOut.filter((s) => s.agreed && s.disposition === 'fix')
 let applied = []
+// Agreed fixes the Apply phase did not cleanly land. Two failure shapes, both of
+// which would otherwise be rendered as "applied" and reported under a consensus:
+//  - missing: the agent dropped the fix from its output entirely (no entry, no
+//    files) — we can't tell if it was applied, so it must not be reported as done.
+//  - uncommitted: in commit mode the agent changed files for the fix but returned
+//    no SHA — its per-fix commit didn't land, breaking "one commit per fix".
+// The edits (when present) stay in the tree, so this is a status downgrade, not a
+// hard abort: the caller reconciles the gap rather than losing a converged debate.
+const applyGaps = []
 if (apply && fixes.length) {
   phase('Apply')
   const res = await agent(applyAllBrief(fixes, commit), { label: 'apply:all', phase: 'Apply', model, schema: APPLY_SCHEMA })
@@ -490,16 +499,34 @@ if (apply && fixes.length) {
   // dropped from its output still surfaces — as 0 files / uncommitted — instead
   // of vanishing from `applied` and the PR comment.
   applied = fixes.map((f) => {
-    const a = byId[f.id] || {}
+    const entry = byId[f.id]
+    const a = entry || {}
     const sha = (a.commit || '').trim()
-    // Mirror codex-debate's mismatch log: surface a fix the agent reported as
-    // changed-but-uncommitted instead of silently recording commit: null.
-    if (!sha && (a.filesChanged ?? []).length > 0) {
-      log(`Apply ${f.id}: agent changed ${a.filesChanged.length} file(s) but returned no commit SHA`)
+    const files = a.filesChanged ?? []
+    if (!entry) {
+      // The agent never reported this agreed fix. We can't confirm it was applied,
+      // so flag it rather than render a phantom 0-file "applied" row as success.
+      applyGaps.push({ id: f.id, reason: 'missing-from-output' })
+      log(`Apply ${f.id}: agreed fix absent from apply-agent output — not confirmed applied`)
+    } else if (commit && !sha && files.length > 0) {
+      // Reported changed-but-uncommitted in commit mode: the per-fix commit the
+      // agent was told to make didn't land. Surface it as a gap, not a clean apply.
+      applyGaps.push({ id: f.id, reason: 'uncommitted' })
+      log(`Apply ${f.id}: agent changed ${files.length} file(s) but returned no commit SHA`)
     }
-    return { id: f.id, title: f.title, files: a.filesChanged ?? [], commit: sha || null }
+    return { id: f.id, title: f.title, files, commit: sha || null }
   })
   applied.forEach((a) => log(`Applied ${a.id}: ${a.files.length} file(s)${a.commit ? `, committed ${a.commit.slice(0, 9)}` : ' (uncommitted)'}`))
+  // A converged debate whose fixes didn't cleanly land is NOT a clean consensus:
+  // downgrade so /be-review (which keys off this status) and the comment don't
+  // advertise success over an unconfirmed/uncommitted fix. Only touch a status
+  // that was otherwise clean ('consensus'/'clean'); 'unresolved' already signals
+  // the human must act.
+  if (applyGaps.length && (status === 'consensus' || status === 'clean')) {
+    const prior = status
+    status = 'apply-incomplete'
+    log(`Apply incomplete: ${applyGaps.map((g) => `${g.id} (${g.reason})`).join(', ')} — downgrading ${prior} to apply-incomplete.`)
+  }
 } else if (fixes.length) {
   log(`Apply skipped (apply: false) — returning ${fixes.length} agreed fix plan(s) to the caller.`)
 }
@@ -512,6 +539,10 @@ return {
   settled: settledOut,
   unresolved,
   applied,
+  // Agreed fixes that didn't cleanly land (missing from the apply output, or
+  // changed-but-uncommitted). Empty unless status is 'apply-incomplete'; lets the
+  // caller pinpoint which fix to reconcile.
+  applyGaps,
   // The agreed `fix` findings with their converged plans — the caller's
   // change-request payload under `apply: false` (redundant with `settled` when
   // the Apply phase ran, but always present so consumers need not re-filter).

--- a/.claude/skills/lens-debate/debate.workflow.js
+++ b/.claude/skills/lens-debate/debate.workflow.js
@@ -1,9 +1,11 @@
 // The Workflow runtime requires `export const meta` to be the FIRST statement
 // and a PURE LITERAL (no variable interpolation), so the primary model is
-// inlined as 'opus' in the phase entries below; commit agents within Apply run
-// on mechModel (haiku). The single `const MODEL` socket lives just after meta —
-// every other model reference in this script reads it lazily at
-// input-resolution time, well after meta is evaluated.
+// inlined as 'opus' in the phase entries below. The only Apply-phase agent is a
+// single `apply:all` on `model` (Opus) that implements and commits each agreed
+// fix in-session. Those inlined 'opus' phase entries plus the `const MODEL`
+// socket just after meta are the model bindings — every other model reference in
+// this script reads MODEL lazily at input-resolution time, well after meta is
+// evaluated.
 export const meta = {
   name: 'lens-debate',
   description:
@@ -60,8 +62,8 @@ const rationale = (a.rationale || '').trim()
 const model = a.model || MODEL
 // Mechanical tier (Haiku). The lenses' reviews + the per-finding debate + applying
 // an agreed fix all do real reasoning → `model` (Opus, load-bearing for the
-// lenses). The merge-base resolver and the per-fix committer are pure git → run
-// them on `mechModel`. Defaults match a direct invocation; /be-review passes it.
+// lenses). The merge-base resolver is pure git → run it on `mechModel`.
+// Defaults match a direct invocation; /be-review passes it.
 const mechModel = a.mechModel || 'haiku'
 // Per-worktree scratch for commit-message files; gitignored so it never shows up
 // in the diff the lenses review, and parallel debates in different worktrees

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -313,12 +313,12 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .agents/skills/be-review/SKILL.md: sha256:9869bfec8241f0d03e54db1a673a932d0169c570f9ffd3d9144ab81f9011aabc
+  .agents/skills/be-review/SKILL.md: sha256:e835e4f3716c717155c154ea67b1556d9ce0895a5ef541195440bcf59dc28005
   .agents/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:acc717fea08e8c359c8133f7a7168d5d05de868b8f7a1d8166884956cf636342
+  .agents/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:ed8d9298dd5046bf4c1c8c512902dd2563f00d43df6ba0ba4ece2f79a7099c9e
+  .agents/skills/codex-debate/debate.workflow.js: sha256:1624c71d0acfd839b88c25ad01fd953d0f431c455bc8e67d399a67a04f93b07d
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -326,8 +326,8 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
-  .agents/skills/lens-debate/SKILL.md: sha256:694a244b181dddd1a9b07e40bccb9501f5167402725b2f15f67bd6bfe1520228
-  .agents/skills/lens-debate/debate.workflow.js: sha256:75e7125574bd9e2fdb4b8ce4fb30bc7b833b537a276f1c30a9dc70632d06fa10
+  .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
+  .agents/skills/lens-debate/debate.workflow.js: sha256:f61ea2d78747fe9b1d4a7c3a955e021c4f5dbe5fef18bf6884252176a973d3c1
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -347,12 +347,12 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .claude/skills/be-review/SKILL.md: sha256:9869bfec8241f0d03e54db1a673a932d0169c570f9ffd3d9144ab81f9011aabc
+  .claude/skills/be-review/SKILL.md: sha256:e835e4f3716c717155c154ea67b1556d9ce0895a5ef541195440bcf59dc28005
   .claude/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:acc717fea08e8c359c8133f7a7168d5d05de868b8f7a1d8166884956cf636342
+  .claude/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:ed8d9298dd5046bf4c1c8c512902dd2563f00d43df6ba0ba4ece2f79a7099c9e
+  .claude/skills/codex-debate/debate.workflow.js: sha256:1624c71d0acfd839b88c25ad01fd953d0f431c455bc8e67d399a67a04f93b07d
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -360,8 +360,8 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
-  .claude/skills/lens-debate/SKILL.md: sha256:694a244b181dddd1a9b07e40bccb9501f5167402725b2f15f67bd6bfe1520228
-  .claude/skills/lens-debate/debate.workflow.js: sha256:75e7125574bd9e2fdb4b8ce4fb30bc7b833b537a276f1c30a9dc70632d06fa10
+  .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
+  .claude/skills/lens-debate/debate.workflow.js: sha256:f61ea2d78747fe9b1d4a7c3a955e021c4f5dbe5fef18bf6884252176a973d3c1
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -327,7 +327,7 @@ local_deployed_file_hashes:
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .agents/skills/lens-debate/SKILL.md: sha256:28632c7894663cb23496c19d733cd9c68cbefc090858e5a11ad0ea606b27e784
-  .agents/skills/lens-debate/debate.workflow.js: sha256:feb62af4f7d9ebc6c68c51102f5cc159c668efd0c755906a2bb8f34a4885504f
+  .agents/skills/lens-debate/debate.workflow.js: sha256:11bcbf482c91ea1acca05893b3012ee86b588ed6d2b0947f43788f22f5022f91
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -361,7 +361,7 @@ local_deployed_file_hashes:
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .claude/skills/lens-debate/SKILL.md: sha256:28632c7894663cb23496c19d733cd9c68cbefc090858e5a11ad0ea606b27e784
-  .claude/skills/lens-debate/debate.workflow.js: sha256:feb62af4f7d9ebc6c68c51102f5cc159c668efd0c755906a2bb8f34a4885504f
+  .claude/skills/lens-debate/debate.workflow.js: sha256:11bcbf482c91ea1acca05893b3012ee86b588ed6d2b0947f43788f22f5022f91
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -326,7 +326,7 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
-  .agents/skills/lens-debate/SKILL.md: sha256:28632c7894663cb23496c19d733cd9c68cbefc090858e5a11ad0ea606b27e784
+  .agents/skills/lens-debate/SKILL.md: sha256:694a244b181dddd1a9b07e40bccb9501f5167402725b2f15f67bd6bfe1520228
   .agents/skills/lens-debate/debate.workflow.js: sha256:11bcbf482c91ea1acca05893b3012ee86b588ed6d2b0947f43788f22f5022f91
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
@@ -360,7 +360,7 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
-  .claude/skills/lens-debate/SKILL.md: sha256:28632c7894663cb23496c19d733cd9c68cbefc090858e5a11ad0ea606b27e784
+  .claude/skills/lens-debate/SKILL.md: sha256:694a244b181dddd1a9b07e40bccb9501f5167402725b2f15f67bd6bfe1520228
   .claude/skills/lens-debate/debate.workflow.js: sha256:11bcbf482c91ea1acca05893b3012ee86b588ed6d2b0947f43788f22f5022f91
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -327,7 +327,7 @@ local_deployed_file_hashes:
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .agents/skills/lens-debate/SKILL.md: sha256:694a244b181dddd1a9b07e40bccb9501f5167402725b2f15f67bd6bfe1520228
-  .agents/skills/lens-debate/debate.workflow.js: sha256:11bcbf482c91ea1acca05893b3012ee86b588ed6d2b0947f43788f22f5022f91
+  .agents/skills/lens-debate/debate.workflow.js: sha256:75e7125574bd9e2fdb4b8ce4fb30bc7b833b537a276f1c30a9dc70632d06fa10
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -361,7 +361,7 @@ local_deployed_file_hashes:
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .claude/skills/lens-debate/SKILL.md: sha256:694a244b181dddd1a9b07e40bccb9501f5167402725b2f15f67bd6bfe1520228
-  .claude/skills/lens-debate/debate.workflow.js: sha256:11bcbf482c91ea1acca05893b3012ee86b588ed6d2b0947f43788f22f5022f91
+  .claude/skills/lens-debate/debate.workflow.js: sha256:75e7125574bd9e2fdb4b8ce4fb30bc7b833b537a276f1c30a9dc70632d06fa10
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -316,9 +316,9 @@ local_deployed_file_hashes:
   .agents/skills/be-review/SKILL.md: sha256:9869bfec8241f0d03e54db1a673a932d0169c570f9ffd3d9144ab81f9011aabc
   .agents/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:595c607447a68fcade0983d8a411bec326be9cd1eb0fe06da05e83e9b6858ab7
+  .agents/skills/codex-debate/SKILL.md: sha256:acc717fea08e8c359c8133f7a7168d5d05de868b8f7a1d8166884956cf636342
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:61203406107f8e2ecdb07e12df44c690eefcd950adaf8aff798bc6e58a21ea22
+  .agents/skills/codex-debate/debate.workflow.js: sha256:ed8d9298dd5046bf4c1c8c512902dd2563f00d43df6ba0ba4ece2f79a7099c9e
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -326,8 +326,8 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
-  .agents/skills/lens-debate/SKILL.md: sha256:1693987c14e9081ad073921f6c1d7839354a2e93f59bbb25fc87aaec5560acbc
-  .agents/skills/lens-debate/debate.workflow.js: sha256:97b8eba518ba749bf53b542b9784285973fe1d011e7d147bd20e1ce2f46a4c78
+  .agents/skills/lens-debate/SKILL.md: sha256:28632c7894663cb23496c19d733cd9c68cbefc090858e5a11ad0ea606b27e784
+  .agents/skills/lens-debate/debate.workflow.js: sha256:feb62af4f7d9ebc6c68c51102f5cc159c668efd0c755906a2bb8f34a4885504f
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -350,9 +350,9 @@ local_deployed_file_hashes:
   .claude/skills/be-review/SKILL.md: sha256:9869bfec8241f0d03e54db1a673a932d0169c570f9ffd3d9144ab81f9011aabc
   .claude/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:595c607447a68fcade0983d8a411bec326be9cd1eb0fe06da05e83e9b6858ab7
+  .claude/skills/codex-debate/SKILL.md: sha256:acc717fea08e8c359c8133f7a7168d5d05de868b8f7a1d8166884956cf636342
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:61203406107f8e2ecdb07e12df44c690eefcd950adaf8aff798bc6e58a21ea22
+  .claude/skills/codex-debate/debate.workflow.js: sha256:ed8d9298dd5046bf4c1c8c512902dd2563f00d43df6ba0ba4ece2f79a7099c9e
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -360,8 +360,8 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
-  .claude/skills/lens-debate/SKILL.md: sha256:1693987c14e9081ad073921f6c1d7839354a2e93f59bbb25fc87aaec5560acbc
-  .claude/skills/lens-debate/debate.workflow.js: sha256:97b8eba518ba749bf53b542b9784285973fe1d011e7d147bd20e1ce2f46a4c78
+  .claude/skills/lens-debate/SKILL.md: sha256:28632c7894663cb23496c19d733cd9c68cbefc090858e5a11ad0ea606b27e784
+  .claude/skills/lens-debate/debate.workflow.js: sha256:feb62af4f7d9ebc6c68c51102f5cc159c668efd0c755906a2bb8f34a4885504f
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -313,7 +313,7 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .agents/skills/be-review/SKILL.md: sha256:e835e4f3716c717155c154ea67b1556d9ce0895a5ef541195440bcf59dc28005
+  .agents/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
   .agents/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
@@ -327,7 +327,7 @@ local_deployed_file_hashes:
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
-  .agents/skills/lens-debate/debate.workflow.js: sha256:f61ea2d78747fe9b1d4a7c3a955e021c4f5dbe5fef18bf6884252176a973d3c1
+  .agents/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -347,7 +347,7 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .claude/skills/be-review/SKILL.md: sha256:e835e4f3716c717155c154ea67b1556d9ce0895a5ef541195440bcf59dc28005
+  .claude/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
   .claude/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
@@ -361,7 +361,7 @@ local_deployed_file_hashes:
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
-  .claude/skills/lens-debate/debate.workflow.js: sha256:f61ea2d78747fe9b1d4a7c3a955e021c4f5dbe5fef18bf6884252176a973d3c1
+  .claude/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8


### PR DESCRIPTION
**The review gauntlet's two workflow-based steps spawned a throwaway subagent for every commit — and `/lens-debate` spawned a second one to *implement* every fix — each re-orienting on the repo from scratch.** A 4-fix lens apply paid ~8 agent spin-ups (read SKILL, `git diff`, re-read files… ×8) to execute plans the debate had already finalized. This collapses that work into one session per phase.

The root cause is structural: the Workflow runtime can't run `git` or edit files itself, so every edit and every commit has to be tunneled through an `agent()`. That forces the work into *at least one* agent — it does **not** force one agent per fix plus one per commit. The two plain-skill steps (`/simplify`, code-police) already run in the main session and were never affected.

### What changed

| Step | Before | After |
| --- | --- | --- |
| **`/lens-debate` Apply** | per-fix `apply:` agent **+** per-fix `commit:` agent, serial | one `apply:all` agent implements every agreed fix and commits each, one orientation |
| **`/codex-debate` round** | author edits the tree, then a separate `commit:roundN` agent commits | author commits its own round in-session and returns the SHA |

_Crucially, the granularity is unchanged_ — still **one commit per lens finding** and **one commit per codex round**, with the same debate-context commit messages. Only the agent that produces them moved.

### Why codex keeps more machinery than lens

The lens fixes are independent and pre-planned, so they collapse fully into a single session. The codex **rounds can't** — each is gated on an external `codex exec` running between author turns, so they stay sequential. Only the per-round *commit* folds into the author. The ledger writer also stays: it sections terminal rounds (consensus / reviewer-error) where there is no author turn to write one.

> Generated artifacts under `.claude/` and `.agents/` were regenerated from the `.apm/` sources via `just ai::apm`; the lens-debate and codex-debate `SKILL.md` prose was updated to match.

_Generated by Claude Code (model `claude-opus-4-8`)._