### PR TITLE
ci: switch Nix binary cache from attic to Cachix

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,5 +1,5 @@
 # Build the default package on linux + darwin and push each closure to the
-# shared Attic cache (https://cache.nixos.asia/oss). The flake already lists
+# shared Cachix cache (https://kolu.cachix.org). The flake already lists
 # this cache as a substituter, so a green push here warms CI boxes and local
 # `nix build`s on both platforms.
 name: nix-cache
@@ -10,7 +10,7 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Least privilege — this job only needs the checkout and ATTIC_TOKEN secret.
+# Least privilege — this job only needs the checkout and CACHIX_AUTH_TOKEN secret.
 permissions:
   contents: read
 
@@ -37,39 +37,18 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
         with:
           nix_conf: |
-            extra-substituters = https://cache.nixos.asia/oss
-            extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
+            extra-substituters = https://kolu.cachix.org
+            extra-trusted-public-keys = kolu.cachix.org-1:jXCB7PDK4v+9fcOmiFSKWHdYU31mfbCvpPiJ0l0zaRs=
             accept-flake-config = true
 
-      # ryanccn/attic-action used to do the install/login/push below, but it
-      # installs attic by resolving UNPINNED nixpkgs-unstable through the
-      # GitHub API at run time — one API 503 fails the job (it did, repo-wide,
-      # 2026-07-16), and even green runs re-fetch an unpinned rev. Its logic
-      # is four CLI calls, so do them directly, installing attic from the
-      # repo's own npins-pinned nixpkgs: the exact tarball URL nix/nixpkgs.nix
-      # builds from (no ref resolution, no api.github.com), with attic-client
-      # substituted from cache.nixos.org. Needs a Nix new enough for
-      # `nix profile add` (hence v35 above — v31's 2.29 only had
-      # `profile install`, which is why #1731 dropped the action once before).
-      # No `attic use` — the nix_conf above already wires the substituter.
-      - name: Install attic (pinned) and log in
-        run: |
-          nix profile add "$(jq -r .pins.nixpkgs.url npins/sources.json)#attic-client"
-          attic login --set-default oss https://cache.nixos.asia '${{ secrets.ATTIC_TOKEN }}'
-          nix path-info --all | sort > "$RUNNER_TEMP/pre-build-paths"
+      # Pin by commit (CodeQL: unpinned third-party action). v17 → 5f2d7c5.
+      # Pulls from kolu.cachix.org; pushes newly built paths when the auth
+      # token is present (master / same-repo PRs). Fork PRs without the
+      # secret stay pull-only.
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: kolu
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build
         run: nix build -L --print-out-paths
-
-      # Push every store path the build produced (post minus pre snapshot,
-      # minus .drv/.check/.lock clutter) — same set attic-action pushed from
-      # its post step, without the action.
-      - name: Push to Attic
-        # Explicit `shell: bash` turns on pipefail, so a failure anywhere in
-        # the pipe fails the step — not just the final `attic push`.
-        shell: bash
-        run: |
-          nix path-info --all | sort \
-            | comm -13 "$RUNNER_TEMP/pre-build-paths" - \
-            | grep -Ev '\.(drv|drv\.chroot|check|lock)$' \
-            | attic push --stdin oss

--- a/ci/mod.just
+++ b/ci/mod.just
@@ -72,7 +72,7 @@ install:
 # path doesn't exist yet. The first `nix build` realizes the path (from
 # substituter or fresh fetch); --rebuild then forces re-execution and
 # compares, so a stale cached artifact at the declared hash (local store
