### PR TITLE
fix(claude-code): stop the live pill lying `thinking` after a completed fast turn (#1754)

### DIFF
--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -411,6 +411,46 @@ function toolUseOrAwaitingUser(content: unknown): "tool_use" | "awaiting_user" {
   return classifyByAwaiting(awaiting, total);
 }
 
+/** Stop reasons on a *finalized* assistant message that mean the turn is NOT
+ *  done — the harness will resume it — so the pill stays a working state rather
+ *  than clearing to `waiting`. This is deliberately a small, bounded
+ *  CONTINUATION set, NOT an open terminal allow-list: any OTHER populated
+ *  `stop_reason` — `end_turn`, `max_tokens`, `stop_sequence`, `refusal`, or an
+ *  emulated Messages-API provider's own marker (ollama's `"stop"`, …) — means
+ *  the turn yielded → `waiting`. Tracking the small continuation set is robust
+ *  to new emulator vocab; the next SDK continuation reason is added HERE (a
+ *  discoverable extension point), from the canonical union
+ *  `@anthropic-ai/sdk`'s `StopReason`
+ *  (`end_turn | max_tokens | stop_sequence | tool_use | pause_turn | refusal`).
+ *
+ *  Failure-direction trade-off (disclosed, #1754): the pre-fix bug failed
+ *  CLOSED — a non-`end_turn` reason stranded on a *working* state (annoying but
+ *  safe). This deny-list fails OPEN — a future continuation reason not listed
+ *  here would clear the pill EARLY ("done" while the agent still works, so a
+ *  user could type over a live turn). Accepted because the continuation set is
+ *  small and rarely grows, but it is precisely why a new continuation reason
+ *  must be added to this set. `tool_use` is included for semantic completeness
+ *  though it never reaches the fallthrough (it has its own explicit derive arm
+ *  → `tool_use`/`awaiting_user` upstream). */
+const CONTINUATION_STOP_REASONS: ReadonlySet<string> = new Set([
+  "tool_use",
+  "pause_turn",
+]);
+
+/** State for a trailing `assistant` entry whose `stop_reason` was neither
+ *  `end_turn` nor `tool_use` (both handled by explicit arms upstream). A
+ *  populated `stop_reason` means the message finalized: unless it is a
+ *  CONTINUATION reason (`pause_turn` — the turn will resume), the turn has
+ *  yielded → `waiting`. A `null`/absent `stop_reason` is a not-yet-finalized
+ *  message (mid-stream, or a `claude -c` synthetic replay) → still `thinking`.
+ *  Exported for the #1754 fold pins. */
+export function assistantTailState(
+  stopReason: string | null,
+): "waiting" | "thinking" {
+  if (stopReason === null) return "thinking";
+  return CONTINUATION_STOP_REASONS.has(stopReason) ? "thinking" : "waiting";
+}
+
 /** Derive Claude Code state from the last relevant JSONL message.
  *
  *  Walks backwards once, tracking two independent signals with different
@@ -505,8 +545,13 @@ export function deriveState(
             state: toolUseOrAwaitingUser(entry.message?.content),
             model,
           }))
-          .with({ type: "assistant" }, () => ({
-            state: "thinking" as const,
+          // #1754: a finalized assistant tail that yielded (any populated
+          // non-`tool_use`/non-`pause_turn` stop_reason — `end_turn` is matched
+          // above; `max_tokens`/`stop_sequence`/`refusal`/emulator `"stop"`
+          // land here) reads `waiting`, not stuck `thinking`. `pause_turn` and a
+          // null/streaming stop_reason stay `thinking` (see `assistantTailState`).
+          .with({ type: "assistant" }, ({ stopReason }) => ({
+            state: assistantTailState(stopReason),
             model,
           }))
           .with({ type: "user" }, () => ({
@@ -1174,6 +1219,54 @@ export function outstandingForkRuns(
  *  decay. A false positive self-heals: the next transcript write fires the
  *  watcher and re-derives the true state. */
 export const TRANSIENT_STALE_MS = 2 * 60 * 1000;
+
+/** M1 (#1754) append-robust re-poll cadence. While a stranding-prone working
+ *  state is published, re-read the transcript tail off our OWN timer this often
+ *  — so a completion append whose `fs.watch` event was coalesced/dropped is
+ *  picked up within one interval instead of stranding the pill for the whole
+ *  poll window. Below user-perceptible lag (the field strand was ~60 s), above
+ *  `TRANSCRIPT_DEBOUNCE_MS` (150 ms) so it can't thrash the debounce. */
+export const APPEND_REPOLL_MS = 750;
+
+/** M1 (#1754) settle window: the re-poll only runs while the transcript was
+ *  written within this window (measured by `transcriptQuietMs`), and the window
+ *  RESETS on every observed write. Correctness bound (not merely cost): an
+ *  `fs.watch` event can only be dropped *near* a write, so polling long after
+ *  the last transcript activity cannot recover an event that was never going to
+ *  fire — it is pure waste. A genuinely long turn keeps emitting real appends
+ *  that fire `fs.watch` and reset this window, so the re-poll is the quiet-tail
+ *  backstop, not a standing poll. Generous (comfortably above the debounce and
+ *  any normal inter-write gap) so the practical strand-gap is nil. */
+export const APPEND_SETTLE_WINDOW_MS = 10 * 1000;
+
+/** M1 (#1754) policy: when (if ever) to arm the append-robust re-poll, given the
+ *  state about to be published and how long the transcript has been quiet. Pure
+ *  — the watcher folds the returned deadline into its existing one-shot recheck
+ *  timer (`min` with any decay/workflow-stale deadline).
+ *
+ *   - not a stranding-prone working state (`thinking`/`tool_use`) → no re-poll
+ *     (a terminal `waiting`/`running_background`/`awaiting_user` can't be
+ *     stranded by a missed *completion* append, so this is self-terminating).
+ *   - quiet unknown (stat failed) or past the settle window → no re-poll (the
+ *     drop is unrecoverable this far from a write; see `APPEND_SETTLE_WINDOW_MS`).
+ *   - otherwise → re-poll at `now + repollMs`.
+ *
+ *  Interaction with `decayTransientState`: for `thinking` (non-orphaned) decay
+ *  returns `recheckAt: null`, so this re-poll is the ONLY recheck (the genuine
+ *  net-new coverage). For `tool_use`, decay already re-arms at
+ *  `TRANSIENT_STALE_MS` (2 min); folding this in tightens that recheck to the
+ *  re-poll cadence within the window (a large factor sooner). */
+export function appendRepollDeadline(
+  state: ClaudeCodeInfo["state"],
+  quietMs: number | null,
+  now: number,
+  repollMs: number = APPEND_REPOLL_MS,
+  windowMs: number = APPEND_SETTLE_WINDOW_MS,
+): number | null {
+  if (state !== "thinking" && state !== "tool_use") return null;
+  if (quietMs === null || quietMs >= windowMs) return null;
+  return now + repollMs;
+}
 
 /** One process-table row: a pid and its parent pid. */
 export interface ProcEntry {

--- a/packages/integrations/claude-code/src/core.ts
+++ b/packages/integrations/claude-code/src/core.ts
@@ -411,16 +411,21 @@ function toolUseOrAwaitingUser(content: unknown): "tool_use" | "awaiting_user" {
   return classifyByAwaiting(awaiting, total);
 }
 
-/** Stop reasons on a *finalized* assistant message that mean the turn is NOT
- *  done — the harness will resume it — so the pill stays a working state rather
- *  than clearing to `waiting`. This is deliberately a small, bounded
- *  CONTINUATION set, NOT an open terminal allow-list: any OTHER populated
- *  `stop_reason` — `end_turn`, `max_tokens`, `stop_sequence`, `refusal`, or an
- *  emulated Messages-API provider's own marker (ollama's `"stop"`, …) — means
- *  the turn yielded → `waiting`. Tracking the small continuation set is robust
- *  to new emulator vocab; the next SDK continuation reason is added HERE (a
- *  discoverable extension point), from the canonical union
- *  `@anthropic-ai/sdk`'s `StopReason`
+/** Continuation `stop_reason`s that reach the assistant *fallthrough* arm and
+ *  mean the turn is NOT done — the harness will resume it — so the pill stays
+ *  `thinking` rather than clearing to `waiting`. Today that is only `pause_turn`
+ *  (Anthropic's server-tool pause). `tool_use` is ALSO a continuation reason but
+ *  is handled by its own explicit arm upstream (→ `tool_use`/`awaiting_user`),
+ *  so it never reaches here and is deliberately NOT listed — listing it would be
+ *  dead and would invite deleting that upstream arm.
+ *
+ *  This is deliberately a small, bounded DENY-list, NOT an open terminal
+ *  allow-list: any OTHER populated `stop_reason` — `end_turn`, `max_tokens`,
+ *  `stop_sequence`, `refusal`, or an emulated Messages-API provider's own marker
+ *  (ollama's `"stop"`, …) — means the turn yielded → `waiting`. Tracking the
+ *  small continuation set is robust to new emulator vocab; the next SDK
+ *  continuation reason is added HERE (a discoverable extension point), from the
+ *  canonical union `@anthropic-ai/sdk`'s `StopReason`
  *  (`end_turn | max_tokens | stop_sequence | tool_use | pause_turn | refusal`).
  *
  *  Failure-direction trade-off (disclosed, #1754): the pre-fix bug failed
@@ -429,13 +434,8 @@ function toolUseOrAwaitingUser(content: unknown): "tool_use" | "awaiting_user" {
  *  here would clear the pill EARLY ("done" while the agent still works, so a
  *  user could type over a live turn). Accepted because the continuation set is
  *  small and rarely grows, but it is precisely why a new continuation reason
- *  must be added to this set. `tool_use` is included for semantic completeness
- *  though it never reaches the fallthrough (it has its own explicit derive arm
- *  → `tool_use`/`awaiting_user` upstream). */
-const CONTINUATION_STOP_REASONS: ReadonlySet<string> = new Set([
-  "tool_use",
-  "pause_turn",
-]);
+ *  must be added to this set. */
+const CONTINUATION_STOP_REASONS: ReadonlySet<string> = new Set(["pause_turn"]);
 
 /** State for a trailing `assistant` entry whose `stop_reason` was neither
  *  `end_turn` nor `tool_use` (both handled by explicit arms upstream). A
@@ -541,6 +541,11 @@ export function deriveState(
             state: "waiting" as const,
             model,
           }))
+          // `tool_use` is a continuation reason too, but it resolves to a
+          // richer state (`tool_use`/`awaiting_user`) than the fallthrough's
+          // `thinking`, so it keeps its own explicit arm and is intentionally
+          // absent from `CONTINUATION_STOP_REASONS` (which only lists reasons
+          // that reach the fallthrough below).
           .with({ type: "assistant", stopReason: "tool_use" }, () => ({
             state: toolUseOrAwaitingUser(entry.message?.content),
             model,
@@ -1220,6 +1225,18 @@ export function outstandingForkRuns(
  *  watcher and re-derives the true state. */
 export const TRANSIENT_STALE_MS = 2 * 60 * 1000;
 
+/** The published states that self-clear ONLY via kolu's own recheck timer — no
+ *  fs event announces their end: a trailing `thinking` prompt or a dangling
+ *  `tool_use`. BOTH timer policies key off this one set —
+ *  `decayTransientState` (is the transient abandoned?) and `appendRepollDeadline`
+ *  (recover a dropped completion event) — so a new state that needs
+ *  timer-driven reconciliation is added HERE once, and the two can't diverge and
+ *  silently reintroduce the stranding-pill bug (#1754). */
+const TRANSIENT_WORKING_STATES: ReadonlySet<ClaudeCodeInfo["state"]> = new Set([
+  "thinking",
+  "tool_use",
+]);
+
 /** M1 (#1754) append-robust re-poll cadence. While a stranding-prone working
  *  state is published, re-read the transcript tail off our OWN timer this often
  *  — so a completion append whose `fs.watch` event was coalesced/dropped is
@@ -1263,7 +1280,7 @@ export function appendRepollDeadline(
   repollMs: number = APPEND_REPOLL_MS,
   windowMs: number = APPEND_SETTLE_WINDOW_MS,
 ): number | null {
-  if (state !== "thinking" && state !== "tool_use") return null;
+  if (!TRANSIENT_WORKING_STATES.has(state)) return null;
   if (quietMs === null || quietMs >= windowMs) return null;
   return now + repollMs;
 }
@@ -1351,7 +1368,7 @@ export function decayTransientState(
   staleMs: number = TRANSIENT_STALE_MS,
   now: number = Date.now(),
 ): { state: ClaudeCodeInfo["state"]; recheckAt: number | null } {
-  if (state !== "tool_use" && state !== "thinking") {
+  if (!TRANSIENT_WORKING_STATES.has(state)) {
     return { state, recheckAt: null };
   }
   // A `thinking` turn is childless and quiet whether live or abandoned; only an

--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -13,6 +13,7 @@ import fs from "node:fs";
 import { agentInfoEqual } from "anyagent";
 import { match } from "ts-pattern";
 import {
+  appendRepollDeadline,
   completedBackgroundTaskIds,
   decayTransientState,
   deriveState,
@@ -84,6 +85,16 @@ const TRANSCRIPT_DEBOUNCE_MS = 150;
  *  over V8's 4 GB ceiling. 1 MB bounds peak transient memory regardless
  *  of file size. */
 const TASK_SCAN_CHUNK_BYTES = 1024 * 1024;
+
+/** Soonest of two one-shot recheck deadlines, either possibly null ("no
+ *  deadline"). Used to fold the M1 append re-poll into the existing
+ *  decay/workflow-stale deadline so `scheduleStaleRecheck` always arms the
+ *  earliest — one never suppresses the other. */
+function earliestDeadline(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.min(a, b);
+}
 
 // --- Transcript watching lifecycle ---
 
@@ -429,6 +440,18 @@ export function createSessionWatcher(
         );
         publishedState = decayed.state;
         staleDeadline = decayed.recheckAt;
+        // M1 (#1754): append-robust re-poll. A completion append landing AFTER
+        // attach whose fs.watch event is coalesced/dropped would otherwise
+        // strand a working state (the fs.watch fire is today the sole re-derive
+        // trigger, and a non-orphaned trailing `thinking` arms no decay
+        // recheck). While a stranding-prone working state is published and the
+        // transcript was written within the settle window, arm a short re-poll
+        // that re-reads the tail off our own timer — folded (soonest wins) with
+        // any decay/stale deadline so it never delays a sooner recheck.
+        staleDeadline = earliestDeadline(
+          staleDeadline,
+          appendRepollDeadline(publishedState, quietMs, now),
+        );
       }
     }
     scheduleStaleRecheck(staleDeadline);

