### PR TITLE
chore(skills): stop local-execution OOM from killing production; end gauntlet babysitting

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -64,6 +64,16 @@ already ran `git fetch origin` and resolved the base, so pass `MB` straight into
 each step and **skip the per-skill step-1 fetch / base resolution** — don't redo
 it once per step.
 
+**How to "wait for the Workflow" — let its own settle notification resume you.**
+The debate skills run as a backgrounded `Workflow` ("launched in background; Task
+ID: …"); a debate can legitimately take 20–30 min. When it settles it fires its
+own task-notification that resumes this run automatically — that is the wait. So
+after dispatching a step, go to rest and let that notification wake you; **do not
+schedule redundant `ScheduleWakeup` polls** and there is nothing to babysit. (A
+prior run scheduled 4-min wakeups *and* the user wired a 5-min `/loop` to nudge a
+gauntlet that was simply mid-debate — both were unnecessary churn.) Only act when
+the workflow's notification arrives or it has provably errored.
+
 1. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
    `base` = `MB`, **apply mode** (the default — do *not* pass `--no-apply`),
    **`--no-comment`** (so it doesn't advertise its local-only commits before

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -82,6 +82,15 @@ guessed (a faithfully-reproduced negative counts too).
 
 ## 5. Ship — CI and evidence in parallel
 
+**Heavy work runs on a pu box, never locally — production kolu lives on this
+machine.** Builds, the dev server, and evidence capture all go on an ephemeral pu
+box whenever `systemctl --user is-active kolu` is `active` (the normal case). A
+prior run piled local `just dev-auto` + nix builds beside a live production kolu
+and the **OOM-killer `SIGKILL`ed production**; random ports dodged its *ports* but
+not its *RAM*. Load **`/dev-server`** §0 for the local-vs-pu venue gate before
+launching the app for *any* reason — including an interactive "let me SEE it"
+check during §2. `/ci` and `/evidence` already run on pu; keep it that way.
+
 `/ci` and `/evidence` are independent — one exercises the build/test pipeline, the
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.

--- a/.agents/skills/dev-server/SKILL.md
+++ b/.agents/skills/dev-server/SKILL.md
@@ -19,6 +19,30 @@ happened on [#1109](https://github.com/juspay/kolu/issues/1109). Never bind the
 defaults; never touch the systemd unit. This skill is the canonical "run the app
 locally" path so that can't recur.
 
+## 0. First decide local vs. pu — production lives on this machine
+
+Disrupting production is **not only a port collision.** A second incident: an
+agent ran `just dev-auto` repeatedly (each forks a node server + a kaval daemon)
+plus nix builds, all on the user's machine *while production kolu and other
+agents were live* — the pile-up drove the **OOM-killer to `SIGKILL` production**
+(`status=9/KILL`). Random ports kept it off production's *ports*; nothing kept it
+off production's *RAM*. The user's standing rule after that: **"always run on pu,
+nothing locally."**
+
+So before launching anything, decide where it runs:
+
+- **Run on a `pu` box (the default for `/be`-style runs)** whenever production
+  kolu is live on this machine — i.e. any time `systemctl --user is-active kolu`
+  is `active`. Builds, the dev server, and evidence capture all go on a fresh pu
+  box (see the **pu** and **evidence** skills): the box has its own RAM and
+  loopback, so a local OOM can't reach production. **Never** loop `just dev-auto`
+  + nix builds locally next to a live production kolu.
+- **Run locally only** when production is **not** running here (`is-active` →
+  `inactive`/`failed`), or the user has explicitly OK'd local execution this
+  session. Then the rest of this skill (random ports, scoped teardown) applies.
+
+When in doubt, prefer pu — a clean CI-like box never touches the user's machine.
+
 ## 1. Launch on two random free ports — always `just dev-auto`
 
 ```sh
@@ -99,9 +123,15 @@ production or unrelated processes. Match the remembered ports only.
 
 ## Acceptance (verify before declaring the app launched / torn down)
 
+- **Local was the right venue at all** — production kolu was `inactive` (or the
+  user OK'd local). If production is live here, heavy work belonged on a pu box
+  (§0); a single throwaway local launch is one thing, but **never** a loop of
+  `dev-auto` + builds beside it.
 - Two **random** ports, both remembered in `.dev-server/ports.json` and reused
   across the session (no re-grepping, no guessing).
 - Production `kolu.service` **provably untouched** — `systemctl --user status
-  kolu` shows the same PID/uptime before and after your run.
+  kolu` shows the same PID **and uptime** before and after your run (a changed
+  uptime means it restarted — an OOM kill counts as touching it, even if no
+  command of yours named it).
 - Teardown removes **only** the dev instance (the remembered PIDs); production
   keeps running.

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -64,6 +64,16 @@ already ran `git fetch origin` and resolved the base, so pass `MB` straight into
 each step and **skip the per-skill step-1 fetch / base resolution** — don't redo
 it once per step.
 
+**How to "wait for the Workflow" — let its own settle notification resume you.**
+The debate skills run as a backgrounded `Workflow` ("launched in background; Task
+ID: …"); a debate can legitimately take 20–30 min. When it settles it fires its
+own task-notification that resumes this run automatically — that is the wait. So
+after dispatching a step, go to rest and let that notification wake you; **do not
+schedule redundant `ScheduleWakeup` polls** and there is nothing to babysit. (A
+prior run scheduled 4-min wakeups *and* the user wired a 5-min `/loop` to nudge a
+gauntlet that was simply mid-debate — both were unnecessary churn.) Only act when
+the workflow's notification arrives or it has provably errored.
+
 1. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
    `base` = `MB`, **apply mode** (the default — do *not* pass `--no-apply`),
    **`--no-comment`** (so it doesn't advertise its local-only commits before

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -82,6 +82,15 @@ guessed (a faithfully-reproduced negative counts too).
 
 ## 5. Ship — CI and evidence in parallel
 
+**Heavy work runs on a pu box, never locally — production kolu lives on this
+machine.** Builds, the dev server, and evidence capture all go on an ephemeral pu
+box whenever `systemctl --user is-active kolu` is `active` (the normal case). A
+prior run piled local `just dev-auto` + nix builds beside a live production kolu
+and the **OOM-killer `SIGKILL`ed production**; random ports dodged its *ports* but
+not its *RAM*. Load **`/dev-server`** §0 for the local-vs-pu venue gate before
+launching the app for *any* reason — including an interactive "let me SEE it"
+check during §2. `/ci` and `/evidence` already run on pu; keep it that way.
+
 `/ci` and `/evidence` are independent — one exercises the build/test pipeline, the
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.

--- a/.apm/skills/dev-server/SKILL.md
+++ b/.apm/skills/dev-server/SKILL.md
@@ -19,6 +19,30 @@ happened on [#1109](https://github.com/juspay/kolu/issues/1109). Never bind the
 defaults; never touch the systemd unit. This skill is the canonical "run the app
 locally" path so that can't recur.
 
+## 0. First decide local vs. pu — production lives on this machine
+
+Disrupting production is **not only a port collision.** A second incident: an
+agent ran `just dev-auto` repeatedly (each forks a node server + a kaval daemon)
+plus nix builds, all on the user's machine *while production kolu and other
+agents were live* — the pile-up drove the **OOM-killer to `SIGKILL` production**
+(`status=9/KILL`). Random ports kept it off production's *ports*; nothing kept it
+off production's *RAM*. The user's standing rule after that: **"always run on pu,
+nothing locally."**
+
+So before launching anything, decide where it runs:
+
+- **Run on a `pu` box (the default for `/be`-style runs)** whenever production
+  kolu is live on this machine — i.e. any time `systemctl --user is-active kolu`
+  is `active`. Builds, the dev server, and evidence capture all go on a fresh pu
+  box (see the **pu** and **evidence** skills): the box has its own RAM and
+  loopback, so a local OOM can't reach production. **Never** loop `just dev-auto`
+  + nix builds locally next to a live production kolu.
+- **Run locally only** when production is **not** running here (`is-active` →
+  `inactive`/`failed`), or the user has explicitly OK'd local execution this
+  session. Then the rest of this skill (random ports, scoped teardown) applies.
+
+When in doubt, prefer pu — a clean CI-like box never touches the user's machine.
+
 ## 1. Launch on two random free ports — always `just dev-auto`
 
 ```sh
@@ -99,9 +123,15 @@ production or unrelated processes. Match the remembered ports only.
 
 ## Acceptance (verify before declaring the app launched / torn down)
 
+- **Local was the right venue at all** — production kolu was `inactive` (or the
+  user OK'd local). If production is live here, heavy work belonged on a pu box
+  (§0); a single throwaway local launch is one thing, but **never** a loop of
+  `dev-auto` + builds beside it.
 - Two **random** ports, both remembered in `.dev-server/ports.json` and reused
   across the session (no re-grepping, no guessing).
 - Production `kolu.service` **provably untouched** — `systemctl --user status
-  kolu` shows the same PID/uptime before and after your run.
+  kolu` shows the same PID **and uptime** before and after your run (a changed
+  uptime means it restarted — an OOM kill counts as touching it, even if no
+  command of yours named it).
 - Teardown removes **only** the dev instance (the remembered PIDs); production
   keeps running.

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -64,6 +64,16 @@ already ran `git fetch origin` and resolved the base, so pass `MB` straight into
 each step and **skip the per-skill step-1 fetch / base resolution** — don't redo
 it once per step.
 
+**How to "wait for the Workflow" — let its own settle notification resume you.**
+The debate skills run as a backgrounded `Workflow` ("launched in background; Task
+ID: …"); a debate can legitimately take 20–30 min. When it settles it fires its
+own task-notification that resumes this run automatically — that is the wait. So
+after dispatching a step, go to rest and let that notification wake you; **do not
+schedule redundant `ScheduleWakeup` polls** and there is nothing to babysit. (A
+prior run scheduled 4-min wakeups *and* the user wired a 5-min `/loop` to nudge a
+gauntlet that was simply mid-debate — both were unnecessary churn.) Only act when
+the workflow's notification arrives or it has provably errored.
+
 1. **lens** — follow `/lens-debate` (Skill tool). `repoPath` = the live worktree,
    `base` = `MB`, **apply mode** (the default — do *not* pass `--no-apply`),
    **`--no-comment`** (so it doesn't advertise its local-only commits before

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -82,6 +82,15 @@ guessed (a faithfully-reproduced negative counts too).
 
 ## 5. Ship — CI and evidence in parallel
 
+**Heavy work runs on a pu box, never locally — production kolu lives on this
+machine.** Builds, the dev server, and evidence capture all go on an ephemeral pu
+box whenever `systemctl --user is-active kolu` is `active` (the normal case). A
+prior run piled local `just dev-auto` + nix builds beside a live production kolu
+and the **OOM-killer `SIGKILL`ed production**; random ports dodged its *ports* but
+not its *RAM*. Load **`/dev-server`** §0 for the local-vs-pu venue gate before
+launching the app for *any* reason — including an interactive "let me SEE it"
+check during §2. `/ci` and `/evidence` already run on pu; keep it that way.
+
 `/ci` and `/evidence` are independent — one exercises the build/test pipeline, the
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -19,6 +19,30 @@ happened on [#1109](https://github.com/juspay/kolu/issues/1109). Never bind the
 defaults; never touch the systemd unit. This skill is the canonical "run the app
 locally" path so that can't recur.
 
+## 0. First decide local vs. pu — production lives on this machine
+
+Disrupting production is **not only a port collision.** A second incident: an
+agent ran `just dev-auto` repeatedly (each forks a node server + a kaval daemon)
+plus nix builds, all on the user's machine *while production kolu and other
+agents were live* — the pile-up drove the **OOM-killer to `SIGKILL` production**
+(`status=9/KILL`). Random ports kept it off production's *ports*; nothing kept it
+off production's *RAM*. The user's standing rule after that: **"always run on pu,
+nothing locally."**
+
+So before launching anything, decide where it runs:
+
+- **Run on a `pu` box (the default for `/be`-style runs)** whenever production
+  kolu is live on this machine — i.e. any time `systemctl --user is-active kolu`
+  is `active`. Builds, the dev server, and evidence capture all go on a fresh pu
+  box (see the **pu** and **evidence** skills): the box has its own RAM and
+  loopback, so a local OOM can't reach production. **Never** loop `just dev-auto`
+  + nix builds locally next to a live production kolu.
+- **Run locally only** when production is **not** running here (`is-active` →
+  `inactive`/`failed`), or the user has explicitly OK'd local execution this
+  session. Then the rest of this skill (random ports, scoped teardown) applies.
+
+When in doubt, prefer pu — a clean CI-like box never touches the user's machine.
+
 ## 1. Launch on two random free ports — always `just dev-auto`
 
 ```sh
@@ -99,9 +123,15 @@ production or unrelated processes. Match the remembered ports only.
 
 ## Acceptance (verify before declaring the app launched / torn down)
 
+- **Local was the right venue at all** — production kolu was `inactive` (or the
+  user OK'd local). If production is live here, heavy work belonged on a pu box
+  (§0); a single throwaway local launch is one thing, but **never** a loop of
+  `dev-auto` + builds beside it.
 - Two **random** ports, both remembered in `.dev-server/ports.json` and reused
   across the session (no re-grepping, no guessing).
 - Production `kolu.service` **provably untouched** — `systemctl --user status
-  kolu` shows the same PID/uptime before and after your run.
+  kolu` shows the same PID **and uptime** before and after your run (a changed
+  uptime means it restarted — an OOM kill counts as touching it, even if no
+  command of yours named it).
 - Teardown removes **only** the dev instance (the remembered PIDs); production
   keeps running.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -319,8 +319,8 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
-  .agents/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
-  .agents/skills/be/SKILL.md: sha256:85ebb42ca032748432cb7faffe9a79073e205bc98389633dc47020f2844cfaf7
+  .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
+  .agents/skills/be/SKILL.md: sha256:8d5e7ec0ae856e387fca58aa9dea3125c46e8ce71be0c7f552df1333db5e591c
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -330,7 +330,7 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .agents/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .agents/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
+  .agents/skills/dev-server/SKILL.md: sha256:c262372b9922036f4dfe2620b5af00750aff4b441e625cf5f56a34f4dbae3516
   .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .agents/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
@@ -354,8 +354,8 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2d6e1255e1e277ef8498b0e0e630b411155d35862c15532b253d96b244c8af89
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
-  .claude/skills/be-review/SKILL.md: sha256:bb2b6f0d452f91311d622cf58803ec737555c853764555911fd5dc465e3abd9f
-  .claude/skills/be/SKILL.md: sha256:85ebb42ca032748432cb7faffe9a79073e205bc98389633dc47020f2844cfaf7
+  .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
+  .claude/skills/be/SKILL.md: sha256:8d5e7ec0ae856e387fca58aa9dea3125c46e8ce71be0c7f552df1333db5e591c
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -365,7 +365,7 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .claude/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .claude/skills/dev-server/SKILL.md: sha256:925026a0764d3330f5369192420f4f6c1fe3bb650017f5f784a9358955cf8acb
+  .claude/skills/dev-server/SKILL.md: sha256:c262372b9922036f4dfe2620b5af00750aff4b441e625cf5f56a34f4dbae3516
   .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .claude/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90


### PR DESCRIPTION
Mined from a `/be` run (session `6c81f230-6e37-45a3-9183-0935eefae10f`) that shipped the terminal live-activity indicator. Two lessons survived the durability filter; both ship as small, evidence-cited edits to the `.apm/skills/*` sources. A human reviews — never merged by the run.

## Lesson 1 — local-execution OOM SIGKILLed production (irreversible near-miss)

The dominant failure of the run. `dev-server` already guards the *port-collision* way of disrupting production (the [#1109](https://github.com/juspay/kolu/issues/1109) incident it was created for) — but it had a complete blind spot on the *resource-contention* way. The agent ran `just dev-auto` repeatedly (each forks a node server + a kaval daemon) plus nix builds, all on the user's machine while production kolu **and** other agents were live. The pile-up drove the OOM-killer to **`SIGKILL` production** (`status=9/KILL`), which systemd then auto-restarted.

The user reacted hard and four times: *"Did you kill production kolu?"* (×2), *"DO NOT KILL PRODUCTION… Don't run things locally. Only over pu box"*, *"always run on pu, nothing locally."* The agent's own honest accounting in-transcript: *"production's kolu server took a `status=9/KILL` (SIGKILL) at 17:45:05 … the OOM-killer signature … my local churn plausibly drove an OOM that took it down. I'm treating that as on me. I should have been running this on a pu box from the start."*

Random ports kept the agent off production's *ports*; nothing kept it off production's *RAM*. This is the same failure class as #1109 (local work disrupting production) recurring through a different mechanism — which is exactly the "repeat of a prior incident" the self-improve filter targets.

| Where | Edit |
|---|---|
| `.apm/skills/dev-server/SKILL.md` → new **§0** | A local-vs-pu venue gate up front: run on a `pu` box whenever `systemctl --user is-active kolu` is `active`; run locally only when production is inactive or the user OK'd it. Names the OOM incident so the *why* is concrete. |
| `.apm/skills/dev-server/SKILL.md` → **Acceptance** | Widened past ports: "local was the right venue at all" + "same PID **and uptime**" (a changed uptime = a restart, e.g. an OOM kill, counts as touching production even when no command named it). |
| `.apm/skills/be/SKILL.md` → **§5** | Cross-links `/dev-server` §0 so the venue gate loads before launching the app for *any* reason — including the interactive "let me SEE it" check during §2 that triggered the first local launch. |

## Lesson 2 — gauntlet babysitting churn (speed/autonomy)

During the review gauntlet the agent went to rest with *"Waiting for lens-debate to complete"* and scheduled redundant 4-min `ScheduleWakeup` polls; the user, not trusting the auto-resume, also wired a 5-min `/loop` that fired ~9 nudges over the codex/lens debates. But the `Workflow` ("launched in background; Task ID: …") fires its **own** settle task-notification that auto-resumes the run — the codex debate's notification arrived on its own at 21:20. Both the wakeups and the loop were unnecessary churn over a gauntlet that was simply mid-debate.

| Where | Edit |
|---|---|
| `.apm/skills/be-review/SKILL.md` → "Run the steps in order" | Spells out *how* to "wait for the Workflow": go to rest, let its settle notification resume you; **don't** schedule redundant `ScheduleWakeup` polls; there's nothing to babysit. |

## Considered, deliberately NOT changed

- The codex debate genuinely took ~27 min — inherent latency no skill edit removes. The fix is to stop the *redundant* polling, not to "block harder."
- The UI-feedback rounds ("dot should align in Dock", "remove the title-bar dot") were normal design iteration on a deliberately subjective feature, not an engineerable autonomy gap.

## Evidence ledger (per edit)

- **Sources only:** all three edits land in `.apm/skills/*`; `.claude/` + `.agents/` copies and `apm.lock.yaml` were regenerated via `just ai::apm` on the same commit (lock diff = exactly the 6 expected checksum bumps, no unrelated drift).
- **`just fmt`** — clean, 0 files reformatted.
- **`just check`** — green (exit 0): full typecheck across all packages + `biome lint --error-on-warnings` (909 files, no fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)