### PR TITLE
skill(perfection-review): adversarial ideal-bar review under eternal-time framing

### DIFF
--- a/.agents/skills/perfection-review/SKILL.md
+++ b/.agents/skills/perfection-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: perfection-review
+description: >-
+  Adversarial "perfection" review — hold a change to an *ideal* bar, not just a correct one,
+  assuming eternal time, unlimited energy, and no ship pressure. Use when the user asks to
+  review "for perfection", to make a defect "impossible to express", or to hunt where a defect
+  "relocates" across review rounds. Grounds every claim in the diff, fans out adversarial
+  verifiers via Workflow, and reports residual surfaces with a structural fix for each. ONLY
+  invoke when the user explicitly asks for a perfection / ideal-bar review.
+argument-hint: "[<pr-number>] [--base <branch>] [--post]"
+---
+
+# Perfection review
+
+The bar is not **"closed"** but **"the defect can no longer be expressed."** Assume eternal
+time, unlimited energy, no deadline. "Overridable", "acceptable for scope", and "documented
+intent" are *still holes*.
+
+Most defects are **one shape in costumes**. Name the shape, then hunt **where it relocates** —
+a fix that satisfies the literal ask but lets the defect resurface one seam over is not done.
+Track it across rounds until it has nowhere left to go.
+
+## Method
+
+1. **Ground in the diff, not the story** — the PR body, commit messages, docs, and the
+   author's claims are assertions to falsify, not facts. Check them against the code.
+2. **Letter vs effect** — a safety added but never exercised is inert. Require a real path
+   that uses it and a test that fails when it is removed.
+3. **Unspellable > absent** — make the wrong thing impossible to write, not merely
+   discouraged. If a future author can still spell the defect, it isn't closed. Beware a
+   guarantee that proves *presence*, not *behaviour*.
+4. **Reconcile claim and code** — an overclaiming comment or doc is itself a defect: make the
+   code earn the sentence, or soften the sentence.
+5. **Finish the blast radius** — not done until every dependent and downstream is carried to
+   the same bar and verified against the final state.
+
+## Verify adversarially — use Workflow
+
+Fan out grounded verifiers (one per claim) **plus an adversary whose only job is to express
+the defect anyway**, each citing the diff; then synthesize. Default to *refuted-if-uncertain*,
+loop until nothing new surfaces, and re-verify the headline finding yourself. Keep agent
+schemas **flat** and isolate the adversary so one failure can't abort the run.
+
+## Report
+
+Lead with **credit** for what's closed — don't move goalposts on done work — then the
+**residual surfaces**, ranked, each with its structural fix. Separate "the product is fine"
+from "the claim isn't yet true". Post to the PR only when asked (`--post`).

--- a/.apm/skills/perfection-review/SKILL.md
+++ b/.apm/skills/perfection-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: perfection-review
+description: >-
+  Adversarial "perfection" review — hold a change to an *ideal* bar, not just a correct one,
+  assuming eternal time, unlimited energy, and no ship pressure. Use when the user asks to
+  review "for perfection", to make a defect "impossible to express", or to hunt where a defect
+  "relocates" across review rounds. Grounds every claim in the diff, fans out adversarial
+  verifiers via Workflow, and reports residual surfaces with a structural fix for each. ONLY
+  invoke when the user explicitly asks for a perfection / ideal-bar review.
+argument-hint: "[<pr-number>] [--base <branch>] [--post]"
+---
+
+# Perfection review
+
+The bar is not **"closed"** but **"the defect can no longer be expressed."** Assume eternal
+time, unlimited energy, no deadline. "Overridable", "acceptable for scope", and "documented
+intent" are *still holes*.
+
+Most defects are **one shape in costumes**. Name the shape, then hunt **where it relocates** —
+a fix that satisfies the literal ask but lets the defect resurface one seam over is not done.
+Track it across rounds until it has nowhere left to go.
+
+## Method
+
+1. **Ground in the diff, not the story** — the PR body, commit messages, docs, and the
+   author's claims are assertions to falsify, not facts. Check them against the code.
+2. **Letter vs effect** — a safety added but never exercised is inert. Require a real path
+   that uses it and a test that fails when it is removed.
+3. **Unspellable > absent** — make the wrong thing impossible to write, not merely
+   discouraged. If a future author can still spell the defect, it isn't closed. Beware a
+   guarantee that proves *presence*, not *behaviour*.
+4. **Reconcile claim and code** — an overclaiming comment or doc is itself a defect: make the
+   code earn the sentence, or soften the sentence.
+5. **Finish the blast radius** — not done until every dependent and downstream is carried to
+   the same bar and verified against the final state.
+
+## Verify adversarially — use Workflow
+
+Fan out grounded verifiers (one per claim) **plus an adversary whose only job is to express
+the defect anyway**, each citing the diff; then synthesize. Default to *refuted-if-uncertain*,
+loop until nothing new surfaces, and re-verify the headline finding yourself. Keep agent
+schemas **flat** and isolate the adversary so one failure can't abort the run.
+
+## Report
+
+Lead with **credit** for what's closed — don't move goalposts on done work — then the
+**residual surfaces**, ranked, each with its structural fix. Separate "the product is fine"
+from "the claim isn't yet true". Post to the PR only when asked (`--post`).

