### PR TITLE
Turn the website into a docs-first product guide

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,16 +1,35 @@
 # kolu website
 
-Marketing + blog + changelog for [kolu](https://github.com/juspay/kolu). Astro +
-Tailwind v4, deployed to <https://kolu.dev> via GitHub Pages.
+Marketing, docs, blog, and changelog for [kolu](https://github.com/juspay/kolu).
+Astro + Tailwind v4, deployed to <https://kolu.dev> via GitHub Pages.
 
 ## Develop
 
 ```sh
 just website::dev          # HMR on http://127.0.0.1:4321
+just website::search-preview # production build + Pagefind search preview
 just website::nix-build    # reproducible Nix build → /nix/store/...
 ```
 
-Blog posts: `src/content/blog/*.md` (schema in `src/content.config.ts`).
+Docs: `src/content/docs/*.{md,mdx}`, rendered at root-level URLs by
+`src/pages/[slug].astro` (`quickstart.mdx` → `/quickstart`). Required
+frontmatter is `title`; `description`, `order`, `section`, and `koluHero` are
+optional. `order` controls sidebar and previous/next order; `section` groups the
+sidebar. Docs render through `DocsLayout`, which provides the native site header,
+sidebar, mobile docs menu, on-this-page TOC, previous/next links, Pagefind
+metadata, and code-copy buttons.
+
+Docs component kit: `src/components/docs/Aside.astro`, `Card.astro`,
+`CardGrid.astro`, `LinkCard.astro`, and `Steps.astro`. Use normal Markdown first;
+reach for these when the page needs callouts, repeated cards, navigation cards,
+or numbered setup steps. Product screenshots can live under `public/` and be
+wrapped in `<figure class="doc-shot">`.
+
+Search: `pnpm build` runs `astro build && pagefind --site dist`. Search is not
+available during `astro dev`; use `just website::search-preview` to build the
+index and serve `dist` locally.
+
+Blog posts: `src/content/blog/*.{md,mdx}` (schema in `src/content.config.ts`).
 Frontmatter `title`, `description`, `pubDate`, optional `author` +
 `authorUrl`. Don't include a leading `# ` heading — it comes from the
 frontmatter `title`.

--- a/website/mod.just
+++ b/website/mod.just
@@ -32,6 +32,10 @@ check: install
 build: install
     cd {{ here }} && {{ nix_shell }} pnpm build
 
+# Build and serve ./dist locally so the Pagefind search index is available
+search-preview: build
+    cd {{ here }} && {{ nix_shell }} pnpm exec astro preview --port 4321
+
 # Build the static site via Nix (reproducible) — prints the store path
 nix-build:
     nix build {{ root }}#website --print-out-paths

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -2,7 +2,7 @@
 const year = new Date().getFullYear();
 ---
 
-<footer class="border-t border-rule mt-28">
+<footer class="border-t border-rule mt-28" data-pagefind-ignore>
   <div
     class="mx-auto max-w-[68rem] px-6 py-10 flex flex-col md:flex-row md:items-end md:justify-between gap-6"
   >

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -8,6 +8,6 @@
 import NavBar from "./NavBar.astro";
 ---
 
-<header class="sticky top-0 z-10 border-b border-rule backdrop-blur-xs bg-void/80">
+<header class="sticky top-0 z-10 border-b border-rule backdrop-blur-xs bg-void/80" data-pagefind-ignore>
   <NavBar />
 </header>

--- a/website/src/components/KoluHero.astro
+++ b/website/src/components/KoluHero.astro
@@ -47,7 +47,12 @@ const lines = headline
       {
         lines.map((line, i) => (
           <>
-            {i > 0 && <br />}
+            {i > 0 && (
+              <>
+                {" "}
+                <br />
+              </>
+            )}
             {line.map((seg) =>
               seg.accent ? (
                 <span class="kolu-hero__accent">{seg.text}</span>

--- a/website/src/components/NavBar.astro
+++ b/website/src/components/NavBar.astro
@@ -24,18 +24,14 @@ const normalized = pathname.replace(new RegExp(`^${base}`), '') || '/';
 const isActive = (p: string) =>
   p === '/' ? normalized === '/' : normalized.startsWith(p);
 
-// `hideOnMobile` drops the longest, most-redundant labels below `sm` so the
-// single-row nav fits narrow phones without overflowing. The brand logo already
-// links home, and architecture is linked prominently from the system sections.
+// `hideOnMobile` drops the longest labels below `sm` so the single-row nav fits
+// narrow phones without overflowing. Product pages such as Padi and Kaval now
+// live in the docs sidebar and the homepage system map.
 const nav = [
-  { label: 'Get started', href: `${href('/')}#quickstart`, path: '/', hideOnMobile: true },
-  // Docs entry point — architecture is the broad overview and the docs front
-  // door; landing on any docs page reveals the full docs sidebar.
-  { label: 'Docs', href: href('/architecture'), path: '/architecture', hideOnMobile: true },
-  { label: 'Padi', href: href('/padi'), path: '/padi' },
-  { label: 'Kaval', href: href('/kaval'), path: '/kaval' },
-  { label: 'Changelog', href: href('/changelog'), path: '/changelog', hideOnMobile: true },
+  { label: 'Docs', href: href('/quickstart'), path: '/quickstart' },
+  { label: 'Architecture', href: href('/architecture'), path: '/architecture', hideOnMobile: true },
   { label: 'Blog', href: href('/blog'), path: '/blog' },
+  { label: 'Changelog', href: href('/changelog'), path: '/changelog', hideOnMobile: true },
   { label: 'Discord', href: 'https://discord.com/invite/9acjNV8nmS', external: true, hideOnMobile: true },
   { label: 'GitHub', href: 'https://github.com/juspay/kolu', external: true },
 ];

--- a/website/src/components/SiteSearch.astro
+++ b/website/src/components/SiteSearch.astro
@@ -4,8 +4,8 @@
  * search button appears in the header on every page. It drives the Pagefind UI
  * (@pagefind/default-ui) directly, loading the /pagefind/ index the postbuild
  * step emits (see package.json `build`). Pagefind indexes the docs pages (they
- * carry data-pagefind-body on the DocsLayout content), so this searches the
- * documentation from anywhere on the site.
+ * carry data-pagefind-body on the DocsLayout content), and every page carries a
+ * Pagefind `section` filter so results read as Docs / Blog / Changelog / Site.
  *
  * The trigger and modal are themed with the site's own --color-* tokens so the
  * button sits flush with the mono nav and the toggle beside it.
@@ -28,7 +28,7 @@
       {
         import.meta.env.DEV ? (
           <div class="nav-search-dev">
-            <p>Search is powered by an index built at production build time, so it is unavailable in dev. Run a production build (or preview) to try it.</p>
+            <p>Search is powered by an index built at production build time, so it is unavailable in dev. Run <code>just website::search-preview</code> to try it locally.</p>
           </div>
         ) : (
           <div class="nav-search-container">
@@ -109,9 +109,37 @@
             element: "#nav-search__pagefind",
             baseUrl: import.meta.env.BASE_URL,
             bundlePath: import.meta.env.BASE_URL.replace(/\/$/, "") + "/pagefind/",
+            filters: {
+              section: "Type",
+            },
+            processResult(result: { meta?: { section?: string; title?: string } }) {
+              const section = result.meta?.section;
+              if (
+                section &&
+                typeof result.meta?.title === "string" &&
+                !result.meta.title.startsWith(`${section} · `)
+              ) {
+                result.meta.title = `${section} · ${result.meta.title}`;
+              }
+              return result;
+            },
             showImages: false,
             showSubResults: true,
           });
+          const labelPagefindInput = () => {
+            const input = this.querySelector<HTMLInputElement>(".pagefind-ui__search-input");
+            if (!input) return false;
+            input.id = "nav-search-input";
+            input.name = "q";
+            input.setAttribute("aria-label", "Search this site");
+            return true;
+          };
+          if (!labelPagefindInput()) {
+            const observer = new MutationObserver(() => {
+              if (labelPagefindInput()) observer.disconnect();
+            });
+            observer.observe(this, { childList: true, subtree: true });
+          }
         });
       });
     }
@@ -262,5 +290,11 @@
     --pagefind-ui-tag: var(--color-void-sunk);
     --pagefind-ui-border-width: 1px;
     --pagefind-ui-font: var(--font-sans);
+  }
+  #nav-search__pagefind .pagefind-ui__filter-name {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 </style>

--- a/website/src/components/docs/Sidebar.astro
+++ b/website/src/components/docs/Sidebar.astro
@@ -35,7 +35,29 @@ for (const entry of entries) {
 }
 ---
 
-<details class="docs-sidebar" open>
+<nav class="docs-sidebar docs-sidebar__nav docs-sidebar--desktop" aria-label="Documentation">
+  {
+    groups.map((group) => (
+      <div class="docs-sidebar__group">
+        <p class="docs-sidebar__grouplabel">{group.label}</p>
+        <ul>
+          {group.items.map((entry) => (
+            <li>
+              <a
+                href={`/${entry.id}`}
+                aria-current={entry.id === current ? "page" : undefined}
+              >
+                {entry.data.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    ))
+  }
+</nav>
+
+<details class="docs-sidebar docs-sidebar--mobile">
   <summary class="docs-sidebar__summary">
     <span>On this site</span>
     <span class="docs-sidebar__current">{currentTitle}</span>
@@ -67,8 +89,26 @@ for (const entry of entries) {
   .docs-sidebar {
     font-size: 0.9rem;
   }
-  .docs-sidebar__summary {
+  .docs-sidebar--mobile {
     display: none;
+  }
+  .docs-sidebar__summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.7rem 0.95rem;
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--color-ink-dim);
+    list-style: none;
+  }
+  .docs-sidebar__summary::-webkit-details-marker {
+    display: none;
+  }
+  .docs-sidebar__current {
+    color: var(--color-kolu-primary);
   }
   .docs-sidebar__grouplabel {
     margin: 0 0 0.6rem;
@@ -113,29 +153,15 @@ for (const entry of entries) {
   /* On narrow viewports the sidebar becomes a collapsible disclosure above the
      content, using the same idiom as the site's other panels. */
   @media (max-width: 60rem) {
-    .docs-sidebar {
+    .docs-sidebar--desktop {
+      display: none;
+    }
+    .docs-sidebar--mobile {
+      display: block;
       border: 1px solid var(--color-rule);
       border-radius: 0.6rem;
       background: color-mix(in srgb, var(--color-void-raised) 70%, transparent);
       margin-bottom: 1.75rem;
-    }
-    .docs-sidebar__summary {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
-      padding: 0.7rem 0.95rem;
-      cursor: pointer;
-      font-family: var(--font-mono);
-      font-size: 0.8rem;
-      color: var(--color-ink-dim);
-      list-style: none;
-    }
-    .docs-sidebar__summary::-webkit-details-marker {
-      display: none;
-    }
-    .docs-sidebar__current {
-      color: var(--color-kolu-primary);
     }
     .docs-sidebar__nav {
       padding: 0 0.95rem 0.95rem;

--- a/website/src/components/docs/Toc.astro
+++ b/website/src/components/docs/Toc.astro
@@ -9,14 +9,15 @@ import type { MarkdownHeading } from "astro";
 
 interface Props {
   headings: MarkdownHeading[];
+  variant?: "rail" | "inline";
 }
-const { headings } = Astro.props;
+const { headings, variant = "rail" } = Astro.props;
 const items = headings.filter((h) => h.depth === 2);
 ---
 
 {
   items.length > 0 && (
-    <nav class="docs-toc" aria-label="On this page">
+    <nav class:list={["docs-toc", `docs-toc--${variant}`]} aria-label="On this page">
       <p class="docs-toc__label">On this page</p>
       <ul>
         {items.map((h) => (
@@ -31,9 +32,18 @@ const items = headings.filter((h) => h.depth === 2);
 
 <style>
   .docs-toc {
+    font-size: 0.85rem;
+  }
+  .docs-toc--rail {
     position: sticky;
     top: 4.5rem;
-    font-size: 0.85rem;
+  }
+  .docs-toc--inline {
+    margin: -0.85rem 0 1.7rem;
+    border: 1px solid var(--color-rule);
+    border-radius: 0.55rem;
+    padding: 0.85rem 1rem;
+    background: color-mix(in srgb, var(--color-void-raised) 70%, transparent);
   }
   .docs-toc__label {
     margin: 0 0 0.7rem;
@@ -62,7 +72,12 @@ const items = headings.filter((h) => h.depth === 2);
     color: var(--color-kolu-primary);
   }
   @media (max-width: 72rem) {
-    .docs-toc {
+    .docs-toc--rail {
+      display: none;
+    }
+  }
+  @media (min-width: 72.001rem) {
+    .docs-toc--inline {
       display: none;
     }
   }

--- a/website/src/content/docs/architecture.mdx
+++ b/website/src/content/docs/architecture.mdx
@@ -1,6 +1,8 @@
 ---
 title: Architecture
 description: "How kolu is built: a stack of daemons that each survive a different failure. Close the tab, restart the server, redeploy — your terminals and the agents in them keep running. The daemon stack (PWA client · kolu-server · padi · kaval) and the @kolu/surface framework underneath it."
+order: 100
+section: System
 koluHero:
   eyebrow: architecture
   headline: How {kolu} is built
@@ -19,9 +21,10 @@ makes that true, and the one contract that ties it together.
 ## The stack
 
 Four layers, each with one job. The top two are _faces_ — they come and go. The
-bottom two are _daemons_ — they hold the state and stay up. The arrows are
-transports: a websocket to the browser, a unix socket between the daemons. Kill
-any layer and everything below it keeps running.
+bottom two are _daemons_ — [padi](/padi) holds the workspace record, and
+[kaval](/kaval) owns the live PTYs. The arrows are transports: a websocket to the
+browser, a unix socket between the daemons. Kill any layer and everything below
+it keeps running.
 
 <figure class="doc-figure">
   <svg viewBox="0 0 720 412" role="img" aria-labelledby="ax-stack-title">
@@ -85,10 +88,10 @@ any layer and everything below it keeps running.
 
 | layer | its one job | killing it does _not_ lose |
 | --- | --- | --- |
-| `PWA client` | the view in your browser — one surface consumer per pane | Reload the tab, switch devices: it re-subscribes. It holds no state to lose. |
+| [`PWA client`](/install-pwa) | the view in your browser — one surface consumer per pane | Reload the tab, switch devices: it re-subscribes. It holds no state to lose. |
 | `kolu-server` | the web shell — HTTP, the PWA, websockets; dials and binds padi | Restart it and no terminal metadata is lost — padi's registry stays warm. |
-| `padi` | the per-host workspace daemon — session, awareness, restore | Kill it and no terminal state is lost — records live in its folder on disk; PTYs survive in kaval. It re-seeds in seconds. |
-| `kaval` | the PTY survivor — owns the shells and their live screens | Kill everything above it and the live shells and scrollback keep running — they live in kaval's memory. |
+| [`padi`](/padi) | the per-host workspace daemon — session, awareness, restore | Kill it and no terminal state is lost — records live in its folder on disk; PTYs survive in kaval. It re-seeds in seconds. |
+| [`kaval`](/kaval) | the PTY survivor — owns the shells and their live screens | Kill everything above it and the live shells and scrollback keep running — they live in kaval's memory. |
 
 ## A deploy _adopts_ what's running
 
@@ -298,7 +301,8 @@ The same surface contract already runs over ssh: it's how
 [`kaval-tui --host`](/kaval) drives a daemon on another machine with nothing
 pre-installed there. Pointing kolu's browser at a `padi` on a remote host — a host
 switcher, remote agents surfacing in your dock — is the next phase. **Coming, not
-here yet.**
+here yet.** That is separate from [Remote Access](/remote-access), which serves
+today's browser UI over private HTTPS.
 
 ## Explore
 

--- a/website/src/content/docs/concepts.mdx
+++ b/website/src/content/docs/concepts.mdx
@@ -1,0 +1,95 @@
+---
+title: Core Concepts
+description: "The vocabulary behind kolu: canvas, tiles, dock, worktrees, palette, detection, GitHub state, and file comments."
+order: 30
+section: Start
+koluHero:
+  eyebrow: vocabulary
+  headline: The words that make {kolu} legible.
+---
+
+import Card from "../../components/docs/Card.astro";
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+
+Eight ideas cover most of the product. Learn these and the rest of kolu reads
+like plain language.
+
+<CardGrid>
+  <Card title="Canvas">
+    An infinite, mode-less 2D plane. Pan with two-finger scroll, zoom with pinch
+    or <kbd>Ctrl</kbd> + scroll, and spread terminals out like Figma or
+    Excalidraw.
+  </Card>
+  <Card title="Tiles">
+    Every terminal is a draggable, resizable tile: a real xterm.js instance with
+    WebGL rendering, clickable URLs, inline images, splits, themes, and mobile
+    keys.
+  </Card>
+  <Card title="Dock">
+    The left-edge navigator and at-a-glance list of every live terminal. Rows
+    show repo, branch, PR/CI, and agent state.
+  </Card>
+  <Card title="Worktrees">
+    Creating a terminal in a repo branches a fresh git worktree under the hood.
+    The name you type becomes the branch and labels the dock row.
+  </Card>
+  <Card title="Command palette">
+    <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd> opens the unified palette. Drilling into a
+    row opens a sub-palette, such as repo → worktree name → agent.
+  </Card>
+  <Card title="Auto-detection">
+    kolu populates itself by watching shell facts: recent repos from `cd`, agent
+    CLIs from command marks, and branch/PR/CI from each terminal's cwd.
+  </Card>
+  <Card title="Git & GitHub">
+    Each terminal knows its repo. Branch, PR number, and CI status are read from
+    the working directory and shown on the dock row.
+  </Card>
+  <Card title="File comments">
+    Select text in the Code tab and pin a quoted note to it. The tray flushes to
+    Markdown you paste back into the agent.
+  </Card>
+</CardGrid>
+
+Those observations do not live only in the browser. [Padi](/padi) keeps the
+workspace record durable, while [Kaval](/kaval) owns the live PTYs underneath it.
+The split is covered in [Architecture](/architecture).
+
+## The code browser
+
+The right-hand panel carries an **Inspector** tab and a **Code** tab. The Code
+tab is a file browser scoped to the active terminal's repo: a Pierre file tree
+with git-status tinting over a syntax-highlighted source view.
+
+- Click a `path/to/file.ts:42` reference in terminal output to jump to that line.
+- Markdown renders as a reading document with a Source/Rendered toggle.
+- Repo-relative links open the target file in the tab.
+- Agent-generated `.html`, `.svg`, and `.pdf` artifacts preview inline in a
+  sandboxed iframe and live-reload on change.
+- Select text in source, a branch diff, or a rendered artifact and leave a quoted
+  comment for the agent.
+
+## The canvas
+
+The desktop workspace has no separate edit mode. Terminals are tiles you arrange
+freely.
+
+- Pan with two-finger scroll; hold <kbd>Shift</kbd> to force pan even when the
+  cursor is over a tile.
+- Zoom with pinch or <kbd>Ctrl</kbd> + scroll; tiles snap to a 24px grid on drag
+  and resize.
+- Double-click a title bar to maximize a tile. That posture persists across
+  reloads.
+- Run **Arrange canvas by repo** from the palette to cluster each repo's tiles
+  into an island.
+- The minimap heatmap marks tiles whose agents are waiting or thinking; the
+  bigger multi-agent workflow lives in [Power Features](/power-features).
+
+## Next
+
+<CardGrid>
+  <LinkCard title="First five minutes" href="/first-five-minutes" description="turn these concepts into the first agent tile" />
+  <LinkCard title="Power features" href="/power-features" description="sessions, sleep/wake, export, recording, and shell control" />
+  <LinkCard title="Architecture" href="/architecture" description="why kolu splits the browser, server, padi, and kaval" />
+</CardGrid>

--- a/website/src/content/docs/first-five-minutes.mdx
+++ b/website/src/content/docs/first-five-minutes.mdx
@@ -1,0 +1,78 @@
+---
+title: First Five Minutes
+description: "Open a repository, create a worktree, launch an agent, and read the dock."
+order: 20
+section: Start
+koluHero:
+  eyebrow: first run
+  headline: Open a repo, launch an {agent}.
+---
+
+import Aside from "../../components/docs/Aside.astro";
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+import Steps from "../../components/docs/Steps.astro";
+
+The whole point lands in one move: open a repository and start an agent in its
+own tile. If the words canvas, tile, dock, and worktree are still fuzzy, keep
+[Core Concepts](/concepts) nearby; kolu watches what you do, so setup is mostly
+just using your shell.
+
+<figure class="doc-shot">
+  <img src="/blog/kolu-evidence-worktree-name-leaf.png" alt="Kolu's New terminal sub-palette with a generated worktree name and a Plain shell choice." loading="lazy" />
+  <figcaption>The New terminal flow names a worktree, then lets you choose a plain shell or an agent.</figcaption>
+</figure>
+
+<Steps>
+
+1. Open the command palette.
+
+   Press <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd>. This is kolu's canonical search
+   surface: terminals, themes, actions, repos, and shortcuts from one box.
+
+2. Drill into **New terminal → your repo**.
+
+   Recent repos appear automatically because kolu tracks the directories you
+   `cd` into. Pick one and the worktree-name step opens with a generated name.
+
+3. Pick an agent, or hit Enter for a shell.
+
+   Any agent CLI you have run before, such as `claude`, `codex`, or `opencode`,
+   appears as a launch option. Choose one and kolu creates a fresh worktree and
+   launches the agent in one step.
+
+4. Watch the dock.
+
+   The dock row pulses while the agent is working and changes when it is waiting
+   on you, so a glance tells you who needs attention even across many tiles. The
+   same state becomes more important once you are using the
+   [multi-agent tools](/power-features).
+
+</Steps>
+
+<Aside type="note" title="Zero setup is real">
+  You never register an agent. Run a CLI once in any kolu terminal and it appears
+  in the palette the next time you create a worktree: no adapter, no config file.
+</Aside>
+
+## Worktrees are the parallel-work model
+
+Each terminal you create in a repo is backed by its own git worktree, so several
+branches can be checked out side by side without stashing or re-cloning.
+
+- Press <kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Enter</kbd> to open the New
+  terminal menu directly.
+- The worktree name you type becomes the branch name and shows verbatim on the
+  dock row.
+- Branch, PR number, and CI status come from each terminal's working directory.
+- You can run several agents on several branches at once; the dock keeps them
+  distinct, and [padi](/padi) is the daemon that keeps that workspace memory
+  durable.
+
+## Next
+
+<CardGrid>
+  <LinkCard title="Core concepts" href="/concepts" description="the vocabulary: canvas, tiles, dock, worktrees, and code comments" />
+  <LinkCard title="Power features" href="/power-features" description="sessions, sleep/wake, export, recording, and shell control" />
+  <LinkCard title="Padi" href="/padi" description="the workspace daemon that makes the dock and repo context durable" />
+</CardGrid>

--- a/website/src/content/docs/install-pwa.mdx
+++ b/website/src/content/docs/install-pwa.mdx
@@ -1,0 +1,65 @@
+---
+title: Install as an App
+description: "Pin kolu as a PWA, understand secure contexts, and make badges and notifications available."
+order: 40
+section: Use Kolu
+koluHero:
+  eyebrow: pwa
+  headline: Pin {kolu} as an app.
+---
+
+import Aside from "../../components/docs/Aside.astro";
+import Card from "../../components/docs/Card.astro";
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+
+Pinning kolu gives it its own window, a dock or home-screen icon, and, on a
+[secure context](/remote-access), a live badge plus
+[desktop notifications](/troubleshooting#i-am-not-getting-desktop-notifications)
+for finished agents.
+
+<Aside type="note" title="HTTP can still be pinned">
+  The automatic Install prompt and address-bar Install icon need a secure
+  context: `https://...` or loopback/`localhost`. Plain `http://` LAN and
+  Tailscale `100.x` URLs can still be pinned manually, but app badges,
+  notifications, and service workers are unavailable there. Use
+  [Remote Access](/remote-access) for the private HTTPS route.
+</Aside>
+
+## Browser paths
+
+<CardGrid>
+  <Card title="Chromium desktop / Android">
+    Chrome, Edge, Brave, and Arc show the one-click Install path on HTTPS or
+    localhost. On plain HTTP, use the menu's Create shortcut flow and choose
+    "Open as window".
+  </Card>
+  <Card title="iOS">
+    Use Share → Add to Home Screen. iOS has no install API, so this is the path
+    from Safari, Chrome, Edge, and Firefox.
+  </Card>
+  <Card title="Safari desktop">
+    Safari 17 on macOS Sonoma or newer can use File → Add to Dock.
+  </Card>
+  <Card title="Firefox desktop">
+    Firefox has no native PWA install path. Use Chrome or Edge for the pinned app
+    window, then keep using Firefox for normal browsing if you want.
+  </Card>
+</CardGrid>
+
+## Why HTTPS matters
+
+Manual pinning gives you the window. HTTPS gives you the rest:
+
+- the automatic Install prompt;
+- the OS app badge;
+- desktop notifications through the service worker;
+- a stable secure context when you open kolu from another device.
+
+For the private HTTPS path, put kolu behind
+[Tailscale Serve](/remote-access).
+
+<CardGrid>
+  <LinkCard title="Reach it anywhere" href="/remote-access" description="serve kolu at a private https://...ts.net URL" />
+  <LinkCard title="Troubleshooting" href="/troubleshooting" description="no install button, missing notifications, and update questions" />
+</CardGrid>

--- a/website/src/content/docs/kaval.mdx
+++ b/website/src/content/docs/kaval.mdx
@@ -1,10 +1,12 @@
 ---
 title: Kaval
 description: "kaval — a standalone PTY daemon built on a multi-client PTY-owner primitive — and kaval-tui, its terminal client: list, create, snapshot, attach to, send input to, and kill your terminals from the shell."
+order: 120
+section: Daemons
 koluHero:
   eyebrow: "the PTY daemon & its client · alpha"
   headline: |
-    a watch over
+    {Kaval}: a watch over
     your {terminals}.
   image: /kaval-logo.svg
   imageAlt: "kaval — a watch over your terminals"
@@ -29,18 +31,20 @@ come and go. `kaval-tui` is its terminal client: list your shells, **create** ne
 ones, dump their scrollback, attach and type, **send** a prompt to an agent
 running in one, or **kill** them — locally, or on a remote machine over ssh
 (`--host`). Run the pair on a box where kolu has never been installed — a
-tmux/zellij-shaped duo, minus the multiplexer's session model.
+tmux/zellij-shaped duo, minus the multiplexer's session model. In kolu's full
+stack, [padi](/padi) is the workspace daemon above kaval, and
+[Architecture](/architecture) shows how the layers survive restarts.
 
 ## How it fits together
 
 One daemon owns the terminals; everything else is a client. `kolu` no longer runs
-PTYs in-process — its per-host daemon, `padi` (Tamil _paḍi_ — the stepped stand a
-_koḷu_ sits on), spawns and supervises its _own_ `kaval` and dials it over a unix
-socket, exactly as `kaval-tui` does from the shell (the kolu-server is just the
-web shell your browser talks to in front of padi). Same daemon, same terminals,
-many faces — and the link runs _both_ ways: kaval streams live updates back to
-every client, so a terminal you `kaval-tui create` from the shell shows up in
-`kolu` the moment it's born.
+PTYs in-process — its per-host daemon, [`padi`](/padi) (Tamil _paḍi_ — the
+stepped stand a _koḷu_ sits on), spawns and supervises its _own_ `kaval` and
+dials it over a unix socket, exactly as `kaval-tui` does from the shell (the
+kolu-server is just the web shell your browser talks to in front of padi). Same
+daemon, same terminals, many faces — and the link runs _both_ ways: kaval streams
+live updates back to every client, so a terminal you `kaval-tui create` from the
+shell shows up in `kolu` the moment it's born.
 
 <figure class="doc-figure">
   <svg viewBox="0 0 760 276" role="img" aria-labelledby="kv-diagram-title">
@@ -118,10 +122,10 @@ every client, so a terminal you `kaval-tui create` from the shell shows up in
 
 ## Drive a running `kolu`
 
-kolu doesn't run terminals in-process anymore — its per-host daemon `padi` spawns
-a kaval of its own and dials it, so kolu is just another consumer of it. So the
-same `kaval-tui` reaches the terminals you have open in kolu, from the shell,
-with **no flags**:
+kolu doesn't run terminals in-process anymore — its per-host daemon
+[`padi`](/padi) spawns a kaval of its own and dials it, so kolu is just another
+consumer of it. So the same `kaval-tui` reaches the terminals you have open in
+kolu, from the shell, with **no flags**:
 
 ```sh
 kaval-tui list                     # the terminals open in your kolu
@@ -140,7 +144,8 @@ automatically. More than one → kaval-tui lists them and asks you to choose wit
 `--host <ssh>` drives a kaval on **another machine**, with nothing to install
 there first. kaval-tui provisions the daemon with Nix (ships the right-arch build
 over ssh, realises it), runs it, and dials it — every subcommand works exactly as
-it does locally, just pointed at the remote.
+it does locally, just pointed at the remote. This is shell-level remote terminal
+control; [Remote Access](/remote-access) is the separate browser-HTTPS path.
 
 ```sh
 kaval-tui create --host nix@prod
@@ -167,7 +172,8 @@ any number of PTYs; each PTY is a real shell child paired with a headless screen
 mirror, fanned out to any number of consumers. It owns **only** the PTY: it knows
 nothing about git, pull requests, agent detection, or any wire protocol — those
 compose on top. The same primitive backs kolu's terminals; kaval just serves it
-over a socket.
+over a socket. The system split is why [padi](/padi) handles workspace meaning
+while kaval handles terminal survival.
 
 <CardGrid>
   <Card title="race-free attach">

--- a/website/src/content/docs/padi.mdx
+++ b/website/src/content/docs/padi.mdx
@@ -1,11 +1,13 @@
 ---
 title: Padi
 description: "padi — the per-host workspace daemon behind kolu. It remembers sessions, terminal records, repo context, restore state, and agent awareness while kaval owns the live PTYs underneath."
+order: 110
+section: Daemons
 koluHero:
   eyebrow: "the workspace daemon & its CLI · alpha"
   headline: |
-    the memory
-    under {kolu}.
+    {Padi}: the memory
+    under kolu.
   image: /padi-logo.svg
   imageAlt: "padi — the per-host workspace daemon"
 ---
@@ -25,7 +27,7 @@ import LinkCard from "../../components/docs/LinkCard.astro";
 workspace _is_: terminals, sessions, restore state, repo context, the code tree,
 git status, diffs, and agent awareness. It sits above [`kaval`](/kaval), which
 owns the live PTYs. The split is simple: kaval keeps shells alive; padi keeps the
-workspace legible.
+workspace legible. The whole layer stack is in [Architecture](/architecture).
 
 ## Where it sits
 
@@ -104,7 +106,8 @@ face.
 
 `padi-tui` reads the same workspace surface kolu uses. Where `kaval-tui` shows
 what's running in each PTY, padi-tui shows what each terminal is in: repo, PR,
-checks, foreground command, live byte activity, and agent state.
+checks, foreground command, live byte activity, and agent state. That is the
+state behind the [multi-agent dock](/power-features).
 
 ```sh
 padi-tui status
@@ -124,7 +127,9 @@ c9d40000  kolu·fix/fold       #1408 ✗   —                 nvim             
 inside a kolu terminal `$PADI_SOCKET` makes `padi-tui` flag-less — an agent
 driving its siblings never guesses a path. Elsewhere it autodiscovers the running
 padi; `--socket <path>` or `--state-root <dir>` point it elsewhere. Remote padi
-over ssh is a later phase; today padi-tui is local.
+over ssh is a later phase in [Architecture](/architecture#next--your-other-machines);
+today padi-tui is local. For remote PTY control that already works, use
+[`kaval-tui --host`](/kaval#reach-a-remote-kaval--over-ssh).
 
 `wait <id> --until awaiting,waiting` blocks until a terminal's agent finishes its
 turn — a done-signal read from real padi state, not guessed from terminal

--- a/website/src/content/docs/power-features.mdx
+++ b/website/src/content/docs/power-features.mdx
@@ -1,0 +1,76 @@
+---
+title: Power Features
+description: "Run many agents, keep sessions legible, sleep terminals, export transcripts, record workspaces, and drive kolu from the shell."
+order: 60
+section: Use Kolu
+koluHero:
+  eyebrow: at scale
+  headline: Run many, lose {none}.
+---
+
+import Aside from "../../components/docs/Aside.astro";
+import Card from "../../components/docs/Card.astro";
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+
+kolu is built for the moment you are running five agents at once. These are the
+tools that keep that legible.
+
+<CardGrid>
+  <Card title="Multi-agent dock">
+    The dock pulses for working agents and changes for awaiting ones. A finished
+    background agent can fire a toast and
+    [native notification](/troubleshooting#i-am-not-getting-desktop-notifications)
+    that jumps straight to the terminal.
+  </Card>
+  <Card title="Keybindings">
+    <kbd>Cmd</kbd> + <kbd>T</kbd> opens a terminal, <kbd>Cmd</kbd> +
+    <kbd>Shift</kbd> + <kbd>Enter</kbd> opens New terminal, <kbd>Cmd</kbd> +
+    <kbd>1...9</kbd> jumps, and <kbd>Cmd</kbd> + <kbd>/</kbd> shows shortcuts.
+  </Card>
+  <Card title="Sessions">
+    Layout, themes, maximized posture, and the activity-window filter persist
+    across reloads so the workspace comes back where you left it; that durable
+    workspace memory lives in [padi](/padi).
+  </Card>
+  <Card title="Sleep & wake">
+    Sleep parks a tile without keeping its live PTY, agent, or WebGL context
+    alive. Wake respawns it in the same directory and resumes the agent through
+    the same restore path described in [Architecture](/architecture).
+  </Card>
+</CardGrid>
+
+## Sleep a terminal
+
+Sleeping is how you keep many agent sessions parked while only the ones you are
+using stay live. A sleeping tile is still a canvas citizen: drag, resize, rename,
+and re-theme it like any other tile.
+
+- Click the moon button on the title bar, or run **Sleep terminal** from the
+  palette.
+- The PTY, agent process, and GPU/WebGL context are released.
+- Last-known metadata stays visible: directory, git branch, and GitHub PR.
+- Wake brings the conversation back through the same restore path used after a
+  restart.
+- Closing a sleeping tile discards it because nothing is running behind it.
+
+## Export and record
+
+- **Transcript export** saves Claude Code, Codex, or OpenCode sessions as
+  self-contained `.html`: a lightweight chat log, a full collapsed transcript,
+  or both.
+- **Workspace recording** captures the whole kolu tab with mic and optional
+  webcam PiP, streamed to a local `.webm`.
+
+<Aside type="note" title="Drive it from the shell">
+  Every terminal kolu opens is reachable from [`kaval-tui`](/kaval): list,
+  snapshot, attach, send a prompt, or kill. It is the same PTY daemon,
+  [`kaval`](/kaval), exposed as a CLI locally or
+  [over ssh](/kaval#reach-a-remote-kaval--over-ssh).
+</Aside>
+
+<CardGrid>
+  <LinkCard title="Padi" href="/padi" description="workspace memory, agent state, and the shell-facing padi-tui" />
+  <LinkCard title="Kaval" href="/kaval" description="the PTY daemon and kaval-tui commands" />
+  <LinkCard title="Troubleshooting" href="/troubleshooting" description="install, notifications, updates, and agent support" />
+</CardGrid>

--- a/website/src/content/docs/quickstart.mdx
+++ b/website/src/content/docs/quickstart.mdx
@@ -1,0 +1,78 @@
+---
+title: Quickstart
+description: "Run kolu with Nix, open the local workspace, and create the first terminal."
+order: 10
+section: Start
+koluHero:
+  eyebrow: start here
+  headline: From zero to {running}.
+---
+
+import Aside from "../../components/docs/Aside.astro";
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+import Steps from "../../components/docs/Steps.astro";
+
+kolu is packaged with Nix. Install Nix with flakes enabled, then run one
+command. The same command runs kolu _and_ updates it: `--refresh` busts Nix's
+flake cache so you pull the current commit.
+
+<Steps>
+
+1. Install Nix if you do not already have it.
+
+   Use a Nix installer that enables flakes, such as the
+   [NixOS Asia guide](https://nixos.asia/en/install).
+
+2. Run kolu. It serves the app on `127.0.0.1:7681`.
+
+   ```sh
+   nix --refresh run github:juspay/kolu
+   ```
+
+3. Open the local URL.
+
+   ```text
+   http://127.0.0.1:7681
+   ```
+
+</Steps>
+
+<figure class="doc-shot">
+  <img src="/demo/hero-demo.webp" alt="Kolu running in a browser workspace with the dock, a terminal tile, and the code panel visible." loading="eager" />
+  <figcaption>The running workspace is the product: real xterm.js terminals on a canvas, with repo and agent state around them.</figcaption>
+</figure>
+
+The [Core Concepts](/concepts) page names the pieces you see here — canvas,
+tiles, dock rows, worktrees, and agent state — once the app is running.
+
+## Bind a different address
+
+By default, kolu listens on loopback. To expose it on your LAN, pass a host and
+port after `--`:
+
+```sh
+nix --refresh run github:juspay/kolu -- --host 0.0.0.0 --port 8080
+```
+
+Open the address you chose. You should see an empty canvas. The empty canvas is
+the welcome state; it goes away when you create the first terminal and returns
+whenever there are none.
+
+For another device, prefer the private HTTPS setup in
+[Remote Access](/remote-access); plain LAN HTTP does not unlock install prompts,
+badges, or notifications.
+
+<Aside type="tip" title="Create the first terminal">
+  Double-click any empty spot on the canvas to open the New terminal menu. The
+  dock's `+` button opens the same flow. The first full walkthrough is
+  [First Five Minutes](/first-five-minutes).
+</Aside>
+
+## Keep going
+
+<CardGrid>
+  <LinkCard title="First five minutes" href="/first-five-minutes" description="open a repo, name a worktree, and launch an agent" />
+  <LinkCard title="Install as an app" href="/install-pwa" description="pin kolu as a PWA and unlock badges/notifications" />
+  <LinkCard title="Reach it anywhere" href="/remote-access" description="put kolu behind a private HTTPS URL with Tailscale Serve" />
+</CardGrid>

--- a/website/src/content/docs/remote-access.mdx
+++ b/website/src/content/docs/remote-access.mdx
@@ -1,0 +1,102 @@
+---
+title: Remote Access
+description: "Reach kolu from another device with Tailscale Serve, and choose the right tunnel for the job."
+order: 50
+section: Use Kolu
+koluHero:
+  eyebrow: remote
+  headline: Reach {kolu} anywhere.
+---
+
+import Aside from "../../components/docs/Aside.astro";
+import Card from "../../components/docs/Card.astro";
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+import Steps from "../../components/docs/Steps.astro";
+
+Tailscale Serve gives kolu a private HTTPS URL. That single move lets your phone
+or laptop reach the workspace and also unlocks the secure-context features used
+by [install prompts and app badges](/install-pwa), notifications, and service
+workers.
+
+<Steps>
+
+1. Install Tailscale on both devices.
+
+   Put Tailscale on the dev box and the phone or laptop, signed into the same
+   account. They join one private tailnet.
+
+2. Enable MagicDNS and HTTPS Certificates.
+
+   In the Tailscale admin console, turn on MagicDNS, then HTTPS Certificates.
+
+3. Serve kolu's port from the dev box.
+
+   ```sh
+   tailscale serve --bg 7681
+   ```
+
+   Tailscale prints a tailnet URL:
+
+   ```text
+   https://your-box.your-tailnet.ts.net/
+   ```
+
+4. Open the printed URL on the other device and pin it there.
+
+   Use the full `https://<machine>.<tailnet>.ts.net` address.
+
+</Steps>
+
+<Aside type="caution" title="Use the full hostname">
+  The bare machine name and the `100.x` address stay plain HTTP. They are useful
+  for manual access, but they do not provide the secure context used by the
+  one-click install prompt or app badge. The browser-specific install paths are
+  in [Install as an App](/install-pwa).
+</Aside>
+
+<Aside type="caution" title="Default to Serve, not Funnel">
+  `tailscale serve` keeps kolu tailnet-only. `tailscale funnel` makes a port
+  public. Keep kolu bound to `127.0.0.1` and let Serve be the only exposed
+  surface unless you have a deliberate public-access setup.
+</Aside>
+
+One more honesty note: the `...ts.net` hostname is visible in public Certificate
+Transparency logs because that is how public certificates are audited. Do not put
+secrets in machine names.
+
+## Which tunnel?
+
+<CardGrid>
+  <Card title="Tailscale Serve">
+    For "just my devices." Tailnet-only, real HTTPS, and the default path for a
+    private kolu.
+  </Card>
+  <Card title="Cloudflare Tunnel + Access">
+    For a public URL that still requires identity before anyone reaches kolu.
+  </Card>
+  <Card title="ngrok">
+    For a throwaway public URL during a demo. No auth by default, so tear it down
+    after.
+  </Card>
+</CardGrid>
+
+This page is about reaching the browser app. For shell-level remote terminals
+over ssh, use [`kaval-tui --host`](/kaval#reach-a-remote-kaval--over-ssh)
+instead.
+
+## Manage the serve
+
+```sh
+tailscale serve status
+tailscale serve reset
+tailscale serve off
+```
+
+## Related
+
+<CardGrid>
+  <LinkCard title="Install as an App" href="/install-pwa" description="browser install paths, secure contexts, badges, and notifications" />
+  <LinkCard title="Troubleshooting" href="/troubleshooting" description="missing install buttons, notification permissions, and update checks" />
+  <LinkCard title="Kaval remote terminals" href="/kaval#reach-a-remote-kaval--over-ssh" description="drive a PTY daemon on another machine over ssh" />
+</CardGrid>

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -1,0 +1,99 @@
+---
+title: Troubleshooting
+description: "Common setup snags: install prompts, notifications, supported agents, updates, and the welcome overlay."
+order: 70
+section: Use Kolu
+koluHero:
+  eyebrow: help
+  headline: Common {snags}.
+---
+
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+
+## I see no one-click Install button
+
+You are probably on plain `http://`: a LAN IP or Tailscale `100.x` address. The
+automatic Install prompt needs HTTPS or loopback/`localhost`; the browser rules
+are in [Install as an App](/install-pwa).
+
+You can still pin manually:
+
+- Chrome: menu → Save and share → Create shortcut → Open as window.
+- iOS: Share → Add to Home Screen.
+
+For the one-click prompt plus app badge, open the `https://...ts.net` URL from
+[Remote Access](/remote-access).
+
+## I am not getting desktop notifications
+
+kolu fires a native OS notification when an agent finishes in a terminal you are
+not actively watching. If you are looking at that terminal, the dock surfaces it
+instead and no banner fires. The multi-agent notification flow is part of
+[Power Features](/power-features).
+
+Past that, check these in order:
+
+1. **Secure context.** Notifications ride a service worker, which needs HTTPS or
+   `localhost`; [Remote Access](/remote-access) gives kolu a private HTTPS URL.
+2. **Browser permission.** Re-enable notifications from the address-bar lock icon
+   if the browser prompt was dismissed.
+3. **OS permission.** On macOS, the browser and the pinned app can have separate
+   notification entries. Allow the right one and check Focus / Do Not Disturb.
+
+Quick browser check:
+
+```js
+navigator.serviceWorker
+  .getRegistration()
+  .then((r) => r?.showNotification("test"));
+```
+
+If that banner shows, the OS/browser layer is fine and the "not watching" rule
+above is the likely explanation.
+
+## Can I use it without Tailscale?
+
+Yes. Locally over `localhost`, everything works, including one-click install,
+because loopback is a secure-context exemption. Tailscale matters when you want
+to reach kolu from another device and keep the install/badge/notification path;
+see [Remote Access](/remote-access).
+
+## Which agents does kolu support?
+
+Run any agent. The terminal is the interface, so `aider`, `gemini`, or whatever
+ships next week works the moment you run it.
+
+Three agents get first-class state today: `claude`, `codex`, and `opencode`.
+For these, kolu reads live agent state into the dock and can export the session
+as a self-contained HTML chat log or full transcript. Other agents still run in
+tiles; they just do not light up the dock.
+
+For launching the first one, see [First Five Minutes](/first-five-minutes). For
+running many and exporting transcripts, see [Power Features](/power-features).
+
+## How do I update kolu?
+
+Run the same command again:
+
+```sh
+nix --refresh run github:juspay/kolu
+```
+
+The `--refresh` flag busts Nix's flake cache so you pull the latest commit; it is
+the same command from [Quickstart](/quickstart).
+
+## I closed the welcome. How do I get it back?
+
+Open the palette with <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd> and run **Tutorial**
+(alias: "Welcome"). It reopens the welcome overlay while you are working. The
+same palette opens the first terminal flow in
+[First Five Minutes](/first-five-minutes).
+
+## Still stuck?
+
+<CardGrid>
+  <LinkCard title="Remote Access" href="/remote-access" description="private HTTPS, install prompts, and Tailscale Serve" />
+  <LinkCard title="Install as an App" href="/install-pwa" description="browser-specific PWA install paths" />
+  <LinkCard title="GitHub" href="https://github.com/juspay/kolu" description="source, issues, and deployment notes" />
+</CardGrid>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -19,6 +19,8 @@ interface Props {
   pubDate?: Date;
   /** Article author — emitted as `article:author`. */
   author?: string;
+  /** Pagefind filter/metadata bucket shown in site search. */
+  searchSection?: "Site" | "Docs" | "Blog" | "Changelog";
 }
 
 const {
@@ -28,6 +30,7 @@ const {
   ogType = "website",
   pubDate,
   author,
+  searchSection = "Site",
 } = Astro.props;
 
 const fullTitle =
@@ -38,6 +41,8 @@ const ogImageUrl = new URL(
   `/open-graph/${ogImageRoute}.png`,
   Astro.site,
 ).toString();
+const socialImageAlt =
+  title === "kolu" ? `kolu — ${SITE_TAGLINE}` : `${title} — kolu`;
 ---
 
 <!doctype html>
@@ -48,6 +53,7 @@ const ogImageUrl = new URL(
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
+    <meta name="pagefind:section" content={searchSection} />
     <link rel="canonical" href={canonical.toString()} />
     <link rel="icon" type="image/svg+xml" href={import.meta.env.BASE_URL + "favicon.svg"} />
     <link rel="sitemap" href={import.meta.env.BASE_URL + "sitemap-index.xml"} />
@@ -63,7 +69,7 @@ const ogImageUrl = new URL(
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content={ogType === "article" ? `${title} — kolu` : `kolu — ${SITE_TAGLINE}`} />
+    <meta property="og:image:alt" content={socialImageAlt} />
     {ogType === "article" && pubDate && (
       <meta property="article:published_time" content={pubDate.toISOString()} />
     )}
@@ -80,7 +86,7 @@ const ogImageUrl = new URL(
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImageUrl} />
-    <meta name="twitter:image:alt" content={ogType === "article" ? `${title} — kolu` : `kolu — ${SITE_TAGLINE}`} />
+    <meta name="twitter:image:alt" content={socialImageAlt} />
 
     <meta name="color-scheme" content="dark light" />
 
@@ -100,7 +106,8 @@ const ogImageUrl = new URL(
   </head>
   <body class="min-h-screen flex flex-col selection:bg-kolu-primary selection:text-void">
     <Header />
-    <main class="flex-1">
+    <main class="flex-1" data-pagefind-body>
+      <span class="pagefind-scope" data-pagefind-meta="section" data-pagefind-filter="section">{searchSection}</span>
       <slot />
     </main>
     <Footer />

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -8,7 +8,7 @@
  * collapses gracefully as width drops.
  */
 import type { MarkdownHeading } from "astro";
-import type { CollectionEntry } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 import KoluHero from "../components/KoluHero.astro";
 import Sidebar from "../components/docs/Sidebar.astro";
 import Toc from "../components/docs/Toc.astro";
@@ -20,25 +20,84 @@ interface Props {
   headings: MarkdownHeading[];
 }
 const { entry, headings } = Astro.props;
+
+const docs = await getCollection("docs");
+docs.sort((a, b) => a.data.order - b.data.order || a.data.title.localeCompare(b.data.title));
+const currentIndex = docs.findIndex((doc) => doc.id === entry.id);
+const prev = currentIndex > 0 ? docs[currentIndex - 1] : undefined;
+const next = currentIndex >= 0 && currentIndex < docs.length - 1 ? docs[currentIndex + 1] : undefined;
 ---
 
 <BaseLayout
   title={entry.data.title}
   description={entry.data.description}
-  ogImageRoute="site"
+  ogImageRoute={`docs/${entry.id}`}
+  searchSection="Docs"
 >
   <div class="docs-shell">
-    <aside class="docs-shell__sidebar">
+    <aside class="docs-shell__sidebar" data-pagefind-ignore>
       <Sidebar current={entry.id} currentTitle={entry.data.title} />
     </aside>
-    <article class="docs-shell__main" data-pagefind-body>
+    <article class="docs-shell__main">
       <KoluHero hero={entry.data.koluHero} title={entry.data.title} />
+      <div class="docs-shell__mobile-toc" data-pagefind-ignore>
+        <Toc headings={headings} variant="inline" />
+      </div>
       <div class="docs-prose"><slot /></div>
+      {
+        (prev || next) && (
+          <nav class="docs-pager" aria-label="Docs pages" data-pagefind-ignore>
+            <div>
+              {prev && (
+                <a href={`/${prev.id}`} rel="prev">
+                  <span>Previous</span>
+                  {prev.data.title}
+                </a>
+              )}
+            </div>
+            <div>
+              {next && (
+                <a href={`/${next.id}`} rel="next">
+                  <span>Next</span>
+                  {next.data.title}
+                </a>
+              )}
+            </div>
+          </nav>
+        )
+      }
     </article>
-    <div class="docs-shell__toc">
+    <div class="docs-shell__toc" data-pagefind-ignore>
       <Toc headings={headings} />
     </div>
   </div>
+
+  <script>
+    const blocks = document.querySelectorAll<HTMLPreElement>(".docs-prose pre");
+    blocks.forEach((block) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "doc-copy";
+      button.textContent = "Copy";
+      button.setAttribute("aria-label", "Copy code");
+      block.append(button);
+
+      button.addEventListener("click", async () => {
+        const code = block.querySelector("code")?.textContent ?? "";
+        try {
+          await navigator.clipboard.writeText(code);
+          button.textContent = "Copied";
+          button.classList.add("is-copied");
+        } catch {
+          button.textContent = "Select";
+        }
+        window.setTimeout(() => {
+          button.textContent = "Copy";
+          button.classList.remove("is-copied");
+        }, 1400);
+      });
+    });
+  </script>
 </BaseLayout>
 
 <style>
@@ -58,6 +117,46 @@ const { entry, headings } = Astro.props;
   .docs-shell__main {
     min-width: 0;
   }
+  .docs-shell__mobile-toc {
+    display: none;
+  }
+  .docs-pager {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: 3.25rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--color-rule);
+  }
+  .docs-pager > div:last-child {
+    text-align: right;
+  }
+  .docs-pager a {
+    display: block;
+    min-height: 5.2rem;
+    border: 1px solid var(--color-rule);
+    border-radius: 0.55rem;
+    padding: 0.85rem 1rem;
+    background: var(--color-void-raised);
+    color: var(--color-ink);
+    text-decoration: none;
+    transition:
+      border-color 120ms ease,
+      background 120ms ease;
+  }
+  .docs-pager a:hover {
+    border-color: var(--color-kolu-primary);
+    background: color-mix(in srgb, var(--color-kolu-primary) 7%, var(--color-void-raised));
+  }
+  .docs-pager span {
+    display: block;
+    margin-bottom: 0.35rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-ink-muted);
+  }
 
   /* Drop the TOC first (wide-but-not-huge), then fold the sidebar into its
      mobile disclosure and go single-column. */
@@ -68,6 +167,9 @@ const { entry, headings } = Astro.props;
     .docs-shell__toc {
       display: none;
     }
+    .docs-shell__mobile-toc {
+      display: block;
+    }
   }
   @media (max-width: 60rem) {
     .docs-shell {
@@ -77,6 +179,12 @@ const { entry, headings } = Astro.props;
     }
     .docs-shell__sidebar {
       position: static;
+    }
+    .docs-pager {
+      grid-template-columns: 1fr;
+    }
+    .docs-pager > div:last-child {
+      text-align: left;
     }
   }
 </style>

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -31,6 +31,7 @@ const showToc = tocHeadings.length >= 4;
   ogType="article"
   pubDate={post.data.pubDate}
   author={post.data.author}
+  searchSection="Blog"
 >
   <article class="mx-auto max-w-[44rem] px-6 pt-20 pb-24">
     <header class="mb-14">

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -10,7 +10,7 @@ const posts = (await getCollection('blog')).sort(
 );
 ---
 
-<BaseLayout title="Blog" description="Notes from building Kolu.">
+<BaseLayout title="Blog" description="Notes from building Kolu." searchSection="Blog">
   <section class="mx-auto max-w-3xl px-6 pt-20 md:pt-28 pb-10">
     <p class="eyebrow mb-4">the blog</p>
     <h1 class="display text-[3.2rem] md:text-[4.2rem] text-ink">

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -54,7 +54,7 @@ const releases = await Promise.all(
 );
 ---
 
-<BaseLayout title="Changelog" description="What's new in kolu, newest first.">
+<BaseLayout title="Changelog" description="What's new in kolu, newest first." searchSection="Changelog">
   <section class="changelog">
     <header class="changelog-head">
       <h1>Changelog</h1>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
 import { KOLU_VERSION } from '../site';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -11,25 +11,30 @@ const posts = (await getCollection('blog')).sort(
 );
 const latest = posts[0];
 
-// Decision aid for the remote section — three tunnels, three intents.
-const tunnels = [
+const docCards = [
   {
-    name: 'Tailscale Serve',
-    intent: 'just my devices',
-    note: 'tailnet-only, real HTTPS, zero config once MagicDNS is on. The default.',
-    accent: 'var(--color-live-teal)',
+    title: 'Quickstart',
+    href: '/quickstart',
+    eyebrow: 'start',
+    copy: 'Run kolu with Nix, open the local workspace, and create the first terminal.',
   },
   {
-    name: 'Cloudflare Tunnel + Access',
-    intent: 'public + identity-gated',
-    note: 'expose to the world, but force a login (SSO / email) before anyone reaches it.',
-    accent: 'var(--color-kolu-primary)',
+    title: 'First five minutes',
+    href: '/first-five-minutes',
+    eyebrow: 'workflow',
+    copy: 'Open a repo, name a worktree, launch an agent, and read the dock.',
   },
   {
-    name: 'ngrok',
-    intent: 'throwaway public URL',
-    note: 'a quick share link for a demo. No auth — tear it down after.',
-    accent: 'var(--color-kolu-top-strong)',
+    title: 'Install as an app',
+    href: '/install-pwa',
+    eyebrow: 'pwa',
+    copy: 'Pin kolu as a desktop/mobile app and unlock badges and notifications.',
+  },
+  {
+    title: 'Remote access',
+    href: '/remote-access',
+    eyebrow: 'https',
+    copy: 'Reach kolu from another device with a private Tailscale Serve URL.',
   },
 ];
 
@@ -39,7 +44,7 @@ const systemNodes = [
     role: 'browser workspace',
     copy: 'the canvas, dock, code browser, PWA shell, and everything you look at.',
     logo: href('/favicon.svg'),
-    href: href('/'),
+    href: href('/quickstart'),
     accent: 'primary',
   },
   {
@@ -59,13 +64,10 @@ const systemNodes = [
     accent: 'top',
   },
 ];
-
 ---
 
-<BaseLayout title="kolu">
+<BaseLayout title="kolu" searchSection="Site">
   <Fragment slot="head">
-    {/* The hero poster is the LCP element — preload it so it paints fast,
-        ahead of the (deferred, in-view-only) demo video bytes. */}
     <link
       rel="preload"
       as="image"
@@ -73,100 +75,103 @@ const systemNodes = [
       fetchpriority="high"
     />
   </Fragment>
-  <!-- ── HERO ─────────────────────────────────────────────────────────────
-       Centered copy; the real product video (next section) is the visual.
-       No hand-coded mockups — the live capture carries the "this is real" feel.
-  -->
-  <section class="mx-auto max-w-[72rem] px-6 pt-20 pb-8 md:pt-24 md:pb-10 relative">
-    <span
-      aria-hidden="true"
-      class="absolute top-10 left-6 mono text-ink-faint text-xs tracking-widest hidden md:block"
-    >
-      ┌ kolu
-    </span>
-    <span
-      aria-hidden="true"
-      class="absolute top-10 right-6 mono text-ink-faint text-xs tracking-widest hidden md:block"
-    >
-      v{KOLU_VERSION} ┐
-    </span>
 
-    <div class="mt-8 mx-auto max-w-3xl text-center">
-      <!-- Centered hero copy; the big demo video is the centerpiece, full-width
-           in its own section just below. -->
-      <div class="reveal reveal-1 flex flex-col items-center">
-        <p class="eyebrow flex items-center justify-center gap-2">
-          <span class="text-kolu-primary-muted">$</span>
-          <span>kolu — the terminal, done right</span>
-        </p>
+  <section class="hero">
+    <span class="hero-corner hero-corner-left" aria-hidden="true">┌ kolu</span>
+    <span class="hero-corner hero-corner-right" aria-hidden="true">v{KOLU_VERSION} ┐</span>
 
-        <h1
-          class="display reveal reveal-2 mt-5 text-[3rem] sm:text-[3.6rem] md:text-[4.4rem]"
-        >
-          The terminal<br />built for <span class="text-kolu-primary">many</span>.<span
-            class="cursor"
-            aria-hidden="true"></span>
-        </h1>
+    <div class="hero-copy">
+      <p class="eyebrow hero-eyebrow">
+        <span aria-hidden="true">$</span>
+        <span>kolu — the terminal, done right</span>
+      </p>
 
-        <p
-          class="reveal reveal-3 mt-6 mono text-[0.78rem] text-ink-muted leading-relaxed"
-        >
-          Not a chat-UI wrapper.<br />Not an editor fork.<br />A real terminal — just better at scale.
-        </p>
+      <h1 class="display hero-title">
+        The terminal<br />built for <span>many</span>.<span class="cursor" aria-hidden="true"></span>
+      </h1>
 
-        <p
-          class="reveal reveal-3 mt-6 mx-auto max-w-2xl text-lg leading-relaxed text-ink-dim"
-        >
-          Real <span class="mono text-ink">xterm.js</span> tiles on an infinite
-          canvas — backed by a host daemon and a PTY daemon, so the browser can
-          come and go without losing the terminals underneath.
-          <span class="mono text-ink">claude</span>, <span class="mono text-ink">codex</span>, <span
-            class="mono text-ink">opencode</span
-          > — anything you can run in a shell, runs in kolu.
-        </p>
+      <p class="hero-kicker mono">
+        Not a chat-UI wrapper.<br />Not an editor fork.<br />A real terminal — just better at scale.
+      </p>
 
-        <div class="reveal reveal-4 mt-8 flex flex-wrap items-center justify-center gap-3">
-          <a
-            href="#quickstart"
-            class="inline-flex items-center gap-2 rounded-sm bg-kolu-primary text-void px-5 py-2.5 mono text-[0.82rem] font-medium hover:bg-kolu-primary-hover transition-colors"
-          >
-            Get started <span aria-hidden="true">→</span>
-          </a>
-          <a
-            href="https://github.com/juspay/kolu"
-            rel="noopener"
-            class="inline-flex items-center gap-2 rounded-sm border border-rule-strong px-5 py-2.5 mono text-[0.82rem] text-ink hover:border-ink-dim hover:bg-void-raised transition-colors"
-          >
-            <svg viewBox="0 0 16 16" class="size-3.5 fill-current" aria-hidden="true">
-              <path
-                d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.34c-2.22.48-2.69-1.07-2.69-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.05-.49.05-.49.8.06 1.23.82 1.23.82.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.58.82-2.14-.08-.2-.36-1.01.08-2.11 0 0 .67-.21 2.2.82a7.63 7.63 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.91.08 2.11.51.56.82 1.27.82 2.14 0 3.06-1.86 3.75-3.64 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
-              ></path>
-            </svg>
-            juspay/kolu
-          </a>
-        </div>
+      <p class="hero-body">
+        Real <span class="mono">xterm.js</span> tiles on an infinite canvas,
+        backed by padi and kaval so the browser can come and go without losing
+        the shells underneath. <span class="mono">claude</span>, <span class="mono">codex</span>,
+        <span class="mono">opencode</span> — anything you run in a shell runs in kolu.
+      </p>
+
+      <div class="hero-actions">
+        <a href={href('/quickstart')} class="hero-primary">
+          Get started <span aria-hidden="true">→</span>
+        </a>
+        <a href="https://github.com/juspay/kolu" rel="noopener" class="hero-secondary">
+          <svg viewBox="0 0 16 16" class="size-3.5 fill-current" aria-hidden="true">
+            <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.34c-2.22.48-2.69-1.07-2.69-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.05-.49.05-.49.8.06 1.23.82 1.23.82.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.58.82-2.14-.08-.2-.36-1.01.08-2.11 0 0 .67-.21 2.2.82a7.63 7.63 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.91.08 2.11.51.56.82 1.27.82 2.14 0 3.06-1.86 3.75-3.64 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"></path>
+          </svg>
+          juspay/kolu
+        </a>
       </div>
     </div>
   </section>
 
-  <!-- ── SYSTEM MAP — one product, three programs ─────────────────────── -->
-  <section class="mx-auto max-w-[72rem] px-6 pb-12 md:pb-14">
-    <div class="system-shell reveal reveal-4">
+  <section class="demo-section" aria-label="Kolu product demo">
+    <figure class="full-demo">
+      <div class="full-demo-frame">
+        <video
+          class="demo-video"
+          muted
+          loop
+          playsinline
+          preload="none"
+          poster="/demo/hero-demo.webp"
+        >
+          <source src="/demo/hero-demo.webm" type="video/webm" />
+          <source src="/demo/hero-demo.mp4" type="video/mp4" />
+        </video>
+      </div>
+      <figcaption class="hero-demo-cap">
+        The dock finds what you cannot see: two agents in two repos, and one
+        buried behind another tile asking for you.
+      </figcaption>
+    </figure>
+  </section>
+
+  <section class="home-band">
+    <div class="section-head">
+      <p class="eyebrow">docs</p>
+      <h2 class="display-sm">Start in the guide.</h2>
+      <p>
+        The durable setup and workflow material now lives in the docs, where it
+        has sidebar navigation, search, code copy, and next-page flow.
+      </p>
+    </div>
+
+    <div class="doc-card-grid">
+      {
+        docCards.map((card) => (
+          <a href={href(card.href)} class="doc-entry-card">
+            <span class="doc-entry-eyebrow">{card.eyebrow}</span>
+            <strong>{card.title}</strong>
+            <span>{card.copy}</span>
+          </a>
+        ))
+      }
+    </div>
+  </section>
+
+  <section class="home-band">
+    <div class="system-shell">
       <div class="system-intro">
         <p class="eyebrow">the system</p>
-        <h2 class="display-sm text-[1.8rem] md:text-[2.15rem] text-ink mt-2">
-          one terminal experience,<br class="hidden sm:block" /> split at the right owners.
-        </h2>
-        <p class="mt-4 text-ink-dim leading-relaxed">
+        <h2 class="display-sm">One terminal experience, split at the right owners.</h2>
+        <p>
           Kolu is what you use. Padi remembers the workspace on the host. Kaval
           owns the shells. That split is why the tab, web server, and PTYs can
           fail or restart on different clocks.
         </p>
-        <a
-          href={href('/architecture')}
-          class="system-link"
-        >
-          see the architecture <span aria-hidden="true">→</span>
+        <a href={href('/architecture')} class="system-link">
+          See the architecture <span aria-hidden="true">→</span>
         </a>
       </div>
 
@@ -194,941 +199,15 @@ const systemNodes = [
     </div>
   </section>
 
-  <!-- ── HERO DEMO — the real product, full-width centerpiece ─────────────
-       A real kolu session, shown big right under the hero copy: two agents in
-       two repos, and the dock flagging the one (buried behind another tile)
-       that needs you. Poster-first / reduced-motion-gated (.demo-video → the
-       inline script at the end of the file governs autoplay). -->
-  <section class="mx-auto max-w-[82rem] px-6 pt-2 pb-14 md:pb-16">
-    <figure class="reveal reveal-4 full-demo">
-      <div class="full-demo-frame">
-        <video
-          class="demo-video"
-          muted
-          loop
-          playsinline
-          preload="none"
-          poster="/demo/hero-demo.webp"
-        >
-          <source src="/demo/hero-demo.webm" type="video/webm" />
-          <source src="/demo/hero-demo.mp4" type="video/mp4" />
-        </video>
-      </div>
-      <figcaption class="hero-demo-cap mx-auto max-w-2xl">
-        The dock finds what you can't see: two agents in two repos, and one —
-        buried behind another tile — asking for you. The dock still says so.
-      </figcaption>
-    </figure>
-  </section>
-
-  <!-- ── 01 · QUICKSTART ──────────────────────────────────────────────── -->
-  <!-- ── ON THIS PAGE — sticky scroll-spy rail over the guide sections ──── -->
-  <nav class="section-rail" aria-label="On this page">
-    <ol>
-      <li><a href="#quickstart"><span class="rail-dot" aria-hidden="true"></span><span class="rail-label">Quickstart</span></a></li>
-      <li><a href="#first"><span class="rail-dot" aria-hidden="true"></span><span class="rail-label">First 5 minutes</span></a></li>
-      <li><a href="#concepts"><span class="rail-dot" aria-hidden="true"></span><span class="rail-label">Core concepts</span></a></li>
-      <li><a href="#install"><span class="rail-dot" aria-hidden="true"></span><span class="rail-label">Pin it as an app</span></a></li>
-      <li><a href="#remote"><span class="rail-dot" aria-hidden="true"></span><span class="rail-label">Reach it anywhere</span></a></li>
-      <li><a href="#power"><span class="rail-dot" aria-hidden="true"></span><span class="rail-label">Power features</span></a></li>
-      <li><a href="#faq"><span class="rail-dot" aria-hidden="true"></span><span class="rail-label">FAQ</span></a></li>
-    </ol>
-  </nav>
-
-  <!-- ── 01 · QUICKSTART ──────────────────────────────────────────────── -->
-  <section id="quickstart" class="guide-section scroll-mt-20">
-    <div class="guide-head">
-      <span class="guide-num">01</span>
-      <div>
-        <p class="eyebrow mb-2">quickstart</p>
-        <h2 class="display-sm text-[2rem] md:text-[2.4rem] text-ink">
-          From zero to running.
-        </h2>
-      </div>
-    </div>
-
-    <p class="guide-lede">
-      kolu is packaged with Nix. <a
-        href="https://nixos.asia/en/install"
-        rel="noopener"
-        class="guide-link">Install Nix</a
-      > with flakes enabled, then run a single command. The same command runs kolu
-      <em>and</em> updates it — <code>--refresh</code> busts Nix's flake cache so
-      you always pull the latest commit.
-    </p>
-
-    <div class="term-frame">
-      <div class="term-bar">
-        <span class="term-dot" style="background:var(--color-dot-close)"></span>
-        <span class="term-dot" style="background:var(--color-dot-minimize)"
-        ></span>
-        <span class="term-dot" style="background:var(--color-dot-maximize)"
-        ></span>
-        <span class="term-bar-label">~/dev — zsh</span>
-      </div>
-      <pre class="term-body"><code><span class="c-comment"># run (or update) kolu — serves on 127.0.0.1:7681</span>
-<span class="c-prompt">$</span> nix --refresh run github:juspay/kolu
-
-<span class="c-comment"># expose on LAN with a custom host / port</span>
-<span class="c-prompt">$</span> nix --refresh run github:juspay/kolu -- --host 0.0.0.0 --port 8080</code></pre>
-    </div>
-
-    <p class="guide-body">
-      Open <a
-        href="http://127.0.0.1:7681"
-        rel="noopener"
-        class="guide-link mono">http://127.0.0.1:7681</a
-      > (or the address you chose). You should see kolu open with an empty canvas.
-    </p>
-
-    <aside class="callout callout-ok">
-      <strong>Next.</strong> An empty canvas is the welcome — it always shows when
-      no terminals are open. The way you "dismiss" it is to open one; come back to
-      zero and it returns. Double-click any empty spot on the canvas to open the
-      <em>New terminal</em> menu — the same flow as the dock's <kbd>+</kbd>.
-    </aside>
-  </section>
-
-  <!-- ── 02 · FIRST 5 MINUTES ─────────────────────────────────────────── -->
-  <section id="first" class="guide-section scroll-mt-20">
-    <div class="guide-head">
-      <span class="guide-num">02</span>
-      <div>
-        <p class="eyebrow mb-2">first 5 minutes</p>
-        <h2 class="display-sm text-[2rem] md:text-[2.4rem] text-ink">
-          Open a repo, launch an agent.
-        </h2>
-      </div>
-    </div>
-
-    <p class="guide-lede">
-      The whole point lands in one move: open a repository and start an agent in
-      its own tile. kolu watches what you do, so you barely configure anything.
-    </p>
-
-    <ol class="step-list">
-      <li>
-        <span class="step-n">1</span>
-        <div>
-          <p class="step-t">Open the command palette</p>
-          <p class="step-b">
-            Press <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd>. This is kolu's canonical
-            search surface — terminals, themes, actions, repos, all from one box.
-          </p>
-        </div>
-      </li>
-      <li>
-        <span class="step-n">2</span>
-        <div>
-          <p class="step-t">Drill into <em>New terminal → your repo</em></p>
-          <p class="step-b">
-            Recent repos appear automatically — kolu tracks the directories you
-            <code>cd</code> into. Pick one and the worktree-naming leaf opens with
-            a name pre-filled (a random <span class="mono">adj-noun</span>) and an
-            agent picker below.
-          </p>
-        </div>
-      </li>
-      <li>
-        <span class="step-n">3</span>
-        <div>
-          <p class="step-t">Pick an agent — or just hit Enter</p>
-          <p class="step-b">
-            Any agent CLI you've run before (<code>claude</code>, <code
-              >codex</code
-            >, <code>opencode</code>, …) shows as a launch option. Choose one and
-            kolu creates a fresh worktree <em>and</em> launches the agent in one
-            step. Or hit <kbd>Enter</kbd> to land in a plain shell.
-          </p>
-        </div>
-      </li>
-      <li>
-        <span class="step-n">4</span>
-        <div>
-          <p class="step-t">Watch the dock</p>
-          <p class="step-b">
-            The new tile's dock row pulses while the agent is working and breathes
-            when it's waiting on you — so a glance tells you who needs attention,
-            even across many tiles.
-          </p>
-        </div>
-      </li>
-    </ol>
-
-    <aside class="callout callout-note">
-      <strong>Zero setup is real.</strong> You never registered that agent. Run any
-      CLI once in any kolu terminal and it appears in the palette the next time you
-      create a worktree — no adapter, no config file.
-    </aside>
-  </section>
-
-  <!-- ── 03 · CORE CONCEPTS ───────────────────────────────────────────── -->
-  <section id="concepts" class="guide-section scroll-mt-20">
-    <div class="guide-head">
-      <span class="guide-num">03</span>
-      <div>
-        <p class="eyebrow mb-2">core concepts</p>
-        <h2 class="display-sm text-[2rem] md:text-[2.4rem] text-ink">
-          The vocabulary.
-        </h2>
-      </div>
-    </div>
-
-    <p class="guide-lede">
-      Eight ideas cover almost everything. Learn these and the rest of kolu reads
-      like plain language.
-    </p>
-
-    <dl class="concept-grid">
-      <div class="concept">
-        <dt>Canvas</dt>
-        <dd>
-          An infinite, mode-less 2D plane. Pan with two-finger scroll, zoom with
-          pinch or <kbd>Ctrl</kbd> + scroll, snap to a 24px grid. No boundaries —
-          spread terminals out like Figma or Excalidraw.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Tiles</dt>
-        <dd>
-          Every terminal is a draggable, resizable tile — a real xterm.js
-          instance: WebGL rendering, clickable URLs, inline images (sixel /
-          iTerm2 / kitty), splits, 200+ themes, and a mobile key bar. Double-click
-          the title bar to maximize.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Dock</dt>
-        <dd>
-          The left-edge navigator — the canonical at-a-glance list of every live
-          terminal. Repo-tinted rows show branch, agent state, and PR/CI status;
-          the state pip's shape tells you who's working vs. awaiting you.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Worktrees</dt>
-        <dd>
-          Creating a terminal in a repo branches a fresh git worktree under the
-          hood. The name you type becomes the branch and shows verbatim on the
-          dock row, so parallel work stays identifiable.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Command &amp; sub-palette</dt>
-        <dd>
-          <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd> opens the unified palette; drilling into
-          a row opens a sub-palette (e.g. repo → worktree name → agent). <kbd
-            >Cmd/Ctrl</kbd
-          > + <kbd>Shift</kbd> + <kbd>K</kbd> jumps straight to the workspace grid.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Auto-detection</dt>
-        <dd>
-          kolu populates itself by watching you — recent repos from <code
-            >cd</code
-          > events, recent agents from shell command marks, branch / PR / CI from
-          each terminal's working directory. If kolu knows it, the shell told it.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Git &amp; GitHub</dt>
-        <dd>
-          Each terminal knows its repo: branch, PR number, and CI status are read
-          from its working directory and shown right on the dock row — no token
-          pasting, no config. Creating a worktree and launching the agent in it is
-          a single palette step.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Comment on any file</dt>
-        <dd>
-          Select text in the Code tab — source, a branch diff, or a rendered
-          artifact — and pin a quoted note to it. The per-terminal tray flushes to
-          Markdown you paste straight back into the agent, which re-locates each
-          comment by quote-matching even after the file changes.
-        </dd>
-      </div>
-    </dl>
-
-    <!-- Growable deep-dives — collapsed by default. -->
-    <details class="deep">
-      <summary>
-        <span class="deep-tag">how-to</span>
-        Using the code browser
-      </summary>
-      <div class="deep-body">
-        <p>
-          The right-hand panel carries an <strong>Inspector</strong> tab and a
-          <strong>Code</strong> tab. The Code tab is a full file browser scoped to
-          the active terminal's repo: a Pierre file tree with git-status tinting
-          (modified / added / untracked, with every changed subtree's ancestors
-          tinted too) over a syntax-highlighted source view.
-        </p>
-        <ul>
-          <li>
-            Click a <code>path/to/file.ts:42</code> reference in terminal output to
-            jump straight to that line.
-          </li>
-          <li>
-            Markdown renders as a reading document with a <strong
-              >Source ⇄ Rendered</strong
-            > toggle; repo-relative links open the target file right in the tab.
-          </li>
-          <li>
-            Agent-generated <code>.html</code> / <code>.svg</code> / <code
-              >.pdf</code
-            > artifacts preview inline in a sandboxed iframe, live-reloading on
-            change.
-          </li>
-          <li>
-            Select text in any file — source, branch diff, or rendered artifact —
-            and leave a quoted comment; the tray flushes to Markdown you paste back
-            into the agent.
-          </li>
-        </ul>
-      </div>
-    </details>
-
-    <details class="deep">
-      <summary>
-        <span class="deep-tag">how-to</span>
-        Working the canvas view
-      </summary>
-      <div class="deep-body">
-        <p>
-          The desktop workspace is mode-less — there's no separate "edit" mode.
-          Terminals are tiles you arrange freely.
-        </p>
-        <ul>
-          <li>
-            <strong>Pan</strong> with two-finger scroll; hold <kbd>Shift</kbd> to force
-            pan even when the cursor is over a tile (hand-tool style).
-          </li>
-          <li>
-            <strong>Zoom</strong> with pinch or <kbd>Ctrl</kbd> + scroll; tiles snap
-            to a 24px grid on drag and resize.
-          </li>
-          <li>
-            <strong>Maximize</strong> a tile by double-clicking its title bar; the
-            posture persists across reload.
-          </li>
-          <li>
-            <strong>Arrange canvas by repo</strong> (from the palette) clusters each
-            repo's tiles into an island — a one-shot action that leaves new tiles where
-            they open.
-          </li>
-          <li>
-            The <strong>minimap heatmap</strong> dots any tile whose agent is waiting
-            or thinking, so you can scan a 20-tile workspace for "who needs me".
-          </li>
-        </ul>
-      </div>
-    </details>
-  </section>
-
-  <!-- ── 04 · PIN IT AS AN APP ────────────────────────────────────────── -->
-  <section id="install" class="guide-section scroll-mt-20">
-    <div class="guide-head">
-      <span class="guide-num">04</span>
-      <div>
-        <p class="eyebrow mb-2">pin it as an app</p>
-        <h2 class="display-sm text-[2rem] md:text-[2.4rem] text-ink">
-          Install kolu as a PWA.
-        </h2>
-      </div>
-    </div>
-
-    <p class="guide-lede">
-      Pinning kolu gives it its own window, a dock / home-screen icon, and — on
-      a secure context — a live badge plus desktop notifications for finished
-      agents. But there's one rule that trips everyone up, so read this first.
-    </p>
-
-    <aside class="callout callout-note">
-      <strong>You can pin kolu over plain HTTP — only <em>one-click</em> install needs
-      HTTPS.</strong> The automatic Install prompt and the address-bar Install icon
-      appear only on a <em>secure context</em> (<code>https://…</code> or loopback /
-      <code>localhost</code>), so on a plain <code>http://</code> LAN
-      (<code>192.168.x.x</code>) or Tailscale <code>100.x</code> address they won't
-      show — and the OS app badge, desktop notifications, and service workers are
-      unavailable there too (notifications ride a service worker). You
-      can still <strong>install manually</strong> (Chrome's <em>Create shortcut →
-      Open as window</em>, iOS <em>Add to Home Screen</em>) — see each browser below.
-      For the frictionless one-click path <em>plus</em> the live badge, give kolu a
-      real HTTPS URL via Tailscale —
-      <a href="#remote" class="guide-link">jump to Reach it anywhere ↓</a>.
-    </aside>
-
-    <p class="guide-body">
-      Install per browser — the <strong>one-click</strong> paths need HTTPS or
-      <code>localhost</code>; the <strong>manual</strong> paths work over plain
-      <code>http://</code> too:
-    </p>
-
-    <div class="browser-grid">
-      <div class="browser">
-        <h4>Chromium desktop / Android</h4>
-        <p>
-          Chrome, Edge, Brave, Arc. On HTTPS/localhost: the <strong>Install</strong>
-          icon in the address bar, or <strong>⋮ menu → Install app</strong> (the
-          one-click path). Over plain <code>http://</code>: <strong>⋮ → Save and
-          share → Create shortcut…</strong> and tick <strong>Open as window</strong>
-          for the same app window.
-        </p>
-      </div>
-      <div class="browser">
-        <h4>iOS — Safari / Chrome / Edge / Firefox</h4>
-        <p>
-          Tap <strong>Share ⬆ → Add to Home Screen</strong>. iOS has no install
-          API, so this is the only path — and since iOS 16.4 it works from any of
-          these browsers, not just Safari.
-        </p>
-      </div>
-      <div class="browser">
-        <h4>Safari desktop (macOS Sonoma+)</h4>
-        <p>
-          Safari 17 on macOS Sonoma or newer: <strong>File → Add to Dock</strong>.
-          Works on any page; no install event needed.
-        </p>
-      </div>
-      <div class="browser">
-        <h4>Firefox desktop</h4>
-        <p>
-          No native PWA install yet (Taskbar Tabs is still experimental). Use
-          <strong>Chrome or Edge</strong> to install, then keep using Firefox for
-          browsing if you like.
-        </p>
-      </div>
-    </div>
-  </section>
-
-  <!-- ── 05 · REACH IT ANYWHERE ───────────────────────────────────────── -->
-  <section id="remote" class="guide-section scroll-mt-20">
-    <div class="guide-head">
-      <span class="guide-num">05</span>
-      <div>
-        <p class="eyebrow mb-2">reach it anywhere</p>
-        <h2 class="display-sm text-[2rem] md:text-[2.4rem] text-ink">
-          Tailscale: HTTPS + your phone, one command.
-        </h2>
-      </div>
-    </div>
-
-    <p class="guide-lede">
-      Here's the payoff that ties the last two sections together: the <em
-        >same</em
-      > Tailscale command that makes kolu reachable from your phone is what gives it
-      the HTTPS secure context that unlocks <em>one-click</em> install and the app
-      badge. One move unlocks both.
-    </p>
-
-    <ol class="step-list">
-      <li>
-        <span class="step-n">1</span>
-        <div>
-          <p class="step-t">Install Tailscale on both devices</p>
-          <p class="step-b">
-            Put Tailscale on the dev box <em>and</em> the phone / laptop, signed into
-            the <strong>same account</strong>. They join one private tailnet.
-          </p>
-        </div>
-      </li>
-      <li>
-        <span class="step-n">2</span>
-        <div>
-          <p class="step-t">Enable MagicDNS + HTTPS Certificates</p>
-          <p class="step-b">
-            In the admin console → DNS, turn on <strong>MagicDNS</strong>, then
-            <strong>HTTPS Certificates</strong> (a one-time toggle). This lets
-            Tailscale issue a real Let's Encrypt cert for your machine.
-          </p>
-        </div>
-      </li>
-      <li>
-        <span class="step-n">3</span>
-        <div>
-          <p class="step-t">Serve the port</p>
-          <p class="step-b">
-            On the dev box, point Serve at kolu's port (<code>--bg</code> keeps it
-            running across reboots):
-          </p>
-          <div class="term-frame term-frame-sm">
-            <div class="term-bar">
-              <span class="term-dot" style="background:var(--color-dot-close)"
-              ></span>
-              <span
-                class="term-dot"
-                style="background:var(--color-dot-minimize)"></span>
-              <span
-                class="term-dot"
-                style="background:var(--color-dot-maximize)"></span>
-              <span class="term-bar-label">dev box</span>
-            </div>
-            <pre class="term-body"><code><span class="c-prompt">$</span> tailscale serve --bg 7681
-
-<span class="c-arrow">→</span> Available within your tailnet:
-  <span class="c-ok">https://your-box.your-tailnet.ts.net/</span></code></pre>
-          </div>
-        </div>
-      </li>
-      <li>
-        <span class="step-n">4</span>
-        <div>
-          <p class="step-t">Open the printed URL on your phone — and install</p>
-          <p class="step-b">
-            Visit the full <code>https://&lt;machine&gt;.&lt;tailnet&gt;.ts.net</code>
-            address. It's a genuine HTTPS secure context, so the Install / Add to
-            Home Screen affordance now appears. Pin it from there.
-          </p>
-        </div>
-      </li>
-    </ol>
-
-    <aside class="callout callout-note">
-      <strong>The full FQDN is mandatory.</strong> Use the complete
-      <code>…ts.net</code> hostname. The bare machine name and the
-      <code>100.x</code> IP stay plain HTTP — no secure context, so no one-click
-      install or app badge (manual pinning still works, as everywhere).
-    </aside>
-
-    <aside class="callout callout-danger">
-      <strong>Default to Serve, not Funnel.</strong> <code>tailscale serve</code>
-      keeps kolu <em>tailnet-only</em> — just your devices. <code>tailscale funnel</code>
-      makes it <strong>public with no authentication</strong>; a single flag flips
-      a port open to the whole internet. Keep the dev server bound to <code
-        >127.0.0.1</code
-      > and let Serve be the only exposed surface.
-    </aside>
-
-    <p class="guide-body">
-      One more honesty note: your <code>…ts.net</code> hostname lands in public
-      Certificate Transparency logs (that's how the public web verifies certs), so
-      don't bake secrets into machine names. Manage everything with <code
-        >tailscale serve status</code
-      >, <code>tailscale serve reset</code>, and <code>tailscale serve off</code>.
-    </p>
-
-    <h3 class="guide-subhead">Which tunnel? A decision aid.</h3>
-    <p class="guide-body">
-      Serve covers "just my devices." If you need something else, match the intent:
-    </p>
-
-    <div class="tunnel-grid">
-      {
-        tunnels.map((t) => (
-          <div class="tunnel" style={`--tun-accent:${t.accent}`}>
-            <div class="tunnel-intent">{t.intent}</div>
-            <div class="tunnel-name">{t.name}</div>
-            <p class="tunnel-note">{t.note}</p>
-          </div>
-        ))
-      }
-    </div>
-
-    <details class="deep">
-      <summary>
-        <span class="deep-tag">how-to</span>
-        Worktrees — the parallel-work model
-      </summary>
-      <div class="deep-body">
-        <p>
-          Each terminal you create in a repo is backed by its own git worktree, so
-          several branches check out side by side without stashing or re-cloning.
-        </p>
-        <ul>
-          <li>
-            Press <kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Enter</kbd> to open
-            the <em>New terminal</em> menu, then pick a recent repo and name the
-            worktree — kolu branches it and (optionally) launches the agent in one
-            step. (The command palette → <em>New terminal</em> is the same flow.)
-          </li>
-          <li>
-            The worktree name you type in the palette becomes the branch name and
-            shows verbatim on the dock row.
-          </li>
-          <li>
-            Branch, PR number, and CI status are derived from each terminal's
-            working directory — no manual wiring.
-          </li>
-          <li>
-            Run five agents on five branches at once; the dock keeps every one
-            distinct, suffixing a stable id when two share a repo + branch.
-          </li>
-        </ul>
-      </div>
-    </details>
-  </section>
-
-  <!-- ── 06 · POWER FEATURES ──────────────────────────────────────────── -->
-  <section id="power" class="guide-section scroll-mt-20">
-    <div class="guide-head">
-      <span class="guide-num">06</span>
-      <div>
-        <p class="eyebrow mb-2">power features</p>
-        <h2 class="display-sm text-[2rem] md:text-[2.4rem] text-ink">
-          Run many, lose none.
-        </h2>
-      </div>
-    </div>
-
-    <p class="guide-lede">
-      kolu is built for the moment you're running five agents at once. These are
-      the tools that keep that legible.
-    </p>
-
-    <dl class="concept-grid">
-      <div class="concept">
-        <dt>Multi-agent at scale</dt>
-        <dd>
-          The dock pulses for working agents and breathes for awaiting ones; a
-          finished background agent fires a loud rose ping plus a toast with a
-          <strong>Switch</strong> action that pans the canvas straight to it —
-          and, on an HTTPS/<code>localhost</code> kolu with notifications
-          granted, a native <strong>OS notification</strong> you can click to
-          jump to that terminal, even when kolu is in the background.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Keybindings</dt>
-        <dd>
-          <kbd>Cmd</kbd> + <kbd>T</kbd> new terminal, <kbd>Cmd</kbd> + <kbd>Shift</kbd>
-          + <kbd>Enter</kbd> opens the New terminal menu (worktree creation),
-          <kbd>Cmd</kbd> + <kbd>1…9</kbd> jump, <kbd>Ctrl</kbd> + <kbd>Tab</kbd>
-          cycles in MRU order, <kbd>Cmd</kbd> + <kbd>/</kbd> shows the full shortcut
-          help. Splits: <kbd>Ctrl</kbd> + <kbd>`</kbd>.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Sessions</dt>
-        <dd>
-          Layout, themes, and maximized posture persist across reloads via
-          localStorage, so you land back exactly where you left off. The
-          activity-window filter hides stale rows without killing them.
-        </dd>
-      </div>
-      <div class="concept">
-        <dt>Sleep &amp; wake <span class="mono">☾</span></dt>
-        <dd>
-          Done with a tile for now? Hit <strong>☾</strong> on its title bar to
-          put it to sleep — its PTY, agent process, and WebGL context are
-          released, exactly as if closed, while the tile stays on the canvas,
-          moonlit and dormant. <strong>Wake</strong> it and kolu re-spawns in
-          the same directory and resumes the agent right where it left off — the
-          conversation returns, not a blank shell. Park many long-lived sessions
-          without paying their live cost.
-        </dd>
-      </div>
-    </dl>
-
-    <details class="deep">
-      <summary>
-        <span class="deep-tag">how-to</span>
-        Sessions — save, restore, and tidy
-      </summary>
-      <div class="deep-body">
-        <p>
-          kolu remembers your workspace without a save button — but you stay in
-          control of what's on screen.
-        </p>
-        <ul>
-          <li>
-            Reopening kolu restores your tiles, their themes, and the maximized
-            tile if you had one.
-          </li>
-          <li>
-            The <strong>activity window</strong> (<span class="mono"
-              >All / 4h / 12h / 24h / 48h</span
-            >, default 24h) hides rows older than the cutoff from the dock; "show
-            all" brings them back. Hidden tiles stop counting toward the dock
-            badge.
-          </li>
-          <li>
-            A fresh agent transition automatically resurfaces a hidden terminal,
-            so nothing important stays buried.
-          </li>
-        </ul>
-      </div>
-    </details>
-
-    <details class="deep">
-      <summary>
-        <span class="deep-tag">how-to</span>
-        Sleep a terminal — park it without paying its cost
-      </summary>
-      <div class="deep-body">
-        <p>
-          Sleeping is how you keep many agent sessions parked while only the ones
-          you're using stay live. A sleeping tile is a full canvas citizen — only
-          the live shell goes dark.
-        </p>
-        <ul>
-          <li>
-            <strong>Put it to sleep.</strong> Click <strong>☾</strong> on the
-            title bar, or run <em>Sleep terminal</em> from the palette. The PTY,
-            agent process, and GPU/WebGL context are released — exactly as if
-            you'd closed it — and the tile goes moonlit and dormant in place.
-          </li>
-          <li>
-            <strong>Still a citizen.</strong> Drag, resize, rename, and re-theme a
-            sleeping tile like any other; only typing is fenced off, since there's
-            no live shell behind it.
-          </li>
-          <li>
-            <strong>Last-known metadata stays put.</strong> The dormant tile keeps
-            showing what it was working — its working directory, git branch, and
-            GitHub PR — so a parked session never loses its identity.
-          </li>
-          <li>
-            <strong>Wake resumes the agent.</strong> Wake it and kolu re-spawns
-            the terminal in the same directory and resumes the agent right where
-            it left off — the same restore path terminals come back through after
-            a restart. The conversation returns, not a blank shell.
-          </li>
-          <li>
-            <strong>Survives a full restart</strong> and reads moonlit in the dock
-            and minimap. Closing a sleeping tile simply <strong>discards</strong>
-            it — there's nothing running to kill.
-          </li>
-        </ul>
-      </div>
-    </details>
-
-    <details class="deep">
-      <summary>
-        <span class="deep-tag">how-to</span>
-        Export &amp; record what your agent did
-      </summary>
-      <div class="deep-body">
-        <p>Two ways to share a session beyond the live workspace:</p>
-        <ul>
-          <li>
-            <strong>Transcript export</strong> — save any Claude Code, Codex, or
-            OpenCode session as self-contained <code>.html</code>: a lightweight
-            chat log for sharing, a full collapsed transcript for audit, or both.
-            No external assets. Opens offline anywhere.
-          </li>
-          <li>
-            <strong>Workspace recording</strong> — one click in the chrome bar
-            captures the whole kolu tab with mic and optional webcam PiP, streamed
-            to a local <code>.webm</code>. Pause / resume with <kbd>⌘⇧.</kbd>.
-          </li>
-        </ul>
-      </div>
-    </details>
-
-    <aside class="callout callout-note">
-      <strong>Drive it all from your shell.</strong> Every terminal kolu opens is
-      reachable from a plain shell too: <code>kaval-tui</code> can list, snapshot,
-      attach, or <em>send a prompt</em> to an agent running in one — so one agent
-      can drive another, with no adapter and no config. It's the same PTY daemon
-      (<strong>kaval</strong>, spawned and supervised by kolu's per-host
-      <strong>padi</strong>) exposed as a CLI, locally or over ssh.
-      <a href={href('/padi')} class="guide-link">Meet padi →</a>{" "}
-      <a href={href('/kaval')} class="guide-link">Meet kaval &amp; kaval-tui →</a>
-    </aside>
-  </section>
-
-  <!-- ── 07 · FAQ ─────────────────────────────────────────────────────── -->
-  <section id="faq" class="guide-section scroll-mt-20">
-    <div class="guide-head">
-      <span class="guide-num">07</span>
-      <div>
-        <p class="eyebrow mb-2">faq / troubleshooting</p>
-        <h2 class="display-sm text-[2rem] md:text-[2.4rem] text-ink">
-          Common snags.
-        </h2>
-      </div>
-    </div>
-
-    <div class="faq-list">
-      <details class="deep" open>
-        <summary>
-          <span class="deep-tag deep-tag-alert">#1</span>
-          I see no one-click Install button
-        </summary>
-        <div class="deep-body">
-          <p>
-            You're almost certainly on plain <code>http://</code> — a LAN IP or a
-            Tailscale <code>100.x</code> address. The <em>automatic</em> Install
-            prompt needs an HTTPS secure context, so it's hidden there — but you can
-            still pin manually: <strong>Chrome ⋮ → Save and share → Create shortcut →
-            Open as window</strong>, or <strong>iOS Share → Add to Home Screen</strong>.
-            For the one-click prompt plus the live app badge, open the
-            <code>https://…ts.net</code> URL from <a href="#remote" class="guide-link"
-              >Reach it anywhere</a
-            >.
-          </p>
-        </div>
-      </details>
-
-      <details class="deep">
-        <summary>
-          <span class="deep-tag deep-tag-alert">#2</span>
-          I'm not getting desktop notifications when an agent finishes
-        </summary>
-        <div class="deep-body">
-          <p>
-            kolu fires a native OS notification when an agent finishes in a
-            terminal you're <em>not</em> actively watching — a background
-            terminal, or any time kolu isn't the focused window. If you're
-            looking right at that terminal as it finishes, the on-canvas dock
-            surfaces it instead and no banner fires (by design). Past that, work
-            these in order:
-          </p>
-          <ul>
-            <li>
-              <strong>Secure context.</strong> Notifications ride a service
-              worker, which only registers over HTTPS or <code>localhost</code> —
-              the same rule as the app badge. Over plain <code>http://</code> (a
-              LAN IP or Tailscale <code>100.x</code>) there's no worker, so no
-              banner. Give kolu an <code>https://…ts.net</code> URL — <a
-                href="#remote"
-                class="guide-link">Reach it anywhere ↑</a
-              >.
-            </li>
-            <li>
-              <strong>Grant permission.</strong> The browser asks once; if it was
-              dismissed, re-enable it via the address-bar lock icon →
-              <strong>Notifications</strong>.
-            </li>
-            <li>
-              <strong>Let the OS through — the step that trips everyone.</strong>
-              The site toggle being on is <em>not</em> enough: your browser must
-              itself be allowed to post notifications at the OS level. On macOS:
-              <strong>System Settings → Notifications → Google Chrome</strong> (or
-              the pinned kolu app — it gets its <em>own</em> entry, separate from
-              Chrome) → <strong>Allow</strong>, style Banners or Alerts, and turn
-              off Focus / Do Not Disturb. Relaunching the browser after toggling
-              helps it take effect.
-            </li>
-          </ul>
-          <p>
-            Quick check: open DevTools console on kolu and run
-            <code
-              >navigator.serviceWorker.getRegistration().then(r =&gt;
-              r.showNotification('test'))</code
-            >. If <em>that</em> banner shows, the OS layer is fine and it's the
-            "not watching" rule above; if it doesn't, it's the OS-level setting.
-          </p>
-        </div>
-      </details>
-
-      <details class="deep">
-        <summary>
-          <span class="deep-tag">q</span>
-          Can I use it without Tailscale?
-        </summary>
-        <div class="deep-body">
-          <p>
-            Yes — locally over <code>localhost</code> everything works, including
-            one-click install (loopback is an HTTPS exemption). Tailscale only
-            matters when you want to reach kolu from another device — and want the
-            frictionless one-click install plus app badge there (manual pinning
-            works over plain HTTP regardless).
-          </p>
-        </div>
-      </details>
-
-      <details class="deep">
-        <summary>
-          <span class="deep-tag">q</span>
-          Which agents does kolu support?
-        </summary>
-        <div class="deep-body">
-          <p>
-            <strong>Run any agent.</strong> The terminal is the interface, so
-            <code>aider</code>, <code>gemini</code>, or whatever ships next week
-            works the moment you run it — and any CLI you've run joins the
-            palette's recent-agents list with no adapter and no config file.
-          </p>
-          <p>
-            <strong>Three get first-class integration today</strong> —
-            <code>claude</code> (Claude Code), <code>codex</code>, and <code
-              >opencode</code
-            >. For these, kolu reads <em>live</em> agent state into the dock
-            (working ▸ / awaiting ⏵ / idle ☾) and can export the session as a
-            self-contained HTML chat log or full transcript. Any other agent
-            still runs in its tile — it just doesn't light up the dock.
-          </p>
-        </div>
-      </details>
-
-      <details class="deep">
-        <summary>
-          <span class="deep-tag">q</span>
-          How do I update kolu?
-        </summary>
-        <div class="deep-body">
-          <p>
-            Re-run the same command: <code>nix --refresh run github:juspay/kolu</code>.
-            The <code>--refresh</code> flag busts Nix's flake cache so you always pull
-            the latest commit. For a long-lived service, wire it into a home-manager
-            module (see the
-            <a
-              href="https://github.com/juspay/kolu#deployment-home-manager"
-              rel="noopener"
-              class="guide-link">deployment guide</a
-            >).
-          </p>
-        </div>
-      </details>
-
-      <details class="deep">
-        <summary>
-          <span class="deep-tag">q</span>
-          I closed the welcome — how do I get it back?
-        </summary>
-        <div class="deep-body">
-          <p>
-            Open the palette (<kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd>) and run
-            <strong>Tutorial</strong> (alias "Welcome"). It re-summons the welcome
-            overlay anytime, even while you're working.
-          </p>
-        </div>
-      </details>
-    </div>
-
-    <div class="faq-cta">
-      <p class="text-ink-dim">
-        Still stuck? The source, issues, and full README live on GitHub.
-      </p>
-      <a
-        href="https://github.com/juspay/kolu"
-        rel="noopener"
-        class="faq-cta-btn"
-      >
-        <svg viewBox="0 0 16 16" class="size-4 fill-current" aria-hidden="true">
-          <path
-            d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.34c-2.22.48-2.69-1.07-2.69-1.07-.36-.92-.89-1.17-.89-1.17-.73-.5.05-.49.05-.49.8.06 1.23.82 1.23.82.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.58.82-2.14-.08-.2-.36-1.01.08-2.11 0 0 .67-.21 2.2.82a7.63 7.63 0 0 1 4 0c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.91.08 2.11.51.56.82 1.27.82 2.14 0 3.06-1.86 3.75-3.64 3.95.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"
-          ></path>
-        </svg>
-        juspay/kolu
-      </a>
-    </div>
-  </section>
-
-  <!-- ── LATEST POST ──────────────────────────────────────────────────── -->
   {
     latest && (
-      <section class="mx-auto max-w-[68rem] px-6 py-20">
-        <div class="mb-10 flex items-baseline justify-between">
+      <section class="home-band latest-band">
+        <div class="latest-head">
           <p class="eyebrow">from the blog</p>
-          <a
-            href={href('/blog')}
-            class="mono text-[0.72rem] text-ink-dim hover:text-kolu-primary transition-colors"
-          >
-            all posts →
-          </a>
+          <a href={href('/blog')} class="latest-all">all posts →</a>
         </div>
-        <a
-          href={href(`/blog/${latest.id}`)}
-          class="block group relative border-t border-b border-rule py-10 hover:border-kolu-primary-muted transition-colors"
-        >
-          <time
-            class="mono text-[0.72rem] text-ink-muted tracking-widest"
-            datetime={latest.data.pubDate.toISOString()}
-          >
+        <a href={href(`/blog/${latest.id}`)} class="latest-card">
+          <time datetime={latest.data.pubDate.toISOString()}>
             {latest.data.pubDate
               .toLocaleDateString('en-US', {
                 year: 'numeric',
@@ -1137,77 +216,127 @@ const systemNodes = [
               })
               .toUpperCase()}
           </time>
-          <h3 class="display-sm text-[2rem] md:text-[2.4rem] mt-3 text-ink group-hover:text-kolu-primary transition-colors">
-            {latest.data.title}
-          </h3>
-          <p class="mt-4 text-ink-dim leading-relaxed max-w-2xl">
-            {latest.data.description}
-          </p>
-          <span class="mt-6 inline-block mono text-[0.76rem] text-ink-dim group-hover:text-kolu-primary transition-colors">
-            read →
-          </span>
+          <h2 class="display-sm">{latest.data.title}</h2>
+          <p>{latest.data.description}</p>
+          <span>read →</span>
         </a>
       </section>
     )
   }
 </BaseLayout>
 
-<!-- ── Component-scoped styles ─────────────────────────────────────────
-     Page-local: only the hero terminal frame and canvas demo strip
-     consume these classes. The reusable live-state vocabulary
-     (.live-chip-*, .live-badge, .live-dot, .live-spinner) lives in
-     global.css alongside its keyframes and reduced-motion override.
--->
 <style>
-  /* ── Hero terminal frame ─────────────────────────────────────────── */
-
-  /* Per-tile theme palettes. Real Kolu ships 200+ xterm themes and each
-     terminal can pick its own — the demo mirrors that with three
-     distinct palettes across the page so the hero, canvas main tile,
-     and canvas side tile each read as a separate terminal.
-     The shared block pins cool-neutral ink + middle-step primary tokens
-     *inside* the terminal regardless of page theme, so light-mode
-     visitors still see legible terminal output on the dark theme bg
-     without washing out the terminal palettes. */
-  .theme-phala,
-  .theme-solarized,
-  .theme-hax0r {
-    --color-ink: #e8e8ed;
-    --color-ink-dim: #a8a8b2;
-    --color-ink-muted: #6e6e78;
-    --color-ink-faint: #3a3a42;
-    --color-kolu-primary: var(--color-kolu-logo-middle);
-    --color-kolu-primary-hover: var(--color-kolu-logo-middle-hover);
-    --color-kolu-primary-muted: var(--color-kolu-logo-middle-muted);
-    --color-kolu-top: var(--color-kolu-logo-top);
-    --color-kolu-top-strong: var(--color-kolu-logo-top-strong);
-    --color-kolu-top-muted: var(--color-kolu-logo-top-muted);
-    --color-kolu-bottom: var(--color-kolu-logo-bottom);
-    --color-kolu-bottom-strong: var(--color-kolu-logo-bottom-strong);
-    --color-kolu-bottom-deep: var(--color-kolu-logo-bottom-deep);
-    --color-rule: #18181d;
-    --color-rule-strong: #28282f;
+  .hero {
+    position: relative;
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 5rem 1.5rem 2rem;
+  }
+  .hero-corner {
+    position: absolute;
+    top: 2.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    letter-spacing: 0.12em;
+    color: var(--color-ink-faint);
+  }
+  .hero-corner-left {
+    left: 1.5rem;
+  }
+  .hero-corner-right {
+    right: 1.5rem;
+  }
+  .hero-copy {
+    max-width: 48rem;
+    margin: 2rem auto 0;
+    text-align: center;
+  }
+  .hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .hero-eyebrow span:first-child {
+    color: var(--color-kolu-primary);
+  }
+  .hero-title {
+    margin-top: 1.25rem;
+    color: var(--color-ink);
+    font-size: clamp(3rem, 2.1rem + 4vw, 5rem);
+  }
+  .hero-title span {
+    color: var(--color-kolu-primary);
+  }
+  .hero-kicker {
+    margin-top: 1.45rem;
+    color: var(--color-ink-muted);
+    font-size: 0.78rem;
+    line-height: 1.75;
+  }
+  .hero-body {
+    max-width: 44rem;
+    margin: 1.6rem auto 0;
+    color: var(--color-ink-dim);
+    font-size: 1.08rem;
+    line-height: 1.75;
+  }
+  .hero-body .mono {
     color: var(--color-ink);
   }
-  .theme-phala {
-    --term-bg: #160721;
-    --term-bg-bar: #1f0a2e;
-    --term-glow: var(--color-kolu-primary);
+  .hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 2rem;
   }
-  .theme-solarized {
-    --term-bg: #02161c;
-    --term-bg-bar: #032936;
-    --term-glow: var(--color-live-teal);
+  .hero-primary,
+  .hero-secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 0.25rem;
+    padding: 0.7rem 1.15rem;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    text-decoration: none;
+    transition:
+      border-color 120ms ease,
+      background 120ms ease,
+      color 120ms ease;
   }
-  .theme-hax0r {
-    --term-bg: #1a0a04;
-    --term-bg-bar: #2a1208;
-    --term-glow: var(--color-live-alert);
+  .hero-primary {
+    background: var(--color-kolu-primary);
+    color: var(--color-void);
   }
-
-  /* ── Hero demo video (the real captured kolu session) ────────────────────
-     The full-width centerpiece right under the hero copy. The clip carries
-     kolu's own chrome, so this is just a bordered, primary-glowing 16:9 frame. */
+  .hero-primary:hover {
+    background: var(--color-kolu-primary-hover);
+  }
+  .hero-secondary {
+    border: 1px solid var(--color-rule-strong);
+    color: var(--color-ink);
+  }
+  .hero-secondary:hover {
+    border-color: var(--color-ink-dim);
+    background: var(--color-void-raised);
+  }
+  .demo-section {
+    max-width: 82rem;
+    margin: 0 auto;
+    padding: 1rem 1.5rem 4rem;
+  }
+  .full-demo {
+    margin: 0;
+  }
+  .full-demo-frame {
+    border: 1px solid var(--color-rule-strong);
+    border-radius: 0.65rem;
+    overflow: hidden;
+    background: var(--color-void-sunk);
+    box-shadow: 0 0 90px -30px
+      color-mix(in srgb, var(--color-kolu-primary) 35%, transparent);
+    line-height: 0;
+  }
   .demo-video {
     display: block;
     width: 100%;
@@ -1215,29 +344,82 @@ const systemNodes = [
     aspect-ratio: 16 / 9;
   }
   .hero-demo-cap {
-    margin-top: 0.9rem;
-    font-size: 0.85rem;
-    line-height: 1.55;
+    max-width: 42rem;
+    margin: 0.9rem auto 0;
     color: var(--color-ink-muted);
+    font-size: 0.86rem;
+    line-height: 1.55;
     text-align: center;
   }
-  .full-demo {
-    margin: 0;
+  .home-band {
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 3.5rem 1.5rem;
+    border-top: 1px solid var(--color-rule);
   }
-  .full-demo-frame {
-    border: 1px solid var(--color-rule-strong);
-    border-radius: 0.7rem;
-    overflow: hidden;
-    background: var(--color-void-sunk);
-    box-shadow: 0 0 90px -30px
-      color-mix(in srgb, var(--color-kolu-primary) 35%, transparent);
-    line-height: 0;
+  .section-head {
+    max-width: 42rem;
+    margin-bottom: 1.8rem;
   }
-
-  /* ── System map — kolu + padi + kaval ──────────────────────────────── */
+  .section-head h2,
+  .system-intro h2,
+  .latest-card h2 {
+    margin-top: 0.45rem;
+    color: var(--color-ink);
+    font-size: clamp(1.9rem, 1.35rem + 2vw, 2.5rem);
+  }
+  .section-head p,
+  .system-intro p,
+  .latest-card p {
+    margin-top: 0.9rem;
+    color: var(--color-ink-dim);
+    line-height: 1.7;
+  }
+  .doc-card-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.85rem;
+  }
+  .doc-entry-card {
+    min-height: 12rem;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--color-rule);
+    border-top: 2px solid var(--color-kolu-primary);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    background: var(--color-void-raised);
+    text-decoration: none;
+    transition:
+      transform 140ms ease,
+      border-color 140ms ease,
+      background 140ms ease;
+  }
+  .doc-entry-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-kolu-primary);
+    background: color-mix(in srgb, var(--color-kolu-primary) 7%, var(--color-void-raised));
+  }
+  .doc-entry-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-kolu-primary);
+  }
+  .doc-entry-card strong {
+    margin-top: 0.75rem;
+    color: var(--color-ink);
+    font-size: 1.05rem;
+    line-height: 1.25;
+  }
+  .doc-entry-card span:last-child {
+    margin-top: 0.55rem;
+    color: var(--color-ink-dim);
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
   .system-shell {
-    border-block: 1px solid var(--color-rule);
-    padding-block: 2.2rem;
     display: grid;
     grid-template-columns: minmax(16rem, 0.72fr) minmax(0, 1.28fr);
     gap: 2rem;
@@ -1246,18 +428,17 @@ const systemNodes = [
   .system-intro {
     max-width: 24rem;
   }
-  .system-link {
+  .system-link,
+  .latest-all {
     display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
     margin-top: 1.15rem;
     font-family: var(--font-mono);
     font-size: 0.78rem;
     color: var(--color-kolu-primary);
     text-decoration: none;
-    transition: color 120ms ease;
   }
-  .system-link:hover {
+  .system-link:hover,
+  .latest-all:hover {
     color: var(--color-kolu-primary-hover);
   }
   .system-flow {
@@ -1280,7 +461,7 @@ const systemNodes = [
     gap: 1rem;
     border: 1px solid var(--node-rule);
     border-top-width: 2px;
-    border-radius: 0.55rem;
+    border-radius: 0.5rem;
     padding: 1rem;
     background: color-mix(in srgb, var(--node-color) 5%, var(--color-void-raised));
     text-decoration: none;
@@ -1358,468 +539,58 @@ const systemNodes = [
     font-family: var(--font-mono);
     font-size: 0.88rem;
   }
-
-  /* ── Copy-to-clipboard button on the primary nix-run command ──────── */
-  .copy-cli-btn {
-    position: absolute;
-    top: -0.15rem;
-    right: 0;
-    font-family: var(--font-mono);
-    font-size: 0.6rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    padding: 0.15rem 0.5rem;
-    border-radius: 3px;
-    border: 1px solid var(--color-rule-strong);
-    background: color-mix(in srgb, var(--color-void-raised) 70%, transparent);
-    color: var(--color-ink-muted);
-    cursor: pointer;
-    transition:
-      color 120ms ease,
-      border-color 120ms ease,
-      background 120ms ease;
+  .latest-band {
+    max-width: 68rem;
   }
-  .copy-cli-btn:hover {
-    color: var(--color-kolu-primary);
-    border-color: var(--color-kolu-primary);
-  }
-  .copy-cli-btn.is-done {
-    color: var(--color-live-lime);
-    border-color: var(--color-live-lime);
-    background: color-mix(in srgb, var(--color-live-lime) 12%, transparent);
-  }
-
-  /* ── Getting-started guide (merged from /welcome) ────────────────────
-     Section scaffold: each numbered guide section shares a head (oversized
-     ghost number + eyebrow + title), a lede, and body rhythm. Page-local. */
-  .guide-section {
-    max-width: 52rem;
-    margin-inline: auto;
-    padding-inline: 1.5rem;
-    padding-block: 3.5rem;
-    border-top: 1px solid var(--color-rule);
-  }
-
-  .guide-head {
+  .latest-head {
     display: flex;
-    align-items: flex-start;
-    gap: 1.1rem;
-    margin-bottom: 1.6rem;
-  }
-  .guide-num {
-    font-family: var(--font-mono);
-    font-size: 1.6rem;
-    font-weight: 700;
-    line-height: 1;
-    color: var(--color-rule-strong);
-    letter-spacing: -0.04em;
-    flex-shrink: 0;
-    padding-top: 0.15rem;
-  }
-
-  .guide-lede {
-    font-size: 1.15rem;
-    line-height: 1.65;
-    color: var(--color-ink-dim);
-    max-width: 42rem;
-    margin-bottom: 1.6rem;
-  }
-  .guide-body {
-    line-height: 1.7;
-    color: var(--color-ink-dim);
-    margin-block: 1.3rem;
-  }
-  .guide-subhead {
-    font-family: var(--font-sans);
-    font-weight: 650;
-    letter-spacing: -0.02em;
-    font-size: 1.3rem;
-    color: var(--color-ink);
-    margin-top: 2.6rem;
-    margin-bottom: 0.5rem;
-  }
-  .guide-link {
-    color: var(--color-ink);
-    border-bottom: 1px solid var(--color-kolu-primary-muted);
-    transition: border-color 120ms ease;
-  }
-  .guide-link:hover {
-    border-bottom-color: var(--color-kolu-primary);
-  }
-
-  .guide-section :not(pre) > code {
-    font-family: var(--font-mono);
-    background: var(--color-void-raised);
-    border: 1px solid var(--color-rule);
-    border-radius: 0.25rem;
-    padding: 0.08rem 0.38rem;
-    font-size: 0.86em;
-    color: var(--color-kolu-top-strong);
-  }
-  .guide-section kbd {
-    font-family: var(--font-mono);
-    font-size: 0.78em;
-    background: var(--color-void-raised);
-    border: 1px solid var(--color-rule-strong);
-    border-bottom-width: 2px;
-    border-radius: 0.25rem;
-    padding: 0.05rem 0.35rem;
-    color: var(--color-ink);
-    white-space: nowrap;
-  }
-
-  /* ── Terminal frame (reused for command blocks) ─────────────────────── */
-  .term-frame {
-    border: 1px solid var(--color-rule-strong);
-    border-radius: 0.5rem;
-    overflow: hidden;
-    background: var(--color-void-sunk);
-    box-shadow: 0 0 60px -25px color-mix(in srgb, var(--color-kolu-primary) 30%, transparent);
-    margin-block: 1.5rem;
-  }
-  .term-frame-sm {
-    margin-block: 1rem;
-    box-shadow: none;
-  }
-  .term-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.55rem 0.85rem;
-    border-bottom: 1px solid var(--color-rule);
-    background: var(--color-void-raised);
-  }
-  .term-dot {
-    width: 0.62rem;
-    height: 0.62rem;
-    border-radius: 50%;
-    display: inline-block;
-  }
-  .term-bar-label {
-    font-family: var(--font-mono);
-    font-size: 0.68rem;
-    letter-spacing: 0.06em;
-    color: var(--color-ink-muted);
-    margin-left: 0.6rem;
-  }
-  .term-body {
-    margin: 0;
-    padding: 1rem 1.15rem;
-    font-family: var(--font-mono);
-    font-variant-ligatures: none;
-    font-size: 0.82rem;
-    line-height: 1.7;
-    color: var(--color-ink);
-    overflow-x: auto;
-  }
-  .term-body code {
-    font-family: inherit;
-    background: none;
-    border: none;
-    padding: 0;
-    color: inherit;
-    font-size: inherit;
-  }
-  .c-comment {
-    color: var(--color-kolu-primary);
-  }
-  .c-prompt {
-    color: var(--color-kolu-primary-muted);
-    user-select: none;
-  }
-  .c-arrow {
-    color: var(--color-ink-faint);
-    user-select: none;
-  }
-  .c-ok {
-    color: var(--color-live-lime);
-  }
-
-  /* ── Callouts ───────────────────────────────────────────────────────── */
-  .callout {
-    border: 1px solid var(--color-rule);
-    border-left-width: 3px;
-    border-radius: 0.5rem;
-    padding: 0.95rem 1.15rem;
-    margin-block: 1.6rem;
-    line-height: 1.6;
-    color: var(--color-ink-dim);
-    background: var(--color-void-raised);
-  }
-  .callout strong {
-    color: var(--color-ink);
-  }
-  .callout-note {
-    border-left-color: var(--color-kolu-primary);
-    background: color-mix(in srgb, var(--color-kolu-primary) 5%, var(--color-void-raised));
-  }
-  .callout-ok {
-    border-left-color: var(--color-live-lime);
-    background: color-mix(in srgb, var(--color-live-lime) 6%, var(--color-void-raised));
-  }
-  .callout-danger {
-    border-left-color: var(--color-live-alert);
-    background: color-mix(in srgb, var(--color-live-alert) 6%, var(--color-void-raised));
-  }
-
-  /* ── Step lists ─────────────────────────────────────────────────────── */
-  .step-list {
-    list-style: none;
-    margin: 1.5rem 0 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 1.4rem;
-  }
-  .step-list > li {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-  }
-  .step-n {
-    flex-shrink: 0;
-    width: 1.8rem;
-    height: 1.8rem;
-    display: grid;
-    place-items: center;
-    border-radius: 50%;
-    border: 1px solid var(--color-rule-strong);
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    color: var(--color-kolu-primary);
-    background: var(--color-void-raised);
-  }
-  .step-t {
-    font-weight: 600;
-    color: var(--color-ink);
-    margin-bottom: 0.25rem;
-  }
-  .step-b {
-    color: var(--color-ink-dim);
-    line-height: 1.6;
-  }
-
-  /* ── Concept grid (definition list) ─────────────────────────────────── */
-  .concept-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1px;
-    background: var(--color-rule);
-    border: 1px solid var(--color-rule);
-    border-radius: 0.5rem;
-    overflow: hidden;
-    margin: 1.5rem 0;
-  }
-  .concept {
-    background: var(--color-void);
-    padding: 1.1rem 1.2rem;
-    transition: background 120ms ease;
-  }
-  .concept:hover {
-    background: var(--color-void-raised);
-  }
-  .concept dt {
-    font-weight: 650;
-    color: var(--color-ink);
-    margin-bottom: 0.4rem;
-    font-size: 1.02rem;
-    letter-spacing: -0.01em;
-  }
-  .concept dd {
-    margin: 0;
-    color: var(--color-ink-dim);
-    font-size: 0.92rem;
-    line-height: 1.6;
-  }
-
-  /* ── Browser grid ───────────────────────────────────────────────────── */
-  .browser-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-    margin: 1.5rem 0;
-  }
-  .browser {
-    border: 1px solid var(--color-rule);
-    border-radius: 0.5rem;
-    padding: 1rem 1.15rem;
-    background: var(--color-void-raised);
-  }
-  .browser h4 {
-    font-weight: 650;
-    color: var(--color-ink);
-    margin-bottom: 0.4rem;
-    font-size: 0.98rem;
-  }
-  .browser p {
-    color: var(--color-ink-dim);
-    font-size: 0.9rem;
-    line-height: 1.6;
-  }
-
-  /* ── Tunnel decision grid ───────────────────────────────────────────── */
-  .tunnel-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1rem;
-    margin: 1.5rem 0;
-  }
-  .tunnel {
-    border: 1px solid var(--color-rule);
-    border-top: 2px solid var(--tun-accent);
-    border-radius: 0.5rem;
-    padding: 1rem 1.1rem;
-    background: var(--color-void-raised);
-  }
-  .tunnel-intent {
-    font-family: var(--font-mono);
-    font-size: 0.66rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--tun-accent);
-    margin-bottom: 0.45rem;
-  }
-  .tunnel-name {
-    font-weight: 650;
-    color: var(--color-ink);
-    margin-bottom: 0.4rem;
-    font-size: 0.98rem;
-  }
-  .tunnel-note {
-    color: var(--color-ink-dim);
-    font-size: 0.88rem;
-    line-height: 1.55;
-  }
-
-  /* ── Collapsible deep-dives (built to grow) ─────────────────────────── */
-  .deep {
-    border: 1px solid var(--color-rule);
-    border-radius: 0.5rem;
-    background: var(--color-void-raised);
-    margin-block: 0.8rem;
-    overflow: hidden;
-  }
-  .deep > summary {
-    list-style: none;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 0.7rem;
-    padding: 0.85rem 1.1rem;
-    font-weight: 600;
-    color: var(--color-ink);
-    user-select: none;
-    transition: background 120ms ease;
-  }
-  .deep > summary::-webkit-details-marker {
-    display: none;
-  }
-  .deep > summary::after {
-    content: "+";
-    margin-left: auto;
-    font-family: var(--font-mono);
-    font-size: 1.1rem;
-    color: var(--color-ink-muted);
-    transition: transform 160ms ease;
-  }
-  .deep[open] > summary::after {
-    content: "−";
-    color: var(--color-kolu-primary);
-  }
-  .deep > summary:hover {
-    background: var(--color-void-sunk);
-  }
-  .deep-tag {
-    font-family: var(--font-mono);
-    font-size: 0.6rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-kolu-primary);
-    border: 1px solid var(--color-kolu-primary-muted);
-    border-radius: 0.25rem;
-    padding: 0.1rem 0.4rem;
-    flex-shrink: 0;
-  }
-  .deep-tag-alert {
-    color: var(--color-live-alert);
-    border-color: var(--color-live-alert);
-  }
-  .deep-body {
-    padding: 0 1.1rem 1.1rem;
-    color: var(--color-ink-dim);
-    line-height: 1.65;
-    border-top: 1px solid var(--color-rule);
-    padding-top: 0.9rem;
-  }
-  .deep-body p {
-    margin-bottom: 0.8rem;
-  }
-  .deep-body ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-  }
-  .deep-body li {
-    position: relative;
-    padding-left: 1.1rem;
-  }
-  .deep-body li::before {
-    content: "›";
-    position: absolute;
-    left: 0;
-    color: var(--color-kolu-primary-muted);
-    font-family: var(--font-mono);
-  }
-  .deep-body strong {
-    color: var(--color-ink);
-    font-weight: 600;
-  }
-
-  /* ── FAQ ────────────────────────────────────────────────────────────── */
-  .faq-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-    margin-top: 0.5rem;
-  }
-  .faq-cta {
-    margin-top: 2.5rem;
-    padding-top: 1.6rem;
-    border-top: 1px solid var(--color-rule);
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
     gap: 1rem;
+    margin-bottom: 1.6rem;
   }
-  .faq-cta-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    border: 1px solid var(--color-rule-strong);
-    border-radius: 0.25rem;
-    padding: 0.6rem 1.1rem;
+  .latest-all {
+    margin-top: 0;
+  }
+  .latest-card {
+    display: block;
+    border-block: 1px solid var(--color-rule);
+    padding-block: 2.3rem;
+    text-decoration: none;
+    transition: border-color 120ms ease;
+  }
+  .latest-card:hover {
+    border-color: var(--color-kolu-primary-muted);
+  }
+  .latest-card time,
+  .latest-card span {
     font-family: var(--font-mono);
-    font-size: 0.82rem;
-    color: var(--color-ink);
-    transition:
-      border-color 120ms ease,
-      background 120ms ease;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-ink-muted);
   }
-  .faq-cta-btn:hover {
-    border-color: var(--color-ink-dim);
-    background: var(--color-void-raised);
+  .latest-card:hover h2,
+  .latest-card:hover span {
+    color: var(--color-kolu-primary);
   }
-
-  /* ── Responsive ─────────────────────────────────────────────────────── */
-  @media (max-width: 640px) {
-    .system-shell {
-      grid-template-columns: 1fr;
-      padding-block: 1.7rem;
+  .latest-card p {
+    max-width: 42rem;
+  }
+  .latest-card span {
+    display: inline-block;
+    margin-top: 1.3rem;
+    transition: color 120ms ease;
+  }
+  @media (max-width: 760px) {
+    .hero-corner {
+      display: none;
     }
+    .hero {
+      padding-top: 3.6rem;
+    }
+    .doc-card-grid,
+    .system-shell,
     .system-flow {
       grid-template-columns: 1fr;
     }
@@ -1836,137 +607,15 @@ const systemNodes = [
       bottom: -1.18rem;
       transform: rotate(90deg);
     }
-    .concept-grid,
-    .browser-grid,
-    .tunnel-grid {
-      grid-template-columns: 1fr;
-    }
-    .guide-head {
-      gap: 0.8rem;
-    }
   }
-
-  /* ── On-this-page rail — sticky scroll-spy over the guide sections ─────── */
-  .section-rail {
-    position: fixed;
-    top: 50%;
-    left: 1.5rem;
-    transform: translateY(-50%);
-    z-index: 30;
-    display: none;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.3s ease;
-  }
-  .section-rail.is-visible {
-    opacity: 1;
-    pointer-events: auto;
-  }
-  .section-rail ol {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-  }
-  .section-rail a {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-    padding: 0.28rem 0.4rem;
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.04em;
-    color: var(--color-ink-faint);
-    text-decoration: none;
-    white-space: nowrap;
-    transition: color 0.2s ease;
-  }
-  .section-rail a:hover {
-    color: var(--color-ink-dim);
-  }
-  .section-rail a.is-active {
-    color: var(--color-kolu-primary);
-  }
-  .rail-dot {
-    flex: none;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: currentColor;
-    opacity: 0.55;
-    transition:
-      opacity 0.2s ease,
-      box-shadow 0.2s ease;
-  }
-  .section-rail a.is-active .rail-dot {
-    opacity: 1;
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-kolu-primary) 22%, transparent);
-  }
-  .rail-label {
-    opacity: 0;
-    transform: translateX(-4px);
-    transition:
-      opacity 0.2s ease,
-      transform 0.2s ease;
-  }
-  .section-rail:hover .rail-label,
-  .section-rail a.is-active .rail-label {
-    opacity: 1;
-    transform: none;
-  }
-  /* Only when the centered 52rem guide column leaves room in the left margin. */
-  @media (min-width: 1200px) {
-    .section-rail {
-      display: block;
-    }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .section-rail,
-    .section-rail a,
-    .rail-dot,
-    .rail-label {
-      transition: none;
+  @media (min-width: 761px) and (max-width: 1050px) {
+    .doc-card-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 </style>
 
-<script>
-  // Wire up the copy-to-clipboard button on the primary CLI snippet.
-  // Plain DOM script — Astro hoists this and ships it as a module.
-  document.querySelectorAll<HTMLButtonElement>(".copy-cli-btn").forEach((btn) => {
-    btn.addEventListener("click", async () => {
-      const text = btn.getAttribute("data-clipboard");
-      if (!text) return;
-      const label = btn.querySelector<HTMLElement>(".copy-cli-label");
-      const original = label?.textContent ?? "copy";
-      try {
-        await navigator.clipboard.writeText(text);
-        if (label) label.textContent = "copied";
-        btn.classList.add("is-done");
-      } catch {
-        if (label) label.textContent = "press ⌘C";
-      }
-      window.setTimeout(() => {
-        if (label) label.textContent = original;
-        btn.classList.remove("is-done");
-      }, 1400);
-    });
-  });
-</script>
-
 <script is:inline>
-  // Reduced-motion gate for the hero demo clip. The markup ships WITHOUT
-  // `autoplay`, so nothing plays until this decides — no race against first
-  // playback.
-  //  - motion allowed → enable autoplay + .play() (with a .catch so iOS
-  //    low-power-mode rejection falls back to the poster gracefully).
-  //  - motion reduced → leave the poster standing and expose native `controls`
-  //    so the visitor has a visible play affordance.
-  // The clip ships with preload="none", so its bytes never race the LCP
-  // poster — playback starts only once it scrolls into view (below).
-  // Re-evaluated on preference change while the page stays open.
   (function () {
     var mq = window.matchMedia("(prefers-reduced-motion: reduce)");
     var io = null;
@@ -2011,54 +660,4 @@ const systemNodes = [
     if (mq.addEventListener) mq.addEventListener("change", apply);
     else if (mq.addListener) mq.addListener(apply);
   })();
-</script>
-
-<script>
-  // Scroll-spy for the on-this-page rail: show it only while a guide section
-  // is on screen, and highlight whichever section the reader is currently in.
-  const rail = document.querySelector<HTMLElement>(".section-rail");
-  const sections = Array.from(
-    document.querySelectorAll<HTMLElement>(".guide-section"),
-  );
-  if (rail && sections.length) {
-    const links = new Map<string, HTMLAnchorElement>(
-      Array.from(rail.querySelectorAll("a")).map((a) => [
-        a.getAttribute("href")?.slice(1) ?? "",
-        a,
-      ]),
-    );
-    let ticking = false;
-    function update() {
-      ticking = false;
-      const line = window.innerHeight * 0.3;
-      let activeId: string | null = null;
-      let inGuide = false;
-      for (const s of sections) {
-        const r = s.getBoundingClientRect();
-        if (r.top < window.innerHeight && r.bottom > 0) inGuide = true;
-        if (r.top <= line) activeId = s.id;
-      }
-      // Before any section crosses the line, treat the topmost on-screen
-      // section as active so a visible rail never highlights nothing.
-      if (!activeId && inGuide) {
-        for (const s of sections) {
-          if (s.getBoundingClientRect().bottom > 0) {
-            activeId = s.id;
-            break;
-          }
-        }
-      }
-      rail!.classList.toggle("is-visible", inGuide);
-      links.forEach((a, id) => a.classList.toggle("is-active", id === activeId));
-    }
-    function onScroll() {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(update);
-      }
-    }
-    window.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("resize", onScroll, { passive: true });
-    update();
-  }
 </script>

--- a/website/src/pages/open-graph/[...route].ts
+++ b/website/src/pages/open-graph/[...route].ts
@@ -3,8 +3,8 @@
  * `astro-og-canvas` (canvaskit-wasm). Routes:
  *
  *   /open-graph/site.png                  — the home / fallback card.
- *   /open-graph/blog/<slug>.png           — per-blog-post card with the
- *                                            post's title + description.
+ *   /open-graph/blog/<slug>.png           — per-blog-post card.
+ *   /open-graph/docs/<slug>.png           — per-docs-page card.
  *
  * `BaseLayout.astro` resolves the route via its `ogImageRoute` prop;
  * blog pages pass `blog/<slug>`, the home passes `site`, and any
@@ -19,6 +19,7 @@ import { OGImageRoute } from "astro-og-canvas";
 import { KOLU_PALETTE, SITE_DESCRIPTION } from "../../site";
 
 const blog = await getCollection("blog");
+const docs = await getCollection("docs");
 
 const pages: Record<string, { title: string; description: string }> = {
   site: {
@@ -29,6 +30,12 @@ const pages: Record<string, { title: string; description: string }> = {
     blog.map(({ id, data }) => [
       `blog/${id}`,
       { title: data.title, description: data.description },
+    ]),
+  ),
+  ...Object.fromEntries(
+    docs.map(({ id, data }) => [
+      `docs/${id}`,
+      { title: data.title, description: data.description ?? SITE_DESCRIPTION },
     ]),
   ),
 };

--- a/website/src/styles/docs.css
+++ b/website/src/styles/docs.css
@@ -86,7 +86,19 @@
   color: var(--color-kolu-top-strong);
   font-weight: 500;
 }
+.docs-prose kbd {
+  font-family: var(--font-mono);
+  font-size: 0.78em;
+  background: var(--color-void-raised);
+  border: 1px solid var(--color-rule-strong);
+  border-bottom-width: 2px;
+  border-radius: 0.25rem;
+  padding: 0.05rem 0.35rem;
+  color: var(--color-ink);
+  white-space: nowrap;
+}
 .docs-prose pre {
+  position: relative;
   margin: 1.4rem 0;
   padding: 0.95rem 1.1rem;
   border: 1px solid var(--color-rule);
@@ -100,6 +112,39 @@
   font-family: var(--font-mono);
   font-variant-ligatures: none;
 }
+.docs-prose pre:hover .doc-copy,
+.doc-copy:focus-visible {
+  opacity: 1;
+}
+.doc-copy {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: 1px solid var(--color-rule-strong);
+  border-radius: 0.25rem;
+  background: color-mix(in srgb, var(--color-void-raised) 86%, transparent);
+  color: var(--color-ink-muted);
+  padding: 0.22rem 0.45rem;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease,
+    background 120ms ease;
+}
+.doc-copy:hover {
+  color: var(--color-kolu-primary);
+  border-color: var(--color-kolu-primary);
+}
+.doc-copy.is-copied {
+  color: var(--color-live-lime);
+  border-color: var(--color-live-lime);
+}
 
 .docs-prose ul,
 .docs-prose ol {
@@ -112,6 +157,28 @@
 }
 .docs-prose li::marker {
   color: var(--color-kolu-primary);
+}
+.docs-prose details {
+  margin: 1rem 0;
+  border: 1px solid var(--color-rule);
+  border-radius: 0.55rem;
+  background: var(--color-void-raised);
+  overflow: hidden;
+}
+.docs-prose summary {
+  cursor: pointer;
+  padding: 0.82rem 1rem;
+  color: var(--color-ink);
+  font-weight: 600;
+}
+.docs-prose details[open] summary {
+  border-bottom: 1px solid var(--color-rule);
+}
+.docs-prose details > :not(summary) {
+  margin-inline: 1rem;
+}
+.docs-prose details > :last-child {
+  margin-bottom: 1rem;
 }
 
 /* Markdown tables (the command references + the survival table). */
@@ -166,6 +233,28 @@
 }
 .doc-figure text {
   font-family: var(--font-mono);
+}
+.doc-shot {
+  margin: 1.75rem 0;
+  border: 1px solid var(--color-rule);
+  border-radius: 0.75rem;
+  background: var(--color-void-sunk);
+  overflow: hidden;
+  box-shadow: 0 0 70px -34px
+    color-mix(in srgb, var(--color-kolu-primary) 35%, transparent);
+}
+.doc-shot img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.doc-shot figcaption {
+  margin: 0;
+  padding: 0.75rem 0.95rem;
+  border-top: 1px solid var(--color-rule);
+  color: var(--color-ink-muted);
+  font-size: 0.86rem;
+  line-height: 1.55;
 }
 
 /* ── padi stack diagram ─────────────────────────────────────────────── */

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -187,6 +187,16 @@ body {
   font-feature-settings: "zero", "ss01";
 }
 
+.pagefind-scope {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
 /* --- Theme toggle icons --------------------------------------------------- */
 
 /* Show the sun in dark mode (clicking it moves to light), moon in light. */


### PR DESCRIPTION
**The website now sends readers into a real docs spine instead of making the homepage carry every job.** The homepage is shorter and product-focused, while durable setup, concepts, remote access, power-user workflows, troubleshooting, architecture, padi, and kaval live as first-class docs pages.

### What changed

- Added docs pages for quickstart, first five minutes, concepts, PWA install, remote access, power features, and troubleshooting.
- Restored a full desktop docs sidebar tree, with a separate compact mobile disclosure.
- Added previous/next docs paging, mobile and desktop table-of-contents views, code-copy buttons, docs Open Graph images, and Pagefind section filtering.
- Tightened cross-links so concepts route readers to the relevant docs page at the point they are introduced.
- Made the Padi and Kaval pages lead with their product names in the visible H1.

> Atlas promotion is intentionally not included here; that is the deferred item 8.

### Validation

- `odu run fmt` selector passed.
- `just website::nix-build` passed: `/nix/store/1ag40nili3x9sfba76advij194c4lk86-kolu-website-1.1.0`.

_Generated by Codex (model `gpt-5`)._