### PR TITLE
chore(skills): close the "terminal render = no on-screen surface" evidence escape hatch

### DIFF
--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -73,6 +73,16 @@ browser.")
   screen, not the cause to a layer.
 - **"No existing scenario exercises it."** That decides *how* you capture (drive it live — §A2's
   chrome-devtools path), never *whether* you capture. Absence of a scenario is not a skip.
+- **"It renders only in a terminal / it's a CLI / TUI / daemon, so a pasted text transcript is the
+  evidence."** A terminal, CLI, or TUI render **is** an on-screen surface — the gate answers YES, not
+  NO. "No *kolu* (browser) surface" is not "no on-screen surface": the screen the user means is
+  whatever the change makes someone *look at*, terminal included. And a real text transcript — a
+  pasted code-block of the binary's actual output — is **not** a visual artifact even though it came
+  from really running the binary: the user wants to *see* it render. Capture an actual
+  `vhs`/`asciinema` recording of the real binary against live data (a GIF/mp4, or a still pulled from
+  it — see the vhs section), never a pasted transcript. A real run posted exactly this — *"CLI/daemon
+  change with no on-screen surface, so the faithful artifact is a terminal transcript"* — and the
+  user rejected it: *"I want actual terminal recording for evidence."*
 - **"The test suite / the unit tests are the honest proof."** Tests prove the logic; they are
   **never** a substitute for a visual artifact when there is on-screen impact. They may *accompany*
   the artifact, never replace it. The user wants to **SEE** it in the actual app.

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -73,6 +73,16 @@ browser.")
   screen, not the cause to a layer.
 - **"No existing scenario exercises it."** That decides *how* you capture (drive it live — §A2's
   chrome-devtools path), never *whether* you capture. Absence of a scenario is not a skip.
+- **"It renders only in a terminal / it's a CLI / TUI / daemon, so a pasted text transcript is the
+  evidence."** A terminal, CLI, or TUI render **is** an on-screen surface — the gate answers YES, not
+  NO. "No *kolu* (browser) surface" is not "no on-screen surface": the screen the user means is
+  whatever the change makes someone *look at*, terminal included. And a real text transcript — a
+  pasted code-block of the binary's actual output — is **not** a visual artifact even though it came
+  from really running the binary: the user wants to *see* it render. Capture an actual
+  `vhs`/`asciinema` recording of the real binary against live data (a GIF/mp4, or a still pulled from
+  it — see the vhs section), never a pasted transcript. A real run posted exactly this — *"CLI/daemon
+  change with no on-screen surface, so the faithful artifact is a terminal transcript"* — and the
+  user rejected it: *"I want actual terminal recording for evidence."*
 - **"The test suite / the unit tests are the honest proof."** Tests prove the logic; they are
   **never** a substitute for a visual artifact when there is on-screen impact. They may *accompany*
   the artifact, never replace it. The user wants to **SEE** it in the actual app.

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -73,6 +73,16 @@ browser.")
   screen, not the cause to a layer.
 - **"No existing scenario exercises it."** That decides *how* you capture (drive it live — §A2's
   chrome-devtools path), never *whether* you capture. Absence of a scenario is not a skip.
+- **"It renders only in a terminal / it's a CLI / TUI / daemon, so a pasted text transcript is the
+  evidence."** A terminal, CLI, or TUI render **is** an on-screen surface — the gate answers YES, not
+  NO. "No *kolu* (browser) surface" is not "no on-screen surface": the screen the user means is
+  whatever the change makes someone *look at*, terminal included. And a real text transcript — a
+  pasted code-block of the binary's actual output — is **not** a visual artifact even though it came
+  from really running the binary: the user wants to *see* it render. Capture an actual
+  `vhs`/`asciinema` recording of the real binary against live data (a GIF/mp4, or a still pulled from
+  it — see the vhs section), never a pasted transcript. A real run posted exactly this — *"CLI/daemon
+  change with no on-screen surface, so the faithful artifact is a terminal transcript"* — and the
+  user rejected it: *"I want actual terminal recording for evidence."*
 - **"The test suite / the unit tests are the honest proof."** Tests prove the logic; they are
   **never** a substitute for a visual artifact when there is on-screen impact. They may *accompany*
   the artifact, never replace it. The user wants to **SEE** it in the actual app.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -361,7 +361,7 @@ local_deployed_file_hashes:
   .agents/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
   .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .agents/skills/dev-server/SKILL.md: sha256:1b56467bc51ddafa778997d1f7a8774f7364e55543d71e3ebf62af47efdcc13a
