### PR TITLE
feat(codex-debate): implementor inherits main-agent context + rationale

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
 description: Run /be's review gauntlet SERIALLY — /lens-debate (lowy ⇄ hickey), then /codex-debate, then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
-argument-hint: "[--base <branch>] [--rationale <note>] [--tracks lens,codex,simplify,police]"
+argument-hint: "[--base <branch>] [--rationale <note>] [--context <note>] [--tracks lens,codex,simplify,police]"
 ---
 
 # Review gauntlet (serial)
@@ -92,7 +92,10 @@ it once per step.
 
 2. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
    worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
-   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
+   local-only round commits before be-review pushes), and thread both `context`
+   (the task / main-agent context, so the codex **author inherits what you know —
+   not just the diff** — every round) and `rationale` (so codex doesn't flag
+   deliberate decisions at the source) straight through. Its step-2 `Workflow` runs
    in the background; **wait for it to finish** before starting the simplify step.
    It commits its rounds and **returns** its rendered comment body — hold onto it
    to post after the final push. (On persistent `reviewer-error` there is **no

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -56,8 +56,10 @@ applies its own fixes directly — no snapshot, no apply pass. be-review pushes 
 at the end and *then* posts the PR comments (lens, codex, and a code-police
 summary), so no comment advertises a local-only commit.
 
-- Pass `base` and the change **`rationale`** (so the lenses don't flag deliberate
-  decisions). Preflight is a non-empty diff and (since codex runs) `codex login
+- Pass `base`, the change **`rationale`** (so the lenses don't flag deliberate
+  decisions), and **`context`** — the task intent and key decisions you hold from
+  this run, so the codex author **inherits what you know instead of re-deriving it
+  from the diff**. Preflight is a non-empty diff and (since codex runs) `codex login
   status`.
 - Lens-debate commits its agreed fixes; codex's rounds commit `fix(…)`; simplify
   and code-police commit `refactor:` / `fix(police):`. Confirm the post-push PR

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -86,8 +86,9 @@ codex/opencode runtimes the skill is inert.
 ## Arguments
 
 A leading `review` subcommand token, if present, is consumed by mode detection;
-what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]` (the
-bare alias passes the whole argument string through unchanged). Parse:
+what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]
+[--rationale <note>] [--context <note>]` (the bare alias passes the whole argument
+string through unchanged). Parse:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -106,6 +107,20 @@ bare alias passes the whole argument string through unchanged). Parse:
 - **`--no-comment`**: don't post the debate summary to the PR. By **default**, when
   a PR exists, the debate summary IS posted as a PR comment (see step 3). Pass
   this to suppress the outward-facing write and report in chat only.
+- **`--rationale <note>`** (optional): the author's note on **deliberate** design
+  decisions. Threaded into **both** sides — codex's round-1 review prompt (so it
+  doesn't flag intentional choices as defects; its warm session carries the note
+  across later rounds) and the Claude author's prompt **every round** (so it
+  *disputes*, rather than "fixes", a finding that contradicts a deliberate choice).
+  Mirrors `/lens-debate`'s `rationale`. Pull it from the PR/issue description, or the
+  caller (`/be-review`) passes the change rationale straight through.
+- **`--context <note>`** (optional): the **main-agent context** the Claude author
+  should **inherit** — what this change is FOR (its task/intent and key decisions the
+  orchestrator already holds). Injected into the author's prompt **every round** so it
+  no longer reconstructs intent from the diff alone (`agent()` is one-shot and can't
+  be resumed the way codex is, so re-injection is how it inherits at all). Given to
+  the **author only**, not codex — codex stays an independent reviewer of the code,
+  not the author's narrative. `/be-review` passes the task context through.
 
 ## Steps
 
@@ -133,7 +148,9 @@ Workflow({
     repoPath: "<worktree root>",        // also the per-worktree scratch dir root
     base: "<base branch>",
     commit: <false only if --no-commit>,
-    skillDir: ".claude/skills/codex-debate"
+    skillDir: ".claude/skills/codex-debate",
+    context: "<main-agent context the author inherits; omit/'' if none>",
+    rationale: "<author's note on deliberate decisions; omit/'' if none>"
   }
 })
 ```
@@ -416,6 +433,15 @@ returns:
   comment step 3 posts, so the author's memory and the published summary are one
   record. The writes stay small (one round each), so the Haiku writer never
   retypes a large blob. codex stays on its own warm session and never reads them.
+- **Inherited context, not just diff.** On top of that cross-round memory, when the
+  caller passes `context` and/or `rationale` the author **inherits them in EVERY
+  round's prompt** — the main-agent intent (what the change is FOR) and the
+  deliberate-decision note. So even **round 1** reasons from the change's purpose
+  rather than the diff alone, and the author *disputes* a finding that contradicts a
+  deliberate choice instead of dutifully "fixing" it. The `rationale` also rides
+  codex's round-1 prompt (see `codex-review.sh`), so the reviewer doesn't raise those
+  intentional choices at the source; `context` is the author's alone (codex stays an
+  independent reviewer of the code, not the narrative).
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-debate
 description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two explicit subcommands. `review` (also the bare/back-compat default) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. `answer` — Claude and codex each answer a freeform prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
-argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  answer \"<prompt>\""
+argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment] [--rationale <note>] [--context <note>]  |  answer \"<prompt>\""
 ---
 
 # Codex ⇄ Claude debate
