### PR TITLE
feat(website): add Discord invite link

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -26,6 +26,13 @@ const year = new Date().getFullYear();
           class="hover:text-amber transition-colors">github.com/juspay/kolu</a
         >
       </div>
+      <div>
+        <a
+          href="https://discord.com/invite/9acjNV8nmS"
+          rel="noopener"
+          class="hover:text-amber transition-colors">discord ↗</a
+        >
+      </div>
     </div>
   </div>
 </footer>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -16,6 +16,7 @@ const nav = [
   { label: 'Get started', href: `${href('/')}#quickstart`, path: '/', hideOnMobile: true },
   { label: 'Changelog', href: href('/changelog'), path: '/changelog' },
   { label: 'Blog', href: href('/blog'), path: '/blog' },
+  { label: 'Discord', href: 'https://discord.com/invite/9acjNV8nmS', external: true },
   { label: 'GitHub', href: 'https://github.com/juspay/kolu', external: true },
 ];
 ---


### PR DESCRIPTION
Adds our Discord community invite link to the marketing website.

- **Header nav** — a `Discord ↗` link alongside the existing GitHub entry.
- **Footer** — a `discord ↗` line under the GitHub link.

Both point to https://discord.com/invite/9acjNV8nmS and mirror the existing external-link styling (no new icon assets needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)