### PR TITLE
fix(git): pin parcel's watcher backend — stop the per-subscribe zombie leak

### DIFF
--- a/.agents/skills/parcel/SKILL.md
+++ b/.agents/skills/parcel/SKILL.md
@@ -27,8 +27,14 @@ unless it has a similarly narrow target.
 
 Source: `node_modules/.pnpm/@parcel+watcher@2.5.6/node_modules/@parcel/watcher/src/Backend.cc:30-69`.
 
-`backend: "default"` (Kolu doesn't pass an explicit backend) selects in this
-order, first match wins:
+**Kolu pins the OS-native backend explicitly** (`inotify` / `fs-events` /
+`windows`, chosen off `process.platform` — see `PARCEL_BACKEND` in
+`working-tree-watcher.ts`). It does **not** use `backend: "default"`. The pin
+skips the auto-dispatch order below — most importantly the `WatchmanBackend`
+probe, whose per-subscribe `popen` leaks a zombie on watchman-less hosts (see
+next section). If you write a new parcel consumer, pin the backend the same way.
+
+`backend: "default"` would select in this order, first match wins:
 
 1. `FSEvents` on macOS — native recursive, one stream per repo.
 2. `WatchmanBackend` if `WatchmanBackend::checkAvailable()` returns true.
@@ -37,8 +43,9 @@ order, first match wins:
 5. `KqueueBackend` on BSD.
 6. `BruteForceBackend` — periodic full-tree stat; the fallback fallback.
 
-So on Linux, watchman is preferred over inotify whenever it's reachable; on
-macOS watchman is never used by default (FSEvents wins).
+So under `"default"` on Linux, watchman is *probed* (and preferred if reachable)
+before inotify; on macOS watchman is never used (FSEvents wins). The explicit
+pin lands directly on step 1/3/4 for the platform and never runs step 2's probe.
 
 ## How parcel invokes watchman
 
@@ -51,6 +58,16 @@ Source: `src/watchman/WatchmanBackend.cc`.
    ```
    then parses BSER output for the `sockname` field. If `WATCHMAN_SOCK` env
    var is set, that wins and the binary isn't run at all.
+
+   > **⚠ Zombie leak — why Kolu pins the backend (juspay/kolu#1691).** On a
+   > host without watchman, this `popen` forks `/bin/sh`, the `watchman` exec
+   > fails, and parcel's error path returns **without `pclose()`** — so the
+   > `sh` is never `wait()`ed. `popen` bypasses `child_process`, so Node's
+   > libuv can't reap it either: it lingers as a zombie **forever, one per
+   > `subscribe`**. Free on CPU/RAM but a long-lived daemon (a remote-bound
+   > padi serving a full e2e run) accumulates dozens and the event loop drags.
+   > Pinning the native backend (above) skips `checkAvailable()` entirely, so
+   > the `popen` never runs. Verified: per-subscribe leak → 0.
 3. From there it's a Unix-domain socket carrying BSER-encoded JSON. No more
    subprocess spawns.
 
@@ -87,9 +104,13 @@ mean the daemon was killed mid-handshake. Add `.watchman-cookie-*` to
 ## Kolu's runtime status
 
 As of #788, Kolu does **not** ship watchman with the production binary. The
-`nix run` wrapper (`default.nix:156`) only adds `nodejs git gh` to PATH, so
-`checkAvailable()` always returns false at runtime and parcel falls through to
-inotify on Linux / FSEvents on macOS. Issue #788 tracks the integration work.
+`nix run` wrapper (`default.nix:156`) only adds `nodejs git gh` to PATH — so
+even under `backend: "default"` the watchman probe would always fail and parcel
+would fall through to inotify on Linux / FSEvents on macOS. Since #1692, Kolu
+doesn't rely on that fall-through: it **pins** the native backend, so
+`checkAvailable()` (and its leaking `popen`) never runs at all. Issue #788
+tracks the watchman integration work; if it lands, the pin is where you'd
+re-enable watchman deliberately (with a `WATCHMAN_SOCK` that avoids the probe).
 
 ## Kolu's wrapper invariants
 
@@ -132,9 +153,22 @@ debounce path swallows event paths silently.
 
 ## Failure modes worth knowing
 
-1. **Container/WSL2 bind mounts** — neither inotify nor FSEvents nor watchman
-   is available. parcel-watcher silently falls back to ~1s polling. Latency
-   degrades, correctness preserved.
+1. **Container/WSL2 bind mounts** — inotify/FSEvents may be unavailable.
+   Nuance since the backend pin (#1692): `BruteForceBackend` (~1s polling) is
+   parcel's *compile-time-last-resort* backend — under `"default"` it's reached
+   only when no earlier backend is **compiled in**, not when a compiled one
+   fails to construct at runtime. On Kolu's Linux build `INOTIFY` is compiled,
+   so `"default"` selects `InotifyBackend` (after the failed watchman probe),
+   and a bind mount that can't inotify makes *both* `"default"` and the pinned
+   `"inotify"` fail identically (`error git: working-tree watcher install
+   failed`) — the pin forgoes **no** polling path there. On the three targets
+   the pin is behaviorally identical to `"default"`'s post-probe outcome, minus
+   the leak. On an **untargeted** platform (not linux/darwin/win32) the pin
+   throws at module init (`unsupported platform …`) rather than degrade to a
+   silent poller — kolu targets exactly those three, and the repo's fail-fast
+   philosophy forbids a graceful-degradation fallback. (If a BSD/other target
+   ever became real, map it to its native backend — `kqueue` etc. — not to a
+   poller.) Net: leak-free everywhere, and no platform silently degrades.
 2. **Linux inotify slot exhaustion** — kernel default is
    `fs.inotify.max_user_watches=8192`. A typical Kolu repo uses ~500–2000
    slots; multiple worktrees compound. Watchman amortizes this across one

--- a/.apm/skills/parcel/SKILL.md
+++ b/.apm/skills/parcel/SKILL.md
@@ -27,8 +27,14 @@ unless it has a similarly narrow target.
 
 Source: `node_modules/.pnpm/@parcel+watcher@2.5.6/node_modules/@parcel/watcher/src/Backend.cc:30-69`.
 
-`backend: "default"` (Kolu doesn't pass an explicit backend) selects in this
-order, first match wins:
+**Kolu pins the OS-native backend explicitly** (`inotify` / `fs-events` /
+`windows`, chosen off `process.platform` — see `PARCEL_BACKEND` in
+`working-tree-watcher.ts`). It does **not** use `backend: "default"`. The pin
+skips the auto-dispatch order below — most importantly the `WatchmanBackend`
+probe, whose per-subscribe `popen` leaks a zombie on watchman-less hosts (see
+next section). If you write a new parcel consumer, pin the backend the same way.
+
+`backend: "default"` would select in this order, first match wins:
 
 1. `FSEvents` on macOS — native recursive, one stream per repo.
 2. `WatchmanBackend` if `WatchmanBackend::checkAvailable()` returns true.
@@ -37,8 +43,9 @@ order, first match wins:
 5. `KqueueBackend` on BSD.
 6. `BruteForceBackend` — periodic full-tree stat; the fallback fallback.
 
-So on Linux, watchman is preferred over inotify whenever it's reachable; on
-macOS watchman is never used by default (FSEvents wins).
+So under `"default"` on Linux, watchman is *probed* (and preferred if reachable)
+before inotify; on macOS watchman is never used (FSEvents wins). The explicit
+pin lands directly on step 1/3/4 for the platform and never runs step 2's probe.
 
 ## How parcel invokes watchman
 
@@ -51,6 +58,16 @@ Source: `src/watchman/WatchmanBackend.cc`.
    ```
    then parses BSER output for the `sockname` field. If `WATCHMAN_SOCK` env
    var is set, that wins and the binary isn't run at all.
+
+   > **⚠ Zombie leak — why Kolu pins the backend (juspay/kolu#1691).** On a
+   > host without watchman, this `popen` forks `/bin/sh`, the `watchman` exec
+   > fails, and parcel's error path returns **without `pclose()`** — so the
+   > `sh` is never `wait()`ed. `popen` bypasses `child_process`, so Node's
+   > libuv can't reap it either: it lingers as a zombie **forever, one per
+   > `subscribe`**. Free on CPU/RAM but a long-lived daemon (a remote-bound
+   > padi serving a full e2e run) accumulates dozens and the event loop drags.
+   > Pinning the native backend (above) skips `checkAvailable()` entirely, so
+   > the `popen` never runs. Verified: per-subscribe leak → 0.
 3. From there it's a Unix-domain socket carrying BSER-encoded JSON. No more
    subprocess spawns.
 
@@ -87,9 +104,13 @@ mean the daemon was killed mid-handshake. Add `.watchman-cookie-*` to
 ## Kolu's runtime status
 
 As of #788, Kolu does **not** ship watchman with the production binary. The
-`nix run` wrapper (`default.nix:156`) only adds `nodejs git gh` to PATH, so
-`checkAvailable()` always returns false at runtime and parcel falls through to
-inotify on Linux / FSEvents on macOS. Issue #788 tracks the integration work.
+`nix run` wrapper (`default.nix:156`) only adds `nodejs git gh` to PATH — so
+even under `backend: "default"` the watchman probe would always fail and parcel
+would fall through to inotify on Linux / FSEvents on macOS. Since #1692, Kolu
+doesn't rely on that fall-through: it **pins** the native backend, so
+`checkAvailable()` (and its leaking `popen`) never runs at all. Issue #788
+tracks the watchman integration work; if it lands, the pin is where you'd
+re-enable watchman deliberately (with a `WATCHMAN_SOCK` that avoids the probe).
 
 ## Kolu's wrapper invariants
 
@@ -132,9 +153,22 @@ debounce path swallows event paths silently.
 
 ## Failure modes worth knowing
 
-1. **Container/WSL2 bind mounts** — neither inotify nor FSEvents nor watchman
-   is available. parcel-watcher silently falls back to ~1s polling. Latency
-   degrades, correctness preserved.
+1. **Container/WSL2 bind mounts** — inotify/FSEvents may be unavailable.
+   Nuance since the backend pin (#1692): `BruteForceBackend` (~1s polling) is
+   parcel's *compile-time-last-resort* backend — under `"default"` it's reached
+   only when no earlier backend is **compiled in**, not when a compiled one
+   fails to construct at runtime. On Kolu's Linux build `INOTIFY` is compiled,
+   so `"default"` selects `InotifyBackend` (after the failed watchman probe),
+   and a bind mount that can't inotify makes *both* `"default"` and the pinned
+   `"inotify"` fail identically (`error git: working-tree watcher install
+   failed`) — the pin forgoes **no** polling path there. On the three targets
+   the pin is behaviorally identical to `"default"`'s post-probe outcome, minus
+   the leak. On an **untargeted** platform (not linux/darwin/win32) the pin
+   throws at module init (`unsupported platform …`) rather than degrade to a
+   silent poller — kolu targets exactly those three, and the repo's fail-fast
+   philosophy forbids a graceful-degradation fallback. (If a BSD/other target
+   ever became real, map it to its native backend — `kqueue` etc. — not to a
+   poller.) Net: leak-free everywhere, and no platform silently degrades.
 2. **Linux inotify slot exhaustion** — kernel default is
    `fs.inotify.max_user_watches=8192`. A typical Kolu repo uses ~500–2000
    slots; multiple worktrees compound. Watchman amortizes this across one

--- a/.claude/skills/parcel/SKILL.md
+++ b/.claude/skills/parcel/SKILL.md
@@ -27,8 +27,14 @@ unless it has a similarly narrow target.
 
 Source: `node_modules/.pnpm/@parcel+watcher@2.5.6/node_modules/@parcel/watcher/src/Backend.cc:30-69`.
 
-`backend: "default"` (Kolu doesn't pass an explicit backend) selects in this
-order, first match wins:
+**Kolu pins the OS-native backend explicitly** (`inotify` / `fs-events` /
+`windows`, chosen off `process.platform` — see `PARCEL_BACKEND` in
+`working-tree-watcher.ts`). It does **not** use `backend: "default"`. The pin
+skips the auto-dispatch order below — most importantly the `WatchmanBackend`
+probe, whose per-subscribe `popen` leaks a zombie on watchman-less hosts (see
+next section). If you write a new parcel consumer, pin the backend the same way.
+
+`backend: "default"` would select in this order, first match wins:
 
 1. `FSEvents` on macOS — native recursive, one stream per repo.
 2. `WatchmanBackend` if `WatchmanBackend::checkAvailable()` returns true.
@@ -37,8 +43,9 @@ order, first match wins:
 5. `KqueueBackend` on BSD.
 6. `BruteForceBackend` — periodic full-tree stat; the fallback fallback.
 
-So on Linux, watchman is preferred over inotify whenever it's reachable; on
-macOS watchman is never used by default (FSEvents wins).
+So under `"default"` on Linux, watchman is *probed* (and preferred if reachable)
+before inotify; on macOS watchman is never used (FSEvents wins). The explicit
+pin lands directly on step 1/3/4 for the platform and never runs step 2's probe.
 
 ## How parcel invokes watchman
 
@@ -51,6 +58,16 @@ Source: `src/watchman/WatchmanBackend.cc`.
    ```
    then parses BSER output for the `sockname` field. If `WATCHMAN_SOCK` env
    var is set, that wins and the binary isn't run at all.
+
+   > **⚠ Zombie leak — why Kolu pins the backend (juspay/kolu#1691).** On a
+   > host without watchman, this `popen` forks `/bin/sh`, the `watchman` exec
+   > fails, and parcel's error path returns **without `pclose()`** — so the
+   > `sh` is never `wait()`ed. `popen` bypasses `child_process`, so Node's
+   > libuv can't reap it either: it lingers as a zombie **forever, one per
+   > `subscribe`**. Free on CPU/RAM but a long-lived daemon (a remote-bound
+   > padi serving a full e2e run) accumulates dozens and the event loop drags.
+   > Pinning the native backend (above) skips `checkAvailable()` entirely, so
+   > the `popen` never runs. Verified: per-subscribe leak → 0.
 3. From there it's a Unix-domain socket carrying BSER-encoded JSON. No more
    subprocess spawns.
 
@@ -87,9 +104,13 @@ mean the daemon was killed mid-handshake. Add `.watchman-cookie-*` to
 ## Kolu's runtime status
 
 As of #788, Kolu does **not** ship watchman with the production binary. The
-`nix run` wrapper (`default.nix:156`) only adds `nodejs git gh` to PATH, so
-`checkAvailable()` always returns false at runtime and parcel falls through to
-inotify on Linux / FSEvents on macOS. Issue #788 tracks the integration work.
+`nix run` wrapper (`default.nix:156`) only adds `nodejs git gh` to PATH — so
+even under `backend: "default"` the watchman probe would always fail and parcel
+would fall through to inotify on Linux / FSEvents on macOS. Since #1692, Kolu
+doesn't rely on that fall-through: it **pins** the native backend, so
+`checkAvailable()` (and its leaking `popen`) never runs at all. Issue #788
+tracks the watchman integration work; if it lands, the pin is where you'd
+re-enable watchman deliberately (with a `WATCHMAN_SOCK` that avoids the probe).
 
 ## Kolu's wrapper invariants
 
@@ -133,8 +154,13 @@ debounce path swallows event paths silently.
 ## Failure modes worth knowing
 
 1. **Container/WSL2 bind mounts** — neither inotify nor FSEvents nor watchman
-   is available. parcel-watcher silently falls back to ~1s polling. Latency
-   degrades, correctness preserved.
+   is available. Under `backend: "default"` parcel would silently fall back to
+   `BruteForceBackend` ~1s polling (latency degrades, correctness preserved).
+   **The backend pin (#1692) forgoes that fallback**: a pinned `inotify` on a
+   bind mount that can't inotify surfaces as an `error git: working-tree watcher
+   install failed` instead of degrading to polling. Accepted trade — Kolu's
+   daemons run on real Linux/macOS with a live inotify/FSEvents, and the pin's
+   value (no per-subscribe zombie leak) outweighs a polling path no target hits.
 2. **Linux inotify slot exhaustion** — kernel default is
    `fs.inotify.max_user_watches=8192`. A typical Kolu repo uses ~500–2000
    slots; multiple worktrees compound. Watchman amortizes this across one

--- a/.claude/skills/parcel/SKILL.md
+++ b/.claude/skills/parcel/SKILL.md
@@ -161,12 +161,14 @@ debounce path swallows event paths silently.
    so `"default"` selects `InotifyBackend` (after the failed watchman probe),
    and a bind mount that can't inotify makes *both* `"default"` and the pinned
    `"inotify"` fail identically (`error git: working-tree watcher install
-   failed`) — the pin forgoes **no** polling path there. The pin only *adds*
-   `brute-force` where it wasn't reached before: an **untargeted** platform
-   (not linux/darwin/win32) now names `brute-force` explicitly instead of
-   auto-selecting into the leaking watchman probe. Net: leak-free on every
-   platform, behaviorally identical to `"default"`'s post-probe outcome on the
-   three targets.
+   failed`) — the pin forgoes **no** polling path there. On the three targets
+   the pin is behaviorally identical to `"default"`'s post-probe outcome, minus
+   the leak. On an **untargeted** platform (not linux/darwin/win32) the pin
+   throws at module init (`unsupported platform …`) rather than degrade to a
+   silent poller — kolu targets exactly those three, and the repo's fail-fast
+   philosophy forbids a graceful-degradation fallback. (If a BSD/other target
+   ever became real, map it to its native backend — `kqueue` etc. — not to a
+   poller.) Net: leak-free everywhere, and no platform silently degrades.
 2. **Linux inotify slot exhaustion** — kernel default is
    `fs.inotify.max_user_watches=8192`. A typical Kolu repo uses ~500–2000
    slots; multiple worktrees compound. Watchman amortizes this across one

--- a/.claude/skills/parcel/SKILL.md
+++ b/.claude/skills/parcel/SKILL.md
@@ -153,14 +153,20 @@ debounce path swallows event paths silently.
 
 ## Failure modes worth knowing
 
-1. **Container/WSL2 bind mounts** — neither inotify nor FSEvents nor watchman
-   is available. Under `backend: "default"` parcel would silently fall back to
-   `BruteForceBackend` ~1s polling (latency degrades, correctness preserved).
-   **The backend pin (#1692) forgoes that fallback**: a pinned `inotify` on a
-   bind mount that can't inotify surfaces as an `error git: working-tree watcher
-   install failed` instead of degrading to polling. Accepted trade — Kolu's
-   daemons run on real Linux/macOS with a live inotify/FSEvents, and the pin's
-   value (no per-subscribe zombie leak) outweighs a polling path no target hits.
+1. **Container/WSL2 bind mounts** — inotify/FSEvents may be unavailable.
+   Nuance since the backend pin (#1692): `BruteForceBackend` (~1s polling) is
+   parcel's *compile-time-last-resort* backend — under `"default"` it's reached
+   only when no earlier backend is **compiled in**, not when a compiled one
+   fails to construct at runtime. On Kolu's Linux build `INOTIFY` is compiled,
+   so `"default"` selects `InotifyBackend` (after the failed watchman probe),
+   and a bind mount that can't inotify makes *both* `"default"` and the pinned
+   `"inotify"` fail identically (`error git: working-tree watcher install
+   failed`) — the pin forgoes **no** polling path there. The pin only *adds*
+   `brute-force` where it wasn't reached before: an **untargeted** platform
+   (not linux/darwin/win32) now names `brute-force` explicitly instead of
+   auto-selecting into the leaking watchman probe. Net: leak-free on every
+   platform, behaviorally identical to `"default"`'s post-probe outcome on the
+   three targets.
 2. **Linux inotify slot exhaustion** — kernel default is
    `fs.inotify.max_user_watches=8192`. A typical Kolu repo uses ~500–2000
    slots; multiple worktrees compound. Watchman amortizes this across one

--- a/packages/integrations/git/src/working-tree-watcher.reap.test.ts
+++ b/packages/integrations/git/src/working-tree-watcher.reap.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Daemon soak: `watchWorkingTree` must not leak child processes across
+ * sustained subscribe/unsubscribe cycles.
+ *
+ * The regression (kolu#1691): parcel auto-selects its watcher backend by
+ * probing **watchman** first, on *every* subscribe, via a native
+ * `popen("watchman … get-sockname 2>/dev/null")`. On a host without watchman
+ * (every kolu pool box) that probe's error path never `pclose()`s, so the
+ * `/bin/sh` it forked leaks as an unreaped zombie — one per subscribe. Node's
+ * libuv can't reap a native-`popen` child, so in a long-lived daemon they pile
+ * up unbounded and drag the event loop; a remote-bound padi serving a whole e2e
+ * run degraded in its back half. The fix pins the OS-native backend so the
+ * probe never runs.
+ *
+ * This is exactly the coverage class two long-lived-daemon incidents (this and
+ * kolu#1680) were begging for: the leak is invisible to a spin-up/tear-down
+ * unit test and only shows under *sustained* life. We assert the structural
+ * invariant — child count returns to baseline — rather than a timing p99, which
+ * the remote-e2e lane itself now guards.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { simpleGit } from "simple-git";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { watchWorkingTree } from "./working-tree-watcher.ts";
+
+/** Count this process's direct children currently in the zombie (`Z`) state —
+ *  i.e. dead but unreaped. Portable across the Linux and macOS CI lanes; a
+ *  reaped child leaves no row, so a healthy watcher yields zero. */
+function zombieChildCount(): number {
+  const out = execFileSync("ps", ["-Ao", "ppid,stat"], { encoding: "utf-8" });
+  return out.split("\n").filter((line) => {
+    const cols = line.trim().split(/\s+/);
+    return Number(cols[0]) === process.pid && (cols[1] ?? "").includes("Z");
+  }).length;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("watchWorkingTree child-process lifetime", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-wt-reap-"));
+    const git = simpleGit(repo);
+    await git.init();
+    await git.addConfig("user.email", "a@b.c");
+    await git.addConfig("user.name", "a");
+    fs.writeFileSync(path.join(repo, "a.txt"), "hi");
+    await git.add(".");
+    await git.commit("init");
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reaps every child across sustained subscribe/unsubscribe cycles", async () => {
+    const baseline = zombieChildCount();
+
+    const CYCLES = 12;
+    for (let i = 0; i < CYCLES; i++) {
+      const unsubscribe = watchWorkingTree(repo, () => {});
+      // Let the async parcel install (and its backend selection) complete
+      // before tearing down — that is where the leaking probe fires.
+      await sleep(80);
+      unsubscribe();
+    }
+    // Give any unreaped child ample time to surface as a zombie.
+    await sleep(1500);
+
+    // Without the backend pin, this is `baseline + CYCLES` (one leaked `sh`
+    // per subscribe). With it, no probe runs and no child leaks.
+    expect(zombieChildCount() - baseline).toBe(0);
+  });
+});

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -54,32 +54,37 @@ import type { Logger } from "kolu-shared";
 import { listIgnoredPaths } from "./browse.ts";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
 
-/** Pin parcel's backend to the OS-native one instead of letting it auto-select.
+/** Pin parcel's watcher backend, per platform, instead of letting it
+ *  auto-select — and pin a *named* backend on EVERY platform, never `undefined`.
  *
- *  Auto-selection probes the **watchman** backend FIRST, on **every**
- *  `subscribe`, via a native `popen("watchman … get-sockname 2>/dev/null")`
- *  (parcel's `WatchmanBackend::checkAvailable`). On a host without watchman
- *  installed — every kolu pool box and most dev machines — that probe fails and
- *  parcel's error path never `pclose()`s the pipe, so the `/bin/sh` it forked
- *  leaks as an **unreaped zombie, one per subscribe**. Node's libuv can't reap
- *  it (the child was spawned by native `popen`, not through `child_process`), so
- *  in a long-lived daemon (a remote-bound padi serving a whole e2e run) the
- *  zombies pile up unbounded — invisible to CPU/RAM, but they drag the daemon's
- *  event loop enough that Code-tab renders time out in the back half of a run.
- *  Surfaced by W3.4's remote-e2e lane; diagnosed to parcel@2.5.6 + no-watchman.
+ *  Auto-selection (`backend: "default"`) probes the **watchman** backend FIRST,
+ *  on **every** `subscribe`, via a native `popen("watchman … get-sockname
+ *  2>/dev/null")` (parcel's `WatchmanBackend::checkAvailable`). On a host
+ *  without watchman — every kolu pool box, most dev machines — that probe fails
+ *  and parcel's error path never `pclose()`s the pipe, so the `/bin/sh` it
+ *  forked leaks as an **unreaped zombie, one per subscribe**. libuv can't reap a
+ *  native-`popen` child, so in a long-lived daemon (a remote-bound padi serving
+ *  a whole e2e run) the zombies pile up unbounded — invisible to CPU/RAM, but
+ *  they drag the event loop enough that Code-tab renders time out in the back
+ *  half of a run. Surfaced by W3.4's remote-e2e lane; parcel@2.5.6 (#1691).
  *
- *  Pinning the native backend skips the watchman probe entirely (verified: the
- *  per-subscribe `sh` leak goes to zero). The only thing forgone is watchman's
- *  fewer-inotify-slots optimization for hosts that HAVE it opted in — which
- *  kolu's targets don't — so this is pure win, not a fallback we're giving up. */
-const PARCEL_BACKEND: BackendType | undefined =
-  process.platform === "darwin"
-    ? "fs-events"
-    : process.platform === "linux"
-      ? "inotify"
-      : process.platform === "win32"
-        ? "windows"
-        : undefined;
+ *  Naming a backend skips the probe. On kolu's targets the pin lands on the
+ *  exact backend `"default"` would have picked *after* the probe failed
+ *  (`inotify` / `fs-events` / `windows`), so nothing changes but the removed
+ *  leak. The `?? "brute-force"` arm matters for correctness, not just tidiness:
+ *  an untargeted platform must still name a NON-watchman backend, or it falls
+ *  back to the leaking auto-select. `brute-force` is parcel's universal poller —
+ *  slower, but leak-free and functional — so the probe is skipped *everywhere*
+ *  and there is no `undefined` "no preference" that quietly re-arms the leak. */
+const PARCEL_BACKEND_BY_PLATFORM: Partial<
+  Record<NodeJS.Platform, BackendType>
+> = {
+  darwin: "fs-events",
+  linux: "inotify",
+  win32: "windows",
+};
+const PARCEL_BACKEND: BackendType =
+  PARCEL_BACKEND_BY_PLATFORM[process.platform] ?? "brute-force";
 
 /** `.git` is always ignored: git never lists its own dir, and the git-dir
  *  watchers (HEAD/reflog/index) cover the parts we care about — watching it

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -47,11 +47,39 @@
 import path from "node:path";
 import {
   type AsyncSubscription,
+  type BackendType,
   subscribe as parcelSubscribe,
 } from "@parcel/watcher";
 import type { Logger } from "kolu-shared";
 import { listIgnoredPaths } from "./browse.ts";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
+
+/** Pin parcel's backend to the OS-native one instead of letting it auto-select.
+ *
+ *  Auto-selection probes the **watchman** backend FIRST, on **every**
+ *  `subscribe`, via a native `popen("watchman … get-sockname 2>/dev/null")`
+ *  (parcel's `WatchmanBackend::checkAvailable`). On a host without watchman
+ *  installed — every kolu pool box and most dev machines — that probe fails and
+ *  parcel's error path never `pclose()`s the pipe, so the `/bin/sh` it forked
+ *  leaks as an **unreaped zombie, one per subscribe**. Node's libuv can't reap
+ *  it (the child was spawned by native `popen`, not through `child_process`), so
+ *  in a long-lived daemon (a remote-bound padi serving a whole e2e run) the
+ *  zombies pile up unbounded — invisible to CPU/RAM, but they drag the daemon's
+ *  event loop enough that Code-tab renders time out in the back half of a run.
+ *  Surfaced by W3.4's remote-e2e lane; diagnosed to parcel@2.5.6 + no-watchman.
+ *
+ *  Pinning the native backend skips the watchman probe entirely (verified: the
+ *  per-subscribe `sh` leak goes to zero). The only thing forgone is watchman's
+ *  fewer-inotify-slots optimization for hosts that HAVE it opted in — which
+ *  kolu's targets don't — so this is pure win, not a fallback we're giving up. */
+const PARCEL_BACKEND: BackendType | undefined =
+  process.platform === "darwin"
+    ? "fs-events"
+    : process.platform === "linux"
+      ? "inotify"
+      : process.platform === "win32"
+        ? "windows"
+        : undefined;
 
 /** `.git` is always ignored: git never lists its own dir, and the git-dir
  *  watchers (HEAD/reflog/index) cover the parts we care about — watching it
@@ -181,7 +209,9 @@ function installSharedWorkingTreeWatcher(
           // exactly once, after the burst settles. Reset on every new batch.
           scheduleFire();
         },
-        { ignore },
+        // `backend` pins the OS-native watcher and skips parcel's leaking
+        // per-subscribe watchman probe — see PARCEL_BACKEND above.
+        { ignore, backend: PARCEL_BACKEND },
       );
 
       if (cancelled) {

--- a/packages/integrations/git/src/working-tree-watcher.ts
+++ b/packages/integrations/git/src/working-tree-watcher.ts
@@ -54,37 +54,52 @@ import type { Logger } from "kolu-shared";
 import { listIgnoredPaths } from "./browse.ts";
 import { WATCHER_DEBOUNCE_MS } from "./git-dir.ts";
 
+/** The one backend we must never hand parcel: `"watchman"` is the leaking one,
+ *  and *omitting* the backend re-selects it. Narrowing the pin's type to exclude
+ *  it makes the leak **unspellable** — `linux: "watchman"` or `?? "watchman"`
+ *  become compile errors, so the invariant below is enforced by the type, not
+ *  just trusted to the comment. */
+type NonWatchmanBackend = Exclude<BackendType, "watchman">;
+
 /** Pin parcel's watcher backend, per platform, instead of letting it
- *  auto-select — and pin a *named* backend on EVERY platform, never `undefined`.
+ *  auto-select — and pin a *named*, non-watchman backend on EVERY platform.
  *
- *  Auto-selection (`backend: "default"`) probes the **watchman** backend FIRST,
- *  on **every** `subscribe`, via a native `popen("watchman … get-sockname
- *  2>/dev/null")` (parcel's `WatchmanBackend::checkAvailable`). On a host
- *  without watchman — every kolu pool box, most dev machines — that probe fails
- *  and parcel's error path never `pclose()`s the pipe, so the `/bin/sh` it
- *  forked leaks as an **unreaped zombie, one per subscribe**. libuv can't reap a
- *  native-`popen` child, so in a long-lived daemon (a remote-bound padi serving
- *  a whole e2e run) the zombies pile up unbounded — invisible to CPU/RAM, but
- *  they drag the event loop enough that Code-tab renders time out in the back
- *  half of a run. Surfaced by W3.4's remote-e2e lane; parcel@2.5.6 (#1691).
+ *  Auto-selection (parcel's default when `backend` is **omitted**) probes the
+ *  **watchman** backend FIRST, on **every** `subscribe`, via a native
+ *  `popen("watchman … get-sockname 2>/dev/null")` (parcel's
+ *  `WatchmanBackend::checkAvailable`). On a host without watchman — every kolu
+ *  pool box, most dev machines — that probe fails and parcel's error path never
+ *  `pclose()`s the pipe, so the `/bin/sh` it forked leaks as an **unreaped
+ *  zombie, one per subscribe**. libuv can't reap a native-`popen` child, so in a
+ *  long-lived daemon (a remote-bound padi serving a whole e2e run) the zombies
+ *  pile up unbounded — invisible to CPU/RAM, but they drag the event loop enough
+ *  that Code-tab renders time out in the back half of a run. Surfaced by W3.4's
+ *  remote-e2e lane; parcel@2.5.6 (#1691).
  *
  *  Naming a backend skips the probe. On kolu's targets the pin lands on the
- *  exact backend `"default"` would have picked *after* the probe failed
+ *  exact backend the default would have picked *after* the probe failed
  *  (`inotify` / `fs-events` / `windows`), so nothing changes but the removed
- *  leak. The `?? "brute-force"` arm matters for correctness, not just tidiness:
- *  an untargeted platform must still name a NON-watchman backend, or it falls
- *  back to the leaking auto-select. `brute-force` is parcel's universal poller —
- *  slower, but leak-free and functional — so the probe is skipped *everywhere*
- *  and there is no `undefined` "no preference" that quietly re-arms the leak. */
+ *  leak. An untargeted platform (not linux/darwin/win32) hits the `throw`
+ *  rather than a poller: kolu runs on exactly those three, and the repo's
+ *  fail-fast philosophy forbids a silent graceful-degradation fallback — so we
+ *  crash loudly instead. That throw also guarantees an omitted/`undefined`
+ *  backend can never reach parcel to re-arm the probe. */
 const PARCEL_BACKEND_BY_PLATFORM: Partial<
-  Record<NodeJS.Platform, BackendType>
+  Record<NodeJS.Platform, NonWatchmanBackend>
 > = {
   darwin: "fs-events",
   linux: "inotify",
   win32: "windows",
 };
-const PARCEL_BACKEND: BackendType =
-  PARCEL_BACKEND_BY_PLATFORM[process.platform] ?? "brute-force";
+const platformBackend = PARCEL_BACKEND_BY_PLATFORM[process.platform];
+if (platformBackend === undefined) {
+  throw new Error(
+    `working-tree watcher: unsupported platform "${process.platform}" — kolu ` +
+      "targets linux/darwin/win32; refusing to omit parcel's backend (that " +
+      "re-selects the leaking watchman probe, #1691)",
+  );
+}
+const PARCEL_BACKEND: NonWatchmanBackend = platformBackend;
 
 /** `.git` is always ignored: git never lists its own dir, and the git-dir
  *  watchers (HEAD/reflog/index) cover the parts we care about — watching it


### PR DESCRIPTION
## The bug

Under a **long-lived daemon** — a remote-bound padi serving a whole e2e run —
the working-tree watcher leaks an **unreaped zombie child per subscribe**. They
pile up without bound (dozens of defunct `sh` in one run), invisible to CPU/RAM
(zombies are free), but they drag the daemon's event loop enough that Code-tab
renders time out in the **back half** of a long run. Surfaced by W3.4's remote
e2e lane (#1689); filed as #1691.

## Root cause (measured, not guessed)

`watchWorkingTree` let `@parcel/watcher` **auto-select** its backend. Auto-select
probes the **watchman** backend *first, on every `subscribe`*, via a native
`popen("watchman … get-sockname 2>/dev/null")`
(`WatchmanBackend::checkAvailable`). On a host **without watchman** — every kolu
pool box, most dev machines — that probe fails and parcel's error path never
`pclose()`s, so the `/bin/sh` `popen` forked is never `wait()`ed. Node's libuv
can't reap a child spawned by native `popen` (it isn't a `child_process`
handle), so the `sh` lingers as a zombie forever.

Bisected end-to-end on a box pair: falsified resource pressure (both boxes
128 GB, load <1); isolated the leak to `subscribeRepoChange` → `watchWorkingTree`
→ `@parcel/watcher.subscribe` (10 subscribes → 10 `sh` zombies) → the
`WatchmanBackend` `popen`; confirmed `git` is a real ELF binary (so the `sh` is
the popen shell, not a git wrapper); confirmed the box has no watchman.

## The fix

Pin the OS-native backend (`inotify` / `fs-events` / `windows`) so the watchman
probe never runs. Verified: the per-subscribe leak goes to **zero**. The only
thing forgone is watchman's fewer-inotify-slots optimization on hosts that opt
into it — which kolu's targets don't — so this is **pure win, not a dropped
fallback** (no-fallbacks stays honored: we pin the *correct* backend, we don't
add a degradation path).

## Repro-first coverage

A **daemon soak test** drives sustained subscribe/unsubscribe cycles and asserts
the child count returns to baseline — **red at 12 leaked children** on the old
auto-select path, **green** on the pinned backend. It's the first of its
coverage class: both this and #1680 (the darwin WAL-watcher death) were
long-lived-daemon defects a spin-up/tear-down unit test structurally can't see.
The timing/p99 half of the soak is guarded by the remote-e2e lane itself.

## The empirical claim the two-greens bar tests

The pin is expected to eliminate **both** failure modes the leak caused: the
**zombie accumulation** (asserted directly by the soak test here) **and** the
**second-half Code-tab latency** in a long remote run — because that latency
*is* the accumulated per-subscribe `popen` fork/leak dragging the daemon's event
loop under Code-tab load. #1689's warm-pool rerun (two consecutive greens on the
linux pair + one darwin-binds-linux) is the test of that claim. If the timeouts
**survive** the pin on the warm-pool rerun, the mechanism story is incomplete —
that is a signal to re-diagnose, not to widen the timeout multiplier.

## Doc sync

Updated the repo's `/parcel` skill — the backend-dispatch, watchman-invocation,
runtime-status, and WSL2-fallback sections now reflect the pin and document the
`popen` zombie leak, so the project's own watcher reference matches the shipped
behavior. The edit lives in the `.apm/skills/parcel/SKILL.md` **source** and is
regenerated into the `.claude`/`.agents` runtime trees via `just ai::apm` (all
three in sync), per the APM two-tree rule.

## Honoring the design philosophy

- **Fail-fast / no fallbacks** — pins the correct native backend rather than
  papering the leak with a periodic reaper; no new knob, no degraded path.
- **Reuse the source of truth** — the fix lives in `kolu-git`'s
  `working-tree-watcher`, the one module that owns the `@parcel/watcher` usage;
  no watcher logic duplicated elsewhere.

## Review gauntlet

Five lenses over the production delta (architecture/lowy, correctness, simplicity/hickey, then architecture-first-principles + perfection on the final form):

- **hickey** — the original `... : undefined` untargeted arm was a silent fallback that handed control back to parcel's leaking auto-select. Fixed → an explicit non-watchman default (later a `throw`).
- **architecture-first-principles (illegal-states)** — `BackendType` still spelled `"watchman"`, so a future edit could re-arm the leak and type-check. Fixed → `NonWatchmanBackend = Exclude<BackendType, "watchman">`; the leaky value is now a compile error.
- **perfection R2** — the `?? "brute-force"` fallback was a graceful-degradation path (silent poll on an unsupported platform) that the repo's fail-fast philosophy forbids. Fixed → `throw` on an unsupported platform.
- **perfection R1 (deferred, documented)** — a future `parcelSubscribe` in another module could forget the pin. The ideal fix (extract the raw subscribe behind a shared boundary + lint-ban the import) conflicts with lowy's lens: extracting for a population of one is premature receptacle-creation, and the repo's electricity principle treats a bounded single-consumer concern as a leaf. Adjudicated: the `/parcel` skill's "pin the backend the same way" note is the interim guard; a real second consumer is the extraction trigger.

CI: the full pipeline is green on both platforms in one clean run on the final
SHA — 28 ok · 0 failed · 0 errored (14 × x86_64-linux + 14 × aarch64-darwin).

Closes #1691. Unblocks the remote-e2e CI node in #1689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
