### PR TITLE
Make palette recency e2e wait for live metadata

### DIFF
--- a/packages/tests/step_definitions/command_palette_steps.ts
+++ b/packages/tests/step_definitions/command_palette_steps.ts
@@ -1,5 +1,6 @@
 import * as assert from "node:assert";
 import { Then, When } from "@cucumber/cucumber";
+import { pollFor } from "../support/poll.ts";
 import { type KoluWorld, MOD_KEY, POLL_TIMEOUT } from "../support/world.ts";
 
 const PALETTE_SELECTOR = '[data-testid="command-palette"]';
@@ -109,7 +110,17 @@ Then(
       )
       .first();
     await first.waitFor({ state: "visible", timeout: POLL_TIMEOUT });
-    const actual = await first.getAttribute("data-palette-name");
+    // A row can mount before its async terminal metadata label is current.
+    // Visibility is setup; the label value is the condition under test.
+    const actual = await pollFor({
+      observe: () => first.getAttribute("data-palette-name"),
+      isDone: (value) => value === name,
+      timeoutMs: POLL_TIMEOUT,
+      onTimeout: (last, elapsedMs) =>
+        new Error(
+          `Expected first Recent terminal row "${name}" after ${elapsedMs}ms, got "${last}"`,
+        ),
+    });
     assert.strictEqual(
       actual,
       name,


### PR DESCRIPTION
**Palette recency e2e assertions now wait for the terminal label they actually assert**, instead of treating the first mounted row as proof that its asynchronous metadata is current. On rasam, the row appeared with the terminal’s earlier e2e-home label and then converged to the expected branch; the old one-shot comparison failed before that update arrived.

The existing 20-second test deadline remains the boundary. A real ranking or metadata defect still times out with the expected name, last observed name, and elapsed time; product code is unchanged.

### Evidence

- Unchanged focused scenario on rasam: failed in 7.395s with the stale e2e-home label.
- Same focused scenario with value polling: 1/1 scenario and 15/15 steps passed.
- Complete terminal-switcher feature on rasam: 22/22 scenarios and 158/158 steps passed.
- `just fmt` and `git diff --check` passed.

_Generated by Codex (model `GPT-5`)._