### PR TITLE
refactor(terminals): endpoint `location` as a first-class, non-optional field (P1 of #1398)

### DIFF
--- a/packages/client/src/canvas/dock/chipInitials.test.ts
+++ b/packages/client/src/canvas/dock/chipInitials.test.ts
@@ -1,4 +1,4 @@
-import type { TerminalMetadata } from "kolu-common/surface";
+import { LOCAL_LOCATION, type TerminalMetadata } from "kolu-common/surface";
 import { describe, expect, it } from "vitest";
 import type { TerminalDisplayInfo } from "../../terminal/terminalDisplay";
 import { chipInitials } from "./chipInitials";
@@ -11,6 +11,7 @@ function info(group: string, label: string): TerminalDisplayInfo {
     meta: {
       cwd: "/tmp",
       git: null,
+      location: LOCAL_LOCATION,
       pr: { kind: "absent" },
       agent: null,
       foreground: null,
@@ -25,6 +26,7 @@ function meta(intent?: string): TerminalMetadata {
   return {
     cwd: "/tmp",
     git: null,
+    location: LOCAL_LOCATION,
     pr: { kind: "absent" },
     agent: null,
     foreground: null,

--- a/packages/client/src/canvas/dock/dockRowRanking.test.ts
+++ b/packages/client/src/canvas/dock/dockRowRanking.test.ts
@@ -1,7 +1,8 @@
-import type {
-  AgentInfo,
-  TerminalId,
-  TerminalMetadata,
+import {
+  type AgentInfo,
+  LOCAL_LOCATION,
+  type TerminalId,
+  type TerminalMetadata,
 } from "kolu-common/surface";
 import { describe, expect, it } from "vitest";
 import { type DockRowBucket, rankDockRows } from "./dockRowRanking";
@@ -23,6 +24,7 @@ function makeMeta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
     cwd: "/tmp",
     git: null,
+    location: LOCAL_LOCATION,
     pr: { kind: "absent" },
     agent: null,
     foreground: null,

--- a/packages/client/src/canvas/dock/dockTree.test.ts
+++ b/packages/client/src/canvas/dock/dockTree.test.ts
@@ -1,4 +1,4 @@
-import type { TerminalId } from "kolu-common/surface";
+import { LOCAL_LOCATION, type TerminalId } from "kolu-common/surface";
 import { describe, expect, it } from "vitest";
 import type { TerminalDisplayInfo } from "../../terminal/terminalDisplay";
 import type { DockRowBucket, RankedDockRow } from "./dockRowRanking";
@@ -21,6 +21,7 @@ function makeGetInfo(
       meta: {
         cwd: "/tmp",
         git: null,
+        location: LOCAL_LOCATION,
         pr: { kind: "absent" },
         agent: null,
         foreground: null,

--- a/packages/client/src/canvas/dockModel.test.ts
+++ b/packages/client/src/canvas/dockModel.test.ts
@@ -1,4 +1,8 @@
-import type { AgentInfo, TerminalMetadata } from "kolu-common/surface";
+import {
+  type AgentInfo,
+  LOCAL_LOCATION,
+  type TerminalMetadata,
+} from "kolu-common/surface";
 import type { GitInfo } from "kolu-git/schemas";
 import { describe, expect, it } from "vitest";
 import type { IdleBucketKey } from "../terminal/activityWindow";
@@ -41,6 +45,7 @@ function makeMeta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
     cwd: "/home/user/kolu",
     git: makeGit(),
+    location: LOCAL_LOCATION,
     pr: { kind: "absent" },
     agent: null,
     foreground: null,

--- a/packages/client/src/sessionTransfer.test.ts
+++ b/packages/client/src/sessionTransfer.test.ts
@@ -1,4 +1,4 @@
-import type { SavedSession } from "kolu-common/surface";
+import { LOCAL_LOCATION, type SavedSession } from "kolu-common/surface";
 import { describe, expect, it, vi } from "vitest";
 
 // `sessionTransfer` imports `solid-sonner` (for toast) at module scope, which
@@ -10,7 +10,15 @@ vi.mock("solid-sonner", () => ({ toast: {} }));
 import { parseSavedSession } from "./sessionTransfer";
 
 const valid: SavedSession = {
-  terminals: [{ id: "t1", cwd: "/home/user", git: null, lastActivityAt: 0 }],
+  terminals: [
+    {
+      id: "t1",
+      cwd: "/home/user",
+      git: null,
+      location: LOCAL_LOCATION,
+      lastActivityAt: 0,
+    },
+  ],
   activeTerminalId: "t1",
   savedAt: 1_700_000_000_000,
 };

--- a/packages/client/src/terminal/terminalDisplay.test.ts
+++ b/packages/client/src/terminal/terminalDisplay.test.ts
@@ -1,4 +1,4 @@
-import type { TerminalMetadata } from "kolu-common/surface";
+import { LOCAL_LOCATION, type TerminalMetadata } from "kolu-common/surface";
 import type { GitInfo } from "kolu-git/schemas";
 import { describe, expect, it } from "vitest";
 import { assignColors, buildTerminalDisplayInfos } from "./terminalDisplay";
@@ -7,6 +7,7 @@ function makeMeta(overrides: Partial<TerminalMetadata> = {}): TerminalMetadata {
   return {
     cwd: "/home/user/project",
     git: null,
+    location: LOCAL_LOCATION,
     pr: { kind: "pending" },
     agent: null,
     foreground: null,

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -242,6 +242,14 @@ export function useSessionRestore(deps: {
       // so the canvas cascade effect sees the saved layout on its first run
       // and skips the default-cascade branch (#642).
       for (const t of topLevel) {
+        // `t.location` is deliberately NOT forwarded: the create seam carries
+        // only client-owned `InitialTerminalMetadata`, and the *endpoint* owns
+        // location — so each terminal re-spawns at `LOCAL_LOCATION`. That is
+        // correct while every terminal is local, but it means restore here is
+        // read-record-and-respawn, not "dial the saved host + adopt". P3
+        // replaces this loop with dial+adopt; until then a remote terminal
+        // would silently restore locally, so remote terminals must not ship
+        // before P3 lands.
         const newId = await deps.handleCreate(t.cwd, {
           themeName: t.themeName,
           canvasLayout: t.canvasLayout,

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -170,6 +170,37 @@ export const RightPanelPerTerminalStateSchema = z.object({
     .optional(),
 });
 
+/**
+ * Where a terminal's endpoint lives — a closed sum, not a host-id string.
+ *
+ * `{ kind: "local" }` is the in-process PTY (this kolu-server). `{ kind:
+ * "remote", hostId }` is a dialed host (kaval-sessions). Modelling the local
+ * case as a distinct *variant* — rather than a reserved `"local"` string in
+ * the same namespace as remote host ids — makes a whole bug class
+ * unrepresentable: a remote host that happens to be named `local` in
+ * `~/.ssh/config` is `{ kind: "remote", hostId: "local" }`, which can never
+ * be confused with the in-process endpoint `{ kind: "local" }`. `hostId`
+ * matches the rest of the system's host-identity spelling (`getHostSession`,
+ * the daemon-status keys).
+ */
+export const HostLocationSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("local") }),
+  z.object({ kind: z.literal("remote"), hostId: z.string() }),
+]);
+
+export type HostLocation = z.infer<typeof HostLocationSchema>;
+
+/** The in-process endpoint's location — the singleton `{ kind: "local" }`.
+ *  `location` is never mutated after spawn (a terminal does not migrate
+ *  hosts), so sharing this one value across every local terminal is safe and
+ *  saves re-spelling the literal at each spawn/restore site. Frozen so the
+ *  "never mutated" invariant is enforced at runtime, not just by convention:
+ *  an accidental in-place write throws instead of silently aliasing every
+ *  local terminal's metadata. */
+export const LOCAL_LOCATION: HostLocation = Object.freeze({
+  kind: "local",
+} as const);
+
 // ── Terminal metadata fields, organized by write-authority + persistence ──
 //
 // Invariant: every terminal-metadata field appears in EXACTLY ONE of
@@ -202,6 +233,20 @@ export const RightPanelPerTerminalStateSchema = z.object({
 export const ServerPersistedTerminalFieldsSchema = z.object({
   cwd: z.string(),
   git: GitInfoSchema.nullable(),
+  /** Where this terminal's endpoint lives — `{ kind: "local" }` for an
+   *  in-process PTY, `{ kind: "remote", hostId }` for a dialed host (kaval-
+   *  sessions). See `HostLocationSchema`. Non-optional and explicit by
+   *  construction: a terminal's host is the value of this field, never the
+   *  *absence* of a host id. So any code that **constructs** a terminal's
+   *  metadata — spawn and host adoption — must name its host: a dropped
+   *  location is a compile error there, not a silent local respawn against the
+   *  wrong machine. (The client "Restore session" path re-creates terminals
+   *  through the create seam, which deliberately omits `location` because the
+   *  *endpoint* owns it; P3 replaces that path with dial-the-host +
+   *  adopt-its-list, so remote terminals must not ship before then.) Set once
+   *  at spawn and never mutated thereafter — a terminal does not migrate hosts
+   *  — so although it rides this server-writable base, no provider writes it. */
+  location: HostLocationSchema,
   /** Normalized agent CLI invocation last observed in this terminal (e.g.
    *  `"claude --model sonnet"`). Preserved across intervening non-agent
    *  input; drives the "resume agent on restore" offer in EmptyState.

--- a/packages/server/src/ptyHost/index.ts
+++ b/packages/server/src/ptyHost/index.ts
@@ -45,7 +45,10 @@ type Identity = PtyHostIdentity | undefined;
 
 /** The single local kaval host's id — the daemon-status key the endpoint reports
  *  under and consumers (e.g. boot adoption's `setAdoptedCount`) read by. Owned
- *  here, where `ensureLocalEndpoint` defines the daemon's identity/lifecycle. */
+ *  here, where `ensureLocalEndpoint` defines the daemon's identity/lifecycle.
+ *  This is a *daemon* identity (the kaval host), distinct from a terminal's
+ *  `location` (a `HostLocation` DU in kolu-common); a terminal placed on the
+ *  local endpoint carries `{ kind: "local" }`, not this string. */
 export const LOCAL_HOST_ID = "local";
 
 let endpoint: Endpoint<PtyHostClient, Identity> | undefined;

--- a/packages/server/src/reconcile.test.ts
+++ b/packages/server/src/reconcile.test.ts
@@ -1,5 +1,9 @@
 import type { PtyHostListEntry } from "kaval";
-import type { SavedSession, SavedTerminal } from "kolu-common/surface";
+import {
+  LOCAL_LOCATION,
+  type SavedSession,
+  type SavedTerminal,
+} from "kolu-common/surface";
 import { describe, expect, it } from "vitest";
 import { reconcile } from "./reconcile.ts";
 
@@ -8,7 +12,13 @@ function live(id: string, pid = 1000): PtyHostListEntry {
   return { id, pid, cwd: "/x", lastActivity: 0 };
 }
 function term(id: string): SavedTerminal {
-  return { id, cwd: "/x", git: null, lastActivityAt: 0 };
+  return {
+    id,
+    cwd: "/x",
+    git: null,
+    location: LOCAL_LOCATION,
+    lastActivityAt: 0,
+  };
 }
 function saved(...terminals: SavedTerminal[]): SavedSession {
   return { terminals, activeTerminalId: terminals[0]?.id ?? null, savedAt: 1 };

--- a/packages/server/src/session.test.ts
+++ b/packages/server/src/session.test.ts
@@ -1,6 +1,10 @@
 import * as assert from "node:assert";
 import { confStore } from "@kolu/surface/server";
-import type { SavedSession, SavedTerminal } from "kolu-common/surface";
+import {
+  LOCAL_LOCATION,
+  type SavedSession,
+  type SavedTerminal,
+} from "kolu-common/surface";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { terminalsDirtyChannel } from "./publisher.ts";
 import {
@@ -30,6 +34,7 @@ const terminal: SavedTerminal = {
     mainRepoRoot: "/home/user/project",
     remoteUrl: null,
   },
+  location: LOCAL_LOCATION,
   lastActivityAt: 0,
 };
 
@@ -106,9 +111,28 @@ describe("session persistence", () => {
 
   it("preserves multiple terminals with array order", () => {
     const terminals: SavedTerminal[] = [
-      { id: "a", cwd: "/a", git: null, lastActivityAt: 0 },
-      { id: "b", cwd: "/b", git: null, lastActivityAt: 0 },
-      { id: "c", cwd: "/c", git: null, parentId: "a", lastActivityAt: 0 },
+      {
+        id: "a",
+        cwd: "/a",
+        git: null,
+        location: LOCAL_LOCATION,
+        lastActivityAt: 0,
+      },
+      {
+        id: "b",
+        cwd: "/b",
+        git: null,
+        location: LOCAL_LOCATION,
+        lastActivityAt: 0,
+      },
+      {
+        id: "c",
+        cwd: "/c",
+        git: null,
+        location: LOCAL_LOCATION,
+        parentId: "a",
+        lastActivityAt: 0,
+      },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();
@@ -124,10 +148,17 @@ describe("session persistence", () => {
         id: "a",
         cwd: "/a",
         git: null,
+        location: LOCAL_LOCATION,
         themeName: "Dracula",
         lastActivityAt: 0,
       },
-      { id: "b", cwd: "/b", git: null, lastActivityAt: 0 },
+      {
+        id: "b",
+        cwd: "/b",
+        git: null,
+        location: LOCAL_LOCATION,
+        lastActivityAt: 0,
+      },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();
@@ -143,8 +174,20 @@ describe("session persistence", () => {
     const t1 = 1_700_000_000_000;
     const t2 = 1_700_000_900_000;
     const terminals: SavedTerminal[] = [
-      { id: "a", cwd: "/a", git: null, lastActivityAt: t1 },
-      { id: "b", cwd: "/b", git: null, lastActivityAt: t2 },
+      {
+        id: "a",
+        cwd: "/a",
+        git: null,
+        location: LOCAL_LOCATION,
+        lastActivityAt: t1,
+      },
+      {
+        id: "b",
+        cwd: "/b",
+        git: null,
+        location: LOCAL_LOCATION,
+        lastActivityAt: t2,
+      },
     ];
     saveSession({ terminals, activeTerminalId: null });
     const session = getSavedSession();

--- a/packages/server/src/state.test.ts
+++ b/packages/server/src/state.test.ts
@@ -1,5 +1,7 @@
+import { LOCAL_LOCATION } from "kolu-common/surface";
 import { describe, expect, it } from "vitest";
 import {
+  backfillLocation_1_26_0,
   backfillRemoteUrl_1_25_0,
   migrateLegacyTerminal_1_18_0,
 } from "./state.ts";
@@ -161,5 +163,34 @@ describe("backfillRemoteUrl_1_25_0", () => {
       git: null,
     });
     expect(migrated).toEqual({ id: "t", cwd: "/tmp", git: null });
+  });
+});
+
+describe("backfillLocation_1_26_0", () => {
+  it("no location ⇒ { kind: local } (every pre-1.26 terminal was in-process)", () => {
+    const migrated = backfillLocation_1_26_0({
+      id: "term-1",
+      cwd: "/home/alice/app",
+      git: null,
+    });
+    expect(migrated).toEqual({
+      id: "term-1",
+      cwd: "/home/alice/app",
+      git: null,
+      location: LOCAL_LOCATION,
+    });
+  });
+
+  it("is idempotent — a record that already carries a location passes through", () => {
+    // A future remote terminal (or a re-run of the migration): the saved
+    // location wins, never clobbered back to local — including a remote host
+    // that happens to be named "local", which the DU keeps distinct.
+    const record = {
+      id: "t",
+      cwd: "/r",
+      git: null,
+      location: { kind: "remote", hostId: "local" },
+    };
+    expect(backfillLocation_1_26_0(record)).toEqual(record);
   });
 });

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -21,6 +21,7 @@ import {
   type ActivityFeed,
   ActivityFeedSchema,
   DEFAULT_PREFERENCES,
+  LOCAL_LOCATION,
   type Preferences,
   PreferencesSchema,
   SavedSessionSchema,
@@ -108,6 +109,26 @@ export function backfillRemoteUrl_1_25_0(
   };
 }
 
+/** Backfill `location = { kind: "local" }` on a restored terminal saved before
+ *  `location` became a required field. Every terminal that could have been
+ *  persisted before this migration was an in-process (local) PTY — remote
+ *  terminals do not yet exist — so the only honest backfill is the local
+ *  variant. Without it, the now-required `location` on `SavedTerminalSchema`
+ *  rejects every legacy session at startup (the same
+ *  EVENT_ITERATOR_VALIDATION_FAILED class as #1237 / #1244).
+ *
+ *  Idempotent: a record that already carries a `location` (a future remote
+ *  terminal, or a re-run of this migration) is left untouched.
+ *
+ *  Exported so `state.test.ts` can exercise the backfill directly without a
+ *  `Conf` store. */
+export function backfillLocation_1_26_0(
+  t: Record<string, unknown>,
+): Record<string, unknown> {
+  if ("location" in t) return t;
+  return { ...t, location: LOCAL_LOCATION };
+}
+
 /** What conf stores to disk — survives server restart. Internal: clients see
  *  the per-domain shapes (Preferences / ActivityFeed / SavedSession), not
  *  this aggregate. Adding a new domain key requires a migration entry below. */
@@ -124,7 +145,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.25.0";
+const SCHEMA_VERSION = "1.26.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -494,6 +515,24 @@ export const store = new Conf<PersistedState>({
       const terminals = (
         session.terminals as unknown as Record<string, unknown>[]
       ).map(backfillRemoteUrl_1_25_0);
+      store.set("session", {
+        ...session,
+        terminals: terminals as typeof session.terminals,
+      });
+    },
+    // `SavedTerminal.location` added and made required — a terminal's host is
+    // now a first-class, non-optional `HostLocation` sum (`{ kind: "local" }`
+    // for an in-process PTY), not the absence of a host id, so a restore can
+    // never silently respawn a remote terminal locally. Every pre-1.26 session
+    // predates remote terminals, so backfill the local variant on each restored
+    // terminal (see `backfillLocation_1_26_0`); without it the now-required
+    // field rejects the whole session at startup.
+    "1.26.0": (store: Conf<PersistedState>) => {
+      const session = store.get("session");
+      if (!session) return;
+      const terminals = (
+        session.terminals as unknown as Record<string, unknown>[]
+      ).map(backfillLocation_1_26_0);
       store.set("session", {
         ...session,
         terminals: terminals as typeof session.terminals,

--- a/packages/server/src/terminalEndpoint/adopt.test.ts
+++ b/packages/server/src/terminalEndpoint/adopt.test.ts
@@ -25,6 +25,11 @@ function liveEntry(over: Partial<PtyHostListEntry> = {}): PtyHostListEntry {
 const sentinel: SavedTerminal = {
   id: "term-sentinel",
   cwd: "/sentinel/cwd",
+  // Deliberately the REMOTE variant: `adoptedMeta` seeds `createMetadata(_,
+  // LOCAL_LOCATION)` then spreads the persisted record over it, so a distinct
+  // host proves the saved `location` wins the round-trip rather than
+  // coincidentally matching the `{ kind: "local" }` seed.
+  location: { kind: "remote", hostId: "sentinel-host" },
   git: {
     repoRoot: "/sentinel/repo",
     repoName: "sentinel-repo",

--- a/packages/server/src/terminalEndpoint/local.ts
+++ b/packages/server/src/terminalEndpoint/local.ts
@@ -23,6 +23,7 @@
 
 import type { ForegroundSample, PtyHostClient, PtyHostListEntry } from "kaval";
 import { inMemoryChannel } from "@kolu/surface/server";
+import { LOCAL_LOCATION } from "kolu-common/surface";
 import type {
   SavedTerminal,
   TerminalId,
@@ -326,7 +327,7 @@ export function adoptedMeta(
 ): TerminalMetadata {
   const { id: _id, ...persisted } = record;
   return {
-    ...createMetadata(liveEntry.cwd),
+    ...createMetadata(liveEntry.cwd, LOCAL_LOCATION),
     ...persisted,
     cwd: liveEntry.cwd,
     foreground: liveForeground(liveEntry),
@@ -343,7 +344,7 @@ export function adoptedMeta(
  *  surviving taps. */
 export function orphanMeta(liveEntry: PtyHostListEntry): TerminalMetadata {
   return {
-    ...createMetadata(liveEntry.cwd),
+    ...createMetadata(liveEntry.cwd, LOCAL_LOCATION),
     foreground: liveForeground(liveEntry),
   };
 }
@@ -375,7 +376,7 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
     // and let the `res.cwd` correction below install the single authority.
     const cwd = opts.cwd ?? "";
     const proxy = new PtyHostTerminalProxy(id, ptyHostClient);
-    const meta: TerminalMetadata = { ...createMetadata(cwd) };
+    const meta: TerminalMetadata = { ...createMetadata(cwd, LOCAL_LOCATION) };
     if (opts.parentId) meta.parentId = opts.parentId;
     const initial = opts.initialMetadata;
     if (initial?.themeName) meta.themeName = initial.themeName;

--- a/packages/server/src/terminalEndpoint/metadata.test.ts
+++ b/packages/server/src/terminalEndpoint/metadata.test.ts
@@ -8,6 +8,7 @@
  * cadence — either over-saving or losing data on restart.
  */
 
+import { LOCAL_LOCATION } from "kolu-common/surface";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { terminalsDirtyChannel } from "../publisher.ts";
 import type { TerminalProcess } from "../terminal-registry.ts";
@@ -28,6 +29,7 @@ function fakeTerminal(): TerminalProcess {
     meta: {
       cwd: "/tmp",
       git: null,
+      location: LOCAL_LOCATION,
       pr: { kind: "pending" },
       agent: null,
       foreground: null,

--- a/packages/server/src/terminalEndpoint/metadata.ts
+++ b/packages/server/src/terminalEndpoint/metadata.ts
@@ -30,6 +30,7 @@
 
 import { prValue } from "anyforge/schemas";
 import {
+  type HostLocation,
   type LiveTerminalFields,
   prUnavailableReason,
   type ServerPersistedTerminalFields,
@@ -44,11 +45,22 @@ import type { TerminalProcess } from "../terminal-registry.ts";
 /** Create initial metadata state for a new terminal. `lastActivityAt: 0`
  *  means "no agent transition observed yet" — the only event that lifts
  *  the recency clock. Idle terminals tie at 0 and fall back to canvas
- *  position. */
-export function createMetadata(cwd: string): TerminalMetadata {
+ *  position.
+ *
+ *  `location` is required, not defaulted: the **owning endpoint** declares
+ *  where the terminal lives (the local endpoint passes `LOCAL_LOCATION`; a
+ *  remote endpoint passes `{ kind: "remote", hostId }`). Threading it as an
+ *  explicit argument — rather than hardcoding `{ kind: "local" }` here — keeps
+ *  the endpoint the sole authority on its own terminals' host and makes a
+ *  dropped location a compile error at every spawn site. */
+export function createMetadata(
+  cwd: string,
+  location: HostLocation,
+): TerminalMetadata {
   return {
     cwd,
     git: null,
+    location,
     pr: { kind: "pending" },
     agent: null,
     foreground: null,

--- a/packages/tests/step_definitions/session_restore_steps.ts
+++ b/packages/tests/step_definitions/session_restore_steps.ts
@@ -1,7 +1,7 @@
 import * as assert from "node:assert";
 import * as os from "node:os";
 import { Given, Then, When } from "@cucumber/cucumber";
-import type { SavedTerminal } from "kolu-common/surface";
+import { LOCAL_LOCATION, type SavedTerminal } from "kolu-common/surface";
 import { pollFor } from "../support/poll.ts";
 import {
   HYDRATION_TIMEOUT,
@@ -41,7 +41,15 @@ async function postSavedSessionPayload(
     savedAt: number;
     activeTerminalId?: string;
   } = {
-    terminals,
+    // Stamp the now-required `location` (local) here so the call sites stay
+    // focused on what they test (cwd/themeName/lastAgentCommand) and never
+    // re-spell it. Unlike `lastActivityAt` — which the server backfills from
+    // its Zod `.default(0)` when it validates this payload — `location` has no
+    // default (a required host has no honest one), so the helper must supply
+    // it; this package is transpiled-not-typechecked, so this runtime stamp,
+    // not the compiler, is what enforces it. A terminal that sets its own
+    // `location` (a future remote case) wins via the spread.
+    terminals: terminals.map((t) => ({ location: LOCAL_LOCATION, ...t })),
     savedAt: world.savedSessionSavedAt,
   };
   if (activeTerminalId !== undefined)


### PR DESCRIPTION
Implements **P1** from the from-scratch remote-terminals design (#1398): make a terminal's *endpoint location* an explicit, non-optional field on the terminal surfaces, so the **restore-to-wrong-endpoint** bug class becomes a compile error instead of a silent local respawn. It's a pure local-world refactor — every terminal today is local, so there's **no behavior change** — and it's the structural seam P2 (dial-list) and P3 (boot via kaval's `terminal.list`) build on. The design note calls this trio the "recommended first move either way."

## The shape: a closed sum, not a magic string

The design proposed a reserved `"local"` host-id string (`LOCAL_HOST_ID`). Reviewing it surfaced a real footgun: once P6 lists `~/.ssh/config` hosts, a remote host *aliased* `local` collides with the local sentinel. So `location` is a discriminated union instead:

```ts
type HostLocation = { kind: "local" } | { kind: "remote"; hostId: string };
```

That makes the collision **unrepresentable** — a remote host named `local` is `{ kind: "remote", hostId: "local" }`, which can never be confused with the in-process endpoint `{ kind: "local" }`. The daemon-status string `LOCAL_HOST_ID` (a *kaval-daemon* identity, a separate concern) stays put in `ptyHost`. `hostId` matches the system's existing host-identity spelling (`getHostSession`, daemon-status keys).

## What changed

- **`kolu-common`** — `HostLocationSchema` + a frozen `LOCAL_LOCATION` singleton. `location` rides `ServerPersistedTerminalFields`, so it flows into both the wire `TerminalMetadata` and the on-disk `SavedTerminal` with no save-path change (`snapshotSession` already strips live fields and keeps the rest).
- **Seam** — `createMetadata(cwd, location)` now *requires* the owning endpoint to declare where the terminal lives; the local endpoint passes `LOCAL_LOCATION` at all three spawn sites (spawn / adopt / orphan). A dropped location is a compile error at every construction site.
- **Migration** — `backfillLocation_1_26_0` stamps `{ kind: "local" }` on every pre-1.26 saved terminal (they all predate remote terminals), `SCHEMA_VERSION` 1.25.0 → 1.26.0, idempotent guard so a future remote `location` survives a downgrade. Plus the "no location ⇒ local" test.
- **Fixtures** — `location` threaded through every metadata/`SavedTerminal` fixture; the adoption sentinel uses a *remote* value to prove it round-trips through `adoptedMeta`'s spread.

## Honest scope

The compile-error guarantee holds where metadata is **constructed** (spawn, host adoption). The client "Restore session" path re-creates terminals through the create seam, which deliberately omits `location` (the *endpoint* owns it) — so restored terminals re-spawn local today. P3 replaces that path with dial+adopt; a code comment marks it so a remote terminal can't silently ship local before then. This matches the design's own bug-class table (the full dissolution is P1 + P2 + P3).

## Review

Ran an adversarial multi-lens review (hickey / lowy / correctness / migration-safety / completeness), each finding verified against the real code: **0 blockers**, 1 "should" (the restore-path claim scoping above — addressed), the rest nits (frozen singleton, comment-wording). The migration-safety lens passed end-to-end against the real conf ladder (null session, zero terminals, future-version downgrade, DU JSON round-trip).

## Test plan

- `just check` (typecheck + biome) — green
- `just test-unit` — green (server 104, client 351, common 17, + rest)
- New: `backfillLocation_1_26_0` migration tests; adoption sentinel proves `location` round-trips

> Caveat per the design note: P1–P4d in #1398 map to commits on the still-open #1385; this PR lands the **P1/P2/P2b** structural bug-proofing directly on current trunk (the "pragmatic blend" the note recommends), independent of the remote code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)