### PR TITLE
[codex] Bring logo colors into the website

### DIFF
--- a/website/default.nix
+++ b/website/default.nix
@@ -10,8 +10,8 @@
 # `import ./website { inherit pkgs; }` with no synthesis of its own.
 { pkgs ? import ../nix/nixpkgs.nix { }
 , src ? # Self-contained website source for the Nix sandbox. The working tree keeps
-  # public/{favicon,kaval-logo}.svg as symlinks into packages/ (one SVG each
-  # on disk, no duplicated bytes) — but those dangle once copied into the
+  # public/{favicon,kaval-logo,padi-logo}.svg as symlinks into packages/ (one SVG
+  # each on disk, no duplicated bytes) — but those dangle once copied into the
   # store, so resolve them to real bytes here. Astro/Vite then sees a
   # complete tree. Add a line per new out-of-tree public/ asset.
   pkgs.runCommand "kolu-website-src" { } ''
@@ -31,6 +31,8 @@
     cp ${../packages/client/favicon.svg} $out/public/favicon.svg
     rm -f $out/public/kaval-logo.svg
     cp ${../packages/kaval/logo.svg} $out/public/kaval-logo.svg
+    rm -f $out/public/padi-logo.svg
+    cp ${../packages/padi/logo.svg} $out/public/padi-logo.svg
   ''
 }:
 let

--- a/website/public/padi-logo.svg
+++ b/website/public/padi-logo.svg
@@ -1,0 +1,1 @@
+../../packages/padi/logo.svg

