### PR TITLE
Spawn the codex-debate reviewer as a split tile beside you

### DIFF
--- a/.agents/skills/codex-debate/SKILL.md
+++ b/.agents/skills/codex-debate/SKILL.md
@@ -24,15 +24,20 @@ contracts.
 You drive the debate from your own turn: spawn a **live `codex` session as a split
 terminal next to you** and take turns with it until you agree. There is no `Workflow`
 tool and no subagent — you *are* one debater, the split codex *is* the other. **All
-the terminal mechanics belong to the [/kolu skill](../kolu/SKILL.md)** — spawning a
+the terminal mechanics belong to the [/kolu skill](../../../apm_modules/_local/agents/.apm/skills/kolu/SKILL.md)** — spawning a
 split, the send→settle→submit sequence, the done-signal, the large-paste file rule,
 and teardown. Read it; this skill only adds the debate protocol on top.
 
 Requires running **inside a kolu terminal** (you need to spawn a sibling split). If
 you can't, the skill is inert — say so and stop.
 
-**Spawn** codex as a split beside you, in this worktree, under `--yolo`, at the chosen
-reasoning effort: `codex --yolo -c model_reasoning_effort=<effort>`. `--yolo` is
+**Spawn** codex as a **split tile beside you** — a sibling on your canvas, NOT a
+detached terminal — in this worktree, under `--yolo`, at the chosen reasoning effort.
+The split is what `--parent` buys: `padi-tui create --parent "$KAVAL_TERMINAL_ID" --
+codex --yolo -c model_reasoning_effort=<effort>` (per [/kolu](../../../apm_modules/_local/agents/.apm/skills/kolu/SKILL.md#provisioning-a-worktreed-agent--padi-tui-create)
+— `$KAVAL_TERMINAL_ID` names your own terminal). **Do NOT reach for raw `kaval-tui
+create`**: it spawns a detached, standalone terminal that isn't a split beside you and
+isn't on the canvas — the exact wrong shape for a debate you drive turn-by-turn. `--yolo` is
 **required, not a convenience**: the two moves that make this engine work — codex
 *writing* its verdict file and *pinging* your terminal (a unix-socket write) — are both
 **denied by every codex sandbox** (`read-only` and `workspace-write` both block the
@@ -361,7 +366,7 @@ next-round rebuttal), and `answer-claude-N.md` / `answer-codex-N.md` / `candidat
 `answer-<slug>.md` for answer mode. **None of this feeds the PR comment** — that is a
 compact commit table (step 4); the debate's per-round detail lives in the commit messages.
 There are **no** workflow or `codex exec` scripts; the engine is this protocol plus the
-[/kolu skill](../kolu/SKILL.md).
+[/kolu skill](../../../apm_modules/_local/agents/.apm/skills/kolu/SKILL.md).
 
 This skill is generated from `agents/.apm/skills/codex-debate/`; edit the source there
 and keep the generated `.claude/` and `.agents/` copies identical in the same commit

--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -171,6 +171,15 @@ kaval-tui wait "$id" --until idle:800 --timeout 600000   # block until the turn 
 - **`--timeout <ms>`** caps the wait and **fails loud (exit 2)** so a wedged agent
   can't hang the loop. If the terminal **exits** before the condition fires,
   `wait` exits **3** (the agent you were driving died). Met → exit **0**.
+  > **A foreground `wait` also runs inside YOUR OWN harness's tool timeout.** A
+  > held `kaval-tui wait "$id" --timeout <big-ms>` (e.g. a long `--until match:` on
+  > another agent's verdict) blocks *your* Bash call, and most agent harnesses cap a
+  > single tool call at ~2 minutes by default — so a `--timeout 1200000` wait is
+  > **SIGKILLed at ~2 min (exit 143)** while the agent you're watching is perfectly
+  > fine. Two ways out: **prefer ending your turn** and being woken by the other
+  > side's ping (the event-driven loop — see `/codex-debate`) instead of holding a
+  > wait; or, if you *must* hold it, **raise the Bash call's own timeout to exceed
+  > the `--timeout`** so the harness doesn't kill it first.
 - **`--json`** → one result frame per outcome: `{ id, result, … }`, where
   `result` is `met`/`timeout`/`gone`/`interrupted`/`closed`. A `met` frame adds
   `fired` (`idle`/`match`), `elapsedMs`, and `matchedLine` on a match — so a
@@ -210,6 +219,18 @@ git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo'
 padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent> <mode-flags>
 # e.g. `-- claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
 ```
+
+> **A split tile BESIDE you — `--parent "$KAVAL_TERMINAL_ID"`.** When you want the
+> new terminal to open as a **split beside your own** (a sibling tile on the same
+> canvas — e.g. driving a live `codex` reviewer per `/codex-debate`), pass
+> **`--parent <your-terminal-id>`**, using your self-knowledge var
+> `$KAVAL_TERMINAL_ID` (see *Reach*): `padi-tui create --parent "$KAVAL_TERMINAL_ID"
+> -- codex --yolo …`. Add `--worktree`/`--repo` too if the split should also get its
+> own worktree; omit them and the split opens in your cwd. **`kaval-tui create` is
+> NOT a split** — it spawns a *detached, standalone* terminal that isn't a tile
+> beside you, isn't on the canvas, and isn't padi-tracked. So whenever the intent is
+> "a split next to me", reach for `padi-tui create --parent`, never raw `kaval-tui
+> create`.
 
 - **Never hardcode the agent CLI.** `<agent>` defaults to the same agent *you*
   are running as (a Claude Code orchestrator spawns `claude`, a codex one

--- a/.claude/skills/codex-debate/SKILL.md
+++ b/.claude/skills/codex-debate/SKILL.md
@@ -24,15 +24,20 @@ contracts.
 You drive the debate from your own turn: spawn a **live `codex` session as a split
 terminal next to you** and take turns with it until you agree. There is no `Workflow`
 tool and no subagent — you *are* one debater, the split codex *is* the other. **All
-the terminal mechanics belong to the [/kolu skill](../kolu/SKILL.md)** — spawning a
+the terminal mechanics belong to the [/kolu skill](../../../apm_modules/_local/agents/.apm/skills/kolu/SKILL.md)** — spawning a
 split, the send→settle→submit sequence, the done-signal, the large-paste file rule,
 and teardown. Read it; this skill only adds the debate protocol on top.
 
 Requires running **inside a kolu terminal** (you need to spawn a sibling split). If
 you can't, the skill is inert — say so and stop.
 
-**Spawn** codex as a split beside you, in this worktree, under `--yolo`, at the chosen
-reasoning effort: `codex --yolo -c model_reasoning_effort=<effort>`. `--yolo` is
+**Spawn** codex as a **split tile beside you** — a sibling on your canvas, NOT a
+detached terminal — in this worktree, under `--yolo`, at the chosen reasoning effort.
+The split is what `--parent` buys: `padi-tui create --parent "$KAVAL_TERMINAL_ID" --
+codex --yolo -c model_reasoning_effort=<effort>` (per [/kolu](../../../apm_modules/_local/agents/.apm/skills/kolu/SKILL.md#provisioning-a-worktreed-agent--padi-tui-create)
+— `$KAVAL_TERMINAL_ID` names your own terminal). **Do NOT reach for raw `kaval-tui
+create`**: it spawns a detached, standalone terminal that isn't a split beside you and
+isn't on the canvas — the exact wrong shape for a debate you drive turn-by-turn. `--yolo` is
 **required, not a convenience**: the two moves that make this engine work — codex
 *writing* its verdict file and *pinging* your terminal (a unix-socket write) — are both
 **denied by every codex sandbox** (`read-only` and `workspace-write` both block the
@@ -361,7 +366,7 @@ next-round rebuttal), and `answer-claude-N.md` / `answer-codex-N.md` / `candidat
 `answer-<slug>.md` for answer mode. **None of this feeds the PR comment** — that is a
 compact commit table (step 4); the debate's per-round detail lives in the commit messages.
 There are **no** workflow or `codex exec` scripts; the engine is this protocol plus the
-[/kolu skill](../kolu/SKILL.md).
+[/kolu skill](../../../apm_modules/_local/agents/.apm/skills/kolu/SKILL.md).
 
 This skill is generated from `agents/.apm/skills/codex-debate/`; edit the source there
 and keep the generated `.claude/` and `.agents/` copies identical in the same commit

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -171,6 +171,15 @@ kaval-tui wait "$id" --until idle:800 --timeout 600000   # block until the turn 
 - **`--timeout <ms>`** caps the wait and **fails loud (exit 2)** so a wedged agent
   can't hang the loop. If the terminal **exits** before the condition fires,
   `wait` exits **3** (the agent you were driving died). Met → exit **0**.
+  > **A foreground `wait` also runs inside YOUR OWN harness's tool timeout.** A
+  > held `kaval-tui wait "$id" --timeout <big-ms>` (e.g. a long `--until match:` on
+  > another agent's verdict) blocks *your* Bash call, and most agent harnesses cap a
+  > single tool call at ~2 minutes by default — so a `--timeout 1200000` wait is
+  > **SIGKILLed at ~2 min (exit 143)** while the agent you're watching is perfectly
+  > fine. Two ways out: **prefer ending your turn** and being woken by the other
+  > side's ping (the event-driven loop — see `/codex-debate`) instead of holding a
+  > wait; or, if you *must* hold it, **raise the Bash call's own timeout to exceed
+  > the `--timeout`** so the harness doesn't kill it first.
 - **`--json`** → one result frame per outcome: `{ id, result, … }`, where
   `result` is `met`/`timeout`/`gone`/`interrupted`/`closed`. A `met` frame adds
   `fired` (`idle`/`match`), `elapsedMs`, and `matchedLine` on a match — so a
@@ -210,6 +219,18 @@ git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo'
 padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent> <mode-flags>
 # e.g. `-- claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
 ```
+
+> **A split tile BESIDE you — `--parent "$KAVAL_TERMINAL_ID"`.** When you want the
+> new terminal to open as a **split beside your own** (a sibling tile on the same
+> canvas — e.g. driving a live `codex` reviewer per `/codex-debate`), pass
+> **`--parent <your-terminal-id>`**, using your self-knowledge var
+> `$KAVAL_TERMINAL_ID` (see *Reach*): `padi-tui create --parent "$KAVAL_TERMINAL_ID"
+> -- codex --yolo …`. Add `--worktree`/`--repo` too if the split should also get its
+> own worktree; omit them and the split opens in your cwd. **`kaval-tui create` is
+> NOT a split** — it spawns a *detached, standalone* terminal that isn't a tile
+> beside you, isn't on the canvas, and isn't padi-tracked. So whenever the intent is
+> "a split next to me", reach for `padi-tui create --parent`, never raw `kaval-tui
+> create`.
 
 - **Never hardcode the agent CLI.** `<agent>` defaults to the same agent *you*
   are running as (a Claude Code orchestrator spawns `claude`, a codex one

--- a/agents/.apm/skills/codex-debate/SKILL.md
+++ b/agents/.apm/skills/codex-debate/SKILL.md
@@ -31,8 +31,13 @@ and teardown. Read it; this skill only adds the debate protocol on top.
 Requires running **inside a kolu terminal** (you need to spawn a sibling split). If
 you can't, the skill is inert — say so and stop.
 
-**Spawn** codex as a split beside you, in this worktree, under `--yolo`, at the chosen
-reasoning effort: `codex --yolo -c model_reasoning_effort=<effort>`. `--yolo` is
+**Spawn** codex as a **split tile beside you** — a sibling on your canvas, NOT a
+detached terminal — in this worktree, under `--yolo`, at the chosen reasoning effort.
+The split is what `--parent` buys: `padi-tui create --parent "$KAVAL_TERMINAL_ID" --
+codex --yolo -c model_reasoning_effort=<effort>` (per [/kolu](../kolu/SKILL.md#provisioning-a-worktreed-agent--padi-tui-create)
+— `$KAVAL_TERMINAL_ID` names your own terminal). **Do NOT reach for raw `kaval-tui
+create`**: it spawns a detached, standalone terminal that isn't a split beside you and
+isn't on the canvas — the exact wrong shape for a debate you drive turn-by-turn. `--yolo` is
 **required, not a convenience**: the two moves that make this engine work — codex
 *writing* its verdict file and *pinging* your terminal (a unix-socket write) — are both
 **denied by every codex sandbox** (`read-only` and `workspace-write` both block the

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -171,6 +171,15 @@ kaval-tui wait "$id" --until idle:800 --timeout 600000   # block until the turn 
 - **`--timeout <ms>`** caps the wait and **fails loud (exit 2)** so a wedged agent
   can't hang the loop. If the terminal **exits** before the condition fires,
   `wait` exits **3** (the agent you were driving died). Met → exit **0**.
+  > **A foreground `wait` also runs inside YOUR OWN harness's tool timeout.** A
+  > held `kaval-tui wait "$id" --timeout <big-ms>` (e.g. a long `--until match:` on
+  > another agent's verdict) blocks *your* Bash call, and most agent harnesses cap a
+  > single tool call at ~2 minutes by default — so a `--timeout 1200000` wait is
+  > **SIGKILLed at ~2 min (exit 143)** while the agent you're watching is perfectly
+  > fine. Two ways out: **prefer ending your turn** and being woken by the other
+  > side's ping (the event-driven loop — see `/codex-debate`) instead of holding a
+  > wait; or, if you *must* hold it, **raise the Bash call's own timeout to exceed
+  > the `--timeout`** so the harness doesn't kill it first.
 - **`--json`** → one result frame per outcome: `{ id, result, … }`, where
   `result` is `met`/`timeout`/`gone`/`interrupted`/`closed`. A `met` frame adds
   `fired` (`idle`/`match`), `elapsedMs`, and `matchedLine` on a match — so a
@@ -210,6 +219,18 @@ git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo'
 padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent> <mode-flags>
 # e.g. `-- claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
 ```
+
+> **A split tile BESIDE you — `--parent "$KAVAL_TERMINAL_ID"`.** When you want the
+> new terminal to open as a **split beside your own** (a sibling tile on the same
+> canvas — e.g. driving a live `codex` reviewer per `/codex-debate`), pass
+> **`--parent <your-terminal-id>`**, using your self-knowledge var
+> `$KAVAL_TERMINAL_ID` (see *Reach*): `padi-tui create --parent "$KAVAL_TERMINAL_ID"
+> -- codex --yolo …`. Add `--worktree`/`--repo` too if the split should also get its
+> own worktree; omit them and the split opens in your cwd. **`kaval-tui create` is
+> NOT a split** — it spawns a *detached, standalone* terminal that isn't a tile
+> beside you, isn't on the canvas, and isn't padi-tracked. So whenever the intent is
+> "a split next to me", reach for `padi-tui create --parent`, never raw `kaval-tui
+> create`.
 
 - **Never hardcode the agent CLI.** `<agent>` defaults to the same agent *you*
   are running as (a Claude Code orchestrator spawns `claude`, a codex one

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-14T17:32:15.041207+00:00'
+generated_at: '2026-07-15T15:26:33.185158+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -53,23 +53,23 @@ dependencies:
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .agents/skills/be-review/SKILL.md: sha256:52f2bec94dbc54fdb4d3fe20e737e52773b6d8c6b233b313ea2718a0348ecde1
     .agents/skills/be/SKILL.md: sha256:e7ad6d775802d78e80bf3e541581240d5933185de527aa00e58354bfeabd7b9e
-    .agents/skills/codex-debate/SKILL.md: sha256:66904b17763ba2f051f99cb648415ed46255c2e74d741b2a5142cb7ccda2f50f
+    .agents/skills/codex-debate/SKILL.md: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .agents/skills/kolu/SKILL.md: sha256:b7251179cca93c0d2039007bd262c76f48a928d33442e1f65b3b8c05873113d9
+    .agents/skills/kolu/SKILL.md: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
     .agents/skills/lens-debate/SKILL.md: sha256:55d66489372d73317a2f92d751f42bf3cf22ee2314ceb250e62fc4011d41920d
     .agents/skills/lens-debate/debate.workflow.js: sha256:24837b4679accd542f35fcd773847235bced09b98d28f95a211fb008ca5016da
-    .agents/skills/orchestrator/SKILL.md: sha256:1e6786852fddbbdecc0c0e122d705ba59724b748d583dbc1eb7e1e04f637e61e
+    .agents/skills/orchestrator/SKILL.md: sha256:21d96242073907087aa29a25e19387d4d284dea616161e93877ddc9d9ca0ba1d
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:d139698f1dbd1ee6edf459c65abd112708a7193abccc5312a8310a9fa7c8f963
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .claude/skills/be-review/SKILL.md: sha256:52f2bec94dbc54fdb4d3fe20e737e52773b6d8c6b233b313ea2718a0348ecde1
     .claude/skills/be/SKILL.md: sha256:e7ad6d775802d78e80bf3e541581240d5933185de527aa00e58354bfeabd7b9e
-    .claude/skills/codex-debate/SKILL.md: sha256:66904b17763ba2f051f99cb648415ed46255c2e74d741b2a5142cb7ccda2f50f
+    .claude/skills/codex-debate/SKILL.md: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .claude/skills/kolu/SKILL.md: sha256:b7251179cca93c0d2039007bd262c76f48a928d33442e1f65b3b8c05873113d9
+    .claude/skills/kolu/SKILL.md: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
     .claude/skills/lens-debate/SKILL.md: sha256:55d66489372d73317a2f92d751f42bf3cf22ee2314ceb250e62fc4011d41920d
     .claude/skills/lens-debate/debate.workflow.js: sha256:24837b4679accd542f35fcd773847235bced09b98d28f95a211fb008ca5016da
-    .claude/skills/orchestrator/SKILL.md: sha256:1e6786852fddbbdecc0c0e122d705ba59724b748d583dbc1eb7e1e04f637e61e
+    .claude/skills/orchestrator/SKILL.md: sha256:21d96242073907087aa29a25e19387d4d284dea616161e93877ddc9d9ca0ba1d
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:d139698f1dbd1ee6edf459c65abd112708a7193abccc5312a8310a9fa7c8f963
   source: local
@@ -449,7 +449,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:66904b17763ba2f051f99cb648415ed46255c2e74d741b2a5142cb7ccda2f50f
+  content_hash: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
 - kind: project-relative
   target: agents
   value: .agents/skills/dev-server
@@ -674,7 +674,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:b7251179cca93c0d2039007bd262c76f48a928d33442e1f65b3b8c05873113d9
+  content_hash: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
 - kind: project-relative
   target: agents
   value: .agents/skills/lens-debate
@@ -827,7 +827,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:1e6786852fddbbdecc0c0e122d705ba59724b748d583dbc1eb7e1e04f637e61e
+  content_hash: sha256:21d96242073907087aa29a25e19387d4d284dea616161e93877ddc9d9ca0ba1d
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1413,7 +1413,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:66904b17763ba2f051f99cb648415ed46255c2e74d741b2a5142cb7ccda2f50f
+  content_hash: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
 - kind: project-relative
   target: claude
   value: .claude/skills/dev-server
@@ -1638,7 +1638,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:b7251179cca93c0d2039007bd262c76f48a928d33442e1f65b3b8c05873113d9
+  content_hash: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
 - kind: project-relative
   target: claude
   value: .claude/skills/lens-debate
@@ -1791,7 +1791,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:1e6786852fddbbdecc0c0e122d705ba59724b748d583dbc1eb7e1e04f637e61e
+  content_hash: sha256:21d96242073907087aa29a25e19387d4d284dea616161e93877ddc9d9ca0ba1d
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel


### PR DESCRIPTION
**`/codex-debate` says "spawn a split beside you" three times but never gave the command** — it delegates all terminal mechanics to `/kolu`, and `/kolu` documented only `kaval-tui create` (a detached, standalone terminal) and `padi-tui create --worktree` (a fresh worktree on a new branch). Neither is a split tile beside the driver. So a `/be` run (SR8.a, [#1835](https://github.com/juspay/kolu/pull/1835)) fell through to raw `kaval-tui create` to spawn its codex reviewer, landing it as a **separate terminal instead of a split** — a gap the human had to flag mid-run. This closes that gap by baking the split command into both skills, so the next run reaches for it unprompted.

The real mechanism was in the CLI all along: `padi-tui create --parent <id>` opens the new terminal as a **split tile of `<id>`**, and every kolu terminal already exports its own id as `$KAVAL_TERMINAL_ID`. That one flag was undocumented in the skill that owns terminal mechanics.

### The edits

| Skill | Change |
| --- | --- |
| `/kolu` | Document `padi-tui create --parent "$KAVAL_TERMINAL_ID"` as the *split-tile-beside-you* mechanism, and state plainly that `kaval-tui create` is **not** a split (detached, off-canvas, not padi-tracked) |
| `/codex-debate` | Make the spawn line concrete — `padi-tui create --parent "$KAVAL_TERMINAL_ID" -- codex --yolo …` — and warn off raw `kaval-tui create` |
| `/kolu` (done-signal) | Warn that a foreground `kaval-tui wait --timeout <big>` is **SIGKILLed by the harness's own ~2-min tool timeout** (exit 143) while the watched agent is fine — end your turn (ping-driven) or raise the Bash call's timeout |

The second `/kolu` edit engineers out a related snag from the same run: a held `kaval-tui wait --timeout 1200000` was killed at 2m0s by the default per-tool timeout, costing a wasted cycle before the driver switched to sub-timeout windows.

> Sources live in `agents/.apm/skills/**`; the `.claude/` and `.agents/` copies plus `apm.lock.yaml` are regenerated by `just ai::apm` and ride the same commit. _(The lock also heals a pre-existing stale `orchestrator` hash — that file's content is byte-identical to master.)_

Provenance: `/self-improve` over session `ebf0dbac-611a-4a90-9b14-36591eec2709`.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._