### PR TITLE
Stop making every run rediscover how to run vitest

### DIFF
--- a/.agency/do.md
+++ b/.agency/do.md
@@ -12,7 +12,7 @@
 
 ## Test command
 
-Invoke the `/test` skill. It selects relevant `.feature` files from the git diff and runs `just test-quick`.
+Invoke the `/test` skill. It owns **both** lanes: the unit lane (`just test-unit`, or a `--filter`ed `test:unit` / `vitest run` narrowed to the packages the diff touches) and the e2e lane (relevant `.feature` files selected from the git diff, run via `just test-quick`). Its "Unit lane" table is the source of truth for the vitest invocations — read it instead of grepping the `justfile` or a `package.json` for them.
 
 ## CI command
 

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -1,11 +1,27 @@
 ---
 name: test
-description: Run e2e tests relevant to the current changes. Selects `.feature` files based on `git diff`, runs `just test-quick`, and skips e2e when changes are server-only with no UI impact. Triggers on "run tests", "test this", "check if it works", "e2e", "test the changes".
+description: Run this repo's tests scoped to the current changes — the unit lane (`just test-unit` / a `--filter`ed vitest run) and the e2e lane (`.feature` files selected from `git diff`, run via `just test-quick`), plus which lane a diff needs and where it is safe to run. Triggers on "run tests", "test this", "check if it works", "unit tests", "vitest", "e2e", "test the changes".
 ---
 
 # Test
 
