### PR TITLE
chore(skills): /be pins a companion repo's darwin lane by --host, never inline $ODU_HOSTS

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -121,6 +121,19 @@ green before capturing.
      even where `.agency/do.md`'s steady-state note still reads "rasam, not
      sincereintent / sincereintent retired": that line is the default pin, this
      ordering supersedes it the moment the primary is dark.
+     - **The same `rasam → sincereintent` order governs *every* darwin lane this
+       run starts — including a downstream/companion repo's CI** (e.g. the drishti
+       PR a `@kolu/surface` change requires per `surface.md`). A consuming repo's
+       own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's
+       `zest`); when it's offline you fall through to the **same** working
+       fallback. But that repo's CI is the shelled-out `nix run … odu -- run`
+       path, not `mcp__odu__run`, so pin the override with **`--host
+       aarch64-darwin=srid@sincereintent`** (per the `/ci` skill) — **never** by
+       exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*,
+       not a value: an inline `$ODU_HOSTS='{…}'` is **silently ignored**, the lane
+       falls back to the repo's on-disk `zest`, and you burn a full CI run on the
+       dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point
+       at it; otherwise reach for `--host`.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -121,6 +121,19 @@ green before capturing.
      even where `.agency/do.md`'s steady-state note still reads "rasam, not
      sincereintent / sincereintent retired": that line is the default pin, this
      ordering supersedes it the moment the primary is dark.
+     - **The same `rasam → sincereintent` order governs *every* darwin lane this
+       run starts — including a downstream/companion repo's CI** (e.g. the drishti
+       PR a `@kolu/surface` change requires per `surface.md`). A consuming repo's
+       own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's
+       `zest`); when it's offline you fall through to the **same** working
+       fallback. But that repo's CI is the shelled-out `nix run … odu -- run`
+       path, not `mcp__odu__run`, so pin the override with **`--host
+       aarch64-darwin=srid@sincereintent`** (per the `/ci` skill) — **never** by
+       exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*,
+       not a value: an inline `$ODU_HOSTS='{…}'` is **silently ignored**, the lane
+       falls back to the repo's on-disk `zest`, and you burn a full CI run on the
+       dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point
+       at it; otherwise reach for `--host`.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -121,6 +121,19 @@ green before capturing.
      even where `.agency/do.md`'s steady-state note still reads "rasam, not
      sincereintent / sincereintent retired": that line is the default pin, this
      ordering supersedes it the moment the primary is dark.
+     - **The same `rasam → sincereintent` order governs *every* darwin lane this
+       run starts — including a downstream/companion repo's CI** (e.g. the drishti
+       PR a `@kolu/surface` change requires per `surface.md`). A consuming repo's
+       own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's
+       `zest`); when it's offline you fall through to the **same** working
+       fallback. But that repo's CI is the shelled-out `nix run … odu -- run`
+       path, not `mcp__odu__run`, so pin the override with **`--host
+       aarch64-darwin=srid@sincereintent`** (per the `/ci` skill) — **never** by
+       exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*,
+       not a value: an inline `$ODU_HOSTS='{…}'` is **silently ignored**, the lane
+       falls back to the repo's on-disk `zest`, and you burn a full CI run on the
+       dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point
+       at it; otherwise reach for `--host`.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,7 +320,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:23be3f7978f176d89e41fa1fedd6b38e4cb848c59654c4a3e09d637bc8e5140f
   .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .agents/skills/be/SKILL.md: sha256:7b0c6306d53c75f42656391d0ca6b87e710298fbfeaaab729bcb2435be3b080c
+  .agents/skills/be/SKILL.md: sha256:9cf8c864be92cfd95263b6b0793290e9f5d671eef7c39d74c432d9c23fb4b3ff
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -355,7 +355,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:23be3f7978f176d89e41fa1fedd6b38e4cb848c59654c4a3e09d637bc8e5140f
   .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .claude/skills/be/SKILL.md: sha256:7b0c6306d53c75f42656391d0ca6b87e710298fbfeaaab729bcb2435be3b080c
