### PR TITLE
fix(lint): master ci::biome red — dashboard skill assets (from #1854)

### DIFF
--- a/.agents/skills/orchestrator/dashboard/index.html
+++ b/.agents/skills/orchestrator/dashboard/index.html
@@ -49,8 +49,6 @@
     padding:0 12px; display:grid; gap:10px;
     grid-template-columns:repeat(auto-fill, minmax(360px, 1fr));
   }
-  section > h2 { grid-column:1 / -1 }
-  section > .pills, section > .empty { grid-column:1 / -1 }
   h2 {
     font-size:11px; font-weight:700; letter-spacing:.28em; text-transform:uppercase;
     color:var(--dim); margin:22px 4px 2px; display:flex; align-items:center; gap:8px;
@@ -157,6 +155,9 @@
   .pill.s-done  { border-color:transparent; color:var(--done); background:var(--panel2) }
   .pill.s-q     { border-style:dashed; color:var(--dim) }
   .empty { color:var(--dim); font-size:12px; padding:2px 4px }
+  /* grid spans — placed AFTER the base h2/.pills/.empty rules (specificity order) */
+  section > h2 { grid-column:1 / -1 }
+  section > .pills, section > .empty { grid-column:1 / -1 }
 
   details.shipped summary {
     cursor:pointer; list-style:none; font-size:11px; font-weight:700;

--- a/.agents/skills/orchestrator/dashboard/index.js
+++ b/.agents/skills/orchestrator/dashboard/index.js
@@ -103,7 +103,9 @@ const trackCard = (item) => {
     if (n.lane.sub) shd.appendChild($("span", "lane-sub", n.lane.sub));
     sub.appendChild(shd);
     const srail = $("div", "rail rail-sub");
-    n.lane.nodes.forEach((x) => srail.appendChild(station(x)));
+    n.lane.nodes.forEach((x) => {
+      srail.appendChild(station(x));
+    });
     sub.appendChild(srail);
     card.appendChild(sub);
   });
@@ -122,7 +124,7 @@ let painted = false;
 function render(d) {
   const meta = document.getElementById("meta");
   meta.replaceChildren($("span", "live-dot"),
-    $("span", null, `${d.project ? d.project + " · " : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
+    $("span", null, `${d.project ? `${d.project} · ` : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
 
   const root = document.getElementById("root");
   root.replaceChildren();
@@ -145,13 +147,17 @@ function render(d) {
   const q = section("Merge queue · srid");
   const qp = $("div", "pills");
   if (d.queue.length === 0) qp.appendChild($("span", "empty", "— empty —"));
-  d.queue.forEach((n) => qp.appendChild(pill(n)));
+  d.queue.forEach((n) => {
+    qp.appendChild(pill(n));
+  });
   q.appendChild(qp);
 
   const det = $("details", "shipped");
   det.appendChild($("summary", null, `Shipped today · ${d.shipped.length}`));
   const sp = $("div", "pills");
-  d.shipped.forEach((n) => sp.appendChild(pill({ ...n, state: "done" })));
+  d.shipped.forEach((n) => {
+    sp.appendChild(pill({ ...n, state: "done" }));
+  });
   det.appendChild(sp);
   root.appendChild(det);
 

--- a/.claude/skills/orchestrator/dashboard/index.html
+++ b/.claude/skills/orchestrator/dashboard/index.html
@@ -49,8 +49,6 @@
     padding:0 12px; display:grid; gap:10px;
     grid-template-columns:repeat(auto-fill, minmax(360px, 1fr));
   }
-  section > h2 { grid-column:1 / -1 }
-  section > .pills, section > .empty { grid-column:1 / -1 }
   h2 {
     font-size:11px; font-weight:700; letter-spacing:.28em; text-transform:uppercase;
     color:var(--dim); margin:22px 4px 2px; display:flex; align-items:center; gap:8px;
@@ -157,6 +155,9 @@
   .pill.s-done  { border-color:transparent; color:var(--done); background:var(--panel2) }
   .pill.s-q     { border-style:dashed; color:var(--dim) }
   .empty { color:var(--dim); font-size:12px; padding:2px 4px }
+  /* grid spans — placed AFTER the base h2/.pills/.empty rules (specificity order) */
+  section > h2 { grid-column:1 / -1 }
+  section > .pills, section > .empty { grid-column:1 / -1 }
 
   details.shipped summary {
     cursor:pointer; list-style:none; font-size:11px; font-weight:700;

--- a/.claude/skills/orchestrator/dashboard/index.js
+++ b/.claude/skills/orchestrator/dashboard/index.js
@@ -103,7 +103,9 @@ const trackCard = (item) => {
     if (n.lane.sub) shd.appendChild($("span", "lane-sub", n.lane.sub));
     sub.appendChild(shd);
     const srail = $("div", "rail rail-sub");
-    n.lane.nodes.forEach((x) => srail.appendChild(station(x)));
+    n.lane.nodes.forEach((x) => {
+      srail.appendChild(station(x));
+    });
     sub.appendChild(srail);
     card.appendChild(sub);
   });
@@ -122,7 +124,7 @@ let painted = false;
 function render(d) {
   const meta = document.getElementById("meta");
   meta.replaceChildren($("span", "live-dot"),
-    $("span", null, `${d.project ? d.project + " · " : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
+    $("span", null, `${d.project ? `${d.project} · ` : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
 
   const root = document.getElementById("root");
   root.replaceChildren();
@@ -145,13 +147,17 @@ function render(d) {
   const q = section("Merge queue · srid");
   const qp = $("div", "pills");
   if (d.queue.length === 0) qp.appendChild($("span", "empty", "— empty —"));
-  d.queue.forEach((n) => qp.appendChild(pill(n)));
+  d.queue.forEach((n) => {
+    qp.appendChild(pill(n));
+  });
   q.appendChild(qp);
 
   const det = $("details", "shipped");
   det.appendChild($("summary", null, `Shipped today · ${d.shipped.length}`));
   const sp = $("div", "pills");
-  d.shipped.forEach((n) => sp.appendChild(pill({ ...n, state: "done" })));
+  d.shipped.forEach((n) => {
+    sp.appendChild(pill({ ...n, state: "done" }));
+  });
   det.appendChild(sp);
   root.appendChild(det);
 

--- a/agents/.apm/skills/orchestrator/dashboard/index.html
+++ b/agents/.apm/skills/orchestrator/dashboard/index.html
@@ -49,8 +49,6 @@
     padding:0 12px; display:grid; gap:10px;
     grid-template-columns:repeat(auto-fill, minmax(360px, 1fr));
   }
-  section > h2 { grid-column:1 / -1 }
-  section > .pills, section > .empty { grid-column:1 / -1 }
   h2 {
     font-size:11px; font-weight:700; letter-spacing:.28em; text-transform:uppercase;
     color:var(--dim); margin:22px 4px 2px; display:flex; align-items:center; gap:8px;
@@ -157,6 +155,9 @@
   .pill.s-done  { border-color:transparent; color:var(--done); background:var(--panel2) }
   .pill.s-q     { border-style:dashed; color:var(--dim) }
   .empty { color:var(--dim); font-size:12px; padding:2px 4px }
+  /* grid spans — placed AFTER the base h2/.pills/.empty rules (specificity order) */
+  section > h2 { grid-column:1 / -1 }
+  section > .pills, section > .empty { grid-column:1 / -1 }
 
   details.shipped summary {
     cursor:pointer; list-style:none; font-size:11px; font-weight:700;

--- a/agents/.apm/skills/orchestrator/dashboard/index.js
+++ b/agents/.apm/skills/orchestrator/dashboard/index.js
@@ -103,7 +103,9 @@ const trackCard = (item) => {
     if (n.lane.sub) shd.appendChild($("span", "lane-sub", n.lane.sub));
     sub.appendChild(shd);
     const srail = $("div", "rail rail-sub");
-    n.lane.nodes.forEach((x) => srail.appendChild(station(x)));
+    n.lane.nodes.forEach((x) => {
+      srail.appendChild(station(x));
+    });
     sub.appendChild(srail);
     card.appendChild(sub);
   });
@@ -122,7 +124,7 @@ let painted = false;
 function render(d) {
   const meta = document.getElementById("meta");
   meta.replaceChildren($("span", "live-dot"),
-    $("span", null, `${d.project ? d.project + " · " : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
+    $("span", null, `${d.project ? `${d.project} · ` : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
 
   const root = document.getElementById("root");
   root.replaceChildren();
@@ -145,13 +147,17 @@ function render(d) {
   const q = section("Merge queue · srid");
   const qp = $("div", "pills");
   if (d.queue.length === 0) qp.appendChild($("span", "empty", "— empty —"));
-  d.queue.forEach((n) => qp.appendChild(pill(n)));
+  d.queue.forEach((n) => {
+    qp.appendChild(pill(n));
+  });
   q.appendChild(qp);
 
   const det = $("details", "shipped");
   det.appendChild($("summary", null, `Shipped today · ${d.shipped.length}`));
   const sp = $("div", "pills");
-  d.shipped.forEach((n) => sp.appendChild(pill({ ...n, state: "done" })));
+  d.shipped.forEach((n) => {
+    sp.appendChild(pill({ ...n, state: "done" }));
+  });
   det.appendChild(sp);
   root.appendChild(det);
 


### PR DESCRIPTION
Master hotfix: #1854 (the docs/atlas branch) carried the orchestrator dashboard's `index.{js,html}` — **code files that never met the code gates** — leaving master deterministically red on `ci::biome` (3 `useIterableCallbackReturn`, 1 `useTemplate`, 3 `noDescendingSpecificity`). Every PR merging master inherits the red until this lands; first bitten: #1862 (TENURE2), holding its CI on this.

Fixes: braced the value-returning `forEach` callbacks, templated the one concat, moved the `section > *` grid-span rules below the base rules they override. All three skill copies synced. `just ci::biome` green locally (1370 files). Renderer behavior unchanged (parse-verified; DOM calls identical).

Same failure class as #1856: a "docs" branch whose diff grew code — the class gate is a property of the diff, not the label. This time the offending committer was the coordinator itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)