### PR TITLE
chore(skills): codex-debate author self-verifies before claiming "fixed"

### DIFF
--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -234,9 +234,9 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-You may run the formatter on files you touched. ${
+You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the finding's detail rather than reporting a clean "fixed". ${
     doCommit
-      ? `Once you've addressed every finding AND you actually changed files, COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
+      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
       : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
   }
 

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -234,9 +234,9 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-You may run the formatter on files you touched. ${
+You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the finding's detail rather than reporting a clean "fixed". ${
     doCommit
-      ? `Once you've addressed every finding AND you actually changed files, COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
+      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
       : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
   }
 

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -234,9 +234,9 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-You may run the formatter on files you touched. ${
+You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the finding's detail rather than reporting a clean "fixed". ${
     doCommit
-      ? `Once you've addressed every finding AND you actually changed files, COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
+      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
       : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
   }
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,17 +320,17 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:08a45894e2ae74182abd31c2f023995469a51be0ddc0e2c24b387819db877b78
   .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .agents/skills/be/SKILL.md: sha256:9cf8c864be92cfd95263b6b0793290e9f5d671eef7c39d74c432d9c23fb4b3ff
+  .agents/skills/be/SKILL.md: sha256:a806f3d8786ee4554a5051c78a21ea3f1586e8f1726d187eb7ec7a584587ad5c
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:8e912895e33937c661393efecde373ec10a0f3d0a6015fea21d065b7b3a16acd
+  .agents/skills/codex-debate/debate.workflow.js: sha256:71c0a508b3eb2cd5f39f0a37e7b1195673abba428283158d06e320eee2d586d0
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .agents/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .agents/skills/dev-server/SKILL.md: sha256:096c10444d951cbbe07ac9756c988bc45514916b20125b2f448c58207f5a223b
+  .agents/skills/dev-server/SKILL.md: sha256:1b56467bc51ddafa778997d1f7a8774f7364e55543d71e3ebf62af47efdcc13a
   .agents/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .agents/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90
@@ -355,17 +355,17 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:08a45894e2ae74182abd31c2f023995469a51be0ddc0e2c24b387819db877b78
   .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .claude/skills/be/SKILL.md: sha256:9cf8c864be92cfd95263b6b0793290e9f5d671eef7c39d74c432d9c23fb4b3ff
+  .claude/skills/be/SKILL.md: sha256:a806f3d8786ee4554a5051c78a21ea3f1586e8f1726d187eb7ec7a584587ad5c
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:8e912895e33937c661393efecde373ec10a0f3d0a6015fea21d065b7b3a16acd
+  .claude/skills/codex-debate/debate.workflow.js: sha256:71c0a508b3eb2cd5f39f0a37e7b1195673abba428283158d06e320eee2d586d0
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
   .claude/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
-  .claude/skills/dev-server/SKILL.md: sha256:096c10444d951cbbe07ac9756c988bc45514916b20125b2f448c58207f5a223b
+  .claude/skills/dev-server/SKILL.md: sha256:1b56467bc51ddafa778997d1f7a8774f7364e55543d71e3ebf62af47efdcc13a
   .claude/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .claude/skills/lens-debate/debate.workflow.js: sha256:73f8ad4f76b3da5b398aceed8a26f2079933773804ef75071876fb7fe928cc90


### PR DESCRIPTION
The `/codex-debate` author subagent fixes findings and may run the formatter — but its prompt **never told it to run the project's static-check gate before claiming a finding `fixed`**. So a fix that doesn't compile or lints clean still gets dispositioned `fixed`, committed, and handed to the next gauntlet step on a **red tree**.

That is exactly what happened in the run this PR was mined from (**[#1515](https://github.com/juspay/kolu/pull/1515)**, double-click empty canvas → New-terminal palette). The codex author caught a real bug — the gesture was wired only on `TerminalCanvas` (workspace mode) and missed the separate zero-terminal empty-canvas branch in `App.tsx` — and fixed it by adding `onDblClick` there. But it **asserted biome's a11y lint wouldn't fire** on that div and committed. It does fire (`noStaticElementInteractions`, same rule that had already fired on `TerminalCanvas` earlier the same run), so the main `/be` thread had to run `just check` itself, catch the red tree, and add the inline suppression.

This is the catalogued recurring gap, not a one-off:

| Source | Pattern |
| --- | --- |
| `llm-autonomy.mdx` → `review-gauntlet-gap` (22 hits, critical) | "Gauntlet doesn't self-execute or **self-verify**" |
| `llm-autonomy.mdx` → `manual-verification-needed` (22 hits) | "'tests pass' stands in for 'I watched it work'" |
| roadmap lever #12 | names `codex-debate` as a target for self-verifying long sub-skills |

## The fix

One sharpened clause in the author prompt (`debate.workflow.js`), the lowest-churn tier:

> SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. `just check`/`npm run lint`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it…

- **Repo-agnostic** — codex-debate carries no kolu/`just` hardcoding, so the author *discovers* the project's check task rather than being pinned to `just check`.
- **Fail-fast** — a red tree surfaces inside the author round, not on the next gauntlet step or in CI; honors reuse-source (runs the repo's own gate, not a hand-rolled lint).

## Evidence ledger

| Edit | Source | Verification |
| --- | --- | --- |
| SELF-VERIFY clause added to author prompt | `.apm/skills/codex-debate/debate.workflow.js` | propagated to `.claude/` + `.agents/` via `just ai::apm`; `just check` green (typecheck all packages + biome 944 files, 0 errors); `just fmt` clean |

> The `apm.lock.yaml` diff also re-syncs two stale hash entries (`be`/`dev-server` SKILL.md) that were already current on disk at `origin/master` — a pre-existing lockfile drift the regen corrected; no content change to those skills.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._