### PR TITLE
Dock repo cards you can actually tell apart

### DIFF
--- a/packages/client/src/canvas/dock/Dock.tsx
+++ b/packages/client/src/canvas/dock/Dock.tsx
@@ -20,26 +20,27 @@
  *     a comment. (Canvas tiles' `--card-color` / `--aura-c` are a
  *     separate module; converging them onto `--repo-color` is future
  *     work, not done here.)
- *  2. **cards** (default) — rows grouped by repo. Each repo gets a
- *     continuous repo-colored **spine** down the section's left edge
- *     plus a faintly repo-tinted **sticky** header (uppercase name +
- *     row count) that pins to the scrollport top until the next
- *     repo's header pushes it off — so a row's repo is legible at a
- *     glance and the label survives the scroll. Rows below stack as
- *     `indicator · branch · pips · time` lines. The leading **status
- *     indicator** (`StatePip`) folds identity · paint · motion · unread
- *     into one glyph (agent brand mark, state colour, spin/glow while
- *     active, amber corner badge when unopened) — so one glance reads
- *     who is driving and whether they need you. Agent kind is not
- *     labeled in text here — it lives on the terminal title bar where
- *     there's room. PR pip is a link to the PR with the live checks
- *     verdict in its tooltip; the sub-terminal chip surfaces when there
- *     are nested terminals. The active row gets a quiet highlight
- *     (`bg-surface-2` + 3 px accent left-edge stripe); row geometry
- *     stays constant so the dock never reflows when the active
- *     terminal changes. Pip columns share a CSS subgrid across each
- *     section so a column whose rows all lack a pip collapses to
- *     0 width and gives that space back to the branch label.
+ *  2. **cards** (default) — rows grouped by repo. Each repo is a
+ *     **card**: continuous repo-colored **spine** (5 px) down the left
+ *     edge, monogram tile + uppercase name in a repo-tinted **sticky**
+ *     header, air between sections so fleets of 8+ repos stay scannable.
+ *     The header pins to the scrollport top until the next repo's header
+ *     pushes it off — so a row's repo is legible at a glance and survives
+ *     the scroll. Rows below stack as `indicator · branch · pips · time`.
+ *     The leading **status indicator** (`StatePip`) folds identity ·
+ *     paint · motion · unread into one glyph (agent brand mark, state
+ *     colour, spin/glow while active, amber corner badge when unopened)
+ *     — so one glance reads who is driving and whether they need you.
+ *     Agent kind is not labeled in text here — it lives on the terminal
+ *     title bar where there's room. PR pip is a link to the PR with the
+ *     live checks verdict in its tooltip; the sub-terminal chip surfaces
+ *     when there are nested terminals. The active row gets a quiet
+ *     highlight (`bg-surface-2` + accent left-edge stripe matching
+ *     `--dock-edge-stripe-w`); row geometry stays constant so the dock
+ *     never reflows when the active terminal changes. Pip columns share
+ *     a CSS subgrid across each section so a column whose rows all lack
+ *     a pip collapses to 0 width and gives that space back to the branch
+ *     label.
  *
  *  The activity-window picker (`24h`/`12h`/`All`) is a hard filter, not
  *  a dim: rows past the window disappear from the dock entirely. It lives
