### PR TITLE
docs(ci): slim the ci skill — extract the #1204 diagnostic to a script

### DIFF
--- a/.agents/skills/ci/SKILL.md
+++ b/.agents/skills/ci/SKILL.md
@@ -17,7 +17,7 @@ description: Run this repo's CI end-to-end — the kolu-specific operational pro
 - **`rasam`** (`aarch64-darwin=nix-infra@rasam.tail12b27.ts.net`; Apple Silicon T6020, 24 cores, 128 GB): **co-tenanted by a vira CI daemon** (discovered 2026-07-16) that schedules multi-hour builds of other projects at will — check `ps axo pid,etime,command | grep 'nix build'` before dispatching, and expect load-class flakes (and possible ssh-transport death) if you share it mid-build. Its fseventsd has also run pegged for weeks between reboots.
 - **`sincereintent`** (`aarch64-darwin=srid@sincereintent` — BARE tailnet name on a different tailnet, the `.tail12b27.ts.net` suffix does NOT resolve there, and it's `srid@`, not `nix-infra@`): UN-retired for kolu CI by srid (2026-07-16) and since proven by a 5× zero-retry certification. Caveat: a stale-FSEvents history — treat fs-watch-class reds (iframe-refresh, file-watch waitFors) as suspect box environment, report before chasing.
 
-**A companion repo's darwin lane uses `--host`, never inline `$ODU_HOSTS`.** A `@kolu/surface` change drags a downstream repo's CI along (e.g. the drishti PR `surface.md` requires), and that repo's CI is the shelled-out `nix run … odu -- run` path, not `mcp__odu__run`. Its own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's `zest`); pin the override with **`--host aarch64-darwin=<the arbitrated darwin host — see above>`** (per the `/odu` skill) — **never** by exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*, not a value: an inline `$ODU_HOSTS='{…}'` is **silently ignored**, the lane falls back to the repo's on-disk `zest`, and you burn a full CI run on the dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point at it.
+**A companion repo's darwin lane uses `--host`, never inline `$ODU_HOSTS`.** A `@kolu/surface` change drags a downstream repo's CI along (the drishti PR `surface.md` requires) via the shelled-out `nix run … odu -- run` path, not `mcp__odu__run`; its own `hosts.json` may name a different, possibly-dark darwin host. Override it with **`--host aarch64-darwin=<the arbitrated darwin host>`** — **never** by exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*: an inline `$ODU_HOSTS='{…}'` is silently ignored and you burn a run on the dead host. If you must set it, point at a real hosts *file*.
 
 **Linux build host: a leased pool box per run.** The linux lane runs on one of a **fixed pool of long-lived warm Incus boxes** — `kolu-ci-1 .. kolu-ci-8` — *leased* for the run's duration, never created or destroyed on the hot path. Since the MCP owns the run, the lease can no longer wrap it; [`.apm/skills/ci/pu/lease.sh`](pu/lease.sh) holds the box as a **separate background process** and you pass its box pin to `mcp__odu__run`. The three-step flow:
 
@@ -43,44 +43,13 @@ host=$(. .ci/pu-lease.env; echo "$PU_LEASE_HOST")
 .apm/skills/ci/pu/lease.sh release
 ```
 
-The lease auto-releases even on a hard crash: stop the backgrounded `acquire` (or end the session) and its open fd dies → the box's `flock` frees within seconds (a `read -t TTL` half-open backstop and a `MAX_HOLD` leak backstop cover the rest). An empty `PU_LEASE_HOST` means the pool was saturated/unreachable and `lease.sh` either took a cold ephemeral box (recorded in `.ci/pu-lease.env`) or left it to `hosts.json` — in that case drop the `$host` pin but **keep the rasam `aarch64-darwin` pin** so the macOS lane still runs.
-
-A warm leased box keeps `ci::nix` ~20s (vs ~180s on a cold box re-realising the closure) and, pulling nothing from the substituter, never triggers the concurrent-load contention that stalls cold boxes when several PRs run at once (juspay/kolu#1173). Box lifecycle is the [`pu`](.claude/skills/pu/SKILL.md) skill; runner mechanics are the [`odu`](.claude/skills/odu/SKILL.md) skill; the MCP face is the [`odu-mcp`](.claude/skills/odu-mcp/SKILL.md) skill.
-
-*Why a lease, not a fork:* the lock lives on the box (`flock`) and is held over the ssh data channel, so it auto-releases the instant the run ends — even on a hard crash (verified). This replaces the old fork-a-golden-per-run model, whose `pu fork` was unreliable — non-deterministic cross-gateway placement left the forked box unreachable (juspay/kolu#1204). Measurements and the full rationale: [`docs/pu-box-ci-ralph-report.md`](docs/pu-box-ci-ralph-report.md).
+An empty `PU_LEASE_HOST` means the pool was saturated/unreachable and `lease.sh` either took a cold ephemeral box (recorded in `.ci/pu-lease.env`) or left it to `hosts.json` — in that case drop the `$host` pin but **keep the `aarch64-darwin` pin** so the macOS lane still runs. The lease auto-releases even on a hard crash (the `flock` frees when the backgrounded `acquire` fd dies). Why a lease and not the old `pu fork`, the backstops, and the warm-box measurements are all documented in [`lease.sh`](pu/lease.sh)'s header and [`docs/pu-box-ci-ralph-report.md`](docs/pu-box-ci-ralph-report.md). Box lifecycle is the [`pu`](.claude/skills/pu/SKILL.md) skill; runner mechanics [`odu`](.claude/skills/odu/SKILL.md); the MCP face [`odu-mcp`](.claude/skills/odu-mcp/SKILL.md).
 
 **Keep the pool warm and healthy.** A pool box warms on its first real CI run and stays warm across leases. Bring the pool up to strength (and repair any missing/unhealthy slot) with `just ci::pool-ensure`; inspect with `just ci::pool-status`. Keep stores hot by periodically running the linux lane against `master` on idle slots (e.g. after a merge) — `mcp__odu__run` with `platforms=["x86_64-linux"]` and `hosts=["x86_64-linux=kolu-ci-<N>"]` (strict and posting, like every run here; warming targets a specific idle box deliberately, so no lease is needed). (The old `kolu-ci-golden` fork template is retired — the pool boxes are themselves the warm hosts.)
 
 **Live failure surfacing — fail fast on the MCP, don't drain the pipeline.** `mcp__odu__wait_for_settle` returns the instant a node goes red (`fail_fast` defaults true) with `{settled, passed, failed[], errored[]}` — so you learn about a failure while sibling lanes are still running. **Don't wait for the whole run to finish, and don't poll `gh pr checks` in a loop.** The moment `wait_for_settle` returns a non-empty `failed[]`/`errored[]`, drill in: read the red node's log via the `surface://collections/logs/{id}` MCP resource (or read the `.ci/<sha7>/x86_64-linux/<recipe>.log` path directly — the failing recipe's full output is already on disk). Begin the fix → fmt → commit → retry-CI loop as soon as you have a confirmed failure; you needn't let the rest of the pipeline drain first. (`gh pr checks` / `just ci::protect --dry-run` remain the source of truth for the *final* green-gate below — the MCP is for reacting fast, the checks are for confirming done.) A node in `errored` (as opposed to `failed`) means infrastructure death — a lane's ssh link dropped or the coordinator was interrupted; `mcp__odu__node_rerun` those rather than hunting for a test bug.
 
