### PR TITLE
refactor(padi): make the daemon lifecycle invariants explicit (L15+L16)

### DIFF
--- a/packages/padi/src/assembly.ts
+++ b/packages/padi/src/assembly.ts
@@ -91,9 +91,14 @@ export { buildPadiSurfaceDeps } from "./servePadi.ts";
 // ── session persistence ─────────────────────────────────────────────────
 export {
   cancelPendingAutosave,
+  freezeAutosave,
+  initAutosaveGate,
+  notifyDirty,
+  unfreezeAutosave,
+} from "./autosaveGate.ts";
+export {
   clearSavedSession,
   getSavedSession,
-  initSessionAutoSave,
   saveSession,
   setSavedSession,
   setSavedSessionFromSnapshot,

--- a/packages/padi/src/assembly.ts
+++ b/packages/padi/src/assembly.ts
@@ -68,6 +68,7 @@ export {
 } from "./stateRoot.ts";
 // ── publisher / surface ctx holder ──────────────────────────────────────
 export {
+  notifyDirty,
   publisher,
   publisherSize,
   terminalsDirtyChannel,
@@ -93,7 +94,6 @@ export {
   cancelPendingAutosave,
   freezeAutosave,
   initAutosaveGate,
-  notifyDirty,
   unfreezeAutosave,
 } from "./autosaveGate.ts";
 export {

--- a/packages/padi/src/assembly.ts
+++ b/packages/padi/src/assembly.ts
@@ -14,14 +14,31 @@
  * INJECTED via `setDaemonProcessId` / `setSpawnServerVersion`, not imported.
  */
 
-// The persisted survivor pairing's type. The pairing is READ + RECORDED entirely
-// inside padi's boot reconcile (its conf store is set by padi's own `daemonMain`).
-export type { PairedDaemon } from "./pairedDaemon.ts";
+// ── session persistence ─────────────────────────────────────────────────
+export {
+  cancelPendingAutosave,
+  freezeAutosave,
+  initAutosaveGate,
+  unfreezeAutosave,
+} from "./autosaveGate.ts";
 // padi's staleKey read — the binder's build-convergence key (#1670). Re-exported
 // through this barrel (not a deep `@kolu/padi/buildId` import) so the binder honors
 // the package-boundary seal: on boot it compares its own baked `PADI_BUILD_ID`
 // against the running padi's `hello.buildId` and drains a same-contract build change.
 export { currentPadiBuildId } from "./buildId.ts";
+// ── host-daemon inventory scanner (the "Running daemons" leak diagnostic) ─
+// The ONE scanner both padi (its `hostInventory` member) and kolu-server's web shell
+// (its local-machine `daemonInventory.localScan` under a remote binding) reuse. Padi
+// owns the daemon domain, so the scan homes here; kolu-server imports it through this
+// barrel for its local arm (the package-boundary seal's allowed direction).
+export {
+  assembleKavalInventory,
+  assemblePadiInventory,
+  enumerateHostDaemons,
+  type HostDaemonScanDeps,
+  type KavalProbe,
+  probeKavalStatus,
+} from "./hostInventory.ts";
 // ── scratch / roots ─────────────────────────────────────────────────────
 export {
   ensureKoluRoot,
@@ -33,6 +50,9 @@ export {
   padiSurfaceCtx,
   setPadiSurfaceCtx,
 } from "./padiSurfaceCtx.ts";
+// The persisted survivor pairing's type. The pairing is READ + RECORDED entirely
+// inside padi's boot reconcile (its conf store is set by padi's own `daemonMain`).
+export type { PairedDaemon } from "./pairedDaemon.ts";
 // The range-capable serve-dir read kolu-server's re-backed Hono preview route
 // calls — the STREAMING form (`previewFile`, bounded heap), the same read
 // `preview.read` serves through its base64 wire-wrapper (`readPreview`).
@@ -49,6 +69,22 @@ export {
   ptyHostClient,
   setSpawnServerVersion,
 } from "./ptyHost/index.ts";
+// ── publisher / surface ctx holder ──────────────────────────────────────
+export {
+  notifyDirty,
+  publisher,
+  publisherSize,
+  terminalsDirtyChannel,
+} from "./publisher.ts";
+// ── native serving (W1.R0) ──────────────────────────────────────────────
+export { buildPadiSurfaceDeps } from "./servePadi.ts";
+export {
+  clearSavedSession,
+  getSavedSession,
+  saveSession,
+  setSavedSession,
+  setSavedSessionFromSnapshot,
+} from "./session.ts";
 // ── padi process rendezvous (W2.2 binder) ───────────────────────────────
 // kolu-server's padi BINDER (`server/src/padiBinding.ts`) resolves the SAME
 // state-root → socket/gate paths padi computes for itself, so the supervisor and
@@ -56,8 +92,8 @@ export {
 // binder reaches the terminal domain only through @kolu/padi's published entry
 // points (the package-boundary seal), not a deep `@kolu/padi/stateRoot` import.
 export {
-  type PadiDaemon,
   discoverPadiDaemons,
+  type PadiDaemon,
   padiDigest,
   padiGatePath,
   padiKavalSocketPath,
@@ -66,43 +102,6 @@ export {
   padiStderrLogPath,
   resolvePadiStateRoot,
 } from "./stateRoot.ts";
-// ── publisher / surface ctx holder ──────────────────────────────────────
-export {
-  notifyDirty,
-  publisher,
-  publisherSize,
-  terminalsDirtyChannel,
-} from "./publisher.ts";
-
-// ── host-daemon inventory scanner (the "Running daemons" leak diagnostic) ─
-// The ONE scanner both padi (its `hostInventory` member) and kolu-server's web shell
-// (its local-machine `daemonInventory.localScan` under a remote binding) reuse. Padi
-// owns the daemon domain, so the scan homes here; kolu-server imports it through this
-// barrel for its local arm (the package-boundary seal's allowed direction).
-export {
-  type HostDaemonScanDeps,
-  type KavalProbe,
-  assembleKavalInventory,
-  assemblePadiInventory,
-  enumerateHostDaemons,
-  probeKavalStatus,
-} from "./hostInventory.ts";
-// ── native serving (W1.R0) ──────────────────────────────────────────────
-export { buildPadiSurfaceDeps } from "./servePadi.ts";
-// ── session persistence ─────────────────────────────────────────────────
-export {
-  cancelPendingAutosave,
-  freezeAutosave,
-  initAutosaveGate,
-  unfreezeAutosave,
-} from "./autosaveGate.ts";
-export {
-  clearSavedSession,
-  getSavedSession,
-  saveSession,
-  setSavedSession,
-  setSavedSessionFromSnapshot,
-} from "./session.ts";
 export type {
   ActiveTerminalProcess,
   TerminalProcess,

--- a/packages/padi/src/autosaveGate.ts
+++ b/packages/padi/src/autosaveGate.ts
@@ -12,7 +12,7 @@
  *   5. four "must NOT arm autosave here" call-site conventions in
  *      `terminalEndpoint/metadata.ts`.
  * They all collapse here. The invariant is now explicit state + named transitions,
- * so a writer that should not arm the gate simply does not call {@link notifyDirty},
+ * so a writer that should not arm the gate simply does not call `notifyDirty`,
  * and one that should does — there is no prose left to get wrong.
  *
  * Explicit state:
@@ -38,8 +38,9 @@
  * `isRestorePending`): it imports nothing from the session/registry layers it drives,
  * so those layers PUSH their facts and effects into it rather than the gate reaching
  * back out. It consumes the shared `terminals:dirty` pulse (also read by the activity
- * taps in `liveActivity.ts`); {@link notifyDirty} is the single writer-facing entry
- * that emits it.
+ * taps in `liveActivity.ts`); the single writer-facing entry that emits it,
+ * `notifyDirty`, lives beside the channel in `./publisher.ts` — the gate is a pure
+ * subscriber here.
  */
 
 import { log } from "./log.ts";
@@ -74,20 +75,6 @@ let saveTimer: ReturnType<typeof setTimeout> | undefined;
 /** The restart critical section's reason while **frozen**, else `undefined`. Pushed
  *  by {@link freezeAutosave} / {@link unfreezeAutosave}; orthogonal to the timer. */
 let frozenReason: string | undefined;
-
-/** Emit the shared `terminals:dirty` pulse — the SINGLE writer-facing arm every
- *  terminal/metadata writer calls when a restore-relevant change lands. Arms this
- *  gate (via its subscription) and reconciles the activity taps (`liveActivity.ts`),
- *  the pulse's other consumer. Guarded at the boundary: a throwing subscriber must
- *  not propagate back into the producer's emit loop (which would freeze a sensor);
- *  logged, not fatal — the next restore-relevant change re-arms. */
-export function notifyDirty(): void {
-  try {
-    terminalsDirtyChannel.publish({});
-  } catch (err) {
-    log.error({ err }, "terminals:dirty publish threw");
-  }
-}
 
 /** Cancel any pending (armed) autosave, returning the gate to **idle** without
  *  firing. Called by the gate's own fire callback (a no-op there — the timer already

--- a/packages/padi/src/autosaveGate.ts
+++ b/packages/padi/src/autosaveGate.ts
@@ -35,9 +35,10 @@
  *     would duplicate that truth and could stale the PATH-B guard.
  *
  * The gate is a pure state machine over injected effects (`snapshot`, `persist`,
- * `isRestorePending`): it imports nothing from the session/registry layers it drives,
- * so those layers PUSH their facts and effects into it rather than the gate reaching
- * back out. It consumes the shared `terminals:dirty` pulse (also read by the activity
+ * `isRestorePending`): it imports no runtime VALUE from the session/registry layers it
+ * drives (only the `SessionSnapshot` type, erased at compile), so those layers PUSH
+ * their facts and effects into it rather than the gate reaching back out. It consumes
+ * the shared `terminals:dirty` pulse (also read by the activity
  * taps in `liveActivity.ts`); the single writer-facing entry that emits it,
  * `notifyDirty`, lives beside the channel in `./publisher.ts` — the gate is a pure
  * subscriber here.

--- a/packages/padi/src/autosaveGate.ts
+++ b/packages/padi/src/autosaveGate.ts
@@ -75,9 +75,6 @@ let saveTimer: ReturnType<typeof setTimeout> | undefined;
  *  by {@link freezeAutosave} / {@link unfreezeAutosave}; orthogonal to the timer. */
 let frozenReason: string | undefined;
 
-/** The injected effects, set once by {@link initAutosaveGate}. */
-let deps: AutosaveGateDeps | undefined;
-
 /** Emit the shared `terminals:dirty` pulse — the SINGLE writer-facing arm every
  *  terminal/metadata writer calls when a restore-relevant change lands. Arms this
  *  gate (via its subscription) and reconciles the activity taps (`liveActivity.ts`),
@@ -125,11 +122,14 @@ export function unfreezeAutosave(): void {
 }
 
 /** Decide, at fire, whether to persist — freeze first (the drain→park window a plain
- *  parked query misses), then the live parked query, else persist. */
-function decideSave(): SaveDecision {
+ *  parked query misses), then the live parked query, else persist. Takes `deps` as a
+ *  parameter (the fire callback threads its own closure), so the restore-pending query
+ *  is a plain call — not an optional on a value that cannot be absent once the gate has
+ *  fired. */
+function decideSave(deps: AutosaveGateDeps): SaveDecision {
   if (frozenReason !== undefined)
     return { kind: "frozen", reason: frozenReason };
-  if (deps?.isRestorePending()) return { kind: "suppressed-parked" };
+  if (deps.isRestorePending()) return { kind: "suppressed-parked" };
   return { kind: "persist" };
 }
 
@@ -147,7 +147,6 @@ function decideSave(): SaveDecision {
  *  anyone makes it async, add an in-flight guard so a new schedule can't race an
  *  unfinished write. */
 export function initAutosaveGate(gateDeps: AutosaveGateDeps): void {
-  deps = gateDeps;
   void (async () => {
     try {
       for await (const _ of terminalsDirtyChannel.subscribe(undefined)) {
@@ -158,7 +157,7 @@ export function initAutosaveGate(gateDeps: AutosaveGateDeps): void {
           // ordering guard in `restartLocal.test.ts` observes the fire through this
           // call, so it must run even when the decision below skips the persist.
           const snap = gateDeps.snapshot();
-          const decision = decideSave();
+          const decision = decideSave(gateDeps);
           log.info(
             {
               decision: decision.kind,

--- a/packages/padi/src/autosaveGate.ts
+++ b/packages/padi/src/autosaveGate.ts
@@ -1,0 +1,177 @@
+/**
+ * The AutosaveGate — the ONE owner of "is it safe to persist the session now, and
+ * with what value?"
+ *
+ * Before this module that question was assembled from five scattered places, each
+ * holding a fragment of the invariant and each documented in prose:
+ *   1. a module-level debounce timer in `session.ts` (arm/fire),
+ *   2. a `restartInFlight` flag in `session.ts`, PUSHED by `ptyHost/restartLocal.ts`,
+ *   3. a live `hasParkedTerminals()` registry query read inside the fire callback,
+ *   4. the padi `session` cell's `onWrite` hook cancelling a pending save
+ *      (`servePadi.ts`), and
+ *   5. four "must NOT arm autosave here" call-site conventions in
+ *      `terminalEndpoint/metadata.ts`.
+ * They all collapse here. The invariant is now explicit state + named transitions,
+ * so a writer that should not arm the gate simply does not call {@link notifyDirty},
+ * and one that should does — there is no prose left to get wrong.
+ *
+ * Explicit state:
+ *   - **idle** — no save pending; the quiescent state.
+ *   - **armed** — a dirty pulse scheduled a save (leading-edge throttle). Arming is
+ *     idempotent within the 500 ms window: the first pulse schedules, the rest are
+ *     absorbed into the one upcoming snapshot.
+ *   - **frozen(reason)** — a restart's critical section (capture → drain → park) has
+ *     the gate pinned; the fire is blocked until {@link unfreezeAutosave}, regardless
+ *     of arming. A PUSHED fact — `restartLocal.ts` calls {@link freezeAutosave} /
+ *     {@link unfreezeAutosave} — because the restart is its own sole authority and
+ *     there is no other source of truth for "is a restart in flight". It is
+ *     orthogonal to the timer: the drain arms a save WHILE frozen (a `terminals:dirty`
+ *     the exiting PTYs fire), and the freeze is what keeps that fire from nulling the
+ *     just-captured session in the drain→park gap.
+ *   - **suppressed(parked)** — a restore is pending (parked entries stand in for the
+ *     on-disk blob). NOT stored here: it is read LIVE at fire via the injected
+ *     `isRestorePending` query, because the terminal-registry is its sole source of
+ *     truth AND the value can change between arm and fire — mirroring it in the gate
+ *     would duplicate that truth and could stale the PATH-B guard.
+ *
+ * The gate is a pure state machine over injected effects (`snapshot`, `persist`,
+ * `isRestorePending`): it imports nothing from the session/registry layers it drives,
+ * so those layers PUSH their facts and effects into it rather than the gate reaching
+ * back out. It consumes the shared `terminals:dirty` pulse (also read by the activity
+ * taps in `liveActivity.ts`); {@link notifyDirty} is the single writer-facing entry
+ * that emits it.
+ */
+
+import { log } from "./log.ts";
+import { terminalsDirtyChannel } from "./publisher.ts";
+import type { SessionSnapshot } from "./session.ts";
+
+/** The effects the gate drives, PUSHED in at boot so the gate imports nothing from
+ *  the session/registry layers it acts on. */
+interface AutosaveGateDeps {
+  /** The live terminal set to persist — computed fresh at each fire. */
+  snapshot: () => SessionSnapshot;
+  /** Is a restore still pending (parked entries present)? Read LIVE at fire — the
+   *  registry is its source of truth and the value can change between arm and fire. */
+  isRestorePending: () => boolean;
+  /** Persist a snapshot (clears the blob on an empty snapshot). */
+  persist: (snapshot: SessionSnapshot) => void;
+}
+
+/** The gate's answer at fire time — computed fresh each fire from the pushed freeze
+ *  flag and the live restore-pending query. Every arm is one of these three outcomes,
+ *  so "must not save here" is a typed branch, not a prose convention. */
+type SaveDecision =
+  | { kind: "persist" }
+  | { kind: "frozen"; reason: string }
+  | { kind: "suppressed-parked" };
+
+/** Pending autosave timer. `undefined` ⇒ **idle**; set ⇒ **armed**. Declared at
+ *  module top so {@link cancelPendingAutosave} (and thus `session.ts`'s direct
+ *  writers) can disarm it. */
+let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+/** The restart critical section's reason while **frozen**, else `undefined`. Pushed
+ *  by {@link freezeAutosave} / {@link unfreezeAutosave}; orthogonal to the timer. */
+let frozenReason: string | undefined;
+
+/** The injected effects, set once by {@link initAutosaveGate}. */
+let deps: AutosaveGateDeps | undefined;
+
+/** Emit the shared `terminals:dirty` pulse — the SINGLE writer-facing arm every
+ *  terminal/metadata writer calls when a restore-relevant change lands. Arms this
+ *  gate (via its subscription) and reconciles the activity taps (`liveActivity.ts`),
+ *  the pulse's other consumer. Guarded at the boundary: a throwing subscriber must
+ *  not propagate back into the producer's emit loop (which would freeze a sensor);
+ *  logged, not fatal — the next restore-relevant change re-arms. */
+export function notifyDirty(): void {
+  try {
+    terminalsDirtyChannel.publish({});
+  } catch (err) {
+    log.error({ err }, "terminals:dirty publish threw");
+  }
+}
+
+/** Cancel any pending (armed) autosave, returning the gate to **idle** without
+ *  firing. Called by the gate's own fire callback (a no-op there — the timer already
+ *  cleared itself), by the padi `session` cell's `onWrite` hook, and by the named
+ *  session writers (`setSavedSession*`) so a stale `terminals:dirty` armed before a
+ *  manual write cannot fire after it and clobber the value with an empty-snapshot
+ *  null (the e2e `test__set` race, #320 / cycle 6). */
+export function cancelPendingAutosave(): void {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = undefined;
+  }
+}
+
+/** Enter **frozen(reason)** for a restart's critical section — set at `capture`
+ *  (before the drain can arm anything), lifted after `park`. While frozen the fire
+ *  bails, so a `terminals:dirty` the drain fires (the PTYs exiting as the daemon is
+ *  killed) cannot arm a save that runs in the drain→park GAP — the window where the
+ *  registry is empty AND no parked entries exist yet, so the parked query is inert
+ *  and an unfrozen fire would null the just-captured session before park runs (the
+ *  zest restart-path clobber). Park then seeds the parked entries and the parked
+ *  query takes over. */
+export function freezeAutosave(reason: string): void {
+  frozenReason = reason;
+}
+
+/** Leave **frozen** — back to **idle** / **armed** per the timer. Safe on a restart's
+ *  success OR failure path; a failed restart pairs it with {@link cancelPendingAutosave}
+ *  so a drain-armed timer cannot clobber the captured session after the freeze lifts. */
+export function unfreezeAutosave(): void {
+  frozenReason = undefined;
+}
+
+/** Decide, at fire, whether to persist — freeze first (the drain→park window a plain
+ *  parked query misses), then the live parked query, else persist. */
+function decideSave(): SaveDecision {
+  if (frozenReason !== undefined)
+    return { kind: "frozen", reason: frozenReason };
+  if (deps?.isRestorePending()) return { kind: "suppressed-parked" };
+  return { kind: "persist" };
+}
+
+/** Wire the gate to the terminal-lifecycle pulse and the injected effects. Called
+ *  once at startup.
+ *
+ *  Leading-edge throttle: the first dirty pulse in a quiet period schedules a save
+ *  500 ms later; pulses during that window are absorbed into the same upcoming
+ *  snapshot (because `snapshot()` runs inside the callback, not at schedule time). A
+ *  trailing-edge debounce — the obvious alternative — starves under bursty inputs:
+ *  the Claude transcript watcher fires every 150 ms while an agent is streaming,
+ *  which would reset the timer indefinitely and the save would never fire.
+ *
+ *  Assumes `persist` is synchronous (it is — a sync `store.set` + sync publish). If
+ *  anyone makes it async, add an in-flight guard so a new schedule can't race an
+ *  unfinished write. */
+export function initAutosaveGate(gateDeps: AutosaveGateDeps): void {
+  deps = gateDeps;
+  void (async () => {
+    try {
+      for await (const _ of terminalsDirtyChannel.subscribe(undefined)) {
+        if (saveTimer) continue; // already armed — absorb into the pending snapshot
+        saveTimer = setTimeout(() => {
+          saveTimer = undefined; // armed → idle before the decision
+          // Take the candidate snapshot on EVERY fire, before the guards — the
+          // ordering guard in `restartLocal.test.ts` observes the fire through this
+          // call, so it must run even when the decision below skips the persist.
+          const snap = gateDeps.snapshot();
+          const decision = decideSave();
+          log.info(
+            {
+              decision: decision.kind,
+              reason: decision.kind === "frozen" ? decision.reason : undefined,
+              snapshot: snap.terminals.length,
+            },
+            `session-trace autosave: ${decision.kind} (snapshot=${snap.terminals.length})`,
+          );
+          if (decision.kind === "persist") gateDeps.persist(snap);
+        }, 500);
+      }
+    } catch (err) {
+      log.error({ err }, "session auto-save subscription failed");
+    }
+  })();
+}

--- a/packages/padi/src/daemonMain.ts
+++ b/packages/padi/src/daemonMain.ts
@@ -122,6 +122,7 @@ type HeldGate = Extract<GateAcquisition, { kind: "acquired" }>;
  *  for anything that reads a padi cell (serve, reconcile). Carries the gate forward so
  *  the whole pipeline is value-threaded to the spine at the end. */
 interface StoresReady {
+  readonly phase: "stores";
   readonly gate: HeldGate;
 }
 
@@ -129,6 +130,7 @@ interface StoresReady {
  *  koluRoot, the exit-wipe hook, the autosave gate) is configured — the precondition
  *  for spawning a terminal or serving. */
 interface IdentityReady {
+  readonly phase: "identity";
   readonly gate: HeldGate;
 }
 
@@ -137,6 +139,7 @@ interface IdentityReady {
  *  kaval endpoint, whose reconcile publishes onto that ctx. Carries the served
  *  router. */
 interface SurfacesServed {
+  readonly phase: "served";
   readonly gate: HeldGate;
   // biome-ignore lint/suspicious/noExplicitAny: a top-level oRPC served router — the same `Router<any, any>` the served fragment narrows to (see `serveDaemonSurfaces`).
   readonly router: Router<any, any>;
@@ -146,6 +149,7 @@ interface SurfacesServed {
  *  reconciled — the precondition for the samplers + manifests that read the held
  *  kaval's socket. */
 interface EndpointBooted {
+  readonly phase: "endpoint";
   readonly gate: HeldGate;
   // biome-ignore lint/suspicious/noExplicitAny: threads the served router (see `SurfacesServed`).
   readonly router: Router<any, any>;
@@ -168,7 +172,7 @@ function openStateStores(
   setPadiSessionStore(stores.session);
   setPadiActivityFeedStore(stores.activityFeed);
   setPadiLastPairedDaemonStore(stores.lastPairedDaemon);
-  return { gate };
+  return { phase: "stores", gate };
 }
 
 /** Configure padi's per-process identity + wire the autosave gate. Requires the stores
@@ -202,7 +206,7 @@ function configureDaemonIdentity(
     isRestorePending: hasParkedTerminals,
     persist: saveSession,
   });
-  return { gate: stores.gate };
+  return { phase: "identity", gate: stores.gate };
 }
 
 /** Serve padiSurface + the frozen control core on ONE socket and wire the late-bound
@@ -246,7 +250,7 @@ function serveDaemonSurfaces(
     surfaceFragment as any,
     // biome-ignore lint/suspicious/noExplicitAny: a top-level oRPC served router — the same `Router<any, any>` cast kaval's inProcessPtyHost narrows to (the contract-derived context doesn't line up, runtime shape is correct).
   ) as Router<any, any>;
-  return { gate: identity.gate, router: servedRouter };
+  return { phase: "served", gate: identity.gate, router: servedRouter };
 }
 
 /** Boot padi's OWN kaval (adopt-or-spawn under `kaval-<digest>/`), reconcile its live
@@ -267,7 +271,7 @@ async function bootLocalEndpoint(
     onNotAdopted: parkSavedSession,
     onBootSettled: startInventoryReconciler,
   });
-  return { gate: served.gate, router: served.router };
+  return { phase: "endpoint", gate: served.gate, router: served.router };
 }
 
 /** Run the padi daemon to completion: own its state-root, adopt-or-spawn its

--- a/packages/padi/src/daemonMain.ts
+++ b/packages/padi/src/daemonMain.ts
@@ -105,12 +105,16 @@ export interface PadiDaemonOptions {
 }
 
 // ── Typed boot pipeline ───────────────────────────────────────────────────────
-// Each phase takes the PRIOR phase's token, so a step invoked before its precondition
+// Each phase takes the PRIOR phase's token, so a PHASE invoked before its predecessor
 // is a COMPILE error, not a silent violation. The two ordering invariants once held by
 // prose — "claim the gate FIRST" (W2.2's B1 blocker) and "the stores are injected
 // before anything reads them" — are now the {@link HeldGate} / {@link StoresReady}
 // types threaded through the chain; the boot below reads as `gate → stores → identity
-// → serve → endpoint` with the dependency edges checked by the compiler.
+// → serve → endpoint`, its PHASE ordering checked by the compiler. The setter sequence
+// WITHIN a phase (e.g. the exit-wipe hook after `ensureKoluRoot` in
+// `configureDaemonIdentity`) is a short, co-located, documented convention — not a
+// compiler-checked edge; the win is that those setters are grouped into one phase
+// instead of scattered across the boot the way they used to be.
 
 /** Padi's HELD single-instance gate — the `acquired` arm of `acquirePidGate`,
  *  narrowed past the `held` / `dir-not-private` exits. Threaded into every boot phase
@@ -147,12 +151,11 @@ interface SurfacesServed {
 
 /** The local kaval endpoint has booted (adopt-or-spawn) and the saved session is
  *  reconciled — the precondition for the samplers + manifests that read the held
- *  kaval's socket. */
+ *  kaval's socket. The served router is NOT re-carried here — this phase neither
+ *  produces nor consumes it; the caller reads it straight off the `served` value. */
 interface EndpointBooted {
   readonly phase: "endpoint";
   readonly gate: HeldGate;
-  // biome-ignore lint/suspicious/noExplicitAny: threads the served router (see `SurfacesServed`).
-  readonly router: Router<any, any>;
 }
 
 /** Open padi's state-root stores UNDER the held gate: open the `Conf`, run the
@@ -271,7 +274,7 @@ async function bootLocalEndpoint(
     onNotAdopted: parkSavedSession,
     onBootSettled: startInventoryReconciler,
   });
-  return { phase: "endpoint", gate: served.gate, router: served.router };
+  return { phase: "endpoint", gate: served.gate };
 }
 
 /** Run the padi daemon to completion: own its state-root, adopt-or-spawn its
@@ -384,7 +387,9 @@ export async function runPadiDaemon(
   return daemonMain({
     gatePath,
     socketPath,
-    router: endpoint.router,
+    // The router is the serve phase's output — read it straight off `served` rather
+    // than re-threading it through the endpoint token that neither owns nor touches it.
+    router: served.router,
     lifetime: { kind: "forever" },
     log,
     signal: drainController.signal,

--- a/packages/padi/src/daemonMain.ts
+++ b/packages/padi/src/daemonMain.ts
@@ -18,6 +18,7 @@ import {
   acquirePidGate,
   type DaemonExit,
   daemonMain,
+  type GateAcquisition,
   type Logger,
 } from "@kolu/surface-daemon";
 
@@ -53,7 +54,9 @@ import {
 } from "./ptyHost/daemonStatus.ts";
 import { ensureLocalEndpoint, setSpawnServerVersion } from "./ptyHost/index.ts";
 import { buildPadiSurfaceDeps } from "./servePadi.ts";
-import { initSessionAutoSave, setSavedSessionFromSnapshot } from "./session.ts";
+import { initAutosaveGate } from "./autosaveGate.ts";
+import { saveSession, setSavedSessionFromSnapshot } from "./session.ts";
+import { hasParkedTerminals } from "./terminal-registry.ts";
 import {
   padiGatePath,
   padiKavalSocketPath,
@@ -101,10 +104,177 @@ export interface PadiDaemonOptions {
   onReady?: (info: { socketPath: string; pid: number }) => void;
 }
 
+// ── Typed boot pipeline ───────────────────────────────────────────────────────
+// Each phase takes the PRIOR phase's token, so a step invoked before its precondition
+// is a COMPILE error, not a silent violation. The two ordering invariants once held by
+// prose — "claim the gate FIRST" (W2.2's B1 blocker) and "the stores are injected
+// before anything reads them" — are now the {@link HeldGate} / {@link StoresReady}
+// types threaded through the chain; the boot below reads as `gate → stores → identity
+// → serve → endpoint` with the dependency edges checked by the compiler.
+
+/** Padi's HELD single-instance gate — the `acquired` arm of `acquirePidGate`,
+ *  narrowed past the `held` / `dir-not-private` exits. Threaded into every boot phase
+ *  that must run UNDER the gate, so a phase reachable before the claim would not
+ *  type-check (the loser of a state-root race can't clobber the winner's disk). */
+type HeldGate = Extract<GateAcquisition, { kind: "acquired" }>;
+
+/** Padi's state-root stores are OPEN, legacy-imported, and INJECTED — the precondition
+ *  for anything that reads a padi cell (serve, reconcile). Carries the gate forward so
+ *  the whole pipeline is value-threaded to the spine at the end. */
+interface StoresReady {
+  readonly gate: HeldGate;
+}
+
+/** The per-process identity (pid, serve socket, spawn version, nix-shell env,
+ *  koluRoot, the exit-wipe hook, the autosave gate) is configured — the precondition
+ *  for spawning a terminal or serving. */
+interface IdentityReady {
+  readonly gate: HeldGate;
+}
+
+/** padiSurface + the frozen control core are served and the late-bound ctx is wired
+ *  (every domain writer can now publish deltas) — the precondition for booting the
+ *  kaval endpoint, whose reconcile publishes onto that ctx. Carries the served
+ *  router. */
+interface SurfacesServed {
+  readonly gate: HeldGate;
+  // biome-ignore lint/suspicious/noExplicitAny: a top-level oRPC served router — the same `Router<any, any>` the served fragment narrows to (see `serveDaemonSurfaces`).
+  readonly router: Router<any, any>;
+}
+
+/** The local kaval endpoint has booted (adopt-or-spawn) and the saved session is
+ *  reconciled — the precondition for the samplers + manifests that read the held
+ *  kaval's socket. */
+interface EndpointBooted {
+  readonly gate: HeldGate;
+  // biome-ignore lint/suspicious/noExplicitAny: threads the served router (see `SurfacesServed`).
+  readonly router: Router<any, any>;
+}
+
+/** Open padi's state-root stores UNDER the held gate: open the `Conf`, run the
+ *  one-shot legacy import BEFORE injecting (so imported values are in place before any
+ *  reader), then inject the three cells' backing stores. The `gate: HeldGate` param is
+ *  the compile-time proof the gate was claimed first — a padi that lost the race exits
+ *  before this is reachable. */
+function openStateStores(
+  gate: HeldGate,
+  stateRoot: string,
+  log: Logger,
+): StoresReady {
+  const stores = openPadiStateStores(stateRoot);
+  // Import BEFORE the injections below — the imported values must be in place before
+  // anything reads a cell. (#1658's backup, inlined per the scope note.)
+  importLegacyConfigOnce(stores, log);
+  setPadiSessionStore(stores.session);
+  setPadiActivityFeedStore(stores.activityFeed);
+  setPadiLastPairedDaemonStore(stores.lastPairedDaemon);
+  return { gate };
+}
+
+/** Configure padi's per-process identity + wire the autosave gate. Requires the stores
+ *  token (its `koluRoot` + autosave observe the injected state), so it cannot run
+ *  before injection. */
+function configureDaemonIdentity(
+  stores: StoresReady,
+  opts: PadiDaemonOptions,
+  socketPath: string,
+): IdentityReady {
+  // padi's OWN pid (a standalone daemon owns its disk) — koluRoot + PTY spawns need it.
+  setDaemonProcessId(String(process.pid));
+  // Record padi's OWN serving socket so every terminal it spawns carries it as
+  // `PADI_SOCKET` (the $KAVAL_SOCKET twin) — set well before `ensureLocalEndpoint` can
+  // spawn a terminal.
+  setPadiServeSocketPath(socketPath);
+  // `||` not `??`: `currentPadiCommitHash()` is "" off-nix and the setter refuses an
+  // empty value — fall through to "dev".
+  setSpawnServerVersion(opts.spawnVersion || currentPadiCommitHash() || "dev");
+  configureNixShellEnv(opts.nixShellWhitelist);
+  ensureKoluRoot();
+  // Register the scratch-root wipe on `exit` — only AFTER `ensureKoluRoot` created the
+  // dir and `setDaemonProcessId` so `koluRoot()` resolves. A hard kill bypasses `exit`
+  // (the XDG logout-wipe is the backstop).
+  process.on("exit", shutdownCleanup);
+  // Wire the AutosaveGate to the live terminal set + the restore-pending query (read
+  // LIVE at fire — the registry is its source of truth) + the persist effect. The gate
+  // owns WHEN to save; the writers only pulse `notifyDirty`.
+  initAutosaveGate({
+    snapshot: snapshotSession,
+    isRestorePending: hasParkedTerminals,
+    persist: saveSession,
+  });
+  return { gate: stores.gate };
+}
+
+/** Serve padiSurface + the frozen control core on ONE socket and wire the late-bound
+ *  ctx. Requires the identity token (spawns/serving observe it), and takes the
+ *  already-built `onDrain` so a control-core drain persists + exits. */
+function serveDaemonSurfaces(
+  identity: IdentityReady,
+  params: { stateRoot: string; onDrain: () => void; log: Logger },
+): SurfacesServed {
+  const { stateRoot, onDrain, log } = params;
+  const localEndpoint = resolveTerminalEndpoint(LOCAL_LOCATION);
+  const { router: surfaceFragment, ctx } = implementSurfaces(
+    padiDaemonSurfaces,
+    {
+      channel: <T>(name: string) => publisherChannel<T>(publisher, name),
+      onStreamReadError: (err, info) =>
+        log.error({ err, stream: info.stream }, "padi stream read error"),
+    },
+    {
+      padi: buildPadiSurfaceDeps({ endpoint: localEndpoint, log: padiLog }),
+      control: buildControlCoreDeps({
+        stateRoot,
+        startedAt: PADI_STARTED_AT,
+        // padi's navigable git commit (`PADI_COMMIT_HASH`), echoed by `hello` so the
+        // binder surfaces the RUNNING padi's build. Empty "" off-nix → honest "—".
+        commit: currentPadiCommitHash(),
+        // padi's staleKey (`PADI_BUILD_ID`) — the binder's build-convergence key: a
+        // same-contract build mismatch drains this padi once at binder boot (#1670).
+        buildId: currentPadiBuildId(),
+        onDrain,
+      }),
+    },
+  );
+  // Wire the late-bound ctx so every padi domain writer publishes deltas.
+  setPadiSurfaceCtx(ctx.padi);
+  // Wrap the fragment in a top-level contract router so the socket's handler can route
+  // it (the bare fragment answers "Not Found"; the same wrap kaval's inProcessPtyHost
+  // does).
+  const servedRouter = implement(padiDaemonContract).router(
+    // biome-ignore lint/suspicious/noExplicitAny: the fragment's procedure-context type doesn't line up with implement().router()'s contract-derived param, though the runtime shape is exactly what serving wants (mirrors kaval's inProcessPtyHost wrap).
+    surfaceFragment as any,
+    // biome-ignore lint/suspicious/noExplicitAny: a top-level oRPC served router — the same `Router<any, any>` cast kaval's inProcessPtyHost narrows to (the contract-derived context doesn't line up, runtime shape is correct).
+  ) as Router<any, any>;
+  return { gate: identity.gate, router: servedRouter };
+}
+
+/** Boot padi's OWN kaval (adopt-or-spawn under `kaval-<digest>/`), reconcile its live
+ *  PTYs against the saved session, and start the live inventory reconciler. Requires
+ *  the served surfaces — the reconcile publishes onto the wired ctx. */
+async function bootLocalEndpoint(
+  served: SurfacesServed,
+  params: { kavalSocket: string; legacyKavalSocket?: string },
+): Promise<EndpointBooted> {
+  await ensureLocalEndpoint({
+    kavalSocket: params.kavalSocket,
+    // The W2.2 upgrade bridge: adopt a surviving pre-W2.2 port-keyed kaval (if the
+    // binder hinted its port socket and this padi has no digest kaval yet) rather than
+    // leaking it. Standalone padi (no binder) passes nothing → no legacy adopt.
+    legacyKavalSocket: params.legacyKavalSocket,
+    onStatus: publishDaemonStatus,
+    onAdopted: adoptSurvivingSession,
+    onNotAdopted: parkSavedSession,
+    onBootSettled: startInventoryReconciler,
+  });
+  return { gate: served.gate, router: served.router };
+}
+
 /** Run the padi daemon to completion: own its state-root, adopt-or-spawn its
  *  kaval, reconcile the saved session, serve `padiSurface` + the control core over
  *  padi's digest-keyed socket, and stay up until drained / signalled. Resolves the
- *  spine's {@link DaemonExit} for the bin to map to an exit code. */
+ *  spine's {@link DaemonExit} for the bin to map to an exit code. The boot is a typed
+ *  pipeline (see the phase functions above); this reads as its call graph. */
 export async function runPadiDaemon(
   opts: PadiDaemonOptions,
 ): Promise<DaemonExit> {
@@ -142,50 +312,15 @@ export async function runPadiDaemon(
     return { kind: "serve-failed", detail: "dir-not-private" };
   }
 
-  // ── padi's own state-root store (the W2.2 move off kolu-server's conf) ──
-  // The three cells padi owns — session, activityFeed, lastPairedDaemon — now
-  // read/write padi's OWN `Conf` under the state-root. Injected BEFORE anything
-  // serves or reconciles (a read before this crashes loudly), exactly as
-  // kolu-server injected its conf stores in-process before the cutover.
-  const stores = openPadiStateStores(stateRoot);
-  // The one-shot import: on the first boot with a legacy `$KOLU_STATE_DIR` set
-  // (kolu-server forwards it), carry session/activityFeed/lastPairedDaemon across
-  // from the old shared config, ONCE — taking a backup first, crashing loudly on a
-  // bad file. Runs BEFORE the stores are injected so the imported values are in
-  // place before anything reads them. (#1658's backup, inlined per the scope note.)
-  importLegacyConfigOnce(stores, log);
-  setPadiSessionStore(stores.session);
-  setPadiActivityFeedStore(stores.activityFeed);
-  setPadiLastPairedDaemonStore(stores.lastPairedDaemon);
+  // Gate → stores → identity: each phase takes the prior's token, so none can run
+  // before the gate is claimed above (a lost gate-race returns before reaching here).
+  const stores = openStateStores(gate, stateRoot, log);
+  const identity = configureDaemonIdentity(stores, opts, socketPath);
 
-  // The per-process identity padi's koluRoot + PTY spawns need — padi's OWN pid
-  // (a standalone daemon owns its disk) and the version stamped on spawned PTYs.
-  setDaemonProcessId(String(process.pid));
-  // Record padi's OWN serving socket so every terminal it spawns carries it as
-  // `PADI_SOCKET` (the $KAVAL_SOCKET twin) — a `padi-tui` inside a kolu terminal
-  // then reaches the padi that owns it flag-free. Set before anything can spawn a
-  // terminal (well before `ensureLocalEndpoint`).
-  setPadiServeSocketPath(socketPath);
-  // `||` not `??`: currentPadiCommitHash() is "" off-nix (no baked env), and the
-  // spawn-version setter refuses an empty value — fall through to "dev".
-  setSpawnServerVersion(opts.spawnVersion || currentPadiCommitHash() || "dev");
-  configureNixShellEnv(opts.nixShellWhitelist);
-  ensureKoluRoot();
-  // padi OWNS its per-process scratch root now (the W2.2 move off kolu-server):
-  // the shell rc files, per-terminal scratch, and upload/init files live under
-  // `${runtimeRoot}/kolu-<padi-pid>`. Register the wipe on `exit` — the same hook
-  // kolu-server used before the cutover — so a normal padi drain/restart (which
-  // ends the process) removes the root instead of leaking it. Registered only
-  // AFTER `ensureKoluRoot` created the dir (a lost gate-race returns above, never
-  // reaching here), and after `setDaemonProcessId` so `koluRoot()` resolves. A
-  // hard kill / power loss bypasses `exit` (the XDG logout-wipe is the backstop),
-  // exactly as before.
-  process.on("exit", shutdownCleanup);
-  initSessionAutoSave(snapshotSession);
-
-  // ── The drain trigger ── control-core `drain` persists + exits; the caller
-  // observes the socket close. Fold it into an abort of the daemon lifetime,
-  // composed with any external stop signal.
+  // ── The drain trigger ── control-core `drain` persists + exits; the caller observes
+  // the socket close. Built HERE (not in a phase) so `onDrain` closes over
+  // `drainController` — which the spine's `daemonMain` also aborts on — and can be
+  // handed to the serve phase; composed with any external stop signal.
   const drainController = new AbortController();
   if (opts.signal) {
     if (opts.signal.aborted) drainController.abort();
@@ -214,99 +349,44 @@ export async function runPadiDaemon(
     drainController.abort();
   };
 
-  // ── Serve padiSurface + the frozen control core on ONE socket ──
-  const localEndpoint = resolveTerminalEndpoint(LOCAL_LOCATION);
-  const { router: surfaceFragment, ctx } = implementSurfaces(
-    padiDaemonSurfaces,
-    {
-      channel: <T>(name: string) => publisherChannel<T>(publisher, name),
-      onStreamReadError: (err, info) =>
-        log.error({ err, stream: info.stream }, "padi stream read error"),
-    },
-    {
-      padi: buildPadiSurfaceDeps({ endpoint: localEndpoint, log: padiLog }),
-      control: buildControlCoreDeps({
-        stateRoot,
-        startedAt: PADI_STARTED_AT,
-        // padi's navigable git commit (`PADI_COMMIT_HASH`), echoed by `hello` so the
-        // binder surfaces the RUNNING padi's build. Empty "" off-nix → honest "—".
-        commit: currentPadiCommitHash(),
-        // padi's staleKey (`PADI_BUILD_ID`) — the binder's build-convergence key: a
-        // same-contract build mismatch drains this padi once at binder boot (#1670).
-        // Empty "" off-nix (the binder never build-drains a "" survivor of a "" binder).
-        buildId: currentPadiBuildId(),
-        onDrain,
-      }),
-    },
-  );
-  // Wire the late-bound ctx so every padi domain writer publishes deltas.
-  setPadiSurfaceCtx(ctx.padi);
-  // Wrap the `implementSurfaces` FRAGMENT in a top-level contract router so the
-  // socket's StandardRPCHandler can route it — the bare fragment answers "Not
-  // Found" over the wire (the same wrap kaval's `createInProcessPtyHost` does).
-  const servedRouter = implement(padiDaemonContract).router(
-    // biome-ignore lint/suspicious/noExplicitAny: the fragment's procedure-context type doesn't line up with implement().router()'s contract-derived param, though the runtime shape is exactly what serving wants (mirrors kaval's inProcessPtyHost wrap).
-    surfaceFragment as any,
-    // biome-ignore lint/suspicious/noExplicitAny: a top-level oRPC served router — the same `Router<any, any>` cast kaval's inProcessPtyHost narrows to (the contract-derived context doesn't line up, runtime shape is correct).
-  ) as Router<any, any>;
-
-  // ── Boot orchestration — padi adopts-or-spawns its OWN kaval under
-  // `kaval-<digest>/`, reconciles its live PTYs against the saved session, and
-  // starts the live inventory reconciler. (The SAME orchestration kolu-server ran
-  // in-process until W2.2; it now runs in padi's process, keyed by state-root.)
-  await ensureLocalEndpoint({
+  // Serve → boot the endpoint: the reconcile publishes onto the ctx the serve phase
+  // wires, so `bootLocalEndpoint` takes the served token.
+  const served = serveDaemonSurfaces(identity, { stateRoot, onDrain, log });
+  const endpoint = await bootLocalEndpoint(served, {
     kavalSocket,
-    // The W2.2 upgrade bridge: adopt a surviving pre-W2.2 port-keyed kaval (if the
-    // binder hinted its port socket and this padi has no digest kaval yet) rather
-    // than leaking it. Standalone padi (no binder) passes nothing → no legacy adopt.
     legacyKavalSocket: opts.legacyKavalSocket,
-    onStatus: publishDaemonStatus,
-    onAdopted: adoptSurvivingSession,
-    onNotAdopted: parkSavedSession,
-    onBootSettled: startInventoryReconciler,
   });
 
-  // Feed the chrome bar's memory rail: sample padi's OWN RSS + poll its kaval's on
-  // a fixed cadence and publish the pair on `padiSurface.processMemory` (kolu-server
-  // folds it into the rail's cell). Started after `ensureLocalEndpoint` so the first
-  // kaval poll can reach a connected daemon; a not-yet-connected kaval reads `absent`.
+  // Samplers + manifests run AFTER the endpoint boot (the `endpoint` token proves it):
+  // they read the held kaval's socket / a connected daemon.
+  // Feed the chrome bar's memory rail: sample padi's OWN RSS + poll its kaval's on a
+  // fixed cadence; a not-yet-connected kaval reads `absent`.
   startPadiMemorySampler();
-
-  // ── Manifests (digest → state-root) so a flag-less kaval-tui can label what it
-  // discovers. padi knows the state-root the opaque digest stands for; write it
-  // into both padi's and its kaval's runtime dirs.
+  // Manifests (digest → state-root) so a flag-less kaval-tui can label what it
+  // discovers — written into both padi's and its kaval's runtime dirs.
   writeStateRootManifest(dirname(socketPath), stateRoot);
   // Beside the kaval this padi ACTUALLY holds — `getLocalSocketPath()` is the digest
-  // socket normally, but the adopted LEGACY port socket after an upgrade adoption. So
-  // discovery labels the real daemon "kolu @ <state-root>" (not the bare "port N"),
-  // and no empty digest dir is minted when the port kaval was adopted instead.
+  // socket normally, but the adopted LEGACY port socket after an upgrade adoption, so
+  // discovery labels the real daemon and no empty digest dir is minted.
   writeStateRootManifest(
     dirname(getLocalSocketPath() ?? kavalSocket),
     stateRoot,
   );
-
-  // Feed the Kaval + Padi dialogs' "Running daemons" list: scan THIS host's running
-  // kaval + padi daemons (read-only) and publish them on `padiSurface.hostInventory`,
-  // marking the kaval this padi holds + itself `active`. Because it rides the re-served
-  // surface, the dialog shows the BOUND host's daemons identically whether kolu-server
-  // reaches this padi locally or over ssh — so a leaked daemon on the machine you're
-  // actually using is finally visible. Started after `ensureLocalEndpoint` so the held
-  // kaval's socket is known, and after the manifests are written so the very first tick
-  // labels the discovered kaval by state-root. The serving padi reports ITSELF by
-  // construction (see `withSelfPadi`), so the liveness tell holds even on this T+0 tick,
-  // before `daemonMain` below opens `padi.sock`.
+  // Feed the Kaval + Padi dialogs' "Running daemons" list — started after the
+  // manifests so the very first tick labels the discovered kaval by state-root. The
+  // serving padi reports ITSELF by construction (see `withSelfPadi`).
   startPadiHostInventorySampler({ padiSocket: socketPath, stateRoot });
 
   return daemonMain({
     gatePath,
     socketPath,
-    router: servedRouter,
+    router: endpoint.router,
     lifetime: { kind: "forever" },
     log,
     signal: drainController.signal,
     onReady: opts.onReady,
-    // The gate we already claimed at the top — the spine serves under it and
-    // releases it on teardown, rather than acquiring it here (too late).
-    gate,
+    // The gate claimed at the top, threaded through the pipeline — the spine serves
+    // under it and releases it on teardown, rather than acquiring it here (too late).
+    gate: endpoint.gate,
   });
 }

--- a/packages/padi/src/daemonMain.ts
+++ b/packages/padi/src/daemonMain.ts
@@ -26,9 +26,11 @@ import {
  *  at process start. The control-core `hello` echoes it so the binder measures
  *  honest uptime instead of resetting the age on every reconnect. */
 const PADI_STARTED_AT = Date.now();
+
 import { implementSurfaces, publisherChannel } from "@kolu/surface/server";
 import { implement, type Router } from "@orpc/server";
 import { configureNixShellEnv } from "kolu-pty";
+import { initAutosaveGate } from "./autosaveGate.ts";
 import { currentPadiBuildId, currentPadiCommitHash } from "./buildId.ts";
 import {
   setPadiActivityFeedStore,
@@ -36,6 +38,7 @@ import {
   setPadiSessionStore,
 } from "./confStores.ts";
 import { buildControlCoreDeps } from "./controlCore.ts";
+import { startPadiHostInventorySampler } from "./hostInventory.ts";
 import { importLegacyConfigOnce } from "./importLegacy.ts";
 import {
   ensureKoluRoot,
@@ -43,20 +46,17 @@ import {
   shutdownCleanup,
 } from "./koluRoot.ts";
 import { configureDaemonLog, log as padiLog } from "./log.ts";
-import { startPadiHostInventorySampler } from "./hostInventory.ts";
 import { startPadiMemorySampler } from "./memorySampler.ts";
 import { setPadiSurfaceCtx } from "./padiSurfaceCtx.ts";
-import { publisher } from "./publisher.ts";
 import {
   getLocalSocketPath,
   publishDaemonStatus,
   setPadiServeSocketPath,
 } from "./ptyHost/daemonStatus.ts";
 import { ensureLocalEndpoint, setSpawnServerVersion } from "./ptyHost/index.ts";
+import { publisher } from "./publisher.ts";
 import { buildPadiSurfaceDeps } from "./servePadi.ts";
-import { initAutosaveGate } from "./autosaveGate.ts";
 import { saveSession, setSavedSessionFromSnapshot } from "./session.ts";
-import { hasParkedTerminals } from "./terminal-registry.ts";
 import {
   padiGatePath,
   padiKavalSocketPath,
@@ -66,6 +66,7 @@ import {
 } from "./stateRoot.ts";
 import { openPadiStateStores } from "./stateStore.ts";
 import { padiDaemonContract, padiDaemonSurfaces } from "./surface.ts";
+import { hasParkedTerminals } from "./terminal-registry.ts";
 import { startInventoryReconciler } from "./terminalEndpoint/inventoryReconcile.ts";
 import {
   adoptSurvivingSession,

--- a/packages/padi/src/ptyHost/index.ts
+++ b/packages/padi/src/ptyHost/index.ts
@@ -191,7 +191,15 @@ export function __setEndpointForTest(
  *  Resolves whether or not the daemon came up — a boot failure reports `dead`
  *  via `onStatus` and leaves `ptyHostClient` throwing, so the server can still
  *  listen and the UI honestly shows the dead/degraded state (never a crash, never
- *  an import-time throw). */
+ *  an import-time throw).
+ *
+ *  This boot is NOT re-cast as a typed pipeline (unlike `runPadiDaemon`, L16): its
+ *  step order is already enforced by DATA FLOW, not prose. `ep = createEndpoint(...)`
+ *  produces the value `converge({ endpoint: ep })` and the `onAdopted`/`onNotAdopted`
+ *  branches consume — you cannot converge or reconcile before the endpoint exists,
+ *  because there is no `ep` to pass. There is no side-effecting "must run before X"
+ *  ordering here for a token to guard, so the same shape read as a latent hazard in
+ *  `runPadiDaemon` (setters with no data edge between them) is a non-issue here. */
 export async function ensureLocalEndpoint(opts: {
   /** The exact socket this endpoint's kaval serves and is dialed on — resolved by
    *  the caller. The padi process passes its digest-keyed

--- a/packages/padi/src/ptyHost/restartLocal.test.ts
+++ b/packages/padi/src/ptyHost/restartLocal.test.ts
@@ -3,14 +3,14 @@
  * recycle → reattach/park) must NOT lose the session — the zest regression.
  *
  * The trace from the deployed diagnostic build: the drain (`killAllTerminals` → the
- * PTYs exit → `emitTerminalsDirty`) arms the 500 ms autosave; it fires in the
+ * PTYs exit → `notifyDirty`) arms the 500 ms autosave; it fires in the
  * drain→park GAP (the daemon recycle), when the registry is empty AND no parked
  * entries exist yet — so the `hasParkedTerminals()` guard is inert and
  * `saveSession([])` nulls the just-captured session before park runs; park then reads
  * null and no-ops. Session lost.
  *
  * This drives the REAL `restartLocalDaemon` (via `__setEndpointForTest`, a fake
- * daemon standing in for the recycle) with the REAL `initSessionAutoSave` loop and
+ * daemon standing in for the recycle) with the REAL `AutosaveGate` loop and
  * the REAL `terminals:dirty` channel, and lets the autosave timer actually fire in
  * the drain→park window. The interleave is the whole bug, so it is pinned
  * explicitly (the recycle gap outlasts the 500 ms autosave).
@@ -34,14 +34,14 @@ import {
 import { terminalsDirtyChannel } from "../publisher.ts";
 import {
   cancelPendingAutosave,
-  getSavedSession,
-  initSessionAutoSave,
-  setSavedSession,
-  unfreezeSessionForRestart,
-} from "../session.ts";
+  initAutosaveGate,
+  unfreezeAutosave,
+} from "../autosaveGate.ts";
+import { getSavedSession, saveSession, setSavedSession } from "../session.ts";
 import {
   type ActiveTerminalProcess,
   getTerminal,
+  hasParkedTerminals,
   registerTerminal,
   terminalEntries,
   unregisterTerminal,
@@ -167,10 +167,14 @@ beforeAll(() => {
   // One real autosave loop for the whole file (module-level subscription). The
   // callback calls this every time it fires (for its diagnostic log), BEFORE the
   // freeze/parked guards, so recording here observes the fire regardless of skip.
-  initSessionAutoSave(() => {
-    const s = snapshotSession();
-    if (autosaveEvals) autosaveEvals.push(s.terminals.length);
-    return s;
+  initAutosaveGate({
+    snapshot: () => {
+      const s = snapshotSession();
+      if (autosaveEvals) autosaveEvals.push(s.terminals.length);
+      return s;
+    },
+    isRestorePending: hasParkedTerminals,
+    persist: saveSession,
   });
 });
 
@@ -184,7 +188,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  unfreezeSessionForRestart();
+  unfreezeAutosave();
   cancelPendingAutosave();
   await delay(0);
   for (const [id] of [...terminalEntries()]) unregisterTerminal(id);

--- a/packages/padi/src/ptyHost/restartLocal.test.ts
+++ b/packages/padi/src/ptyHost/restartLocal.test.ts
@@ -16,6 +16,7 @@
  * explicitly (the recycle gap outlasts the 500 ms autosave).
  */
 
+import type { TerminalSnapshot } from "@kolu/terminal-workspace/schema";
 import {
   afterAll,
   afterEach,
@@ -25,6 +26,11 @@ import {
   expect,
   it,
 } from "vitest";
+import {
+  cancelPendingAutosave,
+  initAutosaveGate,
+  unfreezeAutosave,
+} from "../autosaveGate.ts";
 import { setDaemonProcessId } from "../koluRoot.ts";
 import {
   __resetPadiSurfaceCtxForTest,
@@ -32,11 +38,6 @@ import {
   setPadiSurfaceCtx,
 } from "../padiSurfaceCtx.ts";
 import { terminalsDirtyChannel } from "../publisher.ts";
-import {
-  cancelPendingAutosave,
-  initAutosaveGate,
-  unfreezeAutosave,
-} from "../autosaveGate.ts";
 import { getSavedSession, saveSession, setSavedSession } from "../session.ts";
 import {
   type ActiveTerminalProcess,
@@ -48,7 +49,6 @@ import {
 } from "../terminal-registry.ts";
 import { parkSavedSession } from "../terminalEndpoint/reattach.ts";
 import { snapshotSession } from "../terminals.ts";
-import type { TerminalSnapshot } from "@kolu/terminal-workspace/schema";
 import type {
   AuthoredActiveTerminal,
   SavedActiveTerminal,

--- a/packages/padi/src/ptyHost/restartLocal.ts
+++ b/packages/padi/src/ptyHost/restartLocal.ts
@@ -32,13 +32,13 @@
  * See `docs/atlas/src/content/atlas/pty-daemon.mdx` (B3.2 — supervised restart).
  */
 
-import { log } from "../log.ts";
 import {
   cancelPendingAutosave,
-  freezeSessionForRestart,
-  setSavedSessionFromSnapshot,
-  unfreezeSessionForRestart,
-} from "../session.ts";
+  freezeAutosave,
+  unfreezeAutosave,
+} from "../autosaveGate.ts";
+import { log } from "../log.ts";
+import { setSavedSessionFromSnapshot } from "../session.ts";
 import { parkSavedSession } from "../terminalEndpoint/reattach.ts";
 import { killAllTerminals, snapshotSession } from "../terminals.ts";
 import { restartLocalEndpoint } from "./index.ts";
@@ -56,7 +56,7 @@ export function restartLocalDaemon(): Promise<void> {
       // it: the drain below kills the PTYs → they fire `terminals:dirty` → the 500ms
       // autosave would fire in the recycle GAP with an empty registry and no parked
       // entries yet, nulling the session we're about to capture, before park runs.
-      freezeSessionForRestart();
+      freezeAutosave("restart critical section (capture→drain→park)");
       setSavedSessionFromSnapshot(snapshotSession());
     },
     // Tear down kolu's terminal layer; the recycle takes the PTYs themselves.
@@ -76,7 +76,7 @@ export function restartLocalDaemon(): Promise<void> {
     // from here), OR the restart FAILED before park — either way lift the freeze and
     // cancel any drain-armed timer, so a failed restart can't null the captured
     // session after the freeze lifts.
-    unfreezeSessionForRestart();
+    unfreezeAutosave();
     cancelPendingAutosave();
   });
 }

--- a/packages/padi/src/publisher.ts
+++ b/packages/padi/src/publisher.ts
@@ -25,6 +25,7 @@
 
 import { publisherChannel } from "@kolu/surface/server";
 import { MemoryPublisher } from "@orpc/experimental-publisher/memory";
+import { log } from "./log.ts";
 
 // `MemoryPublisher` constrains its generic to `Record<string, object>`,
 // which excludes the primitive payloads we publish (data strings, exit
@@ -45,3 +46,19 @@ export const terminalsDirtyChannel = publisherChannel<Record<string, never>>(
   publisher,
   "terminals:dirty",
 );
+
+/** Emit the shared `terminals:dirty` pulse — the SINGLE writer-facing arm every
+ *  terminal/metadata writer calls when a restore-relevant change lands. Arms the
+ *  autosave gate (via its subscription) and reconciles the activity taps
+ *  (`liveActivity.ts`), the pulse's other consumer. Lives HERE, beside the channel
+ *  it wraps, so producers depend on the neutral channel registry rather than on
+ *  either consumer. Guarded at the boundary: a throwing subscriber must not propagate
+ *  back into the producer's emit loop (which would freeze a sensor); logged, not
+ *  fatal — the next restore-relevant change re-arms. */
+export function notifyDirty(): void {
+  try {
+    terminalsDirtyChannel.publish({});
+  } catch (err) {
+    log.error({ err }, "terminals:dirty publish threw");
+  }
+}

--- a/packages/padi/src/publisher.ts
+++ b/packages/padi/src/publisher.ts
@@ -3,9 +3,10 @@
  *  One `MemoryPublisher` instance with a single named channel on top:
  *
  *    - `terminalsDirtyChannel` — singleton control-flow signal that
- *      drives the session auto-save debounce loop. Distinct from the
- *      `terminalList` cell's content channel: this is the *trigger*,
- *      not the saved content.
+ *      drives the session autosave gate AND the live-activity tap
+ *      reconciliation (`liveActivity.ts`) — a two-consumer broadcast.
+ *      Distinct from the `terminalList` cell's content channel: this is
+ *      the *trigger*, not the saved content.
  *
  *  The per-terminal VT-tap channels (cwd / title / command-run / git) that
  *  used to live here are now per-terminal in-memory channels created by the
@@ -38,10 +39,11 @@ export const publisher = new MemoryPublisher<Record<string, any>>();
  *  diagnostics (see diagnostics.ts) — climbs if subscribers aren't draining. */
 export const publisherSize = (): number => publisher.size;
 
-/** Singleton broadcast: terminal state mutated. Drives session
- *  auto-save's debounced write loop; the persisted content lives on
- *  the surface's framework-owned `session:changed` channel, written
- *  via `surfaceCtx.cells.session.set(...)` from `./session.ts`. */
+/** Singleton broadcast: terminal state mutated. Drives the session autosave
+ *  gate AND the live-activity tap reconciliation (`liveActivity.ts`) — the
+ *  consumer-agnostic pulse both subscribe to. The persisted content lives on
+ *  the surface's framework-owned `session:changed` channel, written via
+ *  `surfaceCtx.cells.session.set(...)` from `./session.ts`. */
 export const terminalsDirtyChannel = publisherChannel<Record<string, never>>(
   publisher,
   "terminals:dirty",

--- a/packages/padi/src/servePadi.ts
+++ b/packages/padi/src/servePadi.ts
@@ -23,6 +23,7 @@ import { ORPCError } from "@orpc/server";
 import { currentPtyHostIdentity } from "kaval";
 import { worktreeCreate, worktreeRemove } from "kolu-git";
 import type { Logger } from "pino";
+import { cancelPendingAutosave } from "./autosaveGate.ts";
 import {
   requirePadiActivityFeedStore,
   requirePadiSessionStore,
@@ -36,7 +37,6 @@ import {
   readDaemonStatuses,
 } from "./ptyHost/daemonStatus.ts";
 import { restartLocalDaemon } from "./ptyHost/restartLocal.ts";
-import { cancelPendingAutosave } from "./autosaveGate.ts";
 import {
   forfeitSession,
   importSession,

--- a/packages/padi/src/servePadi.ts
+++ b/packages/padi/src/servePadi.ts
@@ -36,7 +36,7 @@ import {
   readDaemonStatuses,
 } from "./ptyHost/daemonStatus.ts";
 import { restartLocalDaemon } from "./ptyHost/restartLocal.ts";
-import { cancelPendingAutosave } from "./session.ts";
+import { cancelPendingAutosave } from "./autosaveGate.ts";
 import {
   forfeitSession,
   importSession,

--- a/packages/padi/src/session.test.ts
+++ b/packages/padi/src/session.test.ts
@@ -20,6 +20,7 @@
 
 import type { TerminalSnapshot } from "@kolu/terminal-workspace/schema";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { cancelPendingAutosave, initAutosaveGate } from "./autosaveGate.ts";
 import { setDaemonProcessId } from "./koluRoot.ts";
 import {
   __resetPadiSurfaceCtxForTest,
@@ -29,7 +30,6 @@ import {
 import { publishDaemonStatus } from "./ptyHost/daemonStatus.ts";
 import { LOCAL_HOST_ID } from "./ptyHost/index.ts";
 import { terminalsDirtyChannel } from "./publisher.ts";
-import { cancelPendingAutosave, initAutosaveGate } from "./autosaveGate.ts";
 import {
   getSavedSession,
   saveSession,

--- a/packages/padi/src/session.test.ts
+++ b/packages/padi/src/session.test.ts
@@ -7,10 +7,10 @@
  * `snapshotSession` deliberately EXCLUDES. Without a guard, a `terminals:dirty`
  * autosave firing while parked entries linger persists a snapshot that omits them
  * — shrinking (or nulling) the saved session on disk, the restore source of
- * truth. The fix is one line in `session.ts`'s autosave callback:
- *   `if (hasParkedTerminals()) return;`
- * Tests (vi) and (iv) are red-when-reverted against that line; the two control
- * cases pin that the guard is scoped (normal autosave still persists / clears).
+ * truth. The guard lives in `autosaveGate.ts`'s fire decision: the LIVE
+ * `isRestorePending()` query short-circuits to `suppressed-parked` before any
+ * persist. Tests (vi) and (iv) are red-when-reverted against that guard; the two
+ * control cases pin that it is scoped (normal autosave still persists / clears).
  *
  * Async-timer pattern mirrors `packages/server/src/session.test.ts`'s autosave
  * test: REAL timers, a `terminalsDirtyChannel.publish({})` to arm the gate, a

--- a/packages/padi/src/session.test.ts
+++ b/packages/padi/src/session.test.ts
@@ -12,10 +12,10 @@
  * Tests (vi) and (iv) are red-when-reverted against that line; the two control
  * cases pin that the guard is scoped (normal autosave still persists / clears).
  *
- * Async-timer pattern mirrors `packages/server/src/session.test.ts`'s
- * `initSessionAutoSave` test: REAL timers, a `terminalsDirtyChannel.publish({})`
- * to arm the loop, a short tick to let it schedule the 500 ms timer, then a
- * longer wait to pass the autosave window.
+ * Async-timer pattern mirrors `packages/server/src/session.test.ts`'s autosave
+ * test: REAL timers, a `terminalsDirtyChannel.publish({})` to arm the gate, a
+ * short tick to let it schedule the 500 ms timer, then a longer wait to pass the
+ * autosave window.
  */
 
 import type { TerminalSnapshot } from "@kolu/terminal-workspace/schema";
@@ -29,15 +29,16 @@ import {
 import { publishDaemonStatus } from "./ptyHost/daemonStatus.ts";
 import { LOCAL_HOST_ID } from "./ptyHost/index.ts";
 import { terminalsDirtyChannel } from "./publisher.ts";
+import { cancelPendingAutosave, initAutosaveGate } from "./autosaveGate.ts";
 import {
-  cancelPendingAutosave,
   getSavedSession,
-  initSessionAutoSave,
+  saveSession,
   setSavedSession,
   setSavedSessionFromSnapshot,
 } from "./session.ts";
 import {
   type ActiveTerminalProcess,
+  hasParkedTerminals,
   type ParkedTerminalProcess,
   registerTerminal,
   terminalEntries,
@@ -179,7 +180,11 @@ async function fireAutosave(): Promise<void> {
 // The autosave loop subscribes exactly ONCE — register it here, not per test, and
 // give the async subscription a moment to attach before the first publish.
 beforeAll(async () => {
-  initSessionAutoSave(snapshotSession);
+  initAutosaveGate({
+    snapshot: snapshotSession,
+    isRestorePending: hasParkedTerminals,
+    persist: saveSession,
+  });
   await tick(10);
 });
 

--- a/packages/padi/src/session.ts
+++ b/packages/padi/src/session.ts
@@ -3,71 +3,17 @@
  *
  * Owns the `session` key of the shared conf store. Writers publish on the
  * `session:changed` channel so the client's `session.get` live query stays
- * current. The autosave loop is driven by the `terminals:dirty` control-flow
- * channel (distinct from the `session:changed` *content* channel) — every
- * terminal/meta mutation fires `terminals:dirty`, this module throttles and
- * then persists.
+ * current. WHEN to auto-persist (the throttle, the restart freeze, the parked
+ * suppression) is the {@link AutosaveGate}'s concern (`autosaveGate.ts`), which
+ * drives `saveSession` from the `terminals:dirty` pulse; this module owns only the
+ * blob read/write, and the named writers cancel a pending autosave through the gate.
  */
 
+import { cancelPendingAutosave } from "./autosaveGate.ts";
 import { log } from "./log.ts";
 import { padiSurfaceCtx } from "./padiSurfaceCtx.ts";
-import { terminalsDirtyChannel } from "./publisher.ts";
 import { hasParkedTerminals } from "./terminal-registry.ts";
 import type { SavedSession, SavedTerminal } from "./vocab.ts";
-
-/** Pending autosave timer — declared at module top so `setSavedSession`
- *  and the surface cell's `store.set` adapter can cancel it (see comment
- *  on `cancelPendingAutosave` for the race). */
-let saveTimer: ReturnType<typeof setTimeout> | undefined;
-
-/** Cancel any pending `saveSession([])` autosave callback that's been
- *  armed by a recent `terminalsDirtyChannel` event but hasn't fired yet.
- *
- *  Called both from the named `setSavedSession` and from padi's session
- *  cell `onWrite` hook (see `servePadi.ts`). Wiring it into
- *  the cell adapter is what extends the cancel to the surface's
- *  `test__set` verb — which the e2e harness uses to seed scenarios,
- *  and which would otherwise be clobbered ~500 ms later by a stale
- *  killAll-time dirty event.
- *
- *  Harmless on the autosave loop's own write path: by the time the
- *  loop's callback reaches `cells.session.set`, the callback has
- *  already cleared `saveTimer` itself (see `initSessionAutoSave`), so
- *  this is a no-op. Subsequent dirty events received after the callback
- *  exits arm a fresh timer that is *not* cancelled — autosave keeps
- *  working as designed.
- *
- *  See `initSessionAutoSave` for the autosave loop, and the original
- *  e2e race description on `setSavedSession` (#320 / cycle 6 of
- *  `docs/flaky-tests-ralph-report-2.md`). */
-export function cancelPendingAutosave(): void {
-  if (saveTimer) {
-    clearTimeout(saveTimer);
-    saveTimer = undefined;
-  }
-}
-
-/** True while a daemon RESTART is in its critical section (capture→drain→park). The
- *  autosave callback bails on it, so a `terminals:dirty` the drain fires (the PTYs
- *  exiting as the daemon is killed) can't arm a save that runs in the drain→park GAP
- *  — the window where the registry is empty AND no parked entries exist yet, so the
- *  `hasParkedTerminals()` guard is inert and `saveSession([])` would null the
- *  just-captured session before park runs (the zest restart-path clobber). Park then
- *  seeds the parked entries and `hasParkedTerminals()` takes over. */
-let restartInFlight = false;
-
-/** Freeze the autosave for a restart's critical section — set at `capture` (before
- *  the drain can arm anything), lifted after `park` (see `restartLocalDaemon`). */
-export function freezeSessionForRestart(): void {
-  restartInFlight = true;
-}
-
-/** Lift the restart freeze. Safe to call on the restart's success OR failure path;
- *  a failed restart pairs it with `cancelPendingAutosave` so a drain-armed timer
- *  can't clobber the captured session after the freeze lifts. */
-export function unfreezeSessionForRestart(): void {
-  restartInFlight = false;
-}
 
 /** Write the session blob (or clear it). The surface owns persist+publish. */
 function writeSession(next: SavedSession | null): void {
@@ -89,8 +35,8 @@ function writeSession(next: SavedSession | null): void {
 
 /** A live snapshot of the terminal set — the shape autosave persists. Exported
  *  so the producer (`snapshotSession` in terminals.ts) and the consumers
- *  (`saveSession` / `initSessionAutoSave`) reference one nominal contract
- *  instead of each re-spelling the inline shape. */
+ *  (`saveSession` / the `AutosaveGate`) reference one nominal contract instead of
+ *  each re-spelling the inline shape. */
 export interface SessionSnapshot {
   terminals: SavedTerminal[];
   activeTerminalId: string | null;
@@ -247,67 +193,4 @@ export function setSavedSessionFromSnapshot(snapshot: SessionSnapshot): void {
     `session-trace capture: snapshot=${snapshot.terminals.length} → persisting`,
   );
   saveSession(snapshot);
-}
-
-// --- Auto-save: terminal lifecycle → session persistence (decoupled via publisher) ---
-
-/** Wire up throttled session save from terminal change events. Called once at startup.
- *
- *  Leading-edge throttle: the first dirty event in a quiet period schedules
- *  a save 500ms later; subsequent events during that window are absorbed
- *  into the same upcoming snapshot (because `snapshot()` runs inside the
- *  callback, not at schedule time). A trailing-edge debounce — the obvious
- *  alternative — starves under bursty inputs: the Claude transcript
- *  watcher fires every 150ms while an agent is streaming, which would
- *  reset the timer indefinitely and the save would never fire.
- *
- *  Assumes `saveSession` is synchronous (it is — `writeSession` does sync
- *  `store.set` + sync publish). If anyone makes it async, add an in-flight
- *  guard so a new schedule can't race an unfinished write. */
-export function initSessionAutoSave(snapshot: () => SessionSnapshot): void {
-  void (async () => {
-    try {
-      for await (const _ of terminalsDirtyChannel.subscribe(undefined)) {
-        if (saveTimer) continue;
-        saveTimer = setTimeout(() => {
-          saveTimer = undefined;
-          // A restore PENDING (parked entries stand in for the saved session on
-          // disk) freezes the blob: `snapshot()` excludes parked records
-          // (`snapshotSession` skips them), so persisting it here would SHRINK the
-          // saved session — destroying the restore source of truth while the user
-          // still has terminal activity (creating/closing a fresh terminal, agent
-          // churn) that arms this autosave (PATH B). The parked entries ARE the
-          // "restore pending" marker; the blob stays put until `session.restore`
-          // consumes it or the user forfeits. Once resolved (no parked left), the
-          // autosave resumes and a genuine user close still clears normally.
-          const restart = restartInFlight;
-          const parked = hasParkedTerminals();
-          const snap = snapshot();
-          log.info(
-            { restart, parked, snapshot: snap.terminals.length },
-            `session-trace autosave: restart=${restart} parked=${parked} snapshot=${snap.terminals.length}`,
-          );
-          // A restart in flight freezes the blob across its drain→park gap (the
-          // registry is transiently empty there and no parked entries exist yet, so
-          // the parked guard is still inert). Checked FIRST — this is the window a
-          // plain `hasParkedTerminals()` misses.
-          if (restart) {
-            log.info({}, "session-trace autosave: skipped (restart in flight)");
-            return;
-          }
-          if (parked) {
-            log.info({}, "session-trace autosave: skipped (parked)");
-            return;
-          }
-          log.info(
-            { terminals: snap.terminals.length },
-            `session-trace autosave: writing ${snap.terminals.length}`,
-          );
-          saveSession(snap);
-        }, 500);
-      }
-    } catch (err) {
-      log.error({ err }, "session auto-save subscription failed");
-    }
-  })();
 }

--- a/packages/padi/src/terminalEndpoint/local.ts
+++ b/packages/padi/src/terminalEndpoint/local.ts
@@ -56,7 +56,7 @@ import type {
 import { log } from "../log.ts";
 import { padiSurfaceCtx } from "../padiSurfaceCtx.ts";
 import { buildTerminalSpawnInput, ptyHostClient } from "../ptyHost/index.ts";
-import { terminalsDirtyChannel } from "../publisher.ts";
+import { notifyDirty } from "../autosaveGate.ts";
 import {
   type ActiveTerminalProcess,
   drainTerminals,
@@ -95,25 +95,6 @@ import {
   updateMemory,
 } from "./metadata.ts";
 import { type OpenedAttach, reattachingDeltas } from "./reattachingDeltas.ts";
-
-// ── PTY-state notification helpers ─────────────────────────────────────
-
-/** Notify that terminal state changed (drives debounced session auto-save).
- *  The autosave *trigger* only — the saved content rides the `session` cell, and
- *  the live terminal SET rides padi's `terminals` collection (fanned out by
- *  `installSnapshot` / `publishTerminalState` / `dropSnapshot`, whose keys stream
- *  is the client's terminal list). */
-function emitTerminalsDirty(): void {
-  // Guard the publish at the boundary (like `commitSnapshot`/`updateMemory`): a
-  // throwing dirty-channel subscriber must not propagate back into the producer's
-  // emit (which would freeze a sensor). Logged, not fatal — the next restore-relevant
-  // change re-arms the autosave.
-  try {
-    terminalsDirtyChannel.publish({});
-  } catch (err) {
-    log.error({ err }, "terminals:dirty publish threw");
-  }
-}
 
 /** Birth a terminal's two halves together — register the entry (whose required
  *  `snapshot` field carries the value) and fan that snapshot out to the
@@ -568,10 +549,10 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
     }
     // `registerAndInstall` above fanned the adopted record onto padi's
     // `terminals` collection, so the client renders the adopted tile from its
-    // keys stream. Deliberately NO `emitTerminalsDirty()`: the saved session
-    // already holds this terminal, and the boot converges the session explicitly
-    // once all survivors are adopted — arming an autosave here could persist a
-    // half-adopted set (or a not-yet-restored active marker).
+    // keys stream. Deliberately NO `notifyDirty()`: the saved session already holds
+    // this terminal, and the boot converges the session explicitly once all
+    // survivors are adopted — arming an autosave here could persist a half-adopted
+    // set (or a not-yet-restored active marker).
     tlog.info({ pid: liveEntry.pid }, "adopted surviving PTY");
   }
 
@@ -820,8 +801,7 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
       const authoredEqual = authoredFactsEqual(before, current);
       if (!authoredEqual)
         updateMemory(id, current.memory, restoreTargetOf(current));
-      if (!restoreRelevantEqual(before, current, authoredEqual))
-        emitTerminalsDirty();
+      if (!restoreRelevantEqual(before, current, authoredEqual)) notifyDirty();
     };
 
     // Bridge the raw VT taps onto the producer's signals (fire-and-forget — the
@@ -922,7 +902,7 @@ class LocalTerminalEndpoint implements TerminalEndpoint {
   private finalizeRemoval(id: TerminalId): void {
     unregisterTerminal(id);
     dropSnapshot(id);
-    emitTerminalsDirty();
+    notifyDirty();
   }
 
   /** A terminal's PTY exited naturally. Stop its sensor layer, publish the
@@ -1374,7 +1354,7 @@ export function adoptLocalInventoryOrphan(
   // Identical orphan adoption to the boot path, plus the autosave arming — so it
   // composes `adoptLocalOrphan` rather than repeating `adoptTerminal(orphanSnapshot…)`.
   adoptLocalOrphan(id, liveEntry);
-  emitTerminalsDirty();
+  notifyDirty();
 }
 
 /** Fail CLOSED on a live PTY whose wire id kolu cannot represent (F1) — a

--- a/packages/padi/src/terminalEndpoint/local.ts
+++ b/packages/padi/src/terminalEndpoint/local.ts
@@ -56,7 +56,7 @@ import type {
 import { log } from "../log.ts";
 import { padiSurfaceCtx } from "../padiSurfaceCtx.ts";
 import { buildTerminalSpawnInput, ptyHostClient } from "../ptyHost/index.ts";
-import { notifyDirty } from "../autosaveGate.ts";
+import { notifyDirty } from "../publisher.ts";
 import {
   type ActiveTerminalProcess,
   drainTerminals,

--- a/packages/padi/src/terminalEndpoint/metadata.ts
+++ b/packages/padi/src/terminalEndpoint/metadata.ts
@@ -48,7 +48,7 @@ import type {
   RestoreTarget,
   TerminalSnapshot,
 } from "@kolu/terminal-workspace/schema";
-import { notifyDirty } from "../autosaveGate.ts";
+import { notifyDirty } from "../publisher.ts";
 import { log } from "../log.ts";
 import { padiSurfaceCtx } from "../padiSurfaceCtx.ts";
 import { PadiParkedTerminalSchema, type PadiTerminal } from "../surface.ts";

--- a/packages/padi/src/terminalEndpoint/metadata.ts
+++ b/packages/padi/src/terminalEndpoint/metadata.ts
@@ -48,9 +48,9 @@ import type {
   RestoreTarget,
   TerminalSnapshot,
 } from "@kolu/terminal-workspace/schema";
-import { notifyDirty } from "../publisher.ts";
 import { log } from "../log.ts";
 import { padiSurfaceCtx } from "../padiSurfaceCtx.ts";
+import { notifyDirty } from "../publisher.ts";
 import { PadiParkedTerminalSchema, type PadiTerminal } from "../surface.ts";
 import { getTerminal, type TerminalProcess } from "../terminal-registry.ts";
 import { recomputeUrgency } from "../urgency.ts";

--- a/packages/padi/src/terminalEndpoint/metadata.ts
+++ b/packages/padi/src/terminalEndpoint/metadata.ts
@@ -16,29 +16,31 @@
  *
  * The write seams:
  *   - `commitSnapshot(id, observation)` — replace `entry.snapshot` and publish the
- *     composed record. Does NOT fire `terminals:dirty`: the ~150 ms
- *     agent-detail/foreground firehose touches only the observation, so it must
- *     never arm autosave. The fold's watch loop fires dirty ITSELF, but only on a
- *     restore-relevant VALUE change (the autosave fence) — never on a bare
- *     observation tick.
+ *     composed record.
  *   - `updateMemory(id, memory)` — write the two remembered `AgentMemory` facts
  *     onto `entry.meta` (the narrowed writer — it CANNOT touch any other field) and
- *     publish the composed record. The fold is its one caller; it likewise leaves
- *     `terminals:dirty` to the watch-loop fence.
- *   - `updateClientMetadata` — client-persisted authored fields. Mutator typed
- *     `TerminalClientMetadata`. Fires `terminals:dirty` (every client field is
- *     persisted), the precedent `updateMemory` mirrors.
+ *     publish the composed record.
+ *   - `updateClientMetadata` — client-persisted authored fields, mutator typed
+ *     `TerminalClientMetadata`.
  *
- * The `urgency` cell is refolded (`recomputeUrgency()`) at every seam where its
- * inputs (agent state, `meta.state`, membership) can change — the agent-state
- * firehose (`commitSnapshot`), the active↔sleeping/spawn state flip
- * (`publishTerminalState`, whose `meta.state` gate the urgency fold reads), and the
- * removal path (`dropSnapshot`). The cell's `equals` (`urgencyEqual`) dedups the
- * redundant fires, so an extra trigger is free while a missed one would stale the
- * badge. `updateMemory` is NOT such a seam: it writes only the remembered
- * `lastActivityAt`/`lastAgentCommand`/`restoreTarget` facts (none read by the fold)
- * and fires only when `commitSnapshot` did not (no snapshot delta → `snapshot.agent`
- * unchanged too), so the fold could never change the projection there.
+ * TWO cross-cutting concerns ride these seams, and each has ONE owner here:
+ *
+ *   - **Urgency.** `publishComposedTerminal` refolds the `urgency` cell
+ *     (`recomputeUrgency()`) on EVERY composed publish — the one call site. The
+ *     cell's `equals` (`urgencyEqual`) dedups, so a seam whose write can't move the
+ *     projection (memory facts, client chrome) refolds to an equal value and
+ *     publishes nothing; a seam whose write can (the agent-state firehose, an
+ *     active↔sleeping flip) updates the badge. The removal path refolds separately
+ *     (`dropSnapshot` — no composed publish to ride). No seam decides "does this
+ *     change urgency?" any more; the fold answers it uniformly and for free.
+ *   - **Autosave arming.** A seam that should schedule a session save calls
+ *     {@link notifyDirty} (the `AutosaveGate`'s single writer entry);
+ *     `updateClientMetadata` and `publishTerminalState` do, because every client
+ *     field / lifecycle flip is persisted. `commitSnapshot` and `updateMemory` do
+ *     NOT — the ~150 ms observation/memory firehose is not itself restore-relevant,
+ *     and the fold's watch loop pulses `notifyDirty` on the restore-relevant VALUE
+ *     change. The arm is a named call, so its presence or absence is the invariant;
+ *     there is no per-seam prose to keep in sync.
  */
 
 import type {
@@ -46,9 +48,9 @@ import type {
   RestoreTarget,
   TerminalSnapshot,
 } from "@kolu/terminal-workspace/schema";
+import { notifyDirty } from "../autosaveGate.ts";
 import { log } from "../log.ts";
 import { padiSurfaceCtx } from "../padiSurfaceCtx.ts";
-import { terminalsDirtyChannel } from "../publisher.ts";
 import { PadiParkedTerminalSchema, type PadiTerminal } from "../surface.ts";
 import { getTerminal, type TerminalProcess } from "../terminal-registry.ts";
 import { recomputeUrgency } from "../urgency.ts";
@@ -79,14 +81,19 @@ export function composePadiTerminal(entry: TerminalProcess): PadiTerminal {
 }
 
 /** Publish a terminal's COMPOSED record — `composeTerminalMetadata(entry.meta,
- *  entry.snapshot)` — onto padi's `terminals` collection. The SOLE channel a
- *  metadata change (an authored-delta OR a snapshot-delta) reaches the client: the
- *  server folds the two halves that share the one registry entry, so the wire
- *  carries the already-joined `active|sleeping` record (the client's reader-join
- *  collapsed to a single read in W1.R1). Reads the CURRENT registry entry via
- *  `getTerminal(id)`; a no-op if the id has no entry (the removal path uses
- *  `dropSnapshot` → `.remove` instead). The `upsert` only fans out to subscribers
- *  — the registry IS the store. */
+ *  entry.snapshot)` — onto padi's `terminals` collection, AND refold the urgency
+ *  projection. The SOLE channel a metadata change (an authored-delta OR a
+ *  snapshot-delta) reaches the client: the server folds the two halves that share
+ *  the one registry entry, so the wire carries the already-joined `active|sleeping`
+ *  record (the client's reader-join collapsed to a single read in W1.R1). Reads the
+ *  CURRENT registry entry via `getTerminal(id)`; a no-op if the id has no entry (the
+ *  removal path uses `dropSnapshot` → `.remove` instead). The `upsert` only fans out
+ *  to subscribers — the registry IS the store.
+ *
+ *  Every composed publish also refolds `urgency` ({@link publishUrgency}): this is
+ *  the ONE call site that answers "did this write move the urgency projection?", so
+ *  no seam has to decide it. The refold is deduped by `urgencyEqual`, free when the
+ *  write can't move the badge. */
 function publishComposedTerminal(terminalId: string): void {
   const entry = getTerminal(terminalId);
   if (!entry) return;
@@ -94,11 +101,12 @@ function publishComposedTerminal(terminalId: string): void {
     terminalId,
     composePadiTerminal(entry),
   );
+  publishUrgency();
 }
 
 /** Refold + publish the recency-free urgency projection. Deduped by the cell's
- *  `urgencyEqual`, so firing it at every seam whose inputs (agent state,
- *  `meta.state`, membership) can change is free. */
+ *  `urgencyEqual`, so folding it into every composed publish (and the removal path)
+ *  is free. */
 function publishUrgency(): void {
   padiSurfaceCtx.cells.urgency.set(recomputeUrgency());
 }
@@ -124,13 +132,13 @@ export function dropSnapshot(terminalId: string): void {
 }
 
 /** Commit a folded `TerminalSnapshot` — REPLACE `entry.snapshot` wholesale (the fold
- *  built a new value; nothing is mutated in place) and publish the composed record.
- *  Does NOT fire `terminals:dirty`: the ~150 ms agent-detail/foreground firehose
- *  touches only the observation, so it must never arm autosave; the fold's watch
- *  loop fires dirty itself, but only on a restore-relevant VALUE change. A no-op if
- *  `id` has no entry (a late commit after removal — sensors are torn down before the
- *  entry is removed, so this "never" fires; logged so a teardown bug is
- *  observable). */
+ *  built a new value; nothing is mutated in place) and publish the composed record
+ *  (which refolds urgency — the agent state rides the observation). Does NOT arm the
+ *  autosave (no {@link notifyDirty}): the ~150 ms agent-detail/foreground firehose is
+ *  not itself restore-relevant, and the fold's watch loop pulses `notifyDirty` on the
+ *  restore-relevant VALUE change. A no-op if `id` has no entry (a late commit after
+ *  removal — sensors are torn down before the entry is removed, so this "never"
+ *  fires; logged so a teardown bug is observable). */
 export function commitSnapshot(
   terminalId: string,
   observation: TerminalSnapshot,
@@ -154,9 +162,6 @@ export function commitSnapshot(
   entry.snapshot = observation;
   try {
     publishComposedTerminal(terminalId);
-    // Agent state rides the observation, so the urgency projection can change here —
-    // refold it (deduped by `urgencyEqual`).
-    publishUrgency();
   } catch (err) {
     log.error(
       { err, terminal: terminalId },
@@ -169,11 +174,10 @@ export function commitSnapshot(
  *  `AgentMemory` fields (`lastActivityAt`, `lastAgentCommand`) and the fold-derived
  *  `restoreTarget` — onto `entry.meta`, then publish the composed record. The ONE
  *  writer of these (the fold's), so no other code path can spell them — the typed
- *  mirror of `updateClientMetadata`. Does NOT fire `terminals:dirty`: these ARE
- *  restore-relevant, but the fold's watch loop already fires dirty on the
- *  restore-relevant value change, so firing here too would double-arm. The CALLER
- *  (the emit loop) invokes this only when an authored fact actually CHANGED, so the
- *  terminals collection never re-publishes on the ~150 ms observation firehose. A
+ *  mirror of `updateClientMetadata`. Does NOT arm the autosave (no {@link notifyDirty}):
+ *  these ARE restore-relevant, but the fold's watch loop already pulses `notifyDirty`
+ *  on the restore-relevant value change, so arming here too would double-arm; the
+ *  CALLER (the emit loop) invokes this only when an authored fact actually CHANGED. A
  *  no-op if `id` has no entry. */
 export function updateMemory(
   terminalId: string,
@@ -196,10 +200,8 @@ export function updateMemory(
   entry.meta.lastActivityAt = memory.lastActivityAt;
   entry.meta.lastAgentCommand = memory.lastAgentCommand;
   entry.meta.restoreTarget = restoreTarget;
-  // No urgency refold: `recomputeUrgency` reads only `meta.state` +
-  // `snapshot.agent.state`, none of the memory facts written above, and this seam
-  // fires only when `commitSnapshot` did NOT (no snapshot delta → `snapshot.agent`
-  // unchanged), so the fold could never change the projection.
+  // The composed publish refolds urgency uniformly; the memory facts written above
+  // are none of `recomputeUrgency`'s inputs, so the refold dedups to a no-op here.
   try {
     publishComposedTerminal(terminalId);
   } catch (err) {
@@ -214,8 +216,8 @@ export function updateMemory(
  *  `canvasLayout`, `subPanel`, `rightPanel`, `intent`) on `entry.meta` and
  *  publish the composed record. The mutator is narrowed to `TerminalClientMetadata`
  *  so RPC handlers cannot overwrite provider-owned state. Every client field is
- *  persisted, so this fires `terminals:dirty`. No urgency refold: client chrome is
- *  not an urgency input. */
+ *  persisted, so this arms the autosave ({@link notifyDirty}). The composed publish
+ *  refolds urgency uniformly (a no-op here — client chrome is not an urgency input). */
 export function updateClientMetadata(
   entry: TerminalProcess,
   terminalId: string,
@@ -223,7 +225,7 @@ export function updateClientMetadata(
 ): void {
   mutate(entry.meta);
   publishComposedTerminal(terminalId);
-  terminalsDirtyChannel.publish({});
+  notifyDirty();
 }
 
 /** Publish a terminal's COMPOSED record AND arm the session autosave — for a
@@ -233,15 +235,14 @@ export function updateClientMetadata(
  *  record reads correctly here.
  *
  *  THE SOLE PUSH CHANNEL for a lifecycle flip: the `terminals` collection's `upsert`
- *  only fans out to subscribers (the registry IS the store), and `terminals:dirty`
- *  alone never re-reads the registry. Every authored active↔sleeping flip and
- *  fresh spawn MUST call this. Refolds urgency: the flip changes `meta.state`, the
- *  gate the urgency fold reads (a slept awaiting-terminal can't self-heal via
- *  `commitSnapshot` — its sensors are torn down). Reads the current registry entry
- *  via the id (the caller already registered the replacement entry), so it needs no
- *  entry argument. */
+ *  only fans out to subscribers (the registry IS the store), and the `terminals:dirty`
+ *  pulse alone never re-reads the registry. Every authored active↔sleeping flip and
+ *  fresh spawn MUST call this. The composed publish refolds urgency (the flip changes
+ *  `meta.state`, an urgency input — a slept awaiting-terminal can't self-heal via
+ *  `commitSnapshot`, its sensors are torn down), and this arms the autosave
+ *  ({@link notifyDirty}). Reads the current registry entry via the id (the caller
+ *  already registered the replacement entry), so it needs no entry argument. */
 export function publishTerminalState(terminalId: string): void {
   publishComposedTerminal(terminalId);
-  publishUrgency();
-  terminalsDirtyChannel.publish({});
+  notifyDirty();
 }

--- a/packages/padi/src/terminals.ts
+++ b/packages/padi/src/terminals.ts
@@ -16,7 +16,7 @@
  */
 
 import type { TerminalId } from "@kolu/terminal-workspace/schema";
-import { terminalsDirtyChannel } from "./publisher.ts";
+import { notifyDirty } from "./autosaveGate.ts";
 import { type SessionSnapshot, saveSession } from "./session.ts";
 import { getTerminal, terminalEntries } from "./terminal-registry.ts";
 import {
@@ -270,7 +270,7 @@ function assignActiveTerminalId(id: TerminalId | null): void {
  *  list at that point, which would clear the saved session. */
 export function setActiveTerminalId(id: TerminalId | null): void {
   assignActiveTerminalId(id);
-  if (id !== null) terminalsDirtyChannel.publish({});
+  if (id !== null) notifyDirty();
 }
 
 /** Restore the active-terminal marker from a session being adopted at boot

--- a/packages/padi/src/terminals.ts
+++ b/packages/padi/src/terminals.ts
@@ -16,7 +16,7 @@
  */
 
 import type { TerminalId } from "@kolu/terminal-workspace/schema";
-import { notifyDirty } from "./autosaveGate.ts";
+import { notifyDirty } from "./publisher.ts";
 import { type SessionSnapshot, saveSession } from "./session.ts";
 import { getTerminal, terminalEntries } from "./terminal-registry.ts";
 import {


### PR DESCRIPTION
Two padi-daemon lifecycle invariants that were held together by prose and per-call-site comments become **types and explicit state** — so violating them is now a compile error or an impossible state, not a silent bug. This is a **behavior-preserving refactor**: the daemon does exactly the same thing, and every red-when-reverted session-safety test stays green *unchanged* (assertions untouched; only symbol locations and the gate's init signature moved).

Both entries live in the same subsystem (`packages/padi/src/`) and **intersect at `daemonMain.ts`** — the boot sequence (L16) wires the autosave step (L15's gate) — so they ship as one coherent "daemon lifecycle correctness" PR.

## L15 — the `metadata.ts` write-seam invariants

"Is it safe to `saveSession()` now, and with what value?" was assembled from **five scattered sources**: a module-level timer, a restart flag, a live `hasParkedTerminals()` query, a cell `onWrite` cancel, and four "must NOT arm autosave here" prose conventions. They collapse into **one `AutosaveGate` module** owning explicit state:

| State | Meaning | How it's set |
|---|---|---|
| `idle` | no save pending | — |
| `armed` | a dirty pulse scheduled a save (leading-edge throttle) | the `terminals:dirty` pulse |
| `frozen(reason)` | a restart's capture→drain→park critical section | **pushed** by `restartLocal.ts` (`freezeAutosave`/`unfreezeAutosave`) |
| `suppressed(parked)` | a restore is pending | **live query** at fire (`isRestorePending`, injected) |

The gate is a **pure state machine over injected effects** (`snapshot` / `persist` / `isRestorePending`) — it imports nothing from the session/registry layers, which *push* their facts and effects in. Restart is a push; **parked stays a live fire-time query** because the terminal-registry is its sole source of truth and the value can change between arm and fire — mirroring it in the gate would duplicate that truth and stale the PATH-B guard. (This one design point diverges from the ledger's literal "registry PUSH" wording; it was consulted and [recorded in the ledger](https://github.com/juspay/kolu/commit/c2d8df249) before implementing.)

Every writer now pulses a single **`notifyDirty()`**; every "must-not-arm" paragraph is gone (a seam that shouldn't arm simply doesn't call it).

**Folded-in urgency invariant:** `publishUrgency()` now rides `publishComposedTerminal`, so **one call site** answers "did this write move the urgency projection?" The existing `urgencyEqual` dedup makes the extra fires free, so the prose justifications on `commitSnapshot`/`updateMemory`/`updateClientMetadata` are deleted with no behavior change.

## L16 — a typed boot pipeline

`runPadiDaemon`'s ~10 boot concerns were ordered only by comments ("Claim the gate FIRST", "Runs BEFORE the stores are injected"). The boot is now a **typed pipeline** — `gate → stores → identity → serve → endpoint` — where each phase takes the prior phase's token:

```
openStateStores(gate: HeldGate, …)        → StoresReady
configureDaemonIdentity(stores: StoresReady, …) → IdentityReady
serveDaemonSurfaces(identity: IdentityReady, …) → SurfacesServed
bootLocalEndpoint(served: SurfacesServed, …)    → EndpointBooted
```

A reorder is now a **compile error**. "Claim the gate FIRST" (W2.2's B1 blocker) is the `HeldGate` type threaded through every disk-touching phase; "stores injected before any read" is `StoresReady`. The **second instance** (`ptyHost/index.ts` `ensureLocalEndpoint`) is recorded **fine-as-is** with an in-code reason: its order is already enforced by *data flow* (`ep = createEndpoint(); converge({ endpoint: ep })`), not prose — there's no side-effecting "must run before X" edge for a token to guard.

## Invariant → the test that now pins it as typed

| Invariant (was prose) | Now | Proof test (green, unchanged) |
|---|---|---|
| restart freeze covers the drain→park gap | `frozen(reason)` gate state | `restartLocal.test.ts` — ordering guard (autosave fires with snapshot=0, freeze keeps it unnulled) |
| never shrink a restore-pending blob | `suppressed(parked)` live query | `session.test.ts` (vi)/(iv) — PATH-B guards |
| which seams arm autosave | presence/absence of `notifyDirty()` | `metadata.test.ts` — dirty-count routing (commit/memory silent; client/lifecycle arm) |
| gate claimed before any side effect | `HeldGate` on every phase | `daemonMain.test.ts` — a second padi exits `already-running` touching nothing |
| daemon still boots + dials | pipeline unchanged in behavior | `dial.test.ts` |

## Design philosophy

- **Fail-fast / no fallbacks** — no override knobs added; the gate crashes on a missing injected effect rather than degrading. Parked stays a live query rather than a stale mirror.
- **Reuse the source of truth** — the terminal-registry remains the *sole* authority for "is a restore pending"; the gate consults it (injected) instead of duplicating it.
- **Volatility boundaries** — the AutosaveGate isolates the "when to persist" volatility (throttle, freeze, suppression) behind one seam; writers only pulse `notifyDirty()`.

## Scope / constraints

- **`packages/padi/src/` only** — no `@kolu/surface*` or other package touched.
- Draft; **do not merge** — review path is coordinator → srid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
