### PR TITLE
fix(dock): render the shell identity glyph on non-agent rows

### DIFF
--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -653,8 +653,7 @@ const DockRow: Component<{
               color: c().info.annotationColor,
             }}
           >
-            <IntentMarkdown
-              inline
+            <IntentMarkdownInline
               markdown={annotationLine(c().meta.intent, c().info.key.label)}
             />
           </span>

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -633,7 +633,7 @@ const DockRow: Component<{
           title="Jump to this terminal"
         >
           {/* Identity status indicator — agent brand or shell glyph, state
-           *  paint/motion, live glow halo, unread corner dot. Centred across
+           *  paint/motion, live plate, unread corner dot. Centred across
            *  both row lines. */}
           <span class="row-span-2 flex self-center">
             <StatePip

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -520,26 +520,24 @@ const RepoSection: Component<{
     style={{ "--repo-color": props.group.color }}
     class={`dock-cards-section grid ${DOCK_ROW_GRID} ${DOCK_ROW_GAP} pl-3 ${DOCK_CARDS_GUTTER_CLASS}`}
   >
-    {/* Header is a sticky, faintly repo-tinted band (see
-     *  `.dock-cards-section-header` — Option C mockup: 6% repo mix),
-     *  riding above the repo-colour spine the section's left border
-     *  draws. The name is a plain uppercase label in the repo colour
-     *  (not a filled chip); count stays neutral. Header text and row
-     *  content both sit at `pl-3` (12 px) from the dock's outer edge,
-     *  so the row's leading status indicator aligns with the repo name
-     *  — the repo spine + tinted header band carry the grouping. */}
+    {/* Sticky repo header — tinted band + colour swatch + uppercase name
+     *  + quiet count capsule (styles in `index.css`). Spine + swatch +
+     *  wash are three scales of the same `--repo-color`. Content inset
+     *  matches the rows (`pl-3`) so the status indicator lines up under
+     *  the name. */}
     <div
       data-testid="dock-section-header"
-      class={`dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 ${DOCK_CARDS_GUTTER_NEG_CLASS} pl-3 pr-3 py-[0.45rem] border-b`}
+      class={`dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 ${DOCK_CARDS_GUTTER_NEG_CLASS} pl-3 pr-3 py-2`}
     >
+      <span class="dock-cards-section-swatch" aria-hidden="true" />
       <span
         data-testid="dock-section-name"
-        class="dock-cards-section-name font-mono text-[0.62rem] font-bold uppercase tracking-[0.1em] truncate min-w-0"
+        class="dock-cards-section-name font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] truncate min-w-0"
         title={props.group.name}
       >
         {props.group.name}
       </span>
-      <span class="ml-auto font-mono text-[0.62rem] tabular-nums text-fg-3 shrink-0">
+      <span class="dock-cards-section-count font-mono text-[0.6rem]">
         {props.group.rows.length}
       </span>
     </div>
@@ -631,16 +629,12 @@ const DockRow: Component<{
               tileStore.activate(props.id);
             }
           }}
-          class={`relative w-full grid grid-cols-subgrid col-span-full items-center py-1.5 ${DOCK_CARDS_SUBGRID_LEFT_RESTORE} ${DOCK_CARDS_GUTTER_NEG_CLASS} ${DOCK_CARDS_GUTTER_CLASS} border-l-[length:var(--dock-edge-stripe-w)] border-l-transparent text-left cursor-pointer transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 hover:bg-surface-2/40 data-[active]:bg-accent/15 data-[active]:border-l-accent`}
+          class={`relative w-full grid grid-cols-subgrid col-span-full items-center py-2 ${DOCK_CARDS_SUBGRID_LEFT_RESTORE} ${DOCK_CARDS_GUTTER_NEG_CLASS} ${DOCK_CARDS_GUTTER_CLASS} border-l-[length:var(--dock-edge-stripe-w)] border-l-transparent text-left cursor-pointer transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40 hover:bg-surface-2/40 data-[active]:bg-accent/15 data-[active]:border-l-accent`}
           title="Jump to this terminal"
         >
-          {/* One merged status indicator — the agent-state CORE
-           *  (`pipVariant`), wrapped by the green live RING when the
-           *  terminal is moving bytes and the amber unread corner BADGE
-           *  when a fired alert is unopened. The old standalone ActivityPip
-           *  column is gone (its dot is now the ring), reclaiming the
-           *  dead left margin. `row-span-2 self-center` centres it across
-           *  both row lines rather than pinning it to line 1. */}
+          {/* Identity status indicator — agent brand or shell glyph, state
+           *  paint/motion, live glow halo, unread corner dot. Centred across
+           *  both row lines. */}
           <span class="row-span-2 flex self-center">
             <StatePip
               variant={pipVariant(props.pip)}
