### PR TITLE
fix(pty): don't leak kolu's KOLU_* env into hosted terminals

### DIFF
--- a/packages/integrations/pty/src/shell.test.ts
+++ b/packages/integrations/pty/src/shell.test.ts
@@ -74,14 +74,16 @@ describe("koluIdentityEnv", () => {
   });
 });
 
-describe("cleanEnv — kolu's own KOLU_* namespace never reaches a hosted shell", () => {
-  // Regression: a production kolu bakes KOLU_KAVAL_BIN (et al.) into its own
-  // env via the nix wrapper. cleanEnv()'s production passthrough would forward
-  // those into every PTY it spawns — so a nested `just dev` (from source, run
-  // inside a kolu terminal) inherited a STALE KOLU_KAVAL_BIN and spawned a
-  // contract-skewed kaval. cleanEnv must strip the KOLU_* namespace. Default
-  // module state (no configureNixShellEnv call) is passthrough mode — the exact
-  // production path that leaked.
+describe("cleanEnv — kolu's own internal env never reaches a hosted shell", () => {
+  // Regression: a production kolu bakes its internal env (KOLU_KAVAL_BIN et al.,
+  // plus the kaval identity vars KAVAL_BUILD_ID / KAVAL_COMMIT_HASH) into its own
+  // process via the nix wrapper (default.nix). cleanEnv()'s production
+  // passthrough would forward those into every PTY it spawns — so a nested
+  // `just dev` (from source, run inside a kolu terminal) inherited a STALE
+  // KOLU_KAVAL_BIN and spawned a contract-skewed kaval, AND inherited the OUTER
+  // kaval identity so its staleness readout reported the wrong build. cleanEnv
+  // must strip both. Default module state (no configureNixShellEnv call) is
+  // passthrough mode — the exact production path that leaked.
   const saved = { ...process.env };
   afterEach(() => {
     for (const k of Object.keys(process.env)) delete process.env[k];
@@ -107,6 +109,31 @@ describe("cleanEnv — kolu's own KOLU_* namespace never reaches a hosted shell"
     // the user's real environment is untouched.
     expect(env.PTY_TEST_USER_VAR).toBe("keep-me");
     expect(env.PATH).toBe(process.env.PATH);
+  });
+
+  it("strips the wrapper-baked kaval identity vars (KAVAL_BUILD_ID / KAVAL_COMMIT_HASH)", () => {
+    // These are --set onto the kolu wrapper (default.nix:336-337) because kaval
+    // runs in-process there; buildId.ts reads them to derive the staleKey /
+    // "update pending" signal. A from-source kolu nested inside a production
+    // kolu terminal must NOT inherit the outer production identity, or its
+    // staleness readout reports the wrong build and masks the stale-daemon nudge.
+    process.env.KAVAL_BUILD_ID = "outer-production-build";
+    process.env.KAVAL_COMMIT_HASH = "deadbeef";
+    // A user's own KAVAL_* env is NOT internal — only the two baked identity
+    // vars are. KAVAL_AGENT_DRVS_JSON (kaval-tui's drv map) and an arbitrary
+    // user KAVAL_* must still reach the shell.
+    process.env.KAVAL_AGENT_DRVS_JSON = '{"x86_64-linux":"/nix/store/x.drv"}';
+    process.env.KAVAL_MY_OWN_VAR = "keep-me";
+
+    const env = cleanEnv();
+
+    expect(env.KAVAL_BUILD_ID).toBeUndefined();
+    expect(env.KAVAL_COMMIT_HASH).toBeUndefined();
+    // not a blanket KAVAL_* strip — unrelated KAVAL_* survives.
+    expect(env.KAVAL_AGENT_DRVS_JSON).toBe(
+      '{"x86_64-linux":"/nix/store/x.drv"}',
+    );
+    expect(env.KAVAL_MY_OWN_VAR).toBe("keep-me");
   });
 });
 

--- a/packages/integrations/pty/src/shell.test.ts
+++ b/packages/integrations/pty/src/shell.test.ts
@@ -15,8 +15,9 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  cleanEnv,
   koluIdentityEnv,
   OSC2_PRECMD_BASH,
   OSC2_PRECMD_ZSH,
@@ -70,6 +71,42 @@ describe("koluIdentityEnv", () => {
     const layered: Record<string, string> = { VTE_VERSION: "9999" };
     Object.assign(layered, koluIdentityEnv("9.9.9"));
     expect(layered.VTE_VERSION).toBe("7603");
+  });
+});
+
+describe("cleanEnv — kolu's own KOLU_* namespace never reaches a hosted shell", () => {
+  // Regression: a production kolu bakes KOLU_KAVAL_BIN (et al.) into its own
+  // env via the nix wrapper. cleanEnv()'s production passthrough would forward
+  // those into every PTY it spawns — so a nested `just dev` (from source, run
+  // inside a kolu terminal) inherited a STALE KOLU_KAVAL_BIN and spawned a
+  // contract-skewed kaval. cleanEnv must strip the KOLU_* namespace. Default
+  // module state (no configureNixShellEnv call) is passthrough mode — the exact
+  // production path that leaked.
+  const saved = { ...process.env };
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    Object.assign(process.env, saved);
+  });
+
+  it("strips KOLU_* (incl. the spawn-deciding KOLU_KAVAL_* vars), keeps the user's env", () => {
+    process.env.KOLU_KAVAL_BIN = "/nix/store/stale-kaval/bin/kaval";
+    process.env.KOLU_KAVAL_SOCKET = "/run/stale/pty-host.sock";
+    process.env.KOLU_KAVAL_SPAWN = "detached";
+    process.env.KOLU_STATE_DIR = "/home/x/.config/kolu";
+    process.env.PTY_TEST_USER_VAR = "keep-me";
+
+    const env = cleanEnv();
+
+    // kolu's namespace is gone — nothing ancestral can ride it into the shell.
+    expect(env.KOLU_KAVAL_BIN).toBeUndefined();
+    expect(env.KOLU_KAVAL_SOCKET).toBeUndefined();
+    expect(env.KOLU_KAVAL_SPAWN).toBeUndefined();
+    expect(env.KOLU_STATE_DIR).toBeUndefined();
+    expect(Object.keys(env).some((k) => k.startsWith("KOLU_"))).toBe(false);
+
+    // the user's real environment is untouched.
+    expect(env.PTY_TEST_USER_VAR).toBe("keep-me");
+    expect(env.PATH).toBe(process.env.PATH);
   });
 });
 