-**`pu` misbehaves → log it on [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204) with full diagnostics.** Whenever `pu` fails to do its job — `create`/`fork` errors out, a box lands with no egress (`nix run` hangs on "Resolving timed out"), a fork lands cross-gateway and is unreachable, retries keep landing on dead hosts, or `connect`/`destroy` misbehaves — don't just silently fall back. **Post a comment on the central pu-issues log [#1204](https://github.com/juspay/kolu/issues/1204)** so the `pu`/Incus admin can read across sessions and fix the underlying host permanently instead of every run papering over it. **This applies in every session, not only `/do`** — any time `pu` misbehaves, drop a #1204 comment. Gather everything the admin needs to pin the bad physical host, then continue per the fallback above (a diagnostic comment must never block the run).
-
-```sh
-# $host is the box name; $stage is the pu subcommand that misbehaved (create|connect|destroy|egress)
-{
-  echo "## ⚠️ \`pu\` misbehaved — Incus admin attention needed"
-  echo
-  echo "- **PR:** #$pr &nbsp; **branch:** \`$(git rev-parse --abbrev-ref HEAD)\` &nbsp; **commit:** \`$(git rev-parse --short HEAD)\`"
-  echo "- **Stage:** \`pu $stage\` &nbsp; **box:** \`$host\` &nbsp; **when:** $(date -u +%FT%TZ)"
-  echo
-  echo "**Box placement (\`pu list\` — NAME + physical LOCATION that needs fixing):**"
-  echo '```'; pu list 2>&1 | grep -E "NAME|$host"; echo '```'
-  echo "**\`pu $stage\` stderr:**"
-  echo '```'; cat /tmp/pu-$host.err 2>/dev/null; echo '```'
-  # Box-side network state — only if the box came up enough to SSH into
-  echo "**Box network state (resolv.conf / routes / egress / gateway TCP):**"
-  echo '```'
-  pu connect "$host" -- '
-    echo "== /etc/resolv.conf =="; cat /etc/resolv.conf
-    echo "== ip route ==";        ip route
-    echo "== egress probe ==";    timeout 15 curl -sS -o /dev/null -w "https HTTP %{http_code}\n" https://api.github.com || echo "egress FAILED"
-    echo "== gateway TCP ==";     gw=$(ip route | awk "/default/{print \$3; exit}"); timeout 5 bash -c "echo > /dev/tcp/$gw/443" && echo "gw $gw:443 ok" || echo "gw $gw:443 FAILED"
-  ' 2>&1
-  echo '```'
-} | gh issue comment 1204 --repo juspay/kolu --body-file -
-```
-
-To capture each stage's stderr for the excerpt above, tee it when you invoke `pu` — e.g. `pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)`.
+**`pu` misbehaves → log it on [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204).** Whenever `pu` fails to do its job — `create`/`fork` errors, a box with no egress (`nix run` hangs on "Resolving timed out"), a cross-gateway fork that's unreachable, retries landing on dead hosts, `connect`/`destroy` misbehaving — don't just silently fall back: **`.apm/skills/ci/pu/diagnose.sh <stage> <host>`** posts the full diagnostics (PR/commit context, `pu list` placement, the stage's stderr, box network state) to #1204 so the pu/Incus admin can permanently fix the bad physical host. **Every session, not just `/do`.** The comment is best-effort and must never block the run — continue per the fallback above. Capture the stage's stderr for the report by tee-ing it: `pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)`.
 
 **Flake → update the [Flaky Test Tracker](docs/atlas/src/content/atlas/flaky-test-tracker.mdx) Atlas note in the SAME PR** (published at <https://kolu.dev/atlas/flaky-test-tracker.html>) — never defer it to a later cleanup. Add a row when your CI surfaces a flake (columns are exactly the tracker's schema: scenario, `recipe@platform` lane, the assertion/timeout symptom, the PR it reproduced in, and status); flip a row to `fixed` (and strike it) when the PR fixes one; and regenerate + commit `docs/atlas/dist/` in the same change. Logging/updating alongside the PR is the obligation; an agent works the backlog from time to time. *(The old GitHub flaky-tests log — issue #320 — is retired: flakes live in the Atlas note now.)*
 

--- a/.agents/skills/ci/pu/diagnose.sh
+++ b/.agents/skills/ci/pu/diagnose.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Post a `pu`-misbehaved diagnostic comment to the central pu-issues log
+# (juspay/kolu#1204) so the pu/Incus admin can pin and permanently fix the bad
+# physical host instead of every CI run papering over it. Whenever `pu` fails to
+# do its job — create/fork errors, a box with no egress ("Resolving timed out"),
+# a cross-gateway fork that's unreachable, retries landing on dead hosts, or
+# connect/destroy misbehaving — run this, then continue per the fallback in the
+# `ci` skill. A diagnostic comment must never block the run: this is best-effort
+# and degrades (a missing box, no ssh) rather than erroring out.
+#
+# It gathers everything the admin needs to identify the bad host: the PR/branch/
+# commit context, `pu list` placement (NAME + physical LOCATION), the failing
+# stage's captured stderr, and — if the box came up enough to ssh into — its
+# network state (resolv.conf / routes / egress probe / gateway TCP).
+#
+# Capture the failing stage's stderr for the excerpt by tee-ing it when you
+# invoke pu, e.g.:  pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)
+#
+# Usage:
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host>            # post to #1204
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host> --dry-run  # print, don't post
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host> --pr 123   # override PR number
+#
+#   <stage> is the pu subcommand that misbehaved: create | connect | destroy | egress
+#   <host>  is the box name.
+set -uo pipefail
+
+stage="${1:?usage: .apm/skills/ci/pu/diagnose.sh <stage> <host> [--pr N] [--dry-run]}"; shift || true
+host="${1:?usage: .apm/skills/ci/pu/diagnose.sh <stage> <host> [--pr N] [--dry-run]}"; shift || true
+
+dry_run=
+pr=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1; shift ;;
+    --pr) pr="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$pr" ] || pr=$(gh pr view --json number --jq .number 2>/dev/null || echo "?")
+
+render() {
+  echo "## ⚠️ \`pu\` misbehaved — Incus admin attention needed"
+  echo
+  echo "- **PR:** #$pr &nbsp; **branch:** \`$(git rev-parse --abbrev-ref HEAD)\` &nbsp; **commit:** \`$(git rev-parse --short HEAD)\`"
+  echo "- **Stage:** \`pu $stage\` &nbsp; **box:** \`$host\` &nbsp; **when:** $(date -u +%FT%TZ)"
+  echo
+  echo "**Box placement (\`pu list\` — NAME + physical LOCATION that needs fixing):**"
+  echo '```'; pu list 2>&1 | grep -E "NAME|$host"; echo '```'
+  echo "**\`pu $stage\` stderr:**"
+  echo '```'; cat "/tmp/pu-$host.err" 2>/dev/null; echo '```'
+  # Box-side network state — only if the box came up enough to SSH into
+  echo "**Box network state (resolv.conf / routes / egress / gateway TCP):**"
+  echo '```'
+  pu connect "$host" -- '
+    echo "== /etc/resolv.conf =="; cat /etc/resolv.conf
+    echo "== ip route ==";        ip route
+    echo "== egress probe ==";    timeout 15 curl -sS -o /dev/null -w "https HTTP %{http_code}\n" https://api.github.com || echo "egress FAILED"
+    echo "== gateway TCP ==";     gw=$(ip route | awk "/default/{print \$3; exit}"); timeout 5 bash -c "echo > /dev/tcp/$gw/443" && echo "gw $gw:443 ok" || echo "gw $gw:443 FAILED"
+  ' 2>&1
+  echo '```'
+}
+
+if [ -n "$dry_run" ]; then
+  render
+else
+  render | gh issue comment 1204 --repo juspay/kolu --body-file -
+fi

