### PR TITLE
chore(skills): /atlas re-plans rewrite, never layer superseded phases

### DIFF
--- a/.agents/skills/atlas/SKILL.md
+++ b/.agents/skills/atlas/SKILL.md
@@ -66,4 +66,15 @@ proposal is just a note carrying `status: proposed` (see `CONTRIBUTING.md`);
 acceptance flips the status, not its `parents` (the index parent was right from
 the start).
 
+- **A plan-of-record describes current + future work, not the path that got here —
+  when you re-plan, *rewrite*, don't layer.** Git already holds the archaeology, so
+  superseded phases, abandoned attempts, closed-PR post-mortems, and "what we tried
+  before" belong in the commit history, **not** as live sections of the note. Each
+  re-plan **replaces** the old phase list outright; never keep the dead phases beside
+  the new ones to show the journey. And carry **one** numbering scheme at a time:
+  renaming P3a/P3b → PR1/PR2 means the P3a/P3b labels are *gone*, not cross-mapped in a
+  table — two parallel schemes for the same work is the confusion, not the cure. If a
+  reader has to ask "how does PR1 relate to P3a?" or "why does P3a still exist?", the
+  note kept clutter it should have deleted.
+
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/atlas/SKILL.md
+++ b/.apm/skills/atlas/SKILL.md
@@ -66,4 +66,15 @@ proposal is just a note carrying `status: proposed` (see `CONTRIBUTING.md`);
 acceptance flips the status, not its `parents` (the index parent was right from
 the start).
 
+- **A plan-of-record describes current + future work, not the path that got here —
+  when you re-plan, *rewrite*, don't layer.** Git already holds the archaeology, so
+  superseded phases, abandoned attempts, closed-PR post-mortems, and "what we tried
+  before" belong in the commit history, **not** as live sections of the note. Each
+  re-plan **replaces** the old phase list outright; never keep the dead phases beside
+  the new ones to show the journey. And carry **one** numbering scheme at a time:
+  renaming P3a/P3b → PR1/PR2 means the P3a/P3b labels are *gone*, not cross-mapped in a
+  table — two parallel schemes for the same work is the confusion, not the cure. If a
+  reader has to ask "how does PR1 relate to P3a?" or "why does P3a still exist?", the
+  note kept clutter it should have deleted.
+
 ARGUMENTS: $ARGUMENTS

--- a/.claude/skills/atlas/SKILL.md
+++ b/.claude/skills/atlas/SKILL.md
@@ -66,4 +66,15 @@ proposal is just a note carrying `status: proposed` (see `CONTRIBUTING.md`);
 acceptance flips the status, not its `parents` (the index parent was right from
 the start).
 
+- **A plan-of-record describes current + future work, not the path that got here —
+  when you re-plan, *rewrite*, don't layer.** Git already holds the archaeology, so
+  superseded phases, abandoned attempts, closed-PR post-mortems, and "what we tried
+  before" belong in the commit history, **not** as live sections of the note. Each
+  re-plan **replaces** the old phase list outright; never keep the dead phases beside
+  the new ones to show the journey. And carry **one** numbering scheme at a time:
+  renaming P3a/P3b → PR1/PR2 means the P3a/P3b labels are *gone*, not cross-mapped in a
+  table — two parallel schemes for the same work is the confusion, not the cure. If a
+  reader has to ask "how does PR1 relate to P3a?" or "why does P3a still exist?", the
+  note kept clutter it should have deleted.
+
 ARGUMENTS: $ARGUMENTS

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -318,7 +318,7 @@ local_deployed_files:
 - .claude/skills/test
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
-  .agents/skills/atlas/SKILL.md: sha256:55abc9a2ebf81716a2250f578903e9e24307d700fba5c9694708d7dabf6457e8
+  .agents/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
   .agents/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .agents/skills/be/SKILL.md: sha256:85ebb42ca032748432cb7faffe9a79073e205bc98389633dc47020f2844cfaf7
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
@@ -353,7 +353,7 @@ local_deployed_file_hashes:
   .claude/rules/streaming.md: sha256:f67ae607dd8c4baf97c656d639452d82027ac295bb551d3dd774386101c5d0ec
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
-  .claude/skills/atlas/SKILL.md: sha256:55abc9a2ebf81716a2250f578903e9e24307d700fba5c9694708d7dabf6457e8
+  .claude/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
   .claude/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
   .claude/skills/be/SKILL.md: sha256:85ebb42ca032748432cb7faffe9a79073e205bc98389633dc47020f2844cfaf7
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a


### PR DESCRIPTION
## What

Sharpens the `/atlas` Lifecycle section with one clause: a re-planned plan-of-record describes **current + future** work only — when you re-plan you **rewrite**, you don't layer new phases on top of dead ones, and you carry **one** numbering scheme at a time.

## Why — the intervention it engineers out

Mined from `/self-improve` on session `fba731c5-5a02-4fb2-b65e-201627337377` (the arivu P3 re-plan). The plan-of-record note churned through four consecutive human-driven re-plan commits because the agent kept superseded phases beside the new ones and ran two parallel numbering schemes for the same work:

| commit | what the human had to correct |
|---|---|
| `1c2023144` | re-plan after closing #1453 |
| `25d118a5f` | split into PR1/PR2 |
| `8ce0a64f4` | "clarify PR1/PR2 **vs** P3a/P3b mapping" — agent kept *both* schemes and cross-mapped them in a table |
| `65e1d71ed` | "drop P3a/P3b + #1453 archaeology" — final demand to delete the past |

Verbatim human follow-ups, all one root cause:
- "wtf bro your P3a is exactly what we tried to do before"
- "The plan is fucking confusing. What's the relation between PR1/PR2 and P3a/P3b"
- "wtf. why do p3a/p3b even fucking exist?"
- "PLAN MUST BE CURRENT/FUTURE, NOT OF PAST"

≥3 hits on a single recurring failure → durable lesson. Lowest-churn fix: sharpen the existing "Notes are living" clause (§4) rather than add a new rule — and it reuses the existing source of truth (git is the archaeology, not the note body).

## Evidence ledger

- **Edit:** `.apm/skills/atlas/SKILL.md` §4 — added the "re-plans rewrite, never layer" bullet. Generated copies (`.claude/`, `.agents/`) regenerated via `just ai::apm` and ride the same commit; `apm.lock.yaml` hashes updated in lockstep.
- **`just fmt`** → clean (0/5 reformatted).
- **`just check`** → green (EXIT=0): all package typechecks pass, biome lint clean (903 files).

Honors fail-fast / electricity / reuse-source; trips no llm-autonomy anti-pattern (no post-§0 question reintroduced, serial gauntlet untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)