### PR TITLE
/spacetime: negotiate artifacts, then implement — superseding /be and /atlas

### DIFF
--- a/.agents/skills/coordinator/SKILL.md
+++ b/.agents/skills/coordinator/SKILL.md
@@ -18,10 +18,14 @@ problem; this skill is what you send, not how.
    the debate peer, and exactly which branch/PR the work lands on — the agent
    should never have to guess where its commits go.
 
-2. **Hand over your terminal id.** Questions come to *you*, not the human:
-   tell the agent to message your terminal on any ambiguity and wait, and that
-   your replies are authoritative. You pull the human in only when a call is
-   genuinely theirs.
+2. **Hand over your terminal id.** The agent's questions come to *you*, not
+   the human: tell it to message your terminal on any ambiguity and wait, and
+   that your replies are authoritative. But you're a router, not an oracle:
+   mechanical unblocks (a path, a flag, a fact in the repo) you answer
+   yourself; anything judgment-shaped — scope, API feel, a tradeoff, "which
+   way did the human mean" — goes to the human as an AskUserQuestion with
+   concrete options, liberally. A wrong confident answer costs a re-run; a
+   question costs a click.
 
 3. **Set the goal** (verbatim, it's task-independent — `/be` carries the
    specifics): *"All of /be is complete — verified against reality (green CI,

