### PR TITLE
refactor(statepip): one amber "attention pill" — Dock unread badge adopts the host-tab chip styling

### DIFF
--- a/packages/client/src/canvas/dock/WorkspaceGrid.tsx
+++ b/packages/client/src/canvas/dock/WorkspaceGrid.tsx
@@ -14,6 +14,7 @@
 
 import { activeArm, activePr } from "@kolu/padi/surface";
 import { StatePip } from "@kolu/solid-statepip";
+import { ATTENTION_PILL_CLASS } from "@kolu/solid-statepip/pipVariant";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import type { TerminalId } from "kolu-common/surface";
 import {
@@ -518,13 +519,21 @@ const WorkspaceCard: Component<{
           style={{ "background-color": props.entry.info.branchColor }}
         />
       </Show>
+      {/* Unread ping — the card-corner twin of the dock row's unread badge.
+       *  Placement + ping motion stay; only the FILL is unified to the shared
+       *  `ATTENTION_PILL_CLASS` amber (was the cool `bg-alert` violet — the same
+       *  "your turn" state hue, a drift from the amber every OTHER unread mark
+       *  paints), so all three unread surfaces read as one cue. The pill class's
+       *  text utilities are inert here (no content); its fill + rounding carry. */}
       <Show when={props.unread}>
         <span
           class="absolute right-2 top-2 inline-flex h-2 w-2"
           aria-hidden="true"
         >
-          <span class="absolute inline-flex h-full w-full rounded-full bg-alert opacity-75 animate-ping" />
-          <span class="relative inline-flex rounded-full h-2 w-2 bg-alert" />
+          <span
+            class={`absolute h-full w-full opacity-75 animate-ping ${ATTENTION_PILL_CLASS}`}
+          />
+          <span class={`relative h-2 w-2 ${ATTENTION_PILL_CLASS}`} />
         </span>
       </Show>
 

--- a/packages/client/src/host/HostSelectorStrip.tsx
+++ b/packages/client/src/host/HostSelectorStrip.tsx
@@ -80,6 +80,7 @@ import {
 import { createStore } from "solid-js/store";
 import { Portal } from "solid-js/web";
 import { toast } from "solid-sonner";
+import { ATTENTION_PILL_CLASS } from "@kolu/solid-statepip/pipVariant";
 import { HomeIcon, SearchIcon } from "../ui/Icons";
 import { surface } from "../ui/Surface";
 import { useCommandPalette } from "../useCommandPalette";
@@ -257,7 +258,11 @@ const HostChip: Component<{ host: HostKey; measure?: boolean }> = (props) => {
           {/* Urgency badge — the host's awaiting count, hidden at zero. */}
           <Show when={awaiting() > 0}>
             <span
-              class="shrink-0 min-w-4 px-1 h-4 inline-flex items-center justify-center rounded-full bg-amber-500/90 text-[10px] font-semibold text-black/80 tabular-nums"
+              // The awaiting-count pill — the pixel REFERENCE for the amber
+              // "needs you" cue. Its fill + shape + numerals are the shared
+              // `ATTENTION_PILL_CLASS` (the single styling source the Dock's
+              // unread badge also consumes); only the count-pill sizing is local.
+              class={`${ATTENTION_PILL_CLASS} shrink-0 min-w-4 px-1 h-4`}
               title={`${awaiting()} awaiting your input`}
             >
               {awaiting()}

--- a/packages/solid-statepip/src/StatePip.tsx
+++ b/packages/solid-statepip/src/StatePip.tsx
@@ -43,6 +43,7 @@
 import { type Component, createMemo, Show } from "solid-js";
 import {
   ALERT_BADGE_CLASS,
+  ATTENTION_PILL_CLASS,
   INDICATOR_BASE,
   LIVE_RING_CLASS,
   PIP_BODY,
@@ -124,14 +125,20 @@ export const StatePip: Component<{
         {(b) => <span class={b().class}>{b().glyph}</span>}
       </Show>
       {/* The two outer-axis overlays — a green arc that sweeps around the core
-          while the terminal is live, and a small amber corner badge while an
-          alert is unread (a badge, not a ring, so the two never compound into
-          nested circles). Visuals in statepip.css. */}
+          while the terminal is live, and the amber corner badge while an alert
+          is unread (a badge, not a ring, so the two never compound into nested
+          circles). The badge shares the host-tab count pill's amber fill + shape
+          via `ATTENTION_PILL_CLASS` (the single styling source); `ALERT_BADGE_CLASS`
+          adds only its corner placement + pill dims + pulse. Boolean here, so no
+          count — the pill FORM, per-terminal semantics. Visuals in statepip.css. */}
       <Show when={props.live}>
         <span class={LIVE_RING_CLASS} aria-hidden="true" />
       </Show>
       <Show when={props.alert}>
-        <span class={ALERT_BADGE_CLASS} aria-hidden="true" />
+        <span
+          class={`${ATTENTION_PILL_CLASS} ${ALERT_BADGE_CLASS}`}
+          aria-hidden="true"
+        />
       </Show>
     </span>
   );

--- a/packages/solid-statepip/src/pipVariant.test.ts
+++ b/packages/solid-statepip/src/pipVariant.test.ts
@@ -5,6 +5,7 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   ALERT_BADGE_CLASS,
+  ATTENTION_PILL_CLASS,
   DOCK_ROW_PIP_BOX,
   INDICATOR_BASE,
   LIVE_RING_CLASS,
@@ -138,5 +139,19 @@ describe("the indicator wrapper + outer-axis overlays", () => {
     // a badge, NOT a halo/ring — the alert uses a distinct shape so it never
     // compounds with the live ring into nested circles.
     expect(ALERT_BADGE_CLASS).toBe("statepip-alert-badge");
+  });
+
+  // The SINGLE styling source for the amber "needs you / unread" cue, shared by
+  // the host-tab awaiting-count pill and the Dock's unread badge (composed with
+  // ALERT_BADGE_CLASS) so the two can't drift in colour or shape. Pin the
+  // identity tokens — the amber fill, the pill rounding, and tabular numerals —
+  // so a colour swap (e.g. back to the mismatched `--color-attention`) or a shape
+  // change is caught here rather than only by eye across two surfaces.
+  it("ATTENTION_PILL_CLASS carries the shared amber-pill identity (fill + shape + numerals)", () => {
+    const cls = ATTENTION_PILL_CLASS.split(/\s+/);
+    expect(cls).toContain("bg-amber-500/90"); // the chip's amber, now the shared truth
+    expect(cls).toContain("rounded-full"); // the pill shape
+    expect(cls).toContain("tabular-nums"); // steady-width count numerals
+    expect(cls).toContain("text-black/80");
   });
 });

--- a/packages/solid-statepip/src/pipVariant.ts
+++ b/packages/solid-statepip/src/pipVariant.ts
@@ -148,10 +148,40 @@ export const TITLE_PIP_BOX = "w-[14px] h-[14px] rounded-full";
  *  `statepip.css`; both surfaces import it, so it can't drift. */
 export const LIVE_RING_CLASS = "statepip-live-ring";
 
-/** The alert overlay class — a small amber CORNER BADGE (top-right), not a ring:
- *  a surrounding alert ring (especially nested with the live ring) read as
+/** The shared "amber attention pill" — the SINGLE source of styling truth for
+ *  every surface that paints the amber "needs you / unread" cue, so the mark
+ *  can't drift in colour or shape between them. Extracted verbatim from the host
+ *  selector strip's awaiting-count badge (`HostSelectorStrip.tsx`), which is the
+ *  pixel reference; consuming it there is a pure regroup (identical class set),
+ *  so that chip stays pixel-identical.
+ *
+ *  Two surfaces consume it:
+ *    - the host-tab chip's COUNT pill — this class + its own `min-w-4 px-1 h-4`
+ *      sizing + the numeric awaiting count inside;
+ *    - the Dock's per-terminal unread BADGE — this class composed with
+ *      `ALERT_BADGE_CLASS` (its absolute corner placement + pill dims + pulse
+ *      from `statepip.css`), boolean, no count.
+ *  pulam-web's fleet rows render the same `StatePip` alert axis, so they adopt it
+ *  too on their next dep bump — the dock-fleet-mirror contract, by construction.
+ *
+ *  A Tailwind class STRING (not a raw-CSS colour) so it is pixel-identical to the
+ *  chip's current utilities; it single-sources across repos the same way
+ *  `PIP_BODY`'s `bg-alert/55` does — every consumer's Tailwind `@source`s this
+ *  package's `src`, so the utilities are generated wherever `StatePip` renders.
+ *  The literal `bg-amber-500/90` (rather than the `--color-attention` theme
+ *  token, which is a DIFFERENT amber) is deliberate: the chip is the designated
+ *  pixel reference and must not shift, so its colour becomes the shared truth. */
+export const ATTENTION_PILL_CLASS =
+  "inline-flex items-center justify-center rounded-full bg-amber-500/90 text-[10px] font-semibold text-black/80 tabular-nums";
+
+/** The alert overlay class — the amber CORNER BADGE (top-right), not a ring: a
+ *  surrounding alert ring (especially nested with the live ring) read as
  *  overwhelming, so the alert uses a different shape that never competes with the
  *  live ring. What the badge MEANS is the surface's to name (`StatePip`'s
- *  `alertLabel`): the Dock's unopened-unread, pulam-web's live notify-class. The
- *  visual lives in `statepip.css`. */
+ *  `alertLabel`): the Dock's unopened-unread, pulam-web's live notify-class.
+ *
+ *  Composed WITH `ATTENTION_PILL_CLASS` at the render site: this class carries
+ *  only the overlay's absolute corner placement, pill dimensions, separator ring
+ *  and pulse (in `statepip.css`); the amber fill + rounded-pill shape come from
+ *  the shared pill, so the badge and the host-tab count pill can't drift. */
 export const ALERT_BADGE_CLASS = "statepip-alert-badge";

--- a/packages/solid-statepip/src/statepip.css
+++ b/packages/solid-statepip/src/statepip.css
@@ -60,18 +60,24 @@
 
 /* alert badge = a fired notification a surface wants surfaced (the Dock's
  * unopened-unread, pulam-web's live notify-class — each names it via `alertLabel`):
- * a small amber CORNER BADGE at the top-right (the pattern the dock rail already
- * uses), NOT a ring — so it never competes with the live ring or nests into a
- * second circle. The dark separator lifts it off the live ring + the row
- * background; the gentle pulse draws the eye without shouting. */
+ * a small amber CORNER BADGE at the top-right, NOT a ring — so it never competes
+ * with the live ring or nests into a second circle. The dark separator lifts it
+ * off the live ring + the row background; the gentle pulse draws the eye without
+ * shouting.
+ *
+ * The amber FILL + rounded-pill SHAPE come from the shared `ATTENTION_PILL_CLASS`
+ * (composed at the render site) — the SAME pill the host-tab awaiting-count badge
+ * paints, so the two can't drift. This class carries only the overlay-specific
+ * geometry: absolute corner placement, the pill DIMENSIONS (a small capsule —
+ * wider than tall — so it reads as the count pill's FORM even with no number, the
+ * per-terminal boolean case), the separator ring, and the pulse. No colour and no
+ * border-radius here: those are the shared pill's, single-sourced. */
 .statepip-alert-badge {
   position: absolute;
-  top: -1px;
-  right: -1px;
-  width: 6px;
-  height: 6px;
-  border-radius: 9999px;
-  background: var(--color-attention);
+  top: -2px;
+  right: -2px;
+  min-width: 12px;
+  height: 8px;
   box-shadow: 0 0 0 1.5px var(--color-surface-1);
   animation: statepip-pulse 1.8s ease-in-out infinite;
   pointer-events: none;


### PR DESCRIPTION
The Dock's per-terminal **unread alert badge** and the host-tab chip's **awaiting-count badge** render the same "needs you" amber cue — but they were styled independently, and had drifted into **three different colours and two different shapes**. srid likes the host tab's badge; this makes it the single source of styling truth and has the Dock adopt it, so the two (and pulam-web) *can't* drift again.

## The drift, before this PR

| Surface | Element | Colour | Shape |
| --- | --- | --- | --- |
| Host-tab chip | awaiting-count badge (`HostSelectorStrip.tsx`) | `bg-amber-500/90` = **#f59e0b** | rounded **count pill** |
| Dock rows / tile title | `StatePip` `alert` axis (`@kolu/solid-statepip`, `statepip-alert-badge`) | `--color-attention` = **#e6a23c** | 6px **dot** |
| Workspace-switcher card | hand-rolled unread ping (`WorkspaceGrid.tsx`) | `bg-alert` = **#a78bfa** (the cool "your turn" **violet**) | ping **dot** |

Same concept, three renderings — a *drift class*, not one defect.

## The fix — one source, in the framework

Per /perfection-review's "kill the drift class, don't repaint it": the host-tab chip's **exact** pill styling is extracted into `ATTENTION_PILL_CLASS` in **`@kolu/solid-statepip/pipVariant`**, and every surface consumes it:

- **Host-tab chip** — now consumes `ATTENTION_PILL_CLASS`. A pure regroup of the *identical* Tailwind token set, so it stays **pixel-identical** (it is the reference; not restyled). Also de-duplicates the two copies that existed in `HostSelectorStrip` (chip + host-switcher row).
- **Dock unread badge** (`StatePip` `alert` axis) — composes `ATTENTION_PILL_CLASS` (the amber fill + rounded-pill shape) with `statepip-alert-badge` (now only corner placement + pill dims + pulse). Adopts the chip's exact amber.
- **WorkspaceGrid ping** — fill unified to the shared amber (was the violet `bg-alert`); placement + ping motion kept.

A **Tailwind class string** (not raw CSS) — pixel-identical to the chip, single-sourced across repos the same way `PIP_BODY`'s `bg-alert/55` already is (every consumer `@source`s the package's `src`). `ATTENTION_PILL_CLASS` is pinned by a pure test so a colour/shape regression is caught.

### Before → after (computed styles, captured live)

| | Host-tab chip | Dock unread badge |
| --- | --- | --- |
| **before** | `oklab(0.769 0.064 0.177 / 0.9)` (amber-500/90), 16px, black/80, 10px semibold tabular | `rgb(230,162,60)` = #e6a23c, **6×6 dot** |
| **after** | `oklab(0.769 0.064 0.177 / 0.9)` — **identical** | `oklab(0.769 0.064 0.177 / 0.9)` (amber-500/90), **12×8 pill** |

Both surfaces now paint the **same** amber (`oklab(0.769 0.064 0.177 / 0.9)`).

## Decisions — what was srid's, and what was delegated

srid's **verbatim** intent: the two surfaces render the same concept with inconsistent styling; the host tab is the reference; extract one shared styling source; the Dock adopts it; semantics unchanged.

Two forks were resolved by a **coordinator ruling (on srid's delegation)**, not by srid directly:

1. **Which Dock element** = the **unread alert badge** (`StatePip` `alert` axis + WorkspaceGrid's ping-dot twin) — not the awaiting agent-state pip *core* (restyling that would break StatePip's shape-carries-state design).
2. **Where the source of truth lives** = the **framework `@kolu/solid-statepip`**. srid's brief said "packages/client, not framework", but the Dock's badge is *already* a framework-shared element governed by the `dock-fleet-mirror` "must read identically" contract — a client-local pill would make the Dock diverge from **pulam-web** (the drift merely relocating). Putting the truth in StatePip keeps the mirror intact and points the dependency arrow outward (client → framework), the electricity rule.

## Presentational choice (noted per the ruling)

The Dock badge is **boolean** per terminal (unread / not), so — adopting the count pill's *form* — it renders as a small **amber capsule (12×8, pill form, no number)**, not a fabricated count. No count is invented; the host tab keeps its real count.

## Cross-repo effect (stated explicitly)

`@kolu/solid-statepip` is consumed by **pulam-web** (separate repo) via `@import`/`@source`. Restyling the shared `alert` badge means **pulam-web's fleet-row unread badge adopts the same amber pill on its next dep bump** — this is the `dock-fleet-mirror` contract working *as intended* (the Dock and its mirror stay identical), surfaced here so it's visible at review.

## Testing

- `just fmt`, `just check` → green (typecheck all packages + biome lint, exit 0).
- `@kolu/solid-statepip` unit tests (21) green, incl. the new `ATTENTION_PILL_CLASS` identity pin.
- Client unit tests in the touched areas (host + dock, 128) green.
- Evidence captured on a live dev instance (random ports; production `kolu.service` PID/uptime verified unchanged before/after). Badge render states were briefly forced for capture; the trigger/clear logic is untouched and unit-tested. See the Evidence comment.
