### PR TITLE
fix(surface): stop the coordinator crashing with write EPIPE on stdio teardown (odu#32)

### DIFF
--- a/packages/surface/src/links/stdio-codec.test.ts
+++ b/packages/surface/src/links/stdio-codec.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The send half of the stdio codec: `framedSend` must treat a write whose
+ * destination is already gone (a dead ssh pipe → EPIPE, or our own stream
+ * destroyed → ERR_STREAM_DESTROYED) as benign during teardown, resolving
+ * rather than rejecting. A rejection here escapes the peer's internal send
+ * path as an unhandled rejection and crashes the coordinator on lane teardown
+ * after a green run (juspay/odu#32, the residual of #25). Any other write
+ * error is real and must still propagate.
+ */
+
+import { Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { framedSend, isBenignWriteError } from "./stdio-codec";
+
+/** A Writable whose write callback fails with a chosen error code, the way a
+ *  dead pipe (EPIPE) or a destroyed stream (ERR_STREAM_DESTROYED) does. It
+ *  carries a no-op `'error'` listener so the failing write doesn't ALSO crash
+ *  via the unrelated stream-'error' path (the real link/peer attach exactly
+ *  such a lifecycle guard) — this isolates the send-promise path under test. */
+function failingWrite(code: string): Writable {
+  const w = new Writable({
+    write(_chunk, _enc, cb) {
+      cb(Object.assign(new Error(`write ${code}`), { code }));
+    },
+  });
+  w.on("error", () => {});
+  return w;
+}
+
+describe("isBenignWriteError", () => {
+  it("treats a dead-pipe write (EPIPE / ERR_STREAM_DESTROYED) as benign", () => {
+    expect(
+      isBenignWriteError(Object.assign(new Error(), { code: "EPIPE" })),
+    ).toBe(true);
+    expect(
+      isBenignWriteError(
+        Object.assign(new Error(), { code: "ERR_STREAM_DESTROYED" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not swallow other write errors", () => {
+    expect(
+      isBenignWriteError(Object.assign(new Error(), { code: "ENOSPC" })),
+    ).toBe(false);
+    expect(isBenignWriteError(new Error("boom"))).toBe(false);
+    expect(isBenignWriteError(undefined)).toBe(false);
+    expect(isBenignWriteError(null)).toBe(false);
+  });
+});
+
+describe("framedSend", () => {
+  it("resolves when the write dies with EPIPE — the #32 teardown race", async () => {
+    await expect(
+      framedSend(failingWrite("EPIPE"), "hello"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves when the write dies with ERR_STREAM_DESTROYED", async () => {
+    await expect(
+      framedSend(failingWrite("ERR_STREAM_DESTROYED"), "bye"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still rejects a non-benign write error (it's a real failure)", async () => {
+    await expect(framedSend(failingWrite("ENOSPC"), "x")).rejects.toThrow(
+      /ENOSPC/,
+    );
+  });
+
+  it("resolves normally on a healthy write", async () => {
+    const written: string[] = [];
+    const ok = new Writable({
+      write(chunk, _enc, cb) {
+        written.push(String(chunk));
+        cb();
+      },
+    });
+    await expect(framedSend(ok, "payload")).resolves.toBeUndefined();
+    // The frame went out as one base64 line + newline (framing unchanged).
+    expect(written.join("")).toMatch(/\n$/);
+  });
+});

--- a/packages/surface/src/links/stdio-codec.ts
+++ b/packages/surface/src/links/stdio-codec.ts
@@ -69,6 +69,37 @@ export function writeFramedMessage(
   });
 }
 
+/** A write failure whose destination is simply gone — the peer closed its end
+ *  (`EPIPE`) or our own stream was already destroyed (`ERR_STREAM_DESTROYED`).
+ *  Benign during teardown: there is nothing left to deliver. Every other write
+ *  error is a real failure and still propagates. */
+export function isBenignWriteError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+  return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+}
+
+/** The send half both peers hand to `ClientPeer` / `ServerPeer`: frame and
+ *  write a message, but treat a dead-pipe teardown write (`isBenignWriteError`)
+ *  as a no-op — the peer is gone, the frame can't be delivered, and each side's
+ *  own `write.on("error", …)` lifecycle guard has already begun tearing the
+ *  link down. Without neutralizing the un-deliverable frame here, its rejection
+ *  escapes the peer's internal send path as an unhandled rejection and crashes
+ *  the process on lane teardown after an otherwise-green run (juspay/odu#32,
+ *  the residual of #25).
+ *
+ *  This keeps the framing/lifecycle split intact: `writeFramedMessage` stays
+ *  framing-only, and the per-side teardown *response* (the client closes its
+ *  link; the server ends its serve loop) stays in each peer's stream `'error'`
+ *  handler. This only swallows the write whose destination is already gone. */
+export function framedSend(
+  write: Writable,
+  message: string | ArrayBufferLike | Uint8Array,
+): Promise<void> {
+  return writeFramedMessage(write, message).catch((err: unknown) => {
+    if (!isBenignWriteError(err)) throw err;
+  });
+}
+
 /** Read line-delimited frames off `read` until the stream ends. Each
  *  non-empty line is base64-decoded and dispatched to `onFrame`. Returns
  *  a Promise that resolves on `'end'` and rejects on `'error'`.

--- a/packages/surface/src/links/stdio-codec.ts
+++ b/packages/surface/src/links/stdio-codec.ts
@@ -58,7 +58,7 @@ export function decodeFrame(line: string): Uint8Array {
  *  `write.on("error", …)` handlers in `./stdio.ts` and `../peer-server.ts`.
  *  The read half splits the same way: `decodeFrame` is framing, the
  *  `read.on("error", …)` in `readFramedLines` is lifecycle. */
-export function writeFramedMessage(
+function writeFramedMessage(
   write: Writable,
   message: string | ArrayBufferLike | Uint8Array,
 ): Promise<void> {

--- a/packages/surface/src/links/stdio.test.ts
+++ b/packages/surface/src/links/stdio.test.ts
@@ -11,7 +11,7 @@
  * than hanging.
  */
 
-import { PassThrough } from "node:stream";
+import { PassThrough, Writable } from "node:stream";
 import { eventIterator, oc } from "@orpc/contract";
 import { implement } from "@orpc/server";
 import { describe, expect, it } from "vitest";
@@ -286,5 +286,46 @@ describe("stdio link over loopback", () => {
     // The link is now closed: a fresh RPC rejects fast rather than hanging
     // (or crashing).
     await expect(client.ping({})).rejects.toThrow();
+  });
+
+  it("does not crash when a fire-and-forget teardown send hits a dead pipe (#32)", async () => {
+    // The #32 residual: #25 closed the stream-'error' path, but a send whose
+    // promise nobody awaits — oRPC's abort frame, an event-iterator cleanup —
+    // still rejected when the pipe was already gone. That rejection was
+    // rethrown via process.nextTick as an uncaught exception that crashed the
+    // coordinator on teardown after a green run. The request frame goes out
+    // fine; the abort frame that follows hits a now-dead write. With
+    // `framedSend` the dead-pipe write resolves, so nothing escapes.
+    //
+    // The guard is the same one the EPIPE-guard test above relies on: an
+    // uncaught error during a test fails the run, so the green run IS the
+    // evidence nothing escaped — strip the `.catch` in `framedSend` and this
+    // test errors with the exact teardown-time `write EPIPE`.
+    const contract = { ping: oc.input(z.object({})).output(z.string()) };
+
+    const read = new PassThrough(); // never fed — the request stays in flight
+    let writes = 0;
+    const write = new Writable({
+      write(_chunk, _enc, cb) {
+        writes += 1;
+        // First write (the request frame) flushes; the next — the abort frame,
+        // sent fire-and-forget by the peer — hits a dead pipe.
+        if (writes === 1) return cb();
+        cb(Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+      },
+    });
+    write.on("error", () => {}); // the link attaches exactly such a guard
+
+    const client = stdioLink<typeof contract>({ read, write });
+    const controller = new AbortController();
+    const call = client.ping({}, { signal: controller.signal });
+    await new Promise((r) => setImmediate(r)); // let the request frame flush
+    controller.abort(); // fire-and-forget abort send → 2nd write → EPIPE
+
+    // The call itself rejects (the transport is dead); what must NOT happen is
+    // the abort send's rejection escaping as an uncaught exception.
+    await expect(call).rejects.toThrow();
+    // Give a would-be escaped throw time to surface (and fail this test).
+    await new Promise((r) => setTimeout(r, 50));
   });
 });

--- a/packages/surface/src/links/stdio.ts
+++ b/packages/surface/src/links/stdio.ts
@@ -37,7 +37,7 @@ import type {
 import { ClientPeer } from "@orpc/standard-server-peer";
 import { SURFACE_STDIO_TRANSPORT_CLOSED, deadTransportError } from "../client";
 import { wireClient, wireRetryPlugins } from "./_wire";
-import { readFramedLines, writeFramedMessage } from "./stdio-codec";
+import { framedSend, readFramedLines } from "./stdio-codec";
 
 /** A `Readable`/`Writable` pair the link reads and writes from. */
 export interface StdioLinkOptions {
@@ -72,9 +72,7 @@ export class LinkStdioClient<T extends ClientContext>
   private closed = false;
 
   constructor(opts: StdioLinkOptions) {
-    this.peer = new ClientPeer((message) =>
-      writeFramedMessage(opts.write, message),
-    );
+    this.peer = new ClientPeer((message) => framedSend(opts.write, message));
     // The write half needs its own 'error' sink. A failed `write()` already
     // rejects the in-flight frame through the callback above, but Node ALSO
     // emits 'error' on the stream itself — and an 'error' event with no

--- a/packages/surface/src/peer-server.ts
+++ b/packages/surface/src/peer-server.ts
@@ -69,7 +69,7 @@ import {
   type HandleStandardServerPeerMessageOptions,
 } from "@orpc/server/standard-peer";
 import { ServerPeer } from "@orpc/standard-server-peer";
-import { readFramedLines, writeFramedMessage } from "./links/stdio-codec";
+import { framedSend, readFramedLines } from "./links/stdio-codec";
 
 /** Transport override for `serveOverStdio`. Default is `process.stdin`
  *  for `read` and `process.stdout` for `write`. */
@@ -173,7 +173,7 @@ export function serveOverStdio<T extends Context>(
   });
 
   const peer = new ServerPeer((message) =>
-    writeFramedMessage(transport.write, message),
+    framedSend(transport.write, message),
   );
 
   return readFramedLines(transport.read, (frame) => {


### PR DESCRIPTION
Fixes the root cause of [juspay/odu#32](https://github.com/juspay/odu/issues/32) — a residual of #25.

After a clean run settles and every GitHub status is posted, odu's coordinator throws an **unhandled `write EPIPE`** during lane teardown and exits 1 — the `── ci run summary ──` never prints. The statuses are green, so `gh pr checks` is fine, but a caller keying on odu's **exit code** (a `/do` loop, a CI wrapper, an `&&` chain) sees the whole run as failed.

## Root cause

On teardown the coordinator writes a framed message to a lane peer (`odu-runner` over ssh stdio) whose pipe has already closed. There are **two** independent failure channels for that write, and #25 only closed one:

| channel | before this PR |
| --- | --- |
| the stream's `'error'` event | **handled** — `write.on("error", …)` logs `outbound write error: EPIPE` and tears the link down |
| the **send-function promise** (`writeFramedMessage` → `reject(err)`) | **escaped** — the rejection surfaced through the peer's internal send path as an unhandled rejection, rethrown via `process.nextTick(() => { throw err })` → crash |

So the link logged the EPIPE *and* crashed on it.

## The fix

A dead-pipe write during teardown is benign: the peer is gone, there's nothing to deliver. Add a single shared send wrapper both peers use:

```ts
framedSend(write, message) = writeFramedMessage(write, message)
  .catch(err => { if (!isBenignWriteError(err)) throw err })   // EPIPE / ERR_STREAM_DESTROYED → resolve
```

`ClientPeer` (`links/stdio.ts`) and `ServerPeer` (`peer-server.ts`) both send through it — so the symmetric crash on `serveOverUnixSocket`'s per-connection serves (kaval) is closed too. This **preserves the framing/lifecycle split** the codec is deliberate about: `writeFramedMessage` stays framing-only, and the per-side teardown *response* (client closes its link; server ends its serve loop) stays in each peer's stream-`'error'` handler. `framedSend` only neutralizes the un-deliverable frame whose rejection currently escapes — every non-dead-pipe write error still propagates.

## Scope & follow-up

- **Internal change** — `framedSend`/`isBenignWriteError` live in the package-internal `stdio-codec.ts` (not re-exported on any `@kolu/surface/*` subpath), no contract/API delta. So: no drishti PR (the surface rule only triggers on API-facing changes; drishti — itself an affected odu consumer — picks the fix up via a pin bump), and no changelog (the user-visible manifestation is odu's exit code, not a kolu-product change).
- **Follow-up:** once this merges, odu bumps its kolu pin to pick up the fix.

## Tests

`packages/surface/src/links/stdio-codec.test.ts` (new): `framedSend` resolves on a write that dies with EPIPE / ERR_STREAM_DESTROYED (the #32 race), still rejects a non-benign write error, and writes the frame unchanged on a healthy stream. The existing #25 stream-`'error'` guard test (`stdio.test.ts`) stays green. Full surface suite: 104 unit tests pass; `tsc` + `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)