### PR TITLE
chore(skills): kill spawned daemons by captured PID, never a socket-path substring

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -112,7 +112,12 @@ green before capturing.
    absent).
 3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
    is posted. If a CI fix-commit changed visible behavior *after* capture,
-   re-capture so the evidence matches what actually merges.
+   re-capture so the evidence matches what actually merges. **Tearing down any
+   daemon you spawned for capture (a local kaval / arivu dialer, an ssh tunnel) is
+   governed by `/dev-server` §5** — kill the PID you captured at spawn (`$!`),
+   **never** `pgrep -f`/`pkill -f` a socket-path/port substring: it matches the
+   production kaval/kolu daemon, not your dialer. Cheaper still: leave the ephemeral
+   test daemon for the user / OS rather than guess a PID.
 
 ## Done
 

--- a/.agents/skills/dev-server/SKILL.md
+++ b/.agents/skills/dev-server/SKILL.md
@@ -132,12 +132,33 @@ done
 rm -f .dev-server/ports.json
 ```
 
-**Never** `pkill -f <substring>` at all — not `kolu` / `vite` / `tsx`, and not a
-"more specific" source path like `packages/server/src/index.ts` either. Production
-runs that exact source from the nix store, so a path substring is *not* safer than
-a name — it matched and killed production `kolu.service` once. A bracket trick
-(`[v]ite`) only dodges self-match, not the production process. Match the
-remembered ports only; if you can't resolve a PID by port, leave the process.
+**Never** `pkill -f <substring>` / `pgrep -f <substring> | kill` at all — not
+`kolu` / `vite` / `tsx`, and not a "more specific" source path or socket path like
+`packages/server/src/index.ts` or `kaval-7692/pty-host.sock` either. Production
+runs that exact source from the nix store and a production daemon *listens on* that
+exact socket path/port, so a path substring is *not* safer than a name — it matched
+and killed production `kolu.service` once, and a `pgrep -f "<sock-path>"` matched
+and killed the production **kaval** daemon another time (the daemon's old **low**
+PID, not your freshly-spawned **high**-PID dialer). A bracket trick (`[v]ite`) only
+dodges self-match, not the production process. Match the remembered ports only; if
+you can't resolve a PID by port, leave the process.
+
+**Any background process *you* spawned — capture its PID at spawn and kill *that*
+exact PID, never re-resolve it.** This applies beyond the dev server: a kaval /
+arivu dialer you start for evidence capture, an ssh-tunnelled daemon, anything
+backgrounded with `&`. Record `$!` the instant you launch it
+(`nohup … & PID=$!; echo "$PID" >> .dev-server/spawned.pids`) and kill by `$PID`.
+A re-resolved `pgrep`/`pkill` can only *guess* which match is yours and will pick
+the wrong one — a production daemon on the same socket/port. Ephemeral test daemons
+are cheap; if you didn't capture the PID, **leave the process** for the user / OS
+rather than guess.
+
+**A cleanup kill that returns non-zero (e.g. exit 144 — `SIGKILL`+128, you killed
+your own process group) or visibly kills your own shell means you mismatched the
+target: STOP.** Do not "retry" it or run a broader pattern — re-check which PID you
+hit (`ps -p "$PID" -o pid,uptime,args`); a long uptime / low PID is production, not
+your seconds-old spawn. Re-running a substring kill after the first failure is how
+the production-kaval kill compounded.
 
 ## Acceptance (verify before declaring the app launched / torn down)
 

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -112,7 +112,12 @@ green before capturing.
    absent).
 3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
    is posted. If a CI fix-commit changed visible behavior *after* capture,
-   re-capture so the evidence matches what actually merges.
+   re-capture so the evidence matches what actually merges. **Tearing down any
+   daemon you spawned for capture (a local kaval / arivu dialer, an ssh tunnel) is
+   governed by `/dev-server` §5** — kill the PID you captured at spawn (`$!`),
+   **never** `pgrep -f`/`pkill -f` a socket-path/port substring: it matches the
+   production kaval/kolu daemon, not your dialer. Cheaper still: leave the ephemeral
+   test daemon for the user / OS rather than guess a PID.
 
 ## Done
 

--- a/.apm/skills/dev-server/SKILL.md
+++ b/.apm/skills/dev-server/SKILL.md
@@ -132,12 +132,33 @@ done
 rm -f .dev-server/ports.json
 ```
 
