### PR TITLE
fix(codex-debate): decouple the author payload from finding count via section files (#1569)

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -169,7 +169,8 @@ the workflow's notification arrives or it has provably errored.
    it). Don't report it as a clean consensus.
 
    **On `section-incomplete`,** the debate converged but a round's author **skipped
-   its disposition section file** (round numbers in `sectionGaps`), so the per-round
+   or under-filled its disposition section file** (missing, empty, or omitting a
+   marker for an open finding; round numbers in `sectionGaps`), so the per-round
    trail — and thus `$workDir/comment.md` — has a gap for that round. The tree edits
    and commits are intact; the missing piece is the record. **Append** a note to the
    already-frozen `$workDir/comment.md` naming the round(s) whose disposition record

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -136,13 +136,22 @@ the workflow's notification arrives or it has provably errored.
    } > "$workDir/comment.md"   # hold this path for the post-after-push step
    ```
 
-   (On persistent `reviewer-error` there is **no body to post** — per
-   `/codex-debate`, an unresolved reviewer error is not a consensus to report; skip
-   the codex comment in that case.)
+   This **freezes** the body now, so any reconciliation a later branch performs
+   (a `commit-incomplete` or `section-incomplete` fix-up below) is **not** in this
+   file yet — **append** that note to `$workDir/comment.md` after you reconcile, or
+   it won't reach the posted comment.
+
+   (On `merge-base-error` the workflow aborted before any debate ran, so there is
+   **no** `commentHeader`/`workDir`/`section-*.md` to assemble — do **not** run the
+   block above. Per `/codex-debate`, report the scope failure from the return's
+   `note`, fix the base ref (e.g. `git fetch`), and re-run; there's nothing to post.
+   On persistent `reviewer-error` there is likewise **no body to post** — an
+   unresolved reviewer error is not a consensus to report; skip the codex comment in
+   that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
-   last meaning codex never
+   in `consensus`, `commit-incomplete` / `section-incomplete` (see below),
+   `reviewer-error`, or `merge-base-error` — `reviewer-error` meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
    per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
    outcome*: re-launch it immediately with the same args. Stop the moment an
@@ -154,9 +163,18 @@ the workflow's notification arrives or it has provably errored.
    edits uncommitted (round numbers in `commitGaps`). The edits are still in the
    tree, but the per-round commit didn't land — **commit the outstanding tree
    yourself** (staging only the files that round changed, message
-   `fix: codex review — debate round N`) before the simplify step, and note the
-   reconciliation in the deferred codex comment. Don't report it as a clean
-   consensus.
+   `fix: codex review — debate round N`) before the simplify step, then **append**
+   the reconciliation note to the already-frozen `$workDir/comment.md` (the body was
+   captured above *before* this fix-up, so editing the section files wouldn't reach
+   it). Don't report it as a clean consensus.
+
+   **On `section-incomplete`,** the debate converged but a round's author **skipped
+   its disposition section file** (round numbers in `sectionGaps`), so the per-round
+   trail — and thus `$workDir/comment.md` — has a gap for that round. The tree edits
+   and commits are intact; the missing piece is the record. **Append** a note to the
+   already-frozen `$workDir/comment.md` naming the round(s) whose disposition record
+   is missing, and report it as **converged-but-not-clean** in your gauntlet summary.
+   Don't report it as a clean consensus.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it

--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -35,9 +35,11 @@ be-review pushes only once, after all selected steps finish. A comment that name
 a commit SHA must never be posted while that SHA is local-only — if a later step
 failed or the run were interrupted, the PR would advertise commits that were
 never pushed. So the debate skills run with their self-commenting **suppressed**
-(`--no-comment`); be-review captures the comment body each returns, pushes once at
-the end, and only then posts the lens comment, the codex comment, and its own
-police summary. No PR comment can reference a local-only commit.
+(`--no-comment`); be-review captures each comment body (the lens skill returns one
+ready; the codex body it assembles from `commentHeader` + the section files —
+step 2), pushes once at the end, and only then posts the lens comment, the codex
+comment, and its own police summary. No PR comment can reference a local-only
+commit.
 
 ## Preflight
 
@@ -122,10 +124,21 @@ the workflow's notification arrives or it has provably errored.
    not just the diff** — every round) and `rationale` (so codex doesn't flag
    deliberate decisions at the source) straight through. Its step-2 `Workflow` runs
    in the background; **wait for it to finish** before starting the simplify step.
-   It commits its rounds and **returns** its rendered comment body — hold onto it
-   to post after the final push. (On persistent `reviewer-error` there is **no
-   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
-   consensus to report; skip the codex comment in that case.)
+   It commits its rounds and returns a `commentHeader` plus the per-round section
+   files under `workDir` (it no longer returns a single pre-rendered comment string).
+   **Assemble the comment body now and hold it** to post after the final push —
+   capture it immediately so a later step can't disturb the scratch:
+
+   ```bash
+   {
+     printf '%s\n' "$commentHeader"
+     for f in "$workDir"/section-*.md; do printf '\n'; cat "$f"; printf '\n'; done
+   } > "$workDir/comment.md"   # hold this path for the post-after-push step
+   ```
+
+   (On persistent `reviewer-error` there is **no body to post** — per
+   `/codex-debate`, an unresolved reviewer error is not a consensus to report; skip
+   the codex comment in that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
    in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
@@ -191,9 +204,10 @@ merges when satisfied.
 When you do post, post **one comment per track that produced a body** — skip any
 track `--tracks` excluded, and skip a track that ran but yielded no postable
 comment (lens on `merge-base-error`, codex on persistent `reviewer-error`): the
-lens body and the codex body verbatim (`gh pr comment -F`), and the police
-summary (the `## [👮 Code-police](https://agency.srid.ca/)` comment described in
-Report).
+lens body and the codex body verbatim (`gh pr comment -F` — the codex body is the
+`$workDir/comment.md` you assembled in step 2 from `commentHeader` + the section
+files), and the police summary (the
+`## [👮 Code-police](https://agency.srid.ca/)` comment described in Report).
 
 ## Report
 

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -170,15 +170,30 @@ worktrees never collide** and the scratch never shows up in the diff codex
 reviews. It returns:
 
 ```
-{ status: "consensus" | "commit-incomplete" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
+{ status: "consensus" | "commit-incomplete" | "section-incomplete" | "reviewer-error",
+  rounds, base, finalVerdict, filesChanged, commitGaps, sectionGaps, transcript,
   commentHeader,        // the comment's small deterministic header (badge + round count + effort + base)
   workDir, sectionGlob } // where the per-round section files live; cat them under the header (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed;
 `commitGaps` lists the round numbers whose author edited files but returned no
-commit SHA — empty unless `status === "commit-incomplete"`.)
+commit SHA — empty unless `status === "commit-incomplete"`; `sectionGaps` lists the
+round numbers whose author left no disposition section file — empty unless
+`status === "section-incomplete"`.)
+
+There is one more, **earlier** terminus the workflow can return **before** the
+debate loop even starts — `merge-base-error`. If `git merge-base <base> HEAD`
+fails (a missing/typoed/stale base, or unrelated history), the diff scope can't be
+trusted, so the workflow **aborts up front** rather than review the base branch's
+drift as if this change made it. It returns a **different, smaller shape** — no
+`commentHeader`, `workDir`, or `sectionGlob`, because no debate (and so no section
+files) ever ran:
+
+```
+{ status: "merge-base-error", base, rounds: 0, transcript: [], finalVerdict: null,
+  note }   // human-readable: which base failed and how to fix it (e.g. `git fetch`)
+```
 The debate is recorded as small Markdown section files under `<workDir>` — **two
 per round**: `section-NNN-1-codex.md` (codex's verdict + findings) and
 `section-NNN-2-claude.md` (the author's per-finding dispositions), zero-padded so
@@ -211,6 +226,22 @@ session and only ever reads the one rebuttal file.
   **not** a clean consensus: a human must reconcile the uncommitted round(s)
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
+- **section-incomplete** — the debate *converged*, but a round's author **skipped
+  its disposition section file** (`section-NNN-2-claude.md` missing or empty for the
+  round(s) in `sectionGaps`). That file is the hole-free trail everyone draws on —
+  the author's memory, the rebuttal codex reads next round, and part of the posted
+  comment — so a miss means the published record has a gap. The code guards against
+  feeding an empty rebuttal to codex (it warns and keeps the prior pointer), and the
+  tree edits are still present, but this is **not** a clean consensus: a human must
+  fill in the missing round(s) before trusting the per-round record. Do **not**
+  report it as a plain consensus (see step 3).
+- **merge-base-error** — an *up-front* abort, **before** any debate round runs:
+  `git merge-base <base> HEAD` failed (missing/typoed/stale base, or unrelated
+  history), so the review scope can't be trusted. The return carries a human-readable
+  `note` (which base failed, how to fix it — e.g. `git fetch`) and **none** of the
+  comment-assembly fields (`commentHeader`/`workDir`/`sectionGlob`), because no
+  section files were ever written. Report the scope failure and **skip comment
+  assembly/posting entirely** (see step 3); fix the base ref and re-run.
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
@@ -224,7 +255,16 @@ session and only ever reads the one rebuttal file.
 
 ### 3. Present the result
 
-**First branch on `status`.** If `status === "reviewer-error"`, the debate did
+**First branch on `status`.** If `status === "merge-base-error"`, the workflow
+**aborted before any debate ran** — `git merge-base <base> HEAD` failed, so the
+review scope couldn't be trusted. This return has **no** `commentHeader`,
+`workDir`, or `sectionGlob` (no section files exist), so there is **nothing to
+assemble**: do **not** run the posting block below. Report the scope failure —
+surface the return's `note` (it names the failing base and the fix) — tell the
+user to repair the base ref (e.g. `git fetch`, fix a typo'd/stale ref) and re-run,
+and **skip the rest of this section**.
+
+If `status === "reviewer-error"`, the debate did
 **not** reach consensus — codex never produced a real verdict. Report it as a
 **failure**, not a success: surface `finalVerdict.summary` (and the workflow log)
 so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
@@ -239,6 +279,13 @@ block below — `commentHeader` already shows a `⚠️` badge, not the consensu
 check), then tell the user which round(s) are uncommitted and that the outstanding
 tree must be committed before the per-round history can be trusted. Do **not** call
 it a clean consensus.
+
+If `status === "section-incomplete"`, the debate converged but at least one round's
+author **skipped its disposition section file** (round numbers in `sectionGaps`).
+Report it as **converged-but-not-clean**: assemble and post the comment as usual
+(the `⚠️` badge is already set), then tell the user which round(s) are missing
+their disposition record and that the per-round history has a gap a human should
+fill before trusting it. Do **not** call it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -164,29 +164,38 @@ codex findings and Claude's dispositions — never pushing or merging. (The comm
 is no longer a separate `commit:roundN` agent: the author already has the tree
 open, so it commits its own round.)
 
-Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
-gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in
-different worktrees never collide** and the scratch never shows up in the diff
-codex reviews. It returns:
+Ephemeral scratch (verdicts, the debate ledger) lives under the gitignored,
+per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in different
+worktrees never collide** and the scratch never shows up in the diff codex
+reviews. It returns:
 
 ```
 { status: "consensus" | "commit-incomplete" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
-  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
+  commentHeader,        // the comment's small deterministic header (badge + round count + effort + base)
+  workDir, sectionGlob } // where the per-round section files live; cat them under the header (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed;
 `commitGaps` lists the round numbers whose author edited files but returned no
 commit SHA — empty unless `status === "commit-incomplete"`.)
-The debate is recorded as **one small Markdown file per round** —
-`<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
-author's cross-round memory** (so each round builds on the last instead of
-re-deriving the diff). The workflow renders the **same** record into `comment` —
-the outcome header followed by every round's section — so **step 3 just posts that
-string** (`gh pr comment -F`), exactly the way `/lens-debate` does. The comment is
-therefore a **deterministic** render, never re-improvised through an agent —
-nothing weak ever retypes a large blob. codex is *not* a reader — it keeps its own
-warm session, so re-feeding it the sections would just duplicate its context.
+The debate is recorded as small Markdown section files under `<workDir>` — **two
+per round**: `section-NNN-1-codex.md` (codex's verdict + findings) and
+`section-NNN-2-claude.md` (the author's per-finding dispositions), zero-padded so
+the `section-*.md` glob sorts in chronological order. **Each file is written by the
+party that owns its content**: a Haiku writer renders codex's small *structured*
+verdict to disk, and the **author writes its own dispositions directly** — the same
+way codex writes its verdict to a path. That author-writes-its-own-file design is
+deliberate: it keeps the author's *structured* return a **minimal ack**
+(`filesChanged`/`commitSha`/`done`), so a big multi-finding narrative can never
+overflow the structured-output encoding (the failure that used to crash the debate
+on large diffs). The author's disposition file does triple duty — it's the author's
+cross-round **memory**, the **rebuttal** codex reads next round (`codex-review.sh`
+cats it straight into codex's prompt), and the **published comment** (step 3 cats
+the section files under `commentHeader`). So the comment is still a **deterministic**
+render — a shell `cat`, never re-improvised through an agent, nothing weak ever
+retyping a large blob. codex is *not* a memory reader — it keeps its own warm
+session and only ever reads the one rebuttal file.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -225,10 +234,11 @@ report. Skip the rest of this section.
 
 If `status === "commit-incomplete"`, the debate converged but at least one round
 left its edits **uncommitted** (the round numbers are in `commitGaps`). Report it
-as **converged-but-not-clean**: post the `comment` (its header already shows a
-`⚠️` badge, not the consensus check), then tell the user which round(s) are
-uncommitted and that the outstanding tree must be committed before the per-round
-history can be trusted. Do **not** call it a clean consensus.
+as **converged-but-not-clean**: assemble and post the comment (see the posting
+block below — `commentHeader` already shows a `⚠️` badge, not the consensus
+check), then tell the user which round(s) are uncommitted and that the outstanding
+tree must be committed before the per-round history can be trusted. Do **not** call
+it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):
@@ -243,31 +253,37 @@ the per-round commits sit on the local branch for the human to review):
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round summary — read it straight from the section files
-  (`cat <workDir>/section-*.md`: each round's codex verdict, Claude's
-  dispositions, and the commit SHA) so the convergence reads round by round. No
-  need to re-derive it from `transcript`; the sections already render it.
+  (`cat <workDir>/section-*.md`: each round's codex verdict, then the author's
+  dispositions and commit SHA) so the convergence reads round by round. No need to
+  re-derive it from `transcript`; the sections already render it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
-  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
+  `--no-comment` was NOT passed, **assemble** the comment from the workflow's
+  return — the small `commentHeader`, then the per-round section files `cat`-ed in
+  glob order — and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  mkdir -p "$repoPath/.codex-debate"   # reviewer-error/--no-commit runs may not have created it
-  printf '%s' "$comment" > "$repoPath/.codex-debate/comment.md"
-  gh pr comment <pr> -F "$repoPath/.codex-debate/comment.md"
+  mkdir -p "$workDir"   # reviewer-error/--no-commit runs may not have created it
+  {
+    printf '%s\n' "$commentHeader"
+    for f in "$workDir"/section-*.md; do printf '\n'; cat "$f"; printf '\n'; done
+  } > "$workDir/comment.md"
+  gh pr comment <pr> -F "$workDir/comment.md"
   ```
 
-  The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
-  header (consensus badge, round count, the **reasoning-effort** note from the
-  workflow's `REASONING_EFFORT` constant) followed by the per-round breakdown of
-  codex's findings and Claude's dispositions
-  that the author also read. So the comment is a **deterministic** render of the
-  same record the commit messages and the author drew on — not an LLM-improvised
-  table. Posting the returned string mirrors `/lens-debate`. This is an
-  outward-facing write — on by default because the whole point is to leave the
-  review trail on the PR; `--no-comment` suppresses it.
+  (`$workDir` is the returned `workDir`, i.e. `<repoPath>/.codex-debate`; the
+  `for`-loop guarantees a blank line between sections regardless of each file's
+  trailing newline.) The result is the `## Codex ⇄ Claude debate` header (consensus
+  badge, round count, the **reasoning-effort** note from the workflow's
+  `REASONING_EFFORT` constant) followed by the per-round breakdown of codex's
+  findings and the author's dispositions — the **same** section files the author
+  read as memory and codex read as the rebuttal. So the comment is a
+  **deterministic** shell concat of the record everyone drew on, not an
+  LLM-improvised table — nothing weak ever retypes a blob. This is an outward-facing
+  write — on by default because the whole point is to leave the review trail on the
+  PR; `--no-comment` suppresses it.
 
 <a id="answer-mode"></a>
 # Answer mode — Codex ⇄ Claude answer debate
@@ -424,15 +440,21 @@ returns:
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
   so there's no session id to carry forward. The equivalent is context, not state:
   each follow-up round the author **reads the per-round section files**
-  (`cat .codex-debate/section-*.md`) — every prior round's findings and its own
-  dispositions — so it builds on its last round rather than re-deriving the whole
-  diff, and won't re-fix or re-litigate findings already settled. A small section
-  is written after each round, so round N>1 always sees rounds 1..N-1; round 1 has
-  none yet, so it's byte-identical to a cold start (and if no sections exist, the
-  author falls back to the diff + verdict). The *same* sections compose the PR
-  comment step 3 posts, so the author's memory and the published summary are one
-  record. The writes stay small (one round each), so the Haiku writer never
-  retypes a large blob. codex stays on its own warm session and never reads them.
+  (`cat .codex-debate/section-*.md`) — every prior round's codex findings and its
+  own dispositions — so it builds on its last round rather than re-deriving the
+  whole diff, and won't re-fix or re-litigate findings already settled. Each round
+  writes two small files (a Haiku-rendered codex section and the author's own
+  disposition section), so round N>1 always sees rounds 1..N-1; round 1 has none
+  yet, so it's byte-identical to a cold start (and if no sections exist, the author
+  falls back to the diff + verdict). The *same* sections compose the PR comment step
+  3 posts and the rebuttal codex reads, so the author's memory, the published
+  summary, and codex's rebuttal are one record. Crucially, the author **writes its
+  own disposition section directly** — it never has to pour that narrative through a
+  structured field — so its structured return stays a minimal ack and can't overflow
+  on a large, many-finding diff (the failure this design replaced). The Haiku writer
+  only ever renders codex's small *structured* verdict, so nothing weak retypes a
+  large blob. codex stays on its own warm session and never reads the sections —
+  only the one rebuttal file each round.
 - **Inherited context, not just diff.** On top of that cross-round memory, when the
   caller passes `context` and/or `rationale` the author **inherits them in EVERY
   round's prompt** — the main-agent intent (what the change is FOR) and the
@@ -446,13 +468,14 @@ returns:
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the per-round
-  sections) lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`,
-  so debates on many worktrees run at once without clobbering each other — no
-  shared `/tmp` paths, and each worktree's section files are its own.
+- **Parallel-safe.** Ephemeral scratch (verdicts and the per-round section files,
+  the author-written ones doubling as the rebuttal) lives under the gitignored,
+  per-worktree `<repoPath>/.codex-debate/`, so debates on many worktrees run at once
+  without clobbering each other — no shared `/tmp` paths, and each worktree's section
+  files are its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  workflow's deterministically rendered `comment` (header + per-round sections) —
-  is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
+  `commentHeader` followed by the per-round section files `cat`-ed together (step 3)
+  — is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
   — the point is to leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because

--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -227,8 +227,9 @@ session and only ever reads the one rebuttal file.
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
 - **section-incomplete** — the debate *converged*, but a round's author **skipped
-  its disposition section file** (`section-NNN-2-claude.md` missing or empty for the
-  round(s) in `sectionGaps`). That file is the hole-free trail everyone draws on —
+  or under-filled its disposition section file** (`section-NNN-2-claude.md` missing,
+  empty, or missing a backticked marker for an open finding, for the round(s) in
+  `sectionGaps`). That file is the hole-free trail everyone draws on —
   the author's memory, the rebuttal codex reads next round, and part of the posted
   comment — so a miss means the published record has a gap. The code guards against
   feeding an empty rebuttal to codex (it warns and keeps the prior pointer), and the
@@ -281,7 +282,8 @@ tree must be committed before the per-round history can be trusted. Do **not** c
 it a clean consensus.
 
 If `status === "section-incomplete"`, the debate converged but at least one round's
-author **skipped its disposition section file** (round numbers in `sectionGaps`).
+author **skipped or under-filled its disposition section file** (missing, empty, or
+omitting a marker for an open finding; round numbers in `sectionGaps`).
 Report it as **converged-but-not-clean**: assemble and post the comment as usual
 (the `⚠️` badge is already set), then tell the user which round(s) are missing
 their disposition record and that the per-round history has a gap a human should

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -363,6 +363,34 @@ async function writeCodexSection(round, verdict) {
   return writeFileAgent(codexSectionFile(round), codexSection(round, verdict), `ledger:codex:round${round}`)
 }
 
+// VERIFY the author actually wrote its disposition section this round. The author's
+// claude section is the load-bearing handoff: it's the next round's rebuttal (codex
+// reads it), the author's own cross-round memory, AND part of the posted comment.
+// If the author skipped the Write, `lastClaudeSectionPath` would still point at a
+// path that doesn't exist — codex-review.sh would warn and proceed with an EMPTY
+// rebuttal, and the debate could still converge over a hole in the trail. So after
+// every author turn we deterministically check the file exists and is non-empty;
+// the workflow has no file I/O of its own, so a thin mechanical agent does the
+// `test -s`. We do NOT parse the file for finding-id coverage — the disposition
+// CONTRACT (one bullet per finding) plus codex's own next-round re-review already
+// police completeness; a markdown-id grep here would be brittle and redundant. This
+// check is the file's EXISTENCE/non-emptiness, the part nothing else guards. A miss
+// is recorded as a section gap and downgrades the terminal status (see below), the
+// same fail-loud-not-silent treatment as a missed commit.
+async function verifyClaudeSection(round) {
+  const path = claudeSectionFile(round)
+  const res = await agent(
+    `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`test -s ${shq(path)} && echo present || echo missing\`. Return \`ok\`: true if the output was "present" (the file exists and is non-empty), false otherwise. Do not edit any file. Do not run git.`,
+    {
+      label: `verify:claude:round${round}`,
+      phase: 'Debate',
+      model: mechModel,
+      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists and is non-empty' } } },
+    },
+  )
+  return res?.ok === true
+}
+
 const transcript = []
 // 'consensus' is the only NORMAL terminus. 'reviewer-error' is the one abnormal
 // terminus: codex itself failed to produce a verdict (broken/unavailable). That
@@ -384,6 +412,13 @@ let lastClaudeSectionPath = null
 // report success over a missed commit. Not a hard abort: a transient SHA omission
 // shouldn't nuke a multi-round debate whose edits are all present in the tree.
 const commitGaps = []
+// Rounds where the author's disposition section file is missing or empty after its
+// turn — the handoff that feeds the rebuttal, the author's memory, and the comment
+// broke. We DON'T silently let an empty rebuttal slip to codex (which would warn and
+// proceed, possibly converging over a hole in the trail): a miss is recorded here
+// and downgrades the terminal status to 'section-incomplete' below. Not a hard abort
+// for the same reason as commitGaps — the tree edits are still present and reviewed.
+const sectionGaps = []
 
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
@@ -498,14 +533,27 @@ for (let round = 1; ; round++) {
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
   // rest, and writes its dispositions to its own claude section file (its memory,
   // the rebuttal codex reads next round, and part of the posted comment). It reads
-  // the per-round section files for its cross-round memory. We remember the path it
-  // just wrote so the NEXT round feeds it to codex as the rebuttal.
+  // the per-round section files for its cross-round memory. We point the rebuttal at
+  // the path it just wrote so the NEXT round feeds it to codex — but only AFTER
+  // verifying the file actually landed (see verifyClaudeSection below).
   const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
-  lastClaudeSectionPath = claudeSectionFile(round)
   log(
     `Round ${round}: claude done=${response.done}, files=${(response.filesChanged || []).length}`,
   )
+
+  // VERIFY the author wrote its disposition section before we lean on it. The file
+  // is the next round's rebuttal, the author's memory, and part of the comment — if
+  // it's missing/empty the handoff broke. Only point `lastClaudeSectionPath` at it
+  // (so codex reads it as the rebuttal next round) once it actually exists; on a miss
+  // record the gap, leave the rebuttal pointer where it was (codex sees `-`/the prior
+  // round's section rather than an empty one), and downgrade the terminal status.
+  if (await verifyClaudeSection(round)) {
+    lastClaudeSectionPath = claudeSectionFile(round)
+  } else {
+    sectionGaps.push(round)
+    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing or empty — handoff broke; not feeding it to codex as the rebuttal.`)
+  }
 
   // The author commits its own round in-session (one commit per round, message
   // carrying codex's findings and its dispositions), so here we just record the
@@ -545,6 +593,19 @@ if (status === 'consensus' && commitGaps.length) {
   log(`Round(s) ${commitGaps.join(', ')} left uncommitted despite changing files — downgrading consensus to commit-incomplete.`)
 }
 
+// Downgrade a would-be consensus when any round's author skipped its disposition
+// section file. The debate may read as converged, but a missing section is a hole in
+// the trail the author, codex (as the rebuttal), and the posted comment all draw on —
+// so we must NOT advertise a clean consensus. 'section-incomplete' is a distinct,
+// non-consensus terminus: a human/caller must fill in the missing round(s) before
+// trusting the per-round record. We don't override an already-abnormal status
+// (reviewer-error, or commit-incomplete which is reported the same converged-but-
+// -not-clean way) — the first downgrade already marks the run unclean.
+if (status === 'consensus' && sectionGaps.length) {
+  status = 'section-incomplete'
+  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section — downgrading consensus to section-incomplete.`)
+}
+
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
 // The terminal round needs no extra section write: codex's section for it was
