### PR TITLE
fix(evidence): reuse fixed release tag

### DIFF
--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -148,8 +148,8 @@ fit — not as a shortcut past a quick scenario that would do.
 **Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so
 the main context stays clear of capture noise. Brief it with the box name, the branch, whether the
 deliverable is an image or a video, the scenario to record (feature file + exact scenario name) or
-the live state to drive, a `<slug>`, and the PR number; have it return only the markdown body it
-posted.
+the live state to drive, a `<slug>`, the PR number, and the fixed `pr-evidence` release tag; have it
+return only the markdown body it posted.
 
 ## How the harness records (wired in `packages/tests/support/hooks.ts`, gated on `KOLU_EVIDENCE`)
 
@@ -270,20 +270,23 @@ pu connect "$host" -- 'bash -lc "
 `gh pr comment` can't attach binaries, so copy artifacts back and upload to a long-lived
 GitHub release. (A screenshot from §A is a `.png` — upload and embed it the same way.)
 
+**`pr-evidence` is the one fixed evidence-release tag.** It already exists. Never derive a release
+tag from the PR number or artifact slug, and never create another release. Verify `pr-evidence`
+exists before uploading; if it does not, fail loudly.
+
 ```sh
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/evidence-<slug>.gif
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/evidence-<slug>.mp4
-gh release view <RELEASE> >/dev/null 2>&1 || \
-  gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
-gh release upload <RELEASE> /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
+gh release view pr-evidence >/dev/null
+gh release upload pr-evidence /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
 
 ```
