### PR TITLE
chore(skills): /be picks the macOS CI host by availability — rasam, then sincereintent

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -105,28 +105,22 @@ green before capturing.
    present is the fallback path, not the default. React to `failed`/`errored` nodes
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
-   - **A pinned CI host being unreachable is an infra fault, not a debate
-     outcome — fail it over, don't park the lane.** When a lane never produces a
-     verdict because its host is *down* (ssh times out, tailscale shows it
-     "offline / last seen Nh ago"), that is distinct from a node that ran and went
-     red: there is nothing in the diff to fix and no `node_rerun` will help. The
-     trap is to declare an "external infrastructure outage," leave the lane
-     unverified, and stop — that hands the run back to the human, who then has to
-     name the alternate host by hand (a prior run stalled the **`aarch64-darwin`**
-     lane this exact way when **`rasam`** — the host pinned in `.agency/do.md` —
-     was offline, and only resumed when the user said "use sincereintent for
-     macos"). So when the pinned darwin host is unreachable, **re-pin the lane to
-     the working secondary darwin box and re-run it yourself** (resolve a reachable
-     host via `tailscale status` + an ssh probe, then `mcp__odu__run
-     hosts=["aarch64-darwin=<user>@<host>"]`), and note the failover in the report.
-     `.agency/do.md` may call a given box "retired for CI" — that is steady-state
-     guidance, not a directive to leave a lane unverified when the *primary* is
-     dark; reach for the live secondary, get a real verdict, and surface that you
-     did. Do **not** silently drop the platform or report green on a lane that
-     never ran — that is the no-fallbacks rule's "a caught error must surface"
-     clause: an unreachable host is the caught error; failing over (or, if no
-     darwin host answers at all, reporting the lane as genuinely blocked) is
-     surfacing it, parking-and-stopping is collapsing it to a silent gap.
+   - **macOS (`aarch64-darwin`) CI host — pick by availability, in this order:
+     `rasam`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
+     `rasam` is the primary and `sincereintent` the fallback. Before pinning the
+     darwin lane, probe them **in that order** — `tailscale status` (skip a host
+     shown `offline` / `last seen Nh ago`) plus a quick `ssh -o ConnectTimeout=8
+     <user>@<host> true` — and pin the **first that answers** in `mcp__odu__run
+     hosts=["aarch64-darwin=<user>@<host>", …]`, noting in the report which host
+     served the lane. An unreachable host is an infra fault, never a lane to park
+     or call green: if `rasam` is down, fall through to `sincereintent` and run the
+     lane yourself; only if **neither** answers is the darwin lane genuinely
+     blocked (report it as blocked — never silently drop the platform or report
+     green on a lane that never ran; an unreachable host is the no-fallbacks rule's
+     "a caught error must surface"). This live availability order is what to apply
+     even where `.agency/do.md`'s steady-state note still reads "rasam, not
+     sincereintent / sincereintent retired": that line is the default pin, this
+     ordering supersedes it the moment the primary is dark.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -105,6 +105,28 @@ green before capturing.
    present is the fallback path, not the default. React to `failed`/`errored` nodes
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
+   - **A pinned CI host being unreachable is an infra fault, not a debate
+     outcome — fail it over, don't park the lane.** When a lane never produces a
+     verdict because its host is *down* (ssh times out, tailscale shows it
+     "offline / last seen Nh ago"), that is distinct from a node that ran and went
+     red: there is nothing in the diff to fix and no `node_rerun` will help. The
+     trap is to declare an "external infrastructure outage," leave the lane
+     unverified, and stop — that hands the run back to the human, who then has to
+     name the alternate host by hand (a prior run stalled the **`aarch64-darwin`**
+     lane this exact way when **`rasam`** — the host pinned in `.agency/do.md` —
+     was offline, and only resumed when the user said "use sincereintent for
+     macos"). So when the pinned darwin host is unreachable, **re-pin the lane to
+     the working secondary darwin box and re-run it yourself** (resolve a reachable
+     host via `tailscale status` + an ssh probe, then `mcp__odu__run
+     hosts=["aarch64-darwin=<user>@<host>"]`), and note the failover in the report.
+     `.agency/do.md` may call a given box "retired for CI" — that is steady-state
+     guidance, not a directive to leave a lane unverified when the *primary* is
+     dark; reach for the live secondary, get a real verdict, and surface that you
+     did. Do **not** silently drop the platform or report green on a lane that
+     never ran — that is the no-fallbacks rule's "a caught error must surface"
+     clause: an unreachable host is the caught error; failing over (or, if no
+     darwin host answers at all, reporting the lane as genuinely blocked) is
+     surfacing it, parking-and-stopping is collapsing it to a silent gap.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -105,28 +105,22 @@ green before capturing.
    present is the fallback path, not the default. React to `failed`/`errored` nodes
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
-   - **A pinned CI host being unreachable is an infra fault, not a debate
-     outcome — fail it over, don't park the lane.** When a lane never produces a
-     verdict because its host is *down* (ssh times out, tailscale shows it
-     "offline / last seen Nh ago"), that is distinct from a node that ran and went
-     red: there is nothing in the diff to fix and no `node_rerun` will help. The
-     trap is to declare an "external infrastructure outage," leave the lane
-     unverified, and stop — that hands the run back to the human, who then has to
-     name the alternate host by hand (a prior run stalled the **`aarch64-darwin`**
-     lane this exact way when **`rasam`** — the host pinned in `.agency/do.md` —
-     was offline, and only resumed when the user said "use sincereintent for
-     macos"). So when the pinned darwin host is unreachable, **re-pin the lane to
-     the working secondary darwin box and re-run it yourself** (resolve a reachable
-     host via `tailscale status` + an ssh probe, then `mcp__odu__run
-     hosts=["aarch64-darwin=<user>@<host>"]`), and note the failover in the report.
-     `.agency/do.md` may call a given box "retired for CI" — that is steady-state
-     guidance, not a directive to leave a lane unverified when the *primary* is
-     dark; reach for the live secondary, get a real verdict, and surface that you
-     did. Do **not** silently drop the platform or report green on a lane that
-     never ran — that is the no-fallbacks rule's "a caught error must surface"
-     clause: an unreachable host is the caught error; failing over (or, if no
-     darwin host answers at all, reporting the lane as genuinely blocked) is
-     surfacing it, parking-and-stopping is collapsing it to a silent gap.
+   - **macOS (`aarch64-darwin`) CI host — pick by availability, in this order:
+     `rasam`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
+     `rasam` is the primary and `sincereintent` the fallback. Before pinning the
+     darwin lane, probe them **in that order** — `tailscale status` (skip a host
+     shown `offline` / `last seen Nh ago`) plus a quick `ssh -o ConnectTimeout=8
+     <user>@<host> true` — and pin the **first that answers** in `mcp__odu__run
+     hosts=["aarch64-darwin=<user>@<host>", …]`, noting in the report which host
+     served the lane. An unreachable host is an infra fault, never a lane to park
+     or call green: if `rasam` is down, fall through to `sincereintent` and run the
+     lane yourself; only if **neither** answers is the darwin lane genuinely
+     blocked (report it as blocked — never silently drop the platform or report
+     green on a lane that never ran; an unreachable host is the no-fallbacks rule's
+     "a caught error must surface"). This live availability order is what to apply
+     even where `.agency/do.md`'s steady-state note still reads "rasam, not
+     sincereintent / sincereintent retired": that line is the default pin, this
+     ordering supersedes it the moment the primary is dark.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -105,6 +105,28 @@ green before capturing.
    present is the fallback path, not the default. React to `failed`/`errored` nodes
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
+   - **A pinned CI host being unreachable is an infra fault, not a debate
+     outcome — fail it over, don't park the lane.** When a lane never produces a
+     verdict because its host is *down* (ssh times out, tailscale shows it
+     "offline / last seen Nh ago"), that is distinct from a node that ran and went
+     red: there is nothing in the diff to fix and no `node_rerun` will help. The
+     trap is to declare an "external infrastructure outage," leave the lane
+     unverified, and stop — that hands the run back to the human, who then has to
+     name the alternate host by hand (a prior run stalled the **`aarch64-darwin`**
+     lane this exact way when **`rasam`** — the host pinned in `.agency/do.md` —
+     was offline, and only resumed when the user said "use sincereintent for
+     macos"). So when the pinned darwin host is unreachable, **re-pin the lane to
+     the working secondary darwin box and re-run it yourself** (resolve a reachable
+     host via `tailscale status` + an ssh probe, then `mcp__odu__run
+     hosts=["aarch64-darwin=<user>@<host>"]`), and note the failover in the report.
+     `.agency/do.md` may call a given box "retired for CI" — that is steady-state
+     guidance, not a directive to leave a lane unverified when the *primary* is
+     dark; reach for the live secondary, get a real verdict, and surface that you
+     did. Do **not** silently drop the platform or report green on a lane that
+     never ran — that is the no-fallbacks rule's "a caught error must surface"
+     clause: an unreachable host is the caught error; failing over (or, if no
+     darwin host answers at all, reporting the lane as genuinely blocked) is
+     surfacing it, parking-and-stopping is collapsing it to a silent gap.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -105,28 +105,22 @@ green before capturing.
    present is the fallback path, not the default. React to `failed`/`errored` nodes
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
-   - **A pinned CI host being unreachable is an infra fault, not a debate
-     outcome — fail it over, don't park the lane.** When a lane never produces a
-     verdict because its host is *down* (ssh times out, tailscale shows it
-     "offline / last seen Nh ago"), that is distinct from a node that ran and went
-     red: there is nothing in the diff to fix and no `node_rerun` will help. The
-     trap is to declare an "external infrastructure outage," leave the lane
-     unverified, and stop — that hands the run back to the human, who then has to
-     name the alternate host by hand (a prior run stalled the **`aarch64-darwin`**
-     lane this exact way when **`rasam`** — the host pinned in `.agency/do.md` —
-     was offline, and only resumed when the user said "use sincereintent for
-     macos"). So when the pinned darwin host is unreachable, **re-pin the lane to
-     the working secondary darwin box and re-run it yourself** (resolve a reachable
-     host via `tailscale status` + an ssh probe, then `mcp__odu__run
-     hosts=["aarch64-darwin=<user>@<host>"]`), and note the failover in the report.
-     `.agency/do.md` may call a given box "retired for CI" — that is steady-state
-     guidance, not a directive to leave a lane unverified when the *primary* is
-     dark; reach for the live secondary, get a real verdict, and surface that you
-     did. Do **not** silently drop the platform or report green on a lane that
-     never ran — that is the no-fallbacks rule's "a caught error must surface"
-     clause: an unreachable host is the caught error; failing over (or, if no
-     darwin host answers at all, reporting the lane as genuinely blocked) is
-     surfacing it, parking-and-stopping is collapsing it to a silent gap.
+   - **macOS (`aarch64-darwin`) CI host — pick by availability, in this order:
+     `rasam`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
+     `rasam` is the primary and `sincereintent` the fallback. Before pinning the
+     darwin lane, probe them **in that order** — `tailscale status` (skip a host
+     shown `offline` / `last seen Nh ago`) plus a quick `ssh -o ConnectTimeout=8
+     <user>@<host> true` — and pin the **first that answers** in `mcp__odu__run
+     hosts=["aarch64-darwin=<user>@<host>", …]`, noting in the report which host
+     served the lane. An unreachable host is an infra fault, never a lane to park
+     or call green: if `rasam` is down, fall through to `sincereintent` and run the
+     lane yourself; only if **neither** answers is the darwin lane genuinely
+     blocked (report it as blocked — never silently drop the platform or report
+     green on a lane that never ran; an unreachable host is the no-fallbacks rule's
+     "a caught error must surface"). This live availability order is what to apply
+     even where `.agency/do.md`'s steady-state note still reads "rasam, not
+     sincereintent / sincereintent retired": that line is the default pin, this
+     ordering supersedes it the moment the primary is dark.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -105,6 +105,28 @@ green before capturing.
    present is the fallback path, not the default. React to `failed`/`errored` nodes
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
+   - **A pinned CI host being unreachable is an infra fault, not a debate
+     outcome — fail it over, don't park the lane.** When a lane never produces a
+     verdict because its host is *down* (ssh times out, tailscale shows it
+     "offline / last seen Nh ago"), that is distinct from a node that ran and went
+     red: there is nothing in the diff to fix and no `node_rerun` will help. The
+     trap is to declare an "external infrastructure outage," leave the lane
+     unverified, and stop — that hands the run back to the human, who then has to
+     name the alternate host by hand (a prior run stalled the **`aarch64-darwin`**
+     lane this exact way when **`rasam`** — the host pinned in `.agency/do.md` —
+     was offline, and only resumed when the user said "use sincereintent for
+     macos"). So when the pinned darwin host is unreachable, **re-pin the lane to
+     the working secondary darwin box and re-run it yourself** (resolve a reachable
+     host via `tailscale status` + an ssh probe, then `mcp__odu__run
+     hosts=["aarch64-darwin=<user>@<host>"]`), and note the failover in the report.
+     `.agency/do.md` may call a given box "retired for CI" — that is steady-state
+     guidance, not a directive to leave a lane unverified when the *primary* is
+     dark; reach for the live secondary, get a real verdict, and surface that you
+     did. Do **not** silently drop the platform or report green on a lane that
+     never ran — that is the no-fallbacks rule's "a caught error must surface"
+     clause: an unreachable host is the caught error; failing over (or, if no
+     darwin host answers at all, reporting the lane as genuinely blocked) is
+     surfacing it, parking-and-stopping is collapsing it to a silent gap.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,7 +320,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:23be3f7978f176d89e41fa1fedd6b38e4cb848c59654c4a3e09d637bc8e5140f
   .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .agents/skills/be/SKILL.md: sha256:66c02bf2998532e64c6885737064b7883a573dc1374642984c4631468f5ef131
+  .agents/skills/be/SKILL.md: sha256:7b0c6306d53c75f42656391d0ca6b87e710298fbfeaaab729bcb2435be3b080c
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -355,7 +355,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:23be3f7978f176d89e41fa1fedd6b38e4cb848c59654c4a3e09d637bc8e5140f
   .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .claude/skills/be/SKILL.md: sha256:66c02bf2998532e64c6885737064b7883a573dc1374642984c4631468f5ef131
+  .claude/skills/be/SKILL.md: sha256:7b0c6306d53c75f42656391d0ca6b87e710298fbfeaaab729bcb2435be3b080c
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,7 +320,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:23be3f7978f176d89e41fa1fedd6b38e4cb848c59654c4a3e09d637bc8e5140f
   .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .agents/skills/be/SKILL.md: sha256:1ffd8c05ece8cf1d358c58572378b2b7113ff6683aef4840ea2d310818b9f77e
+  .agents/skills/be/SKILL.md: sha256:66c02bf2998532e64c6885737064b7883a573dc1374642984c4631468f5ef131
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -355,7 +355,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:23be3f7978f176d89e41fa1fedd6b38e4cb848c59654c4a3e09d637bc8e5140f
   .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .claude/skills/be/SKILL.md: sha256:1ffd8c05ece8cf1d358c58572378b2b7113ff6683aef4840ea2d310818b9f77e
+  .claude/skills/be/SKILL.md: sha256:66c02bf2998532e64c6885737064b7883a573dc1374642984c4631468f5ef131
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f


### PR DESCRIPTION
## What

Teach `/be` §5 to select the **macOS (`aarch64-darwin`) CI host by availability, in order: `rasam`, then `sincereintent`.**

Before pinning the darwin lane, the flow probes the two Apple-Silicon builders in that order (`tailscale status` + a quick `ssh … true`) and pins the **first that answers**, noting in the report which host served the lane. `rasam` is the primary; `sincereintent` is the fallback.

## Why

A prior `/be` run stalled the `aarch64-darwin` lane when `rasam` was offline ("last seen 22h ago"): the run declared an "external infrastructure outage," left the lane unverified, and stopped — taking two human turns to recover (the user had to name sincereintent by hand). An unreachable host is an infra fault to **fail over and surface**, not a lane to park or silently drop.

This supersedes the original (broader) version of this PR, which only said "fail over to *a* working secondary." Per the maintainer's request it now encodes the **concrete ordered preference** (rasam → sincereintent).

## Notes

- The host-name policy lives in the `/be` skill source (`.apm/skills/be/SKILL.md`), not `.agency/do.md` — the latter is vendored from the `srid/agency` apm package and its steady-state note ("rasam, not sincereintent / sincereintent retired") can't be edited here. The skill explicitly flags that this availability order supersedes that default pin when the primary is dark.
- Only if **neither** darwin host answers is the lane reported as genuinely blocked — never a silently dropped platform or a never-run lane reported green.
- Regenerated the `.claude` / `.agents` deployed copies + `apm.lock.yaml` via `just ai::apm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)