--- a/.apm/skills/ci/SKILL.md
+++ b/.apm/skills/ci/SKILL.md
@@ -17,7 +17,7 @@ description: Run this repo's CI end-to-end — the kolu-specific operational pro
 - **`rasam`** (`aarch64-darwin=nix-infra@rasam.tail12b27.ts.net`; Apple Silicon T6020, 24 cores, 128 GB): **co-tenanted by a vira CI daemon** (discovered 2026-07-16) that schedules multi-hour builds of other projects at will — check `ps axo pid,etime,command | grep 'nix build'` before dispatching, and expect load-class flakes (and possible ssh-transport death) if you share it mid-build. Its fseventsd has also run pegged for weeks between reboots.
 - **`sincereintent`** (`aarch64-darwin=srid@sincereintent` — BARE tailnet name on a different tailnet, the `.tail12b27.ts.net` suffix does NOT resolve there, and it's `srid@`, not `nix-infra@`): UN-retired for kolu CI by srid (2026-07-16) and since proven by a 5× zero-retry certification. Caveat: a stale-FSEvents history — treat fs-watch-class reds (iframe-refresh, file-watch waitFors) as suspect box environment, report before chasing.
 
-**A companion repo's darwin lane uses `--host`, never inline `$ODU_HOSTS`.** A `@kolu/surface` change drags a downstream repo's CI along (e.g. the drishti PR `surface.md` requires), and that repo's CI is the shelled-out `nix run … odu -- run` path, not `mcp__odu__run`. Its own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's `zest`); pin the override with **`--host aarch64-darwin=<the arbitrated darwin host — see above>`** (per the `/odu` skill) — **never** by exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*, not a value: an inline `$ODU_HOSTS='{…}'` is **silently ignored**, the lane falls back to the repo's on-disk `zest`, and you burn a full CI run on the dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point at it.
+**A companion repo's darwin lane uses `--host`, never inline `$ODU_HOSTS`.** A `@kolu/surface` change drags a downstream repo's CI along (the drishti PR `surface.md` requires) via the shelled-out `nix run … odu -- run` path, not `mcp__odu__run`; its own `hosts.json` may name a different, possibly-dark darwin host. Override it with **`--host aarch64-darwin=<the arbitrated darwin host>`** — **never** by exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*: an inline `$ODU_HOSTS='{…}'` is silently ignored and you burn a run on the dead host. If you must set it, point at a real hosts *file*.
 
 **Linux build host: a leased pool box per run.** The linux lane runs on one of a **fixed pool of long-lived warm Incus boxes** — `kolu-ci-1 .. kolu-ci-8` — *leased* for the run's duration, never created or destroyed on the hot path. Since the MCP owns the run, the lease can no longer wrap it; [`.apm/skills/ci/pu/lease.sh`](pu/lease.sh) holds the box as a **separate background process** and you pass its box pin to `mcp__odu__run`. The three-step flow:
 
