### PR TITLE
chore(be): drop the ultracode interview question

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -18,9 +18,8 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
 - **Plan first?** — write the plan as an **Atlas note** (`docs/atlas/src/content/atlas/<slug>.mdx`) for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing Atlas note or legacy `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
-- **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now (including the ultracode check above), because everything after this is autonomous.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
 
 ## 1. Set up
 

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -18,9 +18,8 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
 - **Plan first?** — write the plan as an **Atlas note** (`docs/atlas/src/content/atlas/<slug>.mdx`) for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing Atlas note or legacy `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
-- **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now (including the ultracode check above), because everything after this is autonomous.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
 
 ## 1. Set up
 

--- a/agents/.apm/skills/be/SKILL.md
+++ b/agents/.apm/skills/be/SKILL.md
@@ -18,9 +18,8 @@ Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
 
 - **Plan first?** — write the plan as an **Atlas note** (`docs/atlas/src/content/atlas/<slug>.mdx`) for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing Atlas note or legacy `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).
-- **Ultracode?** — include this question *only when no system-reminder says ultracode is on*. Remind the user that `/be` runs richer with ultracode (deeper review fan-out, adversarial verification of each finding) and ask whether to proceed on the standard pass or pause so they can enable it. Options: *Proceed (standard pass)* / *I'll enable ultracode first*. If they pick the latter, stop and let them turn it on, then re-run.
 
-Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now (including the ultracode check above), because everything after this is autonomous.
+Add a question only when something material is genuinely unclear — don't pad. Honor anything the user already pinned in the prompt instead of re-asking. **This single `AskUserQuestion` call is your one and only chance to ask** — surface every clarification you need now, because everything after this is autonomous.
 
 ## 1. Set up
 

--- a/docs/atlas/dist/be-workflow.html
+++ b/docs/atlas/dist/be-workflow.html
@@ -66,7 +66,7 @@ or to deeper reading where there is some.</p>
   <path class="link" d="M750,121 L800,121"/>
   <rect class="chip" x="800" y="94" width="340" height="54" rx="8"/>
   <text class="tool"   x="818" y="116">AskUserQuestion  (batched, once)</text>
-  <text class="skilln" x="818" y="135">Plan first?  ·  Task kind  ·  Ultracode?</text>
+  <text class="skilln" x="818" y="135">Plan first?  ·  Task kind</text>
 
   <!-- ============ §1 Set up ============ -->
   <rect class="phase" x="330" y="192" width="420" height="72" rx="12" fill="#E3E9FD" stroke="#0D32B2"/>
@@ -307,7 +307,7 @@ pin down a few choices up front rather than guessing.</li>
 already live) or another home — so it can decouple from kolu and be used
 anywhere. The kolu-specific pieces it leans on (the <a href="https://github.com/juspay/project-unknown/blob/main/.apm/skills/pu/SKILL.md" style="font-family:var(--mono);font-weight:600;white-space:nowrap">/pu</a> box,
 <a href="https://github.com/juspay/kolu/blob/master/.apm/skills/dev-server/SKILL.md" style="font-family:var(--mono);font-weight:600;white-space:nowrap">/dev-server</a>, the Atlas) are the seams that work would tease apart.</p>
-<p>The interview covers three things:</p>
+<p>The interview covers two things:</p>
 <ul>
 <li><strong>Plan first?</strong> Write the plan as an <a href="/atlas/meta.html">Atlas note</a> for review
 before implementing, or go straight to code. Default: straight, unless the task
@@ -315,8 +315,6 @@ is large or ambiguous.</li>
 <li><strong>Task kind</strong> — bug · feature · refactor. This picks the test strategy: a bug
 needs a red-then-green reproduction; a feature needs a covering test written
 first; a refactor leans on existing coverage.</li>
-<li><strong>Ultracode?</strong> — only asked when it isn’t already on. With it, the review
-gauntlet fans out deeper and adversarially verifies each finding.</li>
 </ul>
 <aside class="callout callout-note" data-astro-cid-q2ml7llr><div class="callout-body" data-astro-cid-q2ml7llr><p><strong>Autonomy doesn’t inherit — it’s propagated.</strong> Every subagent <code>/be</code> delegates to
 is told <em>execute now, don’t wait for confirmation</em>. A subagent starts without the

--- a/docs/atlas/src/content/atlas/be-workflow.mdx
+++ b/docs/atlas/src/content/atlas/be-workflow.mdx
@@ -80,7 +80,7 @@ already live) or another home — so it can decouple from kolu and be used
 anywhere. The kolu-specific pieces it leans on (the <Skill name="pu" /> box,
 <Skill name="dev-server" />, the Atlas) are the seams that work would tease apart.
 
-The interview covers three things:
+The interview covers two things:
 
 - **Plan first?** Write the plan as an [Atlas note](/atlas/meta.html) for review
   before implementing, or go straight to code. Default: straight, unless the task
@@ -88,8 +88,6 @@ The interview covers three things:
 - **Task kind** — bug · feature · refactor. This picks the test strategy: a bug
   needs a red-then-green reproduction; a feature needs a covering test written
   first; a refactor leans on existing coverage.
-- **Ultracode?** — only asked when it isn't already on. With it, the review
-  gauntlet fans out deeper and adversarially verifies each finding.
 
 <Callout type="note">
 **Autonomy doesn't inherit — it's propagated.** Every subagent `/be` delegates to

--- a/docs/atlas/src/diagrams/be-workflow.svg
+++ b/docs/atlas/src/diagrams/be-workflow.svg
@@ -52,7 +52,7 @@
   <path class="link" d="M750,121 L800,121"/>
   <rect class="chip" x="800" y="94" width="340" height="54" rx="8"/>
   <text class="tool"   x="818" y="116">AskUserQuestion  (batched, once)</text>
-  <text class="skilln" x="818" y="135">Plan first?  ·  Task kind  ·  Ultracode?</text>
+  <text class="skilln" x="818" y="135">Plan first?  ·  Task kind</text>
 
   <!-- ============ §1 Set up ============ -->
   <rect class="phase" x="330" y="192" width="420" height="72" rx="12" fill="#E3E9FD" stroke="#0D32B2"/>


### PR DESCRIPTION
`/be`'s opening interview asked a third question — **Ultracode?** — whenever ultracode wasn't already on, nudging the user to enable it before proceeding. This removes that question so the interview stays focused on the two choices that actually shape the work: **Plan first?** and **Task kind**.

## What changed

- `agents/.apm/skills/be/SKILL.md` — dropped the Ultracode bullet from §0's `AskUserQuestion` list, and the "(including the ultracode check above)" aside that referenced it.
- Regenerated the runtime skill (`.claude/` + `.agents/` copies) via `just ai::apm`.
- Kept the `/be` Atlas map in sync (per `be-workflow-atlas.md`): the note now says the interview covers **two** things, the Ultracode bullet is gone, and the diagram node reads `Plan first? · Task kind`. Rebuilt `docs/atlas/dist/` — `just atlas::check-sync` is green.

Docs-only change to agent skills; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)