### PR TITLE
Turn the README into a focused repository front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,126 +4,91 @@
 
 # kolu
 
-kolu is a terminal app built for scale: real `xterm.js` tiles on an infinite 2D canvas, with a dock that never loses one — for `claude`, `codex`, `opencode`, or anything you run in a shell, especially many at once.
+kolu is a terminal app built for scale: real `xterm.js` tiles on an infinite
+2D canvas, with a dock that never loses one — for `claude`, `codex`,
+`opencode`, `grok`, or anything you run in a shell, especially many at once.
 
-Unlike agent command centers that wrap a single model behind their own chat UI, kolu stays out of the agent's way: the terminal is the universal interface, so `claude`, `opencode`, or whatever ships next week works out of the box — and you can drop to a plain shell whenever you want. Two principles shape it — the [**Philosophy**](https://kolu.dev/philosophy) page has the full story:
+<p align="center">
+  <a href="https://kolu.dev">
+    <img src="website/public/demo/hero-demo.webp" width="960" alt="Kolu running in a browser workspace with the dock, terminal tiles, and code panel visible" />
+  </a>
+</p>
 
-- **Agent-agnostic.** No agent registry, no adapter, no vendor lock-in. Run any agent CLI once in a terminal and it picks up first-class features automatically.
-- **Auto-detected, zero setup.** kolu populates its UI by watching what you already do — the repos you `cd` into, the agents you run, the sessions you save — not by asking you to configure it.
+<p align="center">
+  <a href="https://kolu.dev">Documentation</a> ·
+  <a href="https://kolu.dev/quickstart">Quickstart</a> ·
+  <a href="CONTRIBUTING.md">Contributing</a> ·
+  <a href="LICENSE">AGPL-3.0-or-later</a>
+</p>
 
