### PR TITLE
fix(dock): repo name as a filled colour chip so it reads on any ground

### DIFF
--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -397,12 +397,11 @@ const RepoSection: Component<{
      *  reclaimed the old `pl-6` row indent). */}
     <div
       data-testid="dock-section-header"
-      class={`dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 ${DOCK_CARDS_GUTTER_NEG_CLASS} pl-3 pr-3 py-1.5 border-y border-edge/30`}
+      class={`dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 ${DOCK_CARDS_GUTTER_NEG_CLASS} pl-3 pr-3 py-1.5 border-b border-edge/30`}
     >
       <span
         data-testid="dock-section-name"
-        class="font-mono text-[0.6rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-        style={{ color: "var(--repo-color)" }}
+        class="dock-cards-section-name font-mono text-[0.6rem] font-bold uppercase tracking-[0.1em] truncate min-w-0"
         title={props.group.name}
       >
         {props.group.name}

--- a/packages/client/src/canvas/dock/DockList.tsx
+++ b/packages/client/src/canvas/dock/DockList.tsx
@@ -98,12 +98,11 @@ function DockListSection(props: {
     >
       <div
         data-testid="mobile-dock-section-header"
-        class="dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 -mr-3 pl-3 pr-3 py-2 border-y border-edge/30"
+        class="dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 -mr-3 pl-3 pr-3 py-2 border-b border-edge/30"
       >
         <span
           data-testid="mobile-dock-section-name"
-          class="font-mono text-[0.65rem] font-bold uppercase tracking-[0.14em] truncate min-w-0"
-          style={{ color: "var(--repo-color)" }}
+          class="dock-cards-section-name font-mono text-[0.65rem] font-bold uppercase tracking-[0.1em] truncate min-w-0"
         >
           {props.group.name}
         </span>

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -553,13 +553,27 @@ body {
   position: sticky;
   top: 0;
   z-index: 10;
-  /* Opaque tint (surface-2 is opaque) so rows scroll cleanly under
-   * the pinned header with no bleed-through. */
-  background: color-mix(
-    in oklch,
-    var(--repo-color) 16%,
-    var(--color-surface-2)
-  );
+  /* Neutral + opaque — matches the dock body (`bg-surface-1`) so the header
+   * reads as no band at all: the repo colour rides the name chip below and
+   * the section's left spine. Opaque so rows scroll cleanly under the pinned
+   * header with no bleed-through. */
+  background: var(--color-surface-1);
+}
+/* The repo name is a filled colour chip — a tag. The old treatment painted
+ * the name in the raw `--repo-color` (a light `L=0.75`) on a light tinted
+ * band, so in light mode it washed out (light-on-light). A solid chip pops on
+ * any ground, per theme: dark mode uses the bright repo colour with dark text
+ * (chip lifts off the dark dock); light mode deepens the chip toward the
+ * foreground and uses white text (a bold tag on the light dock). */
+.dock-cards-section-name {
+  background: var(--repo-color);
+  color: var(--color-surface-0);
+  padding: 0.1rem 0.4rem;
+  border-radius: 5px;
+}
+:root:not(.dark) .dock-cards-section-name {
+  background: color-mix(in oklch, var(--repo-color) 82%, var(--color-fg));
+  color: #fff;
 }
 
 /* ── Rail-mode chip ────────────────────────────────────────────


### PR DESCRIPTION
The Dock's group headers were hard to read. The repo name was painted in the raw `--repo-color` — a deliberately light `oklch(0.75 0.14 h)` — on a **light tint of that same color** over `surface-2`. In light mode `surface-2` is `#e8e8ec`, so you got light-colored text on a light-colored band: low contrast by construction. (Dark mode hid it — the same `L=0.75` reads fine on a dark ground.)

## The fix — the name becomes a filled chip

The repo color moves off the text-and-band and onto a solid **chip** (a tag). The sticky header band goes neutral-opaque (`surface-1`, matching the dock body) so it reads as *no band at all* while still masking rows that scroll under the pinned header. The grouping is now carried by the chip plus the section's colored left spine.

The chip is tuned **per theme** so it pops on either ground:

| Theme | Chip background | Chip text |
|-------|-----------------|-----------|
| Dark  | bright `--repo-color` | dark (`surface-0`) |
| Light | `--repo-color` deepened toward `fg` (`82% / 18%`) | white |

Shared `.dock-cards-section-name` class, so the desktop (`Dock.tsx`) and mobile drawer (`DockList.tsx`) headers stay in lockstep — same as the existing `.dock-cards-section-header`.

## Notes

- Removed the per-span inline `color: var(--repo-color)`; the color is now a CSS class reading the same `--repo-color` the section already sets. No new color source.
- Header hairline went `border-y` → `border-b` (drop the top rule; keep a faint bottom separator under the pinned header).
- Tightened the name's letter-spacing `0.14em → 0.1em` — chips want a touch less tracking.

Design directions were mocked up against the real palette and golden-angle colors before picking this one (Option B, "filled chip label").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
