### PR TITLE
docs: explain high memory usage and the renderer setting

### DIFF
--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -53,7 +53,7 @@ const RENDERER_HINT: Record<Preferences["terminalRenderer"], Hint> = {
     text: "WebGL on every tile — may thrash past ~16 terminals.",
     tone: "warn",
   },
-  dom: { text: "DOM renderer; lowest GPU, stable font on focus." },
+  dom: { text: "DOM renderer; lowest GPU but more RAM. Auto is recommended." },
 };
 
 /** New-terminal creation strategy. `Inherit` copies the active terminal's

--- a/website/src/content/docs/remote-hosts.mdx
+++ b/website/src/content/docs/remote-hosts.mdx
@@ -135,6 +135,11 @@ for your input — so a host you're not looking at can tell you it needs you wit
 your switching to it first. An [installed PWA](/install-pwa) surfaces the same
 counts as an app-badge and notifications across all your hosts.
 
+Because each host keeps its own canvas warm, its terminals stay **live in your
+browser** even while you're looking at another host — so browser memory scales with
+the number of connected hosts and their terminals. If a two-host session feels
+heavy, see [kolu is using a lot of memory](/troubleshooting#kolu-is-using-a-lot-of-memory).
+
 ## When a host is down
 
 If a host's [padi](/padi) can't bind, its canvas is replaced by a card that names the cause

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -92,6 +92,35 @@ Open the palette with <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd> and run **Tutorial**
 same palette opens the first terminal flow in
 [First Five Minutes](/first-five-minutes).
 
+## kolu is using a lot of memory
+
+kolu runs entirely in your browser tab, and its memory grows with two things: how
+many terminals you have open, and how many hosts you are connected to. Each open
+terminal keeps its own scroll-back history, and **each connected host keeps its
+terminals live** — so two machines with a dozen busy terminals between them is a
+lot of live state in one tab. That is expected, not a leak.
+
+If it climbs higher than feels right, check these in order:
+
+1. **Renderer.** In Settings, the **Renderer** control has three modes — **Auto**,
+   **WebGL**, and **DOM**. Keep it on **Auto** (the default): Auto draws
+   recently-active tiles on the GPU and the rest with the lighter DOM renderer.
+   **DOM** uses the least GPU but noticeably more system RAM; **WebGL** forces every
+   tile onto the GPU and can thrash once you pass ~16 terminals. If you switched it
+   while debugging something, switch it back to Auto.
+2. **Close or sleep what you are done with.** A terminal you will not return to can
+   be closed, or put to **sleep** (the ☾ button) to release its shell and GPU
+   context while the tile stays on the canvas — see
+   [Power Features](/power-features#sleep-a-terminal). Disconnecting a
+   [remote host](/remote-hosts) you are not using frees all of its terminals at once.
+3. **Reload the tab.** Memory freed by closing terminals or hosts is reclaimed
+   immediately on a reload, and your terminals survive it — they live in the kaval
+   daemon, not the tab, so nothing is lost.
+
+The chrome bar shows a live memory figure for each process (server · client ·
+kaval), so you can watch which one is climbing; **Debug → Diagnostic info** in the
+palette has the per-terminal detail.
+
 ## Still stuck?
 
 <CardGrid>


### PR DESCRIPTION
## Why

A user's browser memory sat at **1.7 GB** with 14 terminals across 2 hosts. Diagnosing it live turned up the real cause: the terminal **Renderer** had been left on **DOM** (from an unrelated debugging session), and DOM rasterizes every terminal into CPU/native compositor layers. Switching back to **Auto** and reloading cut Memory Footprint to **762 MB** — a ~940 MB drop from one setting.

Two things made this hard to self-diagnose, and this PR fixes both:

1. Nothing in the user docs explained that memory grows with open terminals **and** connected hosts, or that the Renderer setting has a large RAM implication.
2. The in-app DOM hint (`"lowest GPU, stable font on focus"`) was true but silent about the RAM cost — so leaving it on DOM read as harmless.

Notably, the scroll-back buffer — the first suspect — was **not** the cause: no terminal was near the cap and buffers totalled ~55 MB.

## What changed

| File | Change |
| --- | --- |
| `website/.../troubleshooting.mdx` | New **"kolu is using a lot of memory"** entry: memory scales with terminals × hosts (expected, not a leak), keep Renderer on **Auto**, and how to reclaim memory (close/sleep/disconnect/reload). |
| `website/.../remote-hosts.mdx` | One line under *per-host canvases*: each host's tiles stay **live in the browser**, so memory scales with connected hosts — links to the troubleshooting entry. |
| `packages/client/.../SettingsPopover.tsx` | DOM renderer hint now flags the RAM trade-off and recommends Auto, at the point of choice. |

## Verification

- `just website::build` — clean (54 pages indexed, no MDX/link errors).
- `just fmt` — clean.

Docs only, plus a one-line UI hint string; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)