### PR TITLE
fix(kaval): environment-aware daemon discovery + stop tests leaking zombies

### DIFF
--- a/packages/kaval/src/daemonMain.test.ts
+++ b/packages/kaval/src/daemonMain.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pins kaval's state-root self-exit (zombie hygiene): a padi-spawned kaval whose
+ * ephemeral state-root is deleted out from under it — an e2e/nix-shell run's temp
+ * dir removed when the shell exits — must reap ITSELF rather than linger as a
+ * leaked daemon holding a socket forever. The watcher reads the `state-root`
+ * manifest padi writes beside kaval's socket; when that path is gone it aborts the
+ * daemon through the spine's normal teardown (socket unlinked, gate released).
+ *
+ * A standalone kaval has NO manifest and is deliberately never watched — its
+ * reason to exist isn't tied to any state-root. These run the REAL `runKavalDaemon`
+ * in-process with a tiny poll interval so the reap is observable in milliseconds.
+ */
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DaemonExit, Logger } from "@kolu/surface-daemon";
+import { afterEach, describe, expect, it } from "vitest";
+import { runKavalDaemon } from "./daemonMain.ts";
+import { KAVAL_GATE_FILE, writeStateRootManifest } from "./socketPath.ts";
+
+const silentLog = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLog,
+} as unknown as Logger;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+// Every daemon a test starts, tracked so a failing assertion can't leave it
+// running: `afterEach` aborts each and awaits its clean exit.
+const started: Array<{ ac: AbortController; exit: Promise<DaemonExit> }> = [];
+afterEach(async () => {
+  for (const d of started.splice(0)) {
+    d.ac.abort();
+    await d.exit.catch(() => {});
+  }
+});
+
+interface Started {
+  socketPath: string;
+  gatePath: string;
+  dir: string;
+  ready: Promise<void>;
+  exit: Promise<DaemonExit>;
+}
+
+/** Start a real kaval daemon on a fresh temp rendezvous dir, polling its
+ *  state-root every 20ms. Optionally seed the `state-root` manifest first. */
+function startKaval(opts: { stateRoot?: string }): Started {
+  const dir = mkdtempSync(join(tmpdir(), "kaval-selfexit-"));
+  const socketPath = join(dir, "pty-host.sock");
+  if (opts.stateRoot !== undefined) writeStateRootManifest(dir, opts.stateRoot);
+  const ac = new AbortController();
+  let resolveReady: () => void;
+  const ready = new Promise<void>((r) => {
+    resolveReady = r;
+  });
+  const exit = runKavalDaemon({
+    socketOverride: socketPath,
+    log: silentLog,
+    signal: ac.signal,
+    stateRootPollMs: 20,
+    onReady: () => resolveReady(),
+  });
+  started.push({ ac, exit });
+  return { socketPath, gatePath: join(dir, KAVAL_GATE_FILE), dir, ready, exit };
+}
+
+describe("kaval daemon — state-root self-exit", () => {
+  it("shuts itself down (socket + gate released) when its state-root is deleted", async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), "kaval-stateroot-"));
+    const d = startKaval({ stateRoot });
+    await d.ready;
+    expect(existsSync(d.socketPath)).toBe(true);
+    expect(existsSync(d.gatePath)).toBe(true);
+
+    // Delete the state-root out from under the daemon — the nix-shell/e2e teardown.
+    rmSync(stateRoot, { recursive: true, force: true });
+
+    // The daemon reaps itself: its promise resolves as a clean shutdown and the
+    // socket + gate are gone (torn down via the spine's abort path).
+    const result = await d.exit;
+    expect(result.kind).toBe("shutdown");
+    expect(existsSync(d.socketPath)).toBe(false);
+    expect(existsSync(d.gatePath)).toBe(false);
+  }, 15000);
+
+  it("stays up while its state-root exists (no false-trigger on a live root)", async () => {
+    const stateRoot = mkdtempSync(join(tmpdir(), "kaval-stateroot-"));
+    const d = startKaval({ stateRoot });
+    await d.ready;
+
+    // Well past several poll intervals (20ms each), the daemon is STILL serving —
+    // a live state-root must never trip the self-exit.
+    const outcome = await Promise.race([
+      d.exit.then(() => "exited" as const),
+      sleep(200).then(() => "up" as const),
+    ]);
+    expect(outcome).toBe("up");
+    expect(existsSync(d.socketPath)).toBe(true);
+    rmSync(stateRoot, { recursive: true, force: true }); // afterEach reaps the daemon
+  }, 15000);
+
+  it("never watches a standalone kaval (no state-root manifest)", async () => {
+    // No manifest written — a bare `kaval` daemon. The watcher finds nothing to
+    // watch and never self-exits, even across many poll intervals.
+    const d = startKaval({});
+    await d.ready;
+    const outcome = await Promise.race([
+      d.exit.then(() => "exited" as const),
+      sleep(200).then(() => "up" as const),
+    ]);
+    expect(outcome).toBe("up");
+    expect(existsSync(d.socketPath)).toBe(true);
+  }, 15000);
+});

--- a/packages/kaval/src/daemonMain.ts
+++ b/packages/kaval/src/daemonMain.ts
@@ -11,6 +11,7 @@
  * fully-specified spawns it is handed.
  */
 
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { startHeapDiagnostics } from "@kolu/heap-diag";
 import { type DaemonExit, daemonMain, type Logger } from "@kolu/surface-daemon";
@@ -19,7 +20,19 @@ import {
   getPtyHostSocketPath,
   KAVAL_GATE_FILE,
   KAVAL_NS_PREFIX,
+  readStateRootManifest,
 } from "./socketPath.ts";
