### PR TITLE
fix(website): rename shadowing toString import (master ci::biome latent red)

### DIFF
--- a/website/src/remarkChangelog.ts
+++ b/website/src/remarkChangelog.ts
@@ -1,5 +1,5 @@
 import GithubSlugger from "github-slugger";
-import { toString } from "mdast-util-to-string";
+import { toString as mdastToString } from "mdast-util-to-string";
 import type { Nodes, Root } from "mdast";
 import type {
   MdxJsxAttribute,
@@ -64,7 +64,7 @@ const headingStats = (tree: Root): ChangelogStat[] => {
 
   for (const node of tree.children) {
     if (node.type === "heading" && node.depth === 3) {
-      const label = toString(node).trim();
+      const label = mdastToString(node).trim();
       active = { label, key: slugger.slug(label), count: 0 };
       stats.push(active);
     } else if (node.type === "list" && active) {
@@ -89,7 +89,7 @@ export function remarkChangelog() {
     const headingSlugger = new GithubSlugger();
     const prefix = changelogReleaseKey(version);
     visit(tree, "heading", (node) => {
-      const id = `${prefix}-${headingSlugger.slug(toString(node))}`;
+      const id = `${prefix}-${headingSlugger.slug(mdastToString(node))}`;
       node.data ??= {};
       node.data.hProperties = { ...node.data.hProperties, id };
     });


### PR DESCRIPTION
One-line master hotfix: `website/src/remarkChangelog.ts` (from #1842) imports `toString` from `mdast-util-to-string`, tripping biome's `noShadowRestrictedNames` — deterministic, so **every PR that merges current master inherits a ci::biome red** (first bitten: #1852, which carries the same rename in-branch; LIVE-FIX flagged it for a source fix).

Verified with ci::biome's exact invocation (`biome lint --error-on-warnings`): red on master's file, clean after `toString as mdastToString`. Same rename #1852 used, so the two resolve cleanly.

How it slipped: #1842's final commits added this `.ts` file after its last full-pipeline run, and the coordinator-scoped re-gate (`ci::nix` — the "docs-only" class gate) doesn't run biome. The class call was wrong at the margin: a PR that adds website *code* needs the code gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)