### PR TITLE
Fix theme pill vanishing on non-focused default-theme tiles

### DIFF
--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -10,6 +10,7 @@
 
 import { activeArm, type TerminalId } from "kolu-common/surface";
 import { type Component, Show } from "solid-js";
+import { DEFAULT_THEME_NAME } from "terminal-themes";
 import { useRightPanel } from "../right-panel/useRightPanel";
 import { screenshotTerminal } from "../screenshotTerminal";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
@@ -42,8 +43,17 @@ const TileTitleActions: Component<{
   const { showTipOnce } = useTips();
 
   const meta = () => store.getMetadata(props.id);
+  // The active tile resolves its name via `activeThemeName()`, which falls back
+  // to the default theme name (and reflects the live palette preview). The
+  // non-active tiles read the persisted `meta()?.themeName` directly — with no
+  // fallback — so a terminal that never had a theme persisted (rendered on the
+  // default "Tomorrow Night") showed its pill only while focused and lost it the
+  // moment it wasn't. Give the non-active branch the SAME default fallback so
+  // the pill shows the tile's effective theme on every tile, focused or not.
   const themeName = () =>
-    store.activeId() === props.id ? activeThemeName() : meta()?.themeName;
+    store.activeId() === props.id
+      ? activeThemeName()
+      : (meta()?.themeName ?? DEFAULT_THEME_NAME);
   const subCount = () => store.getDisplayInfo(props.id)?.subCount ?? 0;
   const splitExpanded = () =>
     subCount() > 0 && !subPanel.getSubPanel(props.id).collapsed;


### PR DESCRIPTION
Closes #1480.

The tile title bar resolved its theme-name pill **differently depending on focus**:

```ts
// before
const themeName = () =>
  store.activeId() === props.id ? activeThemeName() : meta()?.themeName;
```

- The **active** tile uses `activeThemeName()` → `committedThemeName` → `getThemeName(id) || DEFAULT_THEME_NAME` — it **falls back to the default theme name**.
- The **non-active** tiles read `meta()?.themeName` raw — **no fallback**.

So a terminal on the default **"Tomorrow Night"** (no `themeName` ever persisted) showed its pill only while focused and **lost it the instant it wasn't** — the pill appeared to chase focus around the canvas. Terminals with a custom theme were unaffected (their `themeName` is set), which is why it only reproduced on default-theme terminals (and seemed to come and go).

The fix gives the non-active branch the same default fallback, so the pill shows each tile's *effective* theme regardless of focus:

```ts
const themeName = () =>
  store.activeId() === props.id
    ? activeThemeName()
    : (meta()?.themeName ?? DEFAULT_THEME_NAME);
```

`getThemeByName(undefined)` already resolves to the default theme, so `DEFAULT_THEME_NAME` is exactly what a `themeName`-less tile is rendered with — the pill correctly reads "Tomorrow Night" instead of vanishing.

**Scope / pre-existing:** this is the April `f1c09e5ea0` asymmetry, agent-independent — it's *not* introduced by the agent-uptime work in #1478; it was diagnosed while reviewing that PR and split out here to keep #1478 focused. Reproduced from a screen recording (pill following focus between two default-theme tiles) and confirmed against the live DOM (the pill element is **absent** on the non-focused default-theme tile, not clipped).

> Verified by `just check` (typecheck + lint). The change is a null-coalescing fallback mirroring the focused branch's existing, working behavior; a small unit test on `themeName()` (active/non-active × set/unset) would be a good lock-in follow-up.

_Generated by Claude Code (model `claude-opus-4-8`)._