### PR TITLE
chore(skills): be-review runs afp when correctness rests on an ordering claim

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -14,11 +14,19 @@ step has already committed, so every reviewer reads a clean, settled tree and
 applies its own fixes directly:
 
 1. **architecture-first-principles** — FIRST, for a diff touching framework packages
-   (`@kolu/surface*`) or adding/reshaping module structure: run the named checks per their SKILL (Workflow fan-out, adversarial verify, scope = diff +
+   (`@kolu/surface*`), adding/reshaping module structure, **or whose correctness
+   rests on a concurrency / ordering claim** (a race declared closed, one event
+   asserted to land "before" another, timing across independent async cascades, a
+   flag flipped by one callback that another path reads back as truth): run the
+   named checks per their SKILL (Workflow fan-out, adversarial verify, scope = diff +
    one hop down its imports). It runs before the lenses so architecture-level
    findings (wrong library, wrong layer, dead API surface) are fixed BEFORE the
    structural/code debates polish details that were about to change shape. Skip
-   ONLY for pure-docs or trivially-local diffs, and say so. Its confirmed
+   ONLY for pure-docs or trivially-local diffs — and a diff is **not**
+   trivially-local when its correctness leans on a happens-before: P3
+   (state-and-time) is the only lens that interrogates an ordering claim, so a
+   leaf-module race-fix that skips it is exactly how an untrue "race-safe /
+   structural" comment ships past a green gauntlet. Say so either way. Its confirmed
    findings are dispositioned like any stage's — fix now or record where, never
    "acceptable for scope".
 2. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -14,11 +14,19 @@ step has already committed, so every reviewer reads a clean, settled tree and
 applies its own fixes directly:
 
 1. **architecture-first-principles** — FIRST, for a diff touching framework packages
-   (`@kolu/surface*`) or adding/reshaping module structure: run the named checks per their SKILL (Workflow fan-out, adversarial verify, scope = diff +
+   (`@kolu/surface*`), adding/reshaping module structure, **or whose correctness
+   rests on a concurrency / ordering claim** (a race declared closed, one event
+   asserted to land "before" another, timing across independent async cascades, a
+   flag flipped by one callback that another path reads back as truth): run the
+   named checks per their SKILL (Workflow fan-out, adversarial verify, scope = diff +
    one hop down its imports). It runs before the lenses so architecture-level
    findings (wrong library, wrong layer, dead API surface) are fixed BEFORE the
    structural/code debates polish details that were about to change shape. Skip
-   ONLY for pure-docs or trivially-local diffs, and say so. Its confirmed
+   ONLY for pure-docs or trivially-local diffs — and a diff is **not**
+   trivially-local when its correctness leans on a happens-before: P3
+   (state-and-time) is the only lens that interrogates an ordering claim, so a
+   leaf-module race-fix that skips it is exactly how an untrue "race-safe /
+   structural" comment ships past a green gauntlet. Say so either way. Its confirmed
    findings are dispositioned like any stage's — fix now or record where, never
    "acceptable for scope".
 2. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,

--- a/agents/.apm/skills/be-review/SKILL.md
+++ b/agents/.apm/skills/be-review/SKILL.md
@@ -14,11 +14,19 @@ step has already committed, so every reviewer reads a clean, settled tree and
 applies its own fixes directly:
 
 1. **architecture-first-principles** — FIRST, for a diff touching framework packages
-   (`@kolu/surface*`) or adding/reshaping module structure: run the named checks per their SKILL (Workflow fan-out, adversarial verify, scope = diff +
+   (`@kolu/surface*`), adding/reshaping module structure, **or whose correctness
+   rests on a concurrency / ordering claim** (a race declared closed, one event
+   asserted to land "before" another, timing across independent async cascades, a
+   flag flipped by one callback that another path reads back as truth): run the
+   named checks per their SKILL (Workflow fan-out, adversarial verify, scope = diff +
    one hop down its imports). It runs before the lenses so architecture-level
    findings (wrong library, wrong layer, dead API surface) are fixed BEFORE the
    structural/code debates polish details that were about to change shape. Skip
-   ONLY for pure-docs or trivially-local diffs, and say so. Its confirmed
+   ONLY for pure-docs or trivially-local diffs — and a diff is **not**
+   trivially-local when its correctness leans on a happens-before: P3
+   (state-and-time) is the only lens that interrogates an ordering claim, so a
+   leaf-module race-fix that skips it is exactly how an untrue "race-safe /
+   structural" comment ships past a green gauntlet. Say so either way. Its confirmed
    findings are dispositioned like any stage's — fix now or record where, never
    "acceptable for scope".
 2. **`/lens-debate`** — lowy + hickey debate boundaries/simplicity to consensus,

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-12T22:49:58.747733+00:00'
+generated_at: '2026-07-13T03:08:32.163340+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -65,7 +65,7 @@ dependencies:
   - .claude/skills/surface/SKILL.md
   deployed_file_hashes:
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
-    .agents/skills/be-review/SKILL.md: sha256:effd4d39e369d4e8004c6c30a0c69ea420cfb5820ad576663e443529951197db
+    .agents/skills/be-review/SKILL.md: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
     .agents/skills/be/SKILL.md: sha256:e7ad6d775802d78e80bf3e541581240d5933185de527aa00e58354bfeabd7b9e
     .agents/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238
     .agents/skills/codex-debate/answer.workflow.js: sha256:82ad3a02db21c52cb6b2453a66559bf8742f2ba30f1e8a328c35b896b0e12ada
@@ -83,7 +83,7 @@ dependencies:
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
-    .claude/skills/be-review/SKILL.md: sha256:effd4d39e369d4e8004c6c30a0c69ea420cfb5820ad576663e443529951197db
+    .claude/skills/be-review/SKILL.md: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
     .claude/skills/be/SKILL.md: sha256:e7ad6d775802d78e80bf3e541581240d5933185de527aa00e58354bfeabd7b9e
     .claude/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238
     .claude/skills/codex-debate/answer.workflow.js: sha256:82ad3a02db21c52cb6b2453a66559bf8742f2ba30f1e8a328c35b896b0e12ada
@@ -396,7 +396,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:effd4d39e369d4e8004c6c30a0c69ea420cfb5820ad576663e443529951197db
+  content_hash: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
 - kind: project-relative
   target: agents
   value: .agents/skills/be/SKILL.md
@@ -1423,7 +1423,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:effd4d39e369d4e8004c6c30a0c69ea420cfb5820ad576663e443529951197db
+  content_hash: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
 - kind: project-relative
   target: claude
   value: .claude/skills/be/SKILL.md


### PR DESCRIPTION
## What & why

`/self-improve` mined session `a6be4969-2a1c-45cd-9dcb-56ee09ac115e` (the W12 `/be` run: "restore survives an unclean kaval death"). One lesson cleared the bar; everything else was already covered or an abnormal-run artifact.

### The durable failure

The W12 fix's correctness rested entirely on a **concurrency claim** — an `observable` flag flipped by an async error callback "~10ms before" a null-producing reconcile, so the race was declared closed. The change lived in `@kolu/padi` (a leaf app package) and threaded a callback through an existing seam.

`/be-review` §1 gates **architecture-first-principles** on *framework packages (`@kolu/surface*`) or module-structure reshaping*, skipping "trivially-local" diffs. This diff took that skip — the transcript records it verbatim:

> architecture-first-principles skipped — local `@kolu/padi` diff, no framework/boundary reshape.

So the **one lens whose P3 (state-and-time) check interrogates a happens-before never ran.** The lenses, codex, simplify, and code-police polished style and **blessed a code comment calling a timing mitigation "race-safe / structural."** Only a human distrusting the green gauntlet ("I don't trust you") and injecting an independent afp-at-perfection-bar pass caught the untrue claim before merge — the exact autonomy failure this skill exists to prevent (shipping below the quality bar unprompted).

### The fix (evidence ledger)

| Intervention mined | Root cause | Edit |
|---|---|---|
| Human injected an independent architecture-first-principles review because the gauntlet blessed an untrue "race-safe / structural" comment | afp gated on framework/module-structure diffs; a leaf-module race-fix skipped the only lens that checks a happens-before | `be-review` §1: widen the afp trigger to include any diff **whose correctness rests on a concurrency / ordering claim**, and carve that case out of the "trivially-local" skip |

The edit **strictly widens a gate** (adds a condition under which afp runs) — it never weakens one, and the phase order + reviewer set are unchanged, so it trips no llm-autonomy anti-pattern and needs no be-workflow atlas/diagram update (the pipeline map doesn't enumerate afp's trigger conditions).

### Considered and deliberately NOT changed (restraint)

- **Terminal-id re-key after kaval restart** (3× "no terminal matching" + 2 human corrections) — already patched twice in the `kolu` skill (`1ceb133fe`, `#1788`, the latter now on `master`). The rule **fired correctly on its own** the second time this run (`280206b9` recovery). No third patch.
- **"Merge latest master" (2 human nudges)** — the `/be` §5 rule was followed (transcript shows the fetch + `merge-base` + conditional merge). Both nudges were proactive human prompts *during* the long human-injected review detour, before §5 was reached. No rule gap.
- **"Why is codex running for half an hour"** — codex was legitimately working (`xhigh` over a 13-file diff, round 1 already committed); the agent correctly diagnosed "progressing, not wedged." The session restart was an external kaval restart, not a skill-preventable hang.

## Verification

- `just ai::apm` regenerated the runtime copies; confirmed the new text landed in `.claude/skills/be-review/SKILL.md` and `.agents/` (both match the source).
- `just fmt` — clean, 0 reformatted.
- `just check` — **EXIT=0** (all typechecks + biome lint green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)