### PR TITLE
chore(skills): be-review retries codex on a thrown StructuredOutput Workflow crash, not just reviewer-error

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -127,15 +127,24 @@ the workflow's notification arrives or it has provably errored.
    body to post** — per `/codex-debate`, an unresolved reviewer error is not a
    consensus to report; skip the codex comment in that case.)
 
-   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
-   last meaning codex never
+   **Retry codex (up to 3 attempts) on `reviewer-error` _or_ a workflow-level
+   crash.** `/codex-debate` ends in `consensus`, `commit-incomplete` (see below),
+   or `reviewer-error` — the last meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
-   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
-   outcome*: re-launch it immediately with the same args. Stop the moment an
-   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
-   you give up on codex — report the persistent reviewer-error honestly (no false
-   consensus comment) and move on to the simplify step.
+   per-`codex exec` retries. The **same retry rule covers a thrown Workflow** —
+   a task-notification with `status: failed` and a `TelemetrySafeError`
+   (e.g. `agent({schema}): StructuredOutput retry cap (5) exceeded`) instead of a
+   returned `status`: that is the schema-constrained `agent()` call inside the
+   debate workflow failing, an *infrastructure hiccup, not a debate outcome*,
+   exactly like `reviewer-error`. Both paths: **re-launch immediately with the
+   same args.** The per-round commits the crashed/errored attempt already landed
+   are preserved in git (so each retry reviews an *already-cleaner* diff and may
+   converge in round 1), and the workflow wipes its own stale `section-*.md`
+   ledger on every fresh launch — so **do not hand-clear scratch or cherry-pick
+   the partial round; just re-launch.** Stop the moment an attempt reaches
+   `consensus`. Only if **all 3** come back `reviewer-error`/crash do you give up
+   on codex — report the persistent failure honestly (no false consensus comment),
+   keep the committed round fixes, and move on to the simplify step.
 
    **On `commit-incomplete`,** the debate converged but a round's author left its
    edits uncommitted (round numbers in `commitGaps`). The edits are still in the

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -202,7 +202,8 @@ warm session, so re-feeding it the sections would just duplicate its context.
   **not** a clean consensus: a human must reconcile the uncommitted round(s)
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
-- **reviewer-error** — the one *abnormal* terminus: codex itself failed to
+- **reviewer-error** — an *abnormal* terminus the workflow still **returns**:
+  codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
   **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
@@ -212,6 +213,17 @@ warm session, so re-feeding it the sections would just duplicate its context.
   (default 3 attempts; tune via `CODEX_REVIEW_RETRIES` / `CODEX_REVIEW_BACKOFF`)
   and only synthesizes the reviewer-error verdict once every attempt comes back
   empty — so a single codex hiccup no longer sinks the round.
+- **a thrown Workflow (no returned `status`)** — the *other* infrastructure
+  failure: one of the schema-constrained `agent({schema})` calls (the codex
+  verdict / Claude response / merge-base resolver) exhausts its own retries and
+  throws `TelemetrySafeError: StructuredOutput retry cap (N) exceeded`, which
+  aborts the whole Workflow mid-debate (the task-notification shows
+  `status: failed`, not one of the three returned termini above). Like
+  `reviewer-error` this is **a harness hiccup, not a debate outcome** — and the
+  **same remedy**: re-launch with the same args. Any per-round fix already
+  committed is preserved in git, and the next launch wipes its own stale
+  `section-*.md` ledger, so a fresh attempt owns a fresh ledger — **don't
+  hand-clean scratch.**
 
 ### 3. Present the result
 

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -127,15 +127,24 @@ the workflow's notification arrives or it has provably errored.
    body to post** — per `/codex-debate`, an unresolved reviewer error is not a
    consensus to report; skip the codex comment in that case.)
 
