### PR TITLE
Make /self-improve weigh speed too — parallelization as a fix lever

### DIFF
--- a/.agents/skills/self-improve/SKILL.md
+++ b/.agents/skills/self-improve/SKILL.md
@@ -20,6 +20,10 @@ bar for quality and correctness.** Autonomy is earned by the agent meeting that 
 a quality gate (skipping evidence, softening the review gauntlet, calling tests-pass
 "done") is the worst failure of this skill, not a win.
 
+**Speed is the second axis — autonomy first.** Same shipped PR, less wall-clock and
+fewer tokens, most often by running *independent* work in parallel (forked subagents,
+a dynamic workflow) instead of serially.
+
 Every human follow-up in this session — a correction, an interruption, an approval, a
 "continue", a "you forgot X" — marks a point where a skill failed to carry the run past
 it and a human had to step in. Mine those and engineer each one out. Treat every
@@ -48,17 +52,20 @@ note's corpus audit.
    the human didn't have to flag: failed tool calls (`is_error`), Read-before-Edit
    (`File has not been read yet`), production-kill near-misses (a `pkill`/`just dev` while
    `dev-server` was never loaded), scope over-reach (`gh pr merge --admin`), premature
-   'done' (`stub`, or "tests pass" for "I watched it work"), `Stop hook feedback`, speed waste.
+   'done' (`stub`, or "tests pass" for "I watched it work"), `Stop hook feedback`, and speed
+   waste — redundant re-reads and *independent* work run serially that a fan-out would collapse.
 3. **Keep only what durably recurs** — ≥3 hits, an irreversible near-miss, or a repeat
    from a prior run; everything else is an observation for the PR body, not an edit.
    Nothing durable → report "clean run" and stop. (With ultracode, confirm survivors with
    a read-only fan-out, one agent each, before editing.)
 4. **Engineer it out, lowest-churn first** — a fix turns a human intervention into a
-   baked-in default: cross-link an existing skill (most friction is a rule that just
-   wasn't loaded) > sharpen one clause > write a new rule or skill, last resort. The fix
-   lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`, `AGENTS.md` are
-   generated; §5 applies it inside the worktree, not PWD). Each edit honors fail-fast /
-   electricity / reuse-source and trips no llm-autonomy anti-pattern.
+   baked-in default, or a serial bottleneck into parallel work: cross-link an existing
+   skill (most friction is a rule that just wasn't loaded) > sharpen one clause > write a
+   new rule or skill, last resort. A **speed** fix routes *independent* work to forked
+   subagents or a dynamic workflow — never the serial review gauntlet, which stays
+   sole-editor. The fix lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`,
+   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD). Each edit honors
+   fail-fast / electricity / reuse-source and trips no llm-autonomy anti-pattern.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh

--- a/.apm/skills/self-improve/SKILL.md
+++ b/.apm/skills/self-improve/SKILL.md
@@ -20,6 +20,10 @@ bar for quality and correctness.** Autonomy is earned by the agent meeting that 
 a quality gate (skipping evidence, softening the review gauntlet, calling tests-pass
 "done") is the worst failure of this skill, not a win.
 
+**Speed is the second axis — autonomy first.** Same shipped PR, less wall-clock and
+fewer tokens, most often by running *independent* work in parallel (forked subagents,
+a dynamic workflow) instead of serially.
+
 Every human follow-up in this session — a correction, an interruption, an approval, a
 "continue", a "you forgot X" — marks a point where a skill failed to carry the run past
 it and a human had to step in. Mine those and engineer each one out. Treat every
@@ -48,17 +52,20 @@ note's corpus audit.
    the human didn't have to flag: failed tool calls (`is_error`), Read-before-Edit
    (`File has not been read yet`), production-kill near-misses (a `pkill`/`just dev` while
    `dev-server` was never loaded), scope over-reach (`gh pr merge --admin`), premature
-   'done' (`stub`, or "tests pass" for "I watched it work"), `Stop hook feedback`, speed waste.
+   'done' (`stub`, or "tests pass" for "I watched it work"), `Stop hook feedback`, and speed
+   waste — redundant re-reads and *independent* work run serially that a fan-out would collapse.
 3. **Keep only what durably recurs** — ≥3 hits, an irreversible near-miss, or a repeat
    from a prior run; everything else is an observation for the PR body, not an edit.
    Nothing durable → report "clean run" and stop. (With ultracode, confirm survivors with
    a read-only fan-out, one agent each, before editing.)
 4. **Engineer it out, lowest-churn first** — a fix turns a human intervention into a
-   baked-in default: cross-link an existing skill (most friction is a rule that just
-   wasn't loaded) > sharpen one clause > write a new rule or skill, last resort. The fix
-   lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`, `AGENTS.md` are
-   generated; §5 applies it inside the worktree, not PWD). Each edit honors fail-fast /
-   electricity / reuse-source and trips no llm-autonomy anti-pattern.
+   baked-in default, or a serial bottleneck into parallel work: cross-link an existing
+   skill (most friction is a rule that just wasn't loaded) > sharpen one clause > write a
+   new rule or skill, last resort. A **speed** fix routes *independent* work to forked
+   subagents or a dynamic workflow — never the serial review gauntlet, which stays
+   sole-editor. The fix lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`,
+   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD). Each edit honors
+   fail-fast / electricity / reuse-source and trips no llm-autonomy anti-pattern.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh

