### PR TITLE
Harden the Reset-terminal-size command (review-gauntlet follow-up)

### DIFF
--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -172,10 +172,7 @@ const TerminalCanvas: Component<{
     on(
       () => props.tileIds,
       (ids) => {
-        const { width, height } = viewport.viewportSize();
-        const zoom = viewport.zoom();
-        const cx = viewport.panX() + width / (2 * zoom);
-        const cy = viewport.panY() + height / (2 * zoom);
+        const { x: cx, y: cy } = viewport.viewportCenter();
         const placed: {
           id: TileId;
           layout: TileLayout;

--- a/packages/client/src/canvas/TerminalCanvas.tsx
+++ b/packages/client/src/canvas/TerminalCanvas.tsx
@@ -172,7 +172,11 @@ const TerminalCanvas: Component<{
     on(
       () => props.tileIds,
       (ids) => {
-        const { x: cx, y: cy } = viewport.viewportCenter();
+        const center = viewport.viewportCenter();
+        // Container not mounted yet — defer placement; the effect re-runs when
+        // the tile list next changes (post-mount, with real dimensions).
+        if (!center) return;
+        const { x: cx, y: cy } = center;
         const placed: {
           id: TileId;
           layout: TileLayout;

--- a/packages/client/src/canvas/useCanvasArrange.ts
+++ b/packages/client/src/canvas/useCanvasArrange.ts
@@ -16,10 +16,13 @@ import type { TileId } from "../tile/tileContent";
 import { useTileStore } from "../tile/useTileStore";
 import { getBucketFor } from "./placementPolicy";
 import { arrangeRepoIslands, type RepoIslandTile } from "./repoIslands";
-import { DEFAULT_TILE_H, DEFAULT_TILE_W } from "./tilePlacement";
+import {
+  DEFAULT_TILE_H,
+  DEFAULT_TILE_W,
+  findFreeTilePosition,
+} from "./tilePlacement";
 import { layoutsEqual, type TileLayout } from "./TileLayout";
 import { usePendingLayouts } from "./usePendingLayouts";
-import { snapToGrid } from "./viewport/transforms";
 import { useCanvasViewport } from "./viewport/useCanvasViewport";
 
 export function useCanvasArrange() {
@@ -93,11 +96,14 @@ export function useCanvasArrange() {
     const id = tileStore.activeId();
     if (!id) return;
     // Canvas-space coordinate at the viewport center — same accessor the
-    // default-placement effect uses to drop a freshly created tile.
+    // default-placement effect uses to drop a freshly created tile. Reuse that
+    // effect's placement helper too, with no existing tiles, so reset lands the
+    // tile at the bare center (the empty list skips the cascade — recovery
+    // wants the known center, not collision avoidance) through the one home of
+    // the center→top-left + grid-snap math.
     const { x: cx, y: cy } = viewport.viewportCenter();
     const layout: TileLayout = {
-      x: snapToGrid(cx - DEFAULT_TILE_W / 2),
-      y: snapToGrid(cy - DEFAULT_TILE_H / 2),
+      ...findFreeTilePosition(cx, cy, []),
       w: DEFAULT_TILE_W,
       h: DEFAULT_TILE_H,
     };

--- a/packages/client/src/canvas/useCanvasArrange.ts
+++ b/packages/client/src/canvas/useCanvasArrange.ts
@@ -101,9 +101,10 @@ export function useCanvasArrange() {
     // tile at the bare center (the empty list skips the cascade — recovery
     // wants the known center, not collision avoidance) through the one home of
     // the center→top-left + grid-snap math.
-    const { x: cx, y: cy } = viewport.viewportCenter();
+    const center = viewport.viewportCenter();
+    if (!center) return;
     const layout: TileLayout = {
-      ...findFreeTilePosition(cx, cy, []),
+      ...findFreeTilePosition(center.x, center.y, []),
       w: DEFAULT_TILE_W,
       h: DEFAULT_TILE_H,
     };

--- a/packages/client/src/canvas/useCanvasArrange.ts
+++ b/packages/client/src/canvas/useCanvasArrange.ts
@@ -92,12 +92,9 @@ export function useCanvasArrange() {
     if (!supportsSpatialCanvas()) return;
     const id = tileStore.activeId();
     if (!id) return;
-    // Canvas-space coordinate at the viewport center — same math the
+    // Canvas-space coordinate at the viewport center — same accessor the
     // default-placement effect uses to drop a freshly created tile.
-    const { width, height } = viewport.viewportSize();
-    const zoom = viewport.zoom();
-    const cx = viewport.panX() + width / (2 * zoom);
-    const cy = viewport.panY() + height / (2 * zoom);
+    const { x: cx, y: cy } = viewport.viewportCenter();
     const layout: TileLayout = {
       x: snapToGrid(cx - DEFAULT_TILE_W / 2),
       y: snapToGrid(cy - DEFAULT_TILE_H / 2),

--- a/packages/client/src/canvas/viewport/transforms.test.ts
+++ b/packages/client/src/canvas/viewport/transforms.test.ts
@@ -16,9 +16,11 @@ import { describe, expect, it } from "vitest";
 import {
   accumulateZoom,
   applyGestureBatch,
+  computeCenterPan,
   type GestureBatch,
   MAX_ZOOM,
   MIN_ZOOM,
+  viewportCenter,
   zoomTowardPoint,
 } from "./transforms";
 
@@ -107,6 +109,30 @@ describe("applyGestureBatch", () => {
     // delta divides by the NEW zoom (2), not the old (1): 20 / 2 = 10.
     close(r.panX, 10);
     expect(r.zoom).toBe(2);
+  });
+});
+
+/** `viewportCenter` is the forward projection used to drop a tile under the
+ *  camera (default-placement effect + the "Reset terminal size" command). It is
+ *  the inverse of `computeCenterPan`, so these pin the round-trip: panning so a
+ *  point sits at the viewport center, then asking for the center, returns that
+ *  point — regardless of zoom or viewport size. */
+describe("viewportCenter", () => {
+  it("is the inverse of computeCenterPan (round-trips a desired center)", () => {
+    const cases: { cx: number; cy: number; w: number; h: number; z: number }[] =
+      [
+        { cx: 400, cy: 270, w: 1280, h: 720, z: 1 },
+        { cx: -150, cy: 90, w: 800, h: 600, z: 2 },
+        { cx: 33.5, cy: -12.25, w: 1024, h: 768, z: 0.5 },
+      ];
+    for (const { cx, cy, w, h, z } of cases) {
+      // Pan so (cx, cy) lands at the viewport center...
+      const { panX, panY } = computeCenterPan(cx, cy, cx, cy, w, h, z);
+      // ...then asking for the center recovers exactly that point.
+      const got = viewportCenter(panX, panY, w, h, z);
+      close(got.x, cx);
+      close(got.y, cy);
+    }
   });
 });
 

--- a/packages/client/src/canvas/viewport/transforms.ts
+++ b/packages/client/src/canvas/viewport/transforms.ts
@@ -44,6 +44,22 @@ export function computeCenterPan(
   };
 }
 
+/** Canvas-space point at the viewport center — the forward projection that is
+ *  the inverse of `computeCenterPan` (which solves the opposite direction:
+ *  given a desired center, what pan lands it there). */
+export function viewportCenter(
+  panX: number,
+  panY: number,
+  viewportW: number,
+  viewportH: number,
+  zoom: number,
+): { x: number; y: number } {
+  return {
+    x: panX + viewportW / (2 * zoom),
+    y: panY + viewportH / (2 * zoom),
+  };
+}
+
 /** Compute new pan+zoom after zooming by a factor toward a point.
  *  The point (in screen-space relative to container) stays fixed. */
 export function zoomTowardPoint(

--- a/packages/client/src/canvas/viewport/useCanvasViewport.ts
+++ b/packages/client/src/canvas/viewport/useCanvasViewport.ts
@@ -20,6 +20,7 @@ import {
   type GestureBatch,
   normalizeDelta as normalizeDeltaPure,
   snapToGrid as snapToGridPure,
+  viewportCenter as viewportCenterPure,
   zoomToCenter as zoomToCenterPure,
 } from "./transforms";
 
@@ -136,6 +137,9 @@ export interface CanvasViewport {
   setPan: (x: number, y: number) => void;
   /** Current viewport dimensions in pixels (0×0 before mount). */
   viewportSize: () => { width: number; height: number };
+  /** Canvas-space point at the viewport center — the forward projection of
+   *  pan+zoom+size that consumers use to drop a tile under the camera. */
+  viewportCenter: () => { x: number; y: number };
   /** Snap a value to the canvas grid. */
   snapToGrid: (value: number) => number;
   /** CSS background-position for the grid, tracking pan+zoom. */
@@ -258,6 +262,11 @@ function viewportSize() {
   };
 }
 
+function viewportCenter() {
+  const { width, height } = viewportSize();
+  return viewportCenterPure(panX(), panY(), width, height, zoom());
+}
+
 function applyZoomToCenter(direction: "in" | "out" | "reset") {
   if (!containerEl) return;
   beginAuthoritativeMutation();
@@ -284,6 +293,7 @@ const viewport: CanvasViewport = {
   panTo,
   setPan,
   viewportSize,
+  viewportCenter,
   snapToGrid: snapToGridPure,
   gridBgPosition: () => gridBgPositionCSS(panX(), panY(), zoom()),
   gridBgSize: () => gridBgSizeCSS(zoom()),

--- a/packages/client/src/canvas/viewport/useCanvasViewport.ts
+++ b/packages/client/src/canvas/viewport/useCanvasViewport.ts
@@ -138,8 +138,11 @@ export interface CanvasViewport {
   /** Current viewport dimensions in pixels (0×0 before mount). */
   viewportSize: () => { width: number; height: number };
   /** Canvas-space point at the viewport center — the forward projection of
-   *  pan+zoom+size that consumers use to drop a tile under the camera. */
-  viewportCenter: () => { x: number; y: number };
+   *  pan+zoom+size that consumers use to drop a tile under the camera. `null`
+   *  before the container mounts (no real dimensions yet), mirroring
+   *  `centerOnTile`/`panTo`: callers must guard rather than place at a bogus
+   *  origin-derived point. */
+  viewportCenter: () => { x: number; y: number } | null;
   /** Snap a value to the canvas grid. */
   snapToGrid: (value: number) => number;
   /** CSS background-position for the grid, tracking pan+zoom. */
@@ -263,6 +266,10 @@ function viewportSize() {
 }
 
 function viewportCenter() {
+  // Guard on the container like targetForPoint/targetForTile: without it,
+  // viewportSize() falls back to 0×0 and the "center" collapses to the raw
+  // pan origin — a silently wrong point. Return null so callers no-op.
+  if (!containerEl) return null;
   const { width, height } = viewportSize();
   return viewportCenterPure(panX(), panY(), width, height, zoom());
 }

--- a/packages/client/src/commands.tsx
+++ b/packages/client/src/commands.tsx
@@ -450,13 +450,20 @@ export function createCommands(deps: CommandDeps): Accessor<PaletteCommand[]> {
           name: "Simulate activity alert",
           onSelect: () => deps.simulateAlert(),
         },
-        {
-          kind: "action",
-          name: "Reset terminal size",
-          description:
-            "Restore the active terminal to its default size, centered",
-          onSelect: () => deps.handleResetActiveTileSize(),
-        },
+        // Spatial-canvas action — hidden off the canvas (mobile / narrow),
+        // where the handler would no-op and the command would surface as
+        // broken (same gate as the Canvas section's spatial actions above).
+        ...(supportsSpatialCanvas()
+          ? [
+              {
+                kind: "action" as const,
+                name: "Reset terminal size",
+                description:
+                  "Restore the active terminal to its default size, centered",
+                onSelect: () => deps.handleResetActiveTileSize(),
+              },
+            ]
+          : []),
         {
           kind: "action",
           name: "Clear localStorage",


### PR DESCRIPTION
Follow-up to #1437, which shipped the **Reset terminal size** Debug palette command. Running the review gauntlet (lens-debate → codex-debate → simplify → code-police) over that change surfaced two real issues and a missing test — this PR lands the fixes on top.

### What the gauntlet caught

| Pass | Finding | Fix |
| --- | --- | --- |
| lens-debate | The "canvas point at the viewport center" projection (`panX() + w/(2·zoom)`) was hand-inlined in *both* the reset command and `TerminalCanvas`'s default-placement effect — the receptacle's wires exposed in two places | Extracted `viewportCenter()` onto the `CanvasViewport` receptacle (pure `viewportCenter()` in `transforms.ts`, the inverse of `computeCenterPan`, + a bound accessor in `useCanvasViewport.ts`); both call sites now go through it |
| codex-debate | `Reset terminal size` rendered in the Debug menu even off the spatial canvas, where the handler no-ops — a selectable command that silently does nothing on mobile/narrow | Gated the entry behind `supportsSpatialCanvas()`, matching the Canvas section's existing gate |
| codex-debate | The new center-projection math had no coverage | Added a `viewportCenter` round-trip unit test in `transforms.test.ts` (pans so a point sits at center, then asks for the center back — across zoom and viewport sizes) |

The projection now has **one home in the receptacle** instead of three inline copies, and the command no longer advertises itself where it can't work.

> _The feature itself already merged in #1437; this branch is purely the review-driven hardening, so the diff reads as the fixes, not the feature._

_Generated by [`/be-review`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._