### PR TITLE
chore(skills): route live-daemon evidence to a pu box; bound dev waits

### DIFF
--- a/.agents/skills/dev-server/SKILL.md
+++ b/.agents/skills/dev-server/SKILL.md
@@ -61,6 +61,15 @@ and prints the resolved URLs before forking server + client with HMR:
 ports positionally (`just dev 7681 5173`). `dev-auto` is the only launch command.
 Run it in the background (it stays up serving with hot reload).
 
+**Wait for it with a bounded poll, never a bare `sleep`.** A foreground `sleep` and an
+unbounded busy-spin are killed by this harness (SIGSTKFLT, exit 144), which burns turns.
+To wait for the server to come up, poll the resolved URL with a capped retry — a real
+command per iteration, finite bound — rather than `sleep N` between launch and use:
+
+```sh
+for i in $(seq 1 60); do curl -sf "$server_url/health" >/dev/null && break || curl -s "$server_url" >/dev/null && break; done
+```
+
 ## 2. Remember both ports — persist, don't re-grep
 
 Parse the two URLs once and persist them to a per-worktree scratch file so every

--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -176,7 +176,15 @@ surface no `.feature` touches), drive a running kolu directly with the **chrome-
 1. **Serve kolu from source on the box** the same way §B does — `nix develop -c just test-quick`
    builds the client and spawns the server, and leaves it serving; note the URL/port it prints
    (default `http://localhost:<port>`). Reach it from the MCP browser over the box's ssh tunnel
-   (`pu connect` forwards a port), or run the MCP browser on the box.
+   (`pu connect` forwards a port), or run the MCP browser on the box. **Serve live kolu on the
+   box, never on the user's local host** — the live chrome-devtools path spawns a real server (and,
+   for arivu/kaval, PTYs and unix sockets); on the user's machine that races the running production
+   `kolu.service` and risks killing production terminals. The box has its own loopback, so it binds
+   the defaults safely. **If you genuinely must serve locally** (the box can't reach the state),
+   launch *only* via the **`dev-server` skill** (`just dev-auto` → two random free ports, scratch-file
+   ports, scoped teardown) — never hand-roll `just dev` / `nohup … src/index.ts` / a broad `pkill -f
+   kolu|vite|tsx`, which is exactly the production-kill that made a real run trip "DON'T KILL
+   PRODUCTION KOLU".
 2. **Stage the on-disk precondition the state needs** with a plain shell command on the box —
    ordinary setup, not a parallel capture harness (see the note above). For the symlink case:
    `pu connect "$host" -- 'ln -s /etc/passwd ~/kolu/<workspace>/leak'`. For an empty-state, seed or

--- a/.apm/skills/dev-server/SKILL.md
+++ b/.apm/skills/dev-server/SKILL.md
@@ -61,6 +61,15 @@ and prints the resolved URLs before forking server + client with HMR:
 ports positionally (`just dev 7681 5173`). `dev-auto` is the only launch command.
 Run it in the background (it stays up serving with hot reload).
 
+**Wait for it with a bounded poll, never a bare `sleep`.** A foreground `sleep` and an
+unbounded busy-spin are killed by this harness (SIGSTKFLT, exit 144), which burns turns.
+To wait for the server to come up, poll the resolved URL with a capped retry — a real
+command per iteration, finite bound — rather than `sleep N` between launch and use:
+
+```sh
+for i in $(seq 1 60); do curl -sf "$server_url/health" >/dev/null && break || curl -s "$server_url" >/dev/null && break; done
+```
+
 ## 2. Remember both ports — persist, don't re-grep
 
 Parse the two URLs once and persist them to a per-worktree scratch file so every

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -176,7 +176,15 @@ surface no `.feature` touches), drive a running kolu directly with the **chrome-
 1. **Serve kolu from source on the box** the same way §B does — `nix develop -c just test-quick`
    builds the client and spawns the server, and leaves it serving; note the URL/port it prints
    (default `http://localhost:<port>`). Reach it from the MCP browser over the box's ssh tunnel
-   (`pu connect` forwards a port), or run the MCP browser on the box.
+   (`pu connect` forwards a port), or run the MCP browser on the box. **Serve live kolu on the
+   box, never on the user's local host** — the live chrome-devtools path spawns a real server (and,
+   for arivu/kaval, PTYs and unix sockets); on the user's machine that races the running production
+   `kolu.service` and risks killing production terminals. The box has its own loopback, so it binds
+   the defaults safely. **If you genuinely must serve locally** (the box can't reach the state),
+   launch *only* via the **`dev-server` skill** (`just dev-auto` → two random free ports, scratch-file
+   ports, scoped teardown) — never hand-roll `just dev` / `nohup … src/index.ts` / a broad `pkill -f
+   kolu|vite|tsx`, which is exactly the production-kill that made a real run trip "DON'T KILL
+   PRODUCTION KOLU".
 2. **Stage the on-disk precondition the state needs** with a plain shell command on the box —
    ordinary setup, not a parallel capture harness (see the note above). For the symlink case:
    `pu connect "$host" -- 'ln -s /etc/passwd ~/kolu/<workspace>/leak'`. For an empty-state, seed or

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -61,6 +61,15 @@ and prints the resolved URLs before forking server + client with HMR:
 ports positionally (`just dev 7681 5173`). `dev-auto` is the only launch command.
 Run it in the background (it stays up serving with hot reload).
 
+**Wait for it with a bounded poll, never a bare `sleep`.** A foreground `sleep` and an
+unbounded busy-spin are killed by this harness (SIGSTKFLT, exit 144), which burns turns.
+To wait for the server to come up, poll the resolved URL with a capped retry — a real
+command per iteration, finite bound — rather than `sleep N` between launch and use:
+
+```sh
+for i in $(seq 1 60); do curl -sf "$server_url/health" >/dev/null && break || curl -s "$server_url" >/dev/null && break; done
+```
+
 ## 2. Remember both ports — persist, don't re-grep
 
 Parse the two URLs once and persist them to a per-worktree scratch file so every

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -176,7 +176,15 @@ surface no `.feature` touches), drive a running kolu directly with the **chrome-
 1. **Serve kolu from source on the box** the same way §B does — `nix develop -c just test-quick`
    builds the client and spawns the server, and leaves it serving; note the URL/port it prints
    (default `http://localhost:<port>`). Reach it from the MCP browser over the box's ssh tunnel
