### PR TITLE
fix(deps): bump @xterm to beta.289/288 — shared-atlas tile-focus leak fix (xtermjs #6042)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -125,7 +125,7 @@ let
     # hash-fresh` enforces this stays in sync with pnpm-lock.yaml by forcing
     # fetchPnpmDeps to re-execute (--rebuild), so stale artifacts in the
     # binary cache can't silently satisfy a hash that no longer matches.
-    hash = "sha256-FTPc1K2Zr4AOvEu8rmWM7LIEqU+grVZ1mE1Mpkg2A5s=";
+    hash = "sha256-Iwdperk6QLQoRm1P3xXa45Mc7Qbet7/3RXBT/JppAoQ=";
     fetcherVersion = 3;
   };
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
       "shell-quote": "^1.8.4",
       "qs": "^6.15.2",
       "@anthropic-ai/sdk": "^0.91.1",
-      "@xterm/xterm": "6.1.0-beta.225",
-      "@xterm/addon-webgl": "0.20.0-beta.224"
+      "@xterm/xterm": "6.1.0-beta.289",
+      "@xterm/addon-webgl": "0.20.0-beta.288"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ overrides:
   shell-quote: ^1.8.4
   qs: ^6.15.2
   '@anthropic-ai/sdk': ^0.91.1
-  '@xterm/xterm': 6.1.0-beta.225
-  '@xterm/addon-webgl': 0.20.0-beta.224
+  '@xterm/xterm': 6.1.0-beta.289
+  '@xterm/addon-webgl': 0.20.0-beta.288
 
 packageExtensionsChecksum: sha256-GuGZA8jCJUaUE/saX+uezWes2nMASx9CFDTN3Aun/K8=
 
@@ -153,8 +153,8 @@ importers:
         specifier: ^0.14.0
         version: 0.14.0
       '@xterm/xterm':
-        specifier: 6.1.0-beta.225
-        version: 6.1.0-beta.225
+        specifier: 6.1.0-beta.289
+        version: 6.1.0-beta.289
       fix-webm-duration:
         specifier: ^1.0.6
         version: 1.0.6
@@ -1803,8 +1803,8 @@ importers:
   packages/terminal-themes:
     dependencies:
       '@xterm/xterm':
-        specifier: 6.1.0-beta.225
-        version: 6.1.0-beta.225
+        specifier: 6.1.0-beta.289
+        version: 6.1.0-beta.289
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
@@ -1971,11 +1971,11 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       '@xterm/addon-webgl':
-        specifier: 0.20.0-beta.224
-        version: 0.20.0-beta.224(@xterm/xterm@6.1.0-beta.225)
+        specifier: 0.20.0-beta.288
+        version: 0.20.0-beta.288(@xterm/xterm@6.1.0-beta.289)
       '@xterm/xterm':
-        specifier: 6.1.0-beta.225
-        version: 6.1.0-beta.225
+        specifier: 6.1.0-beta.289
+        version: 6.1.0-beta.289
     devDependencies:
       '@babel/parser':
         specifier: ^7.29.2
@@ -3363,16 +3363,16 @@ packages:
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
-  '@xterm/addon-webgl@0.20.0-beta.224':
-    resolution: {integrity: sha512-7d30YLvlLiEomUhGNbtsi61twsT29K6eo1IsX33Oh1bg8ty6eCDzrHrdLb46UEBwAPYQuHmKnvYjW8oGg95Z9A==}
+  '@xterm/addon-webgl@0.20.0-beta.288':
+    resolution: {integrity: sha512-4Jp7+SjFm8RWQwGX54RRNPmhV5F9kZ3o9+DYGGrj9RmJ2rJEqzfG861QJUynlTz11Ni634MwXxxIoSC1yQkLgw==}
     peerDependencies:
-      '@xterm/xterm': 6.1.0-beta.225
+      '@xterm/xterm': 6.1.0-beta.289
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
 
-  '@xterm/xterm@6.1.0-beta.225':
-    resolution: {integrity: sha512-IGFDoLj7Lx666ciMFXc5ov7sxJMX1QFAUr4zeEwzSmRTllyzgK5u2Z5uy00QjB4l0YDaN+i6duU6r4Ileqxpww==}
+  '@xterm/xterm@6.1.0-beta.289':
+    resolution: {integrity: sha512-Mg8PqFpnDlRwdbpd92TMdu2h6gL5+uyHrNh1zAfOCouYiMia7Djf8VM4YGdj6WR0m3oTvrzZa4SG0wRRQIj+Ew==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -6352,13 +6352,13 @@ snapshots:
 
   '@xterm/addon-web-links@0.12.0': {}
 
-  '@xterm/addon-webgl@0.20.0-beta.224(@xterm/xterm@6.1.0-beta.225)':
+  '@xterm/addon-webgl@0.20.0-beta.288(@xterm/xterm@6.1.0-beta.289)':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.225
+      '@xterm/xterm': 6.1.0-beta.289
 
   '@xterm/headless@6.0.0': {}
 
-  '@xterm/xterm@6.1.0-beta.225': {}
+  '@xterm/xterm@6.1.0-beta.289': {}
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
Fixes the tile-focus glyph corruption in #1825 — switching the active tile made **"characters from the previous terminal leak into the new one."**

## Root cause (reproduced + grounded)

kolu keeps **two tiles' WebGL live** (#1404's recency budget), and xterm's `acquireTextureAtlas` shares **one** `TextureAtlas` across equal-config terminals. The shared atlas's page-merge invalidation was **consume-once** — a single `_requestClearModel` boolean that `atlas.beginFrame()` reads-and-resets — so on an atlas page merge only the **first** renderer to draw cleared its glyph model; the **second** live tile kept stale glyph→slot mappings and drew the previous terminal's glyphs. Reproduced deterministically: two same-config terminals share one atlas instance, and `firstRenderer=true / secondRenderer=false` from the shared flag.

## The upstream fix

xterm.js **PR #6042** (issue #6038; also microsoft/vscode#322756) replaces the consume-once flag with a monotonic per-atlas `pageLayoutVersion` + a per-`GlyphRenderer` `_lastSeenPageLayoutVersion`, so every renderer refreshes independently. It's in **`@xterm/addon-webgl@0.20.0-beta.288` / `@xterm/xterm@6.1.0-beta.289`**.

**Before/after, verified at the mechanism level (venue-independent):**
- **beta.224 (RED):** shared `_requestClearModel`; `beginFrame()` consumes it → second renderer starved → leak.
- **beta.288 (GREEN):** `_requestClearModel` gone; both renderers carry `_lastSeenPageLayoutVersion`; bumping the shared `_pageLayoutVersion` leaves each renderer **independently** behind (A refreshing doesn't reset B) → no starvation.

srid verifies the pixels on **real GPU** (software-GL is a false-positive venue for this bug class).

## This PR

- `pnpm.overrides`: `@xterm/xterm` 225→**289**, `@xterm/addon-webgl` 224→**288** (matched pair). Install clean — no peer conflict on the core jump; other `@xterm` addons + `@xterm/headless` (no renderer) unchanged.
- Refreshed the `fetchPnpmDeps` FOD hash in `default.nix` for the new lockfile.
- xterm-kit contract suites (mirror / internals / renderRecovery / scrollback / snapshot) **green** across the 64-beta jump (79/79).

Doctrine-correct fix — reuse the upstream library, not a hand-rolled clear-on-switch that would fight #1404's flash-avoidance. #1808 stays exonerated. The earlier on-show fix (#1824) was reverted (#1828) and its guard PR (#1826) closed — both targeted the wrong (visibility) path.
