### PR TITLE
Fix the second-click crash: stale <Show> reads made unspellable in the URL card

### DIFF
--- a/packages/client/src/terminal/PrintedUrlCard.dismiss.test.tsx
+++ b/packages/client/src/terminal/PrintedUrlCard.dismiss.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+/**
+ * The second click on a printed URL crashed production: with a card already
+ * open, the document-level mousedown dismiss flips the mount's <Show> in the
+ * same synchronous cascade that still-mounted children are reading through —
+ * Solid's "Stale read from <Show>". The class, not the instance, is what this
+ * pins: every accessor-children (<Show>/<Match> non-keyed function form) along
+ * the card's path must be keyed, so a stale read is unspellable.
+ */
+
+import { render } from "solid-js/web";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../wire", () => ({
+  activeHost: () => ({ kind: "local" as const }),
+}));
+vi.mock("../useServerIdentity", () => ({
+  useServerIdentity: () => ({ hostname: () => "pureintent" }),
+}));
+vi.mock("./useTerminalStore", () => ({
+  useTerminalStore: () => ({
+    getTilePaneIds: () => [],
+    getMetadata: () => undefined,
+  }),
+}));
+vi.mock("../forwards/useForwards", () => ({
+  forwardsForHost: () => [],
+  viewerHost: () => null,
+}));
+vi.mock("../kaval/useDaemonStatus", () => ({
+  isActiveHostLocal: () => true,
+}));
+vi.mock("../forwards/openPort", () => ({
+  urlForPort: () => ({ kind: "none" as const }),
+  ensureDoor: () => Promise.resolve(0),
+}));
+vi.mock("./handleWebLink", () => ({
+  openRawUrl: vi.fn(),
+}));
+vi.mock(import("@kolu/padi/surface"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, activeArm: () => undefined };
+});
+
+const { PrintedUrlCardMount } = await import("./PrintedUrlCard");
+const { openPrintedUrlCard, closePrintedUrlCard } = await import(
+  "./printedUrlCardState"
+);
+
+let dispose: (() => void) | undefined;
+let host: HTMLElement | undefined;
+
+afterEach(() => {
+  closePrintedUrlCard();
+  dispose?.();
+  host?.remove();
+  dispose = undefined;
+  host = undefined;
+});
+
+const target = {
+  terminalId: "t-1" as never,
+  uri: "http://localhost:5173/",
+  port: 5173,
+  protocol: "http:" as const,
+  pathname: "/",
+  search: "",
+  hash: "",
+  x: 40,
+  y: 40,
+};
+
+describe("printed-URL card dismissal", () => {
+  it("survives an outside mousedown while open (the second-click crash)", () => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+
+    // The REAL mount — the same component Terminal renders.
+    dispose = render(
+      () => <PrintedUrlCardMount terminalId={target.terminalId} />,
+      host,
+    );
+
+    openPrintedUrlCard(target);
+    expect(document.querySelector("[data-testid=printed-url-card]")).not.toBe(
+      null,
+    );
+
+    // Second click on the link: the document mousedown fires first (outside
+    // the card panel) and dismisses — this is the cascade that threw in
+    // production.
+    const boom = () => {
+      document.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true }),
+      );
+    };
+    expect(boom).not.toThrow();
+    expect(document.querySelector("[data-testid=printed-url-card]")).toBe(null);
+  });
+});

--- a/packages/client/src/terminal/PrintedUrlCard.tsx
+++ b/packages/client/src/terminal/PrintedUrlCard.tsx
@@ -10,6 +10,7 @@
 import { activeArm } from "@kolu/padi/surface";
 import { parseLoopbackUrl } from "@kolu/url-shape";
 import { portReach } from "kolu-common/surface";
+import type { TerminalId } from "kolu-common/surface";
 import {
   type Component,
   createEffect,
@@ -91,12 +92,17 @@ export const PrintedUrlCard: Component<{ target: PrintedUrlCardTarget }> = (
     ),
   );
 