-   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
-   last meaning codex never
+   **Retry codex (up to 3 attempts) on `reviewer-error` _or_ a workflow-level
+   crash.** `/codex-debate` ends in `consensus`, `commit-incomplete` (see below),
+   or `reviewer-error` — the last meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
-   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
-   outcome*: re-launch it immediately with the same args. Stop the moment an
-   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
-   you give up on codex — report the persistent reviewer-error honestly (no false
-   consensus comment) and move on to the simplify step.
+   per-`codex exec` retries. The **same retry rule covers a thrown Workflow** —
+   a task-notification with `status: failed` and a `TelemetrySafeError`
+   (e.g. `agent({schema}): StructuredOutput retry cap (5) exceeded`) instead of a
+   returned `status`: that is the schema-constrained `agent()` call inside the
+   debate workflow failing, an *infrastructure hiccup, not a debate outcome*,
+   exactly like `reviewer-error`. Both paths: **re-launch immediately with the
+   same args.** The per-round commits the crashed/errored attempt already landed
+   are preserved in git (so each retry reviews an *already-cleaner* diff and may
+   converge in round 1), and the workflow wipes its own stale `section-*.md`
+   ledger on every fresh launch — so **do not hand-clear scratch or cherry-pick
+   the partial round; just re-launch.** Stop the moment an attempt reaches
+   `consensus`. Only if **all 3** come back `reviewer-error`/crash do you give up
+   on codex — report the persistent failure honestly (no false consensus comment),
+   keep the committed round fixes, and move on to the simplify step.
 
    **On `commit-incomplete`,** the debate converged but a round's author left its
    edits uncommitted (round numbers in `commitGaps`). The edits are still in the

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -202,7 +202,8 @@ warm session, so re-feeding it the sections would just duplicate its context.
   **not** a clean consensus: a human must reconcile the uncommitted round(s)
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
-- **reviewer-error** — the one *abnormal* terminus: codex itself failed to
+- **reviewer-error** — an *abnormal* terminus the workflow still **returns**:
+  codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
   **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
@@ -212,6 +213,17 @@ warm session, so re-feeding it the sections would just duplicate its context.
   (default 3 attempts; tune via `CODEX_REVIEW_RETRIES` / `CODEX_REVIEW_BACKOFF`)
   and only synthesizes the reviewer-error verdict once every attempt comes back
   empty — so a single codex hiccup no longer sinks the round.
+- **a thrown Workflow (no returned `status`)** — the *other* infrastructure
+  failure: one of the schema-constrained `agent({schema})` calls (the codex
+  verdict / Claude response / merge-base resolver) exhausts its own retries and
+  throws `TelemetrySafeError: StructuredOutput retry cap (N) exceeded`, which
+  aborts the whole Workflow mid-debate (the task-notification shows
+  `status: failed`, not one of the three returned termini above). Like
+  `reviewer-error` this is **a harness hiccup, not a debate outcome** — and the
+  **same remedy**: re-launch with the same args. Any per-round fix already
+  committed is preserved in git, and the next launch wipes its own stale
+  `section-*.md` ledger, so a fresh attempt owns a fresh ledger — **don't
+  hand-clean scratch.**
 
 ### 3. Present the result
 

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -127,15 +127,24 @@ the workflow's notification arrives or it has provably errored.
    body to post** — per `/codex-debate`, an unresolved reviewer error is not a
    consensus to report; skip the codex comment in that case.)
 
