### PR TITLE
feat(ci): add `just ci::attach` for the odu live dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Only the runner posts GitHub commit statuses; the `just` shortcuts below stay en
 nix run .#odu -- run                  # multi-platform fanout + commit statuses (strict by default)
 nix run .#odu -- run --progress json  # + live NDJSON per-node feed on stdout (for agents/tools driving CI in the background)
 nix run .#odu -- attach               # attach a live dashboard to a run in progress
+just ci::attach                                  # same as `nix run .#odu -- attach`
 just ci                                          # local single-platform pipeline, no statuses
 just ci::e2e                                     # one recipe, no statuses
 ```

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -200,6 +200,14 @@ atlas-sync:
     {{ nix_shell }} just atlas::check-sync
 
 
+# ── odu convenience (coordinator-side; NOT part of the [metadata("ci")] DAG) ──
+# Thin wrappers over `nix run .#odu` so the live dashboard is one just away.
+# Unreachable from `default`, so the runner never schedules them.
+
+# Attach a live dashboard to a run in progress (paints over `.ci/odu.sock`).
+attach:
+    nix run .#odu -- attach
+
 # ── linux CI host pool (coordinator-side; NOT part of the [metadata("ci")] DAG) ──
 # These run on the machine driving CI (not on a pool box), so they're
 # unreachable from `default` and the runner never schedules them. They manage


### PR DESCRIPTION
**`just ci::attach` is now a one-liner for the odu live dashboard** — same thing as `nix run .#odu -- attach`, painted over `.ci/odu.sock`.

Coordinator-side only (like `pool-ensure` / `pool-status`): unreachable from the `[metadata("ci")]` DAG, so the runner never schedules it. README lists the shortcut next to the raw `nix run` form.

_Generated by Grok Build (model `grok-4.5`)._