-  const join = createMemo(() =>
-    joinPrintedUrl({
-      uri: props.target.uri,
-      observation: observation(),
-      forwards: forwardsForHost(host()),
-    }),
+  const join = createMemo(
+    () =>
+      joinPrintedUrl({
+        uri: props.target.uri,
+        observation: observation(),
+        forwards: forwardsForHost(host()),
+      }),
+    undefined,
+    // Structural equality: the keyed <Match> below re-creates its children on
+    // every identity change, so a no-op scan tick must not re-key the card.
+    { equals: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
   );
 
   const viewerOnHost = createMemo(() => {
@@ -311,12 +317,14 @@ export const PrintedUrlCard: Component<{ target: PrintedUrlCardTarget }> = (
         }}
       >
         <Switch>
-          <Match when={join().kind === "joined" ? join() : undefined}>
+          <Match keyed when={join().kind === "joined" ? join() : undefined}>
             {(j) => {
+              // `keyed`: `j` is the VALUE at branch entry — a stale accessor
+              // read is unspellable. The join memo's structural equality keeps
+              // re-keying to real content changes only.
               const joined = () => {
-                const v = j();
-                if (v.kind !== "joined") throw new Error("unreachable");
-                return v;
+                if (j.kind !== "joined") throw new Error("unreachable");
+                return j;
               };
               const action = () => actionForJoined();
               const primaryLabel = () => {
@@ -408,7 +416,7 @@ export const PrintedUrlCard: Component<{ target: PrintedUrlCardTarget }> = (
                   </div>
                   <p class="text-fg-3 text-[11px] mb-2">{prose()}</p>
                   <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-                    <Show when={primaryLabel()}>
+                    <Show keyed when={primaryLabel()}>
                       {(label) => (
                         <button
                           type="button"
@@ -417,11 +425,11 @@ export const PrintedUrlCard: Component<{ target: PrintedUrlCardTarget }> = (
                           disabled={busy()}
                           onClick={() => void forwardAndOpen()}
                         >
-                          {label()}
+                          {label}
                         </button>
                       )}
                     </Show>
-                    <Show when={copyLabel()}>
+                    <Show keyed when={copyLabel()}>
                       {(label) => (
                         <button
                           type="button"
@@ -430,7 +438,7 @@ export const PrintedUrlCard: Component<{ target: PrintedUrlCardTarget }> = (
                           disabled={busy()}
                           onClick={() => void copyDoorUrl()}
                         >
-                          {label()}
+                          {label}
                         </button>
                       )}
                     </Show>
@@ -522,3 +530,22 @@ export const PrintedUrlCard: Component<{ target: PrintedUrlCardTarget }> = (
     </Portal>
   );
 };
+
+/** The card's mount — KEYED, so children receive the target as a VALUE and a
+ *  dismiss mid-cascade cannot produce a stale accessor read (the production
+ *  second-click crash). Terminal renders this; tests render this; there is no
+ *  second copy of the mount pattern to drift. */
+export const PrintedUrlCardMount: Component<{ terminalId: TerminalId }> = (
+  props,
+) => (
+  <Show
+    keyed
+    when={
+      printedUrlCardTarget()?.terminalId === props.terminalId
+        ? printedUrlCardTarget()
+        : undefined
+    }
+  >
+    {(t) => <PrintedUrlCard target={t} />}
+  </Show>
+);

--- a/packages/client/src/terminal/Terminal.tsx
+++ b/packages/client/src/terminal/Terminal.tsx
@@ -61,8 +61,7 @@ import {
   fileRefAtCell,
 } from "./fileRefLinkProvider";
 import { handleWebLink } from "./handleWebLink";
-import { PrintedUrlCard } from "./PrintedUrlCard";
-import { printedUrlCardTarget } from "./printedUrlCardState";
+import { PrintedUrlCardMount } from "./PrintedUrlCard";
 import { deliverScratchPaste } from "./pasteDelivery";
 import { consumeReattachingStream } from "./reattachingStream";
 import ScrollToBottom from "./ScrollToBottom";
@@ -763,15 +762,7 @@ const Terminal: Component<{
       />
       {/* Join card for a printed loopback URL — only while this terminal owns the
        *  open card. Portal-rendered; lives here so App stays a thin shell. */}
-      <Show
-        when={
-          printedUrlCardTarget()?.terminalId === props.terminalId
-            ? printedUrlCardTarget()
-            : undefined
-        }
-      >
-        {(t) => <PrintedUrlCard target={t()} />}
-      </Show>
+      <PrintedUrlCardMount terminalId={props.terminalId} />
     </div>
   );
 };


### PR DESCRIPTION
**Clicking a printed localhost URL twice crashed the client** — `Uncaught Error: Stale read from <Show>` from the document `mousedown` frame. With a card open, the second click's outside-dismiss flips the mount's `<Show>` in the same synchronous cascade that still-mounted children are reading through their non-keyed accessors.

**The fix kills the class, not the instance**: every accessor-children along the card's path is now `keyed` (the Terminal mount, the joined `<Match>`, both action `<Show>`s), so children receive values and a stale read is unspellable. The join memo gains structural equality so keyed re-creation tracks *content*, not identity — a no-op scan tick can't re-key the card. And the mount becomes one exported `PrintedUrlCardMount` that Terminal and the regression test both render — there is no second copy of the pattern to drift.

**Red-first**: the new dismiss test reproduces the exact production error on the unfixed tree (`'Error: Stale read from <Show>.' was thrown`) and passes after. Client suite 1001/1001; `nix build` (typecheck gate included) green.

_Generated by Claude Code (model `claude-fable-5`)._