### PR TITLE
docs: restore the Philosophy section to the website docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 kolu is a terminal app built for scale: real `xterm.js` tiles on an infinite 2D canvas, with a dock that never loses one — for `claude`, `codex`, `opencode`, or anything you run in a shell, especially many at once.
 
-Unlike agent command centers that wrap a single model behind their own chat UI, kolu stays out of the agent's way: the terminal is the universal interface, so `claude`, `opencode`, or whatever ships next week works out of the box — and you can drop to a plain shell whenever you want. Two principles shape it:
+Unlike agent command centers that wrap a single model behind their own chat UI, kolu stays out of the agent's way: the terminal is the universal interface, so `claude`, `opencode`, or whatever ships next week works out of the box — and you can drop to a plain shell whenever you want. Two principles shape it — the [**Philosophy**](https://kolu.dev/philosophy) page has the full story:
 
 - **Agent-agnostic.** No agent registry, no adapter, no vendor lock-in. Run any agent CLI once in a terminal and it picks up first-class features automatically.
 - **Auto-detected, zero setup.** kolu populates its UI by watching what you already do — the repos you `cd` into, the agents you run, the sessions you save — not by asking you to configure it.

--- a/website/src/content/docs/philosophy.mdx
+++ b/website/src/content/docs/philosophy.mdx
@@ -1,0 +1,61 @@
+---
+title: Philosophy
+description: "The two principles that shape what kolu is and isn't: agent-agnostic (the terminal is the universal interface, no model wrapped, no CLI locked in) and auto-detected, zero setup (the UI is built by observing what you already do, not by a preferences pane)."
+order: 5
+section: Foundations
+koluHero:
+  eyebrow: philosophy
+  headline: What {kolu} is — and isn't.
+---
+
+import CardGrid from "../../components/docs/CardGrid.astro";
+import LinkCard from "../../components/docs/LinkCard.astro";
+
+Two principles shape what kolu is and isn't. Neither is a setting you switch on —
+they're the decisions the rest of the product follows from, and the reason kolu
+looks different from the agent command centers it sits beside.
+
+## Agent-agnostic
+
+The terminal is the universal interface. Kolu doesn't wrap a specific model or
+lock you into one CLI — `claude`, `opencode`, or whatever ships next week all
+work the same way, because they're just programs you run in a shell. There's no
+agent registry to update, no adapter to write, no vendor lock-in.
+
+Any new agent CLI picks up first-class features automatically: run it once in any
+kolu terminal and the next time you create a worktree, it appears in the
+sub-palette as a launch option — no configuration, no per-agent code. And you can
+always drop to a plain shell without leaving the app.
+
+The trade kolu makes here is deliberate. Wrapping a single model behind a bespoke
+chat UI buys a tighter, more branded experience — at the cost of betting the
+product on one vendor and re-implementing the wrapper every time the field moves.
+Kolu takes the other side of that bet: the terminal already speaks to every agent,
+so kolu treats terminals as the thesis, not the substrate.
+
+## Auto-detected, zero setup
+
+Kolu populates its UI by watching what you already do — the repos you `cd` into,
+the agents you run, the sessions you save — not by asking you to configure it.
+Recent repos track `cd` events, branch / PR / CI status derive from the terminal's
+working directory, Claude Code state is read from the foreground pid, and recent
+agent CLIs come from preexec command marks emitted by kolu's shell integration.
+
+If kolu knows something, it's because the shell already told it. That's the point
+of the principle: the surface grows with your workflow, not with a preferences
+pane. There's no onboarding form that goes stale, no per-repo config to keep in
+sync — the observations are the configuration, and they're always current because
+they're read live from what your terminals are actually doing.
+
+## Where this shows up
+
+These aren't abstract commitments — they're visible in almost every surface. The
+detection that reads agent state from disk, the palette that offers a new CLI
+after one run, the dock rows that fill themselves from each terminal's cwd: all of
+it is these two principles made concrete.
+
+<CardGrid>
+  <LinkCard title="Agent Detection" href="/agent-detection" description="how kolu reads live agent state from each session on disk — agent-agnostic and zero-setup in one surface" />
+  <LinkCard title="Core Concepts" href="/concepts" description="the vocabulary these principles produce: canvas, dock, worktrees, auto-detection" />
+  <LinkCard title="Architecture" href="/architecture" description="the daemon stack that lets terminals and their agents outlive the browser tab" />
+</CardGrid>


### PR DESCRIPTION
During the docs revamp, kolu's **Philosophy** got deleted — and never landed a home on kolu.dev. This restores it.

## What happened

`#453` first added a Philosophy section to the README. Then `#1739` ("docs: make kolu.dev the canonical docs; slim the README to a pointer") **removed it on purpose**, as part of thinning the README into a link map. But the section was never carried over to the kolu.dev docs, so the product's own philosophy quietly went dark on the docs site — the deletion was deliberate, the *homelessness* was the accident.

## What this does

**Restores the full Philosophy as its own page** at [`/philosophy`](https://kolu.dev/philosophy):

- **Diátaxis:** this is **Explanation** — the *why*, deliberate stances, rejected alternatives (agent registries, adapters, preferences panes) — so it's a standalone page, not folded into a how-to. It ends each principle at the trade-off it makes, per the Explanation contract.
- **Placement:** a new **Foundations** section pinned to the **top of the docs sidebar** (`order: 5`), directly analogous to how the *System* section holds the Architecture explainer. Prominent, and mode-clean.
- **Faithful substance:** the two principles — **Agent-agnostic** and **Auto-detected, zero setup** — are restored verbatim in substance from the source-of-truth README section (md5-verified against pre-revamp `cef91a019`), with only light docs-voice editing. Not watered down; not cited (it's the product's own philosophy, not a quote).

**README stays a pointer.** Its intro already carries the two principles in condensed bullet form — the revamp kept the *substance* and only dropped the `## Philosophy` header. So rather than re-grow the full prose (which `#1739` and `.claude/rules/website-docs.md` — *"Keep the README a pointer. Don't re-grow a feature catalog there"* — deliberately forbid), the existing bullets now **link to the full page**. The README regains a Philosophy presence in its native form; the canonical content lives on kolu.dev.

## Design philosophy

- **Reuse the existing source of truth.** No new nav/taxonomy machinery — the page is a plain content-collection entry; the sidebar auto-derives its Foundations section from the `section` frontmatter (the same mechanism every other page uses). The README pointer reuses the convention the revamp established rather than a parallel one.
- **No fail-fast / electricity surface** to honor here — this is docs content, no runtime behavior, no boundaries, no fallback paths.

## Process (proportionate — docs-only)

- No design gate (content restoration, srid-directed). Review gauntlet **skipped per srid's ruling** (docs restoration).
- `just fmt` clean; `just website::check` green (astro check + unit pins); `just website::build` green — 68 pages indexed, `/philosophy` renders (23 KB) with the two principles and the Foundations section at the top of the sidebar.

## CI — delta-to-green argument

The delta is **`.mdx` docs content + a one-line README link** — platform-neutral by construction. No darwin-specific surface is touched (no PTY, no native binding, no OS-conditional code path), so a **linux-only** run is delta-to-green here: the linux nix/website lanes fully exercise the changed artifact, and a darwin lane would re-run identical, platform-independent content checks. This is the established pattern for platform-neutral `.mdx` changes.

---

Merge-ready; **srid merges.**
