### PR TITLE
docs(skills): kolu — provisioning a worktree'd agent with padi-tui create

### DIFF
--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -193,6 +193,36 @@ returns, **`snapshot --viewport` and read** what's on screen before responding.
 > }
 > ```
 
+## Provisioning a worktree'd agent — `padi-tui create`
+
+When the terminal should be a **kolu-owned** workspace — visible on the canvas,
+tracked by padi's agent sensors so `padi-tui wait` works against it — provision
+it with `padi-tui create` instead of raw `kaval-tui create`:
+
+```sh
+git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
+# prints the new terminal's id; padi owns it and it appears on the canvas
+```
+
+- **Fast-forward the base repo first.** `--worktree` branches from the repo's
+  checkout as it stands — a stale default branch silently seeds the agent an old
+  tree, and nothing errors.
+- **`create` returning ≠ the agent is ready.** Snapshot before dispatching: a
+  fresh worktree's first dev-env build can take minutes, and a first-run agent
+  may sit on a one-time dialog (MCP server selection, a trust prompt) that needs
+  its own `send --key Enter`. Drive every boot step by `snapshot`, never by
+  sleeping and hoping.
+- **Set the permission mode deliberately, then verify it.** An agent that will
+  run unattended goes in **auto mode**: cycle with `kaval-tui send <id> --key
+  Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on` (the
+  cycle is manual → accept edits → plan → auto — verify after each press; never
+  count presses blind, the starting point varies).
+- **Restarting the agent CLI in place:** text typed at a *running* agent becomes
+  a prompt (your `claude …` command line gets answered, not executed), and `C-c`
+  doesn't reliably quit the TUI — send `/exit` (its own three-step submit), wait
+  for the shell prompt to show in the snapshot, then launch again.
+
 ## `padi-tui wait` vs `kaval-tui wait` — two done-signals
 
 They are not rivals; they read different things:

--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -201,10 +201,14 @@ it with `padi-tui create` instead of raw `kaval-tui create`:
 
 ```sh
 git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
-padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent>
 # prints the new terminal's id; padi owns it and it appears on the canvas
 ```
 
+- **Never hardcode the agent CLI.** `<agent>` defaults to the same agent *you*
+  are running as (a Claude Code orchestrator spawns `claude`, a codex one
+  `codex`, …) — unless the human named a different agent in their prompt, which
+  wins.
 - **Fast-forward the base repo first.** `--worktree` branches from the repo's
   checkout as it stands — a stale default branch silently seeds the agent an old
   tree, and nothing errors.
@@ -214,14 +218,16 @@ padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
   its own `send --key Enter`. Drive every boot step by `snapshot`, never by
   sleeping and hoping.
 - **Set the permission mode deliberately, then verify it.** An agent that will
-  run unattended goes in **auto mode**: cycle with `kaval-tui send <id> --key
-  Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on` (the
-  cycle is manual → accept edits → plan → auto — verify after each press; never
-  count presses blind, the starting point varies).
+  run unattended goes in **auto mode**. The mechanics below are Claude Code's
+  (other agent TUIs have their own equivalents): cycle with `kaval-tui send <id>
+  --key Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on`
+  (the cycle is manual → accept edits → plan → auto — verify after each press;
+  never count presses blind, the starting point varies).
 - **Restarting the agent CLI in place:** text typed at a *running* agent becomes
-  a prompt (your `claude …` command line gets answered, not executed), and `C-c`
-  doesn't reliably quit the TUI — send `/exit` (its own three-step submit), wait
-  for the shell prompt to show in the snapshot, then launch again.
+  a prompt (your relaunch command line gets answered, not executed), and `C-c`
+  doesn't reliably quit the TUI — send the agent's quit command (`/exit` in
+  Claude Code) as its own three-step submit, wait for the shell prompt to show
+  in the snapshot, then launch again.
 
 ## `padi-tui wait` vs `kaval-tui wait` — two done-signals
 

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -193,6 +193,36 @@ returns, **`snapshot --viewport` and read** what's on screen before responding.
 > }
 > ```
 
