### PR TITLE
Make the dock sub-terminal count pip subtle

### DIFF
--- a/packages/client/src/canvas/dock/RowPips.tsx
+++ b/packages/client/src/canvas/dock/RowPips.tsx
@@ -137,11 +137,7 @@ export const PrPip: Component<{ meta: TerminalMetadata }> = (props) => {
 export const SubCountCell: Component<{ subCount: number }> = (props) => (
   <span class="flex items-center justify-end">
     <Show when={props.subCount > 0}>
-      <SubCountChip
-        count={props.subCount}
-        active={false}
-        testId="dock-sub-count"
-      />
+      <SubCountChip count={props.subCount} testId="dock-sub-count" />
     </Show>
   </span>
 );

--- a/packages/client/src/canvas/dock/SubCountChip.tsx
+++ b/packages/client/src/canvas/dock/SubCountChip.tsx
@@ -4,9 +4,10 @@
  *  terminals have splits open, without diving into the canvas. Uses
  *  the same `SplitToggleIcon` + numeric vocabulary the tile header
  *  already uses (`TileTitleActions`), so the symbol reads consistently
- *  across surfaces. Active rows get a translucent-white treatment to
- *  survive the accent flood; inactive rows mix `currentColor` so the
- *  chip inherits the row's text tone.
+ *  across surfaces. Rendered as a bare icon + count in the muted
+ *  `fg-3` tone — the same treatment as the sibling `PrPip` — so it
+ *  reads as one of the row's quiet presence pips rather than a framed
+ *  badge that fights the branch label for attention.
  *
  *  `testId` is required (not optional with a default) so each call
  *  site is testable by a stable id. Both desktop and mobile dock rows
@@ -18,20 +19,11 @@ import { SplitToggleIcon } from "../../ui/Icons";
 
 export const SubCountChip: Component<{
   count: number;
-  active: boolean;
   testId: string;
 }> = (props) => (
   <span
     data-testid={props.testId}
-    class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded font-mono text-[0.7rem] font-semibold tabular-nums leading-none shrink-0"
-    style={{
-      "background-color": props.active
-        ? "rgba(255, 255, 255, 0.18)"
-        : "color-mix(in oklch, currentColor 10%, transparent)",
-      border: props.active
-        ? "1px solid rgba(255, 255, 255, 0.32)"
-        : "1px solid color-mix(in oklch, currentColor 22%, transparent)",
-    }}
+    class="inline-flex items-center gap-1 font-mono text-[0.7rem] tabular-nums leading-none shrink-0 text-fg-3"
     title={`${props.count} sub-terminal${props.count === 1 ? "" : "s"}`}
   >
     <SplitToggleIcon class="w-3 h-3" />


### PR DESCRIPTION
**The sub-terminal split count in the Dock now reads as one of the row's quiet presence pips** instead of a framed, bordered badge that fought the branch label for attention. The chip kept a translucent-white fill, a visible border, and bold weight — none of which the sibling pips (`ActivityPip`, `StatePip`, `PrPip`) use — so it stood out as the one glaring element on every row with a split open.

It now mirrors `PrPip` exactly: a bare `SplitToggleIcon` + count in the muted `fg-3` tone, no background, no border, no bold.

| Before | After |
| --- | --- |
| `bg rgba(255,255,255,.18)` + 1px border + `font-semibold` | bare icon + count, `text-fg-3` |
| translucent-white "active" variant + `currentColor`-mix "inactive" variant | single subtle treatment |

_The `active` prop was dead — `SubCountCell` only ever passed `active={false}` — so it's dropped along with the two-variant styling._

### Try it locally

```sh
nix run github:juspay/kolu/dock-subcount-subtle
```

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._