### PR TITLE
chore(skills): orchestrator briefs route implementer reports through /kolu

### DIFF
--- a/.agents/skills/orchestrator/SKILL.md
+++ b/.agents/skills/orchestrator/SKILL.md
@@ -29,7 +29,7 @@ Coordination rules for a supervising agent driving implementing agents. Hard-won
 - Payloads must survive the shell unmangled; large briefs ride in a file with a short pointer.
 - Every brief carries a unique report-back token.
 - A dispatch has landed only when you observe it at the recipient — through whatever record its runtime exposes — never because the send succeeded or a snapshot suggested it.
-- Briefs point the implementing agent at the kolu skill for its own reports back — never hand-transcribe the messaging protocol into a brief. A hand-taught protocol loses steps: a finished report once sat unsent because the agent skipped the submission keystroke.
+- Briefs make LOADING the kolu skill for reports part of the brief itself — never a hand-transcribed protocol, never a parenthetical "two-step send" reminder: neither survives an implementer's long-context run, and a finished report once sat unsent on the input line until the human noticed. The skill's submit loop is the contract: each report submits with its own Enter keystroke and is snapshot-verified as landed.
 - A brief that authorizes dev-server or evidence work quotes the recorded-PIDs-only teardown rule verbatim: teardown kills only the exact PIDs recorded at spawn; pattern kills are banned; strays are reported, never hunted. The skill's own ban did not survive contact — an agent hand-rolled an equivalent `ps|grep` and killed production.
 
 ## Answering agents

--- a/.claude/skills/orchestrator/SKILL.md
+++ b/.claude/skills/orchestrator/SKILL.md
@@ -29,7 +29,7 @@ Coordination rules for a supervising agent driving implementing agents. Hard-won
 - Payloads must survive the shell unmangled; large briefs ride in a file with a short pointer.
 - Every brief carries a unique report-back token.
 - A dispatch has landed only when you observe it at the recipient — through whatever record its runtime exposes — never because the send succeeded or a snapshot suggested it.
-- Briefs point the implementing agent at the kolu skill for its own reports back — never hand-transcribe the messaging protocol into a brief. A hand-taught protocol loses steps: a finished report once sat unsent because the agent skipped the submission keystroke.
+- Briefs make LOADING the kolu skill for reports part of the brief itself — never a hand-transcribed protocol, never a parenthetical "two-step send" reminder: neither survives an implementer's long-context run, and a finished report once sat unsent on the input line until the human noticed. The skill's submit loop is the contract: each report submits with its own Enter keystroke and is snapshot-verified as landed.
 - A brief that authorizes dev-server or evidence work quotes the recorded-PIDs-only teardown rule verbatim: teardown kills only the exact PIDs recorded at spawn; pattern kills are banned; strays are reported, never hunted. The skill's own ban did not survive contact — an agent hand-rolled an equivalent `ps|grep` and killed production.
 
 ## Answering agents

--- a/agents/.apm/skills/orchestrator/SKILL.md
+++ b/agents/.apm/skills/orchestrator/SKILL.md
@@ -29,7 +29,7 @@ Coordination rules for a supervising agent driving implementing agents. Hard-won
 - Payloads must survive the shell unmangled; large briefs ride in a file with a short pointer.
 - Every brief carries a unique report-back token.
 - A dispatch has landed only when you observe it at the recipient — through whatever record its runtime exposes — never because the send succeeded or a snapshot suggested it.
-- Briefs point the implementing agent at the kolu skill for its own reports back — never hand-transcribe the messaging protocol into a brief. A hand-taught protocol loses steps: a finished report once sat unsent because the agent skipped the submission keystroke.
+- Briefs make LOADING the kolu skill for reports part of the brief itself — never a hand-transcribed protocol, never a parenthetical "two-step send" reminder: neither survives an implementer's long-context run, and a finished report once sat unsent on the input line until the human noticed. The skill's submit loop is the contract: each report submits with its own Enter keystroke and is snapshot-verified as landed.
 - A brief that authorizes dev-server or evidence work quotes the recorded-PIDs-only teardown rule verbatim: teardown kills only the exact PIDs recorded at spawn; pattern kills are banned; strays are reported, never hunted. The skill's own ban did not survive contact — an agent hand-rolled an equivalent `ps|grep` and killed production.
 
 ## Answering agents

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-12T13:50:05.644839+00:00'
+generated_at: '2026-07-12T14:07:44.671658+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -79,7 +79,7 @@ dependencies:
     .agents/skills/kolu/SKILL.md: sha256:d4575e21bbcd12e6c1c1ba3c79495a3a50503525cf583d3f208425ce0b20c4df
     .agents/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
