### PR TITLE
docs(blog): add a primitives table + spec diagram to the surface-framework post

### DIFF
--- a/website/src/content/blog/surface-framework.mdx
+++ b/website/src/content/blog/surface-framework.mdx
@@ -21,6 +21,16 @@ So I pulled it out into a package, [`@kolu/surface`](https://github.com/juspay/k
 
 A `Cell` is a single current value. What's the theme right now? One of them, you can read it, you can set it. A `Collection` is the same idea but keyed: what's the current value for each id? Many of them, you set any one by key. A `Stream` is read-only and derived from something the server doesn't own — git, the filesystem, the network. What's the live output for this input? You can read it. You can't set it. An `Event` has no current value at all. Has the thing happened yet? You don't render it; you handle it when it fires. And a `Procedure` is the boring one: run a side-effect on the server, get an answer back. A plain RPC, living in the same namespace as the rest.
 
+The whole set fits on one screen — and the columns _are_ the invariants, the ones the type system holds so you don't have to:
+
+| Primitive | The question it answers | Current value | Who owns the value | Kolu uses it for |
+| --- | --- | --- | --- | --- |
+| **Cell** | "What is it right now?" | one — read **and** set | you | prefs · terminal list · activity feed · session snapshot |
+| **Collection** | "What is it for each key?" | many — set any one by key | you | per-terminal metadata |
+| **Stream** | "What's the live output for this input?" | read-only, derived | something else (git, fs, net) | changed files · diff · repo tree · file contents |
+| **Event** | "Has it happened yet?" | none — you handle the firing | the server emits it | terminal exit |
+| **Procedure** | "Run this and tell me what happened" | none — a plain RPC | the server | terminal create · kill · resize |
+
 You might reasonably ask why these aren't one primitive with some flags. I tried that first. It collapses badly. The distinction that finally convinced me is the one between a Cell and a Stream, and it's older than this framework — it comes from [reflex-frp](https://github.com/reflex-frp/reflex), where the shapes are called `Dynamic` and `Incremental` and `Event`. A Cell is an identity over time: the same logical thing, whose value evolves, like your preferences. You can set it because you own it. A Stream isn't a thing at all; it's a function being re-run. The list of files that changed in your repo isn't a value Kolu owns — git owns it, and Kolu is watching. You can't `set` that without quietly becoming the cache, and the moment you're the cache you've signed up to be wrong. So a Stream is read-only, and the type system won't let you forget. Each of the five carries an invariant like that. Collapse them and you move the invariant from something the compiler checks to something you have to remember. **And you will not remember.**
 
 Anything that fits none of the five stays raw [oRPC](https://orpc.dev/). There's a one-line escape hatch, `unenrolledStreamCall(client.X.Y, input, opts)`, that threads the same retry context the rest of the framework uses, so dropping to the metal doesn't cost you the plumbing you actually wanted. A bidirectional binary stream isn't a Cell. Don't make it one.
@@ -28,6 +38,36 @@ Anything that fits none of the five stays raw [oRPC](https://orpc.dev/). There's
 ## One spec, three places
 
 The whole thing is declared once and read from three places. You write a spec — the cells, collections, streams, events, and procedures, each with its [Zod](https://zod.dev/) schema. From that one spec the framework derives the typed contract, the server router, and the client hooks. There's no parallel list to keep in sync, which matters, because the parallel list is the thing that always drifts.
+
+<svg viewBox="0 0 680 300" role="img" aria-label="One surface spec, derived three ways. At the top, defineSurface declares the five primitives — cells, collections, streams, events, and procedures — each with its own Zod schema. From that single spec the framework derives three artifacts: surface.contract (the typed oRPC contract, built at compile time and shared by both ends), implementSurface (the server router plus a ctx the domain code writes through), and surfaceClient (the client .use() hooks). There is no second copy: the spec is the only source of truth for the schemas, the defaults, and the types." style="width:100%;max-width:680px;display:block;margin:1.75rem auto;">
+  <text x="14" y="22" fill="var(--color-ink)" font-size="13" font-weight="600" font-family="monospace">one spec — derived three ways, no parallel list to drift</text>
+  <rect x="140" y="42" width="400" height="66" rx="6" fill="none" stroke="var(--color-ink-muted)" stroke-width="1.2" />
+  <text x="340" y="66" fill="var(--color-ink)" font-size="12.5" font-weight="600" text-anchor="middle" font-family="monospace">defineSurface(…) — the single spec</text>
+  <text x="340" y="86" fill="var(--color-ink-dim)" font-size="11" text-anchor="middle" font-family="monospace">cells · collections · streams · events · procedures</text>
+  <text x="340" y="101" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">each carries its own Zod schema</text>
+  <line x1="340" y1="108" x2="340" y2="146" stroke="var(--color-rule)" stroke-width="1.2" />
+  <line x1="122" y1="146" x2="558" y2="146" stroke="var(--color-rule)" stroke-width="1.2" />
+  <text x="356" y="140" fill="var(--color-ink-muted)" font-size="10" font-family="monospace">derives ↓</text>
+  <line x1="122" y1="146" x2="122" y2="184" stroke="var(--color-amber)" stroke-width="1.2" />
+  <polygon points="122,192 117,183 127,183" fill="var(--color-amber)" />
+  <line x1="340" y1="146" x2="340" y2="184" stroke="var(--color-live-lime)" stroke-width="1.2" />
+  <polygon points="340,192 335,183 345,183" fill="var(--color-live-lime)" />
+  <line x1="558" y1="146" x2="558" y2="184" stroke="var(--color-live-teal)" stroke-width="1.2" />
+  <polygon points="558,192 553,183 563,183" fill="var(--color-live-teal)" />
+  <rect x="30" y="192" width="184" height="66" rx="6" fill="none" stroke="var(--color-amber)" stroke-width="1.2" />
+  <text x="122" y="214" fill="var(--color-ink)" font-size="12" text-anchor="middle" font-family="monospace">surface.contract</text>
+  <text x="122" y="232" fill="var(--color-ink-dim)" font-size="10.5" text-anchor="middle" font-family="monospace">the typed oRPC contract</text>
+  <text x="122" y="247" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">compile-time · both ends</text>
+  <rect x="248" y="192" width="184" height="66" rx="6" fill="none" stroke="var(--color-live-lime)" stroke-width="1.2" />
+  <text x="340" y="214" fill="var(--color-ink)" font-size="12" text-anchor="middle" font-family="monospace">implementSurface</text>
+  <text x="340" y="232" fill="var(--color-ink-dim)" font-size="10.5" text-anchor="middle" font-family="monospace">router + ctx</text>
+  <text x="340" y="247" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">server fills it in</text>
+  <rect x="466" y="192" width="184" height="66" rx="6" fill="none" stroke="var(--color-live-teal)" stroke-width="1.2" />
+  <text x="558" y="214" fill="var(--color-ink)" font-size="12" text-anchor="middle" font-family="monospace">surfaceClient</text>
+  <text x="558" y="232" fill="var(--color-ink-dim)" font-size="10.5" text-anchor="middle" font-family="monospace">.use() hooks</text>
+  <text x="558" y="247" fill="var(--color-ink-muted)" font-size="10" text-anchor="middle" font-family="monospace">client reads it</text>
+  <text x="14" y="284" fill="var(--color-ink-muted)" font-size="11" font-family="monospace">The spec is the only source of truth for the schemas, the defaults, and the types — one place.</text>
+</svg>
 
 Here's the spec for a little notes app:
 


### PR DESCRIPTION
The [surface-framework post](https://kolu.dev/blog/surface-framework/) leaned entirely on prose for the two things a reader actually scans for: the catalog of the five primitives, and the shape of the *one-spec-derived-three-ways* architecture. Every other diagram-bearing post on the blog (`orpc-over-ssh`, `xtermjs-perf`) carries an inline SVG and, where it helps, a table. This brings surface-framework up to that bar on both fronts.

## What changed

**A primitives table** in the *Five shapes* section — a one-screen recap of Cell / Collection / Stream / Event / Procedure: the question each one answers, whether it has a current value, who owns that value, and what Kolu uses it for. The columns *are* the invariants the type system holds, so the table doubles as the "why these can't collapse into one primitive" argument the prose makes right after it.

**A spec diagram** in the *One spec, three places* section — a hand-authored SVG, drawn in the same CSS-variable palette and monospace style as the existing diagrams, showing a single `defineSurface(…)` spec deriving three artifacts: `surface.contract` (the typed oRPC contract), `implementSurface` (server router + ctx), and `surfaceClient` (the client `.use()` hooks). Each derivation gets its own accent colour; the caption restates that the spec is the only source of truth.

**Rename `.md` → `.mdx`** so the post can carry inline SVG, matching every other diagram-bearing post. The slug (`/blog/surface-framework/`) is unchanged.

## Verification

`just website::build` passes; the built HTML contains both the `<table>` and the SVG. Rendered both in `astro preview` — screenshots below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)