### PR TITLE
Shuffle behaviour: Colourful

### DIFF
--- a/packages/client/src/settings/SettingsPopover.tsx
+++ b/packages/client/src/settings/SettingsPopover.tsx
@@ -75,13 +75,14 @@ const NEW_TERMINAL_THEME_HINT: Record<NewTerminalTheme, Hint> = {
 
 /** Shuffle pool — governs both a `Shuffle` new terminal and the ⌘⇧J action.
  *  `Auto` tracks the app's light/dark mode; `Dark`/`Light` force that family;
- *  `Random` spreads across the whole catalogue. */
+ *  `Colourful` prefers saturated (non-grey) tints; `Random` spans the catalogue. */
 const SHUFFLE_BEHAVIOR_OPTIONS: readonly SegmentedControlOption<ShuffleBehavior>[] =
   [
     { value: "random", label: "Random" },
     { value: "dark", label: "Dark" },
     { value: "light", label: "Light" },
     { value: "auto", label: "Auto" },
+    { value: "colourful", label: "Colourful" },
   ];
 
 /** Reactive hint table — re-read on every shuffle-behaviour change. */
@@ -90,6 +91,9 @@ const SHUFFLE_BEHAVIOR_HINT: Record<ShuffleBehavior, Hint> = {
   dark: { text: "Dark tints only." },
   light: { text: "Light tints only." },
   auto: { text: "Match the app's light/dark mode." },
+  colourful: {
+    text: "Saturated tints only — skip grey / monochrome schemes.",
+  },
 };
 
 const SettingsPopover: Component<{

--- a/packages/client/src/terminal/useTerminalCrud.ts
+++ b/packages/client/src/terminal/useTerminalCrud.ts
@@ -135,8 +135,8 @@ export const useTerminalCrud = createSharedRoot(() => {
 
     // Pick the new terminal's theme by strategy. `inherit` copies the active
     // tile's theme (like size inheritance below); `shuffle` auto-picks a tint
-    // distinct from every open terminal, restricted to the family the shuffle
-    // behaviour resolves to. Either way an explicit `initial.themeName`
+    // distinct from every open terminal, restricted by shuffle behaviour
+    // (light/dark/auto/colourful). Either way an explicit `initial.themeName`
     // (worktree / session restore) wins, and an unresolved theme (no active
     // tile to inherit, or the active tile is on the default) stays `undefined`
     // → the server default. Peers are snapshotted BEFORE creating so the new

--- a/packages/client/src/useThemeManager.ts
+++ b/packages/client/src/useThemeManager.ts
@@ -85,10 +85,11 @@ function init() {
    *  see {@link pickTheme} for the rationale.
    *
    *  Draws from the `shuffleBehavior` preference's pool (`dark`/`light`/`auto`
-   *  restrict to a luminance family; `random` uses the whole catalogue) — the
-   *  same pool a `shuffle` new terminal uses. Independent of the
-   *  `newTerminalTheme` creation strategy: ⌘⇧J is an explicit action and always
-   *  shuffles, even when new terminals are set to `inherit`. */
+   *  restrict to a luminance family; `colourful` keeps saturated tints;
+   *  `random` uses the whole catalogue) — the same pool a `shuffle` new
+   *  terminal uses. Independent of the `newTerminalTheme` creation strategy:
+   *  ⌘⇧J is an explicit action and always shuffles, even when new terminals
+   *  are set to `inherit`. */
   function handleShuffleTheme() {
     const id = store.activeId();
     if (id === null) return;

--- a/packages/common/src/surface.test.ts
+++ b/packages/common/src/surface.test.ts
@@ -1,9 +1,9 @@
 /**
- * `shuffleMode` (in `./surface.ts`) — the single source resolving which luminance
- * family a theme shuffle draws from, given the `shuffleBehavior` preference and
- * the app's resolved dark mode. (The terminal-vocabulary tests —
- * `composeTerminalMetadata` and friends — moved to `@kolu/padi`'s `vocab.test.ts`
- * with the schemas they exercise.)
+ * `shuffleMode` (in `./surface.ts`) — the single source resolving the candidate
+ * pool filter a theme shuffle applies (`light` / `dark` / `colourful` / unrestricted),
+ * given the `shuffleBehavior` preference and the app's resolved dark mode. (The
+ * terminal-vocabulary tests — `composeTerminalMetadata` and friends — moved to
+ * `@kolu/padi`'s `vocab.test.ts` with the schemas they exercise.)
  */
 
 import { padiSurface } from "@kolu/padi/surface";

--- a/packages/common/src/surface.test.ts
+++ b/packages/common/src/surface.test.ts
@@ -48,6 +48,11 @@ describe("shuffleMode", () => {
     expect(shuffleMode("auto", true)).toBe("dark");
     expect(shuffleMode("auto", false)).toBe("light");
   });
+
+  it("colourful is independent of app light/dark", () => {
+    expect(shuffleMode("colourful", true)).toBe("colourful");
+    expect(shuffleMode("colourful", false)).toBe("colourful");
+  });
 });
 
 describe("PadiConvergenceSchema — a discriminated union: build fields can't disagree with state", () => {

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -165,12 +165,14 @@ export const NewTerminalThemeSchema = z.enum(["inherit", "shuffle"]);
 /** Which themes a *shuffle* draws from — both a `shuffle` new terminal and the
  *  ⌘⇧J "Shuffle theme" action. `random` spreads across the whole catalogue;
  *  `dark`/`light` restrict to that luminance family; `auto` tracks the app's
- *  resolved light/dark mode. */
+ *  resolved light/dark mode; `colourful` prefers saturated (non-grey) tints
+ *  across light and dark. */
 export const ShuffleBehaviorSchema = z.enum([
   "random",
   "dark",
   "light",
   "auto",
+  "colourful",
 ]);
 
 /** Right-panel preferences — workspace-level layout chrome: the panel's width
@@ -244,20 +246,25 @@ export type ColorScheme = z.infer<typeof ColorSchemeSchema>;
 export type NewTerminalTheme = z.infer<typeof NewTerminalThemeSchema>;
 export type ShuffleBehavior = z.infer<typeof ShuffleBehaviorSchema>;
 
-/** The luminance family a shuffle should restrict its candidate pool to, from
- *  the `shuffleBehavior` preference and the app's resolved dark mode.
+/** Pool filter for {@link pickTheme}'s `mode` — luminance family, colourful
+ *  (saturated) tints, or unrestricted. */
+export type ShuffleMode = "light" | "dark" | "colourful";
+
+/** The candidate-pool filter a shuffle should apply, from the
+ *  `shuffleBehavior` preference and the app's resolved dark mode.
  *  `undefined` means no restriction (`random` — the whole catalogue). The
  *  single source of truth for every shuffle: a `shuffle` new terminal AND the
  *  ⌘⇧J action both resolve their pool through here. */
 export function shuffleMode(
   behavior: ShuffleBehavior,
   isDark: boolean,
-): "light" | "dark" | undefined {
+): ShuffleMode | undefined {
   return match(behavior)
     .with("random", () => undefined)
     .with("dark", () => "dark" as const)
     .with("light", () => "light" as const)
     .with("auto", () => (isDark ? ("dark" as const) : ("light" as const)))
+    .with("colourful", () => "colourful" as const)
     .exhaustive();
 }
 

--- a/packages/common/src/surface.ts
+++ b/packages/common/src/surface.ts
@@ -246,19 +246,17 @@ export type ColorScheme = z.infer<typeof ColorSchemeSchema>;
 export type NewTerminalTheme = z.infer<typeof NewTerminalThemeSchema>;
 export type ShuffleBehavior = z.infer<typeof ShuffleBehaviorSchema>;
 
-/** Pool filter for {@link pickTheme}'s `mode` — luminance family, colourful
- *  (saturated) tints, or unrestricted. */
-export type ShuffleMode = "light" | "dark" | "colourful";
-
 /** The candidate-pool filter a shuffle should apply, from the
  *  `shuffleBehavior` preference and the app's resolved dark mode.
- *  `undefined` means no restriction (`random` — the whole catalogue). The
+ *  `undefined` means no restriction (`random` — the whole catalogue).
+ *  Otherwise `"light"` / `"dark"` / `"colourful"` — the same literals
+ *  `pickTheme`'s `mode` accepts (`ThemePickMode` in terminal-themes). The
  *  single source of truth for every shuffle: a `shuffle` new terminal AND the
  *  ⌘⇧J action both resolve their pool through here. */
 export function shuffleMode(
   behavior: ShuffleBehavior,
   isDark: boolean,
-): ShuffleMode | undefined {
+): "light" | "dark" | "colourful" | undefined {
   return match(behavior)
     .with("random", () => undefined)
     .with("dark", () => "dark" as const)

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -157,7 +157,7 @@ type PersistedState = z.infer<typeof PersistedStateSchema>;
  * Must be valid semver. `conf` runs all migration handlers
  * whose keys are > the last-seen version and ≤ this value.
  */
-const SCHEMA_VERSION = "1.34.0";
+const SCHEMA_VERSION = "1.35.0";
 
 // Callers must pass an explicit directory via KOLU_STATE_DIR. A bare launch
 // with no env would silently clobber whatever happens to live at conf's
@@ -625,6 +625,11 @@ export const store = new Conf<PersistedState>({
         ) as unknown as Preferences,
       );
     },
+    // `ShuffleBehaviorSchema` gained `colourful` (saturated shuffle pool).
+    // Existing records keep their prior `shuffleBehavior` string — no rewrite.
+    // Ladder step only so a PreferencesSchema change advances SCHEMA_VERSION
+    // (see .claude/rules/state.md).
+    "1.35.0": () => {},
   },
 });
 

--- a/packages/terminal-themes/README.md
+++ b/packages/terminal-themes/README.md
@@ -27,6 +27,12 @@ const name = pickTheme(availableThemes, {
 const shuffled = pickTheme(availableThemes, {
   excludeBgs: ["#1d1f21"],
 });
+
+// Restrict the pool: light/dark family, or colourful (saturated) tints
+const colourful = pickTheme(availableThemes, {
+  excludeBgs: ["#1d1f21"],
+  mode: "colourful",
+});
 ```
 
 ## Regenerating themes

--- a/packages/terminal-themes/src/index.ts
+++ b/packages/terminal-themes/src/index.ts
@@ -9,7 +9,14 @@
 
 export type { ITheme } from "@xterm/xterm";
 // Theme picker
-export { hexToOkLab, okLabDistance, pickTheme } from "./picker.ts";
+export {
+  hexToOkLab,
+  okLabDistance,
+  pickTheme,
+  themeColourful,
+  themeMode,
+  type ThemePickMode,
+} from "./picker.ts";
 // Theme catalog
 export {
   availableThemes,

--- a/packages/terminal-themes/src/picker.test.ts
+++ b/packages/terminal-themes/src/picker.test.ts
@@ -341,15 +341,25 @@ describe("pickTheme – mode restriction", () => {
     }
   });
 
-  it("colourful pool is a non-trivial subset of the real catalogue", () => {
-    let colourful = 0;
+  it("colourful pool is a non-trivial pickable subset of the real catalogue", () => {
+    // Pick path is quality ∩ colourful: floor from themeColourful, ceiling from
+    // the garish quality gate (MAX). Count that mid-band, not floor-only.
+    let pickableColourful = 0;
     let grey = 0;
     for (const t of availableThemes) {
-      if (themeColourful(t)) colourful++;
-      else if (themeMode(t) !== undefined) grey++;
+      const bg = t.theme.background;
+      const lab = bg ? hexToOkLab(bg) : undefined;
+      if (!lab) continue;
+      const c = Math.sqrt(lab.a * lab.a + lab.b * lab.b);
+      if (c >= 0.02 && c <= 0.08) pickableColourful++;
+      else if (c < 0.02 && themeMode(t) !== undefined) grey++;
     }
-    expect(colourful).toBeGreaterThan(20);
+    expect(pickableColourful).toBeGreaterThan(20);
     expect(grey).toBeGreaterThan(10);
+    // Floor-only export may include garish; real picks still quality-gate them.
+    expect(
+      availableThemes.filter((t) => themeColourful(t)).length,
+    ).toBeGreaterThanOrEqual(pickableColourful);
   });
 
   it("relaxes only the family — never quality or distinctness — when a family is empty", () => {

--- a/packages/terminal-themes/src/picker.test.ts
+++ b/packages/terminal-themes/src/picker.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { hexToOkLab, okLabDistance, pickTheme, themeMode } from "./picker";
+import {
+  hexToOkLab,
+  okLabDistance,
+  pickTheme,
+  themeColourful,
+  themeMode,
+} from "./picker";
 import { availableThemes, type NamedTheme } from "./theme";
 
 function mk(name: string, background: string): NamedTheme {
@@ -314,6 +320,36 @@ describe("pickTheme – mode restriction", () => {
     expect(["D1", "D2"]).toContain(
       pickTheme(allDark, { spread: true, peerBgs: [], mode: "light" }),
     );
+  });
+
+  it("colourful mode picks only saturated (non-grey) backgrounds", () => {
+    // Pure greys have ~0 chroma; a deep blue bg is colourful under the floor.
+    const mixed: NonEmptyThemes = [
+      mk("Grey", "#222222"),
+      mk("Blue", "#102040"),
+      mk("Grey2", "#333333"),
+      mk("Teal", "#0a2a28"),
+    ];
+    for (const r of [0, 0.3, 0.6, 0.99]) {
+      expect(["Blue", "Teal"]).toContain(
+        pickTheme(mixed, {
+          excludeBgs: [],
+          mode: "colourful",
+          rand: () => r,
+        }),
+      );
+    }
+  });
+
+  it("colourful pool is a non-trivial subset of the real catalogue", () => {
+    let colourful = 0;
+    let grey = 0;
+    for (const t of availableThemes) {
+      if (themeColourful(t)) colourful++;
+      else if (themeMode(t) !== undefined) grey++;
+    }
+    expect(colourful).toBeGreaterThan(20);
+    expect(grey).toBeGreaterThan(10);
   });
 
   it("relaxes only the family — never quality or distinctness — when a family is empty", () => {

--- a/packages/terminal-themes/src/picker.ts
+++ b/packages/terminal-themes/src/picker.ts
@@ -106,9 +106,28 @@ const L_DOWNWEIGHT = 3;
  *  "garish". */
 const MAX_CANDIDATE_CHROMA = 0.08;
 
+/** Minimum background chroma for `mode: "colourful"`. Below this the bg reads
+ *  grey / near-monochrome; at-or-above is a usable saturated tint. Tuned on
+ *  the ghostty catalogue so colourful is a large non-empty subset while
+ *  pure greys (Wryan, many Black Metal greys, Spacegray) stay out. */
+const MIN_COLOURFUL_CHROMA = 0.02;
+
 function chroma(lab: OkLab): number {
   return Math.sqrt(lab.a * lab.a + lab.b * lab.b);
 }
+
+/** True when the theme's background has enough chroma to count as "colourful"
+ *  (not grey). Exported for the test suite. */
+export function themeColourful(t: NamedTheme): boolean {
+  const bg = t.theme.background;
+  const lab = bg ? getLab(bg) : undefined;
+  if (!lab) return false;
+  const c = chroma(lab);
+  return c >= MIN_COLOURFUL_CHROMA && c <= MAX_CANDIDATE_CHROMA;
+}
+
+/** Pool filter passed to {@link pickTheme}. */
+export type ThemePickMode = "light" | "dark" | "colourful";
 
 /** Anisotropic OkLab distance — luminance is scaled down so the picker
  *  prefers hue spread over luminance swaps. Exported for the test suite. */
@@ -123,16 +142,17 @@ export function okLabDistance(x: OkLab, y: OkLab): number {
  *  exhausted request never silently reintroduces a *worse* theme than the one
  *  constraint it couldn't satisfy. The quality gate (parseable, in-gamut — not
  *  garish) is ALWAYS required; distinctness (`excludeBgs`) is kept longer than
- *  the luminance `mode`, which is dropped first. So a `mode: "dark"` request
- *  that runs out of dark themes yields a *light* theme (family relaxed) before
- *  it would ever yield a garish or duplicate one — never all constraints at
- *  once. Only a degenerate catalogue with no in-gamut theme falls through to
- *  the raw list, preserving the non-emptiness type guarantee. The `??` chain
- *  short-circuits, so the common (non-empty) case runs just the first filter. */
+ *  the pool `mode` (light/dark/colourful), which is dropped first. So a
+ *  `mode: "dark"` request that runs out of dark themes yields a *light* theme
+ *  (family relaxed) before it would ever yield a garish or duplicate one —
+ *  never all constraints at once. Only a degenerate catalogue with no
+ *  in-gamut theme falls through to the raw list, preserving the non-emptiness
+ *  type guarantee. The `??` chain short-circuits, so the common (non-empty)
+ *  case runs just the first filter. */
 function filterEligible(
   candidates: NonEmpty<NamedTheme>,
   excludeBgs?: Set<string>,
-  mode?: "light" | "dark",
+  mode?: ThemePickMode,
 ): NonEmpty<NamedTheme> {
   // Quality gate — never relaxed except in a degenerate catalogue.
   const quality = candidates.filter((t) => {
@@ -141,15 +161,16 @@ function filterEligible(
     const lab = getLab(bg);
     return lab !== undefined && chroma(lab) <= MAX_CANDIDATE_CHROMA;
   });
-  const inFamily = (t: NamedTheme): boolean => {
+  const inMode = (t: NamedTheme): boolean => {
     if (!mode) return true;
+    if (mode === "colourful") return themeColourful(t);
     const lab = getLab(t.theme.background ?? "");
     return lab !== undefined && labFamily(lab) === mode;
   };
   const notExcluded = (t: NamedTheme): boolean =>
     !excludeBgs?.has(t.theme.background ?? "");
   return (
-    nonEmpty(quality.filter((t) => notExcluded(t) && inFamily(t))) ??
+    nonEmpty(quality.filter((t) => notExcluded(t) && inMode(t))) ??
     nonEmpty(quality.filter(notExcluded)) ??
     nonEmpty(quality) ??
     candidates
@@ -169,7 +190,7 @@ function pickSpread(
   candidates: NonEmpty<NamedTheme>,
   peerBgs: string[],
   rand: () => number,
-  mode?: "light" | "dark",
+  mode?: ThemePickMode,
 ): string {
   const pool = filterEligible(candidates, undefined, mode);
   const peerLabs: OkLab[] = [];
@@ -214,7 +235,7 @@ function pickShuffle(
   candidates: NonEmpty<NamedTheme>,
   excludeBgs: string[],
   rand: () => number,
-  mode?: "light" | "dark",
+  mode?: ThemePickMode,
 ): string {
   const pool = filterEligible(candidates, new Set(excludeBgs), mode);
   const idx = Math.floor(rand() * pool.length);
@@ -232,8 +253,8 @@ function pickShuffle(
  *
  * Both modes reject candidates with unparseable backgrounds or chroma
  * above {@link MAX_CANDIDATE_CHROMA}, and — when `mode` is set — restrict the
- * pool to that light/dark family, falling back to the full list when filtering
- * leaves nothing.
+ * pool to that light/dark family or to colourful (saturated) tints, falling
+ * back to the quality-gated list when the mode filter leaves nothing.
  *
  * Caller must pass a non-empty candidates list — empty is a compile error.
  */
@@ -244,13 +265,13 @@ export function pickTheme(
         spread: true;
         peerBgs: string[];
         rand?: () => number;
-        mode?: "light" | "dark";
+        mode?: ThemePickMode;
       }
     | {
         spread?: false;
         excludeBgs: string[];
         rand?: () => number;
-        mode?: "light" | "dark";
+        mode?: ThemePickMode;
       },
 ): string {
   const rand = config.rand ?? Math.random;

--- a/packages/terminal-themes/src/picker.ts
+++ b/packages/terminal-themes/src/picker.ts
@@ -117,13 +117,13 @@ function chroma(lab: OkLab): number {
 }
 
 /** True when the theme's background has enough chroma to count as "colourful"
- *  (not grey). Exported for the test suite. */
+ *  (not grey). Garish ceilings stay on the quality gate only — this is the
+ *  floor. Exported for the test suite. */
 export function themeColourful(t: NamedTheme): boolean {
   const bg = t.theme.background;
   const lab = bg ? getLab(bg) : undefined;
   if (!lab) return false;
-  const c = chroma(lab);
-  return c >= MIN_COLOURFUL_CHROMA && c <= MAX_CANDIDATE_CHROMA;
+  return chroma(lab) >= MIN_COLOURFUL_CHROMA;
 }
 
 /** Pool filter passed to {@link pickTheme}. */
@@ -164,8 +164,7 @@ function filterEligible(
   const inMode = (t: NamedTheme): boolean => {
     if (!mode) return true;
     if (mode === "colourful") return themeColourful(t);
-    const lab = getLab(t.theme.background ?? "");
-    return lab !== undefined && labFamily(lab) === mode;
+    return themeMode(t) === mode;
   };
   const notExcluded = (t: NamedTheme): boolean =>
     !excludeBgs?.has(t.theme.background ?? "");

--- a/packages/terminal-themes/src/picker.ts
+++ b/packages/terminal-themes/src/picker.ts
@@ -163,8 +163,17 @@ function filterEligible(
   });
   const inMode = (t: NamedTheme): boolean => {
     if (!mode) return true;
-    if (mode === "colourful") return themeColourful(t);
-    return themeMode(t) === mode;
+    switch (mode) {
+      case "colourful":
+        return themeColourful(t);
+      case "light":
+      case "dark":
+        return themeMode(t) === mode;
+      default: {
+        const _exhaustive: never = mode;
+        return _exhaustive;
+      }
+    }
   };
   const notExcluded = (t: NamedTheme): boolean =>
     !excludeBgs?.has(t.theme.background ?? "");

--- a/website/src/content/changelog/unreleased.mdx
+++ b/website/src/content/changelog/unreleased.mdx
@@ -10,6 +10,10 @@ version: Unreleased
 
 - <Change kind="changed" title="Tiles land, finish, work, and sleep like things in a place" pr={2038}>The canvas already painted agent state as motion on the border; that language is now a fuller place cue, not only a state pip. A new tile **lands** with a short brightness settle (once, on first open — not every maximize restore). A **working** agent wears the same double frame as the active tile (solid border + outer moat), with a calm rotating highlight on the outer rail instead of crawling dashes. **Needs you** is still the comet. A just-finished agent **exhales** into a soft held ring instead of sharing that comet, so a post-turn lull no longer reads as "blocked on you" from across the room. A sleeping tile **folds** — desaturated and dimmed on the whole card, not only the title bar. And **New terminal** now shows a live **Will create** card — monogram, fleet hue, worktree name, agent mark — so you see the dock row before you spawn it. Reduced motion keeps the static rings and skips the entrances and spins.</Change>
 
+### [Theming](/theming)
+
+- <Change kind="added" title="Shuffle behaviour: Colourful">**Shuffle behaviour** gains **Colourful** — <kbd>⌘⇧J</kbd> and shuffled new terminals stay on saturated schemes and skip grey / monochrome tints, without forcing light or dark. Auto / Dark / Light / Random are unchanged.</Change>
+
 ### [Padi](/padi)
 
 - <Change kind="fixed" title="A shutting-down kaval reaps every terminal it owns — deterministically" pr={2014}>Each terminal kaval spawns lives in its own process session, so nothing the operating system does when kaval dies is guaranteed to take the terminal along — and on macOS, a terminal killed in the first instants after its spawn could dodge the polite hang-up kaval sent on shutdown and sit orphaned for days (aged <code>spawn-helper</code> processes were found accumulating on a CI machine exactly this way). Shutdown now kills each terminal outright instead of asking nicely — the same choice the explicit close-a-terminal path has always made — so a daemon that goes away leaves nothing behind, on any platform.</Change>

--- a/website/src/content/changelog/unreleased.mdx
+++ b/website/src/content/changelog/unreleased.mdx
@@ -12,7 +12,7 @@ version: Unreleased
 
 ### [Theming](/theming)
 
-- <Change kind="added" title="Shuffle behaviour: Colourful">**Shuffle behaviour** gains **Colourful** — <kbd>⌘⇧J</kbd> and shuffled new terminals stay on saturated schemes and skip grey / monochrome tints, without forcing light or dark. Auto / Dark / Light / Random are unchanged.</Change>
+- <Change kind="added" title="Shuffle behaviour: Colourful" pr={2040}>**Shuffle behaviour** gains **Colourful** — <kbd>⌘⇧J</kbd> and shuffled new terminals stay on saturated schemes and skip grey / monochrome tints, without forcing light or dark. Auto / Dark / Light / Random are unchanged.</Change>
 
 ### [Padi](/padi)
 

--- a/website/src/content/docs/theming.mdx
+++ b/website/src/content/docs/theming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Theming
-description: "200+ terminal color schemes, live preview in the palette, per-tile theming, how a new terminal picks its theme (inherit vs shuffle), and the light/dark UI."
+description: "200+ terminal color schemes, live preview in the palette, per-tile theming, how a new terminal picks its theme (inherit vs shuffle, including colourful), and the light/dark UI."
 order: 42
 section: Use Kolu
 koluHero:
@@ -56,6 +56,8 @@ and the <kbd>⌘⇧J</kbd> "shuffle this terminal" shortcut:
 - **Auto** _(default)_ — keep picks in the app's current light or dark family, so
   a tile can't surface as a jarring bright-white panel in a dark workspace.
 - **Dark** / **Light** — force one family regardless of the app theme.
+- **Colourful** — saturated tints only (skip grey / monochrome schemes), across
+  light and dark.
 - **Random** — draw from the whole catalogue.
 
 <Aside type="note" title="Switching light/dark is forward-only">


### PR DESCRIPTION
Settings **Shuffle behaviour** gains **Colourful** — saturated terminal schemes only, greys and monochrome left out.

**⌘⇧J** and new terminals set to Shuffle both use this pool. Auto / Dark / Light / Random are unchanged; Colourful does **not** force light or dark.

### How

`shuffleMode("colourful")` feeds `pickTheme`'s existing `mode` filter. A theme counts as colourful when its background OkLab chroma sits above a floor (enough colour to not read grey) and under the existing garish ceiling (same quality gate as every other shuffle). If that subset is empty, the picker relaxes only the mode filter — same ladder as light/dark.

### Design philosophy

- **Fail-fast** — no second "colour pack" catalogue or mood preference; one enum value on the existing shuffle axis.
- **Reuse** — extends `ShuffleBehaviorSchema` / `pickTheme` mode, not a parallel classifier.
- **Electricity** — pure leaf classification in `terminal-themes`; no new volatility boundary.

### Try it

Settings → Shuffle behaviour → **Colourful**, then ⌘⇧J a few times.

### Try it locally

```sh
nix run github:juspay/kolu/feat/shuffle-colourful
```

_Generated by [`/be`](https://github.com/srid/agency) on Grok (model `grok-4.5`)._