### PR TITLE
chore(skills): classify a value-over-time display as VIDEO evidence

### DIFF
--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -85,6 +85,14 @@ browser.")
 - **VIDEO** — motion is the point: a transition, a multi-step flow, a live update, latency-to-
   payoff, an animation, a drag/resize. You need to *watch it happen.*
 
+> **A value-over-time display is MOTION, never a single moment.** If the element's *job* is to
+> change on its own — a running timer, "Running for" / relative-time / "last seen" string,
+> countdown, live counter, progress that advances, a tick at some cadence — classify it VIDEO and
+> *watch it tick*. A still of `Running for 0s` is structurally blind to the actual defect: a frozen
+> clock and a live one are pixel-identical in one frame, so a screenshot can never prove the tick
+> fires at the cadence the displayed precision implies (seconds shown ⇒ must update every second).
+> Classify by what the element *does over time*, not by what the panel looks like at one instant.
+
 Image and video are **co-equal first-class outputs.** A screenshot is a complete deliverable, not a
 runner-up to video. (A before↔after of a *static* change is two stills; only reach for two clips
 when the difference is itself motion — e.g. an animation-timing change.)

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -85,6 +85,14 @@ browser.")
 - **VIDEO** — motion is the point: a transition, a multi-step flow, a live update, latency-to-
   payoff, an animation, a drag/resize. You need to *watch it happen.*
 
+> **A value-over-time display is MOTION, never a single moment.** If the element's *job* is to
+> change on its own — a running timer, "Running for" / relative-time / "last seen" string,
+> countdown, live counter, progress that advances, a tick at some cadence — classify it VIDEO and
+> *watch it tick*. A still of `Running for 0s` is structurally blind to the actual defect: a frozen
+> clock and a live one are pixel-identical in one frame, so a screenshot can never prove the tick
+> fires at the cadence the displayed precision implies (seconds shown ⇒ must update every second).
+> Classify by what the element *does over time*, not by what the panel looks like at one instant.
+
 Image and video are **co-equal first-class outputs.** A screenshot is a complete deliverable, not a
 runner-up to video. (A before↔after of a *static* change is two stills; only reach for two clips
 when the difference is itself motion — e.g. an animation-timing change.)

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -85,6 +85,14 @@ browser.")
 - **VIDEO** — motion is the point: a transition, a multi-step flow, a live update, latency-to-
   payoff, an animation, a drag/resize. You need to *watch it happen.*
 
+> **A value-over-time display is MOTION, never a single moment.** If the element's *job* is to
+> change on its own — a running timer, "Running for" / relative-time / "last seen" string,
+> countdown, live counter, progress that advances, a tick at some cadence — classify it VIDEO and
+> *watch it tick*. A still of `Running for 0s` is structurally blind to the actual defect: a frozen
+> clock and a live one are pixel-identical in one frame, so a screenshot can never prove the tick
+> fires at the cadence the displayed precision implies (seconds shown ⇒ must update every second).
+> Classify by what the element *does over time*, not by what the panel looks like at one instant.
+
 Image and video are **co-equal first-class outputs.** A screenshot is a complete deliverable, not a
 runner-up to video. (A before↔after of a *static* change is two stills; only reach for two clips
 when the difference is itself motion — e.g. an animation-timing change.)

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -331,7 +331,7 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:a5c58bf2142919c8f2bf95390217f9d1346b31b7c2bbdd62de5d97dc349a8351
-  .agents/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
+  .agents/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .agents/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .agents/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45
@@ -366,7 +366,7 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:a5c58bf2142919c8f2bf95390217f9d1346b31b7c2bbdd62de5d97dc349a8351
-  .claude/skills/evidence/SKILL.md: sha256:80f5e02c4e9c55b27534402465c8cda1710dc34d89c38a8bd438ef52658dbe1e
+  .claude/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .claude/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
   .claude/skills/parcel/SKILL.md: sha256:953c1dad8bd7d7b06d9f30de8597590dcba5a64e1d550aca4963c96eaa4fca45


### PR DESCRIPTION
A `/self-improve` pass on session `1764a8a4-0165-4e41-9097-aa102318dc8a` (the `/be` run that shipped PR #1471, the Inspector "Running for" row).

## The intervention this engineers out

That run completed its ship phase — CI green 30/30, evidence captured — and only **then** the human had to probe the actual behavior:

> Does "Running for" update automatically? Reactive? Every second?
> But what's the performance impact of every second vs every minute?
> DOes it [display seconds]? it only seems to do when <1m

The probing exposed a real defect: the row shows seconds in the first minute (`12s`) but was driven by the shared **60s** ticker, so the seconds reading sat frozen until the next minute. A live-updating timer that doesn't visibly tick at the cadence its own precision implies.

The evidence gate had classified the change as **STATIC → screenshot** ("end-state · single moment") and captured a still of `Running for 0s`. A static frame is structurally incapable of revealing a frozen clock — a frozen clock and a live one are pixel-identical in one frame. So the human became the temporal linter, a job the evidence skill should have done.

## The fix (lowest-churn: sharpen one existing clause)

The decision rule already lists "a live update" under VIDEO; the miss was reasoning about what the panel *looks like* at one instant rather than what the element *does over time*. One callout added under the image-vs-video rule in `.apm/skills/evidence/SKILL.md`:

> A value-over-time display is MOTION, never a single moment. A running timer / "Running for" / relative-time / countdown / live counter / advancing progress is VIDEO by definition — watch it tick. A still is structurally blind to a frozen clock. Classify by what the element does over time, not by what the panel looks like at one instant.

## Evidence ledger

| Edit | Why it's durable | Verification |
| --- | --- | --- |
| Value-over-time ⇒ VIDEO callout in evidence decision rule | `evidence-missing-or-wrong` is a catalogued critical class (n=46) in `llm-autonomy.mdx`; this is the specific temporal-display sub-case. Static still could never catch the frozen-tick defect. | `just ai::apm` regenerated `.claude`/`.agents` copies (lockfile hashes updated to match); `just fmt` clean; `just check` green (typecheck all packages + biome lint). |

## Not engineered out (already catalogued — observations only)

- "merge master to our PR" and "Ignore CI, i merged it. Proceed" are the verbatim `ci-failure` / master-sync patterns already in `llm-autonomy.mdx` (roadmap #3, line-138 quote). No new edit.

Provenance: `/self-improve` on session `1764a8a4-0165-4e41-9097-aa102318dc8a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)