--- a/packages/integrations/claude-code/src/stuck-state.test.ts
+++ b/packages/integrations/claude-code/src/stuck-state.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { deriveState } from "./core.ts";
+import {
+  APPEND_REPOLL_MS,
+  APPEND_SETTLE_WINDOW_MS,
+  appendRepollDeadline,
+  deriveState,
+  TRANSIENT_STALE_MS,
+} from "./core.ts";
 
 // --- #1754: claude-code live state can lie on a fast turn ---
 //
@@ -10,55 +16,122 @@ import { deriveState } from "./core.ts";
 // state (`thinking`) after the turn has fully completed and never reconcile to
 // `waiting` — a permanently lying pill. #1754 (and its two correcting comments)
 // isolate the two mechanisms that are actually reproducible against today's
-// code; each RED below pins one, reproduced first per #1690.
+// code; the fix folds them both. Reproduced first per #1690.
 //
 // NB the issue's ORIGINAL framing ("watcher attaches after the write and only
-// tails, so it never sees the completion") is REFUTED by today's code and is
-// deliberately NOT tested as a RED: every check reads a 256 KB tail
-// (`TAIL_BYTES`) and `setupTranscriptWatching` fires an immediate
-// `onTranscriptMaybeChanged` at attach, so a transcript already carrying
-// `end_turn` at attach derives `waiting` immediately (verified by reproduction).
-// The real defect is the OTHER half — the completion append that lands AFTER
-// attach and whose fs.watch event is coalesced/dropped (Half 2) — pinned below.
+// tails, so it never sees the completion") is REFUTED by the code and is NOT
+// tested: every check reads a 256 KB tail (`TAIL_BYTES`) and
+// `setupTranscriptWatching` fires an immediate `onTranscriptMaybeChanged` at
+// attach, so a transcript already carrying `end_turn` at attach derives
+// `waiting` immediately (verified by reproduction). The real defect is the
+// OTHER half — the completion append that lands AFTER attach and whose fs.watch
+// event is coalesced/dropped (Half 2) — pinned by mechanism 1 below.
 
