### PR TITLE
Prove shellJoin round-trips through a real POSIX shell

### DIFF
--- a/packages/shell-quote/README.md
+++ b/packages/shell-quote/README.md
@@ -61,6 +61,14 @@ shellSplit(`claude --settings '{"ultracode": true}'`);
 shellSplit(`'don'\''t'`); // → ["don't"]   (a general tokenizer shatters this)
 ```
 
+**Target shell.** The replay guarantee — `shellJoin`'s output re-parsing back to
+the same argv — likewise assumes a **POSIX-compatible** shell on the receiving
+end: `sh`, `bash`, `zsh`, and `dash` share the single-quote and tilde semantics
+it relies on. Shells with different quoting rules (`fish`, `csh`) are out of
+scope, so exact replay isn't guaranteed there. A real-shell round-trip test
+([`index.test.ts`](./src/index.test.ts)) pins this against whatever POSIX shell
+the dev/CI environment provides, and skips cleanly where none is available.
+
 ## Tilde handling
 
 A leading `~` is treated as a safe bare word and left **unquoted**, so a shell

--- a/packages/shell-quote/README.md
+++ b/packages/shell-quote/README.md
@@ -45,6 +45,17 @@ shellJoin(["claude", "--settings", `{"ultracode": true}`]);
 // → claude --settings '{"ultracode": true}'
 ```
 
+**Command-head precondition.** The replay equivalence is for the _argument
+tail_, the values after an ordinary command word. It assumes `argv[0]` is a
+plain command name, which is what every consumer here passes (an agent
+basename: `claude`, `codex`, …). A shell resolves the **command-position** word
+by grammar _before_ quote-removal, so a token that survives in argument
+position can still change meaning as `argv[0]`: `shellQuoteArg` leaves
+`FOO=bar` and `if` bare (both are safe bare words), but the shell reads a
+leading `FOO=bar` as a variable assignment and a leading `if` as a reserved
+word, not as a command to run. Quote the head yourself, or keep it a plain
+command name, if you cannot guarantee it is one.
+
 ### `shellSplit(line: string): string[]`
 
 The **exact inverse of `shellJoin`** — `shellSplit(shellJoin(argv))` deep-equals

--- a/packages/shell-quote/package.json
+++ b/packages/shell-quote/package.json
@@ -15,6 +15,7 @@
     "test:unit": "vitest run"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.0"
   }

--- a/packages/shell-quote/src/index.test.ts
+++ b/packages/shell-quote/src/index.test.ts
@@ -129,6 +129,15 @@ const POSIX_SHELL = findPosixShell();
 // word-splits back into exactly the argv it was built from. The shellSplit
 // tests above only check the leaf against its own tokenizer; this checks it
 // against the real grammar that backs the no-word-split / no-injection claim.
