### PR TITLE
chore(deps): bump odu — protect --platform without hosts (odu#53)

### DIFF
--- a/.agents/skills/odu/SKILL.md
+++ b/.agents/skills/odu/SKILL.md
@@ -146,6 +146,8 @@ nix run github:juspay/odu -- dump            # resolved pipeline as JSON
 nix run github:juspay/odu -- graph           # dependency graph (Mermaid)
 nix run github:juspay/odu -- protect --dry-run   # the (recipe × platform) contexts
 nix run github:juspay/odu -- protect             # PATCH branch protection to them
+# --platform P (repeatable) pins the repo's platform set with no hosts config;
+# omitted, the set derives from the machine's hosts file (warned on stderr).
 ```
 
 ## Live introspection (attach to a run in progress)

--- a/.claude/skills/odu/SKILL.md
+++ b/.claude/skills/odu/SKILL.md
@@ -146,6 +146,8 @@ nix run github:juspay/odu -- dump            # resolved pipeline as JSON
 nix run github:juspay/odu -- graph           # dependency graph (Mermaid)
 nix run github:juspay/odu -- protect --dry-run   # the (recipe × platform) contexts
 nix run github:juspay/odu -- protect             # PATCH branch protection to them
+# --platform P (repeatable) pins the repo's platform set with no hosts config;
+# omitted, the set derives from the machine's hosts file (warned on stderr).
 ```
 
 ## Live introspection (attach to a run in progress)

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-21T20:42:11.933129+00:00'
+generated_at: '2026-07-21T20:55:48.957567+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -133,7 +133,7 @@ dependencies:
 - repo_url: juspay/odu
   name: odu
   host: github.com
-  resolved_commit: 37fc20ea0f2dc6e15653c0b29759cfa923d4a79a
+  resolved_commit: c506b43e73473dd3a7dd9cf36cf75535130a784a
   version: 1.0.0
   package_type: apm_package
   deployed_files:
@@ -150,11 +150,11 @@ dependencies:
   deployed_file_hashes:
     .agents/skills/odu-mcp/SKILL.md: sha256:d704536fdd36cfd1298ffc1d0276734bbc177ea22c3c5f0bade95cc1abf54af2
     .agents/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .agents/skills/odu/SKILL.md: sha256:5b9e068002a0144e92c0ff1a60b5a0a6482d6f5b15a895903dcc5757ac5218d6
+    .agents/skills/odu/SKILL.md: sha256:9e387042f15013cc8b2cae1854d56e53bc2db3fed817addedd794e9c55cc8306
     .claude/skills/odu-mcp/SKILL.md: sha256:d704536fdd36cfd1298ffc1d0276734bbc177ea22c3c5f0bade95cc1abf54af2
     .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .claude/skills/odu/SKILL.md: sha256:5b9e068002a0144e92c0ff1a60b5a0a6482d6f5b15a895903dcc5757ac5218d6
-  content_hash: sha256:a4ddd73ff1d7be157cdc6d798126117e33fcfb49fb79570839963c7f6db4ba12
+    .claude/skills/odu/SKILL.md: sha256:9e387042f15013cc8b2cae1854d56e53bc2db3fed817addedd794e9c55cc8306
+  content_hash: sha256:ba06aebb6021366d32dd5d651568249eb765224522d0b7d8e8d24f50b170ce28
 - repo_url: juspay/project-unknown
   name: project-unknown
   host: github.com
@@ -1384,7 +1384,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:5b9e068002a0144e92c0ff1a60b5a0a6482d6f5b15a895903dcc5757ac5218d6
+  content_hash: sha256:9e387042f15013cc8b2cae1854d56e53bc2db3fed817addedd794e9c55cc8306
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel
@@ -2113,7 +2113,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:5b9e068002a0144e92c0ff1a60b5a0a6482d6f5b15a895903dcc5757ac5218d6
+  content_hash: sha256:9e387042f15013cc8b2cae1854d56e53bc2db3fed817addedd794e9c55cc8306
 - kind: project-relative
   target: codex
   value: .agents/skills/perfection-review

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "37fc20ea0f2dc6e15653c0b29759cfa923d4a79a",
-      "url": "https://github.com/juspay/odu/archive/37fc20ea0f2dc6e15653c0b29759cfa923d4a79a.tar.gz",
-      "hash": "sha256-F4yAxkVX1P7ra1vvr2QKXn70rT1SHC0uAEHJQiToInA="
+      "revision": "c506b43e73473dd3a7dd9cf36cf75535130a784a",
+      "url": "https://github.com/juspay/odu/archive/c506b43e73473dd3a7dd9cf36cf75535130a784a.tar.gz",
+      "hash": "sha256-ShcHoPmqnB6E0+AqKP/uSbetFI5ctb4tsnyzFiQR26w="
     }
   },
   "version": 7


### PR DESCRIPTION
## Summary

Advances kolu's odu pin — **both** consumption channels — from `37fc20ea` to current master `c506b43e` (odu#53).

| Channel | What moved |
| --- | --- |
| **npins** (`npins/sources.json` → `nix run .#odu`, `ODU_RUNNER_FLAKE`) | `37fc20ea` → `c506b43e` |
| **apm** (`juspay/odu` → generated `/odu` + `/odu-mcp` skills) | `37fc20ea` → `c506b43e`; `/odu` skill documents hostless `--platform` |

### Upstream (odu#53)

`odu protect --platform P` now works with **no hosts config** — protect only needs platform keys for the `recipe × platform` required-status contexts, not SSH lanes. Without the flag, the platform set still comes from the hosts file and is named on stderr so a one-platform machine can't silently halve branch protection.

### Verified

- `nix build .#odu` succeeds
- `nix run .#odu -- --help` prints the expected CLI

## Test plan

- [x] `npins update odu` + `just ai::apm-update juspay/odu`
- [x] `nix build .#odu` / `nix run .#odu -- --help`
- [ ] Optional: `nix run .#odu -- protect --dry-run --platform x86_64-linux --platform aarch64-darwin` (no hosts required)