### PR TITLE
Two skill rules that pointed at things that don't exist

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -53,6 +53,15 @@ comment can reference a local-only commit.
 - **Commit first.** Reviewers review *committed* code — commit/stash any
   outstanding work before starting (in `/be` this is automatic: §2/§3 commit and
   push before §4).
+- **Verify `<base>` is a remote-tracking ref — mechanically, not by eyeballing the
+  diff stat.** A caller's `--base master` names the **local** `master`, which on a
+  long-lived worktree is routinely tens of commits behind origin, so the merge-base
+  lands in the base branch's own past and the "diff" swells with history nobody wrote:
+  one run resolved a base 40 commits stale and handed the reviewers 377 files instead
+  of 9. After `git fetch origin`, run
+  `git -C "$repoPath" rev-parse --verify --quiet "refs/remotes/$base"` — if it fails,
+  retry once as `origin/$base` and use that; if *that* fails too, **stop and say so**
+  rather than resolving a local ref. Never accept a bare branch name as given.
 - **Resolve the scope once.** `git fetch origin`, then
   `MB=$(git merge-base <base> HEAD)` and `START=$(git rev-parse HEAD)`. Pass `MB`
   as the `base` to every step (their own merge-base resolution is idempotent on a

--- a/.agents/skills/evidence/SKILL.md
+++ b/.agents/skills/evidence/SKILL.md
@@ -148,7 +148,7 @@ fit — not as a shortcut past a quick scenario that would do.
 **Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so
 the main context stays clear of capture noise. Brief it with the box name, the branch, whether the
 deliverable is an image or a video, the scenario to record (feature file + exact scenario name) or
-the live state to drive, a `<slug>`, the PR number, and the fixed `pr-evidence` release tag; have it
+the live state to drive, a `<slug>`, the PR number, and the fixed `evidence-assets` release tag; have it
 return only the markdown body it posted.
 
 ## How the harness records (wired in `packages/tests/support/hooks.ts`, gated on `KOLU_EVIDENCE`)
@@ -270,23 +270,28 @@ pu connect "$host" -- 'bash -lc "
 `gh pr comment` can't attach binaries, so copy artifacts back and upload to a long-lived
 GitHub release. (A screenshot from §A is a `.png` — upload and embed it the same way.)
 
-**`pr-evidence` is the one fixed evidence-release tag.** It already exists. Never derive a release
-tag from the PR number or artifact slug, and never create another release. Verify `pr-evidence`
-exists before uploading; if it does not, fail loudly.
+**`evidence-assets` is the one fixed evidence-release tag.** It already exists (a pre-release
+holding every prior PR's artifacts). Never derive a release tag from the PR number or artifact
+slug, and never create another release. Verify `evidence-assets` exists before uploading; if it
+does not, fail loudly.
+
+**The local filename IS the asset name.** `gh release upload` names each asset after the file's
+basename, and the embed URL below is `…/download/evidence-assets/<slug>.png` — so copy back to
+`/tmp/<slug>.png`, not a decorated `/tmp/evidence-<slug>.png`, or every embed 404s.
 
 ```sh
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/evidence-<slug>.gif
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/evidence-<slug>.mp4
-gh release view pr-evidence >/dev/null
-gh release upload pr-evidence /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/<slug>.png
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/<slug>.gif
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/<slug>.mp4
+gh release view evidence-assets >/dev/null
+gh release upload evidence-assets /tmp/<slug>.png /tmp/<slug>.gif /tmp/<slug>.mp4 --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
 
 ```
-![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.png)
-![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.gif)
+![](https://github.com/<OWNER>/<REPO>/releases/download/evidence-assets/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/evidence-assets/<slug>.gif)
 ```
 
 For a **before↔after** comparison, post the two stills side by side (a small two-cell table or two

--- a/.agents/skills/self-improve/SKILL.md
+++ b/.agents/skills/self-improve/SKILL.md
@@ -63,9 +63,13 @@ note's corpus audit.
    skill (most friction is a rule that just wasn't loaded) > sharpen one clause > write a
    new rule or skill, last resort. A **speed** fix routes *independent* work to forked
    subagents or a dynamic workflow — never the serial review gauntlet, which stays
-   sole-editor. The fix lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`,
-   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD). Each edit honors
-   fail-fast / electricity / reuse-source and trips no llm-autonomy anti-pattern.
+   sole-editor. The fix lands in an apm **source** only (`.claude/`, `.agents/`,
+   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD) — and there are
+   **two** source trees, so grep both before concluding a skill isn't apm-managed: root
+   `.apm/skills/*` for this repo's own skills, `agents/.apm/skills/*` for the reusable
+   gauntlet package (`be`, `be-review`, `lens-debate`, `agent-debate`, …). See
+   `.claude/rules/apm-workflow.md`. Each edit honors fail-fast / electricity /
+   reuse-source and trips no llm-autonomy anti-pattern.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh
@@ -78,9 +82,13 @@ note's corpus audit.
    git worktree prune                                               # clear a stale admin entry from a hard-killed prior run (never reuses a live worktree)
    git worktree add -b "$BR" "$WT" "$DEF"                           # NEW branch cut from origin/master — never rides the /be HEAD
    ```
-   Apply the step-4 edit(s) to `$WT/.apm/skills/*`, then **inside `$WT`**: `just ai::apm`
-   (regen `.claude/.agents/.codex/.opencode` + `AGENTS.md` from the sources — generated copies
-   ride the **same** commit as the sources or the runtimes drift), `just fmt`, `just check`.
+   Apply the step-4 edit(s) to the source tree(s) inside `$WT`, then **inside `$WT`**:
+   `just ai::apm` (regen `.claude/.agents/.codex/.opencode` + `AGENTS.md` from the sources —
+   generated copies ride the **same** commit as the sources or the runtimes drift), `just fmt`,
+   `just check`. **An `agents/.apm/**` edit must be `git commit`ted BEFORE `just ai::apm`** —
+   the regen vendors that package from a git checkout, not your working tree, so an uncommitted
+   edit silently regenerates the OLD text with no error. Commit the source, regen, then confirm
+   the new wording actually landed in `.claude/skills/<name>/SKILL.md` before pushing.
    - **Check green** → commit (`chore(skills): …` + a provenance trailer citing `$SID`),
      `git push -u origin HEAD`, and open it **draft** via `/forge-pr` with a per-edit evidence
      ledger. **Never merge, never `--admin`** — the human reviews; merging is what makes the

--- a/.apm/skills/evidence/SKILL.md
+++ b/.apm/skills/evidence/SKILL.md
@@ -148,7 +148,7 @@ fit — not as a shortcut past a quick scenario that would do.
 **Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so
 the main context stays clear of capture noise. Brief it with the box name, the branch, whether the
 deliverable is an image or a video, the scenario to record (feature file + exact scenario name) or
-the live state to drive, a `<slug>`, the PR number, and the fixed `pr-evidence` release tag; have it
+the live state to drive, a `<slug>`, the PR number, and the fixed `evidence-assets` release tag; have it
 return only the markdown body it posted.
 
 ## How the harness records (wired in `packages/tests/support/hooks.ts`, gated on `KOLU_EVIDENCE`)
@@ -270,23 +270,28 @@ pu connect "$host" -- 'bash -lc "
 `gh pr comment` can't attach binaries, so copy artifacts back and upload to a long-lived
 GitHub release. (A screenshot from §A is a `.png` — upload and embed it the same way.)
 
-**`pr-evidence` is the one fixed evidence-release tag.** It already exists. Never derive a release
-tag from the PR number or artifact slug, and never create another release. Verify `pr-evidence`
-exists before uploading; if it does not, fail loudly.
+**`evidence-assets` is the one fixed evidence-release tag.** It already exists (a pre-release
+holding every prior PR's artifacts). Never derive a release tag from the PR number or artifact
+slug, and never create another release. Verify `evidence-assets` exists before uploading; if it
+does not, fail loudly.
+
+**The local filename IS the asset name.** `gh release upload` names each asset after the file's
+basename, and the embed URL below is `…/download/evidence-assets/<slug>.png` — so copy back to
+`/tmp/<slug>.png`, not a decorated `/tmp/evidence-<slug>.png`, or every embed 404s.
 
 ```sh
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/evidence-<slug>.gif
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/evidence-<slug>.mp4
-gh release view pr-evidence >/dev/null
-gh release upload pr-evidence /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/<slug>.png
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/<slug>.gif
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/<slug>.mp4
+gh release view evidence-assets >/dev/null
+gh release upload evidence-assets /tmp/<slug>.png /tmp/<slug>.gif /tmp/<slug>.mp4 --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
 
 ```
-![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.png)
-![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.gif)
+![](https://github.com/<OWNER>/<REPO>/releases/download/evidence-assets/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/evidence-assets/<slug>.gif)
 ```
 
 For a **before↔after** comparison, post the two stills side by side (a small two-cell table or two

--- a/.apm/skills/self-improve/SKILL.md
+++ b/.apm/skills/self-improve/SKILL.md
@@ -63,9 +63,13 @@ note's corpus audit.
    skill (most friction is a rule that just wasn't loaded) > sharpen one clause > write a
    new rule or skill, last resort. A **speed** fix routes *independent* work to forked
    subagents or a dynamic workflow — never the serial review gauntlet, which stays
-   sole-editor. The fix lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`,
-   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD). Each edit honors
-   fail-fast / electricity / reuse-source and trips no llm-autonomy anti-pattern.
+   sole-editor. The fix lands in an apm **source** only (`.claude/`, `.agents/`,
+   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD) — and there are
+   **two** source trees, so grep both before concluding a skill isn't apm-managed: root
+   `.apm/skills/*` for this repo's own skills, `agents/.apm/skills/*` for the reusable
+   gauntlet package (`be`, `be-review`, `lens-debate`, `agent-debate`, …). See
+   `.claude/rules/apm-workflow.md`. Each edit honors fail-fast / electricity /
+   reuse-source and trips no llm-autonomy anti-pattern.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh
@@ -78,9 +82,13 @@ note's corpus audit.
    git worktree prune                                               # clear a stale admin entry from a hard-killed prior run (never reuses a live worktree)
    git worktree add -b "$BR" "$WT" "$DEF"                           # NEW branch cut from origin/master — never rides the /be HEAD
    ```
-   Apply the step-4 edit(s) to `$WT/.apm/skills/*`, then **inside `$WT`**: `just ai::apm`
-   (regen `.claude/.agents/.codex/.opencode` + `AGENTS.md` from the sources — generated copies
-   ride the **same** commit as the sources or the runtimes drift), `just fmt`, `just check`.
+   Apply the step-4 edit(s) to the source tree(s) inside `$WT`, then **inside `$WT`**:
+   `just ai::apm` (regen `.claude/.agents/.codex/.opencode` + `AGENTS.md` from the sources —
+   generated copies ride the **same** commit as the sources or the runtimes drift), `just fmt`,
+   `just check`. **An `agents/.apm/**` edit must be `git commit`ted BEFORE `just ai::apm`** —
+   the regen vendors that package from a git checkout, not your working tree, so an uncommitted
+   edit silently regenerates the OLD text with no error. Commit the source, regen, then confirm
+   the new wording actually landed in `.claude/skills/<name>/SKILL.md` before pushing.
    - **Check green** → commit (`chore(skills): …` + a provenance trailer citing `$SID`),
      `git push -u origin HEAD`, and open it **draft** via `/forge-pr` with a per-edit evidence
      ledger. **Never merge, never `--admin`** — the human reviews; merging is what makes the

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -53,6 +53,15 @@ comment can reference a local-only commit.
 - **Commit first.** Reviewers review *committed* code — commit/stash any
   outstanding work before starting (in `/be` this is automatic: §2/§3 commit and
   push before §4).
+- **Verify `<base>` is a remote-tracking ref — mechanically, not by eyeballing the
+  diff stat.** A caller's `--base master` names the **local** `master`, which on a
+  long-lived worktree is routinely tens of commits behind origin, so the merge-base
+  lands in the base branch's own past and the "diff" swells with history nobody wrote:
+  one run resolved a base 40 commits stale and handed the reviewers 377 files instead
+  of 9. After `git fetch origin`, run
+  `git -C "$repoPath" rev-parse --verify --quiet "refs/remotes/$base"` — if it fails,
+  retry once as `origin/$base` and use that; if *that* fails too, **stop and say so**
+  rather than resolving a local ref. Never accept a bare branch name as given.
 - **Resolve the scope once.** `git fetch origin`, then
   `MB=$(git merge-base <base> HEAD)` and `START=$(git rev-parse HEAD)`. Pass `MB`
   as the `base` to every step (their own merge-base resolution is idempotent on a

--- a/.claude/skills/evidence/SKILL.md
+++ b/.claude/skills/evidence/SKILL.md
@@ -148,7 +148,7 @@ fit — not as a shortcut past a quick scenario that would do.
 **Delegate to a subagent** (`Agent(subagent_type="general-purpose", model="sonnet")`) so
 the main context stays clear of capture noise. Brief it with the box name, the branch, whether the
 deliverable is an image or a video, the scenario to record (feature file + exact scenario name) or
-the live state to drive, a `<slug>`, the PR number, and the fixed `pr-evidence` release tag; have it
+the live state to drive, a `<slug>`, the PR number, and the fixed `evidence-assets` release tag; have it
 return only the markdown body it posted.
 
 ## How the harness records (wired in `packages/tests/support/hooks.ts`, gated on `KOLU_EVIDENCE`)
@@ -270,23 +270,28 @@ pu connect "$host" -- 'bash -lc "
 `gh pr comment` can't attach binaries, so copy artifacts back and upload to a long-lived
 GitHub release. (A screenshot from §A is a `.png` — upload and embed it the same way.)
 
-**`pr-evidence` is the one fixed evidence-release tag.** It already exists. Never derive a release
-tag from the PR number or artifact slug, and never create another release. Verify `pr-evidence`
-exists before uploading; if it does not, fail loudly.
+**`evidence-assets` is the one fixed evidence-release tag.** It already exists (a pre-release
+holding every prior PR's artifacts). Never derive a release tag from the PR number or artifact
+slug, and never create another release. Verify `evidence-assets` exists before uploading; if it
+does not, fail loudly.
+
+**The local filename IS the asset name.** `gh release upload` names each asset after the file's
+basename, and the embed URL below is `…/download/evidence-assets/<slug>.png` — so copy back to
+`/tmp/<slug>.png`, not a decorated `/tmp/evidence-<slug>.png`, or every embed 404s.
 
 ```sh
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/evidence-<slug>.png
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/evidence-<slug>.gif
-scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/evidence-<slug>.mp4
-gh release view pr-evidence >/dev/null
-gh release upload pr-evidence /tmp/evidence-<slug>.png /tmp/evidence-<slug>.gif /tmp/evidence-<slug>.mp4 --clobber
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.png /tmp/<slug>.png
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.gif /tmp/<slug>.gif
+scp -F ~/.pu-state/"$host"/ssh_config "$host":/tmp/cap/<slug>.mp4 /tmp/<slug>.mp4
+gh release view evidence-assets >/dev/null
+gh release upload evidence-assets /tmp/<slug>.png /tmp/<slug>.gif /tmp/<slug>.mp4 --clobber
 ```
 
 Embed inline (GitHub renders PNG **and** animated GIF from any release URL):
 
 ```
-![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.png)
-![](https://github.com/<OWNER>/<REPO>/releases/download/pr-evidence/<slug>.gif)
+![](https://github.com/<OWNER>/<REPO>/releases/download/evidence-assets/<slug>.png)
+![](https://github.com/<OWNER>/<REPO>/releases/download/evidence-assets/<slug>.gif)
 ```
 
 For a **before↔after** comparison, post the two stills side by side (a small two-cell table or two

--- a/.claude/skills/self-improve/SKILL.md
+++ b/.claude/skills/self-improve/SKILL.md
@@ -63,9 +63,13 @@ note's corpus audit.
    skill (most friction is a rule that just wasn't loaded) > sharpen one clause > write a
    new rule or skill, last resort. A **speed** fix routes *independent* work to forked
    subagents or a dynamic workflow — never the serial review gauntlet, which stays
-   sole-editor. The fix lands in `.apm/skills/*` **sources only** (`.claude/`, `.agents/`,
-   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD). Each edit honors
-   fail-fast / electricity / reuse-source and trips no llm-autonomy anti-pattern.
+   sole-editor. The fix lands in an apm **source** only (`.claude/`, `.agents/`,
+   `AGENTS.md` are generated; §5 applies it inside the worktree, not PWD) — and there are
+   **two** source trees, so grep both before concluding a skill isn't apm-managed: root
+   `.apm/skills/*` for this repo's own skills, `agents/.apm/skills/*` for the reusable
+   gauntlet package (`be`, `be-review`, `lens-debate`, `agent-debate`, …). See
+   `.claude/rules/apm-workflow.md`. Each edit honors fail-fast / electricity /
+   reuse-source and trips no llm-autonomy anti-pattern.
 5. **Ship from a throwaway worktree — PWD is NEVER mutated.** Steps 1–4 only *read*
    PWD (the transcript lives outside the repo; target discovery greps `.apm` read-only),
    so do **zero** mutation here — no `git switch`, no edits, no commit in PWD. Cut a fresh
@@ -78,9 +82,13 @@ note's corpus audit.
    git worktree prune                                               # clear a stale admin entry from a hard-killed prior run (never reuses a live worktree)
    git worktree add -b "$BR" "$WT" "$DEF"                           # NEW branch cut from origin/master — never rides the /be HEAD
    ```
-   Apply the step-4 edit(s) to `$WT/.apm/skills/*`, then **inside `$WT`**: `just ai::apm`
-   (regen `.claude/.agents/.codex/.opencode` + `AGENTS.md` from the sources — generated copies
-   ride the **same** commit as the sources or the runtimes drift), `just fmt`, `just check`.
+   Apply the step-4 edit(s) to the source tree(s) inside `$WT`, then **inside `$WT`**:
+   `just ai::apm` (regen `.claude/.agents/.codex/.opencode` + `AGENTS.md` from the sources —
+   generated copies ride the **same** commit as the sources or the runtimes drift), `just fmt`,
+   `just check`. **An `agents/.apm/**` edit must be `git commit`ted BEFORE `just ai::apm`** —
+   the regen vendors that package from a git checkout, not your working tree, so an uncommitted
+   edit silently regenerates the OLD text with no error. Commit the source, regen, then confirm
+   the new wording actually landed in `.claude/skills/<name>/SKILL.md` before pushing.
    - **Check green** → commit (`chore(skills): …` + a provenance trailer citing `$SID`),
      `git push -u origin HEAD`, and open it **draft** via `/forge-pr` with a per-edit evidence
      ledger. **Never merge, never `--admin`** — the human reviews; merging is what makes the

--- a/agents/.apm/skills/be-review/SKILL.md
+++ b/agents/.apm/skills/be-review/SKILL.md
@@ -53,6 +53,15 @@ comment can reference a local-only commit.
 - **Commit first.** Reviewers review *committed* code — commit/stash any
   outstanding work before starting (in `/be` this is automatic: §2/§3 commit and
   push before §4).
+- **Verify `<base>` is a remote-tracking ref — mechanically, not by eyeballing the
+  diff stat.** A caller's `--base master` names the **local** `master`, which on a
+  long-lived worktree is routinely tens of commits behind origin, so the merge-base
+  lands in the base branch's own past and the "diff" swells with history nobody wrote:
+  one run resolved a base 40 commits stale and handed the reviewers 377 files instead
+  of 9. After `git fetch origin`, run
+  `git -C "$repoPath" rev-parse --verify --quiet "refs/remotes/$base"` — if it fails,
+  retry once as `origin/$base` and use that; if *that* fails too, **stop and say so**
+  rather than resolving a local ref. Never accept a bare branch name as given.
 - **Resolve the scope once.** `git fetch origin`, then
   `MB=$(git merge-base <base> HEAD)` and `START=$(git rev-parse HEAD)`. Pass `MB`
   as the `base` to every step (their own merge-base resolution is idempotent on a

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-27T19:52:17.438550+00:00'
+generated_at: '2026-07-27T20:35:47.242884+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -69,7 +69,7 @@ dependencies:
     .agents/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .agents/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .agents/skills/be-review/SKILL.md: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
+    .agents/skills/be-review/SKILL.md: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
     .agents/skills/be/SKILL.md: sha256:43a343aeee556da0051d3066ad20a5e97c58d4d8d1de6d94f75000b2ced058f5
     .agents/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -87,7 +87,7 @@ dependencies:
     .claude/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .claude/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .claude/skills/be-review/SKILL.md: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
+    .claude/skills/be-review/SKILL.md: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
     .claude/skills/be/SKILL.md: sha256:43a343aeee556da0051d3066ad20a5e97c58d4d8d1de6d94f75000b2ced058f5
     .claude/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -480,7 +480,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
+  content_hash: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
 - kind: project-relative
   target: agents
   value: .agents/skills/parcel
@@ -588,7 +588,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
+  content_hash: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
 - kind: project-relative
   target: agents
   value: .agents/skills/test
@@ -922,7 +922,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
+  content_hash: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
 - kind: project-relative
   target: claude
   value: .claude/skills/be/SKILL.md
@@ -1192,7 +1192,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
+  content_hash: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
 - kind: project-relative
   target: claude
   value: .claude/skills/fact-check
@@ -1660,7 +1660,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
+  content_hash: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
 - kind: project-relative
   target: claude
   value: .claude/skills/surface
@@ -1804,7 +1804,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:30159a9a2da77309ffb832f8e1960196d57310f5e6e231caffaab54df44d7079
+  content_hash: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
 - kind: project-relative
   target: codex
   value: .agents/skills/be/SKILL.md
@@ -2608,13 +2608,13 @@ local_deployed_file_hashes:
   .agents/skills/ci/pu/report.sh: sha256:2bcce1c13acfd168ed70e0793e49eef5cd051864e4bea7b17833b889e3129bb3
   .agents/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .agents/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
-  .agents/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
+  .agents/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
   .agents/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3
   .agents/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .agents/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .agents/skills/release/SKILL.md: sha256:92e14eb40f9c6c8f39e12c10108d2aaacd671968ed73af1e87df0922df27dee4
   .agents/skills/remote-host-testing/SKILL.md: sha256:2f57f20805195cef801120f374232b8522af3407efa5795d2dfb7fa3964019f4
-  .agents/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
+  .agents/skills/self-improve/SKILL.md: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
   .agents/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c
   .claude/commands/whatchanged.md: sha256:283ce7bfddb6213172b2a89259c2b89b65d063c6f1d156dd6ee2b98760183f69
   .claude/rules/apm-sources.md: sha256:90626875e2a63e5658f0b5e77524c9c4f949f4ce890bd1f1ce9a2663d4fc8ea7
@@ -2643,11 +2643,11 @@ local_deployed_file_hashes:
   .claude/skills/ci/pu/pool.sh: sha256:5f8b42d5aaf4b87dcbdcc91f785c1b476f3e7c131dedb66e7e7de0080d9e9c80
   .claude/skills/ci/smoke.sh: sha256:82ffed8708572fba48c231f01bfe6b64a75e8d8523453adc5db3c9c579b2da5d
   .claude/skills/dev-server/SKILL.md: sha256:741b9c44068dd35500e0d88a8299240ec154b476b1fbb2a0bcdc79e2d03e3e4f
-  .claude/skills/evidence/SKILL.md: sha256:c51b1f61e22fe8ad3d5c02c22a05d4c77b672e19959ef60b4f76d4331f4141cd
+  .claude/skills/evidence/SKILL.md: sha256:825c77c039774f15d28acbd4214f4fbe890a647e864c0723ffc4cca5dd24bf34
   .claude/skills/parcel/SKILL.md: sha256:f86f25ebaaf5349542b255b06378ad2b653aa65bb828d6dd7eacea732b9447c3
   .claude/skills/perf-diagnose/SKILL.md: sha256:253d7e174344b2481b2f0a8f0f12ffe206c5f84974bff02b48db297e5023aa0c
   .claude/skills/pierre/SKILL.md: sha256:0c9e0f6c6cb93518bc0fbf5edf22dd57ba0038a35bb6dc757200e0e2327070e8
   .claude/skills/release/SKILL.md: sha256:92e14eb40f9c6c8f39e12c10108d2aaacd671968ed73af1e87df0922df27dee4
   .claude/skills/remote-host-testing/SKILL.md: sha256:2f57f20805195cef801120f374232b8522af3407efa5795d2dfb7fa3964019f4
-  .claude/skills/self-improve/SKILL.md: sha256:0f8c6bacddfe459b60265bc7de5b148a3a66750271f3264f1fad131f9bf870bd
+  .claude/skills/self-improve/SKILL.md: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
   .claude/skills/test/SKILL.md: sha256:5a8f2f1e53fb27464ae6117503b97a97830d644e5e36428453c2d6c2360e006c


### PR DESCRIPTION
Mined from the `/be` run on #2007. Three of the five frictions that run hit were one-offs the agent handled on its own; **two were skill text that named something real-sounding and wrong**, and one of those left an agent with no legal move at all.

### The evidence release the skill named does not exist

`/evidence` said `pr-evidence` is "the one fixed evidence-release tag," that "it already exists," that you must "never create another release," and that a missing one should "fail loudly." Every clause is enforceable except the premise:

```
$ gh release view pr-evidence
release not found
```

The repo's actual long-lived evidence release is **`evidence-assets`** — a pre-release holding 665 artifacts from every prior PR. So the rule as written was a closed trap: verify-or-fail on a tag that isn't there, with creating one explicitly forbidden. #2007's capture subagent had to knowingly deviate to post its screenshots, and said so in its report. That's the worst shape a rule can have — one that a correct agent must break.

The same block had a second, quieter defect. `gh release upload` names each asset after the local file's **basename**, and the copy-back step wrote `/tmp/evidence-<slug>.png` while the embed URL two lines later read `<slug>.png`. Anyone following it literally uploads `evidence-foo.png` and posts a link to `foo.png` — three 404s in a PR comment. The temp filenames now match the URLs.

### `--base master` is not the base you meant

`/be-review`'s preflight took `--base` from its caller and passed it straight into `git merge-base`. On #2007 the caller wrote `--base master`, which names the **local** `master` — 40 commits behind origin on that worktree. The merge-base landed in master's own past and the gauntlet was about to review **377 files of history nobody on the branch wrote**, instead of the 9 it touched.

The rule already existed, in prose, in `/lens-debate`: *"always a remote-tracking ref, never a stale local branch."* Nothing checked it. It was caught by a human reading a diff stat and thinking "that's too many files" — which is not a control, it's luck. Preflight now verifies `refs/remotes/$base`, retries once as `origin/$base`, and **stops** rather than quietly resolving a local ref.

### `/self-improve` couldn't find its own sources

Steps 4 and 5 named `.apm/skills/*` as *the* source tree. There are two: root `.apm/` for this repo's skills, and `agents/.apm/` for the reusable gauntlet package (`be`, `be-review`, `lens-debate`, …). Worse, an `agents/` edit must be **committed before** `just ai::apm`, because the regen vendors that package from a git checkout rather than the working tree — an uncommitted edit regenerates the old text and reports success. This run walked into it while editing `be-review`; the sequencing is now written down where the skill tells you to regen.

### Considered and deliberately not shipped

| Friction | Why no edit |
|---|---|
| `~/.config/odu/hosts.json` mixes `localhost` into the linux pool, so `mcp__odu__run` is refused outright | User config, not skill text — and the agent diagnosed it, pinned around it, declined to edit a global config, and reported it. Correct behavior already. *The config still needs a one-line fix: drop `localhost` from `x86_64-linux`.* |
| The gauntlet composed a boot crash out of two individually-correct fixes (lens added a throwing guard to a lazy accessor; simplify made it a `createMemo`, which Solid runs eagerly) | code-police caught it before the push. The serial gauntlet worked as designed; adding a smoke gate would buy nothing this run didn't already get. |
| `/lens-debate`'s reconcile pass didn't write `.lens-debate/comment.md` | The instruction is already unambiguous and stated twice (lens-debate §5, be-review step 1). A third restatement is churn, not a fix. One occurrence — worth watching for a repeat. |

> Skill-source changes only. The generated `.claude/` / `.agents/` / `.codex/` copies and `apm.lock.yaml` ride the same commits, per the regen rule. `just fmt` and `just check` are green; opening draft because merging is what makes these live.

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5`)._