### PR TITLE
feat(be): reproduce-before-fix gate on the bug path, with a real bar

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -28,7 +28,7 @@ Add a question only when something material is genuinely unclear — don't pad. 
 
 ## 2. Implement
 
-- **Bug:** reproduce first — write a **failing e2e test** that captures the bug (via the `/test` harness), confirm it's red, *then* fix until green. No fix without a reproducing test.
+- **Bug:** reproduce *before* you theorize or fix — start from facts, not a story about the bug. **(1)** Get ground truth from the running system; observe the real symptom, don't trust a description of it. **(2)** Pin the one hard, observable fact the bug produces — a wrong value, an error, a state that can't legally happen (e.g. "the client SHA stays `7deb397` across reloads"). **(3)** Build a reproduction that exhibits *that exact fact* and is **red on the current code** — a **failing e2e test** via the `/test` harness when it can express the bug, otherwise a scripted repro. A repro that *passes / converges / "works"* is **not** a reproduction: if it doesn't show the symptom the **repro** is wrong — fix the repro, never conclude "no bug" from it. **(4)** Only now fix, until that same repro flips green. No fix without a reproduction that was first red for the real reason.
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -28,7 +28,7 @@ Add a question only when something material is genuinely unclear — don't pad. 
 
 ## 2. Implement
 
-- **Bug:** reproduce first — write a **failing e2e test** that captures the bug (via the `/test` harness), confirm it's red, *then* fix until green. No fix without a reproducing test.
+- **Bug:** reproduce *before* you theorize or fix — start from facts, not a story about the bug. **(1)** Get ground truth from the running system; observe the real symptom, don't trust a description of it. **(2)** Pin the one hard, observable fact the bug produces — a wrong value, an error, a state that can't legally happen (e.g. "the client SHA stays `7deb397` across reloads"). **(3)** Build a reproduction that exhibits *that exact fact* and is **red on the current code** — a **failing e2e test** via the `/test` harness when it can express the bug, otherwise a scripted repro. A repro that *passes / converges / "works"* is **not** a reproduction: if it doesn't show the symptom the **repro** is wrong — fix the repro, never conclude "no bug" from it. **(4)** Only now fix, until that same repro flips green. No fix without a reproduction that was first red for the real reason.
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -28,7 +28,7 @@ Add a question only when something material is genuinely unclear — don't pad. 
 
 ## 2. Implement
 
-- **Bug:** reproduce first — write a **failing e2e test** that captures the bug (via the `/test` harness), confirm it's red, *then* fix until green. No fix without a reproducing test.
+- **Bug:** reproduce *before* you theorize or fix — start from facts, not a story about the bug. **(1)** Get ground truth from the running system; observe the real symptom, don't trust a description of it. **(2)** Pin the one hard, observable fact the bug produces — a wrong value, an error, a state that can't legally happen (e.g. "the client SHA stays `7deb397` across reloads"). **(3)** Build a reproduction that exhibits *that exact fact* and is **red on the current code** — a **failing e2e test** via the `/test` harness when it can express the bug, otherwise a scripted repro. A repro that *passes / converges / "works"* is **not** a reproduction: if it doesn't show the symptom the **repro** is wrong — fix the repro, never conclude "no bug" from it. **(4)** Only now fix, until that same repro flips green. No fix without a reproduction that was first red for the real reason.
 - **Feature / new behavior:** write the covering test (e2e/integration/unit as fits) before or alongside the change.
 - **Refactor/chore:** no test-first requirement; rely on existing coverage.
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -314,7 +314,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
   .agents/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
-  .agents/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
+  .agents/skills/be/SKILL.md: sha256:4a49f20dcc62b321e7875891b63975c11b64613154d99d272303f165fb43d4de
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -348,7 +348,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
   .claude/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
-  .claude/skills/be/SKILL.md: sha256:c9d23a783bab82a358ffe9a3753352100805be34de3cae6d1e5baff11089533c
+  .claude/skills/be/SKILL.md: sha256:4a49f20dcc62b321e7875891b63975c11b64613154d99d272303f165fb43d4de
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f


### PR DESCRIPTION
`/be` already told the agent to "reproduce first" on a bug — yet in the cache-loop work behind <kolu#1324> a confident **"there is no bug"** conclusion still shipped a wrong theory. The reason is the gap this PR closes: the agent built a reproduction that **converged** — it reproduced a *proxy*, not the actual symptom — and then read "my repro passes" as "no bug." The old rule said *write a failing e2e test*, but it never defined the bar for what counts as reproducing the bug, and it didn't guard the moment where this goes wrong: theorizing before the symptom is in hand.

## The change

Rewrites the `## 2. Implement` **Bug** rule into a four-step gate:

1. **Ground truth first** — observe the real symptom on the running system, not a description of it.
2. **Pin the one hard fact** the bug produces — a wrong value, an error, a state that can't legally happen (e.g. *"the client SHA stays `7deb397` across reloads"*).
3. **Reproduce that exact fact, red on current code** — a failing `/test` e2e when the harness can express the bug, otherwise a scripted repro.
4. **Only then fix**, until the same repro flips green.

The load-bearing addition is the bar:

> A repro that *passes / converges / "works"* is **not** a reproduction: if it doesn't show the symptom the **repro** is wrong — fix the repro, never conclude "no bug" from it.

## Notes

- Edited the `.apm/skills/be/SKILL.md` **source** and regenerated `.claude/` + `.agents/` via `just ai::apm` (per the repo's APM rule); `apm.lock.yaml` updates only the two `be/SKILL.md` hashes.
- Scope is deliberately `/be` only. `/do` comes from the `srid/agency` dependency and isn't editable here; a global always-on convention would also cover free-form sessions, but per request this is `/be`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