@@ -43,44 +43,13 @@ host=$(. .ci/pu-lease.env; echo "$PU_LEASE_HOST")
 .apm/skills/ci/pu/lease.sh release
 ```
 
-The lease auto-releases even on a hard crash: stop the backgrounded `acquire` (or end the session) and its open fd dies → the box's `flock` frees within seconds (a `read -t TTL` half-open backstop and a `MAX_HOLD` leak backstop cover the rest). An empty `PU_LEASE_HOST` means the pool was saturated/unreachable and `lease.sh` either took a cold ephemeral box (recorded in `.ci/pu-lease.env`) or left it to `hosts.json` — in that case drop the `$host` pin but **keep the rasam `aarch64-darwin` pin** so the macOS lane still runs.
-
-A warm leased box keeps `ci::nix` ~20s (vs ~180s on a cold box re-realising the closure) and, pulling nothing from the substituter, never triggers the concurrent-load contention that stalls cold boxes when several PRs run at once (juspay/kolu#1173). Box lifecycle is the [`pu`](.claude/skills/pu/SKILL.md) skill; runner mechanics are the [`odu`](.claude/skills/odu/SKILL.md) skill; the MCP face is the [`odu-mcp`](.claude/skills/odu-mcp/SKILL.md) skill.
-
-*Why a lease, not a fork:* the lock lives on the box (`flock`) and is held over the ssh data channel, so it auto-releases the instant the run ends — even on a hard crash (verified). This replaces the old fork-a-golden-per-run model, whose `pu fork` was unreliable — non-deterministic cross-gateway placement left the forked box unreachable (juspay/kolu#1204). Measurements and the full rationale: [`docs/pu-box-ci-ralph-report.md`](docs/pu-box-ci-ralph-report.md).
+An empty `PU_LEASE_HOST` means the pool was saturated/unreachable and `lease.sh` either took a cold ephemeral box (recorded in `.ci/pu-lease.env`) or left it to `hosts.json` — in that case drop the `$host` pin but **keep the `aarch64-darwin` pin** so the macOS lane still runs. The lease auto-releases even on a hard crash (the `flock` frees when the backgrounded `acquire` fd dies). Why a lease and not the old `pu fork`, the backstops, and the warm-box measurements are all documented in [`lease.sh`](pu/lease.sh)'s header and [`docs/pu-box-ci-ralph-report.md`](docs/pu-box-ci-ralph-report.md). Box lifecycle is the [`pu`](.claude/skills/pu/SKILL.md) skill; runner mechanics [`odu`](.claude/skills/odu/SKILL.md); the MCP face [`odu-mcp`](.claude/skills/odu-mcp/SKILL.md).
 
 **Keep the pool warm and healthy.** A pool box warms on its first real CI run and stays warm across leases. Bring the pool up to strength (and repair any missing/unhealthy slot) with `just ci::pool-ensure`; inspect with `just ci::pool-status`. Keep stores hot by periodically running the linux lane against `master` on idle slots (e.g. after a merge) — `mcp__odu__run` with `platforms=["x86_64-linux"]` and `hosts=["x86_64-linux=kolu-ci-<N>"]` (strict and posting, like every run here; warming targets a specific idle box deliberately, so no lease is needed). (The old `kolu-ci-golden` fork template is retired — the pool boxes are themselves the warm hosts.)
 
 **Live failure surfacing — fail fast on the MCP, don't drain the pipeline.** `mcp__odu__wait_for_settle` returns the instant a node goes red (`fail_fast` defaults true) with `{settled, passed, failed[], errored[]}` — so you learn about a failure while sibling lanes are still running. **Don't wait for the whole run to finish, and don't poll `gh pr checks` in a loop.** The moment `wait_for_settle` returns a non-empty `failed[]`/`errored[]`, drill in: read the red node's log via the `surface://collections/logs/{id}` MCP resource (or read the `.ci/<sha7>/x86_64-linux/<recipe>.log` path directly — the failing recipe's full output is already on disk). Begin the fix → fmt → commit → retry-CI loop as soon as you have a confirmed failure; you needn't let the rest of the pipeline drain first. (`gh pr checks` / `just ci::protect --dry-run` remain the source of truth for the *final* green-gate below — the MCP is for reacting fast, the checks are for confirming done.) A node in `errored` (as opposed to `failed`) means infrastructure death — a lane's ssh link dropped or the coordinator was interrupted; `mcp__odu__node_rerun` those rather than hunting for a test bug.
 