--- a/packages/integrations/pty/src/shell.ts
+++ b/packages/integrations/pty/src/shell.ts
@@ -62,11 +62,13 @@ export function configureNixShellEnv(whitelist: string | undefined): void {
 /**
  * Sanitize the parent env that will reach the PTY shell.
  *
- * Without a whitelist (production): pass process.env straight through, minus
- * kolu's own KOLU_* namespace (server-internal config that must never reach a
- * user shell — see the inline note in the passthrough branch).
+ * Without a whitelist (production): pass process.env straight through.
  * With a whitelist (dev/test inside nix shell): pick only whitelisted vars
  * and override SHELL with the user's login shell from /etc/passwd.
+ *
+ * Either way, a single shared post-step strips kolu's own KOLU_* namespace
+ * (server-internal config that must never reach a user shell — see the inline
+ * note above the strip) so the invariant holds independent of how env was built.
  *
  * Scope note: this layer only filters what the parent process exposes.
  * Restoring user env that the parent doesn't carry (e.g. PATH from
@@ -88,21 +90,23 @@ export function cleanEnv(): Record<string, string> {
     env.SHELL = loginShell;
   } else {
     env = { ...process.env } as Record<string, string>;
-    // Don't forward kolu's own KOLU_* namespace into the user's shell. These
-    // are the server's internal config (e.g. the wrapper-baked KOLU_KAVAL_BIN
-    // that tells the server which kaval to spawn) — baked into the server's env,
-    // never meant for a hosted terminal. Forwarded, they leak into every PTY
-    // child: a nested from-source kolu (`just dev` run inside a kolu terminal)
-    // inherits a STALE KOLU_KAVAL_BIN and spawns a contract-skewed daemon. kolu
-    // owns this prefix, so stripping it here — at the leak boundary — can't drop
-    // a var a user shell legitimately needs (and a user-defined KOLU_* set in
-    // their own dotfiles is re-applied by the rcfile replay, see prepareShellInit).
-    for (const key of Object.keys(env)) {
-      if (key.startsWith("KOLU_")) delete env[key];
-    }
     // Ensure SHELL is set — systemd user services may not have it.
     env.SHELL ??= loginShell;
   }
+  // Don't forward kolu's own KOLU_* namespace into the user's shell. These
+  // are the server's internal config (e.g. the wrapper-baked KOLU_KAVAL_BIN
+  // that tells the server which kaval to spawn) — baked into the server's env,
+  // never meant for a hosted terminal. Forwarded, they leak into every PTY
+  // child: a nested from-source kolu (`just dev` run inside a kolu terminal)
+  // inherits a STALE KOLU_KAVAL_BIN and spawns a contract-skewed daemon. kolu
+  // owns this prefix, so stripping it here — at the leak boundary — can't drop
+  // a var a user shell legitimately needs (and a user-defined KOLU_* set in
+  // their own dotfiles is re-applied by the rcfile replay, see prepareShellInit).
+  // One shared strip for both branches: the invariant is a property of cleanEnv,
+  // not of one branch (and independent of NIX_ENV_WHITELIST's future contents).
+  env = Object.fromEntries(
+    Object.entries(env).filter(([k]) => !k.startsWith("KOLU_")),
+  );
   return env;
 }
 

--- a/packages/integrations/pty/src/shell.ts
+++ b/packages/integrations/pty/src/shell.ts
@@ -62,7 +62,9 @@ export function configureNixShellEnv(whitelist: string | undefined): void {
 /**
  * Sanitize the parent env that will reach the PTY shell.
  *
- * Without a whitelist (production): pass process.env straight through.
+ * Without a whitelist (production): pass process.env straight through, minus
+ * kolu's own KOLU_* namespace (server-internal config that must never reach a
+ * user shell — see the inline note in the passthrough branch).
  * With a whitelist (dev/test inside nix shell): pick only whitelisted vars
  * and override SHELL with the user's login shell from /etc/passwd.
  *
@@ -86,6 +88,18 @@ export function cleanEnv(): Record<string, string> {
     env.SHELL = loginShell;
   } else {
     env = { ...process.env } as Record<string, string>;
+    // Don't forward kolu's own KOLU_* namespace into the user's shell. These
+    // are the server's internal config (e.g. the wrapper-baked KOLU_KAVAL_BIN
+    // that tells the server which kaval to spawn) — baked into the server's env,
+    // never meant for a hosted terminal. Forwarded, they leak into every PTY
+    // child: a nested from-source kolu (`just dev` run inside a kolu terminal)
+    // inherits a STALE KOLU_KAVAL_BIN and spawns a contract-skewed daemon. kolu
+    // owns this prefix, so stripping it here — at the leak boundary — can't drop
+    // a var a user shell legitimately needs (and a user-defined KOLU_* set in
+    // their own dotfiles is re-applied by the rcfile replay, see prepareShellInit).
+    for (const key of Object.keys(env)) {
+      if (key.startsWith("KOLU_")) delete env[key];
+    }
     // Ensure SHELL is set — systemd user services may not have it.
     env.SHELL ??= loginShell;
   }

--- a/packages/integrations/pty/src/shell.ts
+++ b/packages/integrations/pty/src/shell.ts
@@ -38,6 +38,40 @@ export const NIX_ENV_WHITELIST =
 let envWhitelist: Set<string> | undefined;
 
 /**
+ * Kolu-family internal env that the nix wrapper bakes into the SERVER's own
+ * process (see `default.nix`'s `koluBin` / `default` `--set`s) and that must
+ * never reach a hosted shell. Two groups, both server-internal:
+ *
+ *   - `KOLU_*` — the server's own config (`KOLU_KAVAL_BIN`, `KOLU_STATE_DIR`,
+ *     `KOLU_COMMIT_HASH`, …). `KOLU_KAVAL_BIN` is the spawn-deciding one: a
+ *     nested from-source kolu that inherits a stale value spawns a
+ *     contract-skewed daemon.
+ *   - `KAVAL_BUILD_ID` / `KAVAL_COMMIT_HASH` — the running kaval's *identity*,
+ *     baked onto the kolu wrapper (default.nix:336-337) because kaval runs
+ *     in-process there. `buildId.ts` reads these to derive the "update
+ *     pending" / staleKey signal. A from-source kolu spawned inside a
+ *     production kolu terminal would otherwise inherit the OUTER production
+ *     identity and report the wrong build (masking the stale-daemon nudge) —
+ *     the same wrapper-baked-env leak as `KOLU_*`, one prefix over.
+ *
+ * Note this is NOT the `KAVAL_*` namespace wholesale: a user could legitimately
+ * have their own `KAVAL_*` env, and `KAVAL_AGENT_DRVS_JSON` (kaval-tui) is a
+ * different concern. Only the two identity vars the kolu wrapper bakes are
+ * internal, so they're listed explicitly rather than matched by prefix.
+ */
+const KOLU_INTERNAL_ENV_EXACT = new Set([
+  "KAVAL_BUILD_ID",
+  "KAVAL_COMMIT_HASH",
+]);
+
+/** True for any env key the kolu nix wrapper bakes into the server for its own
+ *  use — the `KOLU_*` namespace plus the two baked kaval identity vars. These
+ *  are stripped at the `cleanEnv` boundary so none ride into a hosted shell. */
+function isKoluInternalEnvKey(key: string): boolean {
+  return key.startsWith("KOLU_") || KOLU_INTERNAL_ENV_EXACT.has(key);
+}
+
+/**
  * Configure nix shell env handling at startup.
  *
  * - "default"       → use NIX_ENV_WHITELIST
@@ -66,9 +100,10 @@ export function configureNixShellEnv(whitelist: string | undefined): void {
  * With a whitelist (dev/test inside nix shell): pick only whitelisted vars
  * and override SHELL with the user's login shell from /etc/passwd.
  *
- * Either way, a single shared post-step strips kolu's own KOLU_* namespace
- * (server-internal config that must never reach a user shell — see the inline
- * note above the strip) so the invariant holds independent of how env was built.
+ * Either way, a single shared post-step strips kolu's own internal env
+ * (the `KOLU_*` namespace plus the wrapper-baked kaval identity vars — see
+ * `isKoluInternalEnvKey` and the inline note above the strip) so the invariant
+ * holds independent of how env was built.
  *
  * Scope note: this layer only filters what the parent process exposes.
  * Restoring user env that the parent doesn't carry (e.g. PATH from
@@ -93,19 +128,22 @@ export function cleanEnv(): Record<string, string> {
     // Ensure SHELL is set — systemd user services may not have it.
     env.SHELL ??= loginShell;
   }
-  // Don't forward kolu's own KOLU_* namespace into the user's shell. These
-  // are the server's internal config (e.g. the wrapper-baked KOLU_KAVAL_BIN
-  // that tells the server which kaval to spawn) — baked into the server's env,
-  // never meant for a hosted terminal. Forwarded, they leak into every PTY
-  // child: a nested from-source kolu (`just dev` run inside a kolu terminal)
-  // inherits a STALE KOLU_KAVAL_BIN and spawns a contract-skewed daemon. kolu
-  // owns this prefix, so stripping it here — at the leak boundary — can't drop
-  // a var a user shell legitimately needs (and a user-defined KOLU_* set in
-  // their own dotfiles is re-applied by the rcfile replay, see prepareShellInit).
-  // One shared strip for both branches: the invariant is a property of cleanEnv,
-  // not of one branch (and independent of NIX_ENV_WHITELIST's future contents).
+  // Don't forward kolu's own internal env into the user's shell. The nix
+  // wrapper bakes these into the SERVER's process for its own use (e.g.
+  // KOLU_KAVAL_BIN, which tells the server which kaval to spawn, and the kaval
+  // identity vars KAVAL_BUILD_ID / KAVAL_COMMIT_HASH that buildId.ts reads to
+  // derive the "update pending" signal) — never meant for a hosted terminal.
+  // Forwarded, they leak into every PTY child: a nested from-source kolu
+  // (`just dev` run inside a kolu terminal) inherits a STALE KOLU_KAVAL_BIN and
+  // spawns a contract-skewed daemon, and inherits the OUTER kaval identity so
+  // its staleness readout reports the wrong build. kolu owns this env, so
+  // stripping it here — at the leak boundary — can't drop a var a user shell
+  // legitimately needs (and a user-defined KOLU_* set in their own dotfiles is
+  // re-applied by the rcfile replay, see prepareShellInit). One shared strip
+  // for both branches: the invariant is a property of cleanEnv, not of one
+  // branch (and independent of NIX_ENV_WHITELIST's future contents).
   env = Object.fromEntries(
-    Object.entries(env).filter(([k]) => !k.startsWith("KOLU_")),
+    Object.entries(env).filter(([k]) => !isKoluInternalEnvKey(k)),
   );
   return env;
 }


### PR DESCRIPTION
## What

kolu's `cleanEnv()` production passthrough copied the **entire** server environment into every terminal it spawns — including kolu's own internal config that the nix wrapper bakes in: `KOLU_KAVAL_BIN` and the kaval identity vars `KAVAL_BUILD_ID`/`KAVAL_COMMIT_HASH`. This strips kolu's internal env at that boundary so none of it reaches a hosted shell.

## The bug

Run `just dev` **inside a kolu terminal** and the dev server dies at boot:

```
DaemonContractSkewError: pty-host contract skew: kaval speaks 3.0, server needs 3.1
kaval endpoint failed to come up at boot
```

## Root cause

A production kolu's nix wrapper bakes its internal config into the server's env (`default.nix:333-338` — `KOLU_KAVAL_BIN`, `KAVAL_BUILD_ID`, `KAVAL_COMMIT_HASH`, …). `cleanEnv()` then forwarded the whole env — `{ ...process.env }` — into every PTY child (`packages/integrations/pty/src/shell.ts`). So any shell opened inside kolu silently carried `KOLU_KAVAL_BIN`, pointing at *that build's* (older) kaval.

Run `just dev` from source in such a terminal and the new (contract 3.1) server reads the inherited `KOLU_KAVAL_BIN` (`localDriver.ts:85`) and spawns the **old** (3.0) kaval. The handshake rejects it (correctly — fail fast, no silent downgrade), and because the respawn re-reads the same stale pointer, it never converges.

## Fix

`cleanEnv()` now drops kolu's internal env before it reaches the shell, via a named `isKoluInternalEnvKey` predicate:

- the **`KOLU_*` namespace** — covers the spawn-hijack surface (`KOLU_KAVAL_BIN` / `KOLU_KAVAL_SOCKET` / `KOLU_KAVAL_SPAWN`);
- the two **wrapper-baked kaval identity vars** `KAVAL_BUILD_ID` / `KAVAL_COMMIT_HASH` — a from-source kaval reads these from inherited env (`buildId.ts`), so leaking the *outer* build's identity into a nested `just dev` would mis-report its build and mask the "update pending" nudge.

One shared strip after **both** `cleanEnv` branches, so the invariant holds regardless of the dev whitelist's contents. Deliberately **not** a blanket `KAVAL_*` strip — a user's own `KAVAL_*` and kaval-tui's `KAVAL_AGENT_DRVS_JSON` survive (the explicit two-var set mirrors `default.nix`'s `koluBin` `--set` manifest exactly). kolu owns this env; a `KOLU_*` a user sets in their *own* dotfiles is re-applied by the rcfile replay (`prepareShellInit`).

## Why not move config off env entirely?

A larger "read kolu's config from an owned channel, never `process.env`" refactor was considered and rejected: ~8 production reads + e2e test-seam migration + a new config layer, all to close a threat (a *non-kolu* ancestor poking the server's own env) that doesn't occur in this single-tenant codebase. The leak boundary *is* the bug; this is the small fix that closes it.

## Test

`cleanEnv` regressions in `shell.test.ts`: passthrough strips `KOLU_*` **and** the two kaval identity vars while the user's env (`PATH`, user vars, unrelated `KAVAL_*` incl. `KAVAL_AGENT_DRVS_JSON`) is untouched. `kolu-pty` unit suite green (26/26); `just fmt` clean.

## Review

Ran the `/be` gauntlet — lens-debate (lowy ⇄ hickey), codex-debate (`xhigh`), simplify, code-police. Lens unified the strip across both branches; codex caught the `KAVAL_BUILD_ID`/`KAVAL_COMMIT_HASH` leak (now fixed); simplify + police clean. See PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