-   **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
-   last meaning codex never
+   **Retry codex (up to 3 attempts) on `reviewer-error` _or_ a workflow-level
+   crash.** `/codex-debate` ends in `consensus`, `commit-incomplete` (see below),
+   or `reviewer-error` — the last meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
-   per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
-   outcome*: re-launch it immediately with the same args. Stop the moment an
-   attempt reaches `consensus`. Only if **all 3** come back `reviewer-error` do
-   you give up on codex — report the persistent reviewer-error honestly (no false
-   consensus comment) and move on to the simplify step.
+   per-`codex exec` retries. The **same retry rule covers a thrown Workflow** —
+   a task-notification with `status: failed` and a `TelemetrySafeError`
+   (e.g. `agent({schema}): StructuredOutput retry cap (5) exceeded`) instead of a
+   returned `status`: that is the schema-constrained `agent()` call inside the
+   debate workflow failing, an *infrastructure hiccup, not a debate outcome*,
+   exactly like `reviewer-error`. Both paths: **re-launch immediately with the
+   same args.** The per-round commits the crashed/errored attempt already landed
+   are preserved in git (so each retry reviews an *already-cleaner* diff and may
+   converge in round 1), and the workflow wipes its own stale `section-*.md`
+   ledger on every fresh launch — so **do not hand-clear scratch or cherry-pick
+   the partial round; just re-launch.** Stop the moment an attempt reaches
+   `consensus`. Only if **all 3** come back `reviewer-error`/crash do you give up
+   on codex — report the persistent failure honestly (no false consensus comment),
+   keep the committed round fixes, and move on to the simplify step.
 
    **On `commit-incomplete`,** the debate converged but a round's author left its
    edits uncommitted (round numbers in `commitGaps`). The edits are still in the

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -202,7 +202,8 @@ warm session, so re-feeding it the sections would just duplicate its context.
   **not** a clean consensus: a human must reconcile the uncommitted round(s)
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
-- **reviewer-error** — the one *abnormal* terminus: codex itself failed to
+- **reviewer-error** — an *abnormal* terminus the workflow still **returns**:
+  codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
   **infrastructure failure, not a debate outcome** — `finalVerdict.summary`
@@ -212,6 +213,17 @@ warm session, so re-feeding it the sections would just duplicate its context.
   (default 3 attempts; tune via `CODEX_REVIEW_RETRIES` / `CODEX_REVIEW_BACKOFF`)
   and only synthesizes the reviewer-error verdict once every attempt comes back
   empty — so a single codex hiccup no longer sinks the round.
+- **a thrown Workflow (no returned `status`)** — the *other* infrastructure
+  failure: one of the schema-constrained `agent({schema})` calls (the codex
+  verdict / Claude response / merge-base resolver) exhausts its own retries and
+  throws `TelemetrySafeError: StructuredOutput retry cap (N) exceeded`, which
+  aborts the whole Workflow mid-debate (the task-notification shows
+  `status: failed`, not one of the three returned termini above). Like
+  `reviewer-error` this is **a harness hiccup, not a debate outcome** — and the
+  **same remedy**: re-launch with the same args. Any per-round fix already
+  committed is preserved in git, and the next launch wipes its own stale
+  `section-*.md` ledger, so a fresh attempt owns a fresh ledger — **don't
+  hand-clean scratch.**
 
 ### 3. Present the result
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -320,10 +320,10 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .agents/skills/be-review/SKILL.md: sha256:2559181daa2a8a491d285bad4287f734964f296011fb5be085f1ae43610a8c73
+  .agents/skills/be-review/SKILL.md: sha256:2574ddf4f7c0eb1c106c1ffde0e1571b4e093c87e4bfee5dbf059c4b1353eb39
   .agents/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
+  .agents/skills/codex-debate/SKILL.md: sha256:8c5c6bbca3cd87282a144349e350fb182f12e0f03db483a82a2887f8a5cad178
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
   .agents/skills/codex-debate/debate.workflow.js: sha256:71c0a508b3eb2cd5f39f0a37e7b1195673abba428283158d06e320eee2d586d0
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
@@ -356,10 +356,10 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2f96cb3cd96e5e985130c5baae68ac4f6d4c91097085dcb96979b8bd9353db8d
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .claude/skills/be-review/SKILL.md: sha256:2559181daa2a8a491d285bad4287f734964f296011fb5be085f1ae43610a8c73
+  .claude/skills/be-review/SKILL.md: sha256:2574ddf4f7c0eb1c106c1ffde0e1571b4e093c87e4bfee5dbf059c4b1353eb39
   .claude/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
