### PR TITLE
Make /be §5 pin BOTH CI platforms, with the linux lane on a pu box

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -146,6 +146,19 @@ green before capturing.
        falls back to the repo's on-disk `zest`, and you burn a full CI run on the
        dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point
        at it; otherwise reach for `--host`.
+   - **x86_64-linux CI lane — on an ephemeral pu box, *never* `localhost`.** Pin it
+     in the **same** `mcp__odu__run hosts=[…]` call as the darwin lane
+     (`hosts=["x86_64-linux=<user>@<pu-box>", "aarch64-darwin=<user>@<host>"]`) so
+     **both** platforms actually run. A platform you don't explicitly pin **silently
+     drops from the fanout** (the `/ci` skill's `hosts.json` contract), so a
+     darwin-only pin is a *false single-platform green*, not full CI — the same
+     "never silently drop the platform" rule the darwin bullet states, applied to
+     the lane that's easy to forget because the host JSON only ever names darwin.
+     And `localhost` is **not** a venue: it runs the heavy build/test lane *beside
+     production kolu* — the OOM-kill hazard this section opens with — so **load
+     `/pu`** (Skill tool) and run the linux lane on a fresh pu box, exactly as `/ci`
+     and `/evidence` already do. Confirm the settled run actually carried **two**
+     platforms before reporting CI green.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -146,6 +146,19 @@ green before capturing.
        falls back to the repo's on-disk `zest`, and you burn a full CI run on the
        dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point
        at it; otherwise reach for `--host`.
+   - **x86_64-linux CI lane — on an ephemeral pu box, *never* `localhost`.** Pin it
+     in the **same** `mcp__odu__run hosts=[…]` call as the darwin lane
+     (`hosts=["x86_64-linux=<user>@<pu-box>", "aarch64-darwin=<user>@<host>"]`) so
+     **both** platforms actually run. A platform you don't explicitly pin **silently
+     drops from the fanout** (the `/ci` skill's `hosts.json` contract), so a
+     darwin-only pin is a *false single-platform green*, not full CI — the same
+     "never silently drop the platform" rule the darwin bullet states, applied to
+     the lane that's easy to forget because the host JSON only ever names darwin.
+     And `localhost` is **not** a venue: it runs the heavy build/test lane *beside
+     production kolu* — the OOM-kill hazard this section opens with — so **load
+     `/pu`** (Skill tool) and run the linux lane on a fresh pu box, exactly as `/ci`
+     and `/evidence` already do. Confirm the settled run actually carried **two**
+     platforms before reporting CI green.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/agents/.apm/skills/be/SKILL.md
+++ b/agents/.apm/skills/be/SKILL.md
@@ -146,6 +146,19 @@ green before capturing.
        falls back to the repo's on-disk `zest`, and you burn a full CI run on the
        dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point
        at it; otherwise reach for `--host`.
+   - **x86_64-linux CI lane — on an ephemeral pu box, *never* `localhost`.** Pin it
+     in the **same** `mcp__odu__run hosts=[…]` call as the darwin lane
+     (`hosts=["x86_64-linux=<user>@<pu-box>", "aarch64-darwin=<user>@<host>"]`) so
+     **both** platforms actually run. A platform you don't explicitly pin **silently
+     drops from the fanout** (the `/ci` skill's `hosts.json` contract), so a
+     darwin-only pin is a *false single-platform green*, not full CI — the same
+     "never silently drop the platform" rule the darwin bullet states, applied to
+     the lane that's easy to forget because the host JSON only ever names darwin.
+     And `localhost` is **not** a venue: it runs the heavy build/test lane *beside
+     production kolu* — the OOM-kill hazard this section opens with — so **load
+     `/pu`** (Skill tool) and run the linux lane on a fresh pu box, exactly as `/ci`
+     and `/evidence` already do. Confirm the settled run actually carried **two**
+     platforms before reporting CI green.
 2. **Concurrently, run `/evidence`** while CI runs — follow the **`## PR
    evidence`** section of `.agency/do.md` for the capture procedure, then post the
    result under `## Evidence`. For bug fixes, demonstrate the now-fixed behavior

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-06-29T17:44:14.926258+00:00'
+generated_at: '2026-06-29T19:58:17.217619+00:00'
 apm_version: 0.23.0
 dependencies:
 - repo_url: _local/agents
@@ -53,7 +53,7 @@ dependencies:
   - .claude/skills/surface/SKILL.md
   deployed_file_hashes:
     .agents/skills/be-review/SKILL.md: sha256:fdb61c7b836caa836f9163660883fec7c9ab8991fe59c6f4b07c77e7ec983ada
-    .agents/skills/be/SKILL.md: sha256:c3520012b9dd7885bceb479572aa5e2b58f5b8438d6213f682218149feb8bc68
+    .agents/skills/be/SKILL.md: sha256:cdc66df505a4045774a63ad449ac2622cc9c9e5aa96ee526c47e65adacab40a5
     .agents/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238
     .agents/skills/codex-debate/answer.workflow.js: sha256:82ad3a02db21c52cb6b2453a66559bf8742f2ba30f1e8a328c35b896b0e12ada
     .agents/skills/codex-debate/debate.workflow.js: sha256:158853fa60b13e7934ef7a91d08f536dcd8bb92d391c9cbd75d9d235f590046d
@@ -68,7 +68,7 @@ dependencies:
     .agents/skills/perfection-review/SKILL.md: sha256:04da07089d67f1e605d2d639b1494a5365be4feeaa0646f4fa740cfd301bfd2c
     .agents/skills/surface/SKILL.md: sha256:96fb2a33b5a615dd1a9b8963baf3107a41a5ebb29a83ed9e168e593177716501
     .claude/skills/be-review/SKILL.md: sha256:fdb61c7b836caa836f9163660883fec7c9ab8991fe59c6f4b07c77e7ec983ada
-    .claude/skills/be/SKILL.md: sha256:c3520012b9dd7885bceb479572aa5e2b58f5b8438d6213f682218149feb8bc68
+    .claude/skills/be/SKILL.md: sha256:cdc66df505a4045774a63ad449ac2622cc9c9e5aa96ee526c47e65adacab40a5
     .claude/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238
     .claude/skills/codex-debate/answer.workflow.js: sha256:82ad3a02db21c52cb6b2453a66559bf8742f2ba30f1e8a328c35b896b0e12ada
     .claude/skills/codex-debate/debate.workflow.js: sha256:158853fa60b13e7934ef7a91d08f536dcd8bb92d391c9cbd75d9d235f590046d


### PR DESCRIPTION
**`/be` §5's odu host-pinning recipe only ever named the macOS (`aarch64-darwin`) lane.** The `x86_64-linux` lane was left unspecified — so a run that pins darwin alone silently drops Linux from the odu fanout and reports a *false single-platform green*, and the obvious stop-gap (`x86_64-linux=localhost`) runs the heavy build/test lane right beside production kolu, the exact OOM-kill hazard the section opens with.

This adds a sibling bullet to the darwin one: **pin both platforms in the same `mcp__odu__run hosts=[…]` call, run the Linux lane on an ephemeral pu box (load `/pu`) never `localhost`, and confirm the settled run carried two platforms before reporting green.**

### Provenance

Mined by `/self-improve` from session `bc7dbabe-41c3-4896-9e89-84e1edfaf069`. The human had to step in **twice on the same ship gate**, both tracing to this one gap:

| Human intervention | Root cause |
| --- | --- |
| *"Why are you not invoking odu on TWO platforms?"* | §5 pinned only darwin; the unpinned Linux platform silently dropped from the fanout |
| *"Doesn't the CI instructions tell you to run pu?"* | §5 gave no venue for the Linux lane, so it ran on `localhost` beside production instead of a pu box |

### Evidence ledger

- **Edit** — `agents/.apm/skills/be/SKILL.md` §5 step 1: new `x86_64-linux CI lane` bullet (both-platform pin + pu venue + two-platform confirmation before green).
- **Regenerated** — `just ai::apm` propagated the source edit to `.claude/skills/be/SKILL.md` and `.agents/skills/be/SKILL.md`; `apm.lock.yaml` diff is only the timestamp + the two `be/SKILL.md` hashes (no dependency bumps).
- **Gates green** — `just fmt` (no reformat), `just check` (tsc + biome clean).

> _Observations not worth an edit this run:_ a single pre-edit interrupt (the agent began applying fixes before establishing the existing e2e was green); the human's intended order was *baseline-green first, then change*. One reversible occurrence — left as a note, not a rule.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._