### PR TITLE
feat(website): publish the Atlas at kolu.dev/atlas/

### DIFF
--- a/.agents/skills/atlas/SKILL.md
+++ b/.agents/skills/atlas/SKILL.md
@@ -38,10 +38,10 @@ committed HTML is stale or host-dependent.
 ## 3. Preview & share
 
 Each `dist/<slug>.html` is self-contained: it previews in kolu's Code tab, and —
-once the branch is pushed — reads on GitHub via
-`https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/docs/atlas/dist/<slug>.html`
-(`<owner>/<repo>` ← `gh repo view --json nameWithOwner -q .nameWithOwner`,
-`<branch>` ← `git branch --show-current`).
+once the note is merged to `master` — is published on the web at
+`https://kolu.dev/atlas/<slug>.html` (the index is `https://kolu.dev/atlas/`).
+The website build folds the committed `dist/` in under `/atlas/`, so a merged
+note ships with the next Pages deploy.
 
 ## 4. Lifecycle
 

--- a/.apm/skills/atlas/SKILL.md
+++ b/.apm/skills/atlas/SKILL.md
@@ -38,10 +38,10 @@ committed HTML is stale or host-dependent.
 ## 3. Preview & share
 
 Each `dist/<slug>.html` is self-contained: it previews in kolu's Code tab, and —
-once the branch is pushed — reads on GitHub via
-`https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/docs/atlas/dist/<slug>.html`
-(`<owner>/<repo>` ← `gh repo view --json nameWithOwner -q .nameWithOwner`,
-`<branch>` ← `git branch --show-current`).
+once the note is merged to `master` — is published on the web at
+`https://kolu.dev/atlas/<slug>.html` (the index is `https://kolu.dev/atlas/`).
+The website build folds the committed `dist/` in under `/atlas/`, so a merged
+note ships with the next Pages deploy.
 
 ## 4. Lifecycle
 

--- a/.claude/skills/atlas/SKILL.md
+++ b/.claude/skills/atlas/SKILL.md
@@ -38,10 +38,10 @@ committed HTML is stale or host-dependent.
 ## 3. Preview & share
 
 Each `dist/<slug>.html` is self-contained: it previews in kolu's Code tab, and —
-once the branch is pushed — reads on GitHub via
-`https://htmlpreview.github.io/?https://github.com/<owner>/<repo>/blob/<branch>/docs/atlas/dist/<slug>.html`
-(`<owner>/<repo>` ← `gh repo view --json nameWithOwner -q .nameWithOwner`,
-`<branch>` ← `git branch --show-current`).
+once the note is merged to `master` — is published on the web at
+`https://kolu.dev/atlas/<slug>.html` (the index is `https://kolu.dev/atlas/`).
+The website build folds the committed `dist/` in under `/atlas/`, so a merged
+note ships with the next Pages deploy.
 
 ## 4. Lifecycle
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,7 @@ on:
     branches: [master]
     paths:
       - "website/**"
+      - "docs/atlas/dist/**"
       - "packages/client/favicon.svg"
       - ".github/workflows/pages.yml"
   workflow_dispatch:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -312,7 +312,7 @@ local_deployed_files:
 - .claude/skills/test
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
-  .agents/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
+  .agents/skills/atlas/SKILL.md: sha256:50f6561bf80334f10b38e9a462f16eb9fe1d5100b5a83df5fa19993316f2382e
   .agents/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .agents/skills/be/SKILL.md: sha256:f3a4f93144b06e41ad681ff0e99331b4ed3ca353e795c2e6e6dd6dd0e2912ae0
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
@@ -346,7 +346,7 @@ local_deployed_file_hashes:
   .claude/rules/streaming.md: sha256:f67ae607dd8c4baf97c656d639452d82027ac295bb551d3dd774386101c5d0ec
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
-  .claude/skills/atlas/SKILL.md: sha256:f47500c2738a00d15f996ba9f56a33442195c74b6300b73cf167b30b058c1ef1
+  .claude/skills/atlas/SKILL.md: sha256:50f6561bf80334f10b38e9a462f16eb9fe1d5100b5a83df5fa19993316f2382e
   .claude/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .claude/skills/be/SKILL.md: sha256:f3a4f93144b06e41ad681ff0e99331b4ed3ca353e795c2e6e6dd6dd0e2912ae0
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a

--- a/docs/atlas/README.md
+++ b/docs/atlas/README.md
@@ -1,17 +1,17 @@
 # kolu Atlas
 
-kolu's in-repo knowledge base — a **self-contained Astro project**, deliberately
-separate from the public website (`../../website`) and **not deployed as a
-standalone site**.
+kolu's in-repo knowledge base — a **self-contained Astro project**, authored
+separately from the public website (`../../website`) but published alongside it
+at **[kolu.dev/atlas/](https://kolu.dev/atlas/)** (the website build folds the
+committed `dist/` in under `/atlas/`).
 
 - **Author** notes as markdown/MDX in `src/content/atlas/` (+ frontmatter).
 - **Build** the self-contained HTML with `just atlas::build` → `dist/`.
 - **Preview** any `dist/<slug>.html` directly in kolu's Code tab — styles are
   inlined and links are relative, so no dev server is needed.
