### PR TITLE
refactor(server): split padiBinding.ts — carve convergence, collapse identity (L6)

### DIFF
--- a/packages/server/src/padiBinding.test.ts
+++ b/packages/server/src/padiBinding.test.ts
@@ -59,13 +59,16 @@ import { connectPadi } from "@kolu/padi/dial";
 import {
   ensurePadiBinding,
   localPadiDriver,
-  PADI_CONVERGENCE_POLICY,
   PADI_HOST_ID,
   PadiBindingSession,
   type PadiBindingSessionDeps,
-  probePadiForConvergence,
   resolvePadiLaunch,
 } from "./padiBinding.ts";
+// padi's convergence declaration + probe moved to `./padiConvergence.ts` in L6.
+import {
+  PADI_CONVERGENCE_POLICY,
+  probePadiForConvergence,
+} from "./padiConvergence.ts";
 import { buildAppRouter } from "./router.ts";
 
 /** A silent structural logger for the in-test endpoint + the newer-binder bind

--- a/packages/server/src/padiBinding.ts
+++ b/packages/server/src/padiBinding.ts
@@ -331,6 +331,34 @@ export interface PadiBindingSessionDeps {
 }
 
 /**
+ * The bound padi's HONEST identity off its control-core `hello` — the three
+ * kolu-server-facing readouts as ONE value, so they can never disagree about
+ * whether padi is bound. Present ⇔ padi is bound (a fresh `connected` sets the
+ * whole record); `null` ⇔ unbound (a degraded/dead close, or `destroy`, clears
+ * the whole record) — the three fields share EXACTLY one lifecycle, so one
+ * nullable value makes a partial identity (e.g. an uptime with no version)
+ * unrepresentable (illegal-states-unrepresentable; L6, collapsing three parallel
+ * nullable fields set/cleared together in four places).
+ *
+ * Each member is itself nullable for an honest per-field "unknown" WHILE bound:
+ *   - `startedAtMs` — boot time (ms epoch), off the connected status's `startedAt`
+ *     (`hello.startedAt`). Feeds koluSurface's `processStartedAt` cell (the rail's
+ *     padi uptime). `null` while unbound renders as the honest "unknown".
+ *   - `surfaceVersion` — the `padiSurface` version the LIVE padi serves, off the
+ *     handshake identity (`connectPadi` → `identity.surfaceVersion`; the handshake
+ *     proved it compatible). Feeds `daemonInventory` (the Padi dialog + rail chip's
+ *     "contract v<x.y>"). Read off the live padi, not the binder's build constant.
+ *   - `buildCommit` — the running padi's navigable git commit off the same identity
+ *     (`identity.commit`), or `null` when a survivor padi predates the field (off-nix
+ *     reads "—", not a blank link). Feeds `daemonInventory`'s "build commit".
+ */
+type BoundIdentity = {
+  startedAtMs: number | null;
+  surfaceVersion: string | null;
+  buildCommit: string | null;
+};
+
+/**
  * The reconnect-mirror session over the supervisor Endpoint. Drives:
  *   - boot: `connectOnce()` → `endpoint.current()` holds the live connection.
  *   - reconnect: on the endpoint reporting degraded/dead, wait a backoff then
@@ -344,30 +372,13 @@ export interface PadiBindingSessionDeps {
 export class PadiBindingSession implements BoundPadi {
   private clientPromise: Promise<PadiSurfaceClient> | null = null;
   private destroyed = false;
-  /** The bound padi's HONEST boot time (ms epoch) off its control-core `hello`
-   *  (echoed on every `connected` endpoint status as `startedAt`), or `null` while
-   *  padi is unbound. Managed on the SAME lifecycle as `clientPromise` — set on a
-   *  fresh `connected` (a respawned padi is a new process, so its boot time is
-   *  fresh), cleared to `null` on a degraded/dead close — so `padiStartedAt()` reports
-   *  a real uptime or an honest "unknown", never a stale boot time from the old
-   *  process. Feeds koluSurface's `processStartedAt` cell (the rail's padi uptime). */
-  private padiStartedAtMs: number | null = null;
-  /** The bound padi's HONEST `padiSurface` version off its control-core `hello`
-   *  (`connectPadi` reads it into `identity.surfaceVersion`; the handshake proved
-   *  it compatible), or `null` while padi is unbound. Managed on the SAME lifecycle
-   *  as `clientPromise`/`padiStartedAtMs` — set on a fresh `connected`, cleared on a
-   *  degraded/dead close — so `padiSurfaceVersion()` reports the version the LIVE
-   *  padi actually serves or an honest "unknown", never a stale value from the old
-   *  process. Feeds koluSurface's `daemonInventory` cell (the Padi dialog + rail
-   *  chip's "contract v<x.y>" readout). */
-  private padiSurfaceVersionStr: string | null = null;
-  /** The bound padi's navigable git commit off its control-core `hello`
-   *  (`connectPadi` reads it into `identity.commit`), or `null` while unbound / when a
-   *  survivor padi predates the field. Managed on the SAME lifecycle as
-   *  `padiSurfaceVersionStr` — set on a fresh `connected`, cleared on close — so
-   *  `padiBuildCommit()` reports the LIVE padi's build or an honest "unknown". Feeds
-   *  koluSurface's `daemonInventory` cell (the Padi dialog's "build commit"). */
-  private padiBuildCommitStr: string | null = null;
+  /** The bound padi's HONEST identity (boot time · surface version · build commit)
+   *  as ONE value, or `null` while padi is unbound. Managed on the SAME lifecycle as
+   *  `clientPromise` — the whole record is set on a fresh `connected` (a respawned padi
+   *  is a new process, so its identity is fresh) and cleared on a degraded/dead close —
+   *  so the three readouts report the LIVE padi or an honest "unknown" together, never a
+   *  stale mix from the old process. See {@link BoundIdentity} for each field's cell. */
+  private boundIdentity: BoundIdentity | null = null;
   /** A reconnect timer is already scheduled — so overlapping degraded/dead events
    *  (a close, then the endpoint's own `dead` emit) don't STACK timers, each firing
    *  its own `adoptOrSpawnOrRefuse`. Cleared when the scheduled attempt fires. */
