### PR TITLE
feat(agents): production health gate around heavy agent steps (#1334)

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -1,6 +1,6 @@
 # /do config
 
-`/do` reads this file at the steps that need a project-defined command (check, fmt, test, ci, docs) and at the evidence step.
+`/do` reads this file at the steps that need a project-defined command (check, fmt, test, ci, docs) and at the evidence step. The **ci** and **evidence** steps additionally bracket their heavy local work with the [Production health gate](#production-health-gate) so they can't disrupt the user's live `kolu.service` unnoticed.
 
 ## Check command
 
@@ -96,7 +96,21 @@ To capture each stage's stderr for the excerpt above, tee it when you invoke `pu
 
 **Flake → comment on [#320](https://github.com/juspay/kolu/issues/320)** with scenario/platform/error excerpt/PR.
 
+**Guard production while CI runs.** CI fans most work out to remote pool/rasam boxes, but the orchestration, fix→fmt→commit loop, and any local builds still run on the user's host alongside the live `kolu.service`. Bracket the CI step with the [Production health gate](#production-health-gate) (`just prod-guard snapshot` before, `just prod-guard check` after) so a bounced production instance never hides behind a green pipeline.
+
 **Evidence required → all GitHub status checks green per `odu protect`.** `/do` is done only when every required status check is green on the PR's current `HEAD`. Source the required list from `nix run .#odu -- protect --dry-run` — it prints the `<recipe>@<platform>` contexts the canonical DAG produces, which are exactly the contexts branch protection gates on. Verify with `gh pr checks`; a green from a positional retry counts (final state matters).
+
+## Production health gate
+
+These steps run heavy local work — `nix develop` builds, biome/tsc, e2e, chromium launches — on the **same host** as the user's live `kolu.service` (systemd `--user`). That has disrupted production before: a stray local `just dev` bound its fixed ports (#1109), and sheer host contention can make the live instance bounce mid-session (#1334). Bracket the **ci** and **evidence** steps with the machine check so a disruption can't pass as a clean run:
+
+```sh
+just prod-guard snapshot   # before kicking off CI / evidence — records the live unit's identity
+# … run CI and capture evidence …
+just prod-guard check      # after — exits non-zero + prints a banner if the unit's PID/restarts/start-time moved
+```
+
+`prod-guard` is a no-op success on a host with no live `kolu.service` (a pu/CI box, a fresh dev machine), so it costs nothing where there's nothing to protect. If `check` reports a disruption, **surface it immediately** — don't report the run green while the user's instance bounced.
 
 ## Documentation
 
@@ -114,6 +128,8 @@ Post a `## Evidence` PR comment when **any** of these holds — the trigger is "
 1. **Visible UI impact** — capture screenshots, or **video** when the change is about motion (an animation, a transition, a multi-step interaction a still can't convey). Use judgment — server-only diffs sometimes ripple into rendering.
 2. **Behavioral / round-trip changes** — the diff touches a persistence, restore, session, autosave, debounce/coalesce, or reconnect path, and the proof is *"state survives an interaction or a restart,"* not a pixel change. Capture the before→after **behavior** — often with **zero visual diff** (e.g. resize → stop kolu → start → restore session → the panel returns at the resized width). A video of the round-trip is the proof the fix didn't break recoverability.
 3. **Bug fixes generally** — the default for a fix is *"demonstrate the fixed behavior."* The bug was often a storm, a lost write, or a hang, so a before/after or survives-restart clip is the evidence **even when nothing looks different**. Don't skip evidence just because a fix has no visual diff; skip only when the behavior genuinely can't be observed (e.g. a pure internal refactor with no externally visible effect).
+
+**Bracket capture with the production health gate** (`just prod-guard snapshot` before, `just prod-guard check` after) — see [Production health gate](#production-health-gate). Evidence runs off-machine on a `pu` box precisely so it can't disrupt the user's live `kolu.service`; the gate proves it didn't.
 
 **Capture by recording an e2e scenario — the [`evidence`](../.apm/skills/evidence/SKILL.md) skill owns the procedure** (it builds on the [`pu`](../.apm/skills/pu/SKILL.md) skill; everything runs on an ephemeral `pu` box, off-machine, the way CI runs e2e). Kolu's e2e suite (`@cucumber/cucumber` + Playwright) already drives every UI surface through a maintained step library, so you capture a clip by *recording a scenario* — selected **by name**, with no edit to the feature file — never a hand-rolled Playwright script. Pick the scenario that exercises the change (or author a tiny one reusing existing steps); on the box the skill runs it with `KOLU_EVIDENCE=1`, which makes `packages/tests/support/hooks.ts` record the `.webm` (recordVideo + slowMo, animations left on), then transcodes (ffmpeg → GIF/mp4), uploads to the `evidence-assets` release, and links the shared Pages player.
 

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -71,6 +71,12 @@ summary), so no comment advertises a local-only commit.
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.
 
+**Snapshot production health first.** This step runs the heaviest local work of the
+whole flow (repeated `nix develop` builds, biome/tsc, gauntlet subagents, chromium
+launches) on the *same host* as the user's live `kolu.service` — which has disrupted
+production before (#1334, #1109). Before kicking anything off, run `just prod-guard
+snapshot` to record the live unit's identity (a no-op on a host without one).
+
 1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
    consume `--progress json`) so it churns while you capture evidence. React to
    streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
@@ -82,10 +88,12 @@ green before capturing.
    absent).
 3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
    is posted. If a CI fix-commit changed visible behavior *after* capture,
-   re-capture so the evidence matches what actually merges.
+   re-capture so the evidence matches what actually merges. Then run `just
+   prod-guard check`: if it reports the live unit bounced, **the run is not clean** —
+   say so in Done instead of finishing green, and don't bury it.
 
 ## Done
 
-Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
+Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), CI status, and the **production-health verdict** from `just prod-guard check` (untouched, or — if it bounced — call it out first, not as a footnote). Never merge — the human reviews the commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.agents/skills/dev-server/SKILL.md
+++ b/.agents/skills/dev-server/SKILL.md
@@ -101,7 +101,9 @@ production or unrelated processes. Match the remembered ports only.
 
 - Two **random** ports, both remembered in `.dev-server/ports.json` and reused
   across the session (no re-grepping, no guessing).
-- Production `kolu.service` **provably untouched** — `systemctl --user status
-  kolu` shows the same PID/uptime before and after your run.
+- Production `kolu.service` **provably untouched** — bracket the session with
+  `just prod-guard snapshot` (before) and `just prod-guard check` (after); it
+  fails loudly if the live unit's PID, restart count, or start time moved, instead
+  of relying on you to eyeball `systemctl --user status kolu`.
 - Teardown removes **only** the dev instance (the remembered PIDs); production
   keeps running.

--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -96,6 +96,20 @@ reflects a clean, CI-like build of the PR's own commit and nothing touches the u
 machine. The box has its own loopback, so the harness binds plain ports there with zero
 risk to anything the user is running.
 
+> **Production safety — the pu-box rule is not optional, and it's now machine-checked.**
+> The whole reason capture runs off-machine is that the user's live `kolu.service` shares
+> the host: an agent that ran a bare `just dev`/`just test-quick` *locally* for evidence
+> bound production's fixed ports and knocked it over (#1109), and even heavy local work
+> alongside it is a contention risk (#1334). So: **the e2e harness (§B) and the
+> still-from-clip path (§A1) run on the `pu` box — full stop.** Never run `just
+> test-quick` / `just dev` on the user's machine for evidence. The *only* sanctioned
+> local step is the live chrome-devtools path (§A2), and even then you launch via the
+> **dev-server** skill (`just dev-auto`, two random free ports) — never the fixed
+> defaults. To prove the rule held, bracket the capture with the production-health gate:
+> `just prod-guard snapshot` before you start, `just prod-guard check` after the box is
+> torn down — it fails loudly if the live unit bounced (a no-op where there's no live
+> instance, e.g. on the box itself).
+
 **Prefer the project's existing Cucumber + Playwright e2e harness — record an existing scenario by
 name.** It drives every UI surface through a maintained step library, so the clip is produced by the
 same code CI exercises and the `.feature` files stay pristine. That's why it's the default.

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -71,6 +71,12 @@ summary), so no comment advertises a local-only commit.
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.
 
+**Snapshot production health first.** This step runs the heaviest local work of the
+whole flow (repeated `nix develop` builds, biome/tsc, gauntlet subagents, chromium
+launches) on the *same host* as the user's live `kolu.service` — which has disrupted
+production before (#1334, #1109). Before kicking anything off, run `just prod-guard
+snapshot` to record the live unit's identity (a no-op on a host without one).
+
 1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
    consume `--progress json`) so it churns while you capture evidence. React to
    streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
@@ -82,10 +88,12 @@ green before capturing.
    absent).
 3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
    is posted. If a CI fix-commit changed visible behavior *after* capture,
-   re-capture so the evidence matches what actually merges.
+   re-capture so the evidence matches what actually merges. Then run `just
+   prod-guard check`: if it reports the live unit bounced, **the run is not clean** —
+   say so in Done instead of finishing green, and don't bury it.
 
 ## Done
 
-Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
+Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), CI status, and the **production-health verdict** from `just prod-guard check` (untouched, or — if it bounced — call it out first, not as a footnote). Never merge — the human reviews the commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/dev-server/SKILL.md
+++ b/.apm/skills/dev-server/SKILL.md
@@ -101,7 +101,9 @@ production or unrelated processes. Match the remembered ports only.
 
 - Two **random** ports, both remembered in `.dev-server/ports.json` and reused
   across the session (no re-grepping, no guessing).
-- Production `kolu.service` **provably untouched** — `systemctl --user status
-  kolu` shows the same PID/uptime before and after your run.
+- Production `kolu.service` **provably untouched** — bracket the session with
+  `just prod-guard snapshot` (before) and `just prod-guard check` (after); it
+  fails loudly if the live unit's PID, restart count, or start time moved, instead
+  of relying on you to eyeball `systemctl --user status kolu`.
 - Teardown removes **only** the dev instance (the remembered PIDs); production
   keeps running.

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -96,6 +96,20 @@ reflects a clean, CI-like build of the PR's own commit and nothing touches the u
 machine. The box has its own loopback, so the harness binds plain ports there with zero
 risk to anything the user is running.
 
+> **Production safety — the pu-box rule is not optional, and it's now machine-checked.**
+> The whole reason capture runs off-machine is that the user's live `kolu.service` shares
+> the host: an agent that ran a bare `just dev`/`just test-quick` *locally* for evidence
+> bound production's fixed ports and knocked it over (#1109), and even heavy local work
+> alongside it is a contention risk (#1334). So: **the e2e harness (§B) and the
+> still-from-clip path (§A1) run on the `pu` box — full stop.** Never run `just
+> test-quick` / `just dev` on the user's machine for evidence. The *only* sanctioned
+> local step is the live chrome-devtools path (§A2), and even then you launch via the
+> **dev-server** skill (`just dev-auto`, two random free ports) — never the fixed
+> defaults. To prove the rule held, bracket the capture with the production-health gate:
+> `just prod-guard snapshot` before you start, `just prod-guard check` after the box is
+> torn down — it fails loudly if the live unit bounced (a no-op where there's no live
+> instance, e.g. on the box itself).
+
 **Prefer the project's existing Cucumber + Playwright e2e harness — record an existing scenario by
 name.** It drives every UI surface through a maintained step library, so the clip is produced by the
 same code CI exercises and the `.feature` files stay pristine. That's why it's the default.

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -71,6 +71,12 @@ summary), so no comment advertises a local-only commit.
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.
 
+**Snapshot production health first.** This step runs the heaviest local work of the
+whole flow (repeated `nix develop` builds, biome/tsc, gauntlet subagents, chromium
+launches) on the *same host* as the user's live `kolu.service` — which has disrupted
+production before (#1334, #1109). Before kicking anything off, run `just prod-guard
+snapshot` to record the live unit's identity (a no-op on a host without one).
+
 1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
    consume `--progress json`) so it churns while you capture evidence. React to
    streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
@@ -82,10 +88,12 @@ green before capturing.
    absent).
 3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
    is posted. If a CI fix-commit changed visible behavior *after* capture,
-   re-capture so the evidence matches what actually merges.
+   re-capture so the evidence matches what actually merges. Then run `just
+   prod-guard check`: if it reports the live unit bounced, **the run is not clean** —
+   say so in Done instead of finishing green, and don't bury it.
 
 ## Done
 
-Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), and CI status. Never merge — the human reviews the commits and merges when satisfied.
+Report the PR URL, the gauntlet outcome (lens-debate consensus + fixes applied, codex consensus or reviewer-error, police findings actioned), CI status, and the **production-health verdict** from `just prod-guard check` (untouched, or — if it bounced — call it out first, not as a footnote). Never merge — the human reviews the commits and merges when satisfied.
 
 ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -101,7 +101,9 @@ production or unrelated processes. Match the remembered ports only.
 
 - Two **random** ports, both remembered in `.dev-server/ports.json` and reused
   across the session (no re-grepping, no guessing).
-- Production `kolu.service` **provably untouched** — `systemctl --user status
-  kolu` shows the same PID/uptime before and after your run.
+- Production `kolu.service` **provably untouched** — bracket the session with
+  `just prod-guard snapshot` (before) and `just prod-guard check` (after); it
+  fails loudly if the live unit's PID, restart count, or start time moved, instead
+  of relying on you to eyeball `systemctl --user status kolu`.
 - Teardown removes **only** the dev instance (the remembered PIDs); production
   keeps running.

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -96,6 +96,20 @@ reflects a clean, CI-like build of the PR's own commit and nothing touches the u
 machine. The box has its own loopback, so the harness binds plain ports there with zero
 risk to anything the user is running.
 
+> **Production safety — the pu-box rule is not optional, and it's now machine-checked.**
+> The whole reason capture runs off-machine is that the user's live `kolu.service` shares
+> the host: an agent that ran a bare `just dev`/`just test-quick` *locally* for evidence
+> bound production's fixed ports and knocked it over (#1109), and even heavy local work
+> alongside it is a contention risk (#1334). So: **the e2e harness (§B) and the
+> still-from-clip path (§A1) run on the `pu` box — full stop.** Never run `just
+> test-quick` / `just dev` on the user's machine for evidence. The *only* sanctioned
+> local step is the live chrome-devtools path (§A2), and even then you launch via the
+> **dev-server** skill (`just dev-auto`, two random free ports) — never the fixed
+> defaults. To prove the rule held, bracket the capture with the production-health gate:
+> `just prod-guard snapshot` before you start, `just prod-guard check` after the box is
+> torn down — it fails loudly if the live unit bounced (a no-op where there's no live
+> instance, e.g. on the box itself).
+
 **Prefer the project's existing Cucumber + Playwright e2e harness — record an existing scenario by
 name.** It drives every UI surface through a maintained step library, so the clip is produced by the
 same code CI exercises and the `.feature` files stay pristine. That's why it's the default.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -314,7 +314,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
   .agents/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
-  .agents/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
+  .agents/skills/be/SKILL.md: sha256:989c795e9f4281ed2ef6819c5da77a2538dacffb998258d14a6d0e47038e5ead
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -324,8 +324,8 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .agents/skills/codex-debate/scripts/codex-review.sh: sha256:ffb3da606a74e2fbd2d56a66ca456fae889049c6882f56ef05f856e30257d53b
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
-  .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
+  .agents/skills/dev-server/SKILL.md: sha256:43f15c5dfd07ef6eb96882ff538dc7d3cd452c9c69350302fed17f051c80a769
+  .agents/skills/evidence/SKILL.md: sha256:2afa8c13e1aa929d46b8f4c6aaacba3a1f2fb438ae32cde2c2a2f25871069df3
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .agents/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
@@ -348,7 +348,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
   .claude/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
-  .claude/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
+  .claude/skills/be/SKILL.md: sha256:989c795e9f4281ed2ef6819c5da77a2538dacffb998258d14a6d0e47038e5ead
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -358,8 +358,8 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .claude/skills/codex-debate/scripts/codex-review.sh: sha256:ffb3da606a74e2fbd2d56a66ca456fae889049c6882f56ef05f856e30257d53b
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
-  .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
+  .claude/skills/dev-server/SKILL.md: sha256:43f15c5dfd07ef6eb96882ff538dc7d3cd452c9c69350302fed17f051c80a769
+  .claude/skills/evidence/SKILL.md: sha256:2afa8c13e1aa929d46b8f4c6aaacba3a1f2fb438ae32cde2c2a2f25871069df3
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .claude/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45

--- a/justfile
+++ b/justfile
@@ -57,6 +57,78 @@ dev-auto:
     # to the param, not the value.
     exec just dev "$SERVER_PORT" "$CLIENT_PORT"
 
+# Guard the live production kolu.service against agent-run disruption.
+# A long autonomous agent session shares the host with the user's running
+# `kolu.service` (systemd --user). Heavy local work (nix builds, biome, tsc,
+# chromium launches) can make production sluggish enough to bounce, and a stray
+# `just dev` on the fixed ports can knock it over outright (#1109). This is the
+# machine check that proves it didn't: snapshot the unit's identity before the
+# risky steps, then verify it afterwards.
+#
+#   just prod-guard snapshot   # record MainPID / NRestarts / start-time baseline
+#   just prod-guard check      # fail loudly if any of them moved (a restart)
+#
+# A host with no production unit (a pu/CI box, a fresh dev machine) records
+# present=false and `check` is a no-op success — the guard fires only where
+# there is a live instance to protect. See issue #1334.
+prod-guard ACTION="check":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    state="${XDG_RUNTIME_DIR:-/tmp}/kolu-prod-guard.env"
+    read_unit() {
+        systemctl --user show kolu \
+            --property=LoadState,ActiveState,MainPID,NRestarts,ActiveEnterTimestampMonotonic \
+            2>/dev/null || true
+    }
+    get() { sed -n "s/^$1=//p"; }
+    case "{{ ACTION }}" in
+    snapshot)
+        unit="$(read_unit)"
+        if [ "$(get LoadState <<<"$unit")" != loaded ]; then
+            echo "present=false" > "$state"
+            echo "prod-guard: no production kolu.service on this host — nothing to protect."
+            exit 0
+        fi
+        { echo "present=true"; echo "$unit"; } > "$state"
+        echo "prod-guard: snapshot — MainPID=$(get MainPID <<<"$unit"), NRestarts=$(get NRestarts <<<"$unit")"
+        ;;
+    check)
+        if [ ! -f "$state" ]; then
+            echo "prod-guard: no snapshot — run 'just prod-guard snapshot' before the risky step." >&2
+            exit 0
+        fi
+        if grep -qx 'present=false' "$state"; then
+            echo "prod-guard: no production instance present at snapshot — nothing to verify."
+            exit 0
+        fi
+        before="$(cat "$state")"; after="$(read_unit)"
+        b_pid="$(get MainPID <<<"$before")"; a_pid="$(get MainPID <<<"$after")"
+        b_n="$(get NRestarts <<<"$before")"; a_n="$(get NRestarts <<<"$after")"
+        b_t="$(get ActiveEnterTimestampMonotonic <<<"$before")"; a_t="$(get ActiveEnterTimestampMonotonic <<<"$after")"
+        a_active="$(get ActiveState <<<"$after")"
+        if [ "$b_pid" = "$a_pid" ] && [ "$b_n" = "$a_n" ] && [ "$b_t" = "$a_t" ] && [ "$a_active" = active ]; then
+            echo "prod-guard: production kolu.service untouched (PID $a_pid, $a_n restarts)."
+            exit 0
+        fi
+        {
+            echo "┌────────────────────────────────────────────────────────────┐"
+            echo "│  ⚠  PRODUCTION kolu.service WAS DISRUPTED during this run     │"
+            echo "└────────────────────────────────────────────────────────────┘"
+            printf '  MainPID:      %s → %s\n' "$b_pid" "$a_pid"
+            printf '  NRestarts:    %s → %s\n' "$b_n" "$a_n"
+            printf '  ActiveEnter:  %s → %s\n' "$b_t" "$a_t"
+            printf '  ActiveState now: %s\n' "$a_active"
+            echo "  The user's live instance bounced while the agent ran. Surface this"
+            echo "  immediately — do NOT report the run as clean. See issue #1334."
+        } >&2
+        exit 1
+        ;;
+    *)
+        echo "prod-guard: unknown action '{{ ACTION }}' (use: snapshot | check)" >&2
+        exit 2
+        ;;
+    esac
+
 [private]
 _dev: install _dev-parallel
 


### PR DESCRIPTION
## Why

During the long autonomous `/be` run on #1331, the user's live production `kolu.service` restarted mid-session — clients disconnected, and the run still finished "green." The post-mortem in #1334 found the restart was *clean* (no crash, no OOM), so the most plausible cause is **host contention**: a `/be`/`/do` session does its heaviest local work — repeated `nix develop` builds, `biome`/`tsc`, gauntlet subagents, multiple chromium launches — on the *same host* as production, right at the ship step. Whatever bounced it, the agent reported success while the user's instance was down. That's the gap this closes.

This is the same family as #1109 (an agent ran a bare `just dev` locally and bound production's fixed ports). The pu-box rule already exists for evidence; what was missing was a way to *prove* a run didn't disrupt production, and to surface it when it did.

## What

A single new primitive — `just prod-guard <snapshot|check>` — wired into the agent flows that do the heavy local work.

| | |
|---|---|
| `just prod-guard snapshot` | Records the live `kolu.service` identity (MainPID, NRestarts, ActiveEnter timestamp) to a scratch file before the risky steps. |
| `just prod-guard check` | Re-reads the unit and **exits non-zero with a loud banner** if any of those moved — i.e. the instance restarted/stopped while the agent ran. |

It's dependency-free (no `nix develop`, so it adds no contention itself) and a **no-op success** on a host with no live `kolu.service` (a pu/CI box, a fresh dev machine) — so it only fires where there's a live instance to protect.

### Wiring (the gate is referenced, not duplicated)

- **`/be` §5** snapshots before kicking off CI + evidence and runs `check` in the join-before-Done, surfacing the verdict in **Done** instead of finishing green over a bounced instance.
- **`.agency/do.md`** brackets the **ci** and **evidence** steps with the gate. The `/do` skill is upstream (srid/agency) and can't be edited here, so the gate lives in the project config `/do` already reads at those steps.
- **`evidence`** reaffirms that the pu-box rule is mandatory (harness + still-from-clip run on the box; only the live chrome-devtools path is local, via `just dev-auto`) and machine-checks it by bracketing capture with the gate.
- **`dev-server`** acceptance now uses the gate instead of asking the agent to eyeball `systemctl --user status kolu`.

Skill sources live in `.apm/`; `.claude/` and `.agents/` are regenerated via `just ai::apm` (committed together).

## Scope

Addresses proposals **1** (health gate in the agent flow) and **3** (re-affirm + machine-check the pu-box rule) from #1334. Proposal 2 (nice/cgroup-limiting or relocating agent builds off the production host) is a larger infra change left as follow-up — this gate is the *detection* backstop for it in the meantime.

## Testing

Exercised every `prod-guard` path locally against the real production unit:

- `snapshot` then `check` on an untouched unit → `production kolu.service untouched (PID …)`, exit 0.
- Tampered the baseline PID to simulate a restart → printed the disruption banner, exit 1.
- Unknown action → exit 2; missing snapshot and no-production-unit → no-op exit 0.

No app code changed (justfile recipe + agent-skill prose + regenerated skill copies). `just fmt` clean.

## Evidence

No visual impact: agent-tooling and CI/justfile change only — no kolu UI surface is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)