### PR TITLE
fix(ci): pin devour-flake to an immutable rev to dodge the GitHub API 403 (#1204)

### DIFF
--- a/ci/mod.just
+++ b/ci/mod.just
@@ -24,6 +24,16 @@ set working-directory := '..'
 # inside the shell so local invocations stay cheap.
 nix_shell := if env('IN_NIX_SHELL', '') != '' { '' } else { 'nix develop --accept-flake-config -c' }
 
+# devour-flake, pinned to an immutable rev. An UNPINNED `github:srid/devour-flake`
+# forces nix to resolve HEAD→rev via the unauthenticated GitHub REST API
+# (`GET api.github.com/repos/srid/devour-flake/commits/HEAD`, 60 req/hr per IP),
+# which 403s on a cold/shared CI egress IP and breaks the linux `nix` and
+# `home-manager` lanes (juspay/kolu#1204). Pinning the rev skips that REST call
+# entirely: nix fetches the source straight from the codeload archive
+# (`github.com/…/archive/<rev>.tar.gz`), which isn't REST-rate-limited. No token
+# on the box needed. Bump this SHA by hand to adopt a newer devour-flake.
+devour_flake := "github:srid/devour-flake/e65d15fd4ef46dbde90ac59be581b2a286c35d0f"
+
 # Pipeline root: every recipe listed here becomes a (recipe × platform) node.
 # Body is empty — the runner expands `depends_on` from this DAG and executes
 # each leaf via `just --no-deps <recipe>`. `just ci` (without the runner) still
@@ -88,7 +98,7 @@ pnpm-hash-fresh:
 # the standalone `typecheck` recipe (juspay/kolu#1049). The typecheck result
 # is content-addressed, so it only re-runs when a typechecked source changes.
 nix:
-    nix build github:srid/devour-flake -L --no-link --print-out-paths --override-input flake .
+    nix build {{ devour_flake }} -L --no-link --print-out-paths --override-input flake .
 
 # `nix flake check`: evaluate every flake output and run the flake's `checks.*`.
 # Complements the `nix` node (devour-flake builds the output drvs) with the
@@ -107,7 +117,7 @@ flake-check:
 # concurrent build, letting the home-manager VM work overlap the big build
 # instead of queuing behind every devour-flake output.
 home-manager:
-    nix build github:srid/devour-flake -L --no-link --print-out-paths --override-input flake ./nix/home/example --override-input flake/kolu .
+    nix build {{ devour_flake }} -L --no-link --print-out-paths --override-input flake ./nix/home/example --override-input flake/kolu .
 
 # Boot the packaged Kolu and verify /api/health — runtime smoke that catches
 # packaging regressions where `nix build` passes but the binary crashes at


### PR DESCRIPTION
## What & why

kolu's linux `nix` and `home-manager` CI lanes fail on a cold or warm-pool-down box with:

```
error: unable to download 'https://api.github.com/repos/srid/devour-flake/commits/HEAD':
       HTTP error 403 … API rate limit exceeded for <ip>
```

Both lanes build every flake output through [devour-flake](https://github.com/srid/devour-flake), fetched at `ci/mod.just` as an **unpinned** `github:srid/devour-flake` ref. Because the ref is mutable, nix must resolve `HEAD → rev` on every run by calling the **unauthenticated GitHub REST API** (`GET api.github.com/repos/srid/devour-flake/commits/HEAD`). That endpoint is capped at **60 requests/hour per IP**, so on a shared/cold CI egress IP it `403`s and takes the whole lane down. Tracked in #1204.

This pins devour-flake to an immutable rev, referenced once via a `just` variable and used by both recipes.

## Why the pin actually fixes it (verified, not assumed)

This was the key question — **does a rev-pin actually avoid the rate-limited API, or does the tarball still go through it?** I verified nix's github fetcher directly against the real repo in a fresh, empty nix store (`--store <tmp> -vvvv`, cold-box simulation):

| ref | requests to `api.github.com` | source tarball comes from |
| --- | --- | --- |
| **unpinned** `github:srid/devour-flake` | **1** — `GET /repos/srid/devour-flake/commits/HEAD` (the 403) | `github.com/…/archive/<rev>.tar.gz` → codeload |
| **rev-pinned** `github:srid/devour-flake/<rev>` | **0** | `github.com/…/archive/<rev>.tar.gz` → codeload |

The pin removes the **only** call that touches the rate-limited REST API — the `HEAD → rev` resolution. The source tarball is downloaded from the **git-archive endpoint** (`github.com/…/archive/…` → `codeload.github.com`) in *both* cases, and that endpoint is **not** subject to the 60/hr REST limit (it's the same path npins / `fetchTarball` use everywhere). So the pin is a genuine fix, not a mitigation.

Two supporting facts that make the pin sufficient for the *whole* lane:
- kolu's own `flake.nix` has **zero flake inputs** (nixpkgs etc. come via `fetchTarball`), so there's no other `github:` ref-resolution in the `nix` lane.
- The `home-manager` lane's example flake (`nix/home/example`) has `github:` inputs, but they're **locked in a committed `flake.lock`** → fetched by rev from the archive endpoint, no REST call. Its `kolu` input is `--override-input`'d to the local checkout.

So after this change, **there are no `api.github.com` calls left in either lane.**

## Pin vs. access-token — why the pin

An alternative fix is authenticating the box (`access-tokens = github.com=<token>` in the CI box's `nix.conf`, raising the limit 60 → 5000/hr). That also works, but it's strictly heavier: it requires provisioning a **secret onto every shared CI box** (`ci/pu/*` / `pu create`), which is cross-run infra surface. The pin needs no secret, is immutable/reproducible, and is a one-line-per-recipe change entirely inside this repo. (Related: `ci/pu/pool.sh` already health-probes only `cache.nixos.org`, never `api.github.com` — a box reads "healthy" yet 403s; the pin removes the dependency on that API rather than trying to auth it.)

## Honest caveats

- **linux CI can't validate this PR** — the broken lane is the very thing being fixed, and the warm pool is down. `just fmt` is clean and the `just` recipes parse + the variable resolves locally; darwin lanes weren't run. Real proof is a green linux `nix`/`home-manager` run on a cold box after merge.
- Pinning means adopting a newer devour-flake is now a **manual SHA bump** (called out in the recipe comment). devour-flake is a small, stable tool, so this is low-maintenance and arguably desirable for reproducibility.

## The change

`ci/mod.just`: add a `devour_flake := "github:srid/devour-flake/<rev>"` variable (pinned to devour-flake's current HEAD, so behaviour is unchanged) and reference it from the `nix` and `home-manager` recipes.

Closes #1204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
