### PR TITLE
fix(solid-pierre): move #1846's biome-ignore to the line it suppresses (master is red on ci::biome)

### DIFF
--- a/packages/solid-pierre/src/FileTree.gesture.test.tsx
+++ b/packages/solid-pierre/src/FileTree.gesture.test.tsx
@@ -68,7 +68,6 @@ function mount(onSelect: (p: string | null) => void): HTMLElement {
   const wrapper = document.createElement("div");
   document.body.appendChild(wrapper);
   const dispose = render(
-    // biome-ignore lint/suspicious/noExplicitAny: render's JSX element type
     (() => (
       <FileTree
         paths={PATHS}
@@ -77,6 +76,7 @@ function mount(onSelect: (p: string | null) => void): HTMLElement {
           throw e;
         }}
       />
+      // biome-ignore lint/suspicious/noExplicitAny: render's JSX element type
     )) as any,
     wrapper,
   );


### PR DESCRIPTION
Master's tip is **red on `ci::biome`**: #1846's `FileTree.gesture.test.tsx` placed its `biome-ignore` pragma 9 lines above the `as any` it targets (inside `render()`'s argument, above the JSX thunk), so `--error-on-warnings` flags both an **unused suppression** and an **unsuppressed explicit-any** — inherited by every branch that merges master.

One-line move of the pragma to the line it suppresses. Surfaced by #1842's master merge (which carries the same fix in-branch so its own CI can green); this PR lands it on master independently. Verified: `biome check --error-on-warnings` clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)