@@ -567,6 +628,9 @@ return {
   // Rounds whose author-side commit didn't land (empty unless status is
   // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
   commitGaps,
+  // Rounds whose author-side disposition section file is missing/empty (empty unless
+  // status is 'section-incomplete'). Lets the caller pinpoint the hole in the trail.
+  sectionGaps,
   transcript,
   // The comment's deterministic header (badge + round count + reasoning effort +
   // base). The orchestrator posts: this header, a blank line, then

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -369,23 +369,35 @@ async function writeCodexSection(round, verdict) {
 // If the author skipped the Write, `lastClaudeSectionPath` would still point at a
 // path that doesn't exist — codex-review.sh would warn and proceed with an EMPTY
 // rebuttal, and the debate could still converge over a hole in the trail. So after
-// every author turn we deterministically check the file exists and is non-empty;
-// the workflow has no file I/O of its own, so a thin mechanical agent does the
-// `test -s`. We do NOT parse the file for finding-id coverage — the disposition
-// CONTRACT (one bullet per finding) plus codex's own next-round re-review already
-// police completeness; a markdown-id grep here would be brittle and redundant. This
-// check is the file's EXISTENCE/non-emptiness, the part nothing else guards. A miss
-// is recorded as a section gap and downgrades the terminal status (see below), the
-// same fail-loud-not-silent treatment as a missed commit.
-async function verifyClaudeSection(round) {
+// every author turn we deterministically check the file exists, is non-empty, AND
+// carries a backticked disposition marker for EVERY open finding this round. The
+// workflow has no file I/O of its own, so a thin mechanical agent runs `test -s`
+// plus an exact `grep -F` per finding id. We do NOT parse prose or score the
+// disposition text — only that a `\`Fn\`` token is present, which is an exact,
+// bounded check the author prompt already mandates ("one bullet PER finding",
+// each id backticked). This closes the hole the file-as-source-of-truth opened:
+// a non-empty but INCOMPLETE section (omitting `F2`) used to advance the rebuttal
+// pointer and could converge over a per-finding hole in the durable trail. A miss
+// — empty file OR any missing finding id — is recorded as a section gap and
+// downgrades the terminal status (see below), the same fail-loud-not-silent
+// treatment as a missed commit. Codex's own next-round re-review still polices
+// the SUBSTANCE of each disposition; this guards only the COMPLETENESS of the
+// published per-finding record, which nothing else covers.
+async function verifyClaudeSection(round, openIds) {
   const path = claudeSectionFile(round)
+  // Each open finding must appear as a backticked id token (e.g. `F1`) in the
+  // section. `grep -F` is a literal substring match — no regex/prose brittleness.
+  const idChecks = openIds
+    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo missing-${id}; ok=0; }`)
+    .join('; ')
+  const idList = openIds.length ? openIds.map((id) => `\`${id}\``).join(', ') : '(none)'
   const res = await agent(
-    `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`test -s ${shq(path)} && echo present || echo missing\`. Return \`ok\`: true if the output was "present" (the file exists and is non-empty), false otherwise. Do not edit any file. Do not run git.`,
+    `You are a MECHANICAL RUNNER. Run exactly this and nothing else, then report:\n\`ok=1; test -s ${shq(path)} || { echo empty; ok=0; }${idChecks ? `; ${idChecks}` : ''}; echo "ok=$ok"\`\nThis checks the section file exists, is non-empty, and contains a backticked marker for every open finding (${idList}). Return \`ok\`: true if the final line was "ok=1", false otherwise (any "empty" or "missing-Fn" line means false). Do not edit any file. Do not run git.`,
     {
       label: `verify:claude:round${round}`,
       phase: 'Debate',
       model: mechModel,
-      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists and is non-empty' } } },
+      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists, is non-empty, and carries a backticked marker for every open finding' } } },
     },
   )
   return res?.ok === true
@@ -412,12 +424,14 @@ let lastClaudeSectionPath = null
 // report success over a missed commit. Not a hard abort: a transient SHA omission
 // shouldn't nuke a multi-round debate whose edits are all present in the tree.
 const commitGaps = []
-// Rounds where the author's disposition section file is missing or empty after its
-// turn — the handoff that feeds the rebuttal, the author's memory, and the comment
-// broke. We DON'T silently let an empty rebuttal slip to codex (which would warn and
-// proceed, possibly converging over a hole in the trail): a miss is recorded here
-// and downgrades the terminal status to 'section-incomplete' below. Not a hard abort
-// for the same reason as commitGaps — the tree edits are still present and reviewed.
+// Rounds where the author's disposition section file is missing, empty, OR missing
+// a backticked marker for one or more open findings after its turn — the handoff
+// that feeds the rebuttal, the author's memory, and the comment broke. We DON'T
+// silently let an empty or per-finding-incomplete rebuttal slip to codex (which
+// would warn and proceed, possibly converging over a hole in the trail): a miss is
+// recorded here and downgrades the terminal status to 'section-incomplete' below.
+// Not a hard abort for the same reason as commitGaps — the tree edits are still
+// present and reviewed.
 const sectionGaps = []
 
 // ---------------------------------------------------------------------------
@@ -544,15 +558,18 @@ for (let round = 1; ; round++) {
 
   // VERIFY the author wrote its disposition section before we lean on it. The file
   // is the next round's rebuttal, the author's memory, and part of the comment — if
-  // it's missing/empty the handoff broke. Only point `lastClaudeSectionPath` at it
-  // (so codex reads it as the rebuttal next round) once it actually exists; on a miss
-  // record the gap, leave the rebuttal pointer where it was (codex sees `-`/the prior
-  // round's section rather than an empty one), and downgrade the terminal status.
-  if (await verifyClaudeSection(round)) {
+  // it's missing/empty/incomplete the handoff broke. We require a backticked marker
+  // for every finding the author had to address this round (`open`), so a non-empty
+  // but partial section can't slip a per-finding hole into the trail. Only point
+  // `lastClaudeSectionPath` at it (so codex reads it as the rebuttal next round) once
+  // it exists AND covers every open id; on a miss record the gap, leave the rebuttal
+  // pointer where it was (codex sees `-`/the prior round's section rather than an
+  // incomplete one), and downgrade the terminal status.
+  if (await verifyClaudeSection(round, open.map((f) => f.id))) {
     lastClaudeSectionPath = claudeSectionFile(round)
   } else {
     sectionGaps.push(round)
-    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing or empty — handoff broke; not feeding it to codex as the rebuttal.`)
+    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing, empty, or missing a marker for an open finding — handoff broke; not feeding it to codex as the rebuttal.`)
   }
 
   // The author commits its own round in-session (one commit per round, message
@@ -594,8 +611,9 @@ if (status === 'consensus' && commitGaps.length) {
 }
 
 // Downgrade a would-be consensus when any round's author skipped its disposition
-// section file. The debate may read as converged, but a missing section is a hole in
-// the trail the author, codex (as the rebuttal), and the posted comment all draw on —
+// section file OR left it missing a marker for an open finding. The debate may read
+// as converged, but a missing or per-finding-incomplete section is a hole in the
+// trail the author, codex (as the rebuttal), and the posted comment all draw on —
 // so we must NOT advertise a clean consensus. 'section-incomplete' is a distinct,
 // non-consensus terminus: a human/caller must fill in the missing round(s) before
 // trusting the per-round record. We don't override an already-abnormal status
@@ -603,7 +621,7 @@ if (status === 'consensus' && commitGaps.length) {
 // -not-clean way) — the first downgrade already marks the run unclean.
 if (status === 'consensus' && sectionGaps.length) {
   status = 'section-incomplete'
-  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section — downgrading consensus to section-incomplete.`)
+  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section or a finding marker — downgrading consensus to section-incomplete.`)
 }
 
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -388,7 +388,7 @@ async function verifyClaudeSection(round, openIds) {
   // Each open finding must appear as a backticked id token (e.g. `F1`) in the
   // section. `grep -F` is a literal substring match — no regex/prose brittleness.
   const idChecks = openIds
-    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo missing-${id}; ok=0; }`)
+    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo ${shq(`missing-${id}`)}; ok=0; }`)
     .join('; ')
   const idList = openIds.length ? openIds.map((id) => `\`${id}\``).join(', ') : '(none)'
   const res = await agent(

--- a/.agents/skills/codex-debate/debate.workflow.js
+++ b/.agents/skills/codex-debate/debate.workflow.js
@@ -30,14 +30,29 @@ const workDir = `${repoPath}/.codex-debate`
 // DESTRUCTIVE command (the ledger `rm -f` below); the benign `mkdir -p` prompts
 // elsewhere can tolerate an unquoted path, but a mistargeted `rm -f` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
-// The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
-// written under the gitignored scratch dir) — the claude author reads them as its
-// cross-round memory (full history, no inline blob). The PR comment is rendered
-// from the SAME per-round sections in-process (see renderLedger) and returned as
-// `comment`, so the published summary and the author's context are one record —
-// deterministic, never re-rendered through an agent (nothing weak ever retypes a
-// large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
-// it the ledger would just duplicate what it already remembers.
+// The debate is recorded as small Markdown SECTION FILES under the gitignored
+// scratch dir — TWO per round: `section-NNN-1-codex.md` (codex's verdict) and
+// `section-NNN-2-claude.md` (the author's dispositions). Each is written by the
+// party that OWNS its content, never forced through a structured payload:
+//   * codex's section — a Haiku writer renders the small STRUCTURED verdict
+//     (approval + findings) to disk; faithful, nothing to bloat.
+//   * claude's section — the AUTHOR writes its OWN per-finding dispositions
+//     directly (it's already editing the tree), exactly the way codex writes its
+//     verdict to a path. This is the STRUCTURAL fix for the old crash: the author
+//     used to pour its whole narrative into a structured field, which overflowed
+//     the StructuredOutput encoding and silently dropped the required array until
+//     the retry cap tripped. Now the narrative goes to the file and the author's
+//     structured return is a MINIMAL ACK (filesChanged/commitSha/done) whose size
+//     is decoupled from the finding count entirely, so it can never overflow.
+// These section files serve THREE roles at once, no copy ever re-typed by a weak
+// agent: (1) the author's cross-round memory (it cats them for full history);
+// (2) the REBUTTAL codex reads next round — codex-review.sh `cat`s the author's
+// section file straight into its prompt, so codex still sees every disposition;
+// (3) the published PR comment, which the orchestrator assembles by `cat`-ing the
+// section files after a small in-process header (see ledgerHeader / commentHeader)
+// — a deterministic shell concat, never re-rendered through an agent. codex is NOT
+// a memory reader: it keeps its own warm session, so it only ever reads the one
+// rebuttal file, not the whole ledger.
 // Commit each round's changes individually (default on). The author commits its
 // OWN round in-session — it already edits the tree, so it stages exactly what it
 // changed and writes a message carrying the debate context (codex's findings +
@@ -46,9 +61,11 @@ const commit = a.commit !== false
 // Model tiers. The claude-author round does real reasoning (fixing/disputing
 // codex's findings, and committing its own round) → `model` (Opus). Everything
 // else here is mechanical — the codex runner just shells out to codex-review.sh
-// and copies the verdict, the ledger writer dumps a section file, the merge-base
-// resolver runs one git command → `mechModel`
-// (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
+// and copies the verdict, the codex-section writer dumps a rendered verdict to a
+// file, the merge-base resolver runs one git command → `mechModel`
+// (Haiku). (The CLAUDE section is written by the author itself, on `model`, as part
+// of its round — not by a mechanical writer.) Defaults match a direct invocation;
+// /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
 // Fidelity tier (Sonnet). One "mechanical" job isn't a trivial command but a
@@ -57,7 +74,7 @@ const mechModel = a.mechModel || 'haiku'
 // validation checks the verdict's SHAPE, not its wording), and Haiku is the
 // weakest tier for verbatim reproduction — so the verdict relay runs a notch up.
 // Still far cheaper/faster than Opus; the real reviewing is codex's, not this
-// agent's. The small per-round section writes stay on Haiku (tiny payloads).
+// agent's. The small per-round codex-section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
 // --- Context the Claude implementor INHERITS --------------------------------
@@ -135,31 +152,28 @@ const CODEX_VERDICT_SCHEMA = {
   required: ['approved', 'summary', 'findings', 'responseToRebuttal'],
 }
 
+// The author's structured return is a MINIMAL ACK by design — no `summary`, no
+// per-finding `actions`. The full narrative (the per-finding dispositions AND the
+// round summary) is written by the author to its section file instead (see
+// claudeResponds), exactly the way codex writes its verdict to a path. This is the
+// structural fix for the old crash: a large structured payload (the author pouring
+// its whole F1/F2/F3 narrative into `summary` + one `detail` per finding)
+// overflowed the StructuredOutput encoding, which silently dropped the required
+// array and tripped the retry cap. With only these few small, fixed fields the
+// payload size is decoupled from the finding count entirely, so it can never
+// overflow. `filesChanged` is bounded by the files touched (not narrative);
+// `commitSha` is one hash; `done` is a flag.
 const CLAUDE_RESPONSE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   properties: {
-    summary: { type: 'string' },
-    actions: {
-      type: 'array',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          findingId: { type: 'string' },
-          disposition: { type: 'string', enum: ['fixed', 'disputed', 'partial'] },
-          detail: { type: 'string' },
-        },
-        required: ['findingId', 'disposition', 'detail'],
-      },
-    },
     filesChanged: { type: 'array', items: { type: 'string' } },
     // The author commits its own round (it already edits the tree), so it returns
     // the resulting SHA here. "" when it changed nothing or ran under --no-commit.
     commitSha: { type: 'string' },
     done: { type: 'boolean' },
   },
-  required: ['summary', 'actions', 'filesChanged', 'done'],
+  required: ['filesChanged', 'done'],
 }
 
 // Consensus = no finding left open, any severity. The loop runs until codex