+
+/** How often the daemon checks whether its state-root still exists. Fixed, not a
+ *  knob — a vanished state-root is permanent, so a lazy cadence reaps the zombie
+ *  without busy-watching. (Tests inject a small value via
+ *  {@link KavalDaemonOptions.stateRootPollMs}.) */
+const STATE_ROOT_POLL_MS = 5_000;
+
+/** Consecutive missed checks before self-exit. A single miss could be a transient
+ *  (a brief unmount); a real deletion stays gone, so a second confirm costs one
+ *  interval and rules the transient out. */
+const STATE_ROOT_MISSES_TO_EXIT = 2;
 
 export interface KavalDaemonOptions {
   /** Override the default socket path (`--socket`). The gate and rcDir are
@@ -31,6 +44,9 @@ export interface KavalDaemonOptions {
   signal?: AbortSignal;
   /** Forwarded readiness hook — fired once the socket is listening. */
   onReady?: (info: { socketPath: string; pid: number }) => void;
+  /** State-root liveness poll interval, in ms. A TEST seam (like `signal`) —
+   *  production omits it and uses {@link STATE_ROOT_POLL_MS}. */
+  stateRootPollMs?: number;
 }
 
 /** Run the kaval daemon to completion: own a PTY host, serve `ptyHostSurface`
@@ -64,13 +80,83 @@ export function runKavalDaemon(opts: KavalDaemonOptions): Promise<DaemonExit> {
     extraColumns: () => ({ terminals: terminalCount() }),
   });
 
+  // Self-exit when our state-root is deleted out from under us. A padi-spawned
+  // kaval's reason to exist is its padi's state-root (recorded in the manifest
+  // padi writes beside our socket); when an e2e/nix-shell run's ephemeral
+  // state-root is removed, the daemon it left behind has nothing to serve and
+  // should reap itself rather than linger as a zombie. Fold the watcher's stop
+  // signal together with the caller's own `signal` so whichever fires first tears
+  // the daemon down through the spine's normal abort path (gate released, socket
+  // unlinked) — consistent with the fail-fast doctrine: a vanished invariant is a
+  // loud clean exit, not a silent degrade. A standalone kaval has no manifest and
+  // is simply never watched.
+  const controller = new AbortController();
+  forwardAbort(opts.signal, controller);
+  const stopWatch = watchStateRoot({
+    dir,
+    log,
+    pollMs: opts.stateRootPollMs ?? STATE_ROOT_POLL_MS,
+    onGone: () => controller.abort(),
+  });
+
   return daemonMain({
     gatePath,
     socketPath,
     router: servedRouter,
     lifetime: { kind: "forever" },
     log,
-    signal: opts.signal,
+    signal: controller.signal,
     onReady: opts.onReady,
-  });
+  }).finally(stopWatch);
+}
+
+/** Poll the state-root recorded in the manifest beside kaval's socket; once it
+ *  has been gone for {@link STATE_ROOT_MISSES_TO_EXIT} consecutive checks, log a
+ *  clear line and fire `onGone`. Returns a stop function (cleared on daemon exit).
+ *
+ *  The manifest is re-read every tick, not captured once: padi writes it around
+ *  kaval's boot, so a single startup read could race it, and a standalone kaval
+ *  never has one — re-reading makes both cases self-correcting. The manifest file
+ *  lives in the rendezvous dir (NOT inside the state-root), so it survives the
+ *  state-root's deletion and still names what vanished. */
+function watchStateRoot(opts: {
+  dir: string;
+  log: Logger;
+  pollMs: number;
+  onGone: () => void;
+}): () => void {
+  let misses = 0;
+  const timer = setInterval(() => {
+    const stateRoot = readStateRootManifest(opts.dir);
+    if (stateRoot === undefined || existsSync(stateRoot)) {
+      misses = 0;
+      return;
+    }
+    misses += 1;
+    if (misses < STATE_ROOT_MISSES_TO_EXIT) return;
+    opts.log.info(
+      { stateRoot },
+      "kaval state-root has been deleted; shutting down (its reason to exist is gone)",
+    );
+    clearInterval(timer);
+    opts.onGone();
+  }, opts.pollMs);
+  // Don't let the poll timer alone keep the event loop alive.
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
+/** Forward an external abort into `controller`, so kaval's own stop triggers (the
+ *  state-root watcher) and the caller's `signal` share one teardown path. Fires
+ *  immediately if `external` is already aborted. */
+function forwardAbort(
+  external: AbortSignal | undefined,
+  controller: AbortController,
+): void {
+  if (external === undefined) return;
+  if (external.aborted) {
+    controller.abort();
+    return;
+  }
+  external.addEventListener("abort", () => controller.abort(), { once: true });
 }

--- a/packages/kaval/src/socketDaemon.test.ts
+++ b/packages/kaval/src/socketDaemon.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -22,8 +22,10 @@ import {
   type UnixSocketConnection,
   unixSocketLink,
 } from "@kolu/surface/links/unix-socket";
-import { afterEach, describe, expect, it } from "vitest";
+import { gatePid } from "@kolu/surface-daemon";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { runContractCorpus, spawnInput } from "./contractCorpus.testlib.ts";
+import { KAVAL_GATE_FILE } from "./socketPath.ts";
 import type { ptyHostSurface } from "./ptyHostSurface.ts";
 
 const SRC = dirname(fileURLToPath(import.meta.url));
@@ -92,26 +94,88 @@ interface Daemon {
 // own `dispose`. (An earlier version reaped a single global list after every
 // test in the file, which killed the corpus daemon after its first test.)
 const trackedChildren: ChildProcess[] = [];
-function track<T extends { child: ChildProcess } | ChildProcess>(x: T): T {
-  trackedChildren.push("child" in x ? x.child : x);
+// The rendezvous dirs of the daemon-only block's spawns — reaped BY GATE PID
+// after each of ITS tests (below). A child handle alone is not enough: the
+// tsx-CLI launcher guard forks a GRANDCHILD daemon, and SIGKILL-ing the tracked
+// wrapper never reaches the fork — only its gate pid does. (Same scoping as
+// `trackedChildren`: the corpus daemon is not tracked here.)
+const trackedRendezvous: string[] = [];
+// EVERY rendezvous any spawn (corpus + daemon-only) ever claimed — never spliced,
+// so the file-level `afterAll` can assert the whole suite left NO live kaval
+// behind and sweep every dir regardless of pass/fail.
+const allRendezvous: string[] = [];
+
+/** The rendezvous dir a socket lives in, and its gate file within it. */
+function rendezvousDir(socketPath: string): string {
+  return dirname(socketPath);
+}
+
+/** SIGKILL whatever pid holds this rendezvous' gate (the daemon, INCLUDING a
+ *  forked grandchild), then remove the dir. ESRCH-safe — a cleanly-exited daemon
+ *  left a dead/absent gate, so there's simply nothing to kill. */
+function reapRendezvous(dir: string): void {
+  const pid = gatePid(join(dir, KAVAL_GATE_FILE));
+  if (pid !== undefined) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already gone — nothing to reap.
+    }
+  }
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Is a pid still alive? `kill(pid, 0)` sends no signal — it only probes. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function track<T extends Daemon | ChildProcess>(x: T): T {
+  if ("child" in x) {
+    trackedChildren.push(x.child);
+    trackedRendezvous.push(rendezvousDir(x.socketPath));
+  } else {
+    trackedChildren.push(x);
+  }
   return x;
 }
 
 /** Spawn `kaval --socket <path>` as a real process (under tsx). Does NOT wait
  *  for readiness — callers that need it call `waitForSocket`. NOT auto-tracked;
- *  the caller decides its lifetime (corpus dispose vs the daemon-only backstop). */
+ *  the caller decides its lifetime (corpus dispose vs the daemon-only backstop),
+ *  but its rendezvous IS recorded for the file-level leak sweep. */
 function launch(socketPath: string): Daemon {
   const child = spawnTs(KAVAL_BIN, ["--socket", socketPath], "ignore");
   const exited = new Promise<number | null>((res) => {
     child.on("exit", (code) => res(code));
   });
+  allRendezvous.push(rendezvousDir(socketPath));
   return {
     child,
     exited,
     socketPath,
-    gatePath: join(dirname(socketPath), "kaval.pid"),
+    gatePath: join(dirname(socketPath), KAVAL_GATE_FILE),
   };
 }
+
+// The whole-suite leak assertion (Part 3's pin): after every test has run and
+// every block has reaped its own, NO kaval the suite spawned may still hold a
+// gate. Compute the verdict first, then sweep every rendezvous unconditionally,
+// so a green OR a red run leaves the box clean (a failing test can't strand a
+// daemon), and finally assert.
+afterAll(() => {
+  const leaked = allRendezvous.filter((dir) => {
+    const pid = gatePid(join(dir, KAVAL_GATE_FILE));
+    return pid !== undefined && isAlive(pid);
+  });
+  for (const dir of allRendezvous.splice(0)) reapRendezvous(dir);
+  expect(leaked).toEqual([]);
+});
 
 function connect(socketPath: string): Promise<Conn> {
   return unixSocketLink<typeof ptyHostSurface.contract>({ socketPath });
@@ -138,7 +202,14 @@ function socketIn(): string {
   return join(mkdtempSync(join(tmpdir(), "kaval-e2e-")), "pty-host.sock");
 }
 
-const makeCwd = (): string => mkdtempSync(join(tmpdir(), "kaval-e2e-cwd-"));
+const makeCwd = (): string => {
+  // A cwd for a spawned shell — recorded in `allRendezvous` so the file-level
+  // sweep removes it too (it has no gate, so `reapRendezvous` just `rmSync`s it).
+  // Without this the harness leaked an empty `kaval-e2e-cwd-*` dir per spawn.
+  const dir = mkdtempSync(join(tmpdir(), "kaval-e2e-cwd-"));
+  allRendezvous.push(dir);
+  return dir;
+};
 
 /** Start a daemon and wait until it serves. */
 async function startDaemon(): Promise<Daemon> {
@@ -201,13 +272,16 @@ runContractCorpus({
 
 // ── Daemon-only scenarios ───────────────────────────────────────────────────
 describe("kaval daemon — process-boundary behaviour", () => {
-  // Backstop: SIGKILL any daemon/tui this block spawned that a failing test
-  // left alive. Scoped to THIS describe, so it never touches the corpus's
-  // shared daemon (which lives under a different describe's lifecycle).
+  // Backstop: reap every daemon/tui this block spawned that a failing test left
+  // alive — SIGKILL the tracked child handles AND reap each rendezvous by its
+  // gate pid (which reaches a forked GRANDCHILD the child handle can't). Runs
+  // after EVERY test, pass or fail, so a failing assertion can't strand a daemon.
+  // Scoped to THIS describe, so it never touches the corpus's shared daemon.
   afterEach(() => {
     for (const c of trackedChildren.splice(0)) {
       if (c.exitCode === null) c.kill("SIGKILL");
     }
+    for (const dir of trackedRendezvous.splice(0)) reapRendezvous(dir);
   });
 
   it("single-instance gate: a second kaval yields (exit 0); a SIGKILL'd one leaves a stale gate the next reaps", async () => {
@@ -263,7 +337,12 @@ describe("kaval daemon — process-boundary behaviour", () => {
     }> =>
       (async () => {
         const socketPath = socketIn();
-        const gatePath = join(dirname(socketPath), "kaval.pid");
+        const gatePath = join(dirname(socketPath), KAVAL_GATE_FILE);
+        // The tsx-CLI shape FORKS a grandchild daemon that outlives the tracked
+        // wrapper (the leak this guard demonstrates). Register the rendezvous so
+        // the afterEach reaps that fork BY GATE PID; the wrapper alone can't.
+        trackedRendezvous.push(rendezvousDir(socketPath));
+        allRendezvous.push(rendezvousDir(socketPath));
         const child = track(spawnFn(KAVAL_BIN, ["--socket", socketPath]));
         const exited = new Promise<number | null>((res) =>
           child.on("exit", (code) => res(code)),

--- a/packages/kaval/src/socketPath.test.ts
+++ b/packages/kaval/src/socketPath.test.ts
@@ -16,7 +16,7 @@ import {
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   discoverKavalCandidates,
   discoverKavalDaemons,
@@ -30,6 +30,28 @@ import {
   resolveRunningKavalSocket,
   writeStateRootManifest,
 } from "./socketPath.ts";
+
+const REAL_GETUID = process.getuid;
+
+/** Simulate a platform without uid semantics (Windows) for the duration of a
+ *  discovery test: `process.getuid` becomes undefined, so (a) discovery SKIPS its
+ *  owner-only check (returning true, the documented no-uid behaviour) and (b) the
+ *  `/tmp` fallback root's namespace grammar keys on `-shared` instead of `-$UID`.
+ *
+ *  Why: discovery now unions BOTH runtime roots, so it always also scans the real
+ *  `/tmp`. A dev box can hold genuine off-XDG `/tmp/kaval-<hex>-$UID` daemons; with
+ *  a real uid they'd match the grammar and leak into a test's results. Under the
+ *  no-uid grammar those real daemons match neither the ownership nor the `-shared`
+ *  suffix, so ONLY the test's own XDG-seeded dirs are found — the scan is HERMETIC
+ *  without weakening the production ownership check (pinned separately, under a
+ *  real uid, by "skips a name-matching namespace whose dir is not owner-only" and
+ *  the both-roots regression). Restored in each describe's `afterEach`. */
+function simulateNoUidPlatform(): void {
+  process.getuid = undefined;
+}
+function restoreUid(): void {
+  process.getuid = REAL_GETUID;
+}
 
 /** Bind a real `net.Server` at `path`, leaving a genuine socket inode behind —
  *  discovery now requires the rendezvous file to be an actual socket, not just an
@@ -114,6 +136,7 @@ describe("discoverPtyHostSockets", () => {
   const servers: Server[] = [];
   afterEach(async () => {
     vi.restoreAllMocks(); // the off-XDG grammar test stubs process.getuid
+    restoreUid(); // the hermetic tests below null process.getuid directly
     if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
     else process.env.XDG_RUNTIME_DIR = savedXdg;
     await Promise.all(servers.splice(0).map((s) => closeServer(s)));
@@ -133,6 +156,7 @@ describe("discoverPtyHostSockets", () => {
   }
 
   it("finds per-port server namespaces and a bare standalone one", async () => {
+    simulateNoUidPlatform(); // hermetic: don't let real off-XDG /tmp daemons leak in
     const runtime = await seed([
       "kaval-7681",
       "kaval-18331",
@@ -151,6 +175,7 @@ describe("discoverPtyHostSockets", () => {
   });
 
   it("ignores a namespace dir with no socket yet", async () => {
+    simulateNoUidPlatform(); // hermetic: don't let real off-XDG /tmp daemons leak in
     const runtime = await seed(["kaval-7681"]);
     mkdirSync(join(runtime, "kaval-9999")); // dir but no pty-host.sock
     process.env.XDG_RUNTIME_DIR = runtime;
@@ -160,6 +185,9 @@ describe("discoverPtyHostSockets", () => {
   });
 
   it("returns [] when the runtime root is unreadable / absent", () => {
+    // Both roots empty: the XDG root doesn't exist and (under the no-uid grammar)
+    // the /tmp fallback matches nothing — so the union is genuinely empty.
+    simulateNoUidPlatform();
     process.env.XDG_RUNTIME_DIR = join(tmpdir(), "kdisc-does-not-exist-xyz");
     expect(discoverPtyHostSockets()).toEqual([]);
   });
@@ -186,11 +214,14 @@ describe("discoverPtyHostSockets", () => {
       chmodSync(looseDir, 0o755); // group/other access — not owner-only
       process.env.XDG_RUNTIME_DIR = runtime;
       try {
-        // Only the owner-only dir's socket is returned; the loose one is dropped
-        // despite holding a real, name-matching socket.
-        expect(discoverPtyHostSockets()).toEqual([
-          join(okDir, PTY_HOST_SOCK_FILE),
-        ]);
+        // The owner-only dir's socket is returned; the loose one is dropped
+        // despite holding a real, name-matching socket. This runs under a REAL
+        // uid (it pins the ownership check), so the /tmp fallback root is also
+        // scanned — assert membership, not exact equality, to tolerate any
+        // genuine off-XDG daemon on the box.
+        const found = new Set(discoverPtyHostSockets());
+        expect(found.has(join(okDir, PTY_HOST_SOCK_FILE))).toBe(true);
+        expect(found.has(join(looseDir, PTY_HOST_SOCK_FILE))).toBe(false);
       } finally {
         await Promise.all([closeServer(okServer), closeServer(looseServer)]);
         rmSync(runtime, { recursive: true, force: true });
@@ -232,6 +263,69 @@ describe("discoverPtyHostSockets", () => {
   });
 });
 
+// THE REGRESSION for the reported bug: `kaval-tui` and the Kaval dialog reported
+// DIFFERENT daemon sets on the same box because discovery scanned only the ONE
+// root the CALLER's own env pointed at. It must now union BOTH the XDG root and
+// the fixed `/tmp` fallback, so a daemon in the /tmp drawer is visible to an
+// XDG-set caller (the production dialog) too. Runs under a REAL uid — it seeds a
+// genuine `/tmp/kaval-<hex>-$UID` daemon, the exact shape the fix must see — so it
+// asserts MEMBERSHIP (tolerating any other daemon on the box), never exact set.
+describe.runIf(process.getuid)(
+  "discoverKavalCandidates — unions the XDG root AND the /tmp fallback",
+  () => {
+    const savedXdg = process.env.XDG_RUNTIME_DIR;
+    const servers: Server[] = [];
+    const dirs: string[] = [];
+    afterEach(async () => {
+      if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = savedXdg;
+      await Promise.all(servers.splice(0).map((s) => closeServer(s)));
+      for (const d of dirs.splice(0))
+        rmSync(d, { recursive: true, force: true });
+    });
+
+    it("finds a /tmp daemon EVEN with $XDG_RUNTIME_DIR set, and finds it whether or not XDG is set", async () => {
+      const uid = process.getuid?.();
+      if (uid === undefined) return; // guarded by describe.runIf; narrows the type
+      // A daemon in the /tmp fallback drawer — the one an XDG-set caller was BLIND
+      // to before the fix. Its namespace is unique to THIS test run (a hex pid
+      // suffix) and ends in `-$UID`, so it matches the off-XDG grammar without ever
+      // colliding with (or touching) a real `/tmp/kaval-*` daemon on the box.
+      const tmpNs = `${KAVAL_NS_PREFIX}-de${process.pid.toString(16)}-${uid}`;
+      const tmpDir = join("/tmp", tmpNs);
+      mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
+      dirs.push(tmpDir);
+      const tmpSock = join(tmpDir, PTY_HOST_SOCK_FILE);
+      servers.push(await listenSocket(tmpSock));
+
+      // A daemon in the XDG drawer.
+      const xdgRoot = mkdtempSync(join(tmpdir(), "kboth-xdg-"));
+      dirs.push(xdgRoot);
+      mkdirSync(join(xdgRoot, KAVAL_NS_PREFIX), {
+        recursive: true,
+        mode: 0o700,
+      });
+      const xdgSock = join(xdgRoot, KAVAL_NS_PREFIX, PTY_HOST_SOCK_FILE);
+      servers.push(await listenSocket(xdgSock));
+
+      // With XDG set, BOTH drawers are scanned — the /tmp daemon is no longer
+      // invisible to an XDG-set caller (the exact production bug).
+      process.env.XDG_RUNTIME_DIR = xdgRoot;
+      const withXdg = new Set(discoverPtyHostSockets());
+      expect(withXdg.has(tmpSock)).toBe(true);
+      expect(withXdg.has(xdgSock)).toBe(true);
+
+      // With XDG unset, the /tmp daemon is STILL found: the fallback root is
+      // scanned unconditionally, so the /tmp drawer (the source of the leaked
+      // pile) is visible regardless of the caller's env. That caller-independence
+      // for the /tmp drawer is the regression this pins. (The XDG daemon's root is
+      // $XDG itself, so it is unreachable with XDG unset — by construction.)
+      delete process.env.XDG_RUNTIME_DIR;
+      expect(new Set(discoverPtyHostSockets()).has(tmpSock)).toBe(true);
+    });
+  },
+);
+
 // The STRUCTURAL `kind` each candidate carries (decided at the matching branch, the
 // inverse of `kavalNamespace`) + the gate-pid enrichment `discoverKavalDaemons` adds —
 // the read-only enumeration the Kaval info dialog lists. Exercised over real seeded
@@ -241,6 +335,7 @@ describe("discoverKavalDaemons + candidate kind", () => {
   const savedXdg = process.env.XDG_RUNTIME_DIR;
   const servers: Server[] = [];
   afterEach(async () => {
+    restoreUid();
     if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
     else process.env.XDG_RUNTIME_DIR = savedXdg;
     await Promise.all(servers.splice(0).map((s) => closeServer(s)));
@@ -256,6 +351,7 @@ describe("discoverKavalDaemons + candidate kind", () => {
   }
 
   it("classifies standalone / stateRoot (manifest) / legacy port by matching branch", async () => {
+    simulateNoUidPlatform(); // hermetic: don't let real off-XDG /tmp daemons leak in
     const digest = "680023982235a767";
     const runtime = await seed([`kaval-${digest}`, "kaval-7692", "kaval"]);
     writeStateRootManifest(
@@ -279,6 +375,7 @@ describe("discoverKavalDaemons + candidate kind", () => {
   });
 
   it("reads the gate pid from kaval.pid beside the socket (null when absent)", async () => {
+    simulateNoUidPlatform(); // hermetic: don't let real off-XDG /tmp daemons leak in
     const runtime = await seed(["kaval-7692", "kaval"]);
     // Write a gate holding a pid for one, leave the other gate-less.
     writeFileSync(join(runtime, "kaval-7692", KAVAL_GATE_FILE), "4242\n");
@@ -301,10 +398,20 @@ describe("discoverKavalDaemons + candidate kind", () => {
 // so the policy is pinned end-to-end.
 describe("resolveRunningKavalSocket", () => {
   const savedXdg = process.env.XDG_RUNTIME_DIR;
+  const savedKavalSocket = process.env.KAVAL_SOCKET;
   const servers: Server[] = [];
+  beforeEach(() => {
+    // $KAVAL_SOCKET now takes precedence over discovery; clear it so the
+    // discovery-path tests below aren't hijacked by an inherited value, and each
+    // env-precedence test sets it explicitly.
+    delete process.env.KAVAL_SOCKET;
+  });
   afterEach(async () => {
+    restoreUid();
     if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
     else process.env.XDG_RUNTIME_DIR = savedXdg;
+    if (savedKavalSocket === undefined) delete process.env.KAVAL_SOCKET;
+    else process.env.KAVAL_SOCKET = savedKavalSocket;
     await Promise.all(servers.splice(0).map((s) => closeServer(s)));
   });
 
@@ -317,6 +424,35 @@ describe("resolveRunningKavalSocket", () => {
     return runtime;
   }
 
+  // $KAVAL_SOCKET is stamped into every PTY a kaval/padi spawns; inside a kolu
+  // terminal it names the exact daemon that owns you, so it must win over the
+  // env-blind discovery scan (the ambiguous "more than one daemon" bug). These
+  // pin the precedence chain --socket → $KAVAL_SOCKET → discover.
+  it("returns $KAVAL_SOCKET and does NOT consult discovery when it is set", async () => {
+    // Seed TWO daemons so discovery, IF consulted, would return `many`. With
+    // $KAVAL_SOCKET set we get `env` instead — behavioural proof the env
+    // short-circuits the scan (a `many` here would mean discovery ran).
+    simulateNoUidPlatform(); // hermetic: only the seeded daemons count
+    const runtime = await seed(["kaval", "kaval-7692"]);
+    process.env.XDG_RUNTIME_DIR = runtime;
+    // Sanity: without the env var, this exact state IS ambiguous.
+    expect(resolveRunningKavalSocket(undefined).kind).toBe("many");
+    // With it, the scan is never reached.
+    process.env.KAVAL_SOCKET = "/run/user/1000/kaval-abc123/pty-host.sock";
+    expect(resolveRunningKavalSocket(undefined)).toEqual({
+      kind: "env",
+      socket: "/run/user/1000/kaval-abc123/pty-host.sock",
+    });
+  });
+
+  it("an explicit --socket still overrides $KAVAL_SOCKET", () => {
+    process.env.KAVAL_SOCKET = "/from/env.sock";
+    expect(resolveRunningKavalSocket("/from/flag.sock")).toEqual({
+      kind: "explicit",
+      socket: "/from/flag.sock",
+    });
+  });
+
   it("returns an explicit socket verbatim, without discovery", () => {
     // No XDG root seeded — discovery would find nothing — yet the explicit path
     // is returned as-is, proving it short-circuits discovery.
@@ -328,6 +464,7 @@ describe("resolveRunningKavalSocket", () => {
   });
 
   it("discovers a single running kaval → one", async () => {
+    simulateNoUidPlatform(); // hermetic: only the seeded daemon counts
     const runtime = await seed(["kaval-7692"]);
     process.env.XDG_RUNTIME_DIR = runtime;
     expect(resolveRunningKavalSocket(undefined)).toEqual({
@@ -337,6 +474,8 @@ describe("resolveRunningKavalSocket", () => {
   });
 
   it("falls back to the bare default → none when nothing is running", () => {
+    // Both roots empty under the no-uid grammar, so discovery is genuinely empty.
+    simulateNoUidPlatform();
     process.env.XDG_RUNTIME_DIR = join(tmpdir(), "kresolve-empty-xyz");
     expect(resolveRunningKavalSocket(undefined)).toEqual({
       kind: "none",
@@ -345,6 +484,7 @@ describe("resolveRunningKavalSocket", () => {
   });
 
   it("reports every candidate with an UNAMBIGUOUS namespace label → many", async () => {
+    simulateNoUidPlatform(); // hermetic: only the seeded daemons count
     const runtime = await seed(["kaval", "kaval-7692"]);
     process.env.XDG_RUNTIME_DIR = runtime;
     const resolved = resolveRunningKavalSocket(undefined);
@@ -371,6 +511,7 @@ describe("resolveRunningKavalSocket", () => {
     // legacy in-process kolu-server's `kaval-<port>/` has NO manifest, so it keeps
     // the port label — manifest presence is the discriminant, so an all-decimal
     // digest could never masquerade as a port.
+    simulateNoUidPlatform(); // hermetic: only the seeded daemons count
     const digest = "680023982235a767";
     const runtime = await seed([`kaval-${digest}`, "kaval-7692"]);
     writeStateRootManifest(

--- a/packages/kaval/src/socketPath.ts
+++ b/packages/kaval/src/socketPath.ts
@@ -26,6 +26,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
@@ -150,21 +151,31 @@ export function isPrivateOwnedDir(dir: string): boolean {
   }
 }
 
-/** Discover the rendezvous sockets of running pty-host daemons under the per-user
- *  runtime root, EACH LABELED by the branch that matched — a bare standalone
- *  `kaval/` (→ "standalone kaval"), a padi's digest-keyed `kaval-<digest>/`
- *  (labeled from its state-root manifest → "kolu @ <state-root>"), and, for the
- *  transition, a legacy `kaval-<port>/` (no manifest, numeric suffix → "kolu-server
- *  on port <port>"). Lets a flag-less `kaval-tui` dial the daemon without knowing
- *  padi's digest, and a `many`-candidate error name each one correctly.
+/** Discover the rendezvous sockets of running pty-host daemons across BOTH
+ *  per-user runtime roots — the env-derived `$XDG_RUNTIME_DIR/kaval*` AND the
+ *  fixed `/tmp/kaval-$UID*` fallback — EACH LABELED by the branch that matched: a
+ *  bare standalone `kaval/` (→ "standalone kaval"), a padi's digest-keyed
+ *  `kaval-<digest>/` (labeled from its state-root manifest → "kolu @ <state-root>"),
+ *  and, for the transition, a legacy `kaval-<port>/` (no manifest, numeric suffix
+ *  → "kolu-server on port <port>"). Lets a flag-less `kaval-tui` dial the daemon
+ *  without knowing padi's digest, and a `many`-candidate error name each one.
  *
- *  The runtime root and the env's namespace decoration are NOT re-derived here:
- *  they are READ BACK from `getRuntimeSocketPath` itself, so discovery can never
- *  spell the path shape differently than construction. Build the bare daemon's
- *  socket path, then walk back up — its grandparent is the root to scan, its
- *  parent's basename is the (possibly `-$UID`-decorated) bare namespace dir. The
- *  per-port pattern is the same decoration with a `(\d+)` capture substituted for
- *  the port, learnt from a probe build with port `0`.
+ *  BOTH roots are scanned unconditionally, because a daemon registers in whichever
+ *  drawer ITS binder's env pointed at — a daemon spawned with XDG unset lives under
+ *  /tmp even on a host whose interactive processes have XDG set — so a discoverer
+ *  that read only its own env-derived drawer would be blind to the other (the bug
+ *  where the Kaval dialog and a nix-shell `kaval-tui` reported disjoint sets). The
+ *  union is de-duped by canonical path. See {@link candidatesUnderRegime} for the
+ *  per-root scan.
+ *
+ *  Neither root nor the env's namespace decoration is re-spelled here: both are
+ *  READ BACK from `getRuntimeSocketPath` itself (the /tmp spelling via the builder
+ *  with XDG forced off), so discovery can never spell the path shape differently
+ *  than construction. Build the bare daemon's socket path, then walk back up — its
+ *  grandparent is the root to scan, its parent's basename is the (possibly
+ *  `-$UID`-decorated) bare namespace dir. The per-port pattern is the same
+ *  decoration with a `(\d+)` capture substituted for the port, learnt from a probe
+ *  build with port `0`.
  *
  *  Labeling is the INVERSE of `kavalNamespace`, derived from THIS match — not a
  *  later re-parse of the basename. That distinction matters: a re-parse of a bare
@@ -181,12 +192,81 @@ export function isPrivateOwnedDir(dir: string): boolean {
  *  itself be a socket — not any file a name-squatter dropped in. Returns every
  *  surviving `<ns>/pty-host.sock`; never throws (an unreadable root → []). */
 export function discoverKavalCandidates(): KavalSocketCandidate[] {
+  // A kaval registers in ONE of two drawers, decided by the BINDER's env at spawn
+  // time: `$XDG_RUNTIME_DIR/kaval*` when XDG is set (production padi/kolu-server),
+  // else `/tmp/kaval-$UID*` (a nix-shell / e2e / test daemon with XDG unset). A
+  // scan of only the DISCOVERER's own env-derived drawer is environment-blind: a
+  // caller with XDG set (the Kaval dialog) never sees the /tmp daemons, and one
+  // with XDG unset (a nix-shell kaval-tui) never sees the XDG daemon — the two
+  // report DISJOINT sets on the same box. So union BOTH roots: the env-derived
+  // one AND the fixed `/tmp` fallback, ALWAYS, whatever this process's env says.
+  //
+  // Both roots are read back from `getRuntimeSocketPath` — the SAME construction
+  // the binder uses — so discovery can never spell a path the binder wouldn't.
+  // The `/tmp` spelling is obtained by asking the builder with XDG forced off
+  // (`forceTmp`), NOT by hand-writing `/tmp/kaval-$UID`.
+  const candidates = [
+    ...candidatesUnderRegime(false), // this process's env (XDG when set, else /tmp)
+    ...candidatesUnderRegime(true), // the fixed /tmp fallback, always
+  ];
+
+  // De-dup by CANONICAL path: when XDG is unset both regimes resolve to /tmp (so
+  // every candidate appears twice), and even with XDG set a daemon reachable via
+  // two spellings (e.g. a symlinked runtime dir) must be listed once. `realpath`
+  // collapses them; a socket that vanished mid-scan falls back to its raw path.
+  const seen = new Set<string>();
+  const unique: KavalSocketCandidate[] = [];
+  for (const candidate of candidates) {
+    const key = canonicalPath(candidate.socket);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(candidate);
+  }
+  return unique;
+}
+
+/** Build a kaval socket path exactly as {@link getRuntimeSocketPath} would, but
+ *  under a chosen runtime-root regime: `forceTmp` evaluates the builder with
+ *  `$XDG_RUNTIME_DIR` momentarily unset so it yields the fixed `/tmp/<app>-$UID`
+ *  fallback even when this process has XDG set. The save/restore is synchronous
+ *  and re-entrancy-free (no `await` between them, Node runs it on one thread), so
+ *  it can never race another caller's view of the env. Reusing the builder — not
+ *  re-spelling `/tmp/kaval-$UID` here — keeps discovery's path shape and
+ *  construction's provably identical. */
+function socketPathForApp(app: string, forceTmp: boolean): string {
+  if (!forceTmp) {
+    return getRuntimeSocketPath({ app, file: PTY_HOST_SOCK_FILE });
+  }
+  const saved = process.env.XDG_RUNTIME_DIR;
+  delete process.env.XDG_RUNTIME_DIR;
+  try {
+    return getRuntimeSocketPath({ app, file: PTY_HOST_SOCK_FILE });
+  } finally {
+    if (saved !== undefined) process.env.XDG_RUNTIME_DIR = saved;
+  }
+}
+
+/** The canonical (symlink-resolved) form of `path`, or `path` verbatim if it
+ *  can't be resolved (already unlinked, or a broken link) — the de-dup key that
+ *  collapses two spellings of the same daemon into one. */
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/** Every kaval candidate under ONE runtime-root regime (the env-derived root, or
+ *  the forced `/tmp` fallback). The name grammar is regime-specific — off XDG the
+ *  bare namespace is `kaval-$UID` and the decorated one `kaval-<x>-$UID` — so each
+ *  regime derives its OWN `bareName`/`decoratedRe` from the builder, never a
+ *  cross-regime reuse. {@link discoverKavalCandidates} unions and de-dups both. */
+function candidatesUnderRegime(forceTmp: boolean): KavalSocketCandidate[] {
   // The bare daemon's socket: `<root>/<bareDir>/pty-host.sock`. Whatever shape
   // surface gives it (XDG `kaval/`, or `/tmp` `kaval-$UID/`) the decoration is
   // baked into `bareDir`, never re-decided here.
-  const bareDir = dirname(
-    getRuntimeSocketPath({ app: KAVAL_NS_PREFIX, file: PTY_HOST_SOCK_FILE }),
-  );
+  const bareDir = dirname(socketPathForApp(KAVAL_NS_PREFIX, forceTmp));
   const root = dirname(bareDir);
   const bareName = basename(bareDir);
 
@@ -197,12 +277,7 @@ export function discoverKavalCandidates(): KavalSocketCandidate[] {
   // — then read the suffix back to disambiguate by the manifest below. (Escape
   // the rest so a `/tmp` path can't inject regex metacharacters.)
   const decoratedName = basename(
-    dirname(
-      getRuntimeSocketPath({
-        app: kavalNamespace(0),
-        file: PTY_HOST_SOCK_FILE,
-      }),
-    ),
+    dirname(socketPathForApp(kavalNamespace(0), forceTmp)),
   );
   const decoratedRe = new RegExp(
     `^${decoratedName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace("0", "([0-9a-f]+)")}$`,
@@ -335,21 +410,31 @@ export interface KavalDaemon extends KavalSocketCandidate {
  *  lives here, beside the namespace construction it inverts, so a consumer only
  *  renders the `many`/`none` cases in its own error surface. */
 export type KavalSocketResolution =
-  | { kind: "explicit" | "one" | "none"; socket: string }
+  | { kind: "explicit" | "env" | "one" | "none"; socket: string }
   | { kind: "many"; candidates: KavalSocketCandidate[] };
 
-/** Resolve which running kaval to dial. An explicit path wins (verbatim — it's a
- *  user-supplied `--socket`/`--kaval` flag). Otherwise discover the running
- *  daemon: padi keys its kaval by a digest of its state-root (`kaval-<digest>/`),
- *  so there is no single fixed path to assume. Exactly one found → `one`. More than
- *  one → `many`, with each candidate LABELED (the caller renders a pick-one
- *  error). None → `none` with the bare `kaval` default, so a connect error names
- *  a sensible path. */
+/** Resolve which running kaval to dial, in precedence order (the mirror of
+ *  padi-tui's `resolveRunningPadiSocket`):
+ *   1. an explicit `--socket` path wins verbatim — a user-supplied override;
+ *   2. `$KAVAL_SOCKET` — stamped into every PTY a kaval/padi spawns (the `$TMUX`
+ *      convention) — names the daemon that OWNS this terminal, so a flag-less
+ *      `kaval-tui` INSIDE a kolu terminal "just works" and an agent driving its
+ *      siblings never falls through to discovery's ambiguous `many`. Authoritative
+ *      when set+non-empty: it SHORT-CIRCUITS discovery entirely (no scan runs);
+ *   3. else discover the running daemon: padi keys its kaval by a digest of its
+ *      state-root (`kaval-<digest>/`), so there is no single fixed path to assume.
+ *      Exactly one found → `one`; more than one → `many`, each candidate LABELED
+ *      (the caller renders a pick-one error); none → `none` with the bare `kaval`
+ *      default, so a connect error names a sensible path. */
 export function resolveRunningKavalSocket(
   explicit?: string,
 ): KavalSocketResolution {
   if (explicit !== undefined && explicit !== "") {
     return { kind: "explicit", socket: explicit };
+  }
+  const env = process.env.KAVAL_SOCKET;
+  if (env !== undefined && env !== "") {
+    return { kind: "env", socket: env };
   }
   const found = discoverKavalCandidates();
   const [first, ...rest] = found;


### PR DESCRIPTION
## Why

`kaval-tui list` and the Kaval dialog reported **different** sets of kaval daemons on the *same* machine, and the e2e/integration suite left kaval daemons running after it finished (the `/tmp/kaval-*` pile). Root cause: discovery only ever read the **one** runtime drawer the *calling* process's `$XDG_RUNTIME_DIR` pointed at, and inside a kolu terminal `kaval-tui` ignored the `$KAVAL_SOCKET` that already names the right daemon.

## What changed (all in `packages/kaval`)

**0. `resolveRunningKavalSocket` honours `$KAVAL_SOCKET`** — the precedence chain is now `--socket` → `$KAVAL_SOCKET` → discover, mirroring padi-tui's `resolveRunningPadiSocket`. `$KAVAL_SOCKET` is stamped into every PTY a kaval/padi spawns, so a flag-less `kaval-tui` *inside* a kolu terminal dials the daemon that owns it and never falls through to the ambiguous "more than one daemon" scan. When set, it **short-circuits discovery entirely**.

**1. Discovery scans BOTH runtime roots (the real fix)** — `discoverKavalCandidates` now unions the env-derived `$XDG_RUNTIME_DIR/kaval*` **and** the fixed `/tmp/kaval-$UID*` fallback (always), de-duped by canonical path. Both roots are read back through `getRuntimeSocketPath` (the `/tmp` spelling via the builder with XDG forced off) — never hand-spelled — so discovery can't diverge from construction. The owner-only privacy check is unchanged. A caller with XDG set (the dialog) now sees the `/tmp` daemons a nix-shell left, and vice-versa.

**2. kaval self-exits when its state-root is deleted (zombie safety net)** — a padi-spawned kaval reads the `state-root` manifest padi writes beside its socket and polls it; once that path is gone (2 consecutive checks, to rule out a transient), it logs and shuts down cleanly via the spine's abort path (gate released, socket unlinked). A standalone kaval has no manifest and is never watched. Fail-fast, not silent-degrade.

**3. The e2e harness reaps every daemon it spawns (the actual leak source)** — `socketDaemon.test.ts` now reaps each spawn **by gate pid** on every test, pass or fail — which reaches the tsx-CLI **forked grandchild** daemon that a `SIGKILL` of the tracked child handle never could (the launcher-guard test deliberately forks one). Leaked cwd dirs are swept too, and a file-level assertion proves no spawned kaval survives the suite.

## Regression pins (the three requested)

| Pin | Test |
|---|---|
| discovery scans both roots | `socketPath.test.ts` → *"discoverKavalCandidates — unions the XDG root AND the /tmp fallback"* (seeds a real `/tmp` daemon + an XDG daemon; asserts the `/tmp` one is found **with XDG set** and regardless of XDG) |
| `$KAVAL_SOCKET` short-circuits discovery | `socketPath.test.ts` → *"returns \$KAVAL_SOCKET and does NOT consult discovery"* (seeds two daemons that would be `many`; env yields `env`) + *"an explicit --socket still overrides \$KAVAL_SOCKET"* |
| state-root-gone self-exit | `daemonMain.test.ts` → *"shuts itself down … when its state-root is deleted"* (+ no-false-trigger + standalone-never-watched) |
| harness leaves no zombie | `socketDaemon.test.ts` → file-level `afterAll` asserts no spawned gate holder is alive |

## Testing
- `packages/kaval` unit suite: **139 passing** (incl. the new pins); `kaval-tui`: 127 passing; typecheck clean on kaval/kaval-tui/padi; `biome lint --error-on-warnings` clean.
- No `@kolu/surface*` API change → no drishti mirror PR needed.

## Not part of this PR — pre-existing runtime cruft
There are ~25 live leaked daemons + hundreds of stale dirs under `/tmp` on the box from **before** this fix. This PR does **not** touch them (they're a real machine's running processes — your call). After merge you can list them and decide:

```sh
# LIST leaked off-XDG kaval daemons for your uid (does not kill anything):
for d in /tmp/kaval-$(id -u) /tmp/kaval-*-$(id -u); do
  [ -S "$d/pty-host.sock" ] && echo "$d  (pid $(cat "$d/kaval.pid" 2>/dev/null))"
done
```