### PR TITLE
Bump odu: it ships its own lane runner now — drop the odu-runner re-export

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -166,10 +166,14 @@ host daemon corrupts CA-derivation handling).
   state does not survive a runner restart — the per-SHA log files do.
 - **Skipped nodes post no status**: an absent required context is what
   blocks the merge.
-- The coordinator resolves the lane runner via
-  `nix eval <snapshot>#packages.<platform>.odu-runner.drvPath` — the
-  consuming repo's flake must expose `odu-runner` (re-export odu's, as
-  kolu does) until odu threads its own runner derivation.
+- The coordinator resolves the **generic lane runner from odu's own flake**,
+  not the repo under test:
+  `nix eval $ODU_RUNNER_FLAKE#packages.<platform>.odu-runner.drvPath`, where
+  `ODU_RUNNER_FLAKE` is baked onto the `odu` wrapper from `self.outPath` at
+  build time. A consuming repo no longer re-exports `odu-runner`. There is no
+  override or fallback — the runner is the exact build that shipped the
+  coordinator (they share an RPC contract); a binary built without the baked
+  flake refuses to run.
 
 ## When NOT to use this skill
 

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -166,10 +166,14 @@ host daemon corrupts CA-derivation handling).
   state does not survive a runner restart — the per-SHA log files do.
 - **Skipped nodes post no status**: an absent required context is what
   blocks the merge.
-- The coordinator resolves the lane runner via
-  `nix eval <snapshot>#packages.<platform>.odu-runner.drvPath` — the
-  consuming repo's flake must expose `odu-runner` (re-export odu's, as
-  kolu does) until odu threads its own runner derivation.
+- The coordinator resolves the **generic lane runner from odu's own flake**,
+  not the repo under test:
+  `nix eval $ODU_RUNNER_FLAKE#packages.<platform>.odu-runner.drvPath`, where
+  `ODU_RUNNER_FLAKE` is baked onto the `odu` wrapper from `self.outPath` at
+  build time. A consuming repo no longer re-exports `odu-runner`. There is no
+  override or fallback — the runner is the exact build that shipped the
+  coordinator (they share an RPC contract); a binary built without the baked
+  flake refuses to run.
 
 ## When NOT to use this skill
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -40,7 +40,7 @@ dependencies:
   content_hash: sha256:51308bd8cc8b6ae24781a77b67a7c8140bdea5d793e35427e7b8fcbeb0662074
 - repo_url: juspay/odu
   host: github.com
-  resolved_commit: 5929073bc87bb447f0180722d34c094f5c0eb50c
+  resolved_commit: b826fadad177e7d7efa0afd6f452ea24dd3f9bf9
   package_type: apm_package
   deployed_files:
   - .agents/skills/ci
@@ -54,13 +54,13 @@ dependencies:
   - .claude/skills/odu-mcp/SKILL.md
   - .claude/skills/odu-mcp/bin/serve
   deployed_file_hashes:
-    .agents/skills/ci/SKILL.md: sha256:a06a58c057a3d19e03e44725ba7454fc154851381d707b93293a2b4197fad8ca
+    .agents/skills/ci/SKILL.md: sha256:017232b5ec61da86ecc36babef51ff99477ccded0052f97d396825819b1461fb
     .agents/skills/odu-mcp/SKILL.md: sha256:25cd14d47aa082fb4061e793d3b74095eeb6749672356eea6b9acde9f9de6863
     .agents/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .claude/skills/ci/SKILL.md: sha256:a06a58c057a3d19e03e44725ba7454fc154851381d707b93293a2b4197fad8ca
+    .claude/skills/ci/SKILL.md: sha256:017232b5ec61da86ecc36babef51ff99477ccded0052f97d396825819b1461fb
     .claude/skills/odu-mcp/SKILL.md: sha256:25cd14d47aa082fb4061e793d3b74095eeb6749672356eea6b9acde9f9de6863
     .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-  content_hash: sha256:b2fb52475f4a6f8fb550378355980f10e4e9b10eb23fc08b0a075a70d198625d
+  content_hash: sha256:cd2cafc35a9bd52fa5a7730b01f6aca6811dc662c8b94d61f13604941f12658b
 - repo_url: juspay/project-unknown
   host: github.com
   resolved_commit: 27c4973ae3837eaa54b0439faa5346a3320ac379

--- a/default.nix
+++ b/default.nix
@@ -335,19 +335,21 @@ let
 
   # odu — the CI runner that grew out of the mini-ci example (Atlas:
   # mini-ci-vs-justci) and graduated to github.com/juspay/odu. kolu consumes