@@ -99,7 +100,7 @@ import {
 import { ChevronDownIcon, PlusIcon, SearchIcon } from "../../ui/Icons";
 import { useViewPosture } from "../useViewPosture";
 import { capturePointerGesture } from "../viewport/capturePointerGesture";
-import { chipInitials } from "./chipInitials";
+import { chipInitials, repoMonogram } from "./chipInitials";
 import {
   CARDS_WIDTH_PX,
   clampDockCardsWidth,
@@ -380,11 +381,13 @@ const RailOrCards: Component<{
         <Show
           when={props.mode === "rail"}
           fallback={
-            <For each={props.tree.groups}>
-              {(group) => (
-                <RepoSection group={group} flatIndexOf={flatIndexOf()} />
-              )}
-            </For>
+            <div class="dock-cards-stack">
+              <For each={props.tree.groups}>
+                {(group) => (
+                  <RepoSection group={group} flatIndexOf={flatIndexOf()} />
+                )}
+              </For>
+            </div>
           }
         >
           <For each={props.tree.groups}>
@@ -488,10 +491,10 @@ const DockHeader: Component<{
   );
 };
 
-/** Repo section — a small header (uppercase name + colored swatch +
- *  quiet row tally + attention triplet) over the group's rows. Always
- *  rendered, even for single-repo workspaces — a consistent structure
- *  beats a degenerate-case collapse. */
+/** Repo section — monogram tile + uppercase name + bare row tally +
+ *  attention triplet over the group's rows. Always rendered, even for
+ *  single-repo workspaces — a consistent structure beats a degenerate-case
+ *  collapse. Paint lives in `.dock-cards-section*` (index.css). */
 const RepoSection: Component<{
   group: DockGroup;
   /** Pre-built `id → flat position` lookup so each row's `Cmd+N` hint
@@ -535,20 +538,27 @@ const RepoSection: Component<{
       style={{ "--repo-color": props.group.color }}
       class={`dock-cards-section grid ${DOCK_ROW_GRID} ${DOCK_ROW_GAP} pl-3 ${DOCK_CARDS_GUTTER_CLASS}`}
     >
-      {/* Sticky repo header — tinted band + colour swatch + uppercase name
-       *  + quiet row tally + attention triplet (styles in `index.css`).
-       *  The tally is deliberately BARE text, not a capsule: the capsule
-       *  silhouette is reserved for actionable attention counts, so a
-       *  number in a pill always means "act on this" (fucknotif — the old
-       *  count capsule read as six decoy notification badges). */}
+      {/* Sticky repo header — monogram + uppercase name + bare tally +
+       *  attention triplet (styles in `index.css`). The tally is
+       *  deliberately BARE text, not a capsule: the capsule silhouette is
+       *  reserved for actionable attention counts, so a number in a pill
+       *  always means "act on this" (fucknotif — the old count capsule
+       *  read as six decoy notification badges). Monogram reuses
+       *  `repoMonogram` — the same fold the rail chip's repo half uses. */}
       <div
         data-testid="dock-section-header"
-        class={`dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 ${DOCK_CARDS_GUTTER_NEG_CLASS} pl-3 pr-3 py-2`}
+        class={`dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 ${DOCK_CARDS_GUTTER_NEG_CLASS} pl-2.5 pr-3 py-2`}
       >
-        <span class="dock-cards-section-swatch" aria-hidden="true" />
+        <span
+          class="dock-cards-section-monogram"
+          aria-hidden="true"
+          data-testid="dock-section-monogram"
+        >
+          {repoMonogram(props.group.name)}
+        </span>
         <span
           data-testid="dock-section-name"
-          class="dock-cards-section-name font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] truncate min-w-0"
+          class="dock-cards-section-name font-mono text-[0.7rem] font-extrabold uppercase tracking-[0.1em] truncate min-w-0"
           title={props.group.name}
         >
           {props.group.name}

--- a/packages/client/src/canvas/dock/DockList.tsx
+++ b/packages/client/src/canvas/dock/DockList.tsx
@@ -31,6 +31,7 @@ import {
   DOCK_ROW_GRID,
   SLEEPING_RECEDE_CLASS,
 } from "../../ui/chromeSpacing";
+import { repoMonogram } from "./chipInitials";
 import { dockRowAttrs } from "./dockRowAttrs";
 import { type DockRowBucket, rowRecencyAt } from "./dockRowRanking";
 import { encActiveHost } from "../../wire";
@@ -52,11 +53,13 @@ export function DockList(props: { onSelect: (id: TerminalId) => void }) {
         </span>
       </div>
       <div class="flex-1 min-h-0 overflow-y-auto">
-        <For each={tree().groups}>
-          {(group) => (
-            <DockListSection group={group} onSelect={props.onSelect} />
-          )}
-        </For>
+        <div class="dock-cards-stack">
+          <For each={tree().groups}>
+            {(group) => (
+              <DockListSection group={group} onSelect={props.onSelect} />
+            )}
+          </For>
+        </div>
       </div>
       <HiddenFooter
         hiddenCount={tree().hiddenCount}
@@ -69,12 +72,10 @@ export function DockList(props: { onSelect: (id: TerminalId) => void }) {
   );
 }
 
-/** Repo section — a repo-colored left-edge spine plus a faintly
- *  repo-tinted sticky header (uppercase name + row count) over the
- *  group's rows, sharing the desktop dock's `.dock-cards-section*`
- *  classes so both surfaces carry one repo-identity vocabulary.
- *  Always rendered, matching the desktop dock's "section headers
- *  always on" policy. */
+/** Repo section — monogram + spine + sticky header over the group's
+ *  rows, sharing the desktop dock's `.dock-cards-section*` classes so
+ *  both surfaces carry one repo-identity vocabulary. Always rendered,
+ *  matching the desktop dock's "section headers always on" policy. */
 function DockListSection(props: {
   group: DockGroup;
   onSelect: (id: TerminalId) => void;
@@ -104,12 +105,18 @@ function DockListSection(props: {
     >
       <div
         data-testid="mobile-dock-section-header"
-        class="dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 -mr-3 pl-3 pr-3 py-2.5"
+        class="dock-cards-section-header col-span-full flex items-center gap-2 -ml-3 -mr-3 pl-2.5 pr-3 py-2.5"
       >
-        <span class="dock-cards-section-swatch" aria-hidden="true" />
+        <span
+          class="dock-cards-section-monogram"
+          aria-hidden="true"
+          data-testid="mobile-dock-section-monogram"
+        >
+          {repoMonogram(props.group.name)}
+        </span>
         <span
           data-testid="mobile-dock-section-name"
-          class="dock-cards-section-name font-mono text-[0.65rem] font-bold uppercase tracking-[0.12em] truncate min-w-0"
+          class="dock-cards-section-name font-mono text-[0.7rem] font-extrabold uppercase tracking-[0.1em] truncate min-w-0"
         >
           {props.group.name}
         </span>

--- a/packages/client/src/canvas/dock/chipInitials.test.ts
+++ b/packages/client/src/canvas/dock/chipInitials.test.ts
@@ -1,7 +1,7 @@
 import { LOCAL_LOCATION, type TerminalMetadata } from "@kolu/padi/surface";
 import { describe, expect, it } from "vitest";
 import type { TerminalDisplayInfo } from "../../terminal/terminalDisplay";
-import { chipInitials } from "./chipInitials";
+import { chipInitials, repoMonogram } from "./chipInitials";
 
 function info(group: string, label: string): TerminalDisplayInfo {
   return {
@@ -128,9 +128,11 @@ describe("chipInitials", () => {
     });
   });
 
-  it("falls back to ? when repo and branch are unrenderable", () => {
+  it("falls back to first grapheme when repo has no alphanumeric", () => {
+    // Pure punctuation used to become `?`; the monogram now keeps the
+    // lead grapheme so `~` home and similar names still carry identity.
     expect(chipInitials(meta(), info("---", ""))).toEqual({
-      repo: "?",
+      repo: "-",
       sub: "?",
       subIsGlyph: false,
     });
@@ -189,5 +191,32 @@ describe("chipInitials", () => {
     // İ→ lowercased is the single grapheme cluster `i̇`; one visual glyph.
     expect([...subExpand.sub.normalize("NFC")].length).toBeLessThanOrEqual(2);
     expect(subExpand.subIsGlyph).toBe(false);
+  });
+});
+
+describe("repoMonogram", () => {
+  it("uppercases the first alphanumeric of a repo name", () => {
+    expect(repoMonogram("kolu")).toBe("K");
+    expect(repoMonogram("spacetime")).toBe("S");
+  });
+
+  it("skips leading punctuation to the first letter", () => {
+    expect(repoMonogram(".dotfiles")).toBe("D");
+  });
+
+  it("keeps a non-alphanumeric lead grapheme (home ~)", () => {
+    expect(repoMonogram("~")).toBe("~");
+  });
+
+  it("returns ? only for an empty group", () => {
+    expect(repoMonogram("")).toBe("?");
+  });
+
+  it("matches chipInitials.repo for the same group", () => {
+    for (const group of ["kolu", "~", ".dotfiles", "日本語", "ßeta"]) {
+      expect(chipInitials(meta(), info(group, "main")).repo).toBe(
+        repoMonogram(group),
+      );
+    }
   });
 });

--- a/packages/client/src/canvas/dock/chipInitials.ts
+++ b/packages/client/src/canvas/dock/chipInitials.ts
@@ -1,17 +1,16 @@
-/** Rail-chip label derivation — the two-glyph identity painted on a
- *  32 px tile in the collapsed dock. The repo half is the first
- *  alphanumeric character of the repo name in any script (`répo` → `R`,
- *  `日本語` → `日`), uppercased; the sub half is the first grapheme of the
- *  intent (an emoji or other symbol when the user leads with one), with a
- *  fallback to the first alphanumeric character of the branch tail when the
- *  intent is unset. Each half is clamped to a single grapheme so unicode
- *  case-expansion (`ß` → `SS`) can't paint two glyphs on a one-glyph tile.
+/** Repo monogram + rail-chip label derivation.
  *
- *  Cards mode renders the same intent through `IntentMarkdownInline`,
- *  which preserves emoji and symbol prefixes verbatim. The chip's sub
- *  glyph reads through `intentLeadGlyph` so the rail can't disagree
- *  with the cards header on the same source string — both surfaces
- *  share `packages/client/src/intent/text.ts`. */
+ *  Two independent facts, deliberately not one function:
+ *
+ *  - `repoMonogram(group)` — one glyph for a repo name. Cards-mode section
+ *    headers and the rail chip's *repo* half both call this, so a monogram
+ *    and a rail chip never disagree on the same group string.
+ *  - `chipInitials(meta, info)` — two-glyph rail tile: monogram + branch/
+ *    intent sub. Needs live meta (intent lead); the monogram does not.
+ *
+ *  Hickey: monogram identity is not braided into the intent/branch fold.
+ *  Löwy: monogram revs only when the repo set changes; chip sub revs with
+ *  intent — keep the clocks separate. */
 
 import type { TerminalMetadata } from "@kolu/padi/surface";
 import { firstGrapheme, intentLeadGlyph } from "../../intent/text";
@@ -29,21 +28,33 @@ const ALPHANUM = /[\p{L}\p{N}]/u;
 // falling through to the glyph branch.
 const ALPHANUM_ANCHORED = /^[\p{L}\p{N}]\p{M}*$/u;
 
-/** Case `glyph` (upper or lower) but keep the chip's one-glyph invariant:
+/** Case `glyph` (upper or lower) but keep the one-glyph invariant:
  *  unicode case conversion can *expand* a single letter — `ß`.toUpperCase()
  *  is `"SS"`, `İ`.toLowerCase() is `i` + U+0307 — which would paint two
  *  glyphs on a tile sized for one. We re-clamp to the first grapheme cluster
- *  after casing so the rail chip stays exactly one visual glyph. */
+ *  after casing so every monogram / chip half stays exactly one visual glyph. */
 function caseToOneGlyph(glyph: string, mode: "upper" | "lower"): string {
   const cased = mode === "upper" ? glyph.toUpperCase() : glyph.toLowerCase();
   return firstGrapheme(cased) || cased;
 }
 
+/** One-glyph monogram for a repo `group` (git repo name or cwd basename).
+ *
+ *  Prefers the first alphanumeric in any script, uppercased (`"kolu"` →
+ *  `"K"`, `"répo"` → `"R"`, `".dotfiles"` → `"D"`). When there is none —
+ *  home `~`, pure punctuation — falls through to the first grapheme as-is
+ *  so the tile still carries identity rather than a generic `?`. Empty
+ *  string is the only path to `?`. */
+export function repoMonogram(group: string): string {
+  const alnum = group.match(ALPHANUM)?.[0];
+  if (alnum) return caseToOneGlyph(alnum, "upper");
+  const lead = firstGrapheme(group.normalize("NFC"));
+  return lead || "?";
+}
+
 /** Two-glyph rail-chip label.
  *
- *  - `repo` — first alphanumeric char of `info.key.group` in any script,
- *    uppercased (`"kolu"` → `"K"`, `"répo"` → `"R"`). Repo names don't carry
- *    emoji, so the alphanumeric-only match is intentional here.
+ *  - `repo` — `repoMonogram(info.key.group)` (shared with cards headers).
  *  - `sub` — first grapheme of the intent's display line (line 1, with
  *    leading markdown chrome stripped) when the intent is set;
  *    lowercased when it's a unicode letter or digit (`\p{L}`/`\p{N}`),
@@ -57,8 +68,7 @@ export function chipInitials(
   meta: TerminalMetadata,
   info: TerminalDisplayInfo,
 ): { repo: string; sub: string; subIsGlyph: boolean } {
-  const repoChar = info.key.group.match(ALPHANUM)?.[0] ?? "?";
-  const repo = caseToOneGlyph(repoChar, "upper");
+  const repo = repoMonogram(info.key.group);
   const branchTail = info.key.label.split("/").pop() ?? "";
   // Compose to NFC so a decomposed accented lead (`e` + U+0301) classifies as
   // one letter rather than falling through to the glyph branch.

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -689,13 +689,6 @@ body {
 }
 /* Dark mode: lift the wash a notch so the card doesn't read as sludge
  * over near-black — same pattern as the attention row washes below. */
-:root.dark .dock-cards-stack {
-  background: color-mix(
-    in oklab,
-    var(--color-surface-2) 60%,
-    var(--color-surface-1)
-  );
-}
 :root.dark .dock-cards-section-header {
   background: linear-gradient(
     90deg,

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -568,62 +568,115 @@ body {
 }
 
 /* ── Cards-mode repo section ───────────────────────────────────
- * Repo identity carried by two high-mass surfaces instead of one
- * 9.6 px label: a continuous left-edge SPINE in the repo colour
- * that runs the section's full height (header + every row), and a
- * faintly repo-tinted, STICKY header band that pins to the top of
- * the scrollport until the next repo's header pushes it off — so
- * "which repo is this row?" is answerable at a glance and survives
- * the scroll. `--repo-color` is set inline per-section from
- * `group.color` — the same socket the rail chip and rail divider
- * read — so every repo-tinted dock surface shares one literal name.
+ * Repo identity is a CARD, not a pastel band: each section is a rounded
+ * container with air between siblings (`.dock-cards-stack`), a thick
+ * left SPINE in the repo colour, a solid monogram tile, and a sticky
+ * header wash strong enough that eight repos in a fleet stay scannable
+ * under a squint. `--repo-color` is set inline per-section from
+ * `group.color` — the same socket the rail chip and rail divider read —
+ * so every repo-tinted dock surface shares one literal name.
  *
- * The spine sits at the section's outer edge (x 0–3); the active
- * row's own accent stripe sits just inside it (x 3–6), so an active
- * row reads as "active (accent) AND in this repo (spine)" without the
- * two cues overlapping. That non-overlap depends on the two widths
- * being equal, so both read `--dock-edge-stripe-w` (defined below) —
- * the single token is the anchor: the spine here, and the rows'
- * `border-l-[length:var(--dock-edge-stripe-w)]` left stripe in
- * Dock.tsx / DockList.tsx. Change it in one place and the
- * x0-3 / x3-6 alignment stays honoured everywhere.
+ * The spine sits at the section's outer edge; the active row's own
+ * accent stripe sits just inside it (after the section's left padding),
+ * so an active row reads as "active (accent) AND in this repo (spine)"
+ * without the two cues overlapping. That non-overlap depends on the two
+ * widths being equal, so both read `--dock-edge-stripe-w` (defined
+ * below) — the single token is the anchor: the spine here, and the rows'
+ * `border-l-[length:var(--dock-edge-stripe-w)]` left stripe in Dock.tsx
+ * / DockList.tsx. Change it in one place and the alignment stays
+ * honoured everywhere.
  *
- * Custom CSS (not Tailwind utilities): the tint formula and the
- * spine colour both interpolate the per-section `var(--repo-color)`,
- * which Tailwind's static utilities can't express — same exception
- * the rail chip below takes. */
+ * Custom CSS (not Tailwind utilities): the tint formula and the spine
+ * colour both interpolate the per-section `var(--repo-color)`, which
+ * Tailwind's static utilities can't express — same exception the rail
+ * chip below takes.
+ *
+ * Attention (violet asking / amber unread) is a SEPARATE channel on the
+ * row — deliberately louder than repo identity. Repo paint is ambient
+ * structure; obligation is interrupt. */
 :root {
-  --dock-edge-stripe-w: 3px;
+  --dock-edge-stripe-w: 5px;
+  /* Darker ink for the section name: pastel `oklch(0.75 0.14 …)` on a
+   * light surface fails the squint test; mixing toward black keeps the
+   * hue while landing readable weight. */
+  --dock-repo-ink: color-mix(in oklch, var(--repo-color) 82%, black);
+}
+/* Vertical air between repo cards — structure does half the grouping
+ * work colour alone cannot. Horizontal inset keeps card edges off the
+ * scrollport chrome. */
+.dock-cards-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 8px 8px 10px;
+  background: color-mix(
+    in oklab,
+    var(--color-surface-2) 45%,
+    var(--color-surface-1)
+  );
 }
 .dock-cards-section {
+  border: 1px solid
+    color-mix(in oklab, var(--repo-color) 22%, var(--color-edge));
   border-left: var(--dock-edge-stripe-w) solid var(--repo-color);
+  border-radius: 10px;
+  background: var(--color-surface-1);
+  box-shadow:
+    0 1px 0 color-mix(in oklab, var(--repo-color) 8%, transparent),
+    0 1px 2px color-mix(in oklab, var(--color-fg) 4%, transparent);
+  /* No overflow:clip/hidden — that would trap `position: sticky` inside
+   * the section and break the header pin to the dock scrollport. */
 }
-/* Sticky header band — a quiet repo wash (opaque enough for scroll-under)
- * plus a hairline that borrows a hint of the repo colour so sections
- * separate without a hard edge. */
+/* Sticky header band — a readable repo wash (was 9%; that dissolved
+ * eight hues into the same off-white) plus a hairline that borrows the
+ * repo colour so the pinned header still reads as "this repo" when it
+ * covers foreign rows. Top radii match the card so the pinned band
+ * keeps the rounded corners without needing section overflow. */
 .dock-cards-section-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: color-mix(in oklab, var(--repo-color) 9%, var(--color-surface-1));
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--repo-color) 26%, var(--color-surface-1)) 0%,
+    color-mix(in oklab, var(--repo-color) 12%, var(--color-surface-1)) 100%
+  );
   border-bottom: 1px solid
-    color-mix(in oklab, var(--repo-color) 18%, var(--color-edge));
+    color-mix(in oklab, var(--repo-color) 28%, var(--color-edge));
 }
-/* Solid colour swatch — a 7×7 mark that anchors the section without the
- * old filled-name chip. Spine + swatch + tinted band = three echoes of
- * the same repo colour at different scales. */
-.dock-cards-section-swatch {
+/* Monogram tile — solid repo colour + first letter. Replaces the old
+ * 7×7 swatch: area is what peripheral vision catches (same lesson as
+ * the attention row wash). Glyph comes from `repoMonogram()` so rail
+ * chips and section headers share one fold. */
+.dock-cards-section-monogram {
   flex: none;
-  width: 7px;
-  height: 7px;
-  border-radius: 2px;
-  background: var(--repo-color);
-  box-shadow: 0 0 0 1px color-mix(in oklab, var(--repo-color) 35%, transparent);
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  /* Repo colours are pastel (`oklch(0.75 0.14 …)`); pure white-on-pastel
+   * fails contrast. Darken the fill so the glyph stays legible while
+   * the hue still matches the spine / name. */
+  color: #fff;
+  background: color-mix(in oklch, var(--repo-color) 72%, black);
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklab, white 22%, transparent),
+    0 0 0 1px color-mix(in oklab, var(--repo-color) 35%, black);
+  text-shadow: 0 1px 0 color-mix(in oklab, black 22%, transparent);
 }
-/* Repo name — uppercase mono label in the repo colour. Weight + tracking
- * do the identity work; the swatch and band do the grouping. */
+/* Repo name — uppercase mono in the darker repo ink so pastel hues
+ * still read on a light surface. Weight + tracking do the identity
+ * work; monogram + band + spine do the grouping. */
 .dock-cards-section-name {
-  color: var(--repo-color);
+  color: var(--dock-repo-ink);
 }
 /* Terminal count — deliberately BARE quiet type, no capsule: the capsule
  * silhouette is reserved for the actionable attention counts (the header's
@@ -634,6 +687,27 @@ body {
   flex: none;
   font-variant-numeric: tabular-nums;
   color: var(--color-fg-3);
+}
+/* Dark mode: lift the wash a notch so the card doesn't read as sludge
+ * over near-black — same pattern as the attention row washes below. */
+:root.dark .dock-cards-stack {
+  background: color-mix(
+    in oklab,
+    var(--color-surface-2) 60%,
+    var(--color-surface-1)
+  );
+}
+:root.dark .dock-cards-section-header {
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--repo-color) 32%, var(--color-surface-1)) 0%,
+    color-mix(in oklab, var(--repo-color) 16%, var(--color-surface-1)) 100%
+  );
+}
+:root.dark .dock-cards-section-name {
+  /* On dark surfaces the raw repo colour already has contrast; ink
+   * toward black would muddy it. Prefer a lightened mix. */
+  color: color-mix(in oklch, var(--repo-color) 72%, white);
 }
 /* Branch / intent label on a cards row — slightly denser than body text so
  * the primary line reads as the row title; colour still comes from the

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -604,16 +604,15 @@ body {
 /* Vertical air between repo cards — structure does half the grouping
  * work colour alone cannot. Horizontal inset keeps card edges off the
  * scrollport chrome. */
+/* No stack fill: a second surface under the cards reads as nested
+ * chrome (dock → tray → card) and steals contrast from the monogram/
+ * spine without buying more grouping. Gap + card border do the
+ * separation; the dock's own surface is the ground. */
 .dock-cards-stack {
   display: flex;
   flex-direction: column;
   gap: 10px;
   padding: 8px 8px 10px;
-  background: color-mix(
-    in oklab,
-    var(--color-surface-2) 45%,
-    var(--color-surface-1)
-  );
 }
 .dock-cards-section {
   border: 1px solid

--- a/packages/tests/features/dock.feature
+++ b/packages/tests/features/dock.feature
@@ -115,12 +115,12 @@ Feature: Dock
     Then the dock should show 1 active row indicator
 
   Scenario: Repo sections carry a colour spine and a sticky tinted header
-    # Repo identity rides two high-mass surfaces, not a 9.6px label: a
-    # repo-coloured spine down the section's left edge (the section
-    # element draws it from the per-section `--repo-color` custom
-    # property) and a sticky header band so the repo label survives the
-    # scroll. Assert the structural facts via computed style, never a
-    # class selector (see .claude/rules/e2e-testing.md).
+    # Repo identity rides a card: a repo-coloured spine down the section's
+    # left edge (from the per-section `--repo-color` custom property, width
+    # from `--dock-edge-stripe-w`), a monogram + sticky header band so the
+    # repo label survives the scroll, and air between cards. Assert the
+    # structural facts via computed style, never a class selector
+    # (see .claude/rules/e2e-testing.md).
     Given I create a terminal
     When the dock is expanded
     Then the dock section should carry a repo-colour spine

--- a/packages/tests/step_definitions/dock_steps.ts
+++ b/packages/tests/step_definitions/dock_steps.ts
@@ -449,14 +449,16 @@ Then(
 
 // Repo-identity treatment: the section element draws the spine from a
 // per-section `--repo-color` custom property (the single source the
-// header tint and the name colour also read). Assert the structural
-// facts via computed style, never a class name (e2e-testing rule): the
-// 3px solid left border exists AND its colour resolves to the same value
-// as `--repo-color` — so a regression to e.g. `border-left: 3px solid
-// red` (a non-repo hue) fails the scenario rather than slipping through.
-// `--repo-color` is an oklch() literal while `borderLeftColor` resolves
-// to the browser's rgb form, so we normalise both through a throwaway
-// probe element and compare the computed results.
+// header tint, monogram, and name colour also read). Assert the
+// structural facts via computed style, never a class name (e2e-testing
+// rule): a solid left border whose width matches `--dock-edge-stripe-w`
+// AND whose colour resolves to the same value as `--repo-color` — so a
+// regression to e.g. `border-left: 5px solid red` (a non-repo hue) fails
+// rather than slipping through. Width is read from the CSS token, not
+// hardcoded, so a deliberate stripe-width bump does not orphan this
+// assertion. `--repo-color` is an oklch() literal while `borderLeftColor`
+// resolves to the browser's rgb form, so we normalise both through a
+// throwaway probe element and compare the computed results.
 Then(
   "the dock section should carry a repo-colour spine",
   async function (this: KoluWorld) {
@@ -472,7 +474,10 @@ Then(
           throw new Error(
             `[data-testid="dock-section"] has no --repo-color custom property set`,
           );
-        if (cs.borderLeftStyle !== "solid" || cs.borderLeftWidth !== "3px") {
+        const stripeW = cs.getPropertyValue("--dock-edge-stripe-w").trim();
+        if (!stripeW)
+          throw new Error(`missing --dock-edge-stripe-w (spine width token)`);
+        if (cs.borderLeftStyle !== "solid" || cs.borderLeftWidth !== stripeW) {
           return false;
         }
         // Validate before assigning: an invalid colour value is silently

--- a/website/src/content/changelog/unreleased.mdx
+++ b/website/src/content/changelog/unreleased.mdx
@@ -2,6 +2,10 @@
 version: Unreleased
 ---
 
+### [The Dock](/dock)
+
+- <Change kind="changed" title="Repo cards you can actually tell apart">With many repos open, the dock's section cues — a 3px spine, a 7px swatch, and a 9% pastel header wash — all dissolved into one pale list. Each repo is now a **card**: thicker spine, solid monogram tile (first letter of the repo, the same glyph the rail chip already uses), a stronger sticky header wash, and a little air between sections, so a fleet of eight still passes a squint test. Attention (violet needs-you, amber unread) stays the loudest row signal — repo paint is ambient structure, not another interrupt.</Change>
+
 ### [Padi](/padi)
 
 - <Change kind="fixed" title="A shutting-down kaval reaps every terminal it owns — deterministically" pr={2014}>Each terminal kaval spawns lives in its own process session, so nothing the operating system does when kaval dies is guaranteed to take the terminal along — and on macOS, a terminal killed in the first instants after its spawn could dodge the polite hang-up kaval sent on shutdown and sit orphaned for days (aged <code>spawn-helper</code> processes were found accumulating on a CI machine exactly this way). Shutdown now kills each terminal outright instead of asking nicely — the same choice the explicit close-a-terminal path has always made — so a daemon that goes away leaves nothing behind, on any platform.</Change>

--- a/website/src/content/changelog/unreleased.mdx
+++ b/website/src/content/changelog/unreleased.mdx
@@ -4,7 +4,7 @@ version: Unreleased
 
 ### [The Dock](/dock)
 
-- <Change kind="changed" title="Repo cards you can actually tell apart">With many repos open, the dock's section cues — a 3px spine, a 7px swatch, and a 9% pastel header wash — all dissolved into one pale list. Each repo is now a **card**: thicker spine, solid monogram tile (first letter of the repo, the same glyph the rail chip already uses), a stronger sticky header wash, and a little air between sections, so a fleet of eight still passes a squint test. Attention (violet needs-you, amber unread) stays the loudest row signal — repo paint is ambient structure, not another interrupt.</Change>
+- <Change kind="changed" title="Repo cards you can actually tell apart" pr={2035}>With many repos open, the dock's section cues — a 3px spine, a 7px swatch, and a 9% pastel header wash — all dissolved into one pale list. Each repo is now a **card**: thicker spine, solid monogram tile (first letter of the repo, the same glyph the rail chip already uses), a stronger sticky header wash, and a little air between sections, so a fleet of eight still passes a squint test. Attention (violet needs-you, amber unread) stays the loudest row signal — repo paint is ambient structure, not another interrupt.</Change>
 
 ### [Padi](/padi)
 

--- a/website/src/content/docs/dock.mdx
+++ b/website/src/content/docs/dock.mdx
@@ -24,11 +24,13 @@ The dock has two densities. **Rail** is a narrow strip of one chip per terminal.
 `indicator · branch · pips · time`. Toggle between them with
 <kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd>.
 
-Rows are grouped by repo, and each repo section carries a continuous
-repo-coloured **spine** down its left edge with a faintly tinted header that
-stays **pinned** while you scroll that repo's rows — so which repo a terminal
-belongs to is obvious without reading a label that has scrolled away. Per-branch
-row colours still tell branches apart within a repo.
+Rows are grouped by repo, and each repo is a **card**: a continuous
+repo-coloured **spine** down its left edge, a solid **monogram** tile (first
+letter of the repo) plus the uppercase name on a tinted header that stays
+**pinned** while you scroll that repo's rows, and a little air between cards so
+a busy fleet stays scannable. Which repo a terminal belongs to is obvious
+without reading a label that has scrolled away. Per-branch row colours still
+tell branches apart within a repo.
 
 In **maximized** mode the cards dock is a real sidebar beside the canvas, and
 you can **drag its right edge to resize it** — just like the right panel. Drag


### PR DESCRIPTION
With a busy fleet open, the dock's repo sections all looked the same — a 3px spine, a 7px swatch, and a **9% pastel header wash** dissolved eight different hues into one pale list. This turns each repo into a **scannable card** without rewriting the dock tree or the attention model.

### What changed

| Before | After |
| --- | --- |
| Flush stacked bands | Air between section cards (`10px` gap) |
| 3px spine | 5px spine (`--dock-edge-stripe-w`) |
| 7×7 colour swatch | 22×22 **monogram tile** (first letter) |
| Header mix 9% | Sticky gradient wash ~12–26% + darker name ink |

Attention (violet needs-you / amber unread) stays the **louder** row channel — repo paint is ambient structure, not another interrupt. The bare terminal-count tally stays bare (no fake notification capsules).

### Structure (Hickey / Löwy)

- **`repoMonogram(group)`** extracted from `chipInitials` — one fold for the monogram. Cards headers and the rail chip's repo half share it; intent/branch stays only on the rail's sub glyph (not braided into header paint).
- **Paint in CSS**, tree unchanged (`dockTree`, ranking, attention folds untouched).
- Desktop dock and mobile `DockList` still share `.dock-cards-section*` — one vocabulary.

### Docs

- `dock.mdx` updated for cards / monogram / air.
- Unreleased changelog entry under The Dock (PR ref filled after open).

### Try it locally

```sh
nix run github:juspay/kolu/dock-contrast
```

_Generated by Grok Build (model `grok-4.5`)._