-**`pu` misbehaves → log it on [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204) with full diagnostics.** Whenever `pu` fails to do its job — `create`/`fork` errors out, a box lands with no egress (`nix run` hangs on "Resolving timed out"), a fork lands cross-gateway and is unreachable, retries keep landing on dead hosts, or `connect`/`destroy` misbehaves — don't just silently fall back. **Post a comment on the central pu-issues log [#1204](https://github.com/juspay/kolu/issues/1204)** so the `pu`/Incus admin can read across sessions and fix the underlying host permanently instead of every run papering over it. **This applies in every session, not only `/do`** — any time `pu` misbehaves, drop a #1204 comment. Gather everything the admin needs to pin the bad physical host, then continue per the fallback above (a diagnostic comment must never block the run).
-
-```sh
-# $host is the box name; $stage is the pu subcommand that misbehaved (create|connect|destroy|egress)
-{
-  echo "## ⚠️ \`pu\` misbehaved — Incus admin attention needed"
-  echo
-  echo "- **PR:** #$pr &nbsp; **branch:** \`$(git rev-parse --abbrev-ref HEAD)\` &nbsp; **commit:** \`$(git rev-parse --short HEAD)\`"
-  echo "- **Stage:** \`pu $stage\` &nbsp; **box:** \`$host\` &nbsp; **when:** $(date -u +%FT%TZ)"
-  echo
-  echo "**Box placement (\`pu list\` — NAME + physical LOCATION that needs fixing):**"
-  echo '```'; pu list 2>&1 | grep -E "NAME|$host"; echo '```'
-  echo "**\`pu $stage\` stderr:**"
-  echo '```'; cat /tmp/pu-$host.err 2>/dev/null; echo '```'
-  # Box-side network state — only if the box came up enough to SSH into
-  echo "**Box network state (resolv.conf / routes / egress / gateway TCP):**"
-  echo '```'
-  pu connect "$host" -- '
-    echo "== /etc/resolv.conf =="; cat /etc/resolv.conf
-    echo "== ip route ==";        ip route
-    echo "== egress probe ==";    timeout 15 curl -sS -o /dev/null -w "https HTTP %{http_code}\n" https://api.github.com || echo "egress FAILED"
-    echo "== gateway TCP ==";     gw=$(ip route | awk "/default/{print \$3; exit}"); timeout 5 bash -c "echo > /dev/tcp/$gw/443" && echo "gw $gw:443 ok" || echo "gw $gw:443 FAILED"
-  ' 2>&1
-  echo '```'
-} | gh issue comment 1204 --repo juspay/kolu --body-file -
-```
-
-To capture each stage's stderr for the excerpt above, tee it when you invoke `pu` — e.g. `pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)`.
+**`pu` misbehaves → log it on [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204).** Whenever `pu` fails to do its job — `create`/`fork` errors, a box with no egress (`nix run` hangs on "Resolving timed out"), a cross-gateway fork that's unreachable, retries landing on dead hosts, `connect`/`destroy` misbehaving — don't just silently fall back: **`.apm/skills/ci/pu/diagnose.sh <stage> <host>`** posts the full diagnostics (PR/commit context, `pu list` placement, the stage's stderr, box network state) to #1204 so the pu/Incus admin can permanently fix the bad physical host. **Every session, not just `/do`.** The comment is best-effort and must never block the run — continue per the fallback above. Capture the stage's stderr for the report by tee-ing it: `pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)`.
 
 **Flake → update the [Flaky Test Tracker](docs/atlas/src/content/atlas/flaky-test-tracker.mdx) Atlas note in the SAME PR** (published at <https://kolu.dev/atlas/flaky-test-tracker.html>) — never defer it to a later cleanup. Add a row when your CI surfaces a flake (columns are exactly the tracker's schema: scenario, `recipe@platform` lane, the assertion/timeout symptom, the PR it reproduced in, and status); flip a row to `fixed` (and strike it) when the PR fixes one; and regenerate + commit `docs/atlas/dist/` in the same change. Logging/updating alongside the PR is the obligation; an agent works the backlog from time to time. *(The old GitHub flaky-tests log — issue #320 — is retired: flakes live in the Atlas note now.)*
 

--- a/.apm/skills/ci/pu/diagnose.sh
+++ b/.apm/skills/ci/pu/diagnose.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Post a `pu`-misbehaved diagnostic comment to the central pu-issues log
+# (juspay/kolu#1204) so the pu/Incus admin can pin and permanently fix the bad
+# physical host instead of every CI run papering over it. Whenever `pu` fails to
+# do its job — create/fork errors, a box with no egress ("Resolving timed out"),
+# a cross-gateway fork that's unreachable, retries landing on dead hosts, or
+# connect/destroy misbehaving — run this, then continue per the fallback in the
+# `ci` skill. A diagnostic comment must never block the run: this is best-effort
+# and degrades (a missing box, no ssh) rather than erroring out.
+#
+# It gathers everything the admin needs to identify the bad host: the PR/branch/
+# commit context, `pu list` placement (NAME + physical LOCATION), the failing
+# stage's captured stderr, and — if the box came up enough to ssh into — its
+# network state (resolv.conf / routes / egress probe / gateway TCP).
+#
+# Capture the failing stage's stderr for the excerpt by tee-ing it when you
+# invoke pu, e.g.:  pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)
+#
+# Usage:
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host>            # post to #1204
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host> --dry-run  # print, don't post
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host> --pr 123   # override PR number
+#
+#   <stage> is the pu subcommand that misbehaved: create | connect | destroy | egress
+#   <host>  is the box name.
+set -uo pipefail
+
+stage="${1:?usage: .apm/skills/ci/pu/diagnose.sh <stage> <host> [--pr N] [--dry-run]}"; shift || true
+host="${1:?usage: .apm/skills/ci/pu/diagnose.sh <stage> <host> [--pr N] [--dry-run]}"; shift || true
+
+dry_run=
+pr=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1; shift ;;
+    --pr) pr="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$pr" ] || pr=$(gh pr view --json number --jq .number 2>/dev/null || echo "?")
+
+render() {
+  echo "## ⚠️ \`pu\` misbehaved — Incus admin attention needed"
+  echo
+  echo "- **PR:** #$pr &nbsp; **branch:** \`$(git rev-parse --abbrev-ref HEAD)\` &nbsp; **commit:** \`$(git rev-parse --short HEAD)\`"
+  echo "- **Stage:** \`pu $stage\` &nbsp; **box:** \`$host\` &nbsp; **when:** $(date -u +%FT%TZ)"
+  echo
+  echo "**Box placement (\`pu list\` — NAME + physical LOCATION that needs fixing):**"
+  echo '```'; pu list 2>&1 | grep -E "NAME|$host"; echo '```'
+  echo "**\`pu $stage\` stderr:**"
+  echo '```'; cat "/tmp/pu-$host.err" 2>/dev/null; echo '```'
+  # Box-side network state — only if the box came up enough to SSH into
+  echo "**Box network state (resolv.conf / routes / egress / gateway TCP):**"
+  echo '```'
+  pu connect "$host" -- '
+    echo "== /etc/resolv.conf =="; cat /etc/resolv.conf
+    echo "== ip route ==";        ip route
+    echo "== egress probe ==";    timeout 15 curl -sS -o /dev/null -w "https HTTP %{http_code}\n" https://api.github.com || echo "egress FAILED"
+    echo "== gateway TCP ==";     gw=$(ip route | awk "/default/{print \$3; exit}"); timeout 5 bash -c "echo > /dev/tcp/$gw/443" && echo "gw $gw:443 ok" || echo "gw $gw:443 FAILED"
+  ' 2>&1
+  echo '```'
+}
+
+if [ -n "$dry_run" ]; then
+  render
+else
+  render | gh issue comment 1204 --repo juspay/kolu --body-file -
+fi

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -17,7 +17,7 @@ description: Run this repo's CI end-to-end — the kolu-specific operational pro
 - **`rasam`** (`aarch64-darwin=nix-infra@rasam.tail12b27.ts.net`; Apple Silicon T6020, 24 cores, 128 GB): **co-tenanted by a vira CI daemon** (discovered 2026-07-16) that schedules multi-hour builds of other projects at will — check `ps axo pid,etime,command | grep 'nix build'` before dispatching, and expect load-class flakes (and possible ssh-transport death) if you share it mid-build. Its fseventsd has also run pegged for weeks between reboots.
 - **`sincereintent`** (`aarch64-darwin=srid@sincereintent` — BARE tailnet name on a different tailnet, the `.tail12b27.ts.net` suffix does NOT resolve there, and it's `srid@`, not `nix-infra@`): UN-retired for kolu CI by srid (2026-07-16) and since proven by a 5× zero-retry certification. Caveat: a stale-FSEvents history — treat fs-watch-class reds (iframe-refresh, file-watch waitFors) as suspect box environment, report before chasing.
 
-**A companion repo's darwin lane uses `--host`, never inline `$ODU_HOSTS`.** A `@kolu/surface` change drags a downstream repo's CI along (e.g. the drishti PR `surface.md` requires), and that repo's CI is the shelled-out `nix run … odu -- run` path, not `mcp__odu__run`. Its own `hosts.json` may name a *different*, possibly-dark darwin host (drishti's `zest`); pin the override with **`--host aarch64-darwin=<the arbitrated darwin host — see above>`** (per the `/odu` skill) — **never** by exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*, not a value: an inline `$ODU_HOSTS='{…}'` is **silently ignored**, the lane falls back to the repo's on-disk `zest`, and you burn a full CI run on the dead host. If you must set `$ODU_HOSTS`, write a real hosts *file* and point at it.
+**A companion repo's darwin lane uses `--host`, never inline `$ODU_HOSTS`.** A `@kolu/surface` change drags a downstream repo's CI along (the drishti PR `surface.md` requires) via the shelled-out `nix run … odu -- run` path, not `mcp__odu__run`; its own `hosts.json` may name a different, possibly-dark darwin host. Override it with **`--host aarch64-darwin=<the arbitrated darwin host>`** — **never** by exporting inline JSON into `$ODU_HOSTS`, which odu reads as a *file path*: an inline `$ODU_HOSTS='{…}'` is silently ignored and you burn a run on the dead host. If you must set it, point at a real hosts *file*.
 
 **Linux build host: a leased pool box per run.** The linux lane runs on one of a **fixed pool of long-lived warm Incus boxes** — `kolu-ci-1 .. kolu-ci-8` — *leased* for the run's duration, never created or destroyed on the hot path. Since the MCP owns the run, the lease can no longer wrap it; [`.apm/skills/ci/pu/lease.sh`](pu/lease.sh) holds the box as a **separate background process** and you pass its box pin to `mcp__odu__run`. The three-step flow:
 
