### PR TITLE
Restore card: scrollable on a short viewport, with a pinned Restore footer

### DIFF
--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -93,6 +93,16 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
 
   const resumeCount = () => (resumeAgents() ? resumableIds().length : 0);
 
+  // Lifted to component scope so the scrolling session list and the pinned
+  // action bar — now separate flex children of the card — can both read them.
+  const groups = createMemo(() => {
+    const session = props.savedSession;
+    return session ? groupSavedTerminals(session.terminals) : [];
+  });
+  const subCount = () =>
+    props.savedSession?.terminals.filter((t) => t.parentId).length ?? 0;
+  const hasAnyAgent = () => resumableIds().length > 0;
+
   const handleRestore = () => {
     const resumeIds = resumeAgents()
       ? new Set(resumableIds())
@@ -115,196 +125,201 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
         "pt-5": !isDesktop(),
       }}
     >
-      {/* The card is the ONE scroll container. The wrapper above owns the
-          overflow height but is `pointer-events-none` (so a double-click on the
-          bare canvas falls through to create-on-double-click) — which also means
-          the wheel can't drive its scroll. So cap the card to the wrapper and let
-          IT scroll: it's `pointer-events-auto`, so the wheel reaches it, and the
-          Restore button below stays reachable on a short viewport. */}
+      {/* App-shell card: a flex column capped to the wrapper's height. The
+          wrapper owns the overflow but is `pointer-events-none` (double-click on
+          bare canvas falls through to create-on-double-click), so its scroll is
+          wheel-dead. The card is `pointer-events-auto`, so the scroll lives here.
+          Only the middle region scrolls; the Restore action bar is a pinned
+          FOOTER so the primary action never drops below the fold on a short
+          viewport. */}
       <div
-        class={`${chrome.class} p-5 max-w-md w-full pointer-events-auto max-h-full overflow-y-auto`}
+        class={`${chrome.class} p-5 max-w-md w-full pointer-events-auto flex flex-col max-h-full overflow-hidden`}
       >
