### PR TITLE
skill(perfection-review): review with fresh context, separate from the author

### DIFF
--- a/.agents/skills/perfection-review/SKILL.md
+++ b/.agents/skills/perfection-review/SKILL.md
@@ -36,6 +36,8 @@ Track it across rounds until it has nowhere left to go.
 
 ## Verify adversarially — use Workflow
 
+**Review with fresh context, separate from the author** — a reviewer carrying the author's
+context rationalizes the author's intent; a fresh mind grounded only in the diff does not.
 Fan out grounded verifiers (one per claim) **plus an adversary whose only job is to express
 the defect anyway**, each citing the diff; then synthesize. Default to *refuted-if-uncertain*,
 loop until nothing new surfaces, and re-verify the headline finding yourself. Keep agent

--- a/.apm/skills/perfection-review/SKILL.md
+++ b/.apm/skills/perfection-review/SKILL.md
@@ -36,6 +36,8 @@ Track it across rounds until it has nowhere left to go.
 
 ## Verify adversarially — use Workflow
 
+**Review with fresh context, separate from the author** — a reviewer carrying the author's
+context rationalizes the author's intent; a fresh mind grounded only in the diff does not.
 Fan out grounded verifiers (one per claim) **plus an adversary whose only job is to express
 the defect anyway**, each citing the diff; then synthesize. Default to *refuted-if-uncertain*,
 loop until nothing new surfaces, and re-verify the headline finding yourself. Keep agent

--- a/.claude/skills/perfection-review/SKILL.md
+++ b/.claude/skills/perfection-review/SKILL.md
@@ -36,6 +36,8 @@ Track it across rounds until it has nowhere left to go.
 
 ## Verify adversarially — use Workflow
 
+**Review with fresh context, separate from the author** — a reviewer carrying the author's
+context rationalizes the author's intent; a fresh mind grounded only in the diff does not.
 Fan out grounded verifiers (one per claim) **plus an adversary whose only job is to express
 the defect anyway**, each citing the diff; then synthesize. Default to *refuted-if-uncertain*,
 loop until nothing new surfaces, and re-verify the headline finding yourself. Keep agent


### PR DESCRIPTION
Adds one line to the `perfection-review` skill's **Verify adversarially** section:

> **Review with fresh context, separate from the author** — a reviewer carrying the author's context rationalizes the author's intent; a fresh mind grounded only in the diff does not.

### Why

This is the load-bearing reason the #1568 review held up across eight rounds: the reviewer was a *separate, fresh mind* grounded only in the diff each round, while the implementer kept rationalizing its own intent and overclaiming ("unspellable") in docstrings. Baking "reviewer ≠ author" into the method makes the separation hold wherever the skill runs — not just when a human happens to drive it. It also pairs with the surface-sweep issue (#1580), which requires each `/perfection-review` pass to run in a fresh-context subagent rather than a fork that inherits the implementer's context.

General, no hardcoded examples, consistent with the skill's terse style. Independent of #1579 (different section, no overlap). Runtime copies (`.claude/`, `.agents/`) kept byte-identical to the `.apm` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