+  .claude/skills/be/SKILL.md: sha256:9cf8c864be92cfd95263b6b0793290e9f5d671eef7c39d74c432d9c23fb4b3ff
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f


### PR DESCRIPTION
## What

The R7 `/be` run ([kolu #1505](https://github.com/juspay/kolu/pull/1505) + [drishti #71](https://github.com/srid/drishti/pull/71)) carried a `@kolu/surface` change across two repos. `surface.md` required a drishti companion PR, and drishti's CI runs through a different path than kolu's — which re-surfaced a friction the host-availability family was supposed to have closed.

This sharpens one existing clause in `/be` §5; it does **not** loosen any gate.

## Why — the friction, mined from the transcript

The darwin host-availability order (`rasam → sincereintent`, added in #1504) was scoped to **kolu's own** CI, driven through `mcp__odu__run`. The run hit two snags on the **companion** repo's lane:

| # | What happened | Root cause |
|---|---|---|
| 1 | rasam was offline **and** drishti's configured darwin host `zest` was offline; the fallback for drishti's lane had to be improvised | The `rasam → sincereintent` order was documented only for kolu's MCP-driven lane, not a companion repo's shell lane |
| 2 | A full drishti CI run was **burned on the dead `zest` host** | The pin was attempted via `export ODU_HOSTS='{…}'` (inline JSON) — but odu reads `$ODU_HOSTS` as a **file path**, so it was silently ignored and the lane fell back to the on-disk offline `zest` |

The agent self-corrected both (fell through to `sincereintent`, then wrote a real hosts *file* and re-ran), but only after a wasted run.

## Durability — why this clears the bar

- **Repeat from prior runs.** Third fix in the darwin-host-availability family: `bce44c961` (fail over instead of parking the lane) → `0ffdcc296` / #1504 (rasam → sincereintent) → this. Each prior fix was kolu-specific; the cross-repo shell path was the uncovered surface where it bit again.
- **Concrete near-miss.** The `$ODU_HOSTS`-is-a-file-path mistake burned a real CI run — wasted wall-clock and tokens.

## The edit — per-edit evidence ledger

**`.apm/skills/be/SKILL.md`** (source; `.claude/` + `.agents/` regenerated via `just ai::apm`, `apm.lock.yaml` hashes follow)

- Extends the §5 darwin-host clause so the `rasam → sincereintent` order governs **every** darwin lane the run starts — kolu's `mcp__odu__run` path **and** a companion repo's shelled-out `nix run … odu -- run` path.
- Bakes in the trap: a companion repo's shell-path pin uses **`--host aarch64-darwin=srid@sincereintent`** (per the `/ci` skill); **never** inline `$ODU_HOSTS`, which odu reads as a file path and silently ignores.

**Design philosophy**
- *Reuse the source of truth:* the `/ci` skill already documents `--host PLAT=ADDR` and that `$ODU_HOSTS` is a file path. This routes `/be` to that mechanism rather than re-documenting host config in a second place.
- *Fail fast / no fallbacks:* a silently-ignored inline `$ODU_HOSTS` falling back to a dead on-disk host is exactly the silent-degradation the rule forbids — the fix replaces it with an explicit override that can't be silently dropped.
- *Lowest churn:* one sub-bullet appended to an existing clause; no new rule or skill.

## Not encoded (observation only)

The cross-repo merge-gate had a second, **single-occurrence** snag: the codex-debate author created a drishti migration PR pinned to a *pre-gauntlet* kolu SHA and **without** R7's kill-proof deliverable; re-pinning to the final post-gauntlet SHA and adding the proof were separate steps the agent had to detect. This was self-corrected within the run, is not a prior-run repeat, and is not irreversible — so per `/self-improve`'s "produce nothing unless it durably recurs" it stays an observation, not an edit. If a future run trips the same migrate-vs-prove / re-pin-to-final-SHA gap, it graduates to an edit on `surface.md`.

## Gates

`just ai::apm` ✓ · `just fmt` ✓ (no reformatting) · `just check` ✓ (typecheck + biome green)

Provenance: `/self-improve` on `$CLAUDE_CODE_SESSION_ID=$SID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)