@@ -171,30 +185,28 @@ function openFindings(verdict) {
 // ---------------------------------------------------------------------------
 // The two debaters
 // ---------------------------------------------------------------------------
-async function codexReviews(round, rebuttalJson) {
+async function codexReviews(round, rebuttalPath) {
   const verdictPath = `${workDir}/verdict-${round}.json`
-  const rebuttalPath = `${workDir}/rebuttal.json`
-  const rebuttalStep = rebuttalJson
-    ? `1. Using the Write tool (NOT a shell heredoc — the content has special characters), create the file \`${rebuttalPath}\` with exactly this content:
-
-${rebuttalJson}
-
-2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
-    : `1. (No prior rebuttal this round.)
-
-2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
+  // The rebuttal codex reads is the author's PRIOR-round disposition section file
+  // (it wrote it itself; codex-review.sh `cat`s it straight into codex's prompt).
+  // No inline blob, no separate rebuttal-file write step — the file already exists.
+  // `-` on round 1 (no prior author turn yet).
+  const rebuttalArg = rebuttalPath || '-'
+  const rebuttalNote = rebuttalPath
+    ? `   (\`${rebuttalPath}\` is the author's prior-round disposition section — codex reads it as the rebuttal. If it's somehow missing, the script proceeds with no rebuttal and warns; that's fine.)`
+    : `   (No prior rebuttal this round — the \`-\` argument tells the script there's none.)`
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
 First ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
 
-${rebuttalStep}
+1. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalArg} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\`
+${rebuttalNote}
 
    This shells out to the codex CLI as a read-only reviewer; it can take 1-3 minutes. It prints a JSON verdict as its final stdout and also writes it to the \`-o\` path.
 
-3. Read \`${verdictPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
+2. Read \`${verdictPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
 
   return agent(prompt, {
     label: `codex:round${round}`,
@@ -209,11 +221,12 @@ async function claudeResponds(round, verdict, doCommit) {
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
   // equivalent is context, not state: every follow-up round the author reads the
-  // per-round section files — the record of every prior round's findings and its
-  // OWN dispositions — and builds on them instead of re-deriving the diff. A
-  // section is written after each round (see the loop), so on round N>1 the files
-  // already hold rounds 1..N-1. Round 1 has none yet, so its prompt is
-  // byte-identical to a cold start.
+  // per-round section files — the record of every prior round's findings (codex's
+  // section, Haiku-written) and its OWN dispositions (the claude section it wrote
+  // itself last round) — and builds on them instead of re-deriving the diff. codex's
+  // section is written each round in the loop and the author writes its claude
+  // section as the LAST step of its own turn, so on round N>1 the files already hold
+  // rounds 1..N-1. Round 1 has none yet, so its prompt is byte-identical to a cold start.
   const priorBlock =
     round > 1
       ? `This is a FOLLOW-UP round. Every prior round is recorded as a small Markdown file under the debate's scratch dir — read them FIRST for the full history (codex's past findings and YOUR own dispositions):
@@ -234,13 +247,22 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the finding's detail rather than reporting a clean "fixed". ${
+You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the disposition rather than reporting a clean "fixed". ${
     doCommit
-      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
-      : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
+      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. You'll return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`.`
+      : `Edit the working tree only — do NOT git add/commit/push; you'll leave \`commitSha\` empty.`
   }
 
-Return: actions (one per finding — findingId, disposition, detail), filesChanged, commitSha, and done (true once you've addressed every finding this round).`
+RECORD your dispositions to a file — this is the durable trail and the heart of how this debate stays robust. The next round's author reads it as memory, codex reads it as your rebuttal, and it's what gets posted to the PR. So the FULL per-finding narrative lives in this file, NEVER in your structured return. Using the Write tool, create the file \`${claudeSectionFile(round)}\` (overwrite any existing one) with EXACTLY this Markdown shape:
+
+**claude** — <one sentence: what you did this round>
+
+- \`F1\` **fixed** — <why; what you changed; cite file:line>
+- \`F2\` **disputed** — <the specific technical reason codex is wrong; cite file:line>
+- \`F3\` **partial** — <what you fixed and what you didn't, and why>
+${doCommit ? '... one bullet PER finding (disposition ∈ fixed | disputed | partial), then:\n\ncommit: `<the SHA you committed, or omit this whole line if you changed nothing>`' : '... one bullet PER finding (disposition ∈ fixed | disputed | partial). (No commit line — running under --no-commit.)'}
+
+CRITICAL — your STRUCTURED RETURN IS A MINIMAL ACK, nothing more. Return ONLY: \`filesChanged\` (the source paths you edited — never the scratch file above), \`commitSha\` (the SHA, or "" if you changed nothing / under --no-commit), and \`done\` (true once you've addressed every finding this round). Do NOT put your summary or any per-finding detail in the structured output — all of that goes in the section file and the commit body. (This is deliberate: past runs CRASHED because the author poured a multi-finding narrative into a structured field, which overflowed the output encoding and dropped a required field until the retry cap tripped. Writing the narrative to the file instead removes that failure by construction — keep the structured payload tiny.)`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -251,7 +273,10 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
 }
 
 // ---------------------------------------------------------------------------
-// The shared ledger — rendered from the transcript, deterministically
+// The shared ledger — section files on disk, assembled into the comment by the
+// orchestrator (a faithful `cat`). The workflow renders only the small CODEX
+// section (from the structured verdict) and the comment HEADER in-process; the
+// author writes its own claude section (see claudeResponds).
 // ---------------------------------------------------------------------------
 // One codex finding as a Markdown bullet — the single projection of a finding's
 // fields for the ledger section. (The per-round commit message is now written by
@@ -260,50 +285,39 @@ function findingBullet(f) {
   return `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
 }
 
-// One author disposition as a Markdown bullet — the single projection of an
-// action's fields for the ledger section.
-function actionBullet(a) {
-  return `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
-}
-
-// One round's findings, as a Markdown list. Shared by the section renderer below.
+// One round's findings, as a Markdown list. Shared by the codex-section renderer.
 function renderFindings(verdict) {
   const list = (verdict.findings || []).map((f) => findingBullet(f)).join('\n')
   return list || '- _(none)_'
 }
 
-// One round's author dispositions, as a Markdown list. `null` on a terminal round
-// (codex approved or errored before the author got a turn).
-function renderActions(response) {
-  if (!response) return '_(no author turn — the debate ended this round)_'
-  const list = (response.actions || []).map((a) => actionBullet(a)).join('\n')
-  return list || '- _(no actions)_'
-}
-
-// One round as a Markdown section: codex's verdict, its response to the rebuttal,
-// and the author's dispositions + commit. The single per-round renderer — the
-// author reads these as its memory and they compose into the posted comment.
-function roundLedgerSection(entry) {
-  const { round, codex, claude, commit } = entry
+// CODEX's side of one round, as a Markdown section: its verdict, findings, and
+// response to the author's rebuttal. Rendered in-process from the STRUCTURED
+// verdict (small, faithful) and written to disk by a Haiku writer. The author's
+// side is a SEPARATE file the author writes itself (its dispositions), so this
+// renderer no longer touches the claude response at all — that's the decoupling
+// that keeps the author's structured payload minimal. This carries the round's
+// `### Round N` header (it's written every round, including the terminal one).
+function codexSection(round, verdict) {
   const lines = [
     `### Round ${round}`,
     '',
-    `**codex** — approved: \`${codex.approved}\``,
+    `**codex** — approved: \`${verdict.approved}\``,
     '',
-    codex.summary,
+    verdict.summary,
     '',
     'Findings:',
-    renderFindings(codex),
+    renderFindings(verdict),
   ]
-  if (codex.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${codex.responseToRebuttal}`)
-  lines.push('', `**claude** — ${claude ? claude.summary : '_(no author turn this round)_'}`, '', renderActions(claude))
-  if (commit) lines.push('', `commit: \`${commit}\``)
+  if (verdict.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${verdict.responseToRebuttal}`)
   return lines.join('\n')
 }
 
 // The comment header (small). The full comment is this header followed by the
-// per-round section files (see renderLedger). The workflow renders the whole
-// comment deterministically from the transcript — no agent ever retypes the blob.
+// per-round section files, `cat`-ed together by the orchestrator (see SKILL step 3)
+// — a deterministic shell concat, never re-rendered through an agent. The workflow
+// returns this header as `commentHeader`; it can't read the section files itself
+// (no I/O), so it hands the orchestrator the header + the section dir.
 //
 // This header's chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
 // deliberately kept STRUCTURALLY PARALLEL to lens-debate's renderComment header
@@ -317,27 +331,20 @@ function ledgerHeader(meta) {
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`${meta.reasoningEffort}\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
-// The whole PR comment, rendered deterministically in-process from the transcript:
-// the outcome header followed by each round's Markdown section. The per-round
-// section files on disk remain the author's cross-round memory (see writeSection);
-// this re-uses the SAME `roundLedgerSection` renderer to assemble the published
-// comment, so the orchestrator posts a ready string (`gh pr comment -F`) exactly
-// the way lens-debate does — no bespoke `cat` glob at the consumer, and nothing
-// weak ever retypes a large blob (the workflow builds the string itself).
-function renderLedger(transcript, meta) {
-  return [ledgerHeader(meta), ...transcript.map(roundLedgerSection)].join('\n\n')
-}
-
-// Zero-pad the round so the section glob (`section-*.md`) sorts in round order
-// (section-002 before section-010) for both the author's read and the assembly.
-const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
+// Per-round section file paths. TWO files per round, named so the `section-*.md`
+// glob sorts both into round order AND codex-before-claude WITHIN a round
+// (`section-001-1-codex.md` < `section-001-2-claude.md` < `section-002-1-codex.md`),
+// so `cat`-ing the glob yields the debate in chronological order for both the
+// author's memory read and the comment assembly. Zero-padded for the same reason.
+const codexSectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}-1-codex.md`
+const claudeSectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}-2-claude.md`
 
 // Drop a string to a scratch file via a mechanical Haiku writer — the single home
 // for the "write this content to this path" idiom (the workflow can't do file I/O
 // itself, and Claude isn't headless, so a tiny agent does it). Both the per-round
-// section writer and the one-shot rationale writer route through here; payloads are
-// small (one round / one note) so Haiku is safe, and overwriting is idempotent
-// (safe on a resume).
+// codex-section writer and the one-shot rationale writer route through here;
+// payloads are small (one round / one note) so Haiku is safe, and overwriting is
+// idempotent (safe on a resume).
 function writeFileAgent(path, content, label) {
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
@@ -348,11 +355,12 @@ ${content}`
   return agent(prompt, { label, phase: 'Debate', model: mechModel })
 }
 
-// Write ONE round's section to its own small file — the author reads these as its
-// cross-round memory, and the orchestrator cats them into the posted comment. No
-// whole-ledger retype: the payload is just this round.
-async function writeSection(entry) {
-  return writeFileAgent(sectionFile(entry.round), roundLedgerSection(entry), `ledger:round${entry.round}`)
+// Write ONE round's CODEX section to its own small file (the claude section is the
+// author's own write, in claudeResponds). The author reads these as cross-round
+// memory and the orchestrator cats them into the posted comment. No whole-ledger
+// retype: the payload is just this round's structured verdict, rendered.
+async function writeCodexSection(round, verdict) {
+  return writeFileAgent(codexSectionFile(round), codexSection(round, verdict), `ledger:codex:round${round}`)
 }
 
 const transcript = []
@@ -362,7 +370,12 @@ const transcript = []
 // distinct from the deliberate "no deadlock exit" for substantive disagreement.
 let status = 'consensus'
 let finalVerdict = null
-let lastClaude = null
+// The author's PRIOR-round disposition section file — fed to codex next round as
+// the rebuttal (codex-review.sh cats it into codex's prompt). null until the first
+// author turn writes one. This replaces the old in-memory rebuttal blob: the author
+// writes the file itself, so the dispositions never round-trip through structured
+// output, and codex reads them straight off disk.
+let lastClaudeSectionPath = null
 // Rounds where the author edited files (commit mode on) but returned no SHA —
 // the in-session commit it was told to make didn't land. The edits aren't lost
 // (they stay in the tree and the next reviewer still diffs them against base),
@@ -411,16 +424,18 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 
 // Clear any stale ledger from a PRIOR debate in this worktree. The scratch dir
 // is persistent (per-worktree, not per-run) and the section files use a flat,
-// stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
+// stable `section-NNN-*.md` namespace, so a previous longer debate's high-numbered
 // sections would otherwise survive into this run — the author cats `section-*.md`
-// as its memory (and they compose into the `comment` renderLedger returns), so stale
-// sections would pollute BOTH the author's context and the published trail. A
-// thin mechanical agent (the workflow can't run shell itself). The reset is
-// section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
-// whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
-// and any commit-message file the author writes) keep their own lifecycle and a
-// future pre-loop writer won't be silently wiped. This script has no true resume (agent() is one-shot, the
-// whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
+// as its memory, and the orchestrator cats them into the posted comment, so stale
+// sections would pollute BOTH the author's context and the published trail. (The
+// glob also catches a prior author's claude section files, which double as the
+// rebuttal codex reads, so a stale one must not linger either.) A thin mechanical
+// agent (the workflow can't run shell itself). The reset is section/ledger-scoped:
+// it deletes only the stale `section-*.md` files, not the whole scratch dir, so
+// other artifacts in there (verdict-N.json and any other per-run files) keep their
+// own lifecycle and a future pre-loop writer won't be silently wiped. This script
+// has no true resume (agent() is one-shot, the whole workflow re-runs from
+// scratch), so a fresh start owns a fresh ledger.
 await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
@@ -435,10 +450,18 @@ if (rationale) {
 }
 
 for (let round = 1; ; round++) {
-  const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
+  const verdict = await codexReviews(round, lastClaudeSectionPath)
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
   transcript.push(entry) // record this round (mutated in place as it progresses)
+
+  // Write codex's section for this round to disk straight away — before any
+  // terminal break — so EVERY round (including a consensus-approval or error round
+  // that never reaches the author) lands in the section record the author reads as
+  // memory and the orchestrator cats into the comment. The claude section is the
+  // author's own write later in the round, when there is an author turn.
+  await writeCodexSection(round, verdict)
+
   // Reviewer error — terminal failure path. The runner could not get a verdict
   // out of codex (broken/unavailable CLI), so codex-review.sh synthesized an
   // error verdict carrying reviewerError:true. There are no findings to route to
@@ -473,14 +496,15 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. It reads the per-round section files (written at the end of each round
-  // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
-  // rebuttal next round (see codexReviews) — it is no longer the author's memory.
+  // rest, and writes its dispositions to its own claude section file (its memory,
+  // the rebuttal codex reads next round, and part of the posted comment). It reads
+  // the per-round section files for its cross-round memory. We remember the path it
+  // just wrote so the NEXT round feeds it to codex as the rebuttal.
   const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
-  lastClaude = response
+  lastClaudeSectionPath = claudeSectionFile(round)
   log(
-    `Round ${round}: claude done=${response.done}, actions=${(response.actions || []).length}, files=${(response.filesChanged || []).length}`,
+    `Round ${round}: claude done=${response.done}, files=${(response.filesChanged || []).length}`,
   )
 
   // The author commits its own round in-session (one commit per round, message
@@ -500,11 +524,8 @@ for (let round = 1; ; round++) {
       log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA — round left uncommitted`)
     }
   }
-
-  // Write this round's section so the NEXT round's author can read the full
-  // history. Terminal rounds break above before reaching here, so they're
-  // sectioned just after the loop.
-  await writeSection(entry)
+  // No section write here: codex's section was written at the top of the loop, and
+  // the author wrote its own claude section during its turn — both already on disk.
 }
 
 const filesChanged = Array.from(
@@ -526,18 +547,17 @@ if (status === 'consensus' && commitGaps.length) {
 
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-// Section the terminal round — it broke out of the loop before the in-loop
-// writeSection, so without this its section (a consensus approval, or an error
-// reached before the author got a turn) would be missing from the disk record
-// the orchestrator reads for the chat summary (cat section-*.md) and the
-// author would read as memory if the debate somehow continued.
-if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
+// The terminal round needs no extra section write: codex's section for it was
+// written at the top of the loop (every round), and a terminal round has no author
+// turn (and so no claude section) by definition.
 
-// Hand the orchestrator the ready-to-post comment, rendered deterministically
-// in-process (header + per-round sections) — it just writes the string to a file
-// and posts it (`gh pr comment -F`), the same shape lens-debate uses. The section
-// files on disk stay the author's cross-round memory; this is the published view
-// of that same record, so no agent ever retypes the whole ledger. See SKILL step 3.
+// Hand the orchestrator everything it needs to post the comment, but NOT a single
+// pre-rendered `comment` string — the author's per-round dispositions live in the
+// section files on disk (it wrote them itself), and the workflow can't read files.
+// So we return the small in-process `commentHeader` plus the section dir + glob; the
+// orchestrator assembles the comment with a faithful `cat` (header followed by the
+// section files in glob order) and posts that — a deterministic shell concat, no
+// agent ever retyping the ledger. See SKILL step 3.
 return {
   status,
   rounds: transcript.length,
@@ -548,5 +568,11 @@ return {
   // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
   commitGaps,
   transcript,
-  comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
+  // The comment's deterministic header (badge + round count + reasoning effort +
+  // base). The orchestrator posts: this header, a blank line, then
+  // `cat <workDir>/section-*.md`.
+  commentHeader: ledgerHeader({ status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
+  // Where the per-round section files live, so the orchestrator can cat them.
+  workDir,
+  sectionGlob: `${workDir}/section-*.md`,
 }

--- a/.agents/skills/codex-debate/scripts/codex-review.sh
+++ b/.agents/skills/codex-debate/scripts/codex-review.sh
@@ -16,8 +16,10 @@
 #   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]
 #
 #   <base-branch>    branch to diff against (e.g. master)
-#   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
-#                    or "-" on the first round (no rebuttal yet)
+#   <rebuttal-file>  path to a file holding CLAUDE's previous-round response — the
+#                    author-written Markdown disposition section (its per-finding
+#                    fixed/disputed/partial trail), NOT JSON. "-" on the first round
+#                    (no rebuttal yet). Cat'd verbatim into codex's prompt below.
 #   <out-json>       path the JSON verdict is written to (also echoed to stdout)
 #   <reasoning-effort> codex model_reasoning_effort for this run; the debate
 #                    workflow passes its REASONING_EFFORT constant here so the
@@ -55,9 +57,10 @@ schema="$here/codex-verdict.schema.json"
 # shellcheck source=codex-exec-lib.sh
 source "$here/codex-exec-lib.sh"
 
-# Pull CLAUDE's previous response, if any. Built as a plain string and injected
-# below via a simple variable reference so any special characters in the JSON
-# (backticks, $, ...) stay literal (heredoc expansion results are not re-scanned).
+# Pull CLAUDE's previous-round response (the author's Markdown disposition section),
+# if any. Built as a plain string and injected below via a simple variable reference
+# so any special characters in the text (backticks, $, ...) stay literal (heredoc
+# expansion results are not re-scanned).
 rebuttal=""
 if [ "$rebuttal_file" != "-" ]; then
   if [ -s "$rebuttal_file" ]; then

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -169,7 +169,8 @@ the workflow's notification arrives or it has provably errored.
    it). Don't report it as a clean consensus.
 
    **On `section-incomplete`,** the debate converged but a round's author **skipped
-   its disposition section file** (round numbers in `sectionGaps`), so the per-round
+   or under-filled its disposition section file** (missing, empty, or omitting a
+   marker for an open finding; round numbers in `sectionGaps`), so the per-round
    trail — and thus `$workDir/comment.md` — has a gap for that round. The tree edits
    and commits are intact; the missing piece is the record. **Append** a note to the
    already-frozen `$workDir/comment.md` naming the round(s) whose disposition record

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -136,13 +136,22 @@ the workflow's notification arrives or it has provably errored.
    } > "$workDir/comment.md"   # hold this path for the post-after-push step
    ```
 
-   (On persistent `reviewer-error` there is **no body to post** — per
-   `/codex-debate`, an unresolved reviewer error is not a consensus to report; skip
-   the codex comment in that case.)
+   This **freezes** the body now, so any reconciliation a later branch performs
+   (a `commit-incomplete` or `section-incomplete` fix-up below) is **not** in this
+   file yet — **append** that note to `$workDir/comment.md` after you reconcile, or
+   it won't reach the posted comment.
+
+   (On `merge-base-error` the workflow aborted before any debate ran, so there is
+   **no** `commentHeader`/`workDir`/`section-*.md` to assemble — do **not** run the
+   block above. Per `/codex-debate`, report the scope failure from the return's
+   `note`, fix the base ref (e.g. `git fetch`), and re-run; there's nothing to post.
+   On persistent `reviewer-error` there is likewise **no body to post** — an
+   unresolved reviewer error is not a consensus to report; skip the codex comment in
+   that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
-   last meaning codex never
+   in `consensus`, `commit-incomplete` / `section-incomplete` (see below),
+   `reviewer-error`, or `merge-base-error` — `reviewer-error` meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
    per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
    outcome*: re-launch it immediately with the same args. Stop the moment an
@@ -154,9 +163,18 @@ the workflow's notification arrives or it has provably errored.
    edits uncommitted (round numbers in `commitGaps`). The edits are still in the
    tree, but the per-round commit didn't land — **commit the outstanding tree
    yourself** (staging only the files that round changed, message
-   `fix: codex review — debate round N`) before the simplify step, and note the
-   reconciliation in the deferred codex comment. Don't report it as a clean
-   consensus.
+   `fix: codex review — debate round N`) before the simplify step, then **append**
+   the reconciliation note to the already-frozen `$workDir/comment.md` (the body was
+   captured above *before* this fix-up, so editing the section files wouldn't reach
+   it). Don't report it as a clean consensus.
+
+   **On `section-incomplete`,** the debate converged but a round's author **skipped
+   its disposition section file** (round numbers in `sectionGaps`), so the per-round
+   trail — and thus `$workDir/comment.md` — has a gap for that round. The tree edits
+   and commits are intact; the missing piece is the record. **Append** a note to the
+   already-frozen `$workDir/comment.md` naming the round(s) whose disposition record
+   is missing, and report it as **converged-but-not-clean** in your gauntlet summary.
+   Don't report it as a clean consensus.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it

--- a/.apm/skills/be-review/SKILL.md
+++ b/.apm/skills/be-review/SKILL.md
@@ -35,9 +35,11 @@ be-review pushes only once, after all selected steps finish. A comment that name
 a commit SHA must never be posted while that SHA is local-only — if a later step
 failed or the run were interrupted, the PR would advertise commits that were
 never pushed. So the debate skills run with their self-commenting **suppressed**
-(`--no-comment`); be-review captures the comment body each returns, pushes once at
-the end, and only then posts the lens comment, the codex comment, and its own
-police summary. No PR comment can reference a local-only commit.
+(`--no-comment`); be-review captures each comment body (the lens skill returns one
+ready; the codex body it assembles from `commentHeader` + the section files —
+step 2), pushes once at the end, and only then posts the lens comment, the codex
+comment, and its own police summary. No PR comment can reference a local-only
+commit.
 
 ## Preflight
 
@@ -122,10 +124,21 @@ the workflow's notification arrives or it has provably errored.
    not just the diff** — every round) and `rationale` (so codex doesn't flag
    deliberate decisions at the source) straight through. Its step-2 `Workflow` runs
    in the background; **wait for it to finish** before starting the simplify step.
-   It commits its rounds and **returns** its rendered comment body — hold onto it
-   to post after the final push. (On persistent `reviewer-error` there is **no
-   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
-   consensus to report; skip the codex comment in that case.)
+   It commits its rounds and returns a `commentHeader` plus the per-round section
+   files under `workDir` (it no longer returns a single pre-rendered comment string).
+   **Assemble the comment body now and hold it** to post after the final push —
+   capture it immediately so a later step can't disturb the scratch:
+
+   ```bash
+   {
+     printf '%s\n' "$commentHeader"
+     for f in "$workDir"/section-*.md; do printf '\n'; cat "$f"; printf '\n'; done
+   } > "$workDir/comment.md"   # hold this path for the post-after-push step
+   ```
+
+   (On persistent `reviewer-error` there is **no body to post** — per
+   `/codex-debate`, an unresolved reviewer error is not a consensus to report; skip
+   the codex comment in that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
    in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
@@ -191,9 +204,10 @@ merges when satisfied.
 When you do post, post **one comment per track that produced a body** — skip any
 track `--tracks` excluded, and skip a track that ran but yielded no postable
 comment (lens on `merge-base-error`, codex on persistent `reviewer-error`): the
-lens body and the codex body verbatim (`gh pr comment -F`), and the police
-summary (the `## [👮 Code-police](https://agency.srid.ca/)` comment described in
-Report).
+lens body and the codex body verbatim (`gh pr comment -F` — the codex body is the
+`$workDir/comment.md` you assembled in step 2 from `commentHeader` + the section
+files), and the police summary (the
+`## [👮 Code-police](https://agency.srid.ca/)` comment described in Report).
 
 ## Report
 

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -170,15 +170,30 @@ worktrees never collide** and the scratch never shows up in the diff codex
 reviews. It returns:
 
 ```
-{ status: "consensus" | "commit-incomplete" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
+{ status: "consensus" | "commit-incomplete" | "section-incomplete" | "reviewer-error",
+  rounds, base, finalVerdict, filesChanged, commitGaps, sectionGaps, transcript,
   commentHeader,        // the comment's small deterministic header (badge + round count + effort + base)
   workDir, sectionGlob } // where the per-round section files live; cat them under the header (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed;
 `commitGaps` lists the round numbers whose author edited files but returned no
-commit SHA — empty unless `status === "commit-incomplete"`.)
+commit SHA — empty unless `status === "commit-incomplete"`; `sectionGaps` lists the
+round numbers whose author left no disposition section file — empty unless
+`status === "section-incomplete"`.)
+
+There is one more, **earlier** terminus the workflow can return **before** the
+debate loop even starts — `merge-base-error`. If `git merge-base <base> HEAD`
+fails (a missing/typoed/stale base, or unrelated history), the diff scope can't be
+trusted, so the workflow **aborts up front** rather than review the base branch's
+drift as if this change made it. It returns a **different, smaller shape** — no
+`commentHeader`, `workDir`, or `sectionGlob`, because no debate (and so no section
+files) ever ran:
+
+```
+{ status: "merge-base-error", base, rounds: 0, transcript: [], finalVerdict: null,
+  note }   // human-readable: which base failed and how to fix it (e.g. `git fetch`)
+```
 The debate is recorded as small Markdown section files under `<workDir>` — **two
 per round**: `section-NNN-1-codex.md` (codex's verdict + findings) and
 `section-NNN-2-claude.md` (the author's per-finding dispositions), zero-padded so
@@ -211,6 +226,22 @@ session and only ever reads the one rebuttal file.
   **not** a clean consensus: a human must reconcile the uncommitted round(s)
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
+- **section-incomplete** — the debate *converged*, but a round's author **skipped
+  its disposition section file** (`section-NNN-2-claude.md` missing or empty for the
+  round(s) in `sectionGaps`). That file is the hole-free trail everyone draws on —
+  the author's memory, the rebuttal codex reads next round, and part of the posted
+  comment — so a miss means the published record has a gap. The code guards against
+  feeding an empty rebuttal to codex (it warns and keeps the prior pointer), and the
+  tree edits are still present, but this is **not** a clean consensus: a human must
+  fill in the missing round(s) before trusting the per-round record. Do **not**
+  report it as a plain consensus (see step 3).
+- **merge-base-error** — an *up-front* abort, **before** any debate round runs:
+  `git merge-base <base> HEAD` failed (missing/typoed/stale base, or unrelated
+  history), so the review scope can't be trusted. The return carries a human-readable
+  `note` (which base failed, how to fix it — e.g. `git fetch`) and **none** of the
+  comment-assembly fields (`commentHeader`/`workDir`/`sectionGlob`), because no
+  section files were ever written. Report the scope failure and **skip comment
+  assembly/posting entirely** (see step 3); fix the base ref and re-run.
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
@@ -224,7 +255,16 @@ session and only ever reads the one rebuttal file.
 
 ### 3. Present the result
 
-**First branch on `status`.** If `status === "reviewer-error"`, the debate did
+**First branch on `status`.** If `status === "merge-base-error"`, the workflow
+**aborted before any debate ran** — `git merge-base <base> HEAD` failed, so the
+review scope couldn't be trusted. This return has **no** `commentHeader`,
+`workDir`, or `sectionGlob` (no section files exist), so there is **nothing to
+assemble**: do **not** run the posting block below. Report the scope failure —
+surface the return's `note` (it names the failing base and the fix) — tell the
+user to repair the base ref (e.g. `git fetch`, fix a typo'd/stale ref) and re-run,
+and **skip the rest of this section**.
+
+If `status === "reviewer-error"`, the debate did
 **not** reach consensus — codex never produced a real verdict. Report it as a
 **failure**, not a success: surface `finalVerdict.summary` (and the workflow log)
 so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
@@ -239,6 +279,13 @@ block below — `commentHeader` already shows a `⚠️` badge, not the consensu
 check), then tell the user which round(s) are uncommitted and that the outstanding
 tree must be committed before the per-round history can be trusted. Do **not** call
 it a clean consensus.
+
+If `status === "section-incomplete"`, the debate converged but at least one round's
+author **skipped its disposition section file** (round numbers in `sectionGaps`).
+Report it as **converged-but-not-clean**: assemble and post the comment as usual
+(the `⚠️` badge is already set), then tell the user which round(s) are missing
+their disposition record and that the per-round history has a gap a human should
+fill before trusting it. Do **not** call it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -164,29 +164,38 @@ codex findings and Claude's dispositions — never pushing or merging. (The comm
 is no longer a separate `commit:roundN` agent: the author already has the tree
 open, so it commits its own round.)
 
-Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
-gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in
-different worktrees never collide** and the scratch never shows up in the diff
-codex reviews. It returns:
+Ephemeral scratch (verdicts, the debate ledger) lives under the gitignored,
+per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in different
+worktrees never collide** and the scratch never shows up in the diff codex
+reviews. It returns:
 
 ```
 { status: "consensus" | "commit-incomplete" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
-  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
+  commentHeader,        // the comment's small deterministic header (badge + round count + effort + base)
+  workDir, sectionGlob } // where the per-round section files live; cat them under the header (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed;
 `commitGaps` lists the round numbers whose author edited files but returned no
 commit SHA — empty unless `status === "commit-incomplete"`.)
-The debate is recorded as **one small Markdown file per round** —
-`<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
-author's cross-round memory** (so each round builds on the last instead of
-re-deriving the diff). The workflow renders the **same** record into `comment` —
-the outcome header followed by every round's section — so **step 3 just posts that
-string** (`gh pr comment -F`), exactly the way `/lens-debate` does. The comment is
-therefore a **deterministic** render, never re-improvised through an agent —
-nothing weak ever retypes a large blob. codex is *not* a reader — it keeps its own
-warm session, so re-feeding it the sections would just duplicate its context.
+The debate is recorded as small Markdown section files under `<workDir>` — **two
+per round**: `section-NNN-1-codex.md` (codex's verdict + findings) and
+`section-NNN-2-claude.md` (the author's per-finding dispositions), zero-padded so
+the `section-*.md` glob sorts in chronological order. **Each file is written by the
+party that owns its content**: a Haiku writer renders codex's small *structured*
+verdict to disk, and the **author writes its own dispositions directly** — the same
+way codex writes its verdict to a path. That author-writes-its-own-file design is
+deliberate: it keeps the author's *structured* return a **minimal ack**
+(`filesChanged`/`commitSha`/`done`), so a big multi-finding narrative can never
+overflow the structured-output encoding (the failure that used to crash the debate
+on large diffs). The author's disposition file does triple duty — it's the author's
+cross-round **memory**, the **rebuttal** codex reads next round (`codex-review.sh`
+cats it straight into codex's prompt), and the **published comment** (step 3 cats
+the section files under `commentHeader`). So the comment is still a **deterministic**
+render — a shell `cat`, never re-improvised through an agent, nothing weak ever
+retyping a large blob. codex is *not* a memory reader — it keeps its own warm
+session and only ever reads the one rebuttal file.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -225,10 +234,11 @@ report. Skip the rest of this section.
 
 If `status === "commit-incomplete"`, the debate converged but at least one round
 left its edits **uncommitted** (the round numbers are in `commitGaps`). Report it
-as **converged-but-not-clean**: post the `comment` (its header already shows a
-`⚠️` badge, not the consensus check), then tell the user which round(s) are
-uncommitted and that the outstanding tree must be committed before the per-round
-history can be trusted. Do **not** call it a clean consensus.
+as **converged-but-not-clean**: assemble and post the comment (see the posting
+block below — `commentHeader` already shows a `⚠️` badge, not the consensus
+check), then tell the user which round(s) are uncommitted and that the outstanding
+tree must be committed before the per-round history can be trusted. Do **not** call
+it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):
@@ -243,31 +253,37 @@ the per-round commits sit on the local branch for the human to review):
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round summary — read it straight from the section files
-  (`cat <workDir>/section-*.md`: each round's codex verdict, Claude's
-  dispositions, and the commit SHA) so the convergence reads round by round. No
-  need to re-derive it from `transcript`; the sections already render it.
+  (`cat <workDir>/section-*.md`: each round's codex verdict, then the author's
+  dispositions and commit SHA) so the convergence reads round by round. No need to
+  re-derive it from `transcript`; the sections already render it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
-  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
+  `--no-comment` was NOT passed, **assemble** the comment from the workflow's
+  return — the small `commentHeader`, then the per-round section files `cat`-ed in
+  glob order — and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  mkdir -p "$repoPath/.codex-debate"   # reviewer-error/--no-commit runs may not have created it
-  printf '%s' "$comment" > "$repoPath/.codex-debate/comment.md"
-  gh pr comment <pr> -F "$repoPath/.codex-debate/comment.md"
+  mkdir -p "$workDir"   # reviewer-error/--no-commit runs may not have created it
+  {
+    printf '%s\n' "$commentHeader"
+    for f in "$workDir"/section-*.md; do printf '\n'; cat "$f"; printf '\n'; done
+  } > "$workDir/comment.md"
+  gh pr comment <pr> -F "$workDir/comment.md"
   ```
 
-  The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
-  header (consensus badge, round count, the **reasoning-effort** note from the
-  workflow's `REASONING_EFFORT` constant) followed by the per-round breakdown of
-  codex's findings and Claude's dispositions
-  that the author also read. So the comment is a **deterministic** render of the
-  same record the commit messages and the author drew on — not an LLM-improvised
-  table. Posting the returned string mirrors `/lens-debate`. This is an
-  outward-facing write — on by default because the whole point is to leave the
-  review trail on the PR; `--no-comment` suppresses it.
+  (`$workDir` is the returned `workDir`, i.e. `<repoPath>/.codex-debate`; the
+  `for`-loop guarantees a blank line between sections regardless of each file's
+  trailing newline.) The result is the `## Codex ⇄ Claude debate` header (consensus
+  badge, round count, the **reasoning-effort** note from the workflow's
+  `REASONING_EFFORT` constant) followed by the per-round breakdown of codex's
+  findings and the author's dispositions — the **same** section files the author
+  read as memory and codex read as the rebuttal. So the comment is a
+  **deterministic** shell concat of the record everyone drew on, not an
+  LLM-improvised table — nothing weak ever retypes a blob. This is an outward-facing
+  write — on by default because the whole point is to leave the review trail on the
+  PR; `--no-comment` suppresses it.
 
 <a id="answer-mode"></a>
 # Answer mode — Codex ⇄ Claude answer debate
@@ -424,15 +440,21 @@ returns:
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
   so there's no session id to carry forward. The equivalent is context, not state:
   each follow-up round the author **reads the per-round section files**
-  (`cat .codex-debate/section-*.md`) — every prior round's findings and its own
-  dispositions — so it builds on its last round rather than re-deriving the whole
-  diff, and won't re-fix or re-litigate findings already settled. A small section
-  is written after each round, so round N>1 always sees rounds 1..N-1; round 1 has
-  none yet, so it's byte-identical to a cold start (and if no sections exist, the
-  author falls back to the diff + verdict). The *same* sections compose the PR
-  comment step 3 posts, so the author's memory and the published summary are one
-  record. The writes stay small (one round each), so the Haiku writer never
-  retypes a large blob. codex stays on its own warm session and never reads them.
+  (`cat .codex-debate/section-*.md`) — every prior round's codex findings and its
+  own dispositions — so it builds on its last round rather than re-deriving the
+  whole diff, and won't re-fix or re-litigate findings already settled. Each round
+  writes two small files (a Haiku-rendered codex section and the author's own
+  disposition section), so round N>1 always sees rounds 1..N-1; round 1 has none
+  yet, so it's byte-identical to a cold start (and if no sections exist, the author
+  falls back to the diff + verdict). The *same* sections compose the PR comment step
+  3 posts and the rebuttal codex reads, so the author's memory, the published
+  summary, and codex's rebuttal are one record. Crucially, the author **writes its
+  own disposition section directly** — it never has to pour that narrative through a
+  structured field — so its structured return stays a minimal ack and can't overflow
+  on a large, many-finding diff (the failure this design replaced). The Haiku writer
+  only ever renders codex's small *structured* verdict, so nothing weak retypes a
+  large blob. codex stays on its own warm session and never reads the sections —
+  only the one rebuttal file each round.
 - **Inherited context, not just diff.** On top of that cross-round memory, when the
   caller passes `context` and/or `rationale` the author **inherits them in EVERY
   round's prompt** — the main-agent intent (what the change is FOR) and the