@@ -43,44 +43,13 @@ host=$(. .ci/pu-lease.env; echo "$PU_LEASE_HOST")
 .apm/skills/ci/pu/lease.sh release
 ```
 
-The lease auto-releases even on a hard crash: stop the backgrounded `acquire` (or end the session) and its open fd dies → the box's `flock` frees within seconds (a `read -t TTL` half-open backstop and a `MAX_HOLD` leak backstop cover the rest). An empty `PU_LEASE_HOST` means the pool was saturated/unreachable and `lease.sh` either took a cold ephemeral box (recorded in `.ci/pu-lease.env`) or left it to `hosts.json` — in that case drop the `$host` pin but **keep the rasam `aarch64-darwin` pin** so the macOS lane still runs.
-
-A warm leased box keeps `ci::nix` ~20s (vs ~180s on a cold box re-realising the closure) and, pulling nothing from the substituter, never triggers the concurrent-load contention that stalls cold boxes when several PRs run at once (juspay/kolu#1173). Box lifecycle is the [`pu`](.claude/skills/pu/SKILL.md) skill; runner mechanics are the [`odu`](.claude/skills/odu/SKILL.md) skill; the MCP face is the [`odu-mcp`](.claude/skills/odu-mcp/SKILL.md) skill.
-
-*Why a lease, not a fork:* the lock lives on the box (`flock`) and is held over the ssh data channel, so it auto-releases the instant the run ends — even on a hard crash (verified). This replaces the old fork-a-golden-per-run model, whose `pu fork` was unreliable — non-deterministic cross-gateway placement left the forked box unreachable (juspay/kolu#1204). Measurements and the full rationale: [`docs/pu-box-ci-ralph-report.md`](docs/pu-box-ci-ralph-report.md).
+An empty `PU_LEASE_HOST` means the pool was saturated/unreachable and `lease.sh` either took a cold ephemeral box (recorded in `.ci/pu-lease.env`) or left it to `hosts.json` — in that case drop the `$host` pin but **keep the `aarch64-darwin` pin** so the macOS lane still runs. The lease auto-releases even on a hard crash (the `flock` frees when the backgrounded `acquire` fd dies). Why a lease and not the old `pu fork`, the backstops, and the warm-box measurements are all documented in [`lease.sh`](pu/lease.sh)'s header and [`docs/pu-box-ci-ralph-report.md`](docs/pu-box-ci-ralph-report.md). Box lifecycle is the [`pu`](.claude/skills/pu/SKILL.md) skill; runner mechanics [`odu`](.claude/skills/odu/SKILL.md); the MCP face [`odu-mcp`](.claude/skills/odu-mcp/SKILL.md).
 
 **Keep the pool warm and healthy.** A pool box warms on its first real CI run and stays warm across leases. Bring the pool up to strength (and repair any missing/unhealthy slot) with `just ci::pool-ensure`; inspect with `just ci::pool-status`. Keep stores hot by periodically running the linux lane against `master` on idle slots (e.g. after a merge) — `mcp__odu__run` with `platforms=["x86_64-linux"]` and `hosts=["x86_64-linux=kolu-ci-<N>"]` (strict and posting, like every run here; warming targets a specific idle box deliberately, so no lease is needed). (The old `kolu-ci-golden` fork template is retired — the pool boxes are themselves the warm hosts.)
 
 **Live failure surfacing — fail fast on the MCP, don't drain the pipeline.** `mcp__odu__wait_for_settle` returns the instant a node goes red (`fail_fast` defaults true) with `{settled, passed, failed[], errored[]}` — so you learn about a failure while sibling lanes are still running. **Don't wait for the whole run to finish, and don't poll `gh pr checks` in a loop.** The moment `wait_for_settle` returns a non-empty `failed[]`/`errored[]`, drill in: read the red node's log via the `surface://collections/logs/{id}` MCP resource (or read the `.ci/<sha7>/x86_64-linux/<recipe>.log` path directly — the failing recipe's full output is already on disk). Begin the fix → fmt → commit → retry-CI loop as soon as you have a confirmed failure; you needn't let the rest of the pipeline drain first. (`gh pr checks` / `just ci::protect --dry-run` remain the source of truth for the *final* green-gate below — the MCP is for reacting fast, the checks are for confirming done.) A node in `errored` (as opposed to `failed`) means infrastructure death — a lane's ssh link dropped or the coordinator was interrupted; `mcp__odu__node_rerun` those rather than hunting for a test bug.
 
