### PR TITLE
perf(dock): state animations run cold — compositor glow + opacity (#1308)

### DIFF
--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -592,6 +592,15 @@ const RailChip: Component<{
                 {labels().sub}
               </span>
             </span>
+            {/* Agent-state glow on its own child so it animates opacity/transform
+             *  (compositor) rather than repainting the chip's box-shadow every
+             *  frame — see #1308. Only the two live buckets render it; the CSS
+             *  in index.css picks breath (awaiting) vs orbit (working). */}
+            <Show
+              when={props.bucket === "awaiting" || props.bucket === "working"}
+            >
+              <div class="dock-rail-chip-glow" aria-hidden="true" />
+            </Show>
           </button>
         );
       }}

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -127,45 +127,45 @@ body {
   background: oklch(from var(--card-color) l c h / 0.8);
 }
 
+/* The breathing ring paints its color-mix background ONCE and animates only
+ * `opacity` (compositor-accelerated) — animating the `background` color-mix
+ * repainted the masked ring every frame (#1308). The trough opacities
+ * (.22 ≈ 20/90, .44 ≈ 35/80) preserve the original dim-to-bright range. */
 .pill-border-awaiting::before {
+  background: color-mix(
+    in oklch,
+    var(--pill-state-color, var(--color-alert)) 90%,
+    transparent
+  );
   animation: pill-awaiting-breathe 1.6s ease-in-out infinite;
+  will-change: opacity;
 }
 @keyframes pill-awaiting-breathe {
   0%,
   100% {
-    background: color-mix(
-      in oklch,
-      var(--pill-state-color, var(--color-alert)) 20%,
-      transparent
-    );
+    opacity: 0.22;
   }
   50% {
-    background: color-mix(
-      in oklch,
-      var(--pill-state-color, var(--color-alert)) 90%,
-      transparent
-    );
+    opacity: 1;
   }
 }
 
 .pill-border-working::before {
+  background: color-mix(
+    in oklch,
+    var(--pill-state-color, var(--color-accent)) 80%,
+    transparent
+  );
   animation: pill-working-pulse 2.4s ease-in-out infinite;
+  will-change: opacity;
 }
 @keyframes pill-working-pulse {
   0%,
   100% {
-    background: color-mix(
-      in oklch,
-      var(--pill-state-color, var(--color-accent)) 35%,
-      transparent
-    );
+    opacity: 0.44;
   }
   50% {
-    background: color-mix(
-      in oklch,
-      var(--pill-state-color, var(--color-accent)) 80%,
-      transparent
-    );
+    opacity: 1;
   }
 }
 
@@ -175,21 +175,16 @@ body {
  * to a dim-and-static state visually indistinguishable from idle
  * + working when reduce-motion is requested. */
 @media (prefers-reduced-motion: reduce) {
+  /* Base background already sits on the `::before` at full strength; hold a
+   * static opacity that matches the old reduced-motion strengths
+   * (0.89 ≈ 80/90, 0.75 = 60/80) so awaiting still reads strongly. */
   .pill-border-awaiting::before {
     animation: none;
-    background: color-mix(
-      in oklch,
-      var(--pill-state-color, var(--color-alert)) 80%,
-      transparent
-    );
+    opacity: 0.89;
   }
   .pill-border-working::before {
     animation: none;
-    background: color-mix(
-      in oklch,
-      var(--pill-state-color, var(--color-accent)) 60%,
-      transparent
-    );
+    opacity: 0.75;
   }
 }
 
@@ -525,11 +520,9 @@ body {
 }
 .dock-rail-chip[data-bucket="awaiting"] {
   border-color: var(--color-alert);
-  animation: dock-chip-breathe 1.6s ease-in-out infinite;
 }
 .dock-rail-chip[data-bucket="working"] {
   border-color: var(--color-accent);
-  animation: dock-chip-spin-glow 2.4s linear infinite;
 }
 .dock-rail-chip[data-bucket="none"] {
   opacity: 0.5;
@@ -539,36 +532,46 @@ body {
 .dock-rail-chip[data-bucket="none"][data-active] {
   opacity: 1;
 }
+/* The state glow lives on a child element (`.dock-rail-chip-glow`) so it can
+ * animate opacity/transform on the COMPOSITOR instead of repainting the chip's
+ * box-shadow every frame. Animating box-shadow per chip was the dominant
+ * rail-mode cost in #1308 (a busy rail turned a few paints/6s into tens of
+ * thousands, ~150x the GPU work at idle). The glow's box-shadow is now
+ * rasterized ONCE; only opacity+scale (awaiting "breath") or transform:rotate
+ * (working "orbit", carrying the directional glow around the perimeter)
+ * animate. The child keeps the chip's own `::before` (active halo) and
+ * `::after` (unread badge) pseudos free. */
+.dock-rail-chip-glow {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+}
+.dock-rail-chip[data-bucket="awaiting"] .dock-rail-chip-glow {
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-alert) 70%, transparent);
+  will-change: opacity, transform;
+  animation: dock-chip-breathe 1.6s ease-in-out infinite;
+}
 @keyframes dock-chip-breathe {
   0%,
   100% {
-    box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-alert) 70%, transparent);
+    opacity: 0.45;
+    transform: scale(0.985);
   }
   50% {
-    box-shadow: 0 0 0 3px
-      color-mix(in oklch, var(--color-alert) 35%, transparent);
+    opacity: 1;
+    transform: scale(1);
   }
 }