@@ -446,13 +468,14 @@ returns:
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the per-round
-  sections) lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`,
-  so debates on many worktrees run at once without clobbering each other — no
-  shared `/tmp` paths, and each worktree's section files are its own.
+- **Parallel-safe.** Ephemeral scratch (verdicts and the per-round section files,
+  the author-written ones doubling as the rebuttal) lives under the gitignored,
+  per-worktree `<repoPath>/.codex-debate/`, so debates on many worktrees run at once
+  without clobbering each other — no shared `/tmp` paths, and each worktree's section
+  files are its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  workflow's deterministically rendered `comment` (header + per-round sections) —
-  is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
+  `commentHeader` followed by the per-round section files `cat`-ed together (step 3)
+  — is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
   — the point is to leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because

--- a/.apm/skills/codex-debate/SKILL.md
+++ b/.apm/skills/codex-debate/SKILL.md
@@ -227,8 +227,9 @@ session and only ever reads the one rebuttal file.
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
 - **section-incomplete** — the debate *converged*, but a round's author **skipped
-  its disposition section file** (`section-NNN-2-claude.md` missing or empty for the
-  round(s) in `sectionGaps`). That file is the hole-free trail everyone draws on —
+  or under-filled its disposition section file** (`section-NNN-2-claude.md` missing,
+  empty, or missing a backticked marker for an open finding, for the round(s) in
+  `sectionGaps`). That file is the hole-free trail everyone draws on —
   the author's memory, the rebuttal codex reads next round, and part of the posted
   comment — so a miss means the published record has a gap. The code guards against
   feeding an empty rebuttal to codex (it warns and keeps the prior pointer), and the
@@ -281,7 +282,8 @@ tree must be committed before the per-round history can be trusted. Do **not** c
 it a clean consensus.
 
 If `status === "section-incomplete"`, the debate converged but at least one round's
-author **skipped its disposition section file** (round numbers in `sectionGaps`).
+author **skipped or under-filled its disposition section file** (missing, empty, or
+omitting a marker for an open finding; round numbers in `sectionGaps`).
 Report it as **converged-but-not-clean**: assemble and post the comment as usual
 (the `⚠️` badge is already set), then tell the user which round(s) are missing
 their disposition record and that the per-round history has a gap a human should

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -363,6 +363,34 @@ async function writeCodexSection(round, verdict) {
   return writeFileAgent(codexSectionFile(round), codexSection(round, verdict), `ledger:codex:round${round}`)
 }
 
+// VERIFY the author actually wrote its disposition section this round. The author's
+// claude section is the load-bearing handoff: it's the next round's rebuttal (codex
+// reads it), the author's own cross-round memory, AND part of the posted comment.
+// If the author skipped the Write, `lastClaudeSectionPath` would still point at a
+// path that doesn't exist — codex-review.sh would warn and proceed with an EMPTY
+// rebuttal, and the debate could still converge over a hole in the trail. So after
+// every author turn we deterministically check the file exists and is non-empty;
+// the workflow has no file I/O of its own, so a thin mechanical agent does the
+// `test -s`. We do NOT parse the file for finding-id coverage — the disposition
+// CONTRACT (one bullet per finding) plus codex's own next-round re-review already
+// police completeness; a markdown-id grep here would be brittle and redundant. This
+// check is the file's EXISTENCE/non-emptiness, the part nothing else guards. A miss
+// is recorded as a section gap and downgrades the terminal status (see below), the
+// same fail-loud-not-silent treatment as a missed commit.
+async function verifyClaudeSection(round) {
+  const path = claudeSectionFile(round)
+  const res = await agent(
+    `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`test -s ${shq(path)} && echo present || echo missing\`. Return \`ok\`: true if the output was "present" (the file exists and is non-empty), false otherwise. Do not edit any file. Do not run git.`,
+    {
+      label: `verify:claude:round${round}`,
+      phase: 'Debate',
+      model: mechModel,
+      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists and is non-empty' } } },
+    },
+  )
+  return res?.ok === true
+}
+
 const transcript = []
 // 'consensus' is the only NORMAL terminus. 'reviewer-error' is the one abnormal
 // terminus: codex itself failed to produce a verdict (broken/unavailable). That
@@ -384,6 +412,13 @@ let lastClaudeSectionPath = null
 // report success over a missed commit. Not a hard abort: a transient SHA omission
 // shouldn't nuke a multi-round debate whose edits are all present in the tree.
 const commitGaps = []
+// Rounds where the author's disposition section file is missing or empty after its
+// turn — the handoff that feeds the rebuttal, the author's memory, and the comment
+// broke. We DON'T silently let an empty rebuttal slip to codex (which would warn and
+// proceed, possibly converging over a hole in the trail): a miss is recorded here
+// and downgrades the terminal status to 'section-incomplete' below. Not a hard abort
+// for the same reason as commitGaps — the tree edits are still present and reviewed.
+const sectionGaps = []
 
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
@@ -498,14 +533,27 @@ for (let round = 1; ; round++) {
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
   // rest, and writes its dispositions to its own claude section file (its memory,
   // the rebuttal codex reads next round, and part of the posted comment). It reads
-  // the per-round section files for its cross-round memory. We remember the path it
-  // just wrote so the NEXT round feeds it to codex as the rebuttal.
+  // the per-round section files for its cross-round memory. We point the rebuttal at
+  // the path it just wrote so the NEXT round feeds it to codex — but only AFTER
+  // verifying the file actually landed (see verifyClaudeSection below).
   const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
-  lastClaudeSectionPath = claudeSectionFile(round)
   log(
     `Round ${round}: claude done=${response.done}, files=${(response.filesChanged || []).length}`,
   )
+
+  // VERIFY the author wrote its disposition section before we lean on it. The file
+  // is the next round's rebuttal, the author's memory, and part of the comment — if
+  // it's missing/empty the handoff broke. Only point `lastClaudeSectionPath` at it
+  // (so codex reads it as the rebuttal next round) once it actually exists; on a miss
+  // record the gap, leave the rebuttal pointer where it was (codex sees `-`/the prior
+  // round's section rather than an empty one), and downgrade the terminal status.
+  if (await verifyClaudeSection(round)) {
+    lastClaudeSectionPath = claudeSectionFile(round)
+  } else {
+    sectionGaps.push(round)
+    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing or empty — handoff broke; not feeding it to codex as the rebuttal.`)
+  }
 
   // The author commits its own round in-session (one commit per round, message
   // carrying codex's findings and its dispositions), so here we just record the
@@ -545,6 +593,19 @@ if (status === 'consensus' && commitGaps.length) {
   log(`Round(s) ${commitGaps.join(', ')} left uncommitted despite changing files — downgrading consensus to commit-incomplete.`)
 }
 
+// Downgrade a would-be consensus when any round's author skipped its disposition
+// section file. The debate may read as converged, but a missing section is a hole in
+// the trail the author, codex (as the rebuttal), and the posted comment all draw on —
+// so we must NOT advertise a clean consensus. 'section-incomplete' is a distinct,
+// non-consensus terminus: a human/caller must fill in the missing round(s) before
+// trusting the per-round record. We don't override an already-abnormal status
+// (reviewer-error, or commit-incomplete which is reported the same converged-but-
+// -not-clean way) — the first downgrade already marks the run unclean.
+if (status === 'consensus' && sectionGaps.length) {
+  status = 'section-incomplete'
+  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section — downgrading consensus to section-incomplete.`)
+}
+
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
 // The terminal round needs no extra section write: codex's section for it was
@@ -567,6 +628,9 @@ return {
   // Rounds whose author-side commit didn't land (empty unless status is
   // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
   commitGaps,
+  // Rounds whose author-side disposition section file is missing/empty (empty unless
+  // status is 'section-incomplete'). Lets the caller pinpoint the hole in the trail.
+  sectionGaps,
   transcript,
   // The comment's deterministic header (badge + round count + reasoning effort +
   // base). The orchestrator posts: this header, a blank line, then

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -369,23 +369,35 @@ async function writeCodexSection(round, verdict) {
 // If the author skipped the Write, `lastClaudeSectionPath` would still point at a
 // path that doesn't exist — codex-review.sh would warn and proceed with an EMPTY
 // rebuttal, and the debate could still converge over a hole in the trail. So after
-// every author turn we deterministically check the file exists and is non-empty;
-// the workflow has no file I/O of its own, so a thin mechanical agent does the
-// `test -s`. We do NOT parse the file for finding-id coverage — the disposition
-// CONTRACT (one bullet per finding) plus codex's own next-round re-review already
-// police completeness; a markdown-id grep here would be brittle and redundant. This
-// check is the file's EXISTENCE/non-emptiness, the part nothing else guards. A miss
-// is recorded as a section gap and downgrades the terminal status (see below), the
-// same fail-loud-not-silent treatment as a missed commit.
-async function verifyClaudeSection(round) {
+// every author turn we deterministically check the file exists, is non-empty, AND
+// carries a backticked disposition marker for EVERY open finding this round. The
+// workflow has no file I/O of its own, so a thin mechanical agent runs `test -s`
+// plus an exact `grep -F` per finding id. We do NOT parse prose or score the
+// disposition text — only that a `\`Fn\`` token is present, which is an exact,
+// bounded check the author prompt already mandates ("one bullet PER finding",
+// each id backticked). This closes the hole the file-as-source-of-truth opened:
+// a non-empty but INCOMPLETE section (omitting `F2`) used to advance the rebuttal
+// pointer and could converge over a per-finding hole in the durable trail. A miss
+// — empty file OR any missing finding id — is recorded as a section gap and
+// downgrades the terminal status (see below), the same fail-loud-not-silent
+// treatment as a missed commit. Codex's own next-round re-review still polices
+// the SUBSTANCE of each disposition; this guards only the COMPLETENESS of the
+// published per-finding record, which nothing else covers.
+async function verifyClaudeSection(round, openIds) {
   const path = claudeSectionFile(round)
+  // Each open finding must appear as a backticked id token (e.g. `F1`) in the
+  // section. `grep -F` is a literal substring match — no regex/prose brittleness.
+  const idChecks = openIds
+    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo missing-${id}; ok=0; }`)
+    .join('; ')
+  const idList = openIds.length ? openIds.map((id) => `\`${id}\``).join(', ') : '(none)'
   const res = await agent(
-    `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`test -s ${shq(path)} && echo present || echo missing\`. Return \`ok\`: true if the output was "present" (the file exists and is non-empty), false otherwise. Do not edit any file. Do not run git.`,
+    `You are a MECHANICAL RUNNER. Run exactly this and nothing else, then report:\n\`ok=1; test -s ${shq(path)} || { echo empty; ok=0; }${idChecks ? `; ${idChecks}` : ''}; echo "ok=$ok"\`\nThis checks the section file exists, is non-empty, and contains a backticked marker for every open finding (${idList}). Return \`ok\`: true if the final line was "ok=1", false otherwise (any "empty" or "missing-Fn" line means false). Do not edit any file. Do not run git.`,
     {
       label: `verify:claude:round${round}`,
       phase: 'Debate',
       model: mechModel,
-      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists and is non-empty' } } },
+      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists, is non-empty, and carries a backticked marker for every open finding' } } },
     },
   )
   return res?.ok === true
@@ -412,12 +424,14 @@ let lastClaudeSectionPath = null
 // report success over a missed commit. Not a hard abort: a transient SHA omission
 // shouldn't nuke a multi-round debate whose edits are all present in the tree.
 const commitGaps = []
-// Rounds where the author's disposition section file is missing or empty after its
-// turn — the handoff that feeds the rebuttal, the author's memory, and the comment
-// broke. We DON'T silently let an empty rebuttal slip to codex (which would warn and
-// proceed, possibly converging over a hole in the trail): a miss is recorded here
-// and downgrades the terminal status to 'section-incomplete' below. Not a hard abort
-// for the same reason as commitGaps — the tree edits are still present and reviewed.
+// Rounds where the author's disposition section file is missing, empty, OR missing
+// a backticked marker for one or more open findings after its turn — the handoff
+// that feeds the rebuttal, the author's memory, and the comment broke. We DON'T
+// silently let an empty or per-finding-incomplete rebuttal slip to codex (which
+// would warn and proceed, possibly converging over a hole in the trail): a miss is
+// recorded here and downgrades the terminal status to 'section-incomplete' below.
+// Not a hard abort for the same reason as commitGaps — the tree edits are still
+// present and reviewed.
 const sectionGaps = []
 
 // ---------------------------------------------------------------------------
@@ -544,15 +558,18 @@ for (let round = 1; ; round++) {
 
   // VERIFY the author wrote its disposition section before we lean on it. The file
   // is the next round's rebuttal, the author's memory, and part of the comment — if
-  // it's missing/empty the handoff broke. Only point `lastClaudeSectionPath` at it
-  // (so codex reads it as the rebuttal next round) once it actually exists; on a miss
-  // record the gap, leave the rebuttal pointer where it was (codex sees `-`/the prior
-  // round's section rather than an empty one), and downgrade the terminal status.
-  if (await verifyClaudeSection(round)) {
+  // it's missing/empty/incomplete the handoff broke. We require a backticked marker
+  // for every finding the author had to address this round (`open`), so a non-empty
+  // but partial section can't slip a per-finding hole into the trail. Only point
+  // `lastClaudeSectionPath` at it (so codex reads it as the rebuttal next round) once
+  // it exists AND covers every open id; on a miss record the gap, leave the rebuttal
+  // pointer where it was (codex sees `-`/the prior round's section rather than an
+  // incomplete one), and downgrade the terminal status.
+  if (await verifyClaudeSection(round, open.map((f) => f.id))) {
     lastClaudeSectionPath = claudeSectionFile(round)
   } else {
     sectionGaps.push(round)
-    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing or empty — handoff broke; not feeding it to codex as the rebuttal.`)
+    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing, empty, or missing a marker for an open finding — handoff broke; not feeding it to codex as the rebuttal.`)
   }
 
   // The author commits its own round in-session (one commit per round, message
@@ -594,8 +611,9 @@ if (status === 'consensus' && commitGaps.length) {
 }
 
 // Downgrade a would-be consensus when any round's author skipped its disposition
-// section file. The debate may read as converged, but a missing section is a hole in
-// the trail the author, codex (as the rebuttal), and the posted comment all draw on —
+// section file OR left it missing a marker for an open finding. The debate may read
+// as converged, but a missing or per-finding-incomplete section is a hole in the
+// trail the author, codex (as the rebuttal), and the posted comment all draw on —
 // so we must NOT advertise a clean consensus. 'section-incomplete' is a distinct,
 // non-consensus terminus: a human/caller must fill in the missing round(s) before
 // trusting the per-round record. We don't override an already-abnormal status
@@ -603,7 +621,7 @@ if (status === 'consensus' && commitGaps.length) {
 // -not-clean way) — the first downgrade already marks the run unclean.
 if (status === 'consensus' && sectionGaps.length) {
   status = 'section-incomplete'
-  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section — downgrading consensus to section-incomplete.`)
+  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section or a finding marker — downgrading consensus to section-incomplete.`)
 }
 
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -388,7 +388,7 @@ async function verifyClaudeSection(round, openIds) {
   // Each open finding must appear as a backticked id token (e.g. `F1`) in the
   // section. `grep -F` is a literal substring match — no regex/prose brittleness.
   const idChecks = openIds
-    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo missing-${id}; ok=0; }`)
+    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo ${shq(`missing-${id}`)}; ok=0; }`)
     .join('; ')
   const idList = openIds.length ? openIds.map((id) => `\`${id}\``).join(', ') : '(none)'
   const res = await agent(

--- a/.apm/skills/codex-debate/debate.workflow.js
+++ b/.apm/skills/codex-debate/debate.workflow.js
@@ -30,14 +30,29 @@ const workDir = `${repoPath}/.codex-debate`
 // DESTRUCTIVE command (the ledger `rm -f` below); the benign `mkdir -p` prompts
 // elsewhere can tolerate an unquoted path, but a mistargeted `rm -f` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
-// The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
-// written under the gitignored scratch dir) — the claude author reads them as its
-// cross-round memory (full history, no inline blob). The PR comment is rendered
-// from the SAME per-round sections in-process (see renderLedger) and returned as
-// `comment`, so the published summary and the author's context are one record —
-// deterministic, never re-rendered through an agent (nothing weak ever retypes a
-// large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
-// it the ledger would just duplicate what it already remembers.
+// The debate is recorded as small Markdown SECTION FILES under the gitignored
+// scratch dir — TWO per round: `section-NNN-1-codex.md` (codex's verdict) and
+// `section-NNN-2-claude.md` (the author's dispositions). Each is written by the
+// party that OWNS its content, never forced through a structured payload:
+//   * codex's section — a Haiku writer renders the small STRUCTURED verdict
+//     (approval + findings) to disk; faithful, nothing to bloat.
+//   * claude's section — the AUTHOR writes its OWN per-finding dispositions
+//     directly (it's already editing the tree), exactly the way codex writes its
+//     verdict to a path. This is the STRUCTURAL fix for the old crash: the author
+//     used to pour its whole narrative into a structured field, which overflowed
+//     the StructuredOutput encoding and silently dropped the required array until
+//     the retry cap tripped. Now the narrative goes to the file and the author's
+//     structured return is a MINIMAL ACK (filesChanged/commitSha/done) whose size
+//     is decoupled from the finding count entirely, so it can never overflow.
+// These section files serve THREE roles at once, no copy ever re-typed by a weak
+// agent: (1) the author's cross-round memory (it cats them for full history);
+// (2) the REBUTTAL codex reads next round — codex-review.sh `cat`s the author's
+// section file straight into its prompt, so codex still sees every disposition;
+// (3) the published PR comment, which the orchestrator assembles by `cat`-ing the
+// section files after a small in-process header (see ledgerHeader / commentHeader)
+// — a deterministic shell concat, never re-rendered through an agent. codex is NOT
+// a memory reader: it keeps its own warm session, so it only ever reads the one
+// rebuttal file, not the whole ledger.
 // Commit each round's changes individually (default on). The author commits its
 // OWN round in-session — it already edits the tree, so it stages exactly what it
 // changed and writes a message carrying the debate context (codex's findings +
@@ -46,9 +61,11 @@ const commit = a.commit !== false
 // Model tiers. The claude-author round does real reasoning (fixing/disputing
 // codex's findings, and committing its own round) → `model` (Opus). Everything
 // else here is mechanical — the codex runner just shells out to codex-review.sh
-// and copies the verdict, the ledger writer dumps a section file, the merge-base
-// resolver runs one git command → `mechModel`
-// (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
+// and copies the verdict, the codex-section writer dumps a rendered verdict to a
+// file, the merge-base resolver runs one git command → `mechModel`
+// (Haiku). (The CLAUDE section is written by the author itself, on `model`, as part
+// of its round — not by a mechanical writer.) Defaults match a direct invocation;
+// /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
 // Fidelity tier (Sonnet). One "mechanical" job isn't a trivial command but a
@@ -57,7 +74,7 @@ const mechModel = a.mechModel || 'haiku'
 // validation checks the verdict's SHAPE, not its wording), and Haiku is the
 // weakest tier for verbatim reproduction — so the verdict relay runs a notch up.
 // Still far cheaper/faster than Opus; the real reviewing is codex's, not this
-// agent's. The small per-round section writes stay on Haiku (tiny payloads).
+// agent's. The small per-round codex-section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
 // --- Context the Claude implementor INHERITS --------------------------------
@@ -135,31 +152,28 @@ const CODEX_VERDICT_SCHEMA = {
   required: ['approved', 'summary', 'findings', 'responseToRebuttal'],
 }
 
+// The author's structured return is a MINIMAL ACK by design — no `summary`, no
+// per-finding `actions`. The full narrative (the per-finding dispositions AND the
+// round summary) is written by the author to its section file instead (see
+// claudeResponds), exactly the way codex writes its verdict to a path. This is the
+// structural fix for the old crash: a large structured payload (the author pouring
+// its whole F1/F2/F3 narrative into `summary` + one `detail` per finding)
+// overflowed the StructuredOutput encoding, which silently dropped the required
+// array and tripped the retry cap. With only these few small, fixed fields the
+// payload size is decoupled from the finding count entirely, so it can never
+// overflow. `filesChanged` is bounded by the files touched (not narrative);
+// `commitSha` is one hash; `done` is a flag.
 const CLAUDE_RESPONSE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   properties: {
-    summary: { type: 'string' },
-    actions: {
-      type: 'array',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          findingId: { type: 'string' },
-          disposition: { type: 'string', enum: ['fixed', 'disputed', 'partial'] },
-          detail: { type: 'string' },
-        },
-        required: ['findingId', 'disposition', 'detail'],
-      },
-    },
     filesChanged: { type: 'array', items: { type: 'string' } },
     // The author commits its own round (it already edits the tree), so it returns
     // the resulting SHA here. "" when it changed nothing or ran under --no-commit.
     commitSha: { type: 'string' },
     done: { type: 'boolean' },
   },
-  required: ['summary', 'actions', 'filesChanged', 'done'],
+  required: ['filesChanged', 'done'],
 }
 
 // Consensus = no finding left open, any severity. The loop runs until codex