+  .claude/skills/codex-debate/SKILL.md: sha256:8c5c6bbca3cd87282a144349e350fb182f12e0f03db483a82a2887f8a5cad178
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
   .claude/skills/codex-debate/debate.workflow.js: sha256:71c0a508b3eb2cd5f39f0a37e7b1195673abba428283158d06e320eee2d586d0
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25


### PR DESCRIPTION
## Why

The `/be` review gauntlet's **codex** step can fail two distinct ways, but `be-review` only named one — so when the *other* hit, the run had to improvise.

| failure | shape | named before? |
|---|---|---|
| `reviewer-error` | a **returned** `status` — codex produced no verdict (broken/unavailable CLI) | yes — retry up to 3× |
| **thrown Workflow** | a **`status: failed`** task-notification with `TelemetrySafeError: agent({schema}): StructuredOutput retry cap (N) exceeded` — a schema-constrained `agent()` call inside `debate.workflow.js` exhausts its own retries and throws, aborting the debate mid-flight | **no** |

Both are infrastructure hiccups, not debate outcomes, and both want the same remedy (re-launch with the same args). But because the second wasn't named, on the crash the agent had to *reason out* the analogy to `reviewer-error` before re-launching — a place a human could easily have had to step in instead.

## What

- **`be-review/SKILL.md`** — the retry clause now covers `reviewer-error` **or** a thrown StructuredOutput Workflow crash, routing both to the same "re-launch immediately, up to 3 attempts" path. It also bakes in two facts the agent had to derive live: any per-round fix the crashed attempt committed is **preserved in git** (so each retry reviews an already-cleaner diff and often converges in round 1), and the workflow **wipes its own stale `section-*.md` ledger on every launch** — so *don't* hand-clear scratch or cherry-pick the partial round; just re-launch.
- **`codex-debate/SKILL.md`** — added the thrown-Workflow failure mode to the terminus list (alongside `consensus` / `commit-incomplete` / `reviewer-error`) so it's named **at the source**, not re-derived by every caller.
- Generated runtime copies (`.claude/`, `.agents/`) + `apm.lock.yaml` regenerated via `just ai::apm` and ride the same commit; markdown-only.

## Evidence

| edit | claim | evidence |
|---|---|---|
| be-review retry clause | the gap was real — `reviewer-error` covered, workflow-crash not | pre-edit `be-review/SKILL.md:130-138` named only `reviewer-error`; `codex-debate/SKILL.md:173` returns `consensus \| commit-incomplete \| reviewer-error` — a thrown `TelemetrySafeError` is none of these |
| "preserved in git, don't hand-clean scratch" | the remedy is just-re-launch, not manual cleanup | `debate.workflow.js:415-424` self-resets `section-*.md` on every launch ("no true resume … a fresh start owns a fresh ledger"); round commits live in git |
| both edits | source + generated copies carry the new text | `grep 'StructuredOutput retry cap'` matches `.claude/` + `.agents/` copies; `apm.lock.yaml` hashes updated |
| gates | markdown-only, nothing breaks | `just fmt` → 0 reformatted; `just check` → typecheck all packages + biome `--error-on-warnings` green |

## Provenance

Mined from `/be` run session `740fcd18-7ff4-49c3-a52d-6b27a2d61353` (PR #1555, R-activity-merge). `/codex-debate` crashed **twice** mid-debate with the identical `StructuredOutput retry cap (5) exceeded` error (`wbuq2v9wf`, `wwepa5k11`), each **after round 1 had committed a real fix** (`8617bf9f9`, `cff0f0790` — the second was a genuine `sideEffects` tree-shaking catch); attempt 3 (`w7b8k6kzk`) converged in round 1. The agent recovered correctly each time, but only by deriving the `reviewer-error` analogy itself — this PR bakes that derivation in.

Other turns in that run (a visual ring-diameter / Dock-whitespace correction, a client-doesn't-show-activity bug report, a `--pause` flag question, an explicit master-merge request) were content-specific or feature ideas, not durably-recurring engineerable friction, so no edit was made for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)