### PR TITLE
chore(skills): correct kolu large-paste fold trigger to line count

### DIFF
--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -78,18 +78,24 @@ done-signal section), then submit as its own command. `send "$id" "text" --key
 Enter` in one call is a **hard error** for exactly this reason — the trap is
 unspellable, not merely discouraged.
 
-> **⚠️ LARGE pastes don't submit — a known-open limitation ([#1702](https://github.com/juspay/kolu/issues/1702)).**
-> The three-step flow above is verified for **normal-size** prompts. A **large**
-> paste (multi-KB — enough that Claude Code folds it into a `[Pasted text +N
-> lines]` / "paste again to expand" placeholder) does **NOT** reliably submit:
+> **⚠️ MULTI-LINE pastes don't submit — a known-open limitation ([#1702](https://github.com/juspay/kolu/issues/1702)).**
+> The three-step flow above is verified for a **short** prompt (a line or two). The fold
+> that breaks submission is triggered by **line count, not byte size**: Claude Code folds a
+> paste into a `[Pasted text +N lines]` / "paste again to expand" placeholder once it spans
+> more than a handful of lines — which happens **well under 1 KB** (observed folding at
+> ~900 bytes / ~a dozen lines, so "multi-KB" badly understates it). Treat *any* multi-line
+> message — a status report, a ruling, a review verdict — as fold-prone, not just a big
+> brief. A folded paste does **NOT** reliably submit:
 > even after `wait --until idle` fires (idle proves Claude finished *folding* the
 > paste, not that a following Enter submits it), the Enter leaves the paste
 > **staged** — and the Enter *write itself* can stall against the placeholder
 > state (the bounded write deadline turns that stall into a loud failure instead
-> of a >30s hang, but it still doesn't submit). **Workaround for a big brief:**
-> write it to a file and send a **short** prompt that points the agent at it —
-> `kaval-tui send "$id" "read /tmp/brief.md and carry it out"` then the three-step
-> submit above. A short prompt submits cleanly; the agent reads the file itself.
+> of a >30s hang, but it still doesn't submit). **Workaround for any multi-line message
+> (a brief, a report, a ruling):** write it to a file and send a **short** prompt that
+> points the agent at it — `kaval-tui send "$id" "read /tmp/brief.md and carry it out"`
+> then the three-step submit above. A short prompt submits cleanly; the agent reads the
+> file itself. Reach for the file-pointer by default the moment a message runs past a
+> couple of lines — don't wait to get bitten by a fold-and-resend cycle first.
 
 > **Step 2 fires cleanly only when the agent is AT THE PROMPT** (awaiting input —
 > the normal case for dispatching a new prompt: `idle:300` fires in a fraction of

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -78,18 +78,24 @@ done-signal section), then submit as its own command. `send "$id" "text" --key
 Enter` in one call is a **hard error** for exactly this reason — the trap is
 unspellable, not merely discouraged.
 
-> **⚠️ LARGE pastes don't submit — a known-open limitation ([#1702](https://github.com/juspay/kolu/issues/1702)).**
-> The three-step flow above is verified for **normal-size** prompts. A **large**
-> paste (multi-KB — enough that Claude Code folds it into a `[Pasted text +N
-> lines]` / "paste again to expand" placeholder) does **NOT** reliably submit:
+> **⚠️ MULTI-LINE pastes don't submit — a known-open limitation ([#1702](https://github.com/juspay/kolu/issues/1702)).**
+> The three-step flow above is verified for a **short** prompt (a line or two). The fold
+> that breaks submission is triggered by **line count, not byte size**: Claude Code folds a
+> paste into a `[Pasted text +N lines]` / "paste again to expand" placeholder once it spans
+> more than a handful of lines — which happens **well under 1 KB** (observed folding at
+> ~900 bytes / ~a dozen lines, so "multi-KB" badly understates it). Treat *any* multi-line
+> message — a status report, a ruling, a review verdict — as fold-prone, not just a big
+> brief. A folded paste does **NOT** reliably submit:
 > even after `wait --until idle` fires (idle proves Claude finished *folding* the
 > paste, not that a following Enter submits it), the Enter leaves the paste
 > **staged** — and the Enter *write itself* can stall against the placeholder
 > state (the bounded write deadline turns that stall into a loud failure instead
-> of a >30s hang, but it still doesn't submit). **Workaround for a big brief:**
-> write it to a file and send a **short** prompt that points the agent at it —
-> `kaval-tui send "$id" "read /tmp/brief.md and carry it out"` then the three-step
-> submit above. A short prompt submits cleanly; the agent reads the file itself.
+> of a >30s hang, but it still doesn't submit). **Workaround for any multi-line message
+> (a brief, a report, a ruling):** write it to a file and send a **short** prompt that
+> points the agent at it — `kaval-tui send "$id" "read /tmp/brief.md and carry it out"`
+> then the three-step submit above. A short prompt submits cleanly; the agent reads the
+> file itself. Reach for the file-pointer by default the moment a message runs past a
+> couple of lines — don't wait to get bitten by a fold-and-resend cycle first.
 
 > **Step 2 fires cleanly only when the agent is AT THE PROMPT** (awaiting input —
 > the normal case for dispatching a new prompt: `idle:300` fires in a fraction of

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -78,18 +78,24 @@ done-signal section), then submit as its own command. `send "$id" "text" --key
 Enter` in one call is a **hard error** for exactly this reason — the trap is
 unspellable, not merely discouraged.
 
-> **⚠️ LARGE pastes don't submit — a known-open limitation ([#1702](https://github.com/juspay/kolu/issues/1702)).**
-> The three-step flow above is verified for **normal-size** prompts. A **large**
-> paste (multi-KB — enough that Claude Code folds it into a `[Pasted text +N
-> lines]` / "paste again to expand" placeholder) does **NOT** reliably submit:
+> **⚠️ MULTI-LINE pastes don't submit — a known-open limitation ([#1702](https://github.com/juspay/kolu/issues/1702)).**
+> The three-step flow above is verified for a **short** prompt (a line or two). The fold
+> that breaks submission is triggered by **line count, not byte size**: Claude Code folds a
+> paste into a `[Pasted text +N lines]` / "paste again to expand" placeholder once it spans
+> more than a handful of lines — which happens **well under 1 KB** (observed folding at
+> ~900 bytes / ~a dozen lines, so "multi-KB" badly understates it). Treat *any* multi-line
+> message — a status report, a ruling, a review verdict — as fold-prone, not just a big
+> brief. A folded paste does **NOT** reliably submit:
 > even after `wait --until idle` fires (idle proves Claude finished *folding* the
 > paste, not that a following Enter submits it), the Enter leaves the paste
 > **staged** — and the Enter *write itself* can stall against the placeholder
 > state (the bounded write deadline turns that stall into a loud failure instead
-> of a >30s hang, but it still doesn't submit). **Workaround for a big brief:**
-> write it to a file and send a **short** prompt that points the agent at it —
-> `kaval-tui send "$id" "read /tmp/brief.md and carry it out"` then the three-step
-> submit above. A short prompt submits cleanly; the agent reads the file itself.
+> of a >30s hang, but it still doesn't submit). **Workaround for any multi-line message
+> (a brief, a report, a ruling):** write it to a file and send a **short** prompt that
+> points the agent at it — `kaval-tui send "$id" "read /tmp/brief.md and carry it out"`
+> then the three-step submit above. A short prompt submits cleanly; the agent reads the
+> file itself. Reach for the file-pointer by default the moment a message runs past a
+> couple of lines — don't wait to get bitten by a fold-and-resend cycle first.
 
 > **Step 2 fires cleanly only when the agent is AT THE PROMPT** (awaiting input —
 > the normal case for dispatching a new prompt: `idle:300` fires in a fraction of

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-13T23:04:24.465429+00:00'
+generated_at: '2026-07-14T03:34:10.463520+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -76,7 +76,7 @@ dependencies:
     .agents/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
     .agents/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .agents/skills/kolu/SKILL.md: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
+    .agents/skills/kolu/SKILL.md: sha256:07f3229f717c1fded0c0e340c8be8f151e8bb8583605b520de95f08e679e414c
     .agents/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .agents/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
     .agents/skills/orchestrator/SKILL.md: sha256:4d6818094b053455c0b6409fe4e5974bcb0837a838b9aa1d07c114693fa19926
@@ -94,7 +94,7 @@ dependencies:
     .claude/skills/codex-debate/scripts/codex-review.sh: sha256:8d97126372d6e716d9455f7e9e821c6fa717d1f55968dd82b93f9bb8999d0fc9
     .claude/skills/codex-debate/scripts/codex-verdict.schema.json: sha256:93e33150cd20b300eddb590adcf2c9253c85d68a7ef70aa42e4c8a49049a1fe3
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .claude/skills/kolu/SKILL.md: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
+    .claude/skills/kolu/SKILL.md: sha256:07f3229f717c1fded0c0e340c8be8f151e8bb8583605b520de95f08e679e414c
     .claude/skills/lens-debate/SKILL.md: sha256:7b08a00e9f088e64aa7886659175926e4afaac14a725d53d202e8de14aa30192
     .claude/skills/lens-debate/debate.workflow.js: sha256:94ecd7a58059af0606a1ce1bfc0feb942b80f90f80f993e538ae827f1eedbac3
     .claude/skills/orchestrator/SKILL.md: sha256:4d6818094b053455c0b6409fe4e5974bcb0837a838b9aa1d07c114693fa19926
@@ -765,7 +765,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
+  content_hash: sha256:07f3229f717c1fded0c0e340c8be8f151e8bb8583605b520de95f08e679e414c
 - kind: project-relative
   target: agents
   value: .agents/skills/lens-debate
@@ -1792,7 +1792,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:c24560da43a6d75f984454c28073b3ac20ba51d62dcaad6fd955735f13a46128
+  content_hash: sha256:07f3229f717c1fded0c0e340c8be8f151e8bb8583605b520de95f08e679e414c
 - kind: project-relative
   target: claude
   value: .claude/skills/lens-debate


### PR DESCRIPTION
## What

The `/kolu` skill warns that a paste can fold into a `[Pasted text +N lines]`
placeholder and fail to submit — but it frames that limit as **"multi-KB" / "large"**
and calls anything smaller a **"normal-size"** prompt safe for the three-step submit.
That mental model is wrong, and it bit the driving agent repeatedly.

The fold is triggered by **line count, not byte size**. A multi-line status report
folds well under 1 KB. This PR reframes the callout around line count and makes the
file-pointer workaround the *default* for any multi-line message, not a special case
for a "big brief."

## Why — the evidence

Mined from the XKIT-PR2 `/be` run (session `fdc62b24`), where this session drove a
coordinator terminal over `kaval-tui send`. Its reports kept folding into placeholders
that would not submit, each forcing a *clear + short-pointer resend* cycle:

| Observed fold | Size | The agent's own note |
| --- | --- | --- |
| `[Pasted text #13 +15 lines]` | 1807 B / 15 lines | "the known large-paste limitation" |
| `[Pasted text #6]` | ~2414 B | "an Enter now would leave it staged" |
| `[Pasted text #12]` | ~909 B | "clear it and send a tight venue question" |
| (another) | ~1011 B | **"Folded again (the fold threshold is low)."** |

Two of these folded at **under 1.1 KB** — nowhere near "multi-KB." The agent had to
*discover empirically* that "the fold threshold is low" and switch to the
file-pointer workaround, which the skill had already documented but mis-scoped as a
big-brief-only path.

## The fix (per-edit ledger)

`agents/.apm/skills/kolu/SKILL.md` (the source; generated `.claude/` + `.agents/`
copies + `apm.lock.yaml` regenerated via `just ai::apm`, same commit):

1. **Callout framing** — "LARGE pastes (multi-KB) ... normal-size prompts" →
   "MULTI-LINE pastes ... a short prompt (a line or two)", stating the trigger is
   **line count, not byte size**, folding **well under 1 KB** (~900 B / ~a dozen
   lines), and that *any* multi-line message (report, ruling, verdict) is fold-prone.
2. **Workaround scope** — "Workaround for a big brief" → "for any multi-line message",
   with an explicit steer to reach for the file-pointer **by default** past a couple
   of lines rather than after getting bitten by a fold-and-resend cycle.

## Not shipped (observations only — did not meet the durability bar)

- **Browser pointer/hover media emulation** (the e2e-gate took three escalations to
  learn Chromium welds `(hover)` to touch capability): a one-time domain discovery,
  self-corrected by the review gauntlet + `/perfection-review`, and already encoded in
  the shipped code comments. Not a recurring skill gap.
- **`ci/pu/lease.sh` granting the quarantined `kolu-ci-1`** (forcing a two-lease
  dance): a transient infra quarantine; the real fix is a lease-script exclusion flag,
  which is out of `/self-improve`'s `.apm/skills/*` scope. Single incident.

## Verification

- `just fmt` — clean (no reformats).
- `just check` — green (exit 0): all typechecks + biome lint pass.
- `just ai::apm` regen confirmed to land in `.claude/` and `.agents/` (hashes match in
  `apm.lock.yaml`); no unrelated skill drifted.

Provenance: `/self-improve` micro-loop over session `fdc62b24-b5c8-4c0b-ad4c-577f8ab87b08`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
