### PR TITLE
chore(atlas): stop generated dist/ HTML from producing merge conflict markers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,8 +9,14 @@ CLAUDE.md linguist-generated
 .opencode/** linguist-generated
 
 # Generated Astro output, committed for in-app (Code tab) preview of the Atlas.
+# dist/ is a pure function of src/, so a 3-way text merge of the HTML is never
+# meaningful — it only splatters conflict markers into generated pages. `-merge`
+# keeps our side intact (no markers) and flags the path conflicted; resolve by
+# rebuilding (`just atlas::build && git add docs/atlas/dist`). The atlas-sync CI
+# gate is the backstop: a stale dist/ fails loudly, so picking a side is safe.
 docs/atlas/dist/** linguist-generated
 docs/atlas/dist/** -diff
+docs/atlas/dist/** -merge
 
 # Release notes are append-only — every PR adds a line under Unreleased. `union`
 # auto-resolves concurrent appends (keep both sides) so PRs never conflict here.


### PR DESCRIPTION
## What

Add one line to `.gitattributes`:

```
docs/atlas/dist/** -merge
```

## Why

`docs/atlas/dist/` is a self-contained Astro build committed for the in-app Code-tab preview. It's a **pure function of `src/`**, so when two branches each regenerate it, git's default 3-way *text* merge of the HTML is meaningless — it just splatters `<<<<<<<` markers into generated pages that no one can hand-resolve.

`-merge` tells git not to content-merge those files. On a conflict it keeps **our** side intact (no markers) and flags the path conflicted. You resolve the only way that's ever correct for a build artifact:

```
just atlas::build && git add docs/atlas/dist
```

The existing `atlas-sync` CI gate (`just atlas::check-sync`) is the backstop: a stale `dist/` fails loudly, so auto-picking a side at merge time is safe.

### Why not `merge=union`?

`union` (used right below for the append-only changelog) concatenates both sides — perfect for a line list, poison for HTML (duplicate doctype/`<head>`, structurally broken pages).

### Why not a custom `merge=ours` driver?

A named driver must be registered via `git config` in every clone; `.gitattributes` can only reference it. That's a per-machine setup knob (against the repo's no-knobs / fail-fast philosophy). `-merge` is purely committable and needs zero local config.

## Verification

Confirmed the `-merge` behavior empirically in a throwaway repo before committing: on a conflicting merge git left our side intact with **zero conflict markers** and flagged the path `UU` (conflicted) — exactly the intended resolution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)