### PR TITLE
chore(skills): gate /test e2e on a pu box when production is live

### DIFF
--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -14,6 +14,7 @@ Run e2e tests scoped to the current branch's changes.
 3. **Decide whether to run e2e**:
    - If changes touch `packages/client/src/`, `packages/tests/`, or `packages/common/src/` — run the matching feature files.
    - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
-4. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
+4. **Decide where it runs — pu box, not locally, whenever production is live.** `just test-quick` builds the client and spawns a server: that is **heavy work**, and it goes on an ephemeral pu box (see `/pu` / `/evidence`) any time `systemctl --user is-active kolu` is `active` (the normal case). A pile-up of local e2e runs OOM-`SIGKILL`ed production `kolu.service` beside this command before — "fast" is not "safe to run beside production." Apply `/dev-server` §0's local-vs-pu venue gate before invoking it, and run locally **only** when production is `inactive` here.
+5. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
 
-`just test-quick` is fast — no nix build, no separate dev server needed.
+`just test-quick` is fast — no nix build, no separate dev server needed — but **fast is not local-by-default**: see step 4.

--- a/.apm/skills/test/SKILL.md
+++ b/.apm/skills/test/SKILL.md
@@ -14,6 +14,7 @@ Run e2e tests scoped to the current branch's changes.
 3. **Decide whether to run e2e**:
    - If changes touch `packages/client/src/`, `packages/tests/`, or `packages/common/src/` — run the matching feature files.
    - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
-4. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
+4. **Decide where it runs — pu box, not locally, whenever production is live.** `just test-quick` builds the client and spawns a server: that is **heavy work**, and it goes on an ephemeral pu box (see `/pu` / `/evidence`) any time `systemctl --user is-active kolu` is `active` (the normal case). A pile-up of local e2e runs OOM-`SIGKILL`ed production `kolu.service` beside this command before — "fast" is not "safe to run beside production." Apply `/dev-server` §0's local-vs-pu venue gate before invoking it, and run locally **only** when production is `inactive` here.
+5. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
 
-`just test-quick` is fast — no nix build, no separate dev server needed.
+`just test-quick` is fast — no nix build, no separate dev server needed — but **fast is not local-by-default**: see step 4.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -14,6 +14,7 @@ Run e2e tests scoped to the current branch's changes.
 3. **Decide whether to run e2e**:
    - If changes touch `packages/client/src/`, `packages/tests/`, or `packages/common/src/` — run the matching feature files.
    - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
-4. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
+4. **Decide where it runs — pu box, not locally, whenever production is live.** `just test-quick` builds the client and spawns a server: that is **heavy work**, and it goes on an ephemeral pu box (see `/pu` / `/evidence`) any time `systemctl --user is-active kolu` is `active` (the normal case). A pile-up of local e2e runs OOM-`SIGKILL`ed production `kolu.service` beside this command before — "fast" is not "safe to run beside production." Apply `/dev-server` §0's local-vs-pu venue gate before invoking it, and run locally **only** when production is `inactive` here.
+5. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
 
-`just test-quick` is fast — no nix build, no separate dev server needed.
+`just test-quick` is fast — no nix build, no separate dev server needed — but **fast is not local-by-default**: see step 4.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -339,7 +339,7 @@ local_deployed_file_hashes:
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .agents/skills/release/SKILL.md: sha256:9ecdcae3c7e44df8984f5edb877d8fb3c613fde4abd80e230bc5f83dbec5a8e4
   .agents/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
-  .agents/skills/test/SKILL.md: sha256:48ed47865035a0d527bbbc7cd3ba900f44c6b6f79d3db837b9aa09db3bb8a005
+  .agents/skills/test/SKILL.md: sha256:ab8421b6937ad1687b6670fca17eacb908bdf637d7cddd4cc734f2a0e3c16c53
   .claude/rules/apm-sources.md: sha256:90626875e2a63e5658f0b5e77524c9c4f949f4ce890bd1f1ce9a2663d4fc8ea7
   .claude/rules/apm-workflow.md: sha256:16f4fed3d8fe9b1e334444b8885443c2ac26963270d3df0f3505075cc3bd604d
   .claude/rules/architecture.md: sha256:0f47ba876432c25a2cd54e3ed7995e8bbbb8b383fe3b790b0b3e252949c18032
@@ -374,4 +374,4 @@ local_deployed_file_hashes:
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .claude/skills/release/SKILL.md: sha256:9ecdcae3c7e44df8984f5edb877d8fb3c613fde4abd80e230bc5f83dbec5a8e4
   .claude/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
-  .claude/skills/test/SKILL.md: sha256:48ed47865035a0d527bbbc7cd3ba900f44c6b6f79d3db837b9aa09db3bb8a005
+  .claude/skills/test/SKILL.md: sha256:ab8421b6937ad1687b6670fca17eacb908bdf637d7cddd4cc734f2a0e3c16c53


### PR DESCRIPTION
## Why

A `/be` run mined by `/self-improve` killed production: the agent ran `just test-quick` (e2e) **locally**, beside a live production `kolu.service`, and the OOM-killer `SIGKILL`ed production. This is a repeat of the documented OOM/port incidents ([#1109](https://github.com/juspay/kolu/issues/1109) and the prior OOM already cited in `/be` §5), so it clears the durability bar.

The pu-box venue gate already exists — prominently — in `/be` §2, `/be` §5, `/evidence`, and `/dev-server` §0. But it was **never in view at the moment the command ran**: the agent reached the e2e via the `/test` skill (and bare `just test-quick`) during the review/CI loop, and `/test` had **zero** venue gate. Worse, its closing line actively sold local execution: *"`just test-quick` is fast — no nix build, no separate dev server needed."* "Fast" read as "safe to run beside production." A rule that lives only in `/be` doesn't fire when the command is invoked through `/test`.

## What changed

The fix is a **cross-link of the existing rule** (lowest-churn lever), landed in the one skill that actually runs the command — not a new rule.

| Edit | File (source) | Change |
|---|---|---|
| Venue gate added | `.apm/skills/test/SKILL.md` | New step 4: decide pu-box-vs-local before running, gated on `systemctl --user is-active kolu`, cross-linking `/dev-server` §0 and the OOM rationale. The run command becomes step 5. |
| Misleading "fast" line qualified | `.apm/skills/test/SKILL.md` | Closing line now reads "fast is not local-by-default — see step 4," so speed no longer implies a safe local venue. |
| Generated runtimes regenerated | `.agents/`, `.claude/`, `apm.lock.yaml` | `just ai::apm` — generated copies ride the same commit as the source so the runtimes don't drift. |

## Evidence per edit

- **Gate present in source and both runtimes:** `grep -l "pu box, not locally, whenever production"` matches `.apm/`, `.agents/`, and `.claude/` copies of `test/SKILL.md`.
- **Cross-link resolves:** `/dev-server` §0 ("First decide local vs. pu") is the live anchor the new step points at; the OOM rationale matches `/be` §5's existing wording.
- **Gates green in the worktree:** `just ai::apm` (regen) clean, `just fmt` reformatted 0 files, `just check` (typecheck + biome lint, 915 files) exited 0. Diff is the 4 expected files only.

## Anti-patterns checked

No post-§0 question reintroduced; the serial review gauntlet is untouched (this only gates the e2e *venue*, not the gauntlet's order). Honors reuse-the-source-of-truth: it points at the existing `/dev-server` §0 gate rather than restating it.

Provenance: `/self-improve` on session `fd679661-3de8-4958-adfb-135b2cef4454`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)