-        {/* The bird's-eye welcome — desktop only (no mobile welcome, by design). */}
-        <Show when={showsWelcome()}>
-          <div class="mb-5 pb-5 border-b border-edge">
-            <WelcomeMoments install={props.install} />
-          </div>
-        </Show>
-        <Show when={props.savedSession}>
-          {(session) => {
-            const subCount = () =>
-              session().terminals.filter((t) => t.parentId).length;
-            const groups = () => groupSavedTerminals(session().terminals);
-            const hasAnyAgent = () => resumableIds().length > 0;
-            return (
-              <div
-                data-testid="session-restore"
-                class="mb-5 pb-5 border-b border-edge"
-              >
-                <p class="text-sm font-medium text-fg mb-3">Restore session</p>
-                {/* No nested scroll here — the whole card scrolls as one unit.
-                    A second `overflow-y-auto` inside the card's scroll traps the
-                    wheel in this list and never lets the page reach the button. */}
-                <div class="space-y-4">
-                  <For each={groups()}>
-                    {(group) => (
-                      <div data-testid="repo-group" data-repo-name={group.key}>
-                        {/* NOT sticky. A pinned, opaque heading masks its own
+        {/* The scroll region — the welcome header, the session list, and (on
+            touch) the create button + shortcut list. `flex-1 min-h-0
+            overflow-y-auto` absorbs all the overflow so the footer below stays
+            pinned. `min-h-0` is load-bearing: without it a flex child won't
+            shrink below its content and the scroll never engages. `-mr-2 pr-2`
+            insets the scrollbar off the card's rounded edge. */}
+        <div class="flex-1 min-h-0 overflow-y-auto -mr-2 pr-2">
+          {/* The bird's-eye welcome — desktop only (no mobile welcome, by design). */}
+          <Show when={showsWelcome()}>
+            <div class="mb-5 pb-5 border-b border-edge">
+              <WelcomeMoments install={props.install} />
+            </div>
+          </Show>
+          <Show when={props.savedSession}>
+            <div data-testid="session-restore">
+              <p class="text-sm font-medium text-fg mb-3">Restore session</p>
+              <div class="space-y-4">
+                <For each={groups()}>
+                  {(group) => (
+                    <div data-testid="repo-group" data-repo-name={group.key}>
+                      {/* NOT sticky. A pinned, opaque heading masks its own
                             two-line rows as they scroll under it — the name line
                             hides behind the heading while the subtitle peeks out,
                             leaving an orphaned "Asleep · restores dormant" with no
                             session above it. Let the heading scroll with its rows. */}
-                        <div class="pb-1.5">
-                          <span
-                            data-testid="repo-heading"
-                            class="text-sm font-semibold text-fg truncate"
-                          >
-                            {group.key}
-                          </span>
-                        </div>
-                        <div class="ml-1 pl-3 border-l border-edge/70 space-y-2.5">
-                          <For each={group.terminals}>
-                            {(t) => (
-                              <div title={t.cwd}>
-                                <div
-                                  class="text-sm text-fg-2 truncate leading-snug"
-                                  classList={{
-                                    "opacity-60": t.state === "sleeping",
-                                  }}
-                                >
-                                  <Show when={t.state === "sleeping"}>
-                                    <span
-                                      data-testid="restore-sleeping"
-                                      data-terminal-id={t.id}
-                                      class="mr-1 text-fg-3"
-                                      title="Asleep — restores dormant; wake it later"
-                                      aria-hidden="true"
-                                    >
-                                      ☾
-                                    </span>
+                      <div class="pb-1.5">
+                        <span
+                          data-testid="repo-heading"
+                          class="text-sm font-semibold text-fg truncate"
+                        >
+                          {group.key}
+                        </span>
+                      </div>
+                      <div class="ml-1 pl-3 border-l border-edge/70 space-y-2.5">
+                        <For each={group.terminals}>
+                          {(t) => (
+                            <div title={t.cwd}>
+                              <div
+                                class="text-sm text-fg-2 truncate leading-snug"
+                                classList={{
+                                  "opacity-60": t.state === "sleeping",
+                                }}
+                              >
+                                <Show when={t.state === "sleeping"}>
+                                  <span
+                                    data-testid="restore-sleeping"
+                                    data-terminal-id={t.id}
+                                    class="mr-1 text-fg-3"
+                                    title="Asleep — restores dormant; wake it later"
+                                    aria-hidden="true"
+                                  >
+                                    ☾
+                                  </span>
+                                </Show>
+                                {terminalKey(t).label}
+                              </div>
+                              <Show
+                                when={t.state === "sleeping"}
+                                fallback={
+                                  <Show
+                                    when={
+                                      resumeAgents()
+                                        ? resumableCommand(t.restoreTarget)
+                                        : undefined
+                                    }
+                                  >
+                                    {(cmd) => (
+                                      <div
+                                        data-testid="resume-command"
+                                        data-terminal-id={t.id}
+                                        title={cmd()}
+                                        class="mt-1 font-mono text-[11px] text-fg-3/80 truncate leading-relaxed"
+                                      >
+                                        {cmd()}
+                                      </div>
+                                    )}
                                   </Show>
-                                  {terminalKey(t).label}
-                                </div>
-                                <Show
-                                  when={t.state === "sleeping"}
-                                  fallback={
-                                    <Show
-                                      when={
-                                        resumeAgents()
-                                          ? resumableCommand(t.restoreTarget)
-                                          : undefined
-                                      }
-                                    >
-                                      {(cmd) => (
-                                        <div
-                                          data-testid="resume-command"
-                                          data-terminal-id={t.id}
-                                          title={cmd()}
-                                          class="mt-1 font-mono text-[11px] text-fg-3/80 truncate leading-relaxed"
-                                        >
-                                          {cmd()}
-                                        </div>
-                                      )}
-                                    </Show>
-                                  }
-                                >
-                                  {/* A sleeping record restores DORMANT — no agent
+                                }
+                              >
+                                {/* A sleeping record restores DORMANT — no agent
                                       relaunches on restore; it comes back asleep
                                       and the user wakes it later. Say so plainly
                                       instead of a resume-command line. */}
-                                  <div class="mt-1 text-[11px] text-fg-3/60 truncate leading-relaxed italic">
-                                    Asleep · restores dormant
-                                  </div>
-                                </Show>
-                              </div>
-                            )}
-                          </For>
-                        </div>
+                                <div class="mt-1 text-[11px] text-fg-3/60 truncate leading-relaxed italic">
+                                  Asleep · restores dormant
+                                </div>
+                              </Show>
+                            </div>
+                          )}
+                        </For>
                       </div>
-                    )}
-                  </For>
-                  <Show when={subCount() > 0}>
-                    <div class="text-xs text-fg-3/50 ml-1">
-                      +{subCount()} split{subCount() > 1 ? "s" : ""}
                     </div>
-                  </Show>
-                </div>
-                <Show when={hasAnyAgent()}>
-                  <div class="mt-4 flex items-center justify-between gap-4">
-                    <span class="text-sm text-fg-2">Resume agent sessions</span>
-                    <Toggle
-                      testId="resume-agents-toggle"
-                      enabled={resumeAgents()}
-                      onChange={setResumeAgents}
-                    />
+                  )}
+                </For>
+                <Show when={subCount() > 0}>
+                  <div class="text-xs text-fg-3/50 ml-1">
+                    +{subCount()} split{subCount() > 1 ? "s" : ""}
                   </div>
                 </Show>
+              </div>
+            </div>
+          </Show>
+          {/* Touch create button — the tappable path to the first terminal on the
+              phone + compact layouts, which mount no Dock (its clickable `+` is
+              desktop-only) and can't action the shortcut list with a finger. On
+              desktop the empty Dock owns the `+`, so this is suppressed there. */}
+          <Show when={!isDesktop() && props.onCreate}>
+            <button
+              type="button"
+              data-testid="empty-create-terminal"
+              class="mb-5 w-full px-3 py-2 text-sm rounded-xl bg-accent text-surface-1 font-medium hover:brightness-110 active:brightness-95 transition-all"
+              onClick={() => props.onCreate?.()}
+            >
+              New terminal
+            </button>
+          </Show>
+          {/* Shortcut list — only where the welcome moments aren't shown (mobile).
+              On desktop the moments above already advertise these, so the list is
+              redundant there. */}
+          <Show when={!showsWelcome()}>
+            <p class="text-sm font-medium text-fg mb-3">Get started</p>
+            <div class="space-y-2">
+              <For each={features}>
+                {(f) => (
+                  <div class="flex items-center justify-between text-sm">
+                    <span class="text-fg-3">{f.label}</span>
+                    <Kbd>{formatKeybind(f.shortcut)}</Kbd>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+        {/* Pinned action bar — the Restore controls live OUTSIDE the scroll
+            region so the primary action never scrolls off on a short viewport.
+            Present only with a saved session; `border-t` divides it from the
+            scrolling list above. */}
+        <Show when={props.savedSession}>
+          {(session) => (
+            <div class="shrink-0 mt-4 pt-4 border-t border-edge">
+              <Show when={hasAnyAgent()}>
+                <div class="flex items-center justify-between gap-4">
+                  <span class="text-sm text-fg-2">Resume agent sessions</span>
+                  <Toggle
+                    testId="resume-agents-toggle"
+                    enabled={resumeAgents()}
+                    onChange={setResumeAgents}
+                  />
+                </div>
+              </Show>
+              <button
+                type="button"
+                data-testid="restore-session"
+                disabled={props.isRestoring}
+                class="mt-4 w-full px-3 py-2 text-sm rounded-xl bg-accent text-surface-1 font-medium hover:brightness-110 disabled:opacity-70 disabled:cursor-wait transition-all"
+                onClick={handleRestore}
+              >
+                <Show when={!props.isRestoring} fallback={<>Restoring…</>}>
+                  Restore {session().terminals.length} terminal
+                  {session().terminals.length > 1 ? "s" : ""}
+                  <Show when={resumeCount() > 0}>
+                    <span class="opacity-80">
+                      {" · resume "}
+                      {resumeCount()} agent{resumeCount() > 1 ? "s" : ""}
+                    </span>
+                  </Show>
+                </Show>
+              </button>
+              {/* Explicit forfeit — the deliberate "discard my previous
+                  session" path. Kept visually secondary to Restore (a bare
+                  text button, no fill) so it never competes with the primary
+                  action. Only rendered when the parent wires `onForfeit`. */}
+              <Show when={props.onForfeit}>
                 <button
                   type="button"
-                  data-testid="restore-session"
+                  data-testid="forfeit-session"
                   disabled={props.isRestoring}
-                  class="mt-4 w-full px-3 py-2 text-sm rounded-xl bg-accent text-surface-1 font-medium hover:brightness-110 disabled:opacity-70 disabled:cursor-wait transition-all"
-                  onClick={handleRestore}
+                  class="mt-2 w-full px-3 py-1.5 text-xs text-fg-3 hover:text-fg-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  onClick={() => props.onForfeit?.()}
                 >
-                  <Show when={!props.isRestoring} fallback={<>Restoring…</>}>
-                    Restore {session().terminals.length} terminal
-                    {session().terminals.length > 1 ? "s" : ""}
-                    <Show when={resumeCount() > 0}>
-                      <span class="opacity-80">
-                        {" · resume "}
-                        {resumeCount()} agent{resumeCount() > 1 ? "s" : ""}
-                      </span>
-                    </Show>
-                  </Show>
+                  Start fresh
                 </button>
-                {/* Explicit forfeit — the deliberate "discard my previous
-                    session" path. Kept visually secondary to Restore (a bare
-                    text button, no fill) so it never competes with the primary
-                    action. Only rendered when the parent wires `onForfeit`. */}
-                <Show when={props.onForfeit}>
-                  <button
-                    type="button"
-                    data-testid="forfeit-session"
-                    disabled={props.isRestoring}
-                    class="mt-2 w-full px-3 py-1.5 text-xs text-fg-3 hover:text-fg-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    onClick={() => props.onForfeit?.()}
-                  >
-                    Start fresh
-                  </button>
-                </Show>
-              </div>
-            );
-          }}
-        </Show>
-        {/* Touch create button — the tappable path to the first terminal on the
-            phone + compact layouts, which mount no Dock (its clickable `+` is
-            desktop-only) and can't action the shortcut list with a finger. On
-            desktop the empty Dock owns the `+`, so this is suppressed there. */}
-        <Show when={!isDesktop() && props.onCreate}>
-          <button
-            type="button"
-            data-testid="empty-create-terminal"
-            class="mb-5 w-full px-3 py-2 text-sm rounded-xl bg-accent text-surface-1 font-medium hover:brightness-110 active:brightness-95 transition-all"
-            onClick={() => props.onCreate?.()}
-          >
-            New terminal
-          </button>
-        </Show>
-        {/* Shortcut list — only where the welcome moments aren't shown (mobile).
-            On desktop the moments above already advertise these, so the list is
-            redundant there. */}
-        <Show when={!showsWelcome()}>
-          <p class="text-sm font-medium text-fg mb-3">Get started</p>
-          <div class="space-y-2">
-            <For each={features}>
-              {(f) => (
-                <div class="flex items-center justify-between text-sm">
-                  <span class="text-fg-3">{f.label}</span>
-                  <Kbd>{formatKeybind(f.shortcut)}</Kbd>
-                </div>
-              )}
-            </For>
-          </div>
+              </Show>
+            </div>
+          )}
         </Show>
       </div>
     </div>

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -138,7 +138,12 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
                   <For each={groups()}>
                     {(group) => (
                       <div data-testid="repo-group" data-repo-name={group.key}>
-                        <div class="sticky top-0 z-10 bg-surface-1 pb-1.5">
+                        {/* NOT sticky. A pinned, opaque heading masks its own
+                            two-line rows as they scroll under it — the name line
+                            hides behind the heading while the subtitle peeks out,
+                            leaving an orphaned "Asleep · restores dormant" with no
+                            session above it. Let the heading scroll with its rows. */}
+                        <div class="pb-1.5">
                           <span
                             data-testid="repo-heading"
                             class="text-sm font-semibold text-fg truncate"

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -131,9 +131,12 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
           wheel-dead. The card is `pointer-events-auto`, so the scroll lives here.
           Only the middle region scrolls; the Restore action bar is a pinned
           FOOTER so the primary action never drops below the fold on a short
-          viewport. */}
+          viewport. The card keeps `overflow-y-auto` as a fallback: if the
+          viewport is shorter than the pinned footer's own height, the `flex-1`
+          list shrinks to zero and the footer would otherwise be clipped — the
+          card scroll still lets the user reach it. */}
       <div
-        class={`${chrome.class} p-5 max-w-md w-full pointer-events-auto flex flex-col max-h-full overflow-hidden`}
+        class={`${chrome.class} p-5 max-w-md w-full pointer-events-auto flex flex-col max-h-full overflow-y-auto`}
       >
         {/* The scroll region — the welcome header, the session list, and (on
             touch) the create button + shortcut list. `flex-1 min-h-0
@@ -149,7 +152,16 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
             </div>
           </Show>
           <Show when={props.savedSession}>
-            <div data-testid="session-restore">
+            <div
+              data-testid="session-restore"
+              classList={{
+                // On touch layouts the create button / Get started list follow
+                // this block in the SAME scroll region — restore the gap +
+                // divider that separated them. On desktop the pinned footer's
+                // own `border-t` is the separator, so no divider here.
+                "mb-5 pb-5 border-b border-edge": !isDesktop(),
+              }}
+            >
               <p class="text-sm font-medium text-fg mb-3">Restore session</p>
               <div class="space-y-4">
                 <For each={groups()}>

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -115,7 +115,15 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
         "pt-5": !isDesktop(),
       }}
     >
-      <div class={`${chrome.class} p-5 max-w-md w-full pointer-events-auto`}>
+      {/* The card is the ONE scroll container. The wrapper above owns the
+          overflow height but is `pointer-events-none` (so a double-click on the
+          bare canvas falls through to create-on-double-click) — which also means
+          the wheel can't drive its scroll. So cap the card to the wrapper and let
+          IT scroll: it's `pointer-events-auto`, so the wheel reaches it, and the
+          Restore button below stays reachable on a short viewport. */}
+      <div
+        class={`${chrome.class} p-5 max-w-md w-full pointer-events-auto max-h-full overflow-y-auto`}
+      >
         {/* The bird's-eye welcome — desktop only (no mobile welcome, by design). */}
         <Show when={showsWelcome()}>
           <div class="mb-5 pb-5 border-b border-edge">
@@ -134,7 +142,10 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
                 class="mb-5 pb-5 border-b border-edge"
               >
                 <p class="text-sm font-medium text-fg mb-3">Restore session</p>
-                <div class="max-h-[55vh] overflow-y-auto space-y-4">
+                {/* No nested scroll here — the whole card scrolls as one unit.
+                    A second `overflow-y-auto` inside the card's scroll traps the
+                    wheel in this list and never lets the page reach the button. */}
+                <div class="space-y-4">
                   <For each={groups()}>
                     {(group) => (
                       <div data-testid="repo-group" data-repo-name={group.key}>

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -93,14 +93,19 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
 
   const resumeCount = () => (resumeAgents() ? resumableIds().length : 0);
 
-  // Lifted to component scope so the scrolling session list and the pinned
-  // action bar — now separate flex children of the card — can both read them.
+  // Lifted to component scope: the restore list (scroll region) and the pinned
+  // action bar are now separate flex children of the card, so these derivations
+  // are read outside a single render-prop — the list reads groups/subCount, the
+  // footer reads hasAnyAgent. Memo the two that do real work per read (groups
+  // sorts; subCount filters and is read 3× per render); hasAnyAgent is a trivial
+  // single-consumer length check over the resumableIds memo.
   const groups = createMemo(() => {
     const session = props.savedSession;
     return session ? groupSavedTerminals(session.terminals) : [];
   });
-  const subCount = () =>
-    props.savedSession?.terminals.filter((t) => t.parentId).length ?? 0;
+  const subCount = createMemo(
+    () => props.savedSession?.terminals.filter((t) => t.parentId).length ?? 0,
+  );
   const hasAnyAgent = () => resumableIds().length > 0;
 
   const handleRestore = () => {
@@ -116,10 +121,13 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
     // through to the canvas-container's double-click-to-create gesture (the
     // container guards on `target === currentTarget`). The card itself is
     // `pointer-events-auto`, so its buttons/toggles stay clickable and a
-    // double-click on the card never reaches the create handler.
+    // double-click on the card never reaches the create handler. No overflow
+    // here — the `max-h-full` card can never exceed the wrapper, so the card
+    // owns the scroll (and a scroll on this `pointer-events-none` layer would
+    // be wheel-dead anyway).
     <div
       data-testid="empty-state"
-      class="flex h-full items-start justify-center overflow-y-auto px-5 pb-6 pointer-events-none"
+      class="flex h-full items-start justify-center px-5 pb-6 pointer-events-none"
       classList={{
         "pt-20": isDesktop(),
         "pt-5": !isDesktop(),
@@ -136,15 +144,16 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
           list shrinks to zero and the footer would otherwise be clipped — the
           card scroll still lets the user reach it. */}
       <div
-        class={`${chrome.class} p-5 max-w-md w-full pointer-events-auto flex flex-col max-h-full overflow-y-auto`}
+        class={`${chrome.class} scrollbar-subtle p-5 max-w-md w-full pointer-events-auto flex flex-col max-h-full overflow-y-auto`}
       >
         {/* The scroll region — the welcome header, the session list, and (on
             touch) the create button + shortcut list. `flex-1 min-h-0
             overflow-y-auto` absorbs all the overflow so the footer below stays
             pinned. `min-h-0` is load-bearing: without it a flex child won't
-            shrink below its content and the scroll never engages. `-mr-2 pr-2`
-            insets the scrollbar off the card's rounded edge. */}
-        <div class="flex-1 min-h-0 overflow-y-auto -mr-2 pr-2">
+            shrink below its content and the scroll never engages. `scrollbar-subtle`
+            is the app's thin themed scrollbar; `-mr-2 pr-2` insets it off the
+            card's rounded edge. */}
+        <div class="scrollbar-subtle flex-1 min-h-0 overflow-y-auto -mr-2 pr-2">
           {/* The bird's-eye welcome — desktop only (no mobile welcome, by design). */}
           <Show when={showsWelcome()}>
             <div class="mb-5 pb-5 border-b border-edge">


### PR DESCRIPTION
On a short window the session-restore card overflowed the viewport and the Restore button dropped below the fold — with a scrollbar you couldn't actually scroll.

### Why it was stuck

The scroll container was the **`empty-state` wrapper** (`overflow-y-auto`; its content overflows, so the scrollbar renders). But that wrapper is deliberately `pointer-events-none` so a double-click on the bare canvas falls through to create-on-double-click — and `pointer-events-none` **also stops the wheel from driving its scroll**. The **card** inside was `overflow: visible`, so it just spilled its Restore button past the bottom of the screen. On top of that, the list had a *second*, nested `max-h-[55vh] overflow-y-auto` — a scroll-within-a-scroll trapping the wheel.

### The fix — an app-shell card

The card is now a flex column capped to the viewport (`pointer-events-auto`, so the wheel reaches it):

- a **scroll region** (`flex-1 min-h-0 overflow-y-auto`) holds the welcome header, the session list, and the touch create/shortcut blocks, and
- the **Restore controls are a pinned footer** (`shrink-0`, `border-t`) — the "Resume agent sessions" toggle, the Restore button, and "Start fresh" stay put at the bottom, always one tap away, while only the list scrolls in the middle.

`groups` / `subCount` / `hasAnyAgent` were lifted to component scope so both the scrolling list and the pinned footer can read them.

Also folded in: the group heading was `sticky top-0` with an opaque mask, which tears a two-line session row as it scrolls under the pinned heading (name hidden, "Asleep · restores dormant" subtitle orphaned below it). Made it non-sticky.

Verified live against a 560px-tall dev server (see Evidence) — `just check` green, CI on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)