-**`pu` misbehaves → log it on [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204) with full diagnostics.** Whenever `pu` fails to do its job — `create`/`fork` errors out, a box lands with no egress (`nix run` hangs on "Resolving timed out"), a fork lands cross-gateway and is unreachable, retries keep landing on dead hosts, or `connect`/`destroy` misbehaves — don't just silently fall back. **Post a comment on the central pu-issues log [#1204](https://github.com/juspay/kolu/issues/1204)** so the `pu`/Incus admin can read across sessions and fix the underlying host permanently instead of every run papering over it. **This applies in every session, not only `/do`** — any time `pu` misbehaves, drop a #1204 comment. Gather everything the admin needs to pin the bad physical host, then continue per the fallback above (a diagnostic comment must never block the run).
-
-```sh
-# $host is the box name; $stage is the pu subcommand that misbehaved (create|connect|destroy|egress)
-{
-  echo "## ⚠️ \`pu\` misbehaved — Incus admin attention needed"
-  echo
-  echo "- **PR:** #$pr &nbsp; **branch:** \`$(git rev-parse --abbrev-ref HEAD)\` &nbsp; **commit:** \`$(git rev-parse --short HEAD)\`"
-  echo "- **Stage:** \`pu $stage\` &nbsp; **box:** \`$host\` &nbsp; **when:** $(date -u +%FT%TZ)"
-  echo
-  echo "**Box placement (\`pu list\` — NAME + physical LOCATION that needs fixing):**"
-  echo '```'; pu list 2>&1 | grep -E "NAME|$host"; echo '```'
-  echo "**\`pu $stage\` stderr:**"
-  echo '```'; cat /tmp/pu-$host.err 2>/dev/null; echo '```'
-  # Box-side network state — only if the box came up enough to SSH into
-  echo "**Box network state (resolv.conf / routes / egress / gateway TCP):**"
-  echo '```'
-  pu connect "$host" -- '
-    echo "== /etc/resolv.conf =="; cat /etc/resolv.conf
-    echo "== ip route ==";        ip route
-    echo "== egress probe ==";    timeout 15 curl -sS -o /dev/null -w "https HTTP %{http_code}\n" https://api.github.com || echo "egress FAILED"
-    echo "== gateway TCP ==";     gw=$(ip route | awk "/default/{print \$3; exit}"); timeout 5 bash -c "echo > /dev/tcp/$gw/443" && echo "gw $gw:443 ok" || echo "gw $gw:443 FAILED"
-  ' 2>&1
-  echo '```'
-} | gh issue comment 1204 --repo juspay/kolu --body-file -
-```
-
-To capture each stage's stderr for the excerpt above, tee it when you invoke `pu` — e.g. `pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)`.
+**`pu` misbehaves → log it on [juspay/kolu#1204](https://github.com/juspay/kolu/issues/1204).** Whenever `pu` fails to do its job — `create`/`fork` errors, a box with no egress (`nix run` hangs on "Resolving timed out"), a cross-gateway fork that's unreachable, retries landing on dead hosts, `connect`/`destroy` misbehaving — don't just silently fall back: **`.apm/skills/ci/pu/diagnose.sh <stage> <host>`** posts the full diagnostics (PR/commit context, `pu list` placement, the stage's stderr, box network state) to #1204 so the pu/Incus admin can permanently fix the bad physical host. **Every session, not just `/do`.** The comment is best-effort and must never block the run — continue per the fallback above. Capture the stage's stderr for the report by tee-ing it: `pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)`.
 
 **Flake → update the [Flaky Test Tracker](docs/atlas/src/content/atlas/flaky-test-tracker.mdx) Atlas note in the SAME PR** (published at <https://kolu.dev/atlas/flaky-test-tracker.html>) — never defer it to a later cleanup. Add a row when your CI surfaces a flake (columns are exactly the tracker's schema: scenario, `recipe@platform` lane, the assertion/timeout symptom, the PR it reproduced in, and status); flip a row to `fixed` (and strike it) when the PR fixes one; and regenerate + commit `docs/atlas/dist/` in the same change. Logging/updating alongside the PR is the obligation; an agent works the backlog from time to time. *(The old GitHub flaky-tests log — issue #320 — is retired: flakes live in the Atlas note now.)*
 

--- a/.claude/skills/ci/pu/diagnose.sh
+++ b/.claude/skills/ci/pu/diagnose.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Post a `pu`-misbehaved diagnostic comment to the central pu-issues log
+# (juspay/kolu#1204) so the pu/Incus admin can pin and permanently fix the bad
+# physical host instead of every CI run papering over it. Whenever `pu` fails to
+# do its job — create/fork errors, a box with no egress ("Resolving timed out"),
+# a cross-gateway fork that's unreachable, retries landing on dead hosts, or
+# connect/destroy misbehaving — run this, then continue per the fallback in the
+# `ci` skill. A diagnostic comment must never block the run: this is best-effort
+# and degrades (a missing box, no ssh) rather than erroring out.
+#
+# It gathers everything the admin needs to identify the bad host: the PR/branch/
+# commit context, `pu list` placement (NAME + physical LOCATION), the failing
+# stage's captured stderr, and — if the box came up enough to ssh into — its
+# network state (resolv.conf / routes / egress probe / gateway TCP).
+#
+# Capture the failing stage's stderr for the excerpt by tee-ing it when you
+# invoke pu, e.g.:  pu create "$host" 2> >(tee /tmp/pu-$host.err >&2)
+#
+# Usage:
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host>            # post to #1204
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host> --dry-run  # print, don't post
+#   .apm/skills/ci/pu/diagnose.sh <stage> <host> --pr 123   # override PR number
+#
+#   <stage> is the pu subcommand that misbehaved: create | connect | destroy | egress
+#   <host>  is the box name.
+set -uo pipefail
+
+stage="${1:?usage: .apm/skills/ci/pu/diagnose.sh <stage> <host> [--pr N] [--dry-run]}"; shift || true
+host="${1:?usage: .apm/skills/ci/pu/diagnose.sh <stage> <host> [--pr N] [--dry-run]}"; shift || true
+
+dry_run=
+pr=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1; shift ;;
+    --pr) pr="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$pr" ] || pr=$(gh pr view --json number --jq .number 2>/dev/null || echo "?")
+
+render() {
+  echo "## ⚠️ \`pu\` misbehaved — Incus admin attention needed"
+  echo
+  echo "- **PR:** #$pr &nbsp; **branch:** \`$(git rev-parse --abbrev-ref HEAD)\` &nbsp; **commit:** \`$(git rev-parse --short HEAD)\`"
+  echo "- **Stage:** \`pu $stage\` &nbsp; **box:** \`$host\` &nbsp; **when:** $(date -u +%FT%TZ)"
+  echo
+  echo "**Box placement (\`pu list\` — NAME + physical LOCATION that needs fixing):**"
+  echo '```'; pu list 2>&1 | grep -E "NAME|$host"; echo '```'
+  echo "**\`pu $stage\` stderr:**"
+  echo '```'; cat "/tmp/pu-$host.err" 2>/dev/null; echo '```'
+  # Box-side network state — only if the box came up enough to SSH into
+  echo "**Box network state (resolv.conf / routes / egress / gateway TCP):**"
+  echo '```'
+  pu connect "$host" -- '
+    echo "== /etc/resolv.conf =="; cat /etc/resolv.conf
+    echo "== ip route ==";        ip route
+    echo "== egress probe ==";    timeout 15 curl -sS -o /dev/null -w "https HTTP %{http_code}\n" https://api.github.com || echo "egress FAILED"
+    echo "== gateway TCP ==";     gw=$(ip route | awk "/default/{print \$3; exit}"); timeout 5 bash -c "echo > /dev/tcp/$gw/443" && echo "gw $gw:443 ok" || echo "gw $gw:443 FAILED"
+  ' 2>&1
+  echo '```'
+}
+
+if [ -n "$dry_run" ]; then
+  render
+else
+  render | gh issue comment 1204 --repo juspay/kolu --body-file -
+fi

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-22T01:41:53.969037+00:00'
+generated_at: '2026-07-22T01:48:12.855476+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -375,7 +375,16 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:2426035e6a433df59f49492d7e6f135d5a121c797b7e2fcceffe8ee42d5254fa
+  content_hash: sha256:0cf2e42f2f8de848d8bbe23fc9efa4790eece5dd815873ba90c2cc340ea9b1ac
+- kind: project-relative
+  target: agents
+  value: .agents/skills/ci/pu/diagnose.sh
+  runtime: null
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
 - kind: project-relative
   target: agents
   value: .agents/skills/ci/pu/lease.sh