@@ -31,8 +31,8 @@ Look at the **first whitespace-delimited token** of `$ARGUMENTS`:
 - **`answer`** → **answer mode**. The prompt is everything after the `answer`
   token. Jump to [Answer mode](#answer-mode); the review-mode steps do not apply.
 - **`review`** → **review mode**. The remaining args are the review grammar
-  (`[<pr-number>] [--base …] [--no-commit] [--no-comment]`). Continue with
-  [Review mode](#review-mode).
+  (`[<pr-number>] [--base …] [--no-commit] [--no-comment] [--rationale <note>]
+  [--context <note>]`). Continue with [Review mode](#review-mode).
 - **No args, OR the first token is a number (a PR number) or a `--flag`** →
   **review mode** (the backward-compatible bare alias for the original
   `/codex-debate [<pr>] [flags]`, so existing callers like `/be-review` keep

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -60,6 +60,38 @@ const mechModel = a.mechModel || 'haiku'
 // agent's. The small per-round section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
+// --- Context the Claude implementor INHERITS --------------------------------
+// Two optional notes the CALLER threads in so the implementor (the Claude author)
+// no longer reasons from the diff alone — the gap that made it re-derive the
+// change's intent every round and re-litigate deliberate choices codex (rightly,
+// on a bare diff) flags.
+//
+// `context` (#1): the MAIN-AGENT context — what this change is FOR (the task/intent
+// and key decisions the orchestrator already holds). Injected into the implementor
+// EVERY round: agent() is one-shot and Claude isn't headless under Max auth, so it
+// can't be resumed the way codex is — re-injection is how it "inherits" at all.
+// Deliberately NOT given to codex, which stays an independent reviewer of the
+// actual code rather than the author's narrative.
+const context = (a.context || '').trim()
+// `rationale` (#2): the author's note on DELIBERATE decisions — the same note
+// /lens-debate already accepts, now threaded here too. Given to BOTH sides: codex
+// (its round-1 prompt, via codexReviews → codex-review.sh — so the reviewer doesn't
+// raise them at the source; codex's warm session carries the note across rounds)
+// AND the implementor (so it DISPUTES, rather than "fixes", a finding that
+// contradicts a deliberate choice).
+const rationale = (a.rationale || '').trim()
+// The two notes as ready-to-interpolate implementor-prompt blocks. Empty when the
+// note is absent, so the prompt stays byte-identical to the contextless form then.
+const contextBlock = context
+  ? `\nContext you INHERIT from the main agent — what this change is FOR (its task/intent and key decisions). Weigh codex's findings against it: a finding that contradicts this intent is a candidate to DISPUTE, not blindly fix.\n${context}\n`
+  : ''
+const rationaleBlock = rationale
+  ? `\nAuthor's note on DELIBERATE decisions (chosen on purpose — do NOT "fix" them away; dispute the finding unless codex shows the decision itself is wrong):\n${rationale}\n`
+  : ''
+// codex reads the rationale from a file (it's constant across rounds, written once
+// before the loop); `-` means "no rationale" to codex-review.sh.
+const rationaleFileArg = rationale ? `${workDir}/rationale.md` : '-'
+
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
 // the SINGLE home for the value: it is passed script-ward (a 4th positional arg
 // to codex-review.sh, which sets `-c model_reasoning_effort`) and read by
@@ -147,11 +179,11 @@ async function codexReviews(round, rebuttalJson) {
 ${rebuttalJson}
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
     : `1. (No prior rebuttal this round.)
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -192,7 +224,7 @@ Build on what you already did; don't re-derive the diff from scratch, and don't 
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
-
+${contextBlock}${rationaleBlock}
 ${priorBlock}CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
@@ -386,6 +418,23 @@ await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
+
+// Persist the author's rationale ONCE (it's constant across rounds) so
+// codex-review.sh can inject it into codex's round-1 prompt; codex's warm session
+// then carries the note across later rounds without re-injection. Only when a
+// rationale was passed — otherwise rationaleFileArg is `-` and no file is needed.
+// A thin mechanical writer (the workflow can't do file I/O); the payload is small.
+if (rationale) {
+  await agent(
+    `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${workDir}/rationale.md\` with EXACTLY this content, overwriting any existing file:
+
+${rationale}`,
+    { label: 'rationale:write', phase: 'Debate', model: mechModel },
+  )
+}
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -90,7 +90,8 @@ const rationaleBlock = rationale
   : ''
 // codex reads the rationale from a file (it's constant across rounds, written once
 // before the loop); `-` means "no rationale" to codex-review.sh.
-const rationaleFileArg = rationale ? `${workDir}/rationale.md` : '-'
+const rationaleFile = `${workDir}/rationale.md`
+const rationaleFileArg = rationale ? rationaleFile : '-'
 
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
 // the SINGLE home for the value: it is passed script-ward (a 4th positional arg
@@ -429,7 +430,7 @@ if (rationale) {
     `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${workDir}/rationale.md\` with EXACTLY this content, overwriting any existing file:
+2. Using the Write tool, create \`${rationaleFile}\` with EXACTLY this content, overwriting any existing file:
 
 ${rationale}`,
     { label: 'rationale:write', phase: 'Debate', model: mechModel },

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -332,21 +332,27 @@ function renderLedger(transcript, meta) {
 // (section-002 before section-010) for both the author's read and the assembly.
 const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
 
-// Write ONE round's section to its own small file — the author reads these as its
-// cross-round memory, and the orchestrator cats them into the posted comment. A
-// thin mechanical agent (the workflow can't do file I/O), but the payload is just
-// this round, so it stays small and Haiku-safe — no whole-ledger retype, and
-// rewriting a round's own file is idempotent (safe on a resume).
-async function writeSection(entry) {
-  const text = roundLedgerSection(entry)
-  const path = sectionFile(entry.round)
+// Drop a string to a scratch file via a mechanical Haiku writer — the single home
+// for the "write this content to this path" idiom (the workflow can't do file I/O
+// itself, and Claude isn't headless, so a tiny agent does it). Both the per-round
+// section writer and the one-shot rationale writer route through here; payloads are
+// small (one round / one note) so Haiku is safe, and overwriting is idempotent
+// (safe on a resume).
+function writeFileAgent(path, content, label) {
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
 2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
-${text}`
-  return agent(prompt, { label: `ledger:round${entry.round}`, phase: 'Debate', model: mechModel })
+${content}`
+  return agent(prompt, { label, phase: 'Debate', model: mechModel })
+}
+
+// Write ONE round's section to its own small file — the author reads these as its
+// cross-round memory, and the orchestrator cats them into the posted comment. No
+// whole-ledger retype: the payload is just this round.
+async function writeSection(entry) {
+  return writeFileAgent(sectionFile(entry.round), roundLedgerSection(entry), `ledger:round${entry.round}`)
 }
 
 const transcript = []
@@ -424,17 +430,8 @@ await agent(
 // codex-review.sh can inject it into codex's round-1 prompt; codex's warm session
 // then carries the note across later rounds without re-injection. Only when a
 // rationale was passed — otherwise rationaleFileArg is `-` and no file is needed.
-// A thin mechanical writer (the workflow can't do file I/O); the payload is small.
 if (rationale) {
-  await agent(
-    `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${rationaleFile}\` with EXACTLY this content, overwriting any existing file:
-
-${rationale}`,
-    { label: 'rationale:write', phase: 'Debate', model: mechModel },
-  )
+  await writeFileAgent(rationaleFile, rationale, 'rationale:write')
 }
 
 for (let round = 1; ; round++) {

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -13,7 +13,7 @@
 # codex-exec-lib.sh.
 #
 # Usage:
-#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
+#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]
 #
 #   <base-branch>    branch to diff against (e.g. master)
 #   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
@@ -22,6 +22,10 @@
 #   <reasoning-effort> codex model_reasoning_effort for this run; the debate
 #                    workflow passes its REASONING_EFFORT constant here so the
 #                    value has one home. Defaults to "xhigh" for standalone runs.
+#   <rationale-file> path to a file holding the author's note on DELIBERATE
+#                    decisions, or "-" for none. Injected into the round-1 (cold)
+#                    review prompt so codex doesn't flag intentional choices as
+#                    defects; codex's warm session carries it across later rounds.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
@@ -42,6 +46,9 @@ out="${3:?missing out-json path}"
 # The debate workflow owns this value (its REASONING_EFFORT constant) and passes
 # it down; "xhigh" is only the default for a standalone invocation of this script.
 effort="${4:-xhigh}"
+# Author's note on deliberate decisions (constant across rounds); "-" = none. Only
+# the cold/round-1 prompt injects it — codex's warm session retains it after that.
+rationale_file="${5:--}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
@@ -79,6 +86,23 @@ $rebuttal
 "
 fi
 
+# The author's note on DELIBERATE decisions, if supplied — injected into the COLD
+# review prompt below so codex doesn't raise intentional choices as findings. Read
+# from a file (the workflow writes it once) so multi-line notes with special chars
+# survive intact, the same way the rebuttal is handled.
+rationale=""
+if [ "$rationale_file" != "-" ] && [ -s "$rationale_file" ]; then
+  rationale="$(cat "$rationale_file")"
+fi
+rationale_block=""
+if [ -n "$rationale" ]; then
+  rationale_block="
+The author flagged the following as DELIBERATE decisions. Do NOT raise them as
+findings unless the reasoning itself is wrong — if it is, say specifically why:
+$rationale
+"
+fi
+
 # WARM SESSION. Round 1 (rebuttal_file == "-") cold-starts and resets any stale id;
 # later rounds resume codex's own review session. Resolve the id first so the prompt
 # below can lean on codex's retained context when warm.
@@ -103,8 +127,10 @@ synthesize_error_verdict() {
 # Two prompts: a lean follow-up for the WARM (resume) path that leans on codex's
 # retained context, and the full review prompt for the COLD path (round 1, or the
 # fallback when no session id was captured). Unquoted heredocs: only $base,
-# $rebuttal, and $rebuttal_block expand; their expansions are inserted literally
-# (heredoc results aren't re-scanned), so special chars in $rebuttal stay inert.
+# $rebuttal, $rebuttal_block, and (in the cold prompt) $rationale_block expand;
+# their expansions are inserted literally (heredoc results aren't re-scanned), so
+# special chars in $rebuttal / $rationale stay inert. The rationale rides the cold
+# prompt ONLY — codex's warm session already retains it from round 1.
 if [ -n "$resume_id" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME review session you started earlier — you still
@@ -154,7 +180,7 @@ and run no git write command: add/commit/push/stash/checkout):
 
 Read every changed file plus enough surrounding code to judge it in context.
 Ignore the debate's own scratch dir '.codex-debate/' if it appears.
-
+$rationale_block
 Give ALL your feedback in this pass — every issue worth raising, at EVERY severity
 (blocking, major, minor, nit): correctness bugs, logic errors, silently swallowed
 errors, unjustified fallbacks, security problems, and clear simplicity/efficiency

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -91,8 +91,19 @@ fi
 # from a file (the workflow writes it once) so multi-line notes with special chars
 # survive intact, the same way the rebuttal is handled.
 rationale=""
-if [ "$rationale_file" != "-" ] && [ -s "$rationale_file" ]; then
-  rationale="$(cat "$rationale_file")"
+if [ "$rationale_file" != "-" ]; then
+  if [ -s "$rationale_file" ]; then
+    rationale="$(cat "$rationale_file")"
+  else
+    # A rationale was expected (path given, not "-") but the file is missing or
+    # empty — the rationale:write handoff broke. Proceed without it (a missing
+    # rationale degrades to a bare-diff review the IMPLEMENTOR still disputes from
+    # its own inherited rationale block — it is a false-finding SUPPRESSOR, not a
+    # correctness input, so we don't abort the round), but make the failure loud
+    # so the round isn't silently mistaken for a rationale-aware review. Mirrors
+    # the rebuttal warning above.
+    echo "WARNING: expected rationale file '$rationale_file' is missing or empty; proceeding with no deliberate-decisions note this round (codex reviews the bare diff)." >&2
+  fi
 fi
 rationale_block=""
 if [ -n "$rationale" ]; then

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -40,7 +40,7 @@
 #     OWN prior review + reasoning across rounds.
 set -uo pipefail
 
-base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
+base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]}"
 rebuttal_file="${2:?missing rebuttal-file (use - for none)}"
 out="${3:?missing out-json path}"
 # The debate workflow owns this value (its REASONING_EFFORT constant) and passes

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
 description: Run /be's review gauntlet SERIALLY — /lens-debate (lowy ⇄ hickey), then /codex-debate, then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
-argument-hint: "[--base <branch>] [--rationale <note>] [--tracks lens,codex,simplify,police]"
+argument-hint: "[--base <branch>] [--rationale <note>] [--context <note>] [--tracks lens,codex,simplify,police]"
 ---
 
 # Review gauntlet (serial)
@@ -92,7 +92,10 @@ it once per step.
 
 2. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
    worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
-   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
+   local-only round commits before be-review pushes), and thread both `context`
+   (the task / main-agent context, so the codex **author inherits what you know —
+   not just the diff** — every round) and `rationale` (so codex doesn't flag
+   deliberate decisions at the source) straight through. Its step-2 `Workflow` runs
    in the background; **wait for it to finish** before starting the simplify step.
    It commits its rounds and **returns** its rendered comment body — hold onto it
    to post after the final push. (On persistent `reviewer-error` there is **no

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -56,8 +56,10 @@ applies its own fixes directly — no snapshot, no apply pass. be-review pushes 
 at the end and *then* posts the PR comments (lens, codex, and a code-police
 summary), so no comment advertises a local-only commit.
 
-- Pass `base` and the change **`rationale`** (so the lenses don't flag deliberate
-  decisions). Preflight is a non-empty diff and (since codex runs) `codex login
+- Pass `base`, the change **`rationale`** (so the lenses don't flag deliberate
+  decisions), and **`context`** — the task intent and key decisions you hold from
+  this run, so the codex author **inherits what you know instead of re-deriving it
+  from the diff**. Preflight is a non-empty diff and (since codex runs) `codex login
   status`.
 - Lens-debate commits its agreed fixes; codex's rounds commit `fix(…)`; simplify
   and code-police commit `refactor:` / `fix(police):`. Confirm the post-push PR

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -86,8 +86,9 @@ codex/opencode runtimes the skill is inert.
 ## Arguments
 
 A leading `review` subcommand token, if present, is consumed by mode detection;
-what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]` (the
-bare alias passes the whole argument string through unchanged). Parse:
+what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]
+[--rationale <note>] [--context <note>]` (the bare alias passes the whole argument
+string through unchanged). Parse:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -106,6 +107,20 @@ bare alias passes the whole argument string through unchanged). Parse:
 - **`--no-comment`**: don't post the debate summary to the PR. By **default**, when
   a PR exists, the debate summary IS posted as a PR comment (see step 3). Pass
   this to suppress the outward-facing write and report in chat only.
+- **`--rationale <note>`** (optional): the author's note on **deliberate** design
+  decisions. Threaded into **both** sides — codex's round-1 review prompt (so it
+  doesn't flag intentional choices as defects; its warm session carries the note
+  across later rounds) and the Claude author's prompt **every round** (so it
+  *disputes*, rather than "fixes", a finding that contradicts a deliberate choice).
+  Mirrors `/lens-debate`'s `rationale`. Pull it from the PR/issue description, or the
+  caller (`/be-review`) passes the change rationale straight through.
+- **`--context <note>`** (optional): the **main-agent context** the Claude author
+  should **inherit** — what this change is FOR (its task/intent and key decisions the
+  orchestrator already holds). Injected into the author's prompt **every round** so it
+  no longer reconstructs intent from the diff alone (`agent()` is one-shot and can't
+  be resumed the way codex is, so re-injection is how it inherits at all). Given to
+  the **author only**, not codex — codex stays an independent reviewer of the code,
+  not the author's narrative. `/be-review` passes the task context through.
 
 ## Steps
 
@@ -133,7 +148,9 @@ Workflow({
     repoPath: "<worktree root>",        // also the per-worktree scratch dir root
     base: "<base branch>",
     commit: <false only if --no-commit>,
-    skillDir: ".claude/skills/codex-debate"
+    skillDir: ".claude/skills/codex-debate",
+    context: "<main-agent context the author inherits; omit/'' if none>",
+    rationale: "<author's note on deliberate decisions; omit/'' if none>"
   }
 })
 ```
@@ -416,6 +433,15 @@ returns:
   comment step 3 posts, so the author's memory and the published summary are one
   record. The writes stay small (one round each), so the Haiku writer never
   retypes a large blob. codex stays on its own warm session and never reads them.
+- **Inherited context, not just diff.** On top of that cross-round memory, when the
+  caller passes `context` and/or `rationale` the author **inherits them in EVERY
+  round's prompt** — the main-agent intent (what the change is FOR) and the
+  deliberate-decision note. So even **round 1** reasons from the change's purpose
+  rather than the diff alone, and the author *disputes* a finding that contradicts a
+  deliberate choice instead of dutifully "fixing" it. The `rationale` also rides
+  codex's round-1 prompt (see `codex-review.sh`), so the reviewer doesn't raise those
+  intentional choices at the source; `context` is the author's alone (codex stays an
+  independent reviewer of the code, not the narrative).
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-debate
 description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two explicit subcommands. `review` (also the bare/back-compat default) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. `answer` — Claude and codex each answer a freeform prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
-argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  answer \"<prompt>\""
+argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment] [--rationale <note>] [--context <note>]  |  answer \"<prompt>\""
 ---
 
 # Codex ⇄ Claude debate
@@ -31,8 +31,8 @@ Look at the **first whitespace-delimited token** of `$ARGUMENTS`:
 - **`answer`** → **answer mode**. The prompt is everything after the `answer`
   token. Jump to [Answer mode](#answer-mode); the review-mode steps do not apply.
 - **`review`** → **review mode**. The remaining args are the review grammar
-  (`[<pr-number>] [--base …] [--no-commit] [--no-comment]`). Continue with
-  [Review mode](#review-mode).
+  (`[<pr-number>] [--base …] [--no-commit] [--no-comment] [--rationale <note>]
+  [--context <note>]`). Continue with [Review mode](#review-mode).
 - **No args, OR the first token is a number (a PR number) or a `--flag`** →
   **review mode** (the backward-compatible bare alias for the original
   `/codex-debate [<pr>] [flags]`, so existing callers like `/be-review` keep

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -60,6 +60,38 @@ const mechModel = a.mechModel || 'haiku'
 // agent's. The small per-round section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
+// --- Context the Claude implementor INHERITS --------------------------------
+// Two optional notes the CALLER threads in so the implementor (the Claude author)
+// no longer reasons from the diff alone — the gap that made it re-derive the
+// change's intent every round and re-litigate deliberate choices codex (rightly,
+// on a bare diff) flags.
+//
+// `context` (#1): the MAIN-AGENT context — what this change is FOR (the task/intent
+// and key decisions the orchestrator already holds). Injected into the implementor
+// EVERY round: agent() is one-shot and Claude isn't headless under Max auth, so it
+// can't be resumed the way codex is — re-injection is how it "inherits" at all.
+// Deliberately NOT given to codex, which stays an independent reviewer of the
+// actual code rather than the author's narrative.
+const context = (a.context || '').trim()
+// `rationale` (#2): the author's note on DELIBERATE decisions — the same note
+// /lens-debate already accepts, now threaded here too. Given to BOTH sides: codex
+// (its round-1 prompt, via codexReviews → codex-review.sh — so the reviewer doesn't
+// raise them at the source; codex's warm session carries the note across rounds)
+// AND the implementor (so it DISPUTES, rather than "fixes", a finding that
+// contradicts a deliberate choice).
+const rationale = (a.rationale || '').trim()
+// The two notes as ready-to-interpolate implementor-prompt blocks. Empty when the
+// note is absent, so the prompt stays byte-identical to the contextless form then.
+const contextBlock = context
+  ? `\nContext you INHERIT from the main agent — what this change is FOR (its task/intent and key decisions). Weigh codex's findings against it: a finding that contradicts this intent is a candidate to DISPUTE, not blindly fix.\n${context}\n`
+  : ''
+const rationaleBlock = rationale
+  ? `\nAuthor's note on DELIBERATE decisions (chosen on purpose — do NOT "fix" them away; dispute the finding unless codex shows the decision itself is wrong):\n${rationale}\n`
+  : ''
+// codex reads the rationale from a file (it's constant across rounds, written once
+// before the loop); `-` means "no rationale" to codex-review.sh.
+const rationaleFileArg = rationale ? `${workDir}/rationale.md` : '-'
+
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
 // the SINGLE home for the value: it is passed script-ward (a 4th positional arg
 // to codex-review.sh, which sets `-c model_reasoning_effort`) and read by
@@ -147,11 +179,11 @@ async function codexReviews(round, rebuttalJson) {
 ${rebuttalJson}
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
     : `1. (No prior rebuttal this round.)
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -192,7 +224,7 @@ Build on what you already did; don't re-derive the diff from scratch, and don't 
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
-
+${contextBlock}${rationaleBlock}
 ${priorBlock}CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
@@ -386,6 +418,23 @@ await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
+
+// Persist the author's rationale ONCE (it's constant across rounds) so
+// codex-review.sh can inject it into codex's round-1 prompt; codex's warm session
+// then carries the note across later rounds without re-injection. Only when a
+// rationale was passed — otherwise rationaleFileArg is `-` and no file is needed.
+// A thin mechanical writer (the workflow can't do file I/O); the payload is small.
+if (rationale) {
+  await agent(
+    `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${workDir}/rationale.md\` with EXACTLY this content, overwriting any existing file:
+
+${rationale}`,
+    { label: 'rationale:write', phase: 'Debate', model: mechModel },
+  )
+}
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -90,7 +90,8 @@ const rationaleBlock = rationale
   : ''
 // codex reads the rationale from a file (it's constant across rounds, written once
 // before the loop); `-` means "no rationale" to codex-review.sh.
-const rationaleFileArg = rationale ? `${workDir}/rationale.md` : '-'
+const rationaleFile = `${workDir}/rationale.md`
+const rationaleFileArg = rationale ? rationaleFile : '-'
 
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
 // the SINGLE home for the value: it is passed script-ward (a 4th positional arg
@@ -429,7 +430,7 @@ if (rationale) {
     `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${workDir}/rationale.md\` with EXACTLY this content, overwriting any existing file:
+2. Using the Write tool, create \`${rationaleFile}\` with EXACTLY this content, overwriting any existing file:
 
 ${rationale}`,
     { label: 'rationale:write', phase: 'Debate', model: mechModel },

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -332,21 +332,27 @@ function renderLedger(transcript, meta) {
 // (section-002 before section-010) for both the author's read and the assembly.
 const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
 
-// Write ONE round's section to its own small file — the author reads these as its
-// cross-round memory, and the orchestrator cats them into the posted comment. A
-// thin mechanical agent (the workflow can't do file I/O), but the payload is just
-// this round, so it stays small and Haiku-safe — no whole-ledger retype, and
-// rewriting a round's own file is idempotent (safe on a resume).
-async function writeSection(entry) {
-  const text = roundLedgerSection(entry)
-  const path = sectionFile(entry.round)
+// Drop a string to a scratch file via a mechanical Haiku writer — the single home
+// for the "write this content to this path" idiom (the workflow can't do file I/O
+// itself, and Claude isn't headless, so a tiny agent does it). Both the per-round
+// section writer and the one-shot rationale writer route through here; payloads are
+// small (one round / one note) so Haiku is safe, and overwriting is idempotent
+// (safe on a resume).
+function writeFileAgent(path, content, label) {
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
 2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
-${text}`
-  return agent(prompt, { label: `ledger:round${entry.round}`, phase: 'Debate', model: mechModel })
+${content}`
+  return agent(prompt, { label, phase: 'Debate', model: mechModel })
+}
+
+// Write ONE round's section to its own small file — the author reads these as its
+// cross-round memory, and the orchestrator cats them into the posted comment. No
+// whole-ledger retype: the payload is just this round.
+async function writeSection(entry) {
+  return writeFileAgent(sectionFile(entry.round), roundLedgerSection(entry), `ledger:round${entry.round}`)
 }
 
 const transcript = []
@@ -424,17 +430,8 @@ await agent(
 // codex-review.sh can inject it into codex's round-1 prompt; codex's warm session
 // then carries the note across later rounds without re-injection. Only when a
 // rationale was passed — otherwise rationaleFileArg is `-` and no file is needed.
-// A thin mechanical writer (the workflow can't do file I/O); the payload is small.
 if (rationale) {
-  await agent(
-    `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${rationaleFile}\` with EXACTLY this content, overwriting any existing file:
-
-${rationale}`,
-    { label: 'rationale:write', phase: 'Debate', model: mechModel },
-  )
+  await writeFileAgent(rationaleFile, rationale, 'rationale:write')
 }
 
 for (let round = 1; ; round++) {

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -13,7 +13,7 @@
 # codex-exec-lib.sh.
 #
 # Usage:
-#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
+#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]
 #
 #   <base-branch>    branch to diff against (e.g. master)
 #   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
@@ -22,6 +22,10 @@
 #   <reasoning-effort> codex model_reasoning_effort for this run; the debate
 #                    workflow passes its REASONING_EFFORT constant here so the
 #                    value has one home. Defaults to "xhigh" for standalone runs.
+#   <rationale-file> path to a file holding the author's note on DELIBERATE
+#                    decisions, or "-" for none. Injected into the round-1 (cold)
+#                    review prompt so codex doesn't flag intentional choices as
+#                    defects; codex's warm session carries it across later rounds.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
@@ -42,6 +46,9 @@ out="${3:?missing out-json path}"
 # The debate workflow owns this value (its REASONING_EFFORT constant) and passes
 # it down; "xhigh" is only the default for a standalone invocation of this script.
 effort="${4:-xhigh}"
+# Author's note on deliberate decisions (constant across rounds); "-" = none. Only
+# the cold/round-1 prompt injects it — codex's warm session retains it after that.
+rationale_file="${5:--}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
@@ -79,6 +86,23 @@ $rebuttal
 "
 fi
 
+# The author's note on DELIBERATE decisions, if supplied — injected into the COLD
+# review prompt below so codex doesn't raise intentional choices as findings. Read
+# from a file (the workflow writes it once) so multi-line notes with special chars
+# survive intact, the same way the rebuttal is handled.
+rationale=""
+if [ "$rationale_file" != "-" ] && [ -s "$rationale_file" ]; then
+  rationale="$(cat "$rationale_file")"
+fi
+rationale_block=""
+if [ -n "$rationale" ]; then
+  rationale_block="
+The author flagged the following as DELIBERATE decisions. Do NOT raise them as
+findings unless the reasoning itself is wrong — if it is, say specifically why:
+$rationale
+"
+fi
+
 # WARM SESSION. Round 1 (rebuttal_file == "-") cold-starts and resets any stale id;
 # later rounds resume codex's own review session. Resolve the id first so the prompt
 # below can lean on codex's retained context when warm.
@@ -103,8 +127,10 @@ synthesize_error_verdict() {
 # Two prompts: a lean follow-up for the WARM (resume) path that leans on codex's
 # retained context, and the full review prompt for the COLD path (round 1, or the
 # fallback when no session id was captured). Unquoted heredocs: only $base,
-# $rebuttal, and $rebuttal_block expand; their expansions are inserted literally
-# (heredoc results aren't re-scanned), so special chars in $rebuttal stay inert.
+# $rebuttal, $rebuttal_block, and (in the cold prompt) $rationale_block expand;
+# their expansions are inserted literally (heredoc results aren't re-scanned), so
+# special chars in $rebuttal / $rationale stay inert. The rationale rides the cold
+# prompt ONLY — codex's warm session already retains it from round 1.
 if [ -n "$resume_id" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME review session you started earlier — you still
@@ -154,7 +180,7 @@ and run no git write command: add/commit/push/stash/checkout):
 
 Read every changed file plus enough surrounding code to judge it in context.
 Ignore the debate's own scratch dir '.codex-debate/' if it appears.
-
+$rationale_block
 Give ALL your feedback in this pass — every issue worth raising, at EVERY severity
 (blocking, major, minor, nit): correctness bugs, logic errors, silently swallowed
 errors, unjustified fallbacks, security problems, and clear simplicity/efficiency

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -91,8 +91,19 @@ fi
 # from a file (the workflow writes it once) so multi-line notes with special chars
 # survive intact, the same way the rebuttal is handled.
 rationale=""
-if [ "$rationale_file" != "-" ] && [ -s "$rationale_file" ]; then
-  rationale="$(cat "$rationale_file")"
+if [ "$rationale_file" != "-" ]; then
+  if [ -s "$rationale_file" ]; then
+    rationale="$(cat "$rationale_file")"
+  else
+    # A rationale was expected (path given, not "-") but the file is missing or
+    # empty — the rationale:write handoff broke. Proceed without it (a missing
+    # rationale degrades to a bare-diff review the IMPLEMENTOR still disputes from
+    # its own inherited rationale block — it is a false-finding SUPPRESSOR, not a
+    # correctness input, so we don't abort the round), but make the failure loud
+    # so the round isn't silently mistaken for a rationale-aware review. Mirrors
+    # the rebuttal warning above.
+    echo "WARNING: expected rationale file '$rationale_file' is missing or empty; proceeding with no deliberate-decisions note this round (codex reviews the bare diff)." >&2
+  fi
 fi
 rationale_block=""
 if [ -n "$rationale" ]; then

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -40,7 +40,7 @@
 #     OWN prior review + reasoning across rounds.
 set -uo pipefail
 
-base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
+base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]}"
 rebuttal_file="${2:?missing rebuttal-file (use - for none)}"
 out="${3:?missing out-json path}"
 # The debate workflow owns this value (its REASONING_EFFORT constant) and passes

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: be-review
 description: Run /be's review gauntlet SERIALLY — /lens-debate (lowy ⇄ hickey), then /codex-debate, then /simplify, then code-police, each editing and committing on the live branch in turn. Use from /be §4, or when the user asks to "run the review gauntlet". Requires Claude Code's Skill tool.
-argument-hint: "[--base <branch>] [--rationale <note>] [--tracks lens,codex,simplify,police]"
+argument-hint: "[--base <branch>] [--rationale <note>] [--context <note>] [--tracks lens,codex,simplify,police]"
 ---
 
 # Review gauntlet (serial)
@@ -92,7 +92,10 @@ it once per step.
 
 2. **codex** — follow `/codex-debate` (Skill tool). `repoPath` = the live
    worktree, `base` = `MB`, **`--no-comment`** (so it doesn't advertise its
-   local-only round commits before be-review pushes). Its step-2 `Workflow` runs
+   local-only round commits before be-review pushes), and thread both `context`
+   (the task / main-agent context, so the codex **author inherits what you know —
+   not just the diff** — every round) and `rationale` (so codex doesn't flag
+   deliberate decisions at the source) straight through. Its step-2 `Workflow` runs
    in the background; **wait for it to finish** before starting the simplify step.
    It commits its rounds and **returns** its rendered comment body — hold onto it
    to post after the final push. (On persistent `reviewer-error` there is **no

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -56,8 +56,10 @@ applies its own fixes directly — no snapshot, no apply pass. be-review pushes 
 at the end and *then* posts the PR comments (lens, codex, and a code-police
 summary), so no comment advertises a local-only commit.
 
-- Pass `base` and the change **`rationale`** (so the lenses don't flag deliberate
-  decisions). Preflight is a non-empty diff and (since codex runs) `codex login
+- Pass `base`, the change **`rationale`** (so the lenses don't flag deliberate
+  decisions), and **`context`** — the task intent and key decisions you hold from
+  this run, so the codex author **inherits what you know instead of re-deriving it
+  from the diff**. Preflight is a non-empty diff and (since codex runs) `codex login
   status`.
 - Lens-debate commits its agreed fixes; codex's rounds commit `fix(…)`; simplify
   and code-police commit `refactor:` / `fix(police):`. Confirm the post-push PR

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -86,8 +86,9 @@ codex/opencode runtimes the skill is inert.
 ## Arguments
 
 A leading `review` subcommand token, if present, is consumed by mode detection;
-what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]` (the
-bare alias passes the whole argument string through unchanged). Parse:
+what remains is `[<pr-number>] [--base <branch>] [--no-commit] [--no-comment]
+[--rationale <note>] [--context <note>]` (the bare alias passes the whole argument
+string through unchanged). Parse:
 
 - **`<pr-number>`** (optional): a PR to debate. If given, `gh pr checkout <n>`
   first and default the base to that PR's base branch. If omitted, debate the
@@ -106,6 +107,20 @@ bare alias passes the whole argument string through unchanged). Parse:
 - **`--no-comment`**: don't post the debate summary to the PR. By **default**, when
   a PR exists, the debate summary IS posted as a PR comment (see step 3). Pass
   this to suppress the outward-facing write and report in chat only.
+- **`--rationale <note>`** (optional): the author's note on **deliberate** design
+  decisions. Threaded into **both** sides — codex's round-1 review prompt (so it
+  doesn't flag intentional choices as defects; its warm session carries the note
+  across later rounds) and the Claude author's prompt **every round** (so it
+  *disputes*, rather than "fixes", a finding that contradicts a deliberate choice).
+  Mirrors `/lens-debate`'s `rationale`. Pull it from the PR/issue description, or the
+  caller (`/be-review`) passes the change rationale straight through.
+- **`--context <note>`** (optional): the **main-agent context** the Claude author
+  should **inherit** — what this change is FOR (its task/intent and key decisions the
+  orchestrator already holds). Injected into the author's prompt **every round** so it
+  no longer reconstructs intent from the diff alone (`agent()` is one-shot and can't
+  be resumed the way codex is, so re-injection is how it inherits at all). Given to
+  the **author only**, not codex — codex stays an independent reviewer of the code,
+  not the author's narrative. `/be-review` passes the task context through.
 
 ## Steps
 
@@ -133,7 +148,9 @@ Workflow({
     repoPath: "<worktree root>",        // also the per-worktree scratch dir root
     base: "<base branch>",
     commit: <false only if --no-commit>,
-    skillDir: ".claude/skills/codex-debate"
+    skillDir: ".claude/skills/codex-debate",
+    context: "<main-agent context the author inherits; omit/'' if none>",
+    rationale: "<author's note on deliberate decisions; omit/'' if none>"
   }
 })
 ```
@@ -416,6 +433,15 @@ returns:
   comment step 3 posts, so the author's memory and the published summary are one
   record. The writes stay small (one round each), so the Haiku writer never
   retypes a large blob. codex stays on its own warm session and never reads them.
+- **Inherited context, not just diff.** On top of that cross-round memory, when the
+  caller passes `context` and/or `rationale` the author **inherits them in EVERY
+  round's prompt** — the main-agent intent (what the change is FOR) and the
+  deliberate-decision note. So even **round 1** reasons from the change's purpose
+  rather than the diff alone, and the author *disputes* a finding that contradicts a
+  deliberate choice instead of dutifully "fixing" it. The `rationale` also rides
+  codex's round-1 prompt (see `codex-review.sh`), so the reviewer doesn't raise those
+  intentional choices at the source; `context` is the author's alone (codex stays an
+  independent reviewer of the code, not the narrative).
 - **Commits, but never pushes or merges.** Each round is committed locally (unless
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-debate
 description: 'Run an automated codex⇄Claude debate to consensus — no round cap, no deadlock exit. Two explicit subcommands. `review` (also the bare/back-compat default) — codex (reviewer) critiques the current diff and a Claude subagent (author) fixes/disputes, looping until they agree. `answer` — Claude and codex each answer a freeform prompt in parallel, then cross-check until they agree, and a unified answer is returned. Use when the user types `/codex-debate`, asks to "have codex review this", "run the codex debate", "review this PR with codex", "argue this with codex until you agree", or passes a question to "have Claude and codex debate/answer until they agree".'
-argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment]  |  answer \"<prompt>\""
+argument-hint: "review [<pr-number>] [--base <branch>] [--no-commit] [--no-comment] [--rationale <note>] [--context <note>]  |  answer \"<prompt>\""
 ---
 
 # Codex ⇄ Claude debate
@@ -31,8 +31,8 @@ Look at the **first whitespace-delimited token** of `$ARGUMENTS`:
 - **`answer`** → **answer mode**. The prompt is everything after the `answer`
   token. Jump to [Answer mode](#answer-mode); the review-mode steps do not apply.
 - **`review`** → **review mode**. The remaining args are the review grammar
-  (`[<pr-number>] [--base …] [--no-commit] [--no-comment]`). Continue with
-  [Review mode](#review-mode).
+  (`[<pr-number>] [--base …] [--no-commit] [--no-comment] [--rationale <note>]
+  [--context <note>]`). Continue with [Review mode](#review-mode).
 - **No args, OR the first token is a number (a PR number) or a `--flag`** →
   **review mode** (the backward-compatible bare alias for the original
   `/codex-debate [<pr>] [flags]`, so existing callers like `/be-review` keep

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -60,6 +60,38 @@ const mechModel = a.mechModel || 'haiku'
 // agent's. The small per-round section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
+// --- Context the Claude implementor INHERITS --------------------------------
+// Two optional notes the CALLER threads in so the implementor (the Claude author)
+// no longer reasons from the diff alone — the gap that made it re-derive the
+// change's intent every round and re-litigate deliberate choices codex (rightly,
+// on a bare diff) flags.
+//
+// `context` (#1): the MAIN-AGENT context — what this change is FOR (the task/intent
+// and key decisions the orchestrator already holds). Injected into the implementor
+// EVERY round: agent() is one-shot and Claude isn't headless under Max auth, so it
+// can't be resumed the way codex is — re-injection is how it "inherits" at all.
+// Deliberately NOT given to codex, which stays an independent reviewer of the
+// actual code rather than the author's narrative.
+const context = (a.context || '').trim()
+// `rationale` (#2): the author's note on DELIBERATE decisions — the same note
+// /lens-debate already accepts, now threaded here too. Given to BOTH sides: codex
+// (its round-1 prompt, via codexReviews → codex-review.sh — so the reviewer doesn't
+// raise them at the source; codex's warm session carries the note across rounds)
+// AND the implementor (so it DISPUTES, rather than "fixes", a finding that
+// contradicts a deliberate choice).
+const rationale = (a.rationale || '').trim()
+// The two notes as ready-to-interpolate implementor-prompt blocks. Empty when the
+// note is absent, so the prompt stays byte-identical to the contextless form then.
+const contextBlock = context
+  ? `\nContext you INHERIT from the main agent — what this change is FOR (its task/intent and key decisions). Weigh codex's findings against it: a finding that contradicts this intent is a candidate to DISPUTE, not blindly fix.\n${context}\n`
+  : ''
+const rationaleBlock = rationale
+  ? `\nAuthor's note on DELIBERATE decisions (chosen on purpose — do NOT "fix" them away; dispute the finding unless codex shows the decision itself is wrong):\n${rationale}\n`
+  : ''
+// codex reads the rationale from a file (it's constant across rounds, written once
+// before the loop); `-` means "no rationale" to codex-review.sh.
+const rationaleFileArg = rationale ? `${workDir}/rationale.md` : '-'
+
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
 // the SINGLE home for the value: it is passed script-ward (a 4th positional arg
 // to codex-review.sh, which sets `-c model_reasoning_effort`) and read by
@@ -147,11 +179,11 @@ async function codexReviews(round, rebuttalJson) {
 ${rebuttalJson}
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
     : `1. (No prior rebuttal this round.)
 
 2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT}\``
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
@@ -192,7 +224,7 @@ Build on what you already did; don't re-derive the diff from scratch, and don't 
   const prompt = `You authored the changes on this branch. CODEX reviewed them and returned the verdict below — what do you think? Fix what you agree with, push back (with reasons) on what you don't.
 
 Work in the repo at \`${repoPath}\` — your shell cwd may be a different worktree, so use ABSOLUTE paths under it and \`git -C ${repoPath}\`. See the change with \`git -C ${repoPath} diff ${base}\`.
-
+${contextBlock}${rationaleBlock}
 ${priorBlock}CODEX's verdict (JSON):
 ${JSON.stringify(verdict, null, 2)}
 
@@ -386,6 +418,23 @@ await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
 )
+
+// Persist the author's rationale ONCE (it's constant across rounds) so
+// codex-review.sh can inject it into codex's round-1 prompt; codex's warm session
+// then carries the note across later rounds without re-injection. Only when a
+// rationale was passed — otherwise rationaleFileArg is `-` and no file is needed.
+// A thin mechanical writer (the workflow can't do file I/O); the payload is small.
+if (rationale) {
+  await agent(
+    `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
+
+1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
+2. Using the Write tool, create \`${workDir}/rationale.md\` with EXACTLY this content, overwriting any existing file:
+
+${rationale}`,
+    { label: 'rationale:write', phase: 'Debate', model: mechModel },
+  )
+}
 
 for (let round = 1; ; round++) {
   const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -90,7 +90,8 @@ const rationaleBlock = rationale
   : ''
 // codex reads the rationale from a file (it's constant across rounds, written once
 // before the loop); `-` means "no rationale" to codex-review.sh.
-const rationaleFileArg = rationale ? `${workDir}/rationale.md` : '-'
+const rationaleFile = `${workDir}/rationale.md`
+const rationaleFileArg = rationale ? rationaleFile : '-'
 
 // The reasoning effort codex runs at, scoped to the debate. This JS constant is
 // the SINGLE home for the value: it is passed script-ward (a 4th positional arg
@@ -429,7 +430,7 @@ if (rationale) {
     `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${workDir}/rationale.md\` with EXACTLY this content, overwriting any existing file:
+2. Using the Write tool, create \`${rationaleFile}\` with EXACTLY this content, overwriting any existing file:
 
 ${rationale}`,
     { label: 'rationale:write', phase: 'Debate', model: mechModel },

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -332,21 +332,27 @@ function renderLedger(transcript, meta) {
 // (section-002 before section-010) for both the author's read and the assembly.
 const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
 
-// Write ONE round's section to its own small file — the author reads these as its
-// cross-round memory, and the orchestrator cats them into the posted comment. A
-// thin mechanical agent (the workflow can't do file I/O), but the payload is just
-// this round, so it stays small and Haiku-safe — no whole-ledger retype, and
-// rewriting a round's own file is idempotent (safe on a resume).
-async function writeSection(entry) {
-  const text = roundLedgerSection(entry)
-  const path = sectionFile(entry.round)
+// Drop a string to a scratch file via a mechanical Haiku writer — the single home
+// for the "write this content to this path" idiom (the workflow can't do file I/O
+// itself, and Claude isn't headless, so a tiny agent does it). Both the per-round
+// section writer and the one-shot rationale writer route through here; payloads are
+// small (one round / one note) so Haiku is safe, and overwriting is idempotent
+// (safe on a resume).
+function writeFileAgent(path, content, label) {
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
 1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
 2. Using the Write tool, create \`${path}\` with EXACTLY this content, overwriting any existing file:
 
-${text}`
-  return agent(prompt, { label: `ledger:round${entry.round}`, phase: 'Debate', model: mechModel })
+${content}`
+  return agent(prompt, { label, phase: 'Debate', model: mechModel })
+}
+
+// Write ONE round's section to its own small file — the author reads these as its
+// cross-round memory, and the orchestrator cats them into the posted comment. No
+// whole-ledger retype: the payload is just this round.
+async function writeSection(entry) {
+  return writeFileAgent(sectionFile(entry.round), roundLedgerSection(entry), `ledger:round${entry.round}`)
 }
 
 const transcript = []
@@ -424,17 +430,8 @@ await agent(
 // codex-review.sh can inject it into codex's round-1 prompt; codex's warm session
 // then carries the note across later rounds without re-injection. Only when a
 // rationale was passed — otherwise rationaleFileArg is `-` and no file is needed.
-// A thin mechanical writer (the workflow can't do file I/O); the payload is small.
 if (rationale) {
-  await agent(
-    `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
-
-1. Ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
-2. Using the Write tool, create \`${rationaleFile}\` with EXACTLY this content, overwriting any existing file:
-
-${rationale}`,
-    { label: 'rationale:write', phase: 'Debate', model: mechModel },
-  )
+  await writeFileAgent(rationaleFile, rationale, 'rationale:write')
 }
 
 for (let round = 1; ; round++) {

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -13,7 +13,7 @@
 # codex-exec-lib.sh.
 #
 # Usage:
-#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]
+#   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]
 #
 #   <base-branch>    branch to diff against (e.g. master)
 #   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
@@ -22,6 +22,10 @@
 #   <reasoning-effort> codex model_reasoning_effort for this run; the debate
 #                    workflow passes its REASONING_EFFORT constant here so the
 #                    value has one home. Defaults to "xhigh" for standalone runs.
+#   <rationale-file> path to a file holding the author's note on DELIBERATE
+#                    decisions, or "-" for none. Injected into the round-1 (cold)
+#                    review prompt so codex doesn't flag intentional choices as
+#                    defects; codex's warm session carries it across later rounds.
 #
 # Notes:
 #   * codex runs under `--sandbox read-only` (see codex-exec-lib.sh), which enforces
@@ -42,6 +46,9 @@ out="${3:?missing out-json path}"
 # The debate workflow owns this value (its REASONING_EFFORT constant) and passes
 # it down; "xhigh" is only the default for a standalone invocation of this script.
 effort="${4:-xhigh}"
+# Author's note on deliberate decisions (constant across rounds); "-" = none. Only
+# the cold/round-1 prompt injects it — codex's warm session retains it after that.
+rationale_file="${5:--}"
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 schema="$here/codex-verdict.schema.json"
@@ -79,6 +86,23 @@ $rebuttal
 "
 fi
 
+# The author's note on DELIBERATE decisions, if supplied — injected into the COLD
+# review prompt below so codex doesn't raise intentional choices as findings. Read
+# from a file (the workflow writes it once) so multi-line notes with special chars
+# survive intact, the same way the rebuttal is handled.
+rationale=""
+if [ "$rationale_file" != "-" ] && [ -s "$rationale_file" ]; then
+  rationale="$(cat "$rationale_file")"
+fi
+rationale_block=""
+if [ -n "$rationale" ]; then
+  rationale_block="
+The author flagged the following as DELIBERATE decisions. Do NOT raise them as
+findings unless the reasoning itself is wrong — if it is, say specifically why:
+$rationale
+"
+fi
+
 # WARM SESSION. Round 1 (rebuttal_file == "-") cold-starts and resets any stale id;
 # later rounds resume codex's own review session. Resolve the id first so the prompt
 # below can lean on codex's retained context when warm.
@@ -103,8 +127,10 @@ synthesize_error_verdict() {
 # Two prompts: a lean follow-up for the WARM (resume) path that leans on codex's
 # retained context, and the full review prompt for the COLD path (round 1, or the
 # fallback when no session id was captured). Unquoted heredocs: only $base,
-# $rebuttal, and $rebuttal_block expand; their expansions are inserted literally
-# (heredoc results aren't re-scanned), so special chars in $rebuttal stay inert.
+# $rebuttal, $rebuttal_block, and (in the cold prompt) $rationale_block expand;
+# their expansions are inserted literally (heredoc results aren't re-scanned), so
+# special chars in $rebuttal / $rationale stay inert. The rationale rides the cold
+# prompt ONLY — codex's warm session already retains it from round 1.
 if [ -n "$resume_id" ]; then
   prompt="$(cat <<EOF
 You are CODEX, continuing the SAME review session you started earlier — you still
@@ -154,7 +180,7 @@ and run no git write command: add/commit/push/stash/checkout):
 
 Read every changed file plus enough surrounding code to judge it in context.
 Ignore the debate's own scratch dir '.codex-debate/' if it appears.
-
+$rationale_block
 Give ALL your feedback in this pass — every issue worth raising, at EVERY severity
 (blocking, major, minor, nit): correctness bugs, logic errors, silently swallowed
 errors, unjustified fallbacks, security problems, and clear simplicity/efficiency

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -91,8 +91,19 @@ fi
 # from a file (the workflow writes it once) so multi-line notes with special chars
 # survive intact, the same way the rebuttal is handled.
 rationale=""
-if [ "$rationale_file" != "-" ] && [ -s "$rationale_file" ]; then
-  rationale="$(cat "$rationale_file")"
+if [ "$rationale_file" != "-" ]; then
+  if [ -s "$rationale_file" ]; then
+    rationale="$(cat "$rationale_file")"
+  else
+    # A rationale was expected (path given, not "-") but the file is missing or
+    # empty — the rationale:write handoff broke. Proceed without it (a missing
+    # rationale degrades to a bare-diff review the IMPLEMENTOR still disputes from
+    # its own inherited rationale block — it is a false-finding SUPPRESSOR, not a
+    # correctness input, so we don't abort the round), but make the failure loud
+    # so the round isn't silently mistaken for a rationale-aware review. Mirrors
+    # the rebuttal warning above.
+    echo "WARNING: expected rationale file '$rationale_file' is missing or empty; proceeding with no deliberate-decisions note this round (codex reviews the bare diff)." >&2
+  fi
 fi
 rationale_block=""
 if [ -n "$rationale" ]; then

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -40,7 +40,7 @@
 #     OWN prior review + reasoning across rounds.
 set -uo pipefail
 
-base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort]}"
+base="${1:?usage: codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]}"
 rebuttal_file="${2:?missing rebuttal-file (use - for none)}"
 out="${3:?missing out-json path}"
 # The debate workflow owns this value (its REASONING_EFFORT constant) and passes

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -316,13 +316,13 @@ local_deployed_file_hashes:
   .agents/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .agents/skills/be/SKILL.md: sha256:f3a4f93144b06e41ad681ff0e99331b4ed3ca353e795c2e6e6dd6dd0e2912ae0
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:2fee33cfea0c2c9b818220dcbf7e4a28daa071a834534c1604e4afa298077650
+  .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
   .agents/skills/codex-debate/debate.workflow.js: sha256:ce2e7c8e77d5260bf767aefcc8647ad2b6457349924006f6b93b9d8d9d091d17
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:6aeae0b1ed2b71a3e14952404a0b1b9a404ec28b68b91bfa21d6cdfa8559ee3d
+  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
@@ -350,13 +350,13 @@ local_deployed_file_hashes:
   .claude/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .claude/skills/be/SKILL.md: sha256:f3a4f93144b06e41ad681ff0e99331b4ed3ca353e795c2e6e6dd6dd0e2912ae0
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:2fee33cfea0c2c9b818220dcbf7e4a28daa071a834534c1604e4afa298077650
+  .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
   .claude/skills/codex-debate/debate.workflow.js: sha256:ce2e7c8e77d5260bf767aefcc8647ad2b6457349924006f6b93b9d8d9d091d17
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:6aeae0b1ed2b71a3e14952404a0b1b9a404ec28b68b91bfa21d6cdfa8559ee3d
+  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -318,7 +318,7 @@ local_deployed_file_hashes:
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:ce2e7c8e77d5260bf767aefcc8647ad2b6457349924006f6b93b9d8d9d091d17
+  .agents/skills/codex-debate/debate.workflow.js: sha256:8e912895e33937c661393efecde373ec10a0f3d0a6015fea21d065b7b3a16acd
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -352,7 +352,7 @@ local_deployed_file_hashes:
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:ce2e7c8e77d5260bf767aefcc8647ad2b6457349924006f6b93b9d8d9d091d17
+  .claude/skills/codex-debate/debate.workflow.js: sha256:8e912895e33937c661393efecde373ec10a0f3d0a6015fea21d065b7b3a16acd
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -318,7 +318,7 @@ local_deployed_file_hashes:
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:2fee33cfea0c2c9b818220dcbf7e4a28daa071a834534c1604e4afa298077650
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:417fbb2243ca84cfca4601fca465fb0837bed8a6ee4f7de94ec3133a5fff9ab0
+  .agents/skills/codex-debate/debate.workflow.js: sha256:ce2e7c8e77d5260bf767aefcc8647ad2b6457349924006f6b93b9d8d9d091d17
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -352,7 +352,7 @@ local_deployed_file_hashes:
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:2fee33cfea0c2c9b818220dcbf7e4a28daa071a834534c1604e4afa298077650
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:417fbb2243ca84cfca4601fca465fb0837bed8a6ee4f7de94ec3133a5fff9ab0
+  .claude/skills/codex-debate/debate.workflow.js: sha256:ce2e7c8e77d5260bf767aefcc8647ad2b6457349924006f6b93b9d8d9d091d17
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -313,16 +313,16 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .agents/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
-  .agents/skills/be/SKILL.md: sha256:4a49f20dcc62b321e7875891b63975c11b64613154d99d272303f165fb43d4de
+  .agents/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
+  .agents/skills/be/SKILL.md: sha256:f3a4f93144b06e41ad681ff0e99331b4ed3ca353e795c2e6e6dd6dd0e2912ae0
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
+  .agents/skills/codex-debate/SKILL.md: sha256:2fee33cfea0c2c9b818220dcbf7e4a28daa071a834534c1604e4afa298077650
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:1624c71d0acfd839b88c25ad01fd953d0f431c455bc8e67d399a67a04f93b07d
+  .agents/skills/codex-debate/debate.workflow.js: sha256:417fbb2243ca84cfca4601fca465fb0837bed8a6ee4f7de94ec3133a5fff9ab0
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:ffb3da606a74e2fbd2d56a66ca456fae889049c6882f56ef05f856e30257d53b
+  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:c5278cb562d475b43c49edba92faee4d45c29eaa2cbfc86313b584be65b680a6
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
@@ -347,16 +347,16 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
-  .claude/skills/be-review/SKILL.md: sha256:32926b02ad8c4731c04989eec0b68502fa394053f7d6b7c199d130147bb1d59b
-  .claude/skills/be/SKILL.md: sha256:4a49f20dcc62b321e7875891b63975c11b64613154d99d272303f165fb43d4de
+  .claude/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
+  .claude/skills/be/SKILL.md: sha256:f3a4f93144b06e41ad681ff0e99331b4ed3ca353e795c2e6e6dd6dd0e2912ae0
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:058fcc61f9773ce1b9547b844c3fbf87a0f2d4517be5721d2e4fbdcb84c7f75d
+  .claude/skills/codex-debate/SKILL.md: sha256:2fee33cfea0c2c9b818220dcbf7e4a28daa071a834534c1604e4afa298077650
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:1624c71d0acfd839b88c25ad01fd953d0f431c455bc8e67d399a67a04f93b07d
+  .claude/skills/codex-debate/debate.workflow.js: sha256:417fbb2243ca84cfca4601fca465fb0837bed8a6ee4f7de94ec3133a5fff9ab0
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:ffb3da606a74e2fbd2d56a66ca456fae889049c6882f56ef05f856e30257d53b
+  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:c5278cb562d475b43c49edba92faee4d45c29eaa2cbfc86313b584be65b680a6
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -322,7 +322,7 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:c5278cb562d475b43c49edba92faee4d45c29eaa2cbfc86313b584be65b680a6
+  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:6aeae0b1ed2b71a3e14952404a0b1b9a404ec28b68b91bfa21d6cdfa8559ee3d
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
@@ -356,7 +356,7 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:c5278cb562d475b43c49edba92faee4d45c29eaa2cbfc86313b584be65b680a6
+  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:6aeae0b1ed2b71a3e14952404a0b1b9a404ec28b68b91bfa21d6cdfa8559ee3d
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e


### PR DESCRIPTION
## What

In `/codex-debate`'s review mode, the Claude **implementor** (the "author" side that fixes/disputes codex's findings) was a fresh one-shot `agent()` subagent. It reconstructed the change from `git diff` alone:

- it inherited **none** of the main agent's task/intent, and
- unlike the lens step, it never received the change **rationale**.

So each round it re-derived intent from scratch and re-litigated *deliberate* choices that codex — correctly, reviewing a bare diff — flagged as findings. Noise the implementor then had to spend rounds disputing.

This threads two optional notes from the caller into the debate.

## The two notes

| Note | Goes to | When | Why |
|---|---|---|---|
| **`context`** (#1) | implementor only | **every round** | The main-agent context — what the change is *for*. `agent()` can't be resumed the way codex is, so re-injecting each round is how the implementor "inherits" at all. Kept off codex so it stays an independent reviewer of the code, not the author's narrative. |
| **`rationale`** (#2) | codex (round-1) + implementor | once / every round | The deliberate-decisions note (mirrors `/lens-debate`). codex sees it in its round-1 prompt — its warm session carries it forward — so it doesn't raise intentional choices *at the source*; the implementor sees it so it *disputes* rather than "fixes" a finding that contradicts a deliberate choice. |

## How

- `debate.workflow.js` — reads `args.context` / `args.rationale`; injects both into the implementor prompt every round; writes `rationale` to a file once before the loop and passes it to `codex-review.sh`.
- `codex-review.sh` — new optional `[rationale-file|-]` positional; injects a deliberate-decisions block into the **cold** review prompt (round 1 / degraded fallback) only — the warm session retains it after.
- `/be-review` (codex step) and `/be` §4 — thread `context` + `rationale` straight through.

Empty notes render byte-identical to the old prompts, so a contextless invocation is unchanged.

## Verification

- `node --check` (async-wrapped) parses the edited workflow; matches the original's parse profile.
- `bash -n codex-review.sh` clean.
- `just ai::apm` regenerated `.claude/` + `.agents/` (no `.codex`/`.opencode` variants — codex-debate needs the Workflow tool); `apm.lock.yaml` carries the new hashes.
- `just fmt` — no changes.

Sources live under `.apm/`; the `.claude/` + `.agents/` copies are generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)