+.dock-rail-chip[data-bucket="working"] .dock-rail-chip-glow {
+  box-shadow: 2px 0 6px
+    color-mix(in oklch, var(--color-accent) 55%, transparent);
+  will-change: transform;
+  animation: dock-chip-spin-glow 2.4s linear infinite;
+}
 @keyframes dock-chip-spin-glow {
-  0% {
-    box-shadow: 2px 0 6px
-      color-mix(in oklch, var(--color-accent) 55%, transparent);
-  }
-  25% {
-    box-shadow: 0 2px 6px
-      color-mix(in oklch, var(--color-accent) 55%, transparent);
-  }
-  50% {
-    box-shadow: -2px 0 6px
-      color-mix(in oklch, var(--color-accent) 55%, transparent);
-  }
-  75% {
-    box-shadow: 0 -2px 6px
-      color-mix(in oklch, var(--color-accent) 55%, transparent);
-  }
-  100% {
-    box-shadow: 2px 0 6px
-      color-mix(in oklch, var(--color-accent) 55%, transparent);
+  to {
+    transform: rotate(1turn);
   }
 }
 /* Active halo — same accent treatment cards mode uses for the active
@@ -636,10 +639,9 @@ body {
   margin-top: 0;
 }
 @media (prefers-reduced-motion: reduce) {
-  .dock-rail-chip[data-bucket="awaiting"],
-  .dock-rail-chip[data-bucket="working"] {
+  /* Freeze the glow to a static themed ring (it still reads as state). */
+  .dock-rail-chip-glow {
     animation: none;
-    box-shadow: none;
   }
   .dock-rail-chip[data-unread]::after {
     animation: none;


### PR DESCRIPTION
First PR in the **#1308** batch (compositor stress under heavy canvas load). The maintainer asked to **reproduce before fixing** — so this is measurement-led.

## Reproduced (no theory)

The dock's per-terminal state animations all animate **paint-only** properties — `box-shadow` (dock chips, capsule) and `background` color-mix (pills) — so each working/awaiting chip and pill **repaints on the main thread every frame, forever**. Idle-window CDP trace (6s, zero interaction):

**On your real GPU (zest, M1 Max — where the production instances run):**

| Scene | GPU process | Paints / 6s |
|---|---|---|
| baseline (no anims) | 16 ms | 12 |
| 24 chips + 12 pills | 2,512 ms | 1,230 |
| 48 chips + 24 pills | 2,250 ms | **49,034** |

**Software regime (weak/contended GPU — the AMD/Wayland case #1308 crashed on):**

| Scene | Main-thread | Paints / 6s |
|---|---|---|
| baseline | 99 ms | 8 |
| 24 chips + 12 pills | 1,112 ms | 12,639 |
| 48 chips + 24 pills | 1,910 ms | 24,553 |

The super-linear blow-up at 48 chips (49k paints) is the compositor-queue saturation #1308 ties to the Mutter crash.

## Fix (compositor-only, look preserved)

| Animation | Was | Now |
|---|---|---|
| dock chip **breath** (awaiting) | `box-shadow` spread/alpha | halo on a `.dock-rail-chip-glow` child, animate **opacity + scale** |
| dock chip **orbit** (working) | `box-shadow` offset around the ring | directional glow on the child, animate **transform: rotate** (carries the glow around) |
| pill awaiting / working ring | `background` color-mix 20↔90% | background painted **once**, animate **opacity** |

`will-change` promotes each once; `prefers-reduced-motion` freezes to a static ring. The glow lives on a child so the chip's `::before` (active halo) and `::after` (unread badge) stay free.

## Validated (same harness, after)

| | current | fixed |
|---|---|---|
| zest GPU (24 / 48) | 2,512 / 2,250 ms | **165 / 193 ms (−93 / −91%)** |
| zest paints | 1,230 / 49,034 | **12 / 12** |
| software main-thread (24 / 48) | 1,112 / 1,910 ms | **401 / 580 ms (−64 / −70%)** |

Visual parity confirmed by screenshot (chips keep their glow, pills their ring, capsule its dot).

## Deferred to later PRs in this batch (measure-first)

- **record-capsule halo** — single element (negligible at scale), and its host is `overflow-hidden`, so the pseudo-halo needs structural validation first.
- **Tailwind `animate-*`** (RowPips/AgentIndicator/…) — already `transform`/`opacity`; not a measured culprit.
- **#1308's JS event-loop items** — resize-observer→`fit()` loop, wheel-signal throttle, `--app-h` churn. A *different* failure mode I haven't reproduced yet; separate PR with its own repro.

Refs #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)