### PR TITLE
Bump odu pin: pick up the ci-skill "run CI ≠ just ci" fix

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci
-description: Reference for the `odu` runner — how to invoke a full pipeline, a single recipe, or a platform-pinned node, and how to attach to a live run, from a project whose CI odu runs. Trigger when the user asks to "run CI", "run the pipeline", "re-run a check", or names a specific recipe by `<recipe>@<platform>`.
+description: Reference for the `odu` runner — how to invoke a full pipeline, a single recipe, or a platform-pinned node, and how to attach to a live run, from a project whose CI odu runs. Trigger when the user asks to "run CI", "run the pipeline", "re-run a check", to run named lanes or recipes (e.g. "run fmt and nix", "just the e2e lane", bare selectors like `fmt`/`nix`/`e2e`), or names a recipe by `<recipe>@<platform>`. This skill — not a repo's local `just ci` / `just <recipe>` — is how an odu-run request is served.
 ---
 
 # odu
@@ -12,13 +12,22 @@ the run is **live state you attach to**: the coordinator serves a typed
 surface on `.ci/odu.sock`, so `status`/`logs`/`attach` are in-band — no
 process-compose, no separately-versioned socket client.
 
+> **A request to run CI is a request to run `odu` — never `just ci`.** Many
+> consuming repos expose a `just ci` (or `just <recipe>`) target that runs a
+> pipeline locally. Do **not** shell out to it: it is a parallel, non-attachable
+> path that bypasses everything odu gives you — the live surface, per-node GitHub
+> statuses, structured results, fail-fast, `cancel`/`supersede`, and the log
+> resources below. "run CI", "run fmt and nix", "re-run the e2e lane" all mean
+> *drive an odu run*, by the MCP face first and the `odu` CLI otherwise.
+>
 > **Prefer the MCP face for runs.** When the `odu-mcp` skill is present (the
 > `mcp__odu__*` tools — check for an odu MCP server before shelling out), drive
-> runs through it — `run` → `wait_for_settle` (fail-fast) → read the red node's
-> log → `node_rerun`, with `cancel` / `run({supersede})` to call off or replace
-> a run. It spawns the same coordinator but gives you structured results and the
-> fail-fast loop instead of scraping terminal output. The `nix run … -- run`
-> CLI below is the reference and the fallback when no MCP server is wired.
+> runs through it — `run` (pass `selectors` for named lanes/recipes) →
+> `wait_for_settle` (fail-fast) → read the red node's log → `node_rerun`, with
+> `cancel` / `run({supersede})` to call off or replace a run. It spawns the same
+> coordinator but gives you structured results and the fail-fast loop instead of
+> scraping terminal output. The `nix run … -- run` CLI below is the reference and
+> the fallback when no MCP server is wired.
 >
 > **Logs are a resource, not a tool.** Don't look for a log-tail tool — there
 > isn't one. A node's output is the MCP **resource** `surface://collections/logs/{id}`

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci
-description: Reference for the `odu` runner — how to invoke a full pipeline, a single recipe, or a platform-pinned node, and how to attach to a live run, from a project whose CI odu runs. Trigger when the user asks to "run CI", "run the pipeline", "re-run a check", or names a specific recipe by `<recipe>@<platform>`.
+description: Reference for the `odu` runner — how to invoke a full pipeline, a single recipe, or a platform-pinned node, and how to attach to a live run, from a project whose CI odu runs. Trigger when the user asks to "run CI", "run the pipeline", "re-run a check", to run named lanes or recipes (e.g. "run fmt and nix", "just the e2e lane", bare selectors like `fmt`/`nix`/`e2e`), or names a recipe by `<recipe>@<platform>`. This skill — not a repo's local `just ci` / `just <recipe>` — is how an odu-run request is served.
 ---
 
 # odu
@@ -12,13 +12,22 @@ the run is **live state you attach to**: the coordinator serves a typed
 surface on `.ci/odu.sock`, so `status`/`logs`/`attach` are in-band — no
 process-compose, no separately-versioned socket client.
 
+> **A request to run CI is a request to run `odu` — never `just ci`.** Many
+> consuming repos expose a `just ci` (or `just <recipe>`) target that runs a
+> pipeline locally. Do **not** shell out to it: it is a parallel, non-attachable
+> path that bypasses everything odu gives you — the live surface, per-node GitHub
+> statuses, structured results, fail-fast, `cancel`/`supersede`, and the log
+> resources below. "run CI", "run fmt and nix", "re-run the e2e lane" all mean
+> *drive an odu run*, by the MCP face first and the `odu` CLI otherwise.
+>
 > **Prefer the MCP face for runs.** When the `odu-mcp` skill is present (the
 > `mcp__odu__*` tools — check for an odu MCP server before shelling out), drive
