### PR TITLE
The gauntlet report is not a Done — /be-review now drives CI to green

### DIFF
--- a/.agents/skills/be-review/SKILL.md
+++ b/.agents/skills/be-review/SKILL.md
@@ -257,4 +257,18 @@ Summarize in chat — reporting **only the selected tracks**, and naming any tra
 - `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
   result is visible.
 
+**The report is not the end of the run.** When the branch has an **open PR**,
+delivering this summary while its checks are **pending or red** is one step short
+of done, and the human is left to type "Status?". This bites hardest when
+be-review was the run's *entry point* rather than `/be` §4 — the same gap that
+forced `/ci` to absorb the master-sync obligation (`.apm/skills/ci/SKILL.md`): a
+run that never entered `/be` never reaches §5, so nothing carries it to green.
+One session closed the gauntlet with "**PR #2018 is MERGEABLE** with CI running",
+even listing *"remaining before merge: CI green"* in the same breath, and stopped;
+an hour earlier it had reported that PR with "the JS CodeQL analysis still
+running", which then went red and had to be pointed at by hand. So after
+reporting, **continue into `/be` §5 yourself** — load `/ci` (Skill tool) and drive
+the pipeline to green on the final `HEAD`, fixing whatever reds. Stop at the
+report only when the branch has **no** open PR: then there is no gate to close.
+
 ARGUMENTS:

--- a/.claude/skills/be-review/SKILL.md
+++ b/.claude/skills/be-review/SKILL.md
@@ -257,4 +257,18 @@ Summarize in chat — reporting **only the selected tracks**, and naming any tra
 - `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
   result is visible.
 
+**The report is not the end of the run.** When the branch has an **open PR**,
+delivering this summary while its checks are **pending or red** is one step short
+of done, and the human is left to type "Status?". This bites hardest when
+be-review was the run's *entry point* rather than `/be` §4 — the same gap that
+forced `/ci` to absorb the master-sync obligation (`.apm/skills/ci/SKILL.md`): a
+run that never entered `/be` never reaches §5, so nothing carries it to green.
+One session closed the gauntlet with "**PR #2018 is MERGEABLE** with CI running",
+even listing *"remaining before merge: CI green"* in the same breath, and stopped;
+an hour earlier it had reported that PR with "the JS CodeQL analysis still
+running", which then went red and had to be pointed at by hand. So after
+reporting, **continue into `/be` §5 yourself** — load `/ci` (Skill tool) and drive
+the pipeline to green on the final `HEAD`, fixing whatever reds. Stop at the
+report only when the branch has **no** open PR: then there is no gate to close.
+
 ARGUMENTS:

--- a/agents/.apm/skills/be-review/SKILL.md
+++ b/agents/.apm/skills/be-review/SKILL.md
@@ -257,4 +257,18 @@ Summarize in chat — reporting **only the selected tracks**, and naming any tra
 - `git log --oneline <base>..HEAD` + `git diff --stat <base>` so the combined
   result is visible.
 
+**The report is not the end of the run.** When the branch has an **open PR**,
+delivering this summary while its checks are **pending or red** is one step short
+of done, and the human is left to type "Status?". This bites hardest when
+be-review was the run's *entry point* rather than `/be` §4 — the same gap that
+forced `/ci` to absorb the master-sync obligation (`.apm/skills/ci/SKILL.md`): a
+run that never entered `/be` never reaches §5, so nothing carries it to green.
+One session closed the gauntlet with "**PR #2018 is MERGEABLE** with CI running",
+even listing *"remaining before merge: CI green"* in the same breath, and stopped;
+an hour earlier it had reported that PR with "the JS CodeQL analysis still
+running", which then went red and had to be pointed at by hand. So after
+reporting, **continue into `/be` §5 yourself** — load `/ci` (Skill tool) and drive
+the pipeline to green on the final `HEAD`, fixing whatever reds. Stop at the
+report only when the branch has **no** open PR: then there is no gate to close.
+
 ARGUMENTS:

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-27T22:18:10.531237+00:00'
+generated_at: '2026-07-28T01:05:09.073214+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -69,7 +69,7 @@ dependencies:
     .agents/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .agents/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .agents/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .agents/skills/be-review/SKILL.md: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+    .agents/skills/be-review/SKILL.md: sha256:d334040b3d7ae23fb28e61e488fbfab614e2f3449555c6ab60fdab07a7eb2b1c
     .agents/skills/be/SKILL.md: sha256:43a343aeee556da0051d3066ad20a5e97c58d4d8d1de6d94f75000b2ced058f5
     .agents/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -87,7 +87,7 @@ dependencies:
     .claude/skills/agent-debate/SKILL.md: sha256:2e4fcfa42231af5c661a685ecbc5e9446dc5320e422fbbcd073704bff006bedd
     .claude/skills/architecture-first-principles/SKILL.md: sha256:f91c89a3546235fb8f2e95489d9a943a540fb4477af37fe4512d731f9e9f312f
     .claude/skills/be-review/RATIONALE.md: sha256:cac9be3c3be87dae93442ed2b6f0549c7d1710fbf4fa9ac2437455810cbcab7a
