### PR TITLE
test: pin intent surviving git branch changes

### DIFF
--- a/packages/tests/features/terminal-intent.feature
+++ b/packages/tests/features/terminal-intent.feature
@@ -60,6 +60,46 @@ Feature: Terminal intent
     And the active terminal annotation slot should render no anchor
     And there should be no page errors
 
+  Scenario: Intent survives a branch change in the terminal
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I run "rm -rf /tmp/kolu-intent-branch && git init /tmp/kolu-intent-branch && cd /tmp/kolu-intent-branch && git commit --allow-empty -m init"
+    Then the header should show a branch name
+    When I click the active terminal annotation slot
+    And I type "🎯 fix the bug" into the intent editor
+    And I save the intent
+    Then the active terminal annotation slot should start with "🎯"
+    When I run "git checkout -b new-branch"
+    Then the header branch should contain "new-branch"
+    But the active terminal annotation slot should start with "🎯"
+
+  Scenario: Intent survives an external branch change (git watcher path)
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I run "rm -rf /tmp/kolu-intent-ext && git init /tmp/kolu-intent-ext && cd /tmp/kolu-intent-ext && git commit --allow-empty -m init"
+    Then the header should show a branch name
+    When I click the active terminal annotation slot
+    And I type "🚀 ship it" into the intent editor
+    And I save the intent
+    Then the active terminal annotation slot should start with "🚀"
+    When the branch is switched to "ext-test" in "/tmp/kolu-intent-ext"
+    Then the header branch should contain "ext-test"
+    But the active terminal annotation slot should start with "🚀"
+
+  Scenario: Intent survives cd into a worktree on a new branch
+    When I press the toggle inspector shortcut
+    Then the right panel should be visible
+    When I run "rm -rf /tmp/kolu-intent-wt-main /tmp/kolu-intent-wt-feature && git init /tmp/kolu-intent-wt-main && cd /tmp/kolu-intent-wt-main && git commit --allow-empty -m init"
+    Then the header should show a branch name
+    When I click the active terminal annotation slot
+    And I type "🔍 investigate" into the intent editor
+    And I save the intent
+    Then the active terminal annotation slot should start with "🔍"
+    When I run "git worktree add -b feature-branch /tmp/kolu-intent-wt-feature"
+    And I run "cd /tmp/kolu-intent-wt-feature"
+    Then the header branch should contain "feature-branch"
+    But the active terminal annotation slot should start with "🔍"
+
   Scenario: Edit intent via the command palette
     When I open the command palette
     And I select "Edit intent" in the palette


### PR DESCRIPTION
## What

Three e2e regression scenarios covering the supplant-rule invariant: the terminal-intent annotation must stay visible when the git branch changes underneath it.

## Why

A bug report described the intent disappearing (replaced by the new branch name) after a branch change. These scenarios reproduce the exact sequence — set intent, change branch, verify intent still leads — across three branch-change paths:

- **In-terminal `git checkout -b`** — the OSC 7 cwd channel triggers the git watcher
- **External branch switch** — `.git/HEAD` file watcher path (no OSC 7)
- **`cd` into a worktree** on a new branch — both cwd and git change

All three pass on the current code. The intent IS preserved — the compose function (`{...observation, ...authored}`) spreads the authored record last, so `intent` survives every snapshot-delta.

## Test output

```
11 scenarios (11 passed)
80 steps (80 passed)
```