-- **Read externally** (off GitHub, no checkout) — the canonical link is
-  htmlpreview, which renders the committed self-contained HTML and follows the
-  relative links between notes:
-  <https://htmlpreview.github.io/?https://github.com/juspay/kolu/blob/master/docs/atlas/dist/index.html>
+- **Read on the web** (no checkout) — published at <https://kolu.dev/atlas/>,
+  which serves the committed self-contained HTML with the relative links between
+  notes intact. Reflects what's merged to `master`.
 
 The rendered `dist/` is **committed** (marked generated in `.gitattributes`); an
 `.apm` rule regenerates it whenever a note changes. Author markdown/MDX only —

--- a/docs/atlas/src/components/IndexTree.astro
+++ b/docs/atlas/src/components/IndexTree.astro
@@ -4,7 +4,7 @@
 // their parent via Astro.self with an indent guide — the within-section
 // hierarchy. A cross-category parent is shown as a `related` link under the row,
 // not as a tree edge. Scales to ~100 links. Links stay relative (`./slug.html`)
-// so they resolve in kolu's Code tab AND externally via htmlpreview.github.io.
+// so they resolve in kolu's Code tab AND on the web at kolu.dev/atlas/.
 import type { CatTreeNode } from "../lib/indexTree";
 
 interface Props {

--- a/docs/atlas/src/pages/index.astro
+++ b/docs/atlas/src/pages/index.astro
@@ -9,8 +9,8 @@ import { buildCategoryGroups } from "../lib/indexTree";
 // edges become "related" links). Drafts are hidden from the build but reachable
 // in `astro dev`. Membership is automatic — a note's `kind` always lands it in a
 // section, so nothing falls through unfiled. Links are relative (`./<slug>.html`)
-// so the committed pages navigate both in kolu's Code tab and externally via
-// htmlpreview.github.io.
+// so the committed pages navigate both in kolu's Code tab and on the web at
+// kolu.dev/atlas/.
 const notes = (await getCollection("atlas")).filter(
   (n) => import.meta.env.DEV || !n.data.draft,
 );

--- a/packages/kaval-tui/README.md
+++ b/packages/kaval-tui/README.md
@@ -79,4 +79,4 @@ unreachable daemon is a one-line error, never a hang. `spawn` / `kill` —
 creating and ending terminals from the shell — are later phases.
 
 The full design lives in the
-[kaval atlas note](https://htmlpreview.github.io/?https://github.com/juspay/kolu/blob/master/docs/atlas/dist/pty-daemon.html).
+[kaval atlas note](https://kolu.dev/atlas/pty-daemon.html).

--- a/website/default.nix
+++ b/website/default.nix
@@ -94,6 +94,11 @@ let
     installPhase = ''
       runHook preInstall
       cp -r dist $out
+      # Fold the committed Atlas dist in at /atlas/. The notes are
+      # self-contained HTML with inlined CSS and relative cross-links (Astro
+      # `format: "file"`), so they need no Astro/Vite processing — copy them in
+      # verbatim. `kolu.dev/atlas/` serves docs/atlas/dist/index.html.
+      cp -r ${../docs/atlas/dist} $out/atlas
       runHook postInstall
     '';
   };

--- a/website/src/pages/kaval.astro
+++ b/website/src/pages/kaval.astro
@@ -285,7 +285,7 @@ const escapes = [
         The full design — architecture, phasing, and the decisions behind the
         escape model — lives in the{" "}
         <a
-          href="https://htmlpreview.github.io/?https://github.com/juspay/kolu/blob/master/docs/atlas/dist/pty-daemon.html"
+          href="https://kolu.dev/atlas/pty-daemon.html"
           class="text-amber hover:underline"
           rel="noopener">kaval atlas note</a
         >.


### PR DESCRIPTION
## What

Publishes the in-repo **Atlas** (`docs/atlas/dist`) on the public site at **kolu.dev/atlas/**, and migrates every link off the old `htmlpreview.github.io` workaround.

## How

- **`website/default.nix`** — the `installPhase` copies `docs/atlas/dist` into `$out/atlas` after the Astro build. The notes are self-contained HTML (inlined CSS, relative cross-links via Astro `format: "file"`), so they need no Astro/Vite processing — a verbatim copy is correct. `kolu.dev/atlas/` resolves to the generated `index.html`.
- **`.github/workflows/pages.yml`** — added `docs/atlas/dist/**` to the trigger paths so a rebuilt Atlas redeploys on its own, not only when `website/**` changes.
- **Link migration** — replaced all `htmlpreview.github.io/?...docs/atlas/dist/...` references with `https://kolu.dev/atlas/...`:
  - website `/kaval` page + `kaval-tui` README → `kolu.dev/atlas/pty-daemon.html`
  - `docs/atlas/README.md` → `kolu.dev/atlas/` (and dropped the now-stale "not deployed as a standalone site" framing)
  - Atlas `index.astro` / `IndexTree.astro` source comments
  - the `/atlas` skill (`.apm/` source, regenerated into `.claude/` + `.agents/`) — the Preview & share section now points at `kolu.dev/atlas/<slug>.html`

## Verification

- `nix build .#website` produces `$out/atlas/` with all 40 notes; the root site (`index.html`, `_astro`, `blog`, `CNAME`, …) is intact. Cross-links are relative, so they resolve under `/atlas/`.
- `just atlas::check-sync` idempotent (no rendered dist change from the comment edits).
- Pages `build` job is green on this branch; `deploy` is gated to `master` by the `github-pages` environment protection rule, so `/atlas/` goes live on merge.
- No remaining `htmlpreview.github.io` references outside the generated `dist/` (which never contained them).

## Notes

- The Atlas dist stays committed and is consumed as-is; no new build step is added to the website's pnpm build.
- The published URL reflects what's merged to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)