@@ -171,30 +185,28 @@ function openFindings(verdict) {
 // ---------------------------------------------------------------------------
 // The two debaters
 // ---------------------------------------------------------------------------
-async function codexReviews(round, rebuttalJson) {
+async function codexReviews(round, rebuttalPath) {
   const verdictPath = `${workDir}/verdict-${round}.json`
-  const rebuttalPath = `${workDir}/rebuttal.json`
-  const rebuttalStep = rebuttalJson
-    ? `1. Using the Write tool (NOT a shell heredoc — the content has special characters), create the file \`${rebuttalPath}\` with exactly this content:
-
-${rebuttalJson}
-
-2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
-    : `1. (No prior rebuttal this round.)
-
-2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
+  // The rebuttal codex reads is the author's PRIOR-round disposition section file
+  // (it wrote it itself; codex-review.sh `cat`s it straight into codex's prompt).
+  // No inline blob, no separate rebuttal-file write step — the file already exists.
+  // `-` on round 1 (no prior author turn yet).
+  const rebuttalArg = rebuttalPath || '-'
+  const rebuttalNote = rebuttalPath
+    ? `   (\`${rebuttalPath}\` is the author's prior-round disposition section — codex reads it as the rebuttal. If it's somehow missing, the script proceeds with no rebuttal and warns; that's fine.)`
+    : `   (No prior rebuttal this round — the \`-\` argument tells the script there's none.)`
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
 First ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
 
-${rebuttalStep}
+1. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalArg} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\`
+${rebuttalNote}
 
    This shells out to the codex CLI as a read-only reviewer; it can take 1-3 minutes. It prints a JSON verdict as its final stdout and also writes it to the \`-o\` path.
 
-3. Read \`${verdictPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
+2. Read \`${verdictPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
 
   return agent(prompt, {
     label: `codex:round${round}`,
@@ -209,11 +221,12 @@ async function claudeResponds(round, verdict, doCommit) {
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
   // equivalent is context, not state: every follow-up round the author reads the
-  // per-round section files — the record of every prior round's findings and its
-  // OWN dispositions — and builds on them instead of re-deriving the diff. A
-  // section is written after each round (see the loop), so on round N>1 the files
-  // already hold rounds 1..N-1. Round 1 has none yet, so its prompt is
-  // byte-identical to a cold start.
+  // per-round section files — the record of every prior round's findings (codex's
+  // section, Haiku-written) and its OWN dispositions (the claude section it wrote
+  // itself last round) — and builds on them instead of re-deriving the diff. codex's
+  // section is written each round in the loop and the author writes its claude
+  // section as the LAST step of its own turn, so on round N>1 the files already hold
+  // rounds 1..N-1. Round 1 has none yet, so its prompt is byte-identical to a cold start.
   const priorBlock =
     round > 1
       ? `This is a FOLLOW-UP round. Every prior round is recorded as a small Markdown file under the debate's scratch dir — read them FIRST for the full history (codex's past findings and YOUR own dispositions):
@@ -234,13 +247,22 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the finding's detail rather than reporting a clean "fixed". ${
+You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the disposition rather than reporting a clean "fixed". ${
     doCommit
-      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
-      : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
+      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. You'll return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`.`
+      : `Edit the working tree only — do NOT git add/commit/push; you'll leave \`commitSha\` empty.`
   }
 
-Return: actions (one per finding — findingId, disposition, detail), filesChanged, commitSha, and done (true once you've addressed every finding this round).`
+RECORD your dispositions to a file — this is the durable trail and the heart of how this debate stays robust. The next round's author reads it as memory, codex reads it as your rebuttal, and it's what gets posted to the PR. So the FULL per-finding narrative lives in this file, NEVER in your structured return. Using the Write tool, create the file \`${claudeSectionFile(round)}\` (overwrite any existing one) with EXACTLY this Markdown shape:
+
+**claude** — <one sentence: what you did this round>
+
+- \`F1\` **fixed** — <why; what you changed; cite file:line>
+- \`F2\` **disputed** — <the specific technical reason codex is wrong; cite file:line>
+- \`F3\` **partial** — <what you fixed and what you didn't, and why>
+${doCommit ? '... one bullet PER finding (disposition ∈ fixed | disputed | partial), then:\n\ncommit: `<the SHA you committed, or omit this whole line if you changed nothing>`' : '... one bullet PER finding (disposition ∈ fixed | disputed | partial). (No commit line — running under --no-commit.)'}
+
+CRITICAL — your STRUCTURED RETURN IS A MINIMAL ACK, nothing more. Return ONLY: \`filesChanged\` (the source paths you edited — never the scratch file above), \`commitSha\` (the SHA, or "" if you changed nothing / under --no-commit), and \`done\` (true once you've addressed every finding this round). Do NOT put your summary or any per-finding detail in the structured output — all of that goes in the section file and the commit body. (This is deliberate: past runs CRASHED because the author poured a multi-finding narrative into a structured field, which overflowed the output encoding and dropped a required field until the retry cap tripped. Writing the narrative to the file instead removes that failure by construction — keep the structured payload tiny.)`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -251,7 +273,10 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
 }
 
 // ---------------------------------------------------------------------------
-// The shared ledger — rendered from the transcript, deterministically
+// The shared ledger — section files on disk, assembled into the comment by the
+// orchestrator (a faithful `cat`). The workflow renders only the small CODEX
+// section (from the structured verdict) and the comment HEADER in-process; the
+// author writes its own claude section (see claudeResponds).
 // ---------------------------------------------------------------------------
 // One codex finding as a Markdown bullet — the single projection of a finding's
 // fields for the ledger section. (The per-round commit message is now written by
@@ -260,50 +285,39 @@ function findingBullet(f) {
   return `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
 }
 
-// One author disposition as a Markdown bullet — the single projection of an
-// action's fields for the ledger section.
-function actionBullet(a) {
-  return `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
-}
-
-// One round's findings, as a Markdown list. Shared by the section renderer below.
+// One round's findings, as a Markdown list. Shared by the codex-section renderer.
 function renderFindings(verdict) {
   const list = (verdict.findings || []).map((f) => findingBullet(f)).join('\n')
   return list || '- _(none)_'
 }
 
-// One round's author dispositions, as a Markdown list. `null` on a terminal round
-// (codex approved or errored before the author got a turn).
-function renderActions(response) {
-  if (!response) return '_(no author turn — the debate ended this round)_'
-  const list = (response.actions || []).map((a) => actionBullet(a)).join('\n')
-  return list || '- _(no actions)_'
-}
-
-// One round as a Markdown section: codex's verdict, its response to the rebuttal,
-// and the author's dispositions + commit. The single per-round renderer — the
-// author reads these as its memory and they compose into the posted comment.
-function roundLedgerSection(entry) {
-  const { round, codex, claude, commit } = entry
+// CODEX's side of one round, as a Markdown section: its verdict, findings, and
+// response to the author's rebuttal. Rendered in-process from the STRUCTURED
+// verdict (small, faithful) and written to disk by a Haiku writer. The author's
+// side is a SEPARATE file the author writes itself (its dispositions), so this
+// renderer no longer touches the claude response at all — that's the decoupling
+// that keeps the author's structured payload minimal. This carries the round's
+// `### Round N` header (it's written every round, including the terminal one).
+function codexSection(round, verdict) {
   const lines = [
     `### Round ${round}`,
     '',
-    `**codex** — approved: \`${codex.approved}\``,
+    `**codex** — approved: \`${verdict.approved}\``,
     '',
-    codex.summary,
+    verdict.summary,
     '',
     'Findings:',
-    renderFindings(codex),
+    renderFindings(verdict),
   ]
-  if (codex.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${codex.responseToRebuttal}`)
-  lines.push('', `**claude** — ${claude ? claude.summary : '_(no author turn this round)_'}`, '', renderActions(claude))
-  if (commit) lines.push('', `commit: \`${commit}\``)
+  if (verdict.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${verdict.responseToRebuttal}`)
   return lines.join('\n')
 }
 
 // The comment header (small). The full comment is this header followed by the
-// per-round section files (see renderLedger). The workflow renders the whole
-// comment deterministically from the transcript — no agent ever retypes the blob.
+// per-round section files, `cat`-ed together by the orchestrator (see SKILL step 3)
+// — a deterministic shell concat, never re-rendered through an agent. The workflow
+// returns this header as `commentHeader`; it can't read the section files itself
+// (no I/O), so it hands the orchestrator the header + the section dir.
 //
 // This header's chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
 // deliberately kept STRUCTURALLY PARALLEL to lens-debate's renderComment header
@@ -317,27 +331,20 @@ function ledgerHeader(meta) {
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`${meta.reasoningEffort}\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
-// The whole PR comment, rendered deterministically in-process from the transcript:
-// the outcome header followed by each round's Markdown section. The per-round
-// section files on disk remain the author's cross-round memory (see writeSection);
-// this re-uses the SAME `roundLedgerSection` renderer to assemble the published
-// comment, so the orchestrator posts a ready string (`gh pr comment -F`) exactly
-// the way lens-debate does — no bespoke `cat` glob at the consumer, and nothing
-// weak ever retypes a large blob (the workflow builds the string itself).
-function renderLedger(transcript, meta) {
-  return [ledgerHeader(meta), ...transcript.map(roundLedgerSection)].join('\n\n')
-}
-
-// Zero-pad the round so the section glob (`section-*.md`) sorts in round order
-// (section-002 before section-010) for both the author's read and the assembly.
-const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
+// Per-round section file paths. TWO files per round, named so the `section-*.md`
+// glob sorts both into round order AND codex-before-claude WITHIN a round
+// (`section-001-1-codex.md` < `section-001-2-claude.md` < `section-002-1-codex.md`),
+// so `cat`-ing the glob yields the debate in chronological order for both the
+// author's memory read and the comment assembly. Zero-padded for the same reason.
+const codexSectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}-1-codex.md`
+const claudeSectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}-2-claude.md`
 
 // Drop a string to a scratch file via a mechanical Haiku writer — the single home
 // for the "write this content to this path" idiom (the workflow can't do file I/O
 // itself, and Claude isn't headless, so a tiny agent does it). Both the per-round
-// section writer and the one-shot rationale writer route through here; payloads are
-// small (one round / one note) so Haiku is safe, and overwriting is idempotent
-// (safe on a resume).
+// codex-section writer and the one-shot rationale writer route through here;
+// payloads are small (one round / one note) so Haiku is safe, and overwriting is
+// idempotent (safe on a resume).
 function writeFileAgent(path, content, label) {
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
@@ -348,11 +355,12 @@ ${content}`
   return agent(prompt, { label, phase: 'Debate', model: mechModel })
 }
 
-// Write ONE round's section to its own small file — the author reads these as its
-// cross-round memory, and the orchestrator cats them into the posted comment. No
-// whole-ledger retype: the payload is just this round.
-async function writeSection(entry) {
-  return writeFileAgent(sectionFile(entry.round), roundLedgerSection(entry), `ledger:round${entry.round}`)
+// Write ONE round's CODEX section to its own small file (the claude section is the
+// author's own write, in claudeResponds). The author reads these as cross-round
+// memory and the orchestrator cats them into the posted comment. No whole-ledger
+// retype: the payload is just this round's structured verdict, rendered.
+async function writeCodexSection(round, verdict) {
+  return writeFileAgent(codexSectionFile(round), codexSection(round, verdict), `ledger:codex:round${round}`)
 }
 
 const transcript = []
@@ -362,7 +370,12 @@ const transcript = []
 // distinct from the deliberate "no deadlock exit" for substantive disagreement.
 let status = 'consensus'
 let finalVerdict = null
-let lastClaude = null
+// The author's PRIOR-round disposition section file — fed to codex next round as
+// the rebuttal (codex-review.sh cats it into codex's prompt). null until the first
+// author turn writes one. This replaces the old in-memory rebuttal blob: the author
+// writes the file itself, so the dispositions never round-trip through structured
+// output, and codex reads them straight off disk.
+let lastClaudeSectionPath = null
 // Rounds where the author edited files (commit mode on) but returned no SHA —
 // the in-session commit it was told to make didn't land. The edits aren't lost
 // (they stay in the tree and the next reviewer still diffs them against base),
@@ -411,16 +424,18 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 
 // Clear any stale ledger from a PRIOR debate in this worktree. The scratch dir
 // is persistent (per-worktree, not per-run) and the section files use a flat,
-// stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
+// stable `section-NNN-*.md` namespace, so a previous longer debate's high-numbered
 // sections would otherwise survive into this run — the author cats `section-*.md`
-// as its memory (and they compose into the `comment` renderLedger returns), so stale
-// sections would pollute BOTH the author's context and the published trail. A
-// thin mechanical agent (the workflow can't run shell itself). The reset is
-// section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
-// whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
-// and any commit-message file the author writes) keep their own lifecycle and a
-// future pre-loop writer won't be silently wiped. This script has no true resume (agent() is one-shot, the
-// whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
+// as its memory, and the orchestrator cats them into the posted comment, so stale
+// sections would pollute BOTH the author's context and the published trail. (The
+// glob also catches a prior author's claude section files, which double as the
+// rebuttal codex reads, so a stale one must not linger either.) A thin mechanical
+// agent (the workflow can't run shell itself). The reset is section/ledger-scoped:
+// it deletes only the stale `section-*.md` files, not the whole scratch dir, so
+// other artifacts in there (verdict-N.json and any other per-run files) keep their
+// own lifecycle and a future pre-loop writer won't be silently wiped. This script
+// has no true resume (agent() is one-shot, the whole workflow re-runs from
+// scratch), so a fresh start owns a fresh ledger.
 await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
@@ -435,10 +450,18 @@ if (rationale) {
 }
 
 for (let round = 1; ; round++) {
-  const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
+  const verdict = await codexReviews(round, lastClaudeSectionPath)
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
   transcript.push(entry) // record this round (mutated in place as it progresses)
+
+  // Write codex's section for this round to disk straight away — before any
+  // terminal break — so EVERY round (including a consensus-approval or error round
+  // that never reaches the author) lands in the section record the author reads as
+  // memory and the orchestrator cats into the comment. The claude section is the
+  // author's own write later in the round, when there is an author turn.
+  await writeCodexSection(round, verdict)
+
   // Reviewer error — terminal failure path. The runner could not get a verdict
   // out of codex (broken/unavailable CLI), so codex-review.sh synthesized an
   // error verdict carrying reviewerError:true. There are no findings to route to
@@ -473,14 +496,15 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. It reads the per-round section files (written at the end of each round
-  // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
-  // rebuttal next round (see codexReviews) — it is no longer the author's memory.
+  // rest, and writes its dispositions to its own claude section file (its memory,
+  // the rebuttal codex reads next round, and part of the posted comment). It reads
+  // the per-round section files for its cross-round memory. We remember the path it
+  // just wrote so the NEXT round feeds it to codex as the rebuttal.
   const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
-  lastClaude = response
+  lastClaudeSectionPath = claudeSectionFile(round)
   log(
-    `Round ${round}: claude done=${response.done}, actions=${(response.actions || []).length}, files=${(response.filesChanged || []).length}`,
+    `Round ${round}: claude done=${response.done}, files=${(response.filesChanged || []).length}`,
   )
 
   // The author commits its own round in-session (one commit per round, message
@@ -500,11 +524,8 @@ for (let round = 1; ; round++) {
       log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA — round left uncommitted`)
     }
   }
-
-  // Write this round's section so the NEXT round's author can read the full
-  // history. Terminal rounds break above before reaching here, so they're
-  // sectioned just after the loop.
-  await writeSection(entry)
+  // No section write here: codex's section was written at the top of the loop, and
+  // the author wrote its own claude section during its turn — both already on disk.
 }
 
 const filesChanged = Array.from(
@@ -526,18 +547,17 @@ if (status === 'consensus' && commitGaps.length) {
 
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-// Section the terminal round — it broke out of the loop before the in-loop
-// writeSection, so without this its section (a consensus approval, or an error
-// reached before the author got a turn) would be missing from the disk record
-// the orchestrator reads for the chat summary (cat section-*.md) and the
-// author would read as memory if the debate somehow continued.
-if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
+// The terminal round needs no extra section write: codex's section for it was
+// written at the top of the loop (every round), and a terminal round has no author
+// turn (and so no claude section) by definition.
 
-// Hand the orchestrator the ready-to-post comment, rendered deterministically
-// in-process (header + per-round sections) — it just writes the string to a file
-// and posts it (`gh pr comment -F`), the same shape lens-debate uses. The section
-// files on disk stay the author's cross-round memory; this is the published view
-// of that same record, so no agent ever retypes the whole ledger. See SKILL step 3.
+// Hand the orchestrator everything it needs to post the comment, but NOT a single
+// pre-rendered `comment` string — the author's per-round dispositions live in the
+// section files on disk (it wrote them itself), and the workflow can't read files.
+// So we return the small in-process `commentHeader` plus the section dir + glob; the
+// orchestrator assembles the comment with a faithful `cat` (header followed by the
+// section files in glob order) and posts that — a deterministic shell concat, no
+// agent ever retyping the ledger. See SKILL step 3.
 return {
   status,
   rounds: transcript.length,
@@ -548,5 +568,11 @@ return {
   // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
   commitGaps,
   transcript,
-  comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
+  // The comment's deterministic header (badge + round count + reasoning effort +
+  // base). The orchestrator posts: this header, a blank line, then
+  // `cat <workDir>/section-*.md`.
+  commentHeader: ledgerHeader({ status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
+  // Where the per-round section files live, so the orchestrator can cat them.
+  workDir,
+  sectionGlob: `${workDir}/section-*.md`,
 }

--- a/.apm/skills/codex-debate/scripts/codex-review.sh
+++ b/.apm/skills/codex-debate/scripts/codex-review.sh
@@ -16,8 +16,10 @@
 #   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]
 #
 #   <base-branch>    branch to diff against (e.g. master)
-#   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
-#                    or "-" on the first round (no rebuttal yet)
+#   <rebuttal-file>  path to a file holding CLAUDE's previous-round response — the
+#                    author-written Markdown disposition section (its per-finding
+#                    fixed/disputed/partial trail), NOT JSON. "-" on the first round
+#                    (no rebuttal yet). Cat'd verbatim into codex's prompt below.
 #   <out-json>       path the JSON verdict is written to (also echoed to stdout)
 #   <reasoning-effort> codex model_reasoning_effort for this run; the debate
 #                    workflow passes its REASONING_EFFORT constant here so the
@@ -55,9 +57,10 @@ schema="$here/codex-verdict.schema.json"
 # shellcheck source=codex-exec-lib.sh
 source "$here/codex-exec-lib.sh"
 
-# Pull CLAUDE's previous response, if any. Built as a plain string and injected
-# below via a simple variable reference so any special characters in the JSON
-# (backticks, $, ...) stay literal (heredoc expansion results are not re-scanned).
+# Pull CLAUDE's previous-round response (the author's Markdown disposition section),
+# if any. Built as a plain string and injected below via a simple variable reference
+# so any special characters in the text (backticks, $, ...) stay literal (heredoc
+# expansion results are not re-scanned).
 rebuttal=""
 if [ "$rebuttal_file" != "-" ]; then
   if [ -s "$rebuttal_file" ]; then

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -169,7 +169,8 @@ the workflow's notification arrives or it has provably errored.
    it). Don't report it as a clean consensus.
 
    **On `section-incomplete`,** the debate converged but a round's author **skipped
-   its disposition section file** (round numbers in `sectionGaps`), so the per-round
+   or under-filled its disposition section file** (missing, empty, or omitting a
+   marker for an open finding; round numbers in `sectionGaps`), so the per-round
    trail — and thus `$workDir/comment.md` — has a gap for that round. The tree edits
    and commits are intact; the missing piece is the record. **Append** a note to the
    already-frozen `$workDir/comment.md` naming the round(s) whose disposition record

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -136,13 +136,22 @@ the workflow's notification arrives or it has provably errored.
    } > "$workDir/comment.md"   # hold this path for the post-after-push step
    ```
 
-   (On persistent `reviewer-error` there is **no body to post** — per
-   `/codex-debate`, an unresolved reviewer error is not a consensus to report; skip
-   the codex comment in that case.)
+   This **freezes** the body now, so any reconciliation a later branch performs
+   (a `commit-incomplete` or `section-incomplete` fix-up below) is **not** in this
+   file yet — **append** that note to `$workDir/comment.md` after you reconcile, or
+   it won't reach the posted comment.
+
+   (On `merge-base-error` the workflow aborted before any debate ran, so there is
+   **no** `commentHeader`/`workDir`/`section-*.md` to assemble — do **not** run the
+   block above. Per `/codex-debate`, report the scope failure from the return's
+   `note`, fix the base ref (e.g. `git fetch`), and re-run; there's nothing to post.
+   On persistent `reviewer-error` there is likewise **no body to post** — an
+   unresolved reviewer error is not a consensus to report; skip the codex comment in
+   that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
-   in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
-   last meaning codex never
+   in `consensus`, `commit-incomplete` / `section-incomplete` (see below),
+   `reviewer-error`, or `merge-base-error` — `reviewer-error` meaning codex never
    produced a structured verdict even after `codex-review.sh`'s built-in
    per-`codex exec` retries. That is an *infrastructure hiccup, not a debate
    outcome*: re-launch it immediately with the same args. Stop the moment an
@@ -154,9 +163,18 @@ the workflow's notification arrives or it has provably errored.
    edits uncommitted (round numbers in `commitGaps`). The edits are still in the
    tree, but the per-round commit didn't land — **commit the outstanding tree
    yourself** (staging only the files that round changed, message
-   `fix: codex review — debate round N`) before the simplify step, and note the
-   reconciliation in the deferred codex comment. Don't report it as a clean
-   consensus.
+   `fix: codex review — debate round N`) before the simplify step, then **append**
+   the reconciliation note to the already-frozen `$workDir/comment.md` (the body was
+   captured above *before* this fix-up, so editing the section files wouldn't reach
+   it). Don't report it as a clean consensus.
+
+   **On `section-incomplete`,** the debate converged but a round's author **skipped
+   its disposition section file** (round numbers in `sectionGaps`), so the per-round
+   trail — and thus `$workDir/comment.md` — has a gap for that round. The tree edits
+   and commits are intact; the missing piece is the record. **Append** a note to the
+   already-frozen `$workDir/comment.md` naming the round(s) whose disposition record
+   is missing, and report it as **converged-but-not-clean** in your gauntlet summary.
+   Don't report it as a clean consensus.
 
 3. **simplify** — invoke `/simplify` (Skill tool), scoped to the change vs `MB`.
    It applies its fixes to the working tree. When it finishes, **commit** what it

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -35,9 +35,11 @@ be-review pushes only once, after all selected steps finish. A comment that name
 a commit SHA must never be posted while that SHA is local-only — if a later step
 failed or the run were interrupted, the PR would advertise commits that were
 never pushed. So the debate skills run with their self-commenting **suppressed**
-(`--no-comment`); be-review captures the comment body each returns, pushes once at
-the end, and only then posts the lens comment, the codex comment, and its own
-police summary. No PR comment can reference a local-only commit.
+(`--no-comment`); be-review captures each comment body (the lens skill returns one
+ready; the codex body it assembles from `commentHeader` + the section files —
+step 2), pushes once at the end, and only then posts the lens comment, the codex
+comment, and its own police summary. No PR comment can reference a local-only
+commit.
 
 ## Preflight
 
@@ -122,10 +124,21 @@ the workflow's notification arrives or it has provably errored.
    not just the diff** — every round) and `rationale` (so codex doesn't flag
    deliberate decisions at the source) straight through. Its step-2 `Workflow` runs
    in the background; **wait for it to finish** before starting the simplify step.
-   It commits its rounds and **returns** its rendered comment body — hold onto it
-   to post after the final push. (On persistent `reviewer-error` there is **no
-   body to post** — per `/codex-debate`, an unresolved reviewer error is not a
-   consensus to report; skip the codex comment in that case.)
+   It commits its rounds and returns a `commentHeader` plus the per-round section
+   files under `workDir` (it no longer returns a single pre-rendered comment string).
+   **Assemble the comment body now and hold it** to post after the final push —
+   capture it immediately so a later step can't disturb the scratch:
+
+   ```bash
+   {
+     printf '%s\n' "$commentHeader"
+     for f in "$workDir"/section-*.md; do printf '\n'; cat "$f"; printf '\n'; done
+   } > "$workDir/comment.md"   # hold this path for the post-after-push step
+   ```
+
+   (On persistent `reviewer-error` there is **no body to post** — per
+   `/codex-debate`, an unresolved reviewer error is not a consensus to report; skip
+   the codex comment in that case.)
 
    **Retry codex on `reviewer-error` (up to 3 attempts).** `/codex-debate` ends
    in `consensus`, `commit-incomplete` (see below), or `reviewer-error` — the
@@ -191,9 +204,10 @@ merges when satisfied.
 When you do post, post **one comment per track that produced a body** — skip any
 track `--tracks` excluded, and skip a track that ran but yielded no postable
 comment (lens on `merge-base-error`, codex on persistent `reviewer-error`): the
-lens body and the codex body verbatim (`gh pr comment -F`), and the police
-summary (the `## [👮 Code-police](https://agency.srid.ca/)` comment described in
-Report).
+lens body and the codex body verbatim (`gh pr comment -F` — the codex body is the
+`$workDir/comment.md` you assembled in step 2 from `commentHeader` + the section
+files), and the police summary (the
+`## [👮 Code-police](https://agency.srid.ca/)` comment described in Report).
 
 ## Report
 

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -170,15 +170,30 @@ worktrees never collide** and the scratch never shows up in the diff codex
 reviews. It returns:
 
 ```
-{ status: "consensus" | "commit-incomplete" | "reviewer-error",
-  rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
+{ status: "consensus" | "commit-incomplete" | "section-incomplete" | "reviewer-error",
+  rounds, base, finalVerdict, filesChanged, commitGaps, sectionGaps, transcript,
   commentHeader,        // the comment's small deterministic header (badge + round count + effort + base)
   workDir, sectionGlob } // where the per-round section files live; cat them under the header (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed;
 `commitGaps` lists the round numbers whose author edited files but returned no
-commit SHA — empty unless `status === "commit-incomplete"`.)
+commit SHA — empty unless `status === "commit-incomplete"`; `sectionGaps` lists the
+round numbers whose author left no disposition section file — empty unless
+`status === "section-incomplete"`.)
+
+There is one more, **earlier** terminus the workflow can return **before** the
+debate loop even starts — `merge-base-error`. If `git merge-base <base> HEAD`
+fails (a missing/typoed/stale base, or unrelated history), the diff scope can't be
+trusted, so the workflow **aborts up front** rather than review the base branch's
+drift as if this change made it. It returns a **different, smaller shape** — no
+`commentHeader`, `workDir`, or `sectionGlob`, because no debate (and so no section
+files) ever ran:
+
+```
+{ status: "merge-base-error", base, rounds: 0, transcript: [], finalVerdict: null,
+  note }   // human-readable: which base failed and how to fix it (e.g. `git fetch`)
+```
 The debate is recorded as small Markdown section files under `<workDir>` — **two
 per round**: `section-NNN-1-codex.md` (codex's verdict + findings) and
 `section-NNN-2-claude.md` (the author's per-finding dispositions), zero-padded so
@@ -211,6 +226,22 @@ session and only ever reads the one rebuttal file.
   **not** a clean consensus: a human must reconcile the uncommitted round(s)
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
+- **section-incomplete** — the debate *converged*, but a round's author **skipped
+  its disposition section file** (`section-NNN-2-claude.md` missing or empty for the
+  round(s) in `sectionGaps`). That file is the hole-free trail everyone draws on —
+  the author's memory, the rebuttal codex reads next round, and part of the posted
+  comment — so a miss means the published record has a gap. The code guards against
+  feeding an empty rebuttal to codex (it warns and keeps the prior pointer), and the
+  tree edits are still present, but this is **not** a clean consensus: a human must
+  fill in the missing round(s) before trusting the per-round record. Do **not**
+  report it as a plain consensus (see step 3).
+- **merge-base-error** — an *up-front* abort, **before** any debate round runs:
+  `git merge-base <base> HEAD` failed (missing/typoed/stale base, or unrelated
+  history), so the review scope can't be trusted. The return carries a human-readable
+  `note` (which base failed, how to fix it — e.g. `git fetch`) and **none** of the
+  comment-assembly fields (`commentHeader`/`workDir`/`sectionGlob`), because no
+  section files were ever written. Report the scope failure and **skip comment
+  assembly/posting entirely** (see step 3); fix the base ref and re-run.
 - **reviewer-error** — the one *abnormal* terminus: codex itself failed to
   produce a verdict (broken/unavailable CLI), so the workflow synthesized an
   error verdict and aborted rather than spin forever on a dead reviewer. This is
@@ -224,7 +255,16 @@ session and only ever reads the one rebuttal file.
 
 ### 3. Present the result
 
-**First branch on `status`.** If `status === "reviewer-error"`, the debate did
+**First branch on `status`.** If `status === "merge-base-error"`, the workflow
+**aborted before any debate ran** — `git merge-base <base> HEAD` failed, so the
+review scope couldn't be trusted. This return has **no** `commentHeader`,
+`workDir`, or `sectionGlob` (no section files exist), so there is **nothing to
+assemble**: do **not** run the posting block below. Report the scope failure —
+surface the return's `note` (it names the failing base and the fix) — tell the
+user to repair the base ref (e.g. `git fetch`, fix a typo'd/stale ref) and re-run,
+and **skip the rest of this section**.
+
+If `status === "reviewer-error"`, the debate did
 **not** reach consensus — codex never produced a real verdict. Report it as a
 **failure**, not a success: surface `finalVerdict.summary` (and the workflow log)
 so the user sees codex was broken/unavailable, and tell them to fix codex (e.g.
@@ -239,6 +279,13 @@ block below — `commentHeader` already shows a `⚠️` badge, not the consensu
 check), then tell the user which round(s) are uncommitted and that the outstanding
 tree must be committed before the per-round history can be trusted. Do **not** call
 it a clean consensus.
+
+If `status === "section-incomplete"`, the debate converged but at least one round's
+author **skipped its disposition section file** (round numbers in `sectionGaps`).
+Report it as **converged-but-not-clean**: assemble and post the comment as usual
+(the `⚠️` badge is already set), then tell the user which round(s) are missing
+their disposition record and that the per-round history has a gap a human should
+fill before trusting it. Do **not** call it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -164,29 +164,38 @@ codex findings and Claude's dispositions — never pushing or merging. (The comm
 is no longer a separate `commit:roundN` agent: the author already has the tree
 open, so it commits its own round.)
 
-Ephemeral scratch (verdicts, rebuttals, the debate ledger) lives under the
-gitignored, per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in
-different worktrees never collide** and the scratch never shows up in the diff
-codex reviews. It returns:
+Ephemeral scratch (verdicts, the debate ledger) lives under the gitignored,
+per-worktree `<repoPath>/.codex-debate/`, so **parallel debates in different
+worktrees never collide** and the scratch never shows up in the diff codex
+reviews. It returns:
 
 ```
 { status: "consensus" | "commit-incomplete" | "reviewer-error",
   rounds, base, finalVerdict, filesChanged, commitGaps, transcript,
-  comment }    // the deterministically rendered PR comment body — post it VERBATIM (step 3)
+  commentHeader,        // the comment's small deterministic header (badge + round count + effort + base)
+  workDir, sectionGlob } // where the per-round section files live; cat them under the header (step 3)
 ```
 
 (each `transcript[]` round also carries a `commit` SHA when that round committed;
 `commitGaps` lists the round numbers whose author edited files but returned no
 commit SHA — empty unless `status === "commit-incomplete"`.)
-The debate is recorded as **one small Markdown file per round** —
-`<workDir>/section-NNN.md` (zero-padded). Those section files are the **Claude
-author's cross-round memory** (so each round builds on the last instead of
-re-deriving the diff). The workflow renders the **same** record into `comment` —
-the outcome header followed by every round's section — so **step 3 just posts that
-string** (`gh pr comment -F`), exactly the way `/lens-debate` does. The comment is
-therefore a **deterministic** render, never re-improvised through an agent —
-nothing weak ever retypes a large blob. codex is *not* a reader — it keeps its own
-warm session, so re-feeding it the sections would just duplicate its context.
+The debate is recorded as small Markdown section files under `<workDir>` — **two
+per round**: `section-NNN-1-codex.md` (codex's verdict + findings) and
+`section-NNN-2-claude.md` (the author's per-finding dispositions), zero-padded so
+the `section-*.md` glob sorts in chronological order. **Each file is written by the
+party that owns its content**: a Haiku writer renders codex's small *structured*
+verdict to disk, and the **author writes its own dispositions directly** — the same
+way codex writes its verdict to a path. That author-writes-its-own-file design is
+deliberate: it keeps the author's *structured* return a **minimal ack**
+(`filesChanged`/`commitSha`/`done`), so a big multi-finding narrative can never
+overflow the structured-output encoding (the failure that used to crash the debate
+on large diffs). The author's disposition file does triple duty — it's the author's
+cross-round **memory**, the **rebuttal** codex reads next round (`codex-review.sh`
+cats it straight into codex's prompt), and the **published comment** (step 3 cats
+the section files under `commentHeader`). So the comment is still a **deterministic**
+render — a shell `cat`, never re-improvised through an agent, nothing weak ever
+retyping a large blob. codex is *not* a memory reader — it keeps its own warm
+session and only ever reads the one rebuttal file.
 
 - **consensus** — every finding codex raised is resolved (any severity — Claude
   fixed it or codex conceded the dispute). This is the *only* way the debate ends
@@ -225,10 +234,11 @@ report. Skip the rest of this section.
 
 If `status === "commit-incomplete"`, the debate converged but at least one round
 left its edits **uncommitted** (the round numbers are in `commitGaps`). Report it
-as **converged-but-not-clean**: post the `comment` (its header already shows a
-`⚠️` badge, not the consensus check), then tell the user which round(s) are
-uncommitted and that the outstanding tree must be committed before the per-round
-history can be trusted. Do **not** call it a clean consensus.
+as **converged-but-not-clean**: assemble and post the comment (see the posting
+block below — `commentHeader` already shows a `⚠️` badge, not the consensus
+check), then tell the user which round(s) are uncommitted and that the outstanding
+tree must be committed before the per-round history can be trusted. Do **not** call
+it a clean consensus.
 
 Otherwise (`status === "consensus"`) report in chat (do **not** push or merge —
 the per-round commits sit on the local branch for the human to review):
@@ -243,31 +253,37 @@ the per-round commits sit on the local branch for the human to review):
 - `git log --oneline <base>..HEAD` (the per-round debate commits) and
   `git diff --stat <base>` so the user sees what the debate changed.
 - A compact per-round summary — read it straight from the section files
-  (`cat <workDir>/section-*.md`: each round's codex verdict, Claude's
-  dispositions, and the commit SHA) so the convergence reads round by round. No
-  need to re-derive it from `transcript`; the sections already render it.
+  (`cat <workDir>/section-*.md`: each round's codex verdict, then the author's
+  dispositions and commit SHA) so the convergence reads round by round. No need to
+  re-derive it from `transcript`; the sections already render it.
 - The agreed changes are committed per round on the local branch (or, under
   `--no-commit`, uncommitted in the working tree). The user reviews, then pushes
   / merges (or runs `/do --from post-implement`) when satisfied.
 - **Post the debate summary to the PR (default).** When a PR exists and
-  `--no-comment` was NOT passed, post the workflow's **deterministically rendered
-  `comment`** verbatim — write it to a file and `gh pr comment <pr> -F <file>`:
+  `--no-comment` was NOT passed, **assemble** the comment from the workflow's
+  return — the small `commentHeader`, then the per-round section files `cat`-ed in
+  glob order — and `gh pr comment <pr> -F <file>`:
 
   ```bash
-  mkdir -p "$repoPath/.codex-debate"   # reviewer-error/--no-commit runs may not have created it
-  printf '%s' "$comment" > "$repoPath/.codex-debate/comment.md"
-  gh pr comment <pr> -F "$repoPath/.codex-debate/comment.md"
+  mkdir -p "$workDir"   # reviewer-error/--no-commit runs may not have created it
+  {
+    printf '%s\n' "$commentHeader"
+    for f in "$workDir"/section-*.md; do printf '\n'; cat "$f"; printf '\n'; done
+  } > "$workDir/comment.md"
+  gh pr comment <pr> -F "$workDir/comment.md"
   ```
 
-  The workflow returns `comment` already rendered — the `## Codex ⇄ Claude debate`
-  header (consensus badge, round count, the **reasoning-effort** note from the
-  workflow's `REASONING_EFFORT` constant) followed by the per-round breakdown of
-  codex's findings and Claude's dispositions
-  that the author also read. So the comment is a **deterministic** render of the
-  same record the commit messages and the author drew on — not an LLM-improvised
-  table. Posting the returned string mirrors `/lens-debate`. This is an
-  outward-facing write — on by default because the whole point is to leave the
-  review trail on the PR; `--no-comment` suppresses it.
+  (`$workDir` is the returned `workDir`, i.e. `<repoPath>/.codex-debate`; the
+  `for`-loop guarantees a blank line between sections regardless of each file's
+  trailing newline.) The result is the `## Codex ⇄ Claude debate` header (consensus
+  badge, round count, the **reasoning-effort** note from the workflow's
+  `REASONING_EFFORT` constant) followed by the per-round breakdown of codex's
+  findings and the author's dispositions — the **same** section files the author
+  read as memory and codex read as the rebuttal. So the comment is a
+  **deterministic** shell concat of the record everyone drew on, not an
+  LLM-improvised table — nothing weak ever retypes a blob. This is an outward-facing
+  write — on by default because the whole point is to leave the review trail on the
+  PR; `--no-comment` suppresses it.
 
 <a id="answer-mode"></a>
 # Answer mode — Codex ⇄ Claude answer debate
@@ -424,15 +440,21 @@ returns:
   way codex is — `agent()` is one-shot and Claude isn't headless under Max auth,
   so there's no session id to carry forward. The equivalent is context, not state:
   each follow-up round the author **reads the per-round section files**
-  (`cat .codex-debate/section-*.md`) — every prior round's findings and its own
-  dispositions — so it builds on its last round rather than re-deriving the whole
-  diff, and won't re-fix or re-litigate findings already settled. A small section
-  is written after each round, so round N>1 always sees rounds 1..N-1; round 1 has
-  none yet, so it's byte-identical to a cold start (and if no sections exist, the
-  author falls back to the diff + verdict). The *same* sections compose the PR
-  comment step 3 posts, so the author's memory and the published summary are one
-  record. The writes stay small (one round each), so the Haiku writer never
-  retypes a large blob. codex stays on its own warm session and never reads them.
+  (`cat .codex-debate/section-*.md`) — every prior round's codex findings and its
+  own dispositions — so it builds on its last round rather than re-deriving the
+  whole diff, and won't re-fix or re-litigate findings already settled. Each round
+  writes two small files (a Haiku-rendered codex section and the author's own
+  disposition section), so round N>1 always sees rounds 1..N-1; round 1 has none
+  yet, so it's byte-identical to a cold start (and if no sections exist, the author
+  falls back to the diff + verdict). The *same* sections compose the PR comment step
+  3 posts and the rebuttal codex reads, so the author's memory, the published
+  summary, and codex's rebuttal are one record. Crucially, the author **writes its
+  own disposition section directly** — it never has to pour that narrative through a
+  structured field — so its structured return stays a minimal ack and can't overflow
+  on a large, many-finding diff (the failure this design replaced). The Haiku writer
+  only ever renders codex's small *structured* verdict, so nothing weak retypes a
+  large blob. codex stays on its own warm session and never reads the sections —
+  only the one rebuttal file each round.
 - **Inherited context, not just diff.** On top of that cross-round memory, when the
   caller passes `context` and/or `rationale` the author **inherits them in EVERY
   round's prompt** — the main-agent intent (what the change is FOR) and the
