### PR TITLE
Spin dock pip when a sticky-finished waiting terminal is still printing

### DIFF
--- a/packages/client/src/canvas/dock/RecencyCell.tsx
+++ b/packages/client/src/canvas/dock/RecencyCell.tsx
@@ -6,7 +6,7 @@
  *  hides it.
  *
  *  Active rows hide the label: effectively active terminals (same predicate as
- *  `pipIsActive` — working ∨ live ∨ waiting∧¬finished) are "just now" by
+ *  `pipIsActive` — do not re-derive the formula here) are "just now" by
  *  definition, so the text is noise. The fixed `w-[8ch]` still reserves the
  *  column so rows do not jump when the cell appears on quiet.
  *

--- a/packages/client/src/terminal/pipMotion.test.ts
+++ b/packages/client/src/terminal/pipMotion.test.ts
@@ -55,6 +55,33 @@ describe("pipIsActive", () => {
       }),
     ).toBe(false);
   });
+
+  // Sticky EF2 finish must not silence motion when the terminal is still
+  // printing (#1955). finishedIds is the chime question; isLive is motion.
+  it("sticky-finished waiting agent with live output is active", () => {
+    const waitingAgent = agent("waiting");
+    expect(
+      pipIsActive({
+        agent: waitingAgent,
+        isLive: true,
+        isFinished: true,
+      }),
+    ).toBe(true);
+    expect(
+      pipMotionKind({
+        variant: "awaiting",
+        agent: waitingAgent,
+        active: true,
+      }),
+    ).toBe("spin");
+    expect(
+      pipIsActive({
+        agent: waitingAgent,
+        isLive: false,
+        isFinished: true,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("pipMotionKind", () => {

--- a/packages/client/src/terminal/pipMotion.ts
+++ b/packages/client/src/terminal/pipMotion.ts
@@ -25,8 +25,9 @@ import type {
 import { agentBucket, type AgentInfo } from "kolu-common/surface";
 
 /** Whether the terminal is "effectively active" for motion — complement of
- *  EF2 effective finish for waiting agents; live-output for shells; always
- *  for working / awaiting_user. Also gates recency-cell hide.
+ *  EF2 effective finish for waiting agents (OR live output: sticky finish
+ *  must not silence a still-printing terminal); live-output for shells;
+ *  always for working / awaiting_user. Also gates recency-cell hide.
  *  Exhaustive over `agentBucket` (`case "other"`, no bare default). */
 export function pipIsActive(input: {
   agent: AgentInfo | null | undefined;
@@ -40,7 +41,9 @@ export function pipIsActive(input: {
     case "awaiting":
       return true;
     case "waiting":
-      return !input.isFinished;
+      // EF2 linger until quiet, OR live output once sticky-finish latches
+      // (finishedIds answers chime; isLive answers motion — #1955).
+      return !input.isFinished || input.isLive;
     case "other":
       return input.isLive;
   }

--- a/packages/client/src/terminal/useFinishedQuiet.ts
+++ b/packages/client/src/terminal/useFinishedQuiet.ts
@@ -3,8 +3,9 @@
  *
  *  Same shape as `useTerminalActivity`: full-member fan-out over host urgency
  *  cells, `createActivityFrameReducer` for the prev-snapshot / Set-diff fence,
- *  flat per-id store. Dock and title pips read `isFinished(id)` so motion can
- *  hold still once EF2 says the turn is done. */
+ *  flat per-id store. Dock and title pips read `isFinished(id)` so the motion
+ *  fold can apply the EF2 linger leg (`!isFinished`); live output re-lights
+ *  motion independently (#1955). */
 
 import { decodeHostKey, encodeHostKey } from "kolu-common/hostKey";
 import type { TerminalId } from "kolu-common/surface";


### PR DESCRIPTION
A Grok terminal could be **visibly animating** (planner output flowing) while its dock pip sat still — motion only resumed when the main turn flipped the agent out of `waiting`. **If either the agent is active or the terminal is printing, the pip should show active.**

The finished chime's EF2 sticky finish was doing its job: once a `waiting` episode goes quiet for 5s, mid-turn TUI noise must not un-finish and re-chime. But the motion fold treated that same sticky bit as "no output flowing," so live edges could never re-light a waiting pip. This change keeps sticky finish for the chime and teaches motion to honor **live output** as a separate leg:

| Bucket | Motion |
| --- | --- |
| working / awaiting | always active |
| waiting | EF2 linger **or** live output |
| shell / other | live output only |

_EF2 / `finishQuiet` / chime path untouched — only `pipIsActive` (and comments that re-derived it)._ Closes #1955. Related: #1954 (Grok still reporting `waiting` during `/goal` planner — independent).

### Try it locally

```sh
nix run github:juspay/kolu/fix/1955-pip-waiting-live-motion
```

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Grok Build (model `grok-4.5`)._