### PR TITLE
Scrub leaked CLAUDE_CODE_CHILD_SESSION at every kolu-terminal agent spawn

### DIFF
--- a/.agents/skills/kolu/SKILL.md
+++ b/.agents/skills/kolu/SKILL.md
@@ -32,7 +32,8 @@ terminals a **kolu owns** (the last section); for raw terminals, reach for
 ## The loop
 
 ```sh
-id=$(kaval-tui create --json -- claude | jq -r .id)            # spawn the inner agent
+id=$(kaval-tui create --json -- env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID \
+    claude | jq -r .id)                                        # spawn the inner agent (env -u: below)
 kaval-tui send  "$id" "refactor the parser to use a lexer"     # 1. the text (no Enter)
 kaval-tui wait  "$id" --until idle:300                         # 2. observe the TUI settle
 kaval-tui send  "$id" --key Enter                              # 3. submit (its own command)
@@ -45,6 +46,21 @@ Leaf commands, all `kaval-tui`: **create** (spawn) · **send** (write text, OR a
 Submitting a prompt is its **own** `send --key Enter`, sent *after* you observe
 the TUI settle — never folded into the text send. Why: a same-breath Enter races
 the TUI's paste debounce and is silently dropped. See the next section.
+
+> **⚠️ ALWAYS spawn the agent behind `env -u CLAUDE_CODE_CHILD_SESSION -u
+> CLAUDE_CODE_SESSION_ID` — or a spawned Claude's transcript is silently lost.**
+> `create` (kaval-tui and padi-tui alike) hands the **caller's full environment**
+> to the new PTY. When the driver is itself a Claude Code session, its Bash tool
+> exports `CLAUDE_CODE_CHILD_SESSION=1` and `CLAUDE_CODE_SESSION_ID=<driver's
+> id>` — and an interactive `claude` launched with `CLAUDE_CODE_CHILD_SESSION=1`
+> treats itself as a nested child session and **never persists its root
+> transcript** (`~/.claude/projects/…/<session>.jsonl`) nor registers in the
+> session registry. Nothing errors; the run just becomes un-resumable after a
+> crash and un-minable forever (`/self-improve`, `/blog-post` mine those
+> transcripts). All three lanes of one 2026-07-16 campaign lost their entire
+> histories this way. The `env -u` prefix is a no-op for non-Claude agents
+> (`codex`, `opencode`) and for drivers that aren't Claude sessions, so bake it
+> into **every** spawn rather than remembering when it matters.
 
 > **Read with `snapshot --viewport`, not `| tail`.** A bare `snapshot` prints the
 > **whole scrollback** — thousands of lines on a long-running or compacted agent —
@@ -216,8 +232,10 @@ it with `padi-tui create` instead of raw `kaval-tui create`:
 
 ```sh
 git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
-padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent> <mode-flags>
-# e.g. `-- claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- \
+    env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID <agent> <mode-flags>
+# e.g. `… claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
+# (env -u: the transcript-loss guard from "The loop" — padi-tui create leaks your env too)
 ```
 
 > **A split tile BESIDE you — `--parent "$KAVAL_TERMINAL_ID"`.** When you want the

--- a/.agents/skills/orchestrator/dashboard/index.html
+++ b/.agents/skills/orchestrator/dashboard/index.html
@@ -49,8 +49,6 @@
     padding:0 12px; display:grid; gap:10px;
     grid-template-columns:repeat(auto-fill, minmax(360px, 1fr));
   }
-  section > h2 { grid-column:1 / -1 }
-  section > .pills, section > .empty { grid-column:1 / -1 }
   h2 {
     font-size:11px; font-weight:700; letter-spacing:.28em; text-transform:uppercase;
     color:var(--dim); margin:22px 4px 2px; display:flex; align-items:center; gap:8px;
@@ -157,6 +155,12 @@
   .pill.s-done  { border-color:transparent; color:var(--done); background:var(--panel2) }
   .pill.s-q     { border-style:dashed; color:var(--dim) }
   .empty { color:var(--dim); font-size:12px; padding:2px 4px }
+
+  /* Full-width rows inside the section grid — placed AFTER the generic
+     h2/.pills/.empty definitions (biome noDescendingSpecificity); the
+     property sets don't overlap, so the cascade is unchanged. */
+  section > h2 { grid-column:1 / -1 }
+  section > .pills, section > .empty { grid-column:1 / -1 }
 
   details.shipped summary {
     cursor:pointer; list-style:none; font-size:11px; font-weight:700;

--- a/.agents/skills/orchestrator/dashboard/index.js
+++ b/.agents/skills/orchestrator/dashboard/index.js
@@ -62,9 +62,7 @@ const station = (n) => {
 const trackCard = (item) => {
   // headline: prefer the deepest live detail; else the macro rail's own
   const liveNode = item.nodes.find((n) => n.lane);
-  const head = liveNode
-    ? headline(liveNode.lane.nodes)
-    : headline(item.nodes);
+  const head = liveNode ? headline(liveNode.lane.nodes) : headline(item.nodes);
   const card = $("div", `card s-${head.state ?? "q"}`);
 
   const hd = $("div", "card-head");
@@ -97,13 +95,21 @@ const trackCard = (item) => {
     if (!n.lane) return;
     const sub = $("div", "sub-lane");
     const shd = $("div", "sub-head");
-    const t = $(n.lane.href ? "a" : "span", "sub-title", n.lane.name ?? n.label);
-    if (n.lane.href) { t.href = n.lane.href; t.title = "jump to this agent's terminal"; badge(t, n.lane.href); }
+    const t = $(
+      n.lane.href ? "a" : "span",
+      "sub-title",
+      n.lane.name ?? n.label,
+    );
+    if (n.lane.href) {
+      t.href = n.lane.href;
+      t.title = "jump to this agent's terminal";
+      badge(t, n.lane.href);
+    }
     shd.appendChild(t);
     if (n.lane.sub) shd.appendChild($("span", "lane-sub", n.lane.sub));
     sub.appendChild(shd);
     const srail = $("div", "rail rail-sub");
-    n.lane.nodes.forEach((x) => srail.appendChild(station(x)));
+    for (const x of n.lane.nodes) srail.appendChild(station(x));
     sub.appendChild(srail);
     card.appendChild(sub);
   });
@@ -112,7 +118,10 @@ const trackCard = (item) => {
 
 const pill = (n) => {
   const el = $(n.href ? "a" : "span", `pill s-${n.state ?? "q"}`, n.label);
-  if (n.href) { el.href = n.href; badge(el, n.href); }
+  if (n.href) {
+    el.href = n.href;
+    badge(el, n.href);
+  }
   if (n.title) el.title = n.title;
   return el;
 };
@@ -121,8 +130,14 @@ let painted = false;
 
 function render(d) {
   const meta = document.getElementById("meta");
-  meta.replaceChildren($("span", "live-dot"),
-    $("span", null, `${d.project ? d.project + " · " : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
+  meta.replaceChildren(
+    $("span", "live-dot"),
+    $(
+      "span",
+      null,
+      `${d.project ? `${d.project} · ` : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`,
+    ),
+  );
 
   const root = document.getElementById("root");
   root.replaceChildren();
@@ -145,13 +160,13 @@ function render(d) {
   const q = section("Merge queue · srid");
   const qp = $("div", "pills");
   if (d.queue.length === 0) qp.appendChild($("span", "empty", "— empty —"));
-  d.queue.forEach((n) => qp.appendChild(pill(n)));
+  for (const n of d.queue) qp.appendChild(pill(n));
   q.appendChild(qp);
 
   const det = $("details", "shipped");
   det.appendChild($("summary", null, `Shipped today · ${d.shipped.length}`));
   const sp = $("div", "pills");
-  d.shipped.forEach((n) => sp.appendChild(pill({ ...n, state: "done" })));
+  for (const n of d.shipped) sp.appendChild(pill({ ...n, state: "done" }));
   det.appendChild(sp);
   root.appendChild(det);
 
@@ -170,9 +185,15 @@ function reloadData() {
   s.src = `${DATA_SRC}?t=${Date.now()}`;
   s.onerror = () => {
     const meta = document.getElementById("meta");
-    if (meta) meta.replaceChildren(
-      $("span", "live-dot"),
-      $("span", null, "orchestrator-data.js not found at the project root — retrying in 30s"));
+    if (meta)
+      meta.replaceChildren(
+        $("span", "live-dot"),
+        $(
+          "span",
+          null,
+          "orchestrator-data.js not found at the project root — retrying in 30s",
+        ),
+      );
   };
   document.body.appendChild(s);
 }

--- a/.claude/skills/kolu/SKILL.md
+++ b/.claude/skills/kolu/SKILL.md
@@ -32,7 +32,8 @@ terminals a **kolu owns** (the last section); for raw terminals, reach for
 ## The loop
 
 ```sh
-id=$(kaval-tui create --json -- claude | jq -r .id)            # spawn the inner agent
+id=$(kaval-tui create --json -- env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID \
+    claude | jq -r .id)                                        # spawn the inner agent (env -u: below)
 kaval-tui send  "$id" "refactor the parser to use a lexer"     # 1. the text (no Enter)
 kaval-tui wait  "$id" --until idle:300                         # 2. observe the TUI settle
 kaval-tui send  "$id" --key Enter                              # 3. submit (its own command)
@@ -45,6 +46,21 @@ Leaf commands, all `kaval-tui`: **create** (spawn) · **send** (write text, OR a
 Submitting a prompt is its **own** `send --key Enter`, sent *after* you observe
 the TUI settle — never folded into the text send. Why: a same-breath Enter races
 the TUI's paste debounce and is silently dropped. See the next section.
+
+> **⚠️ ALWAYS spawn the agent behind `env -u CLAUDE_CODE_CHILD_SESSION -u
+> CLAUDE_CODE_SESSION_ID` — or a spawned Claude's transcript is silently lost.**
+> `create` (kaval-tui and padi-tui alike) hands the **caller's full environment**
+> to the new PTY. When the driver is itself a Claude Code session, its Bash tool
+> exports `CLAUDE_CODE_CHILD_SESSION=1` and `CLAUDE_CODE_SESSION_ID=<driver's
+> id>` — and an interactive `claude` launched with `CLAUDE_CODE_CHILD_SESSION=1`
+> treats itself as a nested child session and **never persists its root
+> transcript** (`~/.claude/projects/…/<session>.jsonl`) nor registers in the
+> session registry. Nothing errors; the run just becomes un-resumable after a
+> crash and un-minable forever (`/self-improve`, `/blog-post` mine those
+> transcripts). All three lanes of one 2026-07-16 campaign lost their entire
+> histories this way. The `env -u` prefix is a no-op for non-Claude agents
+> (`codex`, `opencode`) and for drivers that aren't Claude sessions, so bake it
+> into **every** spawn rather than remembering when it matters.
 
 > **Read with `snapshot --viewport`, not `| tail`.** A bare `snapshot` prints the
 > **whole scrollback** — thousands of lines on a long-running or compacted agent —
@@ -216,8 +232,10 @@ it with `padi-tui create` instead of raw `kaval-tui create`:
 
 ```sh
 git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
-padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent> <mode-flags>
-# e.g. `-- claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- \
+    env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID <agent> <mode-flags>
+# e.g. `… claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
+# (env -u: the transcript-loss guard from "The loop" — padi-tui create leaks your env too)
 ```
 
 > **A split tile BESIDE you — `--parent "$KAVAL_TERMINAL_ID"`.** When you want the

--- a/.claude/skills/orchestrator/dashboard/index.html
+++ b/.claude/skills/orchestrator/dashboard/index.html
@@ -49,8 +49,6 @@
     padding:0 12px; display:grid; gap:10px;
     grid-template-columns:repeat(auto-fill, minmax(360px, 1fr));
   }
-  section > h2 { grid-column:1 / -1 }
-  section > .pills, section > .empty { grid-column:1 / -1 }
   h2 {
     font-size:11px; font-weight:700; letter-spacing:.28em; text-transform:uppercase;
     color:var(--dim); margin:22px 4px 2px; display:flex; align-items:center; gap:8px;
@@ -157,6 +155,12 @@
   .pill.s-done  { border-color:transparent; color:var(--done); background:var(--panel2) }
   .pill.s-q     { border-style:dashed; color:var(--dim) }
   .empty { color:var(--dim); font-size:12px; padding:2px 4px }
+
+  /* Full-width rows inside the section grid — placed AFTER the generic
+     h2/.pills/.empty definitions (biome noDescendingSpecificity); the
+     property sets don't overlap, so the cascade is unchanged. */
+  section > h2 { grid-column:1 / -1 }
+  section > .pills, section > .empty { grid-column:1 / -1 }
 
   details.shipped summary {
     cursor:pointer; list-style:none; font-size:11px; font-weight:700;

--- a/.claude/skills/orchestrator/dashboard/index.js
+++ b/.claude/skills/orchestrator/dashboard/index.js
@@ -62,9 +62,7 @@ const station = (n) => {
 const trackCard = (item) => {
   // headline: prefer the deepest live detail; else the macro rail's own
   const liveNode = item.nodes.find((n) => n.lane);
-  const head = liveNode
-    ? headline(liveNode.lane.nodes)
-    : headline(item.nodes);
+  const head = liveNode ? headline(liveNode.lane.nodes) : headline(item.nodes);
   const card = $("div", `card s-${head.state ?? "q"}`);
 
   const hd = $("div", "card-head");
@@ -97,13 +95,21 @@ const trackCard = (item) => {
     if (!n.lane) return;
     const sub = $("div", "sub-lane");
     const shd = $("div", "sub-head");
-    const t = $(n.lane.href ? "a" : "span", "sub-title", n.lane.name ?? n.label);
-    if (n.lane.href) { t.href = n.lane.href; t.title = "jump to this agent's terminal"; badge(t, n.lane.href); }
+    const t = $(
+      n.lane.href ? "a" : "span",
+      "sub-title",
+      n.lane.name ?? n.label,
+    );
+    if (n.lane.href) {
+      t.href = n.lane.href;
+      t.title = "jump to this agent's terminal";
+      badge(t, n.lane.href);
+    }
     shd.appendChild(t);
     if (n.lane.sub) shd.appendChild($("span", "lane-sub", n.lane.sub));
     sub.appendChild(shd);
     const srail = $("div", "rail rail-sub");
-    n.lane.nodes.forEach((x) => srail.appendChild(station(x)));
+    for (const x of n.lane.nodes) srail.appendChild(station(x));
     sub.appendChild(srail);
     card.appendChild(sub);
   });
@@ -112,7 +118,10 @@ const trackCard = (item) => {
 
 const pill = (n) => {
   const el = $(n.href ? "a" : "span", `pill s-${n.state ?? "q"}`, n.label);
-  if (n.href) { el.href = n.href; badge(el, n.href); }
+  if (n.href) {
+    el.href = n.href;
+    badge(el, n.href);
+  }
   if (n.title) el.title = n.title;
   return el;
 };
@@ -121,8 +130,14 @@ let painted = false;
 
 function render(d) {
   const meta = document.getElementById("meta");
-  meta.replaceChildren($("span", "live-dot"),
-    $("span", null, `${d.project ? d.project + " · " : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
+  meta.replaceChildren(
+    $("span", "live-dot"),
+    $(
+      "span",
+      null,
+      `${d.project ? `${d.project} · ` : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`,
+    ),
+  );
 
   const root = document.getElementById("root");
   root.replaceChildren();
@@ -145,13 +160,13 @@ function render(d) {
   const q = section("Merge queue · srid");
   const qp = $("div", "pills");
   if (d.queue.length === 0) qp.appendChild($("span", "empty", "— empty —"));
-  d.queue.forEach((n) => qp.appendChild(pill(n)));
+  for (const n of d.queue) qp.appendChild(pill(n));
   q.appendChild(qp);
 
   const det = $("details", "shipped");
   det.appendChild($("summary", null, `Shipped today · ${d.shipped.length}`));
   const sp = $("div", "pills");
-  d.shipped.forEach((n) => sp.appendChild(pill({ ...n, state: "done" })));
+  for (const n of d.shipped) sp.appendChild(pill({ ...n, state: "done" }));
   det.appendChild(sp);
   root.appendChild(det);
 
@@ -170,9 +185,15 @@ function reloadData() {
   s.src = `${DATA_SRC}?t=${Date.now()}`;
   s.onerror = () => {
     const meta = document.getElementById("meta");
-    if (meta) meta.replaceChildren(
-      $("span", "live-dot"),
-      $("span", null, "orchestrator-data.js not found at the project root — retrying in 30s"));
+    if (meta)
+      meta.replaceChildren(
+        $("span", "live-dot"),
+        $(
+          "span",
+          null,
+          "orchestrator-data.js not found at the project root — retrying in 30s",
+        ),
+      );
   };
   document.body.appendChild(s);
 }

--- a/agents/.apm/skills/kolu/SKILL.md
+++ b/agents/.apm/skills/kolu/SKILL.md
@@ -32,7 +32,8 @@ terminals a **kolu owns** (the last section); for raw terminals, reach for
 ## The loop
 
 ```sh
-id=$(kaval-tui create --json -- claude | jq -r .id)            # spawn the inner agent
+id=$(kaval-tui create --json -- env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID \
+    claude | jq -r .id)                                        # spawn the inner agent (env -u: below)
 kaval-tui send  "$id" "refactor the parser to use a lexer"     # 1. the text (no Enter)
 kaval-tui wait  "$id" --until idle:300                         # 2. observe the TUI settle
 kaval-tui send  "$id" --key Enter                              # 3. submit (its own command)
@@ -45,6 +46,21 @@ Leaf commands, all `kaval-tui`: **create** (spawn) · **send** (write text, OR a
 Submitting a prompt is its **own** `send --key Enter`, sent *after* you observe
 the TUI settle — never folded into the text send. Why: a same-breath Enter races
 the TUI's paste debounce and is silently dropped. See the next section.
+
+> **⚠️ ALWAYS spawn the agent behind `env -u CLAUDE_CODE_CHILD_SESSION -u
+> CLAUDE_CODE_SESSION_ID` — or a spawned Claude's transcript is silently lost.**
+> `create` (kaval-tui and padi-tui alike) hands the **caller's full environment**
+> to the new PTY. When the driver is itself a Claude Code session, its Bash tool
+> exports `CLAUDE_CODE_CHILD_SESSION=1` and `CLAUDE_CODE_SESSION_ID=<driver's
+> id>` — and an interactive `claude` launched with `CLAUDE_CODE_CHILD_SESSION=1`
+> treats itself as a nested child session and **never persists its root
+> transcript** (`~/.claude/projects/…/<session>.jsonl`) nor registers in the
+> session registry. Nothing errors; the run just becomes un-resumable after a
+> crash and un-minable forever (`/self-improve`, `/blog-post` mine those
+> transcripts). All three lanes of one 2026-07-16 campaign lost their entire
+> histories this way. The `env -u` prefix is a no-op for non-Claude agents
+> (`codex`, `opencode`) and for drivers that aren't Claude sessions, so bake it
+> into **every** spawn rather than remembering when it matters.
 
 > **Read with `snapshot --viewport`, not `| tail`.** A bare `snapshot` prints the
 > **whole scrollback** — thousands of lines on a long-running or compacted agent —
@@ -216,8 +232,10 @@ it with `padi-tui create` instead of raw `kaval-tui create`:
 
 ```sh
 git -C /abs/path/to/repo pull --ff-only     # the worktree is cut from the repo's CURRENT checkout
-padi-tui create --repo /abs/path/to/repo --worktree my-branch -- <agent> <mode-flags>
-# e.g. `-- claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
+padi-tui create --repo /abs/path/to/repo --worktree my-branch -- \
+    env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID <agent> <mode-flags>
+# e.g. `… claude --dangerously-skip-permissions` — prints the new terminal's id; padi owns it
+# (env -u: the transcript-loss guard from "The loop" — padi-tui create leaks your env too)
 ```
 
 > **A split tile BESIDE you — `--parent "$KAVAL_TERMINAL_ID"`.** When you want the

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-16T19:42:43.648645+00:00'
+generated_at: '2026-07-17T04:45:03.998195+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -24,6 +24,8 @@ dependencies:
   - .agents/skills/lens-debate/debate.workflow.js
   - .agents/skills/orchestrator
   - .agents/skills/orchestrator/SKILL.md
+  - .agents/skills/orchestrator/dashboard/index.html
+  - .agents/skills/orchestrator/dashboard/index.js
   - .agents/skills/perfection-review
   - .agents/skills/perfection-review/SKILL.md
   - .agents/skills/surface
@@ -45,6 +47,8 @@ dependencies:
   - .claude/skills/lens-debate/debate.workflow.js
   - .claude/skills/orchestrator
   - .claude/skills/orchestrator/SKILL.md
+  - .claude/skills/orchestrator/dashboard/index.html
+  - .claude/skills/orchestrator/dashboard/index.js
   - .claude/skills/perfection-review
   - .claude/skills/perfection-review/SKILL.md
   - .claude/skills/surface
@@ -55,10 +59,12 @@ dependencies:
     .agents/skills/be/SKILL.md: sha256:92ba0686110e83b93af94ffa8b5b87b561229e6169e56b8b03253200e0bf6b44
     .agents/skills/codex-debate/SKILL.md: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .agents/skills/kolu/SKILL.md: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
+    .agents/skills/kolu/SKILL.md: sha256:0c98f834d5f9031449d100890611e5d43bd81ab00b1e6f05fd772ba2aa82c277
     .agents/skills/lens-debate/SKILL.md: sha256:34638d461c9341ff433360dcddc8d20a82b15a8307cb894b9c638b644a5b12c5
     .agents/skills/lens-debate/debate.workflow.js: sha256:52f3c6e85209e5204f06fe39f7191aa5b37f05b6b29dd71f6a28ed09192ba10b
-    .agents/skills/orchestrator/SKILL.md: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+    .agents/skills/orchestrator/SKILL.md: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+    .agents/skills/orchestrator/dashboard/index.html: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+    .agents/skills/orchestrator/dashboard/index.js: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
@@ -66,10 +72,12 @@ dependencies:
     .claude/skills/be/SKILL.md: sha256:92ba0686110e83b93af94ffa8b5b87b561229e6169e56b8b03253200e0bf6b44
     .claude/skills/codex-debate/SKILL.md: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
-    .claude/skills/kolu/SKILL.md: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
+    .claude/skills/kolu/SKILL.md: sha256:0c98f834d5f9031449d100890611e5d43bd81ab00b1e6f05fd772ba2aa82c277
     .claude/skills/lens-debate/SKILL.md: sha256:34638d461c9341ff433360dcddc8d20a82b15a8307cb894b9c638b644a5b12c5
     .claude/skills/lens-debate/debate.workflow.js: sha256:52f3c6e85209e5204f06fe39f7191aa5b37f05b6b29dd71f6a28ed09192ba10b
-    .claude/skills/orchestrator/SKILL.md: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+    .claude/skills/orchestrator/SKILL.md: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+    .claude/skills/orchestrator/dashboard/index.html: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+    .claude/skills/orchestrator/dashboard/index.js: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
   source: local
@@ -674,7 +682,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
+  content_hash: sha256:0c98f834d5f9031449d100890611e5d43bd81ab00b1e6f05fd772ba2aa82c277
 - kind: project-relative
   target: agents
   value: .agents/skills/lens-debate
@@ -827,7 +835,25 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+  content_hash: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+- kind: project-relative
+  target: agents
+  value: .agents/skills/orchestrator/dashboard/index.html
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+- kind: project-relative
+  target: agents
+  value: .agents/skills/orchestrator/dashboard/index.js
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1638,7 +1664,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
+  content_hash: sha256:0c98f834d5f9031449d100890611e5d43bd81ab00b1e6f05fd772ba2aa82c277
 - kind: project-relative
   target: claude
   value: .claude/skills/lens-debate
@@ -1791,7 +1817,25 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+  content_hash: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+- kind: project-relative
+  target: claude
+  value: .claude/skills/orchestrator/dashboard/index.html
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/orchestrator/dashboard/index.js
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel


### PR DESCRIPTION
**Every Claude Code agent spawned into a kolu terminal by another Claude session has been silently losing its entire session transcript.** `kaval-tui create` / `padi-tui create` hand the caller's full environment to the new PTY (`kaval-tui/src/main.ts` passes `env: process.env`), and a Claude driver's Bash tool exports `CLAUDE_CODE_CHILD_SESSION=1` — which makes the spawned interactive `claude` treat itself as a nested child session and **never write its root transcript** (`~/.claude/projects/…/<session>.jsonl`) nor register in the session registry. Nothing errors; the run just becomes un-resumable after a crash and permanently un-minable (`/self-improve` and `/blog-post` both mine those transcripts).

This PR bakes the guard into the `kolu` skill's spawn commands — every documented `create` now launches the agent behind `env -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_SESSION_ID`, with a callout explaining why. _The prefix is a no-op for `codex`/`opencode` and for non-Claude drivers, so it's unconditional rather than a remembered special case._

### Evidence ledger

| Claim | Evidence |
| --- | --- |
| All 3 lanes of the 2026-07-16 campaign lost their transcripts | `session-unref`, `kaval-skew`, `shiki-grammar-preload` project dirs under `~/.claude/projects/` contain subagent/tool-result artifacts but **no root `.jsonl`**; the 4 older, hand-launched lanes on the same box all persist normally |
| The leaked env is the discriminator | All 3 affected `claude` processes carry `CLAUDE_CODE_CHILD_SESSION=1` + `CLAUDE_CODE_SESSION_ID=<coordinator's id>` (read from `/proc/<pid>/environ`); the healthy lanes carry neither |
| `CLAUDE_CODE_CHILD_SESSION=1` alone suppresses persistence | Controlled interactive runs (claude 2.1.212, pty via `script`): leaked env → prompt processed, **no transcript**; same run with `env -u` scrub → transcript persists; bisect keeping `CLAUDECODE`/`ENTRYPOINT`/`SESSION_ID` but dropping only `CHILD_SESSION` → **persists** |
| The leak vector is `create`'s env handoff | `packages/kaval-tui/src/main.ts:515` sends `env: process.env` in the create request; the affected lanes' environ even includes the coordinator's `DIRENV_DIR` |
| This broke `/self-improve` itself | Step 1 (`find ~/.claude/projects -name "$SID.jsonl"`) returned zero matches for the UNREF1 run — the transcript this PR's own analysis needed does not exist |

### What rode along

`just ai::apm` regen also caught up the **orchestrator dashboard** generated copies (`.claude/` + `.agents/`), whose committed sources had drifted ahead of the generated tree on master — pre-existing lag, now reconciled so generated == sources again, plus the `apm.lock.yaml` file-manifest entries for them.

> **The durable fix belongs in the product**: `kaval-tui`/`padi-tui` (or the pty-host) could scrub `CLAUDE_CODE_CHILD_SESSION` from the create request unconditionally, making the skill guard unnecessary. This PR is the skill-level default so the next campaign doesn't lose history while that's weighed.

_Provenance: `/self-improve` on session `e69381d8-a561-4190-bc16-98a8bd317e76` (UNREF1 `/be` run). Non-durable observations from that run, recorded here rather than engineered out: machine-wide `nix develop` CA-derivation skew (this PR's gates ran via store-realized pnpm 10.32.1 / biome 2.4.7), and the rasam darwin wedge — both machine-state, not skill defects._

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8[1m]`)._