### PR TITLE
refactor(padi): retire lifecycle.restoreSleeping (W12 disposition)

### DIFF
--- a/packages/client/src/perHostCanvas.test.ts
+++ b/packages/client/src/perHostCanvas.test.ts
@@ -86,7 +86,6 @@ vi.mock("./wire", async () => {
         },
         lifecycle: {
           create: vi.fn(async () => {}),
-          restoreSleeping: vi.fn(async () => {}),
           sendInput: vi.fn(async () => {}),
         },
       },

--- a/packages/client/src/terminal/useSessionRestore.test.ts
+++ b/packages/client/src/terminal/useSessionRestore.test.ts
@@ -23,14 +23,14 @@ const h = vi.hoisted(() => ({
 
 // Spies for every RPC `handleRestoreSession` could conceivably fire. The W1.R6
 // contract: restore issues ONLY `session.restore` — the former client respawn
-// loop (`lifecycle.create` / `restoreSleeping` / `sendInput`) is DELETED, so
-// those must stay at zero.
+// loop (`lifecycle.create` / `sendInput`) is DELETED, so those must stay at zero.
+// (`lifecycle.restoreSleeping` was also part of that dead loop and is now retired
+// from the padi surface entirely — see #1784's W12 disposition.)
 const rpc = vi.hoisted(() => ({
   restore: vi.fn(async () => {}),
   import: vi.fn(async () => {}),
   forfeit: vi.fn(async () => {}),
   create: vi.fn(async () => {}),
-  restoreSleeping: vi.fn(async () => {}),
   sendInput: vi.fn(async () => {}),
 }));
 
@@ -62,7 +62,6 @@ vi.mock("../wire", async () => {
         },
         lifecycle: {
           create: rpc.create,
-          restoreSleeping: rpc.restoreSleeping,
           sendInput: rpc.sendInput,
         },
       },
@@ -253,7 +252,6 @@ describe("useSessionRestore — restore fires ONLY session.restore (respawn loop
   it("issues session.restore with the resume set and ZERO lifecycle.* RPCs", async () => {
     rpc.restore.mockClear();
     rpc.create.mockClear();
-    rpc.restoreSleeping.mockClear();
     rpc.sendInput.mockClear();
 
     await new Promise<void>((resolve, reject) => {
@@ -294,7 +292,6 @@ describe("useSessionRestore — restore fires ONLY session.restore (respawn loop
             expect(rpc.restore).toHaveBeenCalledWith({ resumeIds: ["0"] });
             // The deleted client respawn loop: zero of these fire.
             expect(rpc.create).not.toHaveBeenCalled();
-            expect(rpc.restoreSleeping).not.toHaveBeenCalled();
             expect(rpc.sendInput).not.toHaveBeenCalled();
 
             dispose();

--- a/packages/client/src/terminal/useSessionRestore.ts
+++ b/packages/client/src/terminal/useSessionRestore.ts
@@ -222,8 +222,8 @@ export function useSessionRestore(deps: { store: TerminalStore }) {
     try {
       // ONE writer, ONE call: padi re-spawns every terminal server-side (the
       // former client respawn loop is deleted). No `lifecycle.*` create /
-      // restoreSleeping / sendInput fires from the client during restore — only
-      // this `session.restore` — so restore can't half-apply across a mid-flight
+      // sendInput fires from the client during restore — only this
+      // `session.restore` — so restore can't half-apply across a mid-flight
       // reconnect. The client-side view-state (active tile + canvas viewport +
       // sub-panel tabs + MRU) is seeded by the HYDRATION effect below once the
       // restored terminals arrive on the `terminals` collection, exactly as a

--- a/packages/padi/src/dial.test.ts
+++ b/packages/padi/src/dial.test.ts
@@ -402,13 +402,13 @@ describe("padi the process — dial acceptance", () => {
     const p = await startPadi(stateRoot);
     const conn = await connect(p.socketPath);
 
-    // A binder NEWER than this padi (it requires padiSurface 4.0; padi serves 3.x)
+    // A binder NEWER than this padi (it requires padiSurface 5.0; padi serves 4.x)
     // reads the running version from the FROZEN control-core `hello` — the call
     // that must work at a mismatch — and finds it INCOMPATIBLE, so it REFUSES to
     // bind the versioned surface.
     const hello = await conn.client.surface.control.core.hello();
     expect(hello.surfaceVersion).toBe(PADI_SURFACE_VERSION);
-    expect(isContractVersionCompatible(hello.surfaceVersion, "4.0")).toBe(
+    expect(isContractVersionCompatible(hello.surfaceVersion, "5.0")).toBe(
       false,
     );
 
@@ -619,7 +619,7 @@ describe("assertPadiSurfaceCompatible", () => {
     // "Too old" is an earlier minor within the same major, or an earlier major
     // entirely. At a `.0` build (this major's floor) only the earlier-major form
     // is expressible, so pick whichever is genuinely older than this build — this
-    // keeps the older-skew covered even at a fresh major (2.0), where an in-major
+    // keeps the older-skew covered even at a fresh major (4.0), where an in-major
     // older minor doesn't exist.
     const older = minor > 0 ? `${major}.${minor - 1}` : `${major - 1}.0`;
     expect(() => assertPadiSurfaceCompatible(older)).toThrow(

--- a/packages/padi/src/servePadi.ts
+++ b/packages/padi/src/servePadi.ts
@@ -69,7 +69,6 @@ import {
 } from "./terminal-registry.ts";
 import {
   discardLocalSleeping,
-  seedSleepingTerminal,
   wakeLocalTerminal,
 } from "./terminalEndpoint/local.ts";
 import { composePadiTerminal } from "./terminalEndpoint/metadata.ts";
@@ -371,9 +370,6 @@ export function buildPadiSurfaceDeps(deps: {
         discardSleeping: ({ input }) => {
           log.info({ terminal: input.id }, "discard sleeping");
           discardLocalSleeping(input.id);
-        },
-        restoreSleeping: ({ input }) => {
-          seedSleepingTerminal(input);
         },
         // Fire-and-forget stream ops: a resize/keystroke landing just after a
         // kill is an EXPECTED race, so quiet-drop via `getActiveTerminal`

--- a/packages/padi/src/surface.test.ts
+++ b/packages/padi/src/surface.test.ts
@@ -24,43 +24,36 @@ describe("padiSurface 1.0 contract", () => {
     expect(padiSurface.contract).toBeTruthy();
   });
 
-  it("is version 3.0, and DEFAULT_PADI_VERSION carries + validates it", () => {
-    // 1.1 ADDED `lifecycle.recycleKaval` (the "Restart kaval" button); 1.2 ADDS the
-    // `hostInventory` cell (the "Running daemons" leak diagnostic); 1.3 ADDS the
-    // `identity` cell (padi's own build commit/surfaceVersion/boot time, per host) —
-    // all additive minors over 1.0. 2.0 was the first MAJOR, carrying TWO breaking
-    // changes: (a) it ADDS the per-terminal right-panel `collapsed` field (the panel
-    // follows the terminal, #959) — a major because its unsafe skew is old-client/
-    // new-padi (an older client's whole-record `chrome.setRightPanel` write omits
-    // `collapsed`, the schema defaults it false, and the REPLACE clobbers a newer
-    // client's persisted `collapsed:true` — the direction `isContractVersionCompatible`
-    // otherwise waves through); and (b) it REMOVES `fs.statFileMtimeMs` for
-    // `fs.filePreviewTag` — a shape-breaking rename. 3.0 is the second MAJOR
+  it("is version 4.0, and DEFAULT_PADI_VERSION carries + validates it", () => {
+    // 1.1–1.3 were additive minors over 1.0 (recycleKaval, hostInventory, identity).
+    // 2.0 was the first MAJOR: (a) it ADDED the per-terminal right-panel `collapsed`
+    // field (the panel follows the terminal, #959) — a major because an older client's
+    // whole-record `chrome.setRightPanel` write omits it and the REPLACE clobbers a
+    // newer client's `collapsed:true`; and (b) it REMOVED `fs.statFileMtimeMs` for
+    // `fs.filePreviewTag` — a shape-breaking rename. 3.0 was the second MAJOR
     // (scrollback-backfill): the `terminalAttach` stream output was RESHAPED from a
     // bare `z.string()` to a discriminated `{ kind, data, topLine? }` union frame —
-    // breaking in BOTH skew directions (each side's schema rejects the other's
-    // frame), so only a major
-    // refuses the skew both ways. (The additive `screen.history` procedure rides the
-    // same release but alone would be only a minor.) 3.1 (additive minor) adds the
-    // scrollback-backfill reflow guard (F3): OPTIONAL `reflowEpoch` on the attach
-    // snapshot frame + `epoch`/`stale` on `screen.history` — no reshape, no
-    // required field, so both skew directions stay graceful (fail-open).
-    expect(PADI_SURFACE_VERSION).toBe("3.1");
+    // breaking in BOTH skew directions. 3.1 (additive minor) added the reflow guard
+    // (F3): OPTIONAL `reflowEpoch` + `epoch`/`stale`, both skew directions graceful.
+    // 4.0 is the third MAJOR: it REMOVES the dead `lifecycle.restoreSleeping` procedure
+    // (retired per #1784's W12 disposition — no production caller). A removed procedure
+    // is a shape-break, so an old binder that still called it must refuse a 4.0 padi
+    // rather than hit a missing proc — only a major closes that skew in both directions.
+    expect(PADI_SURFACE_VERSION).toBe("4.0");
     expect(DEFAULT_PADI_VERSION.contractVersion).toBe(PADI_SURFACE_VERSION);
     expect(PadiVersionSchema.parse(DEFAULT_PADI_VERSION)).toEqual(
       DEFAULT_PADI_VERSION,
     );
-    // A newer additive minor (a future 3.x) still serves a 3.0 consumer; a
+    // A newer additive minor (a future 4.x) still serves a 4.0 consumer; a
     // major bump is mutually incompatible in both directions.
-    expect(isContractVersionCompatible("3.1", "3.0")).toBe(true);
-    expect(isContractVersionCompatible("4.0", "3.0")).toBe(false);
-    expect(isContractVersionCompatible("3.0", "4.0")).toBe(false);
-    // The 3.0 major gate closes BOTH skew directions against any 2.x peer: a new
-    // client (needs 3.0) REFUSES an older 2.x padi still emitting bare-string attach
-    // frames, AND an older 2.x client REFUSES this 3.0 padi whose object frames its
-    // `z.string()` schema can't parse.
-    expect(isContractVersionCompatible("2.4", "3.0")).toBe(false);
-    expect(isContractVersionCompatible("3.0", "2.4")).toBe(false);
+    expect(isContractVersionCompatible("4.1", "4.0")).toBe(true);
+    expect(isContractVersionCompatible("5.0", "4.0")).toBe(false);
+    expect(isContractVersionCompatible("4.0", "5.0")).toBe(false);
+    // The 4.0 major gate closes BOTH skew directions against any 3.x peer: a new
+    // client (needs 4.0) REFUSES an older 3.x padi, AND an older 3.x client REFUSES
+    // this 4.0 padi rather than calling the removed `restoreSleeping`.
+    expect(isContractVersionCompatible("3.4", "4.0")).toBe(false);
+    expect(isContractVersionCompatible("4.0", "3.4")).toBe(false);
   });
 
   it("pins the EXACT member list — every member from the surface section", () => {
@@ -108,7 +101,6 @@ describe("padiSurface 1.0 contract", () => {
       "sleep",
       "wake",
       "discardSleeping",
-      "restoreSleeping",
       "resize",
       "sendInput",
       "recycleKaval",

--- a/packages/padi/src/surface.ts
+++ b/packages/padi/src/surface.ts
@@ -99,7 +99,6 @@ import {
   PersistedSnapshotSchema,
   PtyHostIdentitySchema,
   SavedSessionSchema,
-  SavedSleepingTerminalSchema,
   SleepingTerminalSchema,
   TerminalInfoSchema,
   TerminalOnExitOutputSchema,
@@ -185,8 +184,23 @@ export * from "./vocab.ts";
  *  optional, so both skew directions are graceful: an older 3.0 client ignores
  *  the extra fields, and a 3.1 client meeting a 3.0 padi reads them absent and
  *  runs fail-open (no epoch → no gate, the historical single-width behavior).
- *  A minor, not a major — no reshape, no required field, no emitted variant. */
-export const PADI_SURFACE_VERSION = "3.1";
+ *  A minor, not a major — no reshape, no required field, no emitted variant.
+ *
+ *  4.0 is a MAJOR bump that REMOVES the dead `lifecycle.restoreSleeping` procedure
+ *  (retired per #1784's W12 review disposition: it had no production caller — the
+ *  only writer, the client respawn loop, was already deleted; the real cold-boot
+ *  restore seeds a sleeping terminal directly via `seedSleepingTerminal` in
+ *  `sessionRestore.ts` / `reattach.ts`, never over the wire). A removed procedure is
+ *  a shape-break in BOTH directions (an old binder that still called `restoreSleeping`
+ *  would hit a missing proc on a 4.0 padi), so — exactly like 3.0's `terminalAttach`
+ *  reshape — only a major flips `isContractVersionCompatible` to refuse the skew and
+ *  force the honest recycle. The version is an honest statement of the wire SHAPE;
+ *  encoding "no caller today" as a minor would bake in exactly the soft assumption the
+ *  fail-fast rule rejects. Its consequence is the graceful padi-ONLY drain every
+ *  code-change deploy already pays (a newer binder drains the straddling 3.x padi —
+ *  save + exit — then respawns it at 4.0): kaval and the PTYs are UNTOUCHED, because a
+ *  padi-surface bump does not touch the kaval contract. */
+export const PADI_SURFACE_VERSION = "4.0";
 
 /** The `version` cell payload — padi's self-declared surface contract version. */
 export const PadiVersionSchema = z.object({ contractVersion: z.string() });
@@ -777,7 +791,7 @@ export const padiSurface = defineSurface({
   },
   procedures: {
     /** Terminal lifecycle — create · kill · killAll · sleep · wake ·
-     *  discardSleeping · restoreSleeping · resize · sendInput · recycleKaval. */
+     *  discardSleeping · resize · sendInput · recycleKaval. */
     lifecycle: {
       create: { input: PadiCreateInputSchema, output: TerminalInfoSchema },
       kill: { input: PadiTerminalIdInputSchema, output: TerminalInfoSchema },
@@ -785,7 +799,6 @@ export const padiSurface = defineSurface({
       sleep: { input: PadiTerminalIdInputSchema },
       wake: { input: PadiTerminalIdInputSchema, output: TerminalInfoSchema },
       discardSleeping: { input: PadiTerminalIdInputSchema },
-      restoreSleeping: { input: SavedSleepingTerminalSchema },
       resize: { input: PadiResizeInputSchema },
       sendInput: { input: PadiSendInputSchema },
       /** Force-recycle THIS host's kaval daemon, preserving the session — the

--- a/packages/padi/src/terminalEndpoint/local.ts
+++ b/packages/padi/src/terminalEndpoint/local.ts
@@ -1342,8 +1342,9 @@ function seedHandlelessTerminal<Saved extends { id: string }>(
 
 /** Seed a SLEEPING terminal into the registry from its saved record — the dormant
  *  analogue of adoption (there is no PTY to re-wire). Used by BOTH boot paths: the
- *  surviving-daemon reconcile (`adoptSurvivingSession`) and the cold-boot restore
- *  (`terminal.restoreSleeping`), so a slept terminal reappears as ☾ on any restart.
+ *  surviving-daemon reconcile (`adoptSurvivingSession`) and the host-side cold-boot
+ *  restore (`restoreSession` in `sessionRestore.ts`), so a slept terminal reappears
+ *  as ☾ on any restart.
  *  The agent the terminal will resume rides the AUTHORED sleeping record's
  *  `restoreTarget` (its `exact` arm keeps only the identity — no full-agent
  *  reconstruction needed across a cold restart). */


### PR DESCRIPTION
## What

Retire `lifecycle.restoreSleeping` — a dead client-facing verb — from the padi surface, its `servePadi` handler, and every client-side stub/type/mock. Bump `PADI_SURFACE_VERSION` **3.1 → 4.0** (a removed procedure is a shape-break → MAJOR).

## ⚠️ Version number: ratified as 3.0, shipping as 4.0 (same rule)

srid ratified **MAJOR 3.0** when this branch was off a stale master at surface **2.0**. Master has since advanced — **#1783** (scrollback backfill) took `padiSurface` to **3.0** (its `terminalAttach` reshape) then **3.1** (reflow guard). This branch was rebased onto current master and the removal re-applied on top of 3.1, so the faithful application of the *same ratified rule* is **3.1 → 4.0**. Nothing else changed. The coordinator confirmed this handling before this PR opened.

## Why it's dead

`restoreSleeping` had **no production caller**. Its only writer — the client respawn loop — was already deleted (W1.R6), and the real cold-boot restore seeds a sleeping terminal directly via `seedSleepingTerminal` in `sessionRestore.ts` / `reattach.ts`, never over the wire. #1784's W12 review dispositioned it as removable.

## Why a MAJOR bump

A removed procedure is a shape-break in **both** skew directions — an old binder that still called `restoreSleeping` would hit a missing proc on a 4.0 padi. Only a major flips `isContractVersionCompatible` to refuse the skew both ways (mirrors 3.0's `terminalAttach` reshape and 2.0's `fs.statFileMtimeMs` removal). The version is an honest statement of the wire **shape**; encoding "no caller today" as a minor would bake in exactly the soft assumption the fail-fast rule rejects.

## Deploy consequence (flagged + ratified pre-push)

A major skew is refused, so on the next deploy a newer binder **DRAINS** any straddling 3.x padi — the graceful `save + exit` every code-change deploy already pays via the build-digest mismatch — then respawns it at 4.0. **kaval and the PTYs are untouched**: a padi-surface bump does not touch the kaval contract.

## Disposition history

- **#1784** (W12, "restore survives an unclean kaval death") — its independent perfection review dispositioned `restoreSleeping` as a dead verb with no production caller. This PR is that follow-up removal.

## Verification

- Repo-wide grep: nothing outside tests/docs references the verb; `surface.test.ts` now **pins its absence** from the wire (dropped from the lifecycle-verb list).
- `just fmt` clean · `just check` (tsc + biome) green · padi **309/309** · touched client tests green.
- Version pins across `surface.test.ts` / `dial.test.ts` updated to 4.0 (skew-scenario re-pegged to a 5.0 binder vs a 4.x padi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
