### PR TITLE
Advance odu to the juspay/odu#67 head (lazy host-pool validation)

### DIFF
--- a/.agents/skills/odu-mcp/SKILL.md
+++ b/.agents/skills/odu-mcp/SKILL.md
@@ -32,9 +32,11 @@ blocks settle — the test verdict stays the truth).
 Called with **no run live**
 it fails loud (an error mirroring `odu status`, not an empty `settled: false`),
 and an optional `expected_sha` (prefix-matched against the run's `sha7`) refuses
-loud when the live run's commit doesn't match. The `nodes` resource carries the
-same `unposted`. MCP `run` tees coordinator stdout/stderr to
-`.ci/<sha7>/runs/<seq>.log`.
+loud when the live run's commit doesn't match. If the coordinator's socket
+closes before it publishes a terminal frame, the verdict comes from the run's
+finalized record on disk — never green for a run torn down mid-flight. The
+`nodes` resource carries the same `unposted`. MCP `run` tees coordinator
+stdout/stderr to `.ci/<sha7>/runs/<seq>.log`.
 
 `cancel` stops the live run and waits until it's torn down; `run`'s `supersede`
 cancels a run already live here before starting (the "stop this, run the fixed

--- a/.agents/skills/odu/SKILL.md
+++ b/.agents/skills/odu/SKILL.md
@@ -216,8 +216,11 @@ the fanout, but a run that resolves **zero** lanes — no file anywhere, no
 `--host`, no `--platform` — is **refused**, not defaulted to `localhost`
 (juspay/odu#46). `--host PLAT=ADDR` pins one box for the run; run on this
 machine on purpose with `--host PLAT=localhost` or a `"PLAT": "localhost"`
-entry. A mixed pool may list localhost explicitly as a real candidate when
-remotes are busy — still never an implicit fallback.
+entry. A pool must be pure-local or pure-remote: mixing localhost with remotes
+is refused when a run leases that platform, because a lease-exempt localhost
+reads as always-free and starves the busy remotes beside it (juspay/odu#54). A
+mixed pool for a platform the run never leases is nobody's business and does
+not refuse the run (juspay/odu#66).
 
 A lane host needs only **ssh + Nix + outbound https**: the runner ships as
 a Nix closure (`nix copy` → realise on the host), and the source arrives by

--- a/.claude/skills/odu-mcp/SKILL.md
+++ b/.claude/skills/odu-mcp/SKILL.md
@@ -32,9 +32,11 @@ blocks settle — the test verdict stays the truth).
 Called with **no run live**
 it fails loud (an error mirroring `odu status`, not an empty `settled: false`),
 and an optional `expected_sha` (prefix-matched against the run's `sha7`) refuses
-loud when the live run's commit doesn't match. The `nodes` resource carries the
-same `unposted`. MCP `run` tees coordinator stdout/stderr to
-`.ci/<sha7>/runs/<seq>.log`.
+loud when the live run's commit doesn't match. If the coordinator's socket
+closes before it publishes a terminal frame, the verdict comes from the run's
+finalized record on disk — never green for a run torn down mid-flight. The
+`nodes` resource carries the same `unposted`. MCP `run` tees coordinator
+stdout/stderr to `.ci/<sha7>/runs/<seq>.log`.
 
 `cancel` stops the live run and waits until it's torn down; `run`'s `supersede`
 cancels a run already live here before starting (the "stop this, run the fixed

--- a/.claude/skills/odu/SKILL.md
+++ b/.claude/skills/odu/SKILL.md
@@ -216,8 +216,11 @@ the fanout, but a run that resolves **zero** lanes — no file anywhere, no
 `--host`, no `--platform` — is **refused**, not defaulted to `localhost`
 (juspay/odu#46). `--host PLAT=ADDR` pins one box for the run; run on this
 machine on purpose with `--host PLAT=localhost` or a `"PLAT": "localhost"`
-entry. A mixed pool may list localhost explicitly as a real candidate when
-remotes are busy — still never an implicit fallback.
+entry. A pool must be pure-local or pure-remote: mixing localhost with remotes
+is refused when a run leases that platform, because a lease-exempt localhost
+reads as always-free and starves the busy remotes beside it (juspay/odu#54). A
+mixed pool for a platform the run never leases is nobody's business and does
+not refuse the run (juspay/odu#66).
 
 A lane host needs only **ssh + Nix + outbound https**: the runner ships as
 a Nix closure (`nix copy` → realise on the host), and the source arrives by

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-26T01:45:42.058435+00:00'
+generated_at: '2026-07-26T01:50:32.141861+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -145,8 +145,7 @@ dependencies:
 - repo_url: juspay/odu
   name: odu
   host: github.com
-  resolved_commit: 8839fa2a18f2b3962c564101ab9c46733813428e
-  resolved_ref: fix/lazy-pool-validation
+  resolved_commit: 677507d76a71d5f88967ffceb69d7d59379464da
   version: 1.0.0
   package_type: apm_package
   deployed_files:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-25T12:57:40.838031+00:00'
+generated_at: '2026-07-26T01:45:42.058435+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -145,7 +145,8 @@ dependencies:
 - repo_url: juspay/odu
   name: odu
   host: github.com
-  resolved_commit: 04373fc31777555073ec8b6c3052bd67fd46b9c6
+  resolved_commit: 8839fa2a18f2b3962c564101ab9c46733813428e
+  resolved_ref: fix/lazy-pool-validation
   version: 1.0.0
   package_type: apm_package
   deployed_files:
@@ -160,13 +161,13 @@ dependencies:
   - .claude/skills/odu-mcp/bin/serve
   - .claude/skills/odu/SKILL.md
   deployed_file_hashes:
-    .agents/skills/odu-mcp/SKILL.md: sha256:429d55a46af84fb231b47fc95fd65706ea2282ed05b5dc59d2acacba0a3c8765
+    .agents/skills/odu-mcp/SKILL.md: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
     .agents/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .agents/skills/odu/SKILL.md: sha256:494f485abc756acfe504200c64b51605a1535edb266a75b1d47be853d61854a0
-    .claude/skills/odu-mcp/SKILL.md: sha256:429d55a46af84fb231b47fc95fd65706ea2282ed05b5dc59d2acacba0a3c8765
+    .agents/skills/odu/SKILL.md: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
+    .claude/skills/odu-mcp/SKILL.md: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
     .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .claude/skills/odu/SKILL.md: sha256:494f485abc756acfe504200c64b51605a1535edb266a75b1d47be853d61854a0
-  content_hash: sha256:3aa5ce95fc838f61b544a1f1533f2206bf2d1983ff73ce8d2a73eb904707b09a
+    .claude/skills/odu/SKILL.md: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
+  content_hash: sha256:1f178beb2276b91db22cbe6829c47dd65f3c5687dd3ce729d05b91df66449178
 - repo_url: juspay/project-unknown
   name: project-unknown
   host: github.com
@@ -1453,7 +1454,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:429d55a46af84fb231b47fc95fd65706ea2282ed05b5dc59d2acacba0a3c8765
+  content_hash: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
 - kind: project-relative
   target: claude
   value: .claude/skills/odu-mcp/bin/serve
@@ -1471,7 +1472,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:494f485abc756acfe504200c64b51605a1535edb266a75b1d47be853d61854a0
+  content_hash: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel
@@ -2236,7 +2237,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:429d55a46af84fb231b47fc95fd65706ea2282ed05b5dc59d2acacba0a3c8765
+  content_hash: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
 - kind: project-relative
   target: codex
   value: .agents/skills/odu-mcp/bin/serve
@@ -2254,7 +2255,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:494f485abc756acfe504200c64b51605a1535edb266a75b1d47be853d61854a0
+  content_hash: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
 - kind: project-relative
   target: codex
   value: .agents/skills/perfection-review

--- a/apm.yml
+++ b/apm.yml
@@ -39,5 +39,7 @@ dependencies:
     - juspay/skills/skills/pg
     - anthropics/skills/skills/frontend-design
     - juspay/nix-chrome-devtools-mcp
-    - juspay/odu
+    # Temporarily riding the PR branch for juspay/odu#67 (lazy host-pool
+    # validation); drop the `#ref` back to `juspay/odu` once it merges.
+    - juspay/odu#fix/lazy-pool-validation
     - juspay/project-unknown

--- a/apm.yml
+++ b/apm.yml
@@ -39,7 +39,5 @@ dependencies:
     - juspay/skills/skills/pg
     - anthropics/skills/skills/frontend-design
     - juspay/nix-chrome-devtools-mcp
-    # Temporarily riding the PR branch for juspay/odu#67 (lazy host-pool
-    # validation); drop the `#ref` back to `juspay/odu` once it merges.
-    - juspay/odu#fix/lazy-pool-validation
+    - juspay/odu
     - juspay/project-unknown

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -33,10 +33,10 @@
         "owner": "juspay",
         "repo": "odu"
       },
-      "branch": "fix/lazy-pool-validation",
+      "branch": "master",
       "submodules": false,
-      "revision": "8839fa2a18f2b3962c564101ab9c46733813428e",
-      "url": "https://github.com/juspay/odu/archive/8839fa2a18f2b3962c564101ab9c46733813428e.tar.gz",
+      "revision": "677507d76a71d5f88967ffceb69d7d59379464da",
+      "url": "https://github.com/juspay/odu/archive/677507d76a71d5f88967ffceb69d7d59379464da.tar.gz",
       "hash": "sha256-kRdFW76sTBV9JsfSUaTLLM8D3hqB/uTTxBPUQ5LyNLQ="
     },
     "rhai-lsp": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -33,11 +33,11 @@
         "owner": "juspay",
         "repo": "odu"
       },
-      "branch": "master",
+      "branch": "fix/lazy-pool-validation",
       "submodules": false,
-      "revision": "04373fc31777555073ec8b6c3052bd67fd46b9c6",
-      "url": "https://github.com/juspay/odu/archive/04373fc31777555073ec8b6c3052bd67fd46b9c6.tar.gz",
-      "hash": "sha256-5y+mtJlh3Fd3flwqxAJ3rN9bEeYE0PoLWpeQ9GjPX+w="
+      "revision": "8839fa2a18f2b3962c564101ab9c46733813428e",
+      "url": "https://github.com/juspay/odu/archive/8839fa2a18f2b3962c564101ab9c46733813428e.tar.gz",
+      "hash": "sha256-kRdFW76sTBV9JsfSUaTLLM8D3hqB/uTTxBPUQ5LyNLQ="
     },
     "rhai-lsp": {
       "type": "Git",


### PR DESCRIPTION
**Pins odu to `8839fa2` — the head of juspay/odu#67** ("Judge host-pool locality per run, not per hosts file") — in both places Kolu tracks it: the npins entry (`npins/sources.json`, now on branch `fix/lazy-pool-validation`) and the APM dependency (`apm.yml` ref + `apm.lock.yaml`). The APM-managed `odu` / `odu-mcp` skill copies for Claude and Codex were regenerated from that commit.

_This is a temporary branch pin to exercise the PR before it merges upstream — the `apm.yml` entry carries a note to drop the `#fix/lazy-pool-validation` ref back to `juspay/odu` once odu#67 lands, and npins should return to `master` at the same time._

Verified with `just fmt` and `nix build ./ci#odu` (builds clean from the new pin).

_Generated by Claude Code (model `claude-fable-5`)._