### PR TITLE
ci: warm Attic cache from macos-latest too

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,6 +1,7 @@
-# Build the default package and push its closure to the shared Attic cache
-# (https://cache.nixos.asia/oss). The flake already lists this cache as a
-# substituter, so a green push here warms CI boxes and local `nix build`s.
+# Build the default package on linux + darwin and push each closure to the
+# shared Attic cache (https://cache.nixos.asia/oss). The flake already lists
+# this cache as a substituter, so a green push here warms CI boxes and local
+# `nix build`s on both platforms.
 name: nix-cache
 
 on:
@@ -19,7 +20,15 @@ concurrency:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-latest → x86_64-linux; macos-latest → aarch64-darwin
+        # (GitHub's current macos-latest image). Covers the two platforms
+        # that actually run kolu day-to-day; aarch64-linux / x86_64-darwin
+        # stay out of the matrix until something needs them warmed.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -32,8 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Pin by commit (CodeQL: unpinned third-party action). v31 → 889f318.
-      - uses: nixbuild/nix-quick-install-action@889f3180bb5f064ee9e3201428d04ae9e41d54ad # v31
+      # Pin by commit (CodeQL: unpinned third-party action). v35 → 9f63be7.
+      # Defaults to Nix 2.34.7 (`nix profile add`; v31 was still on 2.29.0 /
+      # `profile install` only, which broke ryanccn/attic-action).
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
           nix_conf: |
             extra-substituters = https://cache.nixos.asia/oss
@@ -41,9 +43,7 @@ jobs:
             accept-flake-config = true
 
       - name: Install attic
-        # Prefer `install` — nix-quick-install's Nix still uses that subcommand
-        # (newer Nix renamed it to `add`; ryanccn/attic-action only tries `add`).
-        run: nix profile install nixpkgs#attic-client
+        run: nix profile add nixpkgs#attic-client
 
       - name: Login to Attic
         env:

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -33,8 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Pin by commit (CodeQL: unpinned third-party action). v35 → 9f63be7.
-      # Defaults to Nix 2.34.7 (`nix profile add`; v31 was still on 2.29.0 /
-      # `profile install` only, which broke ryanccn/attic-action).
+      # Defaults to Nix 2.34.7 (`nix profile add`).
       - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
           nix_conf: |
@@ -42,20 +41,15 @@ jobs:
             extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
             accept-flake-config = true
 
-      - name: Install attic
-        run: nix profile add nixpkgs#attic-client
-
-      - name: Login to Attic
-        env:
-          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
-        run: attic login ci https://cache.nixos.asia "$ATTIC_TOKEN"
+      # Installs attic, logs in, uses the cache as a substituter, and at job
+      # end pushes every store path this run produced. Needs a Nix new enough
+      # for `nix profile add` (hence v35 above — v31's 2.29 only had
+      # `profile install`, which is why #1731 dropped this action).
+      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
+        with:
+          endpoint: https://cache.nixos.asia
+          cache: oss
+          token: ${{ secrets.ATTIC_TOKEN }}
 
       - name: Build
-        id: build
-        run: |
-          out=$(nix build -L --print-out-paths --no-link)
-          echo "out=$out" >> "$GITHUB_OUTPUT"
-          echo "Built: $out"
-
-      - name: Push to Attic
-        run: attic push ci:oss "${{ steps.build.outputs.out }}"
+        run: nix build -L --print-out-paths


### PR DESCRIPTION
**Darwin builds now warm the shared Attic cache** as well as Linux. Follow-up to #1731, which only ran the cache job on `ubuntu-latest` (`x86_64-linux`).

The flake already exposes packages for four systems; day-to-day kolu is run on **linux x86_64** and **darwin aarch64**. Matrixing `ubuntu-latest` + `macos-latest` covers both, so local `nix build` / cold CI on a Mac can hit `cache.nixos.asia/oss` instead of rebuilding from source.

| Runner | Platform pushed |
| --- | --- |
| `ubuntu-latest` | `x86_64-linux` |
| `macos-latest` | `aarch64-darwin` |

### Also un-winds the #1731 workaround

#1731 dropped `ryanccn/attic-action` because `nix-quick-install@v31` shipped Nix 2.29, which only had `nix profile install` — and the action hard-codes `profile add`. That was never a reason to stay on old Nix or hand-roll the login/push.

This PR:

- bumps `nix-quick-install-action` **v31 → v35** (Nix 2.29.0 → 2.34.7)
- restores **`ryanccn/attic-action@v0.5.0`** (pinned by SHA) so it owns install, login, substituter use, and end-of-job push of every store path the run produced

`fail-fast: false` so a red linux job still lets darwin push (and vice versa). *`aarch64-linux` / `x86_64-darwin` stay out of the matrix until something needs those closures warmed.*

Same triggers and secret as #1731 (`ATTIC_TOKEN`).

_Generated by Grok Build (model `grok-4.5`)._