-describe("#1754 mechanism 2 — stop_reason fold strands `thinking`", () => {
-  // A completed assistant reply whose turn has yielded, but whose `stop_reason`
+describe("#1754 M2 — stop_reason fold: a yielded turn reads `waiting`", () => {
+  // A completed assistant reply whose turn has yielded but whose `stop_reason`
   // is NOT `end_turn`. Real Anthropic terminal reasons (`max_tokens`,
-  // `stop_sequence`) and a Messages-API-emulation reason (`stop`, ollama's shape
-  // — the issue's named culprit) all fall through the fold's
-  // `assistant + end_turn → waiting` / `assistant + tool_use → tool_use` cases
-  // into the bare `assistant → thinking` branch. None of these is `tool_use`
-  // (no further work is queued), so the turn HAS ended — the pill must read
-  // `waiting`, not spin `thinking` forever. Fails today: all three derive
-  // `thinking`.
-  const YIELDED_NON_END_TURN = ["stop", "max_tokens", "stop_sequence"] as const;
+  // `stop_sequence`, `refusal`) and a Messages-API-emulation reason (`stop`,
+  // ollama's shape — the issue's named culprit) all fall through the fold's
+  // `end_turn`/`tool_use` arms into the assistant fallthrough. None is a
+  // CONTINUATION reason, so the turn HAS ended → `waiting`, not stuck
+  // `thinking`. (Pre-fix: all derived `thinking`.)
+  const YIELDED_TERMINAL = [
+    "stop",
+    "max_tokens",
+    "stop_sequence",
+    "refusal", // C1: locks the "populated non-continuation ⇒ waiting" direction
+  ] as const;
 
-  it.fails.each(
-    YIELDED_NON_END_TURN,
-  )("assistant with stop_reason=%s (turn yielded, not a tool call) → waiting", (stopReason) => {
+  it.each(
+    YIELDED_TERMINAL,
+  )("assistant with stop_reason=%s (turn yielded) → waiting", (stopReason) => {
     const line = JSON.stringify({
       type: "assistant",
       message: { stop_reason: stopReason, model: "claude-opus-4-8" },
     });
     expect(deriveState([line])?.state).toBe("waiting");
   });
+
+  // C1 — the sharpest gap the gate flagged: a fix spelled `stopReason !== null
+  // && stopReason !== "tool_use"` passes every `waiting` pin above while
+  // silently clearing `pause_turn` early. `pause_turn` is a CONTINUATION reason
+  // (the harness resumes the turn), so it MUST stay a working state; and a
+  // null/streaming stop_reason is a not-yet-finalized message. These pin the
+  // continuation direction so a wrong deny-list can't pass.
+  it.each([
+    { stop_reason: "pause_turn", label: "pause_turn (turn will resume)" },
+    { stop_reason: null, label: "null (message not finalized)" },
+  ])("assistant with stop_reason=$label stays thinking", ({ stop_reason }) => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { stop_reason, model: "claude-opus-4-8" },
+    });
+    expect(deriveState([line])?.state).toBe("thinking");
+  });
+
+  // C4 — M2 widens `running_background` eligibility: a truncated turn
+  // (`max_tokens`) that reaches `waiting` and holds a live workflow runId IS
+  // busy-waiting, so it must promote — today only `end_turn` did. (Pre-fix:
+  // `max_tokens` → `thinking`, never promoted.)
+  it("promotes a `max_tokens` turn holding a live workflow to running_background", () => {
+    const maxTokens = JSON.stringify({
+      type: "assistant",
+      message: { stop_reason: "max_tokens", model: "claude-opus-4-8" },
+    });
+    expect(
+      deriveState([maxTokens], [{ taskId: "t1", runId: "wf_1" }])?.state,
+    ).toBe("running_background");
+  });
 });
 
-describe("#1754 mechanism 1 — completion append after attach must reconcile", () => {
+describe("#1754 M1 — appendRepollDeadline (append-robust re-poll policy)", () => {
+  const now = 1_700_000_000_000;
+
+  it.each([
+    "thinking",
+    "tool_use",
+  ] as const)("arms a re-poll for a stranding-prone working state (%s) within the settle window", (state) => {
+    // Net-new for `thinking`: `decayTransientState` returns null for a live
+    // (non-orphaned) thinking, so this is the ONLY recheck that recovers a
+    // dropped completion event.
+    expect(appendRepollDeadline(state, 200, now)).toBe(now + APPEND_REPOLL_MS);
+  });
+
+  it.each([
+    "waiting",
+    "running_background",
+    "awaiting_user",
+  ] as const)("never arms a re-poll for terminal state %s (self-terminating)", (state) => {
+    expect(appendRepollDeadline(state, 200, now)).toBeNull();
+  });
+
+  it("stops re-polling once the transcript has been quiet past the settle window", () => {
+    // A dropped fs.watch event can only occur near a write; polling this far
+    // from the last write recovers nothing (the correctness bound, not cost).
+    expect(
+      appendRepollDeadline("thinking", APPEND_SETTLE_WINDOW_MS + 1, now),
+    ).toBeNull();
+  });
+
+  it("does not re-poll when the transcript quiet is unknown (stat failed)", () => {
+    expect(appendRepollDeadline("thinking", null, now)).toBeNull();
+  });
+
+  it("tightens a `tool_use` recheck far below the 2-min decay window", () => {
+    // decay re-arms tool_use at TRANSIENT_STALE_MS; the re-poll fires first.
+    expect(appendRepollDeadline("tool_use", 200, now)).toBeLessThan(
+      now + TRANSIENT_STALE_MS,
+    );
+  });
+});
+
+describe("#1754 M1 — watcher reconciles a missed completion append", () => {
   // Half 2, the ACTUAL flake: the terminal `end_turn` lands AFTER the watcher
-  // has attached (on a fast turn), and its fs.watch event is coalesced/dropped
-  // — most reliably on macOS kqueue, but structurally possible anywhere. Today
-  // the watcher reconciles ONLY on an fs.watch fire (a trailing `thinking` that
-  // is not orphaned arms no decay recheck — `decayTransientState` returns
-  // `recheckAt: null`), so a missed completion event strands `thinking` for the
-  // whole poll window. The fix is an fs.watch-independent re-read (a bounded
-  // re-poll / re-stat while a working state is published) so a dropped event
-  // can't strand a completed turn.
-  //
-  // fs.watch is neutralized for the whole test so NO append ever produces an
-  // event — this isolates exactly the coalesced-miss case deterministically
-  // (the real OS drop is timing-dependent and can't be forced). A correct fix
-  // reconciles to `waiting` purely off its own timer; today it stays `thinking`.
+  // attaches (fast turn), and its fs.watch event is coalesced/dropped. fs.watch
+  // is neutralized for the whole test so NO append ever produces an event —
+  // this isolates the coalesced-miss case deterministically (the real OS drop
+  // is timing-dependent). A correct watcher reconciles to `waiting` purely off
+  // its own append re-poll timer. (Pre-fix: stayed `thinking` forever.)
   let tmpDir: string;
   let createSessionWatcher: typeof import("./index.ts").createSessionWatcher;
   let encodeProjectPath: typeof import("./index.ts").encodeProjectPath;
@@ -107,7 +180,7 @@ describe("#1754 mechanism 1 — completion append after attach must reconcile", 
     return latest();
   }
 
-  it.fails("reconciles to `waiting` after a post-attach completion append with no watch event", async () => {
+  it("reconciles to `waiting` after a post-attach completion append with no watch event", async () => {
     const watchSpy = vi
       .spyOn(fs, "watch")
       .mockImplementation(() => ({ close() {} }) as unknown as fs.FSWatcher);
@@ -125,8 +198,8 @@ describe("#1754 mechanism 1 — completion append after attach must reconcile", 
     try {
       expect(await waitForState(state, "thinking", 1000)).toBe("thinking");
       // The turn completes: `end_turn` is appended, but fs.watch delivers
-      // nothing (coalesced/dropped). A correct watcher re-reads off its own
-      // timer within a bounded window and publishes `waiting`.
+      // nothing (coalesced/dropped). The watcher's own append re-poll re-reads
+      // the tail within a bounded window and publishes `waiting`.
       fs.appendFileSync(p, `${endTurn()}\n`);
       expect(await waitForState(state, "waiting", 4000)).toBe("waiting");
     } finally {

--- a/packages/integrations/claude-code/src/stuck-state.test.ts
+++ b/packages/integrations/claude-code/src/stuck-state.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { deriveState } from "./core.ts";
+
+// --- #1754: claude-code live state can lie on a fast turn ---
+//
+// On a fast/short turn kolu's claude-code live state can stick on a *working*
+// state (`thinking`) after the turn has fully completed and never reconcile to
+// `waiting` — a permanently lying pill. #1754 (and its two correcting comments)
+// isolate the two mechanisms that are actually reproducible against today's
+// code; each RED below pins one, reproduced first per #1690.
+//
+// NB the issue's ORIGINAL framing ("watcher attaches after the write and only
+// tails, so it never sees the completion") is REFUTED by today's code and is
+// deliberately NOT tested as a RED: every check reads a 256 KB tail
+// (`TAIL_BYTES`) and `setupTranscriptWatching` fires an immediate
+// `onTranscriptMaybeChanged` at attach, so a transcript already carrying
+// `end_turn` at attach derives `waiting` immediately (verified by reproduction).
+// The real defect is the OTHER half — the completion append that lands AFTER
+// attach and whose fs.watch event is coalesced/dropped (Half 2) — pinned below.
+
+describe("#1754 mechanism 2 — stop_reason fold strands `thinking`", () => {
+  // A completed assistant reply whose turn has yielded, but whose `stop_reason`
+  // is NOT `end_turn`. Real Anthropic terminal reasons (`max_tokens`,
+  // `stop_sequence`) and a Messages-API-emulation reason (`stop`, ollama's shape
+  // — the issue's named culprit) all fall through the fold's
+  // `assistant + end_turn → waiting` / `assistant + tool_use → tool_use` cases
+  // into the bare `assistant → thinking` branch. None of these is `tool_use`
+  // (no further work is queued), so the turn HAS ended — the pill must read
+  // `waiting`, not spin `thinking` forever. Fails today: all three derive
+  // `thinking`.
+  const YIELDED_NON_END_TURN = ["stop", "max_tokens", "stop_sequence"] as const;
+
+  it.fails.each(
+    YIELDED_NON_END_TURN,
+  )("assistant with stop_reason=%s (turn yielded, not a tool call) → waiting", (stopReason) => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { stop_reason: stopReason, model: "claude-opus-4-8" },
+    });
+    expect(deriveState([line])?.state).toBe("waiting");
+  });
+});
+
+describe("#1754 mechanism 1 — completion append after attach must reconcile", () => {
+  // Half 2, the ACTUAL flake: the terminal `end_turn` lands AFTER the watcher
+  // has attached (on a fast turn), and its fs.watch event is coalesced/dropped
+  // — most reliably on macOS kqueue, but structurally possible anywhere. Today
+  // the watcher reconciles ONLY on an fs.watch fire (a trailing `thinking` that
+  // is not orphaned arms no decay recheck — `decayTransientState` returns
+  // `recheckAt: null`), so a missed completion event strands `thinking` for the
+  // whole poll window. The fix is an fs.watch-independent re-read (a bounded
+  // re-poll / re-stat while a working state is published) so a dropped event
+  // can't strand a completed turn.
+  //
+  // fs.watch is neutralized for the whole test so NO append ever produces an
+  // event — this isolates exactly the coalesced-miss case deterministically
+  // (the real OS drop is timing-dependent and can't be forced). A correct fix
+  // reconciles to `waiting` purely off its own timer; today it stays `thinking`.
+  let tmpDir: string;
+  let createSessionWatcher: typeof import("./index.ts").createSessionWatcher;
+  let encodeProjectPath: typeof import("./index.ts").encodeProjectPath;
+  const sessionId = "stuck-state-session";
+  const cwd = "/home/user/stuck-state-project";
+  const session = { pid: 1, sessionId, cwd };
+  const noopLog = { debug() {}, info() {}, warn() {}, error() {} };
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-stuck-state-"));
+    process.env.KOLU_CLAUDE_PROJECTS_DIR = tmpDir;
+    vi.resetModules();
+    const mod = await import("./index.ts");
+    createSessionWatcher = mod.createSessionWatcher;
+    encodeProjectPath = mod.encodeProjectPath;
+  });
+  afterAll(() => {
+    delete process.env.KOLU_CLAUDE_PROJECTS_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const projectDir = () => path.join(tmpDir, encodeProjectPath(cwd));
+  const transcriptPath = () => path.join(projectDir(), `${sessionId}.jsonl`);
+  const endTurn = () =>
+    JSON.stringify({
+      type: "assistant",
+      message: { stop_reason: "end_turn", model: "claude-opus-4-8" },
+    });
+  const userPrompt = () =>
+    JSON.stringify({ type: "user", message: { content: "hi" } });
+
+  /** Poll the latest emitted state until it equals `want` or the deadline
+   *  passes; returns the last observed state. No `onTick` re-fire (unlike the
+   *  fork-lifecycle harness) — the point is that reconciliation must NOT depend
+   *  on a re-delivered fs event. */
+  async function waitForState(
+    latest: () => string | null,
+    want: string,
+    timeoutMs: number,
+  ): Promise<string | null> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (latest() === want) return want;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    return latest();
+  }
+
+  it.fails("reconciles to `waiting` after a post-attach completion append with no watch event", async () => {
+    const watchSpy = vi
+      .spyOn(fs, "watch")
+      .mockImplementation(() => ({ close() {} }) as unknown as fs.FSWatcher);
+    const p = transcriptPath();
+    fs.mkdirSync(projectDir(), { recursive: true });
+    // Attach while the tail is a bare user prompt → `thinking`.
+    fs.writeFileSync(p, `${userPrompt()}\n`);
+    const emitted: import("./index.ts").ClaudeCodeInfo[] = [];
+    const watcher = createSessionWatcher(
+      session,
+      (i) => emitted.push(i),
+      noopLog,
+    );
+    const state = () => emitted.at(-1)?.state ?? null;
+    try {
+      expect(await waitForState(state, "thinking", 1000)).toBe("thinking");
+      // The turn completes: `end_turn` is appended, but fs.watch delivers
+      // nothing (coalesced/dropped). A correct watcher re-reads off its own
+      // timer within a bounded window and publishes `waiting`.
+      fs.appendFileSync(p, `${endTurn()}\n`);
+      expect(await waitForState(state, "waiting", 4000)).toBe("waiting");
+    } finally {
+      watcher.destroy();
+      watchSpy.mockRestore();
+    }
+  }, 20_000);
+});


### PR DESCRIPTION
## The lie

On a fast, short turn the claude-code dock pill could stick on **`thinking`
after the turn had fully completed** and never reconcile to `waiting` — a
permanently lying state (field report: a pill sat "thinking" ~30 min while the
agent was idle; CI evidence on aarch64-darwin: a 2.88 s ollama turn stuck
`thinking` for the full 60 s poll). Two independent mechanisms produce it, and
this PR folds both. **Reproduced first** (per #1690) — the committed RED pins
each; the issue's *original* "read-from-start on attach" framing was **refuted**
against today's code and is documented rather than tested (see below).

## M2 — the `stop_reason` fold stranded a yielded turn

`deriveState` mapped only `assistant + end_turn → waiting`; every other
*completed* (non-`tool_use`) stop_reason fell into the bare `assistant →
thinking` branch. So an emulated Messages-API provider (ollama's `"stop"`) — or a
real non-`end_turn` terminal reason (`max_tokens`, `stop_sequence`, `refusal`) —
read as working forever.

Now a finalized assistant tail whose `stop_reason` is a **populated** value not in
`CONTINUATION_STOP_REASONS` reads `waiting`. The set is a deliberate **deny-list**
(named, per gate C2): the *terminal* set is open across emulators, so keying off
the small, bounded *continuation* set (today just `pause_turn`) is the robust cut
— the next SDK continuation reason is a discoverable extension point, not a silent
early-clear. `pause_turn` and a `null`/streaming stop_reason stay `thinking`.

| trailing `stop_reason` | before | after |
|---|---|---|
| `end_turn` | waiting | waiting |
| `tool_use` | tool_use | tool_use |
| `pause_turn` | thinking | thinking |
| `null` / absent | thinking | thinking |
| `max_tokens` · `stop_sequence` · `refusal` · emulator `"stop"` | **thinking (bug)** | **waiting** |

**Disclosed failure-direction flip (gate C2):** the old bug failed *closed* (stuck
working — safe); the deny-list fails *open* (a future unlisted continuation reason
would clear the pill early). Accepted because the continuation set is small and
rarely grows — which is exactly why a new one must be added to the set.

## M1 — a dropped completion event stranded the watcher

The terminal `end_turn` often lands *after* the transcript watcher attaches (fast
turn), and its `fs.watch` event can be coalesced/dropped (kqueue on macOS
especially). The watcher re-derived **only** on an `fs.watch` fire — a non-orphaned
trailing `thinking` arms no decay recheck (`decayTransientState → recheckAt:
null`) — so a missed completion event stranded `thinking` for the whole poll
window.

`appendRepollDeadline` arms a short (`APPEND_REPOLL_MS` = 750 ms) re-read off the
**existing** one-shot recheck timer while a stranding-prone working state is
published, `min`-folded with any decay/workflow-stale deadline. Per gate **C3** it
is bounded to a **settle window** (`APPEND_SETTLE_WINDOW_MS` = 10 s) that resets on
every write — a correctness bound, not just cost: an `fs.watch` event can only be
dropped *near* a write, so polling long after the last activity recovers nothing.
A genuinely long turn keeps emitting real appends that reset the window, so the
re-poll is the quiet-tail backstop, not a standing poll. Decay is left pure.

M2 also **widens `running_background` eligibility** (gate C4): a truncated turn
(`max_tokens`) holding a live workflow runId now promotes — it *is* busy-waiting.
Covered by a test.

## Why the issue's original direction was refuted

The issue first proposed "initial full-scan on attach (read from the START)". Its
own comment 2 corrects this, and the correction holds against today's code
(reproduced): every check already reads a **256 KB tail** and
`setupTranscriptWatching` fires an immediate on-attach derive, so a transcript
already carrying `end_turn` at attach derives `waiting` immediately. Reading from
byte 0 changes nothing (the terminal state is at the tail) and is strictly worse on
a multi-MB transcript. The real gap is the *other* half — the dropped
**append-after-attach** — which is M1. The gate panel ratified this refutation.

## Review gauntlet

RED → design gate (two-refuter panel, GO-with-corrections C1–C6, all folded) →
lens-debate (lowy ⇄ hickey) → correctness pass. Folded: a shared
`TRANSIENT_WORKING_STATES` set so the two timer policies can't diverge and
reintroduce the bug (hickey); dropped a dead `tool_use` deny-list entry (hickey);
`earliestDeadline` kept local as call-site glue (lowy, over hickey's move-it
suggestion — generalizing `nextStaleDeadline` would complect an array-of-runs fold
with a scalar min).

## Scope & residuals

- **claude-code only** (gate C6). The identical robustness gap in **grok** (which
  has *no* recheck timer at all, so it strands *unbounded*) plus extracting a
  **shared watch + fs.watch-independent-repoll primitive** for grok/codex is filed
  as **#1918** — intentionally not touched here so the diff stays true to its title.
- **Residual (out of scope, symmetric to the mid-turn-miss residual):** M1
  self-terminates on a terminal state, so a dropped append that *resumes* work
  after a non-`end_turn`/non-`pause_turn` reason could strand on `waiting` (the
  mirror). Requires a resume-after-yield *and* a coalesced drop — largely
  theoretical for real claude-code.
- **Follow-up (noted, non-blocking):** the 750 ms re-poll fires the fire-and-forget
  `refreshSummary()` even on no-op passes, adding bounded idle `getSessionInfo`
  load in production; a content-change gate on the whole fetch path fits the #1918
  primitive work.
- **Descoped e2e:** the real-agent `-real.feature` state-arc restorations the issue
  lists live in the unmerged PR #1751, not `master`; this PR lands the code fix +
  unit REDs, and those restorations are a stated downstream follow-up when #1751
  merges (not fabricated here).

## Tests

`stuck-state.test.ts`: the two REDs (flipped green), the C1 `pause_turn →
thinking` / `refusal → waiting` boundary pins, the C4 `max_tokens` + live-workflow
→ `running_background` promotion, and the C3 `appendRepollDeadline` policy
(window-bounded, self-terminating on terminal states). 199 tests green in the
package; typecheck clean.

Fixes #1754. Refs #1918, #1690, #1751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