-  .agents/skills/evidence/SKILL.md: sha256:4c9037b031bf782e52903207f7ec4f0323438b6b59bbf85d542b46292e21a0ee
+  .agents/skills/evidence/SKILL.md: sha256:84152c26c4708fd0332ac1c15423be57b0fc19e78bb0a284b79684216ca8845d
   .agents/skills/kolu/SKILL.md: sha256:fc81e62c5b1b37c77465a0dfc6ce5b67b59bcfc4f3a98fddd6a2d0f6161b24af
   .agents/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
@@ -401,7 +401,7 @@ local_deployed_file_hashes:
   .claude/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
   .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
   .claude/skills/dev-server/SKILL.md: sha256:1b56467bc51ddafa778997d1f7a8774f7364e55543d71e3ebf62af47efdcc13a
-  .claude/skills/evidence/SKILL.md: sha256:4c9037b031bf782e52903207f7ec4f0323438b6b59bbf85d542b46292e21a0ee
+  .claude/skills/evidence/SKILL.md: sha256:84152c26c4708fd0332ac1c15423be57b0fc19e78bb0a284b79684216ca8845d
   .claude/skills/kolu/SKILL.md: sha256:fc81e62c5b1b37c77465a0dfc6ce5b67b59bcfc4f3a98fddd6a2d0f6161b24af
   .claude/skills/lens-debate/SKILL.md: sha256:07972d265dc9845f6f0c848b1511768ef0183b66bb2d707e305d06b5f407fbeb
   .claude/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3


### PR DESCRIPTION
## What

Closes a gap in the `/evidence` skill that let a `/be` run post a **static text transcript** as PR evidence for a terminal feature, instead of an actual terminal recording.

## Why — the intervention this engineers out

In session `9111d77c` (PR #1610, a `kaval-tui` `--viewport`/`--tail` feature), the agent reached the evidence step and reasoned:

> "This is a CLI/daemon change with no kolu on-screen surface, so the faithful artifact is a terminal transcript."

It captured the real binary's output, pasted it as a markdown code-block, and **posted it to the PR** (comment on #1610). The user rejected it bluntly: *"I want actual terminal recording for evidence."*

The `/evidence` skill already has the vhs/asciinema TUI path and already documents two prior real-run evidence failures — but the **closed-escape-hatch list at the §0 gate** (the section the agent reads first, before any mechanics) did not enumerate *this* rationalization. The agent answered the gate "NO on-screen surface" and never reached the vhs guidance. This is the third recurrence in the evidence-artifact-validity family, and unlike the prior two (a skip, a fabrication) it's a **real-but-static-text** artifact — an uncovered case.

## The fix

One new bullet in the §0 closed-escape-hatch list (lowest-churn — it sits exactly where the agent was reading and quotes its own words back). It closes both halves of the bad reasoning:

1. A terminal / CLI / TUI render **is** an on-screen surface — the gate answers YES. "No *kolu* (browser) surface" is not "no on-screen surface."
2. A real text transcript is **not** a visual artifact even when captured from the real binary — capture a `vhs`/`asciinema` recording (GIF/mp4 or a still pulled from it), never a pasted code-block.

## Evidence ledger

| Edit | Source | Verification |
|---|---|---|
| New closed-escape-hatch bullet | `.apm/skills/evidence/SKILL.md` §0 | Generated `.claude`/`.agents` copies + `apm.lock.yaml` regenerated via `just ai::apm` (same commit); `just fmt` clean; `just check` green (typecheck all packages + biome lint, 0 errors). Docs-only change — no runtime behavior touched. |

Honors the design philosophy: reuses the skill's existing escape-hatch mechanism rather than adding a parallel section; no new knob/fallback; trips no `llm-autonomy` anti-pattern (no new question, no gauntlet parallelization).

Provenance: self-improve of session `9111d77c-9bd1-49b9-bf52-dd7390a9f1af`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)