-   (`pu connect` forwards a port), or run the MCP browser on the box.
+   (`pu connect` forwards a port), or run the MCP browser on the box. **Serve live kolu on the
+   box, never on the user's local host** — the live chrome-devtools path spawns a real server (and,
+   for arivu/kaval, PTYs and unix sockets); on the user's machine that races the running production
+   `kolu.service` and risks killing production terminals. The box has its own loopback, so it binds
+   the defaults safely. **If you genuinely must serve locally** (the box can't reach the state),
+   launch *only* via the **`dev-server` skill** (`just dev-auto` → two random free ports, scratch-file
+   ports, scoped teardown) — never hand-roll `just dev` / `nohup … src/index.ts` / a broad `pkill -f
+   kolu|vite|tsx`, which is exactly the production-kill that made a real run trip "DON'T KILL
+   PRODUCTION KOLU".
 2. **Stage the on-disk precondition the state needs** with a plain shell command on the box —
    ordinary setup, not a parallel capture harness (see the note above). For the symlink case:
    `pu connect "$host" -- 'ln -s /etc/passwd ~/kolu/<workspace>/leak'`. For an empty-state, seed or

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -330,8 +330,8 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .agents/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .agents/skills/dev-server/SKILL.md: sha256:c262372b9922036f4dfe2620b5af00750aff4b441e625cf5f56a34f4dbae3516
-  .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
+  .agents/skills/dev-server/SKILL.md: sha256:e48c90b267dcfd047a783c9df8b2a039e20cf936b3c2761c6cbe39297aca5de0
+  .agents/skills/evidence/SKILL.md: sha256:0cea85fa6cc3e4539b51743cafc04ac34c7ba0738bdda5b7929b02c0eddf5c77
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .agents/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
@@ -365,8 +365,8 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .claude/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .claude/skills/dev-server/SKILL.md: sha256:c262372b9922036f4dfe2620b5af00750aff4b441e625cf5f56a34f4dbae3516
-  .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
+  .claude/skills/dev-server/SKILL.md: sha256:e48c90b267dcfd047a783c9df8b2a039e20cf936b3c2761c6cbe39297aca5de0
+  .claude/skills/evidence/SKILL.md: sha256:0cea85fa6cc3e4539b51743cafc04ac34c7ba0738bdda5b7929b02c0eddf5c77
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .claude/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45


### PR DESCRIPTION
## What

Two low-churn skill edits mined from a `/be` run where a human had to intervene to stop a production-kill. Both **cross-link rules that already exist** rather than adding new machinery.

The standout intervention: a `/be` run drove the `/evidence` live chrome-devtools path against a kolu server it spawned **on the user's local host**, managed with broad `pkill -f kolu|vite|tsx`. That races the running production `kolu.service` and its terminals — the user had to halt it with a literal **"DON'T KILL PRODUCTION KOLU"**. The same run also leaned on `sleep N` / `setsid … & disown` workarounds because foreground sleeps are **SIGSTKFLT (exit 144)**-killed in this harness, burning turns.

Both failures already had a documented-but-unlinked remedy:
- `/evidence` already says *capture runs on an ephemeral pu box* — but its §A2 live path said only "serve kolu from source on the box" without forbidding the local host or routing a local fallback safely.
- The `dev-server` skill already forbids `pkill -f kolu|vite|tsx` and uses random ports so it never collides with production — yet the run never loaded it.

## Edits

| Skill | Change |
|---|---|
| `evidence` §A2 | Make the pu box the explicit home for the live chrome-devtools path (spawns a real server + PTYs/sockets); any genuine local fallback must go through the **`dev-server`** skill (random ports, scoped teardown) — never hand-rolled `just dev` / `nohup … src/index.ts` / broad `pkill`. |
| `dev-server` §1 | Wait for the server with a **bounded URL poll**, never a bare `sleep` — foreground sleeps are SIGSTKFLT(144)-killed here. |

## Evidence ledger

| Claim | Where |
|---|---|
| Production-kill near-miss + "DON'T KILL PRODUCTION KOLU" | Mined `/be` transcript: human turn `DON'T KILL PRODUCTION KOLU. Continue`; assistant ran `pkill -f "src/index.ts"`, `pkill -f vite`, `pkill -f "just dev"` repeatedly against the local host while production `kolu.service` ran. |
| 144 / foreground-sleep waste | Same transcript: `Exit code 144` in tool results; commands worked around it with `setsid … & disown` and scattered `sleep 2`. |
| Remedy already existed, just unlinked | `dev-server/SKILL.md` already bans broad `pkill` + uses random ports; `evidence/SKILL.md` already defaults capture to a pu box. The edits cross-link them at the exact gap. |
| Gates green | `just ai::apm` (regen `.claude`/`.agents` + `apm.lock.yaml` hashes ride the same commit), `just fmt` clean, `just check` exit 0. |

A human reviews and merges — this is not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)