--- a/.agents/skills/spacetime/SKILL.md
+++ b/.agents/skills/spacetime/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: spacetime
+description: >-
+  Take a task from intent to shipped code by negotiating artifacts, not prose:
+  a hello world for space (call shapes), traces for time (interleavings,
+  lifetimes, windows). The human judges artifacts; the LLM generates candidates
+  and implements the settled ones. Supersedes /be and /atlas.
+---
+
+# Spacetime — negotiate artifacts, then implement them
+
+Prose can hold a contradiction forever; code and timelines can't. So the plan
+IS its artifacts, and the human's review is reading them — never paragraphs.
+(Space and time per [The spacetime of code](https://kolu.dev/blog/hickey-lowy/).)
+
+1. **Pin intent.** One batched question round with the human: scope, consumers,
+   constraints, what's already decided. No artifact before the ambiguities die.
+
+2. **Negotiate space — the hello world.** Write consumer-position code for
+   every new surface: what the consumer types, complete, with no implementation
+   behind it. Iterate with the human until the call sites stop being awkward —
+   an architectural wart is an awkward line, visible in seconds. A primitive
+   deletes consumer code; a helper just adds an import. No phase list before
+   this settles.
+
+3. **Negotiate time — the traces.** A worked timeline for every concurrent
+   actor, lifetime, and cross-version window: who acts, in what order, what
+   breaks, where it terminates. Same loop: the human reads five lines and sees
+   the livelock or the terminus. Interleavings explode, so time keeps a machine
+   assist — adversary agents attack each trace looking for the ordering nobody
+   wrote down.
+
+4. **Fix the plan.** One plain-markdown file in the repo (hand-authored SVG
+   only where a diagram beats the text), carrying: the settled hello world, the
+   traces, and phases whose done-when is "the implementation adds up to the
+   example; the traces ship as fixtures/tests". Every phased item gets a
+   track-unique id. Anything added to the plan later regenerates its artifacts
+   — a late addition is an unreviewed design in a reviewed plan's clothing.
+
+5. **Implement, then the slim tail.** The coding agent implements the settled
+   artifacts autonomously (dispatch via /coordinator or run inline). After it:
+   lowy + hickey as refactor passes on the implementation — never as
+   architects; adversarial verification of the traces against the real code;
+   code-police; CI green on all platforms; visual evidence when the screen
+   changes. Ship on the negotiated branch/PR, nowhere else.

--- a/.agents/skills/spacetime/SKILL.md
+++ b/.agents/skills/spacetime/SKILL.md
@@ -13,22 +13,26 @@ Prose can hold a contradiction forever; code and timelines can't. So the plan
 IS its artifacts, and the human's review is reading them — never paragraphs.
 (Space and time per [The spacetime of code](https://kolu.dev/blog/hickey-lowy/).)
 
-1. **Pin intent.** One batched question round with the human: scope, consumers,
-   constraints, what's already decided. No artifact before the ambiguities die.
+1. **Pin intent.** One batched AskUserQuestion round with the human: scope,
+   consumers, constraints, what's already decided. No artifact before the
+   ambiguities die.
 
 2. **Negotiate space — the hello world.** Write consumer-position code for
    every new surface: what the consumer types, complete, with no implementation
-   behind it. Iterate with the human until the call sites stop being awkward —
-   an architectural wart is an awkward line, visible in seconds. A primitive
+   behind it. Where the call shape genuinely forks, put the candidates in front
+   of the human as AskUserQuestion options with code previews — one hello world
+   per option; iterate until the call sites stop being awkward. An
+   architectural wart is an awkward line, visible in seconds. A primitive
    deletes consumer code; a helper just adds an import. No phase list before
    this settles.
 
 3. **Negotiate time — the traces.** A worked timeline for every concurrent
    actor, lifetime, and cross-version window: who acts, in what order, what
-   breaks, where it terminates. Same loop: the human reads five lines and sees
-   the livelock or the terminus. Interleavings explode, so time keeps a machine
-   assist — adversary agents attack each trace looking for the ordering nobody
-   wrote down.
+   breaks, where it terminates. Same loop, same tool — forking semantics
+   (who wins, what resets, where it parks) go to the human as AskUserQuestion
+   options with the trace as the preview; five lines show the livelock or the
+   terminus. Interleavings explode, so time keeps a machine assist — adversary
+   agents attack each trace looking for the ordering nobody wrote down.
 
 4. **Fix the plan.** One plain-markdown file in the repo (hand-authored SVG
    only where a diagram beats the text), carrying: the settled hello world, the

--- a/.claude/skills/coordinator/SKILL.md
+++ b/.claude/skills/coordinator/SKILL.md
@@ -18,10 +18,14 @@ problem; this skill is what you send, not how.
    the debate peer, and exactly which branch/PR the work lands on — the agent
    should never have to guess where its commits go.
 
-2. **Hand over your terminal id.** Questions come to *you*, not the human:
-   tell the agent to message your terminal on any ambiguity and wait, and that
-   your replies are authoritative. You pull the human in only when a call is
-   genuinely theirs.
+2. **Hand over your terminal id.** The agent's questions come to *you*, not
+   the human: tell it to message your terminal on any ambiguity and wait, and
+   that your replies are authoritative. But you're a router, not an oracle:
+   mechanical unblocks (a path, a flag, a fact in the repo) you answer
+   yourself; anything judgment-shaped — scope, API feel, a tradeoff, "which
+   way did the human mean" — goes to the human as an AskUserQuestion with
+   concrete options, liberally. A wrong confident answer costs a re-run; a
+   question costs a click.
 
 3. **Set the goal** (verbatim, it's task-independent — `/be` carries the
    specifics): *"All of /be is complete — verified against reality (green CI,

--- a/.claude/skills/spacetime/SKILL.md
+++ b/.claude/skills/spacetime/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: spacetime
+description: >-
+  Take a task from intent to shipped code by negotiating artifacts, not prose:
+  a hello world for space (call shapes), traces for time (interleavings,
+  lifetimes, windows). The human judges artifacts; the LLM generates candidates
+  and implements the settled ones. Supersedes /be and /atlas.
+---
+
+# Spacetime — negotiate artifacts, then implement them
+
+Prose can hold a contradiction forever; code and timelines can't. So the plan
+IS its artifacts, and the human's review is reading them — never paragraphs.
+(Space and time per [The spacetime of code](https://kolu.dev/blog/hickey-lowy/).)
+
+1. **Pin intent.** One batched question round with the human: scope, consumers,
+   constraints, what's already decided. No artifact before the ambiguities die.
+
+2. **Negotiate space — the hello world.** Write consumer-position code for
+   every new surface: what the consumer types, complete, with no implementation
+   behind it. Iterate with the human until the call sites stop being awkward —
+   an architectural wart is an awkward line, visible in seconds. A primitive
+   deletes consumer code; a helper just adds an import. No phase list before
+   this settles.
+
+3. **Negotiate time — the traces.** A worked timeline for every concurrent
+   actor, lifetime, and cross-version window: who acts, in what order, what
+   breaks, where it terminates. Same loop: the human reads five lines and sees
+   the livelock or the terminus. Interleavings explode, so time keeps a machine
+   assist — adversary agents attack each trace looking for the ordering nobody
+   wrote down.
+
+4. **Fix the plan.** One plain-markdown file in the repo (hand-authored SVG
+   only where a diagram beats the text), carrying: the settled hello world, the
+   traces, and phases whose done-when is "the implementation adds up to the
+   example; the traces ship as fixtures/tests". Every phased item gets a
+   track-unique id. Anything added to the plan later regenerates its artifacts
+   — a late addition is an unreviewed design in a reviewed plan's clothing.
+
+5. **Implement, then the slim tail.** The coding agent implements the settled
+   artifacts autonomously (dispatch via /coordinator or run inline). After it:
+   lowy + hickey as refactor passes on the implementation — never as
+   architects; adversarial verification of the traces against the real code;
+   code-police; CI green on all platforms; visual evidence when the screen
+   changes. Ship on the negotiated branch/PR, nowhere else.

--- a/.claude/skills/spacetime/SKILL.md
+++ b/.claude/skills/spacetime/SKILL.md
@@ -13,22 +13,26 @@ Prose can hold a contradiction forever; code and timelines can't. So the plan
 IS its artifacts, and the human's review is reading them — never paragraphs.
 (Space and time per [The spacetime of code](https://kolu.dev/blog/hickey-lowy/).)
 
-1. **Pin intent.** One batched question round with the human: scope, consumers,
-   constraints, what's already decided. No artifact before the ambiguities die.
+1. **Pin intent.** One batched AskUserQuestion round with the human: scope,
+   consumers, constraints, what's already decided. No artifact before the
+   ambiguities die.
 
 2. **Negotiate space — the hello world.** Write consumer-position code for
    every new surface: what the consumer types, complete, with no implementation
-   behind it. Iterate with the human until the call sites stop being awkward —
-   an architectural wart is an awkward line, visible in seconds. A primitive
+   behind it. Where the call shape genuinely forks, put the candidates in front
+   of the human as AskUserQuestion options with code previews — one hello world
+   per option; iterate until the call sites stop being awkward. An
+   architectural wart is an awkward line, visible in seconds. A primitive
    deletes consumer code; a helper just adds an import. No phase list before
    this settles.
 
 3. **Negotiate time — the traces.** A worked timeline for every concurrent
    actor, lifetime, and cross-version window: who acts, in what order, what
-   breaks, where it terminates. Same loop: the human reads five lines and sees
-   the livelock or the terminus. Interleavings explode, so time keeps a machine
-   assist — adversary agents attack each trace looking for the ordering nobody
-   wrote down.
+   breaks, where it terminates. Same loop, same tool — forking semantics
+   (who wins, what resets, where it parks) go to the human as AskUserQuestion
+   options with the trace as the preview; five lines show the livelock or the
+   terminus. Interleavings explode, so time keeps a machine assist — adversary
+   agents attack each trace looking for the ordering nobody wrote down.
 
 4. **Fix the plan.** One plain-markdown file in the repo (hand-authored SVG
    only where a diagram beats the text), carrying: the settled hello world, the

--- a/agents/.apm/skills/coordinator/SKILL.md
+++ b/agents/.apm/skills/coordinator/SKILL.md
@@ -18,10 +18,14 @@ problem; this skill is what you send, not how.
    the debate peer, and exactly which branch/PR the work lands on — the agent
    should never have to guess where its commits go.
 
-2. **Hand over your terminal id.** Questions come to *you*, not the human:
-   tell the agent to message your terminal on any ambiguity and wait, and that
-   your replies are authoritative. You pull the human in only when a call is
-   genuinely theirs.
+2. **Hand over your terminal id.** The agent's questions come to *you*, not
+   the human: tell it to message your terminal on any ambiguity and wait, and
+   that your replies are authoritative. But you're a router, not an oracle:
+   mechanical unblocks (a path, a flag, a fact in the repo) you answer
+   yourself; anything judgment-shaped — scope, API feel, a tradeoff, "which
+   way did the human mean" — goes to the human as an AskUserQuestion with
+   concrete options, liberally. A wrong confident answer costs a re-run; a
+   question costs a click.
 
 3. **Set the goal** (verbatim, it's task-independent — `/be` carries the
    specifics): *"All of /be is complete — verified against reality (green CI,

--- a/agents/.apm/skills/spacetime/SKILL.md
+++ b/agents/.apm/skills/spacetime/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: spacetime
+description: >-
+  Take a task from intent to shipped code by negotiating artifacts, not prose:
+  a hello world for space (call shapes), traces for time (interleavings,
+  lifetimes, windows). The human judges artifacts; the LLM generates candidates
+  and implements the settled ones. Supersedes /be and /atlas.
+---
+
+# Spacetime — negotiate artifacts, then implement them
+
+Prose can hold a contradiction forever; code and timelines can't. So the plan
+IS its artifacts, and the human's review is reading them — never paragraphs.
+(Space and time per [The spacetime of code](https://kolu.dev/blog/hickey-lowy/).)
+
+1. **Pin intent.** One batched question round with the human: scope, consumers,
+   constraints, what's already decided. No artifact before the ambiguities die.
+
+2. **Negotiate space — the hello world.** Write consumer-position code for
+   every new surface: what the consumer types, complete, with no implementation
+   behind it. Iterate with the human until the call sites stop being awkward —
+   an architectural wart is an awkward line, visible in seconds. A primitive
+   deletes consumer code; a helper just adds an import. No phase list before
+   this settles.
+
+3. **Negotiate time — the traces.** A worked timeline for every concurrent
+   actor, lifetime, and cross-version window: who acts, in what order, what
+   breaks, where it terminates. Same loop: the human reads five lines and sees
+   the livelock or the terminus. Interleavings explode, so time keeps a machine
+   assist — adversary agents attack each trace looking for the ordering nobody
+   wrote down.
+
+4. **Fix the plan.** One plain-markdown file in the repo (hand-authored SVG
+   only where a diagram beats the text), carrying: the settled hello world, the
+   traces, and phases whose done-when is "the implementation adds up to the
+   example; the traces ship as fixtures/tests". Every phased item gets a
+   track-unique id. Anything added to the plan later regenerates its artifacts
+   — a late addition is an unreviewed design in a reviewed plan's clothing.
+
+5. **Implement, then the slim tail.** The coding agent implements the settled
+   artifacts autonomously (dispatch via /coordinator or run inline). After it:
+   lowy + hickey as refactor passes on the implementation — never as
+   architects; adversarial verification of the traces against the real code;
+   code-police; CI green on all platforms; visual evidence when the screen
+   changes. Ship on the negotiated branch/PR, nowhere else.

--- a/agents/.apm/skills/spacetime/SKILL.md
+++ b/agents/.apm/skills/spacetime/SKILL.md
@@ -13,22 +13,26 @@ Prose can hold a contradiction forever; code and timelines can't. So the plan
 IS its artifacts, and the human's review is reading them — never paragraphs.
 (Space and time per [The spacetime of code](https://kolu.dev/blog/hickey-lowy/).)
 
-1. **Pin intent.** One batched question round with the human: scope, consumers,
-   constraints, what's already decided. No artifact before the ambiguities die.
+1. **Pin intent.** One batched AskUserQuestion round with the human: scope,
+   consumers, constraints, what's already decided. No artifact before the
+   ambiguities die.
 
 2. **Negotiate space — the hello world.** Write consumer-position code for
    every new surface: what the consumer types, complete, with no implementation
-   behind it. Iterate with the human until the call sites stop being awkward —
-   an architectural wart is an awkward line, visible in seconds. A primitive
+   behind it. Where the call shape genuinely forks, put the candidates in front
+   of the human as AskUserQuestion options with code previews — one hello world
+   per option; iterate until the call sites stop being awkward. An
+   architectural wart is an awkward line, visible in seconds. A primitive
    deletes consumer code; a helper just adds an import. No phase list before
    this settles.
 
 3. **Negotiate time — the traces.** A worked timeline for every concurrent
    actor, lifetime, and cross-version window: who acts, in what order, what
-   breaks, where it terminates. Same loop: the human reads five lines and sees
-   the livelock or the terminus. Interleavings explode, so time keeps a machine
-   assist — adversary agents attack each trace looking for the ordering nobody
-   wrote down.
+   breaks, where it terminates. Same loop, same tool — forking semantics
+   (who wins, what resets, where it parks) go to the human as AskUserQuestion
+   options with the trace as the preview; five lines show the livelock or the
+   terminus. Interleavings explode, so time keeps a machine assist — adversary
+   agents attack each trace looking for the ordering nobody wrote down.
 
 4. **Fix the plan.** One plain-markdown file in the repo (hand-authored SVG
    only where a diagram beats the text), carrying: the settled hello world, the

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-28T17:23:58.832749+00:00'
+generated_at: '2026-07-28T17:25:42.131932+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -90,7 +90,7 @@ dependencies:
     .agents/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
     .agents/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
-    .agents/skills/spacetime/SKILL.md: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
+    .agents/skills/spacetime/SKILL.md: sha256:857b5bd61e5de8947aa7f5f7eb2bcdf9b47459fbabc274990ff2d1302a18f77e
     .agents/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
     .claude/skills/agent-debate/ANSWER.md: sha256:47456419d24ab041d69dd85ddfb1d640fa8a26410eba24f2f6a7715276900b52
     .claude/skills/agent-debate/REVIEW.md: sha256:026eb88a4e29e521d9a0209bf9f83d0684f4231b8a10b772e9565cbd0713d82e
@@ -110,7 +110,7 @@ dependencies:
     .claude/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
     .claude/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
-    .claude/skills/spacetime/SKILL.md: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
+    .claude/skills/spacetime/SKILL.md: sha256:857b5bd61e5de8947aa7f5f7eb2bcdf9b47459fbabc274990ff2d1302a18f77e
     .claude/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
   source: local
   local_path: ./agents
@@ -1708,7 +1708,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
+  content_hash: sha256:857b5bd61e5de8947aa7f5f7eb2bcdf9b47459fbabc274990ff2d1302a18f77e
 - kind: project-relative
   target: claude
   value: .claude/skills/surface
@@ -2419,7 +2419,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
+  content_hash: sha256:857b5bd61e5de8947aa7f5f7eb2bcdf9b47459fbabc274990ff2d1302a18f77e
 - kind: project-relative
   target: codex
   value: .agents/skills/surface

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-28T15:43:47.131940+00:00'
+generated_at: '2026-07-28T17:23:58.832749+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: _local/agents
@@ -35,6 +35,8 @@ dependencies:
   - .agents/skills/lens-debate/SKILL.md
   - .agents/skills/perfection-review
   - .agents/skills/perfection-review/SKILL.md
+  - .agents/skills/spacetime
+  - .agents/skills/spacetime/SKILL.md
   - .agents/skills/surface
   - .agents/skills/surface/SKILL.md
   - .claude/skills/agent-debate
@@ -65,6 +67,8 @@ dependencies:
   - .claude/skills/lens-debate/SKILL.md
   - .claude/skills/perfection-review
   - .claude/skills/perfection-review/SKILL.md
+  - .claude/skills/spacetime
+  - .claude/skills/spacetime/SKILL.md
   - .claude/skills/surface
   - .claude/skills/surface/SKILL.md
   deployed_file_hashes:
@@ -79,13 +83,14 @@ dependencies:
     .agents/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .agents/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
     .agents/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
-    .agents/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+    .agents/skills/coordinator/SKILL.md: sha256:484d109b59936a0f609e36da9e22ec51e4f41dcb44bfda4b065302930d6a8104
     .agents/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .agents/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .agents/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .agents/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
     .agents/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
     .agents/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
+    .agents/skills/spacetime/SKILL.md: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
     .agents/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
     .claude/skills/agent-debate/ANSWER.md: sha256:47456419d24ab041d69dd85ddfb1d640fa8a26410eba24f2f6a7715276900b52
     .claude/skills/agent-debate/REVIEW.md: sha256:026eb88a4e29e521d9a0209bf9f83d0684f4231b8a10b772e9565cbd0713d82e
@@ -98,13 +103,14 @@ dependencies:
     .claude/skills/bridge/dashboard/index.html: sha256:7289bb60245087ce5b57c833bd8bb2b766153cec31b92a413647547b3e9742b0
     .claude/skills/bridge/dashboard/index.js: sha256:f58c4b996f6b9df7f13f30fbd061404cbc95ab3e5881f53066cde199f3501f38
     .claude/skills/bridge/dashboard/red-alert.mp3: sha256:61a535db70bb68738df7929c29b11a3bcb11ca23bf5eb7793a0b84f3e699e0fb
-    .claude/skills/coordinator/SKILL.md: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+    .claude/skills/coordinator/SKILL.md: sha256:484d109b59936a0f609e36da9e22ec51e4f41dcb44bfda4b065302930d6a8104
     .claude/skills/diataxis/SKILL.md: sha256:596e06f555aa0218ea2138270ceb3419584038a519ba43c8ff1823bf597d9aa6
     .claude/skills/kolu/SKILL.md: sha256:4688c89300aca3571358285502c0dbb8612656020baee760c86f34ff6b979291
     .claude/skills/kolu/TUI.md: sha256:e7a206b1f1d2738bdaf2e2af3bdfdb785da94872df03d45e7ac47ae92361244c
     .claude/skills/lens-debate/RATIONALE.md: sha256:5d27af06f554fb81fc344450f2d5031a097287c3282f19945eec2b55712a656a
     .claude/skills/lens-debate/SKILL.md: sha256:e5afec03dd8659583bc724d5bd35691affa8082f0e21f88a137616f062ab813f
     .claude/skills/perfection-review/SKILL.md: sha256:81e96416552beaa8a59299007bfd0280e008c2b41290cb2f9b7e8efa20ec0056
+    .claude/skills/spacetime/SKILL.md: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
     .claude/skills/surface/SKILL.md: sha256:2bb20756fe7292b5b6f00ed77cb7f9d4239c41d6751bf460a93266927f112eea
   source: local
   local_path: ./agents
@@ -1081,7 +1087,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+  content_hash: sha256:484d109b59936a0f609e36da9e22ec51e4f41dcb44bfda4b065302930d6a8104
 - kind: project-relative
   target: claude
   value: .claude/skills/dev-server
@@ -1687,6 +1693,24 @@ deployments:
   content_hash: sha256:cb5e57cbafcaf1db108dd20de6eeb4fe300fae0a295df81ae33140070e767da7
 - kind: project-relative
   target: claude
+  value: .claude/skills/spacetime
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/spacetime/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
+- kind: project-relative
+  target: claude
   value: .claude/skills/surface
   runtime: null
   scope: project
@@ -1918,7 +1942,7 @@ deployments:
   owners:
   - ./agents
   active_owner: ./agents
-  content_hash: sha256:abac6960f10c8ce2603f94e9101cbbd3e876f073c13e6b3741698d98eaff39c7
+  content_hash: sha256:484d109b59936a0f609e36da9e22ec51e4f41dcb44bfda4b065302930d6a8104
 - kind: project-relative
   target: codex
   value: .agents/skills/diataxis
@@ -2378,6 +2402,24 @@ deployments:
   - srid/agency
   active_owner: srid/agency
   content_hash: sha256:1b2c547102584c87384b90b291536bedc0494dcb8382ac776bd0a3cec0fe1b4a
+- kind: project-relative
+  target: codex
+  value: .agents/skills/spacetime
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/spacetime/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - ./agents
+  active_owner: ./agents
+  content_hash: sha256:6cc1ae9cb30c31296703b05df94d688a8653c6c4d15ea0c160949e896503742c
 - kind: project-relative
   target: codex
   value: .agents/skills/surface


### PR DESCRIPTION
A new `agents/` skill born from a live failure analysis: a 72-agent review gauntlet missed an architectural wart (`daemonHome` shipped as a helper, not a primitive) that a single "show me the hello world" prompt exposed in seconds. The lesson — **prose can hold a contradiction forever; code and timelines can't** — becomes the workflow.

`/spacetime` replaces the planning-vs-coding duality with three stages: *Planning → high-level DSL → coding* (cognate: [Balakrishnan on agent design](https://maheshba.bitbucket.io/blog/2026/07/22/agentdesign.html)). The human negotiates **artifacts**, never paragraphs:

- **Space** — a hello world in consumer position for every new surface; an architectural wart is an awkward call site, visible in seconds ("a primitive deletes consumer code; a helper just adds an import").
- **Time** — worked traces for every concurrent actor, lifetime, and cross-version window; livelocks and dead ends read off five lines. Interleavings explode, so time keeps the one machine assist that demonstrably earns its cost: adversary agents attacking each trace.
- The plan is one plain-markdown file whose phases' done-when is "the implementation adds up to the example; the traces ship as fixtures". Late additions regenerate their artifacts — an addition after review is an unreviewed design in a reviewed plan's clothing.
- The review tail slims to what paid: lowy/hickey as **refactor passes on implementation, never architects**; trace verification; code-police; CI; evidence.

It names `/be` and `/atlas` as superseded in its description; physically retiring those source trees is left for after `/spacetime`'s first proven run.

Also folds in a coordinator amendment from the same session: **the supervisor is a router, not an oracle** — mechanical unblocks it answers itself, judgment-shaped escalations go to the human as `AskUserQuestion`s, liberally. A wrong confident answer costs a re-run; a question costs a click.

_Generated by Claude Code (model `claude-fable-5`)._