### PR TITLE
/be interview routes through a coordinator's brief, not AskUserQuestion

### DIFF
--- a/.agents/skills/be/SKILL.md
+++ b/.agents/skills/be/SKILL.md
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 ## 0. Interview (the differentiator)
 
-Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
+Before any work, ask the user via **`AskUserQuestion`** (one call, batched) — **unless a delegating brief routes questions elsewhere.** When you run under a coordinator whose brief says questions go to its terminal (e.g. via `/kolu`, blocking on the reply), that channel *replaces* `AskUserQuestion` for the **whole** interview: write the batch to a file, send a one-line pointer, and block — never open a question dialog in your own PTY, where it hangs unseen until a human happens to look. The brief's route wins even when it only *routes* without naming the tool: reaching for `AskUserQuestion` here is `/be`'s built-in reflex (this *is* the interview step), so treat "a coordinator is driving me" as itself the ban.
 
 - **Plan first?** — write the plan as an **Atlas note** (`docs/atlas/src/content/atlas/<slug>.mdx`) for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing Atlas note or legacy `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).

--- a/.agents/skills/orchestrator/dashboard/index.html
+++ b/.agents/skills/orchestrator/dashboard/index.html
@@ -49,8 +49,6 @@
     padding:0 12px; display:grid; gap:10px;
     grid-template-columns:repeat(auto-fill, minmax(360px, 1fr));
   }
-  section > h2 { grid-column:1 / -1 }
-  section > .pills, section > .empty { grid-column:1 / -1 }
   h2 {
     font-size:11px; font-weight:700; letter-spacing:.28em; text-transform:uppercase;
     color:var(--dim); margin:22px 4px 2px; display:flex; align-items:center; gap:8px;
@@ -157,6 +155,12 @@
   .pill.s-done  { border-color:transparent; color:var(--done); background:var(--panel2) }
   .pill.s-q     { border-style:dashed; color:var(--dim) }
   .empty { color:var(--dim); font-size:12px; padding:2px 4px }
+
+  /* Full-width rows inside the section grid — placed AFTER the generic
+     h2/.pills/.empty definitions (biome noDescendingSpecificity); the
+     property sets don't overlap, so the cascade is unchanged. */
+  section > h2 { grid-column:1 / -1 }
+  section > .pills, section > .empty { grid-column:1 / -1 }
 
   details.shipped summary {
     cursor:pointer; list-style:none; font-size:11px; font-weight:700;

--- a/.agents/skills/orchestrator/dashboard/index.js
+++ b/.agents/skills/orchestrator/dashboard/index.js
@@ -62,9 +62,7 @@ const station = (n) => {
 const trackCard = (item) => {
   // headline: prefer the deepest live detail; else the macro rail's own
   const liveNode = item.nodes.find((n) => n.lane);
-  const head = liveNode
-    ? headline(liveNode.lane.nodes)
-    : headline(item.nodes);
+  const head = liveNode ? headline(liveNode.lane.nodes) : headline(item.nodes);
   const card = $("div", `card s-${head.state ?? "q"}`);
 
   const hd = $("div", "card-head");
@@ -97,13 +95,21 @@ const trackCard = (item) => {
     if (!n.lane) return;
     const sub = $("div", "sub-lane");
     const shd = $("div", "sub-head");
-    const t = $(n.lane.href ? "a" : "span", "sub-title", n.lane.name ?? n.label);
-    if (n.lane.href) { t.href = n.lane.href; t.title = "jump to this agent's terminal"; badge(t, n.lane.href); }
+    const t = $(
+      n.lane.href ? "a" : "span",
+      "sub-title",
+      n.lane.name ?? n.label,
+    );
+    if (n.lane.href) {
+      t.href = n.lane.href;
+      t.title = "jump to this agent's terminal";
+      badge(t, n.lane.href);
+    }
     shd.appendChild(t);
     if (n.lane.sub) shd.appendChild($("span", "lane-sub", n.lane.sub));
     sub.appendChild(shd);
     const srail = $("div", "rail rail-sub");
-    n.lane.nodes.forEach((x) => srail.appendChild(station(x)));
+    for (const x of n.lane.nodes) srail.appendChild(station(x));
     sub.appendChild(srail);
     card.appendChild(sub);
   });
@@ -112,7 +118,10 @@ const trackCard = (item) => {
 
 const pill = (n) => {
   const el = $(n.href ? "a" : "span", `pill s-${n.state ?? "q"}`, n.label);
-  if (n.href) { el.href = n.href; badge(el, n.href); }
+  if (n.href) {
+    el.href = n.href;
+    badge(el, n.href);
+  }
   if (n.title) el.title = n.title;
   return el;
 };
@@ -121,8 +130,14 @@ let painted = false;
 
 function render(d) {
   const meta = document.getElementById("meta");
-  meta.replaceChildren($("span", "live-dot"),
-    $("span", null, `${d.project ? d.project + " · " : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
+  meta.replaceChildren(
+    $("span", "live-dot"),
+    $(
+      "span",
+      null,
+      `${d.project ? `${d.project} · ` : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`,
+    ),
+  );
 
   const root = document.getElementById("root");
   root.replaceChildren();
@@ -145,13 +160,13 @@ function render(d) {
   const q = section("Merge queue · srid");
   const qp = $("div", "pills");
   if (d.queue.length === 0) qp.appendChild($("span", "empty", "— empty —"));
-  d.queue.forEach((n) => qp.appendChild(pill(n)));
+  for (const n of d.queue) qp.appendChild(pill(n));
   q.appendChild(qp);
 
   const det = $("details", "shipped");
   det.appendChild($("summary", null, `Shipped today · ${d.shipped.length}`));
   const sp = $("div", "pills");
-  d.shipped.forEach((n) => sp.appendChild(pill({ ...n, state: "done" })));
+  for (const n of d.shipped) sp.appendChild(pill({ ...n, state: "done" }));
   det.appendChild(sp);
   root.appendChild(det);
 
@@ -170,9 +185,15 @@ function reloadData() {
   s.src = `${DATA_SRC}?t=${Date.now()}`;
   s.onerror = () => {
     const meta = document.getElementById("meta");
-    if (meta) meta.replaceChildren(
-      $("span", "live-dot"),
-      $("span", null, "orchestrator-data.js not found at the project root — retrying in 30s"));
+    if (meta)
+      meta.replaceChildren(
+        $("span", "live-dot"),
+        $(
+          "span",
+          null,
+          "orchestrator-data.js not found at the project root — retrying in 30s",
+        ),
+      );
   };
   document.body.appendChild(s);
 }

--- a/.claude/skills/be/SKILL.md
+++ b/.claude/skills/be/SKILL.md
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 ## 0. Interview (the differentiator)
 
-Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
+Before any work, ask the user via **`AskUserQuestion`** (one call, batched) — **unless a delegating brief routes questions elsewhere.** When you run under a coordinator whose brief says questions go to its terminal (e.g. via `/kolu`, blocking on the reply), that channel *replaces* `AskUserQuestion` for the **whole** interview: write the batch to a file, send a one-line pointer, and block — never open a question dialog in your own PTY, where it hangs unseen until a human happens to look. The brief's route wins even when it only *routes* without naming the tool: reaching for `AskUserQuestion` here is `/be`'s built-in reflex (this *is* the interview step), so treat "a coordinator is driving me" as itself the ban.
 
 - **Plan first?** — write the plan as an **Atlas note** (`docs/atlas/src/content/atlas/<slug>.mdx`) for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing Atlas note or legacy `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).

--- a/.claude/skills/orchestrator/dashboard/index.html
+++ b/.claude/skills/orchestrator/dashboard/index.html
@@ -49,8 +49,6 @@
     padding:0 12px; display:grid; gap:10px;
     grid-template-columns:repeat(auto-fill, minmax(360px, 1fr));
   }
-  section > h2 { grid-column:1 / -1 }
-  section > .pills, section > .empty { grid-column:1 / -1 }
   h2 {
     font-size:11px; font-weight:700; letter-spacing:.28em; text-transform:uppercase;
     color:var(--dim); margin:22px 4px 2px; display:flex; align-items:center; gap:8px;
@@ -157,6 +155,12 @@
   .pill.s-done  { border-color:transparent; color:var(--done); background:var(--panel2) }
   .pill.s-q     { border-style:dashed; color:var(--dim) }
   .empty { color:var(--dim); font-size:12px; padding:2px 4px }
+
+  /* Full-width rows inside the section grid — placed AFTER the generic
+     h2/.pills/.empty definitions (biome noDescendingSpecificity); the
+     property sets don't overlap, so the cascade is unchanged. */
+  section > h2 { grid-column:1 / -1 }
+  section > .pills, section > .empty { grid-column:1 / -1 }
 
   details.shipped summary {
     cursor:pointer; list-style:none; font-size:11px; font-weight:700;

--- a/.claude/skills/orchestrator/dashboard/index.js
+++ b/.claude/skills/orchestrator/dashboard/index.js
@@ -62,9 +62,7 @@ const station = (n) => {
 const trackCard = (item) => {
   // headline: prefer the deepest live detail; else the macro rail's own
   const liveNode = item.nodes.find((n) => n.lane);
-  const head = liveNode
-    ? headline(liveNode.lane.nodes)
-    : headline(item.nodes);
+  const head = liveNode ? headline(liveNode.lane.nodes) : headline(item.nodes);
   const card = $("div", `card s-${head.state ?? "q"}`);
 
   const hd = $("div", "card-head");
@@ -97,13 +95,21 @@ const trackCard = (item) => {
     if (!n.lane) return;
     const sub = $("div", "sub-lane");
     const shd = $("div", "sub-head");
-    const t = $(n.lane.href ? "a" : "span", "sub-title", n.lane.name ?? n.label);
-    if (n.lane.href) { t.href = n.lane.href; t.title = "jump to this agent's terminal"; badge(t, n.lane.href); }
+    const t = $(
+      n.lane.href ? "a" : "span",
+      "sub-title",
+      n.lane.name ?? n.label,
+    );
+    if (n.lane.href) {
+      t.href = n.lane.href;
+      t.title = "jump to this agent's terminal";
+      badge(t, n.lane.href);
+    }
     shd.appendChild(t);
     if (n.lane.sub) shd.appendChild($("span", "lane-sub", n.lane.sub));
     sub.appendChild(shd);
     const srail = $("div", "rail rail-sub");
-    n.lane.nodes.forEach((x) => srail.appendChild(station(x)));
+    for (const x of n.lane.nodes) srail.appendChild(station(x));
     sub.appendChild(srail);
     card.appendChild(sub);
   });
@@ -112,7 +118,10 @@ const trackCard = (item) => {
 
 const pill = (n) => {
   const el = $(n.href ? "a" : "span", `pill s-${n.state ?? "q"}`, n.label);
-  if (n.href) { el.href = n.href; badge(el, n.href); }
+  if (n.href) {
+    el.href = n.href;
+    badge(el, n.href);
+  }
   if (n.title) el.title = n.title;
   return el;
 };
@@ -121,8 +130,14 @@ let painted = false;
 
 function render(d) {
   const meta = document.getElementById("meta");
-  meta.replaceChildren($("span", "live-dot"),
-    $("span", null, `${d.project ? d.project + " · " : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`));
+  meta.replaceChildren(
+    $("span", "live-dot"),
+    $(
+      "span",
+      null,
+      `${d.project ? `${d.project} · ` : ""}${d.updated} · coordinator ${d.coordinator} · data reloads 30s · hover for detail`,
+    ),
+  );
 
   const root = document.getElementById("root");
   root.replaceChildren();
@@ -145,13 +160,13 @@ function render(d) {
   const q = section("Merge queue · srid");
   const qp = $("div", "pills");
   if (d.queue.length === 0) qp.appendChild($("span", "empty", "— empty —"));
-  d.queue.forEach((n) => qp.appendChild(pill(n)));
+  for (const n of d.queue) qp.appendChild(pill(n));
   q.appendChild(qp);
 
   const det = $("details", "shipped");
   det.appendChild($("summary", null, `Shipped today · ${d.shipped.length}`));
   const sp = $("div", "pills");
-  d.shipped.forEach((n) => sp.appendChild(pill({ ...n, state: "done" })));
+  for (const n of d.shipped) sp.appendChild(pill({ ...n, state: "done" }));
   det.appendChild(sp);
   root.appendChild(det);
 
@@ -170,9 +185,15 @@ function reloadData() {
   s.src = `${DATA_SRC}?t=${Date.now()}`;
   s.onerror = () => {
     const meta = document.getElementById("meta");
-    if (meta) meta.replaceChildren(
-      $("span", "live-dot"),
-      $("span", null, "orchestrator-data.js not found at the project root — retrying in 30s"));
+    if (meta)
+      meta.replaceChildren(
+        $("span", "live-dot"),
+        $(
+          "span",
+          null,
+          "orchestrator-data.js not found at the project root — retrying in 30s",
+        ),
+      );
   };
   document.body.appendChild(s);
 }

--- a/agents/.apm/skills/be/SKILL.md
+++ b/agents/.apm/skills/be/SKILL.md
@@ -14,7 +14,7 @@ Take a task to a shipped, reviewed PR. Unlike `/do` (autonomous start to finish)
 
 ## 0. Interview (the differentiator)
 
-Before any work, ask the user via **`AskUserQuestion`** (one call, batched):
+Before any work, ask the user via **`AskUserQuestion`** (one call, batched) — **unless a delegating brief routes questions elsewhere.** When you run under a coordinator whose brief says questions go to its terminal (e.g. via `/kolu`, blocking on the reply), that channel *replaces* `AskUserQuestion` for the **whole** interview: write the batch to a file, send a one-line pointer, and block — never open a question dialog in your own PTY, where it hangs unseen until a human happens to look. The brief's route wins even when it only *routes* without naming the tool: reaching for `AskUserQuestion` here is `/be`'s built-in reflex (this *is* the interview step), so treat "a coordinator is driving me" as itself the ban.
 
 - **Plan first?** — write the plan as an **Atlas note** (`docs/atlas/src/content/atlas/<slug>.mdx`) for review *before* implementing, or implement straight. Default: straight, unless the task is large/ambiguous. *(If the prompt already points at an existing Atlas note or legacy `docs/plans/*.html`, skip this question — that file is the plan of record; reuse it.)*
 - **Task kind** — bug fix · feature/new behavior · refactor/chore. This sets the test strategy (see §2).

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-16T19:42:43.648645+00:00'
+generated_at: '2026-07-17T05:06:48.987410+00:00'
 apm_version: 0.25.0
 dependencies:
 - repo_url: _local/agents
@@ -24,6 +24,8 @@ dependencies:
   - .agents/skills/lens-debate/debate.workflow.js
   - .agents/skills/orchestrator
   - .agents/skills/orchestrator/SKILL.md
+  - .agents/skills/orchestrator/dashboard/index.html
+  - .agents/skills/orchestrator/dashboard/index.js
   - .agents/skills/perfection-review
   - .agents/skills/perfection-review/SKILL.md
   - .agents/skills/surface
@@ -45,6 +47,8 @@ dependencies:
   - .claude/skills/lens-debate/debate.workflow.js
   - .claude/skills/orchestrator
   - .claude/skills/orchestrator/SKILL.md
+  - .claude/skills/orchestrator/dashboard/index.html
+  - .claude/skills/orchestrator/dashboard/index.js
   - .claude/skills/perfection-review
   - .claude/skills/perfection-review/SKILL.md
   - .claude/skills/surface
@@ -52,24 +56,28 @@ dependencies:
   deployed_file_hashes:
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .agents/skills/be-review/SKILL.md: sha256:9dc6c1d05ebe50c5b11896da0c7e47e16726631ac9136c30e9ffcb7fe24d7773
-    .agents/skills/be/SKILL.md: sha256:92ba0686110e83b93af94ffa8b5b87b561229e6169e56b8b03253200e0bf6b44
+    .agents/skills/be/SKILL.md: sha256:01f9ac8dbc48461247936096728436eae9dff207042b959dab0b6b2be5a5c761
     .agents/skills/codex-debate/SKILL.md: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .agents/skills/kolu/SKILL.md: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
     .agents/skills/lens-debate/SKILL.md: sha256:34638d461c9341ff433360dcddc8d20a82b15a8307cb894b9c638b644a5b12c5
     .agents/skills/lens-debate/debate.workflow.js: sha256:52f3c6e85209e5204f06fe39f7191aa5b37f05b6b29dd71f6a28ed09192ba10b
-    .agents/skills/orchestrator/SKILL.md: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+    .agents/skills/orchestrator/SKILL.md: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+    .agents/skills/orchestrator/dashboard/index.html: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+    .agents/skills/orchestrator/dashboard/index.js: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .claude/skills/be-review/SKILL.md: sha256:9dc6c1d05ebe50c5b11896da0c7e47e16726631ac9136c30e9ffcb7fe24d7773
-    .claude/skills/be/SKILL.md: sha256:92ba0686110e83b93af94ffa8b5b87b561229e6169e56b8b03253200e0bf6b44
+    .claude/skills/be/SKILL.md: sha256:01f9ac8dbc48461247936096728436eae9dff207042b959dab0b6b2be5a5c761
     .claude/skills/codex-debate/SKILL.md: sha256:373780e07a861b5ccd05e50f61a228452c53835009d82f2ab292f0427d8f3531
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .claude/skills/kolu/SKILL.md: sha256:d58f0d2dcb5e606d94a61e59c4d7d59eafa0707cf80a2b53c8559da1d044d59b
     .claude/skills/lens-debate/SKILL.md: sha256:34638d461c9341ff433360dcddc8d20a82b15a8307cb894b9c638b644a5b12c5
     .claude/skills/lens-debate/debate.workflow.js: sha256:52f3c6e85209e5204f06fe39f7191aa5b37f05b6b29dd71f6a28ed09192ba10b
-    .claude/skills/orchestrator/SKILL.md: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+    .claude/skills/orchestrator/SKILL.md: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+    .claude/skills/orchestrator/dashboard/index.html: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+    .claude/skills/orchestrator/dashboard/index.js: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
   source: local
@@ -377,7 +385,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:92ba0686110e83b93af94ffa8b5b87b561229e6169e56b8b03253200e0bf6b44
+  content_hash: sha256:01f9ac8dbc48461247936096728436eae9dff207042b959dab0b6b2be5a5c761
 - kind: project-relative
   target: agents
   value: .agents/skills/blog-post
@@ -827,7 +835,25 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+  content_hash: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+- kind: project-relative
+  target: agents
+  value: .agents/skills/orchestrator/dashboard/index.html
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+- kind: project-relative
+  target: agents
+  value: .agents/skills/orchestrator/dashboard/index.js
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1341,7 +1367,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:92ba0686110e83b93af94ffa8b5b87b561229e6169e56b8b03253200e0bf6b44
+  content_hash: sha256:01f9ac8dbc48461247936096728436eae9dff207042b959dab0b6b2be5a5c761
 - kind: project-relative
   target: claude
   value: .claude/skills/blog-post
@@ -1791,7 +1817,25 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:2ce99dbb55cf62cb60ea395dd2ecf1f22e8b578649f69a02993e7f46c2fa0595
+  content_hash: sha256:3bba496ef6447c8a9b85e6f470e6c071a06095a50c23b5f0885be94bdf5716ea
+- kind: project-relative
+  target: claude
+  value: .claude/skills/orchestrator/dashboard/index.html
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9d5de52f7ed29f3585d67ac3e128c914e2bb59c3cbc5fa47f2abcb525cf6ff9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/orchestrator/dashboard/index.js
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:c9326eb0d419444e6e2c3b298c05c2d10bf2063969bc5cb702e5bc21bfdb332a
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel


### PR DESCRIPTION
**When /be runs as an implementing agent under an orchestrator, its §0 interview now goes through the coordinator's channel instead of `AskUserQuestion`** — a question dialog opened in the agent's own PTY hangs unseen until a human happens to glance at that terminal, stalling the run at its very first step.

The orchestrator side already name-bans `AskUserQuestion` in briefs (#1821, #1850, after #1773), yet the stall kept recurring — because the reflex lives in `/be` itself: §0 *is* the interview step, so the skill reaches for the dialog even when the brief only routes questions without naming the tool. The edit makes "a coordinator is driving me" itself the ban: write the question batch to a file, send a one-line pointer over the brief's channel, and block on the reply.

### Evidence ledger

| Edit | Evidence |
| --- | --- |
| `agents/.apm/skills/be/SKILL.md` §0 — brief's route replaces `AskUserQuestion` for the whole interview | Recurs across ≥3 prior rounds: #1773 introduced the coordinator-answers pattern, #1821 and #1850 hardened the orchestrator-side ban, and the stall still resurfaced in a coordinator-driven /be run — the fix was sitting uncommitted in the hard-killed self-improve worktree for session `73e4da1a` |
| `.claude/` + `.agents/` copies of `be/SKILL.md`, `apm.lock.yaml` | `just ai::apm` regen — generated copies ride the same commit as the source |
| Orchestrator dashboard copies (`index.html` / `index.js`) | Same regen trued up copies that drifted from their `agents/.apm` source in #1868 |

> **Provenance**: self-improve pass for session `f3183bfb-f468-4e8d-b2eb-43fb66a033ce` (the /be run that shipped #1874). That session's own transcript was never persisted (see report to the user: interactive child sessions spawned in kolu PTYs currently write no JSONL), so the primary lesson here is rescued from the prior run's orphaned worktree rather than mined fresh.

Gates run with repo-pinned tools sourced via `nix-build` (`nix develop` is broken on this host — CA-derivation skew): `biome format` clean, `nixpkgs-fmt` clean, `pnpm typecheck` green, `biome lint --error-on-warnings` green, `pnpm-lock.yaml` untouched.

*Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-4-8[1m]`).*