-📖 **Full documentation lives at [kolu.dev](https://kolu.dev).** This README is a map; the canonical guides are there.
+## Run it
 
-## Install & run
-
-[Install Nix](https://nixos.asia/en/install) with flakes enabled, then run one command — the same command runs kolu _and_ updates it (`--refresh` busts Nix's flake cache so you always pull the latest commit):
+[Install Nix](https://nixos.asia/en/install) with flakes enabled, then:
 
 ```sh
-nix --refresh run github:juspay/kolu       # serve on 127.0.0.1:7681
-nix --refresh run github:juspay/kolu -- --host 0.0.0.0 --port 8080  # expose on LAN
+nix --refresh run github:juspay/kolu
 ```
 
-Open <http://127.0.0.1:7681> (or the address you chose). The full walkthrough is [Quickstart](https://kolu.dev/quickstart) → [First five minutes](https://kolu.dev/first-five-minutes).
+Open <http://127.0.0.1:7681>. Continue with the
+[Quickstart](https://kolu.dev/quickstart) and
+[First Five Minutes](https://kolu.dev/first-five-minutes).
 
-## What it does
+## Why kolu
 
-Every capability below is documented in full on [kolu.dev](https://kolu.dev):
+Unlike an agent command center that wraps one model behind its own chat UI,
+kolu keeps the terminal as the universal interface. Any agent CLI works out of
+the box, and a plain shell is always one command away.
 
-- **[Canvas](https://kolu.dev/canvas) & [tiles](https://kolu.dev/tiles)** — every terminal is a draggable, resizable `xterm.js` tile on an infinite, mode-less 2D canvas (WebGL, inline images, splits, font zoom, clickable `file:line` and folder links).
-- **[The dock](https://kolu.dev/dock)** — a two-level left-edge navigator with per-repo grouping, a status indicator per row, recency ordering, and an activity-window filter; **[sleep & wake](https://kolu.dev/sessions)** parks a tile without keeping its PTY, agent, or GPU context alive.
-- **[Agent detection](https://kolu.dev/agent-detection)** — live state (thinking · tool use · awaiting you · working · waiting) for **Claude Code, Codex, Grok, and OpenCode**, read straight from each agent's on-disk session.
-- **[Worktrees](https://kolu.dev/concepts)** & **[the switcher](https://kolu.dev/switcher)** — creating a terminal in a repo branches a fresh git worktree; <kbd>Cmd/Ctrl+K</kbd> searches terminals, hosts, and commands in one box.
-- **[Git & GitHub](https://kolu.dev/code-tab)** — auto-detected repo/branch/PR/CI, a Code-tab file browser with git-status tinting, rendered Markdown, inline HTML/SVG/PDF/image/video preview, and file comments.
-- **[Theming](https://kolu.dev/theming)** · **[Clipboard & files](https://kolu.dev/clipboard)** — 200+ color schemes with inherit/shuffle; paste an image or drop a file and its path lands on the agent's input line.
-- **[Power features](https://kolu.dev/power-features)** — transcript export, workspace screen recording, and driving kolu from the shell.
-- **[Remote access](https://kolu.dev/remote-access)** & **[remote hosts](https://kolu.dev/remote-hosts)** — reach kolu over private HTTPS, and run terminals on other machines as first-class tiles.
+- **Agent-agnostic.** No agent registry, adapter, or vendor lock-in.
+- **Auto-detected, zero setup.** kolu learns from the repositories, agents, and
+  sessions you already use instead of asking you to configure them twice.
 
+Read the full [Philosophy](https://kolu.dev/philosophy).
+
+## Explore
+
+- **[Canvas, tiles, and dock](https://kolu.dev/canvas)** — arrange real
+  terminals freely, then find any one instantly.
+- **[Agent attention](https://kolu.dev/agent-detection)** — see which agents are
+  working, finished, or waiting for you.
+- **[Durable sessions](https://kolu.dev/sessions)** — keep shells and agents
+  alive across tab closes, server restarts, and redeploys.
+- **[Remote access](https://kolu.dev/remote-access) and
+  [hosts](https://kolu.dev/remote-hosts)** — reach kolu from another device and
+  bring other machines onto the same canvas.
+- **[Deployment](https://kolu.dev/deployment)** — keep kolu running as a
+  home-manager service on Linux or macOS.
+
+The complete feature guides and command reference live at
+**[kolu.dev](https://kolu.dev)**. This README is the map.
 
 ## Architecture
 
-kolu splits the terminal problem across a stack of daemons that each survive a different failure: the **PWA client** and **kolu-server** are faces that come and go, while **[padi](https://kolu.dev/padi)** (the per-host workspace daemon) and **[kaval](https://kolu.dev/kaval)** (the PTY daemon) survive restarts and redeploys — so your shells and the agents in them keep running. Every layer talks over one typed reactive contract, **[@kolu/surface](https://kolu.dev/surface)**.
-
-The full picture — the daemon stack, how the layers talk, the two data-flow loops, and the package map — is in **[Architecture](https://kolu.dev/architecture)**.
+Kolu splits the browser workspace, web shell, workspace state, and live PTYs
+across processes that fail and restart independently. See the canonical
+[Architecture](https://kolu.dev/architecture) page for the daemon stack, wire
+protocol, data flow, and package map.
 
 ## Development
 
-Requires [Nix](https://nixos.asia/en/install) with flakes enabled.
-
 ```sh
-nix develop     # enter devshell
-just dev        # run server + client with hot reload (fixed 7681/5173)
-just dev-auto   # same, but on two random free ports — for a second instance
-just dev-clean  # kill that slot's padi/kaval and wipe its state dir (see below)
-just test       # e2e tests (full nix build)
+nix develop
+just dev-auto
+just test
 ```
 
-`just dev-auto` is the safe way to run a second kolu (or to drive one from an agent) without colliding with an instance already holding the default ports; agents capturing evidence launch via the [`dev-server`](.apm/skills/dev-server/SKILL.md) skill. Bare `just dev` shares `$XDG_RUNTIME_DIR/kolu-dev-default/` across worktrees — if another worktree already holds that slot's padi, this branch adopts it. `just dev-clean` (optional port: `just dev-clean 7780`) SIGTERMs that slot's padi/kaval and removes the state + runtime dirs so the next `just dev` spawns a fresh padi from this tree.
+See [Developing kolu](docs/development.md) for local instances, cleanup, and
+checks; [kolu CI](ci/README.md) documents the multi-platform pipeline.
 
-## Contributing
+Bug fixes, build/CI fixes, documentation changes, and behavior-preserving
+refactors are welcome as direct PRs. New user-facing features need a merged
+proposal first. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Bug fixes, build/CI fixes, doc tweaks, and behavior-preserving refactors are welcome as direct PRs. **New user-facing features need a merged proposal first** — an [Atlas](docs/atlas/) note in the right category with `status: proposed`. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full split and the proposal frontmatter.
-
-## CI
-
-The pipeline (defined in [`ci/mod.just`](ci/mod.just)) is driven by [odu](https://github.com/juspay/odu) — the CI runner that grew up here, replaced [juspay/justci](https://github.com/juspay/justci), and graduated to its own repo (design history: the [mini-ci-vs-justci](docs/atlas/dist/mini-ci-vs-justci.html) Atlas note). kolu consumes it via an npins pin (`npins update odu` to bump) re-exported through this repo's flake, so the `nix run .#odu` invocations below work unchanged. It builds all flake outputs on x86_64-linux and aarch64-darwin, runs e2e tests, boots the packaged binary against `/api/health` as a runtime smoke, and posts GitHub commit statuses per `(recipe, platform)` pair. Remote lanes run over SSH against hosts from `~/.config/odu/hosts.json` (falls back to `~/.config/justci/hosts.json`), and a live run is attachable: `nix run .#odu -- attach` paints a dashboard over the run's typed surface on `.ci/odu.sock`. Agents drive CI through odu's MCP server — the single entry point (`mcp__odu__run` to start a run, `wait_for_settle` / `node_rerun` to watch and steer it, per-node logs read as MCP resources). For the x86_64-linux lane, odu **leases an idle box from a fixed pool of warm Incus containers** (`kolu-ci-1..8`, listed as the `x86_64-linux` pool in `~/.config/odu/hosts.json`; pool managed by `just ci::pool-ensure`) so the build starts with a hot Nix store and concurrent PRs don't contend on the substituter. Leasing is native to odu — it claims a free box for the run and releases it on finish; see [`.agency/do.md`](.agency/do.md).
-
-The DAG is shaped to keep the critical path short: `e2e`, `smoke`, and `home-manager` each build the one store path they need (`.#koluBin`, `.#default`, kolu-via-override) rather than depending on the full-output `nix` node, so the ~2-min e2e suite runs **concurrently** with the big build instead of after it (Nix store locking dedups the shared drv). `nix` still runs as a gate, so typecheck/website/packaging coverage is unchanged. See [`docs/ci-workflow-ralph-report.md`](docs/ci-workflow-ralph-report.md) for the critical-path model.
-
-Workspace typechecking runs as a flake check (`checks.x86_64-linux.typecheck`), so the all-outputs build is the type gate. Note that `nix build .#default` on its own does **not** typecheck — the client is bundled by Vite and the server runs under `tsx`, both transpile-only — so a green app build is not a type-proof.
-
-Only the runner posts GitHub commit statuses; the `just` shortcuts below stay entirely local.
-
-```sh
-nix run .#odu -- run                  # multi-platform fanout + commit statuses (strict by default)
-nix run .#odu -- run --progress json  # + live NDJSON per-node feed on stdout (for agents/tools driving CI in the background)
-nix run .#odu -- attach               # attach a live dashboard to a run in progress
-just ci::attach                                  # same as `nix run .#odu -- attach`
-just ci                                          # local single-platform pipeline, no statuses
-just ci::e2e                                     # one recipe, no statuses
-```
-
-`--progress json` streams one line per node transition the instant it happens (`{node, recipe, platform, status, exit_code?, log?}`), so a tool driving CI in the background surfaces a failing recipe immediately — while sibling lanes keep running — instead of waiting for the run to finish. This is how `/do` reacts to failures fast; see [`.agency/do.md`](.agency/do.md).
-
-## Deployment (home-manager)
-
-A home-manager module runs kolu as a systemd user service on Linux and as a launchd LaunchAgent on macOS:
-
-```nix
-{
-  imports = [ kolu.homeManagerModules.default ];
-  services.kolu = {
-    enable = true;
-    package = kolu.packages.${system}.default;
-    host = "127.0.0.1"; # default
-    port = 7681;         # default
-  };
-}
-```
-
-See [`nix/home/example/`](nix/home/example/) for a full configuration — a NixOS VM test exercises the systemd path on Linux, and a standalone home-manager activation build exercises the launchd path on Darwin.
-
-kolu's RPC surface is unauthenticated and same-origin-gated on both transports (see [Architecture → Talking over the wire](https://kolu.dev/architecture)), so it serves only its own origin out of the box. If you front it with a reverse proxy or `tailscale serve` whose browser origin differs from the `Host` kolu receives, list that origin in `services.kolu.allowedOrigins` (which sets the `KOLU_ALLOWED_ORIGINS` env var) so the browser clears the same-origin check:
-
-```nix
-services.kolu.allowedOrigins = [ "https://box.tailnet.ts.net" ];
-```
-
-On macOS, the LaunchAgent writes stdout to `~/Library/Logs/kolu.out.log` and stderr to `~/Library/Logs/kolu.err.log`, so crashes and startup failures leave service logs alongside other user logs.
-
-### Diagnosing memory leaks
-
-If kolu grows unbounded (V8 heap climbing over hours), set `services.kolu.diagnostics.dir` to an absolute path. Each restart gets its own timestamped subdir there, with a baseline heap snapshot at T+5min, periodic `"diag"` stats lines (memory bands + `terminals`/`publisherSize`/`claudeSessions`/`pendingSummaryFetches`), and automatic near-OOM snapshots via V8's `--heapsnapshot-near-heap-limit`. `kill -USR2 <pid>` captures an on-demand snapshot into the same dir. Diff two snapshots offline with [memlab](https://facebook.github.io/memlab/docs/cli/CLI-commands/) to name the retainer. Unset = zero overhead; the code path is fully gated.
-
-## Website
-
-The marketing site, docs, and blog at <https://kolu.dev> live in [`website/`](website/) — Astro + Tailwind, its own zero-input flake, deployed to GitHub Pages via `.github/workflows/pages.yml`. **The docs under [`website/src/content/docs/`](website/src/content/docs/) are the canonical, user-facing description of kolu** — this README points into them.
-
-```sh
-just website::dev          # live preview with HMR
-just website::nix-build    # reproducible build
-```
-
-See [`website/README.md`](website/README.md) for authoring posts and deploy details.
+The marketing site, product docs, blog, and changelog live in
+[`website/`](website/); its [README](website/README.md) covers authoring and
+deployment.
 
 ---
 
-Named after [கோலு](<https://en.wikipedia.org/wiki/Golu_(festival)>), the tradition of arranging figures on tiered steps.
+Named after [கோலு](https://en.wikipedia.org/wiki/Golu_(festival)), the
+tradition of arranging figures on tiered steps.

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,114 @@
+# kolu CI
+
+kolu's CI is a two-platform pipeline driven by
+[odu](https://github.com/juspay/odu). The executable source of truth is
+[`mod.just`](mod.just): its `default` recipe defines the DAG, and odu expands
+each reachable recipe into Linux and macOS nodes.
+
+## Run it
+
+Run the pipeline locally on the current platform:
+
+```sh
+just ci
+```
+
+Run one recipe without posting GitHub statuses:
+
+```sh
+just ci::e2e
+```
+
+Run the canonical multi-platform pipeline:
+
+```sh
+nix run .#odu -- run
+```
+
+Only odu posts GitHub commit statuses. Add its live NDJSON feed when another
+tool is supervising the run:
+
+```sh
+nix run .#odu -- run --progress json
+```
+
+Attach a terminal dashboard to a run already in progress:
+
+```sh
+nix run .#odu -- attach
+# or
+just ci::attach
+```
+
+## Platforms and hosts
+
+Every reachable recipe runs on:
+
+- `x86_64-linux`
+- `aarch64-darwin`
+
+Lane hosts come from `$ODU_HOSTS`, then `~/.config/odu/hosts.json`, with
+`~/.config/justci/hosts.json` accepted as the legacy location. A localhost lane
+runs against the current checkout. A remote lane fetches the pushed commit into
+its own workspace.
+
+Linux runs lease an idle warm Incus container from the configured venue pool.
+Odu owns the lease for the life of the run and releases it when the run ends.
+The coordinator-side maintenance commands are:
+
+```sh
+just ci::pool-status
+just ci::pool-ensure
+```
+
+## Pipeline nodes
+
+The current DAG covers four kinds of work:
+
+| Area | Required nodes |
+| --- | --- |
+| Nix and packaging | `nix`, `flake-check`, `home-manager`, `smoke`, `pnpm-hash-fresh` |
+| Code quality | `fmt`, `biome`, `unit`, `daemon` |
+| Browser behavior | `e2e` |
+| Living docs and examples | `surface-example-build`, `surface-app-example-build`, `atlas-sync` |
+
+`nix` builds every flake output for the lane's system, including checks and dev
+shells. Workspace typechecking is a flake check, so `nix build .#default` alone
+is not a type proof: Vite and `tsx` transpile without checking types.
+
+The `daemon` node is separate from `unit` because it forks real padi and kaval
+processes. Keeping it explicit prevents the default-off daemon suites from
+silently disappearing from CI.
+
+## Critical path
+
+The large `nix` build remains a required gate, but `e2e`, `smoke`, and
+`home-manager` do not wait for it. Each builds only the store path it needs, and
+Nix store locking deduplicates the shared work while the branches run in
+parallel:
+
+```text
+            ┌─ nix ───────────────┐
+setup ──────├─ e2e ──────────────┤
+            ├─ smoke ─────────────┤── required verdict
+            └─ home-manager ──────┘
+```
+
+This keeps the roughly two-minute end-to-end suite off the big build's critical
+path without weakening the merge gate. The measurements and dependency model
+are in the [CI workflow report](../docs/ci-workflow-ralph-report.md).
+
+## Change the pipeline
+
+Edit [`mod.just`](mod.just). Keep leaf recipes platform-neutral: odu currently
+replicates every reachable recipe across both platforms.
+
+The `install` node is the single pnpm installation for a lane. Downstream pnpm
+consumers must depend on it and invoke pnpm directly; concurrent installs can
+corrupt the shared `node_modules`.
+
+After changing the DAG, inspect the required status contexts for both platforms:
+
+```sh
+just ci::protect --dry-run
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,101 @@
+# Developing kolu
+
+This guide gets a local checkout running, keeps it isolated from other kolu
+instances, and names the checks to run before opening a pull request.
+
+## Prepare the checkout
+
+kolu uses Nix for the toolchain and pnpm for the TypeScript workspace.
+
+```sh
+nix develop
+just prepare
+```
+
+`just prepare` installs the workspace dependencies and warms the caches used by
+the other recipes.
+
+## Start a development instance
+
+Use random free ports when another kolu instance or worktree may already be
+running:
+
+```sh
+just dev-auto
+```
+
+The recipe prints the server and Vite URLs. The client has hot reload.
+
+For the canonical development ports, use:
+
+```sh
+just dev
+```
+
+This serves kolu on `127.0.0.1:7681` and the Vite client on
+`127.0.0.1:5173`. To choose both ports explicitly:
+
+```sh
+just dev 7700 5180
+```
+
+Each server port owns an isolated development slot: its own padi state, kaval
+daemon, and runtime directory. A development instance cannot adopt or stop the
+daemons used by a production service.
+
+The default `just dev` slot is shared across worktrees. If another worktree
+already owns it, this checkout connects to that slot's existing daemons. Prefer
+`just dev-auto` when working in parallel.
+
+## Reset a development slot
+
+Stop the slot's padi and kaval processes and remove its development state:
+
+```sh
+just dev-clean
+```
+
+For a custom server port:
+
+```sh
+just dev-clean 7700
+```
+
+This permanently removes only the selected development slot. It does not touch
+a packaged or home-manager kolu service.
+
+## Run checks
+
+| Command | Purpose |
+| --- | --- |
+| `just fmt` | Format TypeScript, Markdown, and Nix files in place. Run this before committing. |
+| `just check` | Run workspace typechecking and Biome lint. |
+| `just test-unit` | Run the fork-free unit-test suite, safe beside a live kolu. |
+| `just test-quick` | Build from source and run the end-to-end suite on random ports. Accepts a feature file or scenario line. |
+| `just test` | Build the Nix package and run the full end-to-end suite. |
+| `just ci` | Run the local, single-platform form of the CI pipeline. |
+
+For example, run one end-to-end feature while iterating:
+
+```sh
+just test-quick features/command-palette.feature
+```
+
+`just test-daemon` forks real padi and kaval daemons in bulk. It is intended for
+CI or a disposable test host, not a workstation running a production kolu.
+
+The canonical multi-platform pipeline, its nodes, and the commands for
+attaching to a live run are documented in [kolu CI](../ci/README.md).
+
+## Work on the website
+
+The website has its own authoring and validation workflow:
+
+```sh
+just website::dev
+just website::check
+just website::nix-build
+```
+
+See the [website README](../website/README.md) for content locations,
+frontmatter, search, changelog entries, and deployment.

--- a/packages/client/src/ui/DocLink.tsx
+++ b/packages/client/src/ui/DocLink.tsx
@@ -19,6 +19,7 @@ export const DOC_SLUGS = [
   "clipboard",
   "code-tab",
   "concepts",
+  "deployment",
   "dock",
   "first-five-minutes",
   "install-pwa",

--- a/website/README.md
+++ b/website/README.md
@@ -19,6 +19,10 @@ sidebar. Docs render through `DocsLayout`, which provides the native site header
 sidebar, mobile docs menu, on-this-page TOC, previous/next links, Pagefind
 metadata, and code-copy buttons.
 
+Adding, renaming, or deleting a product-docs page also requires the same slug
+change in `packages/client/src/ui/DocLink.tsx`. Its set-equality test keeps
+in-app documentation links synchronized with the website.
+
 Docs component kit: `src/components/docs/Aside.astro`, `Card.astro`,
 `CardGrid.astro`, `LinkCard.astro`, and `Steps.astro`. Use normal Markdown first;
 reach for these when the page needs callouts, repeated cards, navigation cards,

--- a/website/src/content/docs/architecture.mdx
+++ b/website/src/content/docs/architecture.mdx
@@ -330,7 +330,9 @@ its **local unix socket** — same oRPC framing, a different transport.
   browser-reachable paths — it rejects a cross-site <code>Origin</code> at the
   websocket upgrade and 403s a cross-site HTTP call. A reverse proxy or
   <code>tailscale serve</code> front-end, whose origin differs from the forwarded
-  host, is allowlisted with <code>KOLU_ALLOWED_ORIGINS</code>.
+  host, is allowlisted with <code>KOLU_ALLOWED_ORIGINS</code>. The
+  <a href="/deployment#allow-a-reverse-proxy-origin">deployment guide</a> shows
+  the home-manager configuration.
 </Aside>
 
 ## Two loops of data flow

--- a/website/src/content/docs/deployment.mdx
+++ b/website/src/content/docs/deployment.mdx
@@ -1,0 +1,126 @@
+---
+title: Deployment
+description: "Run kolu as a home-manager service on Linux or macOS, configure its address and browser origins, inspect logs, and capture heap diagnostics."
+order: 72
+section: Operate
+koluHero:
+  eyebrow: operate
+  headline: Keep {kolu} running.
+---
+
+import Aside from "../../components/docs/Aside.astro";
+
+kolu's home-manager module runs the web server as a systemd user service on
+Linux or a launchd LaunchAgent on macOS. Both supervisors restart a failed
+server, while [padi and kaval](/architecture) keep workspace state and live
+shells below it.
+
+## Enable the service
+
+Import the module and select the package for the current system:
+
+```nix
+{ pkgs, kolu, ... }:
+{
+  imports = [ kolu.homeManagerModules.default ];
+
+  services.kolu = {
+    enable = true;
+    package = kolu.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  };
+}
+```
+
+Apply the home-manager configuration as usual, then open
+[http://127.0.0.1:7681](http://127.0.0.1:7681). The module also puts the
+matching `kolu`, `padi-tui`, and `kaval-tui` commands on `PATH`.
+
+The complete, build-tested flake is in
+[`nix/home/example`](https://github.com/juspay/kolu/tree/master/nix/home/example).
+CI boots its systemd configuration in a NixOS VM and builds its launchd
+activation package on macOS.
+
+## Choose the address
+
+The service listens on loopback port `7681` by default. Change either value in
+the module:
+
+```nix
+services.kolu = {
+  host = "0.0.0.0";
+  port = 8080;
+};
+```
+
+<Aside type="caution" title="The RPC surface has no login">
+  The same-origin gate stops a hostile website from reaching kolu through your
+  browser; it does not authenticate another device that can reach the listening
+  address. Keep access inside a trusted network. For private HTTPS across
+  devices, follow <a href="/remote-access">Remote Access</a>.
+</Aside>
+
+## Allow a reverse-proxy origin
+
+kolu accepts its own browser origin by default. A reverse proxy or
+`tailscale serve` can present a public browser origin that differs from the
+`Host` forwarded to kolu. Add that exact origin:
+
+```nix
+services.kolu.allowedOrigins = [
+  "https://box.tailnet.ts.net"
+];
+```
+
+This sets `KOLU_ALLOWED_ORIGINS` for both the WebSocket and HTTP RPC paths. The
+[architecture page](/architecture#talking-over-the-wire) explains why the gate
+exists.
+
+## Read service logs
+
+On Linux, use the systemd user journal:
+
+```sh
+systemctl --user status kolu
+journalctl --user -u kolu -f
+```
+
+On macOS, launchd writes the two streams to:
+
+```text
+~/Library/Logs/kolu.out.log
+~/Library/Logs/kolu.err.log
+```
+
+Crashes and startup failures remain visible after the process exits.
+
+## Capture memory diagnostics
+
+If the server or kaval daemon grows without bound, set an absolute diagnostics
+directory:
+
+```nix
+services.kolu.diagnostics.dir =
+  "${config.home.homeDirectory}/.local/state/kolu-diagnostics";
+```
+
+Each restart gets a timestamped subdirectory containing:
+
+- a baseline heap snapshot after five minutes;
+- periodic memory statistics;
+- automatic snapshots near the V8 heap limit; and
+- snapshots requested with `SIGUSR2`.
+
+To capture a snapshot on demand:
+
+```sh
+kill -USR2 <pid>
+```
+
+The snapshot lands in the current run's diagnostics directory. Compare
+snapshots offline with
+[MemLab](https://facebook.github.io/memlab/docs/cli/CLI-commands/) to find what
+retains the growing objects.
+
+Diagnostics are disabled by default and add no overhead until `dir` is set.
+Browser-tab or GPU growth has a different checklist in
+[Troubleshooting](/troubleshooting#kolu-is-using-a-lot-of-memory).

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -113,7 +113,7 @@ If it climbs higher than feels right, check these in order:
 2. **Close or sleep what you are done with.** A terminal you will not return to can
    be closed, or put to **sleep** (the ☾ button) to release its shell and GPU
    context while the tile stays on the canvas — see
-   [Power Features](/sessions). Disconnecting a
+   [Sessions, Sleep & Wake](/sessions). Disconnecting a
    [remote host](/remote-hosts) you are not using frees all of its terminals at once.
 3. **Reload the tab.** Memory freed by closing terminals or hosts is reclaimed
    immediately on a reload, and your terminals survive it — they live in the kaval
@@ -123,10 +123,16 @@ The chrome bar shows a live memory figure for each process (server · client ·
 kaval), so you can watch which one is climbing; **Debug → Diagnostic info** in the
 palette has the per-terminal detail.
 
+If the **server or kaval** figure keeps growing rather than the browser, a
+home-manager deployment can write heap snapshots and periodic process stats.
+See [Deployment → Capture memory
+diagnostics](/deployment#capture-memory-diagnostics).
+
 ## Still stuck?
 
 <CardGrid>
   <LinkCard title="Remote Access" href="/remote-access" description="private HTTPS, install prompts, and Tailscale Serve" />
   <LinkCard title="Install as an App" href="/install-pwa" description="browser-specific PWA install paths" />
-  <LinkCard title="GitHub" href="https://github.com/juspay/kolu" description="source, issues, and deployment notes" />
+  <LinkCard title="Deployment" href="/deployment" description="home-manager service, logs, origins, and heap diagnostics" />
+  <LinkCard title="GitHub" href="https://github.com/juspay/kolu" description="source, issues, and pull requests" />
 </CardGrid>


### PR DESCRIPTION
**The root README is now a concise front door instead of a second documentation site.** It leads with the product, a real screenshot, one-command startup, and durable links, while moving contributor and operator detail into documents that can serve those readers properly.

The split also closes the largest product-doc gap: **home-manager deployment now has a canonical kolu.dev page** for service setup, origins, logs, and heap diagnostics. Architecture and troubleshooting link into that page, and the in-app docs registry is kept in sync.

### Where the detail lives

| Reader need | Canonical home |
| --- | --- |
| Understand and try kolu | Root `README.md` → kolu.dev |
| Develop locally and choose an isolated dev slot | `docs/development.md` |
| Run, inspect, or change the two-platform pipeline | `ci/README.md` |
| Deploy and diagnose the home-manager service | `kolu.dev/deployment` |
| Author and validate the site | `website/README.md` |

*The old generated Atlas link disappears with the CI extraction, so the README no longer points at an absent checkout artifact.*

### Verified

- `just fmt`
- `just check`
- `just website::check`
- `just website::build`
- `pnpm --filter kolu-client exec vitest run src/ui/DocLink.test.ts`
- rendered deployment anchors, sidebar entry, local file targets, and `git diff --check`

_Generated by Codex (model `gpt-5`)._