-**Never** `pkill -f <substring>` at all — not `kolu` / `vite` / `tsx`, and not a
-"more specific" source path like `packages/server/src/index.ts` either. Production
-runs that exact source from the nix store, so a path substring is *not* safer than
-a name — it matched and killed production `kolu.service` once. A bracket trick
-(`[v]ite`) only dodges self-match, not the production process. Match the
-remembered ports only; if you can't resolve a PID by port, leave the process.
+**Never** `pkill -f <substring>` / `pgrep -f <substring> | kill` at all — not
+`kolu` / `vite` / `tsx`, and not a "more specific" source path or socket path like
+`packages/server/src/index.ts` or `kaval-7692/pty-host.sock` either. Production
+runs that exact source from the nix store and a production daemon *listens on* that
+exact socket path/port, so a path substring is *not* safer than a name — it matched
+and killed production `kolu.service` once, and a `pgrep -f "<sock-path>"` matched
+and killed the production **kaval** daemon another time (the daemon's old **low**
+PID, not your freshly-spawned **high**-PID dialer). A bracket trick (`[v]ite`) only
+dodges self-match, not the production process. Match the remembered ports only; if
+you can't resolve a PID by port, leave the process.
+
+**Any background process *you* spawned — capture its PID at spawn and kill *that*
+exact PID, never re-resolve it.** This applies beyond the dev server: a kaval /
+arivu dialer you start for evidence capture, an ssh-tunnelled daemon, anything
+backgrounded with `&`. Record `$!` the instant you launch it
+(`nohup … & PID=$!; echo "$PID" >> .dev-server/spawned.pids`) and kill by `$PID`.
+A re-resolved `pgrep`/`pkill` can only *guess* which match is yours and will pick
+the wrong one — a production daemon on the same socket/port. Ephemeral test daemons
+are cheap; if you didn't capture the PID, **leave the process** for the user / OS
+rather than guess.
+
+**A cleanup kill that returns non-zero (e.g. exit 144 — `SIGKILL`+128, you killed
+your own process group) or visibly kills your own shell means you mismatched the
+target: STOP.** Do not "retry" it or run a broader pattern — re-check which PID you
+hit (`ps -p "$PID" -o pid,uptime,args`); a long uptime / low PID is production, not
+your seconds-old spawn. Re-running a substring kill after the first failure is how
+the production-kaval kill compounded.
 
 ## Acceptance (verify before declaring the app launched / torn down)
 

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -112,7 +112,12 @@ green before capturing.
    absent).
 3. **Join before Done** — confirm CI is green on the final `HEAD` **and** evidence
    is posted. If a CI fix-commit changed visible behavior *after* capture,