--- a/.claude/skills/perfection-review/SKILL.md
+++ b/.claude/skills/perfection-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: perfection-review
+description: >-
+  Adversarial "perfection" review — hold a change to an *ideal* bar, not just a correct one,
+  assuming eternal time, unlimited energy, and no ship pressure. Use when the user asks to
+  review "for perfection", to make a defect "impossible to express", or to hunt where a defect
+  "relocates" across review rounds. Grounds every claim in the diff, fans out adversarial
+  verifiers via Workflow, and reports residual surfaces with a structural fix for each. ONLY
+  invoke when the user explicitly asks for a perfection / ideal-bar review.
+argument-hint: "[<pr-number>] [--base <branch>] [--post]"
+---
+
+# Perfection review
+
+The bar is not **"closed"** but **"the defect can no longer be expressed."** Assume eternal
+time, unlimited energy, no deadline. "Overridable", "acceptable for scope", and "documented
+intent" are *still holes*.
+
+Most defects are **one shape in costumes**. Name the shape, then hunt **where it relocates** —
+a fix that satisfies the literal ask but lets the defect resurface one seam over is not done.
+Track it across rounds until it has nowhere left to go.
+
+## Method
+
+1. **Ground in the diff, not the story** — the PR body, commit messages, docs, and the
+   author's claims are assertions to falsify, not facts. Check them against the code.
+2. **Letter vs effect** — a safety added but never exercised is inert. Require a real path
+   that uses it and a test that fails when it is removed.
+3. **Unspellable > absent** — make the wrong thing impossible to write, not merely
+   discouraged. If a future author can still spell the defect, it isn't closed. Beware a
+   guarantee that proves *presence*, not *behaviour*.
+4. **Reconcile claim and code** — an overclaiming comment or doc is itself a defect: make the
+   code earn the sentence, or soften the sentence.
+5. **Finish the blast radius** — not done until every dependent and downstream is carried to
+   the same bar and verified against the final state.
+
+## Verify adversarially — use Workflow
+
+Fan out grounded verifiers (one per claim) **plus an adversary whose only job is to express
+the defect anyway**, each citing the diff; then synthesize. Default to *refuted-if-uncertain*,
+loop until nothing new surfaces, and re-verify the headline finding yourself. Keep agent
+schemas **flat** and isolate the adversary so one failure can't abort the run.
+
+## Report
+
+Lead with **credit** for what's closed — don't move goalposts on done work — then the
+**residual surfaces**, ranked, each with its structural fix. Separate "the product is fine"
+from "the claim isn't yet true". Post to the PR only when asked (`--post`).


### PR DESCRIPTION
Adds a concise `.apm/skills/perfection-review` skill that captures the "perfection" review method we've been running on #1568 — the kind where you assume **eternal time, unlimited energy, no ship pressure**, and hold a change to *"the defect class can no longer be expressed"* rather than *"closed the ticket."*

### What it encodes

- **The one question** — most defects are one shape in costumes (a signal narrower than the truth; a producer-side fix no consumer reads; a guarantee asserted in prose the code doesn't back). Name the shape, then hunt **where it relocates** across rounds.
- **Method** — ground in the *diff*, not the PR body or the author's claims (verify, don't trust); letter-vs-effect (is the safety actually *exercised*?); **unspellable > absent** (a throw over a warning, an un-exported mint over a JSDoc "INTERNAL", a WeakSet brand over discipline); reconcile claim and code; gate the paired downstream at the *final* head.
- **Adversarial verification via Workflow** — fan out grounded verifiers plus an adversary whose only job is to *spell the defect anyway*, then synthesize — with the robustness lessons learned the hard way (flat schemas so StructuredOutput doesn't hit the retry cap; wrap the adversary in `parallel()` so one death isn't fatal; re-verify the headline yourself).
- **Report** — lead with genuine credit (don't move goalposts on done items), then rank residual surfaces with the *structural* fix for each.

Explicit-invoke only (`/perfection-review`) since it drives an expensive multi-agent pass.

### Notes

- Generated runtime dirs (`.claude/skills/`, `.agents/skills/`) are regenerated from the `.apm` source and included; the generated `SKILL.md` is byte-identical to the source.
- Kept scoped to the new skill — the unrelated APM 0.21→0.22 version churn from my local `uvx` was reverted, so this PR only adds files.

Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
