### PR TITLE
chore(skills): /be drives CI through the odu MCP face, not a shelled-out nix run

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -95,10 +95,16 @@ check during §2. `/ci` and `/evidence` already run on pu; keep it that way.
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.
 
-1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
-   consume `--progress json`) so it churns while you capture evidence. React to
-   streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
-   on real failures, confirm green on the final `HEAD`.
+1. **Kick off `/ci` first, backgrounded** — start the pipeline so it churns while
+   you capture evidence. **Drive it through the odu MCP face, not a shelled-out
+   `nix run .#odu`:** when an odu MCP server is wired (the `mcp__odu__*` tools —
+   check before shelling out), every run *and every status/log check* goes through
+   it — `run` → `wait_for_settle` (fail-fast) → read the red node's log via
+   `ReadMcpResourceTool` on `surface://collections/logs/{id}` → `node_rerun`, per
+   the `/ci` skill. Reaching for `nix run .#odu -- run/status` while that server is
+   present is the fallback path, not the default. React to `failed`/`errored` nodes
+   the moment they land: fix→fmt→commit→retry on real failures, confirm green on
+   the final `HEAD`.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -95,10 +95,16 @@ check during §2. `/ci` and `/evidence` already run on pu; keep it that way.
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.
 
-1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
-   consume `--progress json`) so it churns while you capture evidence. React to
-   streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
-   on real failures, confirm green on the final `HEAD`.
+1. **Kick off `/ci` first, backgrounded** — start the pipeline so it churns while
+   you capture evidence. **Drive it through the odu MCP face, not a shelled-out
+   `nix run .#odu`:** when an odu MCP server is wired (the `mcp__odu__*` tools —
+   check before shelling out), every run *and every status/log check* goes through
+   it — `run` → `wait_for_settle` (fail-fast) → read the red node's log via
+   `ReadMcpResourceTool` on `surface://collections/logs/{id}` → `node_rerun`, per
+   the `/ci` skill. Reaching for `nix run .#odu -- run/status` while that server is
+   present is the fallback path, not the default. React to `failed`/`errored` nodes
+   the moment they land: fix→fmt→commit→retry on real failures, confirm green on
+   the final `HEAD`.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -95,10 +95,16 @@ check during §2. `/ci` and `/evidence` already run on pu; keep it that way.
 other captures on-screen behavior — so **run them concurrently**; don't wait for
 green before capturing.
 
-1. **Kick off `/ci` first, backgrounded** — start the pipeline (background;
-   consume `--progress json`) so it churns while you capture evidence. React to
-   streamed `failed`/`errored` nodes the moment they land: fix→fmt→commit→retry
-   on real failures, confirm green on the final `HEAD`.
+1. **Kick off `/ci` first, backgrounded** — start the pipeline so it churns while
+   you capture evidence. **Drive it through the odu MCP face, not a shelled-out
+   `nix run .#odu`:** when an odu MCP server is wired (the `mcp__odu__*` tools —
+   check before shelling out), every run *and every status/log check* goes through
+   it — `run` → `wait_for_settle` (fail-fast) → read the red node's log via
+   `ReadMcpResourceTool` on `surface://collections/logs/{id}` → `node_rerun`, per
+   the `/ci` skill. Reaching for `nix run .#odu -- run/status` while that server is
+   present is the fallback path, not the default. React to `failed`/`errored` nodes
+   the moment they land: fix→fmt→commit→retry on real failures, confirm green on
+   the final `HEAD`.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,7 +320,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
   .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .agents/skills/be/SKILL.md: sha256:6f09c1551ba942e5daea5903a625d01dfddace52ceacc110d7f8468c203ab971
+  .agents/skills/be/SKILL.md: sha256:9c0937e7d7c39d7a5cec4cabcf1767570436b8a39e69d0bf2e799fed7552a7c6
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -355,7 +355,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
   .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .claude/skills/be/SKILL.md: sha256:6f09c1551ba942e5daea5903a625d01dfddace52ceacc110d7f8468c203ab971
+  .claude/skills/be/SKILL.md: sha256:9c0937e7d7c39d7a5cec4cabcf1767570436b8a39e69d0bf2e799fed7552a7c6
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f


### PR DESCRIPTION
## Why

A single `/be` run (session `1764a8a4`) drew **three** human corrections, all the same shape: the agent kept shelling out to `nix run .#odu -- run/status` for CI runs and status checks instead of the `mcp__odu__*` MCP tools.

> - "you are supposed to run ci using odu"
> - "where's the odu MCP call?"
> - "wtf, why are you not using odu MCP to check?"

This is a durable, ≥3-hit recurrence — exactly the friction `/self-improve` exists to engineer out.

## Root cause

The project's canonical guidance already makes the MCP the front door: `.agency/do.md` says *"Drive CI through the odu MCP server — it is the single front door"* and the `/ci` skill says *"Prefer the MCP face for runs."* But `/be` §5 — the *decision point* where the agent actually invokes CI — only pointed at `/ci` and, worse, nudged toward the CLI path (*"consume `--progress json`"*). The rule that mattered wasn't loaded at the moment of the call.

## Fix

Sharpen `/be` §5 step 1 to make the odu MCP face the explicit default for **runs and status/log checks**, naming the loop (`run` → `wait_for_settle` → `ReadMcpResourceTool` on `surface://collections/logs/{id}` → `node_rerun`, per `/ci`) and demoting `nix run .#odu` to the stated fallback. Reuses the existing source of truth rather than restating runner mechanics — lowest-churn cross-link + one-clause sharpen.

Edit lands in the `.apm/skills/be/SKILL.md` **source**; `just ai::apm` regenerated the `.claude` / `.agents` copies and the `apm.lock.yaml` hashes in the same commit.

## Evidence ledger

| Edit | Intervention engineered out | Verification |
|---|---|---|
| `/be` §5 step 1 — odu MCP face is the default for runs + status/log checks; `nix run .#odu` is the fallback | 3× "use odu MCP for CI" corrections in session `1764a8a4` | `just ai::apm` (sources → runtimes + lockfile, same commit) · `just fmt` (no reformats) · `just check` green (typecheck + biome, 912 files) |

Draft for human review — not merged. Merging is what makes the edit live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)