### PR TITLE
Repitch the landing page for remote terminals

### DIFF
--- a/website/src/content/docs/philosophy.mdx
+++ b/website/src/content/docs/philosophy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Philosophy
-description: "The two principles that shape what kolu is and isn't: agent-agnostic (the terminal is the universal interface, no model wrapped, no CLI locked in) and auto-detected, zero setup (the UI is built by observing what you already do, not by a preferences pane)."
+description: "Why kolu is a terminal and not an editor, and the two principles that follow from it: agent-agnostic (the terminal is the universal interface, no model wrapped, no CLI locked in) and auto-detected, zero setup (the UI is built by observing what you already do, not by a preferences pane)."
 order: 5
 section: Foundations
 koluHero:
@@ -11,9 +11,30 @@ koluHero:
 import CardGrid from "../../components/docs/CardGrid.astro";
 import LinkCard from "../../components/docs/LinkCard.astro";
 
-Two principles shape what kolu is and isn't. Neither is a setting you switch on —
-they're the decisions the rest of the product follows from, and the reason kolu
-looks different from the agent command centers it sits beside.
+Start with a premise about the work itself, then the two principles that follow
+from it. Neither principle is a setting you switch on — they're the decisions the
+rest of the product follows from, and the reason kolu looks different from both
+the editors and the agent command centers it sits beside.
+
+## Why a terminal and not an editor
+
+The IDE is an instrument for typing. Autocomplete, the refactor menu, the inline
+error, the cursor itself — every part of it exists to make a human producing one
+character at a time faster and more accurate. For thirty years that was the right
+thing to optimize, because typing was where the work happened.
+
+It isn't where most of it happens now. When an agent writes the change, the human
+work moves up a level: describing what you want, watching several attempts run at
+once, reading the diffs that come back, deciding what survives. None of that is
+typing. And the agents don't use an editor either — they run in a shell, read
+files, and write files.
+
+So the editor-shaped answer to this era is a fork with a chat panel bolted to the
+side: the old instrument, plus a window onto the new one. Kolu takes the other
+route. The terminal is where the agents already live, so kolu makes *that* the
+workspace — many of them at once, on a canvas, across [as many machines as you
+have](/remote-hosts). Reading code and diffs still matters, so that survives as
+[one tab](/code-tab) rather than as the shape of the whole application.
 
 ## Agent-agnostic
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,16 +25,16 @@ const docCards = [
     copy: 'Open a repo, name a worktree, launch an agent, and read the dock.',
   },
   {
-    title: 'Install as an app',
-    href: '/install-pwa',
-    eyebrow: 'pwa',
-    copy: 'Pin kolu as a desktop/mobile app and unlock badges and notifications.',
+    title: 'Remote hosts',
+    href: '/remote-hosts',
+    eyebrow: 'ssh',
+    copy: 'Put another machine on the canvas over ssh, and switch hosts live with ⌘⇧H.',
   },
   {
     title: 'Remote access',
     href: '/remote-access',
     eyebrow: 'https',
-    copy: 'Reach kolu from another device with a private Tailscale Serve URL.',
+    copy: 'The other direction: reach the kolu app itself from your phone over a private Tailscale URL.',
   },
 ];
 
