### PR TITLE
feat(agency): orchestrator skill — the coordination rules as running memory

### DIFF
--- a/.agents/skills/orchestrator/SKILL.md
+++ b/.agents/skills/orchestrator/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: orchestrator
+description: >-
+  Running memory of the coordination rules for an orchestrator agent driving
+  implementing agents on kolu terminals — authorization boundaries, the
+  kaval-tui dispatch protocol, verification discipline, and how to communicate
+  with srid. Load whenever coordinating a multi-agent campaign (dispatching
+  briefs to agents in kolu PTYs, tracking their PRs, verifying their claims),
+  or when acting as the coordinator in a padi/surface-style campaign. Triggers
+  on "orchestrate the agents", "coordinate the campaign", "dispatch to the
+  agents", "act as coordinator", or driving multiple implementing agents from
+  one supervising session.
+---
+
+# Orchestrator
+
+Coordination rules for a supervising agent driving implementing agents on kolu
+terminals. These are hard-won rules from real campaigns — follow them exactly;
+each one exists because its violation caused damage.
+
+## Authorization
+
+- NEVER message another agent (`kaval-tui send` or otherwise) without srid's
+  explicit permission for that specific dispatch. The one exception:
+  overnight/autonomous runs srid has explicitly sanctioned.
+- Use the AskUserQuestion tool whenever clarity from srid would help —
+  ambiguous scope, a decision that forks the work, an unclear instruction —
+  rather than guessing or proceeding on an assumption. Same exception:
+  in an explicitly sanctioned overnight/autonomous run, where blocking on a
+  question is not possible, proceed on documented best judgment instead.
+- When srid asks a design/feasibility question ("can't we…?", "how should
+  we…?"), the deliverable is an answer TO SRID — grounded in the actual code at
+  the tree (read the files fresh; never from memory), with concrete API
+  sketches and examples, judged by /perfection-review and
+  /architecture-first-principles. Only after srid authorizes does anything go
+  to an agent.
+- srid merges ALL PRs. Never merge, never run CI without srid's explicit go
+  when srid has said to hold, and keep PRs DRAFT.
+
+## Dispatch protocol (kaval terminals)
+
+- Two-step send: first
+  `kaval-tui send <terminal-id> --socket <pty-host.sock> "<message>"`, then a
+  SECOND command with `--key Enter` to submit. Never send C-c — it can kill
+  in-flight work.
+- No backticks or shell-expandable syntax in send payloads (bash
+  command-substitutes them and mangles the message). Put large payloads in a
+  file and send a short pointer message.
+- Give every brief a unique report-back token (e.g. `W6COPY-N5T8`) so replies
+  are attributable.
+- Verify landing against the RECIPIENT's transcript: grep the token in the
+  agent's `~/.claude/projects/<project-dir>/*.jsonl`. Never trust the send's
+  exit code or a terminal snapshot — a snapshot recap is narrative, not state.
+
+## Verification discipline
+
+- Verify every agent claim at the tree/forge — `git fetch` and inspect the
+  actual commits, `gh pr view` / `gh pr checks` — never from the agent's
+  report alone.
+- Reproduce-first for bugs. Never skip tests (no skip-with-tags workarounds).
+  Never defer a defect that can be fixed now.
+- Put watchdogs on long-running agents; tear down by captured PID/id. Agents
+  must isolate shared-host state (e.g. `KOLU_REMOTE_PADI_STATE_DIR`) —
+  production hosts and srid's default remote roots are untouchable.
+
+## Communicating with srid
+
+- Plain words, lead with the outcome. No cryptic codenames or arrow chains.
+  srid should never have to ask twice for a TLDR.
+- Per /perfection-review there is NO time-based "cost" — never weigh correct
+  process (e.g. a framework-change gate) against time; the gate is simply the
+  correct process.

--- a/.agents/skills/orchestrator/SKILL.md
+++ b/.agents/skills/orchestrator/SKILL.md
@@ -4,69 +4,39 @@ description: >-
   Running memory of the coordination rules for an orchestrator agent driving
   implementing agents on kolu terminals — authorization boundaries, the
   kaval-tui dispatch protocol, verification discipline, and how to communicate
-  with srid. Load whenever coordinating a multi-agent campaign (dispatching
-  briefs to agents in kolu PTYs, tracking their PRs, verifying their claims),
-  or when acting as the coordinator in a padi/surface-style campaign. Triggers
-  on "orchestrate the agents", "coordinate the campaign", "dispatch to the
-  agents", "act as coordinator", or driving multiple implementing agents from
-  one supervising session.
+  with the human. Load whenever coordinating a multi-agent campaign
+  (dispatching briefs to agents in kolu PTYs, tracking their PRs, verifying
+  their claims), or when acting as the coordinator in a padi/surface-style
+  campaign. Triggers on "orchestrate the agents", "coordinate the campaign",
+  "dispatch to the agents", "act as coordinator", or driving multiple
+  implementing agents from one supervising session.
 ---
 
 # Orchestrator
 
-Coordination rules for a supervising agent driving implementing agents on kolu
-terminals. These are hard-won rules from real campaigns — follow them exactly;
-each one exists because its violation caused damage.
+Coordination rules for a supervising agent driving implementing agents. Hard-won from real campaigns; follow them exactly.
 
 ## Authorization
 
-- NEVER message another agent (`kaval-tui send` or otherwise) without srid's
-  explicit permission for that specific dispatch. The one exception:
-  overnight/autonomous runs srid has explicitly sanctioned.
-- Use the AskUserQuestion tool whenever clarity from srid would help —
-  ambiguous scope, a decision that forks the work, an unclear instruction —
-  rather than guessing or proceeding on an assumption. Same exception:
-  in an explicitly sanctioned overnight/autonomous run, where blocking on a
-  question is not possible, proceed on documented best judgment instead.
-- When srid asks a design/feasibility question ("can't we…?", "how should
-  we…?"), the deliverable is an answer TO SRID — grounded in the actual code at
-  the tree (read the files fresh; never from memory), with concrete API
-  sketches and examples, judged by /perfection-review and
-  /architecture-first-principles. Only after srid authorizes does anything go
-  to an agent.
-- srid merges ALL PRs. Never merge, never run CI without srid's explicit go
-  when srid has said to hold, and keep PRs DRAFT.
+- Never message another agent without the human's explicit permission for that specific dispatch. Exception: overnight/autonomous runs the human has sanctioned.
+- Ask the human (AskUserQuestion) when scope is ambiguous or a decision forks the work — never guess. Overnight exception: proceed on documented best judgment.
+- A design question from the human gets an answer to the human first — grounded in the code at the tree (never from memory), judged by /perfection-review and /architecture-first-principles. Dispatch to an agent only after the human authorizes.
+- The human merges all PRs. Keep PRs draft; hold CI when the human says hold.
 
-## Dispatch protocol (kaval terminals)
+## Dispatch
 
-- Two-step send: first
-  `kaval-tui send <terminal-id> --socket <pty-host.sock> "<message>"`, then a
-  SECOND command with `--key Enter` to submit. Never send C-c — it can kill
-  in-flight work.
-- No backticks or shell-expandable syntax in send payloads (bash
-  command-substitutes them and mangles the message). Put large payloads in a
-  file and send a short pointer message.
-- Give every brief a unique report-back token (e.g. `W6COPY-N5T8`) so replies
-  are attributable.
-- Verify landing against the RECIPIENT's transcript: grep the token in the
-  agent's `~/.claude/projects/<project-dir>/*.jsonl`. Never trust the send's
-  exit code or a terminal snapshot — a snapshot recap is narrative, not state.
+- Drive kolu terminals through the kolu skill's messaging loop; submission is its own keystroke; never interrupt a working agent.
+- Payloads must survive the shell unmangled; large briefs ride in a file with a short pointer.
+- Every brief carries a unique report-back token.
+- A dispatch has landed only when you observe it at the recipient — through whatever record its runtime exposes — never because the send succeeded or a snapshot suggested it.
 
-## Verification discipline
+## Verification
 
-- Verify every agent claim at the tree/forge — `git fetch` and inspect the
-  actual commits, `gh pr view` / `gh pr checks` — never from the agent's
-  report alone.
-- Reproduce-first for bugs. Never skip tests (no skip-with-tags workarounds).
-  Never defer a defect that can be fixed now.
-- Put watchdogs on long-running agents; tear down by captured PID/id. Agents
-  must isolate shared-host state (e.g. `KOLU_REMOTE_PADI_STATE_DIR`) —
-  production hosts and srid's default remote roots are untouchable.
+- Verify every agent claim at the tree/forge, never from the report.
+- Reproduce bugs first. Never skip tests. Never defer a fixable defect.
+- Watchdog long-running agents; tear down by captured id. Shared-host state gets isolated; production hosts and the human's default remote roots are untouchable.
 
-## Communicating with srid
+## Communicating with the human
 
-- Plain words, lead with the outcome. No cryptic codenames or arrow chains.
-  srid should never have to ask twice for a TLDR.
-- Per /perfection-review there is NO time-based "cost" — never weigh correct
-  process (e.g. a framework-change gate) against time; the gate is simply the
-  correct process.
+- Plain words, outcome first. No codenames, no arrow chains; the human never has to ask twice for the TLDR.
+- Time is never a cost against correct process (/perfection-review).

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: orchestrator
+description: >-
+  Running memory of the coordination rules for an orchestrator agent driving
+  implementing agents on kolu terminals — authorization boundaries, the
+  kaval-tui dispatch protocol, verification discipline, and how to communicate
+  with srid. Load whenever coordinating a multi-agent campaign (dispatching
+  briefs to agents in kolu PTYs, tracking their PRs, verifying their claims),
+  or when acting as the coordinator in a padi/surface-style campaign. Triggers
+  on "orchestrate the agents", "coordinate the campaign", "dispatch to the
+  agents", "act as coordinator", or driving multiple implementing agents from
+  one supervising session.
+---
+
+# Orchestrator
+
+Coordination rules for a supervising agent driving implementing agents on kolu
+terminals. These are hard-won rules from real campaigns — follow them exactly;
+each one exists because its violation caused damage.
+
+## Authorization
+
+- NEVER message another agent (`kaval-tui send` or otherwise) without srid's
+  explicit permission for that specific dispatch. The one exception:
+  overnight/autonomous runs srid has explicitly sanctioned.
+- Use the AskUserQuestion tool whenever clarity from srid would help —
+  ambiguous scope, a decision that forks the work, an unclear instruction —
+  rather than guessing or proceeding on an assumption. Same exception:
+  in an explicitly sanctioned overnight/autonomous run, where blocking on a
+  question is not possible, proceed on documented best judgment instead.
+- When srid asks a design/feasibility question ("can't we…?", "how should
+  we…?"), the deliverable is an answer TO SRID — grounded in the actual code at
+  the tree (read the files fresh; never from memory), with concrete API
+  sketches and examples, judged by /perfection-review and
+  /architecture-first-principles. Only after srid authorizes does anything go
+  to an agent.
+- srid merges ALL PRs. Never merge, never run CI without srid's explicit go
+  when srid has said to hold, and keep PRs DRAFT.
+
+## Dispatch protocol (kaval terminals)
+
+- Two-step send: first
+  `kaval-tui send <terminal-id> --socket <pty-host.sock> "<message>"`, then a
+  SECOND command with `--key Enter` to submit. Never send C-c — it can kill
+  in-flight work.
+- No backticks or shell-expandable syntax in send payloads (bash
+  command-substitutes them and mangles the message). Put large payloads in a
+  file and send a short pointer message.
+- Give every brief a unique report-back token (e.g. `W6COPY-N5T8`) so replies
+  are attributable.
+- Verify landing against the RECIPIENT's transcript: grep the token in the
+  agent's `~/.claude/projects/<project-dir>/*.jsonl`. Never trust the send's
+  exit code or a terminal snapshot — a snapshot recap is narrative, not state.
+
+## Verification discipline
+
+- Verify every agent claim at the tree/forge — `git fetch` and inspect the
+  actual commits, `gh pr view` / `gh pr checks` — never from the agent's
+  report alone.
+- Reproduce-first for bugs. Never skip tests (no skip-with-tags workarounds).
+  Never defer a defect that can be fixed now.
+- Put watchdogs on long-running agents; tear down by captured PID/id. Agents
+  must isolate shared-host state (e.g. `KOLU_REMOTE_PADI_STATE_DIR`) —
+  production hosts and srid's default remote roots are untouchable.
+
+## Communicating with srid
+
+- Plain words, lead with the outcome. No cryptic codenames or arrow chains.
+  srid should never have to ask twice for a TLDR.
+- Per /perfection-review there is NO time-based "cost" — never weigh correct
+  process (e.g. a framework-change gate) against time; the gate is simply the
+  correct process.

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -4,69 +4,39 @@ description: >-
   Running memory of the coordination rules for an orchestrator agent driving
   implementing agents on kolu terminals — authorization boundaries, the
   kaval-tui dispatch protocol, verification discipline, and how to communicate
-  with srid. Load whenever coordinating a multi-agent campaign (dispatching
-  briefs to agents in kolu PTYs, tracking their PRs, verifying their claims),
-  or when acting as the coordinator in a padi/surface-style campaign. Triggers
-  on "orchestrate the agents", "coordinate the campaign", "dispatch to the
-  agents", "act as coordinator", or driving multiple implementing agents from
-  one supervising session.
+  with the human. Load whenever coordinating a multi-agent campaign
+  (dispatching briefs to agents in kolu PTYs, tracking their PRs, verifying
+  their claims), or when acting as the coordinator in a padi/surface-style
+  campaign. Triggers on "orchestrate the agents", "coordinate the campaign",
+  "dispatch to the agents", "act as coordinator", or driving multiple
+  implementing agents from one supervising session.
 ---
 
 # Orchestrator
 
-Coordination rules for a supervising agent driving implementing agents on kolu
-terminals. These are hard-won rules from real campaigns — follow them exactly;
-each one exists because its violation caused damage.
+Coordination rules for a supervising agent driving implementing agents. Hard-won from real campaigns; follow them exactly.
 
 ## Authorization
 
-- NEVER message another agent (`kaval-tui send` or otherwise) without srid's
-  explicit permission for that specific dispatch. The one exception:
-  overnight/autonomous runs srid has explicitly sanctioned.
-- Use the AskUserQuestion tool whenever clarity from srid would help —
-  ambiguous scope, a decision that forks the work, an unclear instruction —
-  rather than guessing or proceeding on an assumption. Same exception:
-  in an explicitly sanctioned overnight/autonomous run, where blocking on a
-  question is not possible, proceed on documented best judgment instead.
-- When srid asks a design/feasibility question ("can't we…?", "how should
-  we…?"), the deliverable is an answer TO SRID — grounded in the actual code at
-  the tree (read the files fresh; never from memory), with concrete API
-  sketches and examples, judged by /perfection-review and
-  /architecture-first-principles. Only after srid authorizes does anything go
-  to an agent.
-- srid merges ALL PRs. Never merge, never run CI without srid's explicit go
-  when srid has said to hold, and keep PRs DRAFT.
+- Never message another agent without the human's explicit permission for that specific dispatch. Exception: overnight/autonomous runs the human has sanctioned.
+- Ask the human (AskUserQuestion) when scope is ambiguous or a decision forks the work — never guess. Overnight exception: proceed on documented best judgment.
+- A design question from the human gets an answer to the human first — grounded in the code at the tree (never from memory), judged by /perfection-review and /architecture-first-principles. Dispatch to an agent only after the human authorizes.
+- The human merges all PRs. Keep PRs draft; hold CI when the human says hold.
 
-## Dispatch protocol (kaval terminals)
+## Dispatch
 
-- Two-step send: first
-  `kaval-tui send <terminal-id> --socket <pty-host.sock> "<message>"`, then a
-  SECOND command with `--key Enter` to submit. Never send C-c — it can kill
-  in-flight work.
-- No backticks or shell-expandable syntax in send payloads (bash
-  command-substitutes them and mangles the message). Put large payloads in a
-  file and send a short pointer message.
-- Give every brief a unique report-back token (e.g. `W6COPY-N5T8`) so replies
-  are attributable.
-- Verify landing against the RECIPIENT's transcript: grep the token in the
-  agent's `~/.claude/projects/<project-dir>/*.jsonl`. Never trust the send's
-  exit code or a terminal snapshot — a snapshot recap is narrative, not state.
+- Drive kolu terminals through the kolu skill's messaging loop; submission is its own keystroke; never interrupt a working agent.
+- Payloads must survive the shell unmangled; large briefs ride in a file with a short pointer.
+- Every brief carries a unique report-back token.
+- A dispatch has landed only when you observe it at the recipient — through whatever record its runtime exposes — never because the send succeeded or a snapshot suggested it.
 
-## Verification discipline
+## Verification
 
-- Verify every agent claim at the tree/forge — `git fetch` and inspect the
-  actual commits, `gh pr view` / `gh pr checks` — never from the agent's
-  report alone.
-- Reproduce-first for bugs. Never skip tests (no skip-with-tags workarounds).
-  Never defer a defect that can be fixed now.
-- Put watchdogs on long-running agents; tear down by captured PID/id. Agents
-  must isolate shared-host state (e.g. `KOLU_REMOTE_PADI_STATE_DIR`) —
-  production hosts and srid's default remote roots are untouchable.
+- Verify every agent claim at the tree/forge, never from the report.
+- Reproduce bugs first. Never skip tests. Never defer a fixable defect.
+- Watchdog long-running agents; tear down by captured id. Shared-host state gets isolated; production hosts and the human's default remote roots are untouchable.
 
-## Communicating with srid
+## Communicating with the human
 
-- Plain words, lead with the outcome. No cryptic codenames or arrow chains.
-  srid should never have to ask twice for a TLDR.
-- Per /perfection-review there is NO time-based "cost" — never weigh correct
-  process (e.g. a framework-change gate) against time; the gate is simply the
-  correct process.
+- Plain words, outcome first. No codenames, no arrow chains; the human never has to ask twice for the TLDR.
+- Time is never a cost against correct process (/perfection-review).

--- a/agents/.apm/skills/orchestrator/SKILL.md
+++ b/agents/.apm/skills/orchestrator/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: orchestrator
+description: >-
+  Running memory of the coordination rules for an orchestrator agent driving
+  implementing agents on kolu terminals — authorization boundaries, the
+  kaval-tui dispatch protocol, verification discipline, and how to communicate
+  with srid. Load whenever coordinating a multi-agent campaign (dispatching
+  briefs to agents in kolu PTYs, tracking their PRs, verifying their claims),
+  or when acting as the coordinator in a padi/surface-style campaign. Triggers
+  on "orchestrate the agents", "coordinate the campaign", "dispatch to the
+  agents", "act as coordinator", or driving multiple implementing agents from
+  one supervising session.
+---
+
+# Orchestrator
+
+Coordination rules for a supervising agent driving implementing agents on kolu
+terminals. These are hard-won rules from real campaigns — follow them exactly;
+each one exists because its violation caused damage.
+
+## Authorization
+
+- NEVER message another agent (`kaval-tui send` or otherwise) without srid's
+  explicit permission for that specific dispatch. The one exception:
+  overnight/autonomous runs srid has explicitly sanctioned.
+- Use the AskUserQuestion tool whenever clarity from srid would help —
+  ambiguous scope, a decision that forks the work, an unclear instruction —
+  rather than guessing or proceeding on an assumption. Same exception:
+  in an explicitly sanctioned overnight/autonomous run, where blocking on a
+  question is not possible, proceed on documented best judgment instead.
+- When srid asks a design/feasibility question ("can't we…?", "how should
+  we…?"), the deliverable is an answer TO SRID — grounded in the actual code at
+  the tree (read the files fresh; never from memory), with concrete API
+  sketches and examples, judged by /perfection-review and
+  /architecture-first-principles. Only after srid authorizes does anything go
+  to an agent.
+- srid merges ALL PRs. Never merge, never run CI without srid's explicit go
+  when srid has said to hold, and keep PRs DRAFT.
+
+## Dispatch protocol (kaval terminals)
+
+- Two-step send: first
+  `kaval-tui send <terminal-id> --socket <pty-host.sock> "<message>"`, then a
+  SECOND command with `--key Enter` to submit. Never send C-c — it can kill
+  in-flight work.
+- No backticks or shell-expandable syntax in send payloads (bash
+  command-substitutes them and mangles the message). Put large payloads in a
+  file and send a short pointer message.
+- Give every brief a unique report-back token (e.g. `W6COPY-N5T8`) so replies
+  are attributable.
+- Verify landing against the RECIPIENT's transcript: grep the token in the
+  agent's `~/.claude/projects/<project-dir>/*.jsonl`. Never trust the send's
+  exit code or a terminal snapshot — a snapshot recap is narrative, not state.
+
+## Verification discipline
+
+- Verify every agent claim at the tree/forge — `git fetch` and inspect the
+  actual commits, `gh pr view` / `gh pr checks` — never from the agent's
+  report alone.
+- Reproduce-first for bugs. Never skip tests (no skip-with-tags workarounds).
+  Never defer a defect that can be fixed now.
+- Put watchdogs on long-running agents; tear down by captured PID/id. Agents
+  must isolate shared-host state (e.g. `KOLU_REMOTE_PADI_STATE_DIR`) —
+  production hosts and srid's default remote roots are untouchable.
+
+## Communicating with srid
+
+- Plain words, lead with the outcome. No cryptic codenames or arrow chains.
+  srid should never have to ask twice for a TLDR.
+- Per /perfection-review there is NO time-based "cost" — never weigh correct
+  process (e.g. a framework-change gate) against time; the gate is simply the
+  correct process.

--- a/agents/.apm/skills/orchestrator/SKILL.md
+++ b/agents/.apm/skills/orchestrator/SKILL.md
@@ -4,69 +4,39 @@ description: >-
   Running memory of the coordination rules for an orchestrator agent driving
   implementing agents on kolu terminals — authorization boundaries, the
   kaval-tui dispatch protocol, verification discipline, and how to communicate
-  with srid. Load whenever coordinating a multi-agent campaign (dispatching
-  briefs to agents in kolu PTYs, tracking their PRs, verifying their claims),
-  or when acting as the coordinator in a padi/surface-style campaign. Triggers
-  on "orchestrate the agents", "coordinate the campaign", "dispatch to the
-  agents", "act as coordinator", or driving multiple implementing agents from
-  one supervising session.
+  with the human. Load whenever coordinating a multi-agent campaign
+  (dispatching briefs to agents in kolu PTYs, tracking their PRs, verifying
+  their claims), or when acting as the coordinator in a padi/surface-style
+  campaign. Triggers on "orchestrate the agents", "coordinate the campaign",
+  "dispatch to the agents", "act as coordinator", or driving multiple
+  implementing agents from one supervising session.
 ---
 
 # Orchestrator
 
-Coordination rules for a supervising agent driving implementing agents on kolu
-terminals. These are hard-won rules from real campaigns — follow them exactly;
-each one exists because its violation caused damage.
+Coordination rules for a supervising agent driving implementing agents. Hard-won from real campaigns; follow them exactly.
 
 ## Authorization
 
-- NEVER message another agent (`kaval-tui send` or otherwise) without srid's
-  explicit permission for that specific dispatch. The one exception:
-  overnight/autonomous runs srid has explicitly sanctioned.
-- Use the AskUserQuestion tool whenever clarity from srid would help —
-  ambiguous scope, a decision that forks the work, an unclear instruction —
-  rather than guessing or proceeding on an assumption. Same exception:
-  in an explicitly sanctioned overnight/autonomous run, where blocking on a
-  question is not possible, proceed on documented best judgment instead.
-- When srid asks a design/feasibility question ("can't we…?", "how should
-  we…?"), the deliverable is an answer TO SRID — grounded in the actual code at
-  the tree (read the files fresh; never from memory), with concrete API
-  sketches and examples, judged by /perfection-review and
-  /architecture-first-principles. Only after srid authorizes does anything go
-  to an agent.
-- srid merges ALL PRs. Never merge, never run CI without srid's explicit go
-  when srid has said to hold, and keep PRs DRAFT.
+- Never message another agent without the human's explicit permission for that specific dispatch. Exception: overnight/autonomous runs the human has sanctioned.
+- Ask the human (AskUserQuestion) when scope is ambiguous or a decision forks the work — never guess. Overnight exception: proceed on documented best judgment.
+- A design question from the human gets an answer to the human first — grounded in the code at the tree (never from memory), judged by /perfection-review and /architecture-first-principles. Dispatch to an agent only after the human authorizes.
+- The human merges all PRs. Keep PRs draft; hold CI when the human says hold.
 
-## Dispatch protocol (kaval terminals)
+## Dispatch
 
-- Two-step send: first
-  `kaval-tui send <terminal-id> --socket <pty-host.sock> "<message>"`, then a
-  SECOND command with `--key Enter` to submit. Never send C-c — it can kill
-  in-flight work.
-- No backticks or shell-expandable syntax in send payloads (bash
-  command-substitutes them and mangles the message). Put large payloads in a
-  file and send a short pointer message.
-- Give every brief a unique report-back token (e.g. `W6COPY-N5T8`) so replies
-  are attributable.
-- Verify landing against the RECIPIENT's transcript: grep the token in the
-  agent's `~/.claude/projects/<project-dir>/*.jsonl`. Never trust the send's
-  exit code or a terminal snapshot — a snapshot recap is narrative, not state.
+- Drive kolu terminals through the kolu skill's messaging loop; submission is its own keystroke; never interrupt a working agent.
+- Payloads must survive the shell unmangled; large briefs ride in a file with a short pointer.
+- Every brief carries a unique report-back token.
+- A dispatch has landed only when you observe it at the recipient — through whatever record its runtime exposes — never because the send succeeded or a snapshot suggested it.
 
-## Verification discipline
+## Verification
 
-- Verify every agent claim at the tree/forge — `git fetch` and inspect the
-  actual commits, `gh pr view` / `gh pr checks` — never from the agent's
-  report alone.
-- Reproduce-first for bugs. Never skip tests (no skip-with-tags workarounds).
-  Never defer a defect that can be fixed now.
-- Put watchdogs on long-running agents; tear down by captured PID/id. Agents
-  must isolate shared-host state (e.g. `KOLU_REMOTE_PADI_STATE_DIR`) —
-  production hosts and srid's default remote roots are untouchable.
+- Verify every agent claim at the tree/forge, never from the report.
+- Reproduce bugs first. Never skip tests. Never defer a fixable defect.
+- Watchdog long-running agents; tear down by captured id. Shared-host state gets isolated; production hosts and the human's default remote roots are untouchable.
 
-## Communicating with srid
+## Communicating with the human
 
-- Plain words, lead with the outcome. No cryptic codenames or arrow chains.
-  srid should never have to ask twice for a TLDR.
-- Per /perfection-review there is NO time-based "cost" — never weigh correct
-  process (e.g. a framework-change gate) against time; the gate is simply the
-  correct process.
+- Plain words, outcome first. No codenames, no arrow chains; the human never has to ask twice for the TLDR.
+- Time is never a cost against correct process (/perfection-review).

--- a/agents/README.md
+++ b/agents/README.md
@@ -25,6 +25,7 @@ Repo-agnostic skills that don't depend on kolu internals:
 | `perfection-review`  | Adversarial "ideal-bar" review, fanned out via Workflow                 |
 | `architecture-first-principles` | The state-and-time lens — 5 grounded CS principles (values, pure core, one-authority/clock, illegal-states-unrepresentable, end-to-end) |
 | `kolu`               | Drive one agent from another through kolu terminals (`kaval-tui`)       |
+| `orchestrator`       | Coordination rules for a supervisor driving agents on kolu terminals    |
 | `surface`            | Consume the shared `@kolu/surface` stack in a downstream app            |
 
 The package declares the shared packages these skills call

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-08T20:45:10.966081+00:00'
+generated_at: '2026-07-09T20:25:03.992094+00:00'
 apm_version: 0.24.0
 dependencies:
 - repo_url: _local/agents
@@ -29,6 +29,8 @@ dependencies:
   - .agents/skills/lens-debate
   - .agents/skills/lens-debate/SKILL.md
   - .agents/skills/lens-debate/debate.workflow.js
+  - .agents/skills/orchestrator
+  - .agents/skills/orchestrator/SKILL.md
   - .agents/skills/perfection-review
   - .agents/skills/perfection-review/SKILL.md
   - .agents/skills/surface
@@ -55,6 +57,8 @@ dependencies:
   - .claude/skills/lens-debate
   - .claude/skills/lens-debate/SKILL.md
   - .claude/skills/lens-debate/debate.workflow.js
+  - .claude/skills/orchestrator
+  - .claude/skills/orchestrator/SKILL.md
   - .claude/skills/perfection-review
   - .claude/skills/perfection-review/SKILL.md
   - .claude/skills/surface
@@ -75,6 +79,7 @@ dependencies:
     .agents/skills/kolu/SKILL.md: sha256:943bb2816bf9feb5b88cb5e461cfe2fa4aceedc60b81585d284342dd3865a160
     .agents/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
+    .agents/skills/orchestrator/SKILL.md: sha256:cb0c26db0a96a782828c4b0c0bab439611724b2fd178ad7f448efd1121053836
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
@@ -92,6 +97,7 @@ dependencies:
     .claude/skills/kolu/SKILL.md: sha256:943bb2816bf9feb5b88cb5e461cfe2fa4aceedc60b81585d284342dd3865a160
     .claude/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .claude/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
+    .claude/skills/orchestrator/SKILL.md: sha256:cb0c26db0a96a782828c4b0c0bab439611724b2fd178ad7f448efd1121053836
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
   source: local

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-09T20:25:03.992094+00:00'
+generated_at: '2026-07-09T20:32:49.565344+00:00'
 apm_version: 0.24.0
 dependencies:
 - repo_url: _local/agents
@@ -79,7 +79,7 @@ dependencies:
     .agents/skills/kolu/SKILL.md: sha256:943bb2816bf9feb5b88cb5e461cfe2fa4aceedc60b81585d284342dd3865a160
     .agents/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
-    .agents/skills/orchestrator/SKILL.md: sha256:cb0c26db0a96a782828c4b0c0bab439611724b2fd178ad7f448efd1121053836
+    .agents/skills/orchestrator/SKILL.md: sha256:4a08bcc44bdb547d147ac6d057b9d9e250cf50c2b7a1066a8f28f59195937944
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
@@ -97,7 +97,7 @@ dependencies:
     .claude/skills/kolu/SKILL.md: sha256:943bb2816bf9feb5b88cb5e461cfe2fa4aceedc60b81585d284342dd3865a160
     .claude/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .claude/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
-    .claude/skills/orchestrator/SKILL.md: sha256:cb0c26db0a96a782828c4b0c0bab439611724b2fd178ad7f448efd1121053836
+    .claude/skills/orchestrator/SKILL.md: sha256:4a08bcc44bdb547d147ac6d057b9d9e250cf50c2b7a1066a8f28f59195937944
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
   source: local


### PR DESCRIPTION
A persistent `/orchestrator` skill capturing the coordination rules srid established over the padi/surface multi-agent campaign — written as running memory for any coordinator agent driving implementing agents on kolu terminals.

Four rule areas, imperative voice, ~1 page:

- **Authorization** — never message another agent without srid's explicit per-dispatch permission (sanctioned overnight runs excepted); use AskUserQuestion when scope is ambiguous or a decision forks the work, rather than guessing; design questions get an answer *to srid* grounded in fresh reads of the code, judged by /perfection-review and /architecture-first-principles; srid merges all PRs, and PRs stay DRAFT.
- **Dispatch protocol (kaval terminals)** — the two-step `kaval-tui send` + `--key Enter` submit, no C-c, no backticks in payloads, unique report-back tokens per brief, and landing verified against the recipient's own transcript, never the send's exit code or a snapshot.
- **Verification discipline** — every agent claim verified at the tree/forge; reproduce-first for bugs; no test-skipping, no deferring fixable defects; watchdogs, PID-exact teardown, and isolated shared-host state.
- **Communicating with srid** — plain words, outcome first, and no time-based "cost" ever weighed against correct process.

## Placement

Authored at **`agents/.apm/skills/orchestrator/SKILL.md`** (srid's suggested location), for two reasons the repo layout confirms:

1. `.claude/` (and `.agents/`, `.codex/`, `.opencode/`) are **generated** from `.apm` sources by APM — `.apm/instructions/apm-sources.instructions.md` says direct edits there are overwritten by the next `just ai::apm`. So the skill must be authored in an `.apm` source tree, not in `.claude/skills/` directly.
2. Of the two source trees, the in-tree reusable package `agents/.apm/skills/` (a local-path apm dependency of the root `apm.yml`) is where the agent-coordination skills already live — notably `kolu` (driving one agent from another through kolu terminals), which this skill directly complements. The root `.apm/skills/` holds kolu-app-specific skills (dev-server, evidence, release, …) instead.

`just ai::apm` was run; the regenerated `.claude/skills/orchestrator/` + `.agents/skills/orchestrator/` outputs and the `apm.lock.yaml` entries are committed (only additions plus the lockfile timestamp — no unrelated churn). The skill is also added to the package table in `agents/README.md`.

Do not merge — for srid's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)