@@ -654,12 +648,13 @@ const DockRow: Component<{
             />
           </span>
           <span
-            class="font-medium text-[0.85rem] leading-tight truncate min-w-0"
+            class="dock-cards-row-label text-[0.84rem]"
             style={{
               color: c().info.annotationColor,
             }}
           >
-            <IntentMarkdownInline
+            <IntentMarkdown
+              inline
               markdown={annotationLine(c().meta.intent, c().info.key.label)}
             />
           </span>
@@ -687,7 +682,7 @@ const DockRow: Component<{
            *  foreground process title, or an invisible placeholder
            *  keeping the row two-line tall). */}
           <div
-            class={`${DOCK_ROW_BRANCH_COL} col-end-[-1] flex items-center gap-1.5 min-w-0`}
+            class={`${DOCK_ROW_BRANCH_COL} col-end-[-1] flex items-center gap-1.5 min-w-0 mt-0.5`}
           >
             <PrPip meta={c().meta} />
             <Show
@@ -695,7 +690,7 @@ const DockRow: Component<{
               fallback={
                 <span
                   aria-hidden="true"
-                  class="font-mono text-[0.65rem] leading-tight invisible"
+                  class="font-mono text-[0.68rem] leading-tight invisible"
                 >
                   &nbsp;
                 </span>
@@ -708,7 +703,7 @@ const DockRow: Component<{
                       ? "dock-agent-subline"
                       : "dock-quiet-foreground"
                   }
-                  class="font-mono text-[0.65rem] leading-tight text-fg-2 truncate min-w-0"
+                  class="font-mono text-[0.68rem] leading-snug text-fg-3 truncate min-w-0"
                   title={line()}
                 >
                   {line()}

--- a/packages/client/src/canvas/dock/DockList.tsx
+++ b/packages/client/src/canvas/dock/DockList.tsx
@@ -99,15 +99,16 @@ function DockListSection(props: {
     >
       <div
         data-testid="mobile-dock-section-header"
-        class="dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 -mr-3 pl-3 pr-3 py-[0.45rem] border-b"
+        class="dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 -mr-3 pl-3 pr-3 py-2.5"
       >
+        <span class="dock-cards-section-swatch" aria-hidden="true" />
         <span
           data-testid="mobile-dock-section-name"
-          class="dock-cards-section-name font-mono text-[0.62rem] font-bold uppercase tracking-[0.1em] truncate min-w-0"
+          class="dock-cards-section-name font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] truncate min-w-0"
         >
           {props.group.name}
         </span>
-        <span class="ml-auto font-mono text-[0.62rem] tabular-nums text-fg-3 shrink-0">
+        <span class="dock-cards-section-count font-mono text-[0.6rem]">
           {props.group.rows.length}
         </span>
       </div>
@@ -180,7 +181,7 @@ function DockListRow(props: {
           // desktop rides on `DOCK_CARDS_GUTTER_*` (24 px). The left
           // side is symmetric between the two surfaces, so it ships
           // as one symbol.
-          class={`w-full grid grid-cols-subgrid col-span-full items-center py-3 ${DOCK_CARDS_SUBGRID_LEFT_RESTORE} -mr-3 pr-3 border-l-[length:var(--dock-edge-stripe-w)] border-l-transparent border-b border-b-edge/15 text-left transition-colors duration-150 cursor-pointer active:bg-surface-2 data-[active]:bg-accent/15 data-[active]:border-l-accent`}
+          class={`w-full grid grid-cols-subgrid col-span-full items-center py-3 ${DOCK_CARDS_SUBGRID_LEFT_RESTORE} -mr-3 pr-3 border-l-[length:var(--dock-edge-stripe-w)] border-l-transparent text-left transition-colors duration-150 cursor-pointer active:bg-surface-2 data-[active]:bg-accent/15 data-[active]:border-l-accent`}
         >
           {/* One merged status indicator — agent-state core, green live
            *  ring, amber unread corner badge; centred across both row lines.
@@ -198,7 +199,7 @@ function DockListRow(props: {
             />
           </span>
           <span
-            class="font-medium text-[0.9rem] leading-tight truncate min-w-0"
+            class="dock-cards-row-label text-[0.9rem]"
             style={{
               color: c().info.annotationColor,
             }}
@@ -220,7 +221,7 @@ function DockListRow(props: {
            *  edge so it aligns across every section), subline text
            *  following. */}
           <div
-            class={`${DOCK_ROW_BRANCH_COL} col-end-[-1] flex items-center gap-1.5 min-w-0`}
+            class={`${DOCK_ROW_BRANCH_COL} col-end-[-1] flex items-center gap-1.5 min-w-0 mt-0.5`}
           >
             <PrPip meta={c().meta} />
             <Show
@@ -241,7 +242,7 @@ function DockListRow(props: {
                       ? "mobile-dock-agent-subline"
                       : "mobile-dock-foreground"
                   }
-                  class="font-mono text-[0.7rem] leading-tight text-fg-2 truncate min-w-0"
+                  class="font-mono text-[0.7rem] leading-snug text-fg-3 truncate min-w-0"
                   title={line()}
                 >
                   {line()}

--- a/packages/client/src/canvas/dock/WorkspaceGrid.tsx
+++ b/packages/client/src/canvas/dock/WorkspaceGrid.tsx
@@ -13,7 +13,6 @@
  *  three echoes of the same truth. */
 
 import { activeArm, activePr } from "@kolu/padi/surface";
-import { StatePip } from "@kolu/solid-statepip";
 import { ATTENTION_PILL_CLASS } from "@kolu/solid-statepip/pipVariant";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import type { TerminalId } from "kolu-common/surface";
@@ -44,7 +43,6 @@ import {
   type DockSourceEntry,
 } from "../dockModel";
 import { agentLabel, metaLine, tokenLine } from "./dockRowChrome";
-import { pipVariant } from "./pipVariant";
 
 /** Slot tag on each card. The scroll-into-view effect queries by this
  *  value so the lookup stays scoped to *this* grid instance even if a
@@ -318,14 +316,10 @@ const ColumnView: Component<{
       }}
     >
       <div class="flex items-center gap-1.5 min-w-0">
-        {/* Bucket-state pip — the same StatePip the dock row and tile
-         *  title lead with, here labelling the whole column: the Working
-         *  header carries the spinning ring, Awaiting/Idle a quiet dot.
-         *  A column header is not a terminal, so it carries neither the
-         *  live ring nor the unread badge (both per-terminal). Rendered
-         *  unconditionally, like the dock and mobile rows — StatePip
-         *  draws an empty cell for the No-agent ('none') bucket. */}
-        <StatePip variant={pipVariant(props.column.key)} />
+        {/* Column headers are state legends, not terminals — no identity
+         *  glyph (Option C shell mark would misread every bucket as a shell).
+         *  Colour + label carry the column identity; StatePip stays on real
+         *  terminal rows and the tile title. */}
         <div
           class={`font-mono text-[0.65rem] font-semibold uppercase tracking-[0.2em] ${props.column.textClass}`}
         >

--- a/packages/client/src/canvas/dock/dockRowRanking.test.ts
+++ b/packages/client/src/canvas/dock/dockRowRanking.test.ts
@@ -252,9 +252,13 @@ describe("row ORDER vs row COLOUR are decoupled — the pip matches the tile tit
     }
   });
 
-  it("a sleeping row keeps its ☾ pip; a never-touched shell keeps none", () => {
+  it("a sleeping row keeps sleeping paint; a never-touched shell paints idle (shell glyph)", () => {
     expect(pip(makeSleepingMeta(), false)).toBe("sleeping");
-    expect(pip(makeMeta(), false)).toBe("none");
+    // ORDER still ranks never-touched as `none` (quieter than idle), but PAINT
+    // is `idle` so the shell identity glyph renders — Option C: every row core
+    // is an identity mark; `empty` is only for genuinely blank call sites.
+    expect(bucket(makeMeta(), false)).toBe("none");
+    expect(pip(makeMeta(), false)).toBe("idle");
   });
 });
 

--- a/packages/client/src/canvas/dock/dockRowRanking.ts
+++ b/packages/client/src/canvas/dock/dockRowRanking.ts
@@ -111,11 +111,11 @@ function classifyDockRow(
  *  shared `agentPaintClass` — the SAME fold `TerminalMeta` feeds its title pip —
  *  so a fresh `waiting` agent paints `awaiting` (the lingering dim-alert dot) in
  *  BOTH places, even though `classifyDockRow` ranks it `idle` for ORDERING. The
- *  dock-only triage buckets that have no agent to paint — `sleeping` (☾),
- *  `parked` (hidden) and the never-touched `none`/`idle` shells — keep the order
- *  bucket, since the title shows no pip for them at all (it gates on a live
- *  agent). Order (rank) and colour (paint) are thus decoupled: the row sorts by
- *  urgency but glows by paint. */
+ *  dock-only triage buckets that have no agent to paint — `sleeping` (moonlit
+ *  identity glyph), `parked` (hidden/empty), and plain shells — map shells to
+ *  `idle` paint (shell glyph) even when ORDER ranks them `none`. Order (rank)
+ *  and colour (paint) stay decoupled: the row sorts by urgency but paints by
+ *  identity + agent state. */
 function paintDockRow(meta: TerminalMetadata, parked: boolean): DockRowBucket {
   // The overlay also runs in the paint fold so the two folds stay aligned by
   // construction — even though a parked pip never paints (`dockTree` drops the
@@ -123,11 +123,14 @@ function paintDockRow(meta: TerminalMetadata, parked: boolean): DockRowBucket {
   const overlay = dockOverlayBucket(meta, parked);
   if (overlay) return overlay;
   const agent = activeArm(meta)?.agent;
-  // No live agent → no pip colour to share with the title; keep the order
-  // bucket's plain-shell triage (`idle` if touched, else `none`).
-  if (!agent) return meta.lastActivityAt !== null ? "idle" : "none";
+  // No live agent → shell identity glyph (`idle` paint: fg-3, still). Every
+  // dock row core is an identity mark (Option C); never-touched shells still
+  // ORDER as `none` via `classifyDockRow`, but they PAINT as idle so
+  // `PIP_BODY.empty` does not swallow the shell glyph. `parked` stays empty
+  // via the overlay above (and never reaches a visible row).
+  if (!agent) return "idle";
   const paint = agentPaintClass(agent.state);
-  // An unknown state paints `none`; surface it as `idle` (a quiet dot) when the
+  // An unknown state paints `none`; surface it as `idle` (shell mark) when the
   // row has activity rather than an empty cell, matching the order fold.
   return paint === "none" && meta.lastActivityAt !== null ? "idle" : paint;
 }

--- a/packages/client/src/canvas/dock/pipVariant.test.ts
+++ b/packages/client/src/canvas/dock/pipVariant.test.ts
@@ -6,8 +6,9 @@ import { pipGlyphFor, pipVariant } from "./pipVariant";
 
 // The bucket carries only the CORE state now — `unread` is no longer folded in
 // (R-activity-merge moved it to the indicator's `alert` corner badge). awaiting is the
-// quiet lingering paint; working breathes; idle is muted; none/parked
-// render empty; sleeping is moonlit + still (identity glyph, not ☾).
+// quiet lingering paint; working breathes; idle is the shell mark (fg-3);
+// none/parked render empty (blank call sites only — dock rows paint shells as
+// idle via paintDockRow); sleeping is moonlit + still.
 const cases: Array<[DockRowBucket, PipVariant]> = [
   ["awaiting", "awaiting"],
   ["working", "working"],
@@ -23,6 +24,13 @@ describe("pipVariant", () => {
       expect(pipVariant(bucket)).toBe(expected);
     });
   }
+
+  it("idle is the shell identity paint (not empty) so non-agent rows get a core", () => {
+    // paintDockRow maps every agentless dock row to idle; this is the
+    // body that actually draws the shell glyph.
+    expect(pipVariant("idle")).toBe("idle");
+    expect(pipVariant("none")).toBe("empty");
+  });
 });
 
 // pipGlyphFor only reads activeArm(meta)?.agent?.kind and meta.restoreTarget —

--- a/packages/client/src/canvas/dock/pipVariant.ts
+++ b/packages/client/src/canvas/dock/pipVariant.ts
@@ -6,7 +6,9 @@
  *  the pip a given agent paint class shows is defined ONCE — the same fold
  *  a fleet mirror's `pipVariantFor` calls — and can't drift between surfaces.
  *  This function adds only the dock-only `idle`/`sleeping`/`parked` triage
- *  buckets that have no agent paint to share.
+ *  buckets that have no agent paint to share. Dock *rows* paint plain shells
+ *  as `idle` (shell glyph) via `paintDockRow` — `none`→`empty` remains for
+ *  call sites that genuinely mean blank (parked, workspace column legends).
  *
  *  `unread` is NO LONGER folded in here (R-activity-merge): an unread alert used
  *  to REPLACE the whole pip with a loud `attention` disk; it now rides as the

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -549,22 +549,68 @@ body {
 .dock-cards-section {
   border-left: var(--dock-edge-stripe-w) solid var(--repo-color);
 }
-/* Sticky header band — faintly repo-tinted (Option C mockup: 6% repo mix).
- * Mixed into `surface-1` so the band stays opaque enough for rows to scroll
- * cleanly underneath, while the repo colour still reads as a section break
- * together with the left spine. */
+/* Sticky header band — a quiet repo wash (opaque enough for scroll-under)
+ * plus a hairline that borrows a hint of the repo colour so sections
+ * separate without a hard edge. */
 .dock-cards-section-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: color-mix(in oklab, var(--repo-color) 6%, var(--color-surface-1));
-  border-bottom-color: color-mix(in oklab, var(--color-edge) 50%, transparent);
+  background: color-mix(in oklab, var(--repo-color) 9%, var(--color-surface-1));
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--repo-color) 18%, var(--color-edge));
 }
-/* Repo name is a plain uppercase label in the repo colour — not a filled
- * chip. The mockup's `.sect-hd .name` treatment: colour + weight + tracking
- * carry the identity; the tinted band + spine carry the grouping. */
+/* Solid colour swatch — a 7×7 mark that anchors the section without the
+ * old filled-name chip. Spine + swatch + tinted band = three echoes of
+ * the same repo colour at different scales. */
+.dock-cards-section-swatch {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+  background: var(--repo-color);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--repo-color) 35%, transparent);
+}
+/* Repo name — uppercase mono label in the repo colour. Weight + tracking
+ * do the identity work; the swatch and band do the grouping. */
 .dock-cards-section-name {
   color: var(--repo-color);
+}
+/* Terminal count — a quiet capsule so the number doesn't float as bare
+ * type against a tinted band. */
+.dock-cards-section-count {
+  flex: none;
+  margin-left: auto;
+  min-width: 1.25rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 9999px;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-fg-3);
+  background: color-mix(in oklab, var(--color-surface-0) 55%, transparent);
+  border: 1px solid color-mix(in oklab, var(--color-edge) 55%, transparent);
+}
+/* Branch / intent label on a cards row — slightly denser than body text so
+ * the primary line reads as the row title; colour still comes from the
+ * per-branch `annotationColor` (docs: branch colours distinguish rows
+ * *within* a repo). */
+.dock-cards-row-label {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Soft row dividers — mockup-quiet; last row has none. */
+.dock-cards-section > [data-testid="dock-row"],
+.dock-cards-section > [data-testid="mobile-dock-row"] {
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--color-edge) 28%, transparent);
+}
+.dock-cards-section > [data-testid="dock-row"]:last-child,
+.dock-cards-section > [data-testid="mobile-dock-row"]:last-child {
+  border-bottom: 0;
 }
 
 /* ── Rail-mode chip ────────────────────────────────────────────

--- a/packages/client/src/terminal/TerminalMeta.tsx
+++ b/packages/client/src/terminal/TerminalMeta.tsx
@@ -118,29 +118,23 @@ const TerminalMeta: Component<{
            *  separate glyph chip, so this slot is the canvas tile's
            *  sole intent affordance regardless of git state. */}
           <div class="col-start-1 col-span-2 row-start-2 flex items-center gap-1.5 min-w-0 text-xs">
