### PR TITLE
prototype: hosts on mobile — host row in the pull-down sheet

### DIFF
--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -24,6 +24,7 @@ import { daemonTransportLive, serverDot } from "./kaval/useDaemonStatus";
 import { useRightPanel } from "./right-panel/useRightPanel";
 import type { WsStatus } from "./rpc/rpc";
 import SettingsPopover from "./settings/SettingsPopover";
+import MobileHostRow from "./host/MobileHostRow";
 import { InspectorToggleIcon, SettingsIcon } from "./ui/Icons";
 import Kbd from "./ui/Kbd";
 import { clientStale, StaleBadge } from "./ui/StaleBadge";
@@ -64,6 +65,11 @@ const MobileChromeSheet: Component<{
           aria-label="Connection status"
         />
       </div>
+
+      {/* Host row — the mobile face of the keyed padi host map: per-host chips
+       *  (tap to switch), attention pills, and the shared add-host affordance.
+       *  Closes the sheet on a switch so the canvas is visible immediately. */}
+      <MobileHostRow onSwitch={props.onClose} />
 
       {/* Client out of sync with the server — the actionable mobile form of the
        *  desktop rail's `≠ srv` signal: a one-tap reload onto the deployed build

--- a/packages/client/src/host/HostSelectorStrip.tsx
+++ b/packages/client/src/host/HostSelectorStrip.tsx
@@ -564,7 +564,7 @@ const addHostChrome = surface({
  *  popover that LEADS with that notice + a kolu.dev link before the ssh-target
  *  input (the old inline input is gone). Enter commits via `client.hosts.add`;
  *  the canvas jumps to the new host once it joins membership. */
-const AddHostAffordance: Component = () => {
+export const AddHostAffordance: Component = () => {
   const [open, setOpen] = createSignal(false);
   const [draft, setDraft] = createSignal("");
   let triggerEl: HTMLButtonElement | undefined;

--- a/packages/client/src/host/MobileHostRow.tsx
+++ b/packages/client/src/host/MobileHostRow.tsx
@@ -1,0 +1,130 @@
+/** MobileHostRow — PROTOTYPE host row for the mobile pull-down chrome sheet.
+ *
+ *  The touch layout renders no host chrome: `ChromeBar` + `HostSelectorStrip`
+ *  are desktop-only, so on a phone you can't see, switch, or add hosts even
+ *  though the engine underneath (host map, retained switching, persisted
+ *  fleet, per-host attention) is fully layout-agnostic. This row is the mobile
+ *  face of the same keyed padi host map the desktop strip renders.
+ *
+ *  It DELIBERATELY reuses the desktop strip's vocabulary rather than restyling:
+ *    · `dotClass` for the connection dot tone (green only for `connected`);
+ *    · `hostHue` for the per-host identity accent (`--host-hue`);
+ *    · `ATTENTION_PILL_CLASS` (@kolu/solid-statepip) for the unread pill;
+ *    · `hostLabel` / `sameHost` / `statusTitle` for identity + active compare;
+ *    · `AddHostAffordance` — the SAME add-host popover the desktop "+" opens.
+ *
+ *  Touch ergonomics: each chip is a >= 44px tall hit target and the row scrolls
+ *  horizontally (`overflow-x-auto`) when hosts overflow the viewport width.
+ *
+ *  A tap calls `setActiveHost` — the exact call `HostSelectorStrip` makes; the
+ *  switch is instant (retained-host paint). */
+
+import { encodeHostKey, type HostKey } from "kolu-common/hostKey";
+import { type Component, For, Show } from "solid-js";
+import { toast } from "solid-sonner";
+import { ATTENTION_PILL_CLASS } from "@kolu/solid-statepip/pipVariant";
+import {
+  activeHost,
+  onHostMembershipError,
+  padiMap,
+  setActiveHost,
+} from "../wire";
+import {
+  dotClass,
+  hostHue,
+  hostLabel,
+  sameHost,
+  statusTitle,
+} from "./hostChipTone";
+import { HomeIcon } from "../ui/Icons";
+import { AddHostAffordance } from "./HostSelectorStrip";
+
+/** One touch chip for a host. >= 44px tall; tap switches the canvas host. */
+const MobileHostChip: Component<{ host: HostKey; onSwitch: () => void }> = (
+  props,
+) => {
+  const state = () => padiMap.entry(props.host).state();
+  const isLocal = () => props.host.kind === "local";
+  const isActive = () => sameHost(activeHost(), props.host);
+  const urgency = padiMap.entry(props.host).cells.urgency.use({
+    onError: (err: Error) =>
+      toast.error(
+        `Host ${hostLabel(props.host)} urgency error: ${err.message}`,
+      ),
+  });
+  const awaiting = () => urgency.value()?.awaitingIds.length ?? 0;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isActive()}
+      data-testid="mobile-host-chip"
+      data-host={encodeHostKey(props.host)}
+      data-active={isActive() ? "" : undefined}
+      // 44px min hit target; identity hue rides the active border via --host-hue.
+      class="host-hue-ring shrink-0 flex min-h-[44px] items-center gap-2 rounded-xl border px-3 py-2 text-sm transition-colors"
+      classList={{
+        "border-[var(--host-hue)] bg-[color-mix(in_srgb,var(--host-hue)_16%,transparent)] text-fg":
+          isActive(),
+        "border-edge bg-surface-2 text-fg-2 active:bg-surface-3": !isActive(),
+      }}
+      style={{ "--host-hue": hostHue(props.host) }}
+      title={`${hostLabel(props.host)} — ${statusTitle(state())}`}
+      onClick={() => {
+        if (!isActive()) setActiveHost(props.host);
+        props.onSwitch();
+      }}
+    >
+      <span
+        class={`inline-block h-2.5 w-2.5 rounded-full shrink-0 ${dotClass(state())}`}
+        aria-hidden="true"
+      />
+      <Show when={isLocal()}>
+        <HomeIcon class="h-3.5 w-3.5 shrink-0 opacity-70" />
+      </Show>
+      <span class="truncate max-w-[10rem] font-medium">
+        {hostLabel(props.host)}
+      </span>
+      <Show when={awaiting() > 0}>
+        <span
+          class={`${ATTENTION_PILL_CLASS} shrink-0 min-w-5 px-1.5 h-5`}
+          title={`${awaiting()} awaiting your input`}
+        >
+          {awaiting()}
+        </span>
+      </Show>
+    </button>
+  );
+};
+
+/** The full mobile host row: a horizontally-scrollable strip of host chips plus
+ *  the shared add-host affordance. `onSwitch` closes the sheet after a switch. */
+const MobileHostRow: Component<{ onSwitch: () => void }> = (props) => {
+  const members = padiMap.entries.use({ onError: onHostMembershipError });
+  const hosts = (): HostKey[] => [...members.keys()];
+
+  return (
+    <div class="border-b border-edge/50 px-3 py-2">
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-fg-3">
+        Hosts
+      </div>
+      <div
+        role="tablist"
+        aria-label="Hosts"
+        data-testid="mobile-host-row"
+        // Horizontal scroll when hosts overflow; stop propagation so the Corvu
+        // drawer's drag handler can't claim a horizontal swipe as a dismiss.
+        class="flex items-center gap-2 overflow-x-auto pb-1"
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <For each={hosts()}>
+          {(host) => <MobileHostChip host={host} onSwitch={props.onSwitch} />}
+        </For>
+        <AddHostAffordance />
+      </div>
+    </div>
+  );
+};
+
+export default MobileHostRow;


### PR DESCRIPTION
## ⚠️ PROTOTYPE FOR DESIGN REVIEW — NOT FOR MERGE

This is a **prototype-first** spike (token `MOB-HOSTS-P1`) so srid can *see and react to* hosts on mobile. No `/be`, no review gauntlet, no CI — just something on a phone screen. A real phase note + `/be` follow srid's verdict.

## The gap it fills

On the touch layout, **no host chrome renders at all** — `ChromeBar` + `HostSelectorStrip` are `isDesktop()`-only. So on a phone you cannot see, switch, or add hosts, even though the engine underneath (host map, W9 retained switching, W10 persisted fleet, W5 attention) is fully layout-agnostic and already works.

This adds a **host row to the mobile pull-down chrome sheet** (`MobileChromeSheet`).

## What it does

- **Chips per host** — reuses the desktop strip's vocabulary *verbatim*, not restyled: `dotClass` for the connection dot tone (green only for `connected`, amber warming, red failed), `hostHue` for each host's identity accent, `ATTENTION_PILL_CLASS` (`@kolu/solid-statepip`) for the unread pill, `hostLabel`/`sameHost`/`statusTitle` for identity + active compare.
- **Tap a chip = `setActiveHost`** — the exact call `HostSelectorStrip` makes; W9 makes the switch instant (the whole canvas re-keys to the tapped host).
- **Add-host affordance** — reuses the *same* `AddHostAffordance` popover the desktop `+` opens (exported from `HostSelectorStrip`, not re-implemented).
- **Touch ergonomics** — chips are exactly **44px** tall hit targets; the row is `overflow-x-auto` and scrolls horizontally when hosts overflow.

Three files: new `packages/client/src/host/MobileHostRow.tsx`, one import + mount line in `MobileChromeSheet.tsx`, and `export` on `AddHostAffordance` in `HostSelectorStrip.tsx`.

## Evidence (mobile emulation — 390×844, touch, DPR 3)

Captured against a local dev server driven via chrome-devtools MCP with a phone viewport. To make it real, a second host (`srid@localhost`) and a third (`srid@buildbox`) were added through the actual add-host flow.

**1. Sheet pulled down — single-host resting state.** `local` chip: green connection dot, home glyph, active (its orange identity hue as the border + tinted belly), and the `+`.
![single host](https://github.com/juspay/kolu/releases/download/mob-hosts-p1-evidence/shot-1-sheet-single-host.png)

**2. Multi-host row.** `local` (green/connected, active, orange hue) beside `srid@localhost` (red failed dot, purple identity hue, background). Two different status tones and two different identity hues, straight from `hostChipTone`.
![multi host](https://github.com/juspay/kolu/releases/download/mob-hosts-p1-evidence/shot-2-multi-host-row.png)

**3. Switch changed the canvas host.** Tapping `srid@localhost` re-keyed the whole canvas to that host — note the title is now `Kolu [srid@localhost]` and the host-scoped canvas rendered its state. (The down-state itself is a **dev-only artifact**: the dev server can't build a remote padi — `PADI_AGENT_DRVS_JSON` needs the Nix wrapper — so any remote host fails here. The *host switch* is exactly what the prototype demonstrates; against a real remote box the canvas would show that host's terminals.)
![switched canvas](https://github.com/juspay/kolu/releases/download/mob-hosts-p1-evidence/shot-3-switched-canvas.png)

**4. Add-host dialog on the phone viewport.** The shared `AddHostAffordance` popover — ALPHA notice, "Remote hosts" heading, learn-more link, ssh input.
![add host](https://github.com/juspay/kolu/releases/download/mob-hosts-p1-evidence/shot-4-add-host-dialog.png)

**5. Horizontal scroll on overflow.** Three hosts overflow the 390px row (`scrollWidth 437 > clientWidth 366`); scrolled right reveals `srid@localhost` (purple) and `srid@buildbox` (orange), with `local` clipped at the left edge. All chips measured at exactly 44px.
![overflow scroll](https://github.com/juspay/kolu/releases/download/mob-hosts-p1-evidence/shot-5-overflow-horizontal-scroll.png)

## Design input for srid (not fixed here — prototype scope)

1. **The add-host popover overflows off the right edge on a phone.** It anchors `bottom-start` from the `+` with a 288px min-width; on a 390px viewport the ALPHA copy and the ssh input are clipped past the right edge (visible in screenshot 4). The desktop dialog wasn't designed for a narrow viewport — a mobile-appropriate add-host surface (full-width sheet / centered modal) is a real design question, flagged here rather than patched.
2. **When the active host is down, the host-down canvas replaces the whole tile view — including the pull-handle.** Recovery is still possible via the canvas's own "Switch to local" button, but you can't pull the sheet down to switch hosts while the active one is down. Worth a design look for the down-host mobile flow.
3. **Attention pill is wired but not staged.** The unread pill uses the exact `ATTENTION_PILL_CLASS` and renders on `awaiting > 0`, but staging a real background-host attention count needs a live agent awaiting input on a *connected* second host — not reachable on the dev server (remote padis fail here). The pill styling is proven on desktop; on mobile it's code-complete, just not photographed.

## Open questions for the phase note

- Is a horizontally-scrolling chip row the right mobile model, or should mobile borrow the desktop's overflow `⋯ +N` / dropdown-switcher collapse instead?
- Where should the host row live in the sheet — top (as here, above the controls) or its own section?
- Does the add-host flow need a mobile-native surface (see design input #1)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
