### PR TITLE
fix(bridge): silence biome useIterableCallbackReturn in dashboard

### DIFF
--- a/.agents/skills/bridge/dashboard/index.js
+++ b/.agents/skills/bridge/dashboard/index.js
@@ -172,7 +172,9 @@ const collectBlockKeys = (d) => {
       if (n.state === "block") keys.add(k);
       if (n.lane?.nodes) walk(n.lane.nodes, `${k}~lane`);
     });
-  (d.tracks ?? []).forEach((t, i) => walk(t.nodes, `t:${t.name ?? i}`));
+  (d.tracks ?? []).forEach((t, i) => {
+    walk(t.nodes, `t:${t.name ?? i}`);
+  });
   (d.queue ?? []).forEach((n, i) => {
     if (n.state === "block") keys.add(`q/${n.label ?? i}`);
   });

--- a/.claude/skills/bridge/dashboard/index.js
+++ b/.claude/skills/bridge/dashboard/index.js
@@ -172,7 +172,9 @@ const collectBlockKeys = (d) => {
       if (n.state === "block") keys.add(k);
       if (n.lane?.nodes) walk(n.lane.nodes, `${k}~lane`);
     });
-  (d.tracks ?? []).forEach((t, i) => walk(t.nodes, `t:${t.name ?? i}`));
+  (d.tracks ?? []).forEach((t, i) => {
+    walk(t.nodes, `t:${t.name ?? i}`);
+  });
   (d.queue ?? []).forEach((n, i) => {
     if (n.state === "block") keys.add(`q/${n.label ?? i}`);
   });

--- a/agents/.apm/skills/bridge/dashboard/index.js
+++ b/agents/.apm/skills/bridge/dashboard/index.js
@@ -172,7 +172,9 @@ const collectBlockKeys = (d) => {
       if (n.state === "block") keys.add(k);
       if (n.lane?.nodes) walk(n.lane.nodes, `${k}~lane`);
     });
-  (d.tracks ?? []).forEach((t, i) => walk(t.nodes, `t:${t.name ?? i}`));
+  (d.tracks ?? []).forEach((t, i) => {
+    walk(t.nodes, `t:${t.name ?? i}`);
+  });
   (d.queue ?? []).forEach((n, i) => {
     if (n.state === "block") keys.add(`q/${n.label ?? i}`);
   });

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-21T17:53:14.005413+00:00'
+generated_at: '2026-07-21T19:44:17.769773+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -63,7 +63,7 @@ dependencies:
     .agents/skills/be/SKILL.md: sha256:7c44d9f207d14396cd8548ae20b65902bbd1c51ac76f27c48a88263ba745273c
     .agents/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
-    .agents/skills/bridge/dashboard/index.js: sha256:998a815454868ac02daf2f049bd099cb76b1559d836b2b11adbf73934c6879e8
+    .agents/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
     .agents/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
     .agents/skills/codex-debate/SKILL.md: sha256:87edc39c1b3de77e06a4075fe8ec314838da84f6470dda820ae59eae29f3b5ba
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
@@ -78,7 +78,7 @@ dependencies:
     .claude/skills/be/SKILL.md: sha256:7c44d9f207d14396cd8548ae20b65902bbd1c51ac76f27c48a88263ba745273c
     .claude/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
-    .claude/skills/bridge/dashboard/index.js: sha256:998a815454868ac02daf2f049bd099cb76b1559d836b2b11adbf73934c6879e8
+    .claude/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
     .claude/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
     .claude/skills/codex-debate/SKILL.md: sha256:87edc39c1b3de77e06a4075fe8ec314838da84f6470dda820ae59eae29f3b5ba
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
@@ -898,7 +898,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:998a815454868ac02daf2f049bd099cb76b1559d836b2b11adbf73934c6879e8
+  content_hash: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
 - kind: project-relative
   target: claude
   value: .claude/skills/bridge/dashboard/red-alert.mp3
@@ -1717,7 +1717,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:998a815454868ac02daf2f049bd099cb76b1559d836b2b11adbf73934c6879e8
+  content_hash: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
 - kind: project-relative
   target: codex
   value: .agents/skills/bridge/dashboard/red-alert.mp3


### PR DESCRIPTION
**`ci::biome` was red on master** because the bridge dashboard's `collectBlockKeys` walked tracks with a `forEach` callback that returned the value of `walk(...)`. Biome's `useIterableCallbackReturn` treats that as an error under `--error-on-warnings`.

The fix is a one-line shape change: block-body the callback so the walk runs for its side effect and returns nothing. APM was regenerated so the vendored `.claude` / `.agents` skill trees match the source under `agents/.apm/`.

_Generated by Grok Build (model `grok-4.5`)._