-            {/* Agent-state pip leading the branch/intent annotation —
-             *  the same shape-distinct StatePip the dock row leads its
-             *  annotation line with (spinning ring = working, dot =
-             *  awaiting), reused verbatim so a working/awaiting agent
-             *  reads identically in the title and the dock, and sits
-             *  beside the same branch/intent context it does there.
-             *  `unread` rides as the indicator's amber corner BADGE (the
-             *  `alert` prop) rather than replacing the state core — the
-             *  dock-row treatment, one fold over. A reserved `TITLE_PIP_BOX`
-             *  (smaller than the dock's box, sized to this `text-xs` row) gives
-             *  the badge a corner to anchor to instead of pinning it on the
-             *  6 px core. No live ring here: the title bar has never shown the
-             *  byte-motion axis. Gated on a
-             *  live agent: when none is attached the title shows no pip
-             *  (exactly as its agent-kind indicator vanishes when the
-             *  session ends), leaving the dock's idle/parked triage
-             *  states — which fold in recency/staleness — dock-only. */}
-            <Show when={activeArm(v().meta)?.agent}>
-              {(agent) => (
+            {/* Identity pip leading the branch/intent annotation — the same
+             *  StatePip the dock row leads with (agent brand or shell prompt,
+             *  state paint + motion). Active terminals always show it: a plain
+             *  shell is still "who is driving this" (`shell` glyph, idle/busy).
+             *  Sleeping tiles have no live arm here (the dock paints them via
+             *  the sleeping bucket). `unread` rides as the amber corner DOT.
+             *  No live ring: the title bar has never shown the byte-motion
+             *  axis. `TITLE_PIP_BOX` gives the badge a corner to anchor to. */}
+            <Show when={activeArm(v().meta)}>
+              {(arm) => (
                 <StatePip
-                  variant={pipVariant(paintBucket(agent()))}
+                  variant={
+                    arm().agent ? pipVariant(paintBucket(arm().agent)) : "idle"
+                  }
                   glyph={pipGlyphFor(v().meta)}
-                  still={agent().state === "waiting"}
+                  busy={!!arm().foreground}
+                  still={arm().agent?.state === "waiting"}
                   alert={props.unread}
                   alertLabel="unread alert"
                   class={TITLE_PIP_BOX}

--- a/packages/client/src/ui/chromeSpacing.ts
+++ b/packages/client/src/ui/chromeSpacing.ts
@@ -94,17 +94,18 @@ export const DOCK_CARDS_SUBGRID_LEFT_RESTORE = "-ml-3 pl-3";
  *
  *  R-activity-merge collapsed the old leading pair — a 12 px live-activity
  *  track + a 16/20 px state-pip track — into ONE 18 px column holding the
- *  merged `StatePip` (its green live glow halo replacing the standalone
- *  dot), so the row's dead left margin is reclaimed and desktop/touch no
- *  longer differ in this geometry — hence ONE shared template, not a
- *  desktop/touch pair. 18 px is the pip box; the live halo bleeds into
- *  `DOCK_ROW_GAP` (which does not clip). If a real desktop/touch divergence
- *  returns later, reintroduce a second constant then, when it once again
- *  encodes a difference. */
+ *  merged `StatePip` (its green live plate behind the identity glyph
+ *  replacing the standalone activity dot), so the row's dead left margin is
+ *  reclaimed and desktop/touch no longer differ in this geometry — hence ONE
+ *  shared template, not a desktop/touch pair. 18 px is the pip box; the live
+ *  plate is contained inside it. If a real desktop/touch divergence returns
+ *  later, reintroduce a second constant then, when it once again encodes a
+ *  difference. */
 export const DOCK_ROW_GRID = "grid-cols-[18px_minmax(0,1fr)_auto_auto]";
 /** Column gap between the status indicator and the branch label — matches
- *  the Option C mockup (`gap: 0 0.7rem`). Wide enough that the live glow
- *  halo (≈8 px blur outside the 18 px pip) does not collide with the
- *  branch text. Shared by desktop cards and the touch list. */
+ *  the Option C mockup (`gap: 0 0.7rem`). Gives the 18 px pip + identity
+ *  glyph breathing room from the branch text (the live plate is contained
+ *  inside the pip and no longer bleeds). Shared by desktop cards and the
+ *  touch list. */
 export const DOCK_ROW_GAP = "gap-x-[0.7rem]";
 export const DOCK_ROW_BRANCH_COL = "col-start-2";

--- a/packages/solid-statepip/src/StatePip.tsx
+++ b/packages/solid-statepip/src/StatePip.tsx
@@ -19,21 +19,21 @@
  *      `pipVariant`; a fleet mirror maps its own rows the same way), both folding
  *      the shared agent-paint classes through `pipForPaintClass`.
  *    - `glyph` (the CORE shape) — identity: agent kind or `"shell"`.
- *    - `live` (the RING) — this terminal is moving bytes right now: a static
- *      green glow halo around the core (the row/title live signal, folded into
- *      the indicator's edge; the glyph-only rail + sub-tabs keep the standalone
- *      `LiveActivityDot` corner dot, which has no core to ring).
+ *    - `live` (the PLATE) — this terminal is moving bytes right now: a faint
+ *      green disc BEHIND the identity glyph (contained presence; the glyph-only
+ *      rail + sub-tabs keep the standalone `LiveActivityDot` corner dot, which
+ *      has no plate to sit under).
  *    - `alert` (the BADGE) — a fired notification you haven't opened (the Dock's
- *      `unread`, or a fleet mirror's notify-class): a small amber corner badge, NOT a
- *      ring — a surrounding alert ring (especially nested with the live ring)
+ *      `unread`, or a fleet mirror's notify-class): a small amber corner dot, NOT a
+ *      ring — a surrounding alert ring (especially nested with the live plate)
  *      read as overwhelming, so the two axes use different shapes and never
- *      compound into concentric circles. The state core stays fully visible.
+ *      compound into concentric circles. The glyph stays fully visible.
  *
  *  Pure presentation: the per-variant CORE class set lives in `PIP_BODY`; the
- *  glyph path data in `pipGlyph` / `agentGlyph`; the ring + badge are overlay
+ *  glyph path data in `pipGlyph` / `agentGlyph`; the plate + badge are overlay
  *  elements whose class names (`LIVE_RING_CLASS`, `ALERT_BADGE_CLASS`) and
  *  visuals live in `statepip.css`. Both surfaces `@import` that CSS, so the
- *  rings can't drift; the class data is pinned by a pure test (no DOM harness,
+ *  overlays can't drift; the class data is pinned by a pure test (no DOM harness,
  *  matching the other `@kolu/solid-*` leaves). Colours are the shared
  *  `@kolu/theme` tokens, so both surfaces resolve them identically.
  *
@@ -97,8 +97,8 @@ export const StatePip: Component<{
    *  stay decoupled: order≠colour's paint class stays `awaiting`, motion is
    *  none. Sleeping already has no motion in `PIP_MOTION`. Default off. */
   still?: boolean;
-  /** Terminal moving bytes right now → the green live-output RING around the
-   *  core. The activity dot, folded into the indicator's edge. Default off. */
+  /** Terminal moving bytes right now → the green live-output PLATE behind the
+   *  identity glyph. The activity cue, folded into the indicator. Default off. */
   live?: boolean;
   /** A fired notification not yet opened → a small amber `--color-attention`
    *  corner badge (top-right), NOT a ring, so it never compounds with the live
@@ -181,20 +181,19 @@ export const StatePip: Component<{
       aria-label={label() || undefined}
       aria-hidden={label() ? undefined : "true"}
     >
+      {/* Live plate first so it paints BEHIND the identity glyph (DOM order,
+          not z-index). Alert badge last so it sits on top of both. */}
+      <Show when={props.live}>
+        <span class={LIVE_RING_CLASS} aria-hidden="true" />
+      </Show>
       <Show when={coreClass()}>
         {(cls) => (
-          <span class={`flex items-center justify-center ${cls()}`}>
+          <span class={`relative flex items-center justify-center ${cls()}`}>
             <GlyphSvg def={def()} />
           </span>
         )}
       </Show>
-      {/* The two outer-axis overlays — a green glow halo while the terminal is
-          live, and a small amber attention DOT while an alert is unread (not a
-          ring, not the host-tab count pill — Option C mockup's 7px corner pip).
-          Boolean here; fill + size live in statepip.css. */}
-      <Show when={props.live}>
-        <span class={LIVE_RING_CLASS} aria-hidden="true" />
-      </Show>
+      {/* Unread attention DOT — Option C mockup's 7px corner pip. */}
       <Show when={props.alert}>
         <span class={ALERT_BADGE_CLASS} aria-hidden="true" />
       </Show>

--- a/packages/solid-statepip/src/pipVariant.test.ts
+++ b/packages/solid-statepip/src/pipVariant.test.ts
@@ -147,12 +147,10 @@ describe("pipGlyph / agentGlyph — identity marks", () => {
 });
 
 // The two OUTER axes the merged indicator folds around the core (R-activity-
-// merge): the green live RING (a static glow halo) and the unread ALERT (a small
-// amber corner badge — a different shape, so it never competes with the ring or
-// nests into a second circle), drawn as overlay elements whose visuals live in
-// statepip.css. Both surfaces (Dock + pulam-web) render the same component +
-// import the same CSS, so this is the one definition — the "defined twice →
-// drifts" hazard the two separate dots had, closed the way R-pip-unify closed it.
+// merge): the green live PLATE (a faint disc behind the glyph) and the unread
+// ALERT (a small amber corner dot — a different shape, so it never competes
+// with the plate), drawn as overlay elements whose visuals live in
+// statepip.css. Both surfaces render the same component + import the same CSS.
 describe("the indicator wrapper + outer-axis overlays", () => {
   it("the leaf wrapper is a content-sized relative box (anchors the absolute overlays), no surface geometry", () => {
     const cls = INDICATOR_BASE.split(/\s+/);
@@ -178,9 +176,10 @@ describe("the indicator wrapper + outer-axis overlays", () => {
     expect(cls).toContain("rounded-full");
   });
 
-  it("the live ring + alert badge are the shared statepip.css classes", () => {
-    expect(LIVE_RING_CLASS).toBe("statepip-live-ring");
-    // a corner DOT, not a halo/ring and not the host-tab count pill —
+  it("the live plate + alert badge are the shared statepip.css classes", () => {
+    // Export keeps LIVE_RING_CLASS for the live prop contract; CSS is the plate.
+    expect(LIVE_RING_CLASS).toBe("statepip-live-plate");
+    // a corner DOT, not a ring and not the host-tab count pill —
     // Option C mockup's 7px attention pip.
     expect(ALERT_BADGE_CLASS).toBe("statepip-alert-badge");
   });

--- a/packages/solid-statepip/src/pipVariant.ts
+++ b/packages/solid-statepip/src/pipVariant.ts
@@ -15,12 +15,12 @@
  *  an unread-notification **alert** — were each a SEPARATE dot before, defined
  *  (and drifting) per surface; they now compose here, once, as overlay elements
  *  (`LIVE_RING_CLASS`, `ALERT_BADGE_CLASS`; visuals in `statepip.css`):
- *    - the live RING — a static green glow halo while the terminal is emitting
- *      (the old conic sweep retired once identity glyphs claimed motion);
- *    - the alert BADGE — a small amber `--color-attention` corner badge, the
- *      Dock's old loud `attention` pip retired: a different SHAPE from the ring
- *      (not another circle/halo), so the two never compound into nested rings,
- *      and the live state core stays fully visible.
+ *    - the live PLATE — a faint green disc behind the identity glyph while the
+ *      terminal is emitting (contained presence; no glow bleed past the pip);
+ *    - the alert BADGE — a small amber `--color-attention` corner dot, the
+ *      Dock's old loud `attention` pip retired: a different SHAPE from the plate
+ *      so the two never compound into nested rings, and the glyph stays fully
+ *      visible.
  *  Both default off, so a bare `<StatePip variant=… />` reads exactly as before.
  *
  *  Option C: every core is an **identity glyph** ("who is driving this
@@ -241,10 +241,11 @@ export const DOCK_ROW_PIP_BOX = "w-[18px] h-[18px] rounded-full";
  *  than the taller dock-row track. Caller's geometry, same as `DOCK_ROW_PIP_BOX`. */
 export const TITLE_PIP_BOX = "w-[14px] h-[14px] rounded-full";
 
-/** The live RING overlay class — a static green glow halo while the terminal is
- *  moving bytes (one motion per row: motion belongs to agent state; the halo is
- *  presence only). Visuals in `statepip.css`; both surfaces import it. */
-export const LIVE_RING_CLASS = "statepip-live-ring";
+/** The live PLATE overlay class — a faint green disc behind the identity glyph
+ *  while the terminal is moving bytes (presence only; agent state owns motion).
+ *  Visuals in `statepip.css`; both surfaces import it. Export name kept for the
+ *  `live` prop contract; the CSS class is `statepip-live-plate`. */
+export const LIVE_RING_CLASS = "statepip-live-plate";
 
 /** The shared "amber attention pill" — styling truth for the host-tab
  *  awaiting-count badge (`HostSelectorStrip.tsx`). A Tailwind class STRING so it

--- a/packages/solid-statepip/src/statepip.css
+++ b/packages/solid-statepip/src/statepip.css
@@ -1,20 +1,22 @@
-/* The merged status indicator's outer axes + core motion — the live RING, the
- * alert BADGE, and the identity-glyph breathe/glow animations that `StatePip`
- * composes (R-activity-merge + Option C). Shipped as a CSS leaf rather than
- * Tailwind utilities because the live halo is a multi-stop box-shadow and the
- * glow uses `filter: drop-shadow` — neither express cleanly as utility classes.
- * kolu's client `@import`s `@kolu/solid-statepip/statepip.css`, so the rings are
- * single-sourced (one definition, can't drift). Colours are the shared
- * `@kolu/theme` CSS vars, resolved by whichever surface imports the theme.
+/* The merged status indicator's outer axes + core motion — the live PLATE,
+ * the alert BADGE, and the identity-glyph breathe/glow animations that
+ * `StatePip` composes (R-activity-merge + Option C). Shipped as a CSS leaf
+ * rather than Tailwind utilities because the live plate is a colour-mix
+ * disc and the glyph glow uses `filter: drop-shadow` — neither express
+ * cleanly as utility classes. kolu's client `@import`s
+ * `@kolu/solid-statepip/statepip.css`, so the overlays are single-sourced
+ * (one definition, can't drift). Colours are the shared `@kolu/theme` CSS
+ * vars, resolved by whichever surface imports the theme.
  *
- * The live ring is a static glow halo (it wraps the core); the alert is a small
- * CORNER BADGE, deliberately NOT a second ring — a surrounding alert ring
- * (especially nested with the live ring) read as overwhelming, so the two axes
- * use different shapes and never compound into concentric circles. Motion is
- * transform/opacity/filter only (compositor-friendly — no per-frame layout),
- * and a reduced-motion preference holds animations still. Under reduced motion
- * the awaiting core keeps a violet hollow outline so state never degrades to
- * colour alone (Option C spent shape on identity). */
+ * The live plate is a faint green disc BEHIND the identity glyph (presence,
+ * contained inside the pip — no glow bleed past the box). The alert is a
+ * small CORNER DOT, deliberately NOT a ring — a surrounding alert ring
+ * (especially nested with a live disc) read as overwhelming, so the two
+ * axes use different shapes. Motion is transform/opacity/filter only
+ * (compositor-friendly — no per-frame layout), and a reduced-motion
+ * preference holds animations still. Under reduced motion the awaiting
+ * core keeps a violet hollow outline so state never degrades to colour
+ * alone (Option C spent shape on identity). */
 
 @keyframes statepip-breathe {
   0%,
@@ -59,18 +61,15 @@
   animation: statepip-glow 2.2s ease-in-out infinite;
 }
 
-/* live = this terminal is moving bytes right now: a static green glow halo
- * around the core. The old conic sweep was retired once identity glyphs claimed
- * motion (one motion per row — the halo is presence, agent state is motion).
- * `inset: -1px` so the glow sits just outside the 18px pip box without eating
- * the amber badge's corner. */
-.statepip-live-ring {
+/* live = this terminal is moving bytes right now: a faint green disc
+ * (avatar plate) behind the identity glyph. Contained inside the pip —
+ * no box-shadow bleed past the edge. Presence only; agent state owns
+ * motion. Rendered under the glyph in StatePip's DOM order. */
+.statepip-live-plate {
   position: absolute;
   inset: -1px;
   border-radius: 9999px;
-  box-shadow:
-    0 0 8px 2px color-mix(in oklab, var(--color-ok) 45%, transparent),
-    0 0 2px 0.5px color-mix(in oklab, var(--color-ok) 55%, transparent);
+  background: color-mix(in oklab, var(--color-ok) 13%, transparent);
   pointer-events: none;
 }
 
@@ -78,7 +77,7 @@
  * unopened-unread — each surface names it via `alertLabel`): a small amber
  * CORNER DOT at the top-right, NOT a ring and NOT the host-tab count pill —
  * Option C mockup's 7px attention pip. Shape is deliberately a circle so it
- * never competes with the live glow halo or reads as a count capsule on a
+ * never competes with the live plate or reads as a count capsule on a
  * 14px identity glyph. The surface separator lifts it off the row; a gentle
  * pulse draws the eye without shouting. Fill is `--color-attention` (the
  * warm "needs you" amber), single-sourced in this leaf. */


### PR DESCRIPTION
## Summary

Follow-up to #1949: plain-shell dock rows showed **no** status core because never-touched agentless terminals painted as `none` → `PIP_BODY.empty` (null). Option C says every row core is an identity glyph — including the shell prompt (`❯ _`).

- **`paintDockRow`**: every agentless row paints `idle` (shell glyph, `text-fg-3`, still). Order still ranks never-touched shells as `none` (quieter than idle). Sleeping shells stay moonlit; `busy` still brightens to `fg-2` when a foreground process runs.
- **Tile title**: show the identity pip for any active terminal (agent or shell), not only when an agent is attached.
- **Workspace grid columns**: remove the StatePip legend mark — column headers are not terminals and must not wear a shell glyph.
- **`empty`**: remains only for genuinely blank sites (`parked`, the `none` bucket fold used by non-row legends).

## Test plan

- [x] `dockRowRanking` / `pipVariant` unit tests
- [x] solid-statepip unit tests (unchanged, still green)
- [ ] Visual evidence to follow — screenshot of a plain-shell dock row with the shell glyph (idle + busy if easy)