### PR TITLE
fix(code-tab): stop the file-tree selection shimmer (focus-drag loop)

### DIFF
--- a/packages/solid-pierre/package.json
+++ b/packages/solid-pierre/package.json
@@ -17,7 +17,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "happy-dom": "^20.8.9",
     "typescript": "^7.0.2",
+    "vite-plugin-solid": "^2.11.0",
     "vitest": "^4.1.0"
   },
   "dependencies": {

--- a/packages/solid-pierre/src/FileTree.focus.test.tsx
+++ b/packages/solid-pierre/src/FileTree.focus.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+/**
+ * Regression for the Code-tab file-tree "shimmer" — juspay/kolu#1841.
+ *
+ * The wrapper's selection effect re-applies `props.selectedPath` into Pierre and
+ * reveals the row with `scrollToPath`. Calling it with NO options makes Pierre
+ * DRAG keyboard focus onto the row — `FileTreeController.scrollToPath` runs
+ * `if (options?.focus !== false) this.#setFocusedIndex(...)`. On the live app that
+ * focus move makes Pierre re-emit `onSelectionChange` reporting the NEIGHBOUR row,
+ * which the host writes back into the per-terminal selection store, which re-runs
+ * this effect — a self-sustaining focus/selection loop between two adjacent files
+ * at ~60-120 Hz. A Chrome profile of the live loop shows `HTMLElement.focus()` as
+ * the single hottest leaf, rooted in Pierre's render.
+ *
+ * The fix: reveal the row WITHOUT stealing focus — `scrollToPath(path,
+ * { focus: false })`. This test pins that invariant; it FAILS on the pre-fix code
+ * (bare `scrollToPath(path)`).
+ */
+import { createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// A tiny stand-in for `@pierre/trees`' `FileTree`: it models only what the wrapper
+// touches. `scrollToPath` is a shared spy so the test can inspect the options the
+// wrapper passes. Selecting/deselecting re-emits `onSelectionChange` synchronously,
+// exactly as Pierre's `#applySelection` does.
+const { scrollToPath } = vi.hoisted(() => ({ scrollToPath: vi.fn() }));
+
+vi.mock("@pierre/trees", () => {
+  class MockFileTree {
+    #selected = new Set<string>();
+    #onSel?: (paths: readonly string[]) => void;
+    // biome-ignore lint/suspicious/noExplicitAny: test double for Pierre's options
+    constructor(opts: any) {
+      this.#onSel = opts?.onSelectionChange;
+      for (const p of opts?.initialSelectedPaths ?? []) this.#selected.add(p);
+    }
+    render() {}
+    getSelectedPaths(): readonly string[] {
+      return [...this.#selected];
+    }
+    getItem(path: string) {
+      // A file handle (no `expand`, so `expandDirs`' `"expand" in item` skips it).
+      return {
+        select: () => {
+          this.#selected.add(path);
+          this.#emit();
+        },
+        deselect: () => {
+          this.#selected.delete(path);
+          this.#emit();
+        },
+      };
+    }
+    scrollToPath = scrollToPath;
+    batch() {}
+    setGitStatus() {}
+    cleanUp() {}
+    #emit() {
+      this.#onSel?.(this.getSelectedPaths());
+    }
+  }
+  return { FileTree: MockFileTree };
+});
+
+// Import AFTER the mock so the wrapper closes over the mocked class.
+import { FileTree } from "./FileTree";
+
+const disposers: Array<() => void> = [];
+afterEach(() => {
+  for (const d of disposers.splice(0)) d();
+  scrollToPath.mockReset();
+});
+
+function mount(node: () => unknown): void {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  // biome-ignore lint/suspicious/noExplicitAny: render's JSX element type
+  const dispose = render(node as any, container);
+  disposers.push(dispose, () => container.remove());
+}
+
+const PATHS = ["examples/ChatBot.lean", "examples/Markdown.lean", "README.md"];
+
+describe("FileTree selection reveal (shimmer #1841)", () => {
+  it("reveals an externally-applied selection WITHOUT dragging keyboard focus", () => {
+    const onError = vi.fn();
+    const [sel, setSel] = createSignal<string | null>("examples/ChatBot.lean");
+    mount(() => (
+      <FileTree
+        paths={PATHS}
+        selectedPath={sel()}
+        onSelect={() => {}}
+        onError={onError}
+      />
+    ));
+    // Ignore the mount-time reveal; the loop is the REACTIVE re-application.
+    scrollToPath.mockClear();
+
+    setSel("examples/Markdown.lean");
+
+    // The row must be revealed WITHOUT stealing focus — the pre-fix code passes
+    // no options, which drags focus and drives the neighbour-echo loop.
+    expect(scrollToPath).toHaveBeenCalledWith("examples/Markdown.lean", {
+      focus: false,
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/solid-pierre/src/FileTree.tsx
+++ b/packages/solid-pierre/src/FileTree.tsx
@@ -356,8 +356,16 @@ export const FileTree: Component<FileTreeProps> = (props) => {
             // `select()` marks aria-selected but doesn't move the
             // virtualizer; deep paths in large worktrees would stay
             // off-screen until the user scrolled. `scrollToPath`
-            // reveals the row.
-            tree?.scrollToPath(path);
+            // reveals the row — with `{ focus: false }` so it does NOT
+            // drag Pierre's keyboard focus. Re-applying selection here on
+            // every store change; letting it move focus made Pierre re-emit
+            // `onSelectionChange` at the NEIGHBOUR row, which the host wrote
+            // back into the selection store, re-running this effect — a
+            // self-sustaining focus/selection loop between two adjacent files
+            // (juspay/kolu#1841; a profile of the loop showed `focus()` as the
+            // hottest leaf). Revealing without focus keeps the row on-screen
+            // while leaving focus where the user put it.
+            tree?.scrollToPath(path, { focus: false });
           }
         }, props.onError);
       },

--- a/packages/solid-pierre/vitest.config.ts
+++ b/packages/solid-pierre/vitest.config.ts
@@ -1,0 +1,40 @@
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // The Solid JSX transform — so the `.test.tsx` render harness compiles its JSX
+  // to real DOM. Harmless for the `.test.ts` files (no JSX); the per-file
+  // `// @vitest-environment happy-dom` docblock opts ONLY the render tests into a
+  // DOM, leaving the pure-logic tests (pathReconcile) on the node default.
+  plugins: [solid()],
+  // solid-js' package.json picks `dist/server.cjs` (the SSR build) under Node's
+  // `"node"` export condition, where `createEffect` is a no-op. The render test
+  // exercises real reactive effects, so pin every solid import to the browser
+  // bundle directly — mirrors `packages/surface/vitest.config.ts`.
+  resolve: {
+    alias: {
+      "solid-js/store": new URL(
+        "./node_modules/solid-js/store/dist/store.js",
+        import.meta.url,
+      ).pathname,
+      "solid-js/web": new URL(
+        "./node_modules/solid-js/web/dist/web.js",
+        import.meta.url,
+      ).pathname,
+      "solid-js": new URL(
+        "./node_modules/solid-js/dist/solid.js",
+        import.meta.url,
+      ).pathname,
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    // `vite-plugin-solid` defaults the env to `jsdom`; pin it back to `node` so the
+    // pure-logic `.test.ts` files run plain, and let ONLY the render `.test.tsx`
+    // opt into a DOM via its `// @vitest-environment happy-dom` docblock.
+    environment: "node",
+    // Pull solid-js THROUGH Vitest's transform so the aliases above unify every
+    // solid import onto ONE browser-build core (same fix surface + client carry).
+    server: { deps: { inline: [/solid-js/] } },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1116,9 +1116,15 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.8.9
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vite-plugin-solid:
+        specifier: ^2.11.0
+        version: 2.11.11(solid-js@1.9.11)(vite@8.1.0(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.19.15)(happy-dom@20.8.9)(vite@8.1.0(@types/node@22.19.15)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))

--- a/website/src/content/changelog/unreleased.mdx
+++ b/website/src/content/changelog/unreleased.mdx
@@ -2,6 +2,10 @@
 version: Unreleased
 ---
 
+### Fixed
+
+- <Change title="The Code tab no longer flickers between two files in a runaway loop" pr={1843} tags={["code tab"]}>Clicking around files in the Code tab could suddenly latch into a **runaway loop** — the selection flickered between two neighbouring files many times a second, pegging a CPU core, and only stopped when you switched terminals. The cause: revealing the selected row also **dragged the tree's keyboard focus**, which made the tree re-pick the *neighbour*, which re-revealed it, and so on. Revealing a row now keeps it on-screen **without** moving focus, so the loop can't start. Affected both **All files** and **Branch/Local** diff views.</Change>
+
 ### Changed
 
 - <Change title="Upload larger bug-repro videos to agents" pr={1760} tags={["terminal"]}>Dropped files can now be up to **50 MB**, up from 10 MB. That leaves room for a useful app screen recording while keeping the current whole-file upload path bounded. The same limit applies to every allowed file type and to pasted clipboard images, with matching checks in the browser and padi.</Change>


### PR DESCRIPTION
Resolves #1841.

## The bug

In the Code tab, selecting files could latch into a runaway loop where the tree **selection ping-pongs between two adjacent files** at ~60–120 Hz (once per animation frame), pegging a CPU core and firing an ~800 msg/sec RPC storm. It self-sustains with no further input and stops only when you switch terminals. Seen in both **All files** and **Branch (diff)** modes.

## Root cause (from a Chrome Performance profile of the live loop)

Hottest self-time in the loop:

| samples | leaf | rooted in |
|--:|---|---|
| 4745 | `HTMLElement.focus()` | `@pierre/trees` render |
| 4187 | selection `setAttribute` (recursive row re-render) | same |
| 1839 | `WebSocket.send` | per-flip content-query re-fire |
| 1191 | `AbortController.abort` | per-flip supersede |

The wrapper's selection effect re-applies `props.selectedPath` into Pierre and reveals the row with `scrollToPath` — with **no options**, which makes Pierre **drag keyboard focus** onto the row (`FileTreeController.scrollToPath`: `if (options?.focus !== false) this.#setFocusedIndex(...)`). That focus move makes Pierre re-emit `onSelectionChange` reporting the **neighbouring** row, which `handleSelect` writes back into the per-terminal `selectedFileByMode` store, which re-runs the effect → `scrollToPath` drags focus again. The `send`/`abort` churn is the downstream symptom: each flip changes the selected file, so the content/diff `createPolledQuery` re-fires an RPC and aborts the previous.

## The fix

One line: reveal the row **without** stealing focus — `scrollToPath(path, { focus: false })` ([`FileTree.tsx`](../blob/bug-shimmer/packages/solid-pierre/src/FileTree.tsx)). The row still scrolls on-screen; keyboard focus stays where the user put it; the neighbour-echo loop can't start.

## Test

`FileTree.focus.test.tsx` mounts the wrapper over a `@pierre/trees` stand-in, drives an external `selectedPath` change, and asserts the reveal happens **without** dragging focus (`scrollToPath(path, { focus: false })`). It is **red on the pre-fix code** (bare `scrollToPath(path)`) and green after. Adds `vite-plugin-solid` + `happy-dom` to render the Solid component, mirroring `packages/surface`.

## Verification status

- ✅ Unit test: red → green; the profile-confirmed focus-drag is removed.
- ⚠️ **End-to-end not yet confirmed on a live instance.** The runaway loop is a timing/latch race that only manifests on a busy instance (many terminals + agents churning metadata); a quiet dev box does not reproduce it. The fix removes the exact engine the profile fingered (`focus()`), but it should be confirmed on an instance that actually reproduces the shimmer — e.g. `nix run --refresh github:juspay/kolu/bug-shimmer`.

## Notes
- Only the reactive selection reveal (`FileTree.tsx:360`) is changed. The mount-time reveal (`:237`) still focuses the initial selection; it is a one-shot, not part of the sustained loop (`#1758` already covers remount churn), so it is left as-is.