-   re-capture so the evidence matches what actually merges.
+   re-capture so the evidence matches what actually merges. **Tearing down any
+   daemon you spawned for capture (a local kaval / arivu dialer, an ssh tunnel) is
+   governed by `/dev-server` §5** — kill the PID you captured at spawn (`$!`),
+   **never** `pgrep -f`/`pkill -f` a socket-path/port substring: it matches the
+   production kaval/kolu daemon, not your dialer. Cheaper still: leave the ephemeral
+   test daemon for the user / OS rather than guess a PID.
 
 ## Done
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -132,12 +132,33 @@ done
 rm -f .dev-server/ports.json
 ```
 
-**Never** `pkill -f <substring>` at all — not `kolu` / `vite` / `tsx`, and not a
-"more specific" source path like `packages/server/src/index.ts` either. Production
-runs that exact source from the nix store, so a path substring is *not* safer than
-a name — it matched and killed production `kolu.service` once. A bracket trick
-(`[v]ite`) only dodges self-match, not the production process. Match the
-remembered ports only; if you can't resolve a PID by port, leave the process.
+**Never** `pkill -f <substring>` / `pgrep -f <substring> | kill` at all — not
+`kolu` / `vite` / `tsx`, and not a "more specific" source path or socket path like
+`packages/server/src/index.ts` or `kaval-7692/pty-host.sock` either. Production
+runs that exact source from the nix store and a production daemon *listens on* that
+exact socket path/port, so a path substring is *not* safer than a name — it matched
+and killed production `kolu.service` once, and a `pgrep -f "<sock-path>"` matched
+and killed the production **kaval** daemon another time (the daemon's old **low**
+PID, not your freshly-spawned **high**-PID dialer). A bracket trick (`[v]ite`) only
+dodges self-match, not the production process. Match the remembered ports only; if
+you can't resolve a PID by port, leave the process.
+
+**Any background process *you* spawned — capture its PID at spawn and kill *that*
+exact PID, never re-resolve it.** This applies beyond the dev server: a kaval /
+arivu dialer you start for evidence capture, an ssh-tunnelled daemon, anything
+backgrounded with `&`. Record `$!` the instant you launch it
+(`nohup … & PID=$!; echo "$PID" >> .dev-server/spawned.pids`) and kill by `$PID`.
+A re-resolved `pgrep`/`pkill` can only *guess* which match is yours and will pick
+the wrong one — a production daemon on the same socket/port. Ephemeral test daemons
+are cheap; if you didn't capture the PID, **leave the process** for the user / OS
+rather than guess.
+
+**A cleanup kill that returns non-zero (e.g. exit 144 — `SIGKILL`+128, you killed
+your own process group) or visibly kills your own shell means you mismatched the
+target: STOP.** Do not "retry" it or run a broader pattern — re-check which PID you
+hit (`ps -p "$PID" -o pid,uptime,args`); a long uptime / low PID is production, not
+your seconds-old spawn. Re-running a substring kill after the first failure is how
+the production-kaval kill compounded.
 
 ## Acceptance (verify before declaring the app launched / torn down)
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,7 +320,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
   .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .agents/skills/be/SKILL.md: sha256:9c0937e7d7c39d7a5cec4cabcf1767570436b8a39e69d0bf2e799fed7552a7c6
+  .agents/skills/be/SKILL.md: sha256:1ffd8c05ece8cf1d358c58572378b2b7113ff6683aef4840ea2d310818b9f77e
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -330,7 +330,7 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .agents/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .agents/skills/dev-server/SKILL.md: sha256:a5c58bf2142919c8f2bf95390217f9d1346b31b7c2bbdd62de5d97dc349a8351
+  .agents/skills/dev-server/SKILL.md: sha256:096c10444d951cbbe07ac9756c988bc45514916b20125b2f448c58207f5a223b
   .agents/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .agents/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
@@ -355,7 +355,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:dbb0719ff579299fff9942fb974ba84601a3931aede8d135f3287659540a4df8
   .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .claude/skills/be/SKILL.md: sha256:9c0937e7d7c39d7a5cec4cabcf1767570436b8a39e69d0bf2e799fed7552a7c6
+  .claude/skills/be/SKILL.md: sha256:1ffd8c05ece8cf1d358c58572378b2b7113ff6683aef4840ea2d310818b9f77e
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -365,7 +365,7 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .claude/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .claude/skills/dev-server/SKILL.md: sha256:a5c58bf2142919c8f2bf95390217f9d1346b31b7c2bbdd62de5d97dc349a8351
+  .claude/skills/dev-server/SKILL.md: sha256:096c10444d951cbbe07ac9756c988bc45514916b20125b2f448c58207f5a223b
   .claude/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .claude/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90


### PR DESCRIPTION
## What happened

During the arivu P3·PR2b `/be` run (kolu #1486), evidence-capture **teardown killed the production `kaval` daemon** — tearing down the user's live terminals (kolu auto-respawned kaval and restored the shells, but in-flight agent processes were lost). The fatal command:

```sh
PID=$(pgrep -f "kaval-7692/pty-host.sock" | head -1)   # matched the PRODUCTION daemon
kill "$PID"                                              # ...not the run's own dialer
```

The substring matched the **production kaval daemon listening on that socket** (an old, **low** PID) instead of the run's freshly-spawned `arivu --kaval …7692…` dialer (a **high**-PID child). The run had even captured its own dialer's PID (`echo "arivu PID $!"`) moments earlier and then threw it away to re-resolve by substring. Two of the cleanup kills exited **144** (`SIGKILL`+128 — killing its own process group) and were ignored, then the substring kill was re-run.

The no-pkill-by-substring rule **already existed** (sharpened in #1473 / #1469) and was **quoted earlier in the same session** — but it lives in `/dev-server` framed around the dev server's `kolu`/`vite` ports, so it didn't register during a `kaval`/`arivu` *evidence capture*, and it had no clause for "you spawned a background daemon — keep its `$!`." A recurring rule that arrives as an angry interrupt because nothing surfaced it at the right moment — exactly the llm-autonomy failure mode. This is a **repeat of a prior-run lesson + an irreversible production incident**, so it clears the durability bar.

## The fixes (sources only; runtimes regenerated)

| # | Edit | File | Why |
| --- | --- | --- | --- |
| 1 | Generalize the substring ban to **socket-path/port** substrings (the kaval case); add "capture `$!` at spawn, kill that exact PID, never re-resolve"; add "a cleanup kill returning **non-zero** (exit 144) / killing your own shell means you mismatched the target — **STOP**, don't retry or broaden" | `.apm/skills/dev-server/SKILL.md` §5 | The rule existed but only covered dev-server ports + "kill by remembered port"; it had no captured-PID clause and didn't name the socket-path/low-PID-vs-high-PID trap that actually fired |
| 2 | Cross-link the §5 teardown rule from `/be` §5 evidence step, so it loads **at evidence-capture time** (kaval/arivu dialers), not only at dev-server launch | `.apm/skills/be/SKILL.md` §5 | The rule didn't fire because it wasn't loaded when it mattered — capture, not launch |

Both edits also bake in the cheaper default the incident report asked for: **leave the ephemeral test daemon for the user / OS** rather than guess a PID.

## Evidence

- **Source of the lesson** — `pgrep -f "kaval-7692/pty-host.sock" | head -1 | kill` in the transcript, the run's own confession ("I had even cited that rule earlier and still did it"), and the four ignored `Exit code 144` results. Mined from session `15384001-…` (kolu #1486).
- **Prior-run repeat** — `git log .apm/skills/dev-server/SKILL.md` shows #1473 *"ban pkill-by-substring"* and #1469 *"stop local-execution OOM from killing production"* already added this rule; it still recurred.
- **Validation** — `just ai::apm` regenerated `.claude` + `.agents` + `apm.lock.yaml` (4 hash bumps, no dependency changes); `just fmt` (no markdown reflow); `just check` **green (exit 0)**.

## Not engineered out (single-occurrence — observations only)

- **Agent-state evidence needs a kolu host, not a bare kaval box** — opencode agent-state surfaces via kolu's shell integration (OSC 633 command-mark / OSC-2-title-as-foreground); a standalone-kaval box lacks it. Cost several failed detection attempts. One occurrence → noted, not encoded.
- **OpenTUI `testRender` mid-test reactivity** — the harness doesn't propagate a mid-test signal change to the captured buffer; `flush()`/`waitForFrame` both failed. Working pattern: two separate renders compared.
- **Darwin CI host outages** (rasam + zest down → improvised onto retired sincereintent) and the bun2nix-on-darwin FOD bug (needed `--backend=copyfile`) — recurring infra reality, minor lessons at most.

Provenance: `/be` session `15384001-efb1-44d8-80ee-a4e24159ef20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