@@ -925,7 +934,16 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:2426035e6a433df59f49492d7e6f135d5a121c797b7e2fcceffe8ee42d5254fa
+  content_hash: sha256:0cf2e42f2f8de848d8bbe23fc9efa4790eece5dd815873ba90c2cc340ea9b1ac
+- kind: project-relative
+  target: claude
+  value: .claude/skills/ci/pu/diagnose.sh
+  runtime: null
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
 - kind: project-relative
   target: claude
   value: .claude/skills/ci/pu/lease.sh
@@ -2346,6 +2364,7 @@ local_deployed_files:
 - .agents/skills/blog-post/SKILL.md
 - .agents/skills/ci
 - .agents/skills/ci/SKILL.md
+- .agents/skills/ci/pu/diagnose.sh
 - .agents/skills/ci/pu/lease.sh
 - .agents/skills/ci/pu/pool.sh
 - .agents/skills/ci/pu/report.sh
@@ -2393,6 +2412,7 @@ local_deployed_files:
 - .claude/skills/blog-post/SKILL.md
 - .claude/skills/ci
 - .claude/skills/ci/SKILL.md
+- .claude/skills/ci/pu/diagnose.sh
 - .claude/skills/ci/pu/lease.sh
 - .claude/skills/ci/pu/pool.sh
 - .claude/skills/ci/pu/report.sh
@@ -2418,7 +2438,8 @@ local_deployed_files:
 local_deployed_file_hashes:
   .agents/skills/atlas/SKILL.md: sha256:6ba8ba4a147b450cbf8b51ea5d71999f9592bd40279fd005b2c982bab3296689
   .agents/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .agents/skills/ci/SKILL.md: sha256:2426035e6a433df59f49492d7e6f135d5a121c797b7e2fcceffe8ee42d5254fa
+  .agents/skills/ci/SKILL.md: sha256:0cf2e42f2f8de848d8bbe23fc9efa4790eece5dd815873ba90c2cc340ea9b1ac
+  .agents/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .agents/skills/ci/pu/lease.sh: sha256:5e5ca3de9a41d247f5a7be66044cb5811e15c26f9da2127c299f6939db5275ee
   .agents/skills/ci/pu/pool.sh: sha256:d41f96205e452547489c63df7e0b561293971b9cdbb51580ec6851505a5a646b
   .agents/skills/ci/pu/report.sh: sha256:2bcce1c13acfd168ed70e0793e49eef5cd051864e4bea7b17833b889e3129bb3
@@ -2453,7 +2474,8 @@ local_deployed_file_hashes:
   .claude/rules/website-docs.md: sha256:09c4389e0f30d14acdc722e7d0a58486545c03645df4cbc8f9ccbc2df5612512
   .claude/skills/atlas/SKILL.md: sha256:6ba8ba4a147b450cbf8b51ea5d71999f9592bd40279fd005b2c982bab3296689
   .claude/skills/blog-post/SKILL.md: sha256:617654848591f41e9c41f23f404ab3fa0318bdfbd4e70b21ae2ba42921a86c1a
-  .claude/skills/ci/SKILL.md: sha256:2426035e6a433df59f49492d7e6f135d5a121c797b7e2fcceffe8ee42d5254fa
+  .claude/skills/ci/SKILL.md: sha256:0cf2e42f2f8de848d8bbe23fc9efa4790eece5dd815873ba90c2cc340ea9b1ac
+  .claude/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .claude/skills/ci/pu/lease.sh: sha256:5e5ca3de9a41d247f5a7be66044cb5811e15c26f9da2127c299f6939db5275ee
   .claude/skills/ci/pu/pool.sh: sha256:d41f96205e452547489c63df7e0b561293971b9cdbb51580ec6851505a5a646b
   .claude/skills/ci/pu/report.sh: sha256:2bcce1c13acfd168ed70e0793e49eef5cd051864e4bea7b17833b889e3129bb3


### PR DESCRIPTION
## What

The `ci` skill had grown to ~87 lines / ~2,060 words that mixed three things: the operational procedure an agent must follow, a **26-line bash program embedded inline**, and rationale/history that's already duplicated in the sibling script headers. This slims it to ~56 lines with **zero operational meaning lost** — content moves to files, it isn't deleted.

The `ci/pu/` directory already sets the pattern: `lease.sh`, `pool.sh`, `report.sh` are extracted scripts with self-documenting headers, invoked by name. This makes the skill follow its own convention.

## Changes

- **Extract** the inline `pu`-misbehaved #1204 diagnostic script → **`ci/pu/diagnose.sh`** (self-documenting header + `--dry-run`, matching `report.sh`). The skill prose collapses from a paragraph + 26-line code block + tee note down to a single invocation line.
- **Compress** the lease auto-release / why-a-lease-not-a-fork / warm-box-perf rationale → one-line pointers into `lease.sh`'s header and `docs/pu-box-ci-ralph-report.md`, which already carry the full detail. The load-bearing operational bit (empty `PU_LEASE_HOST` → drop the linux pin, keep the darwin pin) stays inline.
- **Tighten** the companion-repo `$ODU_HOSTS`-is-a-file-path gotcha from 6 lines to 2.

## Untouched (load-bearing procedure)

MCP front door · banned flags · push-first · two-platform rule · the lease three-step flow · live fail-fast surfacing · flaky tracker · green-gate. These are signal, not verbiage.

## Test

- `bash -n ci/pu/diagnose.sh` parses; `--dry-run` renders the full comment (verified against a live `pu list`).
- `just ai::apm` regenerates both runtime trees; confirmed `diagnose.sh` deployed to `.claude`/`.agents` and the inline script is gone from the generated copies.

87 → 56 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)