### PR TITLE
docs(surface-map): fix two stale fold-envelope comments (void member carries no input field)

### DIFF
--- a/packages/surface-map/src/client.ts
+++ b/packages/surface-map/src/client.ts
@@ -166,8 +166,8 @@ export interface SurfaceMapClient<
 
 /** Wrap a leaf call's input in the uniform fold envelope `{ mapKey, input }` — the
  *  map server reads `mapKey` and forwards `input` verbatim. Uniform across object,
- *  primitive, and undefined inputs (a no-input member sends `input: undefined`), and
- *  an entry input carrying its own `mapKey` field can't collide with the folded key
+ *  primitive, and void inputs (a void-input member carries NO `input` field — just
+ *  `{ mapKey }`), and an entry input carrying its own `mapKey` field can't collide with the folded key
  *  (it rides `input`, nested). `mapKey` is ALWAYS the canonical wire string here —
  *  the caller (`clientFor`) already ran the key through `map.codec.encode`. */
 function foldMapKey(mapKey: string, input: unknown): unknown {

--- a/packages/surface-map/src/envelope.ts
+++ b/packages/surface-map/src/envelope.ts
@@ -2,7 +2,8 @@
  * The uniform fold envelope — the map's internal wire codec. Every entry-member
  * call carries its encoded wire key (the {@link KeyCodec}'s `encode` output, always
  * a plain string) in a `mapKey` field and its own input, verbatim, in an `input`
- * field: `{ mapKey, input }`. A no-input member sends `input: undefined`; an entry
+ * field: `{ mapKey, input }`. A void-input member carries NO `input` field at all
+ * (`{ mapKey }`, not `{ mapKey, input: undefined }` — see ENCODE below); an entry
  * input that itself has a `mapKey` field cannot collide with the folded key (it
  * rides `input`, nested).
  *


### PR DESCRIPTION
Two comments in `@kolu/surface-map` still describe the **pre-hardening** fold shape — that a void-input member sends `input: undefined` — which the zod-hardening in c751948a9 replaced. A void-input member now carries **no `input` field at all** (`{ mapKey }`), so a consumer's zod drift onto `>=4.3.7` (which rejects a *missing* `z.void()` key) can't break the fold.

Both stale comments contradicted the `ENCODE` docstring four lines below `envelope.ts:21`, which already states the truth. Fixed to match:

- `envelope.ts` module header (`{ mapKey, input }` … "A no-input member sends `input: undefined`")
- the `foldMapKey` docstring in `client.ts`

**Comment-only** — no code change.

_Generated by Claude Code (model `claude-opus-4-8`)._