### PR TITLE
fix: publish authored snapshot on wake/spawn so client flips sleeping→active

### DIFF
--- a/packages/server/src/terminalEndpoint/local.ts
+++ b/packages/server/src/terminalEndpoint/local.ts
@@ -423,7 +423,17 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
       handle: proxy,
     };
     registerTerminal(id, entry);
-    emitTerminalsDirty();
+    // Push the authored active snapshot — mirroring the sleep path
+    // (`beginSleep` → `publishTerminalState(sleeping, id)`). `terminalMetadata`'s
+    // collection `upsert` is a no-op that only PUSHES to subscribers (the
+    // registry IS the store), so a state change reaches the client ONLY through
+    // this call; `terminals:dirty` alone never re-reads it. A WAKE flips the
+    // registry's `entry.meta` to active on the SAME id the sleep last pushed as
+    // sleeping — without this push the client stays pinned to that stale sleeping
+    // snapshot (`isLive` false → the dormant tile body never yields to the live
+    // xterm). Fresh spawns push their birth record here too. `publishTerminalState`
+    // fires `terminals:dirty` internally, so it subsumes the prior `emitTerminalsDirty()`.
+    publishTerminalState(entry, id);
     emitTerminalListChanged();
 
     void this.spawnAndWire(id, opts, proxy, entry, prior, tlog);

--- a/packages/server/src/terminalEndpoint/local.ts
+++ b/packages/server/src/terminalEndpoint/local.ts
@@ -423,16 +423,10 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
       handle: proxy,
     };
     registerTerminal(id, entry);
-    // Push the authored active snapshot — mirroring the sleep path
-    // (`beginSleep` → `publishTerminalState(sleeping, id)`). `terminalMetadata`'s
-    // collection `upsert` is a no-op that only PUSHES to subscribers (the
-    // registry IS the store), so a state change reaches the client ONLY through
-    // this call; `terminals:dirty` alone never re-reads it. A WAKE flips the
-    // registry's `entry.meta` to active on the SAME id the sleep last pushed as
-    // sleeping — without this push the client stays pinned to that stale sleeping
-    // snapshot (`isLive` false → the dormant tile body never yields to the live
-    // xterm). Fresh spawns push their birth record here too. `publishTerminalState`
-    // fires `terminals:dirty` internally, so it subsumes the prior `emitTerminalsDirty()`.
+    // A lifecycle flip must PUBLISH, mirroring the sleep path — see
+    // `publishTerminalState` for why `terminals:dirty` alone can't reach the
+    // client. A WAKE flips `entry.meta` to active on the SAME id the sleep last
+    // pushed as sleeping; fresh spawns push their birth record through here too.
     publishTerminalState(entry, id);
     emitTerminalListChanged();
 

