### PR TITLE
chore(skills): kolu — recover a re-keyed terminal id by title

### DIFF
--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -283,6 +283,14 @@ Empty → fall back to `kaval-tui list` for the id: you're either not inside a
 kolu-spawned PTY, or in one that predates this var and hasn't been respawned yet
 (a fresh terminal — or sleep/wake — stamps it).
 
+> **A terminal id is not stable across a kaval restart.** kaval re-keys every
+> terminal when it restarts (crash-restore, a "Restart kaval", a redeploy), so an
+> id you were *handed* — a coordinator's terminal from your brief, an id you cached
+> turns ago — can go stale mid-run; a `send`/`snapshot` to it then fails with **"no
+> terminal matching"**. Don't re-assume the id: run `kaval-tui list` and re-find the
+> terminal by its stable **title** (the label survives the re-key), then use its
+> current id. For any long-lived reference, remember the title, not the id.
+
 > **Flags go AFTER the subcommand.** It's `kaval-tui list --socket <path>` and
 > `kaval-tui snapshot <id> --socket <path>` — **not** `kaval-tui --socket <path>
 > list`. A flag before the subcommand fails with "no command"; the CLI error says

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -283,6 +283,14 @@ Empty → fall back to `kaval-tui list` for the id: you're either not inside a
 kolu-spawned PTY, or in one that predates this var and hasn't been respawned yet
 (a fresh terminal — or sleep/wake — stamps it).
 
+> **A terminal id is not stable across a kaval restart.** kaval re-keys every
+> terminal when it restarts (crash-restore, a "Restart kaval", a redeploy), so an
+> id you were *handed* — a coordinator's terminal from your brief, an id you cached
+> turns ago — can go stale mid-run; a `send`/`snapshot` to it then fails with **"no
+> terminal matching"**. Don't re-assume the id: run `kaval-tui list` and re-find the
+> terminal by its stable **title** (the label survives the re-key), then use its
+> current id. For any long-lived reference, remember the title, not the id.
+
 > **Flags go AFTER the subcommand.** It's `kaval-tui list --socket <path>` and
 > `kaval-tui snapshot <id> --socket <path>` — **not** `kaval-tui --socket <path>
 > list`. A flag before the subcommand fails with "no command"; the CLI error says

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -283,6 +283,14 @@ Empty → fall back to `kaval-tui list` for the id: you're either not inside a
 kolu-spawned PTY, or in one that predates this var and hasn't been respawned yet
 (a fresh terminal — or sleep/wake — stamps it).
 
+> **A terminal id is not stable across a kaval restart.** kaval re-keys every
+> terminal when it restarts (crash-restore, a "Restart kaval", a redeploy), so an
+> id you were *handed* — a coordinator's terminal from your brief, an id you cached
+> turns ago — can go stale mid-run; a `send`/`snapshot` to it then fails with **"no
+> terminal matching"**. Don't re-assume the id: run `kaval-tui list` and re-find the
+> terminal by its stable **title** (the label survives the re-key), then use its
+> current id. For any long-lived reference, remember the title, not the id.
+
 > **Flags go AFTER the subcommand.** It's `kaval-tui list --socket <path>` and
 > `kaval-tui snapshot <id> --socket <path>` — **not** `kaval-tui --socket <path>
 > list`. A flag before the subcommand fails with "no command"; the CLI error says

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-12T18:39:09.530757+00:00'
+generated_at: '2026-07-12T22:49:58.747733+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -76,7 +76,7 @@ dependencies:
     .agents/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
     .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .agents/skills/kolu/SKILL.md: sha256:d4575e21bbcd12e6c1c1ba3c79495a3a50503525cf583d3f208425ce0b20c4df
+    .agents/skills/kolu/SKILL.md: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
     .agents/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
     .agents/skills/orchestrator/SKILL.md: sha256:b1d170f632371bd970b01a4c96ed935a08f547b93f7f709ee295a0584fd0697b
@@ -94,7 +94,7 @@ dependencies:
     .claude/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
     .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .claude/skills/kolu/SKILL.md: sha256:d4575e21bbcd12e6c1c1ba3c79495a3a50503525cf583d3f208425ce0b20c4df
+    .claude/skills/kolu/SKILL.md: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
     .claude/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .claude/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
     .claude/skills/orchestrator/SKILL.md: sha256:b1d170f632371bd970b01a4c96ed935a08f547b93f7f709ee295a0584fd0697b
@@ -765,7 +765,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:d4575e21bbcd12e6c1c1ba3c79495a3a50503525cf583d3f208425ce0b20c4df
+  content_hash: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
 - kind: project-relative
   target: agents
   value: .agents/skills/lens-debate
@@ -1792,7 +1792,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:d4575e21bbcd12e6c1c1ba3c79495a3a50503525cf583d3f208425ce0b20c4df
+  content_hash: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
 - kind: project-relative
   target: claude
   value: .claude/skills/lens-debate


### PR DESCRIPTION
Mined from the W12 `/be` run (`W12BE-RSTR`), which was otherwise mechanically clean — zero failed tool calls, zero Read-before-Edit, zero Stop-hook feedback. **One external correction broke autonomy: the agent kept reporting to a coordinator terminal id that had gone stale when kaval re-keyed after the incident restore.** The `kolu` skill's *Reach* section already teaches `kaval-tui list` discovery, but never warns that a terminal id is unstable across a kaval restart — so an agent handed an id in its brief has no rule telling it how to recover when `send` starts erroring `no terminal matching`.

This adds that rule where id discovery already lives: ids re-key on every kaval restart (crash-restore, "Restart kaval", redeploy); recover by re-finding the terminal via `kaval-tui list` and matching its **stable title**, not the assumed id. It's deterministic system behavior, not a flake — any long orchestrated run that spans a kaval restart hits it, and this campaign (whose whole subject *was* kaval restarts) hit it live.

### Evidence ledger

| Intervention in the run | Fix |
| --- | --- |
| `COORDINATOR TERMINAL CORRECTION … the coordinator terminal id in your brief is STALE … terminal ids re-key whenever kaval restarts` | New *Reach* callout in `kolu` skill: recover a re-keyed id via `kaval-tui list` + match by title |

### Not fixed (observation only)

The run also took a `If pu is down, use naiveintent for CI` correction after a `pu` control-plane outage. Left unencoded on purpose — it's a one-off infra flake, and baking a campaign-specific fallback host into a skill would violate the repo's fail-fast / no-fallback philosophy.

### Provenance

Source edit is in `agents/.apm/skills/kolu/SKILL.md`; the `.claude/` + `.agents/` copies and `apm.lock.yaml` are regenerated by `just ai::apm` and ride the same commit. `just fmt` and `just check` are green.

> Draft for human review — self-improve never merges its own edits.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._