### PR TITLE
skill(perfection-review): report the invariant, not a lone exploit

### DIFF
--- a/.agents/skills/perfection-review/SKILL.md
+++ b/.agents/skills/perfection-review/SKILL.md
@@ -44,5 +44,8 @@ schemas **flat** and isolate the adversary so one failure can't abort the run.
 ## Report
 
 Lead with **credit** for what's closed — don't move goalposts on done work — then the
-**residual surfaces**, ranked, each with its structural fix. Separate "the product is fine"
-from "the claim isn't yet true". Post to the PR only when asked (`--post`).
+**residual surfaces**, ranked, each with its structural fix. Frame each finding as the
+**invariant it violates**, not a lone exploit: a single proof-of-concept trains a one-line
+patch and the defect just relocates — give the property, and if you must show an example,
+give a few from different angles and call it one costume of many. Separate "the product is
+fine" from "the claim isn't yet true". Post to the PR only when asked (`--post`).

--- a/.apm/skills/perfection-review/SKILL.md
+++ b/.apm/skills/perfection-review/SKILL.md
@@ -44,5 +44,8 @@ schemas **flat** and isolate the adversary so one failure can't abort the run.
 ## Report
 
 Lead with **credit** for what's closed — don't move goalposts on done work — then the
-**residual surfaces**, ranked, each with its structural fix. Separate "the product is fine"
-from "the claim isn't yet true". Post to the PR only when asked (`--post`).
+**residual surfaces**, ranked, each with its structural fix. Frame each finding as the
+**invariant it violates**, not a lone exploit: a single proof-of-concept trains a one-line
+patch and the defect just relocates — give the property, and if you must show an example,
+give a few from different angles and call it one costume of many. Separate "the product is
+fine" from "the claim isn't yet true". Post to the PR only when asked (`--post`).

--- a/.claude/skills/perfection-review/SKILL.md
+++ b/.claude/skills/perfection-review/SKILL.md
@@ -44,5 +44,8 @@ schemas **flat** and isolate the adversary so one failure can't abort the run.
 ## Report
 
 Lead with **credit** for what's closed — don't move goalposts on done work — then the
-**residual surfaces**, ranked, each with its structural fix. Separate "the product is fine"
-from "the claim isn't yet true". Post to the PR only when asked (`--post`).
+**residual surfaces**, ranked, each with its structural fix. Frame each finding as the
+**invariant it violates**, not a lone exploit: a single proof-of-concept trains a one-line
+patch and the defect just relocates — give the property, and if you must show an example,
+give a few from different angles and call it one costume of many. Separate "the product is
+fine" from "the claim isn't yet true". Post to the PR only when asked (`--post`).


### PR DESCRIPTION
Small follow-up to the `perfection-review` skill (#1578), folding in a lesson from the #1568 review rounds.

### Why

Across those rounds the same defect kept *relocating* — public minter → `heartbeat:false` → fake probe function → fake probe target — and each round's fix tracked the exact **proof-of-concept** the reviewer handed over, not the underlying invariant. A clean PoC silently scopes the fix to that PoC: the author makes that one line stop reproducing, and the defect squeezes one indirection over.

### Change

One line in the **Report** section: frame each finding as the **invariant it violates**, not a lone exploit — give the property, and if you must show an example, give a few from different angles and call it "one costume of many." This is a reviewer-communication discipline that attacks the narrow-patch dynamic at its source, and it's general (no hardcoded examples), consistent with the skill's existing style.

(The complementary "author red-teams its own fix before claiming closure" lesson is already covered by `/codex-debate`, so it's not added here.)

Runtime copies (`.claude/`, `.agents/`) kept byte-identical to the `.apm` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