-  # it back via npins (`npins update odu` to bump) and RE-EXPORTS its two
-  # packages, so `nix run .#odu` and the coordinator's
-  # `nix eval .#packages.<platform>.odu-runner.drvPath` keep working from
-  # this repo. odu is built with its own pinned nixpkgs + kolu pin (it
-  # consumes @kolu/surface upstream, the drishti pattern) — the import here
-  # threads only the system.
+  # it back via npins (`npins update odu` to bump) and re-exports `odu` so
+  # `nix run .#odu` runs this repo's pinned coordinator. The lane runner is no
+  # longer re-exported: odu resolves it from its OWN flake (juspay/odu#30), so
+  # we thread `selfFlake = oduSources.odu` to bake ODU_RUNNER_FLAKE onto the
+  # wrapper — the same value a flake build derives from `self.outPath`. odu is
+  # built with its own pinned nixpkgs + kolu pin (it consumes @kolu/surface
+  # upstream, the drishti pattern) — the import threads the system + self-flake.
   oduSources = import ./npins;
   oduUpstream = import oduSources.odu {
     pkgs = import (oduSources.odu + "/nix/nixpkgs.nix") {
       system = pkgs.stdenv.hostPlatform.system;
     };
+    selfFlake = oduSources.odu;
   };
-  oduPackages = { inherit (oduUpstream) odu odu-runner; };
+  oduPackages = { inherit (oduUpstream) odu; };
 
   # @kolu/solid-browser docsite — a standalone second consumer of createBrowser
   # (the history electricity), built so CI proves the reuse claim doesn't rot.

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "c850b126bb819b7991ef4f5159ce50356f1cd911",
-      "url": "https://github.com/juspay/odu/archive/c850b126bb819b7991ef4f5159ce50356f1cd911.tar.gz",
-      "hash": "sha256-8+A1nY43pwc2BTbp5HrK3S7ojRf5LnfKrQf6gaqZdEA="
+      "revision": "b826fadad177e7d7efa0afd6f452ea24dd3f9bf9",
+      "url": "https://github.com/juspay/odu/archive/b826fadad177e7d7efa0afd6f452ea24dd3f9bf9.tar.gz",
+      "hash": "sha256-RODWjBEt4bBhvEcYDywKABIjiDILtImlMDi/SzdtNHM="
     }
   },
   "version": 7


### PR DESCRIPTION
[juspay/odu#30](https://github.com/juspay/odu/issues/30) is merged: odu now resolves its generic lane runner (`odu-runner`) from its **own** flake, baked onto the `odu` wrapper as `ODU_RUNNER_FLAKE`, instead of evaluating `<consumer>#packages.<plat>.odu-runner.drvPath` against the repo under test. So kolu no longer has to re-export `odu-runner` just to satisfy lane resolution.

## The catch — and why this isn't only a one-line drop

kolu consumes odu via `import oduSources.odu { pkgs }` (odu's `default.nix`, **not** its flake), and runs its own CI through `nix run .#odu` (the re-exported coordinator). The new odu is **no-fallback**: if `ODU_RUNNER_FLAKE` isn't baked, the coordinator refuses to run. A flake build gets that value from `self.outPath`, but a direct `default.nix` import gets `null` — so a naive bump would leave kolu's `.#odu` with no baked runner flake and **break kolu CI**.

So alongside dropping the re-export, this threads the self-flake explicitly:

```nix
oduUpstream = import oduSources.odu {
  pkgs = import (oduSources.odu + "/nix/nixpkgs.nix") { system = …; };
  selfFlake = oduSources.odu;          # bake ODU_RUNNER_FLAKE = the pinned odu source
};
oduPackages = { inherit (oduUpstream) odu; };   # odu-runner re-export is gone
```

`oduSources.odu` is the npins-pinned odu source — exactly the flake the runner should come from, and the same value `self.outPath` would yield in a flake build.

## What's in here

- **npins**: bump `odu` → the merged `b826fad`.
- **default.nix**: thread `selfFlake = oduSources.odu`; drop `odu-runner` from `oduPackages`.
- **APM**: `just ai::apm-update juspay/odu` — redeploys odu's `ci` skill so its guidance (and the `apm.lock` pin) match the new behavior; no other skill churned.

## Verification

Built kolu's re-exported `.#odu` locally and confirmed the wrapper bakes `ODU_RUNNER_FLAKE='/nix/store/…-source'` (the pinned odu source), and that `nix eval <that>#packages.x86_64-linux.odu-runner.drvPath` resolves to a real `odu-runner.drv`. So `nix run .#odu` resolves the lane runner with no consumer re-export — kolu CI on this PR is the full end-to-end gate.

Not user-facing (internal CI plumbing), so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)