### PR TITLE
Stop watch-edge debounce starvation under hot streams

### DIFF
--- a/packages/integrations/claude-code/src/session-watcher.ts
+++ b/packages/integrations/claude-code/src/session-watcher.ts
@@ -11,7 +11,13 @@
 
 import fs from "node:fs";
 import { agentInfoEqual } from "anyagent";
-import { DEFAULT_APPEND_POLL_MS, subscribeFileAppends } from "kolu-io";
+import {
+  COALESCE_DEBOUNCE_MS,
+  COALESCE_MAX_WAIT_MS,
+  createCoalesceSchedule,
+  DEFAULT_APPEND_POLL_MS,
+  subscribeFileAppends,
+} from "kolu-io";
 import {
   completedBackgroundTaskIds,
   decayTransientState,
@@ -68,13 +74,11 @@ function workflowEqual(
 
 // --- Tuning constants ---
 
-/** Trailing-edge debounce for the transcript fs.watch callback. Claude
- *  streams tokens, and Linux fs.watch fires multiple events per write —
- *  without debouncing, `onTranscriptMaybeChanged` runs dozens to hundreds
- *  of times per second, each iteration re-allocating a 256 KB tail buffer
- *  and firing an async SDK summary fetch. 150 ms coalesces bursts into
- *  one handler run while keeping the user-perceptible lag imperceptible. */
-const TRANSCRIPT_DEBOUNCE_MS = 150;
+/** Quiet-window for the transcript coalesce schedule. Claude streams
+ *  tokens, and Linux fs.watch fires multiple events per write — without
+ *  coalescing, `onTranscriptMaybeChanged` runs dozens to hundreds of
+ *  times per second. Shared `COALESCE_DEBOUNCE_MS` + maxWait (#1952). */
+const TRANSCRIPT_DEBOUNCE_MS = COALESCE_DEBOUNCE_MS;
 
 /** Chunk size for `scanTasksIncremental`. The previous one-shot
  *  `Buffer.alloc(size - offset)` could allocate hundreds of MB transiently
@@ -169,9 +173,13 @@ export function createSessionWatcher(
   // tail of one call would be split-processed at the head of the next
   // call as if it were already a complete line — silent task corruption.
   let taskScanRemainder = "";
-  // Trailing-edge debounce timer for transcript fs.watch events.
-  // Null when idle. Cleared on destroy.
-  let transcriptDebounceTimer: NodeJS.Timeout | null = null;
+  // Quiet + maxWait coalesce for transcript edges (#1952 shared primitive).
+  // Destroyed in `destroy()` so late fires can't run after teardown.
+  const transcriptCoalesce = createCoalesceSchedule({
+    debounceMs: TRANSCRIPT_DEBOUNCE_MS,
+    maxWaitMs: COALESCE_MAX_WAIT_MS,
+    onFire: () => onTranscriptMaybeChanged(),
+  });
   // One-shot timer armed at the next workflow-journal stale deadline while
   // `running_background` is published. A journal going stale produces no
   // fs.watch event (it's the *absence* of writes), so without this the phantom
@@ -205,18 +213,12 @@ export function createSessionWatcher(
     }
   }
 
-  /** Trailing-edge debounce: reset the timer on every event, fire
-   *  `onTranscriptMaybeChanged` once after `TRANSCRIPT_DEBOUNCE_MS` of
-   *  quiet. The handler's own `destroyed` guard makes late-firing
-   *  callbacks safe, but we clear the timer in `destroy()` anyway to
-   *  avoid holding closure refs unnecessarily. */
+  /** Coalesced transcript re-derive: quiet window `TRANSCRIPT_DEBOUNCE_MS`,
+   *  hard maxWait `COALESCE_MAX_WAIT_MS` so a continuous token-stream burst
+   *  cannot starve the handler (juspay/kolu#1952). */
   function scheduleTranscriptCheck() {
     if (destroyed) return;
-    if (transcriptDebounceTimer) clearTimeout(transcriptDebounceTimer);
-    transcriptDebounceTimer = setTimeout(() => {
-      transcriptDebounceTimer = null;
-      onTranscriptMaybeChanged();
-    }, TRANSCRIPT_DEBOUNCE_MS);
+    transcriptCoalesce.schedule();
   }
 
   /** Arm (or clear) the one-shot timer that re-runs the derivation when a
@@ -591,10 +593,7 @@ export function createSessionWatcher(
 
     destroy() {
       destroyed = true;
-      if (transcriptDebounceTimer) {
-        clearTimeout(transcriptDebounceTimer);
-        transcriptDebounceTimer = null;
-      }
+      transcriptCoalesce.destroy();
       if (staleDeadlineTimer) {
         clearTimeout(staleDeadlineTimer);
         staleDeadlineTimer = null;

--- a/packages/integrations/grok/src/session-watcher.test.ts
+++ b/packages/integrations/grok/src/session-watcher.test.ts
@@ -1,11 +1,15 @@
 /**
- * grok session-watcher wiring for the append-robust floor (juspay/kolu#1754).
+ * Grok session-watcher regression pins:
  *
- * The exhaustive floor mechanics live in kolu-io's
- * `file-append-watcher.test.ts`; this is the CI regression guard that the floor
- * is actually reachable THROUGH the real grok watcher — a dropped `turn_ended`
- * edge on `events.jsonl` self-heals to `waiting` with no edge and no further
- * write.
+ *  - **#1754** — the append-robust floor is reachable THROUGH the real grok
+ *    watcher: a dropped `turn_ended` edge on `events.jsonl` self-heals to
+ *    `waiting` with no edge and no further write. Exhaustive floor mechanics
+ *    live in `kolu-io`'s `file-append-watcher.test.ts`.
+ *  - **#1952** — phase-spam starvation: continuous fs.watch edges faster than
+ *    the quiet window still publish within maxWait (shared
+ *    `createCoalesceSchedule`). Primitive-level starvation lives in
+ *    `kolu-io`'s `coalesce-schedule.test.ts`; this file pins the guarantee
+ *    through the real grok watcher.
  */
 
 import fs from "node:fs";
@@ -63,6 +67,13 @@ function setupSession(): GrokSession {
     startedAt: Date.parse("2026-07-20T00:00:00.000Z"),
   };
 }
+
+describe("grok watcher — shared coalesce constants", () => {
+  it("DEBOUNCE_MAX_MS ≤ DEFAULT_APPEND_POLL_MS (documented invariant)", () => {
+    expect(DEBOUNCE_MAX_MS).toBeLessThanOrEqual(DEFAULT_APPEND_POLL_MS);
+    expect(DEBOUNCE_MS).toBeLessThanOrEqual(DEBOUNCE_MAX_MS);
+  });
+});
 
 describe("grok watcher — append-robust floor (#1754)", () => {
   beforeEach(() => {
@@ -143,7 +154,11 @@ describe("grok watcher — debounce maxWait under phase spam (#1952)", () => {
   it("publishes a mid-burst state change without a DEBOUNCE_MS quiet gap", async () => {
     const session = setupSession();
     const states: GrokInfo["state"][] = [];
-    const watcher = createGrokWatcher(session, (i) => states.push(i.state));
+    let flipAt: number | null = null;
+    const watcher = createGrokWatcher(session, (i) => {
+      if (i.state === "tool_use" && flipAt === null) flipAt = Date.now();
+      states.push(i.state);
+    });
     expect(states.at(-1)).toBe("thinking");
 
     // Mimic streaming_text / tool_execution spam: append faster than DEBOUNCE_MS
@@ -151,14 +166,32 @@ describe("grok watcher — debounce maxWait under phase spam (#1952)", () => {
     const burstMs = DEBOUNCE_MAX_MS + DEBOUNCE_MS + 100;
     const gapMs = Math.max(10, Math.floor(DEBOUNCE_MS / 3));
     const line = `${JSON.stringify({ type: "phase_changed", phase: "tool_execution" })}\n`;
-    const started = Date.now();
-    while (Date.now() - started < burstMs) {
-      fs.appendFileSync(session.eventsPath, line);
+    const firstAppendAt = Date.now();
+    let lastAppendAt = firstAppendAt;
+    fs.appendFileSync(session.eventsPath, line);
+    while (Date.now() - firstAppendAt < burstMs) {
       await sleep(gapMs);
+      const now = Date.now();
+      const gap = now - lastAppendAt;
+      // Jitter-corrupted burst would let pure-trailing fire mid-burst and
+      // false-pass the pre-fix code — fail loud instead of silent pass.
+      if (gap >= DEBOUNCE_MS) {
+        watcher.destroy();
+        throw new Error(
+          `burst inter-append gap ${gap}ms ≥ DEBOUNCE_MS ${DEBOUNCE_MS} — jitter-corrupted, not a valid #1952 run`,
+        );
+      }
+      fs.appendFileSync(session.eventsPath, line);
+      lastAppendAt = Date.now();
     }
 
-    // Must have flipped to tool_use *during* the burst (maxWait), not only after
-    // a trailing quiet window once the loop ends.
+    // Flip must land within maxWait (+slack) of the *first* append — proves
+    // maxWait, not a lucky quiet gap mid-burst.
+    const slackMs = 100;
+    expect(flipAt).not.toBeNull();
+    expect(flipAt! - firstAppendAt).toBeLessThanOrEqual(
+      DEBOUNCE_MAX_MS + slackMs,
+    );
     expect(states).toContain("tool_use");
     expect(states.at(-1)).toBe("tool_use");
     watcher.destroy();

--- a/packages/integrations/grok/src/session-watcher.test.ts
+++ b/packages/integrations/grok/src/session-watcher.test.ts
@@ -16,20 +16,25 @@ import type { GrokSession } from "./core.ts";
 import type { GrokInfo } from "./schemas.ts";
 import { DEFAULT_APPEND_POLL_MS } from "kolu-io";
 import { suppressFsWatchEdges } from "kolu-io/suppress-fs-watch.testlib";
-import { createGrokWatcher } from "./session-watcher.ts";
+import {
+  createGrokWatcher,
+  DEBOUNCE_MAX_MS,
+  DEBOUNCE_MS,
+} from "./session-watcher.ts";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 let tmp: string;
-let restoreWatch: () => void;
+let restoreWatch: (() => void) | null = null;
 
 beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kolu-grok-floor-"));
-  restoreWatch = suppressFsWatchEdges(); // only the statSync poll floor recovers
+  restoreWatch = null;
 });
 
 afterEach(() => {
-  restoreWatch();
+  restoreWatch?.();
+  restoreWatch = null;
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -60,6 +65,11 @@ function setupSession(): GrokSession {
 }
 
 describe("grok watcher — append-robust floor (#1754)", () => {
+  beforeEach(() => {
+    // only the statSync poll floor recovers — edges suppressed
+    restoreWatch = suppressFsWatchEdges();
+  });
+
   it("self-heals to `waiting` after a dropped `turn_ended` edge", async () => {
     const session = setupSession();
     const states: GrokInfo["state"][] = [];
@@ -122,6 +132,35 @@ describe("grok watcher — append-robust floor (#1754)", () => {
     await sleep(DEFAULT_APPEND_POLL_MS + 400); // > one poll interval
 
     expect(states.at(-1)).toBe("waiting");
+    watcher.destroy();
+  });
+});
+
+describe("grok watcher — debounce maxWait under phase spam (#1952)", () => {
+  // Real fs.watch edges stay armed: Grok's live failure is continuous edges
+  // re-arming a pure trailing debounce so emitIfChanged never runs mid-burst.
+
+  it("publishes a mid-burst state change without a DEBOUNCE_MS quiet gap", async () => {
+    const session = setupSession();
+    const states: GrokInfo["state"][] = [];
+    const watcher = createGrokWatcher(session, (i) => states.push(i.state));
+    expect(states.at(-1)).toBe("thinking");
+
+    // Mimic streaming_text / tool_execution spam: append faster than DEBOUNCE_MS
+    // for longer than DEBOUNCE_MAX_MS so a pure trailing debounce would starve.
+    const burstMs = DEBOUNCE_MAX_MS + DEBOUNCE_MS + 100;
+    const gapMs = Math.max(10, Math.floor(DEBOUNCE_MS / 3));
+    const line = `${JSON.stringify({ type: "phase_changed", phase: "tool_execution" })}\n`;
+    const started = Date.now();
+    while (Date.now() - started < burstMs) {
+      fs.appendFileSync(session.eventsPath, line);
+      await sleep(gapMs);
+    }
+
+    // Must have flipped to tool_use *during* the burst (maxWait), not only after
+    // a trailing quiet window once the loop ends.
+    expect(states).toContain("tool_use");
+    expect(states.at(-1)).toBe("tool_use");
     watcher.destroy();
   });
 });

--- a/packages/integrations/grok/src/session-watcher.ts
+++ b/packages/integrations/grok/src/session-watcher.ts
@@ -12,34 +12,33 @@
  *
  * Grok's `events.jsonl` is *not* a sparse transcript: a single turn can append
  * hundreds of `phase_changed` lines per second (`streaming_text` /
- * `streaming_reasoning`). A pure trailing-edge debounce (reset on every edge)
- * never reaches its quiet window while that burst is live — so `emitIfChanged`
- * freezes on the pre-burst state for the whole stream, and the 1s append-poll
- * floor (#1754) is defeated too (it feeds the *same* `schedule()`, which the
- * next fs.watch edge re-arms before 150ms elapses).
- *
- * `DEBOUNCE_MAX_MS` caps how long a pending re-derive can be postponed: after
- * that budget the timer fires even if edges keep arriving. Quiet turns still
- * settle in `DEBOUNCE_MS`; hot turns publish at least every maxWait.
+ * `streaming_reasoning`). A pure trailing-edge debounce never reaches its
+ * quiet window while that burst is live — so re-derive freezes on the
+ * pre-burst state, and the 1s append-poll floor (#1754) is defeated too
+ * (it feeds the same schedule). Coalescing uses `kolu-io`'s shared
+ * `createCoalesceSchedule` with `COALESCE_MAX_WAIT_MS` so hot turns publish
+ * at least every half-second; quiet turns still settle in 150ms.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { agentInfoEqual } from "anyagent";
-import { DEFAULT_APPEND_POLL_MS, subscribeFileAppends } from "kolu-io";
+import {
+  COALESCE_DEBOUNCE_MS,
+  COALESCE_MAX_WAIT_MS,
+  createCoalesceSchedule,
+  DEFAULT_APPEND_POLL_MS,
+  subscribeFileAppends,
+} from "kolu-io";
 import type { Logger } from "kolu-shared";
 import { deriveGrokInfo, type GrokSession } from "./core.ts";
 import type { GrokInfo } from "./schemas.ts";
 
-/** Quiet-window coalescing for sparse writes (summary rename, single phase). */
-export const DEBOUNCE_MS = 150;
-/**
- * Upper bound on how long continuous `events.jsonl` edges may postpone a
- * re-derive. Must be ≤ the append-poll interval so a hot stream still
- * publishes within one floor tick of the first change in a burst; kept as a
- * named export so the starvation regression pins the same number.
- */
-export const DEBOUNCE_MAX_MS = 500;
+/** Quiet-window — re-export of the shared constant so #1952 tests pin the
+ *  same number the real watcher uses. */
+export const DEBOUNCE_MS = COALESCE_DEBOUNCE_MS;
+/** Hard maxWait — re-export of the shared constant for the starvation pin. */
+export const DEBOUNCE_MAX_MS = COALESCE_MAX_WAIT_MS;
 
 export interface GrokWatcher {
   readonly session: GrokSession;
@@ -53,10 +52,6 @@ export function createGrokWatcher(
 ): GrokWatcher {
   let destroyed = false;
   let lastInfo: GrokInfo | null = null;
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  /** Wall-clock ms when the current pending debounce window opened; null when
-   *  no re-derive is scheduled. Anchors `DEBOUNCE_MAX_MS`. */
-  let pendingSince: number | null = null;
   // One teardown collection for every "run on destroy" concern: raw fs.watch
   // handles wrap to `() => w.close()`, and the append-robust floor
   // (juspay/kolu#1754) already returns an unsubscribe of the same shape.
@@ -78,22 +73,16 @@ export function createGrokWatcher(
     onChange(info);
   }
 
+  const coalesce = createCoalesceSchedule({
+    debounceMs: DEBOUNCE_MS,
+    maxWaitMs: DEBOUNCE_MAX_MS,
+    onFire: emitIfChanged,
+  });
+  cleanups.push(() => coalesce.destroy());
+
   function schedule(): void {
     if (destroyed) return;
-    const now = Date.now();
-    if (pendingSince === null) pendingSince = now;
-    if (timer) clearTimeout(timer);
-    // Trailing quiet window, hard-capped so a phase-spam burst cannot starve
-    // the re-derive past DEBOUNCE_MAX_MS from the first pending edge.
-    const delay = Math.min(
-      DEBOUNCE_MS,
-      Math.max(0, DEBOUNCE_MAX_MS - (now - pendingSince)),
-    );
-    timer = setTimeout(() => {
-      timer = null;
-      pendingSince = null;
-      emitIfChanged();
-    }, delay);
+    coalesce.schedule();
   }
 
   function watchPath(p: string): void {
@@ -178,9 +167,6 @@ export function createGrokWatcher(
     session,
     destroy() {
       destroyed = true;
-      if (timer) clearTimeout(timer);
-      timer = null;
-      pendingSince = null;
       for (const c of cleanups) {
         try {
           c();

--- a/packages/integrations/grok/src/session-watcher.ts
+++ b/packages/integrations/grok/src/session-watcher.ts
@@ -7,6 +7,20 @@
  * missing, watches its parent directory (when that exists) and re-arms
  * when the basename appears — same observe-without-mutate idea as
  * Claude's session watchers.
+ *
+ * ## Debounce + maxWait (juspay/kolu#1952)
+ *
+ * Grok's `events.jsonl` is *not* a sparse transcript: a single turn can append
+ * hundreds of `phase_changed` lines per second (`streaming_text` /
+ * `streaming_reasoning`). A pure trailing-edge debounce (reset on every edge)
+ * never reaches its quiet window while that burst is live — so `emitIfChanged`
+ * freezes on the pre-burst state for the whole stream, and the 1s append-poll
+ * floor (#1754) is defeated too (it feeds the *same* `schedule()`, which the
+ * next fs.watch edge re-arms before 150ms elapses).
+ *
+ * `DEBOUNCE_MAX_MS` caps how long a pending re-derive can be postponed: after
+ * that budget the timer fires even if edges keep arriving. Quiet turns still
+ * settle in `DEBOUNCE_MS`; hot turns publish at least every maxWait.
  */
 
 import fs from "node:fs";
@@ -17,7 +31,15 @@ import type { Logger } from "kolu-shared";
 import { deriveGrokInfo, type GrokSession } from "./core.ts";
 import type { GrokInfo } from "./schemas.ts";
 
-const DEBOUNCE_MS = 150;
+/** Quiet-window coalescing for sparse writes (summary rename, single phase). */
+export const DEBOUNCE_MS = 150;
+/**
+ * Upper bound on how long continuous `events.jsonl` edges may postpone a
+ * re-derive. Must be ≤ the append-poll interval so a hot stream still
+ * publishes within one floor tick of the first change in a burst; kept as a
+ * named export so the starvation regression pins the same number.
+ */
+export const DEBOUNCE_MAX_MS = 500;
 
 export interface GrokWatcher {
   readonly session: GrokSession;
@@ -32,6 +54,9 @@ export function createGrokWatcher(
   let destroyed = false;
   let lastInfo: GrokInfo | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  /** Wall-clock ms when the current pending debounce window opened; null when
+   *  no re-derive is scheduled. Anchors `DEBOUNCE_MAX_MS`. */
+  let pendingSince: number | null = null;
   // One teardown collection for every "run on destroy" concern: raw fs.watch
   // handles wrap to `() => w.close()`, and the append-robust floor
   // (juspay/kolu#1754) already returns an unsubscribe of the same shape.
@@ -55,11 +80,20 @@ export function createGrokWatcher(
 
   function schedule(): void {
     if (destroyed) return;
+    const now = Date.now();
+    if (pendingSince === null) pendingSince = now;
     if (timer) clearTimeout(timer);
+    // Trailing quiet window, hard-capped so a phase-spam burst cannot starve
+    // the re-derive past DEBOUNCE_MAX_MS from the first pending edge.
+    const delay = Math.min(
+      DEBOUNCE_MS,
+      Math.max(0, DEBOUNCE_MAX_MS - (now - pendingSince)),
+    );
     timer = setTimeout(() => {
       timer = null;
+      pendingSince = null;
       emitIfChanged();
-    }, DEBOUNCE_MS);
+    }, delay);
   }
 
   function watchPath(p: string): void {
@@ -146,6 +180,7 @@ export function createGrokWatcher(
       destroyed = true;
       if (timer) clearTimeout(timer);
       timer = null;
+      pendingSince = null;
       for (const c of cleanups) {
         try {
           c();

--- a/packages/integrations/io/src/coalesce-schedule.test.ts
+++ b/packages/integrations/io/src/coalesce-schedule.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Primitive-level starvation regression for `createCoalesceSchedule`
+ * (juspay/kolu#1952). No fs.watch — pure schedule() bursts so the maxWait
+ * guarantee is proven at the source, independent of OS edge delivery.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  COALESCE_DEBOUNCE_MS,
+  COALESCE_MAX_WAIT_MS,
+  createCoalesceSchedule,
+} from "./coalesce-schedule.ts";
+import { DEFAULT_APPEND_POLL_MS } from "./file-append-watcher.ts";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("createCoalesceSchedule", () => {
+  it("COALESCE_MAX_WAIT_MS ≤ DEFAULT_APPEND_POLL_MS (documented invariant)", () => {
+    expect(COALESCE_MAX_WAIT_MS).toBeLessThanOrEqual(DEFAULT_APPEND_POLL_MS);
+    expect(COALESCE_DEBOUNCE_MS).toBeLessThanOrEqual(COALESCE_MAX_WAIT_MS);
+  });
+
+  it("fires after debounceMs of quiet (trailing edge)", async () => {
+    let fires = 0;
+    const s = createCoalesceSchedule({
+      debounceMs: 40,
+      maxWaitMs: 200,
+      onFire: () => {
+        fires++;
+      },
+    });
+    s.schedule();
+    await sleep(20);
+    expect(fires).toBe(0);
+    await sleep(40);
+    expect(fires).toBe(1);
+    s.destroy();
+  });
+
+  it("fires within maxWait under continuous schedule() with no quiet ≥ debounceMs", async () => {
+    const debounceMs = 80;
+    const maxWaitMs = 200;
+    let fires = 0;
+    let firstFireAt: number | null = null;
+    const s = createCoalesceSchedule({
+      debounceMs,
+      maxWaitMs,
+      onFire: () => {
+        fires++;
+        if (firstFireAt === null) firstFireAt = Date.now();
+      },
+    });
+
+    const gapMs = Math.max(10, Math.floor(debounceMs / 3));
+    const burstMs = maxWaitMs + debounceMs + 80;
+    const started = Date.now();
+    let lastScheduleAt = started;
+    s.schedule();
+    while (Date.now() - started < burstMs) {
+      await sleep(gapMs);
+      const now = Date.now();
+      const gap = now - lastScheduleAt;
+      if (gap >= debounceMs) {
+        s.destroy();
+        throw new Error(
+          `burst schedule gap ${gap}ms ≥ debounceMs ${debounceMs} — jitter-corrupted run, not a valid starvation probe`,
+        );
+      }
+      s.schedule();
+      lastScheduleAt = Date.now();
+    }
+
+    // Must have fired *during* the burst (maxWait), not only after quiet.
+    expect(fires).toBeGreaterThanOrEqual(1);
+    expect(firstFireAt).not.toBeNull();
+    expect(firstFireAt! - started).toBeLessThanOrEqual(maxWaitMs + 80);
+    s.destroy();
+  });
+
+  it("destroy prevents further fires", async () => {
+    let fires = 0;
+    const s = createCoalesceSchedule({
+      debounceMs: 30,
+      maxWaitMs: 100,
+      onFire: () => {
+        fires++;
+      },
+    });
+    s.schedule();
+    s.destroy();
+    await sleep(50);
+    expect(fires).toBe(0);
+    s.schedule(); // no-op
+    await sleep(50);
+    expect(fires).toBe(0);
+  });
+});

--- a/packages/integrations/io/src/coalesce-schedule.ts
+++ b/packages/integrations/io/src/coalesce-schedule.ts
@@ -1,0 +1,97 @@
+/**
+ * Trailing-edge coalescing scheduler with a hard maxWait cap.
+ *
+ * ## Why (juspay/kolu#1952)
+ *
+ * A pure trailing debounce (reset the quiet timer on every edge) starves under
+ * a hot source: Grok's `phase_changed` firehose, dense `fs.watch` bursts, WAL
+ * write storms. While edges keep arriving faster than the quiet window, the
+ * callback never fires — and any append-poll floor that feeds the *same*
+ * `schedule()` is defeated the same way (#1754 + #1952).
+ *
+ * `maxWaitMs` caps how long a pending fire can be postponed from the first
+ * edge in a burst. Quiet sources still settle in `debounceMs`; hot sources
+ * publish at least every `maxWaitMs`.
+ *
+ * Production watch sites bake `COALESCE_MAX_WAIT_MS` as a module constant
+ * (no per-call opt-out — conventions.md). Tests pass short real intervals
+ * the same way `subscribeFileAppends` requires `intervalMs`.
+ */
+
+/** Default quiet-window used by agent / git / WAL watchers (150 ms). */
+export const COALESCE_DEBOUNCE_MS = 150;
+
+/**
+ * Hard cap on how long continuous edges may postpone a fire. Must stay
+ * ≤ `DEFAULT_APPEND_POLL_MS` (1s) so a hot stream still publishes within
+ * one append-poll floor tick of the first change in a burst. Module
+ * constant — not a consumer-disableable knob.
+ */
+export const COALESCE_MAX_WAIT_MS = 500;
+
+export interface CoalesceSchedule {
+  /** Arm or re-arm the trailing window (capped by maxWait from first pending). */
+  schedule(): void;
+  /** Drop a pending fire without destroying the handle. */
+  cancel(): void;
+  /** Cancel and refuse further `schedule()` calls. */
+  destroy(): void;
+}
+
+export interface CoalesceScheduleOpts {
+  /** Quiet-window in ms. Required (no default — same fail-fast shape as
+   *  `subscribeFileAppends.intervalMs`). Production passes
+   *  `COALESCE_DEBOUNCE_MS`; tests inject a short real interval. */
+  debounceMs: number;
+  /** Hard cap in ms from the first pending edge. Required. Production
+   *  watchers pass `COALESCE_MAX_WAIT_MS`; never omit to "disable". */
+  maxWaitMs: number;
+  /** Invoked once the quiet window or the maxWait cap elapses. */
+  onFire: () => void;
+  /** Clock for pending-since accounting. Defaults to `Date.now`. Tests
+   *  may inject a controllable clock; real timers still drive the fire. */
+  now?: () => number;
+}
+
+/**
+ * Create a coalescing schedule handle. `onFire` is not wrapped — a throwing
+ * fire escapes to the host timer (callers that need isolation catch inside
+ * `onFire`, matching the prior hand-rolled debounce sites).
+ */
+export function createCoalesceSchedule(
+  opts: CoalesceScheduleOpts,
+): CoalesceSchedule {
+  const now = opts.now ?? Date.now;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pendingSince: number | null = null;
+  let destroyed = false;
+
+  function cancel(): void {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    pendingSince = null;
+  }
+
+  return {
+    schedule() {
+      if (destroyed) return;
+      const t = now();
+      if (pendingSince === null) pendingSince = t;
+      if (timer) clearTimeout(timer);
+      const delay = Math.min(
+        opts.debounceMs,
+        Math.max(0, opts.maxWaitMs - (t - pendingSince)),
+      );
+      timer = setTimeout(() => {
+        timer = null;
+        pendingSince = null;
+        opts.onFire();
+      }, delay);
+    },
+    cancel,
+    destroy() {
+      destroyed = true;
+      cancel();
+    },
+  };
+}

--- a/packages/integrations/io/src/coalesce-schedule.ts
+++ b/packages/integrations/io/src/coalesce-schedule.ts
@@ -48,20 +48,17 @@ export interface CoalesceScheduleOpts {
   maxWaitMs: number;
   /** Invoked once the quiet window or the maxWait cap elapses. */
   onFire: () => void;
-  /** Clock for pending-since accounting. Defaults to `Date.now`. Tests
-   *  may inject a controllable clock; real timers still drive the fire. */
-  now?: () => number;
 }
 
 /**
  * Create a coalescing schedule handle. `onFire` is not wrapped — a throwing
  * fire escapes to the host timer (callers that need isolation catch inside
- * `onFire`, matching the prior hand-rolled debounce sites).
+ * `onFire`, matching the prior hand-rolled debounce sites). Wall clock is
+ * `Date.now` by construction — no optional clock inject (dead-knob ban).
  */
 export function createCoalesceSchedule(
   opts: CoalesceScheduleOpts,
 ): CoalesceSchedule {
-  const now = opts.now ?? Date.now;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let pendingSince: number | null = null;
   let destroyed = false;
@@ -75,7 +72,7 @@ export function createCoalesceSchedule(
   return {
     schedule() {
       if (destroyed) return;
-      const t = now();
+      const t = Date.now();
       if (pendingSince === null) pendingSince = t;
       if (timer) clearTimeout(timer);
       const delay = Math.min(

--- a/packages/integrations/io/src/index.ts
+++ b/packages/integrations/io/src/index.ts
@@ -15,3 +15,11 @@ export {
   subscribeFileAppends,
   type SubscribeFileAppendsOpts,
 } from "./file-append-watcher.ts";
+
+export {
+  COALESCE_DEBOUNCE_MS,
+  COALESCE_MAX_WAIT_MS,
+  createCoalesceSchedule,
+  type CoalesceSchedule,
+  type CoalesceScheduleOpts,
+} from "./coalesce-schedule.ts";

--- a/packages/integrations/io/src/refcounted-dir-watcher.ts
+++ b/packages/integrations/io/src/refcounted-dir-watcher.ts
@@ -14,6 +14,11 @@
 
 import type { Logger } from "@kolu/log";
 import fs from "node:fs";
+import {
+  COALESCE_MAX_WAIT_MS,
+  createCoalesceSchedule,
+  type CoalesceSchedule,
+} from "./coalesce-schedule.ts";
 
 interface SharedFilenameWatcher {
   subscribe(onChange: () => void): () => void;
@@ -35,7 +40,9 @@ export interface DirFilenameWatcherConfig {
   /** Filename inside `resolveDir(cwd)` that fires the listener. Other
    *  events on the directory are ignored. */
   filename: string;
-  /** Trailing-edge debounce window in milliseconds. */
+  /** Trailing-edge debounce quiet-window in milliseconds. A hard maxWait
+   *  (`COALESCE_MAX_WAIT_MS`) is always applied internally — not a
+   *  consumer-facing knob (juspay/kolu#1952). */
   debounceMs: number;
   /** Lifecycle log label, e.g. `"git: head"`. Combined with `installed` /
    *  `retired` / `listener threw` for log lines. */
@@ -93,30 +100,34 @@ export function createDirFilenameWatcher(
     log?: Logger,
   ): SharedFilenameWatcher | null {
     const listeners = new Set<() => void>();
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    // maxWait is baked as COALESCE_MAX_WAIT_MS — no per-call disable (#1952).
+    const coalesce: CoalesceSchedule = createCoalesceSchedule({
+      debounceMs: config.debounceMs,
+      maxWaitMs: COALESCE_MAX_WAIT_MS,
+      onFire: () => {
+        // Snapshot before iteration so a listener that unsubscribes
+        // synchronously can't skip a peer for this event.
+        for (const cb of [...listeners]) {
+          try {
+            cb();
+          } catch (e) {
+            log?.error(
+              { err: e instanceof Error ? e.message : String(e), dir },
+              `${config.logLabel} listener threw`,
+            );
+          }
+        }
+      },
+    });
 
     let watcher: fs.FSWatcher;
     try {
       watcher = fs.watch(dir, (_, filename) => {
         if (filename !== config.filename) return;
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(() => {
-          timer = undefined;
-          // Snapshot before iteration so a listener that unsubscribes
-          // synchronously can't skip a peer for this event.
-          for (const cb of [...listeners]) {
-            try {
-              cb();
-            } catch (e) {
-              log?.error(
-                { err: e instanceof Error ? e.message : String(e), dir },
-                `${config.logLabel} listener threw`,
-              );
-            }
-          }
-        }, config.debounceMs);
+        coalesce.schedule();
       });
     } catch (e) {
+      coalesce.destroy();
       log?.error(
         { err: e instanceof Error ? e.message : String(e), dir },
         `${config.logLabel} failed to watch dir`,
@@ -136,7 +147,7 @@ export function createDirFilenameWatcher(
           // accidentally tear that fresh entry down.
           if (!listeners.delete(onChange)) return;
           if (listeners.size === 0) {
-            if (timer) clearTimeout(timer);
+            coalesce.destroy();
             watcher.close();
             onLast();
             log?.info({ dir }, `${config.logLabel} watcher retired`);
@@ -145,7 +156,7 @@ export function createDirFilenameWatcher(
       },
       _forceClose() {
         listeners.clear();
-        if (timer) clearTimeout(timer);
+        coalesce.destroy();
         watcher.close();
       },
     };

--- a/packages/shared/src/sqlite/debounce-watcher.ts
+++ b/packages/shared/src/sqlite/debounce-watcher.ts
@@ -11,8 +11,16 @@
  *  events per write, and active-generation bursts are several events per
  *  second. Without coalescing, every burst triggers N refresh passes
  *  (each running SQL queries and JSONL tails) for the same logical state
- *  change. */
+ *  change. A pure trailing window would starve under a continuous burst
+ *  (juspay/kolu#1952); maxWait is baked via `COALESCE_MAX_WAIT_MS` from
+ *  `kolu-io` — not a per-call opt-out.
+ */
 
+import {
+  COALESCE_MAX_WAIT_MS,
+  createCoalesceSchedule,
+  type CoalesceSchedule,
+} from "kolu-io";
 import type { Logger } from "../log.ts";
 import type { Closable } from "./with-db.ts";
 
@@ -25,7 +33,8 @@ export interface DebounceWatcherConfig<Session, Info, Db extends Closable> {
    *  on subscribe/unsubscribe (see `.agency/code-police.md` →
    *  `watcher-lifecycle-logs`). */
   label: string;
-  /** Trailing-edge debounce window in milliseconds. */
+  /** Trailing-edge debounce quiet-window in milliseconds. maxWait is
+   *  always `COALESCE_MAX_WAIT_MS` internally (#1952). */
   debounceMs: number;
   /** DB handle held across the watcher's lifetime. The factory closes
    *  it on `destroy()`. Pass `null` if `openDb` failed — `refresh` will
@@ -68,7 +77,6 @@ export function createDebounceWatcher<Session, Info, Db extends Closable>(
   config: DebounceWatcherConfig<Session, Info, Db>,
 ): DebounceWatcher<Session> {
   let destroyed = false;
-  let debounceTimer: NodeJS.Timeout | null = null;
   let lastInfo: Info | null = null;
 
   function performRefresh(): void {
@@ -80,21 +88,19 @@ export function createDebounceWatcher<Session, Info, Db extends Closable>(
     config.onChange(info);
   }
 
-  // Trailing-edge debounce: every event resets the timer; one
-  // `performRefresh` runs after `debounceMs` of quiet. The handler's
-  // own `destroyed` guard makes late-firing callbacks safe, but we
-  // clear the timer in `destroy()` anyway to avoid holding closure refs.
-  function scheduleRefresh(): void {
-    if (destroyed) return;
-    if (debounceTimer) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
-      debounceTimer = null;
-      performRefresh();
-    }, config.debounceMs);
-  }
+  // Quiet window + hard maxWait (COALESCE_MAX_WAIT_MS) — pure trailing would
+  // starve under continuous WAL edges (#1952).
+  const coalesce: CoalesceSchedule = createCoalesceSchedule({
+    debounceMs: config.debounceMs,
+    maxWaitMs: COALESCE_MAX_WAIT_MS,
+    onFire: performRefresh,
+  });
 
   const unsubscribe = config.subscribe(
-    scheduleRefresh,
+    () => {
+      if (destroyed) return;
+      coalesce.schedule();
+    },
     (err) => config.log?.error({ err, ...config.logCtx }, "wal listener threw"),
     config.log,
   );
@@ -105,10 +111,7 @@ export function createDebounceWatcher<Session, Info, Db extends Closable>(
     session: config.session,
     destroy(): void {
       destroyed = true;
-      if (debounceTimer) {
-        clearTimeout(debounceTimer);
-        debounceTimer = null;
-      }
+      coalesce.destroy();
       unsubscribe();
       config.db?.close();
       config.log?.info(config.logCtx, `${config.label} watcher retired`);


### PR DESCRIPTION
**Agent tiles (and any hot `fs.watch` consumer) can freeze on a stale state while the on-disk source keeps moving** — pure trailing-edge debounce never reaches its quiet window under a continuous burst. Live Grok repro for #1952: disk fold was `tool_use` while the published agent stayed `thinking`.

Grok's `events.jsonl` is a firehose (hundreds of `phase_changed` lines/sec). The same shape is latent in claude-code transcript watches, codex/opencode WAL refresh, and the git dir-filename watchers.

### Fix

Shared coalesce in **`kolu-io`**: trailing quiet window + hard **maxWait** (`createCoalesceSchedule`, `COALESCE_MAX_WAIT_MS = 500`).

| Site | Change |
| --- | --- |
| `createDirFilenameWatcher` | maxWait baked in — git watchers get it with zero call-site edits |
| `createDebounceWatcher` | maxWait baked in — codex/opencode WAL refresh gets it with zero call-site edits |
| Grok + Claude session watchers | ported onto the shared primitive; constants re-exported/sourced from `kolu-io` |

```
edge / poll ──▶ schedule() ──▶ quiet 150ms? ──▶ fire
                     │
                     └── past 500ms since first pending? ──▶ fire anyway
```

### Regressions

- Primitive starvation test (no fs.watch): continuous `schedule()` with gaps &lt; debounce still fires within maxWait
- Grok mid-burst pin through the real watcher: flip latency ≤ maxWait+slack from first append; **fails loud** if any inter-append gap ≥ debounce (jitter false-pass guard)
- Invariant: `COALESCE_MAX_WAIT_MS ≤ DEFAULT_APPEND_POLL_MS`

Fixes #1952

### Try it locally

```sh
nix run github:juspay/kolu/fix/grok-agent-state-1952
```

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Grok Build (model `grok-4.5`)._