+## Provisioning a worktree'd agent — `padi-tui create`
+
+When the terminal should be a **kolu-owned** workspace — visible on the canvas,
+tracked by padi's agent sensors so `padi-tui wait` works against it — provision
+it with `padi-tui create` instead of raw `kaval-tui create`:
+
+```sh
+git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
+# prints the new terminal's id; padi owns it and it appears on the canvas
+```
+
+- **Fast-forward the base repo first.** `--worktree` branches from the repo's
+  checkout as it stands — a stale default branch silently seeds the agent an old
+  tree, and nothing errors.
+- **`create` returning ≠ the agent is ready.** Snapshot before dispatching: a
+  fresh worktree's first dev-env build can take minutes, and a first-run agent
+  may sit on a one-time dialog (MCP server selection, a trust prompt) that needs
+  its own `send --key Enter`. Drive every boot step by `snapshot`, never by
+  sleeping and hoping.
+- **Set the permission mode deliberately, then verify it.** An agent that will
+  run unattended goes in **auto mode**: cycle with `kaval-tui send <id> --key
+  Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on` (the
+  cycle is manual → accept edits → plan → auto — verify after each press; never
+  count presses blind, the starting point varies).
+- **Restarting the agent CLI in place:** text typed at a *running* agent becomes
+  a prompt (your `claude …` command line gets answered, not executed), and `C-c`
+  doesn't reliably quit the TUI — send `/exit` (its own three-step submit), wait
+  for the shell prompt to show in the snapshot, then launch again.
+
 ## `padi-tui wait` vs `kaval-tui wait` — two done-signals
 
 They are not rivals; they read different things:

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -201,10 +201,14 @@ it with `padi-tui create` instead of raw `kaval-tui create`:
 
 ```sh
 git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
-padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent>
 # prints the new terminal's id; padi owns it and it appears on the canvas
 ```
 
+- **Never hardcode the agent CLI.** `<agent>` defaults to the same agent *you*
+  are running as (a Claude Code orchestrator spawns `claude`, a codex one
+  `codex`, …) — unless the human named a different agent in their prompt, which
+  wins.
 - **Fast-forward the base repo first.** `--worktree` branches from the repo's
   checkout as it stands — a stale default branch silently seeds the agent an old
   tree, and nothing errors.
@@ -214,14 +218,16 @@ padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
   its own `send --key Enter`. Drive every boot step by `snapshot`, never by
   sleeping and hoping.
 - **Set the permission mode deliberately, then verify it.** An agent that will
-  run unattended goes in **auto mode**: cycle with `kaval-tui send <id> --key
-  Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on` (the
-  cycle is manual → accept edits → plan → auto — verify after each press; never
-  count presses blind, the starting point varies).
+  run unattended goes in **auto mode**. The mechanics below are Claude Code's
+  (other agent TUIs have their own equivalents): cycle with `kaval-tui send <id>
+  --key Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on`
+  (the cycle is manual → accept edits → plan → auto — verify after each press;
+  never count presses blind, the starting point varies).
 - **Restarting the agent CLI in place:** text typed at a *running* agent becomes
-  a prompt (your `claude …` command line gets answered, not executed), and `C-c`
-  doesn't reliably quit the TUI — send `/exit` (its own three-step submit), wait
-  for the shell prompt to show in the snapshot, then launch again.
+  a prompt (your relaunch command line gets answered, not executed), and `C-c`
+  doesn't reliably quit the TUI — send the agent's quit command (`/exit` in
+  Claude Code) as its own three-step submit, wait for the shell prompt to show
+  in the snapshot, then launch again.
 
 ## `padi-tui wait` vs `kaval-tui wait` — two done-signals
 

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -193,6 +193,36 @@ returns, **`snapshot --viewport` and read** what's on screen before responding.
 > }
 > ```
 
+## Provisioning a worktree'd agent — `padi-tui create`
+
+When the terminal should be a **kolu-owned** workspace — visible on the canvas,
+tracked by padi's agent sensors so `padi-tui wait` works against it — provision
+it with `padi-tui create` instead of raw `kaval-tui create`:
+
+```sh
+git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
+# prints the new terminal's id; padi owns it and it appears on the canvas
+```
+
+- **Fast-forward the base repo first.** `--worktree` branches from the repo's
+  checkout as it stands — a stale default branch silently seeds the agent an old
+  tree, and nothing errors.
+- **`create` returning ≠ the agent is ready.** Snapshot before dispatching: a
+  fresh worktree's first dev-env build can take minutes, and a first-run agent
+  may sit on a one-time dialog (MCP server selection, a trust prompt) that needs
+  its own `send --key Enter`. Drive every boot step by `snapshot`, never by
+  sleeping and hoping.
+- **Set the permission mode deliberately, then verify it.** An agent that will
+  run unattended goes in **auto mode**: cycle with `kaval-tui send <id> --key
+  Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on` (the
+  cycle is manual → accept edits → plan → auto — verify after each press; never
+  count presses blind, the starting point varies).
+- **Restarting the agent CLI in place:** text typed at a *running* agent becomes
+  a prompt (your `claude …` command line gets answered, not executed), and `C-c`
+  doesn't reliably quit the TUI — send `/exit` (its own three-step submit), wait
+  for the shell prompt to show in the snapshot, then launch again.
+
 ## `padi-tui wait` vs `kaval-tui wait` — two done-signals
 
 They are not rivals; they read different things:

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -201,10 +201,14 @@ it with `padi-tui create` instead of raw `kaval-tui create`:
 
 ```sh
 git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
-padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent>
 # prints the new terminal's id; padi owns it and it appears on the canvas
 ```
 
+- **Never hardcode the agent CLI.** `<agent>` defaults to the same agent *you*
+  are running as (a Claude Code orchestrator spawns `claude`, a codex one
+  `codex`, …) — unless the human named a different agent in their prompt, which
+  wins.
 - **Fast-forward the base repo first.** `--worktree` branches from the repo's
   checkout as it stands — a stale default branch silently seeds the agent an old
   tree, and nothing errors.
@@ -214,14 +218,16 @@ padi-tui create --repo /abs/path/to/repo --worktree my-branch -- claude
   its own `send --key Enter`. Drive every boot step by `snapshot`, never by
   sleeping and hoping.
 - **Set the permission mode deliberately, then verify it.** An agent that will
-  run unattended goes in **auto mode**: cycle with `kaval-tui send <id> --key
-  Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on` (the
-  cycle is manual → accept edits → plan → auto — verify after each press; never
-  count presses blind, the starting point varies).
+  run unattended goes in **auto mode**. The mechanics below are Claude Code's
+  (other agent TUIs have their own equivalents): cycle with `kaval-tui send <id>
+  --key Shift-Tab` and re-`snapshot` the footer until it reads `auto mode on`
+  (the cycle is manual → accept edits → plan → auto — verify after each press;
+  never count presses blind, the starting point varies).
 - **Restarting the agent CLI in place:** text typed at a *running* agent becomes
-  a prompt (your `claude …` command line gets answered, not executed), and `C-c`
-  doesn't reliably quit the TUI — send `/exit` (its own three-step submit), wait
-  for the shell prompt to show in the snapshot, then launch again.
+  a prompt (your relaunch command line gets answered, not executed), and `C-c`
+  doesn't reliably quit the TUI — send the agent's quit command (`/exit` in
+  Claude Code) as its own three-step submit, wait for the shell prompt to show
+  in the snapshot, then launch again.
 
 ## `padi-tui wait` vs `kaval-tui wait` — two done-signals
 


### PR DESCRIPTION
New section in the kolu skill, between the done-signal section and the two-done-signals comparison: **Provisioning a worktree'd agent — `padi-tui create`**. Field lessons from provisioning the SurfaceRuntime (PR 1) agent terminal:

- `padi-tui create --repo <abs> --worktree <branch> -- claude` is the one-command provision for a kolu-owned, padi-tracked agent terminal — but **fast-forward the base repo first**: the worktree cuts from the current checkout and a stale master seeds an old tree with no error.
- `create` returning is **not** agent-ready: the fresh worktree's first env build takes minutes and a first-run agent can sit on one-time dialogs (MCP selection, trust). Every boot step is driven by `snapshot`, never sleep-and-hope.
- Permission mode is set deliberately and **verified from the footer** after each `Shift-Tab` (manual → accept edits → plan → auto); unattended fleet agents run **auto mode** (per srid's ruling — not bypass).
- Restarting an agent CLI in place: typed text becomes a prompt and `C-c` doesn't reliably quit — `/exit`, wait for the shell in the snapshot, relaunch.

All three skill copies updated identically (`.claude/`, `.agents/`, `agents/.apm/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)