@@ -42,7 +42,7 @@ const systemNodes = [
   {
     name: 'kolu',
     role: 'browser workspace',
-    copy: 'the canvas, dock, code browser, PWA shell, and everything you look at.',
+    copy: 'the canvas, dock, code browser, PWA shell — real xterm.js tiles, and everything you look at.',
     logo: href('/favicon.svg'),
     href: href('/quickstart'),
     accent: 'primary',
@@ -87,18 +87,19 @@ const systemNodes = [
       </p>
 
       <h1 class="display hero-title">
-        The terminal<br />built for <span>many</span>.<span class="cursor" aria-hidden="true"></span>
+        Many agents.<br />Many <span>machines</span>.<br />One terminal.<span class="cursor" aria-hidden="true"></span>
       </h1>
 
       <p class="hero-kicker mono">
-        Not a chat-UI wrapper.<br />Not an editor fork.<br />A real terminal — just better at scale.
+        Not a chat-UI wrapper.<br />Not an editor fork.<br />The IDE was built for typing — and your agents don't type.
       </p>
 
       <p class="hero-body">
-        Real <span class="mono">xterm.js</span> tiles on an infinite canvas,
-        backed by padi and kaval so the browser can come and go without losing
-        the shells underneath. <span class="mono">claude</span>, <span class="mono">codex</span>,
-        <span class="mono">opencode</span>, <span class="mono">grok</span> — anything you run in a shell runs in kolu.
+        Real terminals on an infinite canvas — and the canvas isn't stuck on one
+        box. Point kolu at another machine over <span class="mono">ssh</span> and the whole
+        workspace moves there: your shells run on it, you browse and diff its files,
+        and closing the laptop doesn't kill any of it. <span class="mono">claude</span>, <span class="mono">codex</span>, <span class="mono">opencode</span>, <span class="mono">grok</span> — anything
+        you run in a shell runs in kolu, on any machine you can reach.
       </p>
 
       <div class="hero-actions">
@@ -112,6 +113,12 @@ const systemNodes = [
           juspay/kolu
         </a>
       </div>
+
+      <p class="hero-aside">
+        <a href={href('/philosophy')}>
+          Why a terminal and not an editor <span aria-hidden="true">→</span>
+        </a>
+      </p>
     </div>
   </section>
 
@@ -164,11 +171,13 @@ const systemNodes = [
     <div class="system-shell">
       <div class="system-intro">
         <p class="eyebrow">the system</p>
-        <h2 class="display-sm">One terminal experience, split at the right owners.</h2>
+        <h2 class="display-sm">Three programs. One set per machine.</h2>
         <p>
-          Kolu is what you use. Padi remembers the workspace on the host. Kaval
-          owns the shells. That split is why the tab, web server, and PTYs can
-          fail or restart on different clocks.
+          Kolu is what you use. Padi remembers the workspace on a host. Kaval
+          owns the shells there. That split is why the tab, web server, and PTYs
+          can fail or restart on different clocks — and why adding a remote
+          machine isn't a special case. It gets its own padi and kaval,
+          provisioned with Nix over ssh: the same stack, one floor down.
         </p>
         <a href={href('/architecture')} class="system-link">
           See the architecture <span aria-hidden="true">→</span>
@@ -265,7 +274,10 @@ const systemNodes = [
   .hero-title {
     margin-top: 1.25rem;
     color: var(--color-ink);
-    font-size: clamp(3rem, 2.1rem + 4vw, 5rem);
+    /* Three lines, so the cap sits below the old two-line 5rem: at
+       line-height .95 this keeps the headline block about the height it
+       was before the third line arrived. */
+    font-size: clamp(2.6rem, 2rem + 3vw, 4.2rem);
   }
   .hero-title span {
     color: var(--color-kolu-primary);
@@ -322,6 +334,22 @@ const systemNodes = [
   .hero-secondary:hover {
     border-color: var(--color-ink-dim);
     background: var(--color-void-raised);
+  }
+  /* The kicker asserts the editor is the wrong shape for this era; this is the
+     one click to where that argument is actually made. Deliberately quieter
+     than the two hero buttons — it's a third path, not a third call to act. */
+  .hero-aside {
+    margin-top: 1.15rem;
+  }
+  .hero-aside a {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--color-ink-muted);
+    text-decoration: none;
+    transition: color 120ms ease;
+  }
+  .hero-aside a:hover {
+    color: var(--color-kolu-primary);
   }
   .demo-section {
     max-width: 82rem;

--- a/website/src/site.ts
+++ b/website/src/site.ts
@@ -10,7 +10,7 @@
  */
 
 export const SITE_DESCRIPTION =
-  "kolu is a terminal system built for scale: a browser workspace backed by padi, the per-host workspace daemon, and kaval, the PTY daemon that keeps shells alive.";
+  "kolu is a browser terminal workspace that spans machines: point it at a box over ssh and the whole canvas runs there — terminals, code, git, agents — backed by padi and kaval on every host.";
 
 export const SITE_TAGLINE = "the best way to run terminals";
 


### PR DESCRIPTION
The home page still sold the 1.0 claim — *many terminals on one machine* — while 2.0 ships terminals on **any machine you can ssh to**. **The hero now leads with machines, and the docs finally argue the editor-vs-terminal case the kicker has always asserted.**

### The pitch, before and after

| | Before | After |
| --- | --- | --- |
| Headline | The terminal built for **many**. | Many agents. Many **machines**. One terminal. |
| Kicker payoff | A real terminal — just better at scale. | The IDE was built for typing — and your agents don't type. |
| Body | `xterm.js` tiles backed by padi and kaval | point kolu at another machine over `ssh` and the whole workspace moves there |
| System section | One terminal experience, split at the right owners. | Three programs. **One set per machine.** |

*"Every machine, one canvas" was the first draft of the headline and got cut: it promises you see all your machines at once, which is the multiplexing design [#951](https://github.com/juspay/kolu/issues/951) spent seven weeks rejecting. Kolu switches hosts, so the headline shouldn't imply otherwise.*

### Two confusable "remote"s, now adjacent

The doc-card row offered **Remote access** (reach the kolu app from your phone over Tailscale) and never mentioned **Remote hosts** (run shells on another box) — so post-2.0 the one card on the page with "remote" in it pointed at the wrong feature. Both now sit side by side, and the Tailscale copy opens with *"The other direction:"* so they disambiguate each other.

> **`Install as an app` lost its home-page card** to make room, rather than wrapping a fifth card onto its own row in a four-column grid. It's still in the docs sidebar — worth a second opinion if the PWA path is more load-bearing than it looks.

### Philosophy earns the kicker's claim

"Not an editor fork" has been on the landing page all along, but nothing in the docs backed it — they argue against chat-UI wrappers and never against editors. Philosophy gets a new opening section, **Why a terminal and not an editor**: the IDE optimizes typing, the human work has moved up a level, the agents don't use one either, and the editor-shaped answer to this era is a fork with a chat panel bolted on. It sits *above* the two existing principles rather than beside them — those are decisions with mechanisms behind them (no agent registry, no preferences pane), while this is the premise they follow from.

The section closes by conceding that reading code and diffs still matters — which is *why* kolu ships a Code tab. Without that, it reads as dismissing editors wholesale, which isn't true of the product. A quiet link under the hero buttons now points at it.

### Copy fixes found along the way

- Astro drops any newline **adjacent to an element boundary**, on either side — so `over\n<span>ssh</span>` rendered as `overssh` and `</span>\nand` as `sshand`. Every inline `<span>` in the hero now shares a source line with the words touching it, and the build output is checked for glued words.
- Hero body traded kolu vocabulary for what a newcomer knows: *the Code tab* → **browse and diff its files**, *session restore* → **closing the laptop doesn't kill any of it**.
- `xterm.js` moved out of the opening sentence into the kolu card in the system section, where implementation detail belongs.
- Headline size cap 5rem → 4.2rem, since it's three lines now.

> **Still to come:** a host-strip still under the hero and a re-recorded demo clip — both need live capture. The existing clip and its *"two agents in two repos"* caption are untouched and still accurate to the footage.

### Try it locally

```sh
nix run github:juspay/kolu/website-rmo
```

_Generated by [`/forge-pr`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5[1m]`)._