-    .claude/skills/be-review/SKILL.md: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+    .claude/skills/be-review/SKILL.md: sha256:d334040b3d7ae23fb28e61e488fbfab614e2f3449555c6ab60fdab07a7eb2b1c
     .claude/skills/be/SKILL.md: sha256:43a343aeee556da0051d3066ad20a5e97c58d4d8d1de6d94f75000b2ced058f5
     .claude/skills/bridge/SKILL.md: sha256:f9220d5e89b38bc6370cf9e601229992aa1f642fae3ef6d92d9c5a884d5b1cca
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
@@ -922,7 +922,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+  content_hash: sha256:d334040b3d7ae23fb28e61e488fbfab614e2f3449555c6ab60fdab07a7eb2b1c
 - kind: project-relative
   target: claude
   value: .claude/skills/be/SKILL.md
@@ -1804,7 +1804,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:16e46021f0298c32995153e0477ae11f3fad18283c91114e13143b5e96167ad3
+  content_hash: sha256:d334040b3d7ae23fb28e61e488fbfab614e2f3449555c6ab60fdab07a7eb2b1c
 - kind: project-relative
   target: codex
   value: .agents/skills/be/SKILL.md


### PR DESCRIPTION
Last night's run finished the full review gauntlet on #2018, wrote a genuinely good summary, and then **stopped with CI still running** — even listing *"remaining before merge: CI green on #2018"* in the same breath. The human typed **"Status?"**, then had to set a `/goal` to force the run the last mile. An hour earlier the same run had reported that PR with *"the JS CodeQL analysis still running"*, stopped, and the analysis went red — **"Fix the codeql failures."**

Three interventions, one root cause: **the run entered the gauntlet through `/be-review`, not `/be` §4, so `/be` §5's ship gate was never in context.** Nothing carried it to green. This PR adds one paragraph to be-review's `## Report` making the handback explicit.

### This is a repeat, with a known fix shape

[#1987](https://github.com/juspay/kolu/pull/1987) hit the *identical* structural gap one notch upstream and solved it by relocating the obligation to where it actually fires. That commit's own words, still in `.apm/skills/ci/SKILL.md`:

> "…ordered **four** times in one session even though `/be` §5 already carries this rule, because that session drove CI from a brief and from `/be-review` and §5 was never the entry point. The obligation lives here so it fires no matter who calls CI."

Master-sync got relocated. Its sibling — *don't end the run while the gate is unresolved* — stayed §5-only. This closes that half.

### Evidence ledger

| Signal | Where in the transcript | What it cost |
| --- | --- | --- |
| Reported PR with "JS CodeQL analysis still running", then stopped | `22:44:48` → human `22:45:44` | "Fix the codeql failures" |
| "**PR #2018 is MERGEABLE** with CI running" + "remaining before merge: CI green" | `00:45:16` → human `00:46:32` | "Status?" |
| Human sets `/goal` to force the finish; Stop hook then fires on the same condition | `00:47:24`, `00:55:01` | `Stop hook feedback: CI is still running in the background` |

Taxonomy match in [`llm-autonomy`](https://kolu.dev/atlas/llm-autonomy.html): `incomplete-stopped-early` (n=85, critical — *"status?" (after an hour of silence)* is a verbatim corpus quote) and `ci-failure` (n=14, *"Yields before CI is green"*).

### Why only this one

Three other frictions surfaced and were **deliberately not** turned into edits — a churny skill-set is worse than a slightly leaky one:

- *"You can `pu create` a fresh Linux box and try it out yourself bro"* — the run theorised about the cache instead of reproducing on a clean box. `/be` §2 already mandates reproduce-before-theorise; the run never invoked `/be`. One hit, no new rule earns its place.
- *"in simlpe words, tldr"* — `conventions.md` already makes plain words the default for every turn. Restating it is noise.
- *"Continue (I had to switch model back to Opus)"* — environmental, not a skill defect.

> The edit adds an obligation, never an escape hatch: it does not soften a gate, reintroduce a post-§0 question, or parallelise the serial gauntlet. It is scoped to branches that **have** an open PR — a local-only review still reports and stops.

Gates run in a throwaway worktree off fresh `origin/master`: `just ai::apm` (source committed first, per the two-tree vendoring rule — new wording confirmed present in `.claude/skills/be-review/SKILL.md`), `just fmt` (0/11 reformatted), `just check` (tsc clean across all packages, biome 1612 files clean).

_Generated by [`/self-improve`](https://github.com/srid/agency) on Claude Code (model `claude-opus-5[1m]`)._