### PR TITLE
test: sandbox PTY $HOME so e2e runs stop polluting the real shell history

### DIFF
--- a/packages/tests/support/hooks.ts
+++ b/packages/tests/support/hooks.ts
@@ -142,6 +142,30 @@ process.env.KOLU_FAKE_OPENCODE_BIN = fakeBins.opencode;
  *  `testBaseDir` means the whole run's scratch space cleans up together. */
 const koluStateDir = mkSubDir("state");
 
+/** Per-worker throwaway HOME for PTY shells under test.
+ *
+ *  The kolu server forwards HOME straight into every terminal it spawns:
+ *  `cleanEnv()` whitelists HOME (see NIX_ENV_WHITELIST), `ptyHost` reads it as
+ *  `env.HOME`, and `prepareShellInit`'s `replay` step sources `$HOME/.bashrc` /
+ *  `.zshrc` / `.profile` from it. Inheriting the developer's REAL home is a
+ *  sandbox hole with two costumes of one defect: effects leak OUT — a scenario
+ *  that types `cmd` into a terminal appends it to the real `~/.bash_history`
+ *  (and any tool writing under `~` hits real caches/config) — and inputs leak
+ *  IN — the suite's shell behavior depends on whatever lives in the dev's
+ *  personal dotfiles, so runs aren't reproducible across machines.
+ *
+ *  Pointing HOME at an empty dir under `testBaseDir` closes both by
+ *  construction: history, caches, and dotfile lookups all resolve inside
+ *  throwaway space that AfterAll wipes, and every machine sees the same
+ *  (empty) dotfiles. PATH and git identity don't depend on it — PATH rides the
+ *  whitelist from the parent env and the GIT_AUTHOR / GIT_COMMITTER identity is
+ *  pinned above.
+ *
+ *  ABSENT under KOLU_X11CAP: those recordings launch the REAL claude/codex,
+ *  which read `~/.claude` / `~/.codex` from the real home — the same reason the
+ *  agent-dir overrides go all-undefined there. */
+const fixtureHome = process.env.KOLU_X11CAP ? undefined : mkSubDir("home");
+
 /** Per-worker `XDG_RUNTIME_DIR` so each worker's kolu-server spawns its kaval
  *  daemon at an ISOLATED socket + gate (`$XDG_RUNTIME_DIR/kaval/...`). Without
  *  this, parallel workers collide on the shared runtime socket and the
@@ -586,6 +610,11 @@ async function startServerChild(koluServer: string): Promise<void> {
           // Route server state to an ephemeral $TMPDIR path so test runs
           // never touch ~/.config and the dir can be wiped in AfterAll.
           KOLU_STATE_DIR: koluStateDir,
+          // Point PTY shells at a throwaway HOME (absent under X11CAP, which
+          // needs the real ~/.claude / ~/.codex) so test-typed commands can't
+          // reach the developer's real ~/.bash_history and the suite doesn't
+          // depend on personal dotfiles. See `fixtureHome` above.
+          ...(fixtureHome ? { HOME: fixtureHome } : {}),
           // Per-worker runtime dir → an isolated kaval socket + gate, so
           // parallel workers' daemons never collide on the shared path.
           XDG_RUNTIME_DIR: runtimeDir,


### PR DESCRIPTION
## The bug

Running the e2e suite scribbles junk into your real shell history. You'll see lines like these in `~/.bash_history` that you never typed:

```
/tmp/nix-shell.XBufMf/.../kolu-test-…/bin/codex -c "printf '\033]0;codex\007'; sleep 99999 ; :"
cd /tmp/nix-shell.XBufMf/.../kolu-opencode-… && echo OPENCODE_CWD_READY_1782836655853
printf '# Rich Doc\n…' > README.md
```

Those are e2e scenarios typing commands into terminals — and the commands land in your personal history.

## Root cause — one hole, two costumes

The harness already sandboxes server state (`KOLU_STATE_DIR`), the kaval runtime dir, and kolu's internal env. But the server child inherits the developer's **real `$HOME`**, and kolu forwards `HOME` into every PTY it spawns:

`cleanEnv()` whitelists `HOME` (`NIX_ENV_WHITELIST`) → `ptyHost` reads it as `env.HOME` → `prepareShellInit`'s `replay` step sources `$HOME/.bashrc` / `.zshrc` / `.profile`.

`$HOME` is the master key to all your persistent state, so the same seam leaks both ways:

- **Effects out** — a scenario that types a command into a terminal appends it to the real `~/.bash_history` (and any tool writing under `~` hits real caches/config). This is the symptom you see.
- **Inputs in** — the suite replays your *personal* dotfiles, so its shell behavior depends on whatever's in the dev's `~/.bashrc`. Runs aren't reproducible across machines.

Patching `HISTFILE` alone would close only the first costume and leave the seam open for the next tool that writes under `~`. So this fixes the seam, not the symptom.

## The fix

Point the server child's `HOME` at an empty per-worker dir under the existing `testBaseDir` — the same pattern already used for `KOLU_STATE_DIR` / `XDG_RUNTIME_DIR`. Both leaks then close *by construction*: history, caches, and dotfile lookups all resolve inside throwaway space that `AfterAll` wipes, and every machine sees the same (empty) dotfiles.

`PATH` and git identity don't depend on it — `PATH` rides the whitelist from the parent env, and `GIT_AUTHOR_*` / `GIT_COMMITTER_*` are pinned in the same file.

**Absent under `KOLU_X11CAP`**: those recordings launch the *real* claude/codex, which read `~/.claude` / `~/.codex` from the real home — same reason the agent-dir overrides go all-undefined there.

## Verification

The change is small and mechanical; the proof is the e2e suite itself. It exercises hundreds of PTY commands, so a green run demonstrates that swapping to an empty `HOME` breaks no scenario that relied on real dotfiles (the one blast-radius risk). Relying on CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)