-> runs through it — `run` → `wait_for_settle` (fail-fast) → read the red node's
-> log → `node_rerun`, with `cancel` / `run({supersede})` to call off or replace
-> a run. It spawns the same coordinator but gives you structured results and the
-> fail-fast loop instead of scraping terminal output. The `nix run … -- run`
-> CLI below is the reference and the fallback when no MCP server is wired.
+> runs through it — `run` (pass `selectors` for named lanes/recipes) →
+> `wait_for_settle` (fail-fast) → read the red node's log → `node_rerun`, with
+> `cancel` / `run({supersede})` to call off or replace a run. It spawns the same
+> coordinator but gives you structured results and the fail-fast loop instead of
+> scraping terminal output. The `nix run … -- run` CLI below is the reference and
+> the fallback when no MCP server is wired.
 >
 > **Logs are a resource, not a tool.** Don't look for a log-tail tool — there
 > isn't one. A node's output is the MCP **resource** `surface://collections/logs/{id}`

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -40,7 +40,7 @@ dependencies:
   content_hash: sha256:51308bd8cc8b6ae24781a77b67a7c8140bdea5d793e35427e7b8fcbeb0662074
 - repo_url: juspay/odu
   host: github.com
-  resolved_commit: b826fadad177e7d7efa0afd6f452ea24dd3f9bf9
+  resolved_commit: f3a3e553c00486e7e2999d79495e2e52f6192703
   package_type: apm_package
   deployed_files:
   - .agents/skills/ci
@@ -54,13 +54,13 @@ dependencies:
   - .claude/skills/odu-mcp/SKILL.md
   - .claude/skills/odu-mcp/bin/serve
   deployed_file_hashes:
-    .agents/skills/ci/SKILL.md: sha256:017232b5ec61da86ecc36babef51ff99477ccded0052f97d396825819b1461fb
+    .agents/skills/ci/SKILL.md: sha256:7f22aaac4676523525430c9208a000b7eb8e9e03b506e55350dcfdf3367d05cd
     .agents/skills/odu-mcp/SKILL.md: sha256:25cd14d47aa082fb4061e793d3b74095eeb6749672356eea6b9acde9f9de6863
     .agents/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .claude/skills/ci/SKILL.md: sha256:017232b5ec61da86ecc36babef51ff99477ccded0052f97d396825819b1461fb
+    .claude/skills/ci/SKILL.md: sha256:7f22aaac4676523525430c9208a000b7eb8e9e03b506e55350dcfdf3367d05cd
     .claude/skills/odu-mcp/SKILL.md: sha256:25cd14d47aa082fb4061e793d3b74095eeb6749672356eea6b9acde9f9de6863
     .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-  content_hash: sha256:cd2cafc35a9bd52fa5a7730b01f6aca6811dc662c8b94d61f13604941f12658b
+  content_hash: sha256:07ac573bff03b3ce4df3dffa5b5a15095acf5ac8131a77c2b23ee7a22dd67a58
 - repo_url: juspay/project-unknown
   host: github.com
   resolved_commit: 27c4973ae3837eaa54b0439faa5346a3320ac379

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -48,9 +48,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "b826fadad177e7d7efa0afd6f452ea24dd3f9bf9",
-      "url": "https://github.com/juspay/odu/archive/b826fadad177e7d7efa0afd6f452ea24dd3f9bf9.tar.gz",
-      "hash": "sha256-RODWjBEt4bBhvEcYDywKABIjiDILtImlMDi/SzdtNHM="
+      "revision": "f3a3e553c00486e7e2999d79495e2e52f6192703",
+      "url": "https://github.com/juspay/odu/archive/f3a3e553c00486e7e2999d79495e2e52f6192703.tar.gz",
+      "hash": "sha256-TlTWFf15JjOSP69W2er1u7Dv7isT2JBwcUfEfuIluyA="
     }
   },
   "version": 7


### PR DESCRIPTION
**Bumps the `odu` pin from `b826fad` → `f3a3e55`** so kolu picks up [juspay/odu#36](https://github.com/juspay/odu/pull/36) — the `ci` skill now routes a plain "run CI" request to an odu run instead of letting an agent fall through to the repo's local `just ci`. The old vendored skill is what let *"run CI steps: fmt and nix"* get served by `just ci` in the first place.

The bump rides two transports, both updated here:

| Transport | What it pins | Change |
| --- | --- | --- |
| `npins/sources.json` | the `odu` CLI/runner Nix build | `b826fad` → `f3a3e55` (also folds in the #33 stdio-EPIPE fix) |
| `apm.lock.yaml` + vendored `.agents`/`.claude/skills/ci` | the dogfooded `ci` skill text | re-vendored via `apm update juspay/odu` |

_Skill/guidance + pin only — no app code changes. The `apm update` was scoped to `juspay/odu`, so no other vendored skill drifted._

---
_Generated by Claude Code (model `claude-opus-4-8`)._