-    .agents/skills/orchestrator/SKILL.md: sha256:0dd5ad6d98d98ab08d6be34e3347241abc29f118f4a762290b8e835d2923aec2
+    .agents/skills/orchestrator/SKILL.md: sha256:3cb877e5b61e8fa2deb8bab450c4ffeb0b0a61bfa8d4b2f37d0c2675019816ed
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
@@ -97,7 +97,7 @@ dependencies:
     .claude/skills/kolu/SKILL.md: sha256:d4575e21bbcd12e6c1c1ba3c79495a3a50503525cf583d3f208425ce0b20c4df
     .claude/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .claude/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
-    .claude/skills/orchestrator/SKILL.md: sha256:0dd5ad6d98d98ab08d6be34e3347241abc29f118f4a762290b8e835d2923aec2
+    .claude/skills/orchestrator/SKILL.md: sha256:3cb877e5b61e8fa2deb8bab450c4ffeb0b0a61bfa8d4b2f37d0c2675019816ed
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
   source: local
@@ -918,7 +918,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:0dd5ad6d98d98ab08d6be34e3347241abc29f118f4a762290b8e835d2923aec2
+  content_hash: sha256:3cb877e5b61e8fa2deb8bab450c4ffeb0b0a61bfa8d4b2f37d0c2675019816ed
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1945,7 +1945,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:0dd5ad6d98d98ab08d6be34e3347241abc29f118f4a762290b8e835d2923aec2
+  content_hash: sha256:3cb877e5b61e8fa2deb8bab450c4ffeb0b0a61bfa8d4b2f37d0c2675019816ed
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel


### PR DESCRIPTION
## What

One-clause edit to the **orchestrator** skill's *Dispatch* section: the report-back-token rule now directs the implementing agent to report **through the `/kolu` submit loop** — load `/kolu`, submit each report with its own `--key Enter`, then snapshot-verify it landed — instead of relying on a parenthetical "two-step send" reminder in the brief.

## Why — evidence from /be run `82bef646` (padi W9, PR #1764)

Mined by the `self-improve` skill from this session's transcript. The implementing `/be` agent reported to its coordinator over `kaval-tui` and sent **five consecutive reports** (`kaval-tui send <term> "text"`) with **no follow-up `--key Enter`**. Each one staged on the coordinator's input line until srid pressed Enter by hand. The coordinator then had to intervene: *"your last report sat unsent in my terminal until srid pressed Enter manually … use the /kolu skill for ALL messages to me."*

The `/be` dispatch brief **already** contained the reminder — `kaval-tui send (two-step: message, then --key Enter)` — and the agent dropped it 5 times anyway. This is the canonical llm-autonomy failure mode: *a rule the codebase documents arrives as a mid-run interrupt because nothing loaded it at the right moment*. The durable fix per the lever map is to **cross-link the existing `/kolu` skill into the report-back path** (load it), not to add another prose reminder.

### Evidence ledger

| Edit | Failure it engineers out | Transcript evidence |
| --- | --- | --- |
| Orchestrator *Dispatch* → report-back token now mandates `/kolu` submit loop + snapshot-verify | Implementer reports staged unsent; human hits Enter each time | 5 bare `send "text"` reports (session lines 25, 263, 349, 359, 418); first `--key Enter` only at line 448, after the coordinator's `/kolu` intervention |

## Not shipped (observation only)

A second candidate — the agent shipping an **LRU keep-last cache** where the ratified W9 plan-of-record specified **per-host query ownership** — occurred **once**, was caught by the coordinator + gauntlet, and self-corrected (the realignment then let codex find 2 real bugs the LRU shape had masked). One reversible, gauntlet-caught occurrence does not clear the self-improve recurrence bar (≥3 hits / irreversible near-miss / prior-run repeat), so it's noted here rather than shipped as a rule — shipping a "honor the plan's mechanism" gate on a single data point risks churn and could over-constrain legitimate deviation.

## Scope note

`just ai::apm` regen is entangled with an **unpinned** apm toolchain (`uvx --from apm-cli`, 0.24.0 → 0.24.1), which drifts `AGENTS.md` build-ids, `.codex/config.toml` ordering, and lockfile version/timestamp. That drift is excluded; the commit carries only the orchestrator source, its two generated runtime copies, and the regenerated **orchestrator** hashes in `apm.lock.yaml`. `just fmt` + `just check` (typecheck + biome) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)