### PR TITLE
chore(skills): /be reports a measured before/after when performance IS the deliverable

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -80,6 +80,18 @@ eager heavy import). When the change **banks** an opportunity or **surfaces** a
 new one, update that note via `/atlas` so the map stays current — measured, not
 guessed (a faithfully-reproduced negative counts too).
 
+When **performance is the deliverable** — a toolchain/build migration, a
+render-loop or bundle or caching speedup, anything whose *whole point* is "make it
+faster/smaller" — a measured **before/after is part of the evidence, not an
+extra**: benchmark `master` (baseline) vs the branch on the **same pinned
+toolchain** and post the numbers (the speedup table / the byte delta) in a
+`## Performance` PR comment **and** the PR body, unprompted. Shipping a "make it
+faster" change with green CI and a screenshot but **no number** is a premature
+"done" — the metric is the proof the change did what it set out to do, exactly the
+gap a human otherwise has to flag ("post the performance improvement metrics").
+This is distinct from the regression guard above: there the rule is *don't lose* a
+banked win; here it is *show* the win you set out to bank.
+
 ## 5. Ship — CI and evidence in parallel
 
 **Heavy work runs on a pu box, never locally — production kolu lives on this

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -80,6 +80,18 @@ eager heavy import). When the change **banks** an opportunity or **surfaces** a
 new one, update that note via `/atlas` so the map stays current — measured, not
 guessed (a faithfully-reproduced negative counts too).
 
+When **performance is the deliverable** — a toolchain/build migration, a
+render-loop or bundle or caching speedup, anything whose *whole point* is "make it
+faster/smaller" — a measured **before/after is part of the evidence, not an
+extra**: benchmark `master` (baseline) vs the branch on the **same pinned
+toolchain** and post the numbers (the speedup table / the byte delta) in a
+`## Performance` PR comment **and** the PR body, unprompted. Shipping a "make it
+faster" change with green CI and a screenshot but **no number** is a premature
+"done" — the metric is the proof the change did what it set out to do, exactly the
+gap a human otherwise has to flag ("post the performance improvement metrics").
+This is distinct from the regression guard above: there the rule is *don't lose* a
+banked win; here it is *show* the win you set out to bank.
+
 ## 5. Ship — CI and evidence in parallel
 
 **Heavy work runs on a pu box, never locally — production kolu lives on this

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -80,6 +80,18 @@ eager heavy import). When the change **banks** an opportunity or **surfaces** a
 new one, update that note via `/atlas` so the map stays current — measured, not
 guessed (a faithfully-reproduced negative counts too).
 
+When **performance is the deliverable** — a toolchain/build migration, a
+render-loop or bundle or caching speedup, anything whose *whole point* is "make it
+faster/smaller" — a measured **before/after is part of the evidence, not an
+extra**: benchmark `master` (baseline) vs the branch on the **same pinned
+toolchain** and post the numbers (the speedup table / the byte delta) in a
+`## Performance` PR comment **and** the PR body, unprompted. Shipping a "make it
+faster" change with green CI and a screenshot but **no number** is a premature
+"done" — the metric is the proof the change did what it set out to do, exactly the
+gap a human otherwise has to flag ("post the performance improvement metrics").
+This is distinct from the regression guard above: there the rule is *don't lose* a
+banked win; here it is *show* the win you set out to bank.
+
 ## 5. Ship — CI and evidence in parallel
 
 **Heavy work runs on a pu box, never locally — production kolu lives on this

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,7 +320,7 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
   .agents/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .agents/skills/be/SKILL.md: sha256:4f44403143b4d28055b35eb51219d6ff00793e339d8deefe6cd8be90aefbfb25
+  .agents/skills/be/SKILL.md: sha256:f82be5de83bd1b6e766e50a4f84a96ea2737a59d8bb9e1fa7438a5e5c02a4749
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
@@ -355,7 +355,7 @@ local_deployed_file_hashes:
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
   .claude/skills/be-review/SKILL.md: sha256:07cf8b3e4261e26983d686bd834ac02865195c3ede3c5845293fb13ab234f2dd
-  .claude/skills/be/SKILL.md: sha256:4f44403143b4d28055b35eb51219d6ff00793e339d8deefe6cd8be90aefbfb25
+  .claude/skills/be/SKILL.md: sha256:f82be5de83bd1b6e766e50a4f84a96ea2737a59d8bb9e1fa7438a5e5c02a4749
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f


### PR DESCRIPTION
## What

Extend `/be`'s **Performance pass** (`.apm/skills/be/SKILL.md` §4) with the missing
mirror of its existing regression guard: when **performance is the deliverable**, a
measured **before/after is part of the evidence, not an extra**. Benchmark `master`
vs the branch on the same pinned toolchain and post the numbers (a speedup table /
byte delta) in a `## Performance` PR comment **and** the PR body — unprompted.

This is the micro-loop output of `/self-improve` for one `/be` run; it ships as its
own draft PR for a human to review (never on the originating branch, never merged).

## Why — the intervention it engineers out

Mined from session `91955c97-…` (`/be migrate to Astro 7`). The agent shipped a
faithful Astro 6→7 migration: PR #1527 opened **05:04**, ran the full review
gauntlet, posted visual evidence, green CI — and was about to call it done.

A migration to a *faster* toolchain whose entire value proposition is speed shipped
with **no measured speedup**. At **05:48** the human had to inject a Stop-hook goal —
*"fully leverage astro 7 capabilities and post performance improvement metrica in
PR"* — to force the benchmark. It then found **Atlas builds 25% faster, website 36%
faster**. That number should have shipped without being asked.

The existing §4 clause only guards *against regression* ("don't regress a banked
win"); neither it nor `/evidence` (which gates on whether the *screen* differs)
covers the case where a no-visual-diff perf win **is** the deliverable. This is the
gap.

## Evidence ledger

| Edit | File (source) | Claim it rests on | Verified |
| --- | --- | --- | --- |
| Add the "performance is the deliverable" clause to the Performance pass | `.apm/skills/be/SKILL.md` §4 | The pre-edit clause was a one-directional regression guard with no measure-and-report-a-win branch | Read of §4 lines 72–81 (pre-edit) |
| — | (generated) `.claude/skills/be/SKILL.md`, `.agents/skills/be/SKILL.md`, `apm.lock.yaml` | Generated copies must ride the same commit as the source | `just ai::apm` regenerated; `git status` shows only these + source; lockfile diff is the two SKILL.md hashes only |

Real intervention, verbatim from the transcript (session `91955c97-…`):
> A session-scoped Stop hook is now active with condition: "fully leverage astro 7 capabilities and post performance improvement  metrica in PR".

Measured payoff the forced follow-up produced (PR #1527 `## Performance` comment):
> **Atlas builds 25% faster, website 36% faster** under Astro 7

## Gates

- `just ai::apm` — regenerated runtimes from sources (1 pre-existing orphaned-AGENTS.md warning, unrelated)
- `just fmt` — clean, no fixes applied
- `just check` — green (exit 0)

## Anti-patterns checked (per `llm-autonomy.mdx`)

Strengthens a default; introduces no post-§0 question, no gauntlet parallelization,
no blanket grep/auto-fail. Lands in the lever map's primary home (`be` §4); adjacent
to evidence auto-classify (#13). Honors fail-fast / reuse-source (reuses the existing
`## Performance` comment + benchmark-on-pinned-toolchain conventions).

Provenance: session `91955c97-a15a-46f9-9027-ea376e2db6e9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