-![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.png)
-![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.gif)
+![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.gif)
 ```
 
 For a **before↔after** comparison, post the two stills side by side (a small two-cell table or two

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -148,8 +148,8 @@ fit — not as a shortcut past a quick scenario that would do.
 **Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so
 the main context stays clear of capture noise. Brief it with the box name, the branch, whether the
 deliverable is an image or a video, the scenario to record (feature file + exact scenario name) or
-the live state to drive, a `<slug>`, and the PR number; have it return only the markdown body it
-posted.
+the live state to drive, a `<slug>`, the PR number, and the fixed `pr-evidence` release tag; have it
+return only the markdown body it posted.
 
 ## How the harness records (wired in `packages/tests/support/hooks.ts`, gated on `KOLU_EVIDENCE`)
 
@@ -270,20 +270,23 @@ pu connect "$host" -- 'bash -lc "
 `gh pr comment` can't attach binaries, so copy artifacts back and upload to a long-lived
 GitHub release. (A screenshot from §A is a `.png` — upload and embed it the same way.)
 
+**`pr-evidence` is the one fixed evidence-release tag.** It already exists. Never derive a release
+tag from the PR number or artifact slug, and never create another release. Verify `pr-evidence`
+exists before uploading; if it does not, fail loudly.
+
 ```sh
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/evidence-<slug>.gif
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/evidence-<slug>.mp4
-gh release view <RELEASE> >/dev/null 2>&1 || \
-  gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
-gh release upload <RELEASE> /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
+gh release view pr-evidence >/dev/null
+gh release upload pr-evidence /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
 
 ```
-![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.png)
-![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.gif)
+![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.gif)
 ```
 
 For a **before↔after** comparison, post the two stills side by side (a small two-cell table or two

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -148,8 +148,8 @@ fit — not as a shortcut past a quick scenario that would do.
 **Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so
 the main context stays clear of capture noise. Brief it with the box name, the branch, whether the
 deliverable is an image or a video, the scenario to record (feature file + exact scenario name) or
-the live state to drive, a `<slug>`, and the PR number; have it return only the markdown body it
-posted.
+the live state to drive, a `<slug>`, the PR number, and the fixed `pr-evidence` release tag; have it
+return only the markdown body it posted.
 
 ## How the harness records (wired in `packages/tests/support/hooks.ts`, gated on `KOLU_EVIDENCE`)
 
@@ -270,20 +270,23 @@ pu connect "$host" -- 'bash -lc "
 `gh pr comment` can't attach binaries, so copy artifacts back and upload to a long-lived
 GitHub release. (A screenshot from §A is a `.png` — upload and embed it the same way.)
 
+**`pr-evidence` is the one fixed evidence-release tag.** It already exists. Never derive a release
+tag from the PR number or artifact slug, and never create another release. Verify `pr-evidence`
+exists before uploading; if it does not, fail loudly.
+
 ```sh
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/evidence-<slug>.gif
 scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/evidence-<slug>.mp4
-gh release view <RELEASE> >/dev/null 2>&1 || \
-  gh release create <RELEASE> --prerelease --title "Evidence assets" --notes "Do not delete."
-gh release upload <RELEASE> /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
+gh release view pr-evidence >/dev/null
+gh release upload pr-evidence /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
 
 ```
-![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.png)
-![](https://github.com/<OWNER>/<REPO>/releases/download/<RELEASE>/<slug>.gif)
+![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.gif)
 ```
 
 For a **before↔after** comparison, post the two stills side by side (a small two-cell table or two

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-22T01:48:12.855476+00:00'
+generated_at: '2026-07-22T15:35:42.784796+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -456,7 +456,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:84152c26c4708fd0332ac1c15423be57b0fc19e78bb0a284b79684216ca8845d
+  content_hash: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -1132,7 +1132,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:84152c26c4708fd0332ac1c15423be57b0fc19e78bb0a284b79684216ca8845d
+  content_hash: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
 - kind: project-relative
   target: claude
   value: .claude/skills/fact-check
@@ -2445,7 +2445,7 @@ local_deployed_file_hashes:
   .agents/skills/ci/pu/report.sh: sha256:2bcce1c13acfd168ed70e0793e49eef5cd051864e4bea7b17833b889e3129bb3
   .agents/skills/ci/smoke.sh: sha256:40e266945ae0d1da5785f6bcfb242b041f47ffe1f195ab239ea47828c3eb127a
   .agents/skills/dev-server/SKILL.md: sha256:f1a8947e78b4c42744a1d49be9f607ed67a2d403e0bb673159fd18599461992a
-  .agents/skills/evidence/SKILL.md: sha256:84152c26c4708fd0332ac1c15423be57b0fc19e78bb0a284b79684216ca8845d
+  .agents/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
   .agents/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
@@ -2481,7 +2481,7 @@ local_deployed_file_hashes:
   .claude/skills/ci/pu/report.sh: sha256:2bcce1c13acfd168ed70e0793e49eef5cd051864e4bea7b17833b889e3129bb3
   .claude/skills/ci/smoke.sh: sha256:40e266945ae0d1da5785f6bcfb242b041f47ffe1f195ab239ea47828c3eb127a
   .claude/skills/dev-server/SKILL.md: sha256:f1a8947e78b4c42744a1d49be9f607ed67a2d403e0bb673159fd18599461992a
-  .claude/skills/evidence/SKILL.md: sha256:84152c26c4708fd0332ac1c15423be57b0fc19e78bb0a284b79684216ca8845d
+  .claude/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
   .claude/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8


### PR DESCRIPTION
The evidence skill says artifacts belong on a long-lived release, but its
`<RELEASE>` placeholder left the actual tag up to each agent. Combined with the
create-on-miss fallback, that let an agent invent a PR-specific tag and publish
a new release.

This pins evidence hosting to the existing `pr-evidence` release everywhere:
delegation instructions, release lookup and upload commands, and embed URLs. It
also removes release creation entirely, so a missing canonical release fails
loudly instead of creating another one.

No visual impact: this changes agent workflow instructions and generated skill
copies, not a rendered product surface.

Checks:

- `just ai::apm`
- skill `quick_validate.py`
- `just fmt`
- `git diff --check`
- `gh release view pr-evidence --repo juspay/kolu`
