### PR TITLE
docs(be): pin the macOS CI host by its full Tailscale address

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -108,14 +108,14 @@ green before capturing.
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
    - **macOS (`aarch64-darwin`) CI host — pick by availability, in this order:
-     `rasam`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
-     `rasam` is the primary and `sincereintent` the fallback. Before pinning the
+     `nix-infra@rasam.tail12b27.ts.net`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
+     `nix-infra@rasam.tail12b27.ts.net` is the primary and `sincereintent` the fallback. Before pinning the
      darwin lane, probe them **in that order** — `tailscale status` (skip a host
      shown `offline` / `last seen Nh ago`) plus a quick `ssh -o ConnectTimeout=8
      <user>@<host> true` — and pin the **first that answers** in `mcp__odu__run
      hosts=["aarch64-darwin=<user>@<host>", …]`, noting in the report which host
      served the lane. An unreachable host is an infra fault, never a lane to park
-     or call green: if `rasam` is down, fall through to `sincereintent` and run the
+     or call green: if `nix-infra@rasam.tail12b27.ts.net` is down, fall through to `sincereintent` and run the
      lane yourself; only if **neither** answers is the darwin lane genuinely
      blocked (report it as blocked — never silently drop the platform or report
      green on a lane that never ran; an unreachable host is the no-fallbacks rule's
@@ -123,7 +123,7 @@ green before capturing.
      even where `.agency/do.md`'s steady-state note still reads "rasam, not
      sincereintent / sincereintent retired": that line is the default pin, this
      ordering supersedes it the moment the primary is dark.
-     - **The same `rasam → sincereintent` order governs *every* darwin lane this
+     - **The same `nix-infra@rasam.tail12b27.ts.net → sincereintent` order governs *every* darwin lane this
        run starts — including a downstream/companion repo's CI** (e.g. the drishti
        PR a `@kolu/surface` change requires per `surface.md`). A consuming repo's
        own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's

--- a/.apm/skills/be/SKILL.md
+++ b/.apm/skills/be/SKILL.md
@@ -108,14 +108,14 @@ green before capturing.
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
    - **macOS (`aarch64-darwin`) CI host — pick by availability, in this order:
-     `rasam`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
-     `rasam` is the primary and `sincereintent` the fallback. Before pinning the
+     `nix-infra@rasam.tail12b27.ts.net`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
+     `nix-infra@rasam.tail12b27.ts.net` is the primary and `sincereintent` the fallback. Before pinning the
      darwin lane, probe them **in that order** — `tailscale status` (skip a host
      shown `offline` / `last seen Nh ago`) plus a quick `ssh -o ConnectTimeout=8
      <user>@<host> true` — and pin the **first that answers** in `mcp__odu__run
      hosts=["aarch64-darwin=<user>@<host>", …]`, noting in the report which host
      served the lane. An unreachable host is an infra fault, never a lane to park
-     or call green: if `rasam` is down, fall through to `sincereintent` and run the
+     or call green: if `nix-infra@rasam.tail12b27.ts.net` is down, fall through to `sincereintent` and run the
      lane yourself; only if **neither** answers is the darwin lane genuinely
      blocked (report it as blocked — never silently drop the platform or report
      green on a lane that never ran; an unreachable host is the no-fallbacks rule's
@@ -123,7 +123,7 @@ green before capturing.
      even where `.agency/do.md`'s steady-state note still reads "rasam, not
      sincereintent / sincereintent retired": that line is the default pin, this
      ordering supersedes it the moment the primary is dark.
-     - **The same `rasam → sincereintent` order governs *every* darwin lane this
+     - **The same `nix-infra@rasam.tail12b27.ts.net → sincereintent` order governs *every* darwin lane this
        run starts — including a downstream/companion repo's CI** (e.g. the drishti
        PR a `@kolu/surface` change requires per `surface.md`). A consuming repo's
        own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -108,14 +108,14 @@ green before capturing.
    the moment they land: fix→fmt→commit→retry on real failures, confirm green on
    the final `HEAD`.
    - **macOS (`aarch64-darwin`) CI host — pick by availability, in this order:
-     `rasam`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
-     `rasam` is the primary and `sincereintent` the fallback. Before pinning the
+     `nix-infra@rasam.tail12b27.ts.net`, then `sincereintent`.** Both are Apple-Silicon darwin builders;
+     `nix-infra@rasam.tail12b27.ts.net` is the primary and `sincereintent` the fallback. Before pinning the
      darwin lane, probe them **in that order** — `tailscale status` (skip a host
      shown `offline` / `last seen Nh ago`) plus a quick `ssh -o ConnectTimeout=8
      <user>@<host> true` — and pin the **first that answers** in `mcp__odu__run
      hosts=["aarch64-darwin=<user>@<host>", …]`, noting in the report which host
      served the lane. An unreachable host is an infra fault, never a lane to park
-     or call green: if `rasam` is down, fall through to `sincereintent` and run the
+     or call green: if `nix-infra@rasam.tail12b27.ts.net` is down, fall through to `sincereintent` and run the
      lane yourself; only if **neither** answers is the darwin lane genuinely
      blocked (report it as blocked — never silently drop the platform or report
      green on a lane that never ran; an unreachable host is the no-fallbacks rule's
@@ -123,7 +123,7 @@ green before capturing.
      even where `.agency/do.md`'s steady-state note still reads "rasam, not
      sincereintent / sincereintent retired": that line is the default pin, this
      ordering supersedes it the moment the primary is dark.
-     - **The same `rasam → sincereintent` order governs *every* darwin lane this
+     - **The same `nix-infra@rasam.tail12b27.ts.net → sincereintent` order governs *every* darwin lane this
        run starts — including a downstream/companion repo's CI** (e.g. the drishti
        PR a `@kolu/surface` change requires per `surface.md`). A consuming repo's
        own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's


### PR DESCRIPTION
The `/be` skill named the `aarch64-darwin` builder only as the bare host `rasam`, even though `.agency/do.md` already pins that same box as `nix-infra@rasam.tail12b27.ts.net` (a `user@host` connection string you can actually `ssh`/pin against). This PR brings the skill in line with that canonical pin.

## What changed

In all three vendored copies of the `be` skill (`.apm/`, `.claude/`, `.agents/skills/`), the host-*identifier* mentions of `rasam` become `nix-infra@rasam.tail12b27.ts.net`:

| Where | Before | After |
|-------|--------|-------|
| pick-order | `` `rasam`, then `sincereintent` `` | `` `nix-infra@rasam.tail12b27.ts.net`, then `sincereintent` `` |
| primary | `` `rasam` is the primary `` | `` `nix-infra@rasam.tail12b27.ts.net` is the primary `` |
| down-check | ``if `rasam` is down`` | ``if `nix-infra@rasam.tail12b27.ts.net` is down`` |
| fallback order | `` `rasam → sincereintent` order `` | `` `nix-infra@rasam.tail12b27.ts.net → sincereintent` order `` |

The one remaining bare `rasam` (line 123) is a **verbatim quote of `.agency/do.md`'s** wording — left as-is on purpose.

## Scope notes

- **Vendored files.** These `be/SKILL.md` copies are regenerated by `just ai::apm` from the external `srid/agency` package, so this edit is a stopgap — the durable fix belongs upstream. Edited here per request.
- **Left untouched:** narrative `rasam` mentions in `justfile` comments, `docs/ci-e2e-macos-ralph-report.md`, the atlas table, and the `macos-e2e-lane` blog post — there the bare hostname reads naturally and a connection string would not. Say the word if you want those swapped too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)