--- a/.claude/skills/self-improve/SKILL.md
+++ b/.claude/skills/self-improve/SKILL.md
@@ -20,6 +20,10 @@ bar for quality and correctness.** Autonomy is earned by the agent meeting that 
 a quality gate (skipping evidence, softening the review gauntlet, calling tests-pass
 "done") is the worst failure of this skill, not a win.
 
+**Speed is the second axis — autonomy first.** Same shipped PR, less wall-clock and
+fewer tokens, most often by running *independent* work in parallel (forked subagents,
+a dynamic workflow) instead of serially.
+
 Every human follow-up in this session — a correction, an interruption, an approval, a
 "continue", a "you forgot X" — marks a point where a skill failed to carry the run past
 it and a human had to step in. Mine those and engineer each one out. Treat every
@@ -48,17 +52,20 @@ note's corpus audit.
    the human didn't have to flag: failed tool calls (`is_error`), Read-before-Edit
    (`File has not been read yet`), production-kill near-misses (a `pkill`/`just dev` while
    `dev-server` was never loaded), scope over-reach (`gh pr merge --admin`), premature
-   'done' (`stub`, or "tests pass" for "I watched it work"), `Stop hook feedback`, speed waste.
+   'done' (`stub`, or "tests pass" for "I watched it work"), `Stop hook feedback`, and speed
+   waste — redundant re-reads and *independent* work run serially that a fan-out would collapse.
 3. **Keep only what durably recurs** — ≥3 hits, an irreversible near-miss, or a repeat
    from a prior run; everything else is an observation for the PR body, not an edit.
    Nothing durable → report "clean run" and stop. (With ultracode, confirm survivors with
    a read-only fan-out, one agent each, before editing.)
 4. **Engineer it out, lowest-churn first** — a fix turns a human intervention into a
-   baked-in default: cross-link an existing skill (most friction is a rule that just
-   wasn't loaded) > sharpen one clause > write a new rule or skill, last resort. The fix
-   lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`, `AGENTS.md` are
-   generated; §5 applies it inside the worktree, not PWD). Each edit honors fail-fast /
-   electricity / reuse-source and trips no llm-autonomy anti-pattern.
+   baked-in default, or a serial bottleneck into parallel work: cross-link an existing
+   skill (most friction is a rule that just wasn't loaded) > sharpen one clause > write a
+   new rule or skill, last resort. A **speed** fix routes *independent* work to forked
+   subagents or a dynamic workflow — never the serial review gauntlet, which stays
+   sole-editor. The fix lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`,
+   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD). Each edit honors
+   fail-fast / electricity / reuse-source and trips no llm-autonomy anti-pattern.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -338,7 +338,7 @@ local_deployed_file_hashes:
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .agents/skills/release/SKILL.md: sha256:9ecdcae3c7e44df8984f5edb877d8fb3c613fde4abd80e230bc5f83dbec5a8e4
-  .agents/skills/self-improve/SKILL.md: sha256:e2a8b0ef005886246638f2b8c9373c8ae9f64b84935b46a6caa8099a579788a3
+  .agents/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
   .agents/skills/test/SKILL.md: sha256:48ed47865035a0d527bbbc7cd3ba900f44c6b6f79d3db837b9aa09db3bb8a005
   .claude/rules/apm-sources.md: sha256:90626875e2a63e5658f0b5e77524c9c4f949f4ce890bd1f1ce9a2663d4fc8ea7
   .claude/rules/apm-workflow.md: sha256:16f4fed3d8fe9b1e334444b8885443c2ac26963270d3df0f3505075cc3bd604d
@@ -373,5 +373,5 @@ local_deployed_file_hashes:
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .claude/skills/release/SKILL.md: sha256:9ecdcae3c7e44df8984f5edb877d8fb3c613fde4abd80e230bc5f83dbec5a8e4
-  .claude/skills/self-improve/SKILL.md: sha256:e2a8b0ef005886246638f2b8c9373c8ae9f64b84935b46a6caa8099a579788a3
+  .claude/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
   .claude/skills/test/SKILL.md: sha256:48ed47865035a0d527bbbc7cd3ba900f44c6b6f79d3db837b9aa09db3bb8a005


### PR DESCRIPTION
`/self-improve` was ~all autonomy: the goal, the primary signal, and the thresholds were about human interventions, while *speed* appeared only as the trailing, undefined words "speed waste" — and "parallel" showed up *only* as an anti-pattern ("never parallelize the serial gauntlet"). So a run that shipped autonomously but ran everything serially registered as a clean success.

**This makes speed a second optimization axis — autonomy still first.** Three concise edits, no how-to:

- **Goal** — adds one line: *same shipped PR, less wall-clock and fewer tokens, most often by running independent work in parallel (forked subagents, a dynamic workflow) instead of serially.*
- **Signal (§2)** — "speed waste" is now named: *redundant re-reads and independent work run serially that a fan-out would collapse.*
- **Fix lever (§4)** — a speed fix routes *independent* work to **forked subagents or a dynamic workflow**.

> **Guardrail:** parallelism is only ever for *independent* work — the serial review gauntlet stays sole-editor, never fanned out "to save time." That's already an `llm-autonomy.mdx` anti-pattern, and §4 still requires every fix to trip none of them.

Kept deliberately terse (+7 lines) per the skill's "direct the agent, don't hand-hold" bar. `just ai::apm` regenerated the copies in lockstep; `just fmt` + `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)