+//
+// Scope: this pins the ARGUMENT-TAIL guarantee — the values after an ordinary
+// command word. `replay` deliberately runs a known-safe `printf` head so every
+// corpus token lands in ARGUMENT position, which is exactly how the real
+// consumer joins (argv[0] is always an agent basename like `claude`). The
+// command-POSITION carve-out (a leading `FOO=bar` read as an assignment, a
+// leading `if` as a reserved word — both left bare by shellQuoteArg, since the
+// shell resolves the head by grammar before quote-removal) is out of scope by
+// the same construction; see the README "Command-head precondition".
 describe.skipIf(POSIX_SHELL === null)(
   "shellJoin output parsed by a real POSIX shell",
   () => {
@@ -145,7 +154,13 @@ describe.skipIf(POSIX_SHELL === null)(
      *  remaining argv element NUL-separated — the one separator that cannot
      *  collide with any byte inside a token, so the split is unambiguous. If the
      *  quoting let a value word-split or a metacharacter fire, printf would see a
-     *  different field list and the deep-equality below would fail. */
+     *  different field list and the deep-equality below would fail.
+     *
+     *  The `printf` head is also the known-safe COMMAND word that scopes this to
+     *  the argument tail: it forces every `args` token into argument position,
+     *  where shellQuoteArg's quoting fully governs the result — matching how the
+     *  real consumer joins (argv[0] is always an agent basename). See the
+     *  suite-level comment for the command-position carve-out. */
     function replay(
       args: readonly string[],
       env: NodeJS.ProcessEnv = {},

--- a/packages/shell-quote/src/index.test.ts
+++ b/packages/shell-quote/src/index.test.ts
@@ -1,5 +1,33 @@
+import { execFileSync } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { shellJoin, shellQuoteArg, shellSplit } from "./index.ts";
+
+/** The shared round-trip truth table: argv shapes a consumer joins and must get
+ *  back unchanged. It is exercised two ways from one corpus — against shellSplit
+ *  (the leaf's OWN inverse) and against a real POSIX shell (below) — so the same
+ *  cases prove both the self-consistency and the actual no-word-split /
+ *  no-injection claim that backs this package.
+ *
+ *  The entries carry every shape the bug (#1407) was about: the spaced JSON blob
+ *  (`--settings '{…}'`), a spaced sentence, the apostrophe `'\''` idiom, an
+ *  embedded-double-quote value, the empty token, and a value packed with shell
+ *  metacharacters ($ ` ; & | * ( ) { }) whose quoting must neutralize them. The
+ *  leading-`~` entry round-trips through shellSplit but is filtered out of the
+ *  real-shell test, which deliberately re-expands `~` (see that test's tilde
+ *  case) and so cannot byte-match it. */
+const ROUND_TRIP_CORPUS: readonly (readonly string[])[] = [
+  ["claude", "--model", "sonnet"],
+  ["claude", "--settings", `{"ultracode": true}`],
+  ["codex", "--config", `model_reasoning_effort="xhigh"`],
+  ["claude", "--append-system-prompt", "be terse please"],
+  ["claude", "--append-system-prompt", "don't do that"],
+  ["claude", "--append-system-prompt", "a $b `c` ; d & e | f * (g) {h}"],
+  ["claude", "--add-dir", "~/.claude"],
+  ["a", "", "b"], // empty token survives
+  ["weird", "a'b'c", "x  y"],
+];
 
 describe("shellQuoteArg", () => {
   it("leaves a safe bare word (ssh target / plain socket path) unquoted", () => {
@@ -48,18 +76,8 @@ describe("shellSplit", () => {
     // The property that matters: a consumer reparsing its OWN joined output
     // gets back exactly the argv it joined — including the embedded-single-
     // quote idiom that a general tokenizer (string-argv) shatters.
-    const cases: string[][] = [
-      ["claude", "--model", "sonnet"],
-      ["claude", "--settings", `{"ultracode": true}`],
-      ["codex", "--config", `model_reasoning_effort="xhigh"`],
-      ["claude", "--append-system-prompt", "be terse please"],
-      ["claude", "--append-system-prompt", "don't do that"],
-      ["claude", "--add-dir", "~/.claude"],
-      ["a", "", "b"], // empty token survives
-      ["weird", "a'b'c", "x  y"],
-    ];
-    for (const argv of cases) {
-      expect(shellSplit(shellJoin(argv))).toEqual(argv);
+    for (const argv of ROUND_TRIP_CORPUS) {
+      expect(shellSplit(shellJoin(argv))).toEqual([...argv]);
     }
   });
 
@@ -78,3 +96,83 @@ describe("shellSplit", () => {
     expect(shellSplit("   ")).toEqual([]);
   });
 });
+
+/** Resolve a POSIX shell from PATH without hardcoding `/bin/sh`, so the test runs
+ *  against whatever shell the Nix devshell / CI actually provides. Returns null
+ *  when none is found (e.g. a stripped sandbox), which SKIPS the real-shell suite
+ *  rather than failing it — the suite stays green on any platform. */
+function findPosixShell(): string | null {
+  const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+  for (const name of ["sh", "bash", "dash"]) {
+    for (const dir of dirs) {
+      const candidate = join(dir, name);
+      try {
+        accessSync(candidate, constants.X_OK);
+        return candidate;
+      } catch {
+        // not executable here — keep scanning PATH
+      }
+    }
+  }
+  return null;
+}
+
+const POSIX_SHELL = findPosixShell();
+
+// The substantive guarantee: shellJoin's output, parsed by an ACTUAL shell,
+// word-splits back into exactly the argv it was built from. The shellSplit
+// tests above only check the leaf against its own tokenizer; this checks it
+// against the real grammar that backs the no-word-split / no-injection claim.
+describe.skipIf(POSIX_SHELL === null)(
+  "shellJoin output parsed by a real POSIX shell",
+  () => {
+    // Non-null here by the skipIf guard above.
+    const shell = POSIX_SHELL as string;
+
+    /** Run `<shell> -c "printf '%s\0' <args…>"` and return the argv the shell
+     *  actually built — the proof that shellJoin's output word-splits back into
+     *  exactly its inputs.
+     *
+     *  `printf` is the stub: a safe bare word, so shellJoin leaves it unquoted,
+     *  and a shell BUILTIN, so no executable temp file is needed (a stub script
+     *  would fail under a noexec $TMPDIR). Its recycled `%s\0` format echoes each
+     *  remaining argv element NUL-separated — the one separator that cannot
+     *  collide with any byte inside a token, so the split is unambiguous. If the
+     *  quoting let a value word-split or a metacharacter fire, printf would see a
+     *  different field list and the deep-equality below would fail. */
+    function replay(
+      args: readonly string[],
+      env: NodeJS.ProcessEnv = {},
+    ): string[] {
+      const line = shellJoin(["printf", "%s\\0", ...args]);
+      const out = execFileSync(shell, ["-c", line], {
+        encoding: "buffer",
+        env: { ...process.env, ...env },
+      });
+      // printf writes a trailing \0 after the final field; drop the empty tail.
+      return out.toString("utf8").split("\0").slice(0, -1);
+    }
+
+    it("word-splits each joined argv back into exactly its inputs", () => {
+      // Strict byte-for-byte corpus: excludes leading-`~` tokens, which a real
+      // shell re-expands (asserted separately below) so they cannot byte-match.
+      const strict = ROUND_TRIP_CORPUS.filter(
+        (argv) => !argv.some((token) => token.startsWith("~")),
+      );
+      for (const argv of strict) {
+        expect(replay(argv)).toEqual([...argv]);
+      }
+    });
+
+    it("re-expands a space-separated leading ~ value to $HOME (documented carve-out)", () => {
+      // shellQuoteArg leaves a leading `~` BARE on purpose so the shell re-expands
+      // it to the same home the source used — intended behavior, not a bug. Pin
+      // it: `~/x` resolves to "$HOME/x" under a real shell.
+      const home = "/home/kolu-tilde-test";
+      expect(replay(["--settings", "~/x"], { HOME: home })).toEqual([
+        "--settings",
+        `${home}/x`,
+      ]);
+    });
+  },
+);

--- a/packages/shell-quote/src/index.test.ts
+++ b/packages/shell-quote/src/index.test.ts
@@ -4,6 +4,12 @@ import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { shellJoin, shellQuoteArg, shellSplit } from "./index.ts";
 
+/** The single source of truth for the POSIX shells this package's replay
+ *  guarantee assumes — the same four the README's "Target shell" contract
+ *  enumerates. `findPosixShell` iterates this so the prober and the documented
+ *  set cannot drift. */
+const POSIX_SHELLS = ["sh", "bash", "zsh", "dash"] as const;
+
 /** The shared round-trip truth table: argv shapes a consumer joins and must get
  *  back unchanged. It is exercised two ways from one corpus — against shellSplit
  *  (the leaf's OWN inverse) and against a real POSIX shell (below) — so the same
@@ -103,7 +109,7 @@ describe("shellSplit", () => {
  *  rather than failing it — the suite stays green on any platform. */
 function findPosixShell(): string | null {
   const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
-  for (const name of ["sh", "bash", "dash"]) {
+  for (const name of POSIX_SHELLS) {
     for (const dir of dirs) {
       const candidate = join(dir, name);
       try {

--- a/packages/shell-quote/src/index.test.ts
+++ b/packages/shell-quote/src/index.test.ts
@@ -4,10 +4,10 @@ import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { shellJoin, shellQuoteArg, shellSplit } from "./index.ts";
 
-/** The single source of truth for the POSIX shells this package's replay
- *  guarantee assumes — the same four the README's "Target shell" contract
- *  enumerates. `findPosixShell` iterates this so the prober and the documented
- *  set cannot drift. */
+/** The POSIX shells this package's replay guarantee assumes — the same four the
+ *  README's "Target shell" note enumerates. Declared once so `findPosixShell`'s
+ *  probe order has a single home in code; keep it in step with the README prose,
+ *  which can't import it. */
 const POSIX_SHELLS = ["sh", "bash", "zsh", "dash"] as const;
 
 /** The shared round-trip truth table: argv shapes a consumer joins and must get

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,6 +761,9 @@ importers:
 
   packages/shell-quote:
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
       typescript:
         specifier: ^5.8.0
         version: 5.9.3


### PR DESCRIPTION
The `@kolu/shell-quote` round-trip tests added in #1407 only asserted
`shellSplit(shellJoin(argv)) === argv` — the leaf validated against its **own**
tokenizer. That is a self-consistency check, not a proof: it says nothing about
whether a *real* shell parses `shellJoin`'s output the way the no-word-split /
no-injection claim promises. **This adds a test that runs `shellJoin`'s output
through an actual POSIX shell and asserts the shell word-splits it back into
exactly the input argv** — the property that actually backs the safety claim.

### How the proof works

```
shellJoin(["printf", "%s\0", ...args])
        │   e.g.  printf '%s\0' --settings '{"ultracode": true}' ...
        ▼
  <discovered shell> -c "<that line>"     ← a real grammar parses & word-splits
        ▼
  printf echoes each argv element NUL-separated   ← the argv the shell BUILT
        ▼
  deepEqual( parsed, args )               ← must match byte-for-byte
```

`printf` is the stub by design: it's a **safe bare word** (so `shellJoin` leaves
it unquoted) and a **shell builtin** (so there's no executable temp file to
write — which a `noexec` `$TMPDIR` in a hardened sandbox would reject). Its
recycled `%s\0` format echoes the remaining argv NUL-separated, the one
separator that can't collide with a byte inside a token. *If quoting let a value
word-split or a metacharacter fire, `printf` would see a different field list and
the deep-equality would fail* — verified with a negative control where a naive
unquoted join made `;`/`&`/`|` split the line and backticks execute (exit 127).

### What's covered

- **One shared truth-table corpus** feeds both the existing self-inverse test
  and the new real-shell test — no parallel corpus. Added a metacharacter-soup
  case carrying `$ \` ; & | * ( ) { }` so the quoting is proven to neutralize
  every one of them, plus the spaced JSON blob, a spaced sentence, the
  apostrophe `'\''` idiom, an embedded-double-quote value, and the empty token.
- **The tilde carve-out is pinned, not papered over.** The strict
  deep-equality corpus *excludes* leading-`~` tokens (a real shell re-expands
  them, so they can't byte-match), and a **separate** assertion proves
  `--settings ~/x` *does* expand to `$HOME/x` under a real shell — the
  documented, intended behavior (#1407), asserted rather than treated as a bug.

> **Portable & green everywhere.** The shell is discovered from `PATH` (no
> hardcoded `/bin/sh`), so it runs against whatever the Nix devshell / CI
> provides; when no POSIX shell is found the suite **skips cleanly** instead of
> failing.

The README gains a one-paragraph scope note: the replay guarantee assumes a
**POSIX-compatible target shell** (`sh`/`bash`/`zsh`/`dash`); `fish`/`csh` quote
differently, so exact replay isn't guaranteed there.

*Test + docs only — no user-facing behavior change, so no changelog entry.*
`@types/node` is added as a **devDependency** (matching `integrations/pty`) so
the node-builtin imports in the test typecheck; the leaf's runtime
zero-dependency property is unchanged.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._