### PR TITLE
chore(skills): architecture-first-principles gains a Diagnosing mode — reproduce before naming a root cause, answer plainly

### DIFF
--- a/.agents/skills/architecture-first-principles/SKILL.md
+++ b/.agents/skills/architecture-first-principles/SKILL.md
@@ -93,7 +93,7 @@ logical clocks → **P3** · CQRS / event-sourcing → the composite.
 ## How to use it
 
 A **lens, not a checklist** — five diagnostic questions held as a *covering set* (no fixed order;
-together they cover the space of state/data-flow defects). Two modes:
+together they cover the space of state/data-flow defects). Three modes:
 
 - **Designing:** ask all five *before* committing a state/data-flow decision; prefer the composite
   (a fold over a log) and justify any departure.
@@ -102,6 +102,14 @@ together they cover the space of state/data-flow defects). Two modes:
   under a *no-defer* disposition: each is *fix now* or *no-op* — "acceptable for scope" is not a
   pass. Treat each principle as a **proof obligation**: either cite the structural mechanism that
   enforces it, or construct the concrete defect that is still expressible.
+- **Diagnosing a reported defect** (a bug report / failing symptom / "what's the root cause of X"):
+  **reproduce it first.** Every principle here can be argued from reading code alone — which is
+  exactly how a confident, *hallucinated* root cause ships. Glean the facts from an actual
+  reproduction (or a test that fails for the real reason), *then* name the principle the evidence
+  implicates; never assert a root cause you have only reasoned to, and don't wait to be told to
+  reproduce. State the conclusion in **plain words** — the lens's rigor lives in the analysis, the
+  answer the human reads stays a plain sentence (`conventions` → "Answer in plain words", which
+  holds even when this lens's vocabulary is dense).
 
 It owns **state, data-flow, and time**, and **delegates**: "is this boundary in the right place?" →
 `/lowy`; "are these concerns braided / fragmented?" → `/hickey`; "is the code idiomatic?" →

--- a/.claude/skills/architecture-first-principles/SKILL.md
+++ b/.claude/skills/architecture-first-principles/SKILL.md
@@ -93,7 +93,7 @@ logical clocks → **P3** · CQRS / event-sourcing → the composite.
 ## How to use it
 
 A **lens, not a checklist** — five diagnostic questions held as a *covering set* (no fixed order;
-together they cover the space of state/data-flow defects). Two modes:
+together they cover the space of state/data-flow defects). Three modes:
 
 - **Designing:** ask all five *before* committing a state/data-flow decision; prefer the composite
   (a fold over a log) and justify any departure.
@@ -102,6 +102,14 @@ together they cover the space of state/data-flow defects). Two modes:
   under a *no-defer* disposition: each is *fix now* or *no-op* — "acceptable for scope" is not a
   pass. Treat each principle as a **proof obligation**: either cite the structural mechanism that
   enforces it, or construct the concrete defect that is still expressible.
+- **Diagnosing a reported defect** (a bug report / failing symptom / "what's the root cause of X"):
+  **reproduce it first.** Every principle here can be argued from reading code alone — which is
+  exactly how a confident, *hallucinated* root cause ships. Glean the facts from an actual
+  reproduction (or a test that fails for the real reason), *then* name the principle the evidence
+  implicates; never assert a root cause you have only reasoned to, and don't wait to be told to
+  reproduce. State the conclusion in **plain words** — the lens's rigor lives in the analysis, the
+  answer the human reads stays a plain sentence (`conventions` → "Answer in plain words", which
+  holds even when this lens's vocabulary is dense).
 
 It owns **state, data-flow, and time**, and **delegates**: "is this boundary in the right place?" →
 `/lowy`; "are these concerns braided / fragmented?" → `/hickey`; "is the code idiomatic?" →

--- a/agents/.apm/skills/architecture-first-principles/SKILL.md
+++ b/agents/.apm/skills/architecture-first-principles/SKILL.md
@@ -93,7 +93,7 @@ logical clocks → **P3** · CQRS / event-sourcing → the composite.
 ## How to use it
 
 A **lens, not a checklist** — five diagnostic questions held as a *covering set* (no fixed order;
-together they cover the space of state/data-flow defects). Two modes:
+together they cover the space of state/data-flow defects). Three modes:
 
 - **Designing:** ask all five *before* committing a state/data-flow decision; prefer the composite
   (a fold over a log) and justify any departure.