--- a/website/src/pages/architecture.astro
+++ b/website/src/pages/architecture.astro
@@ -161,6 +161,15 @@ const primitives = [
         {/* layer boxes */}
         <rect x="190" y="28" width="340" height="64" rx="10" class="ax-d-box"
         ></rect>
+        <image
+          href="/favicon.svg"
+          x="208"
+          y="42"
+          width="36"
+          height="36"
+          preserveAspectRatio="xMidYMid meet"
+          class="ax-d-logo"
+        ></image>
         <text x="360" y="54" text-anchor="middle" class="ax-d-label"
           >PWA client</text
         >
@@ -170,6 +179,15 @@ const primitives = [
 
         <rect x="190" y="126" width="340" height="64" rx="10" class="ax-d-box"
         ></rect>
+        <image
+          href="/favicon.svg"
+          x="208"
+          y="140"
+          width="36"
+          height="36"
+          preserveAspectRatio="xMidYMid meet"
+          class="ax-d-logo"
+        ></image>
         <text x="360" y="152" text-anchor="middle" class="ax-d-label"
           >kolu-server</text
         >
@@ -179,6 +197,15 @@ const primitives = [
 
         <rect x="190" y="224" width="340" height="64" rx="10" class="ax-d-daemon"
         ></rect>
+        <image
+          href="/padi-logo.svg"
+          x="208"
+          y="238"
+          width="36"
+          height="36"
+          preserveAspectRatio="xMidYMid meet"
+          class="ax-d-logo"
+        ></image>
         <text x="360" y="250" text-anchor="middle" class="ax-d-daemon-label"
           >padi</text
         >
@@ -188,6 +215,15 @@ const primitives = [
 
         <rect x="190" y="322" width="340" height="64" rx="10" class="ax-d-daemon"
         ></rect>
+        <image
+          href="/kaval-logo.svg"
+          x="208"
+          y="336"
+          width="36"
+          height="36"
+          preserveAspectRatio="xMidYMid meet"
+          class="ax-d-logo"
+        ></image>
         <text x="360" y="348" text-anchor="middle" class="ax-d-daemon-label"
           >kaval</text
         >
@@ -291,10 +327,19 @@ const primitives = [
         {/* top lane: padi drains and respawns */}
         <rect x="48" y="64" width="150" height="50" rx="9" class="ax-d-box"
         ></rect>
-        <text x="123" y="86" text-anchor="middle" class="ax-d-label2"
+        <image
+          href="/padi-logo.svg"
+          x="60"
+          y="75"
+          width="26"
+          height="26"
+          preserveAspectRatio="xMidYMid meet"
+          class="ax-d-logo"
+        ></image>
+        <text x="136" y="86" text-anchor="middle" class="ax-d-label2"
           >padi · vX</text
         >
-        <text x="123" y="103" text-anchor="middle" class="ax-d-sub"
+        <text x="136" y="103" text-anchor="middle" class="ax-d-sub"
           >running</text
         >
 
@@ -309,10 +354,19 @@ const primitives = [
 
         <rect x="522" y="64" width="150" height="50" rx="9" class="ax-d-daemon"
         ></rect>
-        <text x="597" y="86" text-anchor="middle" class="ax-d-daemon-label2"
+        <image
+          href="/padi-logo.svg"
+          x="534"
+          y="75"
+          width="26"
+          height="26"
+          preserveAspectRatio="xMidYMid meet"
+          class="ax-d-logo"
+        ></image>
+        <text x="610" y="86" text-anchor="middle" class="ax-d-daemon-label2"
           >padi · vY</text
         >
-        <text x="597" y="103" text-anchor="middle" class="ax-d-sub"
+        <text x="610" y="103" text-anchor="middle" class="ax-d-sub"
           >the new build</text
         >
 
@@ -324,8 +378,17 @@ const primitives = [
         {/* bottom lane: kaval, unbroken */}
         <rect x="48" y="176" width="624" height="58" rx="10" class="ax-d-daemon"
         ></rect>
-        <text x="68" y="200" class="ax-d-daemon-label2">kaval</text>
-        <text x="68" y="217" class="ax-d-sub">one process · never restarts here</text>
+        <image
+          href="/kaval-logo.svg"
+          x="70"
+          y="187"
+          width="34"
+          height="34"
+          preserveAspectRatio="xMidYMid meet"
+          class="ax-d-logo"
+        ></image>
+        <text x="116" y="200" class="ax-d-daemon-label2">kaval</text>
+        <text x="116" y="217" class="ax-d-sub">one process · never restarts here</text>
 
         {/* the PTY stream — unbroken straight through the deploy */}
         <path d="M232,205 H648" class="ax-d-stream"></path>
@@ -609,7 +672,7 @@ const primitives = [
 
 <style>
   /* Section headings — mirror the kaval page: a display-scale lowercase
-     tech-sans heading led by a tall electric-purple bar. */
+     tech-sans heading led by a tall logo-gold bar. */
   .ax-head {
     position: relative;
     margin-top: 0.2rem;
@@ -832,6 +895,11 @@ const primitives = [
   }
   .ax-diagram text {
     font-family: var(--font-mono);
+  }
+  .ax-d-logo {
+    filter: drop-shadow(
+      0 5px 10px color-mix(in srgb, var(--color-void-sunk) 70%, transparent)
+    );
   }
   .ax-d-box {
     fill: var(--color-void-raised);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -710,7 +710,7 @@ const tunnels = [
         <dt>Multi-agent at scale</dt>
         <dd>
           The dock pulses for working agents and breathes for awaiting ones; a
-          finished background agent fires a loud violet ping plus a toast with a
+          finished background agent fires a loud purple ping plus a toast with a
           <strong>Switch</strong> action that pans the canvas straight to it —
           and, on an HTTPS/<code>localhost</code> kolu with notifications
           granted, a native <strong>OS notification</strong> you can click to
@@ -1092,10 +1092,10 @@ const tunnels = [
      terminal can pick its own — the demo mirrors that with three
      distinct palettes across the page so the hero, canvas main tile,
      and canvas side tile each read as a separate terminal.
-     The shared block pins cool-neutral ink + logo-violet amber tokens
+     The shared block pins cool-neutral ink + logo-gold amber tokens
      *inside* the terminal regardless of page theme, so light-mode
      visitors still see legible terminal output on the dark theme bg
-     without any warm bleedthrough from the page-level light palette. */
+     without washing out the terminal palettes. */
   .theme-phala,
   .theme-solarized,
   .theme-hax0r {
@@ -1103,9 +1103,9 @@ const tunnels = [
     --color-ink-dim: #a8a8b2;
     --color-ink-muted: #6e6e78;
     --color-ink-faint: #3a3a42;
-    --color-amber: #a855f7;
-    --color-amber-bright: #c084fc;
-    --color-amber-dim: #7e22ce;
+    --color-amber: #f59e0b;
+    --color-amber-bright: #facc15;
+    --color-amber-dim: #b45309;
     --color-rule: #18181d;
     --color-rule-strong: #28282f;
     color: var(--color-ink);

--- a/website/src/pages/kaval.astro
+++ b/website/src/pages/kaval.astro
@@ -64,9 +64,8 @@ const escapes = [
   description="kaval — a standalone PTY daemon built on a multi-client PTY-owner primitive — and kaval-tui, its terminal client: list, create, snapshot, attach to, send input to, and kill your terminals from the shell."
 >
   <section class="mx-auto max-w-3xl px-6 pt-20 md:pt-28 pb-10">
-    {/* Warning orange (--color-brand-amber), NOT the site accent: the
-        `amber` token is the purple brand accent, and an alpha warning must
-        read as a warning. */}
+    {/* Warning orange uses the logo-gold token directly; this is a product
+        maturity warning, not a separate danger palette. */}
     <div
       class="mb-8 flex items-start gap-3 border border-brand-amber/50 bg-brand-amber/10 rounded-lg px-4 py-3 max-w-xl"
     >
@@ -206,8 +205,17 @@ const escapes = [
         {/* client boxes */}
         <rect x="24" y="70" width="150" height="56" rx="9" class="kv-d-box"
         ></rect>
-        <text x="99" y="97" text-anchor="middle" class="kv-d-label">padi</text>
-        <text x="99" y="114" text-anchor="middle" class="kv-d-sub"
+        <image
+          href="/padi-logo.svg"
+          x="42"
+          y="84"
+          width="28"
+          height="28"
+          preserveAspectRatio="xMidYMid meet"
+          class="kv-d-logo"
+        ></image>
+        <text x="118" y="97" text-anchor="middle" class="kv-d-label">padi</text>
+        <text x="118" y="114" text-anchor="middle" class="kv-d-sub"
           >kolu's host daemon</text
         >
 
@@ -223,10 +231,19 @@ const escapes = [
         {/* daemon box */}
         <rect x="372" y="104" width="156" height="64" rx="11" class="kv-d-daemon"
         ></rect>
-        <text x="450" y="133" text-anchor="middle" class="kv-d-daemon-label"
+        <image
+          href="/kaval-logo.svg"
+          x="394"
+          y="118"
+          width="36"
+          height="36"
+          preserveAspectRatio="xMidYMid meet"
+          class="kv-d-logo"
+        ></image>
+        <text x="468" y="133" text-anchor="middle" class="kv-d-daemon-label"
           >kaval</text
         >
-        <text x="450" y="151" text-anchor="middle" class="kv-d-sub"
+        <text x="468" y="151" text-anchor="middle" class="kv-d-sub"
           >the PTY daemon</text
         >
 
@@ -416,10 +433,17 @@ const escapes = [
       serves it all as one surface the thin{" "}
       <code class="mono text-ink">padi-tui</code> CLI reads. Where{" "}
       <code class="mono text-ink">kaval-tui</code> shows what's{" "}
-      <em>running</em> in each PTY, padi-tui shows what each terminal{" "}
-      <em>is in</em>.
+          <em>running</em> in each PTY, padi-tui shows what each terminal{" "}
+          <em>is in</em>.
         </p>
       </div>
+      <img
+        src="/padi-logo.svg"
+        width="96"
+        height="96"
+        alt="padi — the per-host workspace daemon"
+        class="kv-padi-logo hidden md:block w-24 shrink-0"
+      />
     </div>
     <div class="kv-term">
       <span class="cmd"
@@ -638,8 +662,8 @@ c9d40000  kolu·fix/fold       #1408 ✗   —                 nvim             
 
 <style>
   /* Hero product mark — a glowing badge, not a stray icon floating in the
-     corner. The purple halo echoes the live-state glow used in the app dock,
-     and the larger size gives it presence opposite the headline. */
+     corner. The gold halo echoes the Kolu logo's top step, and the larger size
+     gives it presence opposite the headline. */
   .kv-logo {
     border-radius: 1.5rem;
     filter: drop-shadow(
@@ -647,10 +671,16 @@ c9d40000  kolu·fix/fold       #1408 ✗   —                 nvim             
     );
   }
 
+  .kv-padi-logo {
+    filter: drop-shadow(
+      0 14px 32px color-mix(in srgb, var(--color-live-lime) 35%, transparent)
+    );
+  }
+
   /* Section headings — real <h2>s. The page jumped from a ~67px display H1
      straight to 13px mono captions with no mid tier, so every section read
      flat. These are now a true display-scale heading (~half the H1) in the
-     same lowercase tech-sans as the hero, with a tall electric-purple bar as
+     same lowercase tech-sans as the hero, with a tall logo-gold bar as
      the section marker — the accent grounds the heading instead of *being* it. */
   .kv-head {
     position: relative;
@@ -771,6 +801,11 @@ c9d40000  kolu·fix/fold       #1408 ✗   —                 nvim             
   }
   .kv-diagram text {
     font-family: var(--font-mono);
+  }
+  .kv-d-logo {
+    filter: drop-shadow(
+      0 5px 10px color-mix(in srgb, var(--color-void-sunk) 70%, transparent)
+    );
   }
   .kv-d-box {
     fill: var(--color-void-raised);

--- a/website/src/pages/open-graph/[...route].ts
+++ b/website/src/pages/open-graph/[...route].ts
@@ -10,8 +10,8 @@
  * blog pages pass `blog/<slug>`, the home passes `site`, and any
  * future page can pass its own key.
  *
- * Brand: void background (#0a0a0a / #121110 gradient) with an amber
- * inline-start border (#e7b87a) — same palette as the site chrome.
+ * Brand: void background with a logo-gold inline-start border — same palette
+ * as the site chrome.
  */
 
 import { getCollection } from "astro:content";
@@ -47,22 +47,22 @@ export const { getStaticPaths, GET } = await OGImageRoute({
     title: page.title,
     description: page.description,
     bgGradient: [
-      [10, 10, 10],
-      [18, 17, 16],
+      [7, 8, 13],
+      [16, 19, 28],
     ],
-    border: { color: [231, 184, 122], width: 8, side: "inline-start" },
+    border: { color: [245, 158, 11], width: 8, side: "inline-start" },
     padding: 80,
     fonts: [NOTO_SANS],
     font: {
       title: {
-        color: [232, 229, 221],
+        color: [244, 247, 251],
         size: 64,
         weight: "Medium",
         lineHeight: 1.15,
         families: ["Noto Sans"],
       },
       description: {
-        color: [169, 165, 154],
+        color: [193, 199, 208],
         size: 28,
         weight: "Normal",
         lineHeight: 1.5,

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -8,41 +8,35 @@
 
 /* --- Design tokens --------------------------------------------------------
 
-  Cool-neutral terminal aesthetic: pure off-black / cool light gray
-  backgrounds, neutral ink, and a brand accent pulled from the violet
-  side of Kolu's three-step rainbow mark. Earlier iterations leaned
-  warm — cream paper, amber dots, peach accents — which read as
-  "boring brown" against the vivid terminal mockups. This palette has
-  zero warmth and is consistent with the logo's identity.
+  Kolu's logo is the palette: gold/yellow top step, rose→purple middle
+  step, teal→cyan→blue base step. The site stays terminal-dark and
+  utilitarian, but the accents now use that full mark instead of reducing
+  the identity to a single violet.
 -------------------------------------------------------------------------- */
 @theme {
-  --color-void: #0a0a0d;
-  --color-void-raised: #131318;
-  --color-void-sunk: #050507;
-  --color-ink: #e8e8ed;
-  --color-ink-dim: #a8a8b2;
-  --color-ink-muted: #6e6e78;
-  --color-ink-faint: #3a3a42;
-  --color-rule: #18181d;
-  --color-rule-strong: #28282f;
+  --color-void: #07080d;
+  --color-void-raised: #10131c;
+  --color-void-sunk: #030409;
+  --color-ink: #f4f7fb;
+  --color-ink-dim: #c1c7d0;
+  --color-ink-muted: #7d8795;
+  --color-ink-faint: #354050;
+  --color-rule: #1a2330;
+  --color-rule-strong: #2e3a4d;
 
-  /* Brand accent — the violet side of the rainbow step mark. Token
-     name stayed `amber` so every existing site class still reads
-     `text-amber*` / `bg-amber*`; only the value is purple. */
-  --color-amber: #a855f7;
-  --color-amber-bright: #c084fc;
-  --color-amber-dim: #7e22ce;
+  /* Primary brand accent — the gold/yellow top step of the logo. The
+     token keeps the historic `amber` name because site classes already
+     use `text-amber*` / `bg-amber*`, but the value now matches the mark. */
+  --color-amber: #f59e0b;
+  --color-amber-bright: #facc15;
+  --color-amber-dim: #b45309;
 
-  /* Live-state accents — *electric*, not pastel. Used wherever the
-     surface reflects *change* (agent working/awaiting in the dock,
-     tile identity on the canvas, code-tree selection, PASS pings).
-     Calibrated against the real Kolu app's saturated repo palette —
-     the earlier muted version made the marketing page look dimmer
-     than the product it advertises. */
-  --color-live-teal: #00ffd4;
-  --color-live-alert: #ef4444;
-  --color-live-violet: #ff3ec9;
-  --color-live-lime: #7cff5b;
+  /* Live-state accents from the other logo steps. Rose covers alert,
+     purple covers "needs you", cyan/teal cover working and success. */
+  --color-live-teal: #06b6d4;
+  --color-live-alert: #f43f5e;
+  --color-live-violet: #a855f7;
+  --color-live-lime: #14b8a6;
 
   /* macOS-style window-control dots — used by every faux terminal frame
      on the site. Kept as tokens so all frames stay in lockstep. */
@@ -78,27 +72,24 @@
    <html data-theme="light|dark"> before first paint (no FOUC). */
 
 [data-theme="light"] {
-  /* Light-mode shell — cool off-white (very slight blue tint) and
-     cool grays. Zero warmth: no cream paper, no beige rules, no warm
-     brown ink. The accent stays in the logo's violet family. */
-  --color-void: #f5f5f8;
-  --color-void-raised: #eeeef2;
-  --color-void-sunk: #e5e5eb;
-  --color-ink: #18181c;
-  --color-ink-dim: #4a4a52;
-  --color-ink-muted: #7c7c84;
-  --color-ink-faint: #b8b8c0;
-  --color-rule: #d8d8de;
-  --color-rule-strong: #c0c0c8;
-  --color-amber: #7e22ce;
-  --color-amber-bright: #6b21a8;
-  --color-amber-dim: #c084fc;
-  /* Light-mode live-state accents — deepened versions of the electric
-     dark tokens. Still saturated, still loud against warm paper. */
-  --color-live-teal: #007a6c;
-  --color-live-alert: #dc2626;
-  --color-live-violet: #c5008a;
-  --color-live-lime: #1a8500;
+  /* Light-mode shell — cool paper and deep ink, with the same logo
+     palette darkened enough for text contrast. */
+  --color-void: #f7f9fc;
+  --color-void-raised: #edf2f7;
+  --color-void-sunk: #e5ebf3;
+  --color-ink: #111827;
+  --color-ink-dim: #3f4b5f;
+  --color-ink-muted: #718096;
+  --color-ink-faint: #b7c2d0;
+  --color-rule: #d7e0eb;
+  --color-rule-strong: #bdcad8;
+  --color-amber: #b45309;
+  --color-amber-bright: #92400e;
+  --color-amber-dim: #f59e0b;
+  --color-live-teal: #0891b2;
+  --color-live-alert: #be123c;
+  --color-live-violet: #7e22ce;
+  --color-live-lime: #0f766e;
 }
 
 [data-theme="dark"] {
@@ -113,22 +104,20 @@
 
 html {
   background: var(--color-void);
-  /* Subtle character-cell lattice — evokes a terminal without shouting.
-     Dot opacity blended per theme via --dot-color below. Hue pulled
-     from the logo's violet step so the bg texture carries brand
-     identity without competing with content. */
-  background-image: radial-gradient(
-    circle at 1px 1px,
-    var(--dot-color) 1px,
-    transparent 0
-  );
-  background-size: 24px 24px;
+  /* Subtle character-cell lattice — gold and cyan dots echo the top/base
+     logo steps without competing with the content. */
+  background-image:
+    radial-gradient(circle at 1px 1px, var(--dot-gold) 1px, transparent 0),
+    radial-gradient(circle at 15px 15px, var(--dot-cyan) 1px, transparent 0);
+  background-size: 28px 28px;
   background-attachment: fixed;
-  --dot-color: rgba(168, 85, 247, 0.06);
+  --dot-gold: rgba(245, 158, 11, 0.08);
+  --dot-cyan: rgba(6, 182, 212, 0.055);
 }
 
 html[data-theme="light"] {
-  --dot-color: rgba(126, 34, 206, 0.08);
+  --dot-gold: rgba(180, 83, 9, 0.08);
+  --dot-cyan: rgba(8, 145, 178, 0.07);
 }
 
 body {


### PR DESCRIPTION
**The public website now follows the actual Kolu logo palette** instead of leaning on the old violet-only accent. Gold becomes the primary site accent, while the rose, purple, teal, cyan, and blue logo colors carry live/status details across the homepage, docs pages, and generated Open Graph cards.

The architecture diagrams now show the program marks directly: Kolu for the browser/server layers, padi for the workspace daemon, and kaval for the PTY daemon. `/kaval` also exposes the padi logo through the same public asset path as the existing kaval logo and uses it in the client diagram and padi-tui section.

### Validation

- `just fmt`
- `just website check` (existing Astro/Zod deprecation hints only)
- `just website build`
- `odu`: `ci::fmt@x86_64-linux` and `ci::nix@x86_64-linux` passed for `5696c2fd02315f3558d5a0369c1a82149fe5ccbe`

### Evidence

Screenshots are posted in [the evidence comment](https://github.com/juspay/kolu/pull/1694#issuecomment-4886283520).

_Generated by Codex (model `gpt-5`)._