-Run e2e tests scoped to the current branch's changes.
+Run tests scoped to the current branch's changes. Two lanes: **unit** (vitest, §Unit lane) and **e2e** (Cucumber + Playwright, §Steps).
+
+## Unit lane — the invocations, so you never re-derive them
+
+Don't go hunting through the `justfile` or a `package.json` for how to run vitest here; these four forms are the whole surface. `pnpm` and `vitest` are **not** on a bare `$PATH` — every form below either is a `just` recipe or must be prefixed with `nix develop -c`.
+
+| Reach | Command |
+| --- | --- |
+| Whole workspace, fork-free | `just test-unit` |
+| One package | `nix develop -c pnpm --filter <pkg> test:unit` |
+| One or more files | `nix develop -c pnpm --filter <pkg> exec vitest run src/foo.test.ts` |
+| Daemon-forking suites (CI / `pu` box **only**) | `just test-daemon` |
+
+- **`<pkg>` is the `name` from that package's own `package.json`, and it is not uniformly `@kolu/…`** — the apps are bare (`kolu-server`, `kolu-client`, `kolu-common`) while the libraries are scoped (`@kolu/surface-remote`). Read the name; don't guess it. `--filter` repeats to span packages: `pnpm --filter kolu-server --filter @kolu/surface-remote test:unit`.
+- **A fresh worktree has no `node_modules`.** `just test-unit` / `just test-daemon` depend on the `install` recipe, so they bootstrap themselves; the two `--filter` forms do **not** — run `just install` once first when `node_modules/` is absent, rather than reading a missing-module error as a broken test.
+- **`just test-daemon` never runs beside a live kolu.** Its suites fork real kaval/padi daemons and PTYs; a workstation run OOM-reaped production kaval in [#1375](https://github.com/juspay/kolu/issues/1375). Apply the same venue gate as step 4 below.
+- Narrow to the packages the diff touches — the whole-workspace run is the fallback, not the default, when you already know which package changed.
 
 ## Steps
 
@@ -13,7 +29,7 @@ Run e2e tests scoped to the current branch's changes.
 2. **Select relevant feature files**: Match changed files to `.feature` files under `packages/tests/features/`. Use file names, component names, and domain knowledge to find the right scenarios.
 3. **Decide whether to run e2e**:
    - If changes touch `packages/client/src/`, `packages/tests/`, or `packages/common/src/` — run the matching feature files.
-   - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
+   - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — the unit lane may suffice; run it with the §Unit lane invocations. Skip e2e if no relevant scenarios exist.
 4. **Decide where it runs — pu box, not locally, whenever production is live.** `just test-quick` builds the client and spawns a server: that is **heavy work**, and it goes on an ephemeral pu box (see `/pu` / `/evidence`) any time `systemctl --user is-active kolu` is `active` (the normal case). A pile-up of local e2e runs OOM-`SIGKILL`ed production `kolu.service` beside this command before — "fast" is not "safe to run beside production." Apply `/dev-server` §0's local-vs-pu venue gate before invoking it, and run locally **only** when production is `inactive` here.
 5. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
 6. **Re-run the feature-scoped suite after *later* commits touching that feature's path — before you push.** A green run at commit N is no evidence about commit N+4: a simplify/police/debate cleanup lands in the same files and nothing re-exercises them. One feature file is ~8 s, far cheaper than a CI cycle, and it is the only thing that catches such a regression locally. In [#1982](https://github.com/juspay/kolu/pull/1982) the ports scenarios were verified at `f199c421`, four cleanup commits followed, and CI became the first thing to exercise the final tree — surfacing a false-green e2e guard as a phantom product bug.

--- a/.apm/skills/test/SKILL.md
+++ b/.apm/skills/test/SKILL.md
@@ -1,11 +1,27 @@
 ---
 name: test
-description: Run e2e tests relevant to the current changes. Selects `.feature` files based on `git diff`, runs `just test-quick`, and skips e2e when changes are server-only with no UI impact. Triggers on "run tests", "test this", "check if it works", "e2e", "test the changes".
+description: Run this repo's tests scoped to the current changes — the unit lane (`just test-unit` / a `--filter`ed vitest run) and the e2e lane (`.feature` files selected from `git diff`, run via `just test-quick`), plus which lane a diff needs and where it is safe to run. Triggers on "run tests", "test this", "check if it works", "unit tests", "vitest", "e2e", "test the changes".
 ---
 
 # Test
 
-Run e2e tests scoped to the current branch's changes.
+Run tests scoped to the current branch's changes. Two lanes: **unit** (vitest, §Unit lane) and **e2e** (Cucumber + Playwright, §Steps).
+
+## Unit lane — the invocations, so you never re-derive them
+
+Don't go hunting through the `justfile` or a `package.json` for how to run vitest here; these four forms are the whole surface. `pnpm` and `vitest` are **not** on a bare `$PATH` — every form below either is a `just` recipe or must be prefixed with `nix develop -c`.
+
+| Reach | Command |
+| --- | --- |
+| Whole workspace, fork-free | `just test-unit` |
+| One package | `nix develop -c pnpm --filter <pkg> test:unit` |
+| One or more files | `nix develop -c pnpm --filter <pkg> exec vitest run src/foo.test.ts` |
+| Daemon-forking suites (CI / `pu` box **only**) | `just test-daemon` |
+
+- **`<pkg>` is the `name` from that package's own `package.json`, and it is not uniformly `@kolu/…`** — the apps are bare (`kolu-server`, `kolu-client`, `kolu-common`) while the libraries are scoped (`@kolu/surface-remote`). Read the name; don't guess it. `--filter` repeats to span packages: `pnpm --filter kolu-server --filter @kolu/surface-remote test:unit`.
+- **A fresh worktree has no `node_modules`.** `just test-unit` / `just test-daemon` depend on the `install` recipe, so they bootstrap themselves; the two `--filter` forms do **not** — run `just install` once first when `node_modules/` is absent, rather than reading a missing-module error as a broken test.
+- **`just test-daemon` never runs beside a live kolu.** Its suites fork real kaval/padi daemons and PTYs; a workstation run OOM-reaped production kaval in [#1375](https://github.com/juspay/kolu/issues/1375). Apply the same venue gate as step 4 below.
+- Narrow to the packages the diff touches — the whole-workspace run is the fallback, not the default, when you already know which package changed.
 
 ## Steps
 
@@ -13,7 +29,7 @@ Run e2e tests scoped to the current branch's changes.
 2. **Select relevant feature files**: Match changed files to `.feature` files under `packages/tests/features/`. Use file names, component names, and domain knowledge to find the right scenarios.
 3. **Decide whether to run e2e**:
    - If changes touch `packages/client/src/`, `packages/tests/`, or `packages/common/src/` — run the matching feature files.
-   - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
+   - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — the unit lane may suffice; run it with the §Unit lane invocations. Skip e2e if no relevant scenarios exist.
 4. **Decide where it runs — pu box, not locally, whenever production is live.** `just test-quick` builds the client and spawns a server: that is **heavy work**, and it goes on an ephemeral pu box (see `/pu` / `/evidence`) any time `systemctl --user is-active kolu` is `active` (the normal case). A pile-up of local e2e runs OOM-`SIGKILL`ed production `kolu.service` beside this command before — "fast" is not "safe to run beside production." Apply `/dev-server` §0's local-vs-pu venue gate before invoking it, and run locally **only** when production is `inactive` here.
 5. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
 6. **Re-run the feature-scoped suite after *later* commits touching that feature's path — before you push.** A green run at commit N is no evidence about commit N+4: a simplify/police/debate cleanup lands in the same files and nothing re-exercises them. One feature file is ~8 s, far cheaper than a CI cycle, and it is the only thing that catches such a regression locally. In [#1982](https://github.com/juspay/kolu/pull/1982) the ports scenarios were verified at `f199c421`, four cleanup commits followed, and CI became the first thing to exercise the final tree — surfacing a false-green e2e guard as a phantom product bug.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,11 +1,27 @@
 ---
 name: test
-description: Run e2e tests relevant to the current changes. Selects `.feature` files based on `git diff`, runs `just test-quick`, and skips e2e when changes are server-only with no UI impact. Triggers on "run tests", "test this", "check if it works", "e2e", "test the changes".
+description: Run this repo's tests scoped to the current changes — the unit lane (`just test-unit` / a `--filter`ed vitest run) and the e2e lane (`.feature` files selected from `git diff`, run via `just test-quick`), plus which lane a diff needs and where it is safe to run. Triggers on "run tests", "test this", "check if it works", "unit tests", "vitest", "e2e", "test the changes".
 ---
 
 # Test
 
-Run e2e tests scoped to the current branch's changes.
+Run tests scoped to the current branch's changes. Two lanes: **unit** (vitest, §Unit lane) and **e2e** (Cucumber + Playwright, §Steps).
+
+## Unit lane — the invocations, so you never re-derive them
+
+Don't go hunting through the `justfile` or a `package.json` for how to run vitest here; these four forms are the whole surface. `pnpm` and `vitest` are **not** on a bare `$PATH` — every form below either is a `just` recipe or must be prefixed with `nix develop -c`.
+
+| Reach | Command |
+| --- | --- |
+| Whole workspace, fork-free | `just test-unit` |
+| One package | `nix develop -c pnpm --filter <pkg> test:unit` |
+| One or more files | `nix develop -c pnpm --filter <pkg> exec vitest run src/foo.test.ts` |
+| Daemon-forking suites (CI / `pu` box **only**) | `just test-daemon` |
+
+- **`<pkg>` is the `name` from that package's own `package.json`, and it is not uniformly `@kolu/…`** — the apps are bare (`kolu-server`, `kolu-client`, `kolu-common`) while the libraries are scoped (`@kolu/surface-remote`). Read the name; don't guess it. `--filter` repeats to span packages: `pnpm --filter kolu-server --filter @kolu/surface-remote test:unit`.
+- **A fresh worktree has no `node_modules`.** `just test-unit` / `just test-daemon` depend on the `install` recipe, so they bootstrap themselves; the two `--filter` forms do **not** — run `just install` once first when `node_modules/` is absent, rather than reading a missing-module error as a broken test.
+- **`just test-daemon` never runs beside a live kolu.** Its suites fork real kaval/padi daemons and PTYs; a workstation run OOM-reaped production kaval in [#1375](https://github.com/juspay/kolu/issues/1375). Apply the same venue gate as step 4 below.
+- Narrow to the packages the diff touches — the whole-workspace run is the fallback, not the default, when you already know which package changed.
 
 ## Steps
 
@@ -13,7 +29,7 @@ Run e2e tests scoped to the current branch's changes.
 2. **Select relevant feature files**: Match changed files to `.feature` files under `packages/tests/features/`. Use file names, component names, and domain knowledge to find the right scenarios.
 3. **Decide whether to run e2e**:
    - If changes touch `packages/client/src/`, `packages/tests/`, or `packages/common/src/` — run the matching feature files.
-   - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — unit tests may suffice. Skip e2e if no relevant scenarios exist.
+   - If changes are purely server-internal (`packages/server/src/` only) with no UI impact — the unit lane may suffice; run it with the §Unit lane invocations. Skip e2e if no relevant scenarios exist.
 4. **Decide where it runs — pu box, not locally, whenever production is live.** `just test-quick` builds the client and spawns a server: that is **heavy work**, and it goes on an ephemeral pu box (see `/pu` / `/evidence`) any time `systemctl --user is-active kolu` is `active` (the normal case). A pile-up of local e2e runs OOM-`SIGKILL`ed production `kolu.service` beside this command before — "fast" is not "safe to run beside production." Apply `/dev-server` §0's local-vs-pu venue gate before invoking it, and run locally **only** when production is `inactive` here.
 5. **Run**: `just test-quick features/foo.feature` (or `just test-quick features/foo.feature:42` for a single scenario).
 6. **Re-run the feature-scoped suite after *later* commits touching that feature's path — before you push.** A green run at commit N is no evidence about commit N+4: a simplify/police/debate cleanup lands in the same files and nothing re-exercises them. One feature file is ~8 s, far cheaper than a CI cycle, and it is the only thing that catches such a regression locally. In [#1982](https://github.com/juspay/kolu/pull/1982) the ports scenarios were verified at `f199c421`, four cleanup commits followed, and CI became the first thing to exercise the final tree — surfacing a false-green e2e guard as a phantom product bug.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-26T14:04:04.193671+00:00'
+generated_at: '2026-07-26T22:22:18.662919+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -69,7 +69,7 @@ dependencies:
     .agents/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .agents/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .agents/skills/be-review/SKILL.md: sha256:254f4aa6e1aa0bd9b2a5d5e8a6cc8e15238f1cec0266bfcf6c94ce3c6c48cde5
+    .agents/skills/be-review/SKILL.md: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
     .agents/skills/be/SKILL.md: sha256:43a343aeee556da0051d3066ad20a5e97c58d4d8d1de6d94f75000b2ced058f5
     .agents/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -79,7 +79,7 @@ dependencies:
     .agents/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .agents/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .agents/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
-    .agents/skills/lens-debate/SKILL.md: sha256:831fa9c049e0bd12ac5a432f488369c9655ff0e0b92fb014bfcab0728461bd6d
+    .agents/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .agents/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
     .claude/skills/agent-debate/ANSWER.md: sha256:47456419d24ab041d69dd85ddfb1d640fa8a26410eba24f2f6a7715276900b52
@@ -87,7 +87,7 @@ dependencies:
     .claude/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .claude/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .claude/skills/be-review/SKILL.md: sha256:254f4aa6e1aa0bd9b2a5d5e8a6cc8e15238f1cec0266bfcf6c94ce3c6c48cde5
+    .claude/skills/be-review/SKILL.md: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
     .claude/skills/be/SKILL.md: sha256:43a343aeee556da0051d3066ad20a5e97c58d4d8d1de6d94f75000b2ced058f5
     .claude/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -97,7 +97,7 @@ dependencies:
     .claude/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .claude/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .claude/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
-    .claude/skills/lens-debate/SKILL.md: sha256:831fa9c049e0bd12ac5a432f488369c9655ff0e0b92fb014bfcab0728461bd6d
+    .claude/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
     .claude/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
   source: local
@@ -606,7 +606,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:8f77c0022d5ccc9bed9a63fb10b589500ee52c433077ecaa0bf9e6397a514423
+  content_hash: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c
 - kind: project-relative
   target: claude
   value: .claude/agents/hickey.md
@@ -922,7 +922,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:254f4aa6e1aa0bd9b2a5d5e8a6cc8e15238f1cec0266bfcf6c94ce3c6c48cde5
+  content_hash: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
 - kind: project-relative
   target: claude
   value: .claude/skills/be/SKILL.md
@@ -1345,7 +1345,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:831fa9c049e0bd12ac5a432f488369c9655ff0e0b92fb014bfcab0728461bd6d
+  content_hash: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
 - kind: project-relative
   target: claude
   value: .claude/skills/lowy
@@ -1714,7 +1714,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:8f77c0022d5ccc9bed9a63fb10b589500ee52c433077ecaa0bf9e6397a514423
+  content_hash: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c
 - kind: project-relative
   target: codex
   value: .agents/skills/agent-debate
@@ -1804,7 +1804,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:254f4aa6e1aa0bd9b2a5d5e8a6cc8e15238f1cec0266bfcf6c94ce3c6c48cde5
+  content_hash: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
 - kind: project-relative
   target: codex
   value: .agents/skills/be/SKILL.md
@@ -2128,7 +2128,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:831fa9c049e0bd12ac5a432f488369c9655ff0e0b92fb014bfcab0728461bd6d
+  content_hash: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
 - kind: project-relative
   target: codex
   value: .agents/skills/lowy
@@ -2615,7 +2615,7 @@ local_deployed_file_hashes:
   .agents/skills/release/SKILL.md: sha256:a4c722541155db92ed871dfc5e5192d23092df8ff4f3ec29a9c1906e5cd48f92
   .agents/skills/remote-host-testing/SKILL.md: sha256:2f57f20805195cef801120f374232b8522af3407efa5795d2dfb7fa3964019f4
   .agents/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
-  .agents/skills/test/SKILL.md: sha256:8f77c0022d5ccc9bed9a63fb10b589500ee52c433077ecaa0bf9e6397a514423
+  .agents/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c
   .claude/commands/whatchanged.md: sha256:283ce7bfddb6213172b2a89259c2b89b65d063c6f1d156dd6ee2b98760183f69
   .claude/rules/apm-sources.md: sha256:90626875e2a63e5658f0b5e77524c9c4f949f4ce890bd1f1ce9a2663d4fc8ea7
   .claude/rules/apm-workflow.md: sha256:6abe84e95e791a26c0667f59f58efd98fc0555175c3c4d68d1bd98bbdab97b46
@@ -2650,4 +2650,4 @@ local_deployed_file_hashes:
   .claude/skills/release/SKILL.md: sha256:a4c722541155db92ed871dfc5e5192d23092df8ff4f3ec29a9c1906e5cd48f92
   .claude/skills/remote-host-testing/SKILL.md: sha256:2f57f20805195cef801120f374232b8522af3407efa5795d2dfb7fa3964019f4
   .claude/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
-  .claude/skills/test/SKILL.md: sha256:8f77c0022d5ccc9bed9a63fb10b589500ee52c433077ecaa0bf9e6397a514423
+  .claude/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c


### PR DESCRIPTION
`just test-unit` exists. It has an `install` dependency so it works in a cold worktree, it is fork-free so it is safe beside a live kolu, and it appears **nowhere in the agent-facing instruction corpus** — not in `.apm/`, `agents/.apm/`, `.agency/`, `.claude/rules/`, or `CLAUDE.md`. Its only home is `docs/development.md`, a human doc no skill points at. So **every run that decides "unit tests will do" re-derives the invocation from scratch**, and the `/test` skill — the thing an agent loads when it thinks "run tests" — was e2e-only, with step 3 saying "unit tests may suffice" and naming no command.

Mined from [#2003](https://github.com/juspay/kolu/pull/2003)'s session, where that rediscovery cost six exploratory bash calls and three outright failures before landing on the working form:

| # | call | outcome |
| --- | --- | --- |
| 1 | `pnpm vitest run packages/…` | `pnpm` isn't on a bare `$PATH` |
| 2–3 | `grep vitest justfile`, `sed -n '140,150p' justfile` | hunting for the recipe |
| 4 | `cd packages/surface-remote && nix develop -c pnpm exec vitest …` | failed |
| 5–6 | `ls -d node_modules` → absent → `just install` | cold worktree |
| 7 | `cd packages/surface-remote && nix develop /abs/path -c …` | failed — already `cd`'d |
| 8 | `nix develop -c pnpm --filter @kolu/surface-remote exec vitest run …` | ✅ |

Not a one-off: **11 of the 60 most recent transcripts** contain the same hunt (a bash call grepping a `justfile` or `package.json` for `vitest` / `test:unit`).

### The fix

`.apm/skills/test/SKILL.md` gains a **Unit lane** section ahead of the e2e steps — a four-row table (workspace · one package · one file · daemon-forking suites) plus the three traps the transcript actually hit:

- **the package name is not uniformly `@kolu/…`** — apps are bare (`kolu-server`, `kolu-client`), libraries are scoped (`@kolu/surface-remote`); read the `name` field, don't guess it
- **`just test-unit` / `just test-daemon` carry the `install` dep, the `--filter` forms don't** — so a cold worktree needs `just install` once, and a missing-module error isn't a broken test
- **`just test-daemon` never runs beside a live kolu** ([#1375](https://github.com/juspay/kolu/issues/1375)), pointing at the same venue gate step 4 already applies to e2e

`.agency/do.md`'s Test section stops describing `/test` as e2e-only and names the skill's table as the source of truth — that file is what `/be` §1 reads for the project's test command.

### Evidence

Both `--filter` forms were run in this worktree before documenting them:

- `nix develop -c pnpm --filter @kolu/surface-remote test:unit` → 30 files, 244 passed / 2 skipped, 8.9s
- `nix develop -c pnpm --filter kolu-client exec vitest run src/host/hostDownCopy.test.ts` → 1 file, 3 passed, 280ms

`just ai::apm` regenerated `.claude/` + `.agents/`, then `just fmt` and `just check` (exit 0).

> The `apm.lock.yaml` diff also refreshes `be-review` and `lens-debate` hashes. That drift is **pre-existing on master** — those source files are unchanged here; their lock entries were simply committed stale. The regen step corrects them as a side effect.

### What did *not* meet the bar

Three other frictions from the same session were single-hit and are left as observations rather than edits: an explicit "CI localhost only" that `/ci`'s mandatory two-platform rule correctly superseded (the agent announced the supersede, so no silent substitution); one mid-run stall where the agent stopped after §2 claiming "as asked" when nothing had asked; and three relative-path bash failures downstream of a single `cd`.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5[1m]`)._