@@ -102,6 +102,14 @@ together they cover the space of state/data-flow defects). Two modes:
   under a *no-defer* disposition: each is *fix now* or *no-op* — "acceptable for scope" is not a
   pass. Treat each principle as a **proof obligation**: either cite the structural mechanism that
   enforces it, or construct the concrete defect that is still expressible.
+- **Diagnosing a reported defect** (a bug report / failing symptom / "what's the root cause of X"):
+  **reproduce it first.** Every principle here can be argued from reading code alone — which is
+  exactly how a confident, *hallucinated* root cause ships. Glean the facts from an actual
+  reproduction (or a test that fails for the real reason), *then* name the principle the evidence
+  implicates; never assert a root cause you have only reasoned to, and don't wait to be told to
+  reproduce. State the conclusion in **plain words** — the lens's rigor lives in the analysis, the
+  answer the human reads stays a plain sentence (`conventions` → "Answer in plain words", which
+  holds even when this lens's vocabulary is dense).
 
 It owns **state, data-flow, and time**, and **delegates**: "is this boundary in the right place?" →
 `/lowy`; "are these concerns braided / fragmented?" → `/hickey`; "is the code idiomatic?" →

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -56,7 +56,7 @@ dependencies:
   - .claude/skills/surface
   - .claude/skills/surface/SKILL.md
   deployed_file_hashes:
-    .agents/skills/architecture-first-principles/SKILL.md: sha256:7ed2b3c42710a666fbdb0be0279ff33df24d1454bbb59b2f20c36f3073b84f65
+    .agents/skills/architecture-first-principles/SKILL.md: sha256:04f230fc2fbbf608624ed164d3173fb5bb3e7d77445a32fffc66451b85dd8509
     .agents/skills/be-review/SKILL.md: sha256:fdb61c7b836caa836f9163660883fec7c9ab8991fe59c6f4b07c77e7ec983ada
     .agents/skills/be/SKILL.md: sha256:1af763c957b9cfa5f4810c48bc8fe906a7843c6c8878422211799f9cb874590a
     .agents/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238
@@ -72,7 +72,7 @@ dependencies:
     .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
     .agents/skills/perfection-review/SKILL.md: sha256:a5464e881cdde4555218325f638289afebee4dd910772fea8efe6e06fff81bdf
     .agents/skills/surface/SKILL.md: sha256:96fb2a33b5a615dd1a9b8963baf3107a41a5ebb29a83ed9e168e593177716501
-    .claude/skills/architecture-first-principles/SKILL.md: sha256:7ed2b3c42710a666fbdb0be0279ff33df24d1454bbb59b2f20c36f3073b84f65
+    .claude/skills/architecture-first-principles/SKILL.md: sha256:04f230fc2fbbf608624ed164d3173fb5bb3e7d77445a32fffc66451b85dd8509
     .claude/skills/be-review/SKILL.md: sha256:fdb61c7b836caa836f9163660883fec7c9ab8991fe59c6f4b07c77e7ec983ada
     .claude/skills/be/SKILL.md: sha256:1af763c957b9cfa5f4810c48bc8fe906a7843c6c8878422211799f9cb874590a
     .claude/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238


### PR DESCRIPTION
## What

`/architecture-first-principles` documents exactly two ways to use the state-and-time lens — **Designing** (ask the five questions before committing a decision) and **Reviewing** (a read-only pass over existing code). Both reason over code that's *already in front of you*. Neither covers the case a human actually reaches for most: **"what's the root cause of this bug?"** — pointing the lens at a *reported, observed* defect.

That gap has a predictable failure mode: every one of P1–P5 can be argued from reading code alone, so the agent produces a confident, fully-reasoned root cause **without ever reproducing the symptom** — and then states it in the lens's dense P1–P5 vocabulary. A human has to step in twice: once to force a reproduction ("no guessing"), and again to get a plain-words answer.

This PR adds a third mode, **Diagnosing a reported defect**, that bakes both corrections in as defaults:

> **Diagnosing a reported defect** … **reproduce it first.** Every principle here can be argued from reading code alone — which is exactly how a confident, *hallucinated* root cause ships. Glean the facts from an actual reproduction … *then* name the principle the evidence implicates; never assert a root cause you have only reasoned to, and don't wait to be told to reproduce. State the conclusion in **plain words** …

## Why — evidence ledger (session `b53e270b`)

This session applied `/architecture-first-principles` to [juspay/kolu#1628](https://github.com/juspay/kolu/issues/1628). It took **~6 human interventions** to break the lens out of code-reading-and-guessing — the autonomy gap this edit closes.

| Lesson (durable) | Human interventions this session | Durability signal |
|---|---|---|
| **Reproduce, don't guess** when diagnosing an observed bug | turns 3, 4, 6, 7 — *"you have been hallucinating … reproduce this and glean the facts. **No guessing**"* · *"how did you reproduce it?"* · *"how does this happen in practice?"* | 4 hits + near-irreversible miss: a code-reading-only root cause was about to be posted to the issue and fed to `/be` |
| **Answer in plain words** | turns 2, 5, 9 — *"In simple words, please."* · *"…in simple words?"* · *"In siple words"* | 3 hits **and a repeat of prior self-improve [#1498](https://github.com/juspay/kolu/pull/1498)** ("make plain-spoken answers the always-loaded default") — the general `conventions` clause exists but got drowned out once this dense-output lens dominated the turn |

The agent *did* eventually reproduce — the shipped fix [#1633](https://github.com/juspay/kolu/pull/1633) cites *"verified by reproduction … xterm's `onData` fires a focus-in report ~243ms **after** the kill"* — but only after being forced to. The point of the edit is to drive that reproduction **unprompted**.

## Files (the edit + its faithful propagation)

| File | Role | Change |
|---|---|---|
| `agents/.apm/skills/architecture-first-principles/SKILL.md` | **source** (first-party `agents` APM package) | the new Diagnosing-mode bullet; `Two modes` → `Three modes` |
| `.claude/skills/architecture-first-principles/SKILL.md` | generated runtime | verbatim propagation |
| `.agents/skills/architecture-first-principles/SKILL.md` | generated runtime | verbatim propagation |
| `apm.lock.yaml` | lock | the two `deployed_file_hashes` entries for this skill |

Generated copies are byte-verbatim with the source (confirmed) and ride the same commit, per APM convention.

## Discipline / scope

- **Lowest-churn lever.** One clause added to an existing skill's "How to use it" — no new skill, no rule re-write. There is no existing skill to *cross-link* for "reproduce an observed bug before diagnosing" (the skill already cross-links `fact-check`, which audits code logic, not empirical reproduction).
- **Trips no `llm-autonomy` anti-pattern** — no post-§0 question reintroduced, no gate weakened, no serial gauntlet parallelized.
- **APM CLI version drift excluded.** `uvx --from apm-cli apm` is unpinned and resolved `0.23.1` in this environment vs master's `0.23.0`, which re-stamped build-IDs and reformatted an unrelated skill (`kolu`). All of that was reverted — this PR is *only* the architecture-first-principles change.
- Gates green in a throwaway worktree off fresh `origin/master`: `just fmt` (no churn) · `just check` (typecheck all packages + biome lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