-# or cache.nixos.asia) can't silently satisfy a hash that no longer
+# or kolu.cachix.org) can't silently satisfy a hash that no longer
 # matches the lockfile.
 pnpm-hash-fresh: nix
     nix build .#pnpmDeps --no-link

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,8 @@
 # Instead, use fetchTarball or callPackage in nix/ files.
 {
   nixConfig = {
-    extra-substituters = "https://cache.nixos.asia/oss";
-    extra-trusted-public-keys = "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=";
+    extra-substituters = "https://kolu.cachix.org";
+    extra-trusted-public-keys = "kolu.cachix.org-1:jXCB7PDK4v+9fcOmiFSKWHdYU31mfbCvpPiJ0l0zaRs=";
   };
 
   outputs = { self, ... }:

--- a/nix/agent-flake.nix
+++ b/nix/agent-flake.nix
@@ -19,8 +19,8 @@
   # without any nix.conf of their own. --accept-flake-config on the local nix
   # invocations accepts this same block for eval-time use.
   nixConfig = {
-    extra-substituters = "https://cache.nixos.asia/oss";
-    extra-trusted-public-keys = "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=";
+    extra-substituters = "https://kolu.cachix.org";
+    extra-trusted-public-keys = "kolu.cachix.org-1:jXCB7PDK4v+9fcOmiFSKWHdYU31mfbCvpPiJ0l0zaRs=";
   };
 
   outputs = { ... }:

--- a/packages/surface/example/flake.nix
+++ b/packages/surface/example/flake.nix
@@ -9,8 +9,8 @@
   # without one. Examples ride Kolu's own cache — they are built from this
   # repo's workspace.
   nixConfig = {
-    extra-substituters = "https://cache.nixos.asia/oss";
-    extra-trusted-public-keys = "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=";
+    extra-substituters = "https://kolu.cachix.org";
+    extra-trusted-public-keys = "kolu.cachix.org-1:jXCB7PDK4v+9fcOmiFSKWHdYU31mfbCvpPiJ0l0zaRs=";
   };
 
   outputs = { self, ... }:

--- a/website/src/content/docs/quickstart.mdx
+++ b/website/src/content/docs/quickstart.mdx
@@ -49,7 +49,7 @@ tiles, dock rows, worktrees, and agent state — once the app is running.
 ## First run compiling? Enable the binary cache
 
 Every kolu commit is pre-built and pushed to a public binary cache,
-`https://cache.nixos.asia/oss`. The flake declares it, but Nix only honors a
+`https://kolu.cachix.org`. The flake declares it, but Nix only honors a
 flake-declared cache if you accept it **and** your user is
 [trusted](https://nix.dev/manual/nix/latest/command-ref/conf-file#conf-trusted-users)
 by the Nix daemon — and on a standard multi-user install it isn't, so the
@@ -62,16 +62,16 @@ To download pre-built binaries instead, add the cache to the **system** Nix
 configuration (`/etc/nix/nix.conf`):
 
 ```text
-extra-substituters = https://cache.nixos.asia/oss
-extra-trusted-public-keys = oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=
+extra-substituters = https://kolu.cachix.org
+extra-trusted-public-keys = kolu.cachix.org-1:jXCB7PDK4v+9fcOmiFSKWHdYU31mfbCvpPiJ0l0zaRs=
 ```
 
 Or, on NixOS:
 
 ```nix
 nix.settings = {
-  extra-substituters = [ "https://cache.nixos.asia/oss" ];
-  extra-trusted-public-keys = [ "oss:KO872wNJkCDgmGN3xy9dT89WAhvv13EiKncTtHDItVU=" ];
+  extra-substituters = [ "https://kolu.cachix.org" ];
+  extra-trusted-public-keys = [ "kolu.cachix.org-1:jXCB7PDK4v+9fcOmiFSKWHdYU31mfbCvpPiJ0l0zaRs=" ];
 };
 ```
 


### PR DESCRIPTION
## Summary

Replace the self-hosted Attic binary cache (`https://cache.nixos.asia/oss`) with the public Cachix cache at [`kolu.cachix.org`](https://kolu.cachix.org).

- Point every `nixConfig` block (root flake, agent flake, surface example) at Cachix + its public signing key
- Rewrite `.github/workflows/nix-cache.yml` to use `cachix/cachix-action` (pull + push) instead of the hand-rolled attic install/login/push path
- Update the Quickstart binary-cache instructions so local `nix.conf` matches

### Before merging — set the secret

```bash
# Paste the Cachix auth token when prompted (Generate at https://app.cachix.org/personal-auth-tokens)
gh secret set CACHIX_AUTH_TOKEN
```

Or non-interactively:

```bash
gh secret set CACHIX_AUTH_TOKEN --body "$CACHIX_AUTH_TOKEN"
```

(Old `ATTIC_TOKEN` can be deleted once this is green: `gh secret delete ATTIC_TOKEN`.)

## Test plan

- [ ] Set `CACHIX_AUTH_TOKEN` on the repo
- [ ] Confirm the `nix-cache` workflow on this PR pulls from `kolu.cachix.org` and (with the secret present) pushes after build on linux + darwin
- [ ] After merge, a cold `nix build` / install with the updated `nix.conf` substitutes from Cachix instead of compiling