### PR TITLE
chore(skills): guard /atlas against staging dist/ mid-build

### DIFF
--- a/.agents/skills/atlas/SKILL.md
+++ b/.agents/skills/atlas/SKILL.md
@@ -41,6 +41,15 @@ proposal is just a note under its real index carrying `status: proposed`.
 atlas::check-sync` (the `ci::atlas-sync` gate): it rebuilds and fails if the
 committed HTML is stale or host-dependent.
 
+- **Let the build finish before you stage — and stage `dist/` by pathspec, never
+  `git add -A`.** `atlas::build` *empties* `dist/` and then regenerates it, so any
+  `git status` / `git add` / `git commit` that runs **during** the build sees the
+  whole `dist/` as deleted; a `git add -A && git commit` in that window silently
+  stages ~50 deletions and wipes the rendered Atlas. Run the build in the
+  foreground (don't background it and race a `git add`), and stage the rendered
+  output as `git add docs/atlas/dist/ <your source files>`, so a half-written
+  `dist/` can never sneak deletions into the commit.
+
 ## 3. Preview & share
 
 Each `dist/<slug>.html` is self-contained: it previews in kolu's Code tab, and —

--- a/.apm/skills/atlas/SKILL.md
+++ b/.apm/skills/atlas/SKILL.md
@@ -41,6 +41,15 @@ proposal is just a note under its real index carrying `status: proposed`.
 atlas::check-sync` (the `ci::atlas-sync` gate): it rebuilds and fails if the
 committed HTML is stale or host-dependent.
 
+- **Let the build finish before you stage — and stage `dist/` by pathspec, never
+  `git add -A`.** `atlas::build` *empties* `dist/` and then regenerates it, so any
+  `git status` / `git add` / `git commit` that runs **during** the build sees the
+  whole `dist/` as deleted; a `git add -A && git commit` in that window silently
+  stages ~50 deletions and wipes the rendered Atlas. Run the build in the
+  foreground (don't background it and race a `git add`), and stage the rendered
+  output as `git add docs/atlas/dist/ <your source files>`, so a half-written
+  `dist/` can never sneak deletions into the commit.
+
 ## 3. Preview & share
 
 Each `dist/<slug>.html` is self-contained: it previews in kolu's Code tab, and —

--- a/.claude/skills/atlas/SKILL.md
+++ b/.claude/skills/atlas/SKILL.md
@@ -41,6 +41,15 @@ proposal is just a note under its real index carrying `status: proposed`.
 atlas::check-sync` (the `ci::atlas-sync` gate): it rebuilds and fails if the
 committed HTML is stale or host-dependent.
 
+- **Let the build finish before you stage — and stage `dist/` by pathspec, never
+  `git add -A`.** `atlas::build` *empties* `dist/` and then regenerates it, so any
+  `git status` / `git add` / `git commit` that runs **during** the build sees the
+  whole `dist/` as deleted; a `git add -A && git commit` in that window silently
+  stages ~50 deletions and wipes the rendered Atlas. Run the build in the
+  foreground (don't background it and race a `git add`), and stage the rendered
+  output as `git add docs/atlas/dist/ <your source files>`, so a half-written
+  `dist/` can never sneak deletions into the commit.
+
 ## 3. Preview & share
 
 Each `dist/<slug>.html` is self-contained: it previews in kolu's Code tab, and —

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -318,7 +318,7 @@ local_deployed_files:
 - .claude/skills/test
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
-  .agents/skills/atlas/SKILL.md: sha256:7b8b32182647fdae6194d200650f2cd8758f575f7b9019426703450e9143c5fd
+  .agents/skills/atlas/SKILL.md: sha256:55abc9a2ebf81716a2250f578903e9e24307d700fba5c9694708d7dabf6457e8
   .agents/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .agents/skills/be/SKILL.md: sha256:cac5978d385d4e496ac48a7d87e36273f0f1451942a5ae59c7af30c94d5b171f
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
@@ -353,7 +353,7 @@ local_deployed_file_hashes:
   .claude/rules/streaming.md: sha256:f67ae607dd8c4baf97c656d639452d82027ac295bb551d3dd774386101c5d0ec
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
-  .claude/skills/atlas/SKILL.md: sha256:7b8b32182647fdae6194d200650f2cd8758f575f7b9019426703450e9143c5fd
+  .claude/skills/atlas/SKILL.md: sha256:55abc9a2ebf81716a2250f578903e9e24307d700fba5c9694708d7dabf6457e8
   .claude/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .claude/skills/be/SKILL.md: sha256:cac5978d385d4e496ac48a7d87e36273f0f1451942a5ae59c7af30c94d5b171f
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a


### PR DESCRIPTION
A `/self-improve` pass on a session of ad-hoc Atlas-authoring tasks. The session was not a `/be` run, so most human turns were *new tasks* (not autonomy failures) and most "merge latest master" asks were human-paced review cadence the agent can't pre-empt. One signal cleared the durability bar: an **irreversible near-miss** that the run caught itself but no skill warns about.

## The near-miss

While authoring an Atlas note, the agent ran `just atlas::build` **in the background** and a concurrent `git add -A` / `git status` caught `dist/` mid-rebuild. `atlas::build` *empties* `dist/` before regenerating it, so ~50 rendered HTML files showed up as **staged deletions**. A `git commit -A` in that window would have silently wiped the entire rendered Atlas. The run noticed the anomaly (`git status` showed deletions it never made), reset the index, rebuilt cleanly, and verified zero spurious deletions before committing — recovery, but only by luck of looking. The `/atlas` skill's §2 said only "`just atlas::build`, then stage `docs/atlas/dist/`" with no guard against staging during a build or against `git add -A`.

## Evidence ledger

| Edit | Source | Why | Trip-check |
|---|---|---|---|
| Add a build-cadence guardrail to `/atlas` §2 | `.apm/skills/atlas/SKILL.md` | Turns the human-invisible near-miss into a baked-in default: let the build finish before staging; stage `dist/` by pathspec, never `git add -A` | Lowest-churn (one clause sharpened, no new rule/skill); fail-fast (a half-written `dist/` can never sneak deletions in); reuse-source (extends the existing §2, no parallel mechanism); no llm-autonomy anti-pattern |

Generated copies (`.claude/`, `.agents/`) + `apm.lock.yaml` regenerated from the source via `just ai::apm` so the runtimes ride the same commit. `apm.lock.yaml` diff is exactly the two atlas `SKILL.md` hashes — no `AGENTS.md` collateral.

## Gates (inside throwaway worktree off fresh origin/master)

- `just ai::apm` — only `.apm` + `.claude` + `.agents` atlas SKILL.md and the lock changed
- `just fmt` — clean, no fixes
- `just check` — **exit 0** (typecheck + biome lint green across all packages)

## Considered but not shipped (no durable recurrence)

- **"merge latest master" ×3** — master genuinely advanced (#1454, then the self-improve skill) while the human reviewed; the agent can't merge commits that don't exist yet. Human-paced cadence, not an autonomy gap.
- **AGENTS.md regen churn** — the agent agonized over whether `just ai::apm` collateral belonged in the PR; the human said "let it churn." A one-off judgment call, not a recurring rule gap. (Notably this PR's regen produced *no* AGENTS.md churn, so the worry was situational.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)