### PR TITLE
Two darwin faults behind one red smoke: a pruned spawn-helper and a 104-byte socket path

### DIFF
--- a/.agents/skills/ci/smoke.sh
+++ b/.agents/skills/ci/smoke.sh
@@ -26,7 +26,15 @@ readonly TEARDOWN_QUIET_SEC=2
 KOLU=$(nix build .#default --no-link --print-out-paths)/bin/kolu
 PADI_TUI=$(nix build .#padi-tui --no-link --print-out-paths)/bin/padi-tui
 
-tmp=$(mktemp -d)
+# Anchor the isolated tree at /tmp rather than $TMPDIR. macOS hands every
+# process a per-user TMPDIR ~49 characters deep (/var/folders/xx/<30 chars>/T/),
+# and the daemons put their unix sockets under XDG_RUNTIME_DIR below it:
+# $TMPDIR/tmp.XXXXXXXXXX/runtime/kaval-<16 hex>/pty-host.sock is 108 bytes,
+# past macOS's 104-byte sun_path cap. kaval then cannot bind, exits, and padi
+# is left with no PTY host — so every hosted terminal silently fails to spawn.
+# Production never nests XDG_RUNTIME_DIR that deep, so this would be the
+# harness testing an OS path limit instead of the packaged binary.
+tmp=$(TMPDIR=/tmp mktemp -d)
 log="$tmp/kolu.log"
 runtime="$tmp/runtime"
 mkdir -m 700 "$runtime"
@@ -123,6 +131,13 @@ probe_terminal_node_tools() {
             else
                 echo "hosted terminal never spawned: padi accepted the create but no PTY ran /bin/sh — check node-pty's build/Release artifacts for this platform" >&2
             fi
+            # kaval owns the PTYs, and when it dies its reason lands ONLY in its
+            # own log — the server just reports a generic socket timeout. Print
+            # it here so the failing lane carries the cause, not just the symptom.
+            while IFS= read -r kavalLog; do
+                echo "--- $kavalLog ---" >&2
+                cat "$kavalLog" >&2
+            done < <(find "$runtime" -name 'kaval*.log' -type f -print)
             cat "$logfile" >&2
             return 1
         fi
@@ -249,7 +264,7 @@ echo "shutdown clean"
 # on .#default deliberately: .#koluBin has no fallback and crashes if the var is
 # unset — that's what tests build, so they never traverse this wrapper, and #530
 # /#531's test-isolation guarantee is untouched.
-state_tmp=$(mktemp -d)
+state_tmp=$(TMPDIR=/tmp mktemp -d)  # short base, same sun_path reason as above
 # Resolve symlinks up front: the server echoes back the KOLU_STATE_DIR we pass
 # verbatim, so we compare against the canonical form to stay robust on the darwin
 # lane (macOS $TMPDIR / `/tmp` resolve under /private) — and against a future

--- a/.agents/skills/ci/smoke.sh
+++ b/.agents/skills/ci/smoke.sh
@@ -99,11 +99,17 @@ wait_for_padi_ready() {
 
 probe_terminal_node_tools() {
     local logfile=$1 proc=$2
-    local socket output="$tmp/terminal-node-tools"
+    local socket spawned="$tmp/terminal-spawned" output="$tmp/terminal-node-tools"
     socket=$(find "$runtime" -name padi.sock -type s -print -quit)
+    # Two markers, not one. `spawned` is written before anything can fail, so it
+    # separates the two ways this probe can time out: padi accepting `create`
+    # but never spawning a PTY, versus a PTY that runs but has lost the Node
+    # toolset. Collapsing them into one "could not run the packaged Node
+    # toolset" message sent an investigation after a PATH bug when the real
+    # regression was #1988 pruning node-pty's darwin spawn-helper.
     "$PADI_TUI" create --socket "$socket" -- /bin/sh -c \
-        'for tool in node npm npx corepack; do command -v "$tool" || exit 1; done; printf ok >"$1"' \
-        _ "$output" >/dev/null
+        'printf spawned >"$1"; for tool in node npm npx corepack; do command -v "$tool" || exit 1; done; printf ok >"$2"' \
+        _ "$spawned" "$output" >/dev/null
 
     local deadline=$((SECONDS + STARTUP_TIMEOUT_SEC))
     while kill -0 "$proc" 2>/dev/null; do
@@ -112,7 +118,11 @@ probe_terminal_node_tools() {
             return 0
         fi
         if (( SECONDS >= deadline )); then
-            echo "hosted terminal could not run the packaged Node toolset" >&2
+            if [[ -s "$spawned" ]]; then
+                echo "hosted terminal ran, but node, npm, npx, or corepack is missing from its PATH" >&2
+            else
+                echo "hosted terminal never spawned: padi accepted the create but no PTY ran /bin/sh — check node-pty's build/Release artifacts for this platform" >&2
+            fi
             cat "$logfile" >&2
             return 1
         fi

--- a/.apm/skills/ci/smoke.sh
+++ b/.apm/skills/ci/smoke.sh
@@ -26,7 +26,15 @@ readonly TEARDOWN_QUIET_SEC=2
 KOLU=$(nix build .#default --no-link --print-out-paths)/bin/kolu
 PADI_TUI=$(nix build .#padi-tui --no-link --print-out-paths)/bin/padi-tui
 
-tmp=$(mktemp -d)
+# Anchor the isolated tree at /tmp rather than $TMPDIR. macOS hands every
+# process a per-user TMPDIR ~49 characters deep (/var/folders/xx/<30 chars>/T/),
+# and the daemons put their unix sockets under XDG_RUNTIME_DIR below it:
+# $TMPDIR/tmp.XXXXXXXXXX/runtime/kaval-<16 hex>/pty-host.sock is 108 bytes,
+# past macOS's 104-byte sun_path cap. kaval then cannot bind, exits, and padi
+# is left with no PTY host — so every hosted terminal silently fails to spawn.
+# Production never nests XDG_RUNTIME_DIR that deep, so this would be the
+# harness testing an OS path limit instead of the packaged binary.
+tmp=$(TMPDIR=/tmp mktemp -d)
 log="$tmp/kolu.log"
 runtime="$tmp/runtime"
 mkdir -m 700 "$runtime"
@@ -123,6 +131,13 @@ probe_terminal_node_tools() {
             else
                 echo "hosted terminal never spawned: padi accepted the create but no PTY ran /bin/sh — check node-pty's build/Release artifacts for this platform" >&2
             fi
+            # kaval owns the PTYs, and when it dies its reason lands ONLY in its
+            # own log — the server just reports a generic socket timeout. Print
+            # it here so the failing lane carries the cause, not just the symptom.
+            while IFS= read -r kavalLog; do
+                echo "--- $kavalLog ---" >&2
+                cat "$kavalLog" >&2
+            done < <(find "$runtime" -name 'kaval*.log' -type f -print)
             cat "$logfile" >&2
             return 1
         fi
@@ -249,7 +264,7 @@ echo "shutdown clean"
 # on .#default deliberately: .#koluBin has no fallback and crashes if the var is
 # unset — that's what tests build, so they never traverse this wrapper, and #530
 # /#531's test-isolation guarantee is untouched.
-state_tmp=$(mktemp -d)
+state_tmp=$(TMPDIR=/tmp mktemp -d)  # short base, same sun_path reason as above
 # Resolve symlinks up front: the server echoes back the KOLU_STATE_DIR we pass
 # verbatim, so we compare against the canonical form to stay robust on the darwin
 # lane (macOS $TMPDIR / `/tmp` resolve under /private) — and against a future

--- a/.apm/skills/ci/smoke.sh
+++ b/.apm/skills/ci/smoke.sh
@@ -99,11 +99,17 @@ wait_for_padi_ready() {
 
 probe_terminal_node_tools() {
     local logfile=$1 proc=$2
-    local socket output="$tmp/terminal-node-tools"
+    local socket spawned="$tmp/terminal-spawned" output="$tmp/terminal-node-tools"
     socket=$(find "$runtime" -name padi.sock -type s -print -quit)
+    # Two markers, not one. `spawned` is written before anything can fail, so it
+    # separates the two ways this probe can time out: padi accepting `create`
+    # but never spawning a PTY, versus a PTY that runs but has lost the Node
+    # toolset. Collapsing them into one "could not run the packaged Node
+    # toolset" message sent an investigation after a PATH bug when the real
+    # regression was #1988 pruning node-pty's darwin spawn-helper.
     "$PADI_TUI" create --socket "$socket" -- /bin/sh -c \
-        'for tool in node npm npx corepack; do command -v "$tool" || exit 1; done; printf ok >"$1"' \
-        _ "$output" >/dev/null
+        'printf spawned >"$1"; for tool in node npm npx corepack; do command -v "$tool" || exit 1; done; printf ok >"$2"' \
+        _ "$spawned" "$output" >/dev/null
 
     local deadline=$((SECONDS + STARTUP_TIMEOUT_SEC))
     while kill -0 "$proc" 2>/dev/null; do
@@ -112,7 +118,11 @@ probe_terminal_node_tools() {
             return 0
         fi
         if (( SECONDS >= deadline )); then
-            echo "hosted terminal could not run the packaged Node toolset" >&2
+            if [[ -s "$spawned" ]]; then
+                echo "hosted terminal ran, but node, npm, npx, or corepack is missing from its PATH" >&2
+            else
+                echo "hosted terminal never spawned: padi accepted the create but no PTY ran /bin/sh — check node-pty's build/Release artifacts for this platform" >&2
+            fi
             cat "$logfile" >&2
             return 1
         fi

--- a/.claude/skills/ci/smoke.sh
+++ b/.claude/skills/ci/smoke.sh
@@ -26,7 +26,15 @@ readonly TEARDOWN_QUIET_SEC=2
 KOLU=$(nix build .#default --no-link --print-out-paths)/bin/kolu
 PADI_TUI=$(nix build .#padi-tui --no-link --print-out-paths)/bin/padi-tui
 
-tmp=$(mktemp -d)
+# Anchor the isolated tree at /tmp rather than $TMPDIR. macOS hands every
+# process a per-user TMPDIR ~49 characters deep (/var/folders/xx/<30 chars>/T/),
+# and the daemons put their unix sockets under XDG_RUNTIME_DIR below it:
+# $TMPDIR/tmp.XXXXXXXXXX/runtime/kaval-<16 hex>/pty-host.sock is 108 bytes,
+# past macOS's 104-byte sun_path cap. kaval then cannot bind, exits, and padi
+# is left with no PTY host — so every hosted terminal silently fails to spawn.
+# Production never nests XDG_RUNTIME_DIR that deep, so this would be the
+# harness testing an OS path limit instead of the packaged binary.
+tmp=$(TMPDIR=/tmp mktemp -d)
 log="$tmp/kolu.log"
 runtime="$tmp/runtime"
 mkdir -m 700 "$runtime"
@@ -123,6 +131,13 @@ probe_terminal_node_tools() {
             else
                 echo "hosted terminal never spawned: padi accepted the create but no PTY ran /bin/sh — check node-pty's build/Release artifacts for this platform" >&2
             fi
+            # kaval owns the PTYs, and when it dies its reason lands ONLY in its
+            # own log — the server just reports a generic socket timeout. Print
+            # it here so the failing lane carries the cause, not just the symptom.
+            while IFS= read -r kavalLog; do
+                echo "--- $kavalLog ---" >&2
+                cat "$kavalLog" >&2
+            done < <(find "$runtime" -name 'kaval*.log' -type f -print)
             cat "$logfile" >&2
             return 1
         fi
@@ -249,7 +264,7 @@ echo "shutdown clean"
 # on .#default deliberately: .#koluBin has no fallback and crashes if the var is
 # unset — that's what tests build, so they never traverse this wrapper, and #530
 # /#531's test-isolation guarantee is untouched.
-state_tmp=$(mktemp -d)
+state_tmp=$(TMPDIR=/tmp mktemp -d)  # short base, same sun_path reason as above
 # Resolve symlinks up front: the server echoes back the KOLU_STATE_DIR we pass
 # verbatim, so we compare against the canonical form to stay robust on the darwin
 # lane (macOS $TMPDIR / `/tmp` resolve under /private) — and against a future

--- a/.claude/skills/ci/smoke.sh
+++ b/.claude/skills/ci/smoke.sh
@@ -99,11 +99,17 @@ wait_for_padi_ready() {
 
 probe_terminal_node_tools() {
     local logfile=$1 proc=$2
-    local socket output="$tmp/terminal-node-tools"
+    local socket spawned="$tmp/terminal-spawned" output="$tmp/terminal-node-tools"
     socket=$(find "$runtime" -name padi.sock -type s -print -quit)
+    # Two markers, not one. `spawned` is written before anything can fail, so it
+    # separates the two ways this probe can time out: padi accepting `create`
+    # but never spawning a PTY, versus a PTY that runs but has lost the Node
+    # toolset. Collapsing them into one "could not run the packaged Node
+    # toolset" message sent an investigation after a PATH bug when the real
+    # regression was #1988 pruning node-pty's darwin spawn-helper.
     "$PADI_TUI" create --socket "$socket" -- /bin/sh -c \
-        'for tool in node npm npx corepack; do command -v "$tool" || exit 1; done; printf ok >"$1"' \
-        _ "$output" >/dev/null
+        'printf spawned >"$1"; for tool in node npm npx corepack; do command -v "$tool" || exit 1; done; printf ok >"$2"' \
+        _ "$spawned" "$output" >/dev/null
 
     local deadline=$((SECONDS + STARTUP_TIMEOUT_SEC))
     while kill -0 "$proc" 2>/dev/null; do
@@ -112,7 +118,11 @@ probe_terminal_node_tools() {
             return 0
         fi
         if (( SECONDS >= deadline )); then
-            echo "hosted terminal could not run the packaged Node toolset" >&2
+            if [[ -s "$spawned" ]]; then
+                echo "hosted terminal ran, but node, npm, npx, or corepack is missing from its PATH" >&2
+            else
+                echo "hosted terminal never spawned: padi accepted the create but no PTY ran /bin/sh — check node-pty's build/Release artifacts for this platform" >&2
+            fi
             cat "$logfile" >&2
             return 1
         fi

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-26T13:45:44.367670+00:00'
+generated_at: '2026-07-26T14:04:04.193671+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -444,7 +444,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
+  content_hash: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
 - kind: project-relative
   target: agents
   value: .agents/skills/dev-server
@@ -1039,7 +1039,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
+  content_hash: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
 - kind: project-relative
   target: claude
   value: .claude/skills/code-police
@@ -2606,7 +2606,7 @@ local_deployed_file_hashes:
   .agents/skills/ci/pu/lease.sh: sha256:5e5ca3de9a41d247f5a7be66044cb5811e15c26f9da2127c299f6939db5275ee
   .agents/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
   .agents/skills/ci/pu/report.sh: sha256:2bcce1c13acfd168ed70e0793e49eef5cd051864e4bea7b17833b889e3129bb3
-  .agents/skills/ci/smoke.sh: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
+  .agents/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .agents/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .agents/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
   .agents/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3
@@ -2641,7 +2641,7 @@ local_deployed_file_hashes:
   .claude/skills/ci/SKILL.md: sha256:70223eed689ad27a7ecb0c5e0c2c8cf56a8fb194a1d6b719bb42b59fcd0b5ddc
   .claude/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .claude/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
-  .claude/skills/ci/smoke.sh: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
+  .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .claude/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .claude/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
   .claude/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-26T01:50:32.141861+00:00'
+generated_at: '2026-07-26T13:45:44.367670+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -444,7 +444,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:bf409bab43e701b1a7de178c711bb30e30ce2b0af1a0de61da4fcb222088b3b5
+  content_hash: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
 - kind: project-relative
   target: agents
   value: .agents/skills/dev-server
@@ -1039,7 +1039,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:bf409bab43e701b1a7de178c711bb30e30ce2b0af1a0de61da4fcb222088b3b5
+  content_hash: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
 - kind: project-relative
   target: claude
   value: .claude/skills/code-police
@@ -2606,7 +2606,7 @@ local_deployed_file_hashes:
   .agents/skills/ci/pu/lease.sh: sha256:5e5ca3de9a41d247f5a7be66044cb5811e15c26f9da2127c299f6939db5275ee
   .agents/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
   .agents/skills/ci/pu/report.sh: sha256:2bcce1c13acfd168ed70e0793e49eef5cd051864e4bea7b17833b889e3129bb3
-  .agents/skills/ci/smoke.sh: sha256:bf409bab43e701b1a7de178c711bb30e30ce2b0af1a0de61da4fcb222088b3b5
+  .agents/skills/ci/smoke.sh: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
   .agents/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .agents/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
   .agents/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3
@@ -2641,7 +2641,7 @@ local_deployed_file_hashes:
   .claude/skills/ci/SKILL.md: sha256:70223eed689ad27a7ecb0c5e0c2c8cf56a8fb194a1d6b719bb42b59fcd0b5ddc
   .claude/skills/ci/pu/diagnose.sh: sha256:7e33aa16ca3a8fb4a52aa35d423bbaf014621564da65b718e68a233efbef89b3
   .claude/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
-  .claude/skills/ci/smoke.sh: sha256:bf409bab43e701b1a7de178c711bb30e30ce2b0af1a0de61da4fcb222088b3b5
+  .claude/skills/ci/smoke.sh: sha256:3bf478c999b6f5da19d7a4c86ba042599be3653373cb295aec5180ce14ce5cb3
   .claude/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
   .claude/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
   .claude/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3

--- a/default.nix
+++ b/default.nix
@@ -357,13 +357,31 @@ let
       local pty
       pty=$(echo node-pty@*/node_modules/node-pty)
       local ptyInstance="''${pty%/node_modules/node-pty}"
-      # node-pty only needs its compiled addon at runtime. Preserve that file
-      # while removing node-gyp inputs, including node-addon-api at both places
-      # where pnpm's package-instance layout links it.
-      cp --preserve=mode "$pty/build/Release/pty.node" "$NIX_BUILD_TOP/pty.node"
+      # node-pty loads a fixed set of artifacts out of build/Release at
+      # runtime. Preserve exactly those and drop the rest of the node-gyp
+      # output, along with node-addon-api at both places where pnpm's
+      # package-instance layout links it.
+      #
+      # The set is PLATFORM-SPECIFIC, and getting it wrong fails asymmetrically:
+      # darwin's binding.gyp carries a second `OS=="mac"` target, `spawn-helper`,
+      # which lib/unixTerminal.js exec's for every fork. Pruning it leaves the
+      # addon loadable and the daemon healthy while no hosted terminal can spawn
+      # at all — invisible on linux, which never builds that target. #1988
+      # pruned it and reddened ci::smoke@aarch64-darwin only.
+      local ptyRuntime=(pty.node ${
+        pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isDarwin "spawn-helper"
+      })
+      mkdir -p "$NIX_BUILD_TOP/pty-runtime"
+      # cp fails the build if an expected artifact is missing, so a node-pty
+      # bump that renames one surfaces here rather than at a user's terminal.
+      for artifact in "''${ptyRuntime[@]}"; do
+        cp --preserve=mode "$pty/build/Release/$artifact" "$NIX_BUILD_TOP/pty-runtime/$artifact"
+      done
       rm -rf "$pty/build"
       mkdir -p "$pty/build/Release"
-      cp --preserve=mode "$NIX_BUILD_TOP/pty.node" "$pty/build/Release/pty.node"
+      for artifact in "''${ptyRuntime[@]}"; do
+        cp --preserve=mode "$NIX_BUILD_TOP/pty-runtime/$artifact" "$pty/build/Release/$artifact"
+      done
       rm -rf $pty/prebuilds $pty/third_party $pty/deps $pty/src $pty/scripts \
              "$ptyInstance"/node-addon-api@* "$ptyInstance/node_modules/node-addon-api"
       popd


### PR DESCRIPTION
`ci::smoke@aarch64-darwin` has been red since #1988, reporting *"hosted terminal could not run the packaged Node toolset"*. That message sent the investigation after a PATH bug, and there isn't one — `node`, `npm`, `npx`, and `corepack` all resolve fine. There were **two** unrelated darwin faults hiding behind one misleading sentence, and the lane needs both fixed.

The tell was that a hosted terminal couldn't run *anything*: submitting a bare `/usr/bin/touch $file` through `padi-tui create` returned a terminal id, exited 0, and produced no file, while `padi-tui status` said `no terminals.`

## Bug 1 — the pruned `spawn-helper`

#1988 trimmed node-pty's node-gyp output to a single file:

```bash
cp --preserve=mode "$pty/build/Release/pty.node" "$NIX_BUILD_TOP/pty.node"
rm -rf "$pty/build"
mkdir -p "$pty/build/Release"
cp --preserve=mode "$NIX_BUILD_TOP/pty.node" "$pty/build/Release/pty.node"
```

On darwin that directory holds **two** artifacts. `binding.gyp` carries a second target gated on the platform:

```python
['OS=="mac"', {
  'targets': [ { 'target_name': 'spawn-helper', 'type': 'executable', ... } ]
}]
```

and `lib/unixTerminal.js` exec's it on every fork:

```js
var helperPath = native.dir + '/spawn-helper';
```

`native.dir` resolves `build/Release` first, so on a pruned darwin closure that path no longer exists. Linux never builds the target — which is exactly why one lane stayed green.

It fails quietly at every layer that reports health: `pty.node` still loads and exports `fork`, padi still boots and serves, `create` still returns an id. Only kaval's own log shows it, and only as `"msg":"spawning"` with no matching `"spawned"`.

The fix preserves the platform's whole runtime artifact set instead of one hardcoded filename, and `cp` fails the build when an expected artifact is absent — so a node-pty bump that renames one surfaces in CI rather than at a user's terminal. Cost: one 50 KB executable against #1988's 654 MB saving.

## Bug 2 — macOS's 104-byte `sun_path` cap

With `spawn-helper` restored the lane was still red, for a completely separate reason. The smoke isolates state under `mktemp -d`, and macOS hands every process a per-user `TMPDIR` about 49 characters deep. The daemons put their unix sockets under `XDG_RUNTIME_DIR` below it:

```
/var/folders/xx/<30 chars>/T/tmp.XXXXXXXXXX/runtime/kaval-<16 hex>/pty-host.sock
└──────────────────────── 108 bytes ────────────────────────┘
```

macOS caps `sun_path` at **104**. kaval can't bind, logs `daemon could not bind its socket; exiting`, and dies — leaving padi with no PTY host at all. Linux's 108-byte cap and shallow `/run/user/<uid>` never come close.

Production never nests `XDG_RUNTIME_DIR` that deep, so this was the harness testing an OS path limit rather than the packaged binary. Both isolated trees now anchor at `/tmp`.

The two bugs are independent — verified by running each combination on a real Mac:

| Build | Runtime path | kaval | Outcome |
| --- | --- | --- | --- |
| master | 108 B | can't bind, exits | no PTY host |
| master | short | binds; `spawning`, never `spawned` | no terminal |
| + bug 1 fix | 108 B | can't bind, exits | no PTY host |
| + both fixes | short | `spawning` → `spawned` (pid) | **terminal active** |

## Diagnostics, so the next one costs minutes

Three things conspired to hide a dead PTY host behind a sentence about `$PATH`:

- The probe wrote one marker and blamed the toolset on *any* timeout. It now writes a marker before anything can fail, so "no PTY spawned" and "tools missing from PATH" are separate messages.
- kaval's death reason lands only in kaval's log; the server surfaces a generic 30 s socket timeout and then an *"adopted a surviving daemon"* line that reads like recovery. The smoke now prints any kaval log on failure.
- The 30 s stall itself was a symptom of the dead PTY host, not an unrelated flake.

## Verification

`nix develop -c bash .apm/skills/ci/smoke.sh` on a real `aarch64-darwin` box, at this branch head — exit 0, all three contracts:

```
kolu listening at http://127.0.0.1:53200
/api/health returned 200
hosted terminal retains node, npm, npx, and corepack
shutdown clean
KOLU_STATE_DIR honored: /private/tmp/tmp.OWWez2y7Tc/relocated
```
