### PR TITLE
chore(odu): advance odu to master (fe0e0fc) — process trees no longer outlive the run

### DIFF
--- a/.agents/skills/odu-mcp/SKILL.md
+++ b/.agents/skills/odu-mcp/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: false
 
 The agent face of [odu](https://github.com/juspay/odu) — an MCP stdio server
 that re-exposes a live CI run as agent tools (`run`, `node_rerun`,
-`wait_for_settle`, `cancel`, `lease`, `release`) and subscribable resources
+`node_cancel`, `lane_cancel`, `wait_for_settle`, `cancel`, `lease`, `release`) and subscribable resources
 (`surface://streams/nodes`, `surface://collections/logs/{id}`), so Claude Code /
 Codex / opencode / Gemini CLI drive CI with structured calls instead of
 scraping terminal output.
@@ -38,7 +38,9 @@ finalized record on disk — never green for a run torn down mid-flight. The
 `nodes` resource carries the same `unposted`. MCP `run` tees coordinator
 stdout/stderr to `.ci/<sha7>/runs/<seq>.log`.
 
-`cancel` stops the live run and waits until it's torn down; `run`'s `supersede`
+`cancel` stops the live run and waits until it's torn down; `node_cancel` stops
+one node (`ci::fmt@plat`) and `lane_cancel` drops a whole platform while the rest
+of the run settles (status `cancelled`, not `errored`/`failed`). `run`'s `supersede`
 cancels a run already live here before starting (the "stop this, run the fixed
 commit" move), `linger` keeps the coordinator serving past settle so a node can
 be rerun afterwards, and `no_wait` fails immediately when every host in a venue

--- a/.agents/skills/odu/SKILL.md
+++ b/.agents/skills/odu/SKILL.md
@@ -175,6 +175,8 @@ nix run github:juspay/odu -- attach          # live TUI dashboard on a tty
                                              # = transition stream
 nix run github:juspay/odu -- logs -f e2e@x86_64-linux
 nix run github:juspay/odu -- cancel          # stop the live run, cleanly
+nix run github:juspay/odu -- cancel @aarch64-darwin   # drop one platform lane
+nix run github:juspay/odu -- cancel ci::fmt@x86_64-linux  # cancel one node
 nix run github:juspay/odu -- runs            # durable history (flags unposted statuses)
 ```
 
@@ -182,13 +184,16 @@ No run in progress ⇒ exit non-zero with `no run in progress in this
 checkout (no live socket at .ci/odu.sock)`. One run per checkout — a
 second `odu run` refuses while the socket is live.
 
-**Cancel / supersede / linger.** `odu cancel` drives the live run's teardown
+**Cancel / supersede / linger.** Bare `odu cancel` drives the live run's teardown
 from a second process (finalize posted statuses, close lanes, drop the socket)
 and waits until it's gone — no need to wait out a doomed run or `pkill` the
-coordinator. `odu run --supersede` cancels whatever's live here first, then
-starts ("stop this, run the fixed commit"). By default a run exits the instant
-it drains; `odu run --linger` keeps it serving past settle so a node can be
-rerun later (retry a flake), self-reaping after an idle period or on `cancel`.
+coordinator. `odu cancel <node>` or `odu cancel @<platform>` cancels only that
+node or lane (`cancelled` status, not red) and leaves the rest of the run
+settling — MCP twins `node_cancel` / `lane_cancel`. `odu run --supersede` cancels whatever's live
+here first, then starts ("stop this, run the fixed commit"). By default a run
+exits the instant it drains; `odu run --linger` keeps it serving past settle so a
+node can be rerun later (retry a flake), self-reaping after an idle period or on
+`cancel`.
 
 ## Hosts config
 

--- a/.claude/skills/odu-mcp/SKILL.md
+++ b/.claude/skills/odu-mcp/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: false
 
 The agent face of [odu](https://github.com/juspay/odu) — an MCP stdio server
 that re-exposes a live CI run as agent tools (`run`, `node_rerun`,
-`wait_for_settle`, `cancel`, `lease`, `release`) and subscribable resources
+`node_cancel`, `lane_cancel`, `wait_for_settle`, `cancel`, `lease`, `release`) and subscribable resources
 (`surface://streams/nodes`, `surface://collections/logs/{id}`), so Claude Code /
 Codex / opencode / Gemini CLI drive CI with structured calls instead of
 scraping terminal output.
@@ -38,7 +38,9 @@ finalized record on disk — never green for a run torn down mid-flight. The
 `nodes` resource carries the same `unposted`. MCP `run` tees coordinator
 stdout/stderr to `.ci/<sha7>/runs/<seq>.log`.
 
-`cancel` stops the live run and waits until it's torn down; `run`'s `supersede`
+`cancel` stops the live run and waits until it's torn down; `node_cancel` stops
+one node (`ci::fmt@plat`) and `lane_cancel` drops a whole platform while the rest
+of the run settles (status `cancelled`, not `errored`/`failed`). `run`'s `supersede`
 cancels a run already live here before starting (the "stop this, run the fixed
 commit" move), `linger` keeps the coordinator serving past settle so a node can
 be rerun afterwards, and `no_wait` fails immediately when every host in a venue

--- a/.claude/skills/odu/SKILL.md
+++ b/.claude/skills/odu/SKILL.md
@@ -175,6 +175,8 @@ nix run github:juspay/odu -- attach          # live TUI dashboard on a tty
                                              # = transition stream
 nix run github:juspay/odu -- logs -f e2e@x86_64-linux
 nix run github:juspay/odu -- cancel          # stop the live run, cleanly
+nix run github:juspay/odu -- cancel @aarch64-darwin   # drop one platform lane
+nix run github:juspay/odu -- cancel ci::fmt@x86_64-linux  # cancel one node
 nix run github:juspay/odu -- runs            # durable history (flags unposted statuses)
 ```
 
@@ -182,13 +184,16 @@ No run in progress ⇒ exit non-zero with `no run in progress in this
 checkout (no live socket at .ci/odu.sock)`. One run per checkout — a
 second `odu run` refuses while the socket is live.
 
-**Cancel / supersede / linger.** `odu cancel` drives the live run's teardown
+**Cancel / supersede / linger.** Bare `odu cancel` drives the live run's teardown
 from a second process (finalize posted statuses, close lanes, drop the socket)
 and waits until it's gone — no need to wait out a doomed run or `pkill` the
-coordinator. `odu run --supersede` cancels whatever's live here first, then
-starts ("stop this, run the fixed commit"). By default a run exits the instant
-it drains; `odu run --linger` keeps it serving past settle so a node can be
-rerun later (retry a flake), self-reaping after an idle period or on `cancel`.
+coordinator. `odu cancel <node>` or `odu cancel @<platform>` cancels only that
+node or lane (`cancelled` status, not red) and leaves the rest of the run
+settling — MCP twins `node_cancel` / `lane_cancel`. `odu run --supersede` cancels whatever's live
+here first, then starts ("stop this, run the fixed commit"). By default a run
+exits the instant it drains; `odu run --linger` keeps it serving past settle so a
+node can be rerun later (retry a flake), self-reaping after an idle period or on
+`cancel`.
 
 ## Hosts config
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -145,7 +145,7 @@ dependencies:
 - repo_url: juspay/odu
   name: odu
   host: github.com
-  resolved_commit: 677507d76a71d5f88967ffceb69d7d59379464da
+  resolved_commit: fe0e0fc21ff639974868d410ce8d9421fdfaa467
   version: 1.0.0
   package_type: apm_package
   deployed_files:
@@ -160,13 +160,13 @@ dependencies:
   - .claude/skills/odu-mcp/bin/serve
   - .claude/skills/odu/SKILL.md
   deployed_file_hashes:
-    .agents/skills/odu-mcp/SKILL.md: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
+    .agents/skills/odu-mcp/SKILL.md: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
     .agents/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .agents/skills/odu/SKILL.md: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
-    .claude/skills/odu-mcp/SKILL.md: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
+    .agents/skills/odu/SKILL.md: sha256:0ebfc14cbeaa2846b718db303758738d0c3dd57f98b24c3974ac7fbdc4d9fd2e
+    .claude/skills/odu-mcp/SKILL.md: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
     .claude/skills/odu-mcp/bin/serve: sha256:6152e8fc4d3478b70a5cd547c172be596787e600b5757233fb82b307186b9e26
-    .claude/skills/odu/SKILL.md: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
-  content_hash: sha256:1f178beb2276b91db22cbe6829c47dd65f3c5687dd3ce729d05b91df66449178
+    .claude/skills/odu/SKILL.md: sha256:0ebfc14cbeaa2846b718db303758738d0c3dd57f98b24c3974ac7fbdc4d9fd2e
+  content_hash: sha256:a08f8496dbb9000c55eb75082b32657562bdd7284d114e53429ecc3ee4cf2f43
 - repo_url: juspay/project-unknown
   name: project-unknown
   host: github.com
@@ -1453,7 +1453,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
+  content_hash: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
 - kind: project-relative
   target: claude
   value: .claude/skills/odu-mcp/bin/serve
@@ -1471,7 +1471,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
+  content_hash: sha256:0ebfc14cbeaa2846b718db303758738d0c3dd57f98b24c3974ac7fbdc4d9fd2e
 - kind: project-relative
   target: claude
   value: .claude/skills/parcel
@@ -2236,7 +2236,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:23caaeb1a648a1cf7fd18fa025e18cca231f3f7cf0205714b5b8af9a43065c11
+  content_hash: sha256:e78f8a99ac11428b71ca40f8bdb7f68b0e508266458d6077d74e916bc655788d
 - kind: project-relative
   target: codex
   value: .agents/skills/odu-mcp/bin/serve
@@ -2254,7 +2254,7 @@ deployments:
   owners:
   - juspay/odu
   active_owner: juspay/odu
-  content_hash: sha256:7fab2d6c20f311549f2cd4b018383cf3317e860ed936f59eea1cad899f10bc50
+  content_hash: sha256:0ebfc14cbeaa2846b718db303758738d0c3dd57f98b24c3974ac7fbdc4d9fd2e
 - kind: project-relative
   target: codex
   value: .agents/skills/perfection-review

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -35,9 +35,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "677507d76a71d5f88967ffceb69d7d59379464da",
-      "url": "https://github.com/juspay/odu/archive/677507d76a71d5f88967ffceb69d7d59379464da.tar.gz",
-      "hash": "sha256-kRdFW76sTBV9JsfSUaTLLM8D3hqB/uTTxBPUQ5LyNLQ="
+      "revision": "fe0e0fc21ff639974868d410ce8d9421fdfaa467",
+      "url": "https://github.com/juspay/odu/archive/fe0e0fc21ff639974868d410ce8d9421fdfaa467.tar.gz",
+      "hash": "sha256-WDDyTtCqMVTYonUITjCcE217fLGJuu13GcnRE3IyywI="
     },
     "rhai-lsp": {
       "type": "Git",


### PR DESCRIPTION
## What this bumps

Advances odu on **both** pin surfaces kolu tracks it by:

| Surface | File | Old | New |
| --- | --- | --- | --- |
| npins (feeds `ci/flake.nix`'s `nix run ./ci#odu`) | `npins/sources.json` | `677507d` | `fe0e0fc` |
| apm (vendors the `odu`/`odu-mcp` skills) | `apm.yml` dep / `apm.lock.yaml` `resolved_commit` | `677507d` | `fe0e0fc` |

Both surfaces now resolve to the **same commit**, `fe0e0fc21ff639974868d410ce8d9421fdfaa467` — current odu master (`git ls-remote` confirmed). `just ai::apm-update juspay/odu` regenerated the `.claude/skills/odu{,-mcp}` and `.agents/skills/odu{,-mcp}` copies from it.

## Why

`fe0e0fc` is [juspay/odu#70](https://github.com/juspay/odu/pull/70), "recipe process trees no longer outlive the run" — this is the fix for the orphaned qemu/pnpm/vitest processes observed leaking on the kolu CI pool (ppid-1 orphans surviving a killed/aborted run). It closes four teardown holes where a recipe's detached process group outlived the runner:

1. The localhost-lane teardown SIGTERMs the runner directly; with no signal handler installed, the process died by default disposition and every running recipe group reparented to init.
2. `node.cancel` / `node.rerun` sent one SIGTERM and deleted the tracking entry without ever escalating — a tree that ignored SIGTERM leaked invisibly.
3. A stray left behind when the node's direct child exited was never swept.
4. `main().catch`'s fatal exit and venue-lease self-release both called `process.exit()` with no group sweep.

All four now route through one seam, `src/runner/reap.ts`: every spawned group is tracked from birth and torn down via SIGTERM → bounded 2s grace → SIGKILL. No sweeper subcommand, no opt-out flag.

Along the way this also carries [juspay/odu#69](https://github.com/juspay/odu/pull/69) (per-lane cancel — `odu cancel @<platform>` / `node_cancel` / `lane_cancel`), visible in the regenerated skill docs.

## Ledger accounting (juspay/odu#43)

Checked the standing odu-impact ledger for open line items to drain at this bump:

- **kolu#1858** (adoption-opportunity) — already marked drained by its own paired PR; no action here.
- **kolu#1865** (adoption-opportunity — MCP `await`ed tool dispatch, `@kolu/surface/wait`) — explicitly optional adoption, no action required at bump.
- **kolu#1876** (adoption-opportunity — declared `ProcedureSpec.errors`) — additive/optional, nothing breaks at bump.
- **kolu#1884** (breaks-at-bump — `sshConnector`/`dialAgentOnce` now require `localEnv`) — verified against the odu tree at the new pin: `src/coordinator/lane.ts:85` already constructs `localEnv: localhostSpawnEnv()`, so this item is already resolved on odu's side (fixed in a prior odu PR, ahead of this bump).

None of these four items are `breaks-at-bump` against *this* bump direction (kolu's pin of odu, not odu's pin of kolu, which is what the ledger tracks) — nothing outstanding to drain.

## Verification

- `nix build ./ci#odu` — builds clean from the new pin.
- `just check` (typecheck + biome) — green.
- `just fmt` — clean.
- Full two-platform odu CI run — see check status on this PR / follow-up comment.

_Generated by Claude Code (model `claude-sonnet-5`)._
