### PR TITLE
feat(pulam-web): tint working / live terminal rows

### DIFF
--- a/packages/pulam-web/src/client/HostGroup.tsx
+++ b/packages/pulam-web/src/client/HostGroup.tsx
@@ -93,6 +93,7 @@ import {
   isVisible,
   locationText,
   pipVariantFor,
+  rowBackground,
   terminalCategory,
   URGENCY,
   URGENCY_LABELS,
@@ -136,14 +137,14 @@ function AgentRow(props: {
           if (v.agent) return agentShortName(v.agent.kind);
           return v.foreground?.name ?? DASH;
         };
+        const rowStyle = (): string | undefined => {
+          const bg = rowBackground(value(), props.live());
+          return bg ? `background:${bg}` : undefined;
+        };
         return (
           <li
             class="flex items-center gap-2 border-b border-[#161b22] px-3 py-1.5 text-[13px]"
-            style={
-              urgency() === "need"
-                ? "background:color-mix(in oklch, var(--color-alert) 10%, transparent)"
-                : undefined
-            }
+            style={rowStyle()}
           >
             {/* One merged status indicator — the SAME component kolu's Dock
              *  renders, folding three axes into one glyph: the agent-state CORE

--- a/packages/pulam-web/src/client/fleet.test.ts
+++ b/packages/pulam-web/src/client/fleet.test.ts
@@ -23,6 +23,8 @@ import {
   compareFleetEntries,
   DEFAULT_FLEET_FILTERS,
   type FleetEntry,
+  ACCENT_WASH,
+  ALERT_WASH,
   fleetAlert,
   isVisible,
   locationText,
@@ -32,9 +34,6 @@ import {
   URGENCY,
   URGENCY_LABELS,
 } from "./fleet.ts";
-
-const ALERT_WASH = "color-mix(in oklch, var(--color-alert) 10%, transparent)";
-const ACCENT_WASH = "color-mix(in oklch, var(--color-accent) 10%, transparent)";
 
 /** Build an awareness value with a given agent state. Only `kind`/`state` are
  *  read by the projection, so a minimal cast keeps the test on the projection

--- a/packages/pulam-web/src/client/fleet.test.ts
+++ b/packages/pulam-web/src/client/fleet.test.ts
@@ -27,10 +27,14 @@ import {
   isVisible,
   locationText,
   pipVariantFor,
+  rowBackground,
   terminalCategory,
   URGENCY,
   URGENCY_LABELS,
 } from "./fleet.ts";
+
+const ALERT_WASH = "color-mix(in oklch, var(--color-alert) 10%, transparent)";
+const ACCENT_WASH = "color-mix(in oklch, var(--color-accent) 10%, transparent)";
 
 /** Build an awareness value with a given agent state. Only `kind`/`state` are
  *  read by the projection, so a minimal cast keeps the test on the projection
@@ -230,5 +234,33 @@ describe("fleetAlert (the per-row badge — fleet ≡ the Dock's alert membershi
       foreground: { name: "vim", title: null },
     };
     expect(fleetAlert(withForeground)).toBe(false);
+  });
+});
+
+describe("rowBackground (the per-row wash — working|live rows stand out)", () => {
+  it("a working agent gets the accent (teal) wash", () => {
+    expect(rowBackground(withAgent("thinking"), false)).toBe(ACCENT_WASH);
+    expect(rowBackground(withAgent("tool_use"), false)).toBe(ACCENT_WASH);
+    expect(rowBackground(withAgent("running_background"), false)).toBe(
+      ACCENT_WASH,
+    );
+  });
+
+  it("live terminal activity gets the accent wash even when the agent is idle", () => {
+    // The green-ring `live` axis alone is enough — a quiet agent whose terminal
+    // is moving bytes still reads as hot.
+    expect(rowBackground(withAgent("waiting"), true)).toBe(ACCENT_WASH);
+    expect(rowBackground(seedAwarenessValue("/x"), true)).toBe(ACCENT_WASH);
+  });
+
+  it("a needs-you agent keeps the alert (violet) wash — and it wins over work/live", () => {
+    expect(rowBackground(withAgent("awaiting_user"), false)).toBe(ALERT_WASH);
+    // `need` is the louder signal: a blocked agent that is ALSO live stays alert.
+    expect(rowBackground(withAgent("awaiting_user"), true)).toBe(ALERT_WASH);
+  });
+
+  it("an idle, quiet row stays bare (no wash)", () => {
+    expect(rowBackground(withAgent("waiting"), false)).toBeUndefined();
+    expect(rowBackground(seedAwarenessValue("/x"), false)).toBeUndefined();
   });
 });

--- a/packages/pulam-web/src/client/fleet.ts
+++ b/packages/pulam-web/src/client/fleet.ts
@@ -100,6 +100,26 @@ export function fleetAlert(value: AwarenessValue): boolean {
   return value.agent ? alertClass(value.agent.state) === "notify" : false;
 }
 
+/** The per-row background WASH — the fleet's at-a-glance "is this row hot?" fold,
+ *  layered behind the pip. A row that NEEDS you keeps the alert (violet) wash; a
+ *  row that is WORKING or has live terminal output (the green-ring `live` axis,
+ *  off the `activity` stream) gets the working (teal) wash; an idle/quiet row
+ *  stays bare. Both tints reuse the SAME agent-state tokens the pip + urgency
+ *  colours do (`--color-alert`, `--color-accent`), so the wash can't drift from
+ *  them. `need` wins over `work`/`live`: a blocked agent is the louder signal.
+ *  Returns the bare `background` value (or `undefined` for no wash). */
+export function rowBackground(
+  value: AwarenessValue,
+  live: boolean,
+): string | undefined {
+  const urgency = agentUrgency(value.agent);
+  if (urgency === "need")
+    return "color-mix(in oklch, var(--color-alert) 10%, transparent)";
+  if (urgency === "work" || live)
+    return "color-mix(in oklch, var(--color-accent) 10%, transparent)";
+  return undefined;
+}
+
 /** Fleet *chrome* colours — the per-host accent. Deliberately NOT a `@kolu/theme`
  *  token: R-pip-unify moved the **agent-state** palette (pip + urgency colour/
  *  label) onto the shared tokens so the pip matches kolu's Dock, and

--- a/packages/pulam-web/src/client/fleet.ts
+++ b/packages/pulam-web/src/client/fleet.ts
@@ -100,6 +100,13 @@ export function fleetAlert(value: AwarenessValue): boolean {
   return value.agent ? alertClass(value.agent.state) === "notify" : false;
 }
 
+/** CSS `background` value for the needs-you (alert/violet) wash. */
+export const ALERT_WASH =
+  "color-mix(in oklch, var(--color-alert) 10%, transparent)";
+/** CSS `background` value for the working/live (accent/teal) wash. */
+export const ACCENT_WASH =
+  "color-mix(in oklch, var(--color-accent) 10%, transparent)";
+
 /** The per-row background WASH — the fleet's at-a-glance "is this row hot?" fold,
  *  layered behind the pip. A row that NEEDS you keeps the alert (violet) wash; a
  *  row that is WORKING or has live terminal output (the green-ring `live` axis,
@@ -113,10 +120,8 @@ export function rowBackground(
   live: boolean,
 ): string | undefined {
   const urgency = agentUrgency(value.agent);
-  if (urgency === "need")
-    return "color-mix(in oklch, var(--color-alert) 10%, transparent)";
-  if (urgency === "work" || live)
-    return "color-mix(in oklch, var(--color-accent) 10%, transparent)";
+  if (urgency === "need") return ALERT_WASH;
+  if (urgency === "work" || live) return ACCENT_WASH;
   return undefined;
 }
 


### PR DESCRIPTION
On the pulam-web fleet board, a row only stood out when it **needed you** — that row gets a violet alert wash. Everything else read the same: a Claude that's actively **working**, a terminal with **live output moving bytes** (the green ring), and a dead-quiet idle shell all sat on the same flat background. The board couldn't answer "what's hot right now?" at a glance.

This adds a second, quieter wash for the **hot** rows: any row whose agent is `working`, **or** whose terminal has live activity (the green-ring `live` axis off the `activity` stream), gets a teal **accent** tint. So the board now reads in three bands:

| Row | Wash |
| --- | --- |
| needs you (`awaiting_user`) | violet — `--color-alert` |
| working **or** live output | teal — `--color-accent` |
| idle / quiet | none |

`need` still wins over `work`/`live` — a blocked agent is the louder signal, so a needs-you row that's also live stays violet.

## How

The decision is a single pure fold in `fleet.ts`:

```ts
export function rowBackground(value, live): string | undefined {
  const urgency = agentUrgency(value.agent);
  if (urgency === "need") return "…var(--color-alert) 10%…";
  if (urgency === "work" || live) return "…var(--color-accent) 10%…";
  return undefined;
}
```

It reuses the **same** agent-state tokens (`--color-alert`, `--color-accent`) that the pip and the urgency colour/label already key off, so the row wash can't drift from them — and the `working` ⇄ `live` distinction rides the existing `agentUrgency` fold + the existing `live` prop rather than re-deriving state. `HostGroup` just calls it. Pinned by `fleet.test.ts` (working states, live-but-idle, need-beats-live, and the bare idle case).

## Test

- `pnpm --filter @kolu/pulam-web test:unit` — fleet (25) + HostGroup (8) green
- `typecheck` clean, `just fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
