### PR TITLE
Seal terminal lifecycle dispatch — HostLocation routing enforced by types

### DIFF
--- a/packages/client/src/terminal/useSessionRestore.test.ts
+++ b/packages/client/src/terminal/useSessionRestore.test.ts
@@ -1,4 +1,9 @@
-import type { TerminalId, TerminalInfo } from "kolu-common/surface";
+import type {
+  SavedActiveTerminal,
+  SavedSession,
+  TerminalId,
+  TerminalInfo,
+} from "kolu-common/surface";
 import { createRoot } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
 
@@ -103,6 +108,48 @@ describe("useSessionRestore — isLoading gate (cold-launch restore race)", () =
       const session = mount();
 
       expect(session.isLoading()).toBe(false);
+
+      dispose();
+    });
+  });
+});
+
+describe("useSessionRestore — restore forwards a saved terminal's host (PR-0)", () => {
+  /** A saved ACTIVE terminal pinned to a non-local host, so the forwarded value is
+   *  distinguishable from a `{ kind: "local" }` default. */
+  function savedRemoteSession(): SavedSession {
+    const term: SavedActiveTerminal = {
+      id: "old-id",
+      state: "active",
+      cwd: "/work/repo",
+      git: null,
+      pr: { kind: "absent" },
+      location: { kind: "remote", hostId: "build-box" },
+      lastActivityAt: 0,
+      restoreTarget: { kind: "none" },
+    };
+    return { terminals: [term], activeTerminalId: "old-id", savedAt: 1 };
+  }
+
+  it("passes the saved `location` as the third handleCreate arg (no longer dropped)", async () => {
+    await createRoot(async (dispose) => {
+      const handleCreate = vi.fn().mockResolvedValue("new-id" as TerminalId);
+      const restore = useSessionRestore({
+        store: makeStore(),
+        handleCreate,
+        handleCreateSubTerminal: vi.fn(),
+      });
+
+      await restore.handleRestoreSession({ session: savedRemoteSession() });
+
+      expect(handleCreate).toHaveBeenCalledTimes(1);
+      // The create→restore round-trip's restore half: `t.location` rides through
+      // handleCreate (the deliberate drop in useSessionRestore.ts is gone), so a
+      // restored terminal re-spawns on its OWN host, not silently the local one.
+      expect(handleCreate.mock.calls[0]?.[2]).toEqual({
+        kind: "remote",
+        hostId: "build-box",
+      });
 
       dispose();
     });

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -2,6 +2,7 @@
 
 import { resumeFormFor } from "anyagent/cli";
 import type {
+  HostLocation,
   InitialTerminalMetadata,
   SavedSession,
   TerminalId,
@@ -30,6 +31,7 @@ export function useSessionRestore(deps: {
   handleCreate: (
     cwd?: string,
     initial?: InitialTerminalMetadata,
+    location?: HostLocation,
   ) => Promise<TerminalId>;
   handleCreateSubTerminal: (
     parentId: TerminalId,
@@ -256,22 +258,25 @@ export function useSessionRestore(deps: {
           }
           continue;
         }
-        // `t.location` is deliberately NOT forwarded: the create seam carries
-        // only client-owned `InitialTerminalMetadata`, and the *endpoint* owns
-        // location — so each terminal re-spawns at `LOCAL_LOCATION`. That is
-        // correct while every terminal is local, but it means restore here is
-        // read-record-and-respawn, not "dial the saved host + adopt". P3
-        // replaces this loop with dial+adopt; until then a remote terminal
-        // would silently restore locally, so remote terminals must not ship
-        // before P3 lands.
-        const newId = await deps.handleCreate(t.cwd, {
-          themeName: t.themeName,
-          canvasLayout: t.canvasLayout,
-          subPanel: t.subPanel,
-          rightPanel: t.rightPanel,
-          lastActivityAt: t.lastActivityAt,
-          intent: t.intent,
-        });
+        // Forward the saved `location` so the terminal re-spawns on its OWN host
+        // (the create seam resolves the endpoint by location; the server's
+        // `resolveTerminalEndpoint` picks it). Today every saved record is local, so
+        // this resolves to `LOCAL_LOCATION` and restore is unchanged. This loop is
+        // still read-record-and-respawn, not "dial the saved host + adopt" — F-REMOTE
+        // replaces it with the boot dial+adopt loop a remote terminal needs to survive
+        // a reload; until then a remote terminal can't be created.
+        const newId = await deps.handleCreate(
+          t.cwd,
+          {
+            themeName: t.themeName,
+            canvasLayout: t.canvasLayout,
+            subPanel: t.subPanel,
+            rightPanel: t.rightPanel,
+            lastActivityAt: t.lastActivityAt,
+            intent: t.intent,
+          },
+          t.location,
+        );
         oldToNew.set(t.id, newId);
         // Step 2: in-loop assert. Combined with step 1, this puts the
         // intended active in place before the first canvas mount.

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -3,7 +3,11 @@
  *  Uses plain oRPC client calls. Server signals propagate list/metadata
  *  changes via the live subscriptions — no optimistic cache needed. */
 
-import type { InitialTerminalMetadata, TerminalId } from "kolu-common/surface";
+import type {
+  HostLocation,
+  InitialTerminalMetadata,
+  TerminalId,
+} from "kolu-common/surface";
 import type { TranscriptHtmlMode } from "kolu-common/transcript";
 import { toast } from "solid-sonner";
 import { availableThemes, pickTheme, resolveThemeBgs } from "terminal-themes";
@@ -102,6 +106,7 @@ export const useTerminalCrud = createSharedRoot(() => {
   async function handleCreate(
     cwd?: string,
     initial?: InitialTerminalMetadata,
+    location?: HostLocation,
   ): Promise<TerminalId> {
     // The one create chokepoint — keyboard (`Cmd+T`/`Cmd+Enter`), palette
     // "New terminal", the Dock `+`, worktree ops, and session restore's
@@ -166,6 +171,10 @@ export const useTerminalCrud = createSharedRoot(() => {
     const info = await client.terminal
       .create({
         cwd,
+        // The host the terminal lives on — forwarded by session restore so a saved
+        // terminal re-spawns on its own host (undefined ⟹ LOCAL_LOCATION, the only
+        // host today, so a fresh create is unchanged).
+        location,
         themeName: theme,
         canvasLayout: initial?.canvasLayout,
         subPanel: initial?.subPanel,

--- a/packages/common/src/contract.ts
+++ b/packages/common/src/contract.ts
@@ -22,6 +22,7 @@ import {
 import { z } from "zod";
 import {
   CanvasLayoutSchema,
+  HostLocationSchema,
   InitialTerminalMetadataSchema,
   RightPanelPerTerminalStateSchema,
   SavedSleepingTerminalSchema,
@@ -41,6 +42,11 @@ export const TerminalCreateInputSchema = z
   .object({
     cwd: z.string().optional(),
     parentId: TerminalIdSchema.optional(),
+    /** The host this terminal lives on. Optional on the wire — absent means the
+     *  local host (`LOCAL_LOCATION`), the only host today. The server resolves a
+     *  sub-terminal's host from its parent and rejects an explicit child location
+     *  that disagrees (BAD_REQUEST). */
+    location: HostLocationSchema.optional(),
   })
   .merge(InitialTerminalMetadataSchema);
 

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -197,6 +197,16 @@ export const LOCAL_LOCATION: HostLocation = Object.freeze({
   kind: "local",
 } as const);
 
+/** Structural equality for two `HostLocation`s — the single source of truth for
+ *  "same host" so call sites don't re-spell the discriminant comparison (the
+ *  create-time parent/child host check, the boot-adoption per-host reconcile
+ *  narrow). Two remote locations match iff their `hostId`s match; a local matches
+ *  only a local. */
+export function hostLocationsEqual(a: HostLocation, b: HostLocation): boolean {
+  if (a.kind === "local") return b.kind === "local";
+  return b.kind === "remote" && a.hostId === b.hostId;
+}
+
 // ── Terminal metadata fields, organized by who OBSERVES vs who REMEMBERS ──
 //
 // After the awareness-derive-store cutover (PR #1621) a terminal's metadata has

--- a/packages/common/src/terminalEndpoint.ts
+++ b/packages/common/src/terminalEndpoint.ts
@@ -47,7 +47,9 @@ import type {
   TerminalEndpointGit,
 } from "@kolu/terminal-workspace/endpoint";
 import type {
+  HostLocation,
   InitialTerminalMetadata,
+  SavedSleepingTerminal,
   TerminalId,
   TerminalInfo,
 } from "./surface.ts";
@@ -74,6 +76,12 @@ export interface TerminalAttachment {
 export interface PtySpawnOpts {
   cwd?: string;
   parentId?: string;
+  /** The host this terminal lives on — the value the lifecycle façade resolved
+   *  this very endpoint from (`resolveTerminalEndpoint(location)`), handed back so
+   *  the endpoint stamps `meta.location` from the façade's decision rather than a
+   *  hardcoded host literal of its own. An endpoint therefore cannot stamp a
+   *  location that disagrees with the one it was resolved for. */
+  location: HostLocation;
   initialMetadata?: InitialTerminalMetadata;
   /** A ready-to-run agent resume invocation (the output of `resumeAgentCommand`,
    *  e.g. `claude -c`), written into the fresh PTY as type-ahead once its sensors
@@ -137,10 +145,6 @@ export interface TerminalEndpoint {
    *  orphan — so unregistering is not a promise that the child is gone. */
   killTerminal(id: TerminalId): Promise<TerminalInfo | undefined>;
 
-  /** Drain and dispose every terminal owned by this endpoint. Used by
-   *  the e2e harness between scenarios. */
-  killAllTerminals(): Promise<void>;
-
   /** Attach to a terminal's output: a screen-state snapshot plus the live
    *  delta stream from exactly that point forward. The snapshot is taken
    *  and the delta stream subscribed atomically, so the boundary between
@@ -151,6 +155,38 @@ export interface TerminalEndpoint {
     id: TerminalId,
     signal: AbortSignal | undefined,
   ): Promise<TerminalAttachment>;
+
+  /** Flip an ACTIVE terminal to the dormant (sleeping) arm IN PLACE (same id),
+   *  stopping its providers but leaving the PTY alive. The lifecycle façade
+   *  persists the session durably, THEN calls `releaseSleptPty` to kill the PTY
+   *  (persist-before-kill). Returns false — a no-op — when `id` is not an active
+   *  terminal. Routed per `entry.meta.location` exactly like `killTerminal`, so a
+   *  remote tile sleeps on its own host. */
+  sleep(id: TerminalId): boolean;
+
+  /** Kill the now-detached PTY of a terminal `sleep` already flipped to sleeping,
+   *  scrubbing its scratch. The registry entry stays (dormant). A kill failure is
+   *  contained, not thrown — the record is sleeping regardless and boot reconcile
+   *  reaps any survivor. */
+  releaseSleptPty(id: TerminalId): Promise<void>;
+
+  /** Wake a SLEEPING terminal: flip it back to active and re-spawn its PTY on the
+   *  SAME id in its saved cwd, replaying the resume form derived from the persisted
+   *  `restoreTarget` (session-restore-of-one). Returns the woken active info, or
+   *  undefined when `id` is not a sleeping terminal. */
+  wake(id: TerminalId): TerminalInfo | undefined;
+
+  /** Discard a SLEEPING terminal's record — there is no PTY to kill (`sleep`
+   *  already released it), so this scrubs any leftover scratch, unregisters, and
+   *  arms the autosave. Returns false when `id` is not a sleeping terminal. */
+  discardSleeping(id: TerminalId): boolean;
+
+  /** Seed a SLEEPING terminal into the registry from its saved record — the dormant
+   *  analogue of adoption (no PTY to re-wire). Tolerates a malformed record by
+   *  DROPPING it (returns false, never throws); idempotent (re-seeding a present id
+   *  is a no-op). The record carries its own `location`, so the façade routes it to
+   *  the matching host's endpoint, never the local one by default. */
+  seedSleeping(record: SavedSleepingTerminal): boolean;
 
   readonly fs: TerminalEndpointFs;
   readonly git: TerminalEndpointGit;

--- a/packages/server/src/reconcile.test.ts
+++ b/packages/server/src/reconcile.test.ts
@@ -1,5 +1,6 @@
 import type { PtyHostListEntry } from "kaval";
 import {
+  type HostLocation,
   LOCAL_LOCATION,
   type SavedSession,
   type SavedTerminal,
@@ -139,5 +140,65 @@ describe("reconcile — boot-time adoption partition (B3.3)", () => {
     expect(adopt.map((p) => p.record.id)).toEqual(["a"]);
     expect(adoptOrphans).toEqual([]);
     expect(reapSleeping.map((e) => e.id)).toEqual(["s"]);
+  });
+});
+
+describe("reconcile — the per-host location filter (PR-0 remote-prep)", () => {
+  // The destructive seam F-REMOTE depends on, previously untested: each host's boot
+  // reconciles against ITS daemon's live list joined with ONLY the saved records on
+  // ITS location. An UNFILTERED join is silently destructive across hosts — a remote
+  // active with no LOCAL live PTY reads as an exited shell and the converge DROPS it;
+  // a remote sleeping record's id can land in the local `reapSleeping`.
+  const REMOTE: HostLocation = { kind: "remote", hostId: "build-box" };
+
+  function remoteTerm(id: string): SavedTerminal {
+    return { ...term(id), location: REMOTE };
+  }
+  function remoteSleeping(id: string): SavedTerminal {
+    return { ...sleepingTerm(id), location: REMOTE };
+  }
+
+  it("the LOCAL reconcile joins ONLY local saved records — a remote active is neither dropped nor adopted here", () => {
+    // The local daemon's live list holds only the LOCAL PTY (a); the saved session
+    // has BOTH a local active (a) and a remote active (r). Scoped to the local
+    // location, the remote record is invisible to THIS reconcile (the remote host's
+    // own reconcile owns it) — so `r` never becomes a phantom orphan, and the converge
+    // never drops it as an exited shell.
+    const { adopt, adoptOrphans, reapSleeping } = reconcile(
+      [live("a")],
+      saved(term("a"), remoteTerm("r")),
+      LOCAL_LOCATION,
+    );
+    expect(adopt.map((p) => p.record.id)).toEqual(["a"]);
+    expect(adoptOrphans).toEqual([]);
+    expect(reapSleeping).toEqual([]);
+  });
+
+  it("the LOCAL reconcile does NOT reap a remote host's sleeping record", () => {
+    // A remote sleeping record (r) must never enter the local `reapSleeping`: the
+    // filter drops it from the local `sleepingIds`, so the local boot can't kill the
+    // remote host's dormant terminal.
+    const { adopt, adoptOrphans, reapSleeping } = reconcile(
+      [live("a")],
+      saved(term("a"), remoteSleeping("r")),
+      LOCAL_LOCATION,
+    );
+    expect(adopt.map((p) => p.record.id)).toEqual(["a"]);
+    expect(adoptOrphans).toEqual([]);
+    expect(reapSleeping).toEqual([]);
+  });
+
+  it("the REMOTE reconcile joins ONLY that host's records against its own daemon's list", () => {
+    // The remote host's reconcile sees ITS daemon's live list (r) and joins only the
+    // remote saved records — the local active (a) is filtered out, never mistaken for
+    // an exited remote shell.
+    const { adopt, adoptOrphans, reapSleeping } = reconcile(
+      [live("r")],
+      saved(term("a"), remoteTerm("r")),
+      REMOTE,
+    );
+    expect(adopt.map((p) => p.record.id)).toEqual(["r"]);
+    expect(adoptOrphans).toEqual([]);
+    expect(reapSleeping).toEqual([]);
   });
 });

--- a/packages/server/src/reconcile.ts
+++ b/packages/server/src/reconcile.ts
@@ -35,7 +35,13 @@
  */
 
 import type { PtyHostListEntry } from "kaval";
-import type { SavedActiveTerminal, SavedSession } from "kolu-common/surface";
+import {
+  type HostLocation,
+  hostLocationsEqual,
+  LOCAL_LOCATION,
+  type SavedActiveTerminal,
+  type SavedSession,
+} from "kolu-common/surface";
 
 /** A saved terminal whose PTY is still alive, paired with that live PTY. The
  *  join lives here (not the caller), so adoption never re-derives it: the
@@ -64,13 +70,25 @@ export interface ReconcileResult {
 
 /** Join a surviving daemon's live PTYs against the saved session on terminal
  *  `id`. A saved terminal that is not live is an exited shell — dropped (in
- *  neither returned list). See the module doc for the full partition. */
+ *  neither returned list). See the module doc for the full partition.
+ *
+ *  `location` is the host whose daemon produced `live` — only the saved records on
+ *  THAT host are joined against it (a remote host's records aren't reaped by the
+ *  local reconcile, and vice versa). Defaults to `LOCAL_LOCATION`: today every saved
+ *  record is local and `live` is the local daemon's, so the narrow keeps the whole
+ *  session and the partition is unchanged. F-REMOTE reconciles each dialed host with
+ *  its own location — this filter is the destructive remote-prep seam (an unfiltered
+ *  join would `reapSleeping` the OTHER host's sleeping survivors and drop its actives
+ *  as exited). */
 export function reconcile(
   live: PtyHostListEntry[],
   saved: SavedSession | null,
+  location: HostLocation = LOCAL_LOCATION,
 ): ReconcileResult {
   const liveById = new Map(live.map((entry) => [entry.id, entry]));
-  const savedTerminals = saved?.terminals ?? [];
+  const savedTerminals = (saved?.terminals ?? []).filter((terminal) =>
+    hostLocationsEqual(terminal.location, location),
+  );
   const savedIds = new Set(savedTerminals.map((terminal) => terminal.id));
   const sleepingIds = new Set(
     savedTerminals

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -37,17 +37,15 @@ import {
   terminalNotFound,
   type TerminalProcess,
 } from "./terminal-registry.ts";
-import {
-  discardLocalSleeping,
-  seedSleepingTerminal,
-  wakeLocalTerminal,
-} from "./terminalEndpoint/local.ts";
-import { resolveTerminalEndpoint } from "./terminalEndpoint/resolve.ts";
 import { saveTerminalFile } from "./terminalScratch.ts";
 import {
+  attachTerminal,
   createTerminal,
+  discardSleepingTerminal,
   killAllTerminals,
   killTerminal,
+  resolveCreateLocation,
+  restoreSleepingTerminal,
   setActiveTerminalId,
   setCanvasLayout,
   setRightPanelState,
@@ -56,6 +54,7 @@ import {
   setTerminalParent,
   setTerminalTheme,
   sleepTerminal,
+  wakeTerminal,
 } from "./terminals.ts";
 
 /** Get terminal or throw — shared by all per-terminal handlers. */
@@ -100,15 +99,30 @@ export const appRouter = t.router({
       // live PTY with no visible home. `requireActiveTerminal` is the same
       // live-PTY narrow every per-terminal handler uses; a sleeping/absent id is
       // "not found" to it by the same code.
-      if (input.parentId !== undefined) requireActiveTerminal(input.parentId);
-      return createTerminal(input.cwd, input.parentId, {
-        themeName: input.themeName,
-        canvasLayout: input.canvasLayout,
-        subPanel: input.subPanel,
-        rightPanel: input.rightPanel,
-        lastActivityAt: input.lastActivityAt,
-        intent: input.intent,
-      });
+      // Resolve the host: a sub-terminal inherits its (live) parent's location, a
+      // top-level terminal uses the requested location (default LOCAL_LOCATION).
+      // `requireActiveTerminal` doubles as the live-parent gate AND hands the parent
+      // entry to the location resolver, which rejects an explicit child location that
+      // disagrees with the parent (BAD_REQUEST). Today every host is local, so this
+      // always resolves to LOCAL_LOCATION.
+      const parentLocation =
+        input.parentId !== undefined
+          ? requireActiveTerminal(input.parentId).meta.location
+          : undefined;
+      const location = resolveCreateLocation(input.location, parentLocation);
+      return createTerminal(
+        input.cwd,
+        input.parentId,
+        {
+          themeName: input.themeName,
+          canvasLayout: input.canvasLayout,
+          subPanel: input.subPanel,
+          rightPanel: input.rightPanel,
+          lastActivityAt: input.lastActivityAt,
+          intent: input.intent,
+        },
+        location,
+      );
     }),
 
     resize: t.terminal.resize.handler(async ({ input }) => {
@@ -178,12 +192,10 @@ export const appRouter = t.router({
      * output is `z.string()` — and a no-op `term.write("")` for xterm.)
      */
     attach: t.terminal.attach.handler(async function* ({ input, signal }) {
-      // Resolve the endpoint by the terminal's OWN location so a remote tile's
-      // attach reaches its host (R9.2) with no change here. Local today.
-      const entry = requireActiveTerminal(input.id);
-      const { snapshot, deltas } = await resolveTerminalEndpoint(
-        entry.meta.location,
-      ).attach(input.id, signal);
+      // The façade narrows to the active arm and resolves the endpoint by the
+      // terminal's OWN location, so a remote tile's attach reaches its host with no
+      // change here. Local today.
+      const { snapshot, deltas } = await attachTerminal(input.id, signal);
       yield snapshot;
       for await (const data of deltas) yield data;
     }),
@@ -239,18 +251,21 @@ export const appRouter = t.router({
 
     wake: t.terminal.wake.handler(async ({ input }) => {
       log.info({ terminal: input.id }, "wake");
-      const info = wakeLocalTerminal(input.id);
+      // The façade routes by the sleeping terminal's OWN location so a remote tile
+      // wakes on its host; an absent id is "not found" by the same fall-through the
+      // local arm gave (undefined).
+      const info = wakeTerminal(input.id);
       if (!info) throw terminalNotFound(input.id);
       return info;
     }),
 
     discardSleeping: t.terminal.discardSleeping.handler(async ({ input }) => {
       log.info({ terminal: input.id }, "discard sleeping");
-      discardLocalSleeping(input.id);
+      discardSleepingTerminal(input.id);
     }),
 
     restoreSleeping: t.terminal.restoreSleeping.handler(async ({ input }) => {
-      seedSleepingTerminal(input);
+      restoreSleepingTerminal(input);
     }),
 
     setParent: t.terminal.setParent.handler(async ({ input }) => {

--- a/packages/server/src/surface.ts
+++ b/packages/server/src/surface.ts
@@ -56,7 +56,6 @@ import type {
 import {
   bytesToWholeMB,
   type koluSurface,
-  LOCAL_LOCATION,
   surfaces,
 } from "kolu-common/surface";
 import {
@@ -85,17 +84,21 @@ import {
   readDaemonStatus,
   readDaemonStatuses,
 } from "./ptyHost/daemonStatus.ts";
-import { resolveTerminalEndpoint } from "./terminalEndpoint/resolve.ts";
+import { localFsGitEndpoint } from "./terminalEndpoint/resolve.ts";
 // kaval's OWN identity assembler — read in the SERVER process it returns the
 // server's baked KAVAL_BUILD_ID/KAVAL_COMMIT_HASH (the build the server would
 // spawn), i.e. the *expected* kaval. Distinct from the connected daemon's
 // *reported* identity, which rides `daemonStatus.identity`, not buildInfo.
 import { currentPtyHostIdentity as expectedKavalIdentity } from "kaval";
 
-// Resolved through the one `HostLocation` seam (R9.1). Eager at module-eval,
-// exactly as the prior direct reference was — the late-bound surface ctx
-// (#1005) is what keeps that read TDZ-safe across ESM load orders.
-const localEndpoint = resolveTerminalEndpoint(LOCAL_LOCATION);
+// The LOCAL host's fs/git surfaces, through the host registry's SEALED accessor —
+// narrowed to `{ fs, git }` (`TerminalWorkspaceEndpoint`), NOT the lifecycle endpoint,
+// so deleting the public `localEndpoint` alias keeps the Code-tab's server fs/git
+// access alive without re-exposing a kill/sleep hatch surface.ts could hard-pin.
+// Eager at module-eval, exactly as the prior alias was — the late-bound surface ctx
+// (#1005) is what keeps that read TDZ-safe across ESM load orders. PR-2 builds
+// per-location fs/git on top; today it's local.
+const localFsGit = localFsGitEndpoint();
 
 // `t` is the host router builder; both `surfaceRouter` and the raw oRPC
 // handlers in `router.ts` plug procedures into it. Exported so `router.ts`
@@ -268,40 +271,40 @@ const koluDeps: Omit<
   },
 
   streams: {
-    // fs/git streams are per-host one-shot ops bound to this endpoint. For now
-    // they read the LOCAL endpoint off the `localEndpoint` alias
-    // (`resolveTerminalEndpoint(LOCAL_LOCATION)`); R9.5's Code-tab rewrite makes
-    // them resolve per-terminal so a remote tile's fs/git dials its host behind
-    // the same TerminalEndpointFs / TerminalEndpointGit seam.
+    // fs/git streams are per-host one-shot ops bound to this endpoint. For now they
+    // read the LOCAL host's fs/git off the sealed `localFsGit` accessor
+    // (`localFsGitEndpoint()`); PR-2's Code-tab rewrite makes them resolve
+    // per-terminal so a remote tile's fs/git dials its host behind the same
+    // TerminalEndpointFs / TerminalEndpointGit seam.
     gitStatus: {
       read: async (input) =>
-        localEndpoint.git.getStatus(input.repoPath, input.mode),
+        localFsGit.git.getStatus(input.repoPath, input.mode),
       install: (input, cb) =>
-        localEndpoint.fs.subscribeRepoChange(input.repoPath, cb),
+        localFsGit.fs.subscribeRepoChange(input.repoPath, cb),
       isEqual: gitStatusOutputEqual,
     },
     gitDiff: {
       read: async (input) =>
-        localEndpoint.git.getDiff(
+        localFsGit.git.getDiff(
           input.repoPath,
           input.filePath,
           input.mode,
           input.oldPath,
         ),
       install: (input, cb) =>
-        localEndpoint.fs.subscribeRepoChange(input.repoPath, cb),
+        localFsGit.fs.subscribeRepoChange(input.repoPath, cb),
       isEqual: gitDiffOutputEqual,
     },
     fsListAll: {
-      read: async (input) => localEndpoint.fs.listAll(input.repoPath),
+      read: async (input) => localFsGit.fs.listAll(input.repoPath),
       install: (input, cb) =>
-        localEndpoint.fs.subscribeRepoChange(input.repoPath, cb),
+        localFsGit.fs.subscribeRepoChange(input.repoPath, cb),
       isEqual: fsListAllOutputEqual,
     },
     fsReadFile: {
       read: async (input): Promise<FsReadFileOutput> => {
         if (isBinaryPreviewable(input.filePath)) {
-          const mtimeMs = await localEndpoint.fs.statFileMtimeMs(
+          const mtimeMs = await localFsGit.fs.statFileMtimeMs(
             input.repoPath,
             input.filePath,
           );
@@ -314,18 +317,14 @@ const koluDeps: Omit<
             ),
           };
         }
-        const { content, truncated } = await localEndpoint.fs.readFile(
+        const { content, truncated } = await localFsGit.fs.readFile(
           input.repoPath,
           input.filePath,
         );
         return { kind: "text", content, truncated };
       },
       install: (input, cb) =>
-        localEndpoint.fs.subscribeFileChange(
-          input.repoPath,
-          input.filePath,
-          cb,
-        ),
+        localFsGit.fs.subscribeFileChange(input.repoPath, input.filePath, cb),
       isEqual: fsReadFileOutputEqual,
     },
   },
@@ -456,7 +455,7 @@ const { router: surfaceRouterFragment, ctx: surfaceCtxBuilt } =
         // truthfully yields the empty live set — not a lie, the honest "nothing
         // known to be moving". R9 injects a live source here instead.
         activity: quietActivity,
-        endpoint: localEndpoint,
+        endpoint: localFsGit,
         log,
       }),
     },

--- a/packages/server/src/terminalEndpoint/bootSweep.test.ts
+++ b/packages/server/src/terminalEndpoint/bootSweep.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Boot-adoption sweep — the `CompleteHostSweep` TYPE GATE.
+ *
+ * The round-1 bug was "save the session on PARTIAL host info": a per-host adopt that
+ * could `saveSession` after reconciling only ITS host would converge the session and
+ * DROP the not-yet-reconciled hosts' terminals. PR-0 makes that structurally
+ * impossible: `adoptSurvivingHost` returns a `HostAdoptionResult` with no save in
+ * scope, and `commitBootAdoption` (the ONLY place that seeds sleeping records + saves)
+ * accepts ONLY a branded `CompleteHostSweep`, which only `completeSweep([...all host
+ * results])` mints. Committing one host's result is a COMPILE error.
+ *
+ * The gate assertions are `@ts-expect-error` lines in blocks that are TYPE-CHECKED but
+ * never RUN — the proof is that they fail to compile.
+ */
+
+import {
+  LOCAL_LOCATION,
+  type SavedSleepingTerminal,
+} from "kolu-common/surface";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getTerminal, unregisterTerminal } from "../terminal-registry.ts";
+import {
+  __resetSurfaceCtxForTest,
+  noopSurfaceCtxForTest,
+  setSurfaceCtx,
+} from "../surfaceCtx.ts";
+import {
+  __resetWorkspaceSurfaceCtxForTest,
+  noopWorkspaceSurfaceCtxForTest,
+  setWorkspaceSurfaceCtx,
+} from "../workspaceSurfaceCtx.ts";
+import {
+  commitBootAdoption,
+  completeSweep,
+  type HostAdoptionResult,
+} from "./reattach.ts";
+import { hostScopes } from "./resolve.ts";
+
+const SLEEP_ID = "55555555-5555-4555-8555-555555555555";
+
+function localResult(
+  sleepingRecords: SavedSleepingTerminal[] = [],
+): HostAdoptionResult {
+  const scope = hostScopes()[0];
+  if (!scope) throw new Error("expected a local host scope");
+  return { scope, adoptedCount: 0, sleepingRecords };
+}
+
+function sleepingRecord(): SavedSleepingTerminal {
+  return {
+    id: SLEEP_ID,
+    state: "sleeping",
+    sleptAt: 222,
+    cwd: "/work/repo",
+    git: null,
+    pr: { kind: "absent" },
+    location: LOCAL_LOCATION,
+    lastActivityAt: 7,
+    lastAgentCommand: "claude --model sonnet",
+  };
+}
+
+beforeEach(() => {
+  setSurfaceCtx(noopSurfaceCtxForTest());
+  setWorkspaceSurfaceCtx(noopWorkspaceSurfaceCtxForTest());
+});
+
+afterEach(() => {
+  unregisterTerminal(SLEEP_ID);
+  __resetSurfaceCtxForTest();
+  __resetWorkspaceSurfaceCtxForTest();
+});
+
+describe("commitBootAdoption — the CompleteHostSweep type gate", () => {
+  it("REJECTS a single host's result at the type layer (the partial-save bug is unspellable)", () => {
+    // Type-checked, never RUN — the assertion IS the compile error.
+    function _commitOneHostResult(result: HostAdoptionResult): void {
+      // @ts-expect-error — a HostAdoptionResult is NOT a CompleteHostSweep; committing
+      // one host's result must be a type error so the session can't be saved on a
+      // subset of hosts.
+      commitBootAdoption(result);
+    }
+    // A bare {results, saved} literal can't fabricate the brand either.
+    function _commitUnbrandedLiteral(): void {
+      // @ts-expect-error — missing the `CompleteHostSweep` brand (a module-private
+      // unique symbol), so a hand-built sweep is rejected — only `completeSweep` mints one.
+      commitBootAdoption({ results: [], saved: null });
+    }
+    expect(typeof _commitOneHostResult).toBe("function");
+    expect(typeof _commitUnbrandedLiteral).toBe("function");
+  });
+
+  it("ACCEPTS a sweep minted by completeSweep (the only mint path)", () => {
+    // No @ts-expect-error here: this MUST compile — `completeSweep` of the gathered
+    // results is the sanctioned commit input.
+    commitBootAdoption(completeSweep([localResult()], null));
+    // Empty sweep is a no-op converge (nothing seeded, no active marker, empty save).
+    expect(getTerminal(SLEEP_ID)).toBeUndefined();
+  });
+
+  it("seeds every host's sleeping records when the complete sweep is committed", () => {
+    // A sleeping record carried in a host's result is seeded dormant on commit —
+    // routed to its own host (local here) through the façade.
+    commitBootAdoption(completeSweep([localResult([sleepingRecord()])], null));
+    expect(getTerminal(SLEEP_ID)?.meta.state).toBe("sleeping");
+  });
+});

--- a/packages/server/src/terminalEndpoint/inventoryReconcile.ts
+++ b/packages/server/src/terminalEndpoint/inventoryReconcile.ts
@@ -13,8 +13,9 @@
  * authority that drifts.
  *
  *   - **snapshot / created** — a PTY kolu does not track is adopted as an orphan
- *     (`adoptLocalOrphan`: metadata seeded from the live daemon snapshot, the
- *     provider DAG re-run against the surviving taps). A `created` for an id kolu
+ *     (the host endpoint's `adoptInventoryOrphan`: metadata seeded from the live
+ *     daemon snapshot, the provider DAG re-run against the surviving taps). A
+ *     `created` for an id kolu
  *     ALREADY has is its own spawn echoing back — `spawnPty` registers
  *     synchronously before the daemon's `created` arrives — so the registry
  *     guard makes it a no-op: no double-register, no double-wire.
@@ -32,13 +33,9 @@
 import type { PtyHostInventoryEvent, PtyHostListEntry } from "kaval";
 import { type TerminalId, TerminalIdSchema } from "kolu-common/surface";
 import { log } from "../log.ts";
-import { ptyHostClient } from "../ptyHost/index.ts";
 import { getTerminal } from "../terminal-registry.ts";
-import {
-  adoptLocalInventoryOrphan,
-  bridgeStream,
-  reapUnrepresentablePty,
-} from "./local.ts";
+import { bridgeStream, type ServerTerminalEndpoint } from "./local.ts";
+import { type HostScope, hostScopes, serverEndpointFor } from "./resolve.ts";
 
 /** Delay before re-subscribing after the inventory stream ends (daemon recycle
  *  / reconnect). Long enough not to hot-loop while the daemon is down — its
@@ -46,15 +43,23 @@ import {
  *  discovery resumes promptly once it returns. */
 const RESUBSCRIBE_DELAY_MS = 2_000;
 
-/** Start the live inventory reconciler for the process lifetime. Re-subscribes
- *  across daemon recycles until `signal` aborts. Fire-and-forget — the loop owns
- *  its own failures (a dropped stream re-subscribes; a per-event failure is
- *  fenced), so nothing here rejects to the caller. */
+/** Start the live inventory reconciler for the process lifetime — one per registered
+ *  host (one local today). Each re-subscribes across daemon recycles until `signal`
+ *  aborts. Fire-and-forget — the loop owns its own failures (a dropped stream
+ *  re-subscribes; a per-event failure is fenced), so nothing here rejects to the
+ *  caller. */
 export function startInventoryReconciler(signal: AbortSignal): void {
-  void runReconciler(signal);
+  for (const scope of hostScopes()) void runReconciler(scope, signal);
 }
 
-async function runReconciler(signal: AbortSignal): Promise<void> {
+async function runReconciler(
+  scope: HostScope,
+  signal: AbortSignal,
+): Promise<void> {
+  // The host this reconciler follows — its inventory feed and its adopt ops both
+  // route through its own endpoint, so an out-of-band PTY is adopted ON the host
+  // whose daemon surfaced it, never the local one by default.
+  const endpoint = serverEndpointFor(scope);
   // The ONLY new mechanism here is the re-subscribe loop across daemon recycles
   // (a B3.2 restart, a supervisor reconnect): per-PTY taps die with their PTY
   // and never re-subscribe, so this loop is genuinely new. The inner consume —
@@ -65,17 +70,15 @@ async function runReconciler(signal: AbortSignal): Promise<void> {
   // ends or aborts; a non-abort end is a daemon drop, so we delay and re-subscribe.
   while (!signal.aborted) {
     try {
-      // The forwarding facade calls `liveClient()` EAGERLY, so `inventory.get`
-      // THROWS synchronously when the daemon isn't connected (a dead-on-boot or
-      // mid-recycle endpoint) — before `bridgeStream` ever runs, so its internal
-      // fence can't catch it. This try owns exactly that pre-subscribe throw (a
-      // distinct failure from the stream draining, which `bridgeStream` resolves
-      // and never rejects); without it the throw escapes to `unhandledRejection`
-      // and exits the server on the honest dead-daemon path. Treat it as a drop.
-      await bridgeStream(
-        ptyHostClient.surface.inventory.get({}, { signal }),
-        signal,
-        applyEvent,
+      // The forwarding facade resolves the live client EAGERLY, so
+      // `subscribeInventory` THROWS synchronously when the daemon isn't connected (a
+      // dead-on-boot or mid-recycle endpoint) — before `bridgeStream` ever runs, so
+      // its internal fence can't catch it. This try owns exactly that pre-subscribe
+      // throw (a distinct failure from the stream draining, which `bridgeStream`
+      // resolves and never rejects); without it the throw escapes to
+      // `unhandledRejection` and exits the server on the honest dead-daemon path.
+      await bridgeStream(endpoint.subscribeInventory(signal), signal, (ev) =>
+        applyEvent(scope, endpoint, ev),
       );
     } catch (err) {
       if (signal.aborted) return;
@@ -99,7 +102,7 @@ export interface InventoryAdoption {
  *  supplies `isTracked` (the registry lookup), `onInvalid` (drop-logging), and
  *  does the adopting — so the routing is unit-testable without the registry or
  *  the daemon. This is the boundary the contract doc names: a raw inventory id is
- *  validated against `TerminalIdSchema` here, so `isTracked` / `adoptLocalOrphan`
+ *  validated against `TerminalIdSchema` here, so `isTracked` / `adoptInventoryOrphan`
  *  downstream receive an already-branded `TerminalId` rather than re-casting a
  *  raw string. A malformed (non-UUID) out-of-band id is routed to `onInvalid`
  *  (which fails closed — kills the unrepresentable PTY — F1), never adopted.
@@ -160,20 +163,26 @@ function assertNever(x: never): never {
   throw new Error(`unexpected inventory event: ${JSON.stringify(x)}`);
 }
 
-/** Apply one inventory frame against the LIVE wiring: adopt every untracked PTY
- *  it contributes through the persisting `adoptLocalInventoryOrphan`. The actual
- *  routing is `dispatchInventoryFrame` (pure in its dependencies, so the
- *  "every adoption persists" guarantee is unit-testable with a spy and no
- *  daemon); this binds it to the registry + adoption + drop wiring. The per-event
- *  fence (a single failed adoption must not end the subscription and silence
- *  discovery for every later PTY) lives in `bridgeStream`, the same receptacle
- *  the per-terminal taps plug into — not re-derived here. */
-function applyEvent(ev: PtyHostInventoryEvent): void {
+/** Apply one inventory frame against the LIVE wiring: adopt every untracked PTY it
+ *  contributes through the host endpoint's persisting `adoptInventoryOrphan` (stamped
+ *  with the host's location). The actual routing is `dispatchInventoryFrame` (pure in
+ *  its dependencies, so the "every adoption persists" guarantee is unit-testable with
+ *  a spy and no daemon); this binds it to the registry lookup + the host endpoint's
+ *  adopt/drop ops. The per-event fence (a single failed adoption must not end the
+ *  subscription and silence discovery for every later PTY) lives in `bridgeStream`,
+ *  the same receptacle the per-terminal taps plug into — not re-derived here. */
+function applyEvent(
+  scope: HostScope,
+  endpoint: ServerTerminalEndpoint,
+  ev: PtyHostInventoryEvent,
+): void {
   dispatchInventoryFrame(
     ev,
     isTrackedById,
-    onInvalidId,
-    adoptLocalInventoryOrphan,
+    // A malformed (non-UUID) out-of-band id FAILS CLOSED — the host endpoint kills
+    // the unrepresentable PTY rather than leaving a live process kolu can't show.
+    (rawId) => endpoint.reapUnrepresentablePty(rawId),
+    (id, entry) => endpoint.adoptInventoryOrphan(id, entry, scope.location),
   );
 }
 
@@ -181,15 +190,14 @@ function applyEvent(ev: PtyHostInventoryEvent): void {
  *  registry lookup, the drop policy, and the adoption fn are all injected), so a
  *  test can assert the routing deterministically: every `created`/`snapshot`
  *  untracked entry reaches `adopt` exactly once, malformed ids reach `onInvalid`,
- *  and `exited` adopts nothing. The production `adopt` is
- *  `adoptLocalInventoryOrphan` — which adopts AND arms the session autosave (F2):
- *  unlike the boot path (which converges + `saveSession`s explicitly after
- *  adopting every survivor), a single tile appearing mid-session has no explicit
- *  save, so the adopt fn must schedule the debounced snapshot itself. This is the
- *  seam that pins it: a regression that swapped back to the non-persisting
- *  `adoptLocalOrphan` would still call `adopt`, so the autosave-arming is asserted
- *  on `adoptLocalInventoryOrphan` directly in `local.ts`'s tests; here we pin that
- *  exactly the untracked entries are dispatched.
+ *  and `exited` adopts nothing. The production `adopt` is the host endpoint's
+ *  `adoptInventoryOrphan` — which adopts AND arms the session autosave (F2): unlike
+ *  the boot path (which converges + `saveSession`s explicitly after adopting every
+ *  survivor), a single tile appearing mid-session has no explicit save, so the adopt
+ *  fn must schedule the debounced snapshot itself. This is the seam that pins it: a
+ *  regression that swapped back to the non-persisting `adoptOrphan` would still call
+ *  `adopt`, so the autosave-arming is asserted on `adoptInventoryOrphan` directly in
+ *  `local.ts`'s tests; here we pin that exactly the untracked entries are dispatched.
  *
  *  A live out-of-band adoption deliberately does NOT call `setAdoptedCount` (the
  *  boot path does — reattach.ts): the "N reattached" toast is a one-shot RESTART
@@ -215,15 +223,6 @@ export function dispatchInventoryFrame(
 
 const isTrackedById = (id: TerminalId): boolean =>
   getTerminal(id) !== undefined;
-
-/** A malformed (non-UUID) out-of-band id never reaches the registry or
- *  `adoptLocalOrphan`: the inventory boundary validates against `TerminalIdSchema`
- *  rather than branding an unvalidated string (the contract doc's "consumer
- *  validates at its boundary"). But it does NOT merely log-and-drop (F1) — a
- *  dropped id is a live PTY kolu can neither show nor kill, a hidden process. So
- *  it FAILS CLOSED through the shared policy: kill the unrepresentable PTY, the
- *  same kolu's-domain-cannot-hold-this answer the boot reconcile gives. */
-const onInvalidId = (rawId: string): void => reapUnrepresentablePty(rawId);
 
 /** Resolve after `ms`, or early if `signal` aborts — so a shutdown during the
  *  re-subscribe gap ends the loop promptly instead of after the full delay. */

--- a/packages/server/src/terminalEndpoint/local.ts
+++ b/packages/server/src/terminalEndpoint/local.ts
@@ -38,10 +38,16 @@ import {
 } from "@kolu/terminal-workspace";
 import { createTerminalWorkspaceEndpoint } from "@kolu/terminal-workspace/endpoint";
 import { resumeFormFor } from "anyagent/cli";
-import type { ForegroundSample, PtyHostClient, PtyHostListEntry } from "kaval";
+import type {
+  ForegroundSample,
+  PtyHostClient,
+  PtyHostInventoryEvent,
+  PtyHostListEntry,
+} from "kaval";
 import type {
   AgentIdentity,
   AuthoredActiveTerminal,
+  HostLocation,
   TerminalSnapshot,
   SavedActiveTerminal,
   SavedSleepingTerminal,
@@ -52,7 +58,6 @@ import {
   AuthoredActiveSchema,
   AuthoredSleepingSchema,
   createAuthoredActive,
-  LOCAL_LOCATION,
   PersistedSnapshotSchema,
   SavedSleepingTerminalSchema,
   TerminalIdSchema,
@@ -407,8 +412,9 @@ export function adoptedAuthored(
  *  owns with NO saved record (F1). A create that never reached the 500ms-debounced
  *  autosave before the restart is the common case — so the PTY is ADOPTED (never
  *  reaped), seeded entirely from the live daemon snapshot. Its authored half is a
- *  bare `createAuthoredActive(LOCAL_LOCATION)` (client chrome that never made it to
- *  disk is gone, but the live shell + scrollback survive — the headline guarantee). */
+ *  bare `createAuthoredActive(location)` for the adopting host (client chrome that never
+ *  made it to disk is gone, but the live shell + scrollback survive — the headline
+ *  guarantee). */
 export function orphanSnapshot(liveEntry: PtyHostListEntry): TerminalSnapshot {
   return {
     ...seedSnapshot(liveEntry.cwd),
@@ -418,7 +424,70 @@ export function orphanSnapshot(liveEntry: PtyHostListEntry): TerminalSnapshot {
 
 // ── Endpoint implementation ────────────────────────────────────────────
 
-class LocalTerminalEndpoint implements TerminalEndpoint {
+/** The SERVER-side terminal endpoint — the common per-terminal `TerminalEndpoint`
+ *  (the id-keyed lifecycle the façade routes) PLUS the host-scoped operations only
+ *  the boot/inventory adoption and the killAll drain reach. These extra ops are
+ *  deliberately NOT on the common interface: they take kaval daemon types
+ *  (`PtyHostListEntry`) and act per HOST, not per terminal, so they are reachable
+ *  ONLY through the package-private host registry (`forEachHost` / `serverEndpointFor`),
+ *  never via the façade's `resolveTerminalEndpoint` (which returns the narrower
+ *  `TerminalEndpoint`). That is what makes "killAll on only the local host" and
+ *  "adopt against one host's daemon from a per-terminal seam" unspellable from a
+ *  caller. */
+export interface ServerTerminalEndpoint extends TerminalEndpoint {
+  /** Drain and dispose every terminal owned by this endpoint. Reached only via the
+   *  host registry's `forEachHost`, so a caller cannot drain a single hard-pinned
+   *  host. Used by the e2e harness between scenarios. */
+  killAllTerminals(): Promise<void>;
+
+  /** Adopt a SURVIVING PTY (B3.3) that HAS a saved record — its persisted chrome
+   *  rides through whole (`adoptedAuthored`/`adoptedSnapshot`), with the live daemon
+   *  snapshot the authority for `cwd`/`foreground`. */
+  adopt(record: SavedActiveTerminal, liveEntry: PtyHostListEntry): void;
+
+  /** Adopt a SURVIVING PTY (B3.3) with NO saved record — a create that never reached
+   *  the debounced autosave. Seeded from the live daemon snapshot, stamped with the
+   *  `location` of the host whose daemon produced it (an orphan carries no saved
+   *  record to read it back from). */
+  adoptOrphan(
+    id: TerminalId,
+    liveEntry: PtyHostListEntry,
+    location: HostLocation,
+  ): void;
+
+  /** Adopt an out-of-band PTY discovered LIVE on the inventory feed (B3.5) on
+   *  `location`, AND arm the session autosave — a single tile appearing mid-session
+   *  has no explicit boot converge, so the adopt must schedule the debounced save. */
+  adoptInventoryOrphan(
+    id: TerminalId,
+    liveEntry: PtyHostListEntry,
+    location: HostLocation,
+  ): void;
+
+  /** Fail CLOSED on a live PTY whose wire id kolu cannot represent (non-UUID) —
+   *  kill it rather than leave a hidden live process kolu can neither show nor kill. */
+  reapUnrepresentablePty(rawId: string): void;
+
+  /** List THIS host's daemon's live PTYs — the boot reconcile joins them against the
+   *  saved session. THROWS on a list failure (the boot fails closed and recycles the
+   *  survivor). The host's own daemon transport, so the boot adoption never reaches a
+   *  daemon-client singleton directly. */
+  listLivePtys(): Promise<PtyHostListEntry[]>;
+
+  /** Kill a PTY on THIS host's daemon by raw wire id, fire-and-forget (a kill failure
+   *  is logged, not thrown). Reaps a sleeping record's crash-surviving PTY at boot. */
+  reapDaemonPty(id: string): void;
+
+  /** Subscribe to THIS host's daemon inventory feed (B3.5) — the live membership
+   *  stream the inventory reconciler consumes to adopt out-of-band PTYs. Throws
+   *  synchronously if the daemon isn't connected (the reconciler treats that as a
+   *  drop and re-subscribes). */
+  subscribeInventory(
+    signal: AbortSignal,
+  ): PromiseLike<AsyncIterable<PtyHostInventoryEvent>>;
+}
+
+class LocalTerminalEndpoint implements ServerTerminalEndpoint {
   readonly fs = localFs;
   readonly git = localGit;
 
@@ -445,11 +514,15 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
     const aw = seedSnapshot(cwd);
 
     // The AUTHORED half — location + memory + the client-owned chrome seeded before
-    // providers run (#642). `lastActivityAt` is the one memory field a caller seeds:
-    // session restore threads the saved recency through so it survives restart (it
-    // lives on the authored record now, the fold's `updateMemory` rewrites it live).
+    // providers run (#642). The `location` is the one the lifecycle façade resolved
+    // THIS endpoint from and handed back via `opts.location`, so the endpoint stamps
+    // the façade's decision — never a host literal of its own (a remote endpoint
+    // stamps remote, the local one local, neither can stamp the wrong host).
+    // `lastActivityAt` is the one memory field a caller seeds: session restore threads
+    // the saved recency through so it survives restart (it lives on the authored
+    // record now, the fold's `updateMemory` rewrites it live).
     const meta: AuthoredActiveTerminal = {
-      ...createAuthoredActive(LOCAL_LOCATION),
+      ...createAuthoredActive(opts.location),
     };
     if (opts.initialMetadata?.lastActivityAt !== undefined)
       meta.lastActivityAt = opts.initialMetadata.lastActivityAt;
@@ -579,7 +652,7 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
    *  failure — the caller (`spawnAndWire`) unwinds the shadow.
    *
    *  The check is by IDENTITY (`getActiveTerminal(id) === expected`), not mere
-   *  presence (F1): a `beginSleep` that flipped the entry to sleeping mid-spawn
+   *  presence (F1): a `sleep` that flipped the entry to sleeping mid-spawn
    *  leaves a DIFFERENT entry under the same id, so a bare presence check would
    *  pass and the tail would wire sensors + republish active metadata over the
    *  sleeping flip — leaking a hidden live PTY the registry believes is dormant.
@@ -673,7 +746,7 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
   /** Unwind the active sync-shadow `entry` whose async spawn/wiring failed.
    *
    *  Identity-gated: acts ONLY while the registry still holds OUR `entry`. A
-   *  `beginSleep` / re-spawn that raced in mid-spawn replaced it with a different
+   *  `sleep` / re-spawn that raced in mid-spawn replaced it with a different
    *  entry under the same id, and that newer entry is authoritative — clobbering
    *  it here would re-introduce the F1/F2 loss (drop the sleeping flip, or evict
    *  a fresh re-spawn). When we DO still own the slot, RESTORE a `prior` sleeping
@@ -969,8 +1042,12 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
    *  go down FIRST so no in-flight tap can re-publish the active meta over the
    *  flip (the sink closes over the active entry) and the later kill can't reach
    *  `handleExit` (which would unregister our sleeping entry). Returns false — a
-   *  no-op — when `id` is not an active terminal (already sleeping / absent). */
-  beginSleep(id: TerminalId): boolean {
+   *  no-op — when `id` is not an active terminal (already sleeping / absent).
+   *
+   *  The local arm of `TerminalEndpoint.sleep` — `sleepTerminal` (terminals.ts)
+   *  reaches it through `resolveTerminalEndpoint(entry.meta.location)`, exactly as
+   *  kill/attach route, so a remote tile sleeps on its own host. */
+  sleep(id: TerminalId): boolean {
     const entry = getActiveTerminal(id);
     if (!entry) return false;
     this.teardownSensors(id);
@@ -980,16 +1057,16 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
     // → `exact`, a quit-to-shell → `none`), so the freeze needs no special capture:
     // wake reads the target straight off `meta`. The frozen-`pr` special case is GONE
     // — `pr` is restore-relevant now and rides the entry's observation, which
-    // `beginSleep` carries over so the dormant tile recomposes its cwd / branch / pr
+    // `sleep` carries over so the dormant tile recomposes its cwd / branch / pr
     // off it. Sensors went down FIRST so no in-flight observation re-publishes the
     // active meta over the flip.
     //
-    // DEFERRED (R9.0): `beginSleep` does NOT drain a final settle before freezing.
+    // DEFERRED (R9.0): `sleep` does NOT drain a final settle before freezing.
     // The freeze takes whatever `restoreTarget` the fold last wrote; it does NOT hold
     // "the last AUTHORITATIVE agent" by construction. So a launch-then-sleep INSIDE
     // the agent settle window (commandRun seen, agent not yet resolved → target still
     // `none`) freezes `none` and wakes to a FALSE bare shell. Narrow + self-correcting
-    // (re-launch fixes it); the active drain is an async-`beginSleep` follow-up.
+    // (re-launch fixes it); the active drain is an async-`sleep` follow-up.
     const sleeping: SleepingTerminalProcess = {
       info: { id, pid: 0 },
       meta: AuthoredSleepingSchema.parse({
@@ -1008,7 +1085,7 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
     return true;
   }
 
-  /** Release the PTY of a terminal `beginSleep` already flipped to sleeping: kill
+  /** Release the PTY of a terminal `sleep` already flipped to sleeping: kill
    *  the now-detached PTY and scrub its scratch. The registry entry STAYS (as
    *  sleeping). A kill failure is logged, not thrown — the record is sleeping
    *  regardless, and boot reconcile reaps any survivor (adopt-or-reap). */
@@ -1054,6 +1131,9 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
     return this.registerActiveAndSpawn(id, meta, wokenAwareness, {
       cwd: wokenAwareness.cwd,
       parentId: meta.parentId,
+      // Wake re-spawns on the SAME id, so the terminal keeps its OWN host — preserve
+      // the location off the dormant record rather than re-deriving a default.
+      location: meta.location,
       resumeCommand: resumeCommand ?? undefined,
     });
   }
@@ -1068,6 +1148,150 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
     this.finalizeRemoval(id);
     log.child({ terminal: id }).info("discarded sleeping terminal");
     return true;
+  }
+
+  /** Seed a SLEEPING terminal into the registry from its saved record — the dormant
+   *  analogue of adoption (there is no PTY to re-wire). Used by BOTH boot paths: the
+   *  boot-adoption commit (`commitBootAdoption`) and the cold-boot restore
+   *  (`terminal.restoreSleeping`), so a slept terminal reappears as ☾ on any restart.
+   *
+   *  Tolerates a malformed record by DROPPING it (returns false, never throws) so one
+   *  corrupt entry — a base truncated by a crash mid-write, hand-edited, or left by an
+   *  older build — can't break the load for every other terminal (the
+   *  `persisted-schema-stays-tolerant` policy). Idempotent: re-seeding a present id is
+   *  a no-op.
+   *
+   *  Fires only `emitTerminalListChanged` (the wire), NEVER the autosave dirty: on
+   *  cold boot the active records are not yet restored, so a snapshot-and-save here
+   *  would persist a set missing them and wipe the saved session. Persistence is the
+   *  caller's job — the boot commit's explicit converge, or the restore loop's active
+   *  spawns. */
+  seedSleeping(record: SavedSleepingTerminal): boolean {
+    const idParsed = TerminalIdSchema.safeParse(record.id);
+    const recordParsed = SavedSleepingTerminalSchema.safeParse(record);
+    if (!idParsed.success || !recordParsed.success) {
+      log.warn(
+        { id: record.id },
+        "dropping malformed sleeping record at the read boundary",
+      );
+      return false;
+    }
+    const id = idParsed.data;
+    if (getTerminal(id)) return false;
+    const parsed = recordParsed.data;
+    // Seed the OBSERVATION from the saved restore-relevant projection (cwd / git / pr),
+    // live agent + foreground reset — the client's join recomposes the dormant tile's
+    // cwd / branch / pr off it. The agent the terminal will resume rides the AUTHORED
+    // sleeping record's `restoreTarget` (its `exact` arm keeps only the identity). The
+    // observation rides the sleeping entry's `snapshot` field (no separate store).
+    const snapshot: TerminalSnapshot = {
+      ...PersistedSnapshotSchema.parse(parsed),
+      agent: null,
+      foreground: null,
+    };
+    registerAndInstall(id, {
+      info: { id, pid: 0 },
+      meta: AuthoredSleepingSchema.parse(parsed),
+      snapshot,
+    });
+    emitTerminalListChanged();
+    return true;
+  }
+
+  /** Adopt a surviving PTY at boot (B3.3) that HAS a saved record — its persisted
+   *  chrome rides through whole (`adoptedAuthored`/`adoptedSnapshot`), with the live
+   *  daemon snapshot the authority for `cwd`/`foreground`. The matched-survivor arm of
+   *  the host's boot reconcile. */
+  adopt(record: SavedActiveTerminal, liveEntry: PtyHostListEntry): void {
+    this.adoptTerminal(
+      record.id as TerminalId,
+      adoptedAuthored(record),
+      adoptedSnapshot(record, liveEntry),
+      liveEntry,
+    );
+  }
+
+  /** Adopt a surviving PTY at boot (B3.3) that has NO saved record (F1) — a create
+   *  that never reached the debounced autosave. The live shell is adopted (never
+   *  reaped), seeded entirely from the daemon snapshot (`orphanSnapshot`). An orphan
+   *  carries no saved record, so its `location` can't be read back — the caller (the
+   *  per-host reconcile) supplies the host's location. */
+  adoptOrphan(
+    id: TerminalId,
+    liveEntry: PtyHostListEntry,
+    location: HostLocation,
+  ): void {
+    this.adoptTerminal(
+      id,
+      createAuthoredActive(location),
+      orphanSnapshot(liveEntry),
+      liveEntry,
+    );
+  }
+
+  /** Adopt a PTY discovered LIVE on the inventory feed (B3.5) — a `kaval-tui create`
+   *  against the daemon kolu is already a client of. Same orphan adoption as
+   *  `adoptOrphan`, but it ALSO arms the session autosave (F2): the boot path converges
+   *  + persists the session EXPLICITLY after adopting all survivors, but a single tile
+   *  appearing mid-session has no such explicit save, so without arming the autosave the
+   *  out-of-band terminal would render yet never enter the saved session until some later
+   *  dirtying event. Emitting `terminalsDirty` schedules the same debounced save a fresh
+   *  spawn does. */
+  adoptInventoryOrphan(
+    id: TerminalId,
+    liveEntry: PtyHostListEntry,
+    location: HostLocation,
+  ): void {
+    this.adoptOrphan(id, liveEntry, location);
+    emitTerminalsDirty();
+  }
+
+  /** Fail CLOSED on a live PTY whose wire id kolu cannot represent (F1) — a non-UUID
+   *  id (kolu's registry is keyed on `TerminalId` = `z.string().uuid()`). Every real
+   *  client mints a UUID, so this is an anomaly outside kolu's domain: it cannot be
+   *  registered (no tile, no exit tap, no way to surface or kill it through kolu), and
+   *  leaving it alive is a hidden live process — so KILL it. A kill failure is logged,
+   *  not thrown — there is nothing else kolu can do, and a throw would abort the boot
+   *  adoption / inventory subscription for every later PTY. */
+  reapUnrepresentablePty(rawId: string): void {
+    log.warn(
+      { rawId },
+      "live PTY id failed TerminalIdSchema — killing the unrepresentable PTY (fail-closed)",
+    );
+    void ptyHostClient.surface.terminal
+      .kill({ id: rawId })
+      .catch((err) =>
+        log.error(
+          { err, rawId },
+          "kill of unrepresentable PTY failed; it remains live on the daemon",
+        ),
+      );
+  }
+
+  /** List this host's daemon's live PTYs. Re-throws a list failure so the boot fails
+   *  CLOSED (recycle the survivor) rather than leaving the endpoint connected to a
+   *  daemon whose PTYs kolu never registered (F3). */
+  async listLivePtys(): Promise<PtyHostListEntry[]> {
+    return (await ptyHostClient.surface.terminal.list({})).entries;
+  }
+
+  /** Kill a daemon PTY by raw wire id, fire-and-forget (a kill failure is logged, not
+   *  thrown — boot reconcile reaps any survivor regardless). */
+  reapDaemonPty(id: string): void {
+    void ptyHostClient.surface.terminal
+      .kill({ id })
+      .catch((err) =>
+        log.error({ err, terminal: id }, "reap of daemon PTY failed"),
+      );
+  }
+
+  /** Subscribe to this host's daemon inventory feed — the forwarding facade resolves
+   *  the live client EAGERLY, so this throws synchronously when the daemon isn't
+   *  connected (the reconciler owns that as a drop-and-re-subscribe). */
+  subscribeInventory(
+    signal: AbortSignal,
+  ): PromiseLike<AsyncIterable<PtyHostInventoryEvent>> {
+    return ptyHostClient.surface.inventory.get({}, { signal });
   }
 
   async killAllTerminals(): Promise<void> {
@@ -1128,169 +1352,18 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
   }
 }
 
-const localEndpointImpl = new LocalTerminalEndpoint();
-export const localTerminalEndpoint: TerminalEndpoint = localEndpointImpl;
-
-// ── Sleep / wake / discard (local-only today, like adoption) ────────────
+// ── The local endpoint instance — PACKAGE-PRIVATE to the host registry ───────
 //
-// Exposed as standalone entries rather than on the shared `TerminalEndpoint`
-// interface — sleep/wake is local-only for now (manual, single-host). P3's
-// remote-host sleep is an additive sibling, not a retrofit of the interface.
-
-/** Flip an active terminal to the sleeping arm IN PLACE (PTY left alive). The
- *  facade persists the session durably, THEN calls `releaseSleptLocalPty` to kill
- *  the PTY (persist-before-kill). Returns false if `id` is not active. */
-export function beginSleepLocal(id: TerminalId): boolean {
-  return localEndpointImpl.beginSleep(id);
-}
-
-/** Kill the PTY of an already-flipped sleeping terminal. */
-export function releaseSleptLocalPty(id: TerminalId): Promise<void> {
-  return localEndpointImpl.releaseSleptPty(id);
-}
-
-/** Wake a sleeping terminal: flip to active + re-spawn on the same id, deriving the
- *  resume form from the persisted `restoreTarget` (the fold-decided resume value). */
-export function wakeLocalTerminal(id: TerminalId): TerminalInfo | undefined {
-  return localEndpointImpl.wake(id);
-}
-
-/** Discard a sleeping terminal's record (no PTY to kill). */
-export function discardLocalSleeping(id: TerminalId): boolean {
-  return localEndpointImpl.discardSleeping(id);
-}
-
-/** Seed a SLEEPING terminal into the registry from its saved record — the dormant
- *  analogue of adoption (there is no PTY to re-wire). Used by BOTH boot paths: the
- *  surviving-daemon reconcile (`adoptSurvivingSession`) and the cold-boot restore
- *  (`terminal.restoreSleeping`), so a slept terminal reappears as ☾ on any restart.
- *
- *  Tolerates a malformed record by DROPPING it (returns false, never throws) so one
- *  corrupt entry — a base truncated by a crash mid-write, hand-edited, or left by an
- *  older build — can't break the load for every other terminal (the
- *  `persisted-schema-stays-tolerant` policy). Idempotent: re-seeding a present id is
- *  a no-op.
- *
- *  Fires only `emitTerminalListChanged` (the wire), NEVER the autosave dirty: on
- *  cold boot the active records are not yet restored, so a snapshot-and-save here
- *  would persist a set missing them and wipe the saved session. Persistence is the
- *  caller's job — the survivor path's explicit converge, or the restore loop's
- *  active spawns. */
-export function seedSleepingTerminal(record: SavedSleepingTerminal): boolean {
-  const idParsed = TerminalIdSchema.safeParse(record.id);
-  const recordParsed = SavedSleepingTerminalSchema.safeParse(record);
-  if (!idParsed.success || !recordParsed.success) {
-    log.warn(
-      { id: record.id },
-      "dropping malformed sleeping record at the read boundary",
-    );
-    return false;
-  }
-  const id = idParsed.data;
-  if (getTerminal(id)) return false;
-  const parsed = recordParsed.data;
-  // Seed the OBSERVATION from the saved restore-relevant projection (cwd / git / pr),
-  // live agent + foreground reset — the client's join recomposes the dormant tile's
-  // cwd / branch / pr off it. The agent the terminal will resume rides the AUTHORED
-  // sleeping record's `restoreTarget` below (its `exact` arm keeps only the identity —
-  // no full-agent reconstruction needed across a cold restart). The observation rides
-  // the sleeping entry's `snapshot` field (no separate store), then fans out.
-  const snapshot: TerminalSnapshot = {
-    ...PersistedSnapshotSchema.parse(parsed),
-    agent: null,
-    foreground: null,
-  };
-  registerAndInstall(id, {
-    info: { id, pid: 0 },
-    meta: AuthoredSleepingSchema.parse(parsed),
-    snapshot,
-  });
-  emitTerminalListChanged();
-  return true;
-}
-
-/** Adopt a surviving local PTY at boot (B3.3) that HAS a saved record — its
- *  persisted chrome rides through whole (`adoptedAuthored`/`adoptedSnapshot`), with the live daemon
- *  snapshot the authority for `cwd`/`foreground`. Exposed as a standalone entry
- *  rather than on the shared `TerminalEndpoint` interface because adoption
- *  is local-only today — P3's remote-host adoption is an additive sibling, not
- *  a retrofit of the shared interface. */
-export function adoptLocalTerminal(
-  record: SavedActiveTerminal,
-  liveEntry: PtyHostListEntry,
-): void {
-  localEndpointImpl.adoptTerminal(
-    record.id as TerminalId,
-    adoptedAuthored(record),
-    adoptedSnapshot(record, liveEntry),
-    liveEntry,
-  );
-}
-
-/** Adopt a surviving local PTY at boot (B3.3) that has NO saved record (F1) — a
- *  create that never reached the debounced autosave before the restart. The live
- *  shell is adopted (never reaped), seeded entirely from the daemon snapshot
- *  (`orphanSnapshot`). The sibling of `adoptLocalTerminal` for the unmatched-survivor
- *  case the reconcile partition surfaces separately. `id` is an ALREADY-VALIDATED
- *  `TerminalId` — the caller (the boot reconcile or the inventory boundary) parsed
- *  it against `TerminalIdSchema`, so this no longer re-casts a raw wire string. */
-export function adoptLocalOrphan(
-  id: TerminalId,
-  liveEntry: PtyHostListEntry,
-): void {
-  localEndpointImpl.adoptTerminal(
-    id,
-    createAuthoredActive(LOCAL_LOCATION),
-    orphanSnapshot(liveEntry),
-    liveEntry,
-  );
-}
-
-/** Adopt a PTY discovered LIVE on the inventory feed (B3.5) — a `kaval-tui create`
- *  against the daemon kolu is already a client of. Same orphan adoption as
- *  `adoptLocalOrphan`, but it ALSO arms the session autosave (F2): the boot path
- *  converges + persists the session EXPLICITLY after adopting all survivors, so
- *  `adoptTerminal` is deliberately silent there — but a single tile appearing
- *  mid-session has no such explicit save, so without arming the autosave the
- *  out-of-band terminal would render yet never enter the saved session until some
- *  LATER dirtying event (a metadata change, an exit) happened to fire. A
- *  kolu-server restart in that window would lose it. Emitting `terminalsDirty`
- *  here schedules the same debounced `saveSession(snapshot())` a fresh spawn does,
- *  so the adopted tile is persisted on the next 500ms tick. */
-export function adoptLocalInventoryOrphan(
-  id: TerminalId,
-  liveEntry: PtyHostListEntry,
-): void {
-  // Identical orphan adoption to the boot path, plus the autosave arming — so it
-  // composes `adoptLocalOrphan` rather than repeating `adoptTerminal(orphanSnapshot…)`.
-  adoptLocalOrphan(id, liveEntry);
-  emitTerminalsDirty();
-}
-
-/** Fail CLOSED on a live PTY whose wire id kolu cannot represent (F1) — a
- *  non-UUID id (kolu's registry is keyed on `TerminalId` = `z.string().uuid()`).
- *  Every real client mints a UUID (`crypto.randomUUID()`: kolu-server, kaval-tui),
- *  so this is an anomaly outside kolu's domain rather than valid state to keep:
- *  it cannot be registered (no tile, no exit tap, no way to surface or kill it
- *  through kolu), and leaving it alive is a hidden live process — the same
- *  fail-open the boot recycle guards against. So KILL it rather than log-and-drop;
- *  the contract's `kill` RPC takes the opaque wire string. A kill failure is
- *  logged, not thrown — there is nothing else kolu can do, and a throw here would
- *  end the inventory subscription / abort the boot adoption for every later PTY.
- *  Shared by the boot reconcile (`reattach.ts`) and the live inventory boundary
- *  (`inventoryReconcile.ts`) so the "unrepresentable id" policy lives in one
- *  place. */
-export function reapUnrepresentablePty(rawId: string): void {
-  log.warn(
-    { rawId },
-    "live PTY id failed TerminalIdSchema — killing the unrepresentable PTY (fail-closed)",
-  );
-  void ptyHostClient.surface.terminal
-    .kill({ id: rawId })
-    .catch((err) =>
-      log.error(
-        { err, rawId },
-        "kill of unrepresentable PTY failed; it remains live on the daemon",
-      ),
-    );
-}
+// The single `{ kind: "local" }` arm of the `TerminalEndpoint` resolver. This is
+// the ONE entry point onto the in-process endpoint, and it is imported by exactly
+// ONE module — the host registry (`resolve.ts`) — which is the only thing allowed
+// to map a `HostLocation` onto it. No `*Local*` standalone per-terminal helper is
+// exported any more: the disease was a caller importing `beginSleepLocal(id)` /
+// `discardLocalSleeping(id)` to reach the local impl WITHOUT routing through
+// `HostLocation`. Every lifecycle op is now a method on the endpoint, reached only
+// through the id-keyed façade (`terminals.ts`) → `resolveTerminalEndpoint(location)`
+// → here. A future missed seam is therefore a COMPILE error, not a reviewer's hunt:
+// there is no symbol a caller can import to hard-pin local. The `sealed-dispatch`
+// guard test pins that this stays the registry's sole import.
+export const localTerminalEndpoint: ServerTerminalEndpoint =
+  new LocalTerminalEndpoint();

--- a/packages/server/src/terminalEndpoint/reattach.ts
+++ b/packages/server/src/terminalEndpoint/reattach.ts
@@ -3,164 +3,161 @@
  *
  * When `ensureLocalEndpoint` ADOPTS a surviving kaval daemon (a redeploy that did
  * not change kaval's source — `adoptOrEnsure` returned `true`), the daemon's PTYs
- * are still alive. This orchestrates the reconciliation that the spine cannot
- * (the endpoint adopts a *connection*; kolu reconciles its *contents*):
+ * are still alive. This orchestrates the reconciliation that the spine cannot (the
+ * endpoint adopts a *connection*; kolu reconciles its *contents*), split into two
+ * structurally-distinct phases so the round-1 "save the session on PARTIAL host
+ * info" bug is impossible by type:
  *
- *   1. List the surviving daemon's live PTYs and `reconcile` them against the
- *      saved session. A failure to list is a FAILED adoption, not a quiet skip
- *      (F3): it throws, and the boot recycles the daemon so it never leaves a
- *      connected survivor holding PTYs kolu has no registry entry for.
- *   2. **Adopt every representable live PTY**, both kinds (never reap a
- *      survivor just because the debounced autosave lagged the daemon — F1):
- *        - survivors WITH a saved record → whole-record (`adoptLocalTerminal`),
- *          live `cwd`/`foreground` from the daemon snapshot (F2);
- *        - survivors with NO saved record (a create that never reached the
- *          debounced autosave) → live-snapshot defaults (`adoptLocalOrphan`).
- *      Either way the provider DAG re-runs against the surviving taps. The ONE
- *      survivor kolu does NOT adopt is one whose wire id is not a UUID — kolu's
- *      registry cannot represent it, so it is killed (`reapUnrepresentablePty`)
- *      rather than left running hidden; fail-closed, not fail-open.
- *   3. **Converge** the saved session to exactly the adopted set: exited shells
- *      (saved but no longer live) drop out so no stale restore card lingers, and
- *      the active marker is preserved iff its terminal survived. An all-exited
- *      survivor clears the session (no restore card for shells that genuinely
- *      ended — exactly `handleExit`'s behavior).
- *   4. **Surface the count** so the client shows its one-shot "N reattached"
- *      confirmation.
+ *   - `adoptSurvivingHost(scope)` reconciles + adopts ONE host and RETURNS its
+ *     `HostAdoptionResult`. It has NO `saveSession` in scope and does NOT seed the
+ *     sleeping records — it cannot converge the session, because it only knows about
+ *     its own host. (Per host: list the daemon's live PTYs, join against the saved
+ *     session FILTERED to this host's location, adopt every representable survivor,
+ *     reap the crash-window sleeping PTYs, surface the "N reattached" count.)
+ *   - `commitBootAdoption(sweep)` is the ONLY place that seeds the sleeping records
+ *     and saves the session — and it requires a branded `CompleteHostSweep`, which
+ *     only `completeSweep([...all host results])` can mint. Committing one host's
+ *     result is a TYPE ERROR, so the session can never be saved on a subset of hosts.
  *
- * Runs ONLY for a daemon that survived. A fresh / recycled boot has no survivors,
- * so the existing restore-card path (the client reads the saved session and
- * offers to re-spawn it) is left untouched — B2 behavior, unchanged.
+ * `adoptSurvivingSession` is the orchestrator index.ts wires as `onAdopted`: sweep
+ * every registered host, then commit the complete sweep. One local host today, so
+ * this is byte-identical to the pre-split single-pass adoption.
+ *
+ * Runs ONLY for a daemon that survived. A fresh / recycled boot has no survivors, so
+ * the existing restore-card path is left untouched — B2 behavior, unchanged.
  */
 
 import { currentPtyHostIdentity as expectedKavalIdentity } from "kaval";
-import { TerminalIdSchema } from "kolu-common/surface";
+import {
+  type SavedSession,
+  type SavedSleepingTerminal,
+  TerminalIdSchema,
+} from "kolu-common/surface";
 import { log } from "../log.ts";
 import { readDaemonStatus, setAdoptedCount } from "../ptyHost/daemonStatus.ts";
-import { LOCAL_HOST_ID, ptyHostClient } from "../ptyHost/index.ts";
 import { reconcile } from "../reconcile.ts";
 import { getSavedSession, saveSession } from "../session.ts";
 import { getTerminal } from "../terminal-registry.ts";
-import { restoreActiveTerminalId, snapshotSession } from "../terminals.ts";
 import {
-  adoptLocalOrphan,
-  adoptLocalTerminal,
-  reapUnrepresentablePty,
-  seedSleepingTerminal,
-} from "./local.ts";
+  restoreActiveTerminalId,
+  restoreSleepingTerminal,
+  snapshotSession,
+} from "../terminals.ts";
+import { type HostScope, hostScopes, serverEndpointFor } from "./resolve.ts";
 
-/** Reconcile a SURVIVING kaval daemon's live PTYs against the saved session and
- *  adopt the survivors. See the module doc. Called from `ensureLocalEndpoint`
- *  only when the boot adopted a surviving daemon.
+/** What reconciling ONE host's survivors yielded — everything the session-wide
+ *  commit needs from this host, and NOTHING that lets this function converge the
+ *  session on its own. `sleepingRecords` are this host's saved sleeping terminals
+ *  (no PTY to adopt) for `commitBootAdoption` to seed once EVERY host is in. */
+export interface HostAdoptionResult {
+  readonly scope: HostScope;
+  readonly adoptedCount: number;
+  readonly sleepingRecords: readonly SavedSleepingTerminal[];
+}
+
+declare const completeSweepBrand: unique symbol;
+
+/** Every host's `HostAdoptionResult`, gathered — the branded token that proves the
+ *  sweep is COMPLETE. Only `completeSweep` mints it (from a full result list), so a
+ *  caller cannot hand `commitBootAdoption` a single host's result: that is a TYPE
+ *  error, which is what makes "save the session on partial host info" unspellable. */
+export interface CompleteHostSweep {
+  readonly [completeSweepBrand]: true;
+  readonly results: readonly HostAdoptionResult[];
+  readonly saved: SavedSession | null;
+}
+
+/** Mint a `CompleteHostSweep` from the results of sweeping EVERY host. The one
+ *  construction site of the brand — the orchestrator calls it after the per-host
+ *  loop, so by type the session is committed only with all hosts accounted for. */
+export function completeSweep(
+  results: readonly HostAdoptionResult[],
+  saved: SavedSession | null,
+): CompleteHostSweep {
+  return { results, saved } as CompleteHostSweep;
+}
+
+/** Reconcile a SURVIVING host's live PTYs against the saved session and adopt the
+ *  survivors — for ONE host. Returns its `HostAdoptionResult`; does NOT seed sleeping
+ *  records, restore the active marker, or save the session (that is the complete
+ *  sweep's job).
  *
- *  THROWS if it cannot list the survivor's PTYs (F3): a connected daemon holding
- *  PTYs kolu has no registry entry for is a fail-closed condition — the boot
- *  recycles it rather than leaving hidden live PTYs behind a stale restore card.
- *  Every per-terminal adoption failure is contained (it reaps just that PTY), so
- *  the only throw is the all-or-nothing `list`. */
-export async function adoptSurvivingSession(): Promise<void> {
-  // Fail CLOSED on a list failure (F3): re-throw so the boot recycles the
-  // survivor. Returning here would leave the endpoint connected to a daemon
-  // whose PTYs kolu never registered — invisible live terminals behind a stale
-  // restore card, and a duplicate-terminal hazard if the user restored it.
-  const live = (await ptyHostClient.surface.terminal.list({})).entries;
+ *  THROWS if it cannot list the survivor's PTYs (F3): a connected daemon holding PTYs
+ *  kolu has no registry entry for is a fail-closed condition — the boot recycles it
+ *  rather than leaving hidden live PTYs behind a stale restore card. Every per-terminal
+ *  adoption failure is contained (it reaps just that PTY), so the only throw is the
+ *  all-or-nothing `list`. */
+export async function adoptSurvivingHost(
+  scope: HostScope,
+): Promise<HostAdoptionResult> {
+  const endpoint = serverEndpointFor(scope);
+  // Fail CLOSED on a list failure (F3): re-throw so the boot recycles the survivor.
+  const live = await endpoint.listLivePtys();
 
   const saved = getSavedSession();
-  const { adopt, adoptOrphans, reapSleeping } = reconcile(live, saved);
+  // Reconcile against the saved records on THIS host's location only — a remote
+  // host's records aren't reaped by another host's reconcile (the destructive
+  // remote-prep filter inside `reconcile`).
+  const { adopt, adoptOrphans, reapSleeping } = reconcile(
+    live,
+    saved,
+    scope.location,
+  );
 
-  // Adopt every live PTY — never reap (F1). A survivor WITH a saved record rides
-  // its whole record through (`adoptLocalTerminal`); a survivor with NO saved
-  // record (a create that never reached the debounced autosave) is adopted from
-  // the live daemon snapshot (`adoptLocalOrphan`). Killing the latter merely
-  // because the debounced session lagged the daemon would break the headline
-  // "terminals survive a kolu update" guarantee. `reconcile` already paired each
-  // adopted record with its live PTY, so there is no join to redo here.
-  for (const pair of adopt) adoptLocalTerminal(pair.record, pair.live);
-  // Validate each orphan's wire id against `TerminalIdSchema` at this boundary
-  // (the contract doc assigns id validation to kolu-server — ptyHostSurface.ts:36)
-  // so `adoptLocalOrphan` receives a branded `TerminalId`, not a re-cast raw
-  // string. A malformed (non-UUID) id is FAIL-CLOSED — the live PTY is killed
-  // (`reapUnrepresentablePty`), never left running hidden (F1).
+  // Adopt every live PTY — never reap (F1). A survivor WITH a saved record rides its
+  // whole record through (`adopt`); a survivor with NO saved record (a create that
+  // never reached the debounced autosave) is adopted from the live daemon snapshot
+  // (`adoptOrphan`), stamped with this host's location.
+  for (const pair of adopt) endpoint.adopt(pair.record, pair.live);
+  // Validate each orphan's wire id against `TerminalIdSchema` at this boundary so the
+  // adopt receives a branded `TerminalId`, not a raw string. A malformed (non-UUID)
+  // id is FAIL-CLOSED — the live PTY is killed, never left running hidden (F1).
   let orphansAdopted = 0;
   for (const orphan of adoptOrphans) {
     const parsed = TerminalIdSchema.safeParse(orphan.id);
     if (!parsed.success) {
-      // Fail CLOSED on an id kolu cannot represent (F1): every real client
-      // mints a UUID (`crypto.randomUUID()` — kolu-server and kaval-tui alike),
-      // so a non-UUID PTY is an anomaly outside kolu's domain. We cannot register
-      // it (the registry is keyed on `TerminalId`), and leaving it alive would be
-      // a hidden live process behind a stale restore card — exactly the fail-open
-      // the boot recycle (index.ts) guards against. So KILL it rather than drop
-      // and forget: kolu's domain genuinely cannot hold it, and the contract's
-      // kill RPC takes the opaque wire string.
-      reapUnrepresentablePty(orphan.id);
+      endpoint.reapUnrepresentablePty(orphan.id);
       continue;
     }
-    adoptLocalOrphan(parsed.data, orphan);
+    endpoint.adoptOrphan(parsed.data, orphan, scope.location);
     orphansAdopted += 1;
   }
 
   const adoptedCount = adopt.length + orphansAdopted;
 
-  // Seed every SLEEPING saved record dormant — they have no PTY to adopt, so they
-  // would otherwise be absent from the registry and wiped by the converge below.
-  // Seeding here makes a slept terminal survive a server restart and ride the wire
-  // as ☾ (the reboot-then-wake journey). A malformed record drops itself (tolerant).
-  for (const record of saved?.terminals ?? []) {
-    if (record.state === "sleeping") seedSleepingTerminal(record);
-  }
   // Adopt-or-REAP the crash-window survivors: a sleep that persisted the dormant
   // record but crashed before the PTY kill completed leaves a PTY whose id is a
-  // sleeping saved id. The record is sleeping, so REAP the orphan (never re-wake) —
-  // the cold path converges with no orphan PTY (the reboot-mid-sleep journey).
+  // sleeping saved id. The record is sleeping, so REAP the orphan (never re-wake).
   for (const orphan of reapSleeping) {
     log.info(
       { terminal: orphan.id },
       "reaping a sleeping terminal's crash-surviving PTY",
     );
-    void ptyHostClient.surface.terminal
-      .kill({ id: orphan.id })
-      .catch((err) =>
-        log.error({ err, terminal: orphan.id }, "reap of sleeping PTY failed"),
-      );
+    endpoint.reapDaemonPty(orphan.id);
   }
 
-  // Converge the saved session to exactly what is now live or dormant: exited
-  // terminals drop out (no stale restore card), and the active marker is kept iff
-  // its terminal is still present (adopted active OR seeded sleeping). An empty
-  // registry clears the session (`saveSession` empty→null).
-  restoreActiveTerminalId(
-    saved?.activeTerminalId && getTerminal(saved.activeTerminalId)
-      ? saved.activeTerminalId
-      : null,
+  // This host's sleeping saved records (no PTY to adopt) — handed to the complete
+  // sweep to seed AFTER every host is reconciled, so the converge can't wipe a
+  // not-yet-reconciled host's terminals.
+  const sleepingRecords = (saved?.terminals ?? []).filter(
+    (record): record is SavedSleepingTerminal => record.state === "sleeping",
   );
-  saveSession(snapshotSession());
 
   if (adoptedCount > 0) {
-    setAdoptedCount(LOCAL_HOST_ID, adoptedCount);
+    setAdoptedCount(scope.hostId, adoptedCount);
     log.info(
-      { adopted: adopt.length, orphansAdopted },
+      { host: scope.hostId, adopted: adopt.length, orphansAdopted },
       "adopted surviving terminals after restart",
     );
   }
 
-  // Currency diagnostic (B3.4): the adopted daemon's REPORTED build vs the kaval
-  // this server WOULD spawn (its own baked `KAVAL_BUILD_ID`). When they differ
-  // the survivor is a build behind — adoption (B3.3) kept a wire-compatible-but-
-  // older daemon alive, so the rail's read-site `kavalStale` nudge fires ("update
-  // pending") and a restart picks up the new build. Logged here — the one place
-  // adoption is confirmed — as the two RAW staleKeys, so operators (and the
-  // build-skew VM gate) can read "running X, would spawn Y" in the journal. The
-  // nudge PREDICATE (the connected-gate + empty-guard comparison) lives in the
-  // client's `kavalStale`; this is observability, not a second source of truth.
-  const status = readDaemonStatus(LOCAL_HOST_ID);
+  // Currency diagnostic (B3.4): the adopted daemon's REPORTED build vs the kaval this
+  // server WOULD spawn. When they differ the survivor is a build behind, so the rail's
+  // read-site `kavalStale` nudge fires. Logged here — the one place adoption is
+  // confirmed — as the two RAW staleKeys.
+  const status = readDaemonStatus(scope.hostId);
   const running = status?.identity?.staleKey ?? "";
   const expected = expectedKavalIdentity().staleKey;
-  // By the time adoption runs the endpoint has already reported `connected` WITH
-  // an identity, so a present-status-but-missing-staleKey here is an anomaly (a
-  // status-propagation bug) — distinct from the benign off-nix empty, where
-  // `expected` is also "". Surface it rather than let `running=""` masquerade as
-  // current (which would read as "up to date" against an equally-empty expected).
   if (status && !running && expected) {
     log.warn(
       { status },
@@ -168,7 +165,47 @@ export async function adoptSurvivingSession(): Promise<void> {
     );
   }
   log.info(
-    { running, expected },
+    { host: scope.hostId, running, expected },
     `kaval currency on adopt: running=${running} expected=${expected}`,
   );
+
+  return { scope, adoptedCount, sleepingRecords };
+}
+
+/** Seed every host's sleeping records and CONVERGE the session — the ONLY place that
+ *  writes the sleeping records to the registry and saves the session, gated on a
+ *  branded `CompleteHostSweep` so it can only run with every host accounted for.
+ *
+ *  Seeds the sleeping records dormant (routed to each record's own host via the
+ *  façade), then keeps the active marker iff its terminal survived (adopted active OR
+ *  seeded sleeping) and persists the converged session — exited terminals drop out (no
+ *  stale restore card); an empty registry clears the session (`saveSession` empty→null). */
+export function commitBootAdoption(sweep: CompleteHostSweep): void {
+  // Seed every SLEEPING saved record dormant BEFORE the converge — they have no PTY to
+  // adopt, so without seeding they would be absent from the registry and wiped by the
+  // converge below. Routed to each record's own host through the façade.
+  for (const result of sweep.results) {
+    for (const record of result.sleepingRecords)
+      restoreSleepingTerminal(record);
+  }
+
+  const saved = sweep.saved;
+  restoreActiveTerminalId(
+    saved?.activeTerminalId && getTerminal(saved.activeTerminalId)
+      ? saved.activeTerminalId
+      : null,
+  );
+  saveSession(snapshotSession());
+}
+
+/** Reconcile EVERY surviving host, then commit the complete sweep — the orchestrator
+ *  `ensureLocalEndpoint` runs as `onAdopted`. Sweeping each host independently and
+ *  committing only the gathered whole is what forecloses the partial-save bug. One
+ *  local host today; F-REMOTE's dialed hosts join the loop with no change here. */
+export async function adoptSurvivingSession(): Promise<void> {
+  const results: HostAdoptionResult[] = [];
+  for (const scope of hostScopes()) {
+    results.push(await adoptSurvivingHost(scope));
+  }
+  commitBootAdoption(completeSweep(results, getSavedSession()));
 }

--- a/packages/server/src/terminalEndpoint/resolve.test.ts
+++ b/packages/server/src/terminalEndpoint/resolve.test.ts
@@ -1,30 +1,77 @@
 /**
- * `resolveTerminalEndpoint` tests — pin the R9.1 local-only mapping.
+ * Host-registry tests — the package-private seam where a `HostLocation` becomes a
+ * concrete endpoint, and the four sealed exits around it.
  *
- * The retrofit's whole point is that a `{ kind: "local" }` location resolves to
- * the in-process singleton and a remote location does NOT silently fall back to
- * it — so the remote arm (R9.2) is a purely additive `case`, not a behavior
- * change to the local path.
+ * The whole point of PR-0 is that a `{ kind: "local" }` location resolves to the
+ * one in-process endpoint and a remote location does NOT silently fall back to it —
+ * AND that the only ways to reach an endpoint are these registry exits, each scoped
+ * so a per-terminal caller can't hard-pin a host. The endpoint INSTANCE is package-
+ * private (imported only here in `resolve.ts`), so these tests assert IDENTITY via
+ * the resolver's own stability, never by importing the instance.
  */
 
 import { type HostLocation, LOCAL_LOCATION } from "kolu-common/surface";
 import { describe, expect, it } from "vitest";
-import { localTerminalEndpoint } from "./local.ts";
-import { resolveTerminalEndpoint } from "./resolve.ts";
+import {
+  forEachHost,
+  hostScopes,
+  localFsGitEndpoint,
+  resolveTerminalEndpoint,
+  serverEndpointFor,
+} from "./resolve.ts";
 
 describe("resolveTerminalEndpoint", () => {
-  it("resolves the shared LOCAL_LOCATION to the in-process localTerminalEndpoint", () => {
-    expect(resolveTerminalEndpoint(LOCAL_LOCATION)).toBe(localTerminalEndpoint);
+  it("resolves the shared LOCAL_LOCATION to a STABLE in-process endpoint", () => {
+    // Identity without importing the instance: two resolutions of the local host
+    // return the very same object (the singleton behind the seam).
+    expect(resolveTerminalEndpoint(LOCAL_LOCATION)).toBe(
+      resolveTerminalEndpoint(LOCAL_LOCATION),
+    );
   });
 
   it("keys on kind, not object identity — any { kind: 'local' } resolves local", () => {
     expect(resolveTerminalEndpoint({ kind: "local" })).toBe(
-      localTerminalEndpoint,
+      resolveTerminalEndpoint(LOCAL_LOCATION),
     );
   });
 
   it("fails loudly on a remote location — never degrades a remote terminal onto the local PTY", () => {
     const remote: HostLocation = { kind: "remote", hostId: "rasam" };
     expect(() => resolveTerminalEndpoint(remote)).toThrow(/remote/i);
+  });
+});
+
+describe("the host registry — the sealed exits", () => {
+  it("registers exactly one local host scope today", () => {
+    const scopes = hostScopes();
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0]?.location).toEqual(LOCAL_LOCATION);
+  });
+
+  it("serverEndpointFor(localScope) is the SAME endpoint resolveTerminalEndpoint returns", () => {
+    const localScope = hostScopes()[0];
+    if (!localScope) throw new Error("expected a local scope");
+    expect(serverEndpointFor(localScope)).toBe(
+      resolveTerminalEndpoint(LOCAL_LOCATION),
+    );
+  });
+
+  it("forEachHost visits every host's endpoint (one local today)", async () => {
+    const visited: unknown[] = [];
+    await forEachHost(async (endpoint) => {
+      visited.push(endpoint);
+    });
+    expect(visited).toHaveLength(1);
+    expect(visited[0]).toBe(resolveTerminalEndpoint(LOCAL_LOCATION));
+  });
+
+  it("localFsGitEndpoint exposes the fs/git surfaces (the sealed Code-tab accessor)", () => {
+    // The accessor's RETURN TYPE is the narrowed `TerminalWorkspaceEndpoint`
+    // (`{ fs, git }`), so a caller cannot CALL kill/sleep through it — the seal is at
+    // the type layer (surface.ts compiles against fs/git only). Here we spot-check
+    // that the fs/git surfaces it hands back are live.
+    const fsGit = localFsGitEndpoint();
+    expect(typeof fsGit.fs.readFile).toBe("function");
+    expect(typeof fsGit.git.getStatus).toBe("function");
   });
 });

--- a/packages/server/src/terminalEndpoint/resolve.ts
+++ b/packages/server/src/terminalEndpoint/resolve.ts
@@ -1,53 +1,130 @@
 /**
- * `resolveTerminalEndpoint` — map a terminal's `HostLocation` to the
- * `TerminalEndpoint` that owns it. THE single seam where a location becomes a
- * concrete endpoint; `router.ts`, `surface.ts`, and `terminals.ts` route their
- * per-terminal ops through here instead of importing `localTerminalEndpoint`
- * directly. The seam is consumed two ways today, and only one is yet additive:
+ * The package-private HOST REGISTRY — the one place a `HostLocation` becomes a
+ * concrete `TerminalEndpoint`, and the one place that holds the live endpoints.
  *
- *  - LOCATION-PASSING sites — attach (`router.ts`) and kill (`terminals.ts`)
- *    pass a terminal's OWN `meta.location`. For these the remote endpoint (R9.2)
- *    is the `remote` arm filled in in THIS file, never a hunt across the call
- *    sites.
- *  - CONSTANT-PINNED sites — createTerminal (`terminals.ts`) and the fs/git
- *    streams (`surface.ts`) resolve the hardcoded `LOCAL_LOCATION` (via the
- *    `localEndpoint` alias), not a per-terminal location. Filling the `remote`
- *    arm here does NOT route them remote; each still needs its own future edit
- *    to thread a real location (R9.2 for create, R9.5 for the fs/git streams).
- *    The seam is in place; the location is not yet plumbed through.
+ * This is the sealed boundary of PR-0. The local endpoint instance
+ * (`localTerminalEndpoint`) is imported HERE and nowhere else; no caller can reach
+ * it directly. Everything downstream routes through one of four exits, each scoped
+ * to its consumer so a hard-pin is structurally unspellable:
  *
- * That is the R9.1 retrofit: make the remote endpoint purely additive for the
- * location-passing sites, and stand the seam in front of the constant-pinned
- * ones so their future edit is local to one call site.
+ *  - `resolveTerminalEndpoint(location)` → the COMMON `TerminalEndpoint` (the
+ *    id-keyed per-terminal lifecycle). Imported ONLY by the lifecycle façade
+ *    (`terminals.ts`); the `sealed-dispatch` guard pins that. The kaval-typed
+ *    host-scoped ops (killAll / adopt) are NOT on this type, so a per-terminal
+ *    caller cannot reach a host's drain or boot-adopt through it.
+ *  - `forEachHost(fn)` → iterate every host's SERVER endpoint. The ONLY entry for
+ *    killAll, so "killAll on only the local host" is unspellable (there is no
+ *    single-host accessor a caller can hard-pin).
+ *  - `serverEndpointFor(scope)` → the SERVER endpoint for a branded `HostScope`.
+ *    The boot/inventory adoption resolves through here. It takes a `HostScope`
+ *    (constructed ONLY in this module), not a raw location, so a per-terminal seam
+ *    cannot fabricate one to reach the host-scoped adopt ops.
+ *  - `localFsGitEndpoint()` → the fs/git surfaces ONLY (`TerminalWorkspaceEndpoint`),
+ *    for `surface.ts`. Narrowed to fs · git, so the Code-tab's server access stays
+ *    alive through the sealed boundary WITHOUT re-exposing a lifecycle hatch.
  *
- * Local-only today. `{ kind: "local" }` (`LOCAL_LOCATION`) is the only location
- * any terminal carries, and the in-process `localTerminalEndpoint` is the only
- * live arm. A `{ kind: "remote" }` location cannot exist until R9.2 dials one,
- * so the `remote` arm FAILS LOUDLY rather than silently degrading onto the local
- * PTY — the no-fallbacks stance (a remote terminal quietly served by the local
- * endpoint would be a wrong-host bug, not a graceful default). The `match` is
- * `.exhaustive()` so R9.2 cannot add a `HostLocation` variant without forcing a
- * deliberate arm here; R9.2 replaces the `remote` throw with the ssh kaval dial.
- * There is no `RemoteTerminalEndpoint` yet.
+ * Local-only today. `{ kind: "local" }` (`LOCAL_LOCATION`) is the only location any
+ * terminal carries; the in-process `localTerminalEndpoint` is the only live arm. A
+ * `{ kind: "remote" }` location FAILS LOUDLY (no-fallbacks) rather than degrading
+ * onto the local PTY — F-REMOTE replaces the throw with the ssh kaval dial and
+ * registers the dialed host here.
  */
 
-import type { HostLocation } from "kolu-common/surface";
+import type { TerminalWorkspaceEndpoint } from "@kolu/terminal-workspace/endpoint";
+import { type HostLocation, LOCAL_LOCATION } from "kolu-common/surface";
 import type { TerminalEndpoint } from "kolu-common/terminalEndpoint";
 import { match } from "ts-pattern";
-import { localTerminalEndpoint } from "./local.ts";
+import { LOCAL_HOST_ID } from "../ptyHost/index.ts";
+import { localTerminalEndpoint, type ServerTerminalEndpoint } from "./local.ts";
 
-export function resolveTerminalEndpoint(
-  location: HostLocation,
-): TerminalEndpoint {
+declare const hostScopeBrand: unique symbol;
+
+/** A host kolu drives, identified by BOTH its daemon `hostId` (the daemon-status
+ *  key, the kaval socket it talks to) AND the `location` its terminals carry. The
+ *  two are paired here, at the ONE construction site, so a caller cannot hand the
+ *  boot adoption a mismatched `(hostId, location)` — the brand makes a hand-built
+ *  scope a type error. F-REMOTE dials a kaval and registers its scope here. */
+export interface HostScope {
+  readonly hostId: string;
+  readonly location: HostLocation;
+  readonly [hostScopeBrand]: true;
+}
+
+/** The ONE place a `HostScope` is minted — pairs `hostId` with `location` so the
+ *  two can't drift. Module-private: every scope a consumer holds came from
+ *  `hostScopes()` (or `forEachHost`), never a hand-built pair. */
+function makeScope(hostId: string, location: HostLocation): HostScope {
+  return { hostId, location } as HostScope;
+}
+
+/** The registered host scopes — `(hostId, location)` pairs only, NO endpoint
+ *  instance, so this list is safe to build eagerly at module-eval (the endpoint is
+ *  resolved LAZILY below, at call time, to stay clear of the `localTerminalEndpoint`
+ *  TDZ across the surface load cycle). One `local` scope today; F-REMOTE pushes a
+ *  dialed host's scope per ssh kaval. A list, not a singleton, so the session-global
+ *  ops (`forEachHost`, the boot sweep) are host-keyed by construction — but PR-0
+ *  dials no remote, so the single local scope keeps every resolution byte-identical. */
+const HOST_SCOPES: readonly HostScope[] = [
+  makeScope(LOCAL_HOST_ID, LOCAL_LOCATION),
+];
+
+/** The SERVER endpoint owning `location` (with the host-scoped adopt/killAll ops),
+ *  or a loud throw on a host kolu has not registered. The local arm reads
+ *  `localTerminalEndpoint` through a THUNK (evaluated at call time, never at
+ *  module-eval) so this module never trips the surface-cycle TDZ on it. */
+function endpointForLocation(location: HostLocation): ServerTerminalEndpoint {
   return match(location)
     .with({ kind: "local" }, () => localTerminalEndpoint)
     .with({ kind: "remote" }, ({ hostId }) => {
-      // R9.2 replaces this throw with the ssh kaval dial. Until then no terminal
-      // carries a remote location, so reaching here is a contract violation —
-      // crash loudly rather than degrade onto the local PTY.
+      // No terminal carries a remote location until F-REMOTE dials one and registers
+      // it — so reaching here is a contract violation. Crash loudly rather than
+      // degrade onto the local PTY (the no-fallbacks stance).
       throw new Error(
-        `no terminal endpoint for remote host "${hostId}" — remote dialing lands in R9.2`,
+        `no terminal endpoint for remote host "${hostId}" — remote dialing lands in F-REMOTE`,
       );
     })
     .exhaustive();
+}
+
+/** Map a terminal's `HostLocation` to the COMMON `TerminalEndpoint` that owns it.
+ *  THE single seam where a location becomes a concrete endpoint — imported ONLY by
+ *  the lifecycle façade (`terminals.ts`), which resolves `getTerminal(id).meta.location`
+ *  internally on every per-terminal op. Returns the narrow common interface, so the
+ *  host-scoped ops stay out of a per-terminal caller's reach. */
+export function resolveTerminalEndpoint(
+  location: HostLocation,
+): TerminalEndpoint {
+  return endpointForLocation(location);
+}
+
+/** Run `fn` against EVERY host's server endpoint. The only entry for session-global
+ *  ops (killAll) — there is no single-host accessor a caller can hard-pin, so
+ *  "killAll on only the local host" is unspellable. One host today. */
+export async function forEachHost(
+  fn: (endpoint: ServerTerminalEndpoint) => Promise<void>,
+): Promise<void> {
+  for (const scope of HOST_SCOPES)
+    await fn(endpointForLocation(scope.location));
+}
+
+/** The `(hostId, location)` scope of every registered host — the boot-adoption
+ *  sweep iterates these, reconciling each host independently. One local scope today. */
+export function hostScopes(): readonly HostScope[] {
+  return HOST_SCOPES;
+}
+
+/** The SERVER endpoint for a branded `HostScope` — the boot/inventory adoption's
+ *  exit. Takes a `HostScope` (minted only in this module), never a raw location, so
+ *  a per-terminal seam can't fabricate one to reach the host-scoped adopt ops. */
+export function serverEndpointFor(scope: HostScope): ServerTerminalEndpoint {
+  return endpointForLocation(scope.location);
+}
+
+/** The LOCAL host's fs/git surfaces ONLY — `surface.ts`'s sealed accessor for the
+ *  Code-tab's one-shot fs/git ops + watcher streams. Narrowed to `{ fs, git }`
+ *  (`TerminalWorkspaceEndpoint`), so deleting the public `localEndpoint` alias keeps
+ *  fs/git's server access alive WITHOUT handing surface.ts a lifecycle endpoint it
+ *  could hard-pin. PR-2 builds per-location fs/git on top; today it's local. */
+export function localFsGitEndpoint(): TerminalWorkspaceEndpoint {
+  return endpointForLocation(LOCAL_LOCATION);
 }

--- a/packages/server/src/terminalEndpoint/sealedDispatch.test.ts
+++ b/packages/server/src/terminalEndpoint/sealedDispatch.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Sealed-dispatch guard — the structural proof that PR-0's escape hatches stay gone.
+ *
+ * "Hard-pin local / bypass `HostLocation` at a per-terminal lifecycle seam" must be a
+ * COMPILE error, which means there must be NO symbol a caller can import to reach the
+ * local endpoint directly. The disease was three importable hatches:
+ *
+ *   - the `localEndpoint = resolveTerminalEndpoint(LOCAL_LOCATION)` aliases (terminals.ts
+ *     + surface.ts) — hard-pinned local endpoints;
+ *   - the eight `*Local*` per-terminal helpers (`beginSleepLocal`, `discardLocalSleeping`,
+ *     …) + `reapUnrepresentablePty` — direct local-impl entry points that never routed;
+ *   - `resolveTerminalEndpoint` imported widely (router, surface, terminals) — the
+ *     resolver any seam could call with a hardcoded `LOCAL_LOCATION`.
+ *
+ * This walks the SOURCE tree (non-test) and asserts each hatch is gone: no alias, no
+ * `*Local*` export, and `resolveTerminalEndpoint` / the local endpoint instance reachable
+ * only from their one sanctioned importer. A future seam that re-imports either symbol
+ * trips this test — the seam-hunt is now mechanical.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC_DIR = fileURLToPath(new URL("../", import.meta.url));
+
+function srcFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...srcFiles(full));
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts"))
+      out.push(full);
+  }
+  return out;
+}
+
+const FILES = srcFiles(SRC_DIR).map((f) => ({
+  rel: path.relative(SRC_DIR, f),
+  content: readFileSync(f, "utf8"),
+}));
+
+/** The identifiers `content` imports via the brace-import form (multi-line aware).
+ *  Distinguishes a real import from a name merely mentioned in a comment. */
+function importedSymbols(content: string): Set<string> {
+  const names = new Set<string>();
+  const re = /import\s+(?:type\s+)?\{([^}]*)\}\s+from\s+["'][^"']+["']/gs;
+  for (const m of content.matchAll(re)) {
+    for (const raw of (m[1] ?? "").split(",")) {
+      const name = raw
+        .replace(/\btype\b/, "")
+        .trim()
+        .split(/\s+as\s+/)[0]
+        ?.trim();
+      if (name) names.add(name);
+    }
+  }
+  return names;
+}
+
+const FORBIDDEN_EXPORTS = [
+  "beginSleepLocal",
+  "wakeLocalTerminal",
+  "discardLocalSleeping",
+  "seedSleepingTerminal",
+  "adoptLocalTerminal",
+  "adoptLocalOrphan",
+  "adoptLocalInventoryOrphan",
+  "releaseSleptLocalPty",
+  "reapUnrepresentablePty",
+];
+
+const RESOLVE_TS = path.join("terminalEndpoint", "resolve.ts");
+const LOCAL_TS = path.join("terminalEndpoint", "local.ts");
+
+describe("sealed terminal dispatch — no escape hatch survives", () => {
+  it("no `*Local*` per-terminal helper is exported anywhere", () => {
+    for (const { rel, content } of FILES) {
+      for (const name of FORBIDDEN_EXPORTS) {
+        const exportRe = new RegExp(
+          `export\\s+(?:async\\s+)?(?:function|const|let|class)\\s+${name}\\b`,
+        );
+        expect(
+          exportRe.test(content),
+          `${rel} must not export the deleted helper \`${name}\``,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("no `localEndpoint` hard-pinned alias is declared", () => {
+    for (const { rel, content } of FILES) {
+      expect(
+        /\bconst\s+localEndpoint\s*=/.test(content),
+        `${rel} must not alias a hard-pinned local endpoint`,
+      ).toBe(false);
+    }
+  });
+
+  it("`resolveTerminalEndpoint` is imported ONLY by the lifecycle façade (terminals.ts)", () => {
+    for (const { rel, content } of FILES) {
+      if (rel === "terminals.ts") continue; // the façade — the sole sanctioned importer
+      expect(
+        importedSymbols(content).has("resolveTerminalEndpoint"),
+        `${rel} must not import resolveTerminalEndpoint — route through the façade instead`,
+      ).toBe(false);
+    }
+  });
+
+  it("the local endpoint INSTANCE is imported ONLY by the host registry (resolve.ts)", () => {
+    for (const { rel, content } of FILES) {
+      if (rel === RESOLVE_TS || rel === LOCAL_TS) continue; // the registry + its definer
+      expect(
+        importedSymbols(content).has("localTerminalEndpoint"),
+        `${rel} must not import the local endpoint instance — it is package-private`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/server/src/terminalEndpoint/sleepWake.test.ts
+++ b/packages/server/src/terminalEndpoint/sleepWake.test.ts
@@ -55,13 +55,14 @@ import {
   noopWorkspaceSurfaceCtxForTest,
   setWorkspaceSurfaceCtx,
 } from "../workspaceSurfaceCtx.ts";
-import {
-  beginSleepLocal,
-  discardLocalSleeping,
-  seedSleepingTerminal,
-  wakeLocalTerminal,
-} from "./local.ts";
 import { installSnapshot } from "./metadata.ts";
+import { resolveTerminalEndpoint } from "./resolve.ts";
+
+// The sleep/wake/discard/seed state machine is exercised through the SEALED resolver
+// (the same seam the lifecycle façade routes through), NOT the deleted `*Local*`
+// direct handles — these are pty-host-free transition tests, so they call the
+// endpoint's sync methods straight (no save / release / routing side effects).
+const endpoint = resolveTerminalEndpoint(LOCAL_LOCATION);
 
 const ID = "11111111-1111-4111-8111-111111111111";
 
@@ -188,7 +189,7 @@ afterEach(() => {
 describe("beginSleep — flip active → sleeping in place", () => {
   it("keeps the SAME id, rides the resume inputs on the authored arm, keeps the snapshot (incl. pr), releases the handle", () => {
     seedActive();
-    expect(beginSleepLocal(ID)).toBe(true);
+    expect(endpoint.sleep(ID)).toBe(true);
 
     const entry = getTerminal(ID);
     expect(entry).toBeDefined();
@@ -230,13 +231,13 @@ describe("beginSleep — flip active → sleeping in place", () => {
   });
 
   it("is a no-op (returns false) on an absent id", () => {
-    expect(beginSleepLocal(ID)).toBe(false);
+    expect(endpoint.sleep(ID)).toBe(false);
   });
 
   it("is a no-op on an already-sleeping id (idempotent)", () => {
     seedActive();
-    expect(beginSleepLocal(ID)).toBe(true);
-    expect(beginSleepLocal(ID)).toBe(false);
+    expect(endpoint.sleep(ID)).toBe(true);
+    expect(endpoint.sleep(ID)).toBe(false);
     expect(getTerminal(ID)?.meta.state).toBe("sleeping");
   });
 });
@@ -244,7 +245,7 @@ describe("beginSleep — flip active → sleeping in place", () => {
 describe("snapshotSession — a slept terminal serializes through the sleeping arm", () => {
   it("emits state=sleeping + sleptAt, strips agent/foreground, keeps the pr snapshot + lastAgentCommand + restoreTarget", () => {
     seedActive();
-    beginSleepLocal(ID);
+    endpoint.sleep(ID);
 
     const saved = snapshotSession().terminals.find((t) => t.id === ID);
     expect(saved).toBeDefined();
@@ -268,11 +269,11 @@ describe("snapshotSession — a slept terminal serializes through the sleeping a
 describe("wake — resets the snapshot, keeps the authored memory", () => {
   it("re-seeds the snapshot to defaults, rides the resume inputs through on the authored record, and resumes the exact conversation", async () => {
     seedActive();
-    expect(beginSleepLocal(ID)).toBe(true);
+    expect(endpoint.sleep(ID)).toBe(true);
 
     // Wake registers the active sync-shadow synchronously (the spawn tail fails on
     // a later microtask — no kaval); assert the store at that sync point.
-    wakeLocalTerminal(ID);
+    endpoint.wake(ID);
     expect(getTerminal(ID)?.meta.state).toBe("active");
 
     const aw = snapshotFor(ID);
@@ -309,9 +310,9 @@ describe("wake — resets the snapshot, keeps the authored memory", () => {
     const entry = authoredActive({ restoreTarget: { kind: "none" } });
     registerTerminal(ID, entry);
     installSnapshot(ID, entry.snapshot);
-    expect(beginSleepLocal(ID)).toBe(true);
+    expect(endpoint.sleep(ID)).toBe(true);
 
-    wakeLocalTerminal(ID);
+    endpoint.wake(ID);
     expect(resumeFormFor(getTerminal(ID)?.meta.restoreTarget)).toBeNull();
 
     await new Promise((r) => setTimeout(r, 0));
@@ -330,9 +331,9 @@ describe("wake — resets the snapshot, keeps the authored memory", () => {
     });
     registerTerminal(ID, entry);
     installSnapshot(ID, entry.snapshot);
-    expect(beginSleepLocal(ID)).toBe(true);
+    expect(endpoint.sleep(ID)).toBe(true);
 
-    wakeLocalTerminal(ID);
+    endpoint.wake(ID);
     const resumeCommand = resumeFormFor(getTerminal(ID)?.meta.restoreTarget);
     expect(resumeCommand).toBe("opencode --continue --model sonnet");
 
@@ -361,11 +362,11 @@ describe("wake — a failed PTY spawn must NOT drop the sleeping record (F2)", (
   });
 
   it("restores the sleeping entry when the wake spawn fails", async () => {
-    expect(seedSleepingTerminal(sleepingRecord())).toBe(true);
+    expect(endpoint.seedSleeping(sleepingRecord())).toBe(true);
 
     // Wake returns synchronously after registering the active sync-shadow; the
     // spawn tail fails on a later microtask. The shadow IS active right after.
-    wakeLocalTerminal(WAKE_ID);
+    endpoint.wake(WAKE_ID);
     expect(getTerminal(WAKE_ID)?.meta.state).toBe("active");
 
     // Let the rejected spawn RPC propagate through `spawnAndWire`'s catch.
@@ -417,11 +418,11 @@ describe("wake/spawn PUSHES the authored active snapshot (issue #1529)", () => {
   });
 
   it("pushes the active snapshot on wake, not just a dirty signal", () => {
-    expect(seedSleepingTerminal(sleepingRecord())).toBe(true);
+    expect(endpoint.seedSleeping(sleepingRecord())).toBe(true);
     // The seed itself doesn't publish the wire; start from a clean slate.
     upserts.length = 0;
 
-    wakeLocalTerminal(PUB_ID);
+    endpoint.wake(PUB_ID);
     expect(getTerminal(PUB_ID)?.meta.state).toBe("active");
     expect(upserts).toContainEqual({ id: PUB_ID, state: "active" });
   });
@@ -430,20 +431,20 @@ describe("wake/spawn PUSHES the authored active snapshot (issue #1529)", () => {
 describe("discardSleeping — removes only a sleeping record (both halves)", () => {
   it("removes a sleeping record and its snapshot", () => {
     seedActive();
-    beginSleepLocal(ID);
-    expect(discardLocalSleeping(ID)).toBe(true);
+    endpoint.sleep(ID);
+    expect(endpoint.discardSleeping(ID)).toBe(true);
     expect(getTerminal(ID)).toBeUndefined();
     expect(snapshotFor(ID)).toBeUndefined();
   });
 
   it("is a no-op on an active id (active terminals must be killed, not discarded)", () => {
     seedActive();
-    expect(discardLocalSleeping(ID)).toBe(false);
+    expect(endpoint.discardSleeping(ID)).toBe(false);
     expect(getTerminal(ID)?.meta.state).toBe("active");
   });
 });
 
-describe("seedSleepingTerminal — boot seed with per-record tolerance", () => {
+describe("seedSleeping — boot seed with per-record tolerance", () => {
   const SEED_ID = "22222222-2222-4222-8222-222222222222";
   const validRecord = () => ({
     id: SEED_ID,
@@ -473,7 +474,7 @@ describe("seedSleepingTerminal — boot seed with per-record tolerance", () => {
   });
 
   it("seeds both halves: authored sleeping in the registry (memory + restore target), snapshot in the entry", () => {
-    expect(seedSleepingTerminal(validRecord())).toBe(true);
+    expect(endpoint.seedSleeping(validRecord())).toBe(true);
     const entry = getTerminal(SEED_ID);
     if (entry?.meta.state !== "sleeping") throw new Error("expected sleeping");
     expect(entry.meta.sleptAt).toBe(111);
@@ -496,19 +497,19 @@ describe("seedSleepingTerminal — boot seed with per-record tolerance", () => {
 
   it("DROPS a malformed record (missing sleptAt) without throwing or polluting the set", () => {
     const malformed = { ...validRecord(), sleptAt: undefined };
-    expect(seedSleepingTerminal(malformed as never)).toBe(false);
+    expect(endpoint.seedSleeping(malformed as never)).toBe(false);
     expect(getTerminal(SEED_ID)).toBeUndefined();
     expect(snapshotFor(SEED_ID)).toBeUndefined();
   });
 
   it("DROPS a record with a non-uuid id", () => {
     const bad = { ...validRecord(), id: "not-a-uuid" };
-    expect(seedSleepingTerminal(bad as never)).toBe(false);
+    expect(endpoint.seedSleeping(bad as never)).toBe(false);
   });
 
   it("is idempotent — re-seeding a present id is a no-op", () => {
-    expect(seedSleepingTerminal(validRecord())).toBe(true);
-    expect(seedSleepingTerminal(validRecord())).toBe(false);
+    expect(endpoint.seedSleeping(validRecord())).toBe(true);
+    expect(endpoint.seedSleeping(validRecord())).toBe(false);
     expect(getTerminal(SEED_ID)?.meta.state).toBe("sleeping");
   });
 });

--- a/packages/server/src/terminals.location.test.ts
+++ b/packages/server/src/terminals.location.test.ts
@@ -1,0 +1,136 @@
+/**
+ * PR-0 — the terminal lifecycle honors `HostLocation` at CREATE (the sole
+ * location-supplying entry).
+ *
+ * Two halves of the create seam, exercised pty-host-free (no kaval daemon is booted in
+ * the unit env, so a create's spawn RPC rejects on a later microtask — the sync-shadow
+ * entry the assertions read is already registered):
+ *
+ *   - `resolveCreateLocation` — the pure inherit/reject rule the create RPC applies: a
+ *     top-level terminal takes the requested location (default local); a sub-terminal
+ *     INHERITS its parent's host and REJECTS an explicit child location that disagrees
+ *     (BAD_REQUEST).
+ *   - `createTerminal` resolves the endpoint BY location (a remote location has no
+ *     endpoint yet, so it throws — never silently degrades onto the local PTY), and a
+ *     created terminal's location rides through to the saved session, so a saved
+ *     `location` round-trips create → snapshot → re-create (the create→restore path).
+ */
+
+import { ORPCError } from "@orpc/server";
+import { type HostLocation, LOCAL_LOCATION } from "kolu-common/surface";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetSurfaceCtxForTest,
+  noopSurfaceCtxForTest,
+  setSurfaceCtx,
+} from "./surfaceCtx.ts";
+import { getTerminal, unregisterTerminal } from "./terminal-registry.ts";
+import {
+  createTerminal,
+  resolveCreateLocation,
+  snapshotSession,
+} from "./terminals.ts";
+import {
+  __resetWorkspaceSurfaceCtxForTest,
+  noopWorkspaceSurfaceCtxForTest,
+  setWorkspaceSurfaceCtx,
+} from "./workspaceSurfaceCtx.ts";
+
+const REMOTE: HostLocation = { kind: "remote", hostId: "build-box" };
+const OTHER_REMOTE: HostLocation = { kind: "remote", hostId: "other-box" };
+
+describe("resolveCreateLocation — inherit from parent, reject a mismatch", () => {
+  it("a top-level terminal defaults to the local host when none is requested", () => {
+    expect(resolveCreateLocation(undefined, undefined)).toEqual(LOCAL_LOCATION);
+  });
+
+  it("a top-level terminal uses the explicitly requested host", () => {
+    expect(resolveCreateLocation(REMOTE, undefined)).toEqual(REMOTE);
+  });
+
+  it("a sub-terminal INHERITS its parent's host when none is requested", () => {
+    expect(resolveCreateLocation(undefined, REMOTE)).toEqual(REMOTE);
+    expect(resolveCreateLocation(undefined, LOCAL_LOCATION)).toEqual(
+      LOCAL_LOCATION,
+    );
+  });
+
+  it("a sub-terminal whose explicit location MATCHES the parent is accepted", () => {
+    expect(resolveCreateLocation(LOCAL_LOCATION, LOCAL_LOCATION)).toEqual(
+      LOCAL_LOCATION,
+    );
+    expect(resolveCreateLocation(REMOTE, REMOTE)).toEqual(REMOTE);
+  });
+
+  it("a sub-terminal whose explicit location DISAGREES with the parent is BAD_REQUEST", () => {
+    // The wrong-host child is rejected loudly, never spawned on a different host than
+    // its parent (one PTY tree, one kaval).
+    for (const [requested, parent] of [
+      [REMOTE, LOCAL_LOCATION],
+      [LOCAL_LOCATION, REMOTE],
+      [REMOTE, OTHER_REMOTE],
+    ] as const) {
+      let thrown: unknown;
+      try {
+        resolveCreateLocation(requested, parent);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(ORPCError);
+      expect((thrown as ORPCError<string, unknown>).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+describe("createTerminal — location selects the endpoint and round-trips to disk", () => {
+  const created: string[] = [];
+
+  beforeEach(() => {
+    setSurfaceCtx(noopSurfaceCtxForTest());
+    setWorkspaceSurfaceCtx(noopWorkspaceSurfaceCtxForTest());
+  });
+
+  afterEach(() => {
+    for (const id of created.splice(0)) unregisterTerminal(id);
+    __resetSurfaceCtxForTest();
+    __resetWorkspaceSurfaceCtxForTest();
+  });
+
+  it("a local create round-trips its location through to the saved session", () => {
+    const info = createTerminal(
+      "/work/repo",
+      undefined,
+      undefined,
+      LOCAL_LOCATION,
+    );
+    created.push(info.id);
+
+    // The created terminal carries the requested host on its authored record…
+    expect(getTerminal(info.id)?.meta.location).toEqual(LOCAL_LOCATION);
+
+    // …and that location rides into the saved session record (the persist half of the
+    // create→restore round-trip).
+    const saved = snapshotSession().terminals.find((t) => t.id === info.id);
+    expect(saved?.location).toEqual(LOCAL_LOCATION);
+
+    // Feeding the saved location back into a create — exactly what session restore does
+    // (forwarding `t.location`) — re-spawns on the same host.
+    const reborn = createTerminal(
+      saved?.cwd,
+      undefined,
+      undefined,
+      saved?.location,
+    );
+    created.push(reborn.id);
+    expect(getTerminal(reborn.id)?.meta.location).toEqual(LOCAL_LOCATION);
+  });
+
+  it("a remote location throws (no remote endpoint yet) rather than degrading onto the local PTY", () => {
+    // The `{kind:"remote"}` resolver arm must fail loudly until F-REMOTE dials one — a
+    // remote terminal silently served by the local endpoint would be a wrong-host bug,
+    // not a graceful default (the no-fallbacks stance).
+    expect(() =>
+      createTerminal("/work/repo", undefined, undefined, REMOTE),
+    ).toThrow(/remote host/);
+  });
+});

--- a/packages/server/src/terminals.ts
+++ b/packages/server/src/terminals.ts
@@ -15,41 +15,39 @@
  * state-reads + lifecycle from this file as a single module.
  */
 
+import { ORPCError } from "@orpc/server";
 import {
   composeTerminalMetadata,
+  type HostLocation,
+  hostLocationsEqual,
   type InitialTerminalMetadata,
   LOCAL_LOCATION,
   type RightPanelPerTerminalState,
+  type SavedSleepingTerminal,
   type SavedTerminal,
   SavedTerminalSchema,
   type TerminalId,
   type TerminalInfo,
 } from "kolu-common/surface";
-// Load-order is cycle-sensitive: importing `terminalEndpoint/metadata.ts`
-// before `terminalEndpoint/local.ts` is what makes the surface cycle
-// converge with `localTerminalEndpoint` already initialized by the time
-// the top-level `localEndpoint` reference below reads it. Reversing these
-// two (biome's alphabetical preference) puts the cycle entry-point at the
-// deeper `activity.ts → surface.ts` branch and trips a TDZ on
-// `localTerminalEndpoint`.
-// biome-ignore-start assist/source/organizeImports: cycle-sensitive load order
-import { updateClientMetadata } from "./terminalEndpoint/metadata.ts";
-import {
-  beginSleepLocal,
-  releaseSleptLocalPty,
-} from "./terminalEndpoint/local.ts";
-// `resolve.ts` re-imports the already-evaluated `local.ts`, so it stays AFTER it
-// to preserve the metadata→local order the TDZ note above depends on.
-import { resolveTerminalEndpoint } from "./terminalEndpoint/resolve.ts";
+import type { TerminalAttachment } from "kolu-common/terminalEndpoint";
 import { terminalsDirtyChannel } from "./publisher.ts";
-import { getTerminal, terminalEntries } from "./terminal-registry.ts";
+import {
+  getTerminal,
+  requireActiveTerminal,
+  terminalEntries,
+} from "./terminal-registry.ts";
 import { type SessionSnapshot, saveSession } from "./session.ts";
-// biome-ignore-end assist/source/organizeImports: cycle-sensitive load order
-
-// A single local endpoint today, resolved through the one `HostLocation` seam.
-// R9.2 selects the endpoint per call site (a remote-dialed kaval, or a
-// sub-terminal inheriting its parent's endpoint).
-const localEndpoint = resolveTerminalEndpoint(LOCAL_LOCATION);
+import { updateClientMetadata } from "./terminalEndpoint/metadata.ts";
+// The lifecycle façade is the SOLE importer of the host registry's
+// `resolveTerminalEndpoint` (every per-terminal op resolves
+// `getTerminal(id).meta.location` internally) and of `forEachHost` (the sole
+// killAll entry). No top-level endpoint read here any more — the deleted
+// `localEndpoint` alias was the one that needed the cycle-sensitive load order; the
+// per-call resolution below runs at call time, after `local.ts` has evaluated.
+import {
+  forEachHost,
+  resolveTerminalEndpoint,
+} from "./terminalEndpoint/resolve.ts";
 
 // Re-export registry accessors + type so external callers (router.ts,
 // diagnostics.ts, index.ts) keep a single import path.
@@ -96,24 +94,51 @@ export function snapshotSession(): SessionSnapshot {
   return { terminals: snappedTerminals, activeTerminalId };
 }
 
-/** Create a new terminal. The endpoint owns PTY spawn, provider
- *  startup, and registry insert; this wrapper just mints an id and
- *  forwards. `initial` seeds client-owned
- *  metadata before providers run — see #642 (avoids racing post-hoc
- *  `setCanvasLayout` / `setTheme` / `setSubPanel` RPCs against the
- *  client's canvas-cascade effect). */
+/** Resolve the host a fresh terminal is created on. A top-level terminal uses the
+ *  requested `location` (default `LOCAL_LOCATION` — the only host today). A
+ *  sub-terminal INHERITS its parent's host (one PTY tree, one kaval): an explicit
+ *  child `location` that disagrees is a client bug — reject loudly (`BAD_REQUEST`)
+ *  rather than silently spawn the child on the wrong host. Pure (the router resolves
+ *  the parent's location and hands it in), so the inherit/reject rule is unit-tested
+ *  without the router. */
+export function resolveCreateLocation(
+  requested: HostLocation | undefined,
+  parentLocation: HostLocation | undefined,
+): HostLocation {
+  if (parentLocation === undefined) return requested ?? LOCAL_LOCATION;
+  if (
+    requested !== undefined &&
+    !hostLocationsEqual(requested, parentLocation)
+  ) {
+    throw new ORPCError("BAD_REQUEST", {
+      message:
+        "a sub-terminal must share its parent's host — drop the explicit location or match the parent's",
+    });
+  }
+  return parentLocation;
+}
+
+/** Create a new terminal on `location`'s endpoint (default the local host) — the
+ *  SOLE location-supplying lifecycle entry (there is no id yet to resolve a location
+ *  from). The endpoint owns PTY spawn, provider startup, and registry insert; this
+ *  wrapper mints an id and routes through `resolveTerminalEndpoint(location)` — the
+ *  same `HostLocation` seam kill/sleep/wake/attach use — handing the SAME `location`
+ *  to `spawnPty` so the endpoint stamps `meta.location` from the façade's decision,
+ *  never a host literal of its own. `initial` seeds client-owned metadata before
+ *  providers run — see #642 (avoids racing post-hoc `setCanvasLayout` / `setTheme` /
+ *  `setSubPanel` RPCs against the client's canvas-cascade effect). */
 export function createTerminal(
   cwd?: string,
   parentId?: string,
   initial?: InitialTerminalMetadata,
+  location: HostLocation = LOCAL_LOCATION,
 ): TerminalInfo {
   const id = crypto.randomUUID();
-  // P3 will select the endpoint per create — e.g. a sub-terminal
-  // inheriting its parent's endpoint; today every terminal is local.
-  return localEndpoint.spawnPty(id, {
+  return resolveTerminalEndpoint(location).spawnPty(id, {
     cwd,
     parentId,
     initialMetadata: initial,
+    location,
   });
 }
 
@@ -137,11 +162,57 @@ export async function killTerminal(
  *  DURABLY, then release its PTY (persist-before-kill). A crash in the kill
  *  window leaves a sleeping record on disk, never a zombie active one; boot
  *  reconcile reaps any briefly-surviving PTY (adopt-or-reap). A no-op if `id`
- *  is not an active terminal. */
+ *  is not an active terminal.
+ *
+ *  Routes by the terminal's OWN location so a remote tile sleeps on its host —
+ *  exactly as `killTerminal` routes. `sleep` flips the dormant arm, the session
+ *  persists durably, THEN `releaseSleptPty` kills the PTY on the SAME host. */
 export async function sleepTerminal(id: TerminalId): Promise<void> {
-  if (!beginSleepLocal(id)) return;
+  const entry = getTerminal(id);
+  if (!entry) return;
+  const endpoint = resolveTerminalEndpoint(entry.meta.location);
+  if (!endpoint.sleep(id)) return;
   saveSession(snapshotSession());
-  await releaseSleptLocalPty(id);
+  await endpoint.releaseSleptPty(id);
+}
+
+/** Wake a sleeping terminal — re-spawn its PTY on the SAME id and resume its agent.
+ *  Routes by the terminal's OWN location (a remote tile wakes on its host); returns
+ *  the woken active info, or undefined when `id` is not a sleeping terminal. */
+export function wakeTerminal(id: TerminalId): TerminalInfo | undefined {
+  const entry = getTerminal(id);
+  if (!entry) return undefined;
+  return resolveTerminalEndpoint(entry.meta.location).wake(id);
+}
+
+/** Discard a sleeping terminal's record (no PTY to kill — sleep already released
+ *  it). Routes by the terminal's OWN location; a no-op (false) when `id` is not a
+ *  sleeping terminal. */
+export function discardSleepingTerminal(id: TerminalId): boolean {
+  const entry = getTerminal(id);
+  if (!entry) return false;
+  return resolveTerminalEndpoint(entry.meta.location).discardSleeping(id);
+}
+
+/** Restore a saved SLEEPING record into the registry as a dormant tile. The record
+ *  carries its OWN `location`, so this routes to that host's endpoint — a saved
+ *  remote sleeping tile reappears on its host, never silently the local one. Returns
+ *  false when the record is malformed (dropped) or already present. */
+export function restoreSleepingTerminal(
+  record: SavedSleepingTerminal,
+): boolean {
+  return resolveTerminalEndpoint(record.location).seedSleeping(record);
+}
+
+/** Attach to a terminal's output — the screen-state snapshot plus the live delta
+ *  stream. Narrows to the active arm (`requireActiveTerminal`) and routes by the
+ *  terminal's OWN location, exactly as kill/sleep/wake route. */
+export function attachTerminal(
+  id: TerminalId,
+  signal: AbortSignal | undefined,
+): Promise<TerminalAttachment> {
+  const entry = requireActiveTerminal(id);
+  return resolveTerminalEndpoint(entry.meta.location).attach(id, signal);
 }
 
 /** Set or clear a terminal's parent relationship. */
@@ -287,7 +358,12 @@ export function setTerminalIntent(id: TerminalId, intent: string): void {
 
 /** Kill and remove all terminals. Used by tests to reset server state between
  *  scenarios. Async since #951 R4c (awaits the daemon's killAll over the
- *  socket before draining the registry). */
+ *  socket before draining the registry).
+ *
+ *  Drains EVERY host through `forEachHost` — the only entry the host registry
+ *  offers for killAll. There is no per-location accessor a caller can hard-pin, so
+ *  "killAll on only the local host" is unspellable (a partial-host kill can't be
+ *  written). One host today; F-REMOTE's dialed hosts drain through the same loop. */
 export async function killAllTerminals(): Promise<void> {
-  await localEndpoint.killAllTerminals();
+  await forEachHost((endpoint) => endpoint.killAllTerminals());
 }


### PR DESCRIPTION
**Every per-terminal lifecycle seam already routes through `HostLocation` — this PR makes the compiler *guarantee* it.** "Hard-pin local / bypass `HostLocation` at a lifecycle seam" is now a **compile error**: there is no symbol a caller can import to reach the local endpoint directly, so a future missed seam is impossible rather than something a reviewer has to hunt for. Pure local no-op — behavior is byte-identical; every existing lifecycle test passes, ported through the sealed seam.

This **supersedes the manual-threading PR-1 (#1637)** — same goal, but enforced by types instead of by review. #1637 should be closed.

### The disease → the cure

The bypass surface was a set of *importable* symbols any seam could reach:

| Escape hatch (deleted) | Replaced by |
| --- | --- |
| `localTerminalEndpoint` instance + eight `*Local*` helpers (`beginSleepLocal`, `discardLocalSleeping`, …) | endpoint methods reached only via the id-keyed façade |
| two `localEndpoint = resolveTerminalEndpoint(LOCAL_LOCATION)` aliases (killAll + fs/git pins) | `forEachHost` (killAll) · `localFsGitEndpoint()` (fs/git, narrowed) |
| `resolveTerminalEndpoint` imported by router/surface/terminals | imported **only** by the lifecycle façade (`terminals.ts`) |
| per-host boot adopt that could `saveSession` on partial host info | `adoptSurvivingHost(scope)` → branded `CompleteHostSweep` → `commitBootAdoption` |

### How dispatch is sealed now

```
caller holds an id ─▶ façade op(id) ─▶ resolveTerminalEndpoint(getTerminal(id).meta.location) ─▶ endpoint.op(id)
                       (terminals.ts)   (package-private to the host registry)
```

- **The id-keyed façade is the only public lifecycle API.** `killTerminal` / `sleepTerminal` / `wakeTerminal` / `discardSleepingTerminal` / `restoreSleepingTerminal` / `attachTerminal` each resolve `getTerminal(id).meta.location` *internally*. The caller holds an id; routing is automatic; there is no location param to hard-pin.
- **Create is the sole location-supplying entry** (no id yet): `createTerminal(…, location = LOCAL_LOCATION)` → `resolveTerminalEndpoint(location).spawnPty(…, { location })`. The façade hands the location to `spawnPty`, which stamps `meta.location` from it — *the endpoint never stamps a host literal of its own*, so "endpoint stamps the wrong location" is unspellable.
- **Session-global ops can't act on partial host info.** `forEachHost` over the package-private registry is the only killAll entry ("killAll on only the local host" is unspellable). Boot adoption splits: `adoptSurvivingHost(scope)` reconciles **one** host and *returns* its `HostAdoptionResult` (no `saveSession` in scope); `commitBootAdoption` is the only place that seeds sleeping records + saves, gated on a **branded `CompleteHostSweep`** that only `completeSweep([…all host results])` mints. Committing one host's result is a **type error** — the round-1 "save on partial host info" bug is structurally impossible.
- **fs/git keeps its server access** through a sealed `localFsGitEndpoint()` that returns only `{ fs, git }` (`TerminalWorkspaceEndpoint`) — Code-tab access stays alive across the boundary without re-exposing a kill/sleep hatch. *(PR-2 builds per-location fs/git on top.)*
- **#1637's location-supply, folded in:** `location?` on the create RPC + client `handleCreate`; `useSessionRestore` stops dropping `t.location`; `resolveCreateLocation` is pure inherit/reject (a sub-terminal inherits its parent's host; an explicit mismatch → `BAD_REQUEST`).

### The proof — former hatches now fail to compile

A throwaway file attempting the old bypasses:

```
src/_proof.ts(6,1): error TS2304: Cannot find name 'discardLocalSleeping'.
src/_proof.ts(9,1): error TS2304: Cannot find name 'localEndpoint'.
src/_proof.ts(12,1): error TS2304: Cannot find name 'resolveTerminalEndpoint'.
```

…and `commitBootAdoption(oneHostResult)` is a type error (a `HostAdoptionResult` is not a `CompleteHostSweep`), pinned by a passing `@ts-expect-error`.

### Honoring the design philosophy

- **Fail fast, no fallbacks** — the `{ kind: "remote" }` resolver arm throws loudly (no terminal carries a remote location yet); a remote create *crashes* rather than silently serving on the local PTY.
- **Electricity / volatility boundary** — host transport is the hard volatility; per-terminal ops expose *commands*, not endpoints. Removing the *symbol* beats a brand that rejects a value the caller can still form.
- **Reuse the source of truth** — every seam resolves through the one `HostLocation` → endpoint mapping; `hostLocationsEqual` is the single "same host" comparison.

### Tests

Existing lifecycle suites (sleepWake, reconcile, adopt, inventoryReconcile, restore) ported through the sealed seam — **not** the deleted `*Local*` exports. New: the missing **reconcile mixed-host filter** (one local + one remote saved record — the destructive remote-prep join, previously untested); create→restore **location round-trip**; sub-terminal **inherit / reject**; the **`CompleteHostSweep` type-gate**; and a **sealed-dispatch guard** asserting no escape-hatch symbol is importable. Full server (176) + client (492) unit suites green; `just check` clean.

> Local no-op: nothing user-facing changes today — every record is `{ kind: "local" }`, so every resolve returns the in-process endpoint and create/restore/sleep/wake/adoption are byte-identical.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._