### PR TITLE
chore(skills): document APM two-tree sources + short-socket rule for standalone kaval

### DIFF
--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -246,6 +246,13 @@ Two ways to point at a specific daemon instead of autodiscovering:
   form — e.g. `/tmp/kaval-7692-501/pty-host.sock` for kolu-server on port 7692. (The
   old `$XDG_RUNTIME_DIR/kolu/…` was wrong on every platform — kolu-server never
   serves under `kolu/` — and on macOS it collapses to a broken `/kolu/…`.)
+
+  > **Socket paths must stay under 108 bytes (the `AF_UNIX` limit).** If you spin
+  > up your *own* standalone kaval to verify (no kolu running), keep `--socket`
+  > short — `/tmp/kv.$$/pty.sock`, **not** a socket under your agent scratchpad.
+  > The scratchpad prefix alone already sits at the 108-byte cap, so a socket
+  > there overflows and the daemon fails to bind. The autodiscovered paths above
+  > are short by construction; this only bites a hand-rolled `--socket`.
 - **`--host <ssh>`** reaches a daemon on another machine (provisioned with Nix);
   a remote PTY survives the link.
 

--- a/.apm/instructions/apm-workflow.instructions.md
+++ b/.apm/instructions/apm-workflow.instructions.md
@@ -9,3 +9,16 @@ APM is not a global CLI — it runs via `uvx` through justfile recipes in `agent
 
 - **Install/regenerate** agent runtime directories from sources: `just ai::apm`
 - **Update a dependency** to its latest ref: `just ai::apm-update <package>` (e.g. `just ai::apm-update srid/agency`)
+
+### Skill/instruction sources live in TWO trees
+
+`.claude/skills/<name>/` and `.claude/rules/<name>.md` are generated from one of two source trees — grep **both** before assuming something isn't apm-managed:
+
+- **Root `.apm/`** — this repo's own package: skills like `atlas`, `test`, `dev-server`, `evidence`, `release`, `self-improve`; instructions like this file, under `.apm/instructions/`.
+- **`agents/.apm/`** — the reusable `agents/` package (a local `path:` dependency in the root `apm.yml`): the skills `be`, `be-review`, `kolu`, `lens-debate`, `codex-debate`, `perfection-review`, `surface`, `architecture-first-principles`.
+
+So editing e.g. the **kolu** skill means editing `agents/.apm/skills/kolu/SKILL.md`, **not** root `.apm/skills/`.
+
+### An `agents/` source edit must be committed before it propagates
+
+`just ai::apm` vendors the `agents/` path-dependency from a **git checkout** (pinned by the `agents/` package version in `apm.lock.yaml`), *not* your working tree. So an **uncommitted** edit to `agents/.apm/skills/**` regenerates the OLD cached content and silently reverts your change. Commit the source edit first, then `just ai::apm`, then **confirm the change actually landed** in the generated `.claude/skills/<name>/` — a stale vendor snapshot can ship the old text with no error.

--- a/.claude/rules/apm-workflow.md
+++ b/.claude/rules/apm-workflow.md
@@ -9,3 +9,16 @@ APM is not a global CLI — it runs via `uvx` through justfile recipes in `agent
 
 - **Install/regenerate** agent runtime directories from sources: `just ai::apm`
 - **Update a dependency** to its latest ref: `just ai::apm-update <package>` (e.g. `just ai::apm-update srid/agency`)
+
+### Skill/instruction sources live in TWO trees
+
+`.claude/skills/<name>/` and `.claude/rules/<name>.md` are generated from one of two source trees — grep **both** before assuming something isn't apm-managed:
+
+- **Root `.apm/`** — this repo's own package: skills like `atlas`, `test`, `dev-server`, `evidence`, `release`, `self-improve`; instructions like this file, under `.apm/instructions/`.
+- **`agents/.apm/`** — the reusable `agents/` package (a local `path:` dependency in the root `apm.yml`): the skills `be`, `be-review`, `kolu`, `lens-debate`, `codex-debate`, `perfection-review`, `surface`, `architecture-first-principles`.
+
+So editing e.g. the **kolu** skill means editing `agents/.apm/skills/kolu/SKILL.md`, **not** root `.apm/skills/`.
+
+### An `agents/` source edit must be committed before it propagates
+
+`just ai::apm` vendors the `agents/` path-dependency from a **git checkout** (pinned by the `agents/` package version in `apm.lock.yaml`), *not* your working tree. So an **uncommitted** edit to `agents/.apm/skills/**` regenerates the OLD cached content and silently reverts your change. Commit the source edit first, then `just ai::apm`, then **confirm the change actually landed** in the generated `.claude/skills/<name>/` — a stale vendor snapshot can ship the old text with no error.

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -246,6 +246,13 @@ Two ways to point at a specific daemon instead of autodiscovering:
   form — e.g. `/tmp/kaval-7692-501/pty-host.sock` for kolu-server on port 7692. (The
   old `$XDG_RUNTIME_DIR/kolu/…` was wrong on every platform — kolu-server never
   serves under `kolu/` — and on macOS it collapses to a broken `/kolu/…`.)
+
+  > **Socket paths must stay under 108 bytes (the `AF_UNIX` limit).** If you spin
+  > up your *own* standalone kaval to verify (no kolu running), keep `--socket`
+  > short — `/tmp/kv.$$/pty.sock`, **not** a socket under your agent scratchpad.
+  > The scratchpad prefix alone already sits at the 108-byte cap, so a socket
+  > there overflows and the daemon fails to bind. The autodiscovered paths above
+  > are short by construction; this only bites a hand-rolled `--socket`.
 - **`--host <ssh>`** reaches a daemon on another machine (provisioned with Nix);
   a remote PTY survives the link.
 

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -246,6 +246,13 @@ Two ways to point at a specific daemon instead of autodiscovering:
   form — e.g. `/tmp/kaval-7692-501/pty-host.sock` for kolu-server on port 7692. (The
   old `$XDG_RUNTIME_DIR/kolu/…` was wrong on every platform — kolu-server never
   serves under `kolu/` — and on macOS it collapses to a broken `/kolu/…`.)
+
+  > **Socket paths must stay under 108 bytes (the `AF_UNIX` limit).** If you spin
+  > up your *own* standalone kaval to verify (no kolu running), keep `--socket`
+  > short — `/tmp/kv.$$/pty.sock`, **not** a socket under your agent scratchpad.
+  > The scratchpad prefix alone already sits at the 108-byte cap, so a socket
+  > there overflows and the daemon fails to bind. The autodiscovered paths above
+  > are short by construction; this only bites a hand-rolled `--socket`.
 - **`--host <ssh>`** reaches a daemon on another machine (provisioned with Nix);
   a remote PTY survives the link.
 


### PR DESCRIPTION
## Why

Mined the `/be` run for kaval-tui `--submit` (PR #1673). That run finished with **zero human interventions** — autonomy held. But it hit two deterministic, self-inflicted traps the agent had to work around mid-run, and both will recur for the next run. This engineers them into the docs so nobody rediscovers them.

## What changed

Two one-paragraph doc additions, each edited at its source and hand-synced to its generated runtime copy.

| Trap (from the run) | Fix | Source edited | Generated synced |
| --- | --- | --- | --- |
| Agent grepped root `.apm/skills/kolu`, found nothing — the kolu skill lives in the **`agents/`** package tree; and `just ai::apm` wouldn't propagate an uncommitted source edit (it vendors the path-dep from a version-pinned git checkout), so it had to be hand-synced. | Document the **two source trees** + the **commit-before-regen** rule in the `apm-workflow` instruction. | `.apm/instructions/apm-workflow.instructions.md` | `.claude/rules/apm-workflow.md` |
| Manual verification spun up a standalone kaval with a `--socket` under the agent scratchpad; the scratchpad prefix is **exactly 108 bytes** (the `AF_UNIX` cap), so the socket overflowed and the daemon failed to bind. Had to switch to `/tmp/kv.XXXX`. | Add a **short-socket caveat** to the kolu skill's socket section. | `agents/.apm/skills/kolu/SKILL.md` | `.claude/skills/kolu/SKILL.md`, `.agents/skills/kolu/SKILL.md` |

Not shipped (observation only): a `send`-style value-flag swallowing the next positional was caught by the code-police pass — the gauntlet already catches it, so no durable doc fix is warranted.

## Why hand-synced instead of `just ai::apm`

The regen is what the first fix is *about*: in a warm local apm cache, `just ai::apm` re-vendors the `agents/` path-dep from a stale, version-pinned git checkout and **reverts unrelated master content** (it rewrote the kolu/be/surface skills back to pre-#1665 `pulam` text). Running it here would corrupt the tree. So each generated copy was hand-synced from its source and verified byte-identical. CI does not verify apm-sync (`just check` = typecheck + biome only), so the runtime copies are correct and consistent.

## Evidence

- `just fmt` — clean, `0 / 5` reformatted.
- `just check` — green: all packages typecheck, biome `Checked 1057 files … No fixes applied`.
- Source ↔ generated parity confirmed byte-identical (`diff` empty for all three generated files).
- Diff is exactly 5 markdown files; no code, no other content touched.

Provenance: self-improve mining of session `b4ef6acd-1234-49c7-9a2a-784c5a4ec712`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