@@ -446,13 +468,14 @@ returns:
   `--no-commit`) so the PR history reads as the debate, but the skill never
   pushes or merges. Consensus means "both AIs agree on the committed code," not
   "ship it" — the human reviews the commits and pushes/merges.
-- **Parallel-safe.** Ephemeral scratch (verdicts, rebuttals, the per-round
-  sections) lives under the gitignored, per-worktree `<repoPath>/.codex-debate/`,
-  so debates on many worktrees run at once without clobbering each other — no
-  shared `/tmp` paths, and each worktree's section files are its own.
+- **Parallel-safe.** Ephemeral scratch (verdicts and the per-round section files,
+  the author-written ones doubling as the rebuttal) lives under the gitignored,
+  per-worktree `<repoPath>/.codex-debate/`, so debates on many worktrees run at once
+  without clobbering each other — no shared `/tmp` paths, and each worktree's section
+  files are its own.
 - **Posts to the PR by default.** When a PR exists, the debate summary — the
-  workflow's deterministically rendered `comment` (header + per-round sections) —
-  is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
+  `commentHeader` followed by the per-round section files `cat`-ed together (step 3)
+  — is posted as a PR comment (outward-facing write) unless `--no-comment` is passed
   — the point is to leave the review trail on the PR.
 - **Runs to consensus — no cap, no deadlock exit.** The loop ends only when codex
   and Claude agree; it does not bail out at a round cap or declare a "deadlock," because

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -227,8 +227,9 @@ session and only ever reads the one rebuttal file.
   (e.g. commit the outstanding tree) before relying on the per-round history. Do
   **not** report it as a plain consensus (see step 3).
 - **section-incomplete** — the debate *converged*, but a round's author **skipped
-  its disposition section file** (`section-NNN-2-claude.md` missing or empty for the
-  round(s) in `sectionGaps`). That file is the hole-free trail everyone draws on —
+  or under-filled its disposition section file** (`section-NNN-2-claude.md` missing,
+  empty, or missing a backticked marker for an open finding, for the round(s) in
+  `sectionGaps`). That file is the hole-free trail everyone draws on —
   the author's memory, the rebuttal codex reads next round, and part of the posted
   comment — so a miss means the published record has a gap. The code guards against
   feeding an empty rebuttal to codex (it warns and keeps the prior pointer), and the
@@ -281,7 +282,8 @@ tree must be committed before the per-round history can be trusted. Do **not** c
 it a clean consensus.
 
 If `status === "section-incomplete"`, the debate converged but at least one round's
-author **skipped its disposition section file** (round numbers in `sectionGaps`).
+author **skipped or under-filled its disposition section file** (missing, empty, or
+omitting a marker for an open finding; round numbers in `sectionGaps`).
 Report it as **converged-but-not-clean**: assemble and post the comment as usual
 (the `⚠️` badge is already set), then tell the user which round(s) are missing
 their disposition record and that the per-round history has a gap a human should

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -363,6 +363,34 @@ async function writeCodexSection(round, verdict) {
   return writeFileAgent(codexSectionFile(round), codexSection(round, verdict), `ledger:codex:round${round}`)
 }
 
+// VERIFY the author actually wrote its disposition section this round. The author's
+// claude section is the load-bearing handoff: it's the next round's rebuttal (codex
+// reads it), the author's own cross-round memory, AND part of the posted comment.
+// If the author skipped the Write, `lastClaudeSectionPath` would still point at a
+// path that doesn't exist — codex-review.sh would warn and proceed with an EMPTY
+// rebuttal, and the debate could still converge over a hole in the trail. So after
+// every author turn we deterministically check the file exists and is non-empty;
+// the workflow has no file I/O of its own, so a thin mechanical agent does the
+// `test -s`. We do NOT parse the file for finding-id coverage — the disposition
+// CONTRACT (one bullet per finding) plus codex's own next-round re-review already
+// police completeness; a markdown-id grep here would be brittle and redundant. This
+// check is the file's EXISTENCE/non-emptiness, the part nothing else guards. A miss
+// is recorded as a section gap and downgrades the terminal status (see below), the
+// same fail-loud-not-silent treatment as a missed commit.
+async function verifyClaudeSection(round) {
+  const path = claudeSectionFile(round)
+  const res = await agent(
+    `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`test -s ${shq(path)} && echo present || echo missing\`. Return \`ok\`: true if the output was "present" (the file exists and is non-empty), false otherwise. Do not edit any file. Do not run git.`,
+    {
+      label: `verify:claude:round${round}`,
+      phase: 'Debate',
+      model: mechModel,
+      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists and is non-empty' } } },
+    },
+  )
+  return res?.ok === true
+}
+
 const transcript = []
 // 'consensus' is the only NORMAL terminus. 'reviewer-error' is the one abnormal
 // terminus: codex itself failed to produce a verdict (broken/unavailable). That
@@ -384,6 +412,13 @@ let lastClaudeSectionPath = null
 // report success over a missed commit. Not a hard abort: a transient SHA omission
 // shouldn't nuke a multi-round debate whose edits are all present in the tree.
 const commitGaps = []
+// Rounds where the author's disposition section file is missing or empty after its
+// turn — the handoff that feeds the rebuttal, the author's memory, and the comment
+// broke. We DON'T silently let an empty rebuttal slip to codex (which would warn and
+// proceed, possibly converging over a hole in the trail): a miss is recorded here
+// and downgrades the terminal status to 'section-incomplete' below. Not a hard abort
+// for the same reason as commitGaps — the tree edits are still present and reviewed.
+const sectionGaps = []
 
 // ---------------------------------------------------------------------------
 // The loop — runs until consensus. No round cap, no deadlock exit.
@@ -498,14 +533,27 @@ for (let round = 1; ; round++) {
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
   // rest, and writes its dispositions to its own claude section file (its memory,
   // the rebuttal codex reads next round, and part of the posted comment). It reads
-  // the per-round section files for its cross-round memory. We remember the path it
-  // just wrote so the NEXT round feeds it to codex as the rebuttal.
+  // the per-round section files for its cross-round memory. We point the rebuttal at
+  // the path it just wrote so the NEXT round feeds it to codex — but only AFTER
+  // verifying the file actually landed (see verifyClaudeSection below).
   const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
-  lastClaudeSectionPath = claudeSectionFile(round)
   log(
     `Round ${round}: claude done=${response.done}, files=${(response.filesChanged || []).length}`,
   )
+
+  // VERIFY the author wrote its disposition section before we lean on it. The file
+  // is the next round's rebuttal, the author's memory, and part of the comment — if
+  // it's missing/empty the handoff broke. Only point `lastClaudeSectionPath` at it
+  // (so codex reads it as the rebuttal next round) once it actually exists; on a miss
+  // record the gap, leave the rebuttal pointer where it was (codex sees `-`/the prior
+  // round's section rather than an empty one), and downgrade the terminal status.
+  if (await verifyClaudeSection(round)) {
+    lastClaudeSectionPath = claudeSectionFile(round)
+  } else {
+    sectionGaps.push(round)
+    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing or empty — handoff broke; not feeding it to codex as the rebuttal.`)
+  }
 
   // The author commits its own round in-session (one commit per round, message
   // carrying codex's findings and its dispositions), so here we just record the
@@ -545,6 +593,19 @@ if (status === 'consensus' && commitGaps.length) {
   log(`Round(s) ${commitGaps.join(', ')} left uncommitted despite changing files — downgrading consensus to commit-incomplete.`)
 }
 
+// Downgrade a would-be consensus when any round's author skipped its disposition
+// section file. The debate may read as converged, but a missing section is a hole in
+// the trail the author, codex (as the rebuttal), and the posted comment all draw on —
+// so we must NOT advertise a clean consensus. 'section-incomplete' is a distinct,
+// non-consensus terminus: a human/caller must fill in the missing round(s) before
+// trusting the per-round record. We don't override an already-abnormal status
+// (reviewer-error, or commit-incomplete which is reported the same converged-but-
+// -not-clean way) — the first downgrade already marks the run unclean.
+if (status === 'consensus' && sectionGaps.length) {
+  status = 'section-incomplete'
+  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section — downgrading consensus to section-incomplete.`)
+}
+
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
 // The terminal round needs no extra section write: codex's section for it was