--- a/packages/server/src/terminalEndpoint/metadata.ts
+++ b/packages/server/src/terminalEndpoint/metadata.ts
@@ -113,10 +113,19 @@ function publishSnapshotAndDirty(
 }
 
 /** Publish a terminal's current metadata snapshot AND arm the session autosave —
- *  for a lifecycle STATE FLIP (active↔sleeping) that REPLACES the registry entry
- *  rather than mutating one field in place, so it can't ride the field mutators
- *  above. Accepts the union: a freshly-flipped sleeping entry publishes its
- *  persisted base; `publishSnapshot` narrows the live overlay away by `state`. */
+ *  for a lifecycle STATE FLIP (active↔sleeping, fresh spawn) that REPLACES the
+ *  registry entry rather than mutating one field in place, so it can't ride the
+ *  field mutators above. Accepts the union: a freshly-flipped sleeping entry
+ *  publishes its persisted base; `publishSnapshot` narrows the live overlay away
+ *  by `state`.
+ *
+ *  THE SOLE PUSH CHANNEL: `terminalMetadata`'s collection `upsert` is a no-op
+ *  that only pushes to subscribers — the registry IS the store — so this call is
+ *  the ONLY way a lifecycle flip reaches the client; `terminals:dirty` alone
+ *  never re-reads the registry. Every authored active↔sleeping flip and fresh
+ *  spawn MUST call this (sleep, wake/spawn, and the failed-wake restore all do).
+ *  `adoptTerminal` deliberately omits it — the saved session already pinned the
+ *  client (see its comment). */
 export function publishTerminalState(
   entry: TerminalProcess,
   terminalId: string,

--- a/packages/server/src/terminalEndpoint/sleepWake.test.ts
+++ b/packages/server/src/terminalEndpoint/sleepWake.test.ts
@@ -70,10 +70,11 @@ function recordingSurfaceCtx(
         return name === "terminalMetadata"
           ? {
               ...(inner as object),
-              upsert: (
-                id: string,
-                value: { state: TerminalMetadata["state"] },
-              ) => sink.push({ id, state: value.state }),
+              // Production upserts the WHOLE metadata record (`{ ...m }`); type
+              // `value` as that, not a `{ state }` projection, so the signature
+              // matches what the collection actually receives.
+              upsert: (id: string, value: TerminalMetadata) =>
+                sink.push({ id, state: value.state }),
             }
           : inner;
       },

--- a/packages/server/src/terminalEndpoint/sleepWake.test.ts
+++ b/packages/server/src/terminalEndpoint/sleepWake.test.ts
@@ -54,19 +54,26 @@ const ID = "11111111-1111-4111-8111-111111111111";
 function recordingSurfaceCtx(
   sink: Array<{ id: string; state: string }>,
 ): ReturnType<typeof noopSurfaceCtxForTest> {
-  const noop = () => {};
+  // Compose the canonical no-op ctx and add only this helper's single concern:
+  // record `terminalMetadata.upsert`. Every other collection member/method
+  // delegates to the base proxy, so the no-op shape lives in exactly one place
+  // (`surfaceCtx.ts`) and can't silently diverge here.
+  const base = noopSurfaceCtxForTest();
   return {
-    ...noopSurfaceCtxForTest(),
+    ...base,
     collections: new Proxy({} as never, {
-      get: (_t, name) => ({
-        upsert: (id: string, value: { state: string }) => {
-          if (name === "terminalMetadata")
-            sink.push({ id, state: value.state });
-        },
-        remove: noop,
-        readAll: () => new Map(),
-        readOne: () => undefined,
-      }),
+      get: (_t, name) => {
+        const inner = (base.collections as Record<string, unknown>)[
+          name as string
+        ];
+        return name === "terminalMetadata"
+          ? {
+              ...(inner as object),
+              upsert: (id: string, value: { state: string }) =>
+                sink.push({ id, state: value.state }),
+            }
+          : inner;
+      },
     }),
   } as ReturnType<typeof noopSurfaceCtxForTest>;
 }

--- a/packages/server/src/terminalEndpoint/sleepWake.test.ts
+++ b/packages/server/src/terminalEndpoint/sleepWake.test.ts
@@ -47,6 +47,30 @@ import {
 
 const ID = "11111111-1111-4111-8111-111111111111";
 
+/** A surface ctx that RECORDS every `terminalMetadata.upsert` into `sink` (id +
+ *  state), so a test can assert the authored snapshot was actually PUSHED to the
+ *  collection — not merely that a `terminals:dirty` trigger fired. Built off the
+ *  no-op ctx, overriding only the collections proxy. */
+function recordingSurfaceCtx(
+  sink: Array<{ id: string; state: string }>,
+): ReturnType<typeof noopSurfaceCtxForTest> {
+  const noop = () => {};
+  return {
+    ...noopSurfaceCtxForTest(),
+    collections: new Proxy({} as never, {
+      get: (_t, name) => ({
+        upsert: (id: string, value: { state: string }) => {
+          if (name === "terminalMetadata")
+            sink.push({ id, state: value.state });
+        },
+        remove: noop,
+        readAll: () => new Map(),
+        readOne: () => undefined,
+      }),
+    }),
+  } as ReturnType<typeof noopSurfaceCtxForTest>;
+}
+
 function activeEntry(): ActiveTerminalProcess {
   return {
     info: { id: ID, pid: 4242 },
@@ -315,6 +339,54 @@ describe("wake — a failed PTY spawn must NOT drop the sleeping record (F2)", (
     expect(entry.meta.lastAgentCommand).toBe("claude --model sonnet");
     expect(entry.meta.sleptAt).toBe(222);
     expect(entry.handle).toBeUndefined();
+  });
+});
+
+describe("wake/spawn PUSHES the authored active snapshot (issue #1529)", () => {
+  // The general invariant: a no-op-upsert collection backed by an external store
+  // (the registry) reaches the client SOLELY through an explicit publish, so
+  // every authored lifecycle flip — especially sleep↔active and spawn — must
+  // publish, not merely fire `terminals:dirty`. Sleep already does
+  // (`publishTerminalState(sleeping, id)`); before this fix the wake/spawn core
+  // (`registerActiveAndSpawn`) emitted only the dirty trigger, so a woken
+  // terminal's registry meta flipped to active while the client stayed pinned to
+  // the stale sleeping snapshot (`isLive` false → the dormant tile body never
+  // yielded to the live xterm).
+  const PUB_ID = "44444444-4444-4444-8444-444444444444";
+  const sleepingRecord = () => ({
+    id: PUB_ID,
+    state: "sleeping" as const,
+    sleptAt: 222,
+    cwd: "/work/repo",
+    git: null,
+    location: LOCAL_LOCATION,
+    lastActivityAt: 7,
+    lastAgentCommand: "claude --model sonnet",
+  });
+
+  let upserts: Array<{ id: string; state: string }>;
+
+  beforeEach(() => {
+    // Replace the suite-wide no-op ctx with a recording one (the double-call
+    // guard forbids swapping ctx without a reset first).
+    __resetSurfaceCtxForTest();
+    upserts = [];
+    setSurfaceCtx(recordingSurfaceCtx(upserts));
+  });
+
+  afterEach(() => unregisterTerminal(PUB_ID));
+
+  it("pushes the active snapshot on wake, not just a dirty signal", () => {
+    expect(seedSleepingTerminal(sleepingRecord())).toBe(true);
+    // The seed itself doesn't publish; start from a clean slate regardless.
+    upserts.length = 0;
+
+    // Wake registers the active sync-shadow synchronously, publishing the active
+    // snapshot BEFORE the async spawn tail (which fails in the unit env — no
+    // kaval — and then restores the sleeping record). Assert at that sync point.
+    wakeLocalTerminal(PUB_ID);
+    expect(getTerminal(PUB_ID)?.meta.state).toBe("active");
+    expect(upserts).toContainEqual({ id: PUB_ID, state: "active" });
   });
 });
 

--- a/packages/server/src/terminalEndpoint/sleepWake.test.ts
+++ b/packages/server/src/terminalEndpoint/sleepWake.test.ts
@@ -23,6 +23,7 @@ import {
   LOCAL_LOCATION,
   SavedTerminalSchema,
   type SleepingTerminal,
+  type TerminalMetadata,
 } from "kolu-common/surface";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -52,7 +53,7 @@ const ID = "11111111-1111-4111-8111-111111111111";
  *  collection — not merely that a `terminals:dirty` trigger fired. Built off the
  *  no-op ctx, overriding only the collections proxy. */
 function recordingSurfaceCtx(
-  sink: Array<{ id: string; state: string }>,
+  sink: Array<{ id: string; state: TerminalMetadata["state"] }>,
 ): ReturnType<typeof noopSurfaceCtxForTest> {
   // Compose the canonical no-op ctx and add only this helper's single concern:
   // record `terminalMetadata.upsert`. Every other collection member/method
@@ -69,8 +70,10 @@ function recordingSurfaceCtx(
         return name === "terminalMetadata"
           ? {
               ...(inner as object),
-              upsert: (id: string, value: { state: string }) =>
-                sink.push({ id, state: value.state }),
+              upsert: (
+                id: string,
+                value: { state: TerminalMetadata["state"] },
+              ) => sink.push({ id, state: value.state }),
             }
           : inner;
       },
@@ -350,15 +353,11 @@ describe("wake — a failed PTY spawn must NOT drop the sleeping record (F2)", (
 });
 
 describe("wake/spawn PUSHES the authored active snapshot (issue #1529)", () => {
-  // The general invariant: a no-op-upsert collection backed by an external store
-  // (the registry) reaches the client SOLELY through an explicit publish, so
-  // every authored lifecycle flip — especially sleep↔active and spawn — must
-  // publish, not merely fire `terminals:dirty`. Sleep already does
-  // (`publishTerminalState(sleeping, id)`); before this fix the wake/spawn core
-  // (`registerActiveAndSpawn`) emitted only the dirty trigger, so a woken
-  // terminal's registry meta flipped to active while the client stayed pinned to
-  // the stale sleeping snapshot (`isLive` false → the dormant tile body never
-  // yielded to the live xterm).
+  // Pins the invariant documented at `publishTerminalState`: a lifecycle flip
+  // reaches the client only through that publish, never through `terminals:dirty`
+  // alone. Before this fix the wake/spawn core (`registerActiveAndSpawn`) emitted
+  // only the dirty trigger, so a woken terminal's registry meta flipped to active
+  // while the client stayed pinned to the stale sleeping snapshot.
   const PUB_ID = "44444444-4444-4444-8444-444444444444";
   const sleepingRecord = () => ({
     id: PUB_ID,
@@ -371,7 +370,7 @@ describe("wake/spawn PUSHES the authored active snapshot (issue #1529)", () => {
     lastAgentCommand: "claude --model sonnet",
   });
 
-  let upserts: Array<{ id: string; state: string }>;
+  let upserts: Array<{ id: string; state: TerminalMetadata["state"] }>;
 
   beforeEach(() => {
     // Replace the suite-wide no-op ctx with a recording one (the double-call


### PR DESCRIPTION
**A woken terminal stays showing its dormant body instead of the live xterm** — because the wake/spawn path never publishes the authored snapshot. `terminalMetadata`'s collection `upsert` is a no-op that only *pushes* to subscribers (the registry **is** the store), so state reaches the client solely through `publishTerminalState`/`publishSnapshot`; `terminals:dirty` alone never re-reads it.

The asymmetry: the **sleep** path publishes (`beginSleep` → `publishTerminalState(sleeping, id)`), but the shared wake/spawn core (`registerActiveAndSpawn`) emitted only `terminals:dirty`. A wake flips `entry.meta` to `active` on the *same id* the sleep last pushed as `sleeping` — so the registry goes active while the client stays pinned to the stale sleeping snapshot (`isLive` false → the dormant tile body never yields to the live xterm). Fresh spawns never push their birth record either.

```
sleep:   beginSleep ───────────────▶ publishTerminalState(sleeping)   ✓ client sees sleeping
wake:    registerActiveAndSpawn ───▶ emitTerminalsDirty() only        ✗ client stuck on sleeping
fix:     registerActiveAndSpawn ───▶ publishTerminalState(active)     ✓ client flips to live
```

The fix pairs the authored flip with an explicit publish, mirroring the sleep path. `publishTerminalState` fires `terminals:dirty` internally, so it *subsumes* the prior `emitTerminalsDirty()` — one call, not two. This is exactly what discarded PR #1510's commit `5bce5eab1` did.

> _Latent today_ — the current collection re-reads on dirty — but it surfaces the moment the sleeping↔active flip rides the browser ws under the one-surface `terminalMetadata` (the R8 awareness compose). The general invariant worth pinning: **a no-op-upsert collection backed by an external store requires an explicit publish on every authored lifecycle flip** (sleep ↔ active, spawn).

### Test

A recording surface ctx asserts the wake path *pushes* the active snapshot — not merely a dirty signal. Red before the fix (`expected [] to contain { state: "active" }`), green after.

Closes #1529

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-8\`)._