### PR TITLE
refactor: derive restated action labels from the ACTIONS registry

### DIFF
--- a/packages/client/src/ChromeBar.tsx
+++ b/packages/client/src/ChromeBar.tsx
@@ -152,7 +152,7 @@ const ChromeBar: Component<{
           </button>
         </Tip>
         <Tip
-          label={`Toggle right panel (${formatKeybind(ACTIONS.toggleRightPanel.keybind)})`}
+          label={`${ACTIONS.toggleRightPanel.label} (${formatKeybind(ACTIONS.toggleRightPanel.keybind)})`}
         >
           <button
             type="button"
@@ -170,7 +170,7 @@ const ChromeBar: Component<{
             // terminal exists (the keybind/palette no-op via togglePanel too).
             disabled={!rightPanel.hasTerminals()}
             onClick={() => rightPanel.togglePanel()}
-            aria-label="Toggle right panel"
+            aria-label={ACTIONS.toggleRightPanel.label}
           >
             <InspectorToggleIcon active={rightPanel.panelOpen()} />
           </button>

--- a/packages/client/src/CommandPalette.tsx
+++ b/packages/client/src/CommandPalette.tsx
@@ -25,6 +25,7 @@ import {
 } from "solid-js";
 import { match } from "ts-pattern";
 import { hostLabel } from "./host/hostChipTone";
+import { ACTIONS } from "./input/actions";
 import type { Keybind } from "./input/keyboard";
 import { HOSTS_GROUP_NAME } from "./palette/hostsGroup";
 import PaletteRow, { type PaletteRowMeta } from "./palette/PaletteRow";
@@ -335,7 +336,7 @@ const CommandPalette: Component<{
     if (p.length >= 2 && p[0]?.name === TERMINALS_GROUP_NAME)
       return "Filter terminals…";
     if (last?.name === HOSTS_GROUP_NAME) return "Filter hosts…";
-    if (p.length === 0) return "Search everything…";
+    if (p.length === 0) return `${ACTIONS.commandPalette.label}…`;
     return "Type a command...";
   }
 

--- a/packages/client/src/EmptyState.tsx
+++ b/packages/client/src/EmptyState.tsx
@@ -19,9 +19,15 @@ import WelcomeMoments from "./WelcomeMoments";
 const chrome = surface();
 
 const features = [
-  { label: "New terminal", shortcut: advertisedNewTerminalKey },
-  { label: "New terminal menu", shortcut: ACTIONS.newTerminalMenu.keybind },
-  { label: "Search everything", shortcut: ACTIONS.commandPalette.keybind },
+  { label: ACTIONS.createTerminal.label, shortcut: advertisedNewTerminalKey },
+  {
+    label: ACTIONS.newTerminalMenu.label,
+    shortcut: ACTIONS.newTerminalMenu.keybind,
+  },
+  {
+    label: ACTIONS.commandPalette.label,
+    shortcut: ACTIONS.commandPalette.keybind,
+  },
   { label: "Cycle terminals", shortcut: ACTIONS.cycleTerminalMru.keybind },
 ];
 
@@ -279,7 +285,7 @@ const EmptyState: Component<EmptyStateProps> = (props) => {
               class="mb-5 w-full px-3 py-2 text-sm rounded-xl bg-accent text-surface-1 font-medium hover:brightness-110 active:brightness-95 transition-all"
               onClick={() => props.onCreate?.()}
             >
-              New terminal
+              {ACTIONS.createTerminal.label}
             </button>
           </Show>
           {/* Shortcut list — only where the welcome moments aren't shown (mobile).

--- a/packages/client/src/MobileChromeSheet.tsx
+++ b/packages/client/src/MobileChromeSheet.tsx
@@ -145,7 +145,7 @@ const MobileChromeSheet: Component<{
             rightPanel.setDrawerOpen(!rightPanel.drawerOpen());
             props.onClose();
           }}
-          aria-label="Toggle right panel"
+          aria-label={ACTIONS.toggleRightPanel.label}
         >
           <InspectorToggleIcon active={rightPanel.drawerOpen()} />
         </button>

--- a/packages/client/src/SplitStrip.tsx
+++ b/packages/client/src/SplitStrip.tsx
@@ -28,7 +28,7 @@ const SplitStrip: Component<SplitStripProps> = (props) => {
       aria-label={
         isCollapsed()
           ? `${count()} split terminal${count() > 1 ? "s" : ""} (Ctrl+\`)`
-          : "Split terminal"
+          : ACTIONS.createSubTerminal.label
       }
       onClick={props.onClick}
     >

--- a/packages/client/src/WelcomeMoments.tsx
+++ b/packages/client/src/WelcomeMoments.tsx
@@ -228,7 +228,7 @@ const WelcomeMoments: Component<{
                 type="button"
                 data-testid="welcome-run-agents"
                 class="cursor-pointer"
-                title="New terminal"
+                title={ACTIONS.createTerminal.label}
                 onClick={runCreateTerminal}
               >
                 <Kbd>{formatKeybind(advertisedNewTerminalKey)}</Kbd>
@@ -241,7 +241,7 @@ const WelcomeMoments: Component<{
           <MomentShell
             testId="welcome-moment-search"
             emoji="⌕"
-            title="Search everything"
+            title={ACTIONS.commandPalette.label}
             body="One box finds terminals, hosts, and commands — type a branch or machine name, no separate switcher."
             docSlug="switcher"
             trailing={

--- a/packages/client/src/canvas/TileTitleActions.tsx
+++ b/packages/client/src/canvas/TileTitleActions.tsx
@@ -11,6 +11,7 @@
 import { activeArm, sleepingArm } from "@kolu/padi/surface";
 import type { TerminalId } from "kolu-common/surface";
 import { type Component, Show } from "solid-js";
+import { ACTIONS } from "../input/actions";
 import { useRightPanel } from "../right-panel/useRightPanel";
 import { screenshotTerminal } from "../screenshotTerminal";
 import { CONTEXTUAL_TIPS } from "../settings/tips";
@@ -138,7 +139,7 @@ const TileTitleActions: Component<{
             </Show>
           </button>
         </Tip>
-        <Tip label="Find in terminal">
+        <Tip label={ACTIONS.findInTerminal.label}>
           <button
             type="button"
             data-testid="tile-find"
@@ -146,7 +147,7 @@ const TileTitleActions: Component<{
             style={{ color: "var(--color-fg-3, currentColor)" }}
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => onTile(e, () => search.openFor(props.id))}
-            aria-label="Find in terminal"
+            aria-label={ACTIONS.findInTerminal.label}
           >
             <SearchIcon />
           </button>
@@ -159,7 +160,7 @@ const TileTitleActions: Component<{
           onClick={(e) =>
             onTile(e, () => void screenshotTerminal(props.id, meta()))
           }
-          title="Screenshot terminal"
+          title={ACTIONS.screenshotTerminal.label}
           data-testid="screenshot-button"
         >
           <ScreenshotIcon />

--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -76,6 +76,7 @@ import {
   Show,
 } from "solid-js";
 import { createSharedRoot } from "../../createSharedRoot";
+import { ACTIONS } from "../../input/actions";
 import { isPlatformModifier } from "../../input/keyboard";
 import { IntentMarkdownInline } from "../../intent/IntentMarkdown";
 import { annotationLine } from "../../intent/text";
@@ -444,8 +445,8 @@ const DockHeader: Component<{
         data-testid="dock-new"
         onClick={props.onCreate}
         class="group/new flex items-center justify-center w-6 h-6 rounded-md cursor-pointer text-fg-3 hover:text-fg hover:bg-surface-2/70 active:bg-surface-2 transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/50"
-        aria-label="New terminal"
-        title="New terminal"
+        aria-label={ACTIONS.createTerminal.label}
+        title={ACTIONS.createTerminal.label}
       >
         <PlusIcon class="w-3.5 h-3.5 transition-transform duration-200 group-hover/new:rotate-90" />
       </button>

--- a/packages/client/src/terminal/SubPanelTabBar.tsx
+++ b/packages/client/src/terminal/SubPanelTabBar.tsx
@@ -4,6 +4,7 @@ import type { TerminalMetadata } from "@kolu/padi/surface";
 import { cwdBasename } from "kolu-common/path";
 import type { TerminalId } from "kolu-common/surface";
 import { type Component, For, Show } from "solid-js";
+import { ACTIONS } from "../input/actions";
 import { IntentMarkdownInline } from "../intent/IntentMarkdown";
 import { annotationLine } from "../intent/text";
 import LiveActivityDot from "./LiveActivityDot";
@@ -79,7 +80,7 @@ const SubPanelTabBar: Component<{
         type="button"
         class="px-2 py-1 text-fg-3 hover:text-fg transition-colors cursor-pointer"
         onClick={props.onCreate}
-        title="Split terminal"
+        title={ACTIONS.createSubTerminal.label}
       >
         +
       </button>


### PR DESCRIPTION
**Every UI surface that shows an action's name now reads it from the `ACTIONS` registry** instead of re-typing the string. `input/actions.ts` is already the single source of truth for chords — the help overlay, palette, tips, and the prohibited-chord test all derive from it — but a handful of call sites still restated the *labels* as literals (`EmptyState` re-typed "New terminal menu" while pulling its chord from the registry one expression over). Renaming an action now propagates everywhere, and a label can no longer silently drift from what the help overlay and palette call the same command.

Nine files, +27/−17, no behavior change: `EmptyState`, `CommandPalette` (the "Search everything…" placeholder), `ChromeBar`, `MobileChromeSheet`, `SplitStrip`, `WelcomeMoments`, `TileTitleActions`, `Dock`, `SubPanelTabBar`. _The palette's deliberate `actionPaletteCommand(..., { name })` re-wordings are intentional overrides and are untouched._

Verified: 909 client unit tests, palette e2e (23 scenarios / 175 steps), typecheck, `just fmt`.

_Generated by Claude Code (model `claude-fable-5`), implemented by Codex (model `gpt-5.6-sol`)._