@@ -386,20 +397,20 @@ export class PadiBindingSession implements BoundPadi {
     // currentClient()), then project + fire ONCE for every transition.
     match(s.state)
       .with("connected", () => {
-        // padi's honest boot time rides the connected status (`hello.startedAt` →
-        // endpoint `startedAt`). Read it off the STATUS, not `endpoint.current()`, so
-        // a respawned padi's FRESH boot time lands (never the old process's).
-        this.padiStartedAtMs = s.startedAt ?? null;
+        // padi's honest identity as ONE record. Boot time rides the connected STATUS
+        // (`hello.startedAt` → endpoint `startedAt`), read off the status not
+        // `endpoint.current()` so a respawned padi's FRESH boot time lands (never the
+        // old process's); the surface version + build commit ride the held connection's
+        // handshake identity (the version the LIVE padi serves, so the Padi dialog/rail
+        // read it rather than the binder's build constant; commit "" → null, the honest
+        // "unknown", so off-nix reads "—" not a blank link).
         const conn = this.deps.endpoint.current();
+        this.boundIdentity = {
+          startedAtMs: s.startedAt ?? null,
+          surfaceVersion: conn?.identity?.surfaceVersion ?? null,
+          buildCommit: conn?.identity?.commit || null,
+        };
         if (conn) {
-          // The bound padi's honest surface version off the handshake `hello`
-          // (`connectPadi` → `identity.surfaceVersion`) — the version the LIVE padi
-          // actually serves, so the Padi dialog/rail read it rather than the binder's
-          // build constant.
-          this.padiSurfaceVersionStr = conn.identity?.surfaceVersion ?? null;
-          // The RUNNING padi's build commit off the same hello identity (empty "" →
-          // null, the honest "unknown", so off-nix reads "—" not a blank link).
-          this.padiBuildCommitStr = conn.identity?.commit || null;
           // Scope the COMBINED dialed client down to the padi sibling so the relay's
           // `client.surface.<member>` resolves at /surface/padi/<member>. The binder
           // keeps `conn.client` (combined) for supervision (`control.core.drain`) and
@@ -410,13 +421,11 @@ export class PadiBindingSession implements BoundPadi {
       })
       .with(P.union("degraded", "dead"), () => {
         // The live link dropped. Clear the client so a forward in the gap fails
-        // honestly, clear padi's boot time so its uptime reads the honest "unknown"
-        // (never a stale age), then schedule ONE reconnect (padi survives its own
-        // unit; the re-adopt re-attaches the surviving kaval + PTYs).
+        // honestly, clear padi's identity so its uptime/version/commit read the honest
+        // "unknown" together (never a stale mix), then schedule ONE reconnect (padi
+        // survives its own unit; the re-adopt re-attaches the surviving kaval + PTYs).
         this.clientPromise = null;
-        this.padiStartedAtMs = null;
-        this.padiSurfaceVersionStr = null;
-        this.padiBuildCommitStr = null;
+        this.boundIdentity = null;
         this.scheduleReconnect();
       })
       // connecting | restarting: transient warming — no client-handle change; the
@@ -464,7 +473,7 @@ export class PadiBindingSession implements BoundPadi {
    *  session is destroyed). kolu-server publishes `now`-relative uptime from this onto
    *  koluSurface's `processStartedAt` cell; `null` renders as the honest "unknown". */
   padiStartedAt(): number | null {
-    return this.destroyed ? null : this.padiStartedAtMs;
+    return this.destroyed ? null : (this.boundIdentity?.startedAtMs ?? null);
   }
 
   /** The bound padi's `padiSurface` version off its control-core `hello`, or `null`
@@ -472,7 +481,7 @@ export class PadiBindingSession implements BoundPadi {
    *  `daemonInventory` cell carries it as the active padi's `surfaceVersion`; `null`
    *  renders as the honest "—". */
   padiSurfaceVersion(): string | null {
-    return this.destroyed ? null : this.padiSurfaceVersionStr;
+    return this.destroyed ? null : (this.boundIdentity?.surfaceVersion ?? null);
   }
 
   /** The bound padi's navigable git commit off its control-core `hello`, or `null`
@@ -480,7 +489,7 @@ export class PadiBindingSession implements BoundPadi {
    *  destroyed). koluSurface's `daemonInventory` cell carries it as the active padi's
    *  `buildCommit`; `null` renders as the honest "—". */
   padiBuildCommit(): string | null {
-    return this.destroyed ? null : this.padiBuildCommitStr;
+    return this.destroyed ? null : (this.boundIdentity?.buildCommit ?? null);
   }
 
   /** The LOCAL arm surfaces no convergence anomaly today: the shared kit collapses a
@@ -511,9 +520,7 @@ export class PadiBindingSession implements BoundPadi {
   destroy(): void {
     this.destroyed = true;
     this.clientPromise = null;
-    this.padiStartedAtMs = null;
-    this.padiSurfaceVersionStr = null;
-    this.padiBuildCommitStr = null;
+    this.boundIdentity = null;
     this.deps.endpoint.current()?.dispose();
     // Re-publish to wake any cursor blocked on the next client so the pump exits.
     this.fire();

--- a/packages/server/src/padiBinding.ts
+++ b/packages/server/src/padiBinding.ts
@@ -14,39 +14,24 @@
  *
  * The DIAL itself (`connectPadi` / `dialPadiHello` — dial + control-core
  * handshake + typed skew refusal) is imported from `@kolu/padi/dial`: W2.3 carved
- * it into padi's package as the client-side dial kit `padi-tui` shares. What stays
- * here is SUPERVISION over that dial — the parts that mutate padi's lifecycle:
- *   1. the convergence POLICY + probe adapter — padi's declaration into the shared kit.
- *   2. `localPadiDriver`      — the twin of `localKavalDriver`: how to launch padi.
- *   3. `PadiBindingSession`   — Endpoint → reconnect-mirror `HostSession` (the crux).
- *   4. `ensurePadiBinding`    — the twin of `ensureLocalEndpoint`: boot the binding.
+ * it into padi's package as the client-side dial kit `padi-tui` shares. And padi's
+ * CONVERGENCE declaration into the shared daemon-convergence kit (the contract-skew
+ * {@link PADI_CONVERGENCE_POLICY}, the FROZEN-control-core {@link probePadiForConvergence}
+ * probe, and the drain plumbing) lives in `./padiConvergence.ts`: W4 ledger L6 carved it
+ * out because it varies with daemon-lifecycle skew policy, a different volatility than the
+ * binder. What stays HERE is the binder proper — the parts that spawn/supervise/re-serve:
+ *   1. `localPadiDriver`      — the twin of `localKavalDriver`: how to launch padi.
+ *   2. `PadiBindingSession`   — Endpoint → reconnect-mirror `HostSession` (the crux).
+ *   3. `ensurePadiBinding`    — the twin of `ensureLocalEndpoint`: boot the binding.
  *
- * padi is NEVER kill-9'd. The boot/reconnect convergence now DELEGATES to the shared
- * daemon-convergence kit (`@kolu/surface-daemon-supervisor`'s `converge`): padi declares
- * its {@link PADI_CONVERGENCE_POLICY} and supplies a probe adapter
- * ({@link probePadiForConvergence}) that reads the running padi's identity over the FROZEN
- * control core, and the kit owns the mechanism, the two-axis ordering, and the build fence.
- * The behaviour is UNCHANGED — just relocated. It still converges on TWO independent axes:
- *   - CONTRACT (`padiSurface` version): a skew where THIS binder is NEWER →
- *     DRAIN it over the frozen control core (persist + exit; its kaval + PTYs
- *     survive), so the spawn path brings up this binder's OWN newer closure —
- *     the padi gate pid changes, the surviving kaval is re-adopted, the session
- *     is intact; a skew where the binder is OLDER / major-behind → the kit's
- *     loud REFUSE, UNCHANGED (leave padi standing + degraded, never touch it).
- *     Older NEVER drains — the monotonicity that stops two mixed-version binders
- *     from livelocking (only the strictly-newer one acts). Declared as
- *     `onContractSkew: drain-newer-else-refuse`.
- *   - BUILD (same contract, different closure; #1670): when the handshake would
- *     otherwise ADOPT, a survivor whose baked `PADI_BUILD_ID` differs from this
- *     binder's expected one (or is ABSENT — a pre-field survivor, an older build)
- *     is DRAINED ONCE at boot so the spawn brings up this binder's build. Store
- *     hashes don't order, so the anti-livelock guarantee here is a once-per-binder-
- *     boot fence (the kit's `createBuildDrainFence`) rather than a version comparison —
- *     a reconnect never re-drains, so sequential deploys converge to last-deployed.
- *     Declared as `onBuildMismatch: drain-and-replace`.
- * And the "restart" verb DRAINS the running padi (persist + exit; the PTYs
- * survive in kaval) via the frozen control core, then the reconnect loop
- * re-spawns it.
+ * padi is NEVER kill-9'd. The boot/reconnect convergence DELEGATES to the shared
+ * daemon-convergence kit (`@kolu/surface-daemon-supervisor`'s `converge`): {@link
+ * ensurePadiBinding} feeds it padi's declared policy + probe (from `./padiConvergence.ts`),
+ * and the kit owns the mechanism, the two-axis ordering (contract drain-newer/refuse-older;
+ * build-mismatch drain-once, #1670), and the build fence — see that file's header for the
+ * full two-axis behaviour. And the "restart" verb DRAINS the running padi (persist + exit;
+ * the PTYs survive in kaval) via the frozen control core (`drainViaControlCore`, same
+ * plumbing), then the reconnect loop re-spawns it.
  */
 
 import { createRequire } from "node:module";
@@ -60,15 +45,13 @@ import {
 } from "@kolu/padi/assembly";
 // The client-side dial kit — carved out of THIS module in W2.3 so `padi-tui` and
 // the binder share it (`@kolu/padi/dial`). What stays here is SUPERVISION: the
-// drivers, padi's convergence policy + probe adapter (the shared kit owns the
-// mechanism), the reconnect-mirror session, and the re-serve — everything that
-// mutates padi's lifecycle, never a mere dial.
+// drivers, the reconnect-mirror session, and the re-serve — everything that mutates
+// padi's lifecycle, never a mere dial. (padi's convergence policy + probe + drain
+// carved out to `./padiConvergence.ts` in L6.)
 import {
   connectPadi,
-  dialPadiHello,
   type PadiConnectionMetadata,
   type PadiDaemonClient,
-  type PadiDial,
   type PadiIdentity,
   type PadiSurfaceClient,
   scopePadiSurface,
@@ -76,8 +59,6 @@ import {
 import { PADI_SURFACE_VERSION, type padiSurface } from "@kolu/padi/surface";
 import type { PadiConvergence } from "kolu-common/surface";
 import {
-  type ConvergencePolicy,
-  type ConvergenceProbe,
   converge,
   createBuildDrainFence,
   createEndpoint,
@@ -94,14 +75,15 @@ import type {
 } from "@kolu/surface-nix-host";
 import { match, P } from "ts-pattern";
 import { log } from "./log.ts";
-
-/** How long `drainBoundPadi` waits for the socket to CLOSE after the drain RPC
- *  rejects, before treating the rejection as a real failure. A drain that reached
- *  padi persists + exits near-instantly, so the close follows within a beat; this
- *  ceiling only bounds the wait for a rejection that is NOT the expected teardown
- *  (a stale link, or an `onDrain` that threw before persisting) so the "restart"
- *  verb reports failure instead of hanging. */
-const DRAIN_TEARDOWN_CEILING_MS = 2000;
+// padi's convergence declaration into the shared daemon-convergence kit — the
+// contract-skew POLICY, the FROZEN-control-core probe, and the drain plumbing the
+// probe and the "restart" verb share. Carved out of this file in W4 ledger L6: it
+// varies with daemon-lifecycle skew policy, a different volatility than the binder.
+import {
+  drainViaControlCore,
+  PADI_CONVERGENCE_POLICY,
+  probePadiForConvergence,
+} from "./padiConvergence.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 //
@@ -119,135 +101,7 @@ type PadiEndpoint = Endpoint<
 type PadiEndpointStatus = EndpointStatus<PadiIdentity, PadiConnectionMetadata>;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 1. The convergence POLICY + probe adapter — padi's declaration into the shared
-//    daemon-convergence kit (`@kolu/surface-daemon-supervisor`'s `converge`). The kit
-//    owns the mechanism, the two-axis ordering, and the build fence; padi declares its
-//    policy and adapts its FROZEN control-core hello into the kit's identity probe. The
-//    two-axis behaviour (contract drain-newer/refuse-older; build-mismatch drain-once,
-//    #1670) is UNCHANGED — just relocated out of a hand-rolled arm into the kit.
-// ─────────────────────────────────────────────────────────────────────────────
-
-// padi declares its policy into the shared kit; the kit owns the mechanism + ordering +
-// fence. padi is drain-capable (its control core has a `drain` verb), so it can spell the
-// drain arms: a contract skew drains-if-newer / refuses-if-older, and a build mismatch
-// drains-and-replaces once per binder boot.
-export const PADI_CONVERGENCE_POLICY: ConvergencePolicy<"drainable"> = {
-  capability: "drainable",
-  onContractSkew: { kind: "drain-newer-else-refuse" },
-  onBuildMismatch: { kind: "drain-and-replace" },
-};
-
-/** The minimal connection shape the drain plumbing needs: the COMBINED dialed
- *  client (to reach `surface.control.core.drain`) and an `onClose` (the socket
- *  close that is the drain's ground truth). Both a held endpoint connection
- *  (`endpoint.current()`) and a fresh convergence probe (`probePadiForConvergence`)
- *  satisfy it. */
-type DrainableConn = {
-  client: PadiDaemonClient;
-  onClose: (cb: () => void) => void;
-};
-
-/**
- * DRAIN a padi over the FROZEN control core, then confirm it actually exited by
- * the SOCKET CLOSING within the teardown window. The one drain mechanism, shared
- * by BOTH the user-facing "restart" (`PadiBindingSession.drainBoundPadi`) and the
- * shared kit's convergence drain (through {@link probePadiForConvergence}'s `drain`)
- * — never re-rolled.
- *
- * GROUND TRUTH is the SOCKET CLOSE (padi actually exited), NOT the drain call's
- * resolve/reject. padi's `onDrain` persists, REPLIES, then triggers the exit that
- * closes the socket — so `drain()` can RESOLVE with padi still momentarily alive
- * (a reply beats the exit), or REJECT (the reply lost as the socket died mid-write),
- * and neither is the completion signal. Waiting only for the resolve would let the
- * convergence pre-flight race `adoptOrSpawnOrRefuse` in and RE-ADOPT the still-live,
- * about-to-exit padi (its gate pid unchanged) — the bug the newer-drain arm exists
- * to avoid. So we ALWAYS wait for the socket to close (the same signal the endpoint
- * reads to flip to `degraded`), and FAIL-FAST if it does not close within the
- * teardown window (a wedged `onDrain`, or a stale link the drain never reached) —
- * so no caller reports success on a drain that did not happen, and the pre-flight
- * never spawns over a padi that did not exit.
- */
-async function drainViaControlCore(conn: DrainableConn): Promise<void> {
-  // Arm the close wait BEFORE the drain, so a fast exit that closes the socket
-  // before `drain()` even settles is never missed.
-  let onClosed!: () => void;
-  const closed = new Promise<void>((resolve) => {
-    onClosed = resolve;
-  });
-  conn.onClose(onClosed);
-
-  // Kick the drain. `.catch` keeps a mid-write rejection from going unhandled and
-  // remembers it only to enrich a timeout failure — the call's outcome does not
-  // decide completion (the socket close does).
-  let drainErr: unknown;
-  void conn.client.surface.control.core.drain().catch((e) => {
-    drainErr = e;
-  });
-
-  let timer!: ReturnType<typeof setTimeout>;
-  const timedOut = new Promise<"timeout">((resolve) => {
-    timer = setTimeout(() => resolve("timeout"), DRAIN_TEARDOWN_CEILING_MS);
-  });
-  try {
-    const outcome = await Promise.race([
-      closed.then(() => "closed" as const),
-      timedOut,
-    ]);
-    if (outcome === "timeout") {
-      throw new Error(
-        `padi drain did not complete — its socket did not close within ${DRAIN_TEARDOWN_CEILING_MS}ms (padi did not exit)` +
-          (drainErr ? `; drain call rejected: ${String(drainErr)}` : ""),
-      );
-    }
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-/**
- * The kit's identity probe for padi: dial the running padi's FROZEN control core and
- * expose its identity + a `drain`, or `null` if none answers (a fresh boot, or padi
- * mid-teardown) — in which case the kit's `converge` simply spawns fresh. This is the
- * intended first use of the frozen control core: "a binder dials the socket, reads
- * control.hello FIRST" (controlCore.ts), then the kit decides. padi is drain-capable, so
- * this returns a `ConvergenceProbe<"drainable">`.
- */
-export async function probePadiForConvergence(
-  socketPath: string,
-): Promise<ConvergenceProbe<"drainable"> | null> {
-  let dialed: PadiDial;
-  try {
-    dialed = await dialPadiHello(socketPath);
-  } catch {
-    return null; // no live padi answering — spawn will handle it.
-  }
-  const { socket, client, hello } = dialed;
-  let closed = false;
-  socket.once("close", () => {
-    closed = true;
-  });
-  return {
-    capability: "drainable",
-    // Identity read over the FROZEN control-core hello (reachable at any skew, Pin 3):
-    // the padiSurface contract version + padi's staleKey (absent → "" = honest unknown).
-    identity: {
-      contractVersion: hello.surfaceVersion,
-      buildId: hello.buildId ?? "",
-    },
-    drain: () =>
-      drainViaControlCore({
-        client,
-        onClose: (cb) => {
-          if (closed) queueMicrotask(cb);
-          else socket.once("close", cb);
-        },
-      }),
-    dispose: () => socket.destroy(),
-  };
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// 2. localPadiDriver — the twin of localKavalDriver (…/ptyHost/localDriver.ts)
+// 1. localPadiDriver — the twin of localKavalDriver (…/ptyHost/localDriver.ts)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -397,7 +251,7 @@ export function localPadiDriver(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 3. PadiBindingSession — Endpoint → reconnect-mirror `HostSession` adapter.
+// 2. PadiBindingSession — Endpoint → reconnect-mirror `HostSession` adapter.
 //    ⚠️ NO kaval analog. THIS is the crux the cutover adds. `reServeSurface`'s
 //    pump loops on the `currentClient()` promise identity + `onState`; the
 //    supervisor Endpoint holds ONE connection and flips to `degraded` on close
@@ -701,7 +555,7 @@ export class PadiBindingSession implements BoundPadi {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 4. ensurePadiBinding — the twin of ensureLocalEndpoint (…/ptyHost/index.ts)
+// 3. ensurePadiBinding — the twin of ensureLocalEndpoint (…/ptyHost/index.ts)
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface EnsurePadiBindingOptions {

--- a/packages/server/src/padiConvergence.ts
+++ b/packages/server/src/padiConvergence.ts
@@ -1,0 +1,159 @@
+/**
+ * padi's CONVERGENCE declaration into the shared daemon-convergence kit
+ * (`@kolu/surface-daemon-supervisor`'s `converge`), plus the drain plumbing the
+ * declaration and the "restart" verb both reach for.
+ *
+ * This is the fourth concern carved out of {@link ./padiBinding.ts} (W4 ledger L6):
+ * the binder proper is the driver + the reconnect-mirror session + `ensurePadiBinding`;
+ * THIS file is padi's contract-skew POLICY and the FROZEN-control-core probe/drain that
+ * enact it. It varies with a DIFFERENT volatility than the binder — the daemon-lifecycle
+ * skew policy — and was already deps-injected (the kit owns the mechanism, the two-axis
+ * ordering, and the build fence; padi only declares its policy + adapts its hello into the
+ * kit's identity probe), so it separates cleanly.
+ *
+ * The two-axis behaviour (contract drain-newer/refuse-older; build-mismatch drain-once,
+ * #1670) lives in the kit — UNCHANGED. What this file owns:
+ *   - {@link PADI_CONVERGENCE_POLICY} — padi's declared policy (drainable; drain-newer-
+ *     else-refuse on contract skew; drain-and-replace on build mismatch).
+ *   - {@link probePadiForConvergence} — the kit's identity probe for padi: dial the FROZEN
+ *     control core, read identity, expose a `drain`.
+ *   - {@link drainViaControlCore} — the ONE drain mechanism, shared by BOTH the probe's
+ *     `drain` and the user-facing "restart" (`PadiBindingSession.drainBoundPadi`).
+ */
+
+import {
+  dialPadiHello,
+  type PadiDaemonClient,
+  type PadiDial,
+} from "@kolu/padi/dial";
+import type {
+  ConvergencePolicy,
+  ConvergenceProbe,
+} from "@kolu/surface-daemon-supervisor";
+
+/** How long `drainViaControlCore` waits for the socket to CLOSE after the drain RPC
+ *  rejects, before treating the rejection as a real failure. A drain that reached
+ *  padi persists + exits near-instantly, so the close follows within a beat; this
+ *  ceiling only bounds the wait for a rejection that is NOT the expected teardown
+ *  (a stale link, or an `onDrain` that threw before persisting) so the "restart"
+ *  verb reports failure instead of hanging. */
+const DRAIN_TEARDOWN_CEILING_MS = 2000;
+
+// padi declares its policy into the shared kit; the kit owns the mechanism + ordering +
+// fence. padi is drain-capable (its control core has a `drain` verb), so it can spell the
+// drain arms: a contract skew drains-if-newer / refuses-if-older, and a build mismatch
+// drains-and-replaces once per binder boot.
+export const PADI_CONVERGENCE_POLICY: ConvergencePolicy<"drainable"> = {
+  capability: "drainable",
+  onContractSkew: { kind: "drain-newer-else-refuse" },
+  onBuildMismatch: { kind: "drain-and-replace" },
+};
+
+/** The minimal connection shape the drain plumbing needs: the COMBINED dialed
+ *  client (to reach `surface.control.core.drain`) and an `onClose` (the socket
+ *  close that is the drain's ground truth). Both a held endpoint connection
+ *  (`endpoint.current()`) and a fresh convergence probe (`probePadiForConvergence`)
+ *  satisfy it. */
+export type DrainableConn = {
+  client: PadiDaemonClient;
+  onClose: (cb: () => void) => void;
+};
+
+/**
+ * DRAIN a padi over the FROZEN control core, then confirm it actually exited by
+ * the SOCKET CLOSING within the teardown window. The one drain mechanism, shared
+ * by BOTH the user-facing "restart" (`PadiBindingSession.drainBoundPadi`) and the
+ * shared kit's convergence drain (through {@link probePadiForConvergence}'s `drain`)
+ * — never re-rolled.
+ *
+ * GROUND TRUTH is the SOCKET CLOSE (padi actually exited), NOT the drain call's
+ * resolve/reject. padi's `onDrain` persists, REPLIES, then triggers the exit that
+ * closes the socket — so `drain()` can RESOLVE with padi still momentarily alive
+ * (a reply beats the exit), or REJECT (the reply lost as the socket died mid-write),
+ * and neither is the completion signal. Waiting only for the resolve would let the
+ * convergence pre-flight race `adoptOrSpawnOrRefuse` in and RE-ADOPT the still-live,
+ * about-to-exit padi (its gate pid unchanged) — the bug the newer-drain arm exists
+ * to avoid. So we ALWAYS wait for the socket to close (the same signal the endpoint
+ * reads to flip to `degraded`), and FAIL-FAST if it does not close within the
+ * teardown window (a wedged `onDrain`, or a stale link the drain never reached) —
+ * so no caller reports success on a drain that did not happen, and the pre-flight
+ * never spawns over a padi that did not exit.
+ */
+export async function drainViaControlCore(conn: DrainableConn): Promise<void> {
+  // Arm the close wait BEFORE the drain, so a fast exit that closes the socket
+  // before `drain()` even settles is never missed.
+  let onClosed!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    onClosed = resolve;
+  });
+  conn.onClose(onClosed);
+
+  // Kick the drain. `.catch` keeps a mid-write rejection from going unhandled and
+  // remembers it only to enrich a timeout failure — the call's outcome does not
+  // decide completion (the socket close does).
+  let drainErr: unknown;
+  void conn.client.surface.control.core.drain().catch((e) => {
+    drainErr = e;
+  });
+
+  let timer!: ReturnType<typeof setTimeout>;
+  const timedOut = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), DRAIN_TEARDOWN_CEILING_MS);
+  });
+  try {
+    const outcome = await Promise.race([
+      closed.then(() => "closed" as const),
+      timedOut,
+    ]);
+    if (outcome === "timeout") {
+      throw new Error(
+        `padi drain did not complete — its socket did not close within ${DRAIN_TEARDOWN_CEILING_MS}ms (padi did not exit)` +
+          (drainErr ? `; drain call rejected: ${String(drainErr)}` : ""),
+      );
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * The kit's identity probe for padi: dial the running padi's FROZEN control core and
+ * expose its identity + a `drain`, or `null` if none answers (a fresh boot, or padi
+ * mid-teardown) — in which case the kit's `converge` simply spawns fresh. This is the
+ * intended first use of the frozen control core: "a binder dials the socket, reads
+ * control.hello FIRST" (controlCore.ts), then the kit decides. padi is drain-capable, so
+ * this returns a `ConvergenceProbe<"drainable">`.
+ */
+export async function probePadiForConvergence(
+  socketPath: string,
+): Promise<ConvergenceProbe<"drainable"> | null> {
+  let dialed: PadiDial;
+  try {
+    dialed = await dialPadiHello(socketPath);
+  } catch {
+    return null; // no live padi answering — spawn will handle it.
+  }
+  const { socket, client, hello } = dialed;
+  let closed = false;
+  socket.once("close", () => {
+    closed = true;
+  });
+  return {
+    capability: "drainable",
+    // Identity read over the FROZEN control-core hello (reachable at any skew, Pin 3):
+    // the padiSurface contract version + padi's staleKey (absent → "" = honest unknown).
+    identity: {
+      contractVersion: hello.surfaceVersion,
+      buildId: hello.buildId ?? "",
+    },
+    drain: () =>
+      drainViaControlCore({
+        client,
+        onClose: (cb) => {
+          if (closed) queueMicrotask(cb);
+          else socket.once("close", cb);
+        },
+      }),
+    dispose: () => socket.destroy(),
+  };
+}

--- a/packages/server/src/seal.test.ts
+++ b/packages/server/src/seal.test.ts
@@ -54,6 +54,12 @@ const WEB_SHELL_FILES = [
   // Web-shell code (it runs no terminal domain — it re-serves padi's), so it lives
   // beside the shell, not in @kolu/padi.
   "padiBinding",
+  // padi's CONVERGENCE declaration into the shared daemon-convergence kit (the
+  // contract-skew policy, the frozen-control-core probe, the drain plumbing) —
+  // carved out of `padiBinding` in W4 ledger L6 as its own volatility. Web-shell
+  // code (it declares padi's policy + adapts its hello; the kit owns the mechanism),
+  // so it lives beside the binder, not in @kolu/padi.
+  "padiConvergence",
   // The W3.1 REMOTE padi binder — the ssh twin of `padiBinding`: it fronts a padi on
   // another host over `getHostSession`/`padi --stdio` and re-serves its surface through
   // the SAME `reServeSurface` seam. Web-shell code (it runs no terminal domain — it


### PR DESCRIPTION
## What & why

W4 ledger **L6** — the audit-and-split of `packages/server/src/padiBinding.ts`, groundwork for W3.2's switch PR (which will *pool* `BoundPadi` sessions and so wants a clean, single-policy binding layer to pool, not today's braids). A kolu-internal, **behavior-preserving** refactor.

The audit re-confirmed the entry's two pre-found structural defects survive the L3 (#1674) dial/convergence carve, and fixes both. It also renders a verdict on the entry's open question (c).

## The audit verdict

**(a) — SPLIT.** The convergence pre-flight is a fourth concern in this file, varying with a *different* volatility than the binder proper: daemon-lifecycle contract-skew policy, not spawn/supervise/re-serve. The entry imagined ~300 lines of hand-rolled `parseMajorMinor`/`probePadiSkew`/`drainSkewedSurvivorIfNewer`/`bindPadiOnce` — **those are gone**: L3 moved the mechanism/ordering/fence into `@kolu/surface-daemon-supervisor`. What survives here is padi's thin *declaration* into that kit — the policy, the frozen-control-core probe, and the drain plumbing the probe and the "restart" verb share. Carved into a new `padiConvergence.ts` (pure motion, no logic change).

**(b) — COLLAPSE.** `PadiBindingSession` shattered the bound padi's identity across three parallel nullable fields (`padiStartedAtMs` / `padiSurfaceVersionStr` / `padiBuildCommitStr`), set and cleared together in four places — a partial identity (an uptime with no version) was representable but never legal. Collapsed into one `boundIdentity: BoundIdentity | null`: present ⇔ bound, null ⇔ unbound. The mix is now unrepresentable. Behavior-preserving (boot time still rides the connected status; version/commit still ride the held connection's identity).

**(c) — VERDICT: binder-specific, NOT relocated.** The reconnect/re-dial loop stays in the binding adapter (see the check-in note posted to the coordinator for the full reasoning). In brief: it bridges the supervisor's *single-shot* `Endpoint` onto the reconnect-mirror `HostSession` contract that `reServeSurface` (surface-nix-host) dictates. Its shape is set by the re-serve pump, its transport by the local Endpoint, and its *policy* already delegates to the shared kit (`converge`). The two arms (local Endpoint, remote ssh HostSession) share policy, not reconnect mechanism — the mechanism is irreducibly transport-specific. Relocating it to `surface-daemon-supervisor` would drag the browser-facing `HostSessionState` projection into the daemon-lifecycle package (wrong volatility — location is structure) and burden kaval's Endpoint consumer with a mirror concern it doesn't have. So it stays. **No drishti gate triggered.**

## Design philosophy

- **Fail-fast / no-fallbacks** — no new knobs, no degradation paths. The drain plumbing still fail-fasts on a socket that doesn't close (unchanged).
- **Electricity boundaries** — the split *reinforces* the boundary already drawn by L3: the daemon-lifecycle mechanism lives in `@kolu/surface-daemon-supervisor`; `padiConvergence.ts` is padi's leaf *declaration* into it, not a parallel receptacle. `padiBinding.ts` is now the binder proper (driver · session · ensure).
- **Reuse the source of truth** — no duplicated mechanism; the one drain primitive (`drainViaControlCore`) is shared by the probe and the "restart" verb, as before.

## Scope guard

The remote arm (`remotePadiBinding.ts`, `RemotePadiSession`) is **untouched** — it imports only `type BoundPadi` (which stays put) and references the moved symbols only in prose. Unifying the remote arm's hand-rolled policy table onto the kit is **L23 (PR 2)**, which rebases on this split.

## Tests

`padiBinding.test.ts` repointed for the two moved symbols; no test semantics changed. Full binder suite + seal validated on a pu box (evidence below once the run lands). `just check` green.
