### PR TITLE
debug(#1841): log selection writes to capture the shimmer's root cause (DO NOT MERGE)

### DIFF
--- a/packages/client/src/right-panel/useRightPanel.ts
+++ b/packages/client/src/right-panel/useRightPanel.ts
@@ -384,6 +384,29 @@ export function useRightPanel() {
     selectedFile: (mode: CodeTabView): string | null =>
       activeState().selectedFileByMode?.[mode] ?? null,
     setSelectedFile: (mode: CodeTabView, path: string | null) => {
+      // [SHIMMER-DEBUG #1841] Every selection write funnels through here. Capture
+      // each with its call stack so a live repro of the shimmer reveals whether the
+      // loop is ONE writer echoing itself or TWO writers fighting. Remove before merge.
+      if (typeof window !== "undefined") {
+        const g = window as unknown as {
+          __selWrites?: Array<{
+            t: number;
+            mode: string;
+            path: string | null;
+            stack: string;
+          }>;
+        };
+        const buf = (g.__selWrites ??= []);
+        const stack = (new Error().stack || "")
+          .split("\n")
+          .slice(2, 10)
+          .map((l) => l.trim())
+          .join(" | ");
+        buf.push({ t: Math.round(performance.now()), mode, path, stack });
+        if (buf.length > 500) buf.shift();
+        if (buf.length <= 80)
+          console.log("[SEL-WRITE]", mode, JSON.stringify(path), stack);
+      }
       mutateActive((s) => {
         const cur = s.selectedFileByMode ?? {};
         if (path === null) {


### PR DESCRIPTION
> **⚠️ DO NOT MERGE — temporary debug instrumentation for #1841.**

The Pierre beta.5 bump (#1844) did **not** fix the Code-tab selection shimmer, so this branch captures the actual root cause instead of theorizing.

## What it adds
23 lines in `useRightPanel.ts`: a logger on `setSelectedFile` — the single chokepoint every `selectedFileByMode` write funnels through. Each write is recorded with `{ t, mode, path, stack }` into `window.__selWrites` (capped at 500).

## How to use
1. Deploy: `nix run --refresh github:juspay/kolu/debug/shimmer-selwrites`
2. Trigger the shimmer (agent actively editing files in a folder + clicking files in it).
3. Let it loop ~2s, then in DevTools: `copy(JSON.stringify(window.__selWrites))`.

## What it answers
Whether the loop is **one writer echoing itself** (`onSelectionChange` → `handleSelect` — the "Pierre's echoed re-selects" path the code already names) or **two writers fighting** (e.g. membership-clear vs the front-door resolution effect), plus the exact stack of each. That names the culprit so the real fix + a mechanism-faithful test can follow.

Refs #1841.