@@ -567,6 +628,9 @@ return {
   // Rounds whose author-side commit didn't land (empty unless status is
   // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
   commitGaps,
+  // Rounds whose author-side disposition section file is missing/empty (empty unless
+  // status is 'section-incomplete'). Lets the caller pinpoint the hole in the trail.
+  sectionGaps,
   transcript,
   // The comment's deterministic header (badge + round count + reasoning effort +
   // base). The orchestrator posts: this header, a blank line, then

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -369,23 +369,35 @@ async function writeCodexSection(round, verdict) {
 // If the author skipped the Write, `lastClaudeSectionPath` would still point at a
 // path that doesn't exist — codex-review.sh would warn and proceed with an EMPTY
 // rebuttal, and the debate could still converge over a hole in the trail. So after
-// every author turn we deterministically check the file exists and is non-empty;
-// the workflow has no file I/O of its own, so a thin mechanical agent does the
-// `test -s`. We do NOT parse the file for finding-id coverage — the disposition
-// CONTRACT (one bullet per finding) plus codex's own next-round re-review already
-// police completeness; a markdown-id grep here would be brittle and redundant. This
-// check is the file's EXISTENCE/non-emptiness, the part nothing else guards. A miss
-// is recorded as a section gap and downgrades the terminal status (see below), the
-// same fail-loud-not-silent treatment as a missed commit.
-async function verifyClaudeSection(round) {
+// every author turn we deterministically check the file exists, is non-empty, AND
+// carries a backticked disposition marker for EVERY open finding this round. The
+// workflow has no file I/O of its own, so a thin mechanical agent runs `test -s`
+// plus an exact `grep -F` per finding id. We do NOT parse prose or score the
+// disposition text — only that a `\`Fn\`` token is present, which is an exact,
+// bounded check the author prompt already mandates ("one bullet PER finding",
+// each id backticked). This closes the hole the file-as-source-of-truth opened:
+// a non-empty but INCOMPLETE section (omitting `F2`) used to advance the rebuttal
+// pointer and could converge over a per-finding hole in the durable trail. A miss
+// — empty file OR any missing finding id — is recorded as a section gap and
+// downgrades the terminal status (see below), the same fail-loud-not-silent
+// treatment as a missed commit. Codex's own next-round re-review still polices
+// the SUBSTANCE of each disposition; this guards only the COMPLETENESS of the
+// published per-finding record, which nothing else covers.
+async function verifyClaudeSection(round, openIds) {
   const path = claudeSectionFile(round)
+  // Each open finding must appear as a backticked id token (e.g. `F1`) in the
+  // section. `grep -F` is a literal substring match — no regex/prose brittleness.
+  const idChecks = openIds
+    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo missing-${id}; ok=0; }`)
+    .join('; ')
+  const idList = openIds.length ? openIds.map((id) => `\`${id}\``).join(', ') : '(none)'
   const res = await agent(
-    `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`test -s ${shq(path)} && echo present || echo missing\`. Return \`ok\`: true if the output was "present" (the file exists and is non-empty), false otherwise. Do not edit any file. Do not run git.`,
+    `You are a MECHANICAL RUNNER. Run exactly this and nothing else, then report:\n\`ok=1; test -s ${shq(path)} || { echo empty; ok=0; }${idChecks ? `; ${idChecks}` : ''}; echo "ok=$ok"\`\nThis checks the section file exists, is non-empty, and contains a backticked marker for every open finding (${idList}). Return \`ok\`: true if the final line was "ok=1", false otherwise (any "empty" or "missing-Fn" line means false). Do not edit any file. Do not run git.`,
     {
       label: `verify:claude:round${round}`,
       phase: 'Debate',
       model: mechModel,
-      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists and is non-empty' } } },
+      schema: { type: 'object', additionalProperties: false, required: ['ok'], properties: { ok: { type: 'boolean', description: 'true when the section file exists, is non-empty, and carries a backticked marker for every open finding' } } },
     },
   )
   return res?.ok === true
@@ -412,12 +424,14 @@ let lastClaudeSectionPath = null
 // report success over a missed commit. Not a hard abort: a transient SHA omission
 // shouldn't nuke a multi-round debate whose edits are all present in the tree.
 const commitGaps = []
-// Rounds where the author's disposition section file is missing or empty after its
-// turn — the handoff that feeds the rebuttal, the author's memory, and the comment
-// broke. We DON'T silently let an empty rebuttal slip to codex (which would warn and
-// proceed, possibly converging over a hole in the trail): a miss is recorded here
-// and downgrades the terminal status to 'section-incomplete' below. Not a hard abort
-// for the same reason as commitGaps — the tree edits are still present and reviewed.
+// Rounds where the author's disposition section file is missing, empty, OR missing
+// a backticked marker for one or more open findings after its turn — the handoff
+// that feeds the rebuttal, the author's memory, and the comment broke. We DON'T
+// silently let an empty or per-finding-incomplete rebuttal slip to codex (which
+// would warn and proceed, possibly converging over a hole in the trail): a miss is
+// recorded here and downgrades the terminal status to 'section-incomplete' below.
+// Not a hard abort for the same reason as commitGaps — the tree edits are still
+// present and reviewed.
 const sectionGaps = []
 
 // ---------------------------------------------------------------------------
@@ -544,15 +558,18 @@ for (let round = 1; ; round++) {
 
   // VERIFY the author wrote its disposition section before we lean on it. The file
   // is the next round's rebuttal, the author's memory, and part of the comment — if
-  // it's missing/empty the handoff broke. Only point `lastClaudeSectionPath` at it
-  // (so codex reads it as the rebuttal next round) once it actually exists; on a miss
-  // record the gap, leave the rebuttal pointer where it was (codex sees `-`/the prior
-  // round's section rather than an empty one), and downgrade the terminal status.
-  if (await verifyClaudeSection(round)) {
+  // it's missing/empty/incomplete the handoff broke. We require a backticked marker
+  // for every finding the author had to address this round (`open`), so a non-empty
+  // but partial section can't slip a per-finding hole into the trail. Only point
+  // `lastClaudeSectionPath` at it (so codex reads it as the rebuttal next round) once
+  // it exists AND covers every open id; on a miss record the gap, leave the rebuttal
+  // pointer where it was (codex sees `-`/the prior round's section rather than an
+  // incomplete one), and downgrade the terminal status.
+  if (await verifyClaudeSection(round, open.map((f) => f.id))) {
     lastClaudeSectionPath = claudeSectionFile(round)
   } else {
     sectionGaps.push(round)
-    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing or empty — handoff broke; not feeding it to codex as the rebuttal.`)
+    log(`Round ${round}: author's disposition section ${claudeSectionFile(round)} is missing, empty, or missing a marker for an open finding — handoff broke; not feeding it to codex as the rebuttal.`)
   }
 
   // The author commits its own round in-session (one commit per round, message
@@ -594,8 +611,9 @@ if (status === 'consensus' && commitGaps.length) {
 }
 
 // Downgrade a would-be consensus when any round's author skipped its disposition
-// section file. The debate may read as converged, but a missing section is a hole in
-// the trail the author, codex (as the rebuttal), and the posted comment all draw on —
+// section file OR left it missing a marker for an open finding. The debate may read
+// as converged, but a missing or per-finding-incomplete section is a hole in the
+// trail the author, codex (as the rebuttal), and the posted comment all draw on —
 // so we must NOT advertise a clean consensus. 'section-incomplete' is a distinct,
 // non-consensus terminus: a human/caller must fill in the missing round(s) before
 // trusting the per-round record. We don't override an already-abnormal status
@@ -603,7 +621,7 @@ if (status === 'consensus' && commitGaps.length) {
 // -not-clean way) — the first downgrade already marks the run unclean.
 if (status === 'consensus' && sectionGaps.length) {
   status = 'section-incomplete'
-  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section — downgrading consensus to section-incomplete.`)
+  log(`Round(s) ${sectionGaps.join(', ')} are missing the author's disposition section or a finding marker — downgrading consensus to section-incomplete.`)
 }
 
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -388,7 +388,7 @@ async function verifyClaudeSection(round, openIds) {
   // Each open finding must appear as a backticked id token (e.g. `F1`) in the
   // section. `grep -F` is a literal substring match — no regex/prose brittleness.
   const idChecks = openIds
-    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo missing-${id}; ok=0; }`)
+    .map((id) => `grep -Fq ${shq(`\`${id}\``)} ${shq(path)} || { echo ${shq(`missing-${id}`)}; ok=0; }`)
     .join('; ')
   const idList = openIds.length ? openIds.map((id) => `\`${id}\``).join(', ') : '(none)'
   const res = await agent(

--- a/.claude/skills/codex-debate/debate.workflow.js
+++ b/.claude/skills/codex-debate/debate.workflow.js
@@ -30,14 +30,29 @@ const workDir = `${repoPath}/.codex-debate`
 // DESTRUCTIVE command (the ledger `rm -f` below); the benign `mkdir -p` prompts
 // elsewhere can tolerate an unquoted path, but a mistargeted `rm -f` cannot.
 const shq = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
-// The debate is recorded as one small Markdown file PER ROUND (`section-NNN.md`,
-// written under the gitignored scratch dir) — the claude author reads them as its
-// cross-round memory (full history, no inline blob). The PR comment is rendered
-// from the SAME per-round sections in-process (see renderLedger) and returned as
-// `comment`, so the published summary and the author's context are one record —
-// deterministic, never re-rendered through an agent (nothing weak ever retypes a
-// large blob). codex is NOT a reader: it keeps its own warm session, so re-feeding
-// it the ledger would just duplicate what it already remembers.
+// The debate is recorded as small Markdown SECTION FILES under the gitignored
+// scratch dir — TWO per round: `section-NNN-1-codex.md` (codex's verdict) and
+// `section-NNN-2-claude.md` (the author's dispositions). Each is written by the
+// party that OWNS its content, never forced through a structured payload:
+//   * codex's section — a Haiku writer renders the small STRUCTURED verdict
+//     (approval + findings) to disk; faithful, nothing to bloat.
+//   * claude's section — the AUTHOR writes its OWN per-finding dispositions
+//     directly (it's already editing the tree), exactly the way codex writes its
+//     verdict to a path. This is the STRUCTURAL fix for the old crash: the author
+//     used to pour its whole narrative into a structured field, which overflowed
+//     the StructuredOutput encoding and silently dropped the required array until
+//     the retry cap tripped. Now the narrative goes to the file and the author's
+//     structured return is a MINIMAL ACK (filesChanged/commitSha/done) whose size
+//     is decoupled from the finding count entirely, so it can never overflow.
+// These section files serve THREE roles at once, no copy ever re-typed by a weak
+// agent: (1) the author's cross-round memory (it cats them for full history);
+// (2) the REBUTTAL codex reads next round — codex-review.sh `cat`s the author's
+// section file straight into its prompt, so codex still sees every disposition;
+// (3) the published PR comment, which the orchestrator assembles by `cat`-ing the
+// section files after a small in-process header (see ledgerHeader / commentHeader)
+// — a deterministic shell concat, never re-rendered through an agent. codex is NOT
+// a memory reader: it keeps its own warm session, so it only ever reads the one
+// rebuttal file, not the whole ledger.
 // Commit each round's changes individually (default on). The author commits its
 // OWN round in-session — it already edits the tree, so it stages exactly what it
 // changed and writes a message carrying the debate context (codex's findings +
@@ -46,9 +61,11 @@ const commit = a.commit !== false
 // Model tiers. The claude-author round does real reasoning (fixing/disputing
 // codex's findings, and committing its own round) → `model` (Opus). Everything
 // else here is mechanical — the codex runner just shells out to codex-review.sh
-// and copies the verdict, the ledger writer dumps a section file, the merge-base
-// resolver runs one git command → `mechModel`
-// (Haiku). Defaults match a direct invocation; /be-review passes both explicitly.
+// and copies the verdict, the codex-section writer dumps a rendered verdict to a
+// file, the merge-base resolver runs one git command → `mechModel`
+// (Haiku). (The CLAUDE section is written by the author itself, on `model`, as part
+// of its round — not by a mechanical writer.) Defaults match a direct invocation;
+// /be-review passes both explicitly.
 const model = a.model || 'opus'
 const mechModel = a.mechModel || 'haiku'
 // Fidelity tier (Sonnet). One "mechanical" job isn't a trivial command but a
@@ -57,7 +74,7 @@ const mechModel = a.mechModel || 'haiku'
 // validation checks the verdict's SHAPE, not its wording), and Haiku is the
 // weakest tier for verbatim reproduction — so the verdict relay runs a notch up.
 // Still far cheaper/faster than Opus; the real reviewing is codex's, not this
-// agent's. The small per-round section writes stay on Haiku (tiny payloads).
+// agent's. The small per-round codex-section writes stay on Haiku (tiny payloads).
 const copyModel = a.copyModel || 'sonnet'
 
 // --- Context the Claude implementor INHERITS --------------------------------
@@ -135,31 +152,28 @@ const CODEX_VERDICT_SCHEMA = {
   required: ['approved', 'summary', 'findings', 'responseToRebuttal'],
 }
 
+// The author's structured return is a MINIMAL ACK by design — no `summary`, no
+// per-finding `actions`. The full narrative (the per-finding dispositions AND the
+// round summary) is written by the author to its section file instead (see
+// claudeResponds), exactly the way codex writes its verdict to a path. This is the
+// structural fix for the old crash: a large structured payload (the author pouring
+// its whole F1/F2/F3 narrative into `summary` + one `detail` per finding)
+// overflowed the StructuredOutput encoding, which silently dropped the required
+// array and tripped the retry cap. With only these few small, fixed fields the
+// payload size is decoupled from the finding count entirely, so it can never
+// overflow. `filesChanged` is bounded by the files touched (not narrative);
+// `commitSha` is one hash; `done` is a flag.
 const CLAUDE_RESPONSE_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   properties: {
-    summary: { type: 'string' },
-    actions: {
-      type: 'array',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          findingId: { type: 'string' },
-          disposition: { type: 'string', enum: ['fixed', 'disputed', 'partial'] },
-          detail: { type: 'string' },
-        },
-        required: ['findingId', 'disposition', 'detail'],
-      },
-    },
     filesChanged: { type: 'array', items: { type: 'string' } },
     // The author commits its own round (it already edits the tree), so it returns
     // the resulting SHA here. "" when it changed nothing or ran under --no-commit.
     commitSha: { type: 'string' },
     done: { type: 'boolean' },
   },
-  required: ['summary', 'actions', 'filesChanged', 'done'],
+  required: ['filesChanged', 'done'],
 }
 
 // Consensus = no finding left open, any severity. The loop runs until codex
@@ -171,30 +185,28 @@ function openFindings(verdict) {
 // ---------------------------------------------------------------------------
 // The two debaters
 // ---------------------------------------------------------------------------
-async function codexReviews(round, rebuttalJson) {
+async function codexReviews(round, rebuttalPath) {
   const verdictPath = `${workDir}/verdict-${round}.json`
-  const rebuttalPath = `${workDir}/rebuttal.json`
-  const rebuttalStep = rebuttalJson
-    ? `1. Using the Write tool (NOT a shell heredoc — the content has special characters), create the file \`${rebuttalPath}\` with exactly this content:
-
-${rebuttalJson}
-
-2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalPath} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
-    : `1. (No prior rebuttal this round.)
-
-2. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
-   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} - ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\``
+  // The rebuttal codex reads is the author's PRIOR-round disposition section file
+  // (it wrote it itself; codex-review.sh `cat`s it straight into codex's prompt).
+  // No inline blob, no separate rebuttal-file write step — the file already exists.
+  // `-` on round 1 (no prior author turn yet).
+  const rebuttalArg = rebuttalPath || '-'
+  const rebuttalNote = rebuttalPath
+    ? `   (\`${rebuttalPath}\` is the author's prior-round disposition section — codex reads it as the rebuttal. If it's somehow missing, the script proceeds with no rebuttal and warns; that's fine.)`
+    : `   (No prior rebuttal this round — the \`-\` argument tells the script there's none.)`
 
   const prompt = `You are a MECHANICAL RUNNER for one round of an automated code-review debate. Do exactly the steps below and nothing else. Do NOT review the code yourself, do NOT edit any repository files, do NOT add commentary.
 
 First ensure the scratch dir exists: \`mkdir -p ${workDir}\`.
 
-${rebuttalStep}
+1. Run (cd into the repo root so the script's internal \`git diff\`/\`git status\` target THIS worktree — your shell cwd may be a different worktree):
+   \`cd ${repoPath} && bash ${skillDir}/scripts/codex-review.sh ${base} ${rebuttalArg} ${verdictPath} ${REASONING_EFFORT} ${rationaleFileArg}\`
+${rebuttalNote}
 
    This shells out to the codex CLI as a read-only reviewer; it can take 1-3 minutes. It prints a JSON verdict as its final stdout and also writes it to the \`-o\` path.
 
-3. Read \`${verdictPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
+2. Read \`${verdictPath}\` and return its exact contents as your structured output. Copy the values faithfully; do not paraphrase or "improve" them.`
 
   return agent(prompt, {
     label: `codex:round${round}`,
@@ -209,11 +221,12 @@ async function claudeResponds(round, verdict, doCommit) {
   // and Claude isn't headless under Max auth, so there's no session to resume the
   // way `codex exec resume` carries codex's reasoning forward). The achievable
   // equivalent is context, not state: every follow-up round the author reads the
-  // per-round section files — the record of every prior round's findings and its
-  // OWN dispositions — and builds on them instead of re-deriving the diff. A
-  // section is written after each round (see the loop), so on round N>1 the files
-  // already hold rounds 1..N-1. Round 1 has none yet, so its prompt is
-  // byte-identical to a cold start.
+  // per-round section files — the record of every prior round's findings (codex's
+  // section, Haiku-written) and its OWN dispositions (the claude section it wrote
+  // itself last round) — and builds on them instead of re-deriving the diff. codex's
+  // section is written each round in the loop and the author writes its claude
+  // section as the LAST step of its own turn, so on round N>1 the files already hold
+  // rounds 1..N-1. Round 1 has none yet, so its prompt is byte-identical to a cold start.
   const priorBlock =
     round > 1
       ? `This is a FOLLOW-UP round. Every prior round is recorded as a small Markdown file under the debate's scratch dir — read them FIRST for the full history (codex's past findings and YOUR own dispositions):
@@ -234,13 +247,22 @@ Address EVERY finding, any severity (don't skip minors/nits):
   - disagree → leave the code, dispute it with a specific technical reason (cite file:line); disposition "disputed". Concede when codex is right.
   - partly → fix the valid part, explain the rest; disposition "partial".
 
-You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the finding's detail rather than reporting a clean "fixed". ${
+You may run the formatter on files you touched. SELF-VERIFY before you claim "fixed": a fix you didn't run isn't a fix. Run the project's own fast static-check gate (its lint + typecheck task — e.g. \`just check\`/\`npm run lint\`; discover it from the repo, don't hand-roll one) over your edits and make it pass; only mark a finding "fixed" once the gate is green. Never claim a lint won't fire without running it — that's the exact "I watched it work" gap that lands a red tree on the next step. If the gate stays red after a genuine attempt, say so in the disposition rather than reporting a clean "fixed". ${
     doCommit
-      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. Return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`. If you changed no files, don't commit and leave \`commitSha\` empty.`
-      : `Edit the working tree only — do NOT git add/commit/push; leave \`commitSha\` empty.`
+      ? `Once you've addressed every finding AND you actually changed files (and the static-check gate is green), COMMIT this round's work yourself — the debate records one commit per round. Stage ONLY the files you changed (never \`git add -A\` or \`git add .\`) and commit with \`git -C ${repoPath}\`, subject \`fix: codex review — debate round ${round}\` and a body that summarizes your changes plus, briefly, codex's findings and how you dispositioned each. Do NOT push. You'll return the resulting SHA (\`git -C ${repoPath} rev-parse HEAD\`) in \`commitSha\`.`
+      : `Edit the working tree only — do NOT git add/commit/push; you'll leave \`commitSha\` empty.`
   }
 
-Return: actions (one per finding — findingId, disposition, detail), filesChanged, commitSha, and done (true once you've addressed every finding this round).`
+RECORD your dispositions to a file — this is the durable trail and the heart of how this debate stays robust. The next round's author reads it as memory, codex reads it as your rebuttal, and it's what gets posted to the PR. So the FULL per-finding narrative lives in this file, NEVER in your structured return. Using the Write tool, create the file \`${claudeSectionFile(round)}\` (overwrite any existing one) with EXACTLY this Markdown shape:
+
+**claude** — <one sentence: what you did this round>
+
+- \`F1\` **fixed** — <why; what you changed; cite file:line>
+- \`F2\` **disputed** — <the specific technical reason codex is wrong; cite file:line>
+- \`F3\` **partial** — <what you fixed and what you didn't, and why>
+${doCommit ? '... one bullet PER finding (disposition ∈ fixed | disputed | partial), then:\n\ncommit: `<the SHA you committed, or omit this whole line if you changed nothing>`' : '... one bullet PER finding (disposition ∈ fixed | disputed | partial). (No commit line — running under --no-commit.)'}
+
+CRITICAL — your STRUCTURED RETURN IS A MINIMAL ACK, nothing more. Return ONLY: \`filesChanged\` (the source paths you edited — never the scratch file above), \`commitSha\` (the SHA, or "" if you changed nothing / under --no-commit), and \`done\` (true once you've addressed every finding this round). Do NOT put your summary or any per-finding detail in the structured output — all of that goes in the section file and the commit body. (This is deliberate: past runs CRASHED because the author poured a multi-finding narrative into a structured field, which overflowed the output encoding and dropped a required field until the retry cap tripped. Writing the narrative to the file instead removes that failure by construction — keep the structured payload tiny.)`
 
   return agent(prompt, {
     label: `claude:round${round}`,
@@ -251,7 +273,10 @@ Return: actions (one per finding — findingId, disposition, detail), filesChang
 }
 
 // ---------------------------------------------------------------------------
-// The shared ledger — rendered from the transcript, deterministically
+// The shared ledger — section files on disk, assembled into the comment by the
+// orchestrator (a faithful `cat`). The workflow renders only the small CODEX
+// section (from the structured verdict) and the comment HEADER in-process; the
+// author writes its own claude section (see claudeResponds).
 // ---------------------------------------------------------------------------
 // One codex finding as a Markdown bullet — the single projection of a finding's
 // fields for the ledger section. (The per-round commit message is now written by
@@ -260,50 +285,39 @@ function findingBullet(f) {
   return `- \`${f.id}\` · ${f.severity} · ${f.status} — ${f.issue} (${f.location})`
 }
 
-// One author disposition as a Markdown bullet — the single projection of an
-// action's fields for the ledger section.
-function actionBullet(a) {
-  return `- \`${a.findingId}\` **${a.disposition}** — ${a.detail}`
-}
-
-// One round's findings, as a Markdown list. Shared by the section renderer below.
+// One round's findings, as a Markdown list. Shared by the codex-section renderer.
 function renderFindings(verdict) {
   const list = (verdict.findings || []).map((f) => findingBullet(f)).join('\n')
   return list || '- _(none)_'
 }
 
-// One round's author dispositions, as a Markdown list. `null` on a terminal round
-// (codex approved or errored before the author got a turn).
-function renderActions(response) {
-  if (!response) return '_(no author turn — the debate ended this round)_'
-  const list = (response.actions || []).map((a) => actionBullet(a)).join('\n')
-  return list || '- _(no actions)_'
-}
-
-// One round as a Markdown section: codex's verdict, its response to the rebuttal,
-// and the author's dispositions + commit. The single per-round renderer — the
-// author reads these as its memory and they compose into the posted comment.
-function roundLedgerSection(entry) {
-  const { round, codex, claude, commit } = entry
+// CODEX's side of one round, as a Markdown section: its verdict, findings, and
+// response to the author's rebuttal. Rendered in-process from the STRUCTURED
+// verdict (small, faithful) and written to disk by a Haiku writer. The author's
+// side is a SEPARATE file the author writes itself (its dispositions), so this
+// renderer no longer touches the claude response at all — that's the decoupling
+// that keeps the author's structured payload minimal. This carries the round's
+// `### Round N` header (it's written every round, including the terminal one).
+function codexSection(round, verdict) {
   const lines = [
     `### Round ${round}`,
     '',
-    `**codex** — approved: \`${codex.approved}\``,
+    `**codex** — approved: \`${verdict.approved}\``,
     '',
-    codex.summary,
+    verdict.summary,
     '',
     'Findings:',
-    renderFindings(codex),
+    renderFindings(verdict),
   ]
-  if (codex.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${codex.responseToRebuttal}`)
-  lines.push('', `**claude** — ${claude ? claude.summary : '_(no author turn this round)_'}`, '', renderActions(claude))
-  if (commit) lines.push('', `commit: \`${commit}\``)
+  if (verdict.responseToRebuttal) lines.push('', `_codex on the rebuttal:_ ${verdict.responseToRebuttal}`)
   return lines.join('\n')
 }
 
 // The comment header (small). The full comment is this header followed by the
-// per-round section files (see renderLedger). The workflow renders the whole
-// comment deterministically from the transcript — no agent ever retypes the blob.
+// per-round section files, `cat`-ed together by the orchestrator (see SKILL step 3)
+// — a deterministic shell concat, never re-rendered through an agent. The workflow
+// returns this header as `commentHeader`; it can't read the section files itself
+// (no I/O), so it hands the orchestrator the header + the section dir.
 //
 // This header's chrome (the `## ` title, the badge, the `base.slice(0, 12)`) is
 // deliberately kept STRUCTURALLY PARALLEL to lens-debate's renderComment header
@@ -317,27 +331,20 @@ function ledgerHeader(meta) {
   return `## Codex ⇄ Claude debate\n\n${badge} after ${meta.rounds} round(s) · codex reviewed at \`${meta.reasoningEffort}\` reasoning effort · base \`${(meta.base || '').slice(0, 12)}\``
 }
 
-// The whole PR comment, rendered deterministically in-process from the transcript:
-// the outcome header followed by each round's Markdown section. The per-round
-// section files on disk remain the author's cross-round memory (see writeSection);
-// this re-uses the SAME `roundLedgerSection` renderer to assemble the published
-// comment, so the orchestrator posts a ready string (`gh pr comment -F`) exactly
-// the way lens-debate does — no bespoke `cat` glob at the consumer, and nothing
-// weak ever retypes a large blob (the workflow builds the string itself).
-function renderLedger(transcript, meta) {
-  return [ledgerHeader(meta), ...transcript.map(roundLedgerSection)].join('\n\n')
-}
-
-// Zero-pad the round so the section glob (`section-*.md`) sorts in round order
-// (section-002 before section-010) for both the author's read and the assembly.
-const sectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}.md`
+// Per-round section file paths. TWO files per round, named so the `section-*.md`
+// glob sorts both into round order AND codex-before-claude WITHIN a round
+// (`section-001-1-codex.md` < `section-001-2-claude.md` < `section-002-1-codex.md`),
+// so `cat`-ing the glob yields the debate in chronological order for both the
+// author's memory read and the comment assembly. Zero-padded for the same reason.
+const codexSectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}-1-codex.md`
+const claudeSectionFile = (round) => `${workDir}/section-${String(round).padStart(3, '0')}-2-claude.md`
 
 // Drop a string to a scratch file via a mechanical Haiku writer — the single home
 // for the "write this content to this path" idiom (the workflow can't do file I/O
 // itself, and Claude isn't headless, so a tiny agent does it). Both the per-round
-// section writer and the one-shot rationale writer route through here; payloads are
-// small (one round / one note) so Haiku is safe, and overwriting is idempotent
-// (safe on a resume).
+// codex-section writer and the one-shot rationale writer route through here;
+// payloads are small (one round / one note) so Haiku is safe, and overwriting is
+// idempotent (safe on a resume).
 function writeFileAgent(path, content, label) {
   const prompt = `You are a MECHANICAL WRITER. Do exactly these steps and nothing else — do not edit any other file, do not run git, do not add commentary.
 
@@ -348,11 +355,12 @@ ${content}`
   return agent(prompt, { label, phase: 'Debate', model: mechModel })
 }
 
-// Write ONE round's section to its own small file — the author reads these as its
-// cross-round memory, and the orchestrator cats them into the posted comment. No
-// whole-ledger retype: the payload is just this round.
-async function writeSection(entry) {
-  return writeFileAgent(sectionFile(entry.round), roundLedgerSection(entry), `ledger:round${entry.round}`)
+// Write ONE round's CODEX section to its own small file (the claude section is the
+// author's own write, in claudeResponds). The author reads these as cross-round
+// memory and the orchestrator cats them into the posted comment. No whole-ledger
+// retype: the payload is just this round's structured verdict, rendered.
+async function writeCodexSection(round, verdict) {
+  return writeFileAgent(codexSectionFile(round), codexSection(round, verdict), `ledger:codex:round${round}`)
 }
 
 const transcript = []
@@ -362,7 +370,12 @@ const transcript = []
 // distinct from the deliberate "no deadlock exit" for substantive disagreement.
 let status = 'consensus'
 let finalVerdict = null
-let lastClaude = null
+// The author's PRIOR-round disposition section file — fed to codex next round as
+// the rebuttal (codex-review.sh cats it into codex's prompt). null until the first
+// author turn writes one. This replaces the old in-memory rebuttal blob: the author
+// writes the file itself, so the dispositions never round-trip through structured
+// output, and codex reads them straight off disk.
+let lastClaudeSectionPath = null
 // Rounds where the author edited files (commit mode on) but returned no SHA —
 // the in-session commit it was told to make didn't land. The edits aren't lost
 // (they stay in the tree and the next reviewer still diffs them against base),
@@ -411,16 +424,18 @@ log(`Diffing against ${base.slice(0, 12)} (merge-base of ${rawBase} and HEAD), s
 
 // Clear any stale ledger from a PRIOR debate in this worktree. The scratch dir
 // is persistent (per-worktree, not per-run) and the section files use a flat,
-// stable `section-NNN.md` namespace, so a previous longer debate's high-numbered
+// stable `section-NNN-*.md` namespace, so a previous longer debate's high-numbered
 // sections would otherwise survive into this run — the author cats `section-*.md`
-// as its memory (and they compose into the `comment` renderLedger returns), so stale
-// sections would pollute BOTH the author's context and the published trail. A
-// thin mechanical agent (the workflow can't run shell itself). The reset is
-// section/ledger-scoped: it deletes only the stale `section-*.md` files, not the
-// whole scratch dir, so other artifacts in there (verdict-N.json, rebuttal.json,
-// and any commit-message file the author writes) keep their own lifecycle and a
-// future pre-loop writer won't be silently wiped. This script has no true resume (agent() is one-shot, the
-// whole workflow re-runs from scratch), so a fresh start owns a fresh ledger.
+// as its memory, and the orchestrator cats them into the posted comment, so stale
+// sections would pollute BOTH the author's context and the published trail. (The
+// glob also catches a prior author's claude section files, which double as the
+// rebuttal codex reads, so a stale one must not linger either.) A thin mechanical
+// agent (the workflow can't run shell itself). The reset is section/ledger-scoped:
+// it deletes only the stale `section-*.md` files, not the whole scratch dir, so
+// other artifacts in there (verdict-N.json and any other per-run files) keep their
+// own lifecycle and a future pre-loop writer won't be silently wiped. This script
+// has no true resume (agent() is one-shot, the whole workflow re-runs from
+// scratch), so a fresh start owns a fresh ledger.
 await agent(
   `You are a MECHANICAL RUNNER. Run exactly this and nothing else: \`mkdir -p -- ${shq(workDir)} && rm -f -- ${shq(workDir)}/section-*.md\`. Do not edit any other file. Do not run git.`,
   { label: 'ledger:reset', phase: 'Debate', model: mechModel },
@@ -435,10 +450,18 @@ if (rationale) {
 }
 
 for (let round = 1; ; round++) {
-  const verdict = await codexReviews(round, lastClaude ? JSON.stringify(lastClaude) : null)
+  const verdict = await codexReviews(round, lastClaudeSectionPath)
   finalVerdict = verdict
   const entry = { round, codex: verdict, claude: null }
   transcript.push(entry) // record this round (mutated in place as it progresses)
+
+  // Write codex's section for this round to disk straight away — before any
+  // terminal break — so EVERY round (including a consensus-approval or error round
+  // that never reaches the author) lands in the section record the author reads as
+  // memory and the orchestrator cats into the comment. The claude section is the
+  // author's own write later in the round, when there is an author turn.
+  await writeCodexSection(round, verdict)
+
   // Reviewer error — terminal failure path. The runner could not get a verdict
   // out of codex (broken/unavailable CLI), so codex-review.sh synthesized an
   // error verdict carrying reviewerError:true. There are no findings to route to
@@ -473,14 +496,15 @@ for (let round = 1; ; round++) {
   }
 
   // Claude responds: fixes what it agrees with (editing the tree), disputes the
-  // rest. It reads the per-round section files (written at the end of each round
-  // below) for its cross-round memory. `lastClaude` is kept only to feed codex's
-  // rebuttal next round (see codexReviews) — it is no longer the author's memory.
+  // rest, and writes its dispositions to its own claude section file (its memory,
+  // the rebuttal codex reads next round, and part of the posted comment). It reads
+  // the per-round section files for its cross-round memory. We remember the path it
+  // just wrote so the NEXT round feeds it to codex as the rebuttal.
   const response = await claudeResponds(round, verdict, commit)
   entry.claude = response
-  lastClaude = response
+  lastClaudeSectionPath = claudeSectionFile(round)
   log(
-    `Round ${round}: claude done=${response.done}, actions=${(response.actions || []).length}, files=${(response.filesChanged || []).length}`,
+    `Round ${round}: claude done=${response.done}, files=${(response.filesChanged || []).length}`,
   )
 
   // The author commits its own round in-session (one commit per round, message
@@ -500,11 +524,8 @@ for (let round = 1; ; round++) {
       log(`Round ${round}: author changed ${response.filesChanged.length} file(s) but returned no commit SHA — round left uncommitted`)
     }
   }
-
-  // Write this round's section so the NEXT round's author can read the full
-  // history. Terminal rounds break above before reaching here, so they're
-  // sectioned just after the loop.
-  await writeSection(entry)
+  // No section write here: codex's section was written at the top of the loop, and
+  // the author wrote its own claude section during its turn — both already on disk.
 }
 
 const filesChanged = Array.from(
@@ -526,18 +547,17 @@ if (status === 'consensus' && commitGaps.length) {
 
 log(`Debate ended: ${status} after ${transcript.length} round(s); ${filesChanged.length} file(s) changed.`)
 
-// Section the terminal round — it broke out of the loop before the in-loop
-// writeSection, so without this its section (a consensus approval, or an error
-// reached before the author got a turn) would be missing from the disk record
-// the orchestrator reads for the chat summary (cat section-*.md) and the
-// author would read as memory if the debate somehow continued.
-if (transcript.length > 0) await writeSection(transcript[transcript.length - 1])
+// The terminal round needs no extra section write: codex's section for it was
+// written at the top of the loop (every round), and a terminal round has no author
+// turn (and so no claude section) by definition.
 
-// Hand the orchestrator the ready-to-post comment, rendered deterministically
-// in-process (header + per-round sections) — it just writes the string to a file
-// and posts it (`gh pr comment -F`), the same shape lens-debate uses. The section
-// files on disk stay the author's cross-round memory; this is the published view
-// of that same record, so no agent ever retypes the whole ledger. See SKILL step 3.
+// Hand the orchestrator everything it needs to post the comment, but NOT a single
+// pre-rendered `comment` string — the author's per-round dispositions live in the
+// section files on disk (it wrote them itself), and the workflow can't read files.
+// So we return the small in-process `commentHeader` plus the section dir + glob; the
+// orchestrator assembles the comment with a faithful `cat` (header followed by the
+// section files in glob order) and posts that — a deterministic shell concat, no
+// agent ever retyping the ledger. See SKILL step 3.
 return {
   status,
   rounds: transcript.length,
@@ -548,5 +568,11 @@ return {
   // 'commit-incomplete'). Lets the caller pinpoint and reconcile the gap.
   commitGaps,
   transcript,
-  comment: renderLedger(transcript, { status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
+  // The comment's deterministic header (badge + round count + reasoning effort +
+  // base). The orchestrator posts: this header, a blank line, then
+  // `cat <workDir>/section-*.md`.
+  commentHeader: ledgerHeader({ status, rounds: transcript.length, base, reasoningEffort: REASONING_EFFORT }),
+  // Where the per-round section files live, so the orchestrator can cat them.
+  workDir,
+  sectionGlob: `${workDir}/section-*.md`,
 }

--- a/.claude/skills/codex-debate/scripts/codex-review.sh
+++ b/.claude/skills/codex-debate/scripts/codex-review.sh
@@ -16,8 +16,10 @@
 #   codex-review.sh <base-branch> <rebuttal-file|-> <out-json> [reasoning-effort] [rationale-file|-]
 #
 #   <base-branch>    branch to diff against (e.g. master)
-#   <rebuttal-file>  path to a file holding CLAUDE's previous response (JSON),
-#                    or "-" on the first round (no rebuttal yet)
+#   <rebuttal-file>  path to a file holding CLAUDE's previous-round response — the
+#                    author-written Markdown disposition section (its per-finding
+#                    fixed/disputed/partial trail), NOT JSON. "-" on the first round
+#                    (no rebuttal yet). Cat'd verbatim into codex's prompt below.
 #   <out-json>       path the JSON verdict is written to (also echoed to stdout)
 #   <reasoning-effort> codex model_reasoning_effort for this run; the debate
 #                    workflow passes its REASONING_EFFORT constant here so the
@@ -55,9 +57,10 @@ schema="$here/codex-verdict.schema.json"
 # shellcheck source=codex-exec-lib.sh
 source "$here/codex-exec-lib.sh"
 
-# Pull CLAUDE's previous response, if any. Built as a plain string and injected
-# below via a simple variable reference so any special characters in the JSON
-# (backticks, $, ...) stay literal (heredoc expansion results are not re-scanned).
+# Pull CLAUDE's previous-round response (the author's Markdown disposition section),
+# if any. Built as a plain string and injected below via a simple variable reference
+# so any special characters in the text (backticks, $, ...) stay literal (heredoc
+# expansion results are not re-scanned).
 rebuttal=""
 if [ "$rebuttal_file" != "-" ]; then
   if [ -s "$rebuttal_file" ]; then

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -326,7 +326,7 @@ local_deployed_file_hashes:
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .agents/skills/codex-debate/SKILL.md: sha256:dd5ee31b9d664d48706fa82a7d5414ad4069cce5eaa416b1e602188cbe54929c
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:bb2929bff82fc7760ab1ae56ddd9d672598c5b5394606074c58d7e8f7254dab2
+  .agents/skills/codex-debate/debate.workflow.js: sha256:bf00aa452e3824244bd3cd7466286111e4972c037c1ee1b6626ef9244faf498c
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -363,7 +363,7 @@ local_deployed_file_hashes:
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
   .claude/skills/codex-debate/SKILL.md: sha256:dd5ee31b9d664d48706fa82a7d5414ad4069cce5eaa416b1e602188cbe54929c
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:bb2929bff82fc7760ab1ae56ddd9d672598c5b5394606074c58d7e8f7254dab2
+  .claude/skills/codex-debate/debate.workflow.js: sha256:bf00aa452e3824244bd3cd7466286111e4972c037c1ee1b6626ef9244faf498c
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -321,16 +321,16 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .agents/skills/be-review/SKILL.md: sha256:5ccd89f93b8ea4432b8ee2d6fa9dd92b00173b88d2da7e912b68ff9fd86625a5
+  .agents/skills/be-review/SKILL.md: sha256:9e141a311dc1ce1d8523fe5319f8b3a9f8b568407c23baab74cfba95626e8149
   .agents/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:b3f8213c7ee3681ee31f23c8e1a8b68b1e185eb756a83d3cc72c45ccc5e2241b
+  .agents/skills/codex-debate/SKILL.md: sha256:c95862368c6b5e9371646599fc64bff80c92447129cf204a96b5c616cbf12bc9
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:fc382c53a8c0537ca5da8aae458f0dc2a910bdaae44b81e2c838c50e19a2a132
+  .agents/skills/codex-debate/debate.workflow.js: sha256:a2370db9d5f7f16c26a4d7a0d6e85fe3638c859907593d0d4fd400934decec60
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
+  .agents/skills/codex-debate/scripts/codex-review.sh: sha256:bc36cc0d21c46a36831d455f2d9d47a821ffa0666cc5708aaac16113fb9af632
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:1b56467bc51ddafa778997d1f7a8774f7364e55543d71e3ebf62af47efdcc13a
   .agents/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538
@@ -358,16 +358,16 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2f96cb3cd96e5e985130c5baae68ac4f6d4c91097085dcb96979b8bd9353db8d
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .claude/skills/be-review/SKILL.md: sha256:5ccd89f93b8ea4432b8ee2d6fa9dd92b00173b88d2da7e912b68ff9fd86625a5
+  .claude/skills/be-review/SKILL.md: sha256:9e141a311dc1ce1d8523fe5319f8b3a9f8b568407c23baab74cfba95626e8149
   .claude/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:b3f8213c7ee3681ee31f23c8e1a8b68b1e185eb756a83d3cc72c45ccc5e2241b
+  .claude/skills/codex-debate/SKILL.md: sha256:c95862368c6b5e9371646599fc64bff80c92447129cf204a96b5c616cbf12bc9
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:fc382c53a8c0537ca5da8aae458f0dc2a910bdaae44b81e2c838c50e19a2a132
+  .claude/skills/codex-debate/debate.workflow.js: sha256:a2370db9d5f7f16c26a4d7a0d6e85fe3638c859907593d0d4fd400934decec60
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
-  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:e7f96490d9bbd13b692b4a80641f69447b2c9051eb3f4222daeb263c73d43b8f
+  .claude/skills/codex-debate/scripts/codex-review.sh: sha256:bc36cc0d21c46a36831d455f2d9d47a821ffa0666cc5708aaac16113fb9af632
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:1b56467bc51ddafa778997d1f7a8774f7364e55543d71e3ebf62af47efdcc13a
   .claude/skills/evidence/SKILL.md: sha256:a6d14104fa5b7a3334da35403347378cf87f93a0d38e65c360bc77d9e70f6538

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -321,12 +321,12 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .agents/skills/be-review/SKILL.md: sha256:9e141a311dc1ce1d8523fe5319f8b3a9f8b568407c23baab74cfba95626e8149
+  .agents/skills/be-review/SKILL.md: sha256:f7a922ce3681d5e6ea0b01b601ba1b7627c35b467a06bdae50f912706e6c7b54
   .agents/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:c95862368c6b5e9371646599fc64bff80c92447129cf204a96b5c616cbf12bc9
+  .agents/skills/codex-debate/SKILL.md: sha256:dd5ee31b9d664d48706fa82a7d5414ad4069cce5eaa416b1e602188cbe54929c
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:a2370db9d5f7f16c26a4d7a0d6e85fe3638c859907593d0d4fd400934decec60
+  .agents/skills/codex-debate/debate.workflow.js: sha256:bb2929bff82fc7760ab1ae56ddd9d672598c5b5394606074c58d7e8f7254dab2
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -358,12 +358,12 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2f96cb3cd96e5e985130c5baae68ac4f6d4c91097085dcb96979b8bd9353db8d
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .claude/skills/be-review/SKILL.md: sha256:9e141a311dc1ce1d8523fe5319f8b3a9f8b568407c23baab74cfba95626e8149
+  .claude/skills/be-review/SKILL.md: sha256:f7a922ce3681d5e6ea0b01b601ba1b7627c35b467a06bdae50f912706e6c7b54
   .claude/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:c95862368c6b5e9371646599fc64bff80c92447129cf204a96b5c616cbf12bc9
+  .claude/skills/codex-debate/SKILL.md: sha256:dd5ee31b9d664d48706fa82a7d5414ad4069cce5eaa416b1e602188cbe54929c
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:a2370db9d5f7f16c26a4d7a0d6e85fe3638c859907593d0d4fd400934decec60
+  .claude/skills/codex-debate/debate.workflow.js: sha256:bb2929bff82fc7760ab1ae56ddd9d672598c5b5394606074c58d7e8f7254dab2
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -321,12 +321,12 @@ local_deployed_files:
 - .claude/skills/test/SKILL.md
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .agents/skills/be-review/SKILL.md: sha256:2559181daa2a8a491d285bad4287f734964f296011fb5be085f1ae43610a8c73
+  .agents/skills/be-review/SKILL.md: sha256:5ccd89f93b8ea4432b8ee2d6fa9dd92b00173b88d2da7e912b68ff9fd86625a5
   .agents/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
+  .agents/skills/codex-debate/SKILL.md: sha256:b3f8213c7ee3681ee31f23c8e1a8b68b1e185eb756a83d3cc72c45ccc5e2241b
   .agents/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .agents/skills/codex-debate/debate.workflow.js: sha256:71c0a508b3eb2cd5f39f0a37e7b1195673abba428283158d06e320eee2d586d0
+  .agents/skills/codex-debate/debate.workflow.js: sha256:fc382c53a8c0537ca5da8aae458f0dc2a910bdaae44b81e2c838c50e19a2a132
   .agents/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .agents/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .agents/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5
@@ -358,12 +358,12 @@ local_deployed_file_hashes:
   .claude/rules/surface.md: sha256:2f96cb3cd96e5e985130c5baae68ac4f6d4c91097085dcb96979b8bd9353db8d
   .claude/rules/toast-conventions.md: sha256:e987215118a5269b05f064a477ca26ad986b014531dfb00bc7ba6b6bd3dce5bc
   .claude/skills/atlas/SKILL.md: sha256:4de315b396e4807b84fb90c95d23661f6c59ce5385d926101620e6f4004379e6
-  .claude/skills/be-review/SKILL.md: sha256:2559181daa2a8a491d285bad4287f734964f296011fb5be085f1ae43610a8c73
+  .claude/skills/be-review/SKILL.md: sha256:5ccd89f93b8ea4432b8ee2d6fa9dd92b00173b88d2da7e912b68ff9fd86625a5
   .claude/skills/be/SKILL.md: sha256:e6434e1fe9bd62dec1c94f6ee8cffa2e6364c3eefd23f0255dfa231f9fa9f5db
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/codex-debate/SKILL.md: sha256:04bff5a353ec49df08815e8f85dff5b5d3932f5f6453c81ef103c010315cf9bf
+  .claude/skills/codex-debate/SKILL.md: sha256:b3f8213c7ee3681ee31f23c8e1a8b68b1e185eb756a83d3cc72c45ccc5e2241b
   .claude/skills/codex-debate/answer.workflow.js: sha256:c7d78f5445d64a985ed6e4bf2a25f1522a1f64d2b66218049a5f3b10a7665f0f
-  .claude/skills/codex-debate/debate.workflow.js: sha256:71c0a508b3eb2cd5f39f0a37e7b1195673abba428283158d06e320eee2d586d0
+  .claude/skills/codex-debate/debate.workflow.js: sha256:fc382c53a8c0537ca5da8aae458f0dc2a910bdaae44b81e2c838c50e19a2a132
   .claude/skills/codex-debate/scripts/codex-answer.schema.json: sha256:6c33a78fc5b21914f34368b06325e67dfeafcaa19ce1f97bd5caa4cd51f0ca25
   .claude/skills/codex-debate/scripts/codex-answer.sh: sha256:05734cad63863b4c27c67b1d87da0bf41ba325c3dd816002acfbd69c66877e67
   .claude/skills/codex-debate/scripts/codex-exec-lib.sh: sha256:8abcec954fac110c0c3bc27a382acc015ed5cd5f29effcbf06eba75f36ced3c5


### PR DESCRIPTION
Closes #1569 — the **structural** fix flagged as a follow-up in that issue (the length-bound in #1568 was the cheap, immediate stopgap; this removes the failure mode by construction).

## The problem

`/codex-debate` (and so `/be-review`'s codex step) crashed on a large diff with:

```
agent({schema}): StructuredOutput retry cap (5) exceeded — 5 failed calls with no valid output
```

The Claude **author** side was forced to return its whole verdict as **one structured JSON payload** — `summary` + one `action` (`findingId`/`disposition`/`detail`) per finding. On a many-finding diff it poured a multi-KB narrative into that payload, overflowed the harness's StructuredOutput encoding, which then **silently dropped the required `actions` array**; validation failed with the misleading `required: actions`, *every retry reproduced the same bloat*, and the cap tripped. The bigger the diff, the more reliably it fired.

## The fix — payload size decoupled from finding count, by construction

The author now writes its **full per-finding dispositions to its own section file** (`section-NNN-2-claude.md`) — exactly the way codex already writes its verdict to a path — and returns only a **minimal structured ack** (`filesChanged` / `commitSha` / `done`). With no large field in the structured payload, it can't overflow no matter how many findings there are.

That one author-written file does **triple duty**, with no weak agent ever retyping a blob:

1. the author's **cross-round memory** (it cats the section files);
2. the **rebuttal** codex reads next round — `codex-review.sh` already `cat`s the rebuttal file straight into codex's prompt, so codex still sees every disposition (the separate in-memory `rebuttal.json` blob is gone);
3. the **published PR comment** — the orchestrator assembles it with a faithful `cat` (the `commentHeader` the workflow returns, then the section files in glob order).

### What changed

- **`CLAUDE_RESPONSE_SCHEMA`** → minimal ack: dropped `summary` and the per-finding `actions` array.
- **`claudeResponds`** → the author `Write`s its dispositions section itself; the prompt names the old failure mode so the model keeps the structured payload tiny.
- **Two section files per round** — codex's (a Haiku writer renders the small *structured* verdict) and claude's (the author writes its own dispositions) — named `section-NNN-{1-codex,2-claude}.md` so the `section-*.md` glob sorts chronologically.
- **Comment contract** — the workflow returns `commentHeader` + `workDir`/`sectionGlob` instead of a pre-rendered `comment`; `codex-debate` and `be-review` SKILLs updated to assemble + post via `cat`.
- Regenerated `.claude/` + `.agents/` via `just ai::apm`.

## On the issue's "upstream caveat"

The issue says the canonical source is `srid/agency` and the change should be mirrored there. **That's not the case for this skill** — I verified it: `srid/agency` ships `do`/`code-police`/`hickey`/`lowy`/`elegance`/etc., and its upstream tree has no `codex-debate`. `codex-debate` is a **kolu first-party skill** under `.apm/skills/`, so there is no upstream copy to mirror and `just ai::apm-update srid/agency` will not overwrite it.

## Dogfooding

The plan is to dogfood this on a real `/be-review` run on a large diff next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)