### PR TITLE
ci(e2e): drop darwin worker cap 6→3 to clear the #1776 liveness force-cycle

### DIFF
--- a/justfile
+++ b/justfile
@@ -257,19 +257,24 @@ test: install
     # unlimited; this is free insurance on every platform.
     ulimit -n 65536 2>/dev/null || true
     # Worker-count cap (the count itself is computed below, after the suite
-    # lock): 6 on darwin, 8 elsewhere. PAR=8 on the 24-core darwin host (rasam)
+    # lock): 3 on darwin, 8 elsewhere. PAR=8 on the 24-core darwin host (rasam)
     # maximizes throughput but its higher concurrent load pressures the
     # slow-hydration tail — under load a handful of interaction waits
     # (per-terminal Code-tab history enablement, content settle) intermittently
     # miss their POLL budget and a scenario loses all its retries, which is
-    # fatal to a *consecutive*-green requirement. PAR=6 trades part of the
-    # speed win for markedly fewer load-correlated races (the report's PAR=6
-    # hardened runs were 0/3 catastrophic). Linux's watch/render stack is
-    # reliable, so it keeps 8. Past the cap the slowest-scenario tail dominates
-    # anyway (PAR=12 measured *slower* than PAR=8 on a 24-core host). See
-    # docs/ci-e2e-macos-ralph-report.md.
+    # fatal to a *consecutive*-green requirement. PAR=6 traded part of the speed
+    # win for fewer load-correlated races, but a WORSE class survived: the
+    # *concurrent-load* the workers + odu + nix put on one mac trips the LOCAL
+    # padi link's liveness watchdog ("remote wedged — force-cycling the link"),
+    # which force-cycles an alive-but-slow padi and 500s every proc during the
+    # down-window, queue-draining a worker (kolu#1776 — a load-marginal
+    # collision, not a per-PR defect). Dropping darwin to PAR=3 (srid-ratified)
+    # cuts the concurrent local-padi pressure below that liveness threshold.
+    # Linux's watch/render + link stack is reliable, so it keeps 8. Past the cap
+    # the slowest-scenario tail dominates anyway. See
+    # docs/ci-e2e-macos-ralph-report.md and kolu#1776.
     cores="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
-    cap=8; [ "$(uname)" = Darwin ] && cap=6
+    cap=8; [ "$(uname)" = Darwin ] && cap=3
     KOLU_SERVER="${KOLU_SERVER:-$(nix build .#koluBin --no-link --print-out-paths)/bin/kolu}"
     cd packages/tests
     # Serialize the cucumber phase across CI runs sharing this host. odu fans


### PR DESCRIPTION
**Ratified lane change (srid), not a workaround-in-the-dark.** Drops the `aarch64-darwin` e2e worker cap from **6 → 3**.

Diagnosed in [#1776](https://github.com/juspay/kolu/issues/1776): the concurrent load of 6 e2e workers + odu + nix on one mac trips the **local padi link's liveness watchdog** ("remote wedged — force-cycling the link"), force-cycling an *alive-but-slow* padi and 500-ing every proc during the reconnect down-window → a worker **queue-drains**. Two darwin-e2e samples on a **verified-clean, cool box** (srid swept; load 2.3) both wedged — one worker, then all four — establishing it's the **run's own load**, not a per-PR defect. `PAR=3` cuts concurrent local-padi pressure below the liveness threshold; linux keeps 8 (its link stack is reliable).

Seam: `justfile` darwin `cap`. The recipe already honors `CUCUMBER_PARALLEL`, but odu's remote lane runs the recipe fresh on the target, so the tree change is what reaches it — hence a shipped cap change rather than a run-only env override.

Surfaced by #1775's darwin e2e; #1775's own code is off the failing path (behaviour-neutral, unreached by the single-host suite).

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._