### PR TITLE
chore(skills): restore fmt-before-gauntlet-push clause in be-review

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -232,6 +232,17 @@ the workflow's notification arrives or it has provably errored.
 First settle whether there is anything to push: `git log --oneline $START..HEAD`
 (`$START` was captured in Preflight). Then:
 
+- **Run `just fmt` before any push, whenever new commits exist.** The four
+  reviewers edit and commit code but **none guarantees formatting**, and `just
+  check` is tsc + biome *lint* — it never runs the formatter. So a hand-edit by
+  lens/codex/police (a reflowed `.ts` closure, a `default.nix` fileset tweak that
+  wants `nixpkgs-fmt`) sails through green `check` yet leaves the tree unformatted,
+  and `ci::fmt` then reds in §5 and burns a whole CI cycle on a re-run (it has,
+  more than once). `just fmt` runs **both** biome-format and nixpkgs-fmt, so it is
+  the only gate that matches `ci::fmt`. Once the steps finish and new commits
+  exist, run `just fmt` and, if it changed anything, commit the reformat (`style:
+  just fmt`, staging only what it touched) so the formatted tree rides this push —
+  don't leave formatting for the §5 CI loop to surface.
 - **New commits exist** and **a PR exists for this branch**
   (`gh pr view --json number -q .number`) → **`git push`**. **Only after the push
   succeeds** do you post the deferred comments — the lens and codex bodies from

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -232,6 +232,17 @@ the workflow's notification arrives or it has provably errored.
 First settle whether there is anything to push: `git log --oneline $START..HEAD`
 (`$START` was captured in Preflight). Then:
 
+- **Run `just fmt` before any push, whenever new commits exist.** The four
+  reviewers edit and commit code but **none guarantees formatting**, and `just
+  check` is tsc + biome *lint* — it never runs the formatter. So a hand-edit by
+  lens/codex/police (a reflowed `.ts` closure, a `default.nix` fileset tweak that
+  wants `nixpkgs-fmt`) sails through green `check` yet leaves the tree unformatted,
+  and `ci::fmt` then reds in §5 and burns a whole CI cycle on a re-run (it has,
+  more than once). `just fmt` runs **both** biome-format and nixpkgs-fmt, so it is
+  the only gate that matches `ci::fmt`. Once the steps finish and new commits
+  exist, run `just fmt` and, if it changed anything, commit the reformat (`style:
+  just fmt`, staging only what it touched) so the formatted tree rides this push —
+  don't leave formatting for the §5 CI loop to surface.
 - **New commits exist** and **a PR exists for this branch**
   (`gh pr view --json number -q .number`) → **`git push`**. **Only after the push
   succeeds** do you post the deferred comments — the lens and codex bodies from

--- a/agents/.apm/skills/be-review/SKILL.md
+++ b/agents/.apm/skills/be-review/SKILL.md
@@ -232,6 +232,17 @@ the workflow's notification arrives or it has provably errored.
 First settle whether there is anything to push: `git log --oneline $START..HEAD`
 (`$START` was captured in Preflight). Then:
 
+- **Run `just fmt` before any push, whenever new commits exist.** The four
+  reviewers edit and commit code but **none guarantees formatting**, and `just
+  check` is tsc + biome *lint* — it never runs the formatter. So a hand-edit by
+  lens/codex/police (a reflowed `.ts` closure, a `default.nix` fileset tweak that
+  wants `nixpkgs-fmt`) sails through green `check` yet leaves the tree unformatted,
+  and `ci::fmt` then reds in §5 and burns a whole CI cycle on a re-run (it has,
+  more than once). `just fmt` runs **both** biome-format and nixpkgs-fmt, so it is
+  the only gate that matches `ci::fmt`. Once the steps finish and new commits
+  exist, run `just fmt` and, if it changed anything, commit the reformat (`style:
+  just fmt`, staging only what it touched) so the formatted tree rides this push —
+  don't leave formatting for the §5 CI loop to surface.
 - **New commits exist** and **a PR exists for this branch**
   (`gh pr view --json number -q .number`) → **`git push`**. **Only after the push
   succeeds** do you post the deferred comments — the lens and codex bodies from

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-13T03:08:32.163340+00:00'
+generated_at: '2026-07-13T23:04:24.465429+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -65,7 +65,7 @@ dependencies:
   - .claude/skills/surface/SKILL.md
   deployed_file_hashes:
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
-    .agents/skills/be-review/SKILL.md: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
+    .agents/skills/be-review/SKILL.md: sha256:ae0cd8a55f037c8fb64f05faf393c746ea7f85dc47efda51c16e6936992cb4a0
     .agents/skills/be/SKILL.md: sha256:e7ad6d775802d78e80bf3e541581240d5933185de527aa00e58354bfeabd7b9e
     .agents/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238
     .agents/skills/codex-debate/answer.workflow.js: sha256:82ad3a02db21c52cb6b2453a66559bf8742f2ba30f1e8a328c35b896b0e12ada
@@ -76,14 +76,14 @@ dependencies:
     .agents/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
     .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .agents/skills/kolu/SKILL.md: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
+    .agents/skills/kolu/SKILL.md: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
     .agents/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
-    .agents/skills/orchestrator/SKILL.md: sha256:b1d170f632371bd970b01a4c96ed935a08f547b93f7f709ee295a0584fd0697b
+    .agents/skills/orchestrator/SKILL.md: sha256:4d6818094b053455c0b6409fe4e5974bcb0837a838b9aa1d07c114693fa19926
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
-    .claude/skills/be-review/SKILL.md: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
+    .claude/skills/be-review/SKILL.md: sha256:ae0cd8a55f037c8fb64f05faf393c746ea7f85dc47efda51c16e6936992cb4a0
     .claude/skills/be/SKILL.md: sha256:e7ad6d775802d78e80bf3e541581240d5933185de527aa00e58354bfeabd7b9e
     .claude/skills/codex-debate/SKILL.md: sha256:5456d1b415ac284e4e7f1d51bab2548124f0dbd0e8175185afc9fb01b0485238
     .claude/skills/codex-debate/answer.workflow.js: sha256:82ad3a02db21c52cb6b2453a66559bf8742f2ba30f1e8a328c35b896b0e12ada
@@ -94,10 +94,10 @@ dependencies:
     .claude/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
     .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .claude/skills/kolu/SKILL.md: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
+    .claude/skills/kolu/SKILL.md: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
     .claude/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .claude/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
-    .claude/skills/orchestrator/SKILL.md: sha256:b1d170f632371bd970b01a4c96ed935a08f547b93f7f709ee295a0584fd0697b
+    .claude/skills/orchestrator/SKILL.md: sha256:4d6818094b053455c0b6409fe4e5974bcb0837a838b9aa1d07c114693fa19926
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:407652ca44fc119dba06be3816009eaa4331189f9bf3807c6b65e95f95b0cbad
   source: local
@@ -396,7 +396,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
+  content_hash: sha256:ae0cd8a55f037c8fb64f05faf393c746ea7f85dc47efda51c16e6936992cb4a0
 - kind: project-relative
   target: agents
   value: .agents/skills/be/SKILL.md
@@ -765,7 +765,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
+  content_hash: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
 - kind: project-relative
   target: agents
   value: .agents/skills/lens-debate
@@ -918,7 +918,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:b1d170f632371bd970b01a4c96ed935a08f547b93f7f709ee295a0584fd0697b
+  content_hash: sha256:4d6818094b053455c0b6409fe4e5974bcb0837a838b9aa1d07c114693fa19926
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1423,7 +1423,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:ccc15c1262dc00f25fb96ebc1b1f37a4b70d8bcd21cffecc2fff58740a69cdac
+  content_hash: sha256:ae0cd8a55f037c8fb64f05faf393c746ea7f85dc47efda51c16e6936992cb4a0
 - kind: project-relative
   target: claude
   value: .claude/skills/be/SKILL.md
@@ -1792,7 +1792,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:e458a419068227b80ebd929d99e6ed48457fb41fc74ce9c70c0db0d9c4b0a12b
+  content_hash: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
 - kind: project-relative
   target: claude
   value: .claude/skills/lens-debate
@@ -1945,7 +1945,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:b1d170f632371bd970b01a4c96ed935a08f547b93f7f709ee295a0584fd0697b
+  content_hash: sha256:4d6818094b053455c0b6409fe4e5974bcb0837a838b9aa1d07c114693fa19926
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel


### PR DESCRIPTION
## What

Restores the **"run `just fmt` before any gauntlet push"** clause to
`be-review`'s _Push, then comment_ section, and sharpens it to name the
`just check` ≠ `just fmt` trap explicitly.

## Why — a regressed fix that recurred

This is a **repeat of a previously-mined lesson whose fix was lost in a skill
migration**:

- `581d227ab` (self-improve on session `e04279b1`, PR #1589) added exactly this
  clause to `be-review` — because the four gauntlet reviewers (lens / codex /
  simplify / police) edit and commit code but **none guarantees formatting**.
- That edit lived in `.apm/skills/be-review/` (root package). When `be-review`
  later migrated into the `agents/` package (`agents/.apm/skills/be-review/`),
  the clause **did not come with it** — the current source has zero mentions of
  `just fmt`.
- Session `fdc62b24` (/be XKIT-GR4D, PR #1795) paid for the gap: codex's
  `default.nix` fileset edit went through the gauntlet push **unformatted**,
  `ci::fmt@aarch64-darwin` went red, and a full CI cycle was burned on the
  re-fire. `just check` is tsc + biome _lint_ — it never runs the formatter, so
  it could not catch this; only `just fmt` (biome-format **and** `nixpkgs-fmt`)
  matches the `ci::fmt` gate.

## Evidence ledger

| Claim | Evidence |
|---|---|
| Clause existed then regressed | `git show 581d227ab -- .apm/skills/be-review/SKILL.md` adds it; `grep -c 'just fmt' agents/.apm/skills/be-review/SKILL.md` on master = **0** |
| It recurred, at CI cost | Session `fdc62b24` transcript: `ci::fmt@aarch64-darwin` red on a biome/nixpkgs-fmt-only diff after a codex `default.nix` edit; agent re-fired a two-platform run to green |
| `just fmt` is the matching gate | `justfile:409` — `biome format --write . && nixpkgs-fmt *.nix …`; `ci/mod.just:166` mirrors it as `ci::fmt` |
| Sources regenerate cleanly | `just ai::apm` propagated the clause into `.claude/` + `.agents/` (both verified); `just fmt` clean; `just check` green |

## Not shipped (observation only)

One more friction point surfaced but did **not** meet the durability bar (single,
reversible, self-corrected — no human intervention): a docs-only flaky-tracker
commit landed **on top of** the green code SHA, and because branch protection
gates on `HEAD`'s checks, it forced another full CI re-fire on the new HEAD. The
agent caught and re-fired autonomously. `/be` §5 already states "confirm CI is
green on the **final** HEAD"; no edit warranted yet. Noted here in case it
recurs.

Provenance: `/self-improve` on session `fdc62b24-b5c8-4c0b-ad4c-577f8ab87b08`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
