### PR TITLE
Install attic from the repo's pinned nixpkgs; drop attic-action

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -41,26 +41,35 @@ jobs:
             extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
             accept-flake-config = true
 
-      # attic-action installs attic by resolving UNPINNED nixpkgs-unstable
-      # through the GitHub API at run time — one API 503 fails the job (it
-      # did, repo-wide, 2026-07-16), and even green runs re-fetch an unpinned
-      # rev. The action skips its install when `attic` is already on PATH, so
-      # pre-install it from the repo's own npins-pinned nixpkgs: the exact
-      # tarball URL nix/nixpkgs.nix builds from (no ref resolution, no
-      # api.github.com), with attic-client substituted from cache.nixos.org.
-      - name: Install attic from pinned nixpkgs
-        run: nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"
-
-      # Logs in, uses the cache as a substituter, and at job end pushes every
-      # store path this run produced. Its attic install is a no-op — the step
-      # above already put a pinned attic on PATH. Needs a Nix new enough for
+      # ryanccn/attic-action used to do the install/login/push below, but it
+      # installs attic by resolving UNPINNED nixpkgs-unstable through the
+      # GitHub API at run time — one API 503 fails the job (it did, repo-wide,
+      # 2026-07-16), and even green runs re-fetch an unpinned rev. Its logic
+      # is four CLI calls, so do them directly, installing attic from the
+      # repo's own npins-pinned nixpkgs: the exact tarball URL nix/nixpkgs.nix
+      # builds from (no ref resolution, no api.github.com), with attic-client
+      # substituted from cache.nixos.org. Needs a Nix new enough for
       # `nix profile add` (hence v35 above — v31's 2.29 only had
-      # `profile install`, which is why #1731 dropped this action).
-      - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
-        with:
-          endpoint: https://cache.nixos.asia
-          cache: oss
-          token: ${{ secrets.ATTIC_TOKEN }}
+      # `profile install`, which is why #1731 dropped the action once before).
+      # No `attic use` — the nix_conf above already wires the substituter.
+      - name: Install attic (pinned) and log in
+        run: |
+          nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"
+          attic login --set-default oss https://cache.nixos.asia '${{ secrets.ATTIC_TOKEN }}'
+          nix path-info --all | sort > "$RUNNER_TEMP/pre-build-paths"
 
       - name: Build
         run: nix build -L --print-out-paths
+
+      # Push every store path the build produced (post minus pre snapshot,
+      # minus .drv/.check/.lock clutter) — same set attic-action pushed from
+      # its post step, without the action.
+      - name: Push to Attic
+        # Explicit `shell: bash` turns on pipefail, so a failure anywhere in
+        # the pipe fails the step — not just the final `attic push`.
+        shell: bash
+        run: |
+          nix path-info --all | sort \
+            | comm -13 "$RUNNER_TEMP/pre-build-paths" - \
+            | grep -Ev '\.(drv|drv\.chroot|check|lock)$' \
+            | attic push --stdin oss

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -41,9 +41,20 @@ jobs:
             extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
             accept-flake-config = true
 
-      # Installs attic, logs in, uses the cache as a substituter, and at job
-      # end pushes every store path this run produced. Needs a Nix new enough
-      # for `nix profile add` (hence v35 above — v31's 2.29 only had
+      # attic-action installs attic by resolving UNPINNED nixpkgs-unstable
+      # through the GitHub API at run time — one API 503 fails the job (it
+      # did, repo-wide, 2026-07-16), and even green runs re-fetch an unpinned
+      # rev. The action skips its install when `attic` is already on PATH, so
+      # pre-install it from the repo's own npins-pinned nixpkgs: the exact
+      # tarball URL nix/nixpkgs.nix builds from (no ref resolution, no
+      # api.github.com), with attic-client substituted from cache.nixos.org.
+      - name: Install attic from pinned nixpkgs
+        run: nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"
+
+      # Logs in, uses the cache as a substituter, and at job end pushes every
+      # store path this run produced. Its attic install is a no-op — the step
+      # above already put a pinned attic on PATH. Needs a Nix new enough for
+      # `nix profile add` (hence v35 above — v31's 2.29 only had
       # `profile install`, which is why #1731 dropped this action).
       - uses: ryanccn/attic-action@5635a15ef0c5462194ffbd05d1daeddc74625c3a # v0.5.0
         with:


### PR DESCRIPTION
**The `nix-cache` workflow no longer resolves unpinned `nixpkgs-unstable` through the GitHub API at run time** — the structural fragility that took it down repo-wide today, and the reason every run re-fetched an unpinned rev even when healthy.

### Failure chain (from [the failing job](https://github.com/juspay/kolu/actions/runs/29540330229/job/87761746323))

1. `unable to download 'https://api.github.com/repos/NixOS/nixpkgs/commits/nixpkgs-unstable': HTTP error 503` ×5 → `nix ... failed with exit code 1`
2. → `Unable to locate executable file: attic` (the install never produced the binary)
3. → post-step ENOENT on `attic-action-store-paths` (noise)

The root is `ryanccn/attic-action@v0.5.0`: its install step runs `nix profile add github:NixOS/nixpkgs/nixpkgs-unstable#attic-client`, so every run gambles on a live API ref-resolution.

### The fix

The action's real work is four CLI calls, so the workflow now does them directly and **installs attic from the repo's own npins pin** — the exact tarball URL `nix/nixpkgs.nix` builds from:

| attic-action did | now |
| --- | --- |
| `nix profile add github:NixOS/nixpkgs/nixpkgs-unstable#attic-client` (unpinned, API ref-resolution) | `nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"` (pinned, no api.github.com, substituted from cache.nixos.org) |
| `attic login --set-default …` | same, direct |
| `attic use oss` (duplicate substituter config) | dropped — `nix_conf` already wires the substituter + public key |
| pre-build `nix path-info` snapshot, post-step diff → `attic push --stdin` | same diff, as an explicit `Push to Attic` step with `pipefail` |

_No retry knobs — a retry around an unpinned fetch would be a fallback, not a fix. The pinned URL removes the failure mode instead._ The push-set semantics are unchanged (everything the run added to the store, minus `.drv`/`.check`/`.lock` clutter); one deliberate difference is that a failed build now pushes nothing, where the action's post-step pushed partial paths.

> Validation: this workflow runs on `pull_request`, so its own run on this PR is the test — watch `nix